### PR TITLE
Phase 4 part 2: tuples, multi-return, deconstruction

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1161,6 +1161,30 @@ public sealed class Binder
             return null;
         }
 
+        if (syntax.IsTuple)
+        {
+            // Phase 4.5: tuple type clause `(T1, T2, ...)`.
+            if (syntax.TupleElements.Count < 2)
+            {
+                Diagnostics.ReportUnexpectedToken(syntax.CloseParenToken.Location, syntax.CloseParenToken.Kind, SyntaxKind.IdentifierToken);
+                return null;
+            }
+
+            var elements = ImmutableArray.CreateBuilder<TypeSymbol>(syntax.TupleElements.Count);
+            for (var i = 0; i < syntax.TupleElements.Count; i++)
+            {
+                var elementType = BindTypeClause(syntax.TupleElements[i]);
+                if (elementType == null)
+                {
+                    return null;
+                }
+
+                elements.Add(elementType);
+            }
+
+            return TupleTypeSymbol.Get(elements.MoveToImmutable());
+        }
+
         var element = LookupType(syntax.Identifier.Text);
         if (element == null)
         {
@@ -1809,6 +1833,8 @@ public sealed class Binder
                 return BindIndexAssignmentExpression((IndexAssignmentExpressionSyntax)syntax);
             case SyntaxKind.StructLiteralExpression:
                 return BindStructLiteralExpression((StructLiteralExpressionSyntax)syntax);
+            case SyntaxKind.TupleLiteralExpression:
+                return BindTupleLiteralExpression((TupleLiteralExpressionSyntax)syntax);
             case SyntaxKind.FieldAssignmentExpression:
                 return BindFieldAssignmentExpression((FieldAssignmentExpressionSyntax)syntax);
             default:
@@ -2096,6 +2122,28 @@ public sealed class Binder
         }
 
         return new BoundStructLiteralExpression(structSymbol, inits.ToImmutable());
+    }
+
+    private BoundExpression BindTupleLiteralExpression(TupleLiteralExpressionSyntax syntax)
+    {
+        // Phase 4.5: bind each element expression, derive the tuple type from
+        // their static types, and produce a BoundTupleLiteralExpression.
+        var bound = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Elements.Count);
+        var elementTypes = ImmutableArray.CreateBuilder<TypeSymbol>(syntax.Elements.Count);
+        foreach (var e in syntax.Elements)
+        {
+            var be = BindExpression(e);
+            if (be.Type == TypeSymbol.Error)
+            {
+                return new BoundErrorExpression();
+            }
+
+            bound.Add(be);
+            elementTypes.Add(be.Type);
+        }
+
+        var tupleType = TupleTypeSymbol.Get(elementTypes.MoveToImmutable());
+        return new BoundTupleLiteralExpression(tupleType, bound.MoveToImmutable());
     }
 
     private BoundExpression BindFieldAssignmentExpression(FieldAssignmentExpressionSyntax syntax)
@@ -2876,6 +2924,20 @@ public sealed class Binder
                     }
 
                     Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
+                }
+                else if (receiver != null && receiver.Type is TupleTypeSymbol tupleSym)
+                {
+                    // Phase 4.5: tuple element access via Item1..ItemN.
+                    var memberName = ne.IdentifierToken.Text;
+                    if (memberName.StartsWith("Item", System.StringComparison.Ordinal)
+                        && int.TryParse(memberName.Substring(4), out var oneBased)
+                        && oneBased >= 1 && oneBased <= tupleSym.Arity)
+                    {
+                        return new BoundTupleElementAccessExpression(receiver, tupleSym, oneBased - 1);
+                    }
+
+                    Diagnostics.ReportUnableToFindMember(ne.Location, memberName);
+                    return new BoundErrorExpression();
                 }
                 else
                 {

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -26,6 +26,7 @@ public sealed class Binder
     private Stack<(BoundLabel BreakLabel, BoundLabel ContinueLabel)> loopStack = new Stack<(BoundLabel BreakLabel, BoundLabel ContinueLabel)>();
     private int labelCounter;
     private int nullConditionalCaptureCounter;
+    private int syntheticLocalCounter;
     private List<Dictionary<VariableSymbol, TypeSymbol>> narrowedVariables = new List<Dictionary<VariableSymbol, TypeSymbol>>();
     private Dictionary<string, TypeParameterSymbol> currentTypeParameters;
     private BoundScope scope;
@@ -1054,6 +1055,8 @@ public sealed class Binder
                 return BindThrowStatement((ThrowStatementSyntax)syntax);
             case SyntaxKind.UsingStatement:
                 return BindUsingStatement((UsingStatementSyntax)syntax);
+            case SyntaxKind.TupleDeconstructionStatement:
+                return BindTupleDeconstructionStatement((TupleDeconstructionStatementSyntax)syntax);
             default:
                 throw new Exception($"Unexpected syntax {syntax.Kind}");
         }
@@ -1152,6 +1155,48 @@ public sealed class Binder
         var convertedInitializer = BindConversion(syntax.Initializer.Location, initializer, variableType);
 
         return new BoundVariableDeclaration(variable, convertedInitializer);
+    }
+
+    private BoundStatement BindTupleDeconstructionStatement(TupleDeconstructionStatementSyntax syntax)
+    {
+        // Phase 4.5: `let (a, b, ...) = expr`. Evaluate the RHS into a single
+        // synthetic readonly local (preserving single-eval semantics), then
+        // declare each named identifier as `let xi = temp.ItemI+1`.
+        var initializer = BindExpression(syntax.Initializer);
+        if (initializer.Type == TypeSymbol.Error)
+        {
+            return new BoundExpressionStatement(initializer);
+        }
+
+        if (!(initializer.Type is TupleTypeSymbol tupleType))
+        {
+            Diagnostics.ReportUnexpectedToken(syntax.OpenParenToken.Location, syntax.OpenParenToken.Kind, SyntaxKind.IdentifierToken);
+            return new BoundExpressionStatement(new BoundErrorExpression());
+        }
+
+        if (syntax.Identifiers.Count != tupleType.Arity)
+        {
+            Diagnostics.ReportUnexpectedToken(syntax.CloseParenToken.Location, syntax.CloseParenToken.Kind, SyntaxKind.IdentifierToken);
+            return new BoundExpressionStatement(new BoundErrorExpression());
+        }
+
+        var tempName = $"<tuple{System.Threading.Interlocked.Increment(ref syntheticLocalCounter)}>";
+        var tempVar = new LocalVariableSymbol(tempName, isReadOnly: true, tupleType);
+        scope.TryDeclareVariable(tempVar);
+
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        statements.Add(new BoundVariableDeclaration(tempVar, initializer));
+
+        for (var i = 0; i < syntax.Identifiers.Count; i++)
+        {
+            var idTok = syntax.Identifiers[i];
+            var elemType = tupleType.ElementTypes[i];
+            var elemVar = BindVariableDeclaration(idTok, isReadOnly: true, elemType);
+            var access = new BoundTupleElementAccessExpression(new BoundVariableExpression(tempVar), tupleType, i);
+            statements.Add(new BoundVariableDeclaration(elemVar, access));
+        }
+
+        return new BoundBlockStatement(statements.ToImmutable());
     }
 
     private TypeSymbol BindNonNullableTypeClause(TypeClauseSyntax syntax)

--- a/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -50,6 +50,8 @@ public enum BoundNodeKind
     FieldAccessExpression,
     FieldAssignmentExpression,
     NullConditionalAccessExpression,
+    TupleLiteralExpression,
+    TupleElementAccessExpression,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -144,6 +144,12 @@ public static class BoundNodePrinter
             case BoundNodeKind.NullConditionalAccessExpression:
                 WriteNullConditionalAccessExpression((BoundNullConditionalAccessExpression)node, writer);
                 break;
+            case BoundNodeKind.TupleLiteralExpression:
+                WriteTupleLiteralExpression((BoundTupleLiteralExpression)node, writer);
+                break;
+            case BoundNodeKind.TupleElementAccessExpression:
+                WriteTupleElementAccessExpression((BoundTupleElementAccessExpression)node, writer);
+                break;
             default:
                 throw new Exception($"Unexpected node {node.Kind}");
         }
@@ -674,5 +680,29 @@ public static class BoundNodePrinter
         node.Receiver.WriteTo(writer);
         writer.WritePunctuation(SyntaxKind.QuestionDotToken);
         node.WhenNotNull.WriteTo(writer);
+    }
+
+    private static void WriteTupleLiteralExpression(BoundTupleLiteralExpression node, IndentedTextWriter writer)
+    {
+        writer.WritePunctuation(SyntaxKind.OpenParenthesisToken);
+        for (var i = 0; i < node.Elements.Length; i++)
+        {
+            if (i > 0)
+            {
+                writer.WritePunctuation(SyntaxKind.CommaToken);
+                writer.WriteSpace();
+            }
+
+            node.Elements[i].WriteTo(writer);
+        }
+
+        writer.WritePunctuation(SyntaxKind.CloseParenthesisToken);
+    }
+
+    private static void WriteTupleElementAccessExpression(BoundTupleElementAccessExpression node, IndentedTextWriter writer)
+    {
+        node.Receiver.WriteTo(writer);
+        writer.WritePunctuation(SyntaxKind.DotToken);
+        writer.WriteIdentifier($"Item{node.Index + 1}");
     }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -330,6 +330,10 @@ public abstract class BoundTreeRewriter
                 return RewriteFieldAssignmentExpression((BoundFieldAssignmentExpression)node);
             case BoundNodeKind.NullConditionalAccessExpression:
                 return RewriteNullConditionalAccessExpression((BoundNullConditionalAccessExpression)node);
+            case BoundNodeKind.TupleLiteralExpression:
+                return RewriteTupleLiteralExpression((BoundTupleLiteralExpression)node);
+            case BoundNodeKind.TupleElementAccessExpression:
+                return RewriteTupleElementAccessExpression((BoundTupleElementAccessExpression)node);
             default:
                 throw new Exception($"Unexpected node: {node.Kind}");
         }
@@ -761,5 +765,39 @@ public abstract class BoundTreeRewriter
         }
 
         return new BoundNullConditionalAccessExpression(receiver, node.Capture, whenNotNull, node.Type);
+    }
+
+    /// <summary>Rewrites a tuple literal (Phase 4.5).</summary>
+    /// <param name="node">The node to rewrite.</param>
+    /// <returns>The rewritten node.</returns>
+    protected virtual BoundExpression RewriteTupleLiteralExpression(BoundTupleLiteralExpression node)
+    {
+        System.Collections.Immutable.ImmutableArray<BoundExpression>.Builder builder = null;
+        for (var i = 0; i < node.Elements.Length; i++)
+        {
+            var oldEl = node.Elements[i];
+            var newEl = RewriteExpression(oldEl);
+            if (newEl != oldEl && builder == null)
+            {
+                builder = System.Collections.Immutable.ImmutableArray.CreateBuilder<BoundExpression>(node.Elements.Length);
+                for (var j = 0; j < i; j++)
+                {
+                    builder.Add(node.Elements[j]);
+                }
+            }
+
+            builder?.Add(newEl);
+        }
+
+        return builder == null ? node : new BoundTupleLiteralExpression(node.TupleType, builder.ToImmutable());
+    }
+
+    /// <summary>Rewrites a tuple element access (Phase 4.5).</summary>
+    /// <param name="node">The node to rewrite.</param>
+    /// <returns>The rewritten node.</returns>
+    protected virtual BoundExpression RewriteTupleElementAccessExpression(BoundTupleElementAccessExpression node)
+    {
+        var receiver = RewriteExpression(node.Receiver);
+        return receiver == node.Receiver ? node : new BoundTupleElementAccessExpression(receiver, node.TupleType, node.Index);
     }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundTupleElementAccessExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTupleElementAccessExpression.cs
@@ -1,0 +1,33 @@
+// <copyright file="BoundTupleElementAccessExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Symbols;
+
+#pragma warning disable CS1591
+#pragma warning disable SA1600
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Access to a tuple element by 1-based <c>ItemN</c> name (Phase 4.5).
+/// </summary>
+public sealed class BoundTupleElementAccessExpression : BoundExpression
+{
+    public BoundTupleElementAccessExpression(BoundExpression receiver, TupleTypeSymbol tupleType, int index)
+    {
+        Receiver = receiver;
+        TupleType = tupleType;
+        Index = index;
+    }
+
+    public BoundExpression Receiver { get; }
+
+    public TupleTypeSymbol TupleType { get; }
+
+    public int Index { get; }
+
+    public override TypeSymbol Type => TupleType.ElementTypes[Index];
+
+    public override BoundNodeKind Kind => BoundNodeKind.TupleElementAccessExpression;
+}

--- a/src/Core/CodeAnalysis/Binding/BoundTupleLiteralExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTupleLiteralExpression.cs
@@ -1,0 +1,34 @@
+// <copyright file="BoundTupleLiteralExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+#pragma warning disable CS1591
+#pragma warning disable SA1600
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// A tuple literal expression <c>(e1, e2, ...)</c> bound to a
+/// <see cref="TupleTypeSymbol"/>. Element conversions are applied at bind
+/// time so the contained <see cref="Elements"/> already match the tuple's
+/// element types.
+/// </summary>
+public sealed class BoundTupleLiteralExpression : BoundExpression
+{
+    public BoundTupleLiteralExpression(TupleTypeSymbol tupleType, ImmutableArray<BoundExpression> elements)
+    {
+        TupleType = tupleType;
+        Elements = elements;
+    }
+
+    public TupleTypeSymbol TupleType { get; }
+
+    public ImmutableArray<BoundExpression> Elements { get; }
+
+    public override TypeSymbol Type => TupleType;
+
+    public override BoundNodeKind Kind => BoundNodeKind.TupleLiteralExpression;
+}

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -205,6 +205,8 @@ public sealed class Evaluator
                 BoundNodeKind.FieldAccessExpression => EvaluateFieldAccessExpression((BoundFieldAccessExpression)node),
                 BoundNodeKind.FieldAssignmentExpression => EvaluateFieldAssignmentExpression((BoundFieldAssignmentExpression)node),
                 BoundNodeKind.NullConditionalAccessExpression => EvaluateNullConditionalAccessExpression((BoundNullConditionalAccessExpression)node),
+                BoundNodeKind.TupleLiteralExpression => EvaluateTupleLiteralExpression((BoundTupleLiteralExpression)node),
+                BoundNodeKind.TupleElementAccessExpression => EvaluateTupleElementAccessExpression((BoundTupleElementAccessExpression)node),
                 _ => throw new EvaluatorException($"Unexpected node {node.Kind}", node),
             };
         }
@@ -323,6 +325,43 @@ public sealed class Evaluator
         }
 
         return sv;
+    }
+
+    private object EvaluateTupleLiteralExpression(BoundTupleLiteralExpression node)
+    {
+        // Phase 4.5: build a CLR ValueTuple instance when an arity is supported,
+        // else materialise as an object[] (interpreter-only fallback).
+        var values = new object[node.Elements.Length];
+        for (var i = 0; i < node.Elements.Length; i++)
+        {
+            values[i] = EvaluateExpression(node.Elements[i]);
+        }
+
+        var clrType = node.TupleType.ClrType;
+        if (clrType != null)
+        {
+            return System.Activator.CreateInstance(clrType, values);
+        }
+
+        return values;
+    }
+
+    private object EvaluateTupleElementAccessExpression(BoundTupleElementAccessExpression node)
+    {
+        var receiver = EvaluateExpression(node.Receiver);
+        if (receiver == null)
+        {
+            throw new EvaluatorException("Attempted to access an element of a null tuple.", node);
+        }
+
+        if (receiver is object[] arr)
+        {
+            return arr[node.Index];
+        }
+
+        var fieldName = $"Item{node.Index + 1}";
+        var field = receiver.GetType().GetField(fieldName);
+        return field.GetValue(receiver);
     }
 
     private object EvaluateConstructorCallExpression(BoundConstructorCallExpression node)

--- a/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
@@ -1,0 +1,89 @@
+// <copyright file="TupleTypeSymbol.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Represents a tuple type <c>(T1, T2, ...)</c> (Phase 4.5).
+/// </summary>
+/// <remarks>
+/// Backed by the CLR <c>System.ValueTuple&lt;...&gt;</c> family. Instances are
+/// cached per element-type sequence so identical tuple types compare by
+/// reference. The CLR backing type is only set for tuple arities 1–8 (the
+/// generic ValueTuple shapes shipped in the BCL); higher arities currently
+/// have a <c>null</c> ClrType and are interpreter-only.
+/// </remarks>
+public sealed class TupleTypeSymbol : TypeSymbol
+{
+    private static readonly ConcurrentDictionary<string, TupleTypeSymbol> Cache = new();
+
+    private TupleTypeSymbol(ImmutableArray<TypeSymbol> elementTypes)
+        : base(BuildName(elementTypes), BuildClrType(elementTypes))
+    {
+        ElementTypes = elementTypes;
+    }
+
+    /// <summary>Gets the tuple element types in declaration order.</summary>
+    public ImmutableArray<TypeSymbol> ElementTypes { get; }
+
+    /// <summary>Gets the arity of the tuple.</summary>
+    public int Arity => ElementTypes.Length;
+
+    /// <summary>Returns the cached <see cref="TupleTypeSymbol"/> for the given element types.</summary>
+    /// <param name="elementTypes">The element types in order.</param>
+    /// <returns>The (cached) tuple type symbol.</returns>
+    public static TupleTypeSymbol Get(ImmutableArray<TypeSymbol> elementTypes)
+    {
+        if (elementTypes.IsDefaultOrEmpty || elementTypes.Length < 2)
+        {
+            throw new ArgumentException("Tuples must have at least two element types.", nameof(elementTypes));
+        }
+
+        var key = BuildName(elementTypes);
+        return Cache.GetOrAdd(key, _ => new TupleTypeSymbol(elementTypes));
+    }
+
+    private static string BuildName(ImmutableArray<TypeSymbol> elementTypes)
+    {
+        var sb = new StringBuilder("(");
+        for (var i = 0; i < elementTypes.Length; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(", ");
+            }
+
+            sb.Append(elementTypes[i].Name);
+        }
+
+        sb.Append(')');
+        return sb.ToString();
+    }
+
+    private static Type BuildClrType(ImmutableArray<TypeSymbol> elementTypes)
+    {
+        if (elementTypes.Any(t => t.ClrType == null))
+        {
+            return null;
+        }
+
+        var clrTypes = elementTypes.Select(t => t.ClrType).ToArray();
+        switch (clrTypes.Length)
+        {
+            case 2: return typeof(ValueTuple<,>).MakeGenericType(clrTypes);
+            case 3: return typeof(ValueTuple<,,>).MakeGenericType(clrTypes);
+            case 4: return typeof(ValueTuple<,,,>).MakeGenericType(clrTypes);
+            case 5: return typeof(ValueTuple<,,,,>).MakeGenericType(clrTypes);
+            case 6: return typeof(ValueTuple<,,,,,>).MakeGenericType(clrTypes);
+            case 7: return typeof(ValueTuple<,,,,,,>).MakeGenericType(clrTypes);
+            default: return null;
+        }
+    }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -772,6 +772,11 @@ public class Parser
 
     private TypeClauseSyntax ParseTypeClause()
     {
+        if (Current.Kind == SyntaxKind.OpenParenthesisToken)
+        {
+            return ParseTupleTypeClause();
+        }
+
         if (Current.Kind == SyntaxKind.OpenSquareBracketToken)
         {
             var openBracket = MatchToken(SyntaxKind.OpenSquareBracketToken);
@@ -792,10 +797,44 @@ public class Parser
         return new TypeClauseSyntax(syntaxTree, openBracketToken: null, lengthToken: null, closeBracketToken: null, identifier, question);
     }
 
+    private TypeClauseSyntax ParseTupleTypeClause()
+    {
+        // Phase 4.5: tuple type clause `(T1, T2, ...)` with optional trailing `?`.
+        var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
+        var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+
+        var parseNext = true;
+        while (parseNext &&
+               Current.Kind != SyntaxKind.CloseParenthesisToken &&
+               Current.Kind != SyntaxKind.EndOfFileToken)
+        {
+            nodesAndSeparators.Add(ParseTypeClause());
+
+            if (Current.Kind == SyntaxKind.CommaToken)
+            {
+                nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
+            }
+            else
+            {
+                parseNext = false;
+            }
+        }
+
+        var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+        var question = Current.Kind == SyntaxKind.QuestionToken ? MatchToken(SyntaxKind.QuestionToken) : null;
+        return new TypeClauseSyntax(
+            syntaxTree,
+            openParen,
+            new SeparatedSyntaxList<TypeClauseSyntax>(nodesAndSeparators.ToImmutable()),
+            closeParen,
+            question);
+    }
+
     private TypeClauseSyntax ParseOptionalTypeClause()
     {
         if (Current.Kind != SyntaxKind.IdentifierToken &&
-            Current.Kind != SyntaxKind.OpenSquareBracketToken)
+            Current.Kind != SyntaxKind.OpenSquareBracketToken &&
+            Current.Kind != SyntaxKind.OpenParenthesisToken)
         {
             return null;
         }
@@ -1944,6 +1983,29 @@ public class Parser
     {
         var left = MatchToken(SyntaxKind.OpenParenthesisToken);
         var expression = ParseExpression();
+
+        // Phase 4.5: `(a, b, ...)` is a tuple literal. Detection is purely
+        // post-fix: parse the first expression, then if a comma follows we
+        // collect the remaining tuple elements; otherwise this is a regular
+        // parenthesized expression.
+        if (Current.Kind == SyntaxKind.CommaToken)
+        {
+            var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+            nodesAndSeparators.Add(expression);
+            while (Current.Kind == SyntaxKind.CommaToken)
+            {
+                nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
+                nodesAndSeparators.Add(ParseExpression());
+            }
+
+            var rightParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+            return new TupleLiteralExpressionSyntax(
+                syntaxTree,
+                left,
+                new SeparatedSyntaxList<ExpressionSyntax>(nodesAndSeparators.ToImmutable()),
+                rightParen);
+        }
+
         var right = MatchToken(SyntaxKind.CloseParenthesisToken);
         return new ParenthesizedExpressionSyntax(syntaxTree, left, expression, right);
     }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -1066,6 +1066,29 @@ public class Parser
         }
 
         var keyword = MatchToken(expected);
+
+        // Phase 4.5: `let (a, b, ...) = expr` deconstructs a tuple-typed
+        // initializer. The opening paren must come *directly* after the
+        // keyword: an explicit type clause or identifier always starts with
+        // an identifier, so this is unambiguous.
+        if (expected == SyntaxKind.LetKeyword && Current.Kind == SyntaxKind.OpenParenthesisToken)
+        {
+            var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
+            var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+            nodesAndSeparators.Add(MatchToken(SyntaxKind.IdentifierToken));
+            while (Current.Kind == SyntaxKind.CommaToken)
+            {
+                nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
+                nodesAndSeparators.Add(MatchToken(SyntaxKind.IdentifierToken));
+            }
+
+            var idents = new SeparatedSyntaxList<SyntaxToken>(nodesAndSeparators.ToImmutable());
+            var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+            var equalsTok = MatchToken(SyntaxKind.EqualsToken);
+            var init = ParseExpression();
+            return new TupleDeconstructionStatementSyntax(syntaxTree, keyword, openParen, idents, closeParen, equalsTok, init);
+        }
+
         var identifier = MatchToken(SyntaxKind.IdentifierToken);
         var typeClause = ParseOptionalTypeClause();
         var equals = MatchToken(SyntaxKind.EqualsToken);
@@ -1342,7 +1365,31 @@ public class Parser
         var currentLine = syntaxTree.Text.GetLineIndex(Current.Span.Start);
         var isEof = Current.Kind == SyntaxKind.EndOfFileToken;
         var sameLine = !isEof && keywordLine == currentLine;
-        var expression = sameLine ? ParseExpression() : null;
+        ExpressionSyntax expression = null;
+        if (sameLine)
+        {
+            expression = ParseExpression();
+
+            // Phase 4.6: multi-return support. `return e1, e2, ...` lowers to
+            // returning a tuple literal so callers can deconstruct or bind it
+            // through the standard tuple machinery.
+            if (Current.Kind == SyntaxKind.CommaToken)
+            {
+                var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+                nodesAndSeparators.Add(expression);
+                var syntheticOpen = new SyntaxToken(syntaxTree, SyntaxKind.OpenParenthesisToken, keyword.Position, null, null);
+                while (Current.Kind == SyntaxKind.CommaToken)
+                {
+                    nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
+                    nodesAndSeparators.Add(ParseExpression());
+                }
+
+                var syntheticClose = new SyntaxToken(syntaxTree, SyntaxKind.CloseParenthesisToken, Current.Position, null, null);
+                var elements = new SeparatedSyntaxList<ExpressionSyntax>(nodesAndSeparators.ToImmutable());
+                expression = new TupleLiteralExpressionSyntax(syntaxTree, syntheticOpen, elements, syntheticClose);
+            }
+        }
+
         return new ReturnStatementSyntax(syntaxTree, keyword, expression);
     }
 

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -174,6 +174,7 @@ public enum SyntaxKind
     FieldInitializer,
     FieldAccessExpression,
     FieldAssignmentExpression,
+    TupleLiteralExpression,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -175,6 +175,7 @@ public enum SyntaxKind
     FieldAccessExpression,
     FieldAssignmentExpression,
     TupleLiteralExpression,
+    TupleDeconstructionStatement,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/src/Core/CodeAnalysis/Syntax/SyntaxNode.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxNode.cs
@@ -74,6 +74,11 @@ public abstract class SyntaxNode
             else if (typeof(SeparatedSyntaxList).IsAssignableFrom(property.PropertyType))
             {
                 var separatedSyntaxList = (SeparatedSyntaxList)property.GetValue(this);
+                if (separatedSyntaxList == null)
+                {
+                    continue;
+                }
+
                 foreach (var child in separatedSyntaxList.GetWithSeparators())
                 {
                     yield return child;

--- a/src/Core/CodeAnalysis/Syntax/TupleDeconstructionStatementSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TupleDeconstructionStatementSyntax.cs
@@ -1,0 +1,60 @@
+// <copyright file="TupleDeconstructionStatementSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// A tuple deconstruction declaration <c>let (a, b, ...) = expr</c> (Phase 4.5).
+/// Each identifier becomes an immutable local bound to the corresponding tuple
+/// element of the right-hand-side initializer.
+/// </summary>
+public sealed class TupleDeconstructionStatementSyntax : StatementSyntax
+{
+    /// <summary>Initializes a new instance of the <see cref="TupleDeconstructionStatementSyntax"/> class.</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="keyword">The <c>let</c> keyword.</param>
+    /// <param name="openParenToken">The opening <c>(</c>.</param>
+    /// <param name="identifiers">The comma-separated identifier list.</param>
+    /// <param name="closeParenToken">The closing <c>)</c>.</param>
+    /// <param name="equalsToken">The <c>=</c> token.</param>
+    /// <param name="initializer">The tuple-typed initializer expression.</param>
+    public TupleDeconstructionStatementSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken keyword,
+        SyntaxToken openParenToken,
+        SeparatedSyntaxList<SyntaxToken> identifiers,
+        SyntaxToken closeParenToken,
+        SyntaxToken equalsToken,
+        ExpressionSyntax initializer)
+        : base(syntaxTree)
+    {
+        Keyword = keyword;
+        OpenParenToken = openParenToken;
+        Identifiers = identifiers;
+        CloseParenToken = closeParenToken;
+        EqualsToken = equalsToken;
+        Initializer = initializer;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.TupleDeconstructionStatement;
+
+    /// <summary>Gets the <c>let</c> keyword token.</summary>
+    public SyntaxToken Keyword { get; }
+
+    /// <summary>Gets the opening parenthesis token.</summary>
+    public SyntaxToken OpenParenToken { get; }
+
+    /// <summary>Gets the deconstruction target identifiers.</summary>
+    public SeparatedSyntaxList<SyntaxToken> Identifiers { get; }
+
+    /// <summary>Gets the closing parenthesis token.</summary>
+    public SyntaxToken CloseParenToken { get; }
+
+    /// <summary>Gets the equals token.</summary>
+    public SyntaxToken EqualsToken { get; }
+
+    /// <summary>Gets the right-hand-side tuple expression.</summary>
+    public ExpressionSyntax Initializer { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/TupleLiteralExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TupleLiteralExpressionSyntax.cs
@@ -1,0 +1,40 @@
+// <copyright file="TupleLiteralExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents a tuple literal expression <c>(e1, e2, ...)</c> (Phase 4.5).
+/// </summary>
+public sealed class TupleLiteralExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>Initializes a new instance of the <see cref="TupleLiteralExpressionSyntax"/> class.</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="openParenToken">The opening <c>(</c>.</param>
+    /// <param name="elements">The comma-separated tuple element expressions.</param>
+    /// <param name="closeParenToken">The closing <c>)</c>.</param>
+    public TupleLiteralExpressionSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken openParenToken,
+        SeparatedSyntaxList<ExpressionSyntax> elements,
+        SyntaxToken closeParenToken)
+        : base(syntaxTree)
+    {
+        OpenParenToken = openParenToken;
+        Elements = elements;
+        CloseParenToken = closeParenToken;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.TupleLiteralExpression;
+
+    /// <summary>Gets the opening <c>(</c> token.</summary>
+    public SyntaxToken OpenParenToken { get; }
+
+    /// <summary>Gets the tuple element expressions.</summary>
+    public SeparatedSyntaxList<ExpressionSyntax> Elements { get; }
+
+    /// <summary>Gets the closing <c>)</c> token.</summary>
+    public SyntaxToken CloseParenToken { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
@@ -61,6 +61,26 @@ public sealed class TypeClauseSyntax : SyntaxNode
         QuestionToken = questionToken;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="TypeClauseSyntax"/> class for a tuple type <c>(T1, T2, ...)</c> (Phase 4.5).</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="openParenToken">The opening <c>(</c> token.</param>
+    /// <param name="tupleElements">The comma-separated element type clauses.</param>
+    /// <param name="closeParenToken">The closing <c>)</c> token.</param>
+    /// <param name="questionToken">The optional trailing <c>?</c> nullability marker.</param>
+    public TypeClauseSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken openParenToken,
+        SeparatedSyntaxList<TypeClauseSyntax> tupleElements,
+        SyntaxToken closeParenToken,
+        SyntaxToken questionToken)
+        : base(syntaxTree)
+    {
+        OpenParenToken = openParenToken;
+        TupleElements = tupleElements;
+        CloseParenToken = closeParenToken;
+        QuestionToken = questionToken;
+    }
+
     /// <inheritdoc/>
     public override SyntaxKind Kind => SyntaxKind.TypeClause;
 
@@ -87,4 +107,16 @@ public sealed class TypeClauseSyntax : SyntaxNode
 
     /// <summary>Gets a value indicating whether this clause denotes a nullable type <c>T?</c> (Phase 3.C.1).</summary>
     public bool IsNullable => QuestionToken != null;
+
+    /// <summary>Gets the opening <c>(</c> token for tuple types, or <c>null</c>.</summary>
+    public SyntaxToken OpenParenToken { get; }
+
+    /// <summary>Gets the closing <c>)</c> token for tuple types, or <c>null</c>.</summary>
+    public SyntaxToken CloseParenToken { get; }
+
+    /// <summary>Gets the comma-separated element-type clauses for a tuple type, or the default value.</summary>
+    public SeparatedSyntaxList<TypeClauseSyntax> TupleElements { get; }
+
+    /// <summary>Gets a value indicating whether this clause denotes a tuple type <c>(T1, T2, ...)</c> (Phase 4.5).</summary>
+    public bool IsTuple => OpenParenToken != null;
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/TupleTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/TupleTests.cs
@@ -1,0 +1,87 @@
+// <copyright file="TupleTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Phase 4.5 — tuple types <c>(T1, T2, ...)</c>, tuple literals, and tuple
+/// element access via <c>.Item1</c>..<c>.ItemN</c> (interpreter-only).
+/// </summary>
+public class TupleTests
+{
+    [Fact]
+    public void TupleLiteral_ItemAccess_ReturnsFirstElement()
+    {
+        var result = Evaluate(@"
+let p = (1, ""x"")
+p.Item1
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void TupleLiteral_ItemAccess_ReturnsSecondElement()
+    {
+        var result = Evaluate(@"
+let p = (1, ""x"")
+p.Item2
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("x", result.Value);
+    }
+
+    [Fact]
+    public void TupleTypeClause_OnLocal_BindsAndEvaluates()
+    {
+        var result = Evaluate(@"
+let p (int, string) = (7, ""hi"")
+p.Item1
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void FunctionReturningTuple_AccessElement()
+    {
+        var result = Evaluate(@"
+func pair() (int, int) {
+    return (3, 4)
+}
+let q = pair()
+q.Item2
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(4, result.Value);
+    }
+
+    [Fact]
+    public void TupleAccess_OutOfRange_ReportsDiagnostic()
+    {
+        var source = @"
+let p = (1, ""x"")
+p.Item3
+";
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/TupleTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/TupleTests.cs
@@ -78,6 +78,56 @@ p.Item3
         Assert.NotEmpty(result.Diagnostics);
     }
 
+    [Fact]
+    public void Deconstruction_BindsNamedLocals()
+    {
+        var result = Evaluate(@"
+let (a, b) = (10, ""ok"")
+a
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(10, result.Value);
+    }
+
+    [Fact]
+    public void Deconstruction_AccessesSecondElement()
+    {
+        var result = Evaluate(@"
+let (a, b) = (10, ""ok"")
+b
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("ok", result.Value);
+    }
+
+    [Fact]
+    public void MultiReturn_PackedIntoTuple_DeconstructAtCallSite()
+    {
+        var result = Evaluate(@"
+func divmod(a int, b int) (int, int) {
+    return a / b, a % b
+}
+let (q, r) = divmod(10, 3)
+q
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(3, result.Value);
+    }
+
+    [Fact]
+    public void MultiReturn_RemainderAccessible()
+    {
+        var result = Evaluate(@"
+func divmod(a int, b int) (int, int) {
+    return a / b, a % b
+}
+let (q, r) = divmod(10, 3)
+r
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var syntaxTree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -141,6 +141,7 @@ ThrowStatement
 TrueKeyword
 TryKeyword
 TryStatement
+TupleLiteralExpression
 TypeAliasDeclaration
 TypeArgumentList
 TypeClause
@@ -185,6 +186,8 @@ ReturnStatement
 StructLiteralExpression
 ThrowStatement
 TryStatement
+TupleElementAccessExpression
+TupleLiteralExpression
 UnaryExpression
 UserInstanceCallExpression
 VariableDeclaration

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -141,6 +141,7 @@ ThrowStatement
 TrueKeyword
 TryKeyword
 TryStatement
+TupleDeconstructionStatement
 TupleLiteralExpression
 TypeAliasDeclaration
 TypeArgumentList


### PR DESCRIPTION
## Summary

Phase 4 part 2 of the GSharp language roadmap — closes work items **4.5 (tuples)** and **4.6 (multi-return)** from the execution plan, both interpreter-only.

### Tuples (4.5)
- New `TupleTypeSymbol` backed by `System.ValueTuple<...>` (arities 2–7 carry a real CLR type; arity 8+ is represented as an `object[]` interpreter-side).
- Tuple type clauses `(T1, T2, ...)` and tuple literals `(e1, e2, ...)` are parsed, bound, and lowered. The parser routes a leading `(` in a type position to a new `ParseTupleTypeClause`, and detects a post-first-expression comma inside `(...)` as the trigger for a tuple literal.
- Element access via `.Item1`..`.ItemN` is bound through `BindAccessorStep` into the new `BoundTupleElementAccessExpression`. The evaluator dereferences the field via reflection on the underlying ValueTuple type.
- New `BoundTreeRewriter` and `BoundNodePrinter` cases handle the two new bound node kinds. `SyntaxNode.GetChildren` now guards against null `SeparatedSyntaxList` properties so non-tuple TypeClauseSyntax nodes still traverse cleanly.

### Multi-return (4.6)
- `return e1, e2, ...` is desugared at parse time into `return (e1, e2, ...)` using a synthesized `TupleLiteralExpressionSyntax`. No separate return-shape representation is needed; the existing tuple-type return clause carries the function signature.
- Combined with deconstruction (below) this enables the canonical `func divmod(a int, b int) (int, int) { return a / b, a % b }` / `let (q, r) = divmod(10, 3)` idiom.

### Deconstruction
- New `TupleDeconstructionStatementSyntax` (kind `TupleDeconstructionStatement`) recognised whenever `let` is followed directly by `(` — unambiguous against the regular `let <ident>` form.
- The binder evaluates the RHS into a synthetic readonly local (single-eval) and emits one `BoundVariableDeclaration` per identifier, each initialized from the matching `Item-N` field.
- Arity mismatches and non-tuple right-hand-sides are reported as diagnostics.

## Tests

Nine new `TupleTests` cases cover:

1. Tuple-literal first/second element access.
2. Typed tuple binding `let p (int, string) = (...)`.
3. Function returning a tuple, accessed by `Item-N`.
4. Out-of-range `Item-N` is a diagnostic.
5. `let (a, b) = (...)` for both element positions.
6. Multi-return + deconstruction (`divmod`) for both `q` and `r`.

Coverage-matrix golden is refreshed for the two new `BoundNodeKind` values and the two new `SyntaxKind` values.

**All 380 tests pass** (Core 333, Sdk 10, Compiler 23, LanguageServer 6, Interpreter 8).

## Deferred

- CLR generic IL emit for tuple-typed locals / fields / signatures. This PR is interpreter-only; the emitter will pick up tuple support alongside the broader generic IL emit work tracked in 4.1b/4.3a-emit.
- Tuple equality / comparison operators on top of `ValueTuple`'s built-in structural equality.
- `==`/`!=` operator overloads for tuples in `BoundBinaryOperator.Bind`.

## Plan items

- ✅ 4.5 Tuples + deconstruction (interpreter)
- ✅ 4.6 Multi-return (interpreter)
- ⏭ 4.7 Lambdas, 4.8 Variadics, 4.9 Trailing-lambda — next in queue.