### PR TITLE
Emit parity (F1): generic functions, type-erased

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -849,15 +849,13 @@ internal sealed class ReflectionMetadataEmitter
 
     private MethodDefinitionHandle EmitFunction(FunctionSymbol function, BoundBlockStatement body, bool isEntryPoint)
     {
-        // Phase 4.1 follow-up: generic-function IL emission lands in 4.1b.
-        // For now throw a clear error at emit time so source that runs under
-        // the interpreter is not silently miscompiled.
-        if (function.IsGeneric)
-        {
-            throw new NotSupportedException(
-                $"Generic function '{function.Name}' cannot yet be lowered to IL (Phase 4.1b will add CLR generic-method emission). Run under the interpreter for now.");
-        }
-
+        // Phase 4 emit parity (F1): generic functions are emitted with a
+        // type-erased signature — each open type parameter is encoded as
+        // System.Object via EncodeTypeSymbol. Call sites insert the box /
+        // unbox.any around the boundary. This matches the interpreter's
+        // type-erased semantics. ADR-0004 still calls for CLR reified
+        // generics as the long-term goal; F2 will widen to GenericParam +
+        // MVAR/VAR encoding and add a MethodSpec at call sites.
         int bodyOffset = -1;
         if (!this.metadataOnly)
         {
@@ -2056,6 +2054,17 @@ internal sealed class ReflectionMetadataEmitter
         {
             throw new InvalidOperationException("Use ReturnTypeEncoder.Void() for void returns.");
         }
+        else if (type is TypeParameterSymbol)
+        {
+            // Phase 4 emit parity (F1, type-erased): generic function emit
+            // currently follows the interpreter's type-erased model — each
+            // open type parameter is encoded as System.Object. Call sites
+            // insert box / unbox.any around the boundary so value-type
+            // arguments and value-typed returns round-trip correctly.
+            // ADR-0004 mandates CLR reified generics as the long-term goal;
+            // a follow-up will add GenericParam rows and MVAR/VAR encoding.
+            encoder.Object();
+        }
         else if (type is ArrayTypeSymbol arr)
         {
             EncodeTypeSymbol(encoder.SZArray(), arr.ElementType);
@@ -2093,6 +2102,29 @@ internal sealed class ReflectionMetadataEmitter
         {
             this.EncodeTypeSymbol(encoder.Type(), type);
         }
+    }
+
+    // Phase 4 emit parity (F1): used by call sites to decide whether a value
+    // crossing the open-generic boundary needs box / unbox.any. Mirrors the
+    // CLR's value-type predicate over GSharp type symbols.
+    private static bool IsValueTypeSymbol(TypeSymbol type)
+    {
+        if (type == TypeSymbol.Int || type == TypeSymbol.Bool)
+        {
+            return true;
+        }
+
+        if (type is StructSymbol s && !s.IsClass)
+        {
+            return true;
+        }
+
+        if (type?.ClrType != null && type.ClrType.IsValueType)
+        {
+            return true;
+        }
+
+        return false;
     }
 
     private void EncodeClrType(SignatureTypeEncoder encoder, Type type)
@@ -2438,9 +2470,24 @@ internal sealed class ReflectionMetadataEmitter
                     this.EmitBinary(b);
                     break;
                 case BoundCallExpression call:
-                    foreach (var arg in call.Arguments)
+                    for (int i = 0; i < call.Arguments.Length; i++)
                     {
+                        var arg = call.Arguments[i];
                         this.EmitExpression(arg);
+
+                        // Phase 4 emit parity (F1, type-erased generics):
+                        // a parameter typed as an open T receives System.Object
+                        // in the emitted signature. Value-type arguments must
+                        // be boxed at the call boundary so the call's stack
+                        // shape matches the signature.
+                        if (i < call.Function.Parameters.Length
+                            && call.Function.Parameters[i].Type is TypeParameterSymbol
+                            && arg.Type is not TypeParameterSymbol
+                            && IsValueTypeSymbol(arg.Type))
+                        {
+                            this.il.OpCode(ILOpCode.Box);
+                            this.il.Token(this.outer.GetElementTypeToken(arg.Type));
+                        }
                     }
 
                     if (!this.outer.functionHandles.TryGetValue(call.Function, out var fnHandle))
@@ -2450,6 +2497,20 @@ internal sealed class ReflectionMetadataEmitter
                     }
 
                     this.il.Call(fnHandle);
+
+                    // Phase 4 emit parity (F1, type-erased generics): a return
+                    // typed as an open T is encoded as System.Object. If the
+                    // call's substituted return type is a value type, unbox
+                    // the result so the rest of the IL sees the expected
+                    // primitive on stack.
+                    if (call.Function.Type is TypeParameterSymbol
+                        && call.Type is not TypeParameterSymbol
+                        && IsValueTypeSymbol(call.Type))
+                    {
+                        this.il.OpCode(ILOpCode.Unbox_any);
+                        this.il.Token(this.outer.GetElementTypeToken(call.Type));
+                    }
+
                     break;
                 case BoundImportedCallExpression impCall:
                     foreach (var arg in impCall.Arguments)

--- a/test/Compiler.Tests/Emit/GenericFunctionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/GenericFunctionEmitTests.cs
@@ -1,0 +1,188 @@
+// <copyright file="GenericFunctionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Phase 4 emit-parity tests for generic function declarations (Phase 4.1) —
+/// emit commit F1: type-erased generic emit.
+/// <para>
+/// Each open type parameter <c>T</c> is encoded as <c>System.Object</c> in
+/// the method's signature. Call sites box value-type arguments crossing
+/// into <c>T</c>-typed parameters, and <c>unbox.any</c> the return when
+/// the substituted return type is a value type. This matches the
+/// interpreter's type-erased model. ADR-0004 still calls for CLR reified
+/// generics as the long-term goal; F2 (follow-up) will widen to
+/// <c>GenericParam</c> rows with MVAR / VAR encoding and MethodSpec tokens
+/// at call sites.
+/// </para>
+/// </summary>
+public class GenericFunctionEmitTests
+{
+    [Fact]
+    public void GenericIdentity_InferredInt()
+    {
+        var source = """
+            package P
+            import System
+
+            func Identity[T any](x T) T { return x }
+            Console.WriteLine(Identity(42))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void GenericIdentity_ExplicitString()
+    {
+        var source = """
+            package P
+            import System
+
+            func Identity[T any](x T) T { return x }
+            Console.WriteLine(Identity[string]("hi"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi\n", output);
+    }
+
+    [Fact]
+    public void GenericIdentity_InferredBool()
+    {
+        var source = """
+            package P
+            import System
+
+            func Identity[T any](x T) T { return x }
+            Console.WriteLine(Identity(true))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void GenericTwoParameters_FirstWins()
+    {
+        var source = """
+            package P
+            import System
+
+            func First[T any, U any](a T, b U) T { return a }
+            Console.WriteLine(First(10, "ignored"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("10\n", output);
+    }
+
+    [Fact]
+    public void GenericTwoParameters_SecondWins()
+    {
+        var source = """
+            package P
+            import System
+
+            func Second[T any, U any](a T, b U) U { return b }
+            Console.WriteLine(Second("ignored", 99))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    [Fact]
+    public void GenericRoundTrip_StoredAndReused()
+    {
+        // Substituted return is int; the call site unboxes, the assignment
+        // stores into an int-typed local, and arithmetic on it works.
+        var source = """
+            package P
+            import System
+
+            func Identity[T any](x T) T { return x }
+
+            var n = Identity(20)
+            Console.WriteLine(n + 22)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_generic_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Phase 4 emit parity commit F1. Generic function definitions (`func Identity[T any](x T) T { ... }`) can now be lowered to IL using a **type-erased** model: each open type parameter is encoded as `System.Object` in the emitted method signature, matching the interpreter's type-erased semantics. Call sites box value-type arguments crossing into `T`-typed parameters and emit `unbox.any` when the substituted return type is a value type. Reference-type arguments cross the boundary unboxed, with no extra IL.

## Implementation (`ReflectionMetadataEmitter`)

- `EncodeTypeSymbol` now handles `TypeParameterSymbol` → `encoder.Object()`. Field, parameter, return, and local signatures all pick this up automatically.
- `EmitFunction` no longer throws on `function.IsGeneric`; the type-erased signature is sufficient. Bodies of generic functions that simply move values around (`return x`) lower identically to non-generic functions — only the signature changes.
- `BoundCallExpression` emit:
  - For each argument whose corresponding parameter type is a `TypeParameterSymbol`, if the argument's runtime type is a value type (per a new `IsValueTypeSymbol` helper), emit `box <argTypeToken>` after pushing the argument.
  - After the call, if the function's open return type is a `TypeParameterSymbol` and the substituted `call.Type` is a value type, emit `unbox.any <returnTypeToken>`.
- Box / unbox tokens go through the existing `GetElementTypeToken` helper so primitives (`int`, `bool`), user value types, and CLR value types all resolve correctly.

## Tests

`test/Compiler.Tests/Emit/GenericFunctionEmitTests.cs` (6 new):

- `GenericIdentity_InferredInt` — `int` → boxed → unboxed → `42`.
- `GenericIdentity_ExplicitString` — explicit `[string]` type arg.
- `GenericIdentity_InferredBool` — `bool` round-trip prints `True`.
- `GenericTwoParameters_FirstWins` — multiple type parameters.
- `GenericTwoParameters_SecondWins` — second-parameter return path.
- `GenericRoundTrip_StoredAndReused` — unboxed result feeds arithmetic.

## Test results

```
Sdk:           10 passed
Interpreter:    8 passed
LanguageServer: 6 passed
Core:         376 passed
Compiler:      53 passed
TOTAL:        453 passed, 0 failed
```

## Out of scope (follow-up F2)

- **Generic user types** (`struct` / `class` / `interface` with `[T, U, ...]`) — emit still throws `NotSupportedException` on definitions with `TypeParameters`.
- **CLR reified generics** (`GenericParam` rows, `MVAR`/`VAR` encoding, `MethodSpec` tokens at call sites). ADR-0004 mandates this as the long-term goal; the type-erased emit here is the bridge so generic-shaped programs can run under the compiler today.
- **Constraints beyond `any`** (comparable, sealed-interface bounds).
- **Bodies that operate on `T` values via slice / array / struct construction beyond the simple identity / projection shapes** — exercise on demand.