### PR TITLE
Phase 4.4: generic BCL consumption in type position

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1364,6 +1364,45 @@ public sealed class Binder
             return TupleTypeSymbol.Get(elements.MoveToImmutable());
         }
 
+        // Phase 4.4 / ADR-0020: if the type clause carries a type-argument list,
+        // first try to resolve the identifier as an open generic CLR type via
+        // imports (mangled name `Name`N`). This lets users write `List[int]` or
+        // `Dictionary[string, int]` directly. Falls through to the regular
+        // identifier lookup (covering GSharp generic interfaces/structs) when
+        // the import-search does not produce a match.
+        if (syntax.HasTypeArguments &&
+            scope.TryLookupImportedGenericClass(syntax.Identifier.Text, syntax.TypeArguments.Count, out var clrOpenType))
+        {
+            var clrArgs = new System.Type[syntax.TypeArguments.Count];
+            for (var i = 0; i < syntax.TypeArguments.Count; i++)
+            {
+                var ta = BindTypeClause(syntax.TypeArguments[i]);
+                if (ta == null)
+                {
+                    return null;
+                }
+
+                if (ta.ClrType == null)
+                {
+                    Diagnostics.ReportTypeNotGeneric(syntax.TypeArguments[i].Identifier?.Location ?? syntax.Identifier.Location, ta.Name);
+                    return null;
+                }
+
+                clrArgs[i] = ta.ClrType;
+            }
+
+            try
+            {
+                var closed = clrOpenType.MakeGenericType(clrArgs);
+                return TypeSymbol.FromClrType(closed);
+            }
+            catch (System.ArgumentException)
+            {
+                Diagnostics.ReportTypeNotGeneric(syntax.Identifier.Location, syntax.Identifier.Text);
+                return null;
+            }
+        }
+
         var element = LookupType(syntax.Identifier.Text);
         if (element == null)
         {

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -160,6 +160,37 @@ public sealed class BoundScope
     }
 
     /// <summary>
+    /// Tries to lookup an imported generic open type by simple name and arity (Phase 4.4 / ADR-0020).
+    /// CLR generic types are stored under the mangled name <c>Name`N</c>; this overload
+    /// searches each active import for <c>Target.Name`arity</c>.
+    /// </summary>
+    /// <param name="name">The simple type name as written in source (without the backtick suffix).</param>
+    /// <param name="arity">The number of type parameters.</param>
+    /// <param name="type">The resolved open generic <see cref="System.Type"/> on success.</param>
+    /// <returns>Whether a matching open generic type was found.</returns>
+    public bool TryLookupImportedGenericClass(string name, int arity, out System.Type type)
+    {
+        type = null;
+        if (imports == null || arity <= 0)
+        {
+            return false;
+        }
+
+        var mangled = name + "`" + arity;
+        foreach (var import in imports)
+        {
+            var typeName = import.Target + "." + mangled;
+            if (References.TryResolveType(typeName, out var t))
+            {
+                type = t;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Tries to lookup an imported class.
     /// </summary>
     /// <param name="name">The class name.</param>

--- a/test/Core.Tests/CodeAnalysis/Binding/GenericBclConsumptionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/GenericBclConsumptionTests.cs
@@ -1,0 +1,72 @@
+// <copyright file="GenericBclConsumptionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Phase 4.4 — generic BCL consumption. Users write
+/// <c>List[int]</c> / <c>Dictionary[string, int]</c> in type position and the
+/// binder constructs the closed CLR generic type via
+/// <see cref="System.Type.MakeGenericType"/>.
+/// </summary>
+public class GenericBclConsumptionTests
+{
+    [Fact]
+    public void ListIntInParameterType_Binds()
+    {
+        var source = @"
+import System.Collections.Generic
+
+func consume(xs List[int]) int {
+    return 0
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void DictionaryStringIntInParameterType_Binds()
+    {
+        var source = @"
+import System.Collections.Generic
+
+func consume(d Dictionary[string, int]) int {
+    return 0
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void GenericTypeWrongArity_FallsThroughAndDiagnoses()
+    {
+        var source = @"
+import System.Collections.Generic
+
+func consume(xs List[int, string]) int {
+    return 0
+}
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Interpreter-only. Closes `p4-4-bcl-generics` from the Phase 4 plan: GSharp users can write closed CLR generics like `List[int]` and `Dictionary[string, int]` directly in type-clause positions.

## What

- `BoundScope.TryLookupImportedGenericClass(name, arity, out Type)` walks active imports and resolves the mangled open-generic name (`Name`N`).
- `BindNonNullableTypeClause`, when the clause carries a type-argument list, first tries the CLR open-generic import path; binds each type argument, calls `Type.MakeGenericType`, and returns `TypeSymbol.FromClrType(closed)`. Falls through to the GSharp generic-interface path when no matching CLR open generic is imported.
- Reports `ReportTypeNotGeneric` on arity mismatch (caught `ArgumentException` from `MakeGenericType`) or when a type argument has no `ClrType` backing.

## Tests

3 new `GenericBclConsumptionTests`:
- `List[int]` parameter type binds.
- `Dictionary[string, int]` parameter type binds.
- `List[int, string]` (wrong arity) diagnoses.

Suite: **404 passing** (Core 357 = 354 + 3; Sdk 10; Compiler 23; LSP 6; Interpreter 8).

## Scope / non-goals

- Constructor calls (`List[int]()`) and method-access on closed CLR generics are out of scope here; they land alongside the Phase 4 exit sample work (`samples/CountWords.gs`).
- Closed-generic field/property binding on closed CLR generics is similarly deferred.