### PR TITLE
Async emit: foundational lowering scaffolding (ADR-0023 Strategy A)

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncBoundTreeQueries.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncBoundTreeQueries.cs
@@ -1,0 +1,72 @@
+// <copyright file="AsyncBoundTreeQueries.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Binding;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Lightweight read-only queries over a bound subtree that the async
+/// lowering passes share. None of these methods mutate the tree.
+/// </summary>
+/// <remarks>
+/// These helpers are intentionally implemented on top of
+/// <see cref="BoundTreeRewriter"/> rather than a separate visitor: the
+/// rewriter's overrides return the same node when nothing changes, so
+/// no allocation is triggered when a query merely observes nodes. This
+/// avoids adding yet another tree-walking infrastructure to the codebase
+/// while still letting each query short-circuit cheaply (see
+/// <see cref="HasAwait(BoundStatement)"/>).
+/// </remarks>
+public static class AsyncBoundTreeQueries
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when the given bound statement subtree
+    /// contains at least one <see cref="BoundAwaitExpression"/>.
+    /// </summary>
+    /// <param name="statement">The bound statement to inspect.</param>
+    /// <returns>Whether the subtree contains an <c>await</c>.</returns>
+    public static bool HasAwait(BoundStatement statement)
+    {
+        if (statement == null)
+        {
+            return false;
+        }
+
+        var probe = new AwaitDetector();
+        probe.RewriteStatement(statement);
+        return probe.Found;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the given bound expression subtree
+    /// contains at least one <see cref="BoundAwaitExpression"/>.
+    /// </summary>
+    /// <param name="expression">The bound expression to inspect.</param>
+    /// <returns>Whether the subtree contains an <c>await</c>.</returns>
+    public static bool HasAwait(BoundExpression expression)
+    {
+        if (expression == null)
+        {
+            return false;
+        }
+
+        var probe = new AwaitDetector();
+        probe.Visit(expression);
+        return probe.Found;
+    }
+
+    private sealed class AwaitDetector : BoundTreeRewriter
+    {
+        public bool Found { get; private set; }
+
+        public BoundExpression Visit(BoundExpression expr) => RewriteExpression(expr);
+
+        protected override BoundExpression RewriteAwaitExpression(BoundAwaitExpression node)
+        {
+            Found = true;
+            return node;
+        }
+    }
+}

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncMethodBuilderInfo.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncMethodBuilderInfo.cs
@@ -1,0 +1,468 @@
+// <copyright file="AsyncMethodBuilderInfo.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Resolved metadata for the BCL "async method builder" associated with an
+/// <c>async</c> method's declared return type. The async state-machine
+/// rewriter consumes one of these per async method to emit the kickoff body
+/// and the per-await sequence inside <c>MoveNext</c>.
+/// </summary>
+/// <remarks>
+/// <para>The selection rules mirror Roslyn's
+/// <c>AsyncMethodBuilderMemberCollection.TryCreate</c>
+/// (see <c>~/roslyn-async.md</c> §1, §11 corner case 18, and Roslyn's
+/// <c>Lowering/AsyncRewriter/AsyncMethodBuilderMemberCollection.cs</c>):</para>
+/// <list type="number">
+/// <item><description>If the method itself carries a
+/// <c>[AsyncMethodBuilder(typeof(T))]</c> attribute, <c>T</c> is the builder
+/// (the method-level attribute takes precedence).</description></item>
+/// <item><description>Otherwise, if the return type carries
+/// <c>[AsyncMethodBuilder(typeof(T))]</c>, <c>T</c> is the builder. For
+/// generic task-likes the builder is constructed with the result type via
+/// <c>builder.MakeGenericType(resultType)</c>.</description></item>
+/// <item><description>Otherwise the builder is one of the four well-known
+/// BCL types:
+/// <list type="bullet">
+/// <item><description><c>System.Void</c> → <c>AsyncVoidMethodBuilder</c>.</description></item>
+/// <item><description><c>System.Threading.Tasks.Task</c> → <c>AsyncTaskMethodBuilder</c>.</description></item>
+/// <item><description><c>System.Threading.Tasks.Task&lt;T&gt;</c> → <c>AsyncTaskMethodBuilder&lt;T&gt;</c>.</description></item>
+/// <item><description><c>System.Collections.Generic.IAsyncEnumerable&lt;T&gt;</c> /
+/// <c>System.Collections.Generic.IAsyncEnumerator&lt;T&gt;</c> →
+/// <c>AsyncIteratorMethodBuilder</c>.</description></item>
+/// </list></description></item>
+/// </list>
+/// <para>This class is a pure resolution helper. It performs no lowering
+/// and produces no diagnostics; callers that need diagnostics should check
+/// <see cref="IsValid"/> and route errors through their own diagnostic bag.</para>
+/// </remarks>
+public sealed class AsyncMethodBuilderInfo
+{
+    private AsyncMethodBuilderInfo(
+        AsyncMethodBuilderKind kind,
+        Type builderType,
+        Type resultType,
+        MethodInfo createMethod,
+        PropertyInfo taskProperty,
+        MethodInfo startMethod,
+        MethodInfo setStateMachineMethod,
+        MethodInfo setResultMethod,
+        MethodInfo setExceptionMethod,
+        MethodInfo awaitOnCompletedMethod,
+        MethodInfo awaitUnsafeOnCompletedMethod)
+    {
+        Kind = kind;
+        BuilderType = builderType;
+        ResultType = resultType;
+        CreateMethod = createMethod;
+        TaskProperty = taskProperty;
+        StartMethod = startMethod;
+        SetStateMachineMethod = setStateMachineMethod;
+        SetResultMethod = setResultMethod;
+        SetExceptionMethod = setExceptionMethod;
+        AwaitOnCompletedMethod = awaitOnCompletedMethod;
+        AwaitUnsafeOnCompletedMethod = awaitUnsafeOnCompletedMethod;
+    }
+
+    /// <summary>Gets the categorisation of this builder.</summary>
+    public AsyncMethodBuilderKind Kind { get; }
+
+    /// <summary>Gets the (possibly constructed) builder <see cref="Type"/>.</summary>
+    public Type BuilderType { get; }
+
+    /// <summary>Gets the unwrapped result type (<c>T</c> for <c>Task&lt;T&gt;</c>,
+    /// <c>typeof(void)</c> for <c>Task</c>/<c>void</c>).</summary>
+    public Type ResultType { get; }
+
+    /// <summary>Gets <c>Builder.Create()</c> static method.</summary>
+    public MethodInfo CreateMethod { get; }
+
+    /// <summary>Gets the <c>Task</c> / <c>Task&lt;T&gt;</c> / iterator property.
+    /// <c>null</c> for <c>AsyncVoidMethodBuilder</c>.</summary>
+    public PropertyInfo TaskProperty { get; }
+
+    /// <summary>Gets the <c>Start&lt;TStateMachine&gt;(ref TStateMachine)</c> open generic.</summary>
+    public MethodInfo StartMethod { get; }
+
+    /// <summary>Gets <c>SetStateMachine(IAsyncStateMachine)</c>.</summary>
+    public MethodInfo SetStateMachineMethod { get; }
+
+    /// <summary>Gets <c>SetResult([T])</c>.</summary>
+    public MethodInfo SetResultMethod { get; }
+
+    /// <summary>Gets <c>SetException(Exception)</c>.</summary>
+    public MethodInfo SetExceptionMethod { get; }
+
+    /// <summary>Gets <c>AwaitOnCompleted&lt;TAwaiter, TStateMachine&gt;(ref TAwaiter, ref TStateMachine)</c>.</summary>
+    public MethodInfo AwaitOnCompletedMethod { get; }
+
+    /// <summary>Gets <c>AwaitUnsafeOnCompleted&lt;TAwaiter, TStateMachine&gt;(ref TAwaiter, ref TStateMachine)</c>.</summary>
+    public MethodInfo AwaitUnsafeOnCompletedMethod { get; }
+
+    /// <summary>Gets a value indicating whether every member required for
+    /// state-machine lowering was successfully resolved. Iterator builders
+    /// have a different member surface and require only the common
+    /// members (<c>Create</c>, <c>MoveNext</c>, <c>AwaitOnCompleted</c>,
+    /// <c>AwaitUnsafeOnCompleted</c>); the rest is bound by the iterator
+    /// rewriter directly.</summary>
+    public bool IsValid
+    {
+        get
+        {
+            if (BuilderType == null
+                || CreateMethod == null
+                || AwaitOnCompletedMethod == null
+                || AwaitUnsafeOnCompletedMethod == null)
+            {
+                return false;
+            }
+
+            if (Kind == AsyncMethodBuilderKind.AsyncIterator)
+            {
+                // StartMethod here holds MoveNext<TSM>(ref TSM).
+                return StartMethod != null;
+            }
+
+            if (StartMethod == null
+                || SetStateMachineMethod == null
+                || SetResultMethod == null
+                || SetExceptionMethod == null)
+            {
+                return false;
+            }
+
+            if (Kind != AsyncMethodBuilderKind.Void && TaskProperty == null)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the builder for an async method whose declared kickoff return
+    /// type (i.e. the wrapped <c>Task</c> / <c>Task&lt;T&gt;</c> / etc.) is
+    /// <paramref name="kickoffReturnClrType"/>.
+    /// </summary>
+    /// <param name="kickoffReturnClrType">The CLR <see cref="Type"/> the
+    /// kickoff method actually returns. For <c>async void</c> pass
+    /// <c>typeof(void)</c>.</param>
+    /// <param name="resolver">The reference resolver used to find BCL types
+    /// in the target framework. May be <see langword="null"/>, in which case
+    /// the host runtime types are used.</param>
+    /// <param name="methodAttributeBuilderType">Optional CLR type captured
+    /// from a method-level <c>[AsyncMethodBuilder(typeof(T))]</c> attribute.
+    /// Takes precedence over a return-type attribute when non-null.</param>
+    /// <returns>A populated <see cref="AsyncMethodBuilderInfo"/>, or
+    /// <see langword="null"/> when no valid builder could be resolved.</returns>
+    public static AsyncMethodBuilderInfo Resolve(
+        Type kickoffReturnClrType,
+        ReferenceResolver resolver,
+        Type methodAttributeBuilderType = null)
+    {
+        if (kickoffReturnClrType == null)
+        {
+            return null;
+        }
+
+        var choice = ChooseBuilder(kickoffReturnClrType, resolver, methodAttributeBuilderType);
+        if (choice.BuilderType == null)
+        {
+            return null;
+        }
+
+        return BindMembers(choice.Kind, choice.BuilderType, choice.ResultType);
+    }
+
+    private static (AsyncMethodBuilderKind Kind, Type BuilderType, Type ResultType) ChooseBuilder(
+        Type kickoffReturnClrType,
+        ReferenceResolver resolver,
+        Type methodAttributeBuilderType)
+    {
+        Type CoreType(string fullName)
+        {
+            if (resolver != null)
+            {
+                if (resolver.TryResolveType(fullName, out var t) && t != null)
+                {
+                    return t;
+                }
+            }
+
+            return Type.GetType(fullName + ", System.Runtime", throwOnError: false)
+                ?? Type.GetType(fullName, throwOnError: false);
+        }
+
+        // 1. Method-level [AsyncMethodBuilder] wins.
+        if (methodAttributeBuilderType != null)
+        {
+            var resultType = ExtractResultType(kickoffReturnClrType);
+            var constructed = ConstructBuilder(methodAttributeBuilderType, resultType);
+            return (AsyncMethodBuilderKind.Custom, constructed, resultType);
+        }
+
+        // 2. async void / async Task / async Task<T> / async ValueTask*
+        //    / async IAsyncEnumerable<T> / async IAsyncEnumerator<T>.
+        if (kickoffReturnClrType == typeof(void) || kickoffReturnClrType.FullName == "System.Void")
+        {
+            var builder = CoreType("System.Runtime.CompilerServices.AsyncVoidMethodBuilder");
+            return (AsyncMethodBuilderKind.Void, builder, typeof(void));
+        }
+
+        if (IsWellKnownTask(kickoffReturnClrType, out var isGeneric, out var taskResultType))
+        {
+            if (isGeneric)
+            {
+                var open = CoreType("System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1");
+                var builder = open?.MakeGenericType(taskResultType);
+                return (AsyncMethodBuilderKind.GenericTask, builder, taskResultType);
+            }
+
+            var nonGeneric = CoreType("System.Runtime.CompilerServices.AsyncTaskMethodBuilder");
+            return (AsyncMethodBuilderKind.Task, nonGeneric, typeof(void));
+        }
+
+        if (IsAsyncIteratorReturnType(kickoffReturnClrType, out var iteratorElement))
+        {
+            var builder = CoreType("System.Runtime.CompilerServices.AsyncIteratorMethodBuilder");
+            return (AsyncMethodBuilderKind.AsyncIterator, builder, iteratorElement);
+        }
+
+        // 3. Custom task-like via [AsyncMethodBuilder] on the return type.
+        var attributeType = kickoffReturnClrType.GetCustomAttributesData()
+            .FirstOrDefault(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.AsyncMethodBuilderAttribute");
+        if (attributeType != null && attributeType.ConstructorArguments.Count == 1)
+        {
+            var customBuilder = attributeType.ConstructorArguments[0].Value as Type;
+            if (customBuilder != null)
+            {
+                var resultType = ExtractResultType(kickoffReturnClrType);
+                var constructed = ConstructBuilder(customBuilder, resultType);
+                return (AsyncMethodBuilderKind.Custom, constructed, resultType);
+            }
+        }
+
+        return (AsyncMethodBuilderKind.Unknown, null, null);
+    }
+
+    private static Type ConstructBuilder(Type openOrClosed, Type resultType)
+    {
+        if (openOrClosed == null)
+        {
+            return null;
+        }
+
+        if (openOrClosed.IsGenericTypeDefinition)
+        {
+            if (resultType == null || resultType == typeof(void))
+            {
+                return null;
+            }
+
+            return openOrClosed.MakeGenericType(resultType);
+        }
+
+        return openOrClosed;
+    }
+
+    private static bool IsWellKnownTask(Type returnType, out bool isGeneric, out Type resultType)
+    {
+        isGeneric = false;
+        resultType = typeof(void);
+
+        if (returnType == null)
+        {
+            return false;
+        }
+
+        var full = returnType.FullName;
+        if (full == "System.Threading.Tasks.Task")
+        {
+            return true;
+        }
+
+        if (returnType.IsGenericType)
+        {
+            var open = returnType.GetGenericTypeDefinition();
+            if (open?.FullName == "System.Threading.Tasks.Task`1")
+            {
+                isGeneric = true;
+                resultType = returnType.GetGenericArguments()[0];
+                return true;
+            }
+
+            if (open?.FullName == "System.Threading.Tasks.ValueTask`1")
+            {
+                // ValueTask<T> resolves through its [AsyncMethodBuilder]
+                // attribute; treat as not-well-known here so the attribute
+                // path runs.
+                return false;
+            }
+        }
+
+        if (full == "System.Threading.Tasks.ValueTask")
+        {
+            // Same as above — handled via the attribute path.
+            return false;
+        }
+
+        return false;
+    }
+
+    private static bool IsAsyncIteratorReturnType(Type returnType, out Type elementType)
+    {
+        elementType = null;
+        if (returnType == null || !returnType.IsGenericType)
+        {
+            return false;
+        }
+
+        var open = returnType.GetGenericTypeDefinition();
+        if (open?.FullName == "System.Collections.Generic.IAsyncEnumerable`1"
+            || open?.FullName == "System.Collections.Generic.IAsyncEnumerator`1")
+        {
+            elementType = returnType.GetGenericArguments()[0];
+            return true;
+        }
+
+        return false;
+    }
+
+    private static Type ExtractResultType(Type returnType)
+    {
+        if (returnType == null)
+        {
+            return typeof(void);
+        }
+
+        if (returnType.IsGenericType)
+        {
+            return returnType.GetGenericArguments()[0];
+        }
+
+        return typeof(void);
+    }
+
+    private static AsyncMethodBuilderInfo BindMembers(
+        AsyncMethodBuilderKind kind,
+        Type builderType,
+        Type resultType)
+    {
+        var create = builderType.GetMethod(
+            "Create",
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly,
+            binder: null,
+            types: Type.EmptyTypes,
+            modifiers: null);
+
+        if (kind == AsyncMethodBuilderKind.AsyncIterator)
+        {
+            // AsyncIteratorMethodBuilder has a different surface:
+            // MoveNext<TStateMachine>(ref TStateMachine) + Complete() in
+            // place of Start / SetStateMachine / SetResult / SetException.
+            // The full iterator binding lives in the iterator rewriter
+            // (todo: iterator-rewriter); here we resolve only the members
+            // that are common with the Task path, so the kind+builder type
+            // are already discoverable by callers.
+            var moveNext = builderType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(m =>
+                    m.Name == "MoveNext"
+                    && m.IsGenericMethodDefinition
+                    && m.GetParameters().Length == 1);
+            var awaitOnCompletedIter = builderType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(m =>
+                    m.Name == "AwaitOnCompleted"
+                    && m.IsGenericMethodDefinition
+                    && m.GetGenericArguments().Length == 2
+                    && m.GetParameters().Length == 2);
+            var awaitUnsafeOnCompletedIter = builderType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(m =>
+                    m.Name == "AwaitUnsafeOnCompleted"
+                    && m.IsGenericMethodDefinition
+                    && m.GetGenericArguments().Length == 2
+                    && m.GetParameters().Length == 2);
+
+            return new AsyncMethodBuilderInfo(
+                kind,
+                builderType,
+                resultType,
+                create,
+                taskProperty: null,
+                startMethod: moveNext,
+                setStateMachineMethod: null,
+                setResultMethod: null,
+                setExceptionMethod: null,
+                awaitOnCompletedMethod: awaitOnCompletedIter,
+                awaitUnsafeOnCompletedMethod: awaitUnsafeOnCompletedIter);
+        }
+
+        var task = builderType.GetProperty(
+            "Task",
+            BindingFlags.Public | BindingFlags.Instance);
+
+        // SetResult: no-arg for void / Task, single-arg for generic.
+        MethodInfo setResult;
+        if (kind == AsyncMethodBuilderKind.GenericTask
+            || (kind == AsyncMethodBuilderKind.Custom && resultType != null && resultType != typeof(void)))
+        {
+            setResult = builderType.GetMethod("SetResult", new[] { resultType });
+        }
+        else
+        {
+            setResult = builderType.GetMethod("SetResult", Type.EmptyTypes);
+        }
+
+        var setException = builderType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(m =>
+                m.Name == "SetException"
+                && m.GetParameters().Length == 1
+                && m.GetParameters()[0].ParameterType.FullName == "System.Exception");
+
+        var setStateMachine = builderType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(m =>
+                m.Name == "SetStateMachine"
+                && m.GetParameters().Length == 1
+                && m.GetParameters()[0].ParameterType.FullName == "System.Runtime.CompilerServices.IAsyncStateMachine");
+
+        var start = builderType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(m =>
+                m.Name == "Start"
+                && m.IsGenericMethodDefinition
+                && m.GetParameters().Length == 1);
+
+        var awaitOnCompleted = builderType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(m =>
+                m.Name == "AwaitOnCompleted"
+                && m.IsGenericMethodDefinition
+                && m.GetGenericArguments().Length == 2
+                && m.GetParameters().Length == 2);
+
+        var awaitUnsafeOnCompleted = builderType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(m =>
+                m.Name == "AwaitUnsafeOnCompleted"
+                && m.IsGenericMethodDefinition
+                && m.GetGenericArguments().Length == 2
+                && m.GetParameters().Length == 2);
+
+        return new AsyncMethodBuilderInfo(
+            kind,
+            builderType,
+            resultType,
+            create,
+            task,
+            start,
+            setStateMachine,
+            setResult,
+            setException,
+            awaitOnCompleted,
+            awaitUnsafeOnCompleted);
+    }
+}

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncMethodBuilderKind.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncMethodBuilderKind.cs
@@ -1,0 +1,37 @@
+// <copyright file="AsyncMethodBuilderKind.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Categorises the BCL async method builder selected for an <c>async</c>
+/// method (see <c>~/roslyn-async.md</c> §1).
+/// </summary>
+public enum AsyncMethodBuilderKind
+{
+    /// <summary>The return type was unrecognised and no
+    /// <c>[AsyncMethodBuilder]</c> attribute applied.</summary>
+    Unknown,
+
+    /// <summary><c>async void</c> — uses <c>AsyncVoidMethodBuilder</c>.</summary>
+    Void,
+
+    /// <summary><c>async Task</c> — uses <c>AsyncTaskMethodBuilder</c>.</summary>
+    Task,
+
+    /// <summary><c>async Task&lt;T&gt;</c> — uses
+    /// <c>AsyncTaskMethodBuilder&lt;T&gt;</c>.</summary>
+    GenericTask,
+
+    /// <summary><c>async IAsyncEnumerable&lt;T&gt;</c> or
+    /// <c>async IAsyncEnumerator&lt;T&gt;</c> — uses
+    /// <c>AsyncIteratorMethodBuilder</c>. The state machine is always a class
+    /// (spec §10).</summary>
+    AsyncIterator,
+
+    /// <summary>The return type or method carried a
+    /// <c>[AsyncMethodBuilder(typeof(T))]</c> attribute. Examples:
+    /// <c>ValueTask</c>, <c>ValueTask&lt;T&gt;</c>, user-defined task-likes.</summary>
+    Custom,
+}

--- a/src/Core/CodeAnalysis/Lowering/Async/AwaitableShape.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AwaitableShape.cs
@@ -1,0 +1,145 @@
+// <copyright file="AwaitableShape.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Resolved per-call-site shape of an awaitable expression. Encapsulates the
+/// duck-typed <c>GetAwaiter</c> / <c>IsCompleted</c> / <c>GetResult</c>
+/// triple and the awaiter's <c>ICriticalNotifyCompletion</c> flag, which the
+/// per-await codegen uses to select between
+/// <c>AwaitOnCompleted</c> and <c>AwaitUnsafeOnCompleted</c>
+/// (see <c>~/roslyn-async.md</c> §1, §6.4, §12 corner case 2).
+/// </summary>
+/// <remarks>
+/// <para>Resolution is strictly nominal — it searches for instance methods
+/// and extension methods named <c>GetAwaiter</c> on the awaitable type, then
+/// for an instance <c>IsCompleted</c> property and an instance
+/// <c>GetResult</c> method on the awaiter type. This matches the C#
+/// language rule: any type exposing those members in the right shape is
+/// awaitable, regardless of whether it implements <c>Task</c>.</para>
+/// <para>This class does not perform conversions or emit diagnostics; it
+/// returns <see langword="null"/> from <see cref="Resolve"/> when the shape
+/// does not match, and the caller is responsible for reporting the error.</para>
+/// </remarks>
+public sealed class AwaitableShape
+{
+    private AwaitableShape(
+        Type awaitableType,
+        Type awaiterType,
+        Type resultType,
+        MethodInfo getAwaiter,
+        PropertyInfo isCompleted,
+        MethodInfo getResult,
+        bool implementsCriticalNotifyCompletion)
+    {
+        AwaitableType = awaitableType;
+        AwaiterType = awaiterType;
+        ResultType = resultType;
+        GetAwaiterMethod = getAwaiter;
+        IsCompletedProperty = isCompleted;
+        GetResultMethod = getResult;
+        ImplementsCriticalNotifyCompletion = implementsCriticalNotifyCompletion;
+    }
+
+    /// <summary>Gets the type of the awaitable expression (e.g. <c>Task&lt;int&gt;</c>).</summary>
+    public Type AwaitableType { get; }
+
+    /// <summary>Gets the type of the awaiter returned by <see cref="GetAwaiterMethod"/>.</summary>
+    public Type AwaiterType { get; }
+
+    /// <summary>Gets the awaited result type (the return type of
+    /// <see cref="GetResultMethod"/>; <c>typeof(void)</c> for void-returning
+    /// <c>GetResult</c>).</summary>
+    public Type ResultType { get; }
+
+    /// <summary>Gets the resolved instance <c>GetAwaiter()</c> method.</summary>
+    public MethodInfo GetAwaiterMethod { get; }
+
+    /// <summary>Gets the resolved instance <c>IsCompleted</c> property
+    /// getter.</summary>
+    public PropertyInfo IsCompletedProperty { get; }
+
+    /// <summary>Gets the resolved instance <c>GetResult()</c> method.</summary>
+    public MethodInfo GetResultMethod { get; }
+
+    /// <summary>Gets a value indicating whether the awaiter implements
+    /// <c>System.Runtime.CompilerServices.ICriticalNotifyCompletion</c>. When
+    /// <see langword="true"/>, the per-await codegen prefers
+    /// <c>AwaitUnsafeOnCompleted</c> (no <c>ExecutionContext</c> flow).</summary>
+    public bool ImplementsCriticalNotifyCompletion { get; }
+
+    /// <summary>
+    /// Resolves the awaitable shape for the given CLR type, or returns
+    /// <see langword="null"/> if the type is not awaitable.
+    /// </summary>
+    /// <param name="awaitableType">The static type of the awaited expression.</param>
+    /// <returns>The resolved shape, or <see langword="null"/>.</returns>
+    public static AwaitableShape Resolve(Type awaitableType)
+    {
+        if (awaitableType == null)
+        {
+            return null;
+        }
+
+        var getAwaiter = awaitableType.GetMethod(
+            "GetAwaiter",
+            BindingFlags.Public | BindingFlags.Instance,
+            binder: null,
+            types: Type.EmptyTypes,
+            modifiers: null);
+
+        if (getAwaiter == null || getAwaiter.ReturnType == null || getAwaiter.ReturnType == typeof(void))
+        {
+            return null;
+        }
+
+        var awaiterType = getAwaiter.ReturnType;
+        var isCompleted = awaiterType.GetProperty(
+            "IsCompleted",
+            BindingFlags.Public | BindingFlags.Instance);
+
+        if (isCompleted == null || isCompleted.PropertyType.FullName != "System.Boolean" || isCompleted.GetMethod == null)
+        {
+            return null;
+        }
+
+        var getResult = awaiterType.GetMethod(
+            "GetResult",
+            BindingFlags.Public | BindingFlags.Instance,
+            binder: null,
+            types: Type.EmptyTypes,
+            modifiers: null);
+
+        if (getResult == null)
+        {
+            return null;
+        }
+
+        var implementsNotify = awaiterType.GetInterfaces()
+            .Any(i => i.FullName == "System.Runtime.CompilerServices.INotifyCompletion");
+
+        if (!implementsNotify)
+        {
+            // Not awaitable — must at minimum implement INotifyCompletion.
+            return null;
+        }
+
+        var implementsCritical = awaiterType.GetInterfaces()
+            .Any(i => i.FullName == "System.Runtime.CompilerServices.ICriticalNotifyCompletion");
+
+        return new AwaitableShape(
+            awaitableType,
+            awaiterType,
+            getResult.ReturnType,
+            getAwaiter,
+            isCompleted,
+            getResult,
+            implementsCritical);
+    }
+}

--- a/src/Core/CodeAnalysis/Lowering/Async/GeneratedNames.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/GeneratedNames.cs
@@ -1,0 +1,87 @@
+// <copyright file="GeneratedNames.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Deterministic mangled-name generator for compiler-synthesized async
+/// state-machine members. The naming scheme intentionally mirrors Roslyn's
+/// generated names so PDB tooling and the debugger surface familiar
+/// identifiers.
+/// </summary>
+/// <remarks>
+/// <para>Per ADR-0023 and the Roslyn-async spec (see <c>~/roslyn-async.md</c> §4),
+/// the CLR does not care about these names; they only matter for debugger
+/// experience and (future) Edit-and-Continue stability. GSharp does not
+/// support EnC, but adopting Roslyn's scheme keeps the diff visible to
+/// users who decompile the produced PE.</para>
+/// <para>The generator is stateful per-method: state machine kind suffixes
+/// (e.g. <c>d__N</c>) and per-type awaiter slot indices (<c>u__N</c>) are
+/// allocated by the caller, which threads its own counters through. All
+/// methods on this class are pure.</para>
+/// </remarks>
+public static class GeneratedNames
+{
+    /// <summary>The hoisted <c>state</c> field on a state-machine type.</summary>
+    public const string StateField = "<>1__state";
+
+    /// <summary>The hoisted async-method-builder field on a state-machine type.</summary>
+    public const string BuilderField = "<>t__builder";
+
+    /// <summary>The hoisted <c>this</c> reference field, present when the
+    /// containing method is an instance method that captures <c>this</c>.</summary>
+    public const string ThisField = "<>4__this";
+
+    /// <summary>
+    /// Returns the name of the hoisted field that mirrors a parameter of the
+    /// original async method.
+    /// </summary>
+    /// <param name="parameterName">The user-visible parameter name.</param>
+    /// <returns>The mangled hoisted-field name.</returns>
+    public static string ParameterField(string parameterName) => "<>3__" + parameterName;
+
+    /// <summary>
+    /// Returns the name of the hoisted field for a user-declared local that
+    /// must survive an await suspension.
+    /// </summary>
+    /// <param name="localName">The user-visible local name.</param>
+    /// <param name="ordinal">A per-method monotonic ordinal that disambiguates
+    /// reused names across shadowing scopes (mirrors Roslyn's
+    /// <c>&lt;&lt;name&gt;&gt;5__N</c> shape).</param>
+    /// <returns>The mangled hoisted-field name.</returns>
+    public static string HoistedLocalField(string localName, int ordinal)
+        => "<" + localName + ">5__" + ordinal.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Returns the name of the per-awaiter-type pooled field. One field is
+    /// shared across every <c>await</c> whose awaiter has the same type;
+    /// reference-typed awaiters collapse into a single <c>System.Object</c>
+    /// field (spec §5, "Awaiter slot pooling").
+    /// </summary>
+    /// <param name="ordinal">A per-method monotonic ordinal.</param>
+    /// <returns>The mangled awaiter-slot field name.</returns>
+    public static string AwaiterField(int ordinal)
+        => "<>u__" + ordinal.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Returns the name of the synthesized state-machine type for an async
+    /// method. The type lives as a nested type on the containing type (or
+    /// at top-level for the script entry point); the ordinal disambiguates
+    /// methods that share a name (overloads / generic instantiations).
+    /// </summary>
+    /// <param name="methodName">The original async method's user-visible name.</param>
+    /// <param name="ordinal">A per-containing-type monotonic ordinal.</param>
+    /// <returns>The mangled state-machine type name.</returns>
+    public static string StateMachineTypeName(string methodName, int ordinal)
+        => "<" + methodName + ">d__" + ordinal.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Returns the name of a reusable hoisted temp introduced by the spiller
+    /// (analogue of Roslyn's <c>&lt;&gt;7__wrapN</c>).
+    /// </summary>
+    /// <param name="ordinal">A per-method monotonic ordinal.</param>
+    /// <returns>The mangled spill-temp field name.</returns>
+    public static string SpillTempField(int ordinal)
+        => "<>7__wrap" + ordinal.ToString(System.Globalization.CultureInfo.InvariantCulture);
+}

--- a/src/Core/CodeAnalysis/Lowering/Async/StateMachineContainerKind.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/StateMachineContainerKind.cs
@@ -1,0 +1,21 @@
+// <copyright file="StateMachineContainerKind.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Storage kind for a synthesized state-machine type (see
+/// <c>~/roslyn-async.md</c> §5).
+/// </summary>
+public enum StateMachineContainerKind
+{
+    /// <summary>Emitted as a <c>struct</c>. Enables the no-alloc fast path
+    /// when an awaited operation completes synchronously: the builder boxes
+    /// the struct exactly once, on first suspension.</summary>
+    Struct,
+
+    /// <summary>Emitted as a <c>class</c>. Required for async-iterators
+    /// (spec §10) and for any future Edit-and-Continue support.</summary>
+    Class,
+}

--- a/src/Core/CodeAnalysis/Lowering/Async/StateMachineStates.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/StateMachineStates.cs
@@ -1,0 +1,42 @@
+// <copyright file="StateMachineStates.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Canonical magic state numbers used by the async state-machine rewriter
+/// (see <c>~/roslyn-async.md</c> §6.2 and Roslyn's
+/// <c>Core/Portable/CodeGen/StateMachineState.cs</c>).
+/// </summary>
+/// <remarks>
+/// The CLR builders rely on these values implicitly. For example,
+/// <c>AsyncTaskMethodBuilder.Start</c> calls <c>MoveNext</c> exactly once;
+/// the state machine must enter that call with <see cref="NotStartedOrRunningState"/>
+/// (<c>-1</c>) so the state-dispatch switch falls through to the first user
+/// statement instead of branching to a resume label.
+/// </remarks>
+public static class StateMachineStates
+{
+    /// <summary>Initial state set by the kickoff before <c>builder.Start</c>;
+    /// also the value the state-machine restores between resume and the next
+    /// suspension (spec §6.2).</summary>
+    public const int NotStartedOrRunningState = -1;
+
+    /// <summary>Terminal state set immediately before <c>SetResult</c> or
+    /// <c>SetException</c> (spec §6.2, §12 corner case 7).</summary>
+    public const int FinishedState = -2;
+
+    /// <summary>Initial state for async-iterators (<c>async IAsyncEnumerable&lt;T&gt;</c>).
+    /// Yield states decrease from this value; await states still increase
+    /// from <see cref="FirstResumableAsyncState"/> (spec §10).</summary>
+    public const int InitialAsyncIteratorState = -3;
+
+    /// <summary>First state number allocated to a suspending <c>await</c>;
+    /// subsequent awaits get monotonically increasing values.</summary>
+    public const int FirstResumableAsyncState = 0;
+
+    /// <summary>First state number allocated to a suspending <c>yield</c>;
+    /// subsequent yields decrease from here (async-iterator only).</summary>
+    public const int FirstResumableAsyncIteratorState = InitialAsyncIteratorState - 1;
+}

--- a/src/Core/CodeAnalysis/Lowering/Async/SynthesizedStateMachineType.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SynthesizedStateMachineType.cs
@@ -1,0 +1,96 @@
+// <copyright file="SynthesizedStateMachineType.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// A compiler-synthesized CLR type that hosts the lowered state machine for
+/// an <c>async</c> method (see <c>~/roslyn-async.md</c> §5). It carries all
+/// hoisted control fields (<c>&lt;&gt;1__state</c>, <c>&lt;&gt;t__builder</c>),
+/// the <c>this</c>-proxy field, parameter proxies, hoisted user locals, and
+/// the per-type pooled awaiter fields.
+/// </summary>
+/// <remarks>
+/// <para>The type is emitted by <see cref="Emit.ReflectionMetadataEmitter"/>
+/// as a nested type on the containing type (or top-level for the script
+/// entry-point's async helpers). Its kind — struct vs class — is fixed at
+/// construction:</para>
+/// <list type="bullet">
+/// <item><description><b>struct</b> by default for <c>async void</c> /
+/// <c>async Task</c> / <c>async Task&lt;T&gt;</c> / custom task-likes; the
+/// no-alloc fast path on synchronously-completing awaits depends on this.</description></item>
+/// <item><description><b>class</b> for async-iterators (always), and as the
+/// fallback when EnC stability is needed (not currently supported by GSharp).</description></item>
+/// </list>
+/// <para>This class is a thin data container. Field population happens in
+/// <c>AsyncStateMachineRewriter</c> (todo: state-rewriter), which decides
+/// hoist set, allocates awaiter slot indices, and registers the synthesized
+/// type with its kickoff <see cref="FunctionSymbol"/>.</para>
+/// </remarks>
+public sealed class SynthesizedStateMachineType : TypeSymbol
+{
+    private readonly List<FieldSymbol> fields = new List<FieldSymbol>();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SynthesizedStateMachineType"/> class.
+    /// </summary>
+    /// <param name="name">The mangled type name produced by
+    /// <see cref="GeneratedNames.StateMachineTypeName"/>.</param>
+    /// <param name="containerKind">Whether the type is a <c>struct</c> or
+    /// <c>class</c>; see <see cref="StateMachineContainerKind"/>.</param>
+    /// <param name="kickoffMethod">The original async method whose body
+    /// the state machine implements.</param>
+    /// <param name="builderInfo">The resolved BCL builder for the kickoff
+    /// method's return type.</param>
+    public SynthesizedStateMachineType(
+        string name,
+        StateMachineContainerKind containerKind,
+        FunctionSymbol kickoffMethod,
+        AsyncMethodBuilderInfo builderInfo)
+        : base(name)
+    {
+        ContainerKind = containerKind;
+        KickoffMethod = kickoffMethod;
+        BuilderInfo = builderInfo;
+    }
+
+    /// <summary>Gets the storage kind (struct or class). Spec §5.</summary>
+    public StateMachineContainerKind ContainerKind { get; }
+
+    /// <summary>Gets the original async method whose body the state machine implements.</summary>
+    public FunctionSymbol KickoffMethod { get; }
+
+    /// <summary>Gets the resolved BCL builder information for the kickoff
+    /// method's return type.</summary>
+    public AsyncMethodBuilderInfo BuilderInfo { get; }
+
+    /// <summary>Gets or sets the <c>&lt;&gt;1__state</c> field. Always
+    /// present; populated by the state-machine rewriter.</summary>
+    public FieldSymbol StateField { get; set; }
+
+    /// <summary>Gets or sets the <c>&lt;&gt;t__builder</c> field. Always
+    /// present; typed as <see cref="AsyncMethodBuilderInfo.BuilderType"/>.</summary>
+    public FieldSymbol BuilderField { get; set; }
+
+    /// <summary>Gets or sets the <c>&lt;&gt;4__this</c> field, present only
+    /// when the kickoff method is an instance method that captures <c>this</c>.</summary>
+    public FieldSymbol ThisField { get; set; }
+
+    /// <summary>Gets the read-only sequence of all synthesized fields on
+    /// the state machine, in declaration order. Includes the control
+    /// fields, the parameter proxies, the hoisted user locals, and the
+    /// pooled awaiter slots.</summary>
+    public ImmutableArray<FieldSymbol> Fields => fields.ToImmutableArray();
+
+    /// <summary>Appends a field to the synthesized type. Call order
+    /// determines emit order; the state-machine rewriter pushes control
+    /// fields first, then parameter proxies, then hoisted locals, then
+    /// awaiter slots, matching Roslyn's emit order.</summary>
+    /// <param name="field">The field to append.</param>
+    public void AddField(FieldSymbol field) => fields.Add(field);
+}

--- a/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -208,4 +208,13 @@ public sealed class FunctionSymbol : Symbol
 
     /// <summary>Gets or sets a value indicating whether this function is declared <c>async</c> (Phase 5.1 / ADR-0023). When true, callers observe the function's return as <c>Task[T]</c> (or <c>Task</c> when no return type was declared) and the body may use <c>await</c>.</summary>
     public bool IsAsync { get; set; }
+
+    /// <summary>Gets or sets the synthesized state-machine type that hosts
+    /// this method's lowered body, when the async state-machine rewriter has
+    /// run on this method. <c>null</c> when the method is not async or when
+    /// the rewriter has not yet visited it. The owning property is typed as
+    /// <see cref="object"/> to avoid a project-layer cycle (state-machine
+    /// types live under <c>Lowering.Async</c>); callers cast to
+    /// <c>SynthesizedStateMachineType</c>.</summary>
+    public object StateMachineType { get; set; }
 }

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncBoundTreeQueriesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncBoundTreeQueriesTests.cs
@@ -1,0 +1,45 @@
+// <copyright file="AsyncBoundTreeQueriesTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Lowering.Async;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
+
+public class AsyncBoundTreeQueriesTests
+{
+    [Fact]
+    public void HasAwait_OnExpressionStatementWithAwait_ReturnsTrue()
+    {
+        var literal = new BoundLiteralExpression(0);
+        var await = new BoundAwaitExpression(literal, TypeSymbol.Int);
+        var stmt = new BoundExpressionStatement(await);
+        Assert.True(AsyncBoundTreeQueries.HasAwait(stmt));
+    }
+
+    [Fact]
+    public void HasAwait_OnPlainBlock_ReturnsFalse()
+    {
+        var stmt = new BoundExpressionStatement(new BoundLiteralExpression(42));
+        Assert.False(AsyncBoundTreeQueries.HasAwait(stmt));
+    }
+
+    [Fact]
+    public void HasAwait_OnNestedBlockWithAwait_ReturnsTrue()
+    {
+        var inner = new BoundExpressionStatement(new BoundAwaitExpression(new BoundLiteralExpression(1), TypeSymbol.Int));
+        var outer = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(inner));
+        Assert.True(AsyncBoundTreeQueries.HasAwait(outer));
+    }
+
+    [Fact]
+    public void HasAwait_OnNullSubtree_ReturnsFalse()
+    {
+        Assert.False(AsyncBoundTreeQueries.HasAwait((BoundStatement)null));
+        Assert.False(AsyncBoundTreeQueries.HasAwait((BoundExpression)null));
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncMethodBuilderInfoTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncMethodBuilderInfoTests.cs
@@ -1,0 +1,86 @@
+// <copyright file="AsyncMethodBuilderInfoTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Lowering.Async;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Resolution of <see cref="AsyncMethodBuilderInfo"/> for the four BCL
+/// builder shapes plus a custom <c>[AsyncMethodBuilder]</c> task-like
+/// (<c>ValueTask&lt;T&gt;</c>).
+/// </summary>
+public class AsyncMethodBuilderInfoTests
+{
+    [Fact]
+    public void Resolve_Void_BindsAsyncVoidMethodBuilder()
+    {
+        var info = AsyncMethodBuilderInfo.Resolve(typeof(void), resolver: null);
+        Assert.NotNull(info);
+        Assert.Equal(AsyncMethodBuilderKind.Void, info.Kind);
+        Assert.Equal("System.Runtime.CompilerServices.AsyncVoidMethodBuilder", info.BuilderType.FullName);
+        Assert.NotNull(info.CreateMethod);
+        Assert.NotNull(info.StartMethod);
+        Assert.Null(info.TaskProperty);
+        Assert.True(info.IsValid);
+    }
+
+    [Fact]
+    public void Resolve_Task_BindsAsyncTaskMethodBuilder()
+    {
+        var info = AsyncMethodBuilderInfo.Resolve(typeof(Task), resolver: null);
+        Assert.NotNull(info);
+        Assert.Equal(AsyncMethodBuilderKind.Task, info.Kind);
+        Assert.Equal("System.Runtime.CompilerServices.AsyncTaskMethodBuilder", info.BuilderType.FullName);
+        Assert.NotNull(info.TaskProperty);
+        Assert.True(info.IsValid);
+    }
+
+    [Fact]
+    public void Resolve_GenericTask_BindsAsyncTaskMethodBuilderOfT()
+    {
+        var info = AsyncMethodBuilderInfo.Resolve(typeof(Task<int>), resolver: null);
+        Assert.NotNull(info);
+        Assert.Equal(AsyncMethodBuilderKind.GenericTask, info.Kind);
+        Assert.True(info.BuilderType.IsGenericType);
+        Assert.Equal(typeof(int), info.ResultType);
+        Assert.NotNull(info.TaskProperty);
+        Assert.True(info.IsValid);
+    }
+
+    [Fact]
+    public void Resolve_ValueTaskOfT_BindsCustomBuilderViaAttribute()
+    {
+        var info = AsyncMethodBuilderInfo.Resolve(typeof(ValueTask<string>), resolver: null);
+        Assert.NotNull(info);
+        Assert.Equal(AsyncMethodBuilderKind.Custom, info.Kind);
+        Assert.Equal(typeof(string), info.ResultType);
+        Assert.True(info.BuilderType.IsGenericType);
+        Assert.Contains("AsyncValueTaskMethodBuilder", info.BuilderType.FullName);
+        Assert.True(info.IsValid);
+    }
+
+    [Fact]
+    public void Resolve_AsyncIteratorElement_BindsAsyncIteratorMethodBuilder()
+    {
+        var info = AsyncMethodBuilderInfo.Resolve(
+            typeof(System.Collections.Generic.IAsyncEnumerable<int>),
+            resolver: null);
+        Assert.NotNull(info);
+        Assert.Equal(AsyncMethodBuilderKind.AsyncIterator, info.Kind);
+        Assert.Equal("System.Runtime.CompilerServices.AsyncIteratorMethodBuilder", info.BuilderType.FullName);
+        Assert.Equal(typeof(int), info.ResultType);
+        Assert.True(info.IsValid);
+    }
+
+    [Fact]
+    public void Resolve_UnknownType_ReturnsNullForBuilder()
+    {
+        var info = AsyncMethodBuilderInfo.Resolve(typeof(object), resolver: null);
+        Assert.Null(info);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AwaitableShapeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AwaitableShapeTests.cs
@@ -1,0 +1,50 @@
+// <copyright file="AwaitableShapeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Lowering.Async;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Resolution of <see cref="AwaitableShape"/> for the BCL awaitable types.
+/// </summary>
+public class AwaitableShapeTests
+{
+    [Fact]
+    public void Resolve_Task_BindsTaskAwaiter()
+    {
+        var shape = AwaitableShape.Resolve(typeof(Task));
+        Assert.NotNull(shape);
+        Assert.Equal("System.Runtime.CompilerServices.TaskAwaiter", shape.AwaiterType.FullName);
+        Assert.Equal(typeof(void), shape.ResultType);
+        Assert.True(shape.ImplementsCriticalNotifyCompletion);
+    }
+
+    [Fact]
+    public void Resolve_TaskOfT_BindsTypedAwaiter()
+    {
+        var shape = AwaitableShape.Resolve(typeof(Task<int>));
+        Assert.NotNull(shape);
+        Assert.Equal(typeof(int), shape.ResultType);
+        Assert.True(shape.AwaiterType.IsGenericType);
+        Assert.True(shape.ImplementsCriticalNotifyCompletion);
+    }
+
+    [Fact]
+    public void Resolve_ValueTaskOfT_BindsValueTaskAwaiter()
+    {
+        var shape = AwaitableShape.Resolve(typeof(ValueTask<string>));
+        Assert.NotNull(shape);
+        Assert.Equal(typeof(string), shape.ResultType);
+        Assert.True(shape.ImplementsCriticalNotifyCompletion);
+    }
+
+    [Fact]
+    public void Resolve_PlainObject_ReturnsNull()
+    {
+        Assert.Null(AwaitableShape.Resolve(typeof(object)));
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/GeneratedNamesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/GeneratedNamesTests.cs
@@ -1,0 +1,48 @@
+// <copyright file="GeneratedNamesTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Lowering.Async;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Naming determinism of <see cref="GeneratedNames"/>. The exact strings
+/// are part of the contract with the debugger and any decompiler/PDB
+/// tooling, so changes here are intentional and visible.
+/// </summary>
+public class GeneratedNamesTests
+{
+    [Fact]
+    public void Constants_MatchRoslynShape()
+    {
+        Assert.Equal("<>1__state", GeneratedNames.StateField);
+        Assert.Equal("<>t__builder", GeneratedNames.BuilderField);
+        Assert.Equal("<>4__this", GeneratedNames.ThisField);
+    }
+
+    [Fact]
+    public void ParameterField_ManglesUserName()
+    {
+        Assert.Equal("<>3__url", GeneratedNames.ParameterField("url"));
+    }
+
+    [Fact]
+    public void HoistedLocalField_IncludesOrdinal()
+    {
+        Assert.Equal("<x>5__1", GeneratedNames.HoistedLocalField("x", 1));
+    }
+
+    [Fact]
+    public void AwaiterField_IncludesOrdinal()
+    {
+        Assert.Equal("<>u__2", GeneratedNames.AwaiterField(2));
+    }
+
+    [Fact]
+    public void StateMachineTypeName_IncludesMethodNameAndOrdinal()
+    {
+        Assert.Equal("<Sum>d__0", GeneratedNames.StateMachineTypeName("Sum", 0));
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/SynthesizedStateMachineTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/SynthesizedStateMachineTypeTests.cs
@@ -1,0 +1,65 @@
+// <copyright file="SynthesizedStateMachineTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Lowering.Async;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
+
+public class SynthesizedStateMachineTypeTests
+{
+    [Fact]
+    public void Construction_RecordsKickoffAndBuilder()
+    {
+        var fn = new FunctionSymbol("foo", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int);
+        fn.IsAsync = true;
+        var builder = AsyncMethodBuilderInfo.Resolve(typeof(Task<int>), resolver: null);
+        var sm = new SynthesizedStateMachineType("<foo>d__0", StateMachineContainerKind.Struct, fn, builder);
+
+        Assert.Equal("<foo>d__0", sm.Name);
+        Assert.Equal(StateMachineContainerKind.Struct, sm.ContainerKind);
+        Assert.Same(fn, sm.KickoffMethod);
+        Assert.Same(builder, sm.BuilderInfo);
+        Assert.Equal(SymbolKind.Type, sm.Kind);
+        Assert.Empty(sm.Fields);
+    }
+
+    [Fact]
+    public void AddField_PreservesInsertionOrder()
+    {
+        var fn = new FunctionSymbol("foo", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int);
+        var sm = new SynthesizedStateMachineType(
+            "<foo>d__0",
+            StateMachineContainerKind.Struct,
+            fn,
+            AsyncMethodBuilderInfo.Resolve(typeof(Task<int>), resolver: null));
+        var state = new FieldSymbol(GeneratedNames.StateField, TypeSymbol.Int, Accessibility.Public);
+        var builderField = new FieldSymbol(GeneratedNames.BuilderField, TypeSymbol.Int, Accessibility.Public);
+        sm.AddField(state);
+        sm.AddField(builderField);
+
+        sm.StateField = state;
+        sm.BuilderField = builderField;
+
+        Assert.Equal(new[] { GeneratedNames.StateField, GeneratedNames.BuilderField }, new[] { sm.Fields[0].Name, sm.Fields[1].Name });
+        Assert.Same(state, sm.StateField);
+        Assert.Same(builderField, sm.BuilderField);
+    }
+
+    [Fact]
+    public void FunctionSymbol_StateMachineType_BackLink()
+    {
+        var fn = new FunctionSymbol("foo", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int);
+        var sm = new SynthesizedStateMachineType(
+            "<foo>d__0",
+            StateMachineContainerKind.Struct,
+            fn,
+            AsyncMethodBuilderInfo.Resolve(typeof(Task<int>), resolver: null));
+        fn.StateMachineType = sm;
+        Assert.Same(sm, fn.StateMachineType);
+    }
+}


### PR DESCRIPTION
Refs #52.

First milestone toward closing the interpreter↔emitter async gap. Lays down the helper layer that the upcoming async state-machine rewriter and emitter will consume. **No behavior change yet** — none of this is wired into `Compilation` or `ReflectionMetadataEmitter`.

## Plan
Posted in full to issue #52: https://github.com/DavidObando/gsharp/issues/52#issuecomment-4530638220 — covers the Roslyn-style pipeline (exception rewriter → spill spiller → capture walker → state-machine rewriter → emitter), per-await codegen, awaiter pooling, builder-call shape, async-iterator extras, testing strategy, and 16 sequenced todos.

## What's in this PR (2/16 todos)
- **`builder-info`** — `AsyncMethodBuilderInfo` resolves the BCL builder per return type (void / Task / Task&lt;T&gt; / ValueTask* via `[AsyncMethodBuilder]` / IAsyncEnumerable&lt;T&gt; iterator builder / custom task-likes).
- **`synthesized-type`** — `SynthesizedStateMachineType : TypeSymbol` + `FunctionSymbol.StateMachineType` back-link (typed as `object` to avoid a project-layer cycle).

### Supporting helpers
- `GeneratedNames` — Roslyn-shaped mangling (`<>1__state`, `<>t__builder`, `<>4__this`, `<>3__<param>`, `<<local>>5__N`, `<>u__N`, `<<Method>>d__N`, `<>7__wrapN`)
- `StateMachineStates` — magic state constants (-1 NotStarted/Running, -2 Finished, -3 InitialAsyncIterator, 0+ resumable, -4↓ yield)
- `AsyncMethodBuilderKind`, `StateMachineContainerKind`
- `AwaitableShape` — per-site GetAwaiter/IsCompleted/GetResult + `ICriticalNotifyCompletion` flag
- `AsyncBoundTreeQueries.HasAwait` — subtree probe via the existing `BoundTreeRewriter` (zero-alloc when nothing changes)

## Tests
22 new unit tests under `test/Core.Tests/CodeAnalysis/Lowering/Async/`. Full suite: **750 passing, 0 warnings**.

## What's still ahead (14 todos)
`exception-rewriter`, `spill-spiller`, `capture-walker`, `state-rewriter` (+ `MoveNextBodyBuilder`), `ref-init-hoister`, `iterator-rewriter`, `compilation-wireup`, `emitter-typedef`, `emitter-kickoff`, `seq-points`, `async-lambda`, `tests-lowering`, `tests-emit`, `docs-update`.

Recommend driving the remainder by end-to-end milestones (empty `async Task` method → awaits → iterators) rather than completing each pass in isolation.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>