### PR TITLE
Async emit: AsyncCaptureWalker (hoist-set analysis)

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncCaptureWalker.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncCaptureWalker.cs
@@ -1,0 +1,141 @@
+// <copyright file="AsyncCaptureWalker.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Computes the set of variables that the async state-machine rewriter must
+/// hoist into fields on the synthesized state-machine type (see
+/// <c>~/roslyn-async.md</c> §5). Roslyn's production implementation runs a
+/// definite-assignment pass to hoist only locals that are live across a
+/// suspension point. GSharp's V1 takes the simpler conservative rule used by
+/// Roslyn's Debug-mode build: every parameter and every referenced
+/// user-declared local in an async method body is hoisted, regardless of
+/// live-range analysis. This may over-hoist (a strictly intra-statement
+/// scratch local that never crosses an <c>await</c> still becomes a field)
+/// but is always correct, never under-hoists, and avoids pulling in a full
+/// data-flow framework before the state machine itself works.
+/// </summary>
+/// <remarks>
+/// <para>The walker explicitly excludes:</para>
+/// <list type="bullet">
+/// <item><description>Spill-temp locals introduced by the spill spiller
+/// (spec §7) — they are managed in a separate hoist set keyed by the spill
+/// expression they represent and registered by the spiller, not here.</description></item>
+/// </list>
+/// <para>Spill-temp detection is by name prefix (<see cref="GeneratedNames.SpillTempPrefix"/>)
+/// because GSharp does not (yet) carry a synthesized-kind tag on
+/// <see cref="LocalVariableSymbol"/>. The spill spiller will use the same
+/// prefix when it emits its locals.</para>
+/// <para>For <c>this</c> capture: the bound tree does not currently
+/// distinguish instance-member field access from local access at the rewriter
+/// level, so the rewriter treats every instance method as capturing
+/// <c>this</c>. The walker itself does not need to detect receiver
+/// references — the orchestrator sets the corresponding flag based on the
+/// kickoff method's receiver.</para>
+/// </remarks>
+public static class AsyncCaptureWalker
+{
+    /// <summary>
+    /// Walks <paramref name="body"/> and returns the hoist set.
+    /// </summary>
+    /// <param name="body">The lowered async method body.</param>
+    /// <param name="parameters">The kickoff method's parameters.</param>
+    /// <returns>The set of parameters and locals to hoist, in stable
+    /// insertion order. Parameters precede locals; within each group, order
+    /// matches first-encounter order in the tree walk so the synthesized
+    /// type's fields have a deterministic layout.</returns>
+    public static HoistResult Analyze(BoundStatement body, ImmutableArray<ParameterSymbol> parameters)
+    {
+        var collector = new ReferenceCollector();
+        collector.Visit(body);
+
+        var orderedLocals = ImmutableArray.CreateBuilder<LocalVariableSymbol>();
+        foreach (var local in collector.Locals)
+        {
+            if (local is ParameterSymbol)
+            {
+                continue;
+            }
+
+            if (local.Name.StartsWith(GeneratedNames.SpillTempPrefix, System.StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            orderedLocals.Add(local);
+        }
+
+        return new HoistResult(parameters, orderedLocals.ToImmutable());
+    }
+
+    /// <summary>
+    /// The set of variables to hoist onto the synthesized state-machine type
+    /// for one kickoff async method.
+    /// </summary>
+    public sealed class HoistResult
+    {
+        /// <summary>Initializes a new instance of the <see cref="HoistResult"/> class.</summary>
+        /// <param name="parameters">Parameters to hoist (always all of them in V1).</param>
+        /// <param name="locals">User-declared locals to hoist.</param>
+        public HoistResult(ImmutableArray<ParameterSymbol> parameters, ImmutableArray<LocalVariableSymbol> locals)
+        {
+            Parameters = parameters;
+            Locals = locals;
+        }
+
+        /// <summary>Gets the parameters to hoist.</summary>
+        public ImmutableArray<ParameterSymbol> Parameters { get; }
+
+        /// <summary>Gets the user-declared locals to hoist, in first-encounter order.</summary>
+        public ImmutableArray<LocalVariableSymbol> Locals { get; }
+    }
+
+    private sealed class ReferenceCollector : BoundTreeRewriter
+    {
+        private readonly HashSet<LocalVariableSymbol> seen = new HashSet<LocalVariableSymbol>();
+        private readonly List<LocalVariableSymbol> orderedLocals = new List<LocalVariableSymbol>();
+
+        public IReadOnlyList<LocalVariableSymbol> Locals => orderedLocals;
+
+        public void Visit(BoundStatement node)
+        {
+            if (node != null)
+            {
+                RewriteStatement(node);
+            }
+        }
+
+        protected override BoundExpression RewriteVariableExpression(BoundVariableExpression node)
+        {
+            Record(node.Variable);
+            return node;
+        }
+
+        protected override BoundExpression RewriteAssignmentExpression(BoundAssignmentExpression node)
+        {
+            Record(node.Variable);
+            return base.RewriteAssignmentExpression(node);
+        }
+
+        protected override BoundStatement RewriteVariableDeclaration(BoundVariableDeclaration node)
+        {
+            Record(node.Variable);
+            return base.RewriteVariableDeclaration(node);
+        }
+
+        private void Record(VariableSymbol variable)
+        {
+            if (variable is LocalVariableSymbol local && seen.Add(local))
+            {
+                orderedLocals.Add(local);
+            }
+        }
+    }
+}

--- a/src/Core/CodeAnalysis/Lowering/Async/GeneratedNames.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/GeneratedNames.cs
@@ -34,6 +34,14 @@ public static class GeneratedNames
     public const string ThisField = "<>4__this";
 
     /// <summary>
+    /// The shared prefix used by every spill-temp field (and the
+    /// corresponding spill-temp local that the spill spiller introduces).
+    /// Consumed by <see cref="AsyncCaptureWalker"/> to skip spill temps —
+    /// they are managed by the spiller, not the capture walker.
+    /// </summary>
+    public const string SpillTempPrefix = "<>7__wrap";
+
+    /// <summary>
     /// Returns the name of the hoisted field that mirrors a parameter of the
     /// original async method.
     /// </summary>
@@ -83,5 +91,5 @@ public static class GeneratedNames
     /// <param name="ordinal">A per-method monotonic ordinal.</param>
     /// <returns>The mangled spill-temp field name.</returns>
     public static string SpillTempField(int ordinal)
-        => "<>7__wrap" + ordinal.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        => SpillTempPrefix + ordinal.ToString(System.Globalization.CultureInfo.InvariantCulture);
 }

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncCaptureWalkerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncCaptureWalkerTests.cs
@@ -1,0 +1,126 @@
+// <copyright file="AsyncCaptureWalkerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Lowering.Async;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
+
+public class AsyncCaptureWalkerTests
+{
+    [Fact]
+    public void Analyze_EmptyBody_NoLocals()
+    {
+        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
+
+        Assert.Empty(result.Parameters);
+        Assert.Empty(result.Locals);
+    }
+
+    [Fact]
+    public void Analyze_DeclaredLocal_IsHoisted()
+    {
+        var local = new LocalVariableSymbol("x", isReadOnly: false, TypeSymbol.Int);
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(local, new BoundLiteralExpression(0))));
+
+        var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
+
+        Assert.Single(result.Locals);
+        Assert.Same(local, result.Locals[0]);
+    }
+
+    [Fact]
+    public void Analyze_ReferencedLocal_IsHoisted()
+    {
+        var local = new LocalVariableSymbol("y", isReadOnly: false, TypeSymbol.Int);
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(new BoundVariableExpression(local))));
+
+        var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
+
+        Assert.Single(result.Locals);
+        Assert.Same(local, result.Locals[0]);
+    }
+
+    [Fact]
+    public void Analyze_SameLocalReferencedTwice_AppearsOnce()
+    {
+        var local = new LocalVariableSymbol("x", isReadOnly: false, TypeSymbol.Int);
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(local, new BoundLiteralExpression(1)),
+            new BoundExpressionStatement(new BoundVariableExpression(local)),
+            new BoundExpressionStatement(new BoundVariableExpression(local))));
+
+        var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
+
+        Assert.Single(result.Locals);
+    }
+
+    [Fact]
+    public void Analyze_DeterministicOrder_FirstEncounterWins()
+    {
+        var first = new LocalVariableSymbol("first", isReadOnly: false, TypeSymbol.Int);
+        var second = new LocalVariableSymbol("second", isReadOnly: false, TypeSymbol.Int);
+        var third = new LocalVariableSymbol("third", isReadOnly: false, TypeSymbol.Int);
+
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(first, new BoundLiteralExpression(1)),
+            new BoundExpressionStatement(new BoundVariableExpression(second)),
+            new BoundVariableDeclaration(third, new BoundLiteralExpression(3)),
+            new BoundExpressionStatement(new BoundVariableExpression(first))));
+
+        var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
+
+        Assert.Equal(new[] { "first", "second", "third" }, result.Locals.Select(l => l.Name).ToArray());
+    }
+
+    [Fact]
+    public void Analyze_SpillTemp_IsExcluded()
+    {
+        var userLocal = new LocalVariableSymbol("x", isReadOnly: false, TypeSymbol.Int);
+        var spillTemp = new LocalVariableSymbol(GeneratedNames.SpillTempField(0), isReadOnly: false, TypeSymbol.Int);
+
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(userLocal, new BoundLiteralExpression(1)),
+            new BoundVariableDeclaration(spillTemp, new BoundLiteralExpression(2))));
+
+        var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
+
+        Assert.Single(result.Locals);
+        Assert.Equal("x", result.Locals[0].Name);
+    }
+
+    [Fact]
+    public void Analyze_Parameters_AlwaysHoistedAsProvided()
+    {
+        var p1 = new ParameterSymbol("a", TypeSymbol.Int);
+        var p2 = new ParameterSymbol("b", TypeSymbol.String);
+        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+
+        var result = AsyncCaptureWalker.Analyze(body, ImmutableArray.Create(p1, p2));
+
+        Assert.Equal(2, result.Parameters.Length);
+        Assert.Same(p1, result.Parameters[0]);
+        Assert.Same(p2, result.Parameters[1]);
+    }
+
+    [Fact]
+    public void Analyze_ParameterReferencedInBody_NotDuplicatedIntoLocals()
+    {
+        var p1 = new ParameterSymbol("a", TypeSymbol.Int);
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(new BoundVariableExpression(p1))));
+
+        var result = AsyncCaptureWalker.Analyze(body, ImmutableArray.Create(p1));
+
+        Assert.Single(result.Parameters);
+        Assert.Empty(result.Locals);
+    }
+}


### PR DESCRIPTION
Refs #52. Continues the async-emit work merged in #106.

## Honest framing
This is the **third foundation piece** on the path to async emit, not yet the end-to-end milestone ("empty `async` method emits and runs"). A working vertical slice requires `AsyncStateMachineRewriter` + `compilation-wireup` + ~500–1000 LOC of `ReflectionMetadataEmitter` changes (nested-struct TypeDef with interface impl, IL kickoff, builder-method resolution, `[AsyncStateMachine]` attribute, IL for `MoveNext` / `SetStateMachine`). That is the next session.

This PR ships the **last foundation** required before the rewriter can begin: the hoist-set analyzer.

**Current emit reality** (verified): `async func F() { … }` compiles silently today and produces invalid IL that throws `InvalidProgramException` at runtime. Cleanly diagnosing that is also part of the rewriter wiring slice.

## What's in this PR (1 todo: `capture-walker`)

`AsyncCaptureWalker` computes which parameters and locals must be promoted to fields on the synthesized state-machine type so they survive across `await` suspensions.

V1 conservative rule (matches Roslyn Debug-mode codegen):
- Every parameter is hoisted.
- Every referenced user-declared `LocalVariableSymbol` is hoisted.
- Spill-temp locals (prefix `<>7__wrap`) are explicitly excluded — they belong to the spill spiller's separate hoist set.

This over-hoists relative to Roslyn Release codegen (which uses definite-assignment to hoist only locals live across an `await`), but is always correct, never under-hoists, and avoids pulling in a flow-analysis framework before the state machine itself works. Documented in the file header.

**Small follow-on cleanup:** promotes `SpillTempPrefix` from an inline literal in `GeneratedNames.SpillTempField` to a `public const` so the walker and the future spiller share a single source of truth.

## Tests
8 new unit tests covering: empty body, declared local hoisting, referenced local hoisting, dedup of repeated refs, deterministic first-encounter ordering, spill-temp exclusion, parameter pass-through, parameter-vs-local separation. Total async-lowering tests: 22 → 30. Full suite: **758 passing, 0 warnings**.

## Todos status (3/16 done)
`builder-info` ✅, `synthesized-type` ✅, `capture-walker` ✅. Next: `exception-rewriter` and `spill-spiller` (both independent of state-rewriter, can ship in parallel), then `state-rewriter` (the orchestrator), then `compilation-wireup` + `emitter-typedef` + `emitter-kickoff` for the first end-to-end milestone.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>