### PR TITLE
Phase 1: gsc CLI emit mode + runtimeconfig.json + SDK plumbing

### DIFF
--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -1,12 +1,12 @@
-﻿// <copyright file="Program.cs" company="GSharp">
+// <copyright file="Program.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
@@ -15,12 +15,18 @@ using GSharp.Core.IO;
 namespace GSharp.Compiler;
 
 /// <summary>
-/// Entry point to gsc.
+/// Entry point to gsc, the GSharp command-line compiler.
 /// </summary>
 public class Program
 {
     private const int Success = 0;
     private const int Error = 1;
+
+    private enum OutputTarget
+    {
+        Exe,
+        Library,
+    }
 
     /// <summary>
     /// Entry point to the GSharp compiler.
@@ -31,13 +37,29 @@ public class Program
     {
         if (args.Length == 0)
         {
-            Console.Error.WriteLine($"Must specify path to a file via arguments.");
+            Console.Error.WriteLine("Must specify path to a file via arguments.");
             return Error;
         }
 
-        var paths = args;
-        var syntaxTrees = new List<SyntaxTree>(paths.Length);
-        foreach (var path in paths)
+        CommandLineArgs parsed;
+        try
+        {
+            parsed = ParseCommandLine(args);
+        }
+        catch (CommandLineException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return Error;
+        }
+
+        if (parsed.SourceFiles.Count == 0)
+        {
+            Console.Error.WriteLine("Must specify at least one source file.");
+            return Error;
+        }
+
+        var syntaxTrees = new List<SyntaxTree>(parsed.SourceFiles.Count);
+        foreach (var path in parsed.SourceFiles)
         {
             if (!File.Exists(path))
             {
@@ -48,8 +70,23 @@ public class Program
             syntaxTrees.Add(SyntaxTree.Load(path));
         }
 
-        if (!Compile(syntaxTrees.ToArray()))
+        var compilation = new Compilation(syntaxTrees.ToArray());
+
+        if (parsed.OutputPath is null)
         {
+            // Legacy / no-output mode: interpret the program (back-compat).
+            return Interpret(compilation);
+        }
+
+        return Emit(compilation, parsed);
+    }
+
+    private static int Interpret(Compilation compilation)
+    {
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        if (result.Diagnostics.Any())
+        {
+            Console.Out.WriteDiagnostics(result.Diagnostics);
             Console.Error.WriteLine("Failed.");
             return Error;
         }
@@ -58,17 +95,239 @@ public class Program
         return Success;
     }
 
-    private static bool Compile(params SyntaxTree[] syntaxTrees)
+    private static int Emit(Compilation compilation, CommandLineArgs args)
     {
-        var compilation = new Compilation(syntaxTrees);
-
-        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
-        if (result.Diagnostics.Any())
+        var outputPath = args.OutputPath;
+        var outputDir = Path.GetDirectoryName(outputPath);
+        if (!string.IsNullOrEmpty(outputDir))
         {
+            Directory.CreateDirectory(outputDir);
+        }
+
+        EmitResult result;
+        using (var peStream = File.Create(outputPath))
+        {
+            result = compilation.Emit(peStream);
+        }
+
+        if (!result.Success)
+        {
+            try
+            {
+                File.Delete(outputPath);
+            }
+            catch (IOException)
+            {
+                // Best-effort cleanup; ignore.
+            }
+
             Console.Out.WriteDiagnostics(result.Diagnostics);
+            Console.Error.WriteLine("Failed.");
+            return Error;
+        }
+
+        if (args.Target == OutputTarget.Exe)
+        {
+            WriteRuntimeConfig(outputPath, args.TargetFramework);
+        }
+
+        Console.WriteLine($"Wrote {outputPath}");
+        return Success;
+    }
+
+    private static void WriteRuntimeConfig(string assemblyPath, string targetFramework)
+    {
+        var tfm = string.IsNullOrEmpty(targetFramework) ? "net10.0" : targetFramework;
+        var (frameworkName, frameworkVersion) = ResolveFrameworkMoniker(tfm);
+
+        var configPath = Path.ChangeExtension(assemblyPath, ".runtimeconfig.json");
+        var json = $$"""
+        {
+          "runtimeOptions": {
+            "tfm": "{{tfm}}",
+            "framework": {
+              "name": "{{frameworkName}}",
+              "version": "{{frameworkVersion}}"
+            },
+            "rollForward": "LatestMinor"
+          }
+        }
+        """;
+        File.WriteAllText(configPath, json);
+    }
+
+    private static (string Name, string Version) ResolveFrameworkMoniker(string tfm)
+    {
+        // Crude TFM → runtime framework mapping good enough for net8/9/10.
+        // The "framework.version" is the minimum shared framework version to load.
+        return tfm switch
+        {
+            "net8.0" => ("Microsoft.NETCore.App", "8.0.0"),
+            "net9.0" => ("Microsoft.NETCore.App", "9.0.0"),
+            "net10.0" => ("Microsoft.NETCore.App", "10.0.0"),
+            _ => ("Microsoft.NETCore.App", "10.0.0"),
+        };
+    }
+
+    private static CommandLineArgs ParseCommandLine(string[] args)
+    {
+        var result = new CommandLineArgs();
+        var expanded = ExpandResponseFiles(args);
+
+        foreach (var raw in expanded)
+        {
+            if (raw.Length == 0)
+            {
+                continue;
+            }
+
+            if (IsSwitch(raw))
+            {
+                var body = raw.Substring(1);
+                var colon = body.IndexOf(':');
+                var name = colon < 0 ? body : body.Substring(0, colon);
+                var value = colon < 0 ? string.Empty : body.Substring(colon + 1);
+
+                switch (name.ToLowerInvariant())
+                {
+                    case "out":
+                        result.OutputPath = value;
+                        break;
+
+                    case "target":
+                        result.Target = value.ToLowerInvariant() switch
+                        {
+                            "exe" => OutputTarget.Exe,
+                            "library" or "lib" or "dll" => OutputTarget.Library,
+                            _ => throw new CommandLineException($"Unsupported /target value: {value}"),
+                        };
+                        break;
+
+                    case "targetframework":
+                    case "tfm":
+                        result.TargetFramework = value;
+                        break;
+
+                    case "r":
+                    case "reference":
+                        // References are accepted for SDK compatibility but unused
+                        // by the Phase 1 emitter (imports resolve via runtime reflection).
+                        result.References.Add(value);
+                        break;
+
+                    case "debug":
+                    case "pdb":
+                        // Accepted for SDK compatibility; debug info emit is Phase 2.
+                        break;
+
+                    case "?":
+                    case "help":
+                        result.ShowHelp = true;
+                        break;
+
+                    default:
+                        // Forward-compatible: ignore unknown flags rather than failing the SDK BuildTask.
+                        break;
+                }
+            }
+            else
+            {
+                result.SourceFiles.Add(raw);
+            }
+        }
+
+        return result;
+    }
+
+    private static List<string> ExpandResponseFiles(string[] args)
+    {
+        var result = new List<string>(args.Length);
+        foreach (var arg in args)
+        {
+            if (arg.Length > 0 && arg[0] == '@')
+            {
+                var path = arg.Substring(1);
+                if (!File.Exists(path))
+                {
+                    throw new CommandLineException($"Response file not found: {path}");
+                }
+
+                foreach (var line in File.ReadAllLines(path, Encoding.UTF8))
+                {
+                    var trimmed = line.Trim();
+                    if (trimmed.Length == 0 || trimmed[0] == '#')
+                    {
+                        continue;
+                    }
+
+                    result.Add(trimmed);
+                }
+            }
+            else
+            {
+                result.Add(arg);
+            }
+        }
+
+        return result;
+    }
+
+    private static bool IsSwitch(string arg)
+    {
+        if (arg.Length == 0)
+        {
             return false;
         }
 
-        return true;
+        if (arg[0] == '-')
+        {
+            return true;
+        }
+
+        if (arg[0] != '/')
+        {
+            return false;
+        }
+
+        // `/?` is the canonical help switch.
+        if (arg == "/?")
+        {
+            return true;
+        }
+
+        // On Unix `/` is also the path separator. We treat `/foo:value` as a
+        // switch only if the substring before the first colon contains no other
+        // path separator (e.g. `/out:bar.dll` is a switch but `/tmp/x.gs` is not).
+        var colon = arg.IndexOf(':');
+        if (colon < 0)
+        {
+            return false;
+        }
+
+        var head = arg.AsSpan(1, colon - 1);
+        return head.IndexOfAny('/', '\\') < 0;
+    }
+
+    private sealed class CommandLineArgs
+    {
+        public List<string> SourceFiles { get; } = new();
+
+        public List<string> References { get; } = new();
+
+        public string OutputPath { get; set; }
+
+        public OutputTarget Target { get; set; } = OutputTarget.Exe;
+
+        public string TargetFramework { get; set; }
+
+        public bool ShowHelp { get; set; }
+    }
+
+    private sealed class CommandLineException : Exception
+    {
+        public CommandLineException(string message)
+            : base(message)
+        {
+        }
     }
 }

--- a/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
+++ b/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
@@ -91,6 +91,11 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
             args.Add($"/target:{t}");
         }
 
+        if (!string.IsNullOrEmpty(this.TargetFramework))
+        {
+            args.Add($"/targetframework:{this.TargetFramework}");
+        }
+
         if (!string.IsNullOrEmpty(this.DebugType))
         {
             args.Add($"/debug:{this.DebugType}");

--- a/test/Compiler.Tests/AssemblyInfo.cs
+++ b/test/Compiler.Tests/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+// <copyright file="AssemblyInfo.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Xunit;
+
+// Tests in this assembly mutate process-wide state (Console.Out/Error, the
+// current working directory), so they must not run in parallel with each other.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/Compiler.Tests/ProgramTests.cs
+++ b/test/Compiler.Tests/ProgramTests.cs
@@ -75,4 +75,78 @@ public class ProgramTests
             try { File.Delete(sample); } catch { }
         }
     }
+
+    [Fact]
+    public void Main_WithOut_EmitsAssemblyAndRuntimeConfig()
+    {
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package HelloWorld\nimport System\nConsole.WriteLine(\"hi from gsc\")\n");
+        var tempDir = Directory.CreateTempSubdirectory("gsc_emit_").FullName;
+        var outPath = Path.Combine(tempDir, "HelloWorld.dll");
+        using var outWriter = new StringWriter();
+        using var errWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(outWriter);
+        Console.SetError(errWriter);
+        try
+        {
+            var exit = Program.Main(new[] { "/out:" + outPath, "/target:exe", "/targetframework:net10.0", sample });
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(outPath), "expected output assembly to exist");
+            var runtimeConfig = Path.ChangeExtension(outPath, ".runtimeconfig.json");
+            Assert.True(File.Exists(runtimeConfig), "expected runtimeconfig.json beside output");
+            Assert.Contains("Microsoft.NETCore.App", File.ReadAllText(runtimeConfig));
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Main_WithOut_LibraryTarget_DoesNotEmitRuntimeConfig()
+    {
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package MyLib\n");
+        var tempDir = Directory.CreateTempSubdirectory("gsc_lib_").FullName;
+        var outPath = Path.Combine(tempDir, "MyLib.dll");
+        try
+        {
+            var exit = Program.Main(new[] { "/out:" + outPath, "/target:library", sample });
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(outPath));
+            Assert.False(File.Exists(Path.ChangeExtension(outPath, ".runtimeconfig.json")));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Main_WithResponseFile_ParsesArgs()
+    {
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package P\n");
+        var tempDir = Directory.CreateTempSubdirectory("gsc_rsp_").FullName;
+        var outPath = Path.Combine(tempDir, "P.dll");
+        var rspPath = Path.Combine(tempDir, "args.rsp");
+        File.WriteAllLines(rspPath, new[] { "/out:" + outPath, "/target:library", sample });
+        try
+        {
+            var exit = Program.Main(new[] { "@" + rspPath });
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(outPath));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
 }


### PR DESCRIPTION
Wires the `gsc` command-line driver to actually produce runnable assemblies end-to-end. With this change, `dotnet gsc.dll /out:HW.dll /target:exe /targetframework:net10.0 sample.gs` writes a real .NET PE plus a sibling `HW.runtimeconfig.json`, and `dotnet HW.dll` executes it. This is what unblocks the `Gsharp.NET.Sdk` BuildTask path: the SDK already invokes gsc with `/out:`/`/target:`/`/r:`/etc.

## What landed

- **`src/Compiler/Program.cs`** rewritten to parse SDK-style switches (`/out`, `/target`, `/targetframework`, `/r`, `/debug`, `/pdb`), `@response` files, and positional sources. When `/out` is absent, behavior falls back to the legacy interpreter mode for back-compat. Unknown switches are tolerated so the SDK BuildTask stays forward-compatible.
- **Unix-safe switch detection:** `/foo:value` is treated as a switch only when the part before `:` contains no path separator, so absolute Unix paths like `/tmp/x.gs` are not mis-parsed as flags. (Without this, `/tmp/x.gs` parsed as a switch named `tmp/x.gs` and the test bench complained about no source files.)
- **`runtimeconfig.json` emission** alongside the `.dll` for `/target:exe`, with a TFM→framework-version mapping for `net8.0`/`net9.0`/`net10.0`.
- **`src/Sdk/Gsharp.NET.Sdk/BuildTask.cs`** now forwards `TargetFramework` to gsc via `/targetframework:` so SDK builds get a correctly-versioned runtimeconfig.
- **`test/Compiler.Tests/AssemblyInfo.cs`** disables xunit parallelism for the assembly — these tests mutate process-wide state (`Console.Out`/`Error`, cwd) and need to run serially.
- **Three new `ProgramTests`**:
  - `Main_WithOut_EmitsAssemblyAndRuntimeConfig`
  - `Main_WithOut_LibraryTarget_DoesNotEmitRuntimeConfig`
  - `Main_WithResponseFile_ParsesArgs`

## Verification

- Built `samples/HelloWorld.gs` via `dotnet gsc.dll /out:/tmp/HW.dll /target:exe /targetframework:net10.0 /tmp/x.gs`, then `dotnet /tmp/HW.dll` printed `hi from gsc`.
- `dotnet build GSharp.sln` clean (0 errors).
- `dotnet test GSharp.sln` — **86/86 pass** (was 83 + 3 new compiler tests).

## Known limitations / follow-ups

- `/r:` (references) is parsed but unused — Phase 2 (`p2-imports`) decides whether to plumb to MetadataReferences or stay reflection-based.
- `/debug:`/`/pdb:` are accepted but ignored; PDB emit is Phase 2.
- The full `Gsharp.NET.Sdk` packaging + `samples/HelloWorld/HelloWorld.gsproj` `dotnet build` flow is the natural next PR (this PR makes gsc itself ready for it).
