### PR TITLE
Phase 7 (p7-tests): Sdk.Tests project + expanded emit round-trip coverage

### DIFF
--- a/GSharp.sln
+++ b/GSharp.sln
@@ -54,6 +54,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gsharp.CodeAnalysis", "src\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gsharp.Templates", "src\Sdk\Gsharp.Templates\Gsharp.Templates.csproj", "{6F955EF0-798B-42D5-BA23-2EF026E6D526}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sdk.Tests", "test\Sdk.Tests\Sdk.Tests.csproj", "{05DB2CB2-6073-434C-BCB3-A2ADECD6B40C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -196,6 +198,18 @@ Global
 		{6F955EF0-798B-42D5-BA23-2EF026E6D526}.Release|x64.Build.0 = Release|Any CPU
 		{6F955EF0-798B-42D5-BA23-2EF026E6D526}.Release|x86.ActiveCfg = Release|Any CPU
 		{6F955EF0-798B-42D5-BA23-2EF026E6D526}.Release|x86.Build.0 = Release|Any CPU
+		{05DB2CB2-6073-434C-BCB3-A2ADECD6B40C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{05DB2CB2-6073-434C-BCB3-A2ADECD6B40C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{05DB2CB2-6073-434C-BCB3-A2ADECD6B40C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{05DB2CB2-6073-434C-BCB3-A2ADECD6B40C}.Debug|x64.Build.0 = Debug|Any CPU
+		{05DB2CB2-6073-434C-BCB3-A2ADECD6B40C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{05DB2CB2-6073-434C-BCB3-A2ADECD6B40C}.Debug|x86.Build.0 = Debug|Any CPU
+		{05DB2CB2-6073-434C-BCB3-A2ADECD6B40C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{05DB2CB2-6073-434C-BCB3-A2ADECD6B40C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{05DB2CB2-6073-434C-BCB3-A2ADECD6B40C}.Release|x64.ActiveCfg = Release|Any CPU
+		{05DB2CB2-6073-434C-BCB3-A2ADECD6B40C}.Release|x64.Build.0 = Release|Any CPU
+		{05DB2CB2-6073-434C-BCB3-A2ADECD6B40C}.Release|x86.ActiveCfg = Release|Any CPU
+		{05DB2CB2-6073-434C-BCB3-A2ADECD6B40C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -214,6 +228,7 @@ Global
 		{C517BC90-4D79-88E3-AB24-3495E97EE04D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{08B0FA1D-B4F3-4303-9C00-9CE64D209E13} = {C517BC90-4D79-88E3-AB24-3495E97EE04D}
 		{6F955EF0-798B-42D5-BA23-2EF026E6D526} = {51B637F8-9C04-5803-F48E-8CB9352021B0}
+		{05DB2CB2-6073-434C-BCB3-A2ADECD6B40C} = {A181298C-7433-4724-808A-E343FC9DC633}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6F06C89F-C7AA-47E2-BB0B-E9F7727EB4B0}

--- a/test/Core.Tests/CodeAnalysis/Emit/EndToEndEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/EndToEndEmitTests.cs
@@ -200,4 +200,33 @@ if x > 5 {
         var output = CompileLoadInvokeCaptureStdout(Source, "EndToEndEmitTests-Cond");
         Assert.Contains("big", output);
     }
+
+    [Fact]
+    public void Emits_String_Concatenation_With_Variable()
+    {
+        const string Source = @"package Concat
+import System
+var name = ""world""
+Console.WriteLine(""hi "" + name)
+";
+        var output = CompileLoadInvokeCaptureStdout(Source, "EndToEndEmitTests-Concat");
+        Assert.Contains("hi world", output);
+    }
+
+    [Fact]
+    public void Emits_Recursive_User_Function()
+    {
+        const string Source = @"package Recurse
+import System
+func factorial(n int) int {
+    if n <= 1 {
+        return 1
+    }
+    return n * factorial(n - 1)
+}
+Console.WriteLine(factorial(5))
+";
+        var output = CompileLoadInvokeCaptureStdout(Source, "EndToEndEmitTests-Recurse");
+        Assert.Contains("120", output);
+    }
 }

--- a/test/Sdk.Tests/RepoRoot.cs
+++ b/test/Sdk.Tests/RepoRoot.cs
@@ -1,0 +1,44 @@
+// <copyright file="RepoRoot.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+
+namespace GSharp.Sdk.Tests;
+
+/// <summary>
+/// Locates the repository root by walking up from the test assembly directory
+/// until a folder containing <c>GSharp.sln</c> is found. This keeps the test
+/// project free of build-time path injection.
+/// </summary>
+internal static class RepoRoot
+{
+    public static string Path { get; } = Find();
+
+    public static string SdkSourceDir { get; } =
+        System.IO.Path.Combine(Path, "src", "Sdk", "Gsharp.NET.Sdk");
+
+    public static string TemplatesSourceDir { get; } =
+        System.IO.Path.Combine(Path, "src", "Sdk", "Gsharp.Templates");
+
+    public static string SamplesDir { get; } =
+        System.IO.Path.Combine(Path, "samples");
+
+    private static string Find()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(System.IO.Path.Combine(dir.FullName, "GSharp.sln")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate GSharp.sln walking up from {AppContext.BaseDirectory}.");
+    }
+}

--- a/test/Sdk.Tests/Sdk.Tests.csproj
+++ b/test/Sdk.Tests/Sdk.Tests.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppTargetFramework)</TargetFramework>
+    <RootNamespace>GSharp.Sdk.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/test/Sdk.Tests/SdkLayoutTests.cs
+++ b/test/Sdk.Tests/SdkLayoutTests.cs
@@ -1,0 +1,116 @@
+// <copyright file="SdkLayoutTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace GSharp.Sdk.Tests;
+
+/// <summary>
+/// Structural tests over the files that ship inside the <c>Gsharp.NET.Sdk</c>
+/// NuGet. These pin the shape MSBuild relies on when it loads the SDK as
+/// <c>&lt;Project Sdk="Gsharp.NET.Sdk"&gt;</c> so accidental edits to the
+/// .props/.targets surface immediately rather than at consumer build time.
+/// </summary>
+public class SdkLayoutTests
+{
+    private static readonly XNamespace MsbuildNs =
+        "http://schemas.microsoft.com/developer/msbuild/2003";
+
+    [Fact]
+    public void Sdk_Props_Imports_MicrosoftNetSdk_And_Gsharp_Build_Props()
+    {
+        var path = Path.Combine(RepoRoot.SdkSourceDir, "Sdk", "Sdk.props");
+        Assert.True(File.Exists(path), path);
+
+        var doc = XDocument.Load(path);
+        var imports = doc.Descendants(MsbuildNs + "Import").ToList();
+
+        Assert.Contains(imports, i =>
+            (string)i.Attribute("Sdk") == "Microsoft.NET.Sdk"
+            && (string)i.Attribute("Project") == "Sdk.props");
+
+        Assert.Contains(imports, i =>
+            ((string)i.Attribute("Project") ?? string.Empty).EndsWith(
+                "Gsharp.NET.Sdk.props",
+                System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Sdk_Targets_Imports_MicrosoftNetSdk_Targets()
+    {
+        var path = Path.Combine(RepoRoot.SdkSourceDir, "Sdk", "Sdk.targets");
+        Assert.True(File.Exists(path), path);
+
+        var doc = XDocument.Load(path);
+        var imports = doc.Descendants(MsbuildNs + "Import").ToList();
+
+        Assert.Contains(imports, i =>
+            (string)i.Attribute("Sdk") == "Microsoft.NET.Sdk"
+            && (string)i.Attribute("Project") == "Sdk.targets");
+    }
+
+    [Fact]
+    public void Build_Props_Sets_Language_And_Tool_Paths_And_LanguageTargets()
+    {
+        var path = Path.Combine(RepoRoot.SdkSourceDir, "build", "Gsharp.NET.Sdk.props");
+        Assert.True(File.Exists(path), path);
+
+        var doc = XDocument.Load(path);
+        var props = doc.Descendants(MsbuildNs + "PropertyGroup")
+            .Elements()
+            .ToDictionary(e => e.Name.LocalName, e => e.Value, System.StringComparer.Ordinal);
+
+        Assert.Equal("Gsharp", props["Language"]);
+        Assert.Equal("Managed", props["TargetRuntime"]);
+        Assert.Contains("Gsharp.NET.Sdk.dll", props["GsharpToolFullPath"]);
+        Assert.Contains("gsc.dll", props["GsharpCompilerFullPath"]);
+        Assert.Contains("Gsharp.NET.Current.Sdk.targets", props["LanguageTargets"]);
+    }
+
+    [Fact]
+    public void Core_Targets_Declares_BuildTask_And_CoreCompile_Override()
+    {
+        var path = Path.Combine(RepoRoot.SdkSourceDir, "build", "Gsharp.NET.Core.Sdk.targets");
+        Assert.True(File.Exists(path), path);
+
+        var doc = XDocument.Load(path);
+
+        var usingTask = doc.Descendants(MsbuildNs + "UsingTask").Single();
+        Assert.Equal("Gsharp.NET.Sdk.Tools.BuildTask", (string)usingTask.Attribute("TaskName"));
+        Assert.Equal("$(GsharpToolFullPath)", (string)usingTask.Attribute("AssemblyFile"));
+
+        var coreCompile = doc.Descendants(MsbuildNs + "Target")
+            .FirstOrDefault(t => (string)t.Attribute("Name") == "CoreCompile");
+        Assert.NotNull(coreCompile);
+
+        var buildTask = coreCompile.Element(MsbuildNs + "BuildTask");
+        Assert.NotNull(buildTask);
+
+        // The BuildTask invocation has to forward the inputs gsc actually
+        // consumes; if any of these drop off, consumer builds silently no-op.
+        var attrs = buildTask!.Attributes().ToDictionary(a => a.Name.LocalName, a => a.Value);
+        Assert.Equal("$(GsharpCompilerFullPath)", attrs["GsharpCompilerFullPath"]);
+        Assert.Equal("@(Compile)", attrs["Compile"]);
+        Assert.Equal("@(ReferencePath)", attrs["References"]);
+        Assert.Equal("$(OutputType)", attrs["OutputType"]);
+        Assert.Equal("$(TargetFramework)", attrs["TargetFramework"]);
+    }
+
+    [Fact]
+    public void Sdk_Csproj_Packs_As_MSBuildSdk()
+    {
+        var csproj = Path.Combine(RepoRoot.SdkSourceDir, "Gsharp.NET.Sdk.csproj");
+        Assert.True(File.Exists(csproj), csproj);
+
+        var text = File.ReadAllText(csproj);
+        // The SDK must ship its tools (gsc + build task) and propsfiles
+        // alongside Sdk.props/Sdk.targets so msbuild can resolve it.
+        Assert.Contains("netstandard2.0", text, System.StringComparison.Ordinal);
+        Assert.Contains("Microsoft.Build.Framework", text, System.StringComparison.Ordinal);
+        Assert.Contains("Microsoft.Build.Utilities.Core", text, System.StringComparison.Ordinal);
+    }
+}

--- a/test/Sdk.Tests/TemplatesLayoutTests.cs
+++ b/test/Sdk.Tests/TemplatesLayoutTests.cs
@@ -1,0 +1,71 @@
+// <copyright file="TemplatesLayoutTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Text.Json;
+using System.Xml.Linq;
+using Xunit;
+
+namespace GSharp.Sdk.Tests;
+
+/// <summary>
+/// Sanity checks the <c>Gsharp.Templates</c> package content: <c>template.json</c>
+/// metadata, the scaffolded <c>.gsproj</c> using <c>Gsharp.NET.Sdk</c>, and the
+/// sample sources we ship for <c>dotnet new gsharp-console</c>.
+/// </summary>
+public class TemplatesLayoutTests
+{
+    private static readonly string ContentRoot =
+        Path.Combine(RepoRoot.TemplatesSourceDir, "content", "gsharp-console");
+
+    [Fact]
+    public void TemplateConfig_Has_Expected_Identity_And_ShortName()
+    {
+        var path = Path.Combine(ContentRoot, ".template.config", "template.json");
+        Assert.True(File.Exists(path), path);
+
+        using var doc = JsonDocument.Parse(File.ReadAllBytes(path));
+        var root = doc.RootElement;
+
+        Assert.Equal("GSharp.Templates.Console", root.GetProperty("identity").GetString());
+        Assert.Equal("gsharp-console", root.GetProperty("shortName").GetString());
+        Assert.Equal("GsharpConsoleApp", root.GetProperty("sourceName").GetString());
+        Assert.Equal("project", root.GetProperty("tags").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void Scaffolded_Gsproj_Uses_GsharpNetSdk_And_Compiles_GsFiles()
+    {
+        var path = Path.Combine(ContentRoot, "GsharpConsoleApp.gsproj");
+        Assert.True(File.Exists(path), path);
+
+        var doc = XDocument.Load(path);
+        var sdkAttr = (string)doc.Root.Attribute("Sdk");
+        Assert.StartsWith("Gsharp.NET.Sdk", sdkAttr, System.StringComparison.Ordinal);
+
+        var text = File.ReadAllText(path);
+        Assert.Contains("<OutputType>Exe</OutputType>", text, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Scaffolded_Program_Has_Package_And_TopLevel_WriteLine()
+    {
+        var path = Path.Combine(ContentRoot, "Program.gs");
+        Assert.True(File.Exists(path), path);
+
+        var src = File.ReadAllText(path);
+        Assert.Contains("package ", src, System.StringComparison.Ordinal);
+        Assert.Contains("Console.WriteLine", src, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HelloWorld_Sample_Uses_GsharpNetSdk()
+    {
+        var path = Path.Combine(RepoRoot.SamplesDir, "HelloWorld", "HelloWorld.gsproj");
+        Assert.True(File.Exists(path), path);
+
+        var doc = XDocument.Load(path);
+        Assert.Equal("Gsharp.NET.Sdk", (string)doc.Root.Attribute("Sdk"));
+    }
+}


### PR DESCRIPTION
## Summary
Phase 7 testing pass: stands up a new `test/Sdk.Tests` xUnit project that pins the structural shape of the `Gsharp.NET.Sdk` and `Gsharp.Templates` packages, and adds two more round-trip emit tests in `test/Core.Tests/CodeAnalysis/Emit` to broaden coverage of the production emit pipeline.

## Changes
- **`test/Sdk.Tests` (new project)**
  - `Sdk.Tests.csproj` — `net10.0`, xUnit, no project references (pure file-shape validation; runs in ms).
  - `RepoRoot.cs` — locates the repo by walking up from `AppContext.BaseDirectory` until it finds `GSharp.sln`. Keeps the project free of build-time path injection.
  - `SdkLayoutTests` — 5 tests pinning `Sdk/Sdk.props`/`Sdk/Sdk.targets`/`build/Gsharp.NET.Sdk.props`/`build/Gsharp.NET.Core.Sdk.targets`: the Microsoft.NET.Sdk imports, the `Language`/`TargetRuntime`/`GsharpToolFullPath`/`GsharpCompilerFullPath`/`LanguageTargets` properties, and the `UsingTask` + `CoreCompile` `BuildTask` invocation (compiler, refs, OutputType, TargetFramework, Compile items). Accidental edits to the SDK XML now fail tests instead of consumer builds.
  - `TemplatesLayoutTests` — 4 tests covering `template.json` identity/shortName/sourceName/tags, the scaffolded `GsharpConsoleApp.gsproj` Sdk attribute + `OutputType`, the scaffolded `Program.gs` shape, and the `samples/HelloWorld/HelloWorld.gsproj` Sdk attribute.
- **`test/Core.Tests/CodeAnalysis/Emit/EndToEndEmitTests.cs`** — two new round-trip tests:
  - `Emits_String_Concatenation_With_Variable` — exercises string-typed locals + `+` concat.
  - `Emits_Recursive_User_Function` — exercises `BoundCallExpression` self-recursion, early `return`, and arithmetic in the recursive case (`factorial(5)` → 120).
- **`GSharp.sln`** — `Sdk.Tests` added under the existing `Tests` solution folder.
- Removed the empty `test/CodeAnalysis.Tests` scaffold directory (Core.Tests already plays that role).

## Validation
- `dotnet test GSharp.sln -c Release` → **113/113 passing** (84 Core + 6 Compiler + 8 Interpreter + 6 LanguageServer + 9 Sdk).
