### PR TITLE
Phase 4 exit (final): samples/aspirational/CountWords.gs

### DIFF
--- a/samples/aspirational/CountWords.golden
+++ b/samples/aspirational/CountWords.golden
@@ -1,0 +1,8 @@
+the: 3
+quick: 2
+brown: 1
+fox: 2
+jumps: 1
+over: 1
+lazy: 1
+dog: 1

--- a/samples/aspirational/CountWords.gs
+++ b/samples/aspirational/CountWords.gs
@@ -1,0 +1,48 @@
+// file: CountWords.gs
+//
+// Phase 4 exit sample. Exercises the CLR-interop features that landed
+// across PRs #62–#65 in one cohesive program:
+//
+//   - `Dictionary[K, V]` instantiation via the generic BCL type-position
+//     resolver (Phase 4.4 / ADR-0020) and the CLR constructor-call
+//     binder (Phase 4 exit, part 1).
+//   - Indexer read/write on a CLR map (`counts[w]`) and instance method
+//     calls (`counts.ContainsKey(w)`) via the CLR member-access binder
+//     (Phase 4 exit, part 2).
+//   - Range iteration over both an array (`for w := range words`) and a
+//     CLR `IDictionary[K, V]` (`for k, v := range counts`) via the
+//     for-range lowerer (Phase 4 exit, part 3).
+//   - Cross-feature use of string interpolation (Phase 1.1) and the
+//     fixed-size array literal syntax (Phase 3.A.2).
+//
+// The sample is interpreter-only for now: the emit backend does not yet
+// understand CLR constructor calls / member access / for-range (the
+// Phase 3+4 CLR-interop work is interpreter-first by design). It
+// therefore lives under `samples/aspirational/` and is excluded from
+// the emit conformance harness (ADR-0010). A sibling
+// `CountWordsSampleTests` runs it through the interpreter and diffs
+// stdout against `CountWords.golden`.
+
+package GSharp.Example.CountWords
+
+import System
+import System.Collections.Generic
+
+var words = [12]string{
+    "the", "quick", "brown", "fox", "jumps", "over",
+    "the", "lazy", "dog", "the", "quick", "fox",
+}
+
+var counts = Dictionary[string, int]()
+
+for w := range words {
+    if counts.ContainsKey(w) {
+        counts[w] = counts[w] + 1
+    } else {
+        counts[w] = 1
+    }
+}
+
+for k, v := range counts {
+    Console.WriteLine("$k: $v")
+}

--- a/test/Core.Tests/LanguageConformance/CountWordsSampleTests.cs
+++ b/test/Core.Tests/LanguageConformance/CountWordsSampleTests.cs
@@ -1,0 +1,80 @@
+// <copyright file="CountWordsSampleTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.LanguageConformance;
+
+/// <summary>
+/// Phase 4 exit / ADR-0001: cross-feature integration test for the
+/// <c>samples/aspirational/CountWords.gs</c> sample. Exercises CLR
+/// constructor calls (#63), CLR member access + indexers (#64), and
+/// <c>for k, v := range coll</c> (#65) end-to-end against an actual
+/// <c>Dictionary[string, int]</c>. The sample lives under
+/// <c>samples/aspirational/</c> because the emit backend does not yet
+/// support these CLR-interop features; this interpreter-side test is
+/// the executable spec until emit catches up.
+/// </summary>
+public class CountWordsSampleTests
+{
+    [Fact]
+    public void CountWordsSample_RunsOnInterpreter_MatchesGolden()
+    {
+        var samplesDir = LocateSamplesDirectory();
+        Assert.NotNull(samplesDir);
+
+        var samplePath = Path.Combine(samplesDir!, "aspirational", "CountWords.gs");
+        var goldenPath = Path.Combine(samplesDir!, "aspirational", "CountWords.golden");
+        Assert.True(File.Exists(samplePath), $"missing sample at {samplePath}");
+        Assert.True(File.Exists(goldenPath), $"missing golden at {goldenPath}");
+
+        var source = File.ReadAllText(samplePath);
+        var expected = File.ReadAllText(goldenPath).Replace("\r\n", "\n");
+
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+
+        var prevOut = Console.Out;
+        var captured = new StringWriter();
+        Console.SetOut(captured);
+        EvaluationResult result;
+        try
+        {
+            result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        Assert.Empty(result.Diagnostics);
+        var actual = captured.ToString().Replace("\r\n", "\n");
+        Assert.Equal(expected, actual);
+    }
+
+    private static string LocateSamplesDirectory()
+    {
+        var dir = new DirectoryInfo(Path.GetDirectoryName(typeof(CountWordsSampleTests).Assembly.Location) !);
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir.FullName, "samples");
+            if (Directory.Exists(candidate) && File.Exists(Path.Combine(dir.FullName, "GSharp.sln")))
+            {
+                return candidate;
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Cross-feature integration sample that closes the Phase 4 exit checklist. Counts occurrences of each word in a pre-tokenized string array using a CLR `Dictionary[string, int]`, then iterates the dictionary to print every entry.

## What it exercises (end-to-end, in one program)

- **`Dictionary[K, V]` instantiation** — generic BCL type-position resolver (#62 / ADR-0020) plus the CLR constructor-call binder (#63).
- **Indexer read/write + instance method calls** — `counts[w] = ...` and `counts.ContainsKey(w)` via the CLR member-access binder (#64).
- **`for k, v := range coll`** — range iteration over the input `[12]string` (Indexed strategy) and the `Dictionary[string, int]` (Dictionary strategy) via the for-range lowerer (#65).
- **String interpolation** (`"$k: $v"`, Phase 1.1) and **fixed-size array literals** (Phase 3.A.2).

## Placement

The sample lives under `samples/aspirational/` because the emit backend does not yet support CLR constructor calls / CLR member access / for-range — Phase 3+4 CLR-interop is interpreter-first by design. Per ADR-0010 the `aspirational/` folder is excluded from `SampleConformanceTests` (emit harness), so this sample does not break the emit conformance baseline.

`test/Core.Tests/LanguageConformance/CountWordsSampleTests.cs` is the interpreter-side executable spec: parses the sample, evaluates under the interpreter, captures stdout, and diffs against `CountWords.golden` bit-for-bit. When emit catches up, the sample can be promoted to top-level `samples/` and `SampleConformanceTests` will pick it up automatically.

## Why not `text.Split(" ")`

The plan envisioned reading stdin and splitting. Two practical blockers:

- GSharp has no `char` literal syntax, so the `Split(char)` overload is awkward.
- More importantly: PR #64 explicitly gates CLR member access on `receiver.Type is ImportedTypeSymbol` to keep `TypeSymbol.String` from picking up reflection-discovered `Length`/`this[int]` (which would have regressed the `s[i]` not-indexable diagnostic). Calling `.Split` on a `string` therefore doesn't dispatch yet.

A pre-tokenized array keeps the sample focused on the Phase-4 surface (generics + CLR ctors + CLR members + for-range) without dragging in a separate string-method-dispatch design call. Lifting the string-CLR-members gate is a clean follow-up.

## Files

- `samples/aspirational/CountWords.gs` — the sample
- `samples/aspirational/CountWords.golden` — expected stdout
- `test/Core.Tests/LanguageConformance/CountWordsSampleTests.cs` — interpreter-side conformance test

## Tests

All suites green: Core 376 + Compiler 23 + LSP 6 + Sdk 10 + Interpreter 8.

## What this closes

This is the final deliverable in the Phase 4 exit checklist. With #62–#65 + this sample landed, Phase 4 (generics + tuples + lambdas + multi-return + CLR consumption + exit sample) is complete.

## Follow-ups (out of scope, tracked separately)

- Emit-side support for CLR ctors / CLR member access / for-range — then promote the sample to top-level `samples/`.
- Lift the string-CLR-members gate (would let `text.Split(" ")` and `s.Length` work uniformly).
- Single-var Dictionary iteration semantics (`for k := range dict` → Go binds to key, currently binds to value).