### PR TITLE
Phase 2 (p2-imports): explicit ReferenceResolver + honor /r: in gsc

### DIFF
--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -70,7 +70,10 @@ public class Program
             syntaxTrees.Add(SyntaxTree.Load(path));
         }
 
-        var compilation = new Compilation(syntaxTrees.ToArray());
+        var references = parsed.References.Count > 0
+            ? ReferenceResolver.WithReferences(parsed.References)
+            : null;
+        var compilation = new Compilation(references, syntaxTrees.ToArray());
 
         if (parsed.OutputPath is null)
         {
@@ -210,8 +213,8 @@ public class Program
 
                     case "r":
                     case "reference":
-                        // References are accepted for SDK compatibility but unused
-                        // by the Phase 1 emitter (imports resolve via runtime reflection).
+                        // Loaded into the binder's ReferenceResolver so imports can resolve types
+                        // declared in user-supplied assemblies in addition to the BCL.
                         result.References.Add(value);
                         break;
 

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -56,8 +56,20 @@ public sealed class Binder
     /// <param name="syntaxTrees">The new syntax trees.</param>
     /// <returns>The new chained bound global scope.</returns>
     public static BoundGlobalScope BindGlobalScope(BoundGlobalScope previous, ImmutableArray<SyntaxTree> syntaxTrees)
+        => BindGlobalScope(previous, syntaxTrees, references: null);
+
+    /// <summary>
+    /// Binds a set of syntax trees to the previous global scope, resulting in
+    /// a new chained global scope, using the supplied reference resolver to
+    /// look up imported CLR types.
+    /// </summary>
+    /// <param name="previous">The previous global scope.</param>
+    /// <param name="syntaxTrees">The new syntax trees.</param>
+    /// <param name="references">The reference resolver; <c>null</c> selects <see cref="ReferenceResolver.Default"/>.</param>
+    /// <returns>The new chained bound global scope.</returns>
+    public static BoundGlobalScope BindGlobalScope(BoundGlobalScope previous, ImmutableArray<SyntaxTree> syntaxTrees, ReferenceResolver references)
     {
-        var parentScope = CreateParentScope(previous);
+        var parentScope = CreateParentScope(previous, references);
         var binder = new Binder(parentScope, function: null);
 
         var importDeclarations = syntaxTrees.SelectMany(st => st.Root.Members)
@@ -108,7 +120,7 @@ public sealed class Binder
     /// <returns>A bound program.</returns>
     public static BoundProgram BindProgram(BoundGlobalScope globalScope)
     {
-        var parentScope = CreateParentScope(globalScope);
+        var parentScope = CreateParentScope(globalScope, references: null);
 
         var functionBodies = ImmutableDictionary.CreateBuilder<FunctionSymbol, BoundBlockStatement>();
         var diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
@@ -149,7 +161,7 @@ public sealed class Binder
         return new BoundProgram(globalScope.Package.Name, diagnostics.ToImmutable(), functionBodies.ToImmutable(), globalScope.EntryPoint, statement);
     }
 
-    private static BoundScope CreateParentScope(BoundGlobalScope previous)
+    private static BoundScope CreateParentScope(BoundGlobalScope previous, ReferenceResolver references)
     {
         var stack = new Stack<BoundGlobalScope>();
         while (previous != null)
@@ -158,7 +170,7 @@ public sealed class Binder
             previous = previous.Previous;
         }
 
-        var parent = CreateRootScope();
+        var parent = CreateRootScope(references);
 
         while (stack.Count > 0)
         {
@@ -186,9 +198,9 @@ public sealed class Binder
         return parent;
     }
 
-    private static BoundScope CreateRootScope()
+    private static BoundScope CreateRootScope(ReferenceResolver references)
     {
-        var result = new BoundScope(null);
+        var result = new BoundScope(parent: null, references: references);
 
         foreach (var f in BuiltinFunctions.GetAll())
         {

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -24,15 +24,33 @@ public sealed class BoundScope
     /// </summary>
     /// <param name="parent">The parent scope.</param>
     public BoundScope(BoundScope parent)
+        : this(parent, references: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundScope"/> class with
+    /// an explicit reference resolver. Child scopes inherit the parent's
+    /// resolver when one is not supplied.
+    /// </summary>
+    /// <param name="parent">The parent scope.</param>
+    /// <param name="references">The reference resolver; defaults to the parent's resolver, or <see cref="ReferenceResolver.Default"/> if none.</param>
+    public BoundScope(BoundScope parent, ReferenceResolver references)
     {
         Parent = parent;
         imports = parent?.imports ?? new List<ImportSymbol>();
+        References = references ?? parent?.References ?? ReferenceResolver.Default();
     }
 
     /// <summary>
     /// Gets the parent scope.
     /// </summary>
     public BoundScope Parent { get; }
+
+    /// <summary>
+    /// Gets the reference resolver used to look up imported CLR types.
+    /// </summary>
+    public ReferenceResolver References { get; }
 
     /// <summary>
     /// Tries to add an import to this scope.
@@ -92,27 +110,18 @@ public sealed class BoundScope
     {
         importedClass = null;
 
-        if (imports != null)
+        if (imports == null)
         {
-            string[] sources = new[]
+            return false;
+        }
+
+        foreach (var import in imports)
+        {
+            var typeName = import.Name + "." + name;
+            if (References.TryResolveType(typeName, out var type))
             {
-                string.Empty,
-                ", mscorlib",
-                ", System.Runtime",
-            };
-            foreach (var source in sources)
-            {
-                foreach (var import in imports)
-                {
-                    Console.WriteLine();
-                    var typeName = import.Name + "." + name + source;
-                    var type = Type.GetType(typeName);
-                    if (type != null)
-                    {
-                        importedClass = new ImportedClassSymbol(type, declaration);
-                        return true;
-                    }
-                }
+                importedClass = new ImportedClassSymbol(type, declaration);
+                return true;
             }
         }
 

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -29,14 +29,26 @@ public class Compilation
     /// </summary>
     /// <param name="syntaxTrees">The syntax trees.</param>
     public Compilation(params SyntaxTree[] syntaxTrees)
-        : this(null, syntaxTrees)
+        : this(null, references: null, syntaxTrees)
     {
     }
 
-    private Compilation(Compilation previous, SyntaxTree[] syntaxTrees)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Compilation"/> class with
+    /// an explicit reference resolver.
+    /// </summary>
+    /// <param name="references">The reference resolver to use for imported CLR type lookups.</param>
+    /// <param name="syntaxTrees">The syntax trees.</param>
+    public Compilation(ReferenceResolver references, params SyntaxTree[] syntaxTrees)
+        : this(null, references, syntaxTrees)
+    {
+    }
+
+    private Compilation(Compilation previous, ReferenceResolver references, SyntaxTree[] syntaxTrees)
     {
         Previous = previous;
         SyntaxTrees = syntaxTrees.ToImmutableArray();
+        References = references ?? previous?.References;
     }
 
     /// <summary>
@@ -50,6 +62,11 @@ public class Compilation
     public ImmutableArray<SyntaxTree> SyntaxTrees { get; }
 
     /// <summary>
+    /// Gets the reference resolver used to look up imported CLR types.
+    /// </summary>
+    public ReferenceResolver References { get; }
+
+    /// <summary>
     /// Gets the global scope.
     /// </summary>
     public BoundGlobalScope GlobalScope
@@ -58,7 +75,7 @@ public class Compilation
         {
             if (globalScope == null)
             {
-                var globalScope = Binder.BindGlobalScope(Previous?.GlobalScope, SyntaxTrees);
+                var globalScope = Binder.BindGlobalScope(Previous?.GlobalScope, SyntaxTrees, References);
                 Interlocked.CompareExchange(ref this.globalScope, globalScope, null);
             }
 
@@ -74,7 +91,7 @@ public class Compilation
     /// <returns>The chained compilation.</returns>
     public Compilation ContinueWith(params SyntaxTree[] syntaxTrees)
     {
-        return new Compilation(this, syntaxTrees);
+        return new Compilation(this, references: null, syntaxTrees);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -1,0 +1,185 @@
+// <copyright file="ReferenceResolver.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Resolves imported types by name across a configurable set of referenced
+/// assemblies.
+/// </summary>
+/// <remarks>
+/// This is the seam that <c>import</c> statements use to find CLR types. The
+/// default resolver covers the BCL by snapshotting the loaded runtime
+/// assemblies plus seeding a handful of well-known ones (<c>mscorlib</c>,
+/// <c>System.Runtime</c>, <c>System.Console</c>). Callers can extend the set
+/// by passing assembly paths to <see cref="WithReferences"/>; these are
+/// loaded with <see cref="Assembly.LoadFrom(string)"/> so the resulting
+/// <see cref="Type"/> instances are usable by the
+/// <c>ReflectionMetadataEmitter</c> alongside the BCL types.
+/// </remarks>
+public sealed class ReferenceResolver
+{
+    private static readonly string[] WellKnownBclAssemblyNames =
+    {
+        "System.Runtime",
+        "System.Console",
+        "System.Private.CoreLib",
+        "mscorlib",
+    };
+
+    private readonly ImmutableArray<Assembly> assemblies;
+
+    private ReferenceResolver(ImmutableArray<Assembly> assemblies)
+    {
+        this.assemblies = assemblies;
+    }
+
+    /// <summary>
+    /// Gets the assemblies this resolver searches, in priority order.
+    /// </summary>
+    public ImmutableArray<Assembly> Assemblies => assemblies;
+
+    /// <summary>
+    /// Gets a resolver that searches the runtime's currently loaded
+    /// assemblies plus the well-known BCL assemblies.
+    /// </summary>
+    /// <returns>A default resolver.</returns>
+    public static ReferenceResolver Default()
+    {
+        return new ReferenceResolver(BuildDefaultAssemblies(Array.Empty<string>()));
+    }
+
+    /// <summary>
+    /// Gets a resolver that searches the runtime's loaded assemblies plus
+    /// any additional assemblies referenced by file path.
+    /// </summary>
+    /// <param name="referencePaths">Paths to additional assemblies to load.</param>
+    /// <returns>A resolver including the supplied references.</returns>
+    public static ReferenceResolver WithReferences(IEnumerable<string> referencePaths)
+    {
+        if (referencePaths is null)
+        {
+            return Default();
+        }
+
+        return new ReferenceResolver(BuildDefaultAssemblies(referencePaths));
+    }
+
+    /// <summary>
+    /// Tries to resolve a fully-qualified type name across the referenced
+    /// assemblies.
+    /// </summary>
+    /// <param name="fullName">The fully-qualified type name (e.g. <c>System.Console</c>).</param>
+    /// <param name="type">The resolved <see cref="Type"/>, if found.</param>
+    /// <returns><c>true</c> if a matching type was found; otherwise <c>false</c>.</returns>
+    public bool TryResolveType(string fullName, out Type type)
+    {
+        type = null;
+        if (string.IsNullOrEmpty(fullName))
+        {
+            return false;
+        }
+
+        foreach (var asm in assemblies)
+        {
+            Type candidate;
+            try
+            {
+                candidate = asm.GetType(fullName, throwOnError: false, ignoreCase: false);
+            }
+            catch (FileNotFoundException)
+            {
+                continue;
+            }
+            catch (BadImageFormatException)
+            {
+                continue;
+            }
+
+            if (candidate != null)
+            {
+                type = candidate;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static ImmutableArray<Assembly> BuildDefaultAssemblies(IEnumerable<string> referencePaths)
+    {
+        var builder = ImmutableArray.CreateBuilder<Assembly>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (asm.IsDynamic)
+            {
+                continue;
+            }
+
+            var name = asm.GetName().FullName;
+            if (seen.Add(name))
+            {
+                builder.Add(asm);
+            }
+        }
+
+        foreach (var name in WellKnownBclAssemblyNames)
+        {
+            try
+            {
+                var asm = Assembly.Load(new AssemblyName(name));
+                if (seen.Add(asm.GetName().FullName))
+                {
+                    builder.Add(asm);
+                }
+            }
+            catch (FileNotFoundException)
+            {
+            }
+            catch (FileLoadException)
+            {
+            }
+            catch (BadImageFormatException)
+            {
+            }
+        }
+
+        foreach (var path in referencePaths)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                continue;
+            }
+
+            try
+            {
+                var asm = Assembly.LoadFrom(path);
+                if (seen.Add(asm.GetName().FullName))
+                {
+                    builder.Add(asm);
+                }
+            }
+            catch (FileNotFoundException)
+            {
+            }
+            catch (FileLoadException)
+            {
+            }
+            catch (BadImageFormatException)
+            {
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
@@ -1,0 +1,58 @@
+// <copyright file="ReferenceResolverTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Tests for <see cref="ReferenceResolver"/>, the seam that <c>import</c>
+/// statements use to resolve CLR types.
+/// </summary>
+public class ReferenceResolverTests
+{
+    [Theory]
+    [InlineData("System.Console")]
+    [InlineData("System.String")]
+    public void Default_Resolves_Bcl_Type(string fullName)
+    {
+        var resolver = ReferenceResolver.Default();
+        Assert.True(resolver.TryResolveType(fullName, out var type));
+        Assert.Equal(fullName, type.FullName);
+    }
+
+    [Fact]
+    public void Default_Returns_False_For_Unknown_Type()
+    {
+        var resolver = ReferenceResolver.Default();
+        Assert.False(resolver.TryResolveType("System.ThisTypeDoesNotExist", out var type));
+        Assert.Null(type);
+    }
+
+    [Fact]
+    public void WithReferences_Resolves_Type_From_Supplied_Assembly()
+    {
+        var corePath = typeof(ReferenceResolver).Assembly.Location;
+        Assert.False(string.IsNullOrEmpty(corePath));
+
+        var resolver = ReferenceResolver.WithReferences(new[] { corePath });
+        Assert.True(resolver.TryResolveType("GSharp.Core.CodeAnalysis.Symbols.ReferenceResolver", out var type));
+        Assert.Equal(typeof(ReferenceResolver).FullName, type.FullName);
+    }
+
+    [Fact]
+    public void WithReferences_Tolerates_Null_Or_Missing_Paths()
+    {
+        var resolver = ReferenceResolver.WithReferences(new[]
+        {
+            string.Empty,
+            "/this/path/does/not/exist.dll",
+        });
+
+        Assert.True(resolver.TryResolveType("System.Console", out _));
+    }
+}


### PR DESCRIPTION
## Phase 2 (p2-imports): explicit `ReferenceResolver` + honor `/r:` in `gsc`

Replaces the ad-hoc `Type.GetType(name + ", mscorlib"|", System.Runtime")` lookup inside `BoundScope` with an explicit, configurable `ReferenceResolver`, and wires the previously-discarded `/r:` references from `gsc` into it. Also removes a stray `Console.WriteLine()` debug print that was firing for every type lookup.

### Changes

- **New `ReferenceResolver`** (`src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs`) — immutable set of `Assembly`s plus `TryResolveType(fullName, out Type)`. Factories:
  - `Default()` — `AppDomain.CurrentDomain.GetAssemblies()` plus well-known BCL (`System.Runtime`, `System.Console`, `System.Private.CoreLib`, `mscorlib`).
  - `WithReferences(IEnumerable<string>)` — default set plus `Assembly.LoadFrom(path)` for each user-supplied reference.
- **`BoundScope`** now carries a `References` property (inherited from parent or defaulted) and a new constructor accepting an explicit resolver. `TryLookupImportedClass` delegates to it.
- **`Binder.BindGlobalScope`** overload accepting `ReferenceResolver`; threaded through `CreateParentScope`/`CreateRootScope`.
- **`Compilation`** new ctor `Compilation(ReferenceResolver, params SyntaxTree[])` plus `References` property. `ContinueWith` inherits the resolver. The plain ctor preserves current behavior.
- **`gsc`** — `/r:` references now feed `ReferenceResolver.WithReferences` rather than being parsed and discarded.

### Tests

- New `ReferenceResolverTests` (5 facts): BCL resolution, unknown-type negative, user-supplied assembly resolution, tolerance of empty/missing paths.
- 82/82 Core.Tests pass (was 77). 102/102 across the full solution. `build/sdk-e2e.sh` PASS. `gsc samples/Arithmetic.gs` still prints `5\n10`.

### Design notes

Kept reflection-based (`Assembly.LoadFrom`) rather than introducing `MetadataLoadContext`. Rationale: the emitter already builds `AssemblyReference` rows from `Type.Assembly.GetName()` against the host runtime, so a separate metadata-load world would force a parallel reflection model. Revisit when emit grows reference-only-assembly support.
