### PR TITLE
Phase 4.8: variadic parameters (interpreter)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -645,6 +645,11 @@ public sealed class Binder
                 {
                     var parameterName = parameterSyntax.Identifier.Text;
                     var parameterType = BindTypeClause(parameterSyntax.Type);
+                    if (parameterSyntax.IsVariadic)
+                    {
+                        Diagnostics.ReportVariadicParameterNotSupportedHere(parameterSyntax.Location, parameterName);
+                    }
+
                     if (!seenParameterNames.Add(parameterName))
                     {
                         Diagnostics.ReportParameterAlreadyDeclared(parameterSyntax.Location, parameterName);
@@ -798,6 +803,11 @@ public sealed class Binder
             {
                 var parameterName = parameterSyntax.Identifier.Text;
                 var parameterType = BindTypeClause(parameterSyntax.Type);
+                if (parameterSyntax.IsVariadic)
+                {
+                    Diagnostics.ReportVariadicParameterNotSupportedHere(parameterSyntax.Location, parameterName);
+                }
+
                 if (!seenParameterNames.Add(parameterName))
                 {
                     Diagnostics.ReportParameterAlreadyDeclared(parameterSyntax.Location, parameterName);
@@ -869,8 +879,26 @@ public sealed class Binder
                 }
                 else
                 {
-                    var parameter = new ParameterSymbol(parameterName, parameterType);
+                    // Phase 4.8: a `...T` parameter has type `[]T` for the body
+                    // and must be the last parameter. Auto-packing of trailing
+                    // arguments happens at the call site.
+                    var isVariadic = parameterSyntax.IsVariadic;
+                    if (isVariadic && parameterType != null && parameterType != TypeSymbol.Error)
+                    {
+                        parameterType = SliceTypeSymbol.Get(parameterType);
+                    }
+
+                    var parameter = new ParameterSymbol(parameterName, parameterType, isVariadic);
                     parameters.Add(parameter);
+                }
+            }
+
+            // Phase 4.8: validate `...T` appears only on the last syntactic parameter.
+            for (var i = 0; i < syntax.Parameters.Count - 1; i++)
+            {
+                if (syntax.Parameters[i].IsVariadic)
+                {
+                    Diagnostics.ReportVariadicParameterMustBeLast(syntax.Parameters[i].Location, syntax.Parameters[i].Identifier.Text);
                 }
             }
 
@@ -2228,6 +2256,11 @@ public sealed class Binder
         {
             var pname = p.Identifier.Text;
             var ptype = BindTypeClause(p.Type) ?? TypeSymbol.Error;
+            if (p.IsVariadic)
+            {
+                Diagnostics.ReportVariadicParameterNotSupportedHere(p.Location, pname);
+            }
+
             if (!seen.Add(pname))
             {
                 Diagnostics.ReportParameterAlreadyDeclared(p.Location, pname);
@@ -2553,7 +2586,18 @@ public sealed class Binder
             return new BoundErrorExpression();
         }
 
-        if (syntax.Arguments.Count != function.Parameters.Length)
+        var isVariadic = function.Parameters.Length > 0 && function.Parameters[function.Parameters.Length - 1].IsVariadic;
+        var fixedParamCount = isVariadic ? function.Parameters.Length - 1 : function.Parameters.Length;
+
+        if (isVariadic)
+        {
+            if (syntax.Arguments.Count < fixedParamCount)
+            {
+                Diagnostics.ReportTooFewArgumentsForVariadic(syntax.Identifier.Location, function.Name, fixedParamCount, syntax.Arguments.Count);
+                return new BoundErrorExpression();
+            }
+        }
+        else if (syntax.Arguments.Count != function.Parameters.Length)
         {
             TextSpan span;
             if (syntax.Arguments.Count > function.Parameters.Length)
@@ -2643,7 +2687,7 @@ public sealed class Binder
             }
         }
 
-        for (var i = 0; i < syntax.Arguments.Count; i++)
+        for (var i = 0; i < fixedParamCount; i++)
         {
             var argument = boundArguments[i];
             var parameter = function.Parameters[i];
@@ -2657,6 +2701,42 @@ public sealed class Binder
                 }
 
                 hasErrors = true;
+            }
+        }
+
+        // Phase 4.8: type-check trailing variadic arguments against the slice
+        // element type, then pack them into a single slice-typed argument.
+        if (isVariadic)
+        {
+            var variadicParam = function.Parameters[function.Parameters.Length - 1];
+            var sliceType = (SliceTypeSymbol)variadicParam.Type;
+            var elementType = sliceType.ElementType;
+            for (var i = fixedParamCount; i < syntax.Arguments.Count; i++)
+            {
+                var argument = boundArguments[i];
+                if (argument.Type != elementType && argument.Type != TypeSymbol.Error)
+                {
+                    Diagnostics.ReportWrongArgumentType(syntax.Arguments[i].Location, variadicParam.Name, elementType, argument.Type);
+                    hasErrors = true;
+                }
+            }
+
+            if (!hasErrors)
+            {
+                var packed = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count - fixedParamCount);
+                for (var i = fixedParamCount; i < syntax.Arguments.Count; i++)
+                {
+                    packed.Add(boundArguments[i]);
+                }
+
+                var finalArgs = ImmutableArray.CreateBuilder<BoundExpression>(fixedParamCount + 1);
+                for (var i = 0; i < fixedParamCount; i++)
+                {
+                    finalArgs.Add(boundArguments[i]);
+                }
+
+                finalArgs.Add(new BoundArrayCreationExpression(sliceType, packed.MoveToImmutable()));
+                boundArguments = finalArgs;
             }
         }
 

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -353,6 +353,35 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, message);
     }
 
+    /// <summary>Reports a variadic parameter (<c>...T</c>) that is not the last parameter (Phase 4.8).</summary>
+    /// <param name="location">The text location of the offending parameter.</param>
+    /// <param name="name">The parameter name.</param>
+    public void ReportVariadicParameterMustBeLast(TextLocation location, string name)
+    {
+        var message = $"Variadic parameter '{name}' must be the last parameter.";
+        Report(location, message);
+    }
+
+    /// <summary>Reports a variadic parameter used in a context that does not yet support it (Phase 4.8 — MVP: top-level functions only).</summary>
+    /// <param name="location">The text location of the offending parameter.</param>
+    /// <param name="name">The parameter name.</param>
+    public void ReportVariadicParameterNotSupportedHere(TextLocation location, string name)
+    {
+        var message = $"Variadic parameter '{name}' is only supported on top-level function declarations.";
+        Report(location, message);
+    }
+
+    /// <summary>Reports a call to a variadic function with too few fixed arguments (Phase 4.8).</summary>
+    /// <param name="location">The text location of the call.</param>
+    /// <param name="name">The callee name.</param>
+    /// <param name="minimumCount">The minimum required argument count (fixed parameters).</param>
+    /// <param name="actualCount">The actual argument count provided.</param>
+    public void ReportTooFewArgumentsForVariadic(TextLocation location, string name, int minimumCount, int actualCount)
+    {
+        var message = $"Function '{name}' requires at least {minimumCount} arguments but was given {actualCount}.";
+        Report(location, message);
+    }
+
     /// <summary>Reports a generic call whose explicit type-argument list has the wrong arity (Phase 4.1 / ADR-0020).</summary>
     /// <param name="location">The text location of the type-argument list.</param>
     /// <param name="name">The callee name.</param>

--- a/src/Core/CodeAnalysis/Symbols/ParameterSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ParameterSymbol.cs
@@ -13,12 +13,17 @@ public sealed class ParameterSymbol : LocalVariableSymbol
     /// Initializes a new instance of the <see cref="ParameterSymbol"/> class.
     /// </summary>
     /// <param name="name">The parameter name.</param>
-    /// <param name="type">The parameter type.</param>
-    public ParameterSymbol(string name, TypeSymbol type)
+    /// <param name="type">The parameter type (already wrapped in <c>SliceTypeSymbol</c> if variadic).</param>
+    /// <param name="isVariadic">Whether the parameter is variadic (Phase 4.8).</param>
+    public ParameterSymbol(string name, TypeSymbol type, bool isVariadic = false)
         : base(name, isReadOnly: true, type)
     {
+        IsVariadic = isVariadic;
     }
 
     /// <inheritdoc/>
     public override SymbolKind Kind => SymbolKind.Parameter;
+
+    /// <summary>Gets a value indicating whether this parameter is variadic (Phase 4.8).</summary>
+    public bool IsVariadic { get; }
 }

--- a/src/Core/CodeAnalysis/Syntax/ParameterSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/ParameterSyntax.cs
@@ -14,12 +14,25 @@ public sealed class ParameterSyntax : SyntaxNode
     /// </summary>
     /// <param name="syntaxTree">The parent syntax tree.</param>
     /// <param name="identifier">The parameter identifier.</param>
+    /// <param name="ellipsisToken">Optional <c>...</c> token preceding the type clause for variadic parameters (Phase 4.8).</param>
     /// <param name="type">The parameter type.</param>
-    public ParameterSyntax(SyntaxTree syntaxTree, SyntaxToken identifier, TypeClauseSyntax type)
+    public ParameterSyntax(SyntaxTree syntaxTree, SyntaxToken identifier, SyntaxToken ellipsisToken, TypeClauseSyntax type)
         : base(syntaxTree)
     {
         Identifier = identifier;
+        EllipsisToken = ellipsisToken;
         Type = type;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParameterSyntax"/> class for a non-variadic parameter.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="identifier">The parameter identifier.</param>
+    /// <param name="type">The parameter type.</param>
+    public ParameterSyntax(SyntaxTree syntaxTree, SyntaxToken identifier, TypeClauseSyntax type)
+        : this(syntaxTree, identifier, ellipsisToken: null, type)
+    {
     }
 
     /// <inheritdoc/>
@@ -30,8 +43,14 @@ public sealed class ParameterSyntax : SyntaxNode
     /// </summary>
     public SyntaxToken Identifier { get; }
 
+    /// <summary>Gets the optional <c>...</c> token marking the parameter as variadic (Phase 4.8).</summary>
+    public SyntaxToken EllipsisToken { get; }
+
     /// <summary>
     /// Gets the parameter type.
     /// </summary>
     public TypeClauseSyntax Type { get; }
+
+    /// <summary>Gets a value indicating whether this is a variadic parameter (Phase 4.8).</summary>
+    public bool IsVariadic => EllipsisToken != null;
 }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -766,8 +766,14 @@ public class Parser
     private ParameterSyntax ParseParameter()
     {
         var identifier = MatchToken(SyntaxKind.IdentifierToken);
+        SyntaxToken ellipsis = null;
+        if (Current.Kind == SyntaxKind.EllipsisToken)
+        {
+            ellipsis = MatchToken(SyntaxKind.EllipsisToken);
+        }
+
         var type = ParseTypeClause();
-        return new ParameterSyntax(syntaxTree, identifier, type);
+        return new ParameterSyntax(syntaxTree, identifier, ellipsis, type);
     }
 
     private TypeClauseSyntax ParseTypeClause()

--- a/test/Core.Tests/CodeAnalysis/Binding/VariadicTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/VariadicTests.cs
@@ -1,0 +1,114 @@
+// <copyright file="VariadicTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Phase 4.8 — variadic parameters (<c>func f(xs ...T)</c>). Inside the
+/// body the parameter has type <c>[]T</c>; at call sites trailing
+/// arguments are packed into a slice. Interpreter-only for now.
+/// </summary>
+public class VariadicTests
+{
+    [Fact]
+    public void Variadic_PacksTrailingArgs_IntoSlice()
+    {
+        var result = Evaluate(@"
+func sum(nums ...int) int {
+    var total = 0
+    for i := 0; i < len(nums); i++ {
+        total = total + nums[i]
+    }
+    return total
+}
+sum(1, 2, 3, 4)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(10, result.Value);
+    }
+
+    [Fact]
+    public void Variadic_AcceptsZeroTrailingArgs_EmptySlice()
+    {
+        var result = Evaluate(@"
+func count(xs ...int) int { return len(xs) }
+count()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+
+    [Fact]
+    public void Variadic_WithFixedParametersBefore()
+    {
+        var result = Evaluate(@"
+func joinWith(sep string, parts ...string) string {
+    var s = """"
+    for i := 0; i < len(parts); i++ {
+        if i > 0 { s = s + sep }
+        s = s + parts[i]
+    }
+    return s
+}
+joinWith("", "", ""a"", ""b"", ""c"")
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("a, b, c", result.Value);
+    }
+
+    [Fact]
+    public void Variadic_TooFewFixedArgs_ReportsDiagnostic()
+    {
+        var result = Evaluate(@"
+func joinWith(sep string, parts ...string) string { return sep }
+joinWith()
+");
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Variadic_WrongElementType_ReportsDiagnostic()
+    {
+        var result = Evaluate(@"
+func sum(nums ...int) int { return 0 }
+sum(1, ""x"", 3)
+");
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Variadic_NotLastParameter_ReportsDiagnostic()
+    {
+        var result = Evaluate(@"
+func bad(xs ...int, n int) int { return n }
+bad(1, 2)
+");
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Variadic_OnLambda_ReportsNotSupported()
+    {
+        var result = Evaluate(@"
+let f = func(xs ...int) int { return 0 }
+f()
+");
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Closes Phase 4.8 of the GSharp execution plan.

Adds Go-style `func f(xs ...T)` variadic parameters on top-level function declarations. Inside the body the parameter has type `[]T` (`SliceTypeSymbol`). At call sites, trailing arguments past the fixed-parameter count are type-checked against the element type and packed into a single `BoundArrayCreationExpression` of the slice type. **Interpreter-only**.

## What's in

* `ParameterSyntax` learns an optional `EllipsisToken` + `IsVariadic`.
* `Parser.ParseParameter` accepts `name ...T`.
* `ParameterSymbol` carries an `IsVariadic` flag; the type seen by the body is the wrapped `SliceTypeSymbol`.
* `Binder.BindFunctionDeclaration` wraps + flags, and emits `ReportVariadicParameterMustBeLast` when `...` isn't on the last parameter.
* `Binder.BindCallExpression`: when the callee's last parameter is variadic, the arity check is "at least fixedCount", trailing arguments are checked against the element type, and packed into a `BoundArrayCreationExpression`.
* Variadic on **struct methods**, **interface methods**, and **lambdas** reports `ReportVariadicParameterNotSupportedHere` for the MVP.
* New diagnostics: `ReportVariadicParameterMustBeLast`, `ReportVariadicParameterNotSupportedHere`, `ReportTooFewArgumentsForVariadic`.
* 7 new `VariadicTests` cover `sum`/`count`/`joinWith` happy paths plus the three new diagnostics and the lambda-not-supported case.

## Intentional MVP limitations

* **No Go-style spread** at the call site (`f(slice...)`) yet.
* **No variadic on lambdas, methods, or interfaces** yet — diagnosed explicitly.
* **No CLR emit**; pure interpreter path. The slice container type already has CLR backing, but the call-site packing isn't wired into the IL emitter.

## Tests

```
Core.Tests            346 passed (was 339)
Sdk.Tests             10 passed
Interpreter.Tests      8 passed
Compiler.Tests        23 passed
LanguageServer.Tests   6 passed
Total                393 passed, 0 failed
```

## Plan tie-in

Closes work item 4.8 of `~/gsharp-execution-plan.md`. Next: 4.9 trailing-lambda call syntax, then 4.1b/4.3a CLR generic IL emission and 4.3c generic interfaces + variance.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>