### PR TITLE
Phase 1: lexical wins (string interpolation, raw strings, numeric variants, let, import aliases, implicit System, Unicode IDs, ADRs)

### DIFF
--- a/docs/adr/0011-string-interpolation-grammar.md
+++ b/docs/adr/0011-string-interpolation-grammar.md
@@ -1,0 +1,74 @@
+# ADR-0011: String interpolation grammar and lowering
+
+- **Status**: Accepted
+- **Date**: 2026-05-22
+- **Phase**: Phase 1 (implementation: 1.1, 1.8)
+- **Related**: ADR-0007 (interpolation choice); execution plan §1.1; gaps doc §3.1.1
+
+## Context
+
+ADR-0007 settled the Kotlin-style choice (`$ident`, `${expr}`, no sigil on the string literal). It left three sub-grammar questions open:
+
+1. **Escape mechanism for a literal `$`.** ADR-0007 sketched `\$`, but GSharp double-quoted strings have no other escape sequences (`\n`, `\t`, etc. are not recognized today — see `ReadString` in the lexer pre-1.1). Adding a one-off `\$` escape would either require introducing a full escape sub-grammar or surfacing a confusing exception.
+2. **Lowering strategy.** ADR-0007 said "simple cases lower to `String.Concat(string[])`, complex cases to `String.Format`." Both work, but the binder needs to convert non-string parts to string somewhere, and the current emitter does **not** support value-type instance dispatch (`Call` on `int.ToString` blows up at runtime — observed during Phase 1.1 implementation).
+3. **Behaviour in raw (backtick) strings.** ADR-0007 said raw strings do not interpolate; ADR-0012 inherits that.
+
+## Decision
+
+### Grammar
+
+Inside a double-quoted string literal:
+
+```
+Interpolation := "$" Identifier              -- $name
+              |  "$" "{" Expression "}"       -- ${a + b}
+              |  "$" "$"                       -- literal $
+              |  "$" <any-other-char>          -- literal $ followed by that char (forward-compat)
+```
+
+- `Identifier` is the standard Unicode identifier production (ADR-0011a aka `docs/lexical.md`).
+- `Expression` is any GSharp expression. The lexer captures the raw source between `${` and the balanced `}`; the parser invokes a fresh `SyntaxTree.Parse` on that source and lifts the first expression-statement's expression as the segment.
+- **`$$` is the literal-`$` escape** (chosen over ADR-0007's tentative `\$` because there is no general backslash-escape grammar in GSharp strings today, and adding one is a separate ADR-sized question).
+- A `$` not followed by `$`, an identifier-start, or `{` lexes as a literal `$`. This is forward-compatible: future grammar extensions can attach meaning to `$<digit>` etc. without breaking existing programs that happen to contain prose like `"$5"` (which produces literal text `$5`).
+- Raw strings (ADR-0012) ignore `$` entirely.
+
+### Lowering
+
+The binder lowers an interpolated-string expression to a left-associative `+`-chain of `String`-typed sub-expressions:
+
+```
+"hi $name, ${a + b}"
+  ⟶  "hi " + Convert.ToString(name) + ", " + Convert.ToString(a + b)
+```
+
+- Literal segments become `BoundLiteralExpression` strings.
+- Expression segments are bound recursively; if the result type is not `String`, the binder wraps the expression in a static call to `System.Convert.ToString(<T>)`. `Convert.ToString` was chosen over instance `.ToString()` because the current emitter uses `Call` (not `Callvirt` with a `constrained.` prefix), which fails on value-type instance dispatch at runtime. `Convert.ToString` has a static overload set covering every primitive plus `object`, sidestepping the issue without requiring emitter changes.
+- An empty interpolation collapses to the empty-string literal.
+- Single-segment literal interpolations (e.g. `"hello"`) never enter this path — they remain `StringToken` and bind as plain literals.
+
+`String.Format` is **not** used. The format-string detection (which calls go to `Format` vs `Concat`) carries no measurable benefit until escape-aware formatting (`${expr:N2}`) is on the table. ADR-0007 left format specifiers for "if user demand emerges"; we make the lowering choice independently.
+
+## Consequences
+
+Positive:
+
+- No new escape sub-grammar needed. `$$` is self-explanatory and reversible (`"$$"` → `"$"` in the bound tree).
+- The `Convert.ToString` lowering works on every primitive that has reflection metadata, with no emitter changes. We pay one extra IL call per interpolation segment vs hand-written `int.ToString`, which is acceptable for an MVP.
+- The grammar leaves room for future `$<digit>` (positional args), `${expr:format}` (format specifiers), and `${expr?.member}` (null-conditional once nullables ship) without breaking existing programs.
+
+Negative:
+
+- `Convert.ToString` boxes value types via the `object` overload when an exact-type overload is missing. Negligible at runtime for the cases we care about, but worth revisiting if a hot path emerges.
+- The brace scanner is balanced but **not string-literal aware**: `"${"abc"}"` will end the brace scan at the first `}`, which in this example never appears, producing an unterminated-string diagnostic. Programs that need to embed strings inside `${...}` must extract a `let` binding. We accept this; fixing it requires a real sub-lexer.
+- Surrogate-pair identifiers in `$ident` are not supported (inherits the same limitation as identifier lexing — see `docs/lexical.md`).
+
+Neutral:
+
+- `\$` may be added as an alias for `$$` if/when a general escape grammar lands; the choice here does not foreclose that.
+
+## Alternatives considered
+
+- **`\$` escape (per ADR-0007 sketch).** Rejected because GSharp strings have no other backslash escapes today; introducing one for `$` alone is asymmetric. Revisit when escape sequences are spec'd.
+- **`%` interpolation (Python printf-style).** Rejected — Python deprecated this in favor of f-strings; we should not adopt a deprecated grammar.
+- **Lowering to `String.Format`.** Considered for "complex" cases. Rejected for Phase 1: it requires building a format string at bind-time and an `object[]` arg pack, both adding lowering complexity for no observable runtime gain. Can be reintroduced behind a heuristic if profiling motivates it.
+- **Lowering to instance `.ToString()`.** Rejected because the current emitter does not support value-type instance dispatch. Re-enable once Phase 2 (constrained-call emit support) lands; until then `Convert.ToString` is the safe path.

--- a/docs/adr/0012-raw-string-delimiter.md
+++ b/docs/adr/0012-raw-string-delimiter.md
@@ -1,0 +1,53 @@
+# ADR-0012: Raw string delimiter — backtick (`` ` ``)
+
+- **Status**: Accepted
+- **Date**: 2026-05-22
+- **Phase**: Phase 1 (implementation: 1.2, 1.8)
+- **Related**: ADR-0007 (interpolation choice — raw strings do not interpolate); ADR-0011 (interpolation grammar); execution plan §1.2
+
+## Context
+
+GSharp needs a "no-escapes, multi-line" string literal form for regexes, paths, JSON snippets, embedded SQL, and the like. Three precedents:
+
+| Language | Delimiter | Notes |
+| --- | --- | --- |
+| Go | `` ` `` (backtick) | Multi-line; no escapes; embedded `` ` `` not representable (must concatenate). |
+| C# | `@"..."`, `"""..."""` | `@` is verbose-string; `"""` is C# 11 raw string with arbitrary delimiter sizing. |
+| Rust | `r"..."`, `r#"..."#`, `r##"..."##` | Hash-balanced; arbitrarily nestable. |
+
+GSharp's grammar is Go-flavored, so the backtick is the natural fit. The question is whether we accept the "embedded backtick not representable" limitation (Go's accepted trade-off) or invent something more flexible (C# 11 / Rust style).
+
+## Decision
+
+**Backtick (`` ` ``) is the raw-string delimiter.** Behaviour:
+
+- All characters between the opening and closing backticks are taken verbatim — no `\n`, `\t`, etc. escape processing.
+- Multi-line raw strings are allowed. The lexer normalizes CR (`\r`) and CRLF (`\r\n`) inside the literal to LF (`\n`) so the value seen by the bound tree is stable across line-ending conventions of the source file. (Matches Go's spec.)
+- `$ident` / `${expr}` interpolation is **not** processed (raw strings are verbatim — period).
+- Embedded backticks are not representable inside a single literal. Workaround: concatenate with `+`, or use a double-quoted interpolated string with `${\"`\"}` (not yet possible — see ADR-0011 known issues).
+
+Token kind: `SyntaxKind.StringToken` (same as interpreted-string non-interpolated form). The bound tree does not distinguish raw vs interpreted strings.
+
+## Consequences
+
+Positive:
+
+- One-character delimiter, easy to type, visually distinct from regular strings.
+- Matches Go exactly, so Go developers will be immediately at home.
+- The lexer change is small and self-contained (`ReadRawString` in `Lexer.cs`).
+
+Negative:
+
+- No way to put a backtick inside a raw string. Concrete impact: regex literals that contain `` ` `` (rare) need concatenation. We accept the trade-off; Go has lived with it for fifteen years.
+- The verbatim multi-line semantics mean indentation inside a raw string ends up in the value. There is no "strip common leading whitespace" pass (Python's `textwrap.dedent`, C# 11 raw-string indentation). Adding one is a non-breaking Phase 3+ enhancement.
+
+Neutral:
+
+- The CRLF/CR-to-LF normalization is a runtime convenience; it diverges from "verbatim" in the strictest sense, but matches Go and produces source-portable behaviour.
+
+## Alternatives considered
+
+- **C# 11 `"""..."""` raw strings with arbitrary delimiter sizing.** Solves the embedded-backtick problem and supports common-leading-whitespace stripping. Rejected for Phase 1 because (a) the grammar is significantly more involved (triple-quote start, optional indentation prefix on the closing quote line), and (b) Go-flavor consistency outweighs the marginal benefit. May revisit if the limitation bites in practice.
+- **`@"..."` verbose-strings (C# pre-11).** Rejected because it conflicts with potential future uses of `@` (decorators, attribute marker, identifier escape) and is less visually distinct than the backtick.
+- **`r"..."` / `r#"..."#` (Rust-style).** Rejected because we have no use for a leading-letter literal prefix elsewhere, and the hash-balanced extension is unnecessary for Phase 1.
+- **`r###"..."###` with sized delimiters.** Same as Rust above. Revisit alongside C# 11-style triple-quote if embedded-backtick becomes painful.

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -37,7 +37,7 @@ Legend: ✅ = supported end-to-end. 🟡 = partially supported (caveats in the N
 | Statement | Parser | Binder | Emit | Interp | Notes |
 | --- | --- | --- | --- | --- | --- |
 | Block `{ … }` | ✅ | ✅ | ✅ | ✅ | |
-| `var x [T] = e` / `const x [T] = e` | ✅ | ✅ | ✅ | ✅ | Single identifier; no `var (…)` group. |
+| `var x [T] = e` / `let x [T] = e` / `const x [T] = e` | ✅ | ✅ | ✅ | ✅ | Single identifier; no `var (…)` group. `let` (since Phase 1.6) is an immutable runtime binding — same binder behavior as `const`. |
 | `x := e` | ✅ | ✅ | ✅ | ✅ | Single identifier; no `a, b := …`. |
 | `x = e` | ✅ | ✅ | ✅ | ✅ | Single identifier on LHS. |
 | `if cond stmt [else stmt]` | ✅ | ✅ | ✅ | ✅ | No `if init; cond` form. |

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -12,9 +12,10 @@ Legend: ✅ = supported end-to-end. 🟡 = partially supported (caveats in the N
 
 | Token / class | Lexer | Reachable by parser? | Notes |
 | --- | --- | --- | --- |
-| Numeric literal (decimal int) | ✅ | ✅ | No float / hex / octal / binary / underscore literals. |
-| String literal (double-quoted) | ✅ | ✅ | No raw strings, no interpolation, no escape verification surfaced in design. |
-| Identifier | ✅ | ✅ | ASCII-oriented; Unicode rules unspecified. |
+| Numeric literal | ✅ | ✅ | Decimal, `0x` hex, `0o` octal, `0b` binary (Phase 1.3); `_` allowed between digits and after the prefix. Floats / Go-style leading-zero octal not yet supported. |
+| String literal (double-quoted) | ✅ | ✅ | Includes Kotlin-style interpolation (`$ident`, `${expr}`) lowered to `+`-chain with `Convert.ToString` (Phase 1.1). `$$` escapes a literal `$`. |
+| Raw string literal (backtick) | ✅ | ✅ | Phase 1.2: contents verbatim, no escapes, CRLF/CR normalized to LF, multi-line allowed; embedded backticks not representable. |
+| Identifier | ✅ | ✅ | Unicode-aware via `char.IsLetter`/`char.IsLetterOrDigit` (categories Lu/Ll/Lt/Lm/Lo/Nl + Nd). Surrogate pairs not yet supported. See `docs/lexical.md`. |
 | `++` / `--` | ✅ | ❌ | Lexed but the parser has no increment/decrement statement form; `Loop.gs`'s `i--` is currently unparseable. |
 | Compound assignment (`+=`, `-=`, `*=`, `/=`, `%=`, `^=`, `&=`, `|=`, `&^=`, `<<=`, `>>=`) | ✅ | ❌ | `ParseAssignmentExpression` only accepts `IdentifierToken EqualsToken …`. |
 | `[` / `]` | ✅ | ❌ | No syntax node consumes them; indexing/slicing unreachable. |
@@ -27,7 +28,7 @@ Legend: ✅ = supported end-to-end. 🟡 = partially supported (caveats in the N
 | Construct | Parser | Binder | Emit | Interp | Notes |
 | --- | --- | --- | --- | --- | --- |
 | `package A.B.C` | ✅ | ✅ | ✅ | ✅ | Dotted; no aliases. |
-| `import A.B.C` | ✅ | ✅ | ✅ | ✅ | No aliases, no parenthesized groups, no string-path imports, no per-file `import` blocks. |
+| `import A.B.C` | ✅ | ✅ | ✅ | ✅ | Aliased form `import alias = path` lands in Phase 1.4. Implicit `import System` is on by default (Phase 1.5; opt-out via `gsc /noimplicitimports`). No parenthesized groups, no string-path imports, no per-file `import` blocks. |
 | Top-level statements | ✅ | ✅ | ✅ | ✅ | Entry point synthesized; one file may carry them. |
 | `func name(params) Ret { … }` | ✅ | ✅ | ✅ | ✅ | Single return type only. |
 | Multiple return values / named returns / variadic / receivers / generic params | ❌ | — | — | — | |
@@ -98,6 +99,6 @@ Implicit and explicit conversions: `BindConversion` exists but the emitter (`Emi
 
 1. **The dominant gap is parser → binder**, not binder → emit. The emitter implements essentially every bound node the binder can currently produce; failures show up as parser-rejections or binder "operator/conversion not supported" diagnostics.
 2. **Two design samples already exceed the implementation.** `samples/Loop.gs` (pre-Phase-0 rewrite) and `design/Gsharp-design-v0.1.md` use C-style `for init; cond; post`, `args[0]` indexing, `i--`, and `*count` — none of which parse today. The Phase-0 rewrite of `samples/Loop.gs` removes those constructs; the v0.1 design Loop section is annotated as aspirational pointing at `design/Gsharp-design-v0.2.md`.
-3. **String literal interpolation is faked in samples.** `"Count value: {i}"` (in the aspirational v0.1 Loop) is emitted verbatim — there is no interpolation pass. Phase 1.1 ships Kotlin-style `$ident` / `${expr}` interpolation.
+3. **String interpolation is real (Phase 1.1).** `"Count value: $i"` lexes as an `InterpolatedStringToken`, parses as `InterpolatedStringExpressionSyntax`, and lowers in the binder to a `+`-chain over `Convert.ToString` calls — emitted unchanged.
 4. **The emitter caps literals at `int`/`string`/`bool`.** Adding any new literal kind (float, char/rune, null) requires coordinated lexer + binder + `EmitLiteral` changes.
 5. **`int ↔ bool` is the only conversion path that emits.** Before adding numeric types or imported-type conversions to the binder, `EmitConversion` must be extended; otherwise valid programs will compile under the interpreter and crash the emitter.

--- a/docs/lexical.md
+++ b/docs/lexical.md
@@ -1,0 +1,61 @@
+# GSharp Lexical Specification
+
+This document describes the lexical structure of GSharp. The grammar follows Go closely, with deliberate divergences noted inline.
+
+## Source representation
+
+Source files are UTF-8 encoded Unicode text. The lexer treats LF (`\n`), CR (`\r`), and CRLF as line terminators; raw string literals normalize CR and CRLF to LF when their contents are exposed to the bound tree.
+
+## Identifiers
+
+```
+identifier = letter { letter | unicode_digit }
+letter     = unicode_letter | "_"
+```
+
+* `unicode_letter` is any Unicode code point classified as a letter (categories `Lu`, `Ll`, `Lt`, `Lm`, `Lo`, `Nl`).
+* `unicode_digit` is any Unicode code point classified as a decimal digit (`Nd`).
+* The underscore (`_`) is a letter.
+
+Implementation note: the lexer uses .NET's `char.IsLetter` and `char.IsLetterOrDigit`, which are Unicode-aware. Examples of valid identifiers: `café`, `π`, `日本語`, `Москва`, `Δx`, `α2β`, `_underscore`. Identifiers starting with a digit are not permitted (`2π` lexes as `NumberToken("2")` followed by `IdentifierToken("π")`).
+
+Identifiers consisting of a surrogate pair (Unicode code points beyond U+FFFF) are not currently supported and will fall through to the bad-character path.
+
+## Keywords
+
+Keywords are reserved and may not be used as identifiers. See `SyntaxFacts.GetKeywordKind` for the canonical list.
+
+## Numeric literals
+
+GSharp supports the following integer literal forms:
+
+| Form    | Prefix    | Digits         | Example       |
+| ------- | --------- | -------------- | ------------- |
+| Decimal | (none)    | `0`–`9`        | `42`, `1_000` |
+| Hex     | `0x` / `0X` | `0`–`9`, `a`–`f`, `A`–`F` | `0xff`, `0xDEAD_BEEF` |
+| Octal   | `0o` / `0O` | `0`–`7`        | `0o755`       |
+| Binary  | `0b` / `0B` | `0`, `1`        | `0b1010_1010` |
+
+* Underscores (`_`) may appear between digits and immediately after a base prefix for readability (`0x_FF` is valid). A trailing underscore (`1_`) or an underscore as the only digit after a prefix (`0x_`) is rejected.
+* GSharp does **not** support Go's leading-zero octal form (e.g., `0755`); the explicit `0o755` is required. This keeps the grammar unambiguous for future floating-point literal work.
+
+## String literals
+
+GSharp has two string forms:
+
+1. **Interpreted strings** delimited by `"…"`. Escape sequences are processed.
+2. **Raw strings** delimited by backticks (`` `…` ``). Contents are taken verbatim with no escape processing. Multi-line raw strings are allowed; CR and CRLF in the source are normalized to LF in the literal value. Embedded backticks are not representable; concatenate with `+` if needed.
+
+## Comments
+
+Single-line comments start with `//` and run to the end of the line. (Block-comment syntax is not yet implemented; see the execution plan.)
+
+## Whitespace and line terminators
+
+Spaces, tabs, and line terminators are insignificant outside of string literals.
+
+## See also
+
+* `docs/coverage-matrix.md` — language-construct coverage matrix.
+* `docs/adr/0011-string-interpolation.md` *(planned)*
+* `docs/adr/0012-raw-string-delimiter.md` *(planned)*

--- a/docs/lexical.md
+++ b/docs/lexical.md
@@ -57,5 +57,5 @@ Spaces, tabs, and line terminators are insignificant outside of string literals.
 ## See also
 
 * `docs/coverage-matrix.md` — language-construct coverage matrix.
-* `docs/adr/0011-string-interpolation.md` *(planned)*
-* `docs/adr/0012-raw-string-delimiter.md` *(planned)*
+* `docs/adr/0011-string-interpolation-grammar.md` — interpolation sub-grammar and lowering.
+* `docs/adr/0012-raw-string-delimiter.md` — rationale for backtick raw strings.

--- a/samples/ImplicitImport.golden
+++ b/samples/ImplicitImport.golden
@@ -1,0 +1,1 @@
+Hello without import!

--- a/samples/ImplicitImport.gs
+++ b/samples/ImplicitImport.gs
@@ -1,0 +1,6 @@
+// file: ImplicitImport.gs
+// Phase 1.5: Console resolves without an explicit `import System`.
+
+package ImplicitImport
+
+Console.WriteLine("Hello without import!")

--- a/samples/ImportAlias.golden
+++ b/samples/ImportAlias.golden
@@ -1,0 +1,1 @@
+Hello from alias!

--- a/samples/ImportAlias.gs
+++ b/samples/ImportAlias.gs
@@ -1,0 +1,7 @@
+// file: ImportAlias.gs
+
+package ImportAlias
+
+import sys = System
+
+sys.Console.WriteLine("Hello from alias!")

--- a/samples/InterpolatedString.golden
+++ b/samples/InterpolatedString.golden
@@ -1,0 +1,3 @@
+Hello, world!
+answer = 42
+$ stays literal

--- a/samples/InterpolatedString.gs
+++ b/samples/InterpolatedString.gs
@@ -1,0 +1,10 @@
+// file: InterpolatedString.gs
+// Phase 1.1 conformance fixture: `$ident`, `${expr}`, and `$$` escape.
+
+package InterpolatedString
+
+let name = "world"
+let n = 6
+Console.WriteLine("Hello, $name!")
+Console.WriteLine("answer = ${n * 7}")
+Console.WriteLine("$$ stays literal")

--- a/samples/Loop.golden
+++ b/samples/Loop.golden
@@ -1,5 +1,5 @@
-1
-2
-3
-4
-5
+Count value: 1
+Count value: 2
+Count value: 3
+Count value: 4
+Count value: 5

--- a/samples/Loop.gs
+++ b/samples/Loop.gs
@@ -1,11 +1,11 @@
 // file: Loop.gs
 // Demonstrates the constructs the front-end accepts today: top-level
 // statements, var declarations, the `for i := lo ... hi` range form,
-// and BCL interop via `Console.WriteLine`. The original aspirational
-// form of this sample (C-style for, decrement, `args[0]` indexing,
-// string interpolation) is preserved in `design/Gsharp-design-v0.1.md`
-// and will be reintroduced as Phases 1 and 2 of the execution plan
-// land — see `docs/adr/0010-aspirational-samples.md`.
+// BCL interop via `Console.WriteLine`, and string interpolation
+// (Phase 1.1). The original aspirational form (C-style for, decrement,
+// `args[0]` indexing) is preserved in `design/Gsharp-design-v0.1.md`
+// and will be reintroduced as later phases land — see
+// `docs/adr/0010-aspirational-samples.md`.
 
 package GSharp.Example.Loop
 
@@ -16,5 +16,5 @@ var count = 5
 // `lo ... hi` is half-open (prints `lo` through `hi - 1`),
 // so use `count + 1` to print 1 through `count` inclusive.
 for i := 1 ... count + 1 {
-    Console.WriteLine(i)
+    Console.WriteLine("Count value: $i")
 }

--- a/samples/RawString.golden
+++ b/samples/RawString.golden
@@ -1,0 +1,4 @@
+raw: no \n escapes here, backslash stays as \
+line one
+line two
+line three

--- a/samples/RawString.gs
+++ b/samples/RawString.gs
@@ -1,0 +1,8 @@
+package GSharp.Example.RawString
+
+import System
+
+Console.WriteLine(`raw: no \n escapes here, backslash stays as \`)
+Console.WriteLine(`line one
+line two
+line three`)

--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -73,7 +73,10 @@ public class Program
         var references = parsed.References.Count > 0
             ? ReferenceResolver.WithReferences(parsed.References)
             : null;
-        var compilation = new Compilation(references, syntaxTrees.ToArray());
+        var compilation = new Compilation(references, syntaxTrees.ToArray())
+        {
+            ImplicitSystemImport = parsed.ImplicitSystemImport,
+        };
 
         if (parsed.OutputPath is null)
         {
@@ -222,6 +225,16 @@ public class Program
                         result.References.Add(value);
                         break;
 
+                    case "implicitimports":
+                    case "implicit-imports":
+                        result.ImplicitSystemImport = ParseBoolFlag(value, defaultIfEmpty: true);
+                        break;
+
+                    case "noimplicitimports":
+                    case "no-implicit-imports":
+                        result.ImplicitSystemImport = false;
+                        break;
+
                     case "debug":
                     case "pdb":
                         // Accepted for SDK compatibility; debug info emit is Phase 2.
@@ -279,6 +292,21 @@ public class Program
         return result;
     }
 
+    private static bool ParseBoolFlag(string value, bool defaultIfEmpty)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return defaultIfEmpty;
+        }
+
+        return value.ToLowerInvariant() switch
+        {
+            "true" or "1" or "on" or "yes" => true,
+            "false" or "0" or "off" or "no" => false,
+            _ => throw new CommandLineException($"Unsupported boolean value: {value}"),
+        };
+    }
+
     private static bool IsSwitch(string arg)
     {
         if (arg.Length == 0)
@@ -330,6 +358,8 @@ public class Program
         public string TargetFramework { get; set; }
 
         public bool ShowHelp { get; set; }
+
+        public bool ImplicitSystemImport { get; set; } = true;
     }
 
     private sealed class CommandLineException : Exception

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -336,7 +336,8 @@ public sealed class Binder
 
     private BoundStatement BindVariableDeclaration(VariableDeclarationSyntax syntax)
     {
-        var isReadOnly = syntax.Keyword?.Kind == SyntaxKind.ConstKeyword;
+        var isReadOnly = syntax.Keyword?.Kind == SyntaxKind.ConstKeyword
+            || syntax.Keyword?.Kind == SyntaxKind.LetKeyword;
         var type = BindTypeClause(syntax.TypeClause);
         var initializer = BindExpression(syntax.Initializer);
         var variableType = type ?? initializer.Type;

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -519,6 +519,8 @@ public sealed class Binder
                 return BindParenthesizedExpression((ParenthesizedExpressionSyntax)syntax);
             case SyntaxKind.LiteralExpression:
                 return BindLiteralExpression((LiteralExpressionSyntax)syntax);
+            case SyntaxKind.InterpolatedStringExpression:
+                return BindInterpolatedStringExpression((InterpolatedStringExpressionSyntax)syntax);
             case SyntaxKind.NameExpression:
                 return BindNameExpression((NameExpressionSyntax)syntax);
             case SyntaxKind.AssignmentExpression:
@@ -545,6 +547,80 @@ public sealed class Binder
     {
         var value = syntax.Value ?? 0;
         return new BoundLiteralExpression(value);
+    }
+
+    private BoundExpression BindInterpolatedStringExpression(InterpolatedStringExpressionSyntax syntax)
+    {
+        // Lower `"a $x b ${expr} c"` to a `+`-chain of string-typed sub-
+        // expressions: literal parts become string literals; expression parts
+        // are bound recursively and, when not already string-typed, wrapped in
+        // an instance `.ToString()` call. An empty interpolation collapses to
+        // the empty-string literal.
+        BoundExpression result = null;
+        foreach (var segment in syntax.Segments)
+        {
+            BoundExpression piece;
+            if (segment.IsExpression)
+            {
+                var bound = BindExpression(segment.Expression);
+                if (bound is BoundErrorExpression)
+                {
+                    return bound;
+                }
+
+                piece = ConvertToString(bound, segment.Expression.Location);
+                if (piece is BoundErrorExpression)
+                {
+                    return piece;
+                }
+            }
+            else
+            {
+                piece = new BoundLiteralExpression(segment.Text ?? string.Empty);
+            }
+
+            result = result == null ? piece : Concat(result, piece);
+        }
+
+        return result ?? new BoundLiteralExpression(string.Empty);
+    }
+
+    private BoundExpression ConvertToString(BoundExpression expression, TextLocation diagnosticLocation)
+    {
+        if (expression.Type == TypeSymbol.String)
+        {
+            return expression;
+        }
+
+        var clrType = expression.Type?.ClrType;
+        if (clrType == null)
+        {
+            Diagnostics.ReportCannotConvert(diagnosticLocation, expression.Type, TypeSymbol.String);
+            return new BoundErrorExpression();
+        }
+
+        // Bind a call to `System.Convert.ToString(<expr.Type>)`. Convert.ToString
+        // is a static overload set covering every primitive (int, long, bool,
+        // double, ...) plus `object`, so it works uniformly without emitter
+        // changes for value-type instance dispatch.
+        var convertType = typeof(System.Convert);
+        var method = convertType.GetMethod("ToString", new[] { clrType })
+            ?? convertType.GetMethod("ToString", new[] { typeof(object) });
+        if (method == null)
+        {
+            Diagnostics.ReportCannotConvert(diagnosticLocation, expression.Type, TypeSymbol.String);
+            return new BoundErrorExpression();
+        }
+
+        var importedClass = new ImportedClassSymbol(convertType, declaration: null);
+        var importedFn = new ImportedFunctionSymbol(method.Name, importedClass, method, declaration: null);
+        return new BoundImportedCallExpression(importedFn, ImmutableArray.Create(expression));
+    }
+
+    private static BoundExpression Concat(BoundExpression left, BoundExpression right)
+    {
+        var op = BoundBinaryOperator.Bind(SyntaxKind.PlusToken, TypeSymbol.String, TypeSymbol.String);
+        return new BoundBinaryExpression(left, op, right);
     }
 
     private BoundExpression BindNameExpression(NameExpressionSyntax syntax)

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -56,7 +56,7 @@ public sealed class Binder
     /// <param name="syntaxTrees">The new syntax trees.</param>
     /// <returns>The new chained bound global scope.</returns>
     public static BoundGlobalScope BindGlobalScope(BoundGlobalScope previous, ImmutableArray<SyntaxTree> syntaxTrees)
-        => BindGlobalScope(previous, syntaxTrees, references: null);
+        => BindGlobalScope(previous, syntaxTrees, references: null, implicitSystemImport: true);
 
     /// <summary>
     /// Binds a set of syntax trees to the previous global scope, resulting in
@@ -68,9 +68,29 @@ public sealed class Binder
     /// <param name="references">The reference resolver; <c>null</c> selects <see cref="ReferenceResolver.Default"/>.</param>
     /// <returns>The new chained bound global scope.</returns>
     public static BoundGlobalScope BindGlobalScope(BoundGlobalScope previous, ImmutableArray<SyntaxTree> syntaxTrees, ReferenceResolver references)
+        => BindGlobalScope(previous, syntaxTrees, references, implicitSystemImport: true);
+
+    /// <summary>
+    /// Binds a set of syntax trees to the previous global scope, with full control over implicit-import seeding.
+    /// </summary>
+    /// <param name="previous">The previous global scope.</param>
+    /// <param name="syntaxTrees">The new syntax trees.</param>
+    /// <param name="references">The reference resolver; <c>null</c> selects <see cref="ReferenceResolver.Default"/>.</param>
+    /// <param name="implicitSystemImport">When <c>true</c>, an implicit <c>import System</c> is seeded before user imports are processed.</param>
+    /// <returns>The new chained bound global scope.</returns>
+    public static BoundGlobalScope BindGlobalScope(BoundGlobalScope previous, ImmutableArray<SyntaxTree> syntaxTrees, ReferenceResolver references, bool implicitSystemImport)
     {
         var parentScope = CreateParentScope(previous, references);
         var binder = new Binder(parentScope, function: null);
+
+        if (implicitSystemImport && previous == null)
+        {
+            // Seed an implicit `import System` so common BCL types (Console,
+            // String, Int32, ...) resolve without an explicit import. The user
+            // may still write `import System` redundantly; lookup short-circuits
+            // on the first matching import so duplicates are harmless.
+            binder.scope.TryImport(new ImportSymbol("System", "System", declaration: null));
+        }
 
         // Resolve each syntax tree's package declaration to a PackageSymbol.
         // Trees without a `package X` declaration fall into the implicit

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -248,8 +248,9 @@ public sealed class Binder
             sb.Append(i.Text);
         }
 
-        var importName = sb.ToString();
-        var importSymbol = new ImportSymbol(importName, import);
+        var targetPath = sb.ToString();
+        var localName = import.AliasIdentifier?.Text ?? targetPath;
+        var importSymbol = new ImportSymbol(localName, targetPath, import);
         scope.TryImport(importSymbol);
     }
 
@@ -695,6 +696,7 @@ public sealed class Binder
         // instance member access). Then apply the right side, which may itself
         // be a chain of accessors (e.g. Guid.NewGuid().ToString()).
         var leftPart = syntax.LeftPart;
+        var rightPart = syntax.RightPart;
         BoundExpression receiver = null;
         ImportedClassSymbol classSymbol = null;
 
@@ -704,6 +706,11 @@ public sealed class Binder
             if (scope.TryLookupSymbol(name) is VariableSymbol variable)
             {
                 receiver = new BoundVariableExpression(variable);
+            }
+            else if (scope.TryLookupImport(name, out var matchedImport)
+                && TryBindImportAccessor(matchedImport, ref rightPart, out var typeFromImport))
+            {
+                classSymbol = typeFromImport;
             }
             else if (scope.TryLookupImportedClass(name, leftName, out var importedClass))
             {
@@ -720,7 +727,44 @@ public sealed class Binder
             receiver = BindExpression(leftPart);
         }
 
-        return BindAccessorStep(receiver, classSymbol, syntax.RightPart);
+        return BindAccessorStep(receiver, classSymbol, rightPart);
+    }
+
+    private bool TryBindImportAccessor(ImportSymbol import, ref ExpressionSyntax rightPart, out ImportedClassSymbol importedClass)
+    {
+        // Handle `<importName>.<TypeName>(.<more>)*` where <importName> is either an
+        // alias or the import's path. The next segment of the chain names the type;
+        // we resolve `<import.Target>.<TypeName>` and consume that segment.
+        importedClass = null;
+
+        NameExpressionSyntax typeNameSyntax;
+        ExpressionSyntax remainder;
+
+        switch (rightPart)
+        {
+            case AccessorExpressionSyntax nested when nested.LeftPart is NameExpressionSyntax leftName:
+                typeNameSyntax = leftName;
+                remainder = nested.RightPart;
+                break;
+
+            case NameExpressionSyntax ne:
+                typeNameSyntax = ne;
+                remainder = ne;
+                break;
+
+            default:
+                return false;
+        }
+
+        var fullTypeName = import.Target + "." + typeNameSyntax.IdentifierToken.Text;
+        if (!scope.References.TryResolveType(fullTypeName, out var type))
+        {
+            return false;
+        }
+
+        importedClass = new ImportedClassSymbol(type, typeNameSyntax);
+        rightPart = remainder;
+        return true;
     }
 
     private BoundExpression BindAccessorStep(BoundExpression receiver, ImportedClassSymbol classSymbol, ExpressionSyntax rightPart)

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -117,10 +117,38 @@ public sealed class BoundScope
 
         foreach (var import in imports)
         {
-            var typeName = import.Name + "." + name;
+            var typeName = import.Target + "." + name;
             if (References.TryResolveType(typeName, out var type))
             {
                 importedClass = new ImportedClassSymbol(type, declaration);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Tries to look up an imported namespace by the name the user references it with
+    /// (the alias if one was declared, otherwise the import path).
+    /// </summary>
+    /// <param name="name">The name as it appears in user code.</param>
+    /// <param name="import">The matching import, when found.</param>
+    /// <returns>Whether a matching import exists.</returns>
+    public bool TryLookupImport(string name, out ImportSymbol import)
+    {
+        import = null;
+
+        if (imports == null)
+        {
+            return false;
+        }
+
+        foreach (var candidate in imports)
+        {
+            if (string.Equals(candidate.Name, name, System.StringComparison.Ordinal))
+            {
+                import = candidate;
                 return true;
             }
         }

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -49,6 +49,7 @@ public class Compilation
         Previous = previous;
         SyntaxTrees = syntaxTrees.ToImmutableArray();
         References = references ?? previous?.References;
+        ImplicitSystemImport = previous?.ImplicitSystemImport ?? true;
     }
 
     /// <summary>
@@ -67,6 +68,13 @@ public class Compilation
     public ReferenceResolver References { get; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether an implicit <c>import System</c>
+    /// should be seeded before user imports are processed. Defaults to
+    /// <see langword="true"/>.
+    /// </summary>
+    public bool ImplicitSystemImport { get; set; }
+
+    /// <summary>
     /// Gets the global scope.
     /// </summary>
     public BoundGlobalScope GlobalScope
@@ -75,7 +83,7 @@ public class Compilation
         {
             if (globalScope == null)
             {
-                var globalScope = Binder.BindGlobalScope(Previous?.GlobalScope, SyntaxTrees, References);
+                var globalScope = Binder.BindGlobalScope(Previous?.GlobalScope, SyntaxTrees, References, ImplicitSystemImport);
                 Interlocked.CompareExchange(ref this.globalScope, globalScope, null);
             }
 

--- a/src/Core/CodeAnalysis/Symbols/ImportSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportSymbol.cs
@@ -16,7 +16,7 @@ public sealed class ImportSymbol : Symbol
     /// </summary>
     /// <param name="name">The local name used to reference this import (the alias when one is declared, otherwise the import path).</param>
     /// <param name="target">The fully-qualified target path used for type resolution (e.g. <c>System</c> or <c>System.IO</c>).</param>
-    /// <param name="declaration">The declaration.</param>
+    /// <param name="declaration">The declaration, or <c>null</c> for compiler-synthesized imports (e.g. the implicit <c>System</c> import).</param>
     public ImportSymbol(string name, string target, ImportSyntax declaration)
         : base(name)
     {
@@ -38,7 +38,12 @@ public sealed class ImportSymbol : Symbol
     public bool IsAlias => !string.Equals(Name, Target, System.StringComparison.Ordinal);
 
     /// <summary>
-    /// Gets the declaration of the import.
+    /// Gets a value indicating whether this import was synthesized by the compiler rather than written by the user.
+    /// </summary>
+    public bool IsImplicit => Declaration == null;
+
+    /// <summary>
+    /// Gets the declaration of the import, or <c>null</c> for compiler-synthesized imports.
     /// </summary>
     public ImportSyntax Declaration { get; }
 }

--- a/src/Core/CodeAnalysis/Symbols/ImportSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportSymbol.cs
@@ -14,16 +14,28 @@ public sealed class ImportSymbol : Symbol
     /// <summary>
     /// Initializes a new instance of the <see cref="ImportSymbol"/> class.
     /// </summary>
-    /// <param name="name">The import name.</param>
+    /// <param name="name">The local name used to reference this import (the alias when one is declared, otherwise the import path).</param>
+    /// <param name="target">The fully-qualified target path used for type resolution (e.g. <c>System</c> or <c>System.IO</c>).</param>
     /// <param name="declaration">The declaration.</param>
-    public ImportSymbol(string name, ImportSyntax declaration)
+    public ImportSymbol(string name, string target, ImportSyntax declaration)
         : base(name)
     {
+        Target = target;
         Declaration = declaration;
     }
 
     /// <inheritdoc/>
     public override SymbolKind Kind => SymbolKind.Import;
+
+    /// <summary>
+    /// Gets the fully-qualified target path used to resolve types under this import.
+    /// </summary>
+    public string Target { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this import was declared with an explicit alias (e.g. <c>import sys = System</c>).
+    /// </summary>
+    public bool IsAlias => !string.Equals(Name, Target, System.StringComparison.Ordinal);
 
     /// <summary>
     /// Gets the declaration of the import.

--- a/src/Core/CodeAnalysis/Syntax/ImportSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/ImportSyntax.cs
@@ -17,14 +17,20 @@ public sealed class ImportSyntax : MemberSyntax
     /// </summary>
     /// <param name="syntaxTree">The parent syntax tree.</param>
     /// <param name="importKeyword">The import keyword.</param>
-    /// <param name="identifiers">The identifiers.</param>
+    /// <param name="aliasIdentifier">Optional alias identifier (the LHS of an <c>import alias = path</c> form).</param>
+    /// <param name="equalsToken">Optional equals token paired with <paramref name="aliasIdentifier"/>.</param>
+    /// <param name="identifiers">The identifiers forming the imported path (dot-included tokens).</param>
     public ImportSyntax(
         SyntaxTree syntaxTree,
         SyntaxToken importKeyword,
+        SyntaxToken aliasIdentifier,
+        SyntaxToken equalsToken,
         ImmutableArray<SyntaxToken> identifiers)
         : base(syntaxTree)
     {
         ImportKeyword = importKeyword;
+        AliasIdentifier = aliasIdentifier;
+        EqualsToken = equalsToken;
         IdentifiersWithDots = identifiers;
         Identifiers = identifiers.Where(t => t.Kind == SyntaxKind.IdentifierToken).ToImmutableArray();
     }
@@ -36,6 +42,16 @@ public sealed class ImportSyntax : MemberSyntax
     /// Gets the import keyword.
     /// </summary>
     public SyntaxToken ImportKeyword { get; }
+
+    /// <summary>
+    /// Gets the alias identifier when the import uses the <c>import alias = path</c> form, or <c>null</c>.
+    /// </summary>
+    public SyntaxToken AliasIdentifier { get; }
+
+    /// <summary>
+    /// Gets the equals token paired with <see cref="AliasIdentifier"/>, or <c>null</c>.
+    /// </summary>
+    public SyntaxToken EqualsToken { get; }
 
     /// <summary>
     /// Gets the import statement identifiers, excluding dots.

--- a/src/Core/CodeAnalysis/Syntax/InterpolatedStringExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/InterpolatedStringExpressionSyntax.cs
@@ -1,0 +1,40 @@
+// <copyright file="InterpolatedStringExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents an interpolated string literal expression (e.g. <c>"hello $name"</c>
+/// or <c>"sum=${a + b}"</c>). The token's structured fragments are projected
+/// into a mix of literal-text segments and embedded expression segments.
+/// </summary>
+public sealed class InterpolatedStringExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InterpolatedStringExpressionSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The owning syntax tree.</param>
+    /// <param name="stringToken">The interpolated-string token produced by the lexer.</param>
+    /// <param name="segments">The mixed text/expression segments.</param>
+    public InterpolatedStringExpressionSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken stringToken,
+        ImmutableArray<InterpolatedStringSegment> segments)
+        : base(syntaxTree)
+    {
+        StringToken = stringToken;
+        Segments = segments;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.InterpolatedStringExpression;
+
+    /// <summary>Gets the source token.</summary>
+    public SyntaxToken StringToken { get; }
+
+    /// <summary>Gets the ordered text/expression segments.</summary>
+    public ImmutableArray<InterpolatedStringSegment> Segments { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/InterpolatedStringSegment.cs
+++ b/src/Core/CodeAnalysis/Syntax/InterpolatedStringSegment.cs
@@ -1,0 +1,37 @@
+// <copyright file="InterpolatedStringSegment.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// One segment of an <see cref="InterpolatedStringExpressionSyntax"/>: either
+/// a literal piece of text or an embedded expression.
+/// </summary>
+public readonly struct InterpolatedStringSegment
+{
+    private InterpolatedStringSegment(string text, ExpressionSyntax expression)
+    {
+        Text = text;
+        Expression = expression;
+    }
+
+    /// <summary>Gets a value indicating whether this segment holds an embedded expression.</summary>
+    public bool IsExpression => Expression != null;
+
+    /// <summary>Gets the literal text, or <c>null</c> when this segment is an expression.</summary>
+    public string Text { get; }
+
+    /// <summary>Gets the embedded expression, or <c>null</c> when this segment is literal text.</summary>
+    public ExpressionSyntax Expression { get; }
+
+    /// <summary>Creates a literal-text segment.</summary>
+    /// <param name="text">The literal text.</param>
+    /// <returns>The segment.</returns>
+    public static InterpolatedStringSegment FromText(string text) => new(text, expression: null);
+
+    /// <summary>Creates an embedded-expression segment.</summary>
+    /// <param name="expression">The bound expression syntax.</param>
+    /// <returns>The segment.</returns>
+    public static InterpolatedStringSegment FromExpression(ExpressionSyntax expression) => new(text: null, expression);
+}

--- a/src/Core/CodeAnalysis/Syntax/InterpolationFragment.cs
+++ b/src/Core/CodeAnalysis/Syntax/InterpolationFragment.cs
@@ -1,0 +1,42 @@
+// <copyright file="InterpolationFragment.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// A raw fragment produced by the lexer for an interpolated string literal.
+/// Stored as the <c>Value</c> of an <see cref="SyntaxKind.InterpolatedStringToken"/>.
+/// Expression fragments still hold un-parsed text; the parser is responsible
+/// for lexing+parsing them into <see cref="ExpressionSyntax"/> nodes when it
+/// builds an <see cref="InterpolatedStringExpressionSyntax"/>.
+/// </summary>
+public readonly struct InterpolationFragment
+{
+    private InterpolationFragment(bool isExpression, string text, int position)
+    {
+        IsExpression = isExpression;
+        Text = text;
+        Position = position;
+    }
+
+    /// <summary>Gets a value indicating whether this fragment is an expression (true) or literal text (false).</summary>
+    public bool IsExpression { get; }
+
+    /// <summary>Gets the fragment's source text (literal content or un-parsed expression source).</summary>
+    public string Text { get; }
+
+    /// <summary>Gets the position in the original source where the fragment text begins (used for diagnostics on expression fragments).</summary>
+    public int Position { get; }
+
+    /// <summary>Creates a literal-text fragment.</summary>
+    /// <param name="text">Literal text.</param>
+    /// <returns>The fragment.</returns>
+    public static InterpolationFragment FromText(string text) => new(isExpression: false, text, position: 0);
+
+    /// <summary>Creates an expression fragment whose <paramref name="text"/> still needs parsing.</summary>
+    /// <param name="text">Un-parsed expression source.</param>
+    /// <param name="position">Position in the enclosing source text where the expression starts.</param>
+    /// <returns>The fragment.</returns>
+    public static InterpolationFragment FromExpression(string text, int position) => new(isExpression: true, text, position);
+}

--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -345,6 +345,9 @@ public sealed class Lexer
             case '"':
                 ReadString();
                 break;
+            case '`':
+                ReadRawString();
+                break;
             case '0':
             case '1':
             case '2':
@@ -473,6 +476,51 @@ public sealed class Lexer
         }
 
         kind = SyntaxKind.CommentToken;
+        value = sb.ToString();
+    }
+
+    private void ReadRawString()
+    {
+        // Backtick-delimited raw strings (Go-style). No escape processing,
+        // multi-line allowed, no interpolation. Embedded backticks are not
+        // representable; concatenate adjacent raw + interpreted literals to
+        // include one (matches Go's choice).
+        position++; // consume opening backtick
+
+        var sb = new StringBuilder();
+        var done = false;
+
+        while (!done)
+        {
+            switch (Current)
+            {
+                case '\0':
+                    var loc = new TextLocation(this.text, new TextSpan(start, position - start));
+                    Diagnostics.ReportUnterminatedString(loc);
+                    done = true;
+                    break;
+                case '`':
+                    position++;
+                    done = true;
+                    break;
+                case '\r':
+                    // Normalize CRLF and bare CR to LF inside raw strings, matching Go's spec.
+                    if (Lookahead == '\n')
+                    {
+                        position++;
+                    }
+
+                    sb.Append('\n');
+                    position++;
+                    break;
+                default:
+                    sb.Append(Current);
+                    position++;
+                    break;
+            }
+        }
+
+        kind = SyntaxKind.StringToken;
         value = sb.ToString();
     }
 

--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Text;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Text;
@@ -530,6 +532,7 @@ public sealed class Lexer
         position++;
 
         var sb = new StringBuilder();
+        List<InterpolationFragment> fragments = null;
         var done = false;
 
         while (!done)
@@ -556,6 +559,86 @@ public sealed class Lexer
                     }
 
                     break;
+                case '$':
+                    // `$$` escapes to a literal `$`. `$ident` and `${expr}`
+                    // open an interpolation segment; bare `$` followed by any
+                    // other character is treated as a literal `$` (forward-
+                    // compatible: future grammar may attach meaning to it).
+                    if (Lookahead == '$')
+                    {
+                        sb.Append('$');
+                        position += 2;
+                        break;
+                    }
+
+                    if (Lookahead == '{')
+                    {
+                        fragments ??= new List<InterpolationFragment>();
+                        if (sb.Length > 0)
+                        {
+                            fragments.Add(InterpolationFragment.FromText(sb.ToString()));
+                            sb.Clear();
+                        }
+
+                        position += 2; // consume '${'
+                        var exprStart = position;
+                        var depth = 1;
+                        while (depth > 0 && Current != '\0' && Current != '\r' && Current != '\n' && Current != '"')
+                        {
+                            if (Current == '{')
+                            {
+                                depth++;
+                            }
+                            else if (Current == '}')
+                            {
+                                depth--;
+                                if (depth == 0)
+                                {
+                                    break;
+                                }
+                            }
+
+                            position++;
+                        }
+
+                        if (depth != 0)
+                        {
+                            var loc = new TextLocation(this.text, new TextSpan(start, 1));
+                            Diagnostics.ReportUnterminatedString(loc);
+                            done = true;
+                            break;
+                        }
+
+                        var exprText = this.text.ToString(exprStart, position - exprStart);
+                        fragments.Add(InterpolationFragment.FromExpression(exprText, exprStart));
+                        position++; // consume '}'
+                        break;
+                    }
+
+                    if (char.IsLetter(Lookahead) || Lookahead == '_')
+                    {
+                        fragments ??= new List<InterpolationFragment>();
+                        if (sb.Length > 0)
+                        {
+                            fragments.Add(InterpolationFragment.FromText(sb.ToString()));
+                            sb.Clear();
+                        }
+
+                        position++; // consume '$'
+                        var idStart = position;
+                        while (char.IsLetterOrDigit(Current) || Current == '_')
+                        {
+                            position++;
+                        }
+
+                        var idText = this.text.ToString(idStart, position - idStart);
+                        fragments.Add(InterpolationFragment.FromExpression(idText, idStart));
+                        break;
+                    }
+
+                    sb.Append('$');
+                    position++;
+                    break;
                 default:
                     sb.Append(Current);
                     position++;
@@ -563,8 +646,21 @@ public sealed class Lexer
             }
         }
 
-        kind = SyntaxKind.StringToken;
-        value = sb.ToString();
+        if (fragments == null)
+        {
+            kind = SyntaxKind.StringToken;
+            value = sb.ToString();
+        }
+        else
+        {
+            if (sb.Length > 0)
+            {
+                fragments.Add(InterpolationFragment.FromText(sb.ToString()));
+            }
+
+            kind = SyntaxKind.InterpolatedStringToken;
+            value = fragments.ToImmutableArray();
+        }
     }
 
     private void ReadWhiteSpace()

--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -531,21 +531,105 @@ public sealed class Lexer
 
     private void ReadNumber()
     {
-        while (char.IsDigit(Current))
+        // Recognized forms (Go-inspired, with C#-style _ separators):
+        //   decimal   42, 1_000_000
+        //   hex       0x1F, 0X_FF, 0xDEAD_BEEF
+        //   octal     0o17, 0O_77  (Go also allows leading-zero octal; we require the prefix
+        //                            to avoid ambiguity with future float literals.)
+        //   binary    0b1010, 0B_1010_1010
+        // A trailing underscore, a leading underscore in the digit body, or a
+        // prefix with no digits is rejected as an invalid number.
+        var numberStart = position;
+        var radix = 10;
+        var digitsStart = position;
+
+        if (Current == '0' && (Lookahead == 'x' || Lookahead == 'X'))
         {
+            radix = 16;
+            position += 2;
+            digitsStart = position;
+        }
+        else if (Current == '0' && (Lookahead == 'o' || Lookahead == 'O'))
+        {
+            radix = 8;
+            position += 2;
+            digitsStart = position;
+        }
+        else if (Current == '0' && (Lookahead == 'b' || Lookahead == 'B'))
+        {
+            radix = 2;
+            position += 2;
+            digitsStart = position;
+        }
+
+        // Disallow leading underscore in a decimal literal (which is impossible
+        // here because the dispatcher only routes digits → ReadNumber, but kept
+        // explicit for clarity). Underscore IS allowed immediately after a
+        // base prefix per Go's spec (e.g., `0x_FF`).
+        bool sawDigit = false;
+        char last = '\0';
+        while (true)
+        {
+            var c = Current;
+            if (c == '_')
+            {
+                last = c;
+                position++;
+                continue;
+            }
+
+            if (!IsDigitForRadix(c, radix))
+            {
+                break;
+            }
+
+            sawDigit = true;
+            last = c;
             position++;
         }
 
-        var length = position - start;
-        var text = this.text.ToString(start, length);
-        if (!int.TryParse(text, out var value))
+        var length = position - numberStart;
+        var fullText = this.text.ToString(numberStart, length);
+
+        if (!sawDigit || last == '_')
         {
-            var location = new TextLocation(this.text, new TextSpan(start, length));
-            Diagnostics.ReportInvalidNumber(location, text, TypeSymbol.Int);
+            var loc = new TextLocation(this.text, new TextSpan(numberStart, length));
+            Diagnostics.ReportInvalidNumber(loc, fullText, TypeSymbol.Int);
+            this.value = 0;
+            kind = SyntaxKind.NumberToken;
+            return;
         }
 
-        this.value = value;
+        var digitText = this.text.ToString(digitsStart, position - digitsStart).Replace("_", string.Empty);
+
+        int parsed;
+        try
+        {
+            parsed = radix == 10
+                ? int.Parse(digitText, System.Globalization.CultureInfo.InvariantCulture)
+                : System.Convert.ToInt32(digitText, radix);
+        }
+        catch (System.Exception)
+        {
+            var loc = new TextLocation(this.text, new TextSpan(numberStart, length));
+            Diagnostics.ReportInvalidNumber(loc, fullText, TypeSymbol.Int);
+            parsed = 0;
+        }
+
+        this.value = parsed;
         kind = SyntaxKind.NumberToken;
+    }
+
+    private static bool IsDigitForRadix(char c, int radix)
+    {
+        return radix switch
+        {
+            2 => c >= '0' && c <= '1',
+            8 => c >= '0' && c <= '7',
+            10 => c >= '0' && c <= '9',
+            16 => (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'),
+            _ => false,
+        };
     }
 
     private void ReadIdentifierOrKeyword()

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -246,6 +246,7 @@ public class Parser
             case SyntaxKind.OpenBraceToken:
                 return ParseBlockStatement();
             case SyntaxKind.ConstKeyword:
+            case SyntaxKind.LetKeyword:
             case SyntaxKind.VarKeyword:
                 return ParseVariableDeclaration();
             case SyntaxKind.IfKeyword:
@@ -288,7 +289,20 @@ public class Parser
 
     private StatementSyntax ParseVariableDeclaration()
     {
-        var expected = Current.Kind == SyntaxKind.ConstKeyword ? SyntaxKind.ConstKeyword : SyntaxKind.VarKeyword;
+        SyntaxKind expected;
+        switch (Current.Kind)
+        {
+            case SyntaxKind.ConstKeyword:
+                expected = SyntaxKind.ConstKeyword;
+                break;
+            case SyntaxKind.LetKeyword:
+                expected = SyntaxKind.LetKeyword;
+                break;
+            default:
+                expected = SyntaxKind.VarKeyword;
+                break;
+        }
+
         var keyword = MatchToken(expected);
         var identifier = MatchToken(SyntaxKind.IdentifierToken);
         var typeClause = ParseOptionalTypeClause();

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -103,6 +103,17 @@ public class Parser
         while (Current.Kind == SyntaxKind.ImportKeyword)
         {
             var importKeyword = MatchToken(SyntaxKind.ImportKeyword);
+
+            // Detect the alias form: `import <ident> = <ident>(.<ident>)*`.
+            // Lookahead: if the next two tokens are IDENT '=', consume them as alias + equals.
+            SyntaxToken aliasIdentifier = null;
+            SyntaxToken equalsToken = null;
+            if (Current.Kind == SyntaxKind.IdentifierToken && Peek(1).Kind == SyntaxKind.EqualsToken)
+            {
+                aliasIdentifier = MatchToken(SyntaxKind.IdentifierToken);
+                equalsToken = MatchToken(SyntaxKind.EqualsToken);
+            }
+
             var identifiers = ImmutableArray.CreateBuilder<SyntaxToken>();
             identifiers.Add(MatchToken(SyntaxKind.IdentifierToken));
             while (Current.Kind == SyntaxKind.DotToken)
@@ -111,7 +122,7 @@ public class Parser
                 identifiers.Add(MatchToken(SyntaxKind.IdentifierToken));
             }
 
-            importsBuilder.Add(new ImportSyntax(syntaxTree, importKeyword, identifiers.ToImmutableArray()));
+            importsBuilder.Add(new ImportSyntax(syntaxTree, importKeyword, aliasIdentifier, equalsToken, identifiers.ToImmutableArray()));
         }
 
         return importsBuilder.ToImmutable();

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -468,6 +468,9 @@ public class Parser
             case SyntaxKind.StringToken:
                 return ParseStringLiteral();
 
+            case SyntaxKind.InterpolatedStringToken:
+                return ParseInterpolatedStringLiteral();
+
             case SyntaxKind.IdentifierToken:
             default:
                 return ParseNameOrCallExpression();
@@ -562,6 +565,53 @@ public class Parser
     {
         var stringToken = MatchToken(SyntaxKind.StringToken);
         return new LiteralExpressionSyntax(syntaxTree, stringToken);
+    }
+
+    private ExpressionSyntax ParseInterpolatedStringLiteral()
+    {
+        var token = MatchToken(SyntaxKind.InterpolatedStringToken);
+        var fragments = (ImmutableArray<InterpolationFragment>)token.Value;
+        var segments = ImmutableArray.CreateBuilder<InterpolatedStringSegment>(fragments.Length);
+        foreach (var fragment in fragments)
+        {
+            if (!fragment.IsExpression)
+            {
+                segments.Add(InterpolatedStringSegment.FromText(fragment.Text));
+                continue;
+            }
+
+            // Parse the captured expression source by spinning up a fresh
+            // parser; embedded expressions are independent of the outer parser
+            // state aside from sharing the same syntax tree.
+            var innerText = SourceText.From(fragment.Text);
+            var innerTree = SyntaxTree.Parse(innerText);
+            var innerExpression = ExtractFirstExpression(innerTree);
+            if (innerExpression == null)
+            {
+                // Fall back to a synthetic missing-name node anchored on the
+                // string token so binders still see a valid (error-producing)
+                // expression syntax.
+                var synthetic = new SyntaxToken(syntaxTree, SyntaxKind.IdentifierToken, token.Position, fragment.Text, null);
+                innerExpression = new NameExpressionSyntax(syntaxTree, synthetic);
+            }
+
+            segments.Add(InterpolatedStringSegment.FromExpression(innerExpression));
+        }
+
+        return new InterpolatedStringExpressionSyntax(syntaxTree, token, segments.ToImmutable());
+    }
+
+    private static ExpressionSyntax ExtractFirstExpression(SyntaxTree innerTree)
+    {
+        foreach (var member in innerTree.Root.Members)
+        {
+            if (member is GlobalStatementSyntax gs && gs.Statement is ExpressionStatementSyntax es)
+            {
+                return es.Expression;
+            }
+        }
+
+        return null;
     }
 
     private SyntaxToken Peek(int offset)

--- a/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -126,6 +126,8 @@ public static class SyntaxFacts
                 return SyntaxKind.ImportKeyword;
             case "interface":
                 return SyntaxKind.InterfaceKeyword;
+            case "let":
+                return SyntaxKind.LetKeyword;
             case "map":
                 return SyntaxKind.MapKeyword;
             case "package":
@@ -322,6 +324,8 @@ public static class SyntaxFacts
                 return "import";
             case SyntaxKind.InterfaceKeyword:
                 return "interface";
+            case SyntaxKind.LetKeyword:
+                return "let";
             case SyntaxKind.MapKeyword:
                 return "map";
             case SyntaxKind.PackageKeyword:

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -70,6 +70,7 @@ public enum SyntaxKind
 
     // Built-in type tokens
     StringToken,
+    InterpolatedStringToken,
     NumberToken,
 
     // Identifier tokens
@@ -114,6 +115,7 @@ public enum SyntaxKind
     BinaryExpression,
     ParenthesizedExpression,
     LiteralExpression,
+    InterpolatedStringExpression,
     NameExpression,
     CallExpression,
     AccessorExpression,

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -93,6 +93,7 @@ public enum SyntaxKind
     IfKeyword,
     ImportKeyword,
     InterfaceKeyword,
+    LetKeyword,
     MapKeyword,
     PackageKeyword,
     RangeKeyword,

--- a/test/Core.Tests/CodeAnalysis/Binding/ImplicitImportTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ImplicitImportTests.cs
@@ -1,0 +1,55 @@
+// <copyright file="ImplicitImportTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Phase 1.5: an implicit <c>import System</c> is seeded by default so common
+/// BCL types (Console, String, ...) resolve without an explicit import. The
+/// behaviour is opt-out via the <c>implicitSystemImport</c> parameter.
+/// </summary>
+public class ImplicitImportTests
+{
+    [Fact]
+    public void Console_Resolves_Without_Explicit_Import()
+    {
+        var diagnostics = Bind("func F() {\n Console.WriteLine(\"hi\")\n }\n", useImplicit: true);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Console_Does_Not_Resolve_When_Implicit_Disabled()
+    {
+        var diagnostics = Bind("func F() {\n Console.WriteLine(\"hi\")\n }\n", useImplicit: false);
+        Assert.NotEmpty(diagnostics);
+    }
+
+    [Fact]
+    public void Explicit_Import_Coexists_With_Implicit()
+    {
+        // Same import declared explicitly + implicitly must not error.
+        var diagnostics = Bind("import System\n\nfunc F() {\n Console.WriteLine(\"hi\")\n }\n", useImplicit: true);
+        Assert.Empty(diagnostics);
+    }
+
+    private static ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source, bool useImplicit)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), references: null, implicitSystemImport: useImplicit);
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/ImportAliasTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ImportAliasTests.cs
@@ -1,0 +1,67 @@
+// <copyright file="ImportAliasTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Phase 1.4: <c>import alias = path</c> introduces an alias for the imported
+/// namespace. Member access through the alias resolves to the same CLR types
+/// the un-aliased import would.
+/// </summary>
+public class ImportAliasTests
+{
+    [Fact]
+    public void Aliased_Import_Resolves_Through_Alias()
+    {
+        var diagnostics = Bind("import sys = System\n\nfunc F() {\n sys.Console.WriteLine(\"hi\")\n }\n");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Plain_Import_Still_Works()
+    {
+        var diagnostics = Bind("import System\n\nfunc F() {\n Console.WriteLine(\"hi\")\n }\n");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Alias_Symbol_Has_Distinct_Name_And_Target()
+    {
+        var tree = SyntaxTree.Parse(SourceText.From("import sys = System\n\nfunc F() {}\n"));
+        Assert.Empty(tree.Diagnostics);
+
+        var importSyntax = tree.Root.Members.OfType<ImportSyntax>().Single();
+        Assert.NotNull(importSyntax.AliasIdentifier);
+        Assert.Equal("sys", importSyntax.AliasIdentifier.Text);
+        Assert.Equal("System", importSyntax.Identifiers.Single().Text);
+    }
+
+    [Fact]
+    public void Aliased_Dotted_Path_Resolves()
+    {
+        var diagnostics = Bind("import io = System.IO\n\nfunc F() {\n io.Directory.GetCurrentDirectory()\n }\n");
+        Assert.Empty(diagnostics);
+    }
+
+    private static ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringTests.cs
@@ -1,0 +1,102 @@
+// <copyright file="InterpolatedStringTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Phase 1.1: string interpolation. <c>"$ident"</c> and <c>"${expr}"</c>
+/// inside an interpreted string literal are lowered by the binder to a
+/// chain of <c>+</c> concatenations over string-typed sub-expressions.
+/// Non-string expressions are wrapped in <c>.ToString()</c>. <c>$$</c>
+/// escapes to a literal <c>$</c>.
+/// </summary>
+public class InterpolatedStringTests
+{
+    [Fact]
+    public void Plain_String_Without_Dollar_Stays_StringToken()
+    {
+        var tokens = SyntaxTree.ParseTokens("\"hello\"").ToArray();
+        Assert.Equal(SyntaxKind.StringToken, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Dollar_Identifier_Produces_InterpolatedStringToken()
+    {
+        var tokens = SyntaxTree.ParseTokens("\"hi $name\"").ToArray();
+        Assert.Equal(SyntaxKind.InterpolatedStringToken, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Dollar_Brace_Produces_InterpolatedStringToken()
+    {
+        var tokens = SyntaxTree.ParseTokens("\"sum=${1 + 2}\"").ToArray();
+        Assert.Equal(SyntaxKind.InterpolatedStringToken, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Double_Dollar_Escapes_To_Literal()
+    {
+        var tokens = SyntaxTree.ParseTokens("\"$$cost\"").ToArray();
+        Assert.Equal(SyntaxKind.StringToken, tokens[0].Kind);
+        Assert.Equal("$cost", tokens[0].Value);
+    }
+
+    [Fact]
+    public void Interpolation_Of_String_Variable_Evaluates()
+    {
+        var source = "let name = \"world\"\nlet msg = \"hello $name\"\n";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        Assert.Equal("hello world", msg.Value);
+    }
+
+    [Fact]
+    public void Interpolation_Of_Int_Variable_Uses_ToString()
+    {
+        var source = "let n = 42\nlet msg = \"answer=$n\"\n";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        Assert.Equal("answer=42", msg.Value);
+    }
+
+    [Fact]
+    public void Brace_Interpolation_Of_Arithmetic()
+    {
+        var source = "let msg = \"sum=${1 + 2}\"\n";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        Assert.Equal("sum=3", msg.Value);
+    }
+
+    [Fact]
+    public void Multiple_Interpolations_Concatenate_In_Order()
+    {
+        var source = "let a = 1\nlet b = 2\nlet msg = \"$a + $b = ${a + b}\"\n";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        var msg = result.Variables.Single(kv => kv.Key.Name == "msg");
+        Assert.Equal("1 + 2 = 3", msg.Value);
+    }
+
+    private static (ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Diagnostics, System.Collections.Generic.Dictionary<VariableSymbol, object> Variables) Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var vars = new System.Collections.Generic.Dictionary<VariableSymbol, object>();
+        var result = compilation.Evaluate(vars);
+        return (result.Diagnostics, vars);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/LetKeywordTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/LetKeywordTests.cs
@@ -1,0 +1,58 @@
+// <copyright file="LetKeywordTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Phase 1.6: <c>let</c> introduces an immutable runtime binding. At the
+/// binder level it produces a <see cref="VariableSymbol"/> with
+/// <c>IsReadOnly == true</c>, indistinguishable from <c>const</c> in
+/// every check that gates assignment.
+/// </summary>
+public class LetKeywordTests
+{
+    [Fact]
+    public void Let_Binding_Is_ReadOnly()
+    {
+        var diagnostics = Bind("func F() { let x = 1\n }\n");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Assignment_To_Let_Binding_Reports_CannotAssign()
+    {
+        var diagnostics = Bind("func F() {\n let x = 1\n x = 2\n }\n");
+
+        Assert.Contains(
+            diagnostics,
+            d => d.Message.Contains("read-only", System.StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Let_Without_Initializer_Reports_Error()
+    {
+        var tree = SyntaxTree.Parse(SourceText.From("func F() {\n let x\n }\n"));
+        Assert.NotEmpty(tree.Diagnostics);
+    }
+
+    private static ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs
@@ -156,9 +156,43 @@ public class LexerTests
     [Fact]
     public void Lexes_BadCharacter_ReportsDiagnostic()
     {
-        SyntaxTree.ParseTokens("`", out var diagnostics);
+        // Backtick alone (without a closing backtick) is now an unterminated
+        // raw string per Phase 1.2, not a bad character. Use a character that
+        // remains unmapped to exercise the bad-character diagnostic.
+        SyntaxTree.ParseTokens("#", out var diagnostics);
         Assert.NotEmpty(diagnostics);
         Assert.Contains(diagnostics, d => d.Message.Contains("Bad character", System.StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("`hello`", "hello")]
+    [InlineData("``", "")]
+    [InlineData("`line1\nline2`", "line1\nline2")]
+    [InlineData("`no \\n escapes here`", "no \\n escapes here")]
+    [InlineData("`\"quoted\"`", "\"quoted\"")]
+    public void Lexes_RawStringLiteral(string text, string expectedValue)
+    {
+        var tokens = SyntaxTree.ParseTokens(text, out var diagnostics);
+        var token = Assert.Single(tokens);
+        Assert.Empty(diagnostics);
+        Assert.Equal(SyntaxKind.StringToken, token.Kind);
+        Assert.Equal(expectedValue, token.Value);
+    }
+
+    [Fact]
+    public void Lexes_RawString_NormalizesCRLF_To_LF()
+    {
+        var tokens = SyntaxTree.ParseTokens("`a\r\nb\rc`", out var diagnostics);
+        var token = Assert.Single(tokens);
+        Assert.Empty(diagnostics);
+        Assert.Equal("a\nb\nc", token.Value);
+    }
+
+    [Fact]
+    public void Lexes_UnterminatedRawString_ReportsDiagnostic()
+    {
+        SyntaxTree.ParseTokens("`unclosed", out var diagnostics);
+        Assert.Contains(diagnostics, d => d.Message.Contains("Unterminated string", System.StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs
@@ -98,6 +98,45 @@ public class LexerTests
         Assert.Equal(int.Parse(text), token.Value);
     }
 
+    [Theory]
+    [InlineData("0x1F", 31)]
+    [InlineData("0X_FF", 255)]
+    [InlineData("0xDEAD_BEEF", unchecked((int)0xDEADBEEFu))]
+    [InlineData("0o17", 15)]
+    [InlineData("0O_77", 63)]
+    [InlineData("0b1010", 10)]
+    [InlineData("0B_1010_1010", 0b10101010)]
+    [InlineData("1_000_000", 1_000_000)]
+    [InlineData("1_2_3", 123)]
+    public void Lexes_NumberLiteral_Variants(string text, int expected)
+    {
+        var tokens = SyntaxTree.ParseTokens(text, out var diagnostics);
+        var token = Assert.Single(tokens);
+        Assert.Empty(diagnostics);
+        Assert.Equal(SyntaxKind.NumberToken, token.Kind);
+        Assert.Equal(expected, token.Value);
+        Assert.Equal(text, token.Text);
+    }
+
+    [Theory]
+    [InlineData("_1")]   // bare leading underscore lexes as identifier, not a number — see Lexes_Identifier
+    [InlineData("1_")]   // trailing _ in a decimal literal is invalid per Go
+    [InlineData("0x_")]  // prefix without digits
+    [InlineData("0b")]   // prefix without digits
+    public void Invalid_NumberLiteral_Reports_Diagnostic(string text)
+    {
+        SyntaxTree.ParseTokens(text, out var diagnostics);
+        if (text == "_1")
+        {
+            // Not actually a number — verify it isn't silently consumed as one.
+            Assert.DoesNotContain(diagnostics, d => d.Message.Contains("number", System.StringComparison.OrdinalIgnoreCase));
+        }
+        else
+        {
+            Assert.Contains(diagnostics, d => d.Message.Contains("number", System.StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
     [Fact]
     public void Lexes_StringLiteral()
     {

--- a/test/Core.Tests/CodeAnalysis/Syntax/UnicodeIdentifierTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/UnicodeIdentifierTests.cs
@@ -1,0 +1,73 @@
+// <copyright file="UnicodeIdentifierTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Phase 1.7: identifiers follow Go's Unicode-letter rules.
+/// <list type="bullet">
+///   <item>Start: Unicode letter (categories Lu/Ll/Lt/Lm/Lo/Nl) or '_'.</item>
+///   <item>Continue: Unicode letter, decimal digit (Nd), or '_'.</item>
+/// </list>
+/// .NET's <c>char.IsLetter</c> / <c>char.IsLetterOrDigit</c> are
+/// Unicode-aware, so this is a verification + policy test set.
+/// </summary>
+public class UnicodeIdentifierTests
+{
+    [Theory]
+    [InlineData("café")]
+    [InlineData("π")]
+    [InlineData("日本語")]
+    [InlineData("Москва")]
+    [InlineData("Δx")]
+    [InlineData("naïve")]
+    [InlineData("_underscore")]
+    [InlineData("α2β")]
+    public void Lexes_Unicode_Identifier_As_Single_Token(string identifier)
+    {
+        var tokens = SyntaxTree.ParseTokens(identifier).ToArray();
+
+        Assert.Single(tokens);
+        Assert.Equal(SyntaxKind.IdentifierToken, tokens[0].Kind);
+        Assert.Equal(identifier, tokens[0].Text);
+    }
+
+    [Fact]
+    public void Identifier_Cannot_Start_With_Digit()
+    {
+        var tokens = SyntaxTree.ParseTokens("2π").ToArray();
+        Assert.Equal(2, tokens.Length);
+        Assert.Equal(SyntaxKind.NumberToken, tokens[0].Kind);
+        Assert.Equal(SyntaxKind.IdentifierToken, tokens[1].Kind);
+        Assert.Equal("π", tokens[1].Text);
+    }
+
+    [Fact]
+    public void Unicode_Identifier_Binds_Correctly()
+    {
+        var source = "func F() {\n let π = 3\n let twoπ = π + π\n }\n";
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    private static ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -61,6 +61,8 @@ IfStatement
 ImportDeclaration
 ImportKeyword
 InterfaceKeyword
+InterpolatedStringExpression
+InterpolatedStringToken
 LeftArrowToken
 LessOrEqualsToken
 LessToken

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -64,6 +64,7 @@ InterfaceKeyword
 LeftArrowToken
 LessOrEqualsToken
 LessToken
+LetKeyword
 LiteralExpression
 MapKeyword
 MinusEqualsToken


### PR DESCRIPTION
Closes Phase 1 of the GSharp execution plan (`~/gsharp-execution-plan.md` §1; issue #52). Eight lexical work items, eight commits, all green.

## Work items shipped

| # | Title | Notes |
|---|---|---|
| 1.2 | Backtick raw string literals | Verbatim, multi-line, CRLF/CR→LF normalized. |
| 1.3 | Numeric literal variants | `0x` / `0o` / `0b` plus `_` digit separators. Decimal `int.Parse`; non-decimal via `Convert.ToInt32(radix)`. Underscore allowed after prefix; rejected as trailing or as sole digit. |
| 1.6 | `let` keyword | Immutable runtime binding; binder treats `let` identically to `const` for the readonly check. |
| 1.4 | Import aliases | `import sys = System`; `ImportSymbol` gains `Target`/`IsAlias`; accessor binder consumes a leading import segment to compose `<Target>.<TypeName>`. |
| 1.5 | Implicit `import System` | On by default; `Compilation.ImplicitSystemImport` and gsc `/noimplicitimports` opt-out. Coexists harmlessly with an explicit `import System`. |
| 1.7 | Unicode identifier rules | `char.IsLetter` was already Unicode-aware; this commit pins the policy down with 10 tests (`café`, `π`, `日本語`, `Москва`, `Δx`, `α2β`, …) and ships `docs/lexical.md` as the authoritative spec. |
| 1.1 | String interpolation | Kotlin-style `$ident` / `${expr}` inside `"…"`; `$$` escapes a literal `$`. Lowered in the binder to a `+`-chain over `Convert.ToString(<T>)`. `samples/Loop.gs` updated to use `"Count value: $i"` per the Phase 1 exit criterion. |
| 1.8 | ADRs 0011 + 0012 | Sub-spec ADR for interpolation grammar/lowering choices; ADR for the backtick raw-string delimiter choice. |

## Notable design choices recorded as ADRs

- **`$$` for literal `$`** (ADR-0011) over the ADR-0007 sketch of `\$`, because GSharp double-quoted strings have no other backslash escapes today.
- **Lower interpolation via `System.Convert.ToString`** (ADR-0011) instead of instance `.ToString()`. The current emitter uses `Call` rather than `Callvirt`/`constrained.`, which crashes on value-type instance dispatch. `Convert.ToString` sidesteps this with a static overload set covering every primitive plus `object`. Revisit in Phase 2.
- **Backtick raw strings** (ADR-0012) match Go exactly; embedded-backtick limitation accepted (Go's accepted trade-off).
- **Brace-scan inside `${…}` is not string-literal aware** (ADR-0011 §Consequences). `${"x"}` is rejected. Fixing requires a real sub-lexer; acceptable Phase 1 trade-off.

## Test results

| Suite | Count |
|---|---|
| Core | 136 |
| Sdk | 9 |
| Interpreter | 8 |
| Compiler (incl. sample conformance) | 15 |
| LanguageServer | 6 |
| **Total** | **174 passing, 0 failing** |

New sample conformance fixtures auto-discovered: `RawString.gs`, `ImportAlias.gs`, `ImplicitImport.gs`, `InterpolatedString.gs`. `Loop.gs` updated to use interpolation; `Loop.golden` updated to match.

## Files touched

- Lexer/Parser/Binder for each work item — see commit messages for line-level detail.
- New syntax: `InterpolatedStringExpressionSyntax`, `InterpolatedStringSegment`, `InterpolationFragment`.
- New docs: `docs/lexical.md`, `docs/adr/0011-string-interpolation-grammar.md`, `docs/adr/0012-raw-string-delimiter.md`.
- Coverage matrix golden + `docs/coverage-matrix.md` regenerated.

## Out of scope (deferred to later phases)

- Backslash escape sequences in interpreted strings (`\n`, `\t`, …) — see ADR-0011.
- String literals inside `${…}` interpolation — see ADR-0011 §Consequences.
- Constrained-call / instance-dispatch emit support for value-type members (Phase 2).
- Format specifiers `${expr:N2}` — deferred per ADR-0007.
- C# 11-style triple-quote raw strings — see ADR-0012 §Alternatives.

Ready for review. Will wait for merge signal before starting Phase 2.
