### PR TITLE
Phase 4 exit (part 1): CLR constructor calls (non-generic + closed-generic)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -2684,6 +2685,17 @@ public sealed class Binder
 
     private BoundExpression BindCallExpression(CallExpressionSyntax syntax)
     {
+        // Phase 4-exit: prefer CLR class instantiation over the single-arg
+        // conversion-call hijack below, so that `StringBuilder(16)` resolves
+        // to a CLR ctor rather than `BindConversion(int → StringBuilder)`.
+        // Also handles closed-generic imports (`List[int]()`,
+        // `Dictionary[string, int]()`). Interpreter-only — resolves a
+        // ConstructorInfo and emits BoundClrConstructorCallExpression.
+        if (TryBindClrConstructorCall(syntax, out var clrCtorCall))
+        {
+            return clrCtorCall;
+        }
+
         if (syntax.Arguments.Count == 1 && LookupType(syntax.Identifier.Text) is TypeSymbol type)
         {
             // A single-arg call to a primitive-typed name is a conversion
@@ -3131,6 +3143,112 @@ public sealed class Binder
             default:
                 return false;
         }
+    }
+
+    private bool TryBindClrConstructorCall(CallExpressionSyntax syntax, out BoundExpression result)
+    {
+        result = null;
+        var name = syntax.Identifier.Text;
+
+        System.Type clrType = null;
+        if (syntax.TypeArgumentList != null)
+        {
+            // `List[int]()`, `Dictionary[string, int]()`, etc. Resolve the open
+            // generic via imports (mangled `Name`N`) and construct the closed
+            // type via Type.MakeGenericType.
+            if (!scope.TryLookupImportedGenericClass(name, syntax.TypeArgumentList.Arguments.Count, out var openType))
+            {
+                return false;
+            }
+
+            var clrArgs = new System.Type[syntax.TypeArgumentList.Arguments.Count];
+            for (var i = 0; i < syntax.TypeArgumentList.Arguments.Count; i++)
+            {
+                var ta = BindTypeClause(syntax.TypeArgumentList.Arguments[i]);
+                if (ta?.ClrType == null)
+                {
+                    return false;
+                }
+
+                clrArgs[i] = ta.ClrType;
+            }
+
+            try
+            {
+                clrType = openType.MakeGenericType(clrArgs);
+            }
+            catch (System.ArgumentException)
+            {
+                return false;
+            }
+        }
+        else
+        {
+            if (!scope.TryLookupImportedClass(name, declaration: null, out var importedClass))
+            {
+                return false;
+            }
+
+            if (importedClass.ClassType.IsGenericTypeDefinition)
+            {
+                // User wrote `List(...)` without `[T]`; can't construct an open generic.
+                return false;
+            }
+
+            clrType = importedClass.ClassType;
+        }
+
+        if (clrType.IsAbstract || clrType.IsInterface)
+        {
+            return false;
+        }
+
+        var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
+        for (var i = 0; i < syntax.Arguments.Count; i++)
+        {
+            boundArguments.Add(BindExpression(syntax.Arguments[i]));
+        }
+
+        // Pick a constructor by arity + argument-type assignability. Mirrors
+        // the matching loop in ImportedClassSymbol.TryLookupFunction.
+        ConstructorInfo bestCtor = null;
+        foreach (var ctor in clrType.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var parameters = ctor.GetParameters();
+            if (parameters.Length != boundArguments.Count)
+            {
+                continue;
+            }
+
+            var matches = true;
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                var argType = boundArguments[i].Type?.ClrType;
+                if (argType == null || !ClrTypeUtilities.IsAssignableByName(parameters[i].ParameterType, argType))
+                {
+                    matches = false;
+                    break;
+                }
+            }
+
+            if (matches)
+            {
+                bestCtor = ctor;
+                break;
+            }
+        }
+
+        if (bestCtor == null)
+        {
+            return false;
+        }
+
+        result = new BoundClrConstructorCallExpression(
+            clrType,
+            bestCtor,
+            boundArguments.MoveToImmutable(),
+            TypeSymbol.FromClrType(clrType));
+        return true;
     }
 
     private BoundExpression BindAccessorExpression(AccessorExpressionSyntax syntax)

--- a/src/Core/CodeAnalysis/Binding/BoundClrConstructorCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrConstructorCallExpression.cs
@@ -1,0 +1,39 @@
+// <copyright file="BoundClrConstructorCallExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+#pragma warning disable CS1591
+#pragma warning disable SA1600
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Constructs a CLR class instance via a resolved <see cref="ConstructorInfo"/>
+/// (Phase 4 exit). Covers both non-generic imports (<c>StringBuilder()</c>) and
+/// closed generic imports (<c>List[int]()</c>, <c>Dictionary[string, int]()</c>).
+/// Interpreter-only: the evaluator calls <c>Constructor.Invoke(args)</c>.
+/// </summary>
+public sealed class BoundClrConstructorCallExpression : BoundExpression
+{
+    public BoundClrConstructorCallExpression(System.Type clrType, ConstructorInfo constructor, ImmutableArray<BoundExpression> arguments, TypeSymbol resultType)
+    {
+        ClrType = clrType;
+        Constructor = constructor;
+        Arguments = arguments;
+        Type = resultType;
+    }
+
+    public System.Type ClrType { get; }
+
+    public ConstructorInfo Constructor { get; }
+
+    public ImmutableArray<BoundExpression> Arguments { get; }
+
+    public override TypeSymbol Type { get; }
+
+    public override BoundNodeKind Kind => BoundNodeKind.ClrConstructorCallExpression;
+}

--- a/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -54,6 +54,7 @@ public enum BoundNodeKind
     TupleElementAccessExpression,
     FunctionLiteralExpression,
     IndirectCallExpression,
+    ClrConstructorCallExpression,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -156,6 +156,9 @@ public static class BoundNodePrinter
             case BoundNodeKind.IndirectCallExpression:
                 WriteIndirectCallExpression((BoundIndirectCallExpression)node, writer);
                 break;
+            case BoundNodeKind.ClrConstructorCallExpression:
+                WriteClrConstructorCallExpression((BoundClrConstructorCallExpression)node, writer);
+                break;
             default:
                 throw new Exception($"Unexpected node {node.Kind}");
         }
@@ -628,6 +631,24 @@ public static class BoundNodePrinter
     private static void WriteConstructorCallExpression(BoundConstructorCallExpression node, IndentedTextWriter writer)
     {
         writer.WriteIdentifier(node.StructType.Name);
+        writer.WritePunctuation(SyntaxKind.OpenParenthesisToken);
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            if (i > 0)
+            {
+                writer.WritePunctuation(SyntaxKind.CommaToken);
+                writer.WriteSpace();
+            }
+
+            node.Arguments[i].WriteTo(writer);
+        }
+
+        writer.WritePunctuation(SyntaxKind.CloseParenthesisToken);
+    }
+
+    private static void WriteClrConstructorCallExpression(BoundClrConstructorCallExpression node, IndentedTextWriter writer)
+    {
+        writer.WriteIdentifier(node.ClrType.Name);
         writer.WritePunctuation(SyntaxKind.OpenParenthesisToken);
         for (var i = 0; i < node.Arguments.Length; i++)
         {

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -338,6 +338,8 @@ public abstract class BoundTreeRewriter
                 return RewriteFunctionLiteralExpression((BoundFunctionLiteralExpression)node);
             case BoundNodeKind.IndirectCallExpression:
                 return RewriteIndirectCallExpression((BoundIndirectCallExpression)node);
+            case BoundNodeKind.ClrConstructorCallExpression:
+                return RewriteClrConstructorCallExpression((BoundClrConstructorCallExpression)node);
             default:
                 throw new Exception($"Unexpected node: {node.Kind}");
         }
@@ -702,6 +704,34 @@ public abstract class BoundTreeRewriter
         }
 
         return builder == null ? node : new BoundConstructorCallExpression(node.StructType, builder.ToImmutable());
+    }
+
+    /// <summary>Rewrites a CLR constructor call (Phase 4 exit).</summary>
+    /// <param name="node">The node to rewrite.</param>
+    /// <returns>The rewritten node.</returns>
+    protected virtual BoundExpression RewriteClrConstructorCallExpression(BoundClrConstructorCallExpression node)
+    {
+        ImmutableArray<BoundExpression>.Builder builder = null;
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            var oldArg = node.Arguments[i];
+            var newArg = RewriteExpression(oldArg);
+            if (newArg != oldArg && builder == null)
+            {
+                builder = ImmutableArray.CreateBuilder<BoundExpression>(node.Arguments.Length);
+                for (var j = 0; j < i; j++)
+                {
+                    builder.Add(node.Arguments[j]);
+                }
+            }
+
+            if (builder != null)
+            {
+                builder.Add(newArg);
+            }
+        }
+
+        return builder == null ? node : new BoundClrConstructorCallExpression(node.ClrType, node.Constructor, builder.ToImmutable(), node.Type);
     }
 
     /// <summary>Rewrites an instance-method call on a user-defined class.</summary>

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -209,6 +209,7 @@ public sealed class Evaluator
                 BoundNodeKind.TupleElementAccessExpression => EvaluateTupleElementAccessExpression((BoundTupleElementAccessExpression)node),
                 BoundNodeKind.FunctionLiteralExpression => EvaluateFunctionLiteralExpression((BoundFunctionLiteralExpression)node),
                 BoundNodeKind.IndirectCallExpression => EvaluateIndirectCallExpression((BoundIndirectCallExpression)node),
+                BoundNodeKind.ClrConstructorCallExpression => EvaluateClrConstructorCallExpression((BoundClrConstructorCallExpression)node),
                 _ => throw new EvaluatorException($"Unexpected node {node.Kind}", node),
             };
         }
@@ -444,6 +445,17 @@ public sealed class Evaluator
         }
 
         return sv;
+    }
+
+    private object EvaluateClrConstructorCallExpression(BoundClrConstructorCallExpression node)
+    {
+        var args = new object[node.Arguments.Length];
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            args[i] = EvaluateExpression(node.Arguments[i]);
+        }
+
+        return node.Constructor.Invoke(args);
     }
 
     private object EvaluateFieldAccessExpression(BoundFieldAccessExpression node)

--- a/test/Core.Tests/CodeAnalysis/Binding/ClrConstructorCallTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClrConstructorCallTests.cs
@@ -1,0 +1,89 @@
+// <copyright file="ClrConstructorCallTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Phase 4 exit — CLR class instantiation at call sites. Covers both
+/// non-generic (<c>StringBuilder()</c>) and closed-generic
+/// (<c>List[int]()</c>, <c>Dictionary[string, int]()</c>) imports through
+/// the new <see cref="BoundClrConstructorCallExpression"/>.
+/// </summary>
+public class ClrConstructorCallTests
+{
+    [Fact]
+    public void StringBuilder_DefaultConstructor_Binds()
+    {
+        var source = @"
+import System.Text
+
+var sb = StringBuilder()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ListInt_DefaultConstructor_Binds()
+    {
+        var source = @"
+import System.Collections.Generic
+
+var lst = List[int]()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void DictionaryStringInt_DefaultConstructor_Binds()
+    {
+        var source = @"
+import System.Collections.Generic
+
+var d = Dictionary[string, int]()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void StringBuilder_WithCapacityArgument_Binds()
+    {
+        var source = @"
+import System.Text
+
+var sb = StringBuilder(16)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void StringBuilder_TooManyArguments_Diagnoses()
+    {
+        var source = @"
+import System.Text
+
+var sb = StringBuilder(""x"", ""y"", ""z"")
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -165,6 +165,7 @@ BinaryExpression
 BlockStatement
 CallExpression
 CapExpression
+ClrConstructorCallExpression
 ConditionalGotoStatement
 ConstructorCallExpression
 ConversionExpression


### PR DESCRIPTION
## Summary

Adds CLR class instantiation at call sites — the first chunk of the Phase 4 exit work needed to land `samples/CountWords.gs`. Covers both non-generic imports (`StringBuilder()`, `StringBuilder(16)`) and closed-generic imports (`List[int]()`, `Dictionary[string, int]()`).

## What's in scope

- New `BoundClrConstructorCallExpression` carrying `System.Type`, `ConstructorInfo`, and the bound argument list. Plumbed through `BoundNodeKind`, `BoundTreeRewriter`, `BoundNodePrinter`, and `Evaluator`.
- `Binder.TryBindClrConstructorCall` picks a constructor by arity then `ClrTypeUtilities.IsAssignableByName` per argument, mirroring `ImportedClassSymbol.TryLookupFunction`. Closed generics resolve through `BoundScope.TryLookupImportedGenericClass` + `Type.MakeGenericType`. Abstract / interface / open-generic types are rejected.
- The new binder hook runs **before** the single-arg conversion-call hijack so that `StringBuilder(16)` reaches the ctor binder rather than attempting an `int -> StringBuilder` conversion.
- Interpreter-only: the evaluator dispatches via `ConstructorInfo.Invoke`. Emit support is out of scope.

## Tests

- New `ClrConstructorCallTests` (5 facts): `StringBuilder()`, `StringBuilder(16)`, `List[int]()`, `Dictionary[string, int]()`, and a negative case (`StringBuilder("x", "y", "z")` -> diagnostic).
- `coverage-matrix` golden refreshed for the new `BoundNodeKind`.
- Full suite: **409 passing** (404 baseline + 5 new).

## What's deferred

Member access on closed-generic CLR instances (instance properties like `.Count`, indexers, `foreach` iteration) is left for a follow-up PR. That follow-up plus the `samples/CountWords.gs` sample close out the Phase 4 exit work.