### PR TITLE
Async emit: materialize synthesized state machines as StructSymbol

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/SynthesizedStateMachineType.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SynthesizedStateMachineType.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -35,6 +36,7 @@ namespace GSharp.Core.CodeAnalysis.Lowering.Async;
 public sealed class SynthesizedStateMachineType : TypeSymbol
 {
     private readonly List<FieldSymbol> fields = new List<FieldSymbol>();
+    private StructSymbol materializedStruct;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SynthesizedStateMachineType"/> class.
@@ -92,5 +94,45 @@ public sealed class SynthesizedStateMachineType : TypeSymbol
     /// fields first, then parameter proxies, then hoisted locals, then
     /// awaiter slots, matching Roslyn's emit order.</summary>
     /// <param name="field">The field to append.</param>
-    public void AddField(FieldSymbol field) => fields.Add(field);
+    public void AddField(FieldSymbol field)
+    {
+        if (materializedStruct != null)
+        {
+            throw new InvalidOperationException("Cannot add fields after the synthesized state-machine type has been materialized.");
+        }
+
+        fields.Add(field);
+    }
+
+    /// <summary>
+    /// Materializes this synthesized type as a real <see cref="StructSymbol"/>
+    /// so later async-rewriter slices can reuse existing bound nodes such as
+    /// <see cref="GSharp.Core.CodeAnalysis.Binding.BoundFieldAccessExpression"/>, which require a
+    /// <see cref="StructSymbol"/> receiver type.
+    /// </summary>
+    /// <remarks>
+    /// Calling this method freezes the field list. Struct state machines are
+    /// projected as value types; async-iterator class state machines are
+    /// projected with <see cref="StructSymbol.IsClass"/> set.
+    /// </remarks>
+    /// <returns>The stable aggregate projection for this state-machine type.</returns>
+    public StructSymbol MaterializeAsStructSymbol()
+    {
+        if (materializedStruct != null)
+        {
+            return materializedStruct;
+        }
+
+        materializedStruct = new StructSymbol(
+            name: Name,
+            fields: Fields,
+            accessibility: Accessibility.Private,
+            declaration: null,
+            packageName: KickoffMethod.Package?.Name,
+            isData: false,
+            isInline: false,
+            isClass: ContainerKind == StateMachineContainerKind.Class);
+
+        return materializedStruct;
+    }
 }

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/SynthesizedStateMachineTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/SynthesizedStateMachineTypeTests.cs
@@ -2,8 +2,10 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Lowering.Async;
 using GSharp.Core.CodeAnalysis.Symbols;
 using Xunit;
@@ -61,5 +63,97 @@ public class SynthesizedStateMachineTypeTests
             AsyncMethodBuilderInfo.Resolve(typeof(Task<int>), resolver: null));
         fn.StateMachineType = sm;
         Assert.Same(sm, fn.StateMachineType);
+    }
+
+    [Fact]
+    public void MaterializeAsStructSymbol_ProjectsFieldsAndMetadata()
+    {
+        var package = new PackageSymbol("main", declaration: null);
+        var fn = new FunctionSymbol("foo", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int, package: package);
+        var sm = new SynthesizedStateMachineType(
+            "<foo>d__0",
+            StateMachineContainerKind.Struct,
+            fn,
+            AsyncMethodBuilderInfo.Resolve(typeof(Task<int>), resolver: null));
+        var state = new FieldSymbol(GeneratedNames.StateField, TypeSymbol.Int, Accessibility.Public);
+        var builder = new FieldSymbol(GeneratedNames.BuilderField, TypeSymbol.Int, Accessibility.Public);
+        sm.AddField(state);
+        sm.AddField(builder);
+
+        var projected = sm.MaterializeAsStructSymbol();
+
+        Assert.Equal("<foo>d__0", projected.Name);
+        Assert.False(projected.IsClass);
+        Assert.Equal(Accessibility.Private, projected.Accessibility);
+        Assert.Equal("main", projected.PackageName);
+        Assert.Equal(2, projected.Fields.Length);
+        Assert.Same(state, projected.Fields[0]);
+        Assert.Same(builder, projected.Fields[1]);
+    }
+
+    [Fact]
+    public void MaterializeAsStructSymbol_ReturnsStableProjection()
+    {
+        var fn = new FunctionSymbol("foo", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int);
+        var sm = new SynthesizedStateMachineType(
+            "<foo>d__0",
+            StateMachineContainerKind.Struct,
+            fn,
+            AsyncMethodBuilderInfo.Resolve(typeof(Task<int>), resolver: null));
+
+        var first = sm.MaterializeAsStructSymbol();
+        var second = sm.MaterializeAsStructSymbol();
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void MaterializeAsStructSymbol_ClassContainerProjectsAsClass()
+    {
+        var fn = new FunctionSymbol("foo", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int);
+        var sm = new SynthesizedStateMachineType(
+            "<foo>d__0",
+            StateMachineContainerKind.Class,
+            fn,
+            AsyncMethodBuilderInfo.Resolve(typeof(Task<int>), resolver: null));
+
+        var projected = sm.MaterializeAsStructSymbol();
+
+        Assert.True(projected.IsClass);
+    }
+
+    [Fact]
+    public void AddField_AfterMaterialization_Throws()
+    {
+        var fn = new FunctionSymbol("foo", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int);
+        var sm = new SynthesizedStateMachineType(
+            "<foo>d__0",
+            StateMachineContainerKind.Struct,
+            fn,
+            AsyncMethodBuilderInfo.Resolve(typeof(Task<int>), resolver: null));
+        sm.MaterializeAsStructSymbol();
+
+        Assert.Throws<InvalidOperationException>(() => sm.AddField(new FieldSymbol("x", TypeSymbol.Int, Accessibility.Public)));
+    }
+
+    [Fact]
+    public void MaterializedStruct_CanBackExistingFieldAccessNode()
+    {
+        var fn = new FunctionSymbol("foo", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int);
+        var sm = new SynthesizedStateMachineType(
+            "<foo>d__0",
+            StateMachineContainerKind.Struct,
+            fn,
+            AsyncMethodBuilderInfo.Resolve(typeof(Task<int>), resolver: null));
+        var field = new FieldSymbol(GeneratedNames.StateField, TypeSymbol.Int, Accessibility.Public);
+        sm.AddField(field);
+        var projected = sm.MaterializeAsStructSymbol();
+        var thisLocal = new LocalVariableSymbol("this", isReadOnly: false, projected);
+
+        var access = new BoundFieldAccessExpression(new BoundVariableExpression(thisLocal), projected, field);
+
+        Assert.Same(projected, access.StructType);
+        Assert.Same(field, access.Field);
+        Assert.Equal(TypeSymbol.Int, access.Type);
     }
 }


### PR DESCRIPTION
Refs #52. Builds on #106, #107, #108, and #109.

## Why

The next real async state-machine rewriter slice needs to synthesize field reads/writes inside `MoveNext`, but GSharp's existing bound-tree/emitter surface expects fields to belong to a `StructSymbol`:

- `BoundFieldAccessExpression(receiver, StructSymbol structType, FieldSymbol field)`
- existing field emit and field-token lookup paths are `StructSymbol`-keyed

The async foundation currently models generated state machines as `SynthesizedStateMachineType : TypeSymbol`, which is the blocker called out in #109.

## What changed

Adds `SynthesizedStateMachineType.MaterializeAsStructSymbol()`, a low-blast-radius projection that lets the future rewriter reuse existing bound nodes instead of adding parallel synthesized-field nodes.

The projection:

- preserves synthesized type name and kickoff package
- preserves field-symbol identity and declaration order
- projects normal async state machines as value types
- projects async-iterator class containers with `StructSymbol.IsClass = true`
- returns the same `StructSymbol` on repeated calls
- freezes the synthesized field list after materialization so the projection cannot go stale

## Tests

Added focused tests for:

- metadata/field projection
- stable projection identity
- class-container projection
- frozen layout after materialization
- direct compatibility with `BoundFieldAccessExpression`

## Validation

- `dotnet build GSharp.sln -nologo -clp:NoSummary`
- `dotnet test GSharp.sln --no-restore --nologo`

Full suite: 789 passing, 0 warnings.

## Next

With this projection in place, the next PR can start the `AsyncStateMachineRewriter` / `MoveNextBodyBuilder` kickoff and field-access scaffolding using the existing `BoundFieldAccessExpression` path.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>