### PR TITLE
Async emit: AsyncEmitPrecheck (clean diagnostic instead of bad IL)

### DIFF
--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -201,6 +201,12 @@ public class Compilation
             return new EmitResult(success: false, program.Diagnostics.ToImmutableArray());
         }
 
+        var asyncDiagnostics = Lowering.Async.AsyncEmitPrecheck.Check(program);
+        if (asyncDiagnostics.Any())
+        {
+            return new EmitResult(success: false, asyncDiagnostics);
+        }
+
         try
         {
             using var stream = File.Create(program.PackageName + ".dll");
@@ -248,6 +254,12 @@ public class Compilation
         if (program.Diagnostics.Any())
         {
             return new EmitResult(success: false, program.Diagnostics.ToImmutableArray());
+        }
+
+        var asyncDiagnostics = Lowering.Async.AsyncEmitPrecheck.Check(program);
+        if (asyncDiagnostics.Any())
+        {
+            return new EmitResult(success: false, asyncDiagnostics);
         }
 
         try

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncEmitPrecheck.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncEmitPrecheck.cs
@@ -1,0 +1,90 @@
+// <copyright file="AsyncEmitPrecheck.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Pre-emit gate that reports a clean diagnostic for every <c>async</c>
+/// function in the bound program. Until the full async state-machine
+/// rewriter and emitter pipeline lands (ADR-0023 / issue #52), the emitter
+/// cannot produce a valid PE for any <c>async</c> method — historically it
+/// silently produced IL that throws <c>InvalidProgramException</c> at
+/// runtime. This pass converts that silent failure into a clean compile-time
+/// error so users see a useful message instead of a runtime crash.
+/// </summary>
+/// <remarks>
+/// <para>The interpreter retains full async support and is unaffected by
+/// this gate (interpreter execution does not go through <see cref="Emit"/>).
+/// The aspirational sample harness (<c>AspirationalSamplesTests</c>) and the
+/// compiler conformance harness (<c>SampleConformanceTests</c>) already skip
+/// async samples for emit per ADR-0022/0023.</para>
+/// <para>The gate is removed (or relaxed to a no-op for the supported subset)
+/// piece-by-piece as the rewriter slices land:</para>
+/// <list type="number">
+/// <item><description>First slice (this PR): always block.</description></item>
+/// <item><description>State-machine rewriter slice: allow async methods
+/// whose state machine has been successfully synthesized.</description></item>
+/// <item><description>Iterator rewriter slice: allow async-iterator
+/// methods.</description></item>
+/// </list>
+/// </remarks>
+public static class AsyncEmitPrecheck
+{
+    /// <summary>The diagnostic message reported for each async function the emitter cannot handle yet.</summary>
+    public const string AsyncEmitNotImplementedMessage =
+        "Emitting 'async' functions is not yet implemented; tracked in https://github.com/DavidObando/gsharp/issues/52. " +
+        "Use the interpreter for async code until the state-machine emitter lands.";
+
+    /// <summary>
+    /// Walks <paramref name="program"/> and returns one diagnostic per
+    /// <c>async</c> function. Returns an empty array when the program has
+    /// no async functions.
+    /// </summary>
+    /// <param name="program">The bound program (post-binding, pre-emit).</param>
+    /// <returns>The diagnostics to surface; empty when emit may proceed.</returns>
+    public static ImmutableArray<Diagnostic> Check(BoundProgram program)
+    {
+        if (program == null)
+        {
+            return ImmutableArray<Diagnostic>.Empty;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<Diagnostic>();
+
+        foreach (var function in program.Functions.Keys)
+        {
+            if (!function.IsAsync)
+            {
+                continue;
+            }
+
+            var location = LocateAsyncFunction(function);
+            builder.Add(new Diagnostic(location, AsyncEmitNotImplementedMessage));
+        }
+
+        if (program.EntryPoint is { } entry && entry.IsAsync && !program.Functions.ContainsKey(entry))
+        {
+            builder.Add(new Diagnostic(LocateAsyncFunction(entry), AsyncEmitNotImplementedMessage));
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static TextLocation LocateAsyncFunction(FunctionSymbol function)
+    {
+        var declaration = function.Declaration;
+        if (declaration == null)
+        {
+            return new TextLocation(SourceText.From(string.Empty), new TextSpan(0, 0));
+        }
+
+        var anchor = declaration.AsyncModifier ?? declaration.Identifier;
+        return anchor?.Location ?? declaration.Location;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncEmitPrecheckTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncEmitPrecheckTests.cs
@@ -1,0 +1,96 @@
+// <copyright file="AsyncEmitPrecheckTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Lowering.Async;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Verifies the pre-emit gate that converts the historical
+/// <c>InvalidProgramException</c>-at-runtime failure for async functions
+/// into a clean compile-time diagnostic until the state-machine emitter
+/// lands.
+/// </summary>
+public class AsyncEmitPrecheckTests
+{
+    [Fact]
+    public void Check_NullProgram_ReturnsEmpty()
+    {
+        Assert.Empty(AsyncEmitPrecheck.Check(null));
+    }
+
+    [Fact]
+    public void Check_NoAsyncFunctions_ReturnsEmpty()
+    {
+        var source = "package main\nimport System\nConsole.WriteLine(\"hi\")\n";
+        var program = Bind(source);
+        Assert.Empty(AsyncEmitPrecheck.Check(program));
+    }
+
+    [Fact]
+    public void Check_AsyncFunction_ReportsDiagnostic_WithExpectedMessage()
+    {
+        var source = "package main\nasync func doIt() {}\n";
+        var program = Bind(source);
+
+        var diagnostics = AsyncEmitPrecheck.Check(program);
+        var d = Assert.Single(diagnostics);
+        Assert.Equal(AsyncEmitPrecheck.AsyncEmitNotImplementedMessage, d.Message);
+    }
+
+    [Fact]
+    public void Check_MultipleAsyncFunctions_OneDiagnosticEach()
+    {
+        var source =
+            "package main\n" +
+            "async func a() {}\n" +
+            "async func b() int { return 1 }\n" +
+            "func c() {}\n";
+        var program = Bind(source);
+
+        var diagnostics = AsyncEmitPrecheck.Check(program);
+        Assert.Equal(2, diagnostics.Length);
+    }
+
+    [Fact]
+    public void Compile_AsyncFunction_PrechecksCleanly_NotInvalidProgramException()
+    {
+        var source = "package main\nasync func doIt() {}\n";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, d => d.Message == AsyncEmitPrecheck.AsyncEmitNotImplementedMessage);
+    }
+
+    [Fact]
+    public void Compile_NonAsyncProgram_StillSucceeds()
+    {
+        var source = "package HelloWorld\nimport System\nConsole.WriteLine(\"hi\")\n";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+
+        Assert.True(result.Success, "non-async compilation must still succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+    }
+
+    private static BoundProgram Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return Binder.BindProgram(compilation.GlobalScope);
+    }
+}


### PR DESCRIPTION
Refs #52. Builds on #106, #107, #108.

## Visible UX fix

This is the first PR in the async-emit series with **user-observable behavior change**, closing a silent-miscompile gap until the full state-machine pipeline lands.

### Before
```gsharp
async func DoIt() { }
let t = DoIt()
t.Wait()
```
`gsc` reports success, writes an assembly, runtime loader throws:
```
Unhandled exception. System.InvalidProgramException:
  Common Language Runtime detected an invalid program.
```
(Verified during the PR #107 investigation.)

### After
```
test.gs(2,1,2,6): Emitting 'async' functions is not yet implemented;
  tracked in https://github.com/DavidObando/gsharp/issues/52.
  Use the interpreter for async code until the state-machine emitter lands.
```
Diagnostic is anchored at the `async` modifier token (or the function identifier when the modifier is absent).

## What it ships

- **`AsyncEmitPrecheck.Check(BoundProgram)`** — walks all functions and reports one diagnostic per `IsAsync` function. Pure function, no state.
- **Wired into both `Compilation.Emit` overloads** (the file-output overload and the `(peStream, refStream, …)` overload).

## Non-impact

- **Interpreter unaffected.** Async execution does not flow through `Compilation.Emit`. `AspirationalSamplesTests` (running `samples/aspirational/AsyncTask.gs` through the interpreter) continues to pass.
- **Conformance harness unaffected.** `SampleConformanceTests` already skipped async samples for emit per ADR-0022/0023.

## Lifecycle

The gate is removed/relaxed piece-by-piece as the rewriter slices land (documented in the file header):
1. **First slice (this PR):** always block.
2. **State-machine rewriter slice:** allow async methods whose state machine has been successfully synthesized.
3. **Iterator rewriter slice:** allow async-iterator methods.

## Tests
6 new unit tests: null program, no-async fast path, single async, multiple async, full `Compile()` integration through `EmitResult.Diagnostics`, plus a regression that non-async programs still emit successfully.

**Full suite: 773 passing (+6), 0 warnings.**

## Todos status (5/16 + 2 composers)
`builder-info` ✅, `synthesized-type` ✅, `capture-walker` ✅, `sm-type-builder` ✅, `emit-precheck` ✅. Remaining: `state-rewriter` (the orchestrator — needs StructSymbol projection of the synthesized type; design noted below), `compilation-wireup` (relax the precheck for synthesized methods), `emitter-typedef` + `emitter-kickoff`, `seq-points`, `spill-spiller`, `exception-rewriter`, `iterator-rewriter`.

### Design note discovered in this session
`SynthesizedStateMachineType : TypeSymbol` cannot flow through GSharp's existing `BoundFieldAccessExpression` (which requires `StructSymbol`) or the `StructSymbol`-keyed emit paths. The `state-rewriter` slice will need either (a) a `MaterializeAsStruct()` method that produces a frozen `StructSymbol`, or (b) unsealing `StructSymbol` so the synthesized type can inherit. Option (a) is less invasive; flagging here so the next session can decide before writing rewriter code.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>