### PR TITLE
Phase 4 exit (part 3): for k, v := range coll

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -47,7 +47,7 @@ Legend: ✅ = supported end-to-end. 🟡 = partially supported (caveats in the N
 | `for i := lo ... hi { }` | ✅ | ✅ | ✅ | ✅ | GSharp-specific; not Go's `for i := lo; i < hi; i++`. |
 | `for cond { }` (while-style) | ✅ | ✅ | ✅ | ✅ | Lowered in the binder to `goto checkLabel; body; check: if cond goto body`. |
 | `for init; cond; post { }` (C-style) | ✅ | ✅ | ✅ | ✅ | Header parts are all optional; `for ;; { }` is the infinite form. `continue` jumps to `post` then re-evaluates `cond`. |
-| `for k, v := range coll` | ❌ | — | — | — | |
+| `for k, v := range coll` | ✅ | ✅ | ✅ | ❌ | Phase 4 exit: binder + interpreter support iterating over arrays/slices (index-based), CLR `IDictionary[K,V]` (key/value), and CLR `IEnumerable[T]` (element-with-counter). Lowerer rewrites to existing `BoundIndexExpression`/`BoundLenExpression` for arrays and to `GetEnumerator`/`MoveNext`/`Current` reflection calls for CLR collections. Emit gap remains. |
 | `break` / `continue` | ✅ | ✅ | ✅ | ✅ | No labels. |
 | `return [e]` | ✅ | ✅ | ✅ | ✅ | Single expr; line-sensitive. |
 | `switch` / `case` / `default` | ✅ | ✅ | ✅ | ✅ | Phase 2.6: discriminant over `int`/`string`/`bool`; each case body is a brace block; binder lowers to a chain of if/else around the bound discriminant. Multiple case values per arm and pattern-matching variants land in Phase 6. |

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1153,6 +1153,8 @@ public sealed class Binder
                 return BindForConditionStatement((ForConditionStatementSyntax)syntax);
             case SyntaxKind.ForClauseStatement:
                 return BindForClauseStatement((ForClauseStatementSyntax)syntax);
+            case SyntaxKind.ForRangeStatement:
+                return BindForRangeStatement((ForRangeStatementSyntax)syntax);
             case SyntaxKind.BreakStatement:
                 return BindBreakStatement((BreakStatementSyntax)syntax);
             case SyntaxKind.ContinueStatement:
@@ -1877,6 +1879,118 @@ public sealed class Binder
         scope = scope.Parent;
 
         return new BoundForEllipsisStatement(variable, lowerBound, upperBound, body, breakLabel, continueLabel);
+    }
+
+    private BoundStatement BindForRangeStatement(ForRangeStatementSyntax syntax)
+    {
+        var collection = BindExpression(syntax.Collection);
+
+        // Decide iteration strategy and element/key types based on the
+        // collection type.
+        ForRangeKind iterationKind;
+        TypeSymbol keyType;
+        TypeSymbol valueType;
+        switch (collection.Type)
+        {
+            case ArrayTypeSymbol arr:
+                iterationKind = ForRangeKind.Indexed;
+                keyType = TypeSymbol.Int;
+                valueType = arr.ElementType;
+                break;
+            case SliceTypeSymbol slice:
+                iterationKind = ForRangeKind.Indexed;
+                keyType = TypeSymbol.Int;
+                valueType = slice.ElementType;
+                break;
+            case ImportedTypeSymbol imp when imp.ClrType != null:
+                if (TryGetClrDictionaryTypes(imp.ClrType, out var dKey, out var dVal))
+                {
+                    iterationKind = ForRangeKind.Dictionary;
+                    keyType = TypeSymbol.FromClrType(dKey);
+                    valueType = TypeSymbol.FromClrType(dVal);
+                }
+                else if (TryGetClrEnumerableElementType(imp.ClrType, out var elemType))
+                {
+                    iterationKind = ForRangeKind.Enumerable;
+                    keyType = TypeSymbol.Int;
+                    valueType = TypeSymbol.FromClrType(elemType);
+                }
+                else
+                {
+                    Diagnostics.ReportTypeNotIndexable(syntax.Collection.Location, collection.Type);
+                    return new BoundExpressionStatement(new BoundErrorExpression());
+                }
+
+                break;
+            default:
+                if (collection.Type != TypeSymbol.Error)
+                {
+                    Diagnostics.ReportTypeNotIndexable(syntax.Collection.Location, collection.Type);
+                }
+
+                return new BoundExpressionStatement(new BoundErrorExpression());
+        }
+
+        scope = new BoundScope(scope);
+
+        VariableSymbol keyVariable = null;
+        VariableSymbol valueVariable;
+        if (syntax.SecondIdentifier != null)
+        {
+            keyVariable = BindVariableDeclaration(syntax.FirstIdentifier, isReadOnly: false, type: keyType);
+            valueVariable = BindVariableDeclaration(syntax.SecondIdentifier, isReadOnly: false, type: valueType);
+        }
+        else
+        {
+            // `for v := range coll` — single var binds the value/element.
+            valueVariable = BindVariableDeclaration(syntax.FirstIdentifier, isReadOnly: false, type: valueType);
+        }
+
+        var body = BindLoopBody(syntax.Body, out var breakLabel, out var continueLabel);
+
+        scope = scope.Parent;
+
+        return new BoundForRangeStatement(keyVariable, valueVariable, collection, iterationKind, body, breakLabel, continueLabel);
+    }
+
+    private static bool TryGetClrDictionaryTypes(System.Type clrType, out System.Type keyType, out System.Type valueType)
+    {
+        foreach (var iface in clrType.GetInterfaces())
+        {
+            if (iface.IsGenericType && iface.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IDictionary`2")
+            {
+                var args = iface.GetGenericArguments();
+                keyType = args[0];
+                valueType = args[1];
+                return true;
+            }
+        }
+
+        keyType = null;
+        valueType = null;
+        return false;
+    }
+
+    private static bool TryGetClrEnumerableElementType(System.Type clrType, out System.Type elementType)
+    {
+        foreach (var iface in clrType.GetInterfaces())
+        {
+            if (iface.IsGenericType && iface.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IEnumerable`1")
+            {
+                elementType = iface.GetGenericArguments()[0];
+                return true;
+            }
+        }
+
+        // Non-generic IEnumerable falls back to object.
+        if (typeof(System.Collections.IEnumerable).IsAssignableFrom(clrType))
+        {
+            elementType = typeof(object);
+            return true;
+        }
+
+        elementType = null;
+        return false;
     }
 
     private BoundStatement BindForConditionStatement(ForConditionStatementSyntax syntax)

--- a/src/Core/CodeAnalysis/Binding/BoundForRangeStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundForRangeStatement.cs
@@ -1,0 +1,76 @@
+// <copyright file="BoundForRangeStatement.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Iteration strategies the evaluator picks per collection kind.
+/// </summary>
+public enum ForRangeKind
+{
+    /// <summary>Iterates an array or slice by integer index.</summary>
+    Indexed,
+
+    /// <summary>Iterates a CLR <c>IDictionary</c> producing key/value pairs.</summary>
+    Dictionary,
+
+    /// <summary>Iterates a CLR <c>IEnumerable</c> (no index — the key variable, if any, is a running counter).</summary>
+    Enumerable,
+}
+
+/// <summary>
+/// Bound for-range statement (Phase 4 exit). Forms:
+/// <c>for v := range coll { ... }</c> (no key) and
+/// <c>for k, v := range coll { ... }</c>. For arrays/slices the key is
+/// the int index; for CLR dictionaries the key is the dictionary key.
+/// </summary>
+public sealed class BoundForRangeStatement : BoundLoopStatement
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundForRangeStatement"/> class.
+    /// </summary>
+    /// <param name="keyVariable">The key variable (may be null when no key was declared).</param>
+    /// <param name="valueVariable">The value variable.</param>
+    /// <param name="collection">The collection expression.</param>
+    /// <param name="kind">The iteration strategy.</param>
+    /// <param name="body">The loop body.</param>
+    /// <param name="breakLabel">The break label.</param>
+    /// <param name="continueLabel">The continue label.</param>
+    public BoundForRangeStatement(
+        VariableSymbol keyVariable,
+        VariableSymbol valueVariable,
+        BoundExpression collection,
+        ForRangeKind kind,
+        BoundStatement body,
+        BoundLabel breakLabel,
+        BoundLabel continueLabel)
+        : base(breakLabel, continueLabel)
+    {
+        KeyVariable = keyVariable;
+        ValueVariable = valueVariable;
+        Collection = collection;
+        IterationKind = kind;
+        Body = body;
+    }
+
+    /// <inheritdoc/>
+    public override BoundNodeKind Kind => BoundNodeKind.ForRangeStatement;
+
+    /// <summary>Gets the key variable (or null when only a value was declared).</summary>
+    public VariableSymbol KeyVariable { get; }
+
+    /// <summary>Gets the value variable.</summary>
+    public VariableSymbol ValueVariable { get; }
+
+    /// <summary>Gets the collection expression.</summary>
+    public BoundExpression Collection { get; }
+
+    /// <summary>Gets the iteration strategy.</summary>
+    public ForRangeKind IterationKind { get; }
+
+    /// <summary>Gets the loop body.</summary>
+    public BoundStatement Body { get; }
+}

--- a/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -19,6 +19,7 @@ public enum BoundNodeKind
     IfStatement,
     ForInfiniteStatement,
     ForEllipsisStatement,
+    ForRangeStatement,
     LabelStatement,
     GotoStatement,
     ConditionalGotoStatement,

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -57,6 +57,9 @@ public static class BoundNodePrinter
             case BoundNodeKind.ForEllipsisStatement:
                 WriteForEllipsisStatement((BoundForEllipsisStatement)node, writer);
                 break;
+            case BoundNodeKind.ForRangeStatement:
+                WriteForRangeStatement((BoundForRangeStatement)node, writer);
+                break;
             case BoundNodeKind.LabelStatement:
                 WriteLabelStatement((BoundLabelStatement)node, writer);
                 break;
@@ -299,6 +302,28 @@ public static class BoundNodePrinter
         writer.WriteKeyword(SyntaxKind.EllipsisToken);
         writer.WriteSpace();
         node.UpperBound.WriteTo(writer);
+        writer.WriteSpace();
+        writer.WriteNestedStatement(node.Body);
+    }
+
+    private static void WriteForRangeStatement(BoundForRangeStatement node, IndentedTextWriter writer)
+    {
+        writer.WriteKeyword(SyntaxKind.ForKeyword);
+        writer.WriteSpace();
+        if (node.KeyVariable != null)
+        {
+            writer.WriteIdentifier(node.KeyVariable.Name);
+            writer.WritePunctuation(SyntaxKind.CommaToken);
+            writer.WriteSpace();
+        }
+
+        writer.WriteIdentifier(node.ValueVariable.Name);
+        writer.WriteSpace();
+        writer.WritePunctuation(SyntaxKind.ColonEqualsToken);
+        writer.WriteSpace();
+        writer.WriteKeyword(SyntaxKind.RangeKeyword);
+        writer.WriteSpace();
+        node.Collection.WriteTo(writer);
         writer.WriteSpace();
         writer.WriteNestedStatement(node.Body);
     }

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -31,6 +31,8 @@ public abstract class BoundTreeRewriter
                 return RewriteForInfiniteStatement((BoundForInfiniteStatement)node);
             case BoundNodeKind.ForEllipsisStatement:
                 return RewriteForEllipsisStatement((BoundForEllipsisStatement)node);
+            case BoundNodeKind.ForRangeStatement:
+                return RewriteForRangeStatement((BoundForRangeStatement)node);
             case BoundNodeKind.LabelStatement:
                 return RewriteLabelStatement((BoundLabelStatement)node);
             case BoundNodeKind.GotoStatement:
@@ -156,6 +158,23 @@ public abstract class BoundTreeRewriter
         }
 
         return new BoundForEllipsisStatement(node.Variable, lowerBound, upperBound, body, node.BreakLabel, node.ContinueLabel);
+    }
+
+    /// <summary>
+    /// Rewrites a for-range statement.
+    /// </summary>
+    /// <param name="node">The for-range statement to rewrite.</param>
+    /// <returns>The rewritten for-range statement.</returns>
+    protected virtual BoundStatement RewriteForRangeStatement(BoundForRangeStatement node)
+    {
+        var collection = RewriteExpression(node.Collection);
+        var body = RewriteStatement(node.Body);
+        if (collection == node.Collection && body == node.Body)
+        {
+            return node;
+        }
+
+        return new BoundForRangeStatement(node.KeyVariable, node.ValueVariable, collection, node.IterationKind, body, node.BreakLabel, node.ContinueLabel);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -219,6 +219,213 @@ public sealed class Lowerer : BoundTreeRewriter
         return RewriteStatement(result);
     }
 
+    /// <inheritdoc/>
+    protected override BoundStatement RewriteForRangeStatement(BoundForRangeStatement node)
+    {
+        // for [<k>,] <v> := range <coll>
+        //     <body>
+        //
+        // ---->  (kind-dependent lowering — see helpers below)
+        //
+        // For arrays/slices (Indexed): index-based iteration using
+        // BoundIndexExpression + BoundLenExpression.
+        // For CLR dictionaries and enumerables: iterator-based iteration
+        // using GetEnumerator()/MoveNext()/Current resolved by reflection.
+        BoundStatement lowered = node.IterationKind switch
+        {
+            ForRangeKind.Indexed => LowerIndexedRange(node),
+            ForRangeKind.Dictionary => LowerCollectionRange(node, isDictionary: true),
+            ForRangeKind.Enumerable => LowerCollectionRange(node, isDictionary: false),
+            _ => throw new System.InvalidOperationException($"Unknown ForRangeKind {node.IterationKind}"),
+        };
+
+        return RewriteStatement(lowered);
+    }
+
+    private BoundStatement LowerIndexedRange(BoundForRangeStatement node)
+    {
+        // {
+        //   var __coll = <collection>
+        //   var __i = 0
+        //   goto start
+        //   body:
+        //   <key> = __i   (only if key var present)
+        //   <value> = __coll[__i]
+        //   <body>
+        //   continue:
+        //   __i = __i + 1
+        //   start:
+        //   gotoTrue (__i < len(__coll)) body
+        //   break:
+        // }
+        var collectionSymbol = new LocalVariableSymbol("__coll", isReadOnly: true, type: node.Collection.Type);
+        var collectionDecl = new BoundVariableDeclaration(collectionSymbol, node.Collection);
+        var collectionExpr = new BoundVariableExpression(collectionSymbol);
+
+        var indexSymbol = new LocalVariableSymbol("__i", isReadOnly: false, type: TypeSymbol.Int);
+        var indexDecl = new BoundVariableDeclaration(indexSymbol, new BoundLiteralExpression(0));
+        var indexExpr = new BoundVariableExpression(indexSymbol);
+
+        var startLabel = GenerateLabel();
+        var bodyLabel = GenerateLabel();
+
+        var perIterationStatements = ImmutableArray.CreateBuilder<BoundStatement>();
+        if (node.KeyVariable != null)
+        {
+            perIterationStatements.Add(new BoundVariableDeclaration(node.KeyVariable, indexExpr));
+        }
+
+        perIterationStatements.Add(new BoundVariableDeclaration(
+            node.ValueVariable,
+            new BoundIndexExpression(collectionExpr, indexExpr, node.ValueVariable.Type)));
+
+        perIterationStatements.Add(node.Body);
+
+        var increment = new BoundExpressionStatement(
+            new BoundAssignmentExpression(
+                indexSymbol,
+                new BoundBinaryExpression(
+                    indexExpr,
+                    BoundBinaryOperator.Bind(SyntaxKind.PlusToken, TypeSymbol.Int, TypeSymbol.Int),
+                    new BoundLiteralExpression(1))));
+
+        var hasMore = new BoundBinaryExpression(
+            indexExpr,
+            BoundBinaryOperator.Bind(SyntaxKind.LessToken, TypeSymbol.Int, TypeSymbol.Int),
+            new BoundLenExpression(collectionExpr));
+
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        statements.Add(collectionDecl);
+        statements.Add(indexDecl);
+        statements.Add(new BoundGotoStatement(startLabel));
+        statements.Add(new BoundLabelStatement(bodyLabel));
+        statements.AddRange(perIterationStatements);
+        statements.Add(new BoundLabelStatement(node.ContinueLabel));
+        statements.Add(increment);
+        statements.Add(new BoundLabelStatement(startLabel));
+        statements.Add(new BoundConditionalGotoStatement(bodyLabel, hasMore, jumpIfTrue: true));
+        statements.Add(new BoundLabelStatement(node.BreakLabel));
+        return new BoundBlockStatement(statements.ToImmutable());
+    }
+
+    private BoundStatement LowerCollectionRange(BoundForRangeStatement node, bool isDictionary)
+    {
+        // {
+        //   var __enum = <coll>.GetEnumerator()
+        //   var __i = 0    (only for Enumerable when keyVar is present)
+        //   goto start
+        //   body:
+        //   <key> = __i  OR  __enum.Current.Key      (depending on kind)
+        //   <value> = __enum.Current  OR  __enum.Current.Value
+        //   <body>
+        //   continue:
+        //   __i = __i + 1   (only for Enumerable when keyVar is present)
+        //   start:
+        //   gotoTrue __enum.MoveNext() body
+        //   break:
+        // }
+        var collClrType = node.Collection.Type.ClrType;
+        var getEnumerator = collClrType.GetMethod("GetEnumerator", System.Type.EmptyTypes);
+        if (getEnumerator == null)
+        {
+            // Defensive: bail out unchanged if we can't resolve. The
+            // binder already validated this case, so this shouldn't fire.
+            return new BoundExpressionStatement(new BoundErrorExpression());
+        }
+
+        var enumeratorClr = getEnumerator.ReturnType;
+        var moveNext = enumeratorClr.GetMethod("MoveNext", System.Type.EmptyTypes)
+                       ?? typeof(System.Collections.IEnumerator).GetMethod("MoveNext", System.Type.EmptyTypes);
+        var currentProp = enumeratorClr.GetProperty("Current")
+                          ?? typeof(System.Collections.IEnumerator).GetProperty("Current");
+
+        var enumeratorType = TypeSymbol.FromClrType(enumeratorClr);
+        var enumeratorSymbol = new LocalVariableSymbol("__enum", isReadOnly: true, type: enumeratorType);
+        var getEnumCall = new BoundImportedInstanceCallExpression(
+            node.Collection,
+            getEnumerator,
+            enumeratorType,
+            ImmutableArray<BoundExpression>.Empty);
+        var enumeratorDecl = new BoundVariableDeclaration(enumeratorSymbol, getEnumCall);
+        var enumeratorExpr = new BoundVariableExpression(enumeratorSymbol);
+
+        var startLabel = GenerateLabel();
+        var bodyLabel = GenerateLabel();
+
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        statements.Add(enumeratorDecl);
+
+        LocalVariableSymbol indexSymbol = null;
+        if (!isDictionary && node.KeyVariable != null)
+        {
+            indexSymbol = new LocalVariableSymbol("__i", isReadOnly: false, type: TypeSymbol.Int);
+            statements.Add(new BoundVariableDeclaration(indexSymbol, new BoundLiteralExpression(0)));
+        }
+
+        statements.Add(new BoundGotoStatement(startLabel));
+        statements.Add(new BoundLabelStatement(bodyLabel));
+
+        var currentAccess = new BoundClrPropertyAccessExpression(
+            enumeratorExpr,
+            currentProp,
+            TypeSymbol.FromClrType(currentProp.PropertyType));
+
+        if (isDictionary)
+        {
+            var kvpClr = currentProp.PropertyType;
+            var keyProp = kvpClr.GetProperty("Key");
+            var valueProp = kvpClr.GetProperty("Value");
+            var kvpSymbol = new LocalVariableSymbol("__kvp", isReadOnly: true, type: TypeSymbol.FromClrType(kvpClr));
+            statements.Add(new BoundVariableDeclaration(kvpSymbol, currentAccess));
+            var kvpExpr = new BoundVariableExpression(kvpSymbol);
+
+            if (node.KeyVariable != null)
+            {
+                statements.Add(new BoundVariableDeclaration(
+                    node.KeyVariable,
+                    new BoundClrPropertyAccessExpression(kvpExpr, keyProp, TypeSymbol.FromClrType(keyProp.PropertyType))));
+            }
+
+            statements.Add(new BoundVariableDeclaration(
+                node.ValueVariable,
+                new BoundClrPropertyAccessExpression(kvpExpr, valueProp, TypeSymbol.FromClrType(valueProp.PropertyType))));
+        }
+        else
+        {
+            if (node.KeyVariable != null)
+            {
+                statements.Add(new BoundVariableDeclaration(node.KeyVariable, new BoundVariableExpression(indexSymbol)));
+            }
+
+            statements.Add(new BoundVariableDeclaration(node.ValueVariable, currentAccess));
+        }
+
+        statements.Add(node.Body);
+        statements.Add(new BoundLabelStatement(node.ContinueLabel));
+
+        if (indexSymbol != null)
+        {
+            var indexExpr = new BoundVariableExpression(indexSymbol);
+            statements.Add(new BoundExpressionStatement(
+                new BoundAssignmentExpression(
+                    indexSymbol,
+                    new BoundBinaryExpression(
+                        indexExpr,
+                        BoundBinaryOperator.Bind(SyntaxKind.PlusToken, TypeSymbol.Int, TypeSymbol.Int),
+                        new BoundLiteralExpression(1)))));
+        }
+
+        statements.Add(new BoundLabelStatement(startLabel));
+        var moveNextCall = new BoundImportedInstanceCallExpression(
+            enumeratorExpr,
+            moveNext,
+            TypeSymbol.Bool,
+            ImmutableArray<BoundExpression>.Empty);
+        statements.Add(new BoundConditionalGotoStatement(bodyLabel, moveNextCall, jumpIfTrue: true));
+        statements.Add(new BoundLabelStatement(node.BreakLabel));
+        return new BoundBlockStatement(statements.ToImmutable());
+    }
+
     private static BoundBlockStatement Flatten(BoundStatement statement)
     {
         var builder = ImmutableArray.CreateBuilder<BoundStatement>();

--- a/src/Core/CodeAnalysis/Syntax/ForRangeStatementSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/ForRangeStatementSyntax.cs
@@ -1,0 +1,76 @@
+// <copyright file="ForRangeStatementSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents a for-range statement: <c>for v := range coll { ... }</c> or
+/// <c>for k, v := range coll { ... }</c>. For arrays and slices the first
+/// identifier binds the int index; for maps / CLR dictionaries the first
+/// identifier binds the key. The second identifier (when present) binds
+/// the element / value. Phase 4 exit.
+/// </summary>
+public sealed class ForRangeStatementSyntax : StatementSyntax
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ForRangeStatementSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="keyword">The <c>for</c> keyword.</param>
+    /// <param name="firstIdentifier">The first identifier (index/key, or value when alone).</param>
+    /// <param name="commaToken">Optional comma separating the two identifiers.</param>
+    /// <param name="secondIdentifier">Optional second identifier (the value).</param>
+    /// <param name="colonEqualsToken">The <c>:=</c> token.</param>
+    /// <param name="rangeKeyword">The <c>range</c> keyword.</param>
+    /// <param name="collection">The collection expression.</param>
+    /// <param name="body">The loop body.</param>
+    public ForRangeStatementSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken keyword,
+        SyntaxToken firstIdentifier,
+        SyntaxToken commaToken,
+        SyntaxToken secondIdentifier,
+        SyntaxToken colonEqualsToken,
+        SyntaxToken rangeKeyword,
+        ExpressionSyntax collection,
+        StatementSyntax body)
+        : base(syntaxTree)
+    {
+        Keyword = keyword;
+        FirstIdentifier = firstIdentifier;
+        CommaToken = commaToken;
+        SecondIdentifier = secondIdentifier;
+        ColonEqualsToken = colonEqualsToken;
+        RangeKeyword = rangeKeyword;
+        Collection = collection;
+        Body = body;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.ForRangeStatement;
+
+    /// <summary>Gets the <c>for</c> keyword.</summary>
+    public SyntaxToken Keyword { get; }
+
+    /// <summary>Gets the first identifier (index/key, or value when no second identifier is present).</summary>
+    public SyntaxToken FirstIdentifier { get; }
+
+    /// <summary>Gets the optional comma separating the two identifiers.</summary>
+    public SyntaxToken CommaToken { get; }
+
+    /// <summary>Gets the optional second identifier (the value).</summary>
+    public SyntaxToken SecondIdentifier { get; }
+
+    /// <summary>Gets the <c>:=</c> token.</summary>
+    public SyntaxToken ColonEqualsToken { get; }
+
+    /// <summary>Gets the <c>range</c> keyword.</summary>
+    public SyntaxToken RangeKeyword { get; }
+
+    /// <summary>Gets the collection expression.</summary>
+    public ExpressionSyntax Collection { get; }
+
+    /// <summary>Gets the loop body.</summary>
+    public StatementSyntax Body { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -1252,6 +1252,11 @@ public class Parser
             return ParseForInfiniteStatement();
         }
 
+        if (LooksLikeForRange())
+        {
+            return ParseForRangeStatement();
+        }
+
         if (LooksLikeForEllipsis())
         {
             return ParseForEllipsisStatement();
@@ -1263,6 +1268,34 @@ public class Parser
         }
 
         return ParseForConditionStatement();
+    }
+
+    private bool LooksLikeForRange()
+    {
+        // `for <ident> := range <expr> { ... }`
+        // `for <ident>, <ident> := range <expr> { ... }`
+        if (Peek(1).Kind != SyntaxKind.IdentifierToken)
+        {
+            return false;
+        }
+
+        int o = 2;
+        if (Peek(o).Kind == SyntaxKind.CommaToken)
+        {
+            if (Peek(o + 1).Kind != SyntaxKind.IdentifierToken)
+            {
+                return false;
+            }
+
+            o += 2;
+        }
+
+        if (Peek(o).Kind != SyntaxKind.ColonEqualsToken)
+        {
+            return false;
+        }
+
+        return Peek(o + 1).Kind == SyntaxKind.RangeKeyword;
     }
 
     private bool LooksLikeForEllipsis()
@@ -1415,6 +1448,25 @@ public class Parser
         var keyword = MatchToken(SyntaxKind.ForKeyword);
         var body = ParseStatement();
         return new ForInfiniteStatementSyntax(syntaxTree, keyword, body);
+    }
+
+    private StatementSyntax ParseForRangeStatement()
+    {
+        var keyword = MatchToken(SyntaxKind.ForKeyword);
+        var firstIdentifier = MatchToken(SyntaxKind.IdentifierToken);
+        SyntaxToken commaToken = null;
+        SyntaxToken secondIdentifier = null;
+        if (Current.Kind == SyntaxKind.CommaToken)
+        {
+            commaToken = MatchToken(SyntaxKind.CommaToken);
+            secondIdentifier = MatchToken(SyntaxKind.IdentifierToken);
+        }
+
+        var colonEqualsToken = MatchToken(SyntaxKind.ColonEqualsToken);
+        var rangeKeyword = MatchToken(SyntaxKind.RangeKeyword);
+        var collection = ParseExpression();
+        var body = ParseStatement();
+        return new ForRangeStatementSyntax(syntaxTree, keyword, firstIdentifier, commaToken, secondIdentifier, colonEqualsToken, rangeKeyword, collection, body);
     }
 
     private StatementSyntax ParseForEllipsisStatement()

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -154,6 +154,7 @@ public enum SyntaxKind
     ForEllipsisStatement,
     ForConditionStatement,
     ForClauseStatement,
+    ForRangeStatement,
     BreakStatement,
     ContinueStatement,
     ReturnStatement,

--- a/test/Core.Tests/CodeAnalysis/Binding/ForRangeStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ForRangeStatementTests.cs
@@ -1,0 +1,146 @@
+// <copyright file="ForRangeStatementTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Phase 4 exit (part 3) — <c>for k, v := range coll</c> over arrays,
+/// slices, CLR dictionaries, and CLR enumerables.
+/// </summary>
+public class ForRangeStatementTests
+{
+    [Fact]
+    public void ForRange_OverArray_ValueOnly_Binds()
+    {
+        var source = @"
+import System
+
+var arr = [3]int{10, 20, 30}
+for v := range arr {
+    Console.WriteLine(v)
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ForRange_OverArray_KeyAndValue_Binds()
+    {
+        var source = @"
+import System
+
+var arr = [3]int{10, 20, 30}
+for i, v := range arr {
+    Console.WriteLine(i)
+    Console.WriteLine(v)
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ForRange_OverList_ValueOnly_Binds()
+    {
+        var source = @"
+import System
+import System.Collections.Generic
+
+var lst = List[int]()
+lst.Add(1)
+lst.Add(2)
+for v := range lst {
+    Console.WriteLine(v)
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ForRange_OverList_KeyAndValue_Binds()
+    {
+        var source = @"
+import System
+import System.Collections.Generic
+
+var lst = List[int]()
+lst.Add(7)
+for i, v := range lst {
+    Console.WriteLine(i)
+    Console.WriteLine(v)
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ForRange_OverDictionary_KeyAndValue_Binds()
+    {
+        var source = @"
+import System
+import System.Collections.Generic
+
+var d = Dictionary[string, int]()
+d[""a""] = 1
+d[""b""] = 2
+for k, v := range d {
+    Console.WriteLine(k)
+    Console.WriteLine(v)
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ForRange_BreakAndContinue_Bind()
+    {
+        var source = @"
+import System
+
+var arr = [4]int{1, 2, 3, 4}
+for i, v := range arr {
+    if v == 2 {
+        continue
+    }
+    if v == 4 {
+        break
+    }
+    Console.WriteLine(v)
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ForRange_OverNonIterable_Diagnoses()
+    {
+        var source = @"
+var x = 42
+for v := range x {
+}
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -59,6 +59,7 @@ ForConditionStatement
 ForEllipsisStatement
 ForInfiniteStatement
 ForKeyword
+ForRangeStatement
 FuncKeyword
 FunctionDeclaration
 FunctionLiteralExpression
@@ -178,6 +179,7 @@ FieldAccessExpression
 FieldAssignmentExpression
 ForEllipsisStatement
 ForInfiniteStatement
+ForRangeStatement
 FunctionLiteralExpression
 GotoStatement
 IfStatement


### PR DESCRIPTION
Adds Go-style range iteration to GSharp `for` statements, completing one of the two remaining items in the Phase 4 exit plan. Interpreter-only for now (emit gap remains, like the rest of the Phase 3/4 CLR-interop work).

## Three iteration strategies

The binder picks one based on the collection's type:

- **Indexed** (arrays + slices, `ArrayTypeSymbol` / `SliceTypeSymbol`): lowered to an index counter loop using existing `BoundIndexExpression` and `BoundLenExpression`.
- **Dictionary** (CLR `IDictionary[K, V]`): lowered to `GetEnumerator()` / `MoveNext()` / `Current` reflection calls. `Current` returns `KeyValuePair[K, V]`, which is unwrapped via `BoundClrPropertyAccessExpression` (lit by #64) into `.Key` and `.Value` and assigned to the user's loop vars.
- **Enumerable** (CLR `IEnumerable[T]`): the same enumerator pattern, with an optional synthesized counter when the user binds both key and value.

`break` and `continue` work naturally because the lowerer reuses the `BoundLoopStatement.BreakLabel`/`ContinueLabel` the binder allocates — no new label fixup machinery needed.

## Surface

Both forms supported:

```go
for v := range coll {        // value/element only
}
for k, v := range coll {     // key (or index) and value
}
```

End-to-end probes pass for arrays, slices, `List[T]`, and `Dictionary[K, V]`.

## Files

New:
- `src/Core/CodeAnalysis/Syntax/ForRangeStatementSyntax.cs`
- `src/Core/CodeAnalysis/Binding/BoundForRangeStatement.cs` (includes `ForRangeKind` enum)
- `test/Core.Tests/CodeAnalysis/Binding/ForRangeStatementTests.cs` (7 tests)

Modified:
- Parser: `LooksLikeForRange` lookahead + `ParseForRangeStatement`; dispatched ahead of ellipsis/clause/condition forms in `ParseForStatement`.
- Binder: `BindForRangeStatement` + `TryGetClrDictionaryTypes` / `TryGetClrEnumerableElementType` reflection helpers walking `IDictionary`2` / `IEnumerable`1`.
- Lowerer: `RewriteForRangeStatement` → `LowerIndexedRange` or `LowerCollectionRange(isDictionary)`.
- BoundTreeRewriter, BoundNodePrinter, BoundNodeKind, SyntaxKind: standard wiring for the new node.
- `docs/coverage-matrix.md`: `for k, v := range coll` row flips to ✅ ✅ ✅ ❌.
- `test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt`: refreshed.

## Tests

All passing: Core.Tests 375 + Compiler.Tests 23 + LanguageServer.Tests 6 — including the new 7 `ForRangeStatementTests` cases (positive: array, list, dictionary, value-only forms, break/continue; negative: range over non-iterable diagnoses).

## What this unblocks

This is part 3 of 3 for Phase 4 exit. With ranges in, the next PR (Phase 4 exit final) ships `samples/CountWords.gs` — the BCL-heavy sample the Phase 4 exit criterion asks for — using `Dictionary[string, int]` with idiomatic `for k, v := range dict` iteration.

## Follow-ups (out of scope)

- Emit support (this PR is interpreter-only, like the rest of CLR interop).
- Single-var Dictionary semantics: today `for v := range dict` would bind `v` to `KeyValuePair` — Go semantics would have `v` be the key. Decide later; the two-var form is the canonical one in samples.
- Generic argument nullability on the dictionary/enumerable type parameters (already a known follow-up from PR #58).