### PR TITLE
Phase 4 exit (part 2): CLR member access (properties, indexers)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -3451,6 +3451,29 @@ public sealed class Binder
                     Diagnostics.ReportUnableToFindMember(ne.Location, memberName);
                     return new BoundErrorExpression();
                 }
+                else if (receiver != null && receiver.Type is ImportedTypeSymbol && receiver.Type.ClrType != null)
+                {
+                    // Phase 4 exit: read a public instance property or field on
+                    // a CLR receiver (e.g. `lst.Count`, `sb.Length`,
+                    // `kvp.Key`). Static members are reached through
+                    // ImportedClassSymbol; this path covers instances.
+                    var clrReceiverType = receiver.Type.ClrType;
+                    var memberName = ne.IdentifierToken.Text;
+                    var prop = clrReceiverType.GetProperty(memberName, BindingFlags.Public | BindingFlags.Instance);
+                    if (prop != null && prop.GetIndexParameters().Length == 0 && prop.CanRead)
+                    {
+                        return new BoundClrPropertyAccessExpression(receiver, prop, TypeSymbol.FromClrType(prop.PropertyType));
+                    }
+
+                    var fld = clrReceiverType.GetField(memberName, BindingFlags.Public | BindingFlags.Instance);
+                    if (fld != null)
+                    {
+                        return new BoundClrPropertyAccessExpression(receiver, fld, TypeSymbol.FromClrType(fld.FieldType));
+                    }
+
+                    Diagnostics.ReportUnableToFindMember(ne.Location, memberName);
+                    return new BoundErrorExpression();
+                }
                 else
                 {
                     Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
@@ -3689,12 +3712,21 @@ public sealed class Binder
     private BoundExpression BindIndexExpression(IndexExpressionSyntax syntax)
     {
         var target = BindExpression(syntax.Target);
-        var index = BindConversion(syntax.Index, TypeSymbol.Int);
 
         var element = GetIndexElementType(target.Type);
         if (element != null)
         {
+            var index = BindConversion(syntax.Index, TypeSymbol.Int);
             return new BoundIndexExpression(target, index, element);
+        }
+
+        // Phase 4 exit: CLR indexer read on an imported reference type
+        // (e.g. `d["k"]` on Dictionary[string, int]). Pick a public
+        // instance indexer (a `PropertyInfo` whose `GetIndexParameters()`
+        // matches the single argument by assignability).
+        if (target.Type is ImportedTypeSymbol && target.Type.ClrType is System.Type clrTarget && TryResolveClrIndexer(clrTarget, new[] { syntax.Index }, out var idxProp, out var idxArgs))
+        {
+            return new BoundClrIndexExpression(target, idxProp, idxArgs, TypeSymbol.FromClrType(idxProp.PropertyType));
         }
 
         if (target.Type != TypeSymbol.Error)
@@ -3715,19 +3747,75 @@ public sealed class Binder
         }
 
         var element = GetIndexElementType(variable.Type);
-        if (element == null)
+        if (element != null)
         {
-            if (variable.Type != TypeSymbol.Error)
-            {
-                Diagnostics.ReportTypeNotIndexable(syntax.TargetIdentifier.Location, variable.Type);
-            }
-
-            return new BoundErrorExpression();
+            var index = BindConversion(syntax.Index, TypeSymbol.Int);
+            var value = BindConversion(syntax.Value, element);
+            return new BoundIndexAssignmentExpression(variable, index, value, element);
         }
 
-        var index = BindConversion(syntax.Index, TypeSymbol.Int);
-        var value = BindConversion(syntax.Value, element);
-        return new BoundIndexAssignmentExpression(variable, index, value, element);
+        // Phase 4 exit: CLR indexer write on an imported reference type
+        // (e.g. `d["k"] = 1` on Dictionary[string, int]).
+        if (variable.Type is ImportedTypeSymbol && variable.Type.ClrType is System.Type clrTarget && TryResolveClrIndexer(clrTarget, new[] { syntax.Index }, out var idxProp, out var idxArgs))
+        {
+            if (!idxProp.CanWrite)
+            {
+                Diagnostics.ReportTypeNotIndexable(syntax.TargetIdentifier.Location, variable.Type);
+                return new BoundErrorExpression();
+            }
+
+            var valueType = TypeSymbol.FromClrType(idxProp.PropertyType);
+            var boundValue = BindConversion(syntax.Value, valueType);
+            return new BoundClrIndexAssignmentExpression(variable, idxProp, idxArgs, boundValue, valueType);
+        }
+
+        if (variable.Type != TypeSymbol.Error)
+        {
+            Diagnostics.ReportTypeNotIndexable(syntax.TargetIdentifier.Location, variable.Type);
+        }
+
+        return new BoundErrorExpression();
+    }
+
+    private bool TryResolveClrIndexer(System.Type clrTarget, IReadOnlyList<ExpressionSyntax> argSyntaxes, out PropertyInfo indexer, out ImmutableArray<BoundExpression> boundArguments)
+    {
+        indexer = null;
+        boundArguments = ImmutableArray<BoundExpression>.Empty;
+
+        var bound = ImmutableArray.CreateBuilder<BoundExpression>(argSyntaxes.Count);
+        for (var i = 0; i < argSyntaxes.Count; i++)
+        {
+            bound.Add(BindExpression(argSyntaxes[i]));
+        }
+
+        foreach (var prop in clrTarget.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var ps = prop.GetIndexParameters();
+            if (ps.Length != bound.Count)
+            {
+                continue;
+            }
+
+            var ok = true;
+            for (var i = 0; i < ps.Length; i++)
+            {
+                var argClr = bound[i].Type?.ClrType;
+                if (argClr == null || !ClrTypeUtilities.IsAssignableByName(ps[i].ParameterType, argClr))
+                {
+                    ok = false;
+                    break;
+                }
+            }
+
+            if (ok)
+            {
+                indexer = prop;
+                boundArguments = bound.ToImmutable();
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static TypeSymbol GetIndexElementType(TypeSymbol type)

--- a/src/Core/CodeAnalysis/Binding/BoundClrIndexAssignmentExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrIndexAssignmentExpression.cs
@@ -1,0 +1,42 @@
+// <copyright file="BoundClrIndexAssignmentExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+#pragma warning disable CS1591
+#pragma warning disable SA1600
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Assigns through a CLR indexer (Phase 4 exit). Example:
+/// <c>d["key"] = 42</c> where <c>d</c> is a <c>Dictionary[string, int]</c>.
+/// Interpreter-only — the evaluator calls
+/// <c>Indexer.SetValue(target, value, args)</c>.
+/// </summary>
+public sealed class BoundClrIndexAssignmentExpression : BoundExpression
+{
+    public BoundClrIndexAssignmentExpression(VariableSymbol target, PropertyInfo indexer, ImmutableArray<BoundExpression> arguments, BoundExpression value, TypeSymbol resultType)
+    {
+        Target = target;
+        Indexer = indexer;
+        Arguments = arguments;
+        Value = value;
+        Type = resultType;
+    }
+
+    public VariableSymbol Target { get; }
+
+    public PropertyInfo Indexer { get; }
+
+    public ImmutableArray<BoundExpression> Arguments { get; }
+
+    public BoundExpression Value { get; }
+
+    public override TypeSymbol Type { get; }
+
+    public override BoundNodeKind Kind => BoundNodeKind.ClrIndexAssignmentExpression;
+}

--- a/src/Core/CodeAnalysis/Binding/BoundClrIndexExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrIndexExpression.cs
@@ -1,0 +1,38 @@
+// <copyright file="BoundClrIndexExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+#pragma warning disable CS1591
+#pragma warning disable SA1600
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Reads a value through a CLR indexer (Phase 4 exit). Example:
+/// <c>d["key"]</c> where <c>d</c> is a <c>Dictionary[string, int]</c>.
+/// Interpreter-only — the evaluator calls <c>Indexer.GetValue(target, args)</c>.
+/// </summary>
+public sealed class BoundClrIndexExpression : BoundExpression
+{
+    public BoundClrIndexExpression(BoundExpression target, PropertyInfo indexer, ImmutableArray<BoundExpression> arguments, TypeSymbol resultType)
+    {
+        Target = target;
+        Indexer = indexer;
+        Arguments = arguments;
+        Type = resultType;
+    }
+
+    public BoundExpression Target { get; }
+
+    public PropertyInfo Indexer { get; }
+
+    public ImmutableArray<BoundExpression> Arguments { get; }
+
+    public override TypeSymbol Type { get; }
+
+    public override BoundNodeKind Kind => BoundNodeKind.ClrIndexExpression;
+}

--- a/src/Core/CodeAnalysis/Binding/BoundClrPropertyAccessExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrPropertyAccessExpression.cs
@@ -1,0 +1,35 @@
+// <copyright file="BoundClrPropertyAccessExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+#pragma warning disable CS1591
+#pragma warning disable SA1600
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Reads a public instance <see cref="PropertyInfo"/> or <see cref="FieldInfo"/>
+/// on a CLR receiver (Phase 4 exit). Examples: <c>lst.Count</c>,
+/// <c>sb.Length</c>, <c>kvp.Key</c>. Interpreter-only — the evaluator dispatches
+/// via <c>PropertyInfo.GetValue</c> / <c>FieldInfo.GetValue</c>.
+/// </summary>
+public sealed class BoundClrPropertyAccessExpression : BoundExpression
+{
+    public BoundClrPropertyAccessExpression(BoundExpression receiver, MemberInfo member, TypeSymbol resultType)
+    {
+        Receiver = receiver;
+        Member = member;
+        Type = resultType;
+    }
+
+    public BoundExpression Receiver { get; }
+
+    public MemberInfo Member { get; }
+
+    public override TypeSymbol Type { get; }
+
+    public override BoundNodeKind Kind => BoundNodeKind.ClrPropertyAccessExpression;
+}

--- a/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -55,6 +55,9 @@ public enum BoundNodeKind
     FunctionLiteralExpression,
     IndirectCallExpression,
     ClrConstructorCallExpression,
+    ClrPropertyAccessExpression,
+    ClrIndexExpression,
+    ClrIndexAssignmentExpression,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -159,6 +159,15 @@ public static class BoundNodePrinter
             case BoundNodeKind.ClrConstructorCallExpression:
                 WriteClrConstructorCallExpression((BoundClrConstructorCallExpression)node, writer);
                 break;
+            case BoundNodeKind.ClrPropertyAccessExpression:
+                WriteClrPropertyAccessExpression((BoundClrPropertyAccessExpression)node, writer);
+                break;
+            case BoundNodeKind.ClrIndexExpression:
+                WriteClrIndexExpression((BoundClrIndexExpression)node, writer);
+                break;
+            case BoundNodeKind.ClrIndexAssignmentExpression:
+                WriteClrIndexAssignmentExpression((BoundClrIndexAssignmentExpression)node, writer);
+                break;
             default:
                 throw new Exception($"Unexpected node {node.Kind}");
         }
@@ -662,6 +671,53 @@ public static class BoundNodePrinter
         }
 
         writer.WritePunctuation(SyntaxKind.CloseParenthesisToken);
+    }
+
+    private static void WriteClrPropertyAccessExpression(BoundClrPropertyAccessExpression node, IndentedTextWriter writer)
+    {
+        node.Receiver.WriteTo(writer);
+        writer.WritePunctuation(SyntaxKind.DotToken);
+        writer.WriteIdentifier(node.Member.Name);
+    }
+
+    private static void WriteClrIndexExpression(BoundClrIndexExpression node, IndentedTextWriter writer)
+    {
+        node.Target.WriteTo(writer);
+        writer.WritePunctuation(SyntaxKind.OpenSquareBracketToken);
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            if (i > 0)
+            {
+                writer.WritePunctuation(SyntaxKind.CommaToken);
+                writer.WriteSpace();
+            }
+
+            node.Arguments[i].WriteTo(writer);
+        }
+
+        writer.WritePunctuation(SyntaxKind.CloseSquareBracketToken);
+    }
+
+    private static void WriteClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node, IndentedTextWriter writer)
+    {
+        writer.WriteIdentifier(node.Target.Name);
+        writer.WritePunctuation(SyntaxKind.OpenSquareBracketToken);
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            if (i > 0)
+            {
+                writer.WritePunctuation(SyntaxKind.CommaToken);
+                writer.WriteSpace();
+            }
+
+            node.Arguments[i].WriteTo(writer);
+        }
+
+        writer.WritePunctuation(SyntaxKind.CloseSquareBracketToken);
+        writer.WriteSpace();
+        writer.WritePunctuation(SyntaxKind.EqualsToken);
+        writer.WriteSpace();
+        node.Value.WriteTo(writer);
     }
 
     private static void WriteUserInstanceCallExpression(BoundUserInstanceCallExpression node, IndentedTextWriter writer)

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -340,6 +340,12 @@ public abstract class BoundTreeRewriter
                 return RewriteIndirectCallExpression((BoundIndirectCallExpression)node);
             case BoundNodeKind.ClrConstructorCallExpression:
                 return RewriteClrConstructorCallExpression((BoundClrConstructorCallExpression)node);
+            case BoundNodeKind.ClrPropertyAccessExpression:
+                return RewriteClrPropertyAccessExpression((BoundClrPropertyAccessExpression)node);
+            case BoundNodeKind.ClrIndexExpression:
+                return RewriteClrIndexExpression((BoundClrIndexExpression)node);
+            case BoundNodeKind.ClrIndexAssignmentExpression:
+                return RewriteClrIndexAssignmentExpression((BoundClrIndexAssignmentExpression)node);
             default:
                 throw new Exception($"Unexpected node: {node.Kind}");
         }
@@ -732,6 +738,85 @@ public abstract class BoundTreeRewriter
         }
 
         return builder == null ? node : new BoundClrConstructorCallExpression(node.ClrType, node.Constructor, builder.ToImmutable(), node.Type);
+    }
+
+    /// <summary>Rewrites a CLR property/field access on a CLR receiver.</summary>
+    /// <param name="node">The node to rewrite.</param>
+    /// <returns>The rewritten node.</returns>
+    protected virtual BoundExpression RewriteClrPropertyAccessExpression(BoundClrPropertyAccessExpression node)
+    {
+        var receiver = RewriteExpression(node.Receiver);
+        return receiver == node.Receiver ? node : new BoundClrPropertyAccessExpression(receiver, node.Member, node.Type);
+    }
+
+    /// <summary>Rewrites a CLR indexer read.</summary>
+    /// <param name="node">The node to rewrite.</param>
+    /// <returns>The rewritten node.</returns>
+    protected virtual BoundExpression RewriteClrIndexExpression(BoundClrIndexExpression node)
+    {
+        var target = RewriteExpression(node.Target);
+        ImmutableArray<BoundExpression>.Builder builder = null;
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            var oldArg = node.Arguments[i];
+            var newArg = RewriteExpression(oldArg);
+            if (newArg != oldArg && builder == null)
+            {
+                builder = ImmutableArray.CreateBuilder<BoundExpression>(node.Arguments.Length);
+                for (var j = 0; j < i; j++)
+                {
+                    builder.Add(node.Arguments[j]);
+                }
+            }
+
+            if (builder != null)
+            {
+                builder.Add(newArg);
+            }
+        }
+
+        if (target == node.Target && builder == null)
+        {
+            return node;
+        }
+
+        var args = builder?.ToImmutable() ?? node.Arguments;
+        return new BoundClrIndexExpression(target, node.Indexer, args, node.Type);
+    }
+
+    /// <summary>Rewrites a CLR indexer write.</summary>
+    /// <param name="node">The node to rewrite.</param>
+    /// <returns>The rewritten node.</returns>
+    protected virtual BoundExpression RewriteClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
+    {
+        ImmutableArray<BoundExpression>.Builder builder = null;
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            var oldArg = node.Arguments[i];
+            var newArg = RewriteExpression(oldArg);
+            if (newArg != oldArg && builder == null)
+            {
+                builder = ImmutableArray.CreateBuilder<BoundExpression>(node.Arguments.Length);
+                for (var j = 0; j < i; j++)
+                {
+                    builder.Add(node.Arguments[j]);
+                }
+            }
+
+            if (builder != null)
+            {
+                builder.Add(newArg);
+            }
+        }
+
+        var value = RewriteExpression(node.Value);
+        if (builder == null && value == node.Value)
+        {
+            return node;
+        }
+
+        var args = builder?.ToImmutable() ?? node.Arguments;
+        return new BoundClrIndexAssignmentExpression(node.Target, node.Indexer, args, value, node.Type);
     }
 
     /// <summary>Rewrites an instance-method call on a user-defined class.</summary>

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -210,6 +210,9 @@ public sealed class Evaluator
                 BoundNodeKind.FunctionLiteralExpression => EvaluateFunctionLiteralExpression((BoundFunctionLiteralExpression)node),
                 BoundNodeKind.IndirectCallExpression => EvaluateIndirectCallExpression((BoundIndirectCallExpression)node),
                 BoundNodeKind.ClrConstructorCallExpression => EvaluateClrConstructorCallExpression((BoundClrConstructorCallExpression)node),
+                BoundNodeKind.ClrPropertyAccessExpression => EvaluateClrPropertyAccessExpression((BoundClrPropertyAccessExpression)node),
+                BoundNodeKind.ClrIndexExpression => EvaluateClrIndexExpression((BoundClrIndexExpression)node),
+                BoundNodeKind.ClrIndexAssignmentExpression => EvaluateClrIndexAssignmentExpression((BoundClrIndexAssignmentExpression)node),
                 _ => throw new EvaluatorException($"Unexpected node {node.Kind}", node),
             };
         }
@@ -456,6 +459,46 @@ public sealed class Evaluator
         }
 
         return node.Constructor.Invoke(args);
+    }
+
+    private object EvaluateClrPropertyAccessExpression(BoundClrPropertyAccessExpression node)
+    {
+        var receiver = EvaluateExpression(node.Receiver);
+        return node.Member switch
+        {
+            System.Reflection.PropertyInfo p => p.GetValue(receiver),
+            System.Reflection.FieldInfo f => f.GetValue(receiver),
+            _ => throw new EvaluatorException($"Unsupported CLR member kind '{node.Member.MemberType}'.", node),
+        };
+    }
+
+    private object EvaluateClrIndexExpression(BoundClrIndexExpression node)
+    {
+        var target = EvaluateExpression(node.Target);
+        var args = new object[node.Arguments.Length];
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            args[i] = EvaluateExpression(node.Arguments[i]);
+        }
+
+        return node.Indexer.GetValue(target, args);
+    }
+
+    private object EvaluateClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
+    {
+        var target = node.Target.Kind == Symbols.SymbolKind.GlobalVariable
+            ? globals[node.Target]
+            : locals.Peek()[node.Target];
+
+        var args = new object[node.Arguments.Length];
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            args[i] = EvaluateExpression(node.Arguments[i]);
+        }
+
+        var value = EvaluateExpression(node.Value);
+        node.Indexer.SetValue(target, value, args);
+        return value;
     }
 
     private object EvaluateFieldAccessExpression(BoundFieldAccessExpression node)

--- a/test/Core.Tests/CodeAnalysis/Binding/ClrMemberAccessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClrMemberAccessTests.cs
@@ -1,0 +1,111 @@
+// <copyright file="ClrMemberAccessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Phase 4 exit (part 2) — member access on CLR instance values. Covers
+/// instance property/field reads, indexer reads, and indexer writes
+/// (including keyed writes on <c>Dictionary[K, V]</c>).
+/// </summary>
+public class ClrMemberAccessTests
+{
+    [Fact]
+    public void ListCount_PropertyRead_Binds()
+    {
+        var source = @"
+import System.Collections.Generic
+
+var lst = List[int]()
+lst.Add(1)
+lst.Add(2)
+var n = lst.Count
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void StringBuilderLength_PropertyRead_Binds()
+    {
+        var source = @"
+import System.Text
+
+var sb = StringBuilder()
+sb.Append(""abc"")
+var n = sb.Length
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void DictionaryIndexer_KeyedWriteAndRead_Bind()
+    {
+        var source = @"
+import System.Collections.Generic
+
+var d = Dictionary[string, int]()
+d[""k""] = 42
+var v = d[""k""]
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ListIndexer_ReadByIntKey_Binds()
+    {
+        var source = @"
+import System.Collections.Generic
+
+var lst = List[int]()
+lst.Add(7)
+var first = lst[0]
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void DictionaryIndexer_WrongKeyType_Diagnoses()
+    {
+        var source = @"
+import System.Collections.Generic
+
+var d = Dictionary[string, int]()
+var v = d[5]
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ClrMember_UnknownProperty_Diagnoses()
+    {
+        var source = @"
+import System.Text
+
+var sb = StringBuilder()
+var x = sb.NotAReal
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -166,6 +166,9 @@ BlockStatement
 CallExpression
 CapExpression
 ClrConstructorCallExpression
+ClrIndexAssignmentExpression
+ClrIndexExpression
+ClrPropertyAccessExpression
 ConditionalGotoStatement
 ConstructorCallExpression
 ConversionExpression


### PR DESCRIPTION
## Summary

Builds on #63 to add the remaining must-have operations on closed-generic CLR instances: property/field reads, indexer reads, and indexer writes. Three new bound nodes; interpreter-only.

## What's in scope

- `BoundClrPropertyAccessExpression` — reads a public instance `PropertyInfo` or `FieldInfo` on a CLR receiver (e.g. `lst.Count`, `sb.Length`).
- `BoundClrIndexExpression` — reads through a CLR indexer (e.g. `d["k"]` on `Dictionary[string, int]`). The binder picks an indexer by arg arity then `ClrTypeUtilities.IsAssignableByName` per arg.
- `BoundClrIndexAssignmentExpression` — writes through a CLR indexer (e.g. `d["k"] = 1`).
- All three plumbed through `BoundNodeKind`, `BoundTreeRewriter`, `BoundNodePrinter`, and the `Evaluator`.
- `Binder.BindAccessorStep` gains a CLR branch for `NameExpression` on an `ImportedTypeSymbol` receiver.
- `Binder.BindIndexExpression` / `BindIndexAssignmentExpression` fall through to a CLR indexer resolver when the target type is an `ImportedTypeSymbol` and the array/slice element-type lookup fails. The indexer argument is bound directly (no coerce-to-int), matching the indexer's parameter type by assignability.
- New `TryResolveClrIndexer` helper mirrors the constructor-resolution pattern in `TryBindClrConstructorCall`.

## Why `ImportedTypeSymbol` only

The new CLR branches are gated on `receiver.Type is ImportedTypeSymbol` so the built-in `TypeSymbol.String` doesn't accidentally pick up reflection-discovered members. This preserves the existing `s[i]` not-indexable diagnostic on strings.

## Tests

- New `ClrMemberAccessTests` (6 facts): `List.Count`, `StringBuilder.Length`, dictionary indexer write+read, list indexer read, key-type mismatch diagnoses, unknown property diagnoses.
- `coverage-matrix` golden refreshed for the three new `BoundNodeKind`s.
- Full suite: **415 passing** (409 baseline + 6 new).

## End-to-end probe

```gsharp
package Probe
import System
import System.Collections.Generic

var d = Dictionary[string, int]()
d["hello"] = 1
d["world"] = 2
Console.WriteLine(d["hello"])    // 1
Console.WriteLine(d.Count)         // 2

var lst = List[int]()
lst.Add(10)
lst.Add(20)
Console.WriteLine(lst.Count)       // 2
Console.WriteLine(lst[0])          // 10
```

## What's deferred

`foreach` / `for k, v := range coll` is still on the roadmap (coverage-matrix shows ❌ today). Without it, iteration over CLR collections requires `for i := 0; i < c.Count; i++` paired with the indexer — which now works. The Phase 4 exit `samples/CountWords.gs` will land next (PR #65) and may either use indexed iteration or motivate landing range-for first.