### PR TITLE
Phase 4.7: function types and lambdas (interpreter)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -19,9 +19,10 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class Binder
 {
-    private readonly FunctionSymbol function;
     private readonly List<(StructDeclarationSyntax Syntax, StructSymbol Symbol)> pendingInterfaceImplementationChecks
         = new List<(StructDeclarationSyntax, StructSymbol)>();
+
+    private FunctionSymbol function;
 
     private Stack<(BoundLabel BreakLabel, BoundLabel ContinueLabel)> loopStack = new Stack<(BoundLabel BreakLabel, BoundLabel ContinueLabel)>();
     private int labelCounter;
@@ -1206,6 +1207,25 @@ public sealed class Binder
             return null;
         }
 
+        if (syntax.IsFunction)
+        {
+            // Phase 4.7: function-type clause `func(T1, T2, ...) R?`.
+            var paramTypes = ImmutableArray.CreateBuilder<TypeSymbol>(syntax.FunctionParameterTypes.Count);
+            for (var i = 0; i < syntax.FunctionParameterTypes.Count; i++)
+            {
+                var pt = BindTypeClause(syntax.FunctionParameterTypes[i]);
+                if (pt == null)
+                {
+                    return null;
+                }
+
+                paramTypes.Add(pt);
+            }
+
+            var ret = syntax.ReturnTypeClause != null ? BindTypeClause(syntax.ReturnTypeClause) : TypeSymbol.Void;
+            return FunctionTypeSymbol.Get(paramTypes.MoveToImmutable(), ret ?? TypeSymbol.Void);
+        }
+
         if (syntax.IsTuple)
         {
             // Phase 4.5: tuple type clause `(T1, T2, ...)`.
@@ -1880,6 +1900,8 @@ public sealed class Binder
                 return BindStructLiteralExpression((StructLiteralExpressionSyntax)syntax);
             case SyntaxKind.TupleLiteralExpression:
                 return BindTupleLiteralExpression((TupleLiteralExpressionSyntax)syntax);
+            case SyntaxKind.FunctionLiteralExpression:
+                return BindFunctionLiteralExpression((FunctionLiteralExpressionSyntax)syntax);
             case SyntaxKind.FieldAssignmentExpression:
                 return BindFieldAssignmentExpression((FieldAssignmentExpressionSyntax)syntax);
             default:
@@ -2191,6 +2213,68 @@ public sealed class Binder
         return new BoundTupleLiteralExpression(tupleType, bound.MoveToImmutable());
     }
 
+    private BoundExpression BindFunctionLiteralExpression(FunctionLiteralExpressionSyntax syntax)
+    {
+        // Phase 4.7: function literal `func(p1 T1, p2 T2) R { body }`.
+        // Bind parameters, push a new scope chained to the current scope so
+        // outer locals are visible by lexical lookup (closure capture), bind
+        // the body against a synthetic FunctionSymbol whose return type is
+        // the declared return clause (or void), then collect the captured
+        // outer variables by inspecting the bound body.
+        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(syntax.Parameters.Count);
+        var parameterSymbols = ImmutableArray.CreateBuilder<ParameterSymbol>(syntax.Parameters.Count);
+        var seen = new HashSet<string>();
+        foreach (var p in syntax.Parameters)
+        {
+            var pname = p.Identifier.Text;
+            var ptype = BindTypeClause(p.Type) ?? TypeSymbol.Error;
+            if (!seen.Add(pname))
+            {
+                Diagnostics.ReportParameterAlreadyDeclared(p.Location, pname);
+            }
+
+            parameterSymbols.Add(new ParameterSymbol(pname, ptype));
+            parameterTypes.Add(ptype);
+        }
+
+        var returnType = syntax.ReturnTypeClause != null ? BindTypeClause(syntax.ReturnTypeClause) : TypeSymbol.Void;
+        returnType ??= TypeSymbol.Void;
+        var fnType = FunctionTypeSymbol.Get(parameterTypes.MoveToImmutable(), returnType);
+        var synthetic = new FunctionSymbol(
+            $"<lambda{System.Threading.Interlocked.Increment(ref syntheticLocalCounter)}>",
+            parameterSymbols.ToImmutable(),
+            returnType);
+
+        // Snapshot current binder state, then push a child scope and bind
+        // the body as if we were inside this synthetic function.
+        var outerScope = scope;
+        var outerFunction = function;
+        scope = new BoundScope(outerScope);
+        function = synthetic;
+        foreach (var ps in synthetic.Parameters)
+        {
+            scope.TryDeclareVariable(ps);
+        }
+
+        var body = BindBlockStatement(syntax.Body);
+
+        scope = outerScope;
+        function = outerFunction;
+
+        var captured = CollectCapturedVariables(body, synthetic.Parameters);
+        return new BoundFunctionLiteralExpression(synthetic, fnType, (BoundBlockStatement)body, captured);
+    }
+
+    private static ImmutableArray<VariableSymbol> CollectCapturedVariables(BoundStatement body, ImmutableArray<ParameterSymbol> parameters)
+    {
+        var paramSet = new HashSet<VariableSymbol>(parameters);
+        var seen = new HashSet<VariableSymbol>();
+        var captured = ImmutableArray.CreateBuilder<VariableSymbol>();
+        var collector = new CapturedVariableCollector(paramSet, seen, captured);
+        collector.RewriteStatement(body);
+        return captured.ToImmutable();
+    }
+
     private BoundExpression BindFieldAssignmentExpression(FieldAssignmentExpressionSyntax syntax)
     {
         var receiverName = syntax.Receiver.Text;
@@ -2440,6 +2524,26 @@ public sealed class Binder
         {
             Diagnostics.ReportUndefinedFunction(syntax.Identifier.Location, syntax.Identifier.Text);
             return new BoundErrorExpression();
+        }
+
+        // Phase 4.7: invoking a function-typed variable goes through the
+        // indirect-call path. Sites like `add(1, 2)` where `add` is `let
+        // add func(int, int) int = ...` reduce to BoundIndirectCallExpression.
+        if (symbol is VariableSymbol variable && variable.Type is FunctionTypeSymbol fnType)
+        {
+            if (syntax.Arguments.Count != fnType.Arity)
+            {
+                Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, variable.Name, fnType.Arity, syntax.Arguments.Count);
+                return new BoundErrorExpression();
+            }
+
+            var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
+            for (var i = 0; i < syntax.Arguments.Count; i++)
+            {
+                convertedArgs.Add(BindConversion(syntax.Arguments[i].Location, boundArguments[i], fnType.ParameterTypes[i]));
+            }
+
+            return new BoundIndirectCallExpression(new BoundVariableExpression(variable), fnType, convertedArgs.MoveToImmutable());
         }
 
         var function = symbol as FunctionSymbol;
@@ -3461,5 +3565,34 @@ public sealed class Binder
         return packagesInOrder.Count > 0
             ? packagesInOrder[0]
             : new PackageSymbol("Default", declaration: null);
+    }
+
+    private sealed class CapturedVariableCollector : BoundTreeRewriter
+    {
+        private readonly HashSet<VariableSymbol> parameters;
+        private readonly HashSet<VariableSymbol> seen;
+        private readonly ImmutableArray<VariableSymbol>.Builder captured;
+
+        public CapturedVariableCollector(
+            HashSet<VariableSymbol> parameters,
+            HashSet<VariableSymbol> seen,
+            ImmutableArray<VariableSymbol>.Builder captured)
+        {
+            this.parameters = parameters;
+            this.seen = seen;
+            this.captured = captured;
+        }
+
+        protected override BoundExpression RewriteVariableExpression(BoundVariableExpression node)
+        {
+            if (!this.parameters.Contains(node.Variable)
+                && !(node.Variable is GlobalVariableSymbol)
+                && this.seen.Add(node.Variable))
+            {
+                this.captured.Add(node.Variable);
+            }
+
+            return node;
+        }
     }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundFunctionLiteralExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundFunctionLiteralExpression.cs
@@ -1,0 +1,44 @@
+// <copyright file="BoundFunctionLiteralExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+#pragma warning disable CS1591
+#pragma warning disable SA1600
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// A bound function literal (Phase 4.7). Holds a synthesized
+/// <see cref="FunctionSymbol"/> together with the bound body. The set of
+/// captured outer variables is recorded so the evaluator can snapshot them
+/// when the literal is evaluated to a runtime closure value.
+/// </summary>
+public sealed class BoundFunctionLiteralExpression : BoundExpression
+{
+    public BoundFunctionLiteralExpression(
+        FunctionSymbol function,
+        FunctionTypeSymbol type,
+        BoundBlockStatement body,
+        ImmutableArray<VariableSymbol> capturedVariables)
+    {
+        Function = function;
+        FunctionType = type;
+        Body = body;
+        CapturedVariables = capturedVariables;
+    }
+
+    public FunctionSymbol Function { get; }
+
+    public FunctionTypeSymbol FunctionType { get; }
+
+    public BoundBlockStatement Body { get; }
+
+    public ImmutableArray<VariableSymbol> CapturedVariables { get; }
+
+    public override TypeSymbol Type => FunctionType;
+
+    public override BoundNodeKind Kind => BoundNodeKind.FunctionLiteralExpression;
+}

--- a/src/Core/CodeAnalysis/Binding/BoundIndirectCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundIndirectCallExpression.cs
@@ -1,0 +1,36 @@
+// <copyright file="BoundIndirectCallExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+#pragma warning disable CS1591
+#pragma warning disable SA1600
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// A call through a function-typed value (Phase 4.7). The <see cref="Target"/>
+/// expression evaluates to a closure / function value at runtime; the
+/// evaluator invokes it with the bound <see cref="Arguments"/>.
+/// </summary>
+public sealed class BoundIndirectCallExpression : BoundExpression
+{
+    public BoundIndirectCallExpression(BoundExpression target, FunctionTypeSymbol functionType, ImmutableArray<BoundExpression> arguments)
+    {
+        Target = target;
+        FunctionType = functionType;
+        Arguments = arguments;
+    }
+
+    public BoundExpression Target { get; }
+
+    public FunctionTypeSymbol FunctionType { get; }
+
+    public ImmutableArray<BoundExpression> Arguments { get; }
+
+    public override TypeSymbol Type => FunctionType.ReturnType;
+
+    public override BoundNodeKind Kind => BoundNodeKind.IndirectCallExpression;
+}

--- a/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -52,6 +52,8 @@ public enum BoundNodeKind
     NullConditionalAccessExpression,
     TupleLiteralExpression,
     TupleElementAccessExpression,
+    FunctionLiteralExpression,
+    IndirectCallExpression,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -150,6 +150,12 @@ public static class BoundNodePrinter
             case BoundNodeKind.TupleElementAccessExpression:
                 WriteTupleElementAccessExpression((BoundTupleElementAccessExpression)node, writer);
                 break;
+            case BoundNodeKind.FunctionLiteralExpression:
+                WriteFunctionLiteralExpression((BoundFunctionLiteralExpression)node, writer);
+                break;
+            case BoundNodeKind.IndirectCallExpression:
+                WriteIndirectCallExpression((BoundIndirectCallExpression)node, writer);
+                break;
             default:
                 throw new Exception($"Unexpected node {node.Kind}");
         }
@@ -704,5 +710,43 @@ public static class BoundNodePrinter
         node.Receiver.WriteTo(writer);
         writer.WritePunctuation(SyntaxKind.DotToken);
         writer.WriteIdentifier($"Item{node.Index + 1}");
+    }
+
+    private static void WriteFunctionLiteralExpression(BoundFunctionLiteralExpression node, IndentedTextWriter writer)
+    {
+        writer.WriteKeyword(SyntaxKind.FuncKeyword);
+        writer.WritePunctuation(SyntaxKind.OpenParenthesisToken);
+        for (var i = 0; i < node.Function.Parameters.Length; i++)
+        {
+            if (i > 0)
+            {
+                writer.WritePunctuation(SyntaxKind.CommaToken);
+                writer.WriteSpace();
+            }
+
+            writer.WriteIdentifier(node.Function.Parameters[i].Name);
+        }
+
+        writer.WritePunctuation(SyntaxKind.CloseParenthesisToken);
+        writer.WriteSpace();
+        node.Body.WriteTo(writer);
+    }
+
+    private static void WriteIndirectCallExpression(BoundIndirectCallExpression node, IndentedTextWriter writer)
+    {
+        node.Target.WriteTo(writer);
+        writer.WritePunctuation(SyntaxKind.OpenParenthesisToken);
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            if (i > 0)
+            {
+                writer.WritePunctuation(SyntaxKind.CommaToken);
+                writer.WriteSpace();
+            }
+
+            node.Arguments[i].WriteTo(writer);
+        }
+
+        writer.WritePunctuation(SyntaxKind.CloseParenthesisToken);
     }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -334,6 +334,10 @@ public abstract class BoundTreeRewriter
                 return RewriteTupleLiteralExpression((BoundTupleLiteralExpression)node);
             case BoundNodeKind.TupleElementAccessExpression:
                 return RewriteTupleElementAccessExpression((BoundTupleElementAccessExpression)node);
+            case BoundNodeKind.FunctionLiteralExpression:
+                return RewriteFunctionLiteralExpression((BoundFunctionLiteralExpression)node);
+            case BoundNodeKind.IndirectCallExpression:
+                return RewriteIndirectCallExpression((BoundIndirectCallExpression)node);
             default:
                 throw new Exception($"Unexpected node: {node.Kind}");
         }
@@ -799,5 +803,44 @@ public abstract class BoundTreeRewriter
     {
         var receiver = RewriteExpression(node.Receiver);
         return receiver == node.Receiver ? node : new BoundTupleElementAccessExpression(receiver, node.TupleType, node.Index);
+    }
+
+    /// <summary>Rewrites a function literal (Phase 4.7). The body is intentionally not rewritten because it forms a separate lexical scope.</summary>
+    /// <param name="node">The node to rewrite.</param>
+    /// <returns>The rewritten node.</returns>
+    protected virtual BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+    {
+        return node;
+    }
+
+    /// <summary>Rewrites an indirect call (Phase 4.7).</summary>
+    /// <param name="node">The node to rewrite.</param>
+    /// <returns>The rewritten node.</returns>
+    protected virtual BoundExpression RewriteIndirectCallExpression(BoundIndirectCallExpression node)
+    {
+        var target = RewriteExpression(node.Target);
+        System.Collections.Immutable.ImmutableArray<BoundExpression>.Builder builder = null;
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            var oldArg = node.Arguments[i];
+            var newArg = RewriteExpression(oldArg);
+            if (newArg != oldArg && builder == null)
+            {
+                builder = System.Collections.Immutable.ImmutableArray.CreateBuilder<BoundExpression>(node.Arguments.Length);
+                for (var j = 0; j < i; j++)
+                {
+                    builder.Add(node.Arguments[j]);
+                }
+            }
+
+            builder?.Add(newArg);
+        }
+
+        if (target == node.Target && builder == null)
+        {
+            return node;
+        }
+
+        return new BoundIndirectCallExpression(target, node.FunctionType, builder?.ToImmutable() ?? node.Arguments);
     }
 }

--- a/src/Core/CodeAnalysis/ClosureValue.cs
+++ b/src/Core/CodeAnalysis/ClosureValue.cs
@@ -1,0 +1,43 @@
+// <copyright file="ClosureValue.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis;
+
+/// <summary>
+/// Runtime representation of a function-literal value (Phase 4.7, interpreter-only).
+/// Captures the synthetic function symbol, body, signature, and a value-snapshot of captured locals.
+/// </summary>
+public sealed class ClosureValue
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClosureValue"/> class.
+    /// </summary>
+    /// <param name="function">The synthetic function symbol.</param>
+    /// <param name="body">The lambda body.</param>
+    /// <param name="functionType">The function-type signature.</param>
+    /// <param name="capturedLocals">Value-snapshot of captured locals at literal-evaluation time.</param>
+    public ClosureValue(FunctionSymbol function, BoundBlockStatement body, FunctionTypeSymbol functionType, Dictionary<VariableSymbol, object> capturedLocals)
+    {
+        Function = function;
+        Body = body;
+        FunctionType = functionType;
+        CapturedLocals = capturedLocals;
+    }
+
+    /// <summary>Gets the synthetic function symbol.</summary>
+    public FunctionSymbol Function { get; }
+
+    /// <summary>Gets the lambda body.</summary>
+    public BoundBlockStatement Body { get; }
+
+    /// <summary>Gets the function type.</summary>
+    public FunctionTypeSymbol FunctionType { get; }
+
+    /// <summary>Gets the captured locals snapshot.</summary>
+    public Dictionary<VariableSymbol, object> CapturedLocals { get; }
+}

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -207,6 +207,8 @@ public sealed class Evaluator
                 BoundNodeKind.NullConditionalAccessExpression => EvaluateNullConditionalAccessExpression((BoundNullConditionalAccessExpression)node),
                 BoundNodeKind.TupleLiteralExpression => EvaluateTupleLiteralExpression((BoundTupleLiteralExpression)node),
                 BoundNodeKind.TupleElementAccessExpression => EvaluateTupleElementAccessExpression((BoundTupleElementAccessExpression)node),
+                BoundNodeKind.FunctionLiteralExpression => EvaluateFunctionLiteralExpression((BoundFunctionLiteralExpression)node),
+                BoundNodeKind.IndirectCallExpression => EvaluateIndirectCallExpression((BoundIndirectCallExpression)node),
                 _ => throw new EvaluatorException($"Unexpected node {node.Kind}", node),
             };
         }
@@ -362,6 +364,61 @@ public sealed class Evaluator
         var fieldName = $"Item{node.Index + 1}";
         var field = receiver.GetType().GetField(fieldName);
         return field.GetValue(receiver);
+    }
+
+    private object EvaluateFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+    {
+        var captured = new Dictionary<VariableSymbol, object>();
+        foreach (var v in node.CapturedVariables)
+        {
+            captured[v] = LookupVariable(v);
+        }
+
+        return new ClosureValue(node.Function, node.Body, node.FunctionType, captured);
+    }
+
+    private object EvaluateIndirectCallExpression(BoundIndirectCallExpression node)
+    {
+        var targetValue = EvaluateExpression(node.Target);
+        if (targetValue == null)
+        {
+            throw new EvaluatorException("Attempted to invoke a nil function.", node);
+        }
+
+        var closure = (ClosureValue)targetValue;
+        var frame = new Dictionary<VariableSymbol, object>();
+        foreach (var kv in closure.CapturedLocals)
+        {
+            frame[kv.Key] = kv.Value;
+        }
+
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            frame[closure.Function.Parameters[i]] = EvaluateExpression(node.Arguments[i]);
+        }
+
+        this.locals.Push(frame);
+        var result = EvaluateStatement(closure.Body);
+        this.locals.Pop();
+        return result;
+    }
+
+    private object LookupVariable(VariableSymbol v)
+    {
+        if (v is GlobalVariableSymbol)
+        {
+            return globals.TryGetValue(v, out var g) ? g : null;
+        }
+
+        foreach (var frame in this.locals)
+        {
+            if (frame.TryGetValue(v, out var value))
+            {
+                return value;
+            }
+        }
+
+        return globals.TryGetValue(v, out var gv) ? gv : null;
     }
 
     private object EvaluateConstructorCallExpression(BoundConstructorCallExpression node)

--- a/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
@@ -1,0 +1,64 @@
+// <copyright file="FunctionTypeSymbol.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Represents a first-class function type <c>func(T1, T2, ...) R</c>
+/// (Phase 4.7). Instances are cached and compared by structural equality of
+/// parameter and return types so two textually identical type clauses share
+/// the same <see cref="FunctionTypeSymbol"/>.
+/// </summary>
+public sealed class FunctionTypeSymbol : TypeSymbol
+{
+    private static readonly ConcurrentDictionary<string, FunctionTypeSymbol> Cache = new ConcurrentDictionary<string, FunctionTypeSymbol>();
+
+    private FunctionTypeSymbol(string name, ImmutableArray<TypeSymbol> parameterTypes, TypeSymbol returnType)
+        : base(name)
+    {
+        ParameterTypes = parameterTypes;
+        ReturnType = returnType;
+    }
+
+    /// <summary>Gets the function's parameter types.</summary>
+    public ImmutableArray<TypeSymbol> ParameterTypes { get; }
+
+    /// <summary>Gets the function's return type. <c>void</c> when the function returns nothing.</summary>
+    public TypeSymbol ReturnType { get; }
+
+    /// <summary>Gets the number of parameters.</summary>
+    public int Arity => ParameterTypes.Length;
+
+    /// <summary>Returns the cached <see cref="FunctionTypeSymbol"/> for the given signature.</summary>
+    /// <param name="parameterTypes">The parameter types.</param>
+    /// <param name="returnType">The return type (use <see cref="TypeSymbol.Void"/> for no return).</param>
+    /// <returns>A cached <see cref="FunctionTypeSymbol"/>.</returns>
+    public static FunctionTypeSymbol Get(ImmutableArray<TypeSymbol> parameterTypes, TypeSymbol returnType)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append("func(");
+        for (var i = 0; i < parameterTypes.Length; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(", ");
+            }
+
+            sb.Append(parameterTypes[i].Name);
+        }
+
+        sb.Append(')');
+        if (returnType != null && returnType != TypeSymbol.Void)
+        {
+            sb.Append(' ');
+            sb.Append(returnType.Name);
+        }
+
+        var name = sb.ToString();
+        return Cache.GetOrAdd(name, n => new FunctionTypeSymbol(n, parameterTypes, returnType ?? TypeSymbol.Void));
+    }
+}

--- a/src/Core/CodeAnalysis/Syntax/FunctionLiteralExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/FunctionLiteralExpressionSyntax.cs
@@ -1,0 +1,60 @@
+// <copyright file="FunctionLiteralExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// A function literal expression <c>func(p1 T1, p2 T2) R { body }</c>
+/// (Phase 4.7). Same shape as a function declaration but without a name,
+/// receiver, or modifiers; produces a first-class function value.
+/// </summary>
+public sealed class FunctionLiteralExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>Initializes a new instance of the <see cref="FunctionLiteralExpressionSyntax"/> class.</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="funcKeyword">The <c>func</c> keyword token.</param>
+    /// <param name="openParenToken">The opening <c>(</c>.</param>
+    /// <param name="parameters">The parameter list.</param>
+    /// <param name="closeParenToken">The closing <c>)</c>.</param>
+    /// <param name="returnTypeClause">The optional return-type clause.</param>
+    /// <param name="body">The function body.</param>
+    public FunctionLiteralExpressionSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken funcKeyword,
+        SyntaxToken openParenToken,
+        SeparatedSyntaxList<ParameterSyntax> parameters,
+        SyntaxToken closeParenToken,
+        TypeClauseSyntax returnTypeClause,
+        BlockStatementSyntax body)
+        : base(syntaxTree)
+    {
+        FuncKeyword = funcKeyword;
+        OpenParenToken = openParenToken;
+        Parameters = parameters;
+        CloseParenToken = closeParenToken;
+        ReturnTypeClause = returnTypeClause;
+        Body = body;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.FunctionLiteralExpression;
+
+    /// <summary>Gets the <c>func</c> keyword token.</summary>
+    public SyntaxToken FuncKeyword { get; }
+
+    /// <summary>Gets the opening parenthesis token.</summary>
+    public SyntaxToken OpenParenToken { get; }
+
+    /// <summary>Gets the parameter list.</summary>
+    public SeparatedSyntaxList<ParameterSyntax> Parameters { get; }
+
+    /// <summary>Gets the closing parenthesis token.</summary>
+    public SyntaxToken CloseParenToken { get; }
+
+    /// <summary>Gets the optional return-type clause.</summary>
+    public TypeClauseSyntax ReturnTypeClause { get; }
+
+    /// <summary>Gets the function body.</summary>
+    public BlockStatementSyntax Body { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -772,6 +772,11 @@ public class Parser
 
     private TypeClauseSyntax ParseTypeClause()
     {
+        if (Current.Kind == SyntaxKind.FuncKeyword)
+        {
+            return ParseFunctionTypeClause();
+        }
+
         if (Current.Kind == SyntaxKind.OpenParenthesisToken)
         {
             return ParseTupleTypeClause();
@@ -830,11 +835,47 @@ public class Parser
             question);
     }
 
+    private TypeClauseSyntax ParseFunctionTypeClause()
+    {
+        // Phase 4.7: function type clause `func(T1, T2, ...) R?`. The return
+        // type is optional; if absent the function returns void.
+        var funcKeyword = MatchToken(SyntaxKind.FuncKeyword);
+        var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
+        var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+
+        while (Current.Kind != SyntaxKind.CloseParenthesisToken &&
+               Current.Kind != SyntaxKind.EndOfFileToken)
+        {
+            nodesAndSeparators.Add(ParseTypeClause());
+            if (Current.Kind == SyntaxKind.CommaToken)
+            {
+                nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+        var returnTypeClause = ParseOptionalTypeClause();
+        var question = Current.Kind == SyntaxKind.QuestionToken ? MatchToken(SyntaxKind.QuestionToken) : null;
+        return new TypeClauseSyntax(
+            syntaxTree,
+            funcKeyword,
+            openParen,
+            new SeparatedSyntaxList<TypeClauseSyntax>(nodesAndSeparators.ToImmutable()),
+            closeParen,
+            returnTypeClause,
+            question);
+    }
+
     private TypeClauseSyntax ParseOptionalTypeClause()
     {
         if (Current.Kind != SyntaxKind.IdentifierToken &&
             Current.Kind != SyntaxKind.OpenSquareBracketToken &&
-            Current.Kind != SyntaxKind.OpenParenthesisToken)
+            Current.Kind != SyntaxKind.OpenParenthesisToken &&
+            Current.Kind != SyntaxKind.FuncKeyword)
         {
             return null;
         }
@@ -1637,10 +1678,25 @@ public class Parser
             case SyntaxKind.OpenSquareBracketToken:
                 return ParseArrayCreationExpression();
 
+            case SyntaxKind.FuncKeyword:
+                return ParseFunctionLiteralExpression();
+
             case SyntaxKind.IdentifierToken:
             default:
                 return ParseNameOrCallExpression();
         }
+    }
+
+    private ExpressionSyntax ParseFunctionLiteralExpression()
+    {
+        // Phase 4.7: function literal `func(p1 T1, p2 T2) R { body }`.
+        var funcKeyword = MatchToken(SyntaxKind.FuncKeyword);
+        var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
+        var parameters = ParseParameterList();
+        var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+        var returnType = ParseOptionalTypeClause();
+        var body = ParseBlockStatement();
+        return new FunctionLiteralExpressionSyntax(syntaxTree, funcKeyword, openParen, parameters, closeParen, returnType, body);
     }
 
     private ExpressionSyntax ParseArrayCreationExpression()

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -176,6 +176,7 @@ public enum SyntaxKind
     FieldAssignmentExpression,
     TupleLiteralExpression,
     TupleDeconstructionStatement,
+    FunctionLiteralExpression,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
@@ -81,6 +81,32 @@ public sealed class TypeClauseSyntax : SyntaxNode
         QuestionToken = questionToken;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="TypeClauseSyntax"/> class for a function type <c>func(T1, T2, ...) R?</c> (Phase 4.7).</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="funcKeyword">The <c>func</c> keyword.</param>
+    /// <param name="openParenToken">The opening <c>(</c> token.</param>
+    /// <param name="functionParameterTypes">The comma-separated parameter-type clauses.</param>
+    /// <param name="closeParenToken">The closing <c>)</c> token.</param>
+    /// <param name="returnTypeClause">The optional return-type clause; <c>null</c> for void.</param>
+    /// <param name="questionToken">The optional trailing <c>?</c> nullability marker.</param>
+    public TypeClauseSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken funcKeyword,
+        SyntaxToken openParenToken,
+        SeparatedSyntaxList<TypeClauseSyntax> functionParameterTypes,
+        SyntaxToken closeParenToken,
+        TypeClauseSyntax returnTypeClause,
+        SyntaxToken questionToken)
+        : base(syntaxTree)
+    {
+        FuncKeyword = funcKeyword;
+        OpenParenToken = openParenToken;
+        FunctionParameterTypes = functionParameterTypes;
+        CloseParenToken = closeParenToken;
+        ReturnTypeClause = returnTypeClause;
+        QuestionToken = questionToken;
+    }
+
     /// <inheritdoc/>
     public override SyntaxKind Kind => SyntaxKind.TypeClause;
 
@@ -118,5 +144,17 @@ public sealed class TypeClauseSyntax : SyntaxNode
     public SeparatedSyntaxList<TypeClauseSyntax> TupleElements { get; }
 
     /// <summary>Gets a value indicating whether this clause denotes a tuple type <c>(T1, T2, ...)</c> (Phase 4.5).</summary>
-    public bool IsTuple => OpenParenToken != null;
+    public bool IsTuple => OpenParenToken != null && FuncKeyword == null;
+
+    /// <summary>Gets the <c>func</c> keyword for function-type clauses, or <c>null</c>.</summary>
+    public SyntaxToken FuncKeyword { get; }
+
+    /// <summary>Gets the function parameter-type clauses, or the default value.</summary>
+    public SeparatedSyntaxList<TypeClauseSyntax> FunctionParameterTypes { get; }
+
+    /// <summary>Gets the function return-type clause, or <c>null</c> when the type is void / not a function type.</summary>
+    public TypeClauseSyntax ReturnTypeClause { get; }
+
+    /// <summary>Gets a value indicating whether this clause denotes a function type <c>func(...) R?</c> (Phase 4.7).</summary>
+    public bool IsFunction => FuncKeyword != null;
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/LambdaTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/LambdaTests.cs
@@ -1,0 +1,103 @@
+// <copyright file="LambdaTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Phase 4.7 — first-class function types (<c>func(T) R</c>), function literals,
+/// indirect calls, and by-value closure capture (interpreter-only).
+/// </summary>
+public class LambdaTests
+{
+    [Fact]
+    public void FunctionLiteral_DirectInvocation_ReturnsResult()
+    {
+        var result = Evaluate(@"
+let add = func(a int, b int) int { return a + b }
+add(2, 3)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void FunctionTypeClause_OnLocal_AcceptsMatchingLiteral()
+    {
+        var result = Evaluate(@"
+let add func(int, int) int = func(a int, b int) int { return a + b }
+add(4, 5)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(9, result.Value);
+    }
+
+    [Fact]
+    public void Closure_CapturesLocalByValue()
+    {
+        var result = Evaluate(@"
+let n = 7
+let f = func() int { return n + 1 }
+f()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(8, result.Value);
+    }
+
+    [Fact]
+    public void Closure_ValueCaptureSnapshotsAtLiteralEvaluation()
+    {
+        // Captured *locals* are snapshotted at literal-evaluation time. Globals
+        // are intentionally not captured (read live at call time). Use a helper
+        // function to exercise local-capture semantics.
+        var result = Evaluate(@"
+func makeReader() func() int {
+    var n = 1
+    let f = func() int { return n }
+    n = 99
+    return f
+}
+let r = makeReader()
+r()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void FunctionLiteral_VoidReturn_Works()
+    {
+        var result = Evaluate(@"
+let noop = func() { }
+noop()
+1
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void IndirectCall_WrongArgCount_ReportsDiagnostic()
+    {
+        var result = Evaluate(@"
+let add = func(a int, b int) int { return a + b }
+add(1)
+");
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -61,6 +61,7 @@ ForInfiniteStatement
 ForKeyword
 FuncKeyword
 FunctionDeclaration
+FunctionLiteralExpression
 GlobalStatement
 GoKeyword
 GotoKeyword
@@ -173,12 +174,14 @@ FieldAccessExpression
 FieldAssignmentExpression
 ForEllipsisStatement
 ForInfiniteStatement
+FunctionLiteralExpression
 GotoStatement
 IfStatement
 ImportedCallExpression
 ImportedInstanceCallExpression
 IndexAssignmentExpression
 IndexExpression
+IndirectCallExpression
 LabelStatement
 LenExpression
 LiteralExpression


### PR DESCRIPTION
Closes Phase 4.7 of the GSharp execution plan.

Adds first-class function types (`func(T1, T2) R`), function-literal expressions (`func(p T) R { body }`), indirect calls through function-typed variables, and by-value closure capture of enclosing locals. **Interpreter-only**; CLR emit is deferred.

## What's in

* `FunctionTypeSymbol` (cached, name-keyed). No CLR backing yet.
* `TypeClauseSyntax` learns the `func(...) R` shape. Parser parses function-type clauses and function-literal primary expressions.
* Binder: routes function-type clauses, binds lambda bodies with a temporarily swapped scope+function (so `return` checks the lambda's return type), and collects captured variables via a `BoundTreeRewriter` walker. `BindCallExpression` recognizes `VariableSymbol` of `FunctionTypeSymbol` and emits a `BoundIndirectCallExpression` with the usual arg-count diagnostic.
* Evaluator: `ClosureValue` carries `{ Function, Body, FunctionType, CapturedLocals }`. Function literals snapshot captures by value at literal-evaluation time. Indirect calls push a locals frame with captures + bound args and run the body.
* `BoundTreeRewriter` and `BoundNodePrinter` learn the two new nodes.
* New `LambdaTests` (6) cover direct invocation, function-typed local, void return, value-capture snapshot, and the wrong-arg-count diagnostic.
* Coverage-matrix golden refreshed for the new `SyntaxKind` and the two new `BoundNodeKind` values.

## Intentional MVP limitations (to revisit)

* **Value capture, not reference capture.** Matches C# value-capture intent; differs from Go's reference-capture. Documented in `LambdaTests`.
* **Globals are not captured.** Top-level variables are read live at call time. Only locals are snapshotted.
* **No CLR emit.** Function types have a null `ClrType`. The reflection-metadata emitter is unchanged.
* Recursion, lambdas calling lambdas, and lambdas passed as parameters are out of MVP scope; they should at minimum not crash.

## Tests

```
Core.Tests            339 passed (was 333)
Sdk.Tests             10 passed
Interpreter.Tests      8 passed
Compiler.Tests        23 passed
LanguageServer.Tests   6 passed
Total                386 passed, 0 failed
```

## Plan tie-in

Closes work item 4.7 of `~/gsharp-execution-plan.md`. Next: 4.8 variadic parameters, 4.9 trailing-lambda call syntax.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>