### PR TITLE
Stream D: user-defined `operator` keyword on GSharp types (ADR-0035)

### DIFF
--- a/docs/adr/0026-operator-by-name-deferral.md
+++ b/docs/adr/0026-operator-by-name-deferral.md
@@ -1,6 +1,6 @@
 # ADR-0026: Operator-by-name on user types — deferred
 
-- **Status**: Accepted (deferral). Imported-CLR `op_*` consumption shipped in ADR-0034; user-type operator overloading still deferred.
+- **Status**: Superseded by ADR-0035 for receiver-form binary and unary operators on GSharp types. Imported-CLR `op_*` consumption shipped in ADR-0034. Free-function form, conversions (`operator implicit` / `operator explicit`), `++` / `--`, and `op_True` / `op_False` short-circuit support remain deferred.
 - **Date**: 2026-05-24
 - **Phase**: Phase 6
 - **Related**: ADR-0019 (extension functions); ADR-0024 (methods vs extensions canonical style); ADR-0029 (data struct synthesized members); ADR-0034 (imported CLR interop); execution plan §6.5

--- a/docs/adr/0035-user-operator-overloads.md
+++ b/docs/adr/0035-user-operator-overloads.md
@@ -1,0 +1,68 @@
+# ADR-0035: User-defined `operator` keyword on GSharp types
+
+- **Status**: Accepted
+- **Date**: 2026 (this PR)
+- **Phase**: Phase 7 — Stream D follow-up to ADR-0034
+- **Related**: ADR-0026 (operator-by-name deferral — **superseded** by this ADR for receiver-form binary and unary operators); ADR-0019 (extension functions / receiver clauses); ADR-0024 (methods-vs-extensions canonical style); ADR-0029 (data struct synthesized `==` / `!=`); ADR-0034 (imported CLR `op_*` consumption); execution plan §6.5.
+
+## Context
+
+ADR-0026 deferred operator overloading on GSharp-declared types pending a real use case and a chosen syntax. ADR-0034 then closed the *consumption* side (GSharp source can call CLR `op_*` static methods on imported types). What remained was a way to *declare* operators on GSharp types so user code can write `p + q` instead of `p.Plus(q)`, and so emitted assemblies expose `op_*` static methods that round-trip to other CLR languages.
+
+After ADR-0024 / Phase 6.4, same-package receiver-form functions (`func (a T) Name(b T) …`) bind onto the user type as ordinary methods rather than going through the extension-function table. This gives us a natural place to hang operators: declare them with the same receiver-form syntax, just with the contextual keyword `operator` in front of the operator token.
+
+## Decision
+
+Ship receiver-form binary and unary `operator` overloads on GSharp `struct` / `data struct` / `class` types. The free-function form, conversions (`operator implicit` / `operator explicit`), `++` / `--`, and `true` / `false` are deferred to a follow-up.
+
+### Syntax
+
+```gsharp
+type Vector2 struct {
+    X int
+    Y int
+}
+
+// receiver-form binary operator
+func (a Vector2) operator +(b Vector2) Vector2 {
+    return Vector2{X: a.X + b.X, Y: a.Y + b.Y}
+}
+
+// receiver-form unary operator
+func (a Vector2) operator -() Vector2 {
+    return Vector2{X: -a.X, Y: -a.Y}
+}
+```
+
+Accepted operator tokens this PR: `+ - * / % & | ^ << >> == != < <= > >=` (binary) and `+ - ! ~` (unary). The disambiguator between unary and binary forms is the parameter list after the operator token: an empty list (`operator -()`) is unary; a non-empty list (`operator -(b T)`) is binary.
+
+Both `struct` and `class` user types can declare operators. Value-type `struct` operators bind, evaluate under the interpreter, and lower through the IL pipeline, but they share the pre-existing receiver-method emit limitation: same-package instance methods on value-type structs (including operators) crash at runtime under the IL backend today. The conformance sample uses `class` to side-step that limitation; `struct` parity rides on the broader value-type-method emit fix.
+
+### Binding
+
+`OperatorNames` (in `src/Core/CodeAnalysis/Binding/OperatorNames.cs`) maps each operator `SyntaxKind` to its CLR `op_*` name. The parser synthesizes an `IdentifierToken` whose text is the resolved `op_*` name, so the rest of the pipeline sees an ordinary receiver-form function and registers it as a method on the user type.
+
+`BindBinaryExpression` and `BindUnaryExpression` consult, in order:
+
+1. The built-in `BoundBinaryOperator` / `BoundUnaryOperator` table (numeric, bool, string concat, etc.).
+2. **User operator** — for each operand whose type is a `StructSymbol`, `TryGetMethodIncludingInherited(op_*)`; for any operand type, `scope.TryLookupExtensionFunction(op_*)` (covers cross-package receiver-form declarations that still register as extension functions).
+3. **Imported CLR operator** — `ClrOperatorResolution.TryResolveBinary` / `TryResolveUnary` on each operand's `ClrType` (ADR-0034).
+
+The user-operator hook lowers to a regular `BoundCallExpression` against the resolved `FunctionSymbol`, so both the interpreter and the IL emitter reuse their existing call paths.
+
+### Emit
+
+Extension-function-shaped operators emit with `MethodAttributes.SpecialName` so the resulting assembly advertises the standard CLR convention. Same-package methods that are operators inherit the user type's emission path; surfacing them as `static specialname` on the user type's `TypeDef` (full C# round-trip) remains a follow-up — today they're callable from GSharp but not from C# consumers as `Vector2 + Vector2`.
+
+## Consequences
+
+- ADR-0026 is superseded for the receiver-form binary and unary operator surface. The "operator-by-name on user types" row in `docs/coverage-matrix.md` flips to ✅ for those forms.
+- The parser grows one contextual keyword (`operator`) and one new `SyntaxKind` (`OperatorKeyword`). Existing code that uses `operator` as an identifier outside a `func` declaration continues to work (it's only recognized after `func [(recv T)]`).
+- Operator declarations can also be written cross-package via the extension-function form `func (a T) operator +(b T) T`. ADR-0024 still applies — when the user type lives in the same package, the operator binds as a method on the struct; cross-package, it registers in the extension-function table. Both routes are handled by the binder hook.
+- The free-function form (`func operator +(a T, b T) T`), conversions (`operator implicit`, `operator explicit`), `op_True` / `op_False` + short-circuit `&&` / `||`, and `++` / `--` overloads are deferred. None block the receiver-form MVP.
+
+## Alternatives considered
+
+- **Kotlin-style operator-by-name** (any method named `plus` becomes `+`). Rejected for the same reasons as ADR-0026: invisible coupling, no CLR round-trip, and conflicts with the existing `Add` / `Plus` method conventions in BCL types.
+- **C# free-function form only** (no receiver clause). Rejected because GSharp's same-package receiver-form is already the canonical style for `struct` methods after ADR-0024; forcing operators into a different shape would be inconsistent. The free-function form can be added later without breaking this design.
+- **Threading operator metadata through a dedicated `OperatorDeclarationSyntax`.** Rejected as overkill for the MVP — the parser's identifier-synthesis approach reuses the entire downstream pipeline. A dedicated syntax node can be introduced when conversions land (they need a different signature shape).

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -122,7 +122,8 @@ Legend: ✅ = supported end-to-end. 🟡 = partially supported (caveats in the N
 | unary `+` `-` `^` | ✅ | — | — | ✅ for `+`/`-` (`op_UnaryPlus`, `op_UnaryNegation`); `~` (CLR `op_OnesComplement`) currently maps to GSharp `^` |
 | unary `!` | — | ✅ | — | ✅ (`op_LogicalNot`) |
 | unary `*` `&` `<-` | ❌ | ❌ | ❌ | ❌ |
-| Operator-by-name on user types (`func (p Point) plus`) | — | — | — | ❌ Phase 6.5 / ADR-0026 (deferred): a method named `plus` on a user type stays a regular method, not an implicit `op_Addition`. Streams C/E land CLR-side `op_*` consumption; declaring `operator` on GSharp types is tracked separately (Stream D — see ADR-0026 follow-up). |
+| Operator-by-name on user types (`func (p Point) plus`) | — | — | — | ❌ Phase 6.5 / ADR-0026 (deferred): Kotlin-style implicit reinterpretation (e.g. a method named `plus` becoming `op_Addition`) is not adopted. |
+| Explicit `operator` keyword on user types (`func (a T) operator +(b T) T`) | ✅ | ✅ | ✅ | ✅ Stream D / ADR-0035: receiver-form binary (`+ - * / % & | ^ << >> == != < <= > >=`) and unary (`+ - ! ~`) operators on `struct` / `data struct` / `class` types. The parser synthesizes an `op_*` identifier; the binder resolves user operators (struct methods then extension functions) ahead of the imported-CLR `op_*` fallback. Value-type `struct` operators bind and run under the interpreter but share the pre-existing value-type-receiver IL-emit limitation (use `class` for compiled scenarios today). Free-function form, `operator implicit` / `operator explicit`, `++` / `--`, and `op_True` / `op_False` are deferred. |
 
 Operator resolution: when neither operand is a built-in, the binder runs the shared `OverloadResolution` over `op_*` candidates collected from both operand types (and their CLR base chains), deduped by identity. Ambiguous matches surface as a binder diagnostic; no first-match fallback. See `ClrOperatorResolution.cs`.
 
@@ -167,5 +168,5 @@ Reference upcasts (Phase 6 exit, added with `samples/aspirational/ExpressionEval
 - `break` / `continue` inside `await for` body (deferred from #79).
 - Async-aware lowering of `await` and emit of state machines (Phase 7 / ADR-0027).
 - Event subscription (`obj.Click += handler`, `-=`) and multi-segment compound-assignment LHS (`a.b.c += …`) — Stream B′, parser-side work.
-- `operator` keyword on GSharp-defined types (declaring `operator +` etc.). Tracked as Stream D; superseding ADR-0026 is part of that follow-up PR.
+- ~~`operator` keyword on GSharp-defined types (declaring `operator +` etc.). Tracked as Stream D; superseding ADR-0026 is part of that follow-up PR.~~ **Shipped** in Stream D / ADR-0035 (receiver-form binary and unary operators). Free-function form, conversions, `++` / `--`, and `op_True` / `op_False` short-circuit remain deferred.
 

--- a/samples/Operators.golden
+++ b/samples/Operators.golden
@@ -1,0 +1,7 @@
+4
+6
+-1
+-2
+False
+True
+True

--- a/samples/Operators.gs
+++ b/samples/Operators.gs
@@ -1,0 +1,41 @@
+// file: Operators.gs
+// Stream D / ADR-0035: receiver-form `operator` keyword on a GSharp struct.
+// Defines binary `+`, binary `==` / `!=`, and unary `-` on Vector2 and uses
+// them at call sites just like built-in operator syntax.
+package GSharp.Sample.Operators
+
+import System
+
+type Vector2 class {
+    X int
+    Y int
+}
+
+func (a Vector2) operator +(b Vector2) Vector2 {
+    return Vector2{X: a.X + b.X, Y: a.Y + b.Y}
+}
+
+func (a Vector2) operator -() Vector2 {
+    return Vector2{X: -a.X, Y: -a.Y}
+}
+
+func (a Vector2) operator ==(b Vector2) bool {
+    return a.X == b.X && a.Y == b.Y
+}
+
+func (a Vector2) operator !=(b Vector2) bool {
+    return a.X != b.X || a.Y != b.Y
+}
+
+var p = Vector2{X: 1, Y: 2}
+var q = Vector2{X: 3, Y: 4}
+var r = p + q
+var n = -p
+
+Console.WriteLine(r.X)
+Console.WriteLine(r.Y)
+Console.WriteLine(n.X)
+Console.WriteLine(n.Y)
+Console.WriteLine(p == q)
+Console.WriteLine(p != q)
+Console.WriteLine(p == Vector2{X: 1, Y: 2})

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -3842,6 +3842,37 @@ public sealed class Binder
 
         if (boundOperator == null)
         {
+            // Stream D: try user-defined `func (a T) operator <op>() R` on the
+            // operand's user type. Same-package methods bind onto the struct
+            // (Phase 6.4); the receiver is Parameters[0] (Parameters.Length==1
+            // for unary ops). Extension-function fallback also covered.
+            var userOpName = OperatorNames.TryGetUnaryName(syntax.OperatorToken.Kind);
+            if (userOpName != null && boundOperand.Type != null)
+            {
+                FunctionSymbol userOp = null;
+                bool isStructReceiver = false;
+                if (boundOperand.Type is StructSymbol operandStruct && operandStruct.TryGetMethodIncludingInherited(userOpName, out var structOp))
+                {
+                    userOp = structOp;
+                    isStructReceiver = true;
+                }
+                else if (scope.TryLookupExtensionFunction(boundOperand.Type, userOpName, out var extOp))
+                {
+                    userOp = extOp;
+                }
+
+                if (userOp != null && userOp.Parameters.Length == 1)
+                {
+                    var convertedOperand = BindConversion(syntax.Operand.Location, boundOperand, userOp.Parameters[0].Type);
+                    if (isStructReceiver)
+                    {
+                        return new BoundUserInstanceCallExpression(convertedOperand, userOp, ImmutableArray<BoundExpression>.Empty);
+                    }
+
+                    return new BoundCallExpression(userOp, ImmutableArray.Create(convertedOperand));
+                }
+            }
+
             // Stream C: fall back to a public-static unary `op_*` method on
             // the operand's CLR type (`-time`, `~bits`, ...).
             var ambiguous = false;
@@ -3898,6 +3929,53 @@ public sealed class Binder
 
         if (boundOperator == null)
         {
+            // Stream D: try user-defined `func (a T) operator <op>(b U) R` on
+            // either operand's user type. Same-package operators are bound as
+            // methods on the struct (Phase 6.4); the receiver is at
+            // Parameters[0] (so binary ops have Parameters.Length == 2).
+            var userOpName = OperatorNames.TryGetBinaryName(syntax.OperatorToken.Kind);
+            if (userOpName != null)
+            {
+                FunctionSymbol userOp = null;
+                bool leftIsStructReceiver = false;
+                bool rightIsStructReceiver = false;
+                if (boundLeft.Type is StructSymbol leftStruct && leftStruct.TryGetMethodIncludingInherited(userOpName, out var leftOp))
+                {
+                    userOp = leftOp;
+                    leftIsStructReceiver = true;
+                }
+                else if (boundRight.Type is StructSymbol rightStruct && rightStruct.TryGetMethodIncludingInherited(userOpName, out var rightOp))
+                {
+                    userOp = rightOp;
+                    rightIsStructReceiver = true;
+                }
+                else if (boundLeft.Type != null && scope.TryLookupExtensionFunction(boundLeft.Type, userOpName, out var leftExt))
+                {
+                    userOp = leftExt;
+                }
+                else if (boundRight.Type != null && scope.TryLookupExtensionFunction(boundRight.Type, userOpName, out var rightExt))
+                {
+                    userOp = rightExt;
+                }
+
+                if (userOp != null && userOp.Parameters.Length == 2)
+                {
+                    var convertedLeft = BindConversion(syntax.Left.Location, boundLeft, userOp.Parameters[0].Type);
+                    var convertedRight = BindConversion(syntax.Right.Location, boundRight, userOp.Parameters[1].Type);
+                    if (leftIsStructReceiver)
+                    {
+                        return new BoundUserInstanceCallExpression(convertedLeft, userOp, ImmutableArray.Create(convertedRight));
+                    }
+
+                    if (rightIsStructReceiver)
+                    {
+                        return new BoundUserInstanceCallExpression(convertedRight, userOp, ImmutableArray.Create(convertedLeft));
+                    }
+
+                    return new BoundCallExpression(userOp, ImmutableArray.Create(convertedLeft, convertedRight));
+                }
+            }
+
             // Stream C: fall back to a public-static `op_*` method on either
             // operand's CLR type (TimeSpan + TimeSpan, BigInteger * int, ...).
             var ambiguous = false;

--- a/src/Core/CodeAnalysis/Binding/OperatorNames.cs
+++ b/src/Core/CodeAnalysis/Binding/OperatorNames.cs
@@ -1,0 +1,63 @@
+// <copyright file="OperatorNames.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Maps GSharp operator tokens (as written inside <c>func (...) operator +(...)</c>
+/// declarations) to the corresponding CLR <c>op_*</c> method name. Stream D —
+/// user-defined operator overloads on GSharp types.
+/// </summary>
+internal static class OperatorNames
+{
+    /// <summary>
+    /// Returns the CLR <c>op_*</c> name for a binary operator token, or
+    /// <see langword="null"/> if the token is not a supported binary operator.
+    /// </summary>
+    /// <param name="kind">The operator token kind.</param>
+    /// <returns>The CLR operator name, or <see langword="null"/>.</returns>
+    public static string TryGetBinaryName(SyntaxKind kind)
+    {
+        return kind switch
+        {
+            SyntaxKind.PlusToken => "op_Addition",
+            SyntaxKind.MinusToken => "op_Subtraction",
+            SyntaxKind.StarToken => "op_Multiply",
+            SyntaxKind.SlashToken => "op_Division",
+            SyntaxKind.PercentToken => "op_Modulus",
+            SyntaxKind.AmpersandToken => "op_BitwiseAnd",
+            SyntaxKind.PipeToken => "op_BitwiseOr",
+            SyntaxKind.HatToken => "op_ExclusiveOr",
+            SyntaxKind.ShiftLeftToken => "op_LeftShift",
+            SyntaxKind.ShiftRightToken => "op_RightShift",
+            SyntaxKind.EqualsEqualsToken => "op_Equality",
+            SyntaxKind.BangEqualsToken => "op_Inequality",
+            SyntaxKind.LessToken => "op_LessThan",
+            SyntaxKind.LessOrEqualsToken => "op_LessThanOrEqual",
+            SyntaxKind.GreaterToken => "op_GreaterThan",
+            SyntaxKind.GreaterOrEqualsToken => "op_GreaterThanOrEqual",
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Returns the CLR <c>op_*</c> name for a unary operator token, or
+    /// <see langword="null"/> if the token is not a supported unary operator.
+    /// </summary>
+    /// <param name="kind">The operator token kind.</param>
+    /// <returns>The CLR operator name, or <see langword="null"/>.</returns>
+    public static string TryGetUnaryName(SyntaxKind kind)
+    {
+        return kind switch
+        {
+            SyntaxKind.PlusToken => "op_UnaryPlus",
+            SyntaxKind.MinusToken => "op_UnaryNegation",
+            SyntaxKind.BangToken => "op_LogicalNot",
+            SyntaxKind.HatToken => "op_OnesComplement",
+            _ => null,
+        };
+    }
+}

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1285,6 +1285,15 @@ internal sealed class ReflectionMetadataEmitter
         //   override (sealed):  Virtual | Final            (reuses base slot, no further override)
         //   open override:      Virtual                    (reuses base slot, still overridable)
         var methodAttrs = visibility | MethodAttributes.HideBySig;
+
+        // Stream D: extension functions whose name follows the CLR `op_*`
+        // convention came from `func (a T) operator +(...)` and should round-
+        // trip as SpecialName so consumers (e.g. C#) see them as operators.
+        if (function.IsExtension && function.Name != null && function.Name.StartsWith("op_"))
+        {
+            methodAttrs |= MethodAttributes.SpecialName;
+        }
+
         if (function.IsInstanceMethod)
         {
             methodAttrs |= MethodAttributes.Virtual;

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -730,7 +730,7 @@ public class Parser
             receiverCloseParen = MatchToken(SyntaxKind.CloseParenthesisToken);
         }
 
-        var identifier = MatchToken(SyntaxKind.IdentifierToken);
+        var identifier = MatchOperatorOrIdentifier(receiver != null);
         var typeParameterList = ParseOptionalTypeParameterList();
         var openParenthesisToken = MatchToken(SyntaxKind.OpenParenthesisToken);
         var parameters = ParseParameterList();
@@ -738,6 +738,45 @@ public class Parser
         var type = ParseOptionalTypeClause();
         var body = ParseBlockStatement();
         return new FunctionDeclarationSyntax(syntaxTree, accessibilityModifier, openModifier, overrideModifier, asyncModifier, functionKeyword, receiverOpenParen, receiver, receiverCloseParen, identifier, typeParameterList, openParenthesisToken, parameters, closeParenthesisToken, type, body);
+    }
+
+    // Stream D: `func (a Point) operator +(b Point) Point { … }`. After the
+    // optional receiver clause, if the current token is the contextual
+    // `operator` keyword we consume it and the following operator token, then
+    // synthesize an IdentifierToken whose text is the CLR op_* name (e.g.
+    // `op_Addition`). Downstream binding sees a regular extension function with
+    // that name; the binder later hooks `BindBinaryExpression` /
+    // `BindUnaryExpression` to look up `op_*` on the user type's symbol.
+    private SyntaxToken MatchOperatorOrIdentifier(bool hasReceiver)
+    {
+        if (Current.Kind != SyntaxKind.OperatorKeyword)
+        {
+            return MatchToken(SyntaxKind.IdentifierToken);
+        }
+
+        var operatorKeyword = NextToken();
+        var operatorToken = NextToken();
+
+        // Disambiguate binary vs unary by peeking the parameter list. With a
+        // receiver clause, the parameter list contains only the *extra*
+        // operands — empty list ⇒ unary, otherwise binary. (Free-function
+        // form without a receiver is not yet wired through this path.)
+        var isUnary = hasReceiver
+            && Current.Kind == SyntaxKind.OpenParenthesisToken
+            && Peek(1).Kind == SyntaxKind.CloseParenthesisToken;
+
+        var name = isUnary
+            ? GSharp.Core.CodeAnalysis.Binding.OperatorNames.TryGetUnaryName(operatorToken.Kind)
+            : GSharp.Core.CodeAnalysis.Binding.OperatorNames.TryGetBinaryName(operatorToken.Kind)
+              ?? GSharp.Core.CodeAnalysis.Binding.OperatorNames.TryGetUnaryName(operatorToken.Kind);
+
+        if (name == null)
+        {
+            Diagnostics.ReportUnexpectedToken(operatorToken.Location, operatorToken.Kind, SyntaxKind.PlusToken);
+            return new SyntaxToken(syntaxTree, SyntaxKind.IdentifierToken, operatorKeyword.Position, "__bad_operator__", null);
+        }
+
+        return new SyntaxToken(syntaxTree, SyntaxKind.IdentifierToken, operatorKeyword.Position, name, null);
     }
 
     private TypeParameterListSyntax ParseOptionalTypeParameterList()
@@ -896,12 +935,22 @@ public class Parser
         }
 
         ahead++;
-        if (Peek(ahead).Kind != SyntaxKind.IdentifierToken)
+        if (Peek(ahead).Kind != SyntaxKind.IdentifierToken && Peek(ahead).Kind != SyntaxKind.OperatorKeyword)
         {
             return false;
         }
 
         ahead++;
+
+        // Stream D: `operator <op>(` follows the receiver clause for operator
+        // overloads. Accept any non-`(`/non-EOF token after `operator` here —
+        // the operator-token validation happens in MatchOperatorOrIdentifier.
+        if (Peek(ahead - 1).Kind == SyntaxKind.OperatorKeyword)
+        {
+            return Peek(ahead).Kind != SyntaxKind.EndOfFileToken
+                && Peek(ahead + 1).Kind == SyntaxKind.OpenParenthesisToken;
+        }
+
         return Peek(ahead).Kind == SyntaxKind.OpenParenthesisToken;
     }
 

--- a/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -179,6 +179,8 @@ public static class SyntaxFacts
                 return SyntaxKind.NilKeyword;
             case "open":
                 return SyntaxKind.OpenKeyword;
+            case "operator":
+                return SyntaxKind.OperatorKeyword;
             case "override":
                 return SyntaxKind.OverrideKeyword;
             case "package":
@@ -425,6 +427,8 @@ public static class SyntaxFacts
                 return "nil";
             case SyntaxKind.OverrideKeyword:
                 return "override";
+            case SyntaxKind.OperatorKeyword:
+                return "operator";
             case SyntaxKind.PackageKeyword:
                 return "package";
             case SyntaxKind.PrivateKeyword:

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -109,6 +109,7 @@ public enum SyntaxKind
     MapKeyword,
     NilKeyword,
     OpenKeyword,
+    OperatorKeyword,
     OverrideKeyword,
     PackageKeyword,
     PrivateKeyword,

--- a/test/Core.Tests/CodeAnalysis/Binding/UserOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/UserOperatorTests.cs
@@ -1,0 +1,100 @@
+// <copyright file="UserOperatorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Stream D — user-defined operator overloads on GSharp struct types via the
+/// <c>func (a T) operator +(...)</c> receiver-form syntax.
+/// </summary>
+public class UserOperatorTests
+{
+    [Fact]
+    public void StructPlusOperator_BinaryAddition_BindsAndEvaluates()
+    {
+        var source = @"
+type Vector2 struct {
+    X int
+    Y int
+}
+
+func (a Vector2) operator +(b Vector2) Vector2 {
+    return Vector2{X: a.X + b.X, Y: a.Y + b.Y}
+}
+
+var p = Vector2{X: 1, Y: 2}
+var q = Vector2{X: 3, Y: 4}
+var r = p + q
+var first = r.X
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(4, result.Value);
+    }
+
+    [Fact]
+    public void StructUnaryNegation_BindsAndEvaluates()
+    {
+        var source = @"
+type Vector2 struct {
+    X int
+    Y int
+}
+
+func (a Vector2) operator -() Vector2 {
+    return Vector2{X: -a.X, Y: -a.Y}
+}
+
+var p = Vector2{X: 3, Y: 4}
+var r = -p
+var negX = r.X
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(-3, result.Value);
+    }
+
+    [Fact]
+    public void StructEqualityOperator_OverridesDefault()
+    {
+        // Two Vector2 values whose X+Y sums match should compare equal under a
+        // user-defined op_Equality even when individual fields differ.
+        var source = @"
+type Vector2 struct {
+    X int
+    Y int
+}
+
+func (a Vector2) operator ==(b Vector2) bool {
+    return a.X + a.Y == b.X + b.Y
+}
+
+func (a Vector2) operator !=(b Vector2) bool {
+    return a.X + a.Y != b.X + b.Y
+}
+
+var p = Vector2{X: 1, Y: 4}
+var q = Vector2{X: 2, Y: 3}
+var eq = p == q
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -120,6 +120,7 @@ OpenBraceToken
 OpenKeyword
 OpenParenthesisToken
 OpenSquareBracketToken
+OperatorKeyword
 OverrideKeyword
 PackageDeclaration
 PackageKeyword


### PR DESCRIPTION
Implements Stream D of the imported-type interop overhaul plan: receiver-form binary and unary `operator` overloads on GSharp-declared types. Supersedes ADR-0026 for those forms.

## What ships

- **Syntax**: `func (a T) operator <op>(b T) R { … }` (binary) and `func (a T) operator <op>() R { … }` (unary).
- **Operator tokens accepted**: `+ - * / % & | ^ << >> == != < <= > >=` (binary) and `+ - ! ~` (unary).
- **Binder resolution order**: built-in → user operator (struct method then extension function) → imported CLR `op_*` (ADR-0034).
- **Disambiguation**: peek the parameter list after `operator <token>` — empty list ⇒ unary, non-empty ⇒ binary.
- **Lowering**: same-package struct operators emit as `BoundUserInstanceCallExpression` (so they reuse the existing instance-call path); cross-package extension-function operators emit as `BoundCallExpression` with `SpecialName` so the CLR convention is preserved.
- **Sample**: `samples/Operators.gs` + golden.
- **Docs**: new ADR-0035; ADR-0026 status → *Superseded by ADR-0035* for the receiver form; coverage-matrix Operators table and golden snapshot updated.

## What is deferred

- Free-function form (`func operator +(a T, b T) T`).
- Conversion operators (`operator implicit`, `operator explicit`).
- `++` / `--` overloads.
- Short-circuit `&&` / `||` via `op_True` / `op_False`.
- Value-type `struct` instance-method IL emit (pre-existing gap; operators inherit it — the sample uses `class` to side-step). Tracked separately.

## Validation

- 3 new `UserOperatorTests` (`+`, unary `-`, `==`/`!=` on a `Vector2 struct`) — all green under the interpreter.
- New `Operators.gs` conformance sample compiles, runs, and matches its golden under the IL backend.
- Full suite: **712 passing** (21 Sdk + 8 Interpreter + 585 Core + 17 LanguageServer + 81 Compiler), 0 failures.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>