### PR TITLE
Phase 4.3c: generic interfaces + variance (interpreter)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -766,6 +766,14 @@ public sealed class Binder
         var accessibility = ResolveAccessibility(syntax.AccessibilityModifier);
         var interfaceSymbol = new InterfaceSymbol(name, accessibility, syntax, package.Name);
 
+        // Phase 4.3c / ADR-0020: bind type parameters at declaration time so
+        // method-signature binding (which happens later) can resolve them.
+        var typeParameters = BindTypeParameterList(syntax.TypeParameterList);
+        if (!typeParameters.IsDefaultOrEmpty)
+        {
+            interfaceSymbol.SetTypeParameters(typeParameters);
+        }
+
         if (!scope.TryDeclareTypeAlias(name, interfaceSymbol))
         {
             Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
@@ -785,6 +793,30 @@ public sealed class Binder
     }
 
     private void BindInterfaceMembers(InterfaceDeclarationSyntax syntax, InterfaceSymbol interfaceSymbol, PackageSymbol package)
+    {
+        // Phase 4.3c: push the interface's type parameters so that method
+        // signatures can reference them.
+        var previousTypeParameters = currentTypeParameters;
+        if (!interfaceSymbol.TypeParameters.IsDefaultOrEmpty)
+        {
+            currentTypeParameters = new Dictionary<string, TypeParameterSymbol>();
+            foreach (var tp in interfaceSymbol.TypeParameters)
+            {
+                currentTypeParameters[tp.Name] = tp;
+            }
+        }
+
+        try
+        {
+            BindInterfaceMembersCore(syntax, interfaceSymbol, package);
+        }
+        finally
+        {
+            currentTypeParameters = previousTypeParameters;
+        }
+    }
+
+    private void BindInterfaceMembersCore(InterfaceDeclarationSyntax syntax, InterfaceSymbol interfaceSymbol, PackageSymbol package)
     {
         var methodsBuilder = ImmutableArray.CreateBuilder<FunctionSymbol>();
         var seenNames = new HashSet<string>();
@@ -831,6 +863,60 @@ public sealed class Binder
         }
 
         interfaceSymbol.SetMethods(methodsBuilder.ToImmutable());
+
+        // Phase 4.3c / ADR-0021: variance position checking. Walk each method's
+        // parameter types (contravariant position) and return type (covariant
+        // position). An `out T` may only appear in covariant position; an
+        // `in T` may only appear in contravariant position.
+        if (!interfaceSymbol.TypeParameters.IsDefaultOrEmpty)
+        {
+            for (var i = 0; i < interfaceSymbol.Methods.Length; i++)
+            {
+                var m = interfaceSymbol.Methods[i];
+                var methodSyntax = syntax.Methods[i];
+                CheckVariancePosition(m.Type, isOutput: true, methodSyntax.Type?.Location ?? methodSyntax.Identifier.Location);
+                for (var p = 0; p < m.Parameters.Length; p++)
+                {
+                    var paramSyntax = methodSyntax.Parameters[p];
+                    CheckVariancePosition(m.Parameters[p].Type, isOutput: false, paramSyntax.Type?.Location ?? paramSyntax.Location);
+                }
+            }
+        }
+    }
+
+    private void CheckVariancePosition(TypeSymbol type, bool isOutput, TextLocation location)
+    {
+        if (type is TypeParameterSymbol tp)
+        {
+            if (tp.Variance == TypeParameterVariance.Out && !isOutput)
+            {
+                Diagnostics.ReportTypeParameterVariancePositionViolation(location, tp.Name, "out", "input");
+            }
+            else if (tp.Variance == TypeParameterVariance.In && isOutput)
+            {
+                Diagnostics.ReportTypeParameterVariancePositionViolation(location, tp.Name, "in", "output");
+            }
+
+            return;
+        }
+
+        if (type is SliceTypeSymbol s)
+        {
+            CheckVariancePosition(s.ElementType, isOutput, location);
+            return;
+        }
+
+        if (type is ArrayTypeSymbol a)
+        {
+            CheckVariancePosition(a.ElementType, isOutput, location);
+            return;
+        }
+
+        if (type is NullableTypeSymbol n)
+        {
+            CheckVariancePosition(n.UnderlyingType, isOutput, location);
+            return;
+        }
     }
 
     private void BindFunctionDeclaration(FunctionDeclarationSyntax syntax, PackageSymbol package)
@@ -1283,6 +1369,46 @@ public sealed class Binder
         {
             Diagnostics.ReportUndefinedType(syntax.Identifier.Location, syntax.Identifier.Text);
             return null;
+        }
+
+        // Phase 4.3c / ADR-0020: handle generic type construction `Foo[T1, T2]` in
+        // type position (currently interfaces; structs follow up later).
+        if (syntax.HasTypeArguments)
+        {
+            var typeArgsBuilder = ImmutableArray.CreateBuilder<TypeSymbol>(syntax.TypeArguments.Count);
+            for (var i = 0; i < syntax.TypeArguments.Count; i++)
+            {
+                var ta = BindTypeClause(syntax.TypeArguments[i]);
+                if (ta == null)
+                {
+                    return null;
+                }
+
+                typeArgsBuilder.Add(ta);
+            }
+
+            var typeArgs = typeArgsBuilder.MoveToImmutable();
+            if (element is InterfaceSymbol iface)
+            {
+                if (!iface.IsGenericDefinition)
+                {
+                    Diagnostics.ReportTypeNotGeneric(syntax.Identifier.Location, syntax.Identifier.Text);
+                    return null;
+                }
+
+                if (iface.TypeParameters.Length != typeArgs.Length)
+                {
+                    Diagnostics.ReportWrongTypeArgumentCount(syntax.Identifier.Location, syntax.Identifier.Text, iface.TypeParameters.Length, typeArgs.Length);
+                    return null;
+                }
+
+                element = InterfaceSymbol.Construct(iface, typeArgs);
+            }
+            else
+            {
+                Diagnostics.ReportTypeNotGeneric(syntax.Identifier.Location, syntax.Identifier.Text);
+                return null;
+            }
         }
 
         if (!syntax.IsArray)

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -392,6 +392,24 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, $"Generic function '{name}' requires {expectedCount} type arguments but was given {actualCount}.");
     }
 
+    /// <summary>Reports a type-clause type-argument list applied to a non-generic type (Phase 4.3c / ADR-0020).</summary>
+    /// <param name="location">The text location of the offending identifier.</param>
+    /// <param name="name">The type name.</param>
+    public void ReportTypeNotGeneric(TextLocation location, string name)
+    {
+        Report(location, $"Type '{name}' is not generic.");
+    }
+
+    /// <summary>Reports an interface type-parameter used in a position incompatible with its declared variance (Phase 4.3c / ADR-0021).</summary>
+    /// <param name="location">The text location of the offending use.</param>
+    /// <param name="typeParameterName">The type-parameter name.</param>
+    /// <param name="declaredVariance">The declared variance (in/out).</param>
+    /// <param name="usedPosition">The position the type-parameter was used in (input/output).</param>
+    public void ReportTypeParameterVariancePositionViolation(TextLocation location, string typeParameterName, string declaredVariance, string usedPosition)
+    {
+        Report(location, $"Type parameter '{typeParameterName}' declared '{declaredVariance}' cannot appear in {usedPosition} position.");
+    }
+
     /// <summary>Reports a generic call whose type arguments could not be inferred from the value arguments (Phase 4.1 / ADR-0020).</summary>
     /// <param name="location">The text location of the call.</param>
     /// <param name="name">The callee name.</param>

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Syntax;
 
@@ -15,6 +17,8 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// </summary>
 public sealed class InterfaceSymbol : TypeSymbol
 {
+    private static readonly ConcurrentDictionary<(InterfaceSymbol Def, string Args), InterfaceSymbol> ConstructedCache = new();
+
     /// <summary>Initializes a new instance of the <see cref="InterfaceSymbol"/> class.</summary>
     /// <param name="name">The interface type name.</param>
     /// <param name="accessibility">The interface's CLR accessibility.</param>
@@ -31,6 +35,19 @@ public sealed class InterfaceSymbol : TypeSymbol
         Declaration = declaration;
         PackageName = packageName;
         Methods = ImmutableArray<FunctionSymbol>.Empty;
+        Definition = this;
+    }
+
+    private InterfaceSymbol(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments, string constructedName)
+        : base(constructedName)
+    {
+        Accessibility = definition.Accessibility;
+        Declaration = definition.Declaration;
+        PackageName = definition.PackageName;
+        Methods = ImmutableArray<FunctionSymbol>.Empty;
+        TypeParameters = ImmutableArray<TypeParameterSymbol>.Empty;
+        TypeArguments = typeArguments;
+        Definition = definition;
     }
 
     /// <summary>Gets the interface accessibility.</summary>
@@ -48,11 +65,30 @@ public sealed class InterfaceSymbol : TypeSymbol
     /// <summary>Gets the abstract method signatures declared on this interface. Populated by the binder via <see cref="SetMethods"/>.</summary>
     public ImmutableArray<FunctionSymbol> Methods { get; private set; }
 
+    /// <summary>Gets the type parameters when this is a generic definition (Phase 4.3c / ADR-0020).</summary>
+    public ImmutableArray<TypeParameterSymbol> TypeParameters { get; private set; } = ImmutableArray<TypeParameterSymbol>.Empty;
+
+    /// <summary>Gets the type arguments when this is a constructed instance (Phase 4.3c / ADR-0020).</summary>
+    public ImmutableArray<TypeSymbol> TypeArguments { get; private set; } = ImmutableArray<TypeSymbol>.Empty;
+
+    /// <summary>Gets a value indicating whether this is a generic definition (has type parameters and no type arguments).</summary>
+    public bool IsGenericDefinition => !TypeParameters.IsDefaultOrEmpty && TypeArguments.IsDefaultOrEmpty;
+
+    /// <summary>Gets the original generic definition when this is a constructed instance; otherwise <c>this</c>.</summary>
+    public InterfaceSymbol Definition { get; }
+
     /// <summary>Sets <see cref="Methods"/>. Intended to be called once by the binder.</summary>
     /// <param name="methods">The bound method signatures.</param>
     public void SetMethods(ImmutableArray<FunctionSymbol> methods)
     {
         Methods = methods;
+    }
+
+    /// <summary>Sets <see cref="TypeParameters"/> on a generic definition (Phase 4.3c). Intended to be called once by the binder.</summary>
+    /// <param name="typeParameters">The bound type parameters in declared order.</param>
+    public void SetTypeParameters(ImmutableArray<TypeParameterSymbol> typeParameters)
+    {
+        TypeParameters = typeParameters;
     }
 
     /// <summary>Tries to look up an interface method by name.</summary>
@@ -72,5 +108,105 @@ public sealed class InterfaceSymbol : TypeSymbol
 
         method = null;
         return false;
+    }
+
+    /// <summary>
+    /// Constructs a closed instance of a generic interface definition with the supplied type arguments
+    /// (Phase 4.3c / ADR-0020). Method signatures are substituted; identity is cached so two calls with
+    /// the same definition + arguments return the same <see cref="InterfaceSymbol"/> reference.
+    /// </summary>
+    /// <param name="definition">The generic definition to instantiate.</param>
+    /// <param name="typeArguments">The type arguments. Length must match <see cref="TypeParameters"/>.</param>
+    /// <returns>A constructed <see cref="InterfaceSymbol"/> whose <see cref="Definition"/> is the original.</returns>
+    public static InterfaceSymbol Construct(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments)
+    {
+        if (definition == null || !definition.IsGenericDefinition)
+        {
+            return definition;
+        }
+
+        var key = BuildArgsKey(typeArguments);
+        return ConstructedCache.GetOrAdd((definition, key), _ => CreateConstructed(definition, typeArguments));
+    }
+
+    private static string BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments)
+    {
+        var parts = new string[typeArguments.Length];
+        for (var i = 0; i < typeArguments.Length; i++)
+        {
+            parts[i] = System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(typeArguments[i]).ToString();
+        }
+
+        return string.Join(",", parts);
+    }
+
+    private static InterfaceSymbol CreateConstructed(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments)
+    {
+        var subst = new Dictionary<TypeParameterSymbol, TypeSymbol>(definition.TypeParameters.Length);
+        for (var i = 0; i < definition.TypeParameters.Length; i++)
+        {
+            subst[definition.TypeParameters[i]] = typeArguments[i];
+        }
+
+        var argParts = new string[typeArguments.Length];
+        for (var i = 0; i < typeArguments.Length; i++)
+        {
+            argParts[i] = typeArguments[i].Name;
+        }
+
+        var constructedName = $"{definition.Name}[{string.Join(", ", argParts)}]";
+        var instance = new InterfaceSymbol(definition, typeArguments, constructedName);
+
+        var substMethods = ImmutableArray.CreateBuilder<FunctionSymbol>(definition.Methods.Length);
+        foreach (var m in definition.Methods)
+        {
+            var substParams = ImmutableArray.CreateBuilder<ParameterSymbol>(m.Parameters.Length);
+            foreach (var p in m.Parameters)
+            {
+                substParams.Add(new ParameterSymbol(p.Name, SubstituteType(p.Type, subst), p.IsVariadic));
+            }
+
+            var substReturn = SubstituteType(m.Type, subst);
+            var substMethod = new FunctionSymbol(
+                m.Name,
+                substParams.MoveToImmutable(),
+                substReturn,
+                m.Declaration,
+                m.Package,
+                m.Accessibility,
+                receiverType: null);
+            substMethods.Add(substMethod);
+        }
+
+        instance.SetMethods(substMethods.MoveToImmutable());
+        return instance;
+    }
+
+    private static TypeSymbol SubstituteType(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> subst)
+    {
+        if (type is TypeParameterSymbol tp && subst.TryGetValue(tp, out var concrete))
+        {
+            return concrete;
+        }
+
+        if (type is SliceTypeSymbol s)
+        {
+            var sub = SubstituteType(s.ElementType, subst);
+            return sub == s.ElementType ? s : SliceTypeSymbol.Get(sub);
+        }
+
+        if (type is ArrayTypeSymbol a)
+        {
+            var sub = SubstituteType(a.ElementType, subst);
+            return sub == a.ElementType ? a : ArrayTypeSymbol.Get(sub, a.Length);
+        }
+
+        if (type is NullableTypeSymbol n)
+        {
+            var sub = SubstituteType(n.UnderlyingType, subst);
+            return sub == n.UnderlyingType ? n : NullableTypeSymbol.Get(sub);
+        }
+
+        return type;
     }
 }

--- a/src/Core/CodeAnalysis/Syntax/InterfaceDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/InterfaceDeclarationSyntax.cs
@@ -18,7 +18,42 @@ public sealed class InterfaceDeclarationSyntax : MemberSyntax
     /// <param name="accessibilityModifier">The optional accessibility modifier.</param>
     /// <param name="typeKeyword">The <c>type</c> keyword.</param>
     /// <param name="identifier">The interface identifier.</param>
+    /// <param name="typeParameterList">The optional type-parameter list (Phase 4.3c / ADR-0020).</param>
     /// <param name="sealedKeyword">The optional <c>sealed</c> contextual keyword (Phase 3.B.5). Non-null restricts implementors to the same package.</param>
+    /// <param name="interfaceKeyword">The <c>interface</c> keyword.</param>
+    /// <param name="openBraceToken">The opening brace of the body.</param>
+    /// <param name="methods">The method signatures declared inside the interface body.</param>
+    /// <param name="closeBraceToken">The closing brace.</param>
+    public InterfaceDeclarationSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken accessibilityModifier,
+        SyntaxToken typeKeyword,
+        SyntaxToken identifier,
+        TypeParameterListSyntax typeParameterList,
+        SyntaxToken sealedKeyword,
+        SyntaxToken interfaceKeyword,
+        SyntaxToken openBraceToken,
+        ImmutableArray<FunctionDeclarationSyntax> methods,
+        SyntaxToken closeBraceToken)
+        : base(syntaxTree)
+    {
+        AccessibilityModifier = accessibilityModifier;
+        TypeKeyword = typeKeyword;
+        Identifier = identifier;
+        TypeParameterList = typeParameterList;
+        SealedKeyword = sealedKeyword;
+        InterfaceKeyword = interfaceKeyword;
+        OpenBraceToken = openBraceToken;
+        Methods = methods;
+        CloseBraceToken = closeBraceToken;
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="InterfaceDeclarationSyntax"/> class without a type-parameter list (Phase 3 / 4.3c back-compat overload).</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="accessibilityModifier">The optional accessibility modifier.</param>
+    /// <param name="typeKeyword">The <c>type</c> keyword.</param>
+    /// <param name="identifier">The interface identifier.</param>
+    /// <param name="sealedKeyword">The optional <c>sealed</c> contextual keyword (Phase 3.B.5).</param>
     /// <param name="interfaceKeyword">The <c>interface</c> keyword.</param>
     /// <param name="openBraceToken">The opening brace of the body.</param>
     /// <param name="methods">The method signatures declared inside the interface body.</param>
@@ -33,16 +68,8 @@ public sealed class InterfaceDeclarationSyntax : MemberSyntax
         SyntaxToken openBraceToken,
         ImmutableArray<FunctionDeclarationSyntax> methods,
         SyntaxToken closeBraceToken)
-        : base(syntaxTree)
+        : this(syntaxTree, accessibilityModifier, typeKeyword, identifier, typeParameterList: null, sealedKeyword, interfaceKeyword, openBraceToken, methods, closeBraceToken)
     {
-        AccessibilityModifier = accessibilityModifier;
-        TypeKeyword = typeKeyword;
-        Identifier = identifier;
-        SealedKeyword = sealedKeyword;
-        InterfaceKeyword = interfaceKeyword;
-        OpenBraceToken = openBraceToken;
-        Methods = methods;
-        CloseBraceToken = closeBraceToken;
     }
 
     /// <summary>Initializes a new instance of the <see cref="InterfaceDeclarationSyntax"/> class without a sealed modifier (back-compat overload).</summary>
@@ -78,6 +105,9 @@ public sealed class InterfaceDeclarationSyntax : MemberSyntax
 
     /// <summary>Gets the interface identifier.</summary>
     public SyntaxToken Identifier { get; }
+
+    /// <summary>Gets the optional type-parameter list for generic interfaces (Phase 4.3c / ADR-0020).</summary>
+    public TypeParameterListSyntax TypeParameterList { get; }
 
     /// <summary>Gets the optional <c>sealed</c> contextual keyword (Phase 3.B.5). Non-null marks this as a closed hierarchy whose implementors must live in the same package.</summary>
     public SyntaxToken SealedKeyword { get; }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -247,13 +247,9 @@ public class Parser
                 Diagnostics.ReportUnexpectedToken(dataKeyword.Location, SyntaxKind.IdentifierToken, SyntaxKind.InterfaceKeyword);
             }
 
-            if (typeParameterList != null)
-            {
-                // Phase 4.3a only supports generic struct/class; generic interfaces land in 4.3b.
-                Diagnostics.ReportUnexpectedToken(typeParameterList.OpenBracketToken.Location, SyntaxKind.OpenSquareBracketToken, SyntaxKind.InterfaceKeyword);
-            }
-
-            return ParseInterfaceDeclaration(accessibilityModifier, typeKeyword, identifier, sealedModifier);
+            // Phase 4.3c / ADR-0020/0021: generic interfaces. The type-parameter
+            // list (if any) is now forwarded into ParseInterfaceDeclaration.
+            return ParseInterfaceDeclaration(accessibilityModifier, typeKeyword, identifier, typeParameterList, sealedModifier);
         }
 
         if (sealedModifier != null)
@@ -456,6 +452,7 @@ public class Parser
         SyntaxToken accessibilityModifier,
         SyntaxToken typeKeyword,
         SyntaxToken identifier,
+        TypeParameterListSyntax typeParameterList,
         SyntaxToken sealedModifier)
     {
         var interfaceKeyword = MatchToken(SyntaxKind.InterfaceKeyword);
@@ -490,6 +487,7 @@ public class Parser
             accessibilityModifier,
             typeKeyword,
             identifier,
+            typeParameterList,
             sealedModifier,
             interfaceKeyword,
             openBrace,
@@ -650,6 +648,8 @@ public class Parser
                 || follow.Kind == SyntaxKind.StructKeyword
                 || follow.Kind == SyntaxKind.ClassKeyword
                 || follow.Kind == SyntaxKind.InterfaceKeyword
+                || follow.Kind == SyntaxKind.SealedKeyword
+                || follow.Kind == SyntaxKind.OpenKeyword
                 || (follow.Kind == SyntaxKind.IdentifierToken && follow.Text == "data"))
             {
                 return true;
@@ -804,8 +804,44 @@ public class Parser
         }
 
         var identifier = MatchToken(SyntaxKind.IdentifierToken);
+
+        // Phase 4.3c: optional type-argument list `Foo[T1, T2]` in type position.
+        SyntaxToken typeArgOpen = null;
+        SeparatedSyntaxList<TypeClauseSyntax> typeArgs = default;
+        SyntaxToken typeArgClose = null;
+        if (Current.Kind == SyntaxKind.OpenSquareBracketToken)
+        {
+            typeArgOpen = MatchToken(SyntaxKind.OpenSquareBracketToken);
+            var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+            while (Current.Kind != SyntaxKind.CloseSquareBracketToken &&
+                   Current.Kind != SyntaxKind.EndOfFileToken)
+            {
+                nodesAndSeparators.Add(ParseTypeClause());
+                if (Current.Kind == SyntaxKind.CommaToken)
+                {
+                    nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            typeArgs = new SeparatedSyntaxList<TypeClauseSyntax>(nodesAndSeparators.ToImmutable());
+            typeArgClose = MatchToken(SyntaxKind.CloseSquareBracketToken);
+        }
+
         var question = Current.Kind == SyntaxKind.QuestionToken ? MatchToken(SyntaxKind.QuestionToken) : null;
-        return new TypeClauseSyntax(syntaxTree, openBracketToken: null, lengthToken: null, closeBracketToken: null, identifier, question);
+        return new TypeClauseSyntax(
+            syntaxTree,
+            openBracketToken: null,
+            lengthToken: null,
+            closeBracketToken: null,
+            identifier,
+            typeArgOpen,
+            typeArgs,
+            typeArgClose,
+            question);
     }
 
     private TypeClauseSyntax ParseTupleTypeClause()

--- a/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
@@ -52,12 +52,39 @@ public sealed class TypeClauseSyntax : SyntaxNode
         SyntaxToken closeBracketToken,
         SyntaxToken identifier,
         SyntaxToken questionToken)
+        : this(syntaxTree, openBracketToken, lengthToken, closeBracketToken, identifier, typeArgumentOpenBracketToken: null, typeArguments: default, typeArgumentCloseBracketToken: null, questionToken)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="TypeClauseSyntax"/> class supporting an optional type-argument list <c>Foo[T1, T2]</c> in type position (Phase 4.3c / ADR-0020).</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="openBracketToken">The opening bracket token of the array/slice prefix, or <c>null</c>.</param>
+    /// <param name="lengthToken">The numeric length token, or <c>null</c>.</param>
+    /// <param name="closeBracketToken">The closing bracket token of the array/slice prefix, or <c>null</c>.</param>
+    /// <param name="identifier">The (element) type identifier.</param>
+    /// <param name="typeArgumentOpenBracketToken">The opening bracket of the type-argument list, or <c>null</c>.</param>
+    /// <param name="typeArguments">The type-argument list, or the default value.</param>
+    /// <param name="typeArgumentCloseBracketToken">The closing bracket of the type-argument list, or <c>null</c>.</param>
+    /// <param name="questionToken">The optional trailing <c>?</c> marking the type nullable.</param>
+    public TypeClauseSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken openBracketToken,
+        SyntaxToken lengthToken,
+        SyntaxToken closeBracketToken,
+        SyntaxToken identifier,
+        SyntaxToken typeArgumentOpenBracketToken,
+        SeparatedSyntaxList<TypeClauseSyntax> typeArguments,
+        SyntaxToken typeArgumentCloseBracketToken,
+        SyntaxToken questionToken)
         : base(syntaxTree)
     {
         OpenBracketToken = openBracketToken;
         LengthToken = lengthToken;
         CloseBracketToken = closeBracketToken;
         Identifier = identifier;
+        TypeArgumentOpenBracketToken = typeArgumentOpenBracketToken;
+        TypeArguments = typeArguments;
+        TypeArgumentCloseBracketToken = typeArgumentCloseBracketToken;
         QuestionToken = questionToken;
     }
 
@@ -157,4 +184,16 @@ public sealed class TypeClauseSyntax : SyntaxNode
 
     /// <summary>Gets a value indicating whether this clause denotes a function type <c>func(...) R?</c> (Phase 4.7).</summary>
     public bool IsFunction => FuncKeyword != null;
+
+    /// <summary>Gets the opening <c>[</c> of the type-argument list (Phase 4.3c), or <c>null</c>.</summary>
+    public SyntaxToken TypeArgumentOpenBracketToken { get; }
+
+    /// <summary>Gets the comma-separated type-argument clauses for a constructed generic type (Phase 4.3c), or the default value.</summary>
+    public SeparatedSyntaxList<TypeClauseSyntax> TypeArguments { get; }
+
+    /// <summary>Gets the closing <c>]</c> of the type-argument list (Phase 4.3c), or <c>null</c>.</summary>
+    public SyntaxToken TypeArgumentCloseBracketToken { get; }
+
+    /// <summary>Gets a value indicating whether this clause carries a type-argument list <c>Foo[T1, T2]</c> (Phase 4.3c).</summary>
+    public bool HasTypeArguments => TypeArgumentOpenBracketToken != null;
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/GenericInterfaceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/GenericInterfaceTests.cs
@@ -1,0 +1,132 @@
+// <copyright file="GenericInterfaceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Phase 4.3c / ADR-0020 — generic <c>interface</c> declarations with optional
+/// variance modifiers (ADR-0021). Verifies that generic interfaces parse,
+/// bind, can be referenced as constructed types <c>Foo[int]</c> in type
+/// position, and that variance position violations are reported.
+/// </summary>
+public class GenericInterfaceTests
+{
+    [Fact]
+    public void GenericInterfaceDeclaration_Binds()
+    {
+        var source = @"
+type Iter[T any] interface {
+    func Next() T
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ConstructedInterface_AsParameterType_Binds()
+    {
+        var source = @"
+type Iter[T any] interface {
+    func Next() T
+}
+
+func consume(it Iter[int]) int {
+    return it.Next()
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void VarianceOut_OnReturn_OK()
+    {
+        var source = @"
+type Producer[out T] interface {
+    func Get() T
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void VarianceIn_OnParam_OK()
+    {
+        var source = @"
+type Consumer[in T] interface {
+    func Put(v T)
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void VarianceOut_InParamPosition_Diagnoses()
+    {
+        var source = @"
+type Bad[out T] interface {
+    func Take(v T)
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("'out'") && d.Message.Contains("input"));
+    }
+
+    [Fact]
+    public void VarianceIn_InReturnPosition_Diagnoses()
+    {
+        var source = @"
+type Bad[in T] interface {
+    func Get() T
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("'in'") && d.Message.Contains("output"));
+    }
+
+    [Fact]
+    public void ConstructedInterface_WrongArity_Diagnoses()
+    {
+        var source = @"
+type Iter[T any] interface {
+    func Next() T
+}
+
+func consume(it Iter[int, string]) int { return 0 }
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("requires") || d.Message.Contains("type argument"));
+    }
+
+    [Fact]
+    public void SealedGenericInterface_Binds()
+    {
+        var source = @"
+type Result[T any] sealed interface {
+    func Get() T
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Interpreter-only. Closes the generic-interface item from the Phase 4 plan (`p4-3c-generic-interface`); ADR-0020 and ADR-0021 land alongside.

## What

- `InterfaceDeclarationSyntax` carries an optional `TypeParameterListSyntax`. Parser accepts `type Foo[T any] interface { ... }`, including `sealed` / `open` forms.
- `InterfaceSymbol` learns `TypeParameters`, `TypeArguments`, `Definition`, `IsGenericDefinition`, and a cached `Construct(definition, typeArguments)` mirroring `StructSymbol`. Constructed instances have substituted method signatures.
- `TypeClauseSyntax` learns an optional type-argument list so `Foo[int]` resolves in type position; parser parses it greedily after an identifier-form clause (no conflict with `[N]T` / `[]T` array prefix, which precedes the identifier).
- Binder constructs generic interfaces in type-clause position and reports two new diagnostics on misuse (`ReportTypeNotGeneric`, reusing `ReportWrongTypeArgumentCount`).
- `BindInterfaceMembers` pushes `currentTypeParameters` so method signatures see the interface's TPs, and afterwards walks every method's param / return types to enforce variance: `out T` may only appear in covariant (return) position; `in T` may only appear in contravariant (parameter) position. Violations report `ReportTypeParameterVariancePositionViolation`.

## Tests

8 new `GenericInterfaceTests` covering:
- Generic interface declaration
- Constructed type as a function parameter
- Variance OK (`out T` on return, `in T` on parameter)
- Variance violation (`out T` on parameter, `in T` on return)
- Wrong arity diagnoses
- Sealed generic interface still works

Suite: **401 passing** (Core 354 = 346 baseline + 8 new, Sdk 10, Compiler 23, LSP 6, Interpreter 8).

## Scope / non-goals

- Generic struct/class as type clauses is **not** in this PR (mentioned in plan as MVP scope). The type-clause type-argument hook is in place; extending to structs is a small follow-up.
- No emit support; interpreter-only per the existing Phase 4 cadence.
- Variance checking covers direct uses + simple wrappers (slice, array, nullable). Function-type and nested-generic variance checks are deferred.