### PR TITLE
Phase 1: synthesize entry point for top-level statements (C# 9-style)

### DIFF
--- a/design/Gsharp-design-v0.1.md
+++ b/design/Gsharp-design-v0.1.md
@@ -1,9 +1,11 @@
 # Ideas for GSharp version 0.1
-The goal of GSharp 0.1 is to be able to produce a "hello world" style console application, ideally targeting .NET Core 3.0. As a stretch goal, it will also support declaration, assignment and evaluation of `int` and `bool` variables, as well as `if` (conditional) and `for` (loop) statements.
+The goal of GSharp 0.1 is to be able to produce a "hello world" style console application, ideally targeting .NET 10. As a stretch goal, it will also support declaration, assignment and evaluation of `int` and `bool` variables, as well as `if` (conditional) and `for` (loop) statements.
 
 The language grammar will be initially derived from Go's grammar, plus additions where it makes sense in order to support using .NET Core libraries. Note that GSharp may not necessarily support generics anytime soon.
 
 ## Prototype program: Hello World
+GSharp supports **top-level statements** (C# 9-style). A `.gs` file may consist of statements directly at the top of the file; the compiler synthesizes an entry point that executes them in order. An explicit `func Main()` is allowed but not required.
+
 Here's an example "hello world" written in GSharp:
 ```go
 // file: HelloWorld.gs
@@ -12,27 +14,20 @@ package HelloWorld
 
 import System
 
-func Main() {
-  Console.WriteLine("Hello, world!")
-}
+Console.WriteLine("Hello, world!")
 ```
 
-Compare to the C# equivalent:
+Compare to the C# equivalent (also using top-level statements):
 ```csharp
 // file: HelloWorld.cs
 
 using System;
 
-class HelloWorld
-{
-    static void Main(string[] args)
-    {
-        Console.WriteLine("Hello, World!");
-    }
-}
+Console.WriteLine("Hello, World!");
 ```
+
 ## Prototype program: if and loop
-This program receives tries to parse the first command line argument as an integer, and then does that many loops printing values all the way to 1.
+This program tries to parse the first command line argument as an integer, and then does that many loops printing values all the way to 1. With top-level statements, command-line arguments are available via the implicit `args` parameter on the synthesized entry point:
 ```go
 // file: Loop.gs
 
@@ -40,43 +35,37 @@ package GSharp.Example.Loop
 
 import System
 
-func Main(args string[]) {
-  count := 0
-  if args.Length == 1 {
-    Int.TryParse(args[0], *count)
-  }
-  
-  for i := count; i > 0; i-- {
-    Console.WriteLine("Count value: {i}")
-  }
+count := 0
+if args.Length == 1 {
+  Int.TryParse(args[0], *count)
+}
+
+for i := count; i > 0; i-- {
+  Console.WriteLine("Count value: {i}")
 }
 ```
-Compare to the C# equivalent:
+Compare to the C# equivalent (top-level statements form):
 ```csharp
 // file: Loop.cs
 
-namespace GSharp.Example
-{
-    using System;
+using System;
 
-    class Loop
-    {
-        static void Main(string[] args)
-        {
-            var count = 0;
-            if (args.Length == 1)
-            {
-                Int.TryParse(args[0], out count);
-            }
-            
-            for (var i = count; i > 0; i--)
-            {
-                Console.WriteLine($"Count value: {i}");
-            }
-        }
-    }
+var count = 0;
+if (args.Length == 1)
+{
+    Int.TryParse(args[0], out count);
+}
+
+for (var i = count; i > 0; i--)
+{
+    Console.WriteLine($"Count value: {i}");
 }
 ```
+
+### Entry-point synthesis rules
+- A compilation that contains any top-level statements must contain exactly one source file with top-level statements; multiple files with top-level statements is a compile error.
+- The binder synthesizes a single hidden method (conceptually `<TopLevel>$.<Main>$(string[] args)`) whose body is the lowered top-level `BoundBlockStatement`. The emitter marks that method as the assembly entry point.
+- An explicit `func Main()` (or `func Main(args string[])`) is supported and takes precedence: when present, top-level statements are not allowed in the same compilation.
 
 ## Notes
 I found an interesting project that attempts to convert Go code to C# code. It has interesting ideas in it:

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -76,7 +76,8 @@ public sealed class Binder
 
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
         var globalStatements = syntaxTrees.SelectMany(st => st.Root.Members)
-                                          .OfType<GlobalStatementSyntax>();
+                                          .OfType<GlobalStatementSyntax>()
+                                          .ToArray();
         foreach (var globalStatement in globalStatements)
         {
             var statement = binder.BindStatement(globalStatement.Statement);
@@ -86,6 +87,9 @@ public sealed class Binder
         var imports = binder.scope.GetDeclaredImports();
         var functions = binder.scope.GetDeclaredFunctions();
         var variables = binder.scope.GetDeclaredVariables();
+
+        var entryPoint = ResolveEntryPoint(binder, functions, globalStatements, syntaxTrees);
+
         var diagnostics = binder.Diagnostics.ToImmutableArray();
 
         if (previous != null)
@@ -94,7 +98,7 @@ public sealed class Binder
         }
 
         var packageSymbol = new PackageSymbol(name: "Default", declaration: null);
-        return new BoundGlobalScope(previous, packageSymbol, diagnostics, imports, functions, variables, statements.ToImmutable());
+        return new BoundGlobalScope(previous, packageSymbol, diagnostics, imports, functions, variables, entryPoint, statements.ToImmutable());
     }
 
     /// <summary>
@@ -134,7 +138,15 @@ public sealed class Binder
 
         var statement = Lowerer.Lower(new BoundBlockStatement(globalScope.Statements));
 
-        return new BoundProgram(globalScope.Package.Name, diagnostics.ToImmutable(), functionBodies.ToImmutable(), statement);
+        // If the entry point is the synthesized top-level function, its body is
+        // the lowered top-level statements block. Register it under EntryPoint so
+        // the emitter sees a uniform "Functions[EntryPoint]" view.
+        if (globalScope.EntryPoint != null && globalScope.EntryPoint.Declaration == null)
+        {
+            functionBodies[globalScope.EntryPoint] = statement;
+        }
+
+        return new BoundProgram(globalScope.Package.Name, diagnostics.ToImmutable(), functionBodies.ToImmutable(), globalScope.EntryPoint, statement);
     }
 
     private static BoundScope CreateParentScope(BoundGlobalScope previous)
@@ -849,5 +861,56 @@ public sealed class Binder
             default:
                 return null;
         }
+    }
+
+    /// <summary>
+    /// Picks or synthesizes the entry-point function symbol for the compilation
+    /// per the rules in design/Gsharp-design-v0.1.md (C#-9-style top-level
+    /// statements). Reports diagnostics for ambiguity.
+    /// </summary>
+    private static FunctionSymbol ResolveEntryPoint(
+        Binder binder,
+        ImmutableArray<FunctionSymbol> functions,
+        GlobalStatementSyntax[] globalStatements,
+        ImmutableArray<SyntaxTree> syntaxTrees)
+    {
+        var explicitMain = functions.FirstOrDefault(f => f.Name == "Main");
+        var hasTopLevel = globalStatements.Length > 0;
+
+        if (hasTopLevel)
+        {
+            var treesWithTopLevel = syntaxTrees
+                .Where(st => st.Root.Members.OfType<GlobalStatementSyntax>().Any())
+                .ToArray();
+            if (treesWithTopLevel.Length > 1)
+            {
+                foreach (var tree in treesWithTopLevel)
+                {
+                    var first = tree.Root.Members.OfType<GlobalStatementSyntax>().First();
+                    binder.Diagnostics.ReportMultipleTopLevelFiles(first.Statement.Location);
+                }
+            }
+
+            if (explicitMain != null)
+            {
+                binder.Diagnostics.ReportTopLevelStatementsConflictWithMain(
+                    explicitMain.Declaration.Identifier.Location);
+            }
+
+            return SynthesizeTopLevelEntryPoint();
+        }
+
+        return explicitMain;
+    }
+
+    private static FunctionSymbol SynthesizeTopLevelEntryPoint()
+    {
+        // <Main>$ — Roslyn-style mangled name; not a legal user identifier so it
+        // cannot collide with a user-declared function.
+        return new FunctionSymbol(
+            name: "<Main>$",
+            parameters: ImmutableArray<ParameterSymbol>.Empty,
+            type: TypeSymbol.Void,
+            declaration: null);
     }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
@@ -21,6 +21,7 @@ public sealed class BoundGlobalScope
     /// <param name="imports">Imports in the current compilation.</param>
     /// <param name="functions">Functions in the current compilation.</param>
     /// <param name="variables">Variables in the current compilation.</param>
+    /// <param name="entryPoint">The entry-point function for this compilation, or null if the compilation is a library.</param>
     /// <param name="statements">Statements in the current compilation.</param>
     public BoundGlobalScope(
         BoundGlobalScope previous,
@@ -29,6 +30,7 @@ public sealed class BoundGlobalScope
         ImmutableArray<ImportSymbol> imports,
         ImmutableArray<FunctionSymbol> functions,
         ImmutableArray<VariableSymbol> variables,
+        FunctionSymbol entryPoint,
         ImmutableArray<BoundStatement> statements)
     {
         Previous = previous;
@@ -37,6 +39,7 @@ public sealed class BoundGlobalScope
         Imports = imports;
         Functions = functions;
         Variables = variables;
+        EntryPoint = entryPoint;
         Statements = statements;
     }
 
@@ -69,6 +72,12 @@ public sealed class BoundGlobalScope
     /// Gets the variables in the current compilation.
     /// </summary>
     public ImmutableArray<VariableSymbol> Variables { get; }
+
+    /// <summary>
+    /// Gets the synthesized or explicit entry-point function for this compilation,
+    /// or null if the compilation produces a library (no entry point).
+    /// </summary>
+    public FunctionSymbol EntryPoint { get; }
 
     /// <summary>
     /// Gets the statements in the current compilation.

--- a/src/Core/CodeAnalysis/Binding/BoundProgram.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundProgram.cs
@@ -18,16 +18,19 @@ public sealed class BoundProgram
     /// <param name="packageName">The package name.</param>
     /// <param name="diagnostics">The diagnostics.</param>
     /// <param name="functions">The functions.</param>
+    /// <param name="entryPoint">The entry-point function, or null if the compilation is a library.</param>
     /// <param name="statement">The statements.</param>
     public BoundProgram(
         string packageName,
         ImmutableArray<Diagnostic> diagnostics,
         ImmutableDictionary<FunctionSymbol, BoundBlockStatement> functions,
+        FunctionSymbol entryPoint,
         BoundBlockStatement statement)
     {
         PackageName = packageName;
         Diagnostics = diagnostics;
         Functions = functions;
+        EntryPoint = entryPoint;
         Statement = statement;
     }
 
@@ -45,6 +48,13 @@ public sealed class BoundProgram
     /// Gets the functions.
     /// </summary>
     public ImmutableDictionary<FunctionSymbol, BoundBlockStatement> Functions { get; }
+
+    /// <summary>
+    /// Gets the synthesized or explicit entry-point function for this program,
+    /// or null when the compilation produces a library. The body of the entry
+    /// point is available via <see cref="Functions"/> using this key.
+    /// </summary>
+    public FunctionSymbol EntryPoint { get; }
 
     /// <summary>
     /// Gets the statements.

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -347,6 +347,28 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, message);
     }
 
+    /// <summary>
+    /// Reports that top-level statements appear in more than one source file in
+    /// the same compilation, which is not allowed.
+    /// </summary>
+    /// <param name="location">A location in one of the offending files.</param>
+    public void ReportMultipleTopLevelFiles(TextLocation location)
+    {
+        var message = "Only one source file in a compilation may contain top-level statements.";
+        Report(location, message);
+    }
+
+    /// <summary>
+    /// Reports that the compilation contains both top-level statements and an
+    /// explicit Main function, which is ambiguous.
+    /// </summary>
+    /// <param name="location">The location of the explicit Main function declaration.</param>
+    public void ReportTopLevelStatementsConflictWithMain(TextLocation location)
+    {
+        var message = "Top-level statements cannot be used together with an explicit Main function.";
+        Report(location, message);
+    }
+
     private void Report(TextLocation location, string message)
     {
         var diagnostic = new Diagnostic(location, message);

--- a/test/Core.Tests/CodeAnalysis/Binding/BinderEntryPointTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/BinderEntryPointTests.cs
@@ -1,0 +1,88 @@
+// <copyright file="BinderEntryPointTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Tests for the C#-9-style top-level-statement entry-point synthesis performed
+/// by <see cref="Binder.BindGlobalScope"/>. The rules are documented in
+/// design/Gsharp-design-v0.1.md.
+/// </summary>
+public class BinderEntryPointTests
+{
+    [Fact]
+    public void Synthesizes_EntryPoint_For_TopLevel_Statements()
+    {
+        var globalScope = BindSource("Console.WriteLine(\"hi\")\n");
+
+        Assert.NotNull(globalScope.EntryPoint);
+        Assert.Equal("<Main>$", globalScope.EntryPoint.Name);
+        Assert.Null(globalScope.EntryPoint.Declaration);
+        Assert.Empty(globalScope.EntryPoint.Parameters);
+    }
+
+    [Fact]
+    public void Picks_Explicit_Main_When_No_TopLevel_Statements()
+    {
+        var globalScope = BindSource("func Main() {\n}\n");
+
+        Assert.NotNull(globalScope.EntryPoint);
+        Assert.Equal("Main", globalScope.EntryPoint.Name);
+        Assert.NotNull(globalScope.EntryPoint.Declaration);
+    }
+
+    [Fact]
+    public void EntryPoint_Null_For_Library_Compilation()
+    {
+        var globalScope = BindSource("func Helper() {\n}\n");
+
+        Assert.Null(globalScope.EntryPoint);
+    }
+
+    [Fact]
+    public void Reports_Conflict_When_TopLevel_And_Explicit_Main_Coexist()
+    {
+        var globalScope = BindSource("Console.WriteLine(\"hi\")\nfunc Main() {\n}\n");
+
+        Assert.NotNull(globalScope.EntryPoint);
+        Assert.Equal("<Main>$", globalScope.EntryPoint.Name);
+        Assert.Contains(globalScope.Diagnostics, d => d.Message.Contains("Top-level statements cannot be used together with an explicit Main"));
+    }
+
+    [Fact]
+    public void Reports_When_TopLevel_Statements_Span_Multiple_Files()
+    {
+        var tree1 = SyntaxTree.Parse(SourceText.From("Console.WriteLine(\"a\")\n"));
+        var tree2 = SyntaxTree.Parse(SourceText.From("Console.WriteLine(\"b\")\n"));
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree1, tree2));
+
+        Assert.NotNull(globalScope.EntryPoint);
+        Assert.Contains(globalScope.Diagnostics, d => d.Message.Contains("Only one source file"));
+    }
+
+    [Fact]
+    public void BindProgram_Registers_Synthesized_EntryPoint_Body_In_Functions()
+    {
+        var globalScope = BindSource("Console.WriteLine(\"hi\")\n");
+        var program = Binder.BindProgram(globalScope);
+
+        Assert.NotNull(program.EntryPoint);
+        Assert.Same(globalScope.EntryPoint, program.EntryPoint);
+        Assert.True(program.Functions.ContainsKey(program.EntryPoint));
+    }
+
+    private static BoundGlobalScope BindSource(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+}


### PR DESCRIPTION
Phase 1 (front-end portion): teach the binder to recognize **top-level statements** as a self-contained entry-point body and synthesize a `FunctionSymbol` named `<Main>$` for them — C# 9-style. An explicit `func Main()` is still supported but mutually exclusive with top-level statements in the same compilation.

This unblocks the Roslyn-side emit work (next PR) by giving it a uniform `program.EntryPoint` + `program.Functions[EntryPoint]` view regardless of which form the user wrote.

## Changes

### Front-end (`src/Core/CodeAnalysis/`)
- **`BoundGlobalScope`** gains `EntryPoint` (`FunctionSymbol?`):
  - synthesized `<Main>$` when top-level statements are present,
  - the explicit `Main` symbol when top-level statements are absent,
  - `null` for library compilations.
- **`BoundProgram`** gains `EntryPoint` and registers the synthesized function's body in `Functions[EntryPoint]` (the body is the existing lowered top-level block — no duplication).
- **`Binder.BindGlobalScope`** routes through a new `ResolveEntryPoint` helper.
- **Two new diagnostics** on `DiagnosticBag`:
  - `ReportMultipleTopLevelFiles` — top-level statements may appear in at most one source file per compilation.
  - `ReportTopLevelStatementsConflictWithMain` — explicit `Main` may not coexist with top-level statements.

### Design doc
- `design/Gsharp-design-v0.1.md` updated:
  - Hello World committed to the top-level-statements form (no `func Main()` wrapper required).
  - Entry-point synthesis rules made explicit (single file constraint, `<Main>$` naming, explicit-Main fallback).
  - `.NET Core 3.0` target bumped to `.NET 10` to match current repo reality.

### Tests
- `test/Core.Tests/CodeAnalysis/Binding/BinderEntryPointTests.cs` (6 cases):
  - synthesizes `<Main>$` for top-level statements,
  - picks explicit `Main` when there are no top-level statements,
  - `EntryPoint == null` for library compilations,
  - reports conflict when both forms are present,
  - reports when top-level statements appear in multiple files,
  - `BindProgram` registers the synthesized body under `EntryPoint` in `Functions`.

## Validated
- `dotnet build GSharp.sln` clean.
- `dotnet test GSharp.sln` — 81/81 pass (was 75; +6 new).

## Next (separate PR)
Roslyn-derived emit: minimal `Gsharp*Symbol` types, `GsharpCompilation : Compilation` overrides, `PEModuleBuilder : CommonPEModuleBuilder`, `MethodGenerator` (`ldstr`/`call`/`ret`), and replacing the `Compilation.EmitAssembly` stub so the synthesized entry point becomes a real PE assembly entry point.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
