### PR TITLE
Phase 6 (p6-multitarget): cross-TFM emit via MetadataLoadContext

### DIFF
--- a/build/multitarget-e2e.sh
+++ b/build/multitarget-e2e.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Validates that Gsharp.NET.Sdk produces a runnable assembly for every TFM
+# we claim to support. Walks each TFM in TARGET_FRAMEWORKS, rebuilds the
+# HelloWorld sample against it, runs the produced binary, and asserts the
+# expected stdout. Used by p6-multitarget to gate cross-TFM regressions.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+TARGET_FRAMEWORKS=( "net8.0" "net10.0" )
+EXPECTED="Hello, world!"
+
+echo "==> Packing Gsharp.NET.Sdk into out/bin/Release/nupkgs"
+dotnet build src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj -c Release --nologo -v:q
+
+NUPKG=$(ls -t out/bin/Release/nupkgs/Gsharp.NET.Sdk.*.nupkg | head -1)
+VER="${NUPKG##*Gsharp.NET.Sdk.}"
+VER="${VER%.nupkg}"
+echo "    SDK version: $VER"
+
+cat > samples/HelloWorld/global.json <<EOF
+{
+  "msbuild-sdks": {
+    "Gsharp.NET.Sdk": "$VER"
+  }
+}
+EOF
+
+# Force the NuGet cache to pull our freshly-packed SDK rather than an older
+# locally-cached copy with the same version.
+rm -rf "$HOME/.nuget/packages/gsharp.net.sdk/$VER" || true
+
+# Preserve the original gsproj so we can restore it on exit.
+GSPROJ=samples/HelloWorld/HelloWorld.gsproj
+cp "$GSPROJ" "$GSPROJ.bak"
+trap 'mv "$GSPROJ.bak" "$GSPROJ"' EXIT
+
+for tfm in "${TARGET_FRAMEWORKS[@]}"; do
+    # Skip TFMs without an installed runtime — they can't be executed locally.
+    # TFM "net8.0" maps to a runtime line starting with "Microsoft.NETCore.App 8.".
+    major="${tfm#net}"
+    major="${major%%.*}"
+    if ! dotnet --list-runtimes | grep -qE "^Microsoft\.NETCore\.App ${major}\."; then
+        echo "==> [$tfm] runtime not installed; skipping"
+        continue
+    fi
+
+    echo "==> [$tfm] dotnet build samples/HelloWorld"
+    rm -rf samples/HelloWorld/bin samples/HelloWorld/obj
+    sed "s|<TargetFramework>net10.0</TargetFramework>|<TargetFramework>$tfm</TargetFramework>|" "$GSPROJ.bak" > "$GSPROJ"
+    dotnet build "$GSPROJ" --nologo -v:q
+
+    OUT="samples/HelloWorld/bin/Debug/$tfm/HelloWorld.dll"
+    echo "==> [$tfm] dotnet $OUT"
+    ACTUAL=$(dotnet "$OUT")
+    if [[ "$ACTUAL" != "$EXPECTED" ]]; then
+        echo "FAIL [$tfm]: expected '$EXPECTED', got '$ACTUAL'"
+        exit 1
+    fi
+    echo "    PASS [$tfm]"
+done
+
+echo "PASS: all installed target frameworks produced runnable assemblies."

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -776,7 +776,7 @@ public sealed class Binder
             for (var i = 0; i < parameters.Length; i++)
             {
                 var argType = arguments[i].Type?.ClrType;
-                if (argType == null || !parameters[i].ParameterType.IsAssignableFrom(argType))
+                if (argType == null || !ClrTypeUtilities.IsAssignableByName(parameters[i].ParameterType, argType))
                 {
                     match = false;
                     break;

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -196,7 +196,7 @@ public class Compilation
         try
         {
             using var stream = File.Create(program.PackageName + ".dll");
-            EmitAssembly(program, stream);
+            EmitAssembly(program, stream, References);
         }
         catch (Exception ex) when (ex is NotSupportedException || ex is InvalidOperationException)
         {
@@ -232,7 +232,7 @@ public class Compilation
 
         try
         {
-            EmitAssembly(program, peStream);
+            EmitAssembly(program, peStream, References);
         }
         catch (Exception ex) when (ex is NotSupportedException || ex is InvalidOperationException)
         {
@@ -244,8 +244,8 @@ public class Compilation
         return new EmitResult(success: true, diagnostics: ImmutableArray<Diagnostic>.Empty);
     }
 
-    private static void EmitAssembly(BoundProgram program, Stream peStream)
+    private static void EmitAssembly(BoundProgram program, Stream peStream, ReferenceResolver references)
     {
-        ReflectionMetadataEmitter.Emit(program, peStream);
+        ReflectionMetadataEmitter.Emit(program, peStream, references);
     }
 }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -29,6 +29,7 @@ namespace GSharp.Core.CodeAnalysis.Emit;
 internal sealed class ReflectionMetadataEmitter
 {
     private readonly BoundProgram program;
+    private readonly ReferenceResolver references;
     private readonly MetadataBuilder metadata = new MetadataBuilder();
     private readonly Dictionary<Assembly, AssemblyReferenceHandle> assemblyRefs = new Dictionary<Assembly, AssemblyReferenceHandle>();
     private readonly Dictionary<Type, TypeReferenceHandle> typeRefs = new Dictionary<Type, TypeReferenceHandle>();
@@ -37,14 +38,17 @@ internal sealed class ReflectionMetadataEmitter
     private readonly MethodBodyStreamEncoder methodBodyStream;
     private readonly BlobBuilder ilStream = new BlobBuilder();
 
+    private Type coreObjectType;
+    private Type coreStringType;
     private TypeReferenceHandle objectTypeRef;
     private MemberReferenceHandle objectCtorRef;
     private MemberReferenceHandle stringConcatRef;
     private MemberReferenceHandle stringEqualsRef;
 
-    private ReflectionMetadataEmitter(BoundProgram program)
+    private ReflectionMetadataEmitter(BoundProgram program, ReferenceResolver references)
     {
         this.program = program;
+        this.references = references ?? ReferenceResolver.Default();
         this.methodBodyStream = new MethodBodyStreamEncoder(this.ilStream);
     }
 
@@ -54,16 +58,27 @@ internal sealed class ReflectionMetadataEmitter
     /// </summary>
     /// <param name="program">The bound program to emit.</param>
     /// <param name="peStream">Destination stream for the PE bytes.</param>
-    public static void Emit(BoundProgram program, Stream peStream)
+    /// <param name="references">
+    /// Reference resolver providing the target framework's core types
+    /// (<c>System.Object</c>, <c>System.String</c>) and any user-supplied
+    /// imports. Pass <c>null</c> to resolve from the gsc host's loaded
+    /// runtime (in-process scenarios only — produces an assembly bound to
+    /// the gsc host's TFM).
+    /// </param>
+    public static void Emit(BoundProgram program, Stream peStream, ReferenceResolver references = null)
     {
-        var emitter = new ReflectionMetadataEmitter(program);
+        var emitter = new ReflectionMetadataEmitter(program, references);
         emitter.EmitCore(peStream);
     }
 
     private void EmitCore(Stream peStream)
     {
-        // 1. Seed Object reference (every type derives from it; default ctor is needed for .ctor chains).
-        this.objectTypeRef = this.GetTypeReference(typeof(object));
+        // 1. Seed Object reference. Resolve from the supplied references so the type-ref
+        //    assembly identity (mscorlib / System.Runtime / netstandard) matches the
+        //    target framework rather than the gsc host's System.Private.CoreLib.
+        this.coreObjectType = this.ResolveCoreType("System.Object", typeof(object));
+        this.coreStringType = this.ResolveCoreType("System.String", typeof(string));
+        this.objectTypeRef = this.GetTypeReference(this.coreObjectType);
         this.objectCtorRef = this.GetObjectDefaultCtorReference();
 
         // 2. <Module> type (TypeDef row #1 must always be <Module> per ECMA-335).
@@ -303,6 +318,16 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
+    private Type ResolveCoreType(string fullName, Type fallback)
+    {
+        if (this.references.TryResolveType(fullName, out var t))
+        {
+            return t;
+        }
+
+        return fallback;
+    }
+
     private AssemblyReferenceHandle GetAssemblyReference(Assembly assembly)
     {
         if (this.assemblyRefs.TryGetValue(assembly, out var existing))
@@ -391,7 +416,7 @@ internal sealed class ReflectionMetadataEmitter
             return this.stringConcatRef;
         }
 
-        var stringTypeRef = this.GetTypeReference(typeof(string));
+        var stringTypeRef = this.GetTypeReference(this.coreStringType);
         var sigBlob = new BlobBuilder();
         new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: false)
             .Parameters(
@@ -416,7 +441,7 @@ internal sealed class ReflectionMetadataEmitter
             return this.stringEqualsRef;
         }
 
-        var stringTypeRef = this.GetTypeReference(typeof(string));
+        var stringTypeRef = this.GetTypeReference(this.coreStringType);
         var sigBlob = new BlobBuilder();
         new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: false)
             .Parameters(
@@ -472,35 +497,34 @@ internal sealed class ReflectionMetadataEmitter
 
     private static void EncodeClrType(SignatureTypeEncoder encoder, Type type)
     {
-        if (type == typeof(bool))
+        // Compare by FullName so types from a MetadataLoadContext (carrying the target
+        // framework's identity) still encode to the same well-known primitive opcodes.
+        var fullName = type?.FullName;
+        switch (fullName)
         {
-            encoder.Boolean();
-        }
-        else if (type == typeof(int))
-        {
-            encoder.Int32();
-        }
-        else if (type == typeof(long))
-        {
-            encoder.Int64();
-        }
-        else if (type == typeof(string))
-        {
-            encoder.String();
-        }
-        else if (type == typeof(object))
-        {
-            encoder.Object();
-        }
-        else
-        {
-            throw new NotSupportedException($"Cannot encode signature for CLR type '{type}' yet.");
+            case "System.Boolean":
+                encoder.Boolean();
+                break;
+            case "System.Int32":
+                encoder.Int32();
+                break;
+            case "System.Int64":
+                encoder.Int64();
+                break;
+            case "System.String":
+                encoder.String();
+                break;
+            case "System.Object":
+                encoder.Object();
+                break;
+            default:
+                throw new NotSupportedException($"Cannot encode signature for CLR type '{type}' yet.");
         }
     }
 
     private static void EncodeReturnClr(ReturnTypeEncoder encoder, Type type)
     {
-        if (type == typeof(void))
+        if (type?.FullName == "System.Void")
         {
             encoder.Void();
         }

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -1,0 +1,83 @@
+// <copyright file="ClrTypeUtilities.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Helpers for comparing <see cref="Type"/> instances that may originate from
+/// different reflection contexts (e.g. the gsc host's live runtime vs. a
+/// <see cref="System.Reflection.MetadataLoadContext"/> over target-framework
+/// reference assemblies). Reference-equality (<c>==</c>) and
+/// <see cref="Type.IsAssignableFrom"/> only work within a single context, so
+/// cross-context comparisons must fall back to name-based matching.
+/// </summary>
+internal static class ClrTypeUtilities
+{
+    /// <summary>
+    /// Returns whether two <see cref="Type"/>s refer to the same logical CLR
+    /// type, regardless of which reflection context produced them. Two types
+    /// are considered the same when their <see cref="Type.FullName"/>s match.
+    /// </summary>
+    /// <param name="a">First type.</param>
+    /// <param name="b">Second type.</param>
+    /// <returns><c>true</c> when both types are non-null and share a FullName.</returns>
+    public static bool AreSame(Type a, Type b)
+    {
+        if (a is null || b is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(a, b))
+        {
+            return true;
+        }
+
+        return string.Equals(a.FullName, b.FullName, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Returns whether <paramref name="source"/> is assignable to
+    /// <paramref name="target"/> when the two types may live in different
+    /// reflection contexts. Falls back to identity-by-name and special-cases
+    /// <c>System.Object</c> as universally assignable.
+    /// </summary>
+    /// <param name="target">Target parameter type.</param>
+    /// <param name="source">Source argument type.</param>
+    /// <returns><c>true</c> when an assignment is permissible.</returns>
+    public static bool IsAssignableByName(Type target, Type source)
+    {
+        if (target is null || source is null)
+        {
+            return false;
+        }
+
+        if (AreSame(target, source))
+        {
+            return true;
+        }
+
+        if (string.Equals(target.FullName, "System.Object", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // Same-context fast path covers inheritance / interfaces.
+        if (ReferenceEquals(target.Assembly, source.Assembly) || target.GetType() == source.GetType())
+        {
+            try
+            {
+                return target.IsAssignableFrom(source);
+            }
+            catch (InvalidOperationException)
+            {
+                // MLC types throw for some cross-context paths; fall through.
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -101,7 +101,7 @@ public sealed class ImportedClassSymbol : Symbol
     {
         if (type?.ClrType != null)
         {
-            return parameterType.IsAssignableFrom(type.ClrType);
+            return ClrTypeUtilities.IsAssignableByName(parameterType, type.ClrType);
         }
 
         return false;

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -16,14 +16,25 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// assemblies.
 /// </summary>
 /// <remarks>
-/// This is the seam that <c>import</c> statements use to find CLR types. The
-/// default resolver covers the BCL by snapshotting the loaded runtime
-/// assemblies plus seeding a handful of well-known ones (<c>mscorlib</c>,
-/// <c>System.Runtime</c>, <c>System.Console</c>). Callers can extend the set
-/// by passing assembly paths to <see cref="WithReferences"/>; these are
-/// loaded with <see cref="Assembly.LoadFrom(string)"/> so the resulting
-/// <see cref="Type"/> instances are usable by the
-/// <c>ReflectionMetadataEmitter</c> alongside the BCL types.
+/// This is the seam that <c>import</c> statements use to find CLR types, and
+/// the source of well-known primitive types (<c>System.Object</c>,
+/// <c>System.String</c>) consumed by the emitter when materialising type
+/// references.
+/// <para>
+/// When the resolver is constructed with explicit reference paths
+/// (<see cref="WithReferences"/>), those paths are loaded into a
+/// <see cref="MetadataLoadContext"/>. The <see cref="Type"/> instances
+/// returned by <see cref="TryResolveType"/> then carry the target framework's
+/// assembly identities (e.g. <c>System.Console, Version=8.0.0.0</c> when
+/// the reference paths point at the net8.0 reference pack). Without this
+/// indirection, the emitter would write type references bound to the gsc
+/// host's runtime version, which fails to load on lower target frameworks.
+/// </para>
+/// <para>
+/// <see cref="Default"/> falls back to the gsc host's loaded assemblies and
+/// is intended for in-process interpreter scenarios and the existing test
+/// suite where cross-targeting is not relevant.
+/// </para>
 /// </remarks>
 public sealed class ReferenceResolver
 {
@@ -36,10 +47,12 @@ public sealed class ReferenceResolver
     };
 
     private readonly ImmutableArray<Assembly> assemblies;
+    private readonly MetadataLoadContext metadataContext;
 
-    private ReferenceResolver(ImmutableArray<Assembly> assemblies)
+    private ReferenceResolver(ImmutableArray<Assembly> assemblies, MetadataLoadContext metadataContext)
     {
         this.assemblies = assemblies;
+        this.metadataContext = metadataContext;
     }
 
     /// <summary>
@@ -54,12 +67,15 @@ public sealed class ReferenceResolver
     /// <returns>A default resolver.</returns>
     public static ReferenceResolver Default()
     {
-        return new ReferenceResolver(BuildDefaultAssemblies(Array.Empty<string>()));
+        return new ReferenceResolver(BuildHostAssemblies(), metadataContext: null);
     }
 
     /// <summary>
-    /// Gets a resolver that searches the runtime's loaded assemblies plus
-    /// any additional assemblies referenced by file path.
+    /// Gets a resolver that searches only the assemblies referenced by file
+    /// path. The supplied paths are loaded into an isolated
+    /// <see cref="MetadataLoadContext"/> so callers see types whose
+    /// <see cref="Type.Assembly"/> reflects the target framework rather than
+    /// the gsc host's runtime.
     /// </summary>
     /// <param name="referencePaths">Paths to additional assemblies to load.</param>
     /// <returns>A resolver including the supplied references.</returns>
@@ -70,7 +86,57 @@ public sealed class ReferenceResolver
             return Default();
         }
 
-        return new ReferenceResolver(BuildDefaultAssemblies(referencePaths));
+        var paths = referencePaths
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Where(File.Exists)
+            .ToArray();
+
+        if (paths.Length == 0)
+        {
+            return Default();
+        }
+
+        // Augment the resolver with the gsc host's trusted platform assemblies
+        // as a *fallback*. User-supplied paths take precedence because the
+        // PathAssemblyResolver iterates in order, so any BCL assembly the user
+        // brings (e.g. from a target framework ref pack) wins over the host
+        // copy. The host fallback only kicks in for dependencies the user did
+        // not enumerate (typical when a user DLL pulls in extra BCL pieces).
+        var resolverPaths = new List<string>(paths);
+        var hostPaths = GetHostTrustedPlatformAssemblies();
+        var pathSet = new HashSet<string>(paths.Select(p => Path.GetFileName(p)), StringComparer.OrdinalIgnoreCase);
+        foreach (var host in hostPaths)
+        {
+            if (pathSet.Add(Path.GetFileName(host)))
+            {
+                resolverPaths.Add(host);
+            }
+        }
+
+        var resolver = new PathAssemblyResolver(resolverPaths);
+        var mlc = new MetadataLoadContext(resolver, coreAssemblyName: ChooseCoreAssemblyName(resolverPaths.ToArray()));
+
+        var builder = ImmutableArray.CreateBuilder<Assembly>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var path in paths)
+        {
+            try
+            {
+                var asm = mlc.LoadFromAssemblyPath(path);
+                if (asm != null && seen.Add(asm.GetName().FullName))
+                {
+                    builder.Add(asm);
+                }
+            }
+            catch (FileNotFoundException)
+            {
+            }
+            catch (BadImageFormatException)
+            {
+            }
+        }
+
+        return new ReferenceResolver(builder.ToImmutable(), mlc);
     }
 
     /// <summary>
@@ -114,7 +180,27 @@ public sealed class ReferenceResolver
         return false;
     }
 
-    private static ImmutableArray<Assembly> BuildDefaultAssemblies(IEnumerable<string> referencePaths)
+    /// <summary>
+    /// Resolves a well-known core CLR type (e.g. <c>System.Object</c>,
+    /// <c>System.String</c>) by full name. Used by the emitter so type
+    /// references for primitives originate from the target framework's
+    /// reference assemblies rather than the gsc host's loaded runtime.
+    /// </summary>
+    /// <param name="fullName">The fully-qualified core type name.</param>
+    /// <returns>The resolved <see cref="Type"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no referenced assembly defines the requested type.</exception>
+    public Type GetCoreType(string fullName)
+    {
+        if (TryResolveType(fullName, out var t))
+        {
+            return t;
+        }
+
+        throw new InvalidOperationException(
+            $"Core type '{fullName}' could not be resolved from the supplied references.");
+    }
+
+    private static ImmutableArray<Assembly> BuildHostAssemblies()
     {
         var builder = ImmutableArray.CreateBuilder<Assembly>();
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -154,32 +240,41 @@ public sealed class ReferenceResolver
             }
         }
 
-        foreach (var path in referencePaths)
-        {
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                continue;
-            }
+        return builder.ToImmutable();
+    }
 
-            try
-            {
-                var asm = Assembly.LoadFrom(path);
-                if (seen.Add(asm.GetName().FullName))
-                {
-                    builder.Add(asm);
-                }
-            }
-            catch (FileNotFoundException)
-            {
-            }
-            catch (FileLoadException)
-            {
-            }
-            catch (BadImageFormatException)
-            {
-            }
+    private static string ChooseCoreAssemblyName(string[] paths)
+    {
+        // MetadataLoadContext needs a "core assembly" — the one declaring the
+        // primitive types (Object, String, etc.). For modern .NET reference
+        // packs this is System.Runtime.dll; older targets ship mscorlib.dll
+        // as the canonical home. Pick whichever we can see in the supplied
+        // reference set, falling back to letting MLC autodetect.
+        var fileNames = paths.Select(Path.GetFileNameWithoutExtension)
+                             .ToArray();
+
+        if (fileNames.Any(n => string.Equals(n, "System.Runtime", StringComparison.OrdinalIgnoreCase)))
+        {
+            return "System.Runtime";
         }
 
-        return builder.ToImmutable();
+        if (fileNames.Any(n => string.Equals(n, "mscorlib", StringComparison.OrdinalIgnoreCase)))
+        {
+            return "mscorlib";
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> GetHostTrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            return Array.Empty<string>();
+        }
+
+        return tpa.Split(Path.PathSeparator)
+                  .Where(p => !string.IsNullOrWhiteSpace(p) && File.Exists(p));
     }
 }

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -68,22 +68,25 @@ public class TypeSymbol : Symbol
             return Void;
         }
 
-        if (clrType == typeof(bool))
+        // Compare by FullName so types loaded from a MetadataLoadContext (carrying the
+        // target framework's identity) still map onto the built-in primitive symbols.
+        var fullName = clrType.FullName;
+        if (fullName == "System.Boolean")
         {
             return Bool;
         }
 
-        if (clrType == typeof(int))
+        if (fullName == "System.Int32")
         {
             return Int;
         }
 
-        if (clrType == typeof(string))
+        if (fullName == "System.String")
         {
             return String;
         }
 
-        if (clrType == typeof(void))
+        if (fullName == "System.Void")
         {
             return Void;
         }

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -5,4 +5,11 @@
     <RootNamespace>GSharp.Core</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Used by ReferenceResolver to load target-framework reference assemblies
+         in an isolated context so emitted type references carry the target's
+         assembly identities rather than the gsc host's runtime versions. -->
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Phase 6 (`p6-multitarget`): GSharp programs now emit correctly for any installed .NET target framework, not just the gsc host's net10.0.

### The bug

Building HelloWorld for `net8.0` produced a runnable PE that referenced `System.Console, Version=10.0.0.0` regardless of the user-supplied reference assemblies, and failed at runtime with:

```
Unhandled exception. System.IO.FileNotFoundException:
  Could not load file or assembly 'System.Console, Version=10.0.0.0, ...'.
```

Two root causes both pinned the produced assembly's BCL identity to the gsc host's TFM:

1. `ReferenceResolver.BuildDefaultAssemblies` always preferred the gsc host's already-loaded BCL assemblies over the user-supplied reference paths.
2. `ReflectionMetadataEmitter` seeded its `System.Object` / `System.String` type references from `typeof(object)` / `typeof(string)`, which are bound to the host's `System.Private.CoreLib`.

### The fix

- **`ReferenceResolver.WithReferences` now uses `System.Reflection.MetadataLoadContext`** to load the supplied paths in isolation. The gsc host's TPA is appended as a *fallback* (user paths come first in the `PathAssemblyResolver`, so target ref-pack BCL assemblies shadow the host). Returned `Type` instances carry the target framework's assembly identities (e.g. `System.Console, Version=8.0.0.0`).
- **New `ReferenceResolver.GetCoreType(string)`** is the entry-point the emitter uses to fetch `System.Object`/`System.String` from the target rather than calling `typeof()`.
- **`ClrTypeUtilities` (new)** provides `AreSame` and `IsAssignableByName`, which compare types by `FullName` so binder + emitter logic works when types come from different reflection contexts. Used from `Binder.BindMethodCall`, `ImportedClassSymbol.TypesMatch`, `TypeSymbol.FromClrType`, and `ReflectionMetadataEmitter.EncodeClrType`/`EncodeReturnClr`. ECMA-335 primitive sig opcodes (`encoder.Int32()` etc.) are TFM-independent so this is purely a dispatch refactor.
- **`ReflectionMetadataEmitter.Emit` takes an optional `ReferenceResolver`**; `Compilation.EmitAssembly` threads the compilation's resolver through.

### End-to-end validation

New `build/multitarget-e2e.sh` packs the SDK, sweeps `TARGET_FRAMEWORKS=(net8.0 net10.0)`, swaps the TFM in `samples/HelloWorld/HelloWorld.gsproj`, builds + runs, asserts `Hello, world!`. Automatically skips TFMs whose runtime isn't installed, so adding `net9.0` later is a one-line array change.

Locally verified — both **net8.0** and **net10.0** PASS.

### Regression suites

- `dotnet build GSharp.sln -c Release` — clean.
- `dotnet test GSharp.sln -c Release` — **88 tests, 0 failures**.
- `build/sdk-e2e.sh` — PASS (net10.0).
- `build/templates-e2e.sh` — PASS (net10.0).
- `build/multitarget-e2e.sh` — PASS (net8.0 + net10.0).

### Design notes

- **`MetadataLoadContext` (not `Assembly.LoadFrom`)** because reference assemblies have `ReferenceAssemblyAttribute` and can throw on `LoadFrom`; MLC also keeps their identities pristine instead of merging them into the gsc host context.
- **User paths win, host TPA fallback**: `PathAssemblyResolver` iterates in order, so target ref-pack assemblies always shadow the host. Host TPA is appended only to satisfy transitive dependencies the user didn't enumerate.
- **FullName-based primitive comparison** in the emitter and binder, rather than maintaining parallel `Type` snapshots per context. Simpler than threading a "type universe" through every encoder, and the CIL primitive sig opcodes are TFM-independent.
- **Task DLL stays `netstandard2.0`** so it loads in any MSBuild host. Confirmed in the packed SDK layout.

Closes the `p6-multitarget` milestone. Remaining open: `p7-docs`, `p7-tests`.
