### PR TITLE
Emit parity (E1): no-capture lambdas and indirect calls

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -57,6 +57,13 @@ internal sealed class ReflectionMetadataEmitter
     // Phase 3.B.3 sub-step 2b: instance methods on user-defined classes.
     private readonly Dictionary<FunctionSymbol, MethodDefinitionHandle> methodHandles = new Dictionary<FunctionSymbol, MethodDefinitionHandle>();
 
+    // Phase 4 emit parity (E1): synthesized lambda bodies (no captures).
+    // Populated by a pre-pass walker over every user function/entry body.
+    // Each lambda's synthetic FunctionSymbol is registered alongside user
+    // functions in functionsByPackage so it gets a MethodDef row, and its
+    // body is emitted via the same EmitFunction path.
+    private readonly Dictionary<FunctionSymbol, BoundBlockStatement> lambdaBodies = new Dictionary<FunctionSymbol, BoundBlockStatement>();
+
     private Type coreObjectType;
     private Type coreStringType;
     private Type coreInt32Type;
@@ -299,6 +306,35 @@ internal sealed class ReflectionMetadataEmitter
 
         var entryPointPackage = this.program.EntryPoint?.Package ?? this.program.EntryPointPackage;
 
+        // Phase 4 emit parity (E1): discover all function literals so they get
+        // MethodDef rows and bodies emitted. Walk every user function body
+        // (including class methods), then attach lambdas to the entry-point
+        // package's <Program> container. Bail on closures — captured-variable
+        // support is a follow-up (closure-class synthesis).
+        var lambdas = this.CollectFunctionLiterals();
+        var lambdaHostPackage = entryPointPackage ?? packages[0];
+        if (lambdas.Count > 0)
+        {
+            if (!functionsByPackage.TryGetValue(lambdaHostPackage, out var hostBucket))
+            {
+                hostBucket = new List<FunctionSymbol>();
+                functionsByPackage[lambdaHostPackage] = hostBucket;
+                packages = packages.Add(lambdaHostPackage);
+            }
+
+            foreach (var literal in lambdas)
+            {
+                if (literal.CapturedVariables.Length > 0)
+                {
+                    throw new NotSupportedException(
+                        $"Function literal '{literal.Function.Name}' captures outer variables ({string.Join(", ", literal.CapturedVariables.Select(v => v.Name))}); closure emit is not yet supported (Phase 4 emit parity E2). Run under the interpreter for now.");
+                }
+
+                this.lambdaBodies[literal.Function] = literal.Body;
+                hostBucket.Add(literal.Function);
+            }
+        }
+
         // Plan method rows AND remember each package's ctor row (the methodList
         // pointer on its <Program> TypeDef). Pre-assign function handles so
         // call sites can be encoded before bodies are written. Class default
@@ -355,7 +391,11 @@ internal sealed class ReflectionMetadataEmitter
 
             foreach (var fn in functionsByPackage[pkg])
             {
-                var body = this.program.Functions[fn];
+                if (!this.program.Functions.TryGetValue(fn, out var body))
+                {
+                    body = this.lambdaBodies[fn];
+                }
+
                 this.EmitFunction(fn, body, isEntryPoint: false);
             }
 
@@ -964,6 +1004,24 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         return list;
+    }
+
+    // Phase 4 emit parity (E1): walk every user function body to collect all
+    // BoundFunctionLiteralExpression nodes. Class instance method bodies are
+    // included too. The collector uses BoundTreeRewriter so it reaches every
+    // expression position; the base rewriter does not descend into the lambda's
+    // body (separate lexical scope), so we recurse on Body explicitly to find
+    // nested lambdas.
+    private List<BoundFunctionLiteralExpression> CollectFunctionLiterals()
+    {
+        var sink = new List<BoundFunctionLiteralExpression>();
+        var collector = new LambdaCollector(sink);
+        foreach (var kvp in this.program.Functions)
+        {
+            collector.RewriteStatement(kvp.Value);
+        }
+
+        return sink;
     }
 
     private static void WalkForStructLiterals(BoundNode node, List<BoundStructLiteralExpression> sink)
@@ -1946,6 +2004,12 @@ internal sealed class ReflectionMetadataEmitter
             case "System.Object":
                 encoder.Object();
                 break;
+            case "System.IntPtr":
+                encoder.IntPtr();
+                break;
+            case "System.UIntPtr":
+                encoder.UIntPtr();
+                break;
             default:
                 if (type == null)
                 {
@@ -1998,6 +2062,79 @@ internal sealed class ReflectionMetadataEmitter
         else
         {
             this.EncodeClrType(encoder.Type(), type);
+        }
+    }
+
+    // Phase 4 emit parity (E1): resolve the BCL delegate type backing a
+    // GSharp function type. The default ClrType on FunctionTypeSymbol uses
+    // host-runtime `typeof(Func<,>)` (which lives in System.Private.CoreLib);
+    // the emitter must instead reference the *target* framework's
+    // System.Func / System.Action so the produced TypeRef binds to the right
+    // assembly. Type arguments are resolved through references too so
+    // signature encoding stays consistent end-to-end.
+    private Type ResolveDelegateClrType(FunctionTypeSymbol fnType)
+    {
+        bool isVoid = fnType.ReturnType == null || fnType.ReturnType == TypeSymbol.Void;
+        int arity = fnType.ParameterTypes.Length;
+
+        if (isVoid && arity == 0)
+        {
+            return this.references.GetCoreType("System.Action");
+        }
+
+        var typeName = isVoid
+            ? "System.Action`" + arity.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : "System.Func`" + (arity + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var openDef = this.references.GetCoreType(typeName);
+
+        var args = new Type[arity + (isVoid ? 0 : 1)];
+        for (int i = 0; i < arity; i++)
+        {
+            args[i] = this.MapToReferenceClrType(fnType.ParameterTypes[i].ClrType);
+        }
+
+        if (!isVoid)
+        {
+            args[arity] = this.MapToReferenceClrType(fnType.ReturnType.ClrType);
+        }
+
+        return openDef.MakeGenericType(args);
+    }
+
+    // Map a host-runtime Type onto the MetadataLoadContext type from the
+    // emitter's references when an equivalent exists. Returns the input
+    // unchanged when no mapping is found — non-primitive host types whose
+    // FullName isn't resolvable will keep their original identity (and may
+    // still encode fine via EncodeClrType's primitive matching).
+    private Type MapToReferenceClrType(Type hostType)
+    {
+        if (hostType == null)
+        {
+            return null;
+        }
+
+        if (this.references.TryResolveType(hostType.FullName ?? hostType.Name, out var mapped))
+        {
+            return mapped;
+        }
+
+        return hostType;
+    }
+
+    private sealed class LambdaCollector : BoundTreeRewriter
+    {
+        private readonly List<BoundFunctionLiteralExpression> sink;
+
+        public LambdaCollector(List<BoundFunctionLiteralExpression> sink)
+        {
+            this.sink = sink;
+        }
+
+        protected override BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+        {
+            this.sink.Add(node);
+            this.RewriteStatement(node.Body);
+            return node;
         }
     }
 
@@ -2210,6 +2347,12 @@ internal sealed class ReflectionMetadataEmitter
                     break;
                 case BoundTupleElementAccessExpression tupleAcc:
                     this.EmitTupleElementAccess(tupleAcc);
+                    break;
+                case BoundFunctionLiteralExpression literal:
+                    this.EmitFunctionLiteral(literal);
+                    break;
+                case BoundIndirectCallExpression indirect:
+                    this.EmitIndirectCall(indirect);
                     break;
                 default:
                     throw new NotSupportedException(
@@ -3070,6 +3213,64 @@ internal sealed class ReflectionMetadataEmitter
             this.EmitInstanceReceiver(access.Receiver);
             this.il.OpCode(ILOpCode.Ldfld);
             this.il.Token(this.outer.GetFieldReference(field));
+        }
+
+        // Phase 4 emit parity (E1): function literal `func(x int) int { return x+1 }`
+        // with no captured variables lowers to:
+        //
+        //   ldnull                            ; the `this` argument of the delegate
+        //   ldftn  <synthesizedStaticMethod>  ; pushes the IntPtr for the body
+        //   newobj Func<int,int>::.ctor(object, IntPtr)
+        //
+        // The synthesized method was registered earlier by CollectFunctionLiterals
+        // and assigned a MethodDef row via functionHandles. The delegate's
+        // constructor is looked up off literal.FunctionType.ClrType — every
+        // Func<>/Action<> shipped by the BCL exposes the single canonical
+        // `(object, IntPtr)` ctor.
+        private void EmitFunctionLiteral(BoundFunctionLiteralExpression literal)
+        {
+            if (literal.CapturedVariables.Length > 0)
+            {
+                throw new NotSupportedException(
+                    $"Function literal '{literal.Function.Name}' captures outer variables; closure emit is not yet supported.");
+            }
+
+            if (!this.outer.functionHandles.TryGetValue(literal.Function, out var methodHandle))
+            {
+                throw new InvalidOperationException(
+                    $"Function literal '{literal.Function.Name}' has no emitted MethodDef.");
+            }
+
+            var delegateType = this.outer.ResolveDelegateClrType(literal.FunctionType);
+            var delegateCtor = delegateType.GetConstructors()[0];
+
+            this.il.OpCode(ILOpCode.Ldnull);
+            this.il.OpCode(ILOpCode.Ldftn);
+            this.il.Token(methodHandle);
+            this.il.OpCode(ILOpCode.Newobj);
+            this.il.Token(this.outer.GetCtorReference(delegateCtor));
+        }
+
+        // Phase 4 emit parity (E1): indirect call through a func-typed value.
+        // Evaluates the target (pushes the delegate on the stack), evaluates
+        // each argument, then calls the delegate's `Invoke` method via
+        // `callvirt`.
+        private void EmitIndirectCall(BoundIndirectCallExpression call)
+        {
+            this.EmitExpression(call.Target);
+            foreach (var arg in call.Arguments)
+            {
+                this.EmitExpression(arg);
+            }
+
+            var delegateType = this.outer.ResolveDelegateClrType(call.FunctionType);
+
+            var invoke = delegateType.GetMethod("Invoke")
+                ?? throw new InvalidOperationException(
+                    $"Delegate type '{delegateType.FullName}' has no Invoke method.");
+
+            this.il.OpCode(ILOpCode.Callvirt);
+            this.il.Token(this.outer.GetMethodReference(invoke));
         }
 
         private void EmitInstanceReceiver(BoundExpression receiver)

--- a/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
@@ -18,7 +18,7 @@ public sealed class FunctionTypeSymbol : TypeSymbol
     private static readonly ConcurrentDictionary<string, FunctionTypeSymbol> Cache = new ConcurrentDictionary<string, FunctionTypeSymbol>();
 
     private FunctionTypeSymbol(string name, ImmutableArray<TypeSymbol> parameterTypes, TypeSymbol returnType)
-        : base(name)
+        : base(name, BuildClrType(parameterTypes, returnType))
     {
         ParameterTypes = parameterTypes;
         ReturnType = returnType;
@@ -60,5 +60,66 @@ public sealed class FunctionTypeSymbol : TypeSymbol
 
         var name = sb.ToString();
         return Cache.GetOrAdd(name, n => new FunctionTypeSymbol(n, parameterTypes, returnType ?? TypeSymbol.Void));
+    }
+
+    private static System.Type BuildClrType(ImmutableArray<TypeSymbol> parameterTypes, TypeSymbol returnType)
+    {
+        // Phase 4 emit parity (E): map func(T1, ..., Tn) R to the matching
+        // System.Func<T1, ..., Tn, R> shape (or System.Action<...> when R
+        // is void). Higher arities (>16 args) have no shipped delegate
+        // shape and return a null ClrType, keeping the type
+        // interpreter-only on the emit side.
+        var paramClr = new System.Type[parameterTypes.Length];
+        for (var i = 0; i < parameterTypes.Length; i++)
+        {
+            var pt = parameterTypes[i]?.ClrType;
+            if (pt == null)
+            {
+                return null;
+            }
+
+            paramClr[i] = pt;
+        }
+
+        bool isVoid = returnType == null || returnType == TypeSymbol.Void;
+        if (isVoid)
+        {
+            switch (paramClr.Length)
+            {
+                case 0: return typeof(System.Action);
+                case 1: return typeof(System.Action<>).MakeGenericType(paramClr);
+                case 2: return typeof(System.Action<,>).MakeGenericType(paramClr);
+                case 3: return typeof(System.Action<,,>).MakeGenericType(paramClr);
+                case 4: return typeof(System.Action<,,,>).MakeGenericType(paramClr);
+                case 5: return typeof(System.Action<,,,,>).MakeGenericType(paramClr);
+                case 6: return typeof(System.Action<,,,,,>).MakeGenericType(paramClr);
+                case 7: return typeof(System.Action<,,,,,,>).MakeGenericType(paramClr);
+                case 8: return typeof(System.Action<,,,,,,,>).MakeGenericType(paramClr);
+                default: return null;
+            }
+        }
+
+        var retClr = returnType.ClrType;
+        if (retClr == null)
+        {
+            return null;
+        }
+
+        var args = new System.Type[paramClr.Length + 1];
+        System.Array.Copy(paramClr, args, paramClr.Length);
+        args[paramClr.Length] = retClr;
+        switch (paramClr.Length)
+        {
+            case 0: return typeof(System.Func<>).MakeGenericType(args);
+            case 1: return typeof(System.Func<,>).MakeGenericType(args);
+            case 2: return typeof(System.Func<,,>).MakeGenericType(args);
+            case 3: return typeof(System.Func<,,,>).MakeGenericType(args);
+            case 4: return typeof(System.Func<,,,,>).MakeGenericType(args);
+            case 5: return typeof(System.Func<,,,,,>).MakeGenericType(args);
+            case 6: return typeof(System.Func<,,,,,,>).MakeGenericType(args);
+            case 7: return typeof(System.Func<,,,,,,,>).MakeGenericType(args);
+            case 8: return typeof(System.Func<,,,,,,,,>).MakeGenericType(args);
+            default: return null;
+        }
     }
 }

--- a/test/Compiler.Tests/Emit/LambdaEmitTests.cs
+++ b/test/Compiler.Tests/Emit/LambdaEmitTests.cs
@@ -1,0 +1,208 @@
+// <copyright file="LambdaEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Phase 4 emit-parity tests for function literals (Phase 4.7) — emit
+/// commit E1: no-capture lambdas + indirect calls.
+/// <para>
+/// Each function literal is lowered to a synthesized static method on the
+/// owning package's <c>&lt;Program&gt;</c> type, and the literal site emits
+/// <c>ldnull / ldftn / newobj Func|Action::.ctor(object, IntPtr)</c>. An
+/// indirect call evaluates the target delegate value and dispatches via
+/// <c>callvirt Invoke</c>. Captures are explicitly not in scope for E1 —
+/// see <see cref="ClosureCaptures_StillUnsupported"/>.
+/// </para>
+/// </summary>
+public class LambdaEmitTests
+{
+    [Fact]
+    public void FuncIntInt_AssignedAndInvoked()
+    {
+        var source = """
+            package P
+            import System
+
+            var inc = func(x int) int { return x + 1 }
+            Console.WriteLine(inc(10))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("11\n", output);
+    }
+
+    [Fact]
+    public void ActionNoArgs_AssignedAndInvoked()
+    {
+        var source = """
+            package P
+            import System
+
+            var greet = func() { Console.WriteLine("hi") }
+            greet()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi\n", output);
+    }
+
+    [Fact]
+    public void FuncTwoArgs_AssignedAndInvoked()
+    {
+        var source = """
+            package P
+            import System
+
+            var add = func(a int, b int) int { return a + b }
+            Console.WriteLine(add(3, 4))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void IndirectCall_ThroughFunctionTypedParameter()
+    {
+        var source = """
+            package P
+            import System
+
+            func apply(f func(int) int, x int) int { return f(x) }
+
+            var dbl = func(x int) int { return x * 2 }
+            Console.WriteLine(apply(dbl, 21))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void ClosureCaptures_StillUnsupported()
+    {
+        // Phase 4 emit parity E2 (closures) is not yet implemented.
+        // The emitter must surface a clear diagnostic rather than miscompile.
+        var source = """
+            package P
+            import System
+
+            func makeAdder(n int) func(int) int {
+              return func(x int) int { return x + n }
+            }
+
+            var addN = makeAdder(5)
+            Console.WriteLine(addN(10))
+            """;
+
+        var tempDir = Directory.CreateTempSubdirectory("gs_lambda_emit_neg_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.NotEqual(0, compileExit);
+            var combined = compileOut.ToString() + compileErr.ToString();
+            Assert.Contains("captures outer variables", combined);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_lambda_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Continues the Phase 4 emit-parity push from PR #67. Adds emit-side support for function literals (Phase 4.7) and indirect calls when the literal has no captured outer variables.

## What changes

- **`FunctionTypeSymbol` carries a ClrType.** `func(T1, …, Tn) R` maps to `System.Func<T1, …, Tn, R>` (or `System.Action<…>` for void) for arities 0–8. Higher arities, or signatures whose params/return have no `ClrType`, keep null and remain interpreter-only.
- **Lambda discovery pass.** `ReflectionMetadataEmitter` walks every user function body with a `BoundTreeRewriter` subclass, harvesting all `BoundFunctionLiteralExpression` nodes (including nested), and registers each synthetic `FunctionSymbol` against the entry-point package so it picks up a `MethodDef` row alongside user functions.
- **Emit sites.**
  - `BoundFunctionLiteralExpression` → `ldnull / ldftn <method> / newobj Func|Action::.ctor(object, IntPtr)`.
  - `BoundIndirectCallExpression` → eval target, eval args, `callvirt Invoke`.
- **Reference-resolver-backed delegate types.** `ResolveDelegateClrType` walks `Func``N / `Action``N through `ReferenceResolver` so the produced TypeRef binds to the target framework's `System.Runtime` rather than the gsc host's `System.Private.CoreLib`. `EncodeClrType` recognises `System.IntPtr` / `System.UIntPtr` as ECMA `native int` / `native uint` primitives, which the Func/Action ctor signature requires.
- **Closures rejected loudly.** Captured-variable lambdas throw a clear `NotSupportedException` at emit time so source that runs under the interpreter is not silently miscompiled. Closure-class synthesis is the follow-up (E2).

## Coverage

`LambdaEmitTests` (new) end-to-end compiles + runs:

- `var inc = func(x int) int { return x + 1 }` → invoked → prints `11`
- `var greet = func() { Console.WriteLine("hi") }` → invoked → prints `hi`
- `var add = func(a int, b int) int { return a + b }` → invoked → prints `7`
- `func apply(f func(int) int, x int) int { return f(x) }` invoked with a lambda → prints `42`
- `func makeAdder(n int) func(int) int { return func(x int) int { return x + n } }` is rejected with a closure diagnostic

Full suite: 442 green — Core 376, Compiler 42 (was 37 + 5 new), LSP 6, Sdk 10, Interpreter 8.

## Not in scope

- **E2: captured-variable closures.** Requires synthesizing a closure class with fields for captures, rewriting captured reads/writes to field accesses, and instantiating the closure at the literal site. Will land on a follow-up branch.
- **F: generic user definitions.** Generic functions/types on the emit side remain the next item on the emit-parity exit list.

## Verification

```
dotnet test
# All 442 green
```