### PR TITLE
Phase 7.5: LSP feature parity (hover, references, rename, code actions, diagnostics on save)

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -128,6 +128,17 @@ Implicit and explicit conversions: `BindConversion` exists but the emitter (`Emi
 
 Reference upcasts (Phase 6 exit, added with `samples/aspirational/ExpressionEval.gs`): a `class` value implicitly converts to any interface it implements and to any of its (transitive) base classes. The interpreter treats the upcast as a no-op (the boxed instance keeps its concrete class identity), so `Lit{Value: 1}` flowing into an `Expr`-typed parameter or composite-literal field works end-to-end on the interpreter. Emit support for the upcast is deferred and shares the same posture as the rest of Phase 6.
 
+## Language server coverage
+
+| Capability | Status | Notes |
+| --- | --- | --- |
+| Document sync diagnostics | ✅ | Open/change publish parse + global-scope diagnostics for responsiveness; save publishes the full binding-stage pipeline. |
+| Folding ranges | ✅ | Top-level function bodies. |
+| Hover | ✅ | Markdown signature hovers for variables, functions, structs/classes, enums, fields, enum members, and known types. |
+| Find references | ✅ | Single-document references through the current document cache; cross-file/package references are a future enhancement. |
+| Rename | ✅ | Single-document workspace edits for user-code symbols; invalid identifiers and CLR/built-in symbols are rejected. |
+| Code actions | ✅ | Sort imports refactor is wired through `textDocument/codeAction`. |
+
 ## Top-line takeaways
 
 1. **The dominant gap is parser → binder**, not binder → emit. The emitter implements essentially every bound node the binder can currently produce; failures show up as parser-rejections or binder "operator/conversion not supported" diagnostics.

--- a/src/LanguageServer/CodeActionHandler.cs
+++ b/src/LanguageServer/CodeActionHandler.cs
@@ -1,0 +1,62 @@
+// <copyright file="CodeActionHandler.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Threading;
+using System.Threading.Tasks;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
+
+namespace GSharp.LanguageServer;
+
+/// <summary>
+/// Code-action handler for GSharp refactorings.
+/// </summary>
+public class CodeActionHandler : CodeActionHandlerBase
+{
+    private readonly ILanguageServerFacade router;
+    private readonly DocumentContentService documentContentService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CodeActionHandler"/> class.
+    /// </summary>
+    /// <param name="router"><see cref="ILanguageServerFacade"/> for LSP.</param>
+    /// <param name="documentContentService"><see cref="DocumentContentService"/> instance.</param>
+    public CodeActionHandler(ILanguageServerFacade router, DocumentContentService documentContentService)
+    {
+        this.router = router;
+        this.documentContentService = documentContentService;
+    }
+
+    /// <inheritdoc/>
+    public override Task<CommandOrCodeActionContainer> Handle(CodeActionParams request, CancellationToken cancellationToken)
+    {
+        var key = request.TextDocument.Uri.ToString();
+        if (!this.documentContentService.TryGet(key, out DocumentContent content))
+        {
+            this.router.Window.LogWarning($"No syntax tree for {key}");
+            return Task.FromResult(new CommandOrCodeActionContainer());
+        }
+
+        return Task.FromResult(CodeActionComputer.ComputeCodeActions(request.TextDocument.Uri, content, request.Range));
+    }
+
+    /// <inheritdoc/>
+    public override Task<CodeAction> Handle(CodeAction request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(request);
+    }
+
+    /// <inheritdoc/>
+    protected override CodeActionRegistrationOptions CreateRegistrationOptions(CodeActionCapability capability, ClientCapabilities clientCapabilities)
+    {
+        return new CodeActionRegistrationOptions
+        {
+            DocumentSelector = Constants.DocumentSelector,
+            CodeActionKinds = new Container<CodeActionKind>(CodeActionKind.RefactorRewrite),
+        };
+    }
+}

--- a/src/LanguageServer/DocumentSyncHandler.cs
+++ b/src/LanguageServer/DocumentSyncHandler.cs
@@ -73,6 +73,13 @@ public class DocumentSyncHandler : TextDocumentSyncHandlerBase
     /// <inheritdoc/>
     public override Task<Unit> Handle(DidSaveTextDocumentParams request, CancellationToken cancellationToken)
     {
+        var text = request.Text;
+        if (!string.IsNullOrEmpty(text))
+        {
+            // Open/change keeps binding diagnostics disabled for responsive typing; save runs the full pipeline.
+            this.DiagnoseText(request.TextDocument.Uri, text, skipBinding: false);
+        }
+
         return Unit.Task;
     }
 
@@ -83,18 +90,7 @@ public class DocumentSyncHandler : TextDocumentSyncHandlerBase
         return Unit.Task;
     }
 
-    /// <inheritdoc/>
-    protected override TextDocumentSyncRegistrationOptions CreateRegistrationOptions(
-        TextSynchronizationCapability capability, ClientCapabilities clientCapabilities)
-    {
-        return new TextDocumentSyncRegistrationOptions(TextDocumentSyncKind.Full)
-        {
-            DocumentSelector = Constants.DocumentSelector,
-            Save = new BooleanOr<SaveOptions>(new SaveOptions { IncludeText = true }),
-        };
-    }
-
-    private void DiagnoseText(DocumentUri documentUri, string text, bool skipBinding = true)
+    internal static DiagnosticComputationResult ComputeDiagnostics(string text, bool skipBinding)
     {
         var newLines = new List<int>();
         int nextNewLine = text.IndexOf(Environment.NewLine, StringComparison.Ordinal);
@@ -107,7 +103,6 @@ public class DocumentSyncHandler : TextDocumentSyncHandlerBase
         var diagnostics = new List<Diagnostic>();
 
         var syntaxTree = SyntaxTree.Parse(text);
-        this.documentContentService.AddOrUpdate(documentUri.ToString(), new DocumentContent(syntaxTree, newLines));
         foreach (var d in syntaxTree.Diagnostics)
         {
             diagnostics.Add(BuildDiagnostic("Syntax", d.Message, d.Location.Span.Start, d.Location.Span.End, newLines));
@@ -128,10 +123,28 @@ public class DocumentSyncHandler : TextDocumentSyncHandlerBase
             }
         }
 
+        return new DiagnosticComputationResult(new DocumentContent(syntaxTree, newLines), diagnostics);
+    }
+
+    /// <inheritdoc/>
+    protected override TextDocumentSyncRegistrationOptions CreateRegistrationOptions(
+        TextSynchronizationCapability capability, ClientCapabilities clientCapabilities)
+    {
+        return new TextDocumentSyncRegistrationOptions(TextDocumentSyncKind.Full)
+        {
+            DocumentSelector = Constants.DocumentSelector,
+            Save = new BooleanOr<SaveOptions>(new SaveOptions { IncludeText = true }),
+        };
+    }
+
+    private void DiagnoseText(DocumentUri documentUri, string text, bool skipBinding = true)
+    {
+        var result = ComputeDiagnostics(text, skipBinding);
+        this.documentContentService.AddOrUpdate(documentUri.ToString(), result.Content);
         this.router.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
         {
             Uri = documentUri,
-            Diagnostics = diagnostics,
+            Diagnostics = new Container<Diagnostic>(result.Diagnostics),
         });
     }
 
@@ -148,4 +161,17 @@ public class DocumentSyncHandler : TextDocumentSyncHandlerBase
             Source = Constants.LanguageIdentifier,
         };
     }
+}
+
+internal sealed class DiagnosticComputationResult
+{
+    public DiagnosticComputationResult(DocumentContent content, IReadOnlyList<Diagnostic> diagnostics)
+    {
+        Content = content;
+        Diagnostics = diagnostics;
+    }
+
+    public DocumentContent Content { get; }
+
+    public IReadOnlyList<Diagnostic> Diagnostics { get; }
 }

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -1,0 +1,274 @@
+// <copyright file="LspFeatureComputers.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace GSharp.LanguageServer;
+
+internal static class HoverComputer
+{
+    public static Hover ComputeHover(DocumentContent content, Position position)
+    {
+        var compilation = new Compilation(content.SyntaxTree);
+        var offset = SemanticLookup.ToOffset(content, position);
+        var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
+        var symbol = SemanticLookup.ResolveSymbol(compilation, token);
+        if (symbol == null)
+        {
+            return null;
+        }
+
+        var signature = FormatSymbol(symbol);
+        return new Hover
+        {
+            Contents = new MarkedStringsOrMarkupContent(new MarkupContent
+            {
+                Kind = MarkupKind.Markdown,
+                Value = $"```gsharp\n{signature}\n```",
+            }),
+            Range = SemanticLookup.ToRange(token),
+        };
+    }
+
+    internal static string FormatSymbol(Symbol symbol)
+    {
+        return symbol switch
+        {
+            VariableSymbol variable => $"let {variable.Name}: {FormatType(variable.Type)}",
+            FunctionSymbol function => FormatFunction(function),
+            StructSymbol aggregate => FormatAggregate(aggregate),
+            EnumSymbol enumSymbol => FormatEnum(enumSymbol),
+            EnumMemberSymbol member => $"enum member {member.EnumType.Name}.{member.Name}: {FormatType(member.EnumType)}",
+            FieldSymbol field => $"field {field.Name}: {FormatType(field.Type)}",
+            TypeSymbol type => $"type {FormatType(type)}",
+            _ => $"{symbol.Kind.ToString().ToLowerInvariant()} {symbol.Name}",
+        };
+    }
+
+    private static string FormatFunction(FunctionSymbol function)
+    {
+        var parameters = string.Join(", ", function.Parameters.Select(p => $"{p.Name} {FormatType(p.Type)}"));
+        var returnType = ReferenceEquals(function.Type, TypeSymbol.Void) ? string.Empty : $" {FormatType(function.Type)}";
+        return $"func {function.Name}({parameters}){returnType}";
+    }
+
+    private static string FormatAggregate(StructSymbol aggregate)
+    {
+        var keyword = aggregate.IsClass ? "class" : "struct";
+        var fields = string.Join("; ", aggregate.Fields.Select(f => $"{f.Name} {FormatType(f.Type)}"));
+        return $"{keyword} {aggregate.Name} {{ {fields} }}";
+    }
+
+    private static string FormatEnum(EnumSymbol enumSymbol)
+    {
+        var members = string.Join(", ", enumSymbol.Members.Select(m => m.Name));
+        return $"enum {enumSymbol.Name} {{ {members} }}";
+    }
+
+    private static string FormatType(TypeSymbol type)
+    {
+        return type?.Name ?? "void";
+    }
+}
+
+internal static class ReferencesComputer
+{
+    public static IReadOnlyList<Location> ComputeReferences(DocumentUri uri, DocumentContent content, Position position, bool includeDeclaration)
+    {
+        var compilation = new Compilation(content.SyntaxTree);
+        var offset = SemanticLookup.ToOffset(content, position);
+        var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
+        var target = SemanticLookup.ResolveSymbol(compilation, token);
+        if (target == null)
+        {
+            return Array.Empty<Location>();
+        }
+
+        // Phase 7.5 intentionally limits references to the currently tracked document; cross-file package awareness is future LSP work.
+        return SemanticLookup.FindReferences(compilation, target)
+            .Where(t => includeDeclaration || !IsDeclaration(compilation, t, target))
+            .Select(t => new Location { Uri = uri, Range = SemanticLookup.ToRange(t) })
+            .ToList();
+    }
+
+    public static IReadOnlyList<SyntaxToken> ComputeReferenceTokens(DocumentContent content, Position position, bool includeDeclaration)
+    {
+        var compilation = new Compilation(content.SyntaxTree);
+        var offset = SemanticLookup.ToOffset(content, position);
+        var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
+        var target = SemanticLookup.ResolveSymbol(compilation, token);
+        if (target == null)
+        {
+            return Array.Empty<SyntaxToken>();
+        }
+
+        return SemanticLookup.FindReferences(compilation, target)
+            .Where(t => includeDeclaration || !IsDeclaration(compilation, t, target))
+            .ToList();
+    }
+
+    private static bool IsDeclaration(Compilation compilation, SyntaxToken token, Symbol target)
+    {
+        foreach (var declaration in SemanticLookup.FindReferences(compilation, target))
+        {
+            if (!ReferenceEquals(declaration, token) || declaration.Span.Start != token.Span.Start)
+            {
+                continue;
+            }
+
+            var parentDeclaration = FindSmallestContainingDeclaration(compilation.SyntaxTrees[0].Root, token);
+            return parentDeclaration switch
+            {
+                VariableDeclarationSyntax v => ReferenceEquals(v.Identifier, token),
+                FunctionDeclarationSyntax f => ReferenceEquals(f.Identifier, token),
+                ParameterSyntax p => ReferenceEquals(p.Identifier, token),
+                StructDeclarationSyntax s => ReferenceEquals(s.Identifier, token),
+                FieldDeclarationSyntax f => ReferenceEquals(f.Identifier, token),
+                EnumDeclarationSyntax e => ReferenceEquals(e.Identifier, token),
+                EnumMemberSyntax e => ReferenceEquals(e.Identifier, token),
+                _ => false,
+            };
+        }
+
+        return false;
+    }
+
+    private static SyntaxNode FindSmallestContainingDeclaration(SyntaxNode node, SyntaxToken token)
+    {
+        SyntaxNode best = null;
+        Visit(node);
+        return best;
+
+        void Visit(SyntaxNode current)
+        {
+            if (current.Span.Start <= token.Span.Start && token.Span.End <= current.Span.End)
+            {
+                if (current is VariableDeclarationSyntax or FunctionDeclarationSyntax or ParameterSyntax or StructDeclarationSyntax or FieldDeclarationSyntax or EnumDeclarationSyntax or EnumMemberSyntax)
+                {
+                    if (best == null || current.Span.Length < best.Span.Length)
+                    {
+                        best = current;
+                    }
+                }
+
+                foreach (var child in current.GetChildren())
+                {
+                    Visit(child);
+                }
+            }
+        }
+    }
+}
+
+internal static class RenameComputer
+{
+    public static WorkspaceEdit ComputeRename(DocumentUri uri, DocumentContent content, Position position, string newName)
+    {
+        if (!SemanticLookup.IsValidIdentifier(newName))
+        {
+            return null;
+        }
+
+        var compilation = new Compilation(content.SyntaxTree);
+        var offset = SemanticLookup.ToOffset(content, position);
+        var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
+        var target = SemanticLookup.ResolveSymbol(compilation, token);
+        if (!SemanticLookup.CanRename(target))
+        {
+            return null;
+        }
+
+        var edits = SemanticLookup.FindReferences(compilation, target)
+            .Select(t => new TextEdit { Range = SemanticLookup.ToRange(t), NewText = newName })
+            .ToList();
+        if (edits.Count == 0)
+        {
+            return null;
+        }
+
+        return new WorkspaceEdit
+        {
+            Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+            {
+                [uri] = edits,
+            },
+        };
+    }
+}
+
+internal static class CodeActionComputer
+{
+    public static CommandOrCodeActionContainer ComputeCodeActions(DocumentUri uri, DocumentContent content, Range range)
+    {
+        var actions = new List<CommandOrCodeAction>();
+        var sortImports = TryCreateSortImports(uri, content);
+        if (sortImports != null)
+        {
+            actions.Add(new CommandOrCodeAction(sortImports));
+        }
+
+        return new CommandOrCodeActionContainer(actions);
+    }
+
+    private static CodeAction TryCreateSortImports(DocumentUri uri, DocumentContent content)
+    {
+        var imports = content.SyntaxTree.Root.Members.OfType<ImportSyntax>().ToList();
+        if (imports.Count < 2)
+        {
+            return null;
+        }
+
+        var source = content.SyntaxTree.Text.ToString();
+        var importTexts = imports.Select(i => source.Substring(i.Span.Start, i.Span.Length).TrimEnd()).ToList();
+        var sorted = importTexts.OrderBy(t => t, StringComparer.Ordinal).ToList();
+        if (importTexts.SequenceEqual(sorted))
+        {
+            return null;
+        }
+
+        var start = imports.First().Span.Start;
+        var end = imports.Last().Span.End;
+        while (end < source.Length && (source[end] == '\r' || source[end] == '\n'))
+        {
+            end++;
+            if (end <= source.Length && source[end - 1] == '\r' && end < source.Length && source[end] == '\n')
+            {
+                end++;
+            }
+
+            break;
+        }
+
+        var newText = string.Join(Environment.NewLine, sorted) + Environment.NewLine;
+        return new CodeAction
+        {
+            Title = "Sort imports",
+            Kind = CodeActionKind.RefactorRewrite,
+            Edit = new WorkspaceEdit
+            {
+                Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                {
+                    [uri] = new[]
+                    {
+                        new TextEdit
+                        {
+                            Range = SemanticLookup.ToRange(content.SyntaxTree.Text, TextSpan.FromBounds(start, end)),
+                            NewText = newText,
+                        },
+                    },
+                },
+            },
+        };
+    }
+}

--- a/src/LanguageServer/HoverHandler.cs
+++ b/src/LanguageServer/HoverHandler.cs
@@ -1,0 +1,55 @@
+// <copyright file="HoverHandler.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Threading;
+using System.Threading.Tasks;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
+
+namespace GSharp.LanguageServer;
+
+/// <summary>
+/// Hover handler for GSharp symbols.
+/// </summary>
+public class HoverHandler : HoverHandlerBase
+{
+    private readonly ILanguageServerFacade router;
+    private readonly DocumentContentService documentContentService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HoverHandler"/> class.
+    /// </summary>
+    /// <param name="router"><see cref="ILanguageServerFacade"/> for LSP.</param>
+    /// <param name="documentContentService"><see cref="DocumentContentService"/> instance.</param>
+    public HoverHandler(ILanguageServerFacade router, DocumentContentService documentContentService)
+    {
+        this.router = router;
+        this.documentContentService = documentContentService;
+    }
+
+    /// <inheritdoc/>
+    public override Task<Hover> Handle(HoverParams request, CancellationToken cancellationToken)
+    {
+        var key = request.TextDocument.Uri.ToString();
+        if (!this.documentContentService.TryGet(key, out DocumentContent content))
+        {
+            this.router.Window.LogWarning($"No syntax tree for {key}");
+            return Task.FromResult<Hover>(null);
+        }
+
+        return Task.FromResult(HoverComputer.ComputeHover(content, request.Position));
+    }
+
+    /// <inheritdoc/>
+    protected override HoverRegistrationOptions CreateRegistrationOptions(HoverCapability capability, ClientCapabilities clientCapabilities)
+    {
+        return new HoverRegistrationOptions
+        {
+            DocumentSelector = Constants.DocumentSelector,
+        };
+    }
+}

--- a/src/LanguageServer/Program.cs
+++ b/src/LanguageServer/Program.cs
@@ -30,7 +30,11 @@ public class Program
                 .ConfigureLogging(builder => builder.SetMinimumLevel(LogLevel.Trace))
                 .WithServices(ConfigureServices)
                 .WithHandler<DocumentSyncHandler>()
-                .WithHandler<FoldingHandler>());
+                .WithHandler<FoldingHandler>()
+                .WithHandler<HoverHandler>()
+                .WithHandler<ReferencesHandler>()
+                .WithHandler<RenameHandler>()
+                .WithHandler<CodeActionHandler>());
 
         await server.WaitForExit;
     }

--- a/src/LanguageServer/ReferencesHandler.cs
+++ b/src/LanguageServer/ReferencesHandler.cs
@@ -1,0 +1,56 @@
+// <copyright file="ReferencesHandler.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Threading;
+using System.Threading.Tasks;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
+
+namespace GSharp.LanguageServer;
+
+/// <summary>
+/// Find-references handler for GSharp symbols.
+/// </summary>
+public class ReferencesHandler : ReferencesHandlerBase
+{
+    private readonly ILanguageServerFacade router;
+    private readonly DocumentContentService documentContentService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReferencesHandler"/> class.
+    /// </summary>
+    /// <param name="router"><see cref="ILanguageServerFacade"/> for LSP.</param>
+    /// <param name="documentContentService"><see cref="DocumentContentService"/> instance.</param>
+    public ReferencesHandler(ILanguageServerFacade router, DocumentContentService documentContentService)
+    {
+        this.router = router;
+        this.documentContentService = documentContentService;
+    }
+
+    /// <inheritdoc/>
+    public override Task<LocationContainer> Handle(ReferenceParams request, CancellationToken cancellationToken)
+    {
+        var key = request.TextDocument.Uri.ToString();
+        if (!this.documentContentService.TryGet(key, out DocumentContent content))
+        {
+            this.router.Window.LogWarning($"No syntax tree for {key}");
+            return Task.FromResult(new LocationContainer());
+        }
+
+        var locations = ReferencesComputer.ComputeReferences(request.TextDocument.Uri, content, request.Position, request.Context.IncludeDeclaration);
+        return Task.FromResult(new LocationContainer(locations));
+    }
+
+    /// <inheritdoc/>
+    protected override ReferenceRegistrationOptions CreateRegistrationOptions(ReferenceCapability capability, ClientCapabilities clientCapabilities)
+    {
+        return new ReferenceRegistrationOptions
+        {
+            DocumentSelector = Constants.DocumentSelector,
+        };
+    }
+}

--- a/src/LanguageServer/RenameHandler.cs
+++ b/src/LanguageServer/RenameHandler.cs
@@ -1,0 +1,56 @@
+// <copyright file="RenameHandler.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Threading;
+using System.Threading.Tasks;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
+
+namespace GSharp.LanguageServer;
+
+/// <summary>
+/// Rename handler for GSharp symbols.
+/// </summary>
+public class RenameHandler : RenameHandlerBase
+{
+    private readonly ILanguageServerFacade router;
+    private readonly DocumentContentService documentContentService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RenameHandler"/> class.
+    /// </summary>
+    /// <param name="router"><see cref="ILanguageServerFacade"/> for LSP.</param>
+    /// <param name="documentContentService"><see cref="DocumentContentService"/> instance.</param>
+    public RenameHandler(ILanguageServerFacade router, DocumentContentService documentContentService)
+    {
+        this.router = router;
+        this.documentContentService = documentContentService;
+    }
+
+    /// <inheritdoc/>
+    public override Task<WorkspaceEdit> Handle(RenameParams request, CancellationToken cancellationToken)
+    {
+        var key = request.TextDocument.Uri.ToString();
+        if (!this.documentContentService.TryGet(key, out DocumentContent content))
+        {
+            this.router.Window.LogWarning($"No syntax tree for {key}");
+            return Task.FromResult<WorkspaceEdit>(null);
+        }
+
+        return Task.FromResult(RenameComputer.ComputeRename(request.TextDocument.Uri, content, request.Position, request.NewName));
+    }
+
+    /// <inheritdoc/>
+    protected override RenameRegistrationOptions CreateRegistrationOptions(RenameCapability capability, ClientCapabilities clientCapabilities)
+    {
+        return new RenameRegistrationOptions
+        {
+            DocumentSelector = Constants.DocumentSelector,
+            PrepareProvider = false,
+        };
+    }
+}

--- a/src/LanguageServer/SemanticLookup.cs
+++ b/src/LanguageServer/SemanticLookup.cs
@@ -1,0 +1,424 @@
+// <copyright file="SemanticLookup.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+
+namespace GSharp.LanguageServer;
+
+internal static class SemanticLookup
+{
+    public static SyntaxToken FindTokenAt(SyntaxTree tree, int position)
+    {
+        SyntaxToken best = null;
+        foreach (var token in EnumerateTokens(tree.Root))
+        {
+            if (token.IsMissing)
+            {
+                continue;
+            }
+
+            if (token.Span.Start <= position && position <= token.Span.End)
+            {
+                if (best == null || token.Span.Length <= best.Span.Length)
+                {
+                    best = token;
+                }
+            }
+        }
+
+        return best;
+    }
+
+    public static Symbol ResolveSymbol(Compilation compilation, SyntaxToken identifierToken)
+    {
+        if (identifierToken == null || identifierToken.Kind != SyntaxKind.IdentifierToken)
+        {
+            return null;
+        }
+
+        var model = BuildModel(compilation);
+        return model.Resolve(identifierToken);
+    }
+
+    public static IEnumerable<SyntaxToken> FindReferences(Compilation compilation, Symbol target)
+    {
+        if (target == null)
+        {
+            yield break;
+        }
+
+        var model = BuildModel(compilation);
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            foreach (var token in EnumerateTokens(tree.Root))
+            {
+                if (token.Kind == SyntaxKind.IdentifierToken && ReferenceEquals(model.Resolve(token), target))
+                {
+                    yield return token;
+                }
+            }
+        }
+    }
+
+    public static bool IsValidIdentifier(string text)
+    {
+        if (string.IsNullOrEmpty(text) || SyntaxFacts.GetKeywordKind(text) != SyntaxKind.IdentifierToken)
+        {
+            return false;
+        }
+
+        if (!IsIdentifierStart(text[0]))
+        {
+            return false;
+        }
+
+        for (var i = 1; i < text.Length; i++)
+        {
+            if (!IsIdentifierPart(text[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static bool CanRename(Symbol symbol)
+    {
+        return symbol is not null and not ImportedTypeSymbol and not ImportedClassSymbol and not ImportedFunctionSymbol
+            && !ReferenceEquals(symbol, TypeSymbol.Bool)
+            && !ReferenceEquals(symbol, TypeSymbol.Int)
+            && !ReferenceEquals(symbol, TypeSymbol.String)
+            && !ReferenceEquals(symbol, TypeSymbol.Void)
+            && !ReferenceEquals(symbol, TypeSymbol.Null);
+    }
+
+    public static IEnumerable<SyntaxToken> EnumerateIdentifierTokens(SyntaxTree tree)
+    {
+        return EnumerateTokens(tree.Root).Where(t => t.Kind == SyntaxKind.IdentifierToken);
+    }
+
+    public static int ToOffset(DocumentContent content, OmniSharp.Extensions.LanguageServer.Protocol.Models.Position position)
+    {
+        if (position.Line < 0 || position.Line >= content.SyntaxTree.Text.Lines.Length)
+        {
+            return content.SyntaxTree.Text.Length;
+        }
+
+        return Math.Min(content.SyntaxTree.Text.Lines[position.Line].Start + position.Character, content.SyntaxTree.Text.Length);
+    }
+
+    public static OmniSharp.Extensions.LanguageServer.Protocol.Models.Range ToRange(SyntaxToken token)
+    {
+        return ToRange(token.SyntaxTree.Text, token.Span);
+    }
+
+    public static OmniSharp.Extensions.LanguageServer.Protocol.Models.Range ToRange(SourceText text, TextSpan span)
+    {
+        var startLine = text.GetLineIndex(span.Start);
+        var endPosition = Math.Max(span.Start, span.End);
+        var endLine = text.GetLineIndex(Math.Min(endPosition, Math.Max(0, text.Length - 1)));
+        if (span.End == text.Length && text.Length > 0 && text[text.Length - 1] == '\n')
+        {
+            endLine = text.Lines.Length - 1;
+        }
+
+        return new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
+            new OmniSharp.Extensions.LanguageServer.Protocol.Models.Position(startLine, span.Start - text.Lines[startLine].Start),
+            new OmniSharp.Extensions.LanguageServer.Protocol.Models.Position(endLine, span.End - text.Lines[endLine].Start));
+    }
+
+    private static SemanticModel BuildModel(Compilation compilation)
+    {
+        var declarations = new Dictionary<SyntaxToken, Symbol>();
+        var globals = new Dictionary<string, Symbol>(StringComparer.Ordinal);
+        var localDeclarations = new Dictionary<FunctionDeclarationSyntax, Dictionary<string, Symbol>>();
+
+        foreach (var variable in compilation.GlobalScope.Variables)
+        {
+            globals[variable.Name] = variable;
+        }
+
+        foreach (var function in compilation.GlobalScope.Functions)
+        {
+            globals[function.Name] = function;
+            if (function.Declaration != null)
+            {
+                declarations[function.Declaration.Identifier] = function;
+                MapParameters(function.Declaration, function.Parameters, declarations, localDeclarations);
+                if (function.ExplicitReceiverParameter != null && function.Declaration.Receiver != null)
+                {
+                    declarations[function.Declaration.Receiver.Identifier] = function.ExplicitReceiverParameter;
+                    GetLocals(localDeclarations, function.Declaration)[function.ExplicitReceiverParameter.Name] = function.ExplicitReceiverParameter;
+                }
+            }
+        }
+
+        foreach (var variable in compilation.GlobalScope.Variables)
+        {
+            foreach (var declaration in FindNodes<VariableDeclarationSyntax>(compilation.SyntaxTrees.Select(t => t.Root)).Where(v => v.Identifier.Text == variable.Name))
+            {
+                declarations[declaration.Identifier] = variable;
+            }
+        }
+
+        foreach (var aggregate in compilation.GlobalScope.Structs)
+        {
+            globals[aggregate.Name] = aggregate;
+            if (aggregate.Declaration != null)
+            {
+                declarations[aggregate.Declaration.Identifier] = aggregate;
+                for (var i = 0; i < aggregate.Declaration.Fields.Length && i < aggregate.Fields.Length; i++)
+                {
+                    declarations[aggregate.Declaration.Fields[i].Identifier] = aggregate.Fields[i];
+                }
+            }
+        }
+
+        foreach (var pair in compilation.GlobalScope.TypeAliases)
+        {
+            globals[pair.Key] = pair.Value;
+            if (pair.Value is EnumSymbol enumSymbol)
+            {
+                declarations[enumSymbol.Declaration.Identifier] = enumSymbol;
+                var members = enumSymbol.Declaration.Members.ToArray();
+                for (var i = 0; i < members.Length && i < enumSymbol.Members.Length; i++)
+                {
+                    declarations[members[i].Identifier] = enumSymbol.Members[i];
+                    globals[members[i].Identifier.Text] = enumSymbol.Members[i];
+                }
+            }
+        }
+
+        MapLocalVariables(compilation, declarations, localDeclarations);
+        return new SemanticModel(compilation, declarations, globals, localDeclarations);
+    }
+
+    private static void MapParameters(
+        FunctionDeclarationSyntax declaration,
+        ImmutableArray<ParameterSymbol> parameters,
+        Dictionary<SyntaxToken, Symbol> declarations,
+        Dictionary<FunctionDeclarationSyntax, Dictionary<string, Symbol>> localDeclarations)
+    {
+        var syntaxParameters = declaration.Parameters.ToArray();
+        var symbolIndex = parameters.Length - syntaxParameters.Length;
+        for (var i = 0; i < syntaxParameters.Length && symbolIndex + i < parameters.Length; i++)
+        {
+            var symbol = parameters[symbolIndex + i];
+            declarations[syntaxParameters[i].Identifier] = symbol;
+            GetLocals(localDeclarations, declaration)[symbol.Name] = symbol;
+        }
+    }
+
+    private static void MapLocalVariables(
+        Compilation compilation,
+        Dictionary<SyntaxToken, Symbol> declarations,
+        Dictionary<FunctionDeclarationSyntax, Dictionary<string, Symbol>> localDeclarations)
+    {
+        BoundProgram program;
+        try
+        {
+            program = Binder.BindProgram(compilation.GlobalScope);
+        }
+        catch (InvalidOperationException)
+        {
+            return;
+        }
+
+        foreach (var pair in program.Functions)
+        {
+            var declaration = pair.Key.Declaration;
+            if (declaration == null)
+            {
+                continue;
+            }
+
+            var syntaxDeclarations = FindNodes<VariableDeclarationSyntax>(new[] { declaration.Body }).ToList();
+            var boundDeclarations = FindBoundNodes<BoundVariableDeclaration>(pair.Value).Where(d => !d.Variable.Name.StartsWith("<", StringComparison.Ordinal)).ToList();
+            var used = new HashSet<int>();
+            foreach (var syntax in syntaxDeclarations)
+            {
+                for (var i = 0; i < boundDeclarations.Count; i++)
+                {
+                    if (used.Contains(i) || boundDeclarations[i].Variable.Name != syntax.Identifier.Text)
+                    {
+                        continue;
+                    }
+
+                    used.Add(i);
+                    declarations[syntax.Identifier] = boundDeclarations[i].Variable;
+                    GetLocals(localDeclarations, declaration)[boundDeclarations[i].Variable.Name] = boundDeclarations[i].Variable;
+                    break;
+                }
+            }
+        }
+    }
+
+    private static Dictionary<string, Symbol> GetLocals(
+        Dictionary<FunctionDeclarationSyntax, Dictionary<string, Symbol>> locals,
+        FunctionDeclarationSyntax declaration)
+    {
+        if (!locals.TryGetValue(declaration, out var functionLocals))
+        {
+            functionLocals = new Dictionary<string, Symbol>(StringComparer.Ordinal);
+            locals[declaration] = functionLocals;
+        }
+
+        return functionLocals;
+    }
+
+    private static IEnumerable<SyntaxToken> EnumerateTokens(SyntaxNode node)
+    {
+        if (node is SyntaxToken token)
+        {
+            yield return token;
+            yield break;
+        }
+
+        foreach (var child in node.GetChildren())
+        {
+            foreach (var childToken in EnumerateTokens(child))
+            {
+                yield return childToken;
+            }
+        }
+    }
+
+    private static IEnumerable<T> FindNodes<T>(IEnumerable<SyntaxNode> roots)
+        where T : SyntaxNode
+    {
+        foreach (var root in roots)
+        {
+            foreach (var node in FindNodes<T>(root))
+            {
+                yield return node;
+            }
+        }
+    }
+
+    private static IEnumerable<T> FindNodes<T>(SyntaxNode root)
+        where T : SyntaxNode
+    {
+        if (root is T matched)
+        {
+            yield return matched;
+        }
+
+        foreach (var child in root.GetChildren())
+        {
+            foreach (var descendant in FindNodes<T>(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+
+    private static IEnumerable<T> FindBoundNodes<T>(BoundNode root)
+        where T : BoundNode
+    {
+        if (root is T matched)
+        {
+            yield return matched;
+        }
+
+        foreach (var property in root.GetType().GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
+        {
+            var value = property.GetValue(root);
+            if (value is BoundNode child)
+            {
+                foreach (var descendant in FindBoundNodes<T>(child))
+                {
+                    yield return descendant;
+                }
+            }
+            else if (value is System.Collections.IEnumerable sequence and not string)
+            {
+                foreach (var item in sequence)
+                {
+                    if (item is BoundNode sequenceChild)
+                    {
+                        foreach (var descendant in FindBoundNodes<T>(sequenceChild))
+                        {
+                            yield return descendant;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static bool IsIdentifierStart(char c)
+    {
+        return c == '_' || char.IsLetter(c);
+    }
+
+    private static bool IsIdentifierPart(char c)
+    {
+        return c == '_' || char.IsLetterOrDigit(c);
+    }
+
+    private sealed class SemanticModel
+    {
+        private readonly Compilation compilation;
+        private readonly Dictionary<SyntaxToken, Symbol> declarations;
+        private readonly Dictionary<string, Symbol> globals;
+        private readonly Dictionary<FunctionDeclarationSyntax, Dictionary<string, Symbol>> localDeclarations;
+
+        public SemanticModel(
+            Compilation compilation,
+            Dictionary<SyntaxToken, Symbol> declarations,
+            Dictionary<string, Symbol> globals,
+            Dictionary<FunctionDeclarationSyntax, Dictionary<string, Symbol>> localDeclarations)
+        {
+            this.compilation = compilation;
+            this.declarations = declarations;
+            this.globals = globals;
+            this.localDeclarations = localDeclarations;
+        }
+
+        public Symbol Resolve(SyntaxToken token)
+        {
+            if (this.declarations.TryGetValue(token, out var declared))
+            {
+                return declared;
+            }
+
+            var function = this.FindContainingFunction(token);
+            if (function != null && this.localDeclarations.TryGetValue(function, out var locals) && locals.TryGetValue(token.Text, out var local))
+            {
+                return local;
+            }
+
+            return this.globals.TryGetValue(token.Text, out var global) ? global : ResolvePrimitiveOrImportedType(token.Text);
+        }
+
+        private FunctionDeclarationSyntax FindContainingFunction(SyntaxToken token)
+        {
+            return FindNodes<FunctionDeclarationSyntax>(this.compilation.SyntaxTrees.Select(t => t.Root))
+                .Where(f => f.Span.Start <= token.Span.Start && token.Span.End <= f.Span.End)
+                .OrderBy(f => f.Span.Length)
+                .FirstOrDefault();
+        }
+
+        private Symbol ResolvePrimitiveOrImportedType(string text)
+        {
+            return text switch
+            {
+                "bool" => TypeSymbol.Bool,
+                "int" => TypeSymbol.Int,
+                "string" => TypeSymbol.String,
+                "void" => TypeSymbol.Void,
+                _ => null,
+            };
+        }
+    }
+}

--- a/test/LanguageServer.Tests/CodeActionHandlerTests.cs
+++ b/test/LanguageServer.Tests/CodeActionHandlerTests.cs
@@ -1,0 +1,28 @@
+// <copyright file="CodeActionHandlerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Xunit;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace GSharp.LanguageServer.Tests;
+
+public class CodeActionHandlerTests
+{
+    [Fact]
+    public void ComputeCodeActions_OffersSortImports()
+    {
+        const string source = "import Zeta\nimport Alpha\nfunc F() {}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var uri = DocumentUri.From("file:///actions.gs");
+
+        var actions = CodeActionComputer.ComputeCodeActions(uri, content, new Range(new Position(0, 0), new Position(0, 0))).ToList();
+
+        var action = Assert.Single(actions).CodeAction;
+        Assert.Equal("Sort imports", action.Title);
+        Assert.Contains("import Alpha", action.Edit.Changes[uri].Single().NewText, System.StringComparison.Ordinal);
+    }
+}

--- a/test/LanguageServer.Tests/DocumentSyncHandlerTests.cs
+++ b/test/LanguageServer.Tests/DocumentSyncHandlerTests.cs
@@ -1,0 +1,23 @@
+// <copyright file="DocumentSyncHandlerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+public class DocumentSyncHandlerTests
+{
+    [Fact]
+    public void ComputeDiagnostics_IncludesBindingDiagnosticsWhenRequested()
+    {
+        const string source = "func F() int {\n}\n";
+
+        var fastDiagnostics = DocumentSyncHandler.ComputeDiagnostics(source, skipBinding: true).Diagnostics;
+        var fullDiagnostics = DocumentSyncHandler.ComputeDiagnostics(source, skipBinding: false).Diagnostics;
+
+        Assert.DoesNotContain(fastDiagnostics, d => d.Message.Contains("Not all code paths", System.StringComparison.Ordinal));
+        Assert.Contains(fullDiagnostics, d => d.Message.Contains("Not all code paths", System.StringComparison.Ordinal));
+    }
+}

--- a/test/LanguageServer.Tests/HoverHandlerTests.cs
+++ b/test/LanguageServer.Tests/HoverHandlerTests.cs
@@ -1,0 +1,24 @@
+// <copyright file="HoverHandlerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+public class HoverHandlerTests
+{
+    [Theory]
+    [InlineData("let answer = 42\n", "answer", "let answer: int")]
+    [InlineData("func add(a int, b int) int { return a + b }\n", "add", "func add(a int, b int) int")]
+    [InlineData("type Point struct {\nX int\nY int\n}\n", "Point", "struct Point { X int; Y int }")]
+    [InlineData("type Color enum { Red, Green }\n", "Color", "enum Color { Red, Green }")]
+    public void ComputeHover_ReturnsMarkdownSignature(string source, string token, string expected)
+    {
+        var content = LanguageServerTestHelpers.Content(source);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, token));
+
+        Assert.NotNull(hover);
+        Assert.Contains(expected, hover.Contents.ToString(), System.StringComparison.Ordinal);
+    }
+}

--- a/test/LanguageServer.Tests/LanguageServerTestHelpers.cs
+++ b/test/LanguageServer.Tests/LanguageServerTestHelpers.cs
@@ -1,0 +1,50 @@
+// <copyright file="LanguageServerTestHelpers.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Syntax;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace GSharp.LanguageServer.Tests;
+
+internal static class LanguageServerTestHelpers
+{
+    public static DocumentContent Content(string source)
+    {
+        var lines = new List<int>();
+        for (var i = 0; i < source.Length; i++)
+        {
+            if (source[i] == '\n')
+            {
+                lines.Add(i);
+            }
+        }
+
+        return new DocumentContent(SyntaxTree.Parse(source), lines);
+    }
+
+    public static Position PositionOf(string source, string text, int occurrence = 0)
+    {
+        var index = -1;
+        var start = 0;
+        for (var i = 0; i <= occurrence; i++)
+        {
+            index = source.IndexOf(text, start, System.StringComparison.Ordinal);
+            start = index + text.Length;
+        }
+
+        var line = 0;
+        var lineStart = 0;
+        for (var i = 0; i < index; i++)
+        {
+            if (source[i] == '\n')
+            {
+                line++;
+                lineStart = i + 1;
+            }
+        }
+
+        return new Position(line, index - lineStart);
+    }
+}

--- a/test/LanguageServer.Tests/ReferencesHandlerTests.cs
+++ b/test/LanguageServer.Tests/ReferencesHandlerTests.cs
@@ -1,0 +1,37 @@
+// <copyright file="ReferencesHandlerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+public class ReferencesHandlerTests
+{
+    [Fact]
+    public void ComputeReferences_ReturnsAllSingleDocumentOccurrences()
+    {
+        const string source = "func F(x int) int {\nlet y = x\nreturn x + y\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var uri = DocumentUri.From("file:///refs.gs");
+
+        var references = ReferencesComputer.ComputeReferences(uri, content, LanguageServerTestHelpers.PositionOf(source, "x"), includeDeclaration: true);
+
+        Assert.Equal(3, references.Count);
+        Assert.All(references, r => Assert.Equal(uri, r.Uri));
+    }
+
+    [Fact]
+    public void ComputeReferences_CanExcludeDeclaration()
+    {
+        const string source = "func F(x int) int {\nlet y = x\nreturn x + y\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var tokens = ReferencesComputer.ComputeReferenceTokens(content, LanguageServerTestHelpers.PositionOf(source, "x"), includeDeclaration: false);
+
+        Assert.Equal(2, tokens.Count);
+        Assert.All(tokens, t => Assert.NotEqual(7, t.Position));
+    }
+}

--- a/test/LanguageServer.Tests/RenameHandlerTests.cs
+++ b/test/LanguageServer.Tests/RenameHandlerTests.cs
@@ -1,0 +1,51 @@
+// <copyright file="RenameHandlerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+public class RenameHandlerTests
+{
+    [Fact]
+    public void ComputeRename_ReturnsWorkspaceEditForAllOccurrences()
+    {
+        const string source = "func F(x int) int {\nlet y = x\nreturn x + y\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var uri = DocumentUri.From("file:///rename.gs");
+
+        var edit = RenameComputer.ComputeRename(uri, content, LanguageServerTestHelpers.PositionOf(source, "x"), "value");
+
+        Assert.NotNull(edit);
+        var edits = edit.Changes[uri].ToList();
+        Assert.Equal(3, edits.Count);
+        Assert.All(edits, e => Assert.Equal("value", e.NewText));
+    }
+
+    [Fact]
+    public void ComputeRename_RejectsInvalidName()
+    {
+        const string source = "let answer = 42\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var uri = DocumentUri.From("file:///rename.gs");
+
+        var edit = RenameComputer.ComputeRename(uri, content, LanguageServerTestHelpers.PositionOf(source, "answer"), "123bad");
+
+        Assert.Null(edit);
+    }
+
+    [Fact]
+    public void ComputeRename_RejectsPrimitiveClrBackedType()
+    {
+        const string source = "let name string = \"g\"\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var uri = DocumentUri.From("file:///rename.gs");
+
+        var edit = RenameComputer.ComputeRename(uri, content, LanguageServerTestHelpers.PositionOf(source, "string"), "text");
+
+        Assert.Null(edit);
+    }
+}


### PR DESCRIPTION
## Phase 7.5 — LSP feature parity

Implements the five LSP capabilities per issue #52 row 7.5. No new ADR (investment work).

### Added handlers

- **Hover** — symbol kind + signature in a fenced ``gsharp`` block; `null` when no symbol matches.
- **Find references** (`textDocument/references`) — all occurrences within the document.
- **Rename** (`textDocument/rename`) — produces a `WorkspaceEdit`; rejects invalid identifiers; refuses to rename CLR-imported symbols.
- **Code actions** — "Sort imports" alphabetically.
- **Diagnostics on save** — `didSave` now runs the full pipeline including bind-stage diagnostics (open/change stay parse + global-scope for responsiveness).

### Architecture

Followed the existing `FoldingComputer` pattern: handlers do I/O, pure helpers (`SemanticLookup`, `HoverComputer`) compute results, tests target the helpers. Core was kept untouched.

### Limitations (intentional scope)

- References + rename are **single-document** only. Multi-file workspace awareness is a follow-up.
- `SemanticLookup` is a pragmatic LSP-layer symbol mapper, not a full Roslyn-style semantic model. Sufficient for the user-visible features in this PR.

### Results

**678 passing** (+11 from 667 baseline), 0 failures, 0 warnings.

Coverage matrix updated to reflect the new LSP surface.

Closes a row of #52.
