### PR TITLE
Phase 4.9: trailing-lambda call syntax (parser desugar)

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -79,8 +79,8 @@ Legend: ✅ = supported end-to-end. 🟡 = partially supported (caveats in the N
 | Type assertion / conversion (`x.(T)`, `T(x)`) | 🟡 | 🟡 | — | 🟡 | Built-in type names invoked as `int(x)` route through `BindCallExpression` → `BindConversion`; emit currently only handles bool↔int. Go-style `x.(T)` does not exist. |
 | Address-of `&x` / dereference `*x` | 🟡 | ❌ | — | — | Parsed as unary, but no `BoundUnaryOperator` entry → binder rejects. The `Loop.gs` design sample's `*count` is **unimplementable today**. |
 | Channel receive `<-ch` | 🟡 | ❌ | — | — | Parsed; no binding. |
-| Higher-order call `f()(args)` / function values | ❌ | — | — | — | |
-| Function literal / lambda | ❌ | — | — | — | |
+| Higher-order call `f()(args)` / function values | ✅ | ✅ | ✅ | ✅ | Phase 4.7 — first-class function types (`func(T) R`), indirect-call expressions, function-typed locals/params/returns. |
+| Function literal / lambda | ✅ | ✅ | ✅ | ✅ | Phase 4.7 (`func(...) {...}` literal); Phase 4.9 adds Kotlin-style trailing-lambda call syntax — `f(args) func(...) {...}` desugars to `f(args, func(...) {...})` at parse time. |
 
 ## Operators (semantic coverage)
 

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -2106,6 +2106,7 @@ public class Parser
         var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
         var arguments = ParseArguments();
         var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+        arguments = MaybeAppendTrailingLambda(arguments);
         return new CallExpressionSyntax(syntaxTree, identifier, typeArguments, openParen, arguments, closeParen);
     }
 
@@ -2141,7 +2142,47 @@ public class Parser
         var openParenthesisToken = MatchToken(SyntaxKind.OpenParenthesisToken);
         var arguments = ParseArguments();
         var closeParenthesisToken = MatchToken(SyntaxKind.CloseParenthesisToken);
+        arguments = MaybeAppendTrailingLambda(arguments);
         return new CallExpressionSyntax(syntaxTree, identifier, openParenthesisToken, arguments, closeParenthesisToken);
+    }
+
+    // Phase 4.9: Kotlin-style trailing-lambda call syntax. When a call's
+    // closing paren is immediately followed by a `func(...) {...}` literal,
+    // the literal is desugared into an additional last positional argument.
+    // Useful for DSL-flavoured call sites like `runBlocking() func() { ... }`
+    // and `xs.forEach() func(x int) { ... }`. The bare-parens form
+    // (`f func(...) {...}` with no `()`) is intentionally out of scope for
+    // v0 to keep the call grammar unambiguous with statement-level function
+    // literals.
+    private SeparatedSyntaxList<ExpressionSyntax> MaybeAppendTrailingLambda(
+        SeparatedSyntaxList<ExpressionSyntax> arguments)
+    {
+        // Only `func(...) {...}` (a function LITERAL) attaches as a trailing
+        // lambda; `func Name(...)` (a function DECLARATION) must stay as the
+        // following statement-level declaration.
+        if (Current.Kind != SyntaxKind.FuncKeyword
+            || Peek(1).Kind != SyntaxKind.OpenParenthesisToken)
+        {
+            return arguments;
+        }
+
+        var lambda = ParseFunctionLiteralExpression();
+        var existing = arguments.GetWithSeparators();
+        var builder = ImmutableArray.CreateBuilder<SyntaxNode>(existing.Length + 2);
+        builder.AddRange(existing);
+        if (existing.Length > 0 && existing[existing.Length - 1] is not SyntaxToken)
+        {
+            var syntheticComma = new SyntaxToken(
+                syntaxTree,
+                SyntaxKind.CommaToken,
+                lambda.Span.Start,
+                null,
+                null);
+            builder.Add(syntheticComma);
+        }
+
+        builder.Add(lambda);
+        return new SeparatedSyntaxList<ExpressionSyntax>(builder.ToImmutable());
     }
 
     private SeparatedSyntaxList<ExpressionSyntax> ParseArguments()

--- a/test/Core.Tests/CodeAnalysis/Binding/TrailingLambdaTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/TrailingLambdaTests.cs
@@ -1,0 +1,105 @@
+// <copyright file="TrailingLambdaTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Phase 4.9 — Kotlin-style trailing-lambda call syntax. A
+/// <c>func(...) {...}</c> literal that immediately follows a call's closing
+/// paren attaches as that call's last positional argument. The bare-parens
+/// form (no <c>()</c>) is intentionally out of scope; see
+/// <see cref="Parser.MaybeAppendTrailingLambda"/>.
+/// </summary>
+public class TrailingLambdaTests
+{
+    [Fact]
+    public void TrailingLambda_SoleArgument_DesugarsToCallArg()
+    {
+        var result = Evaluate(@"
+func runIt(f func() int) int { return f() }
+runIt() func() int { return 42 }
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void TrailingLambda_WithPrecedingArgs_AppendsAsLast()
+    {
+        var result = Evaluate(@"
+func combine(seed int, f func(int) int) int { return f(seed) }
+combine(10) func(x int) int { return x * 2 }
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(20, result.Value);
+    }
+
+    [Fact]
+    public void TrailingLambda_ZeroArityVoidReturn_Works()
+    {
+        var result = Evaluate(@"
+var sum = 0
+func apply(f func()) { f() }
+apply() func() { sum = 5 }
+sum
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void TrailingLambda_MultipleParameters()
+    {
+        var result = Evaluate(@"
+func reduce2(a int, b int, op func(int, int) int) int { return op(a, b) }
+reduce2(3, 4) func(x int, y int) int { return x + y }
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void FuncDeclaration_FollowingCallStatement_StillParsesAsDeclaration()
+    {
+        // Regression: `func Name(...)` after a call must still parse as a
+        // top-level function declaration, not get gobbled as a trailing
+        // lambda. The lookahead `Peek(1).Kind == OpenParen` guard distinguishes
+        // `func(` (literal) from `func Name(` (declaration).
+        var result = Evaluate(@"
+func Helper(x int) int { return x + 1 }
+Helper(41)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void TrailingLambda_ParseError_WhenLastParamIsNotFunctionType()
+    {
+        // If the trailing lambda is attached to a call whose last parameter is
+        // not a function type, the binder reports the usual argument-type
+        // mismatch.
+        var result = Evaluate(@"
+func takesInt(n int) int { return n }
+takesInt(1) func() int { return 0 }
+");
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Kotlin-style trailing-lambda call syntax: when a call expression's closing paren is immediately followed by a function literal (`func(...) {...}`), the literal is desugared into an additional last positional argument at parse time.

## Examples

```gsharp
runIt() func() int { return 42 }
combine(10) func(x int) int { return x * 2 }
xs.forEach() func(x int) { Console.WriteLine(x) }
```

are equivalent to:

```gsharp
runIt(func() int { return 42 })
combine(10, func(x int) int { return x * 2 })
xs.forEach(func(x int) { Console.WriteLine(x) })
```

This is purely a parser-level rewrite — the resulting bound tree is identical to a normal call with a lambda last-arg, so the binder, evaluator, and emitter all work unchanged.

## Implementation

- New `Parser.MaybeAppendTrailingLambda` invoked from both `ParseCallExpression` and `ParseGenericCallExpression` after the call's close-paren is consumed.
- Guard: only `func` followed by `(` (a literal, not a `func Name(` declaration) is consumed as a trailing lambda. Without this guard, a statement-level function declaration after a call (`xs.forEach()\nfunc Helper(){...}`) would be misparsed.
- Synthetic comma separator is spliced in when the args list is non-empty and didn't end with a trailing comma.

## Out of scope (deferred to Phase 7 polish)

- **Bare-parens form** `f func(...) {...}` (no `()`). Requires more grammar disambiguation work and a clearer lookahead heuristic.
- **Kotlin's brace-only shorthand** `{ x => body }` with inferred parameter types and implicit `it`. Needs new arrow-lambda syntax, parameter-type inference from the call-site signature, and `it` binding.

## Tests

New `TrailingLambdaTests` (6 cases):

- `TrailingLambda_SoleArgument_DesugarsToCallArg`
- `TrailingLambda_WithPrecedingArgs_AppendsAsLast`
- `TrailingLambda_ZeroArityVoidReturn_Works`
- `TrailingLambda_MultipleParameters`
- `FuncDeclaration_FollowingCallStatement_StillParsesAsDeclaration` (regression for the lookahead guard)
- `TrailingLambda_ParseError_WhenLastParamIsNotFunctionType`

Full suite: **482 green** (Core 392 + Compiler 66 + LSP 6 + Sdk 10 + Interpreter 8); was 476.

## Docs

`docs/coverage-matrix.md`: flip the two stale "function values" / "function literal" rows to ✅ (Phase 4.7 work that was already shipped) and note the new Phase 4.9 sugar on the lambda row.