### PR TITLE
Async emit: add state-machine field map

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineFieldMap.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineFieldMap.cs
@@ -1,0 +1,179 @@
+// <copyright file="AsyncStateMachineFieldMap.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Maps user variables and synthesized control slots to the fields on a
+/// materialized async state-machine aggregate.
+/// </summary>
+/// <remarks>
+/// The state-machine rewriter needs to replace local/parameter reads with
+/// field reads against the generated <c>this</c> receiver. This helper is the
+/// bridge between the pure <see cref="SynthesizedStateMachineType"/> model and
+/// the existing bound-tree nodes, which are keyed by <see cref="StructSymbol"/>.
+/// </remarks>
+public sealed class AsyncStateMachineFieldMap
+{
+    private readonly Dictionary<ParameterSymbol, FieldSymbol> parameterFields = new Dictionary<ParameterSymbol, FieldSymbol>();
+    private readonly Dictionary<VariableSymbol, FieldSymbol> localFields = new Dictionary<VariableSymbol, FieldSymbol>();
+
+    private AsyncStateMachineFieldMap(SynthesizedStateMachineType stateMachine, StructSymbol structType)
+    {
+        StateMachine = stateMachine;
+        StructType = structType;
+    }
+
+    /// <summary>Gets the synthesized state-machine model.</summary>
+    public SynthesizedStateMachineType StateMachine { get; }
+
+    /// <summary>Gets the materialized aggregate symbol backing field accesses.</summary>
+    public StructSymbol StructType { get; }
+
+    /// <summary>Gets the hoisted state field.</summary>
+    public FieldSymbol StateField => StateMachine.StateField;
+
+    /// <summary>Gets the hoisted async method builder field.</summary>
+    public FieldSymbol BuilderField => StateMachine.BuilderField;
+
+    /// <summary>Gets the optional hoisted <c>this</c> field.</summary>
+    public FieldSymbol ThisField => StateMachine.ThisField;
+
+    /// <summary>
+    /// Creates a field map for <paramref name="stateMachine"/> using the same
+    /// capture-walker ordering that populated the state-machine fields.
+    /// </summary>
+    /// <param name="stateMachine">The synthesized state-machine type.</param>
+    /// <param name="loweredBody">The lowered async body used to compute hoisted locals.</param>
+    /// <returns>A field map whose <see cref="StructType"/> is ready for bound field access nodes.</returns>
+    public static AsyncStateMachineFieldMap Create(SynthesizedStateMachineType stateMachine, BoundStatement loweredBody)
+    {
+        if (stateMachine == null)
+        {
+            throw new ArgumentNullException(nameof(stateMachine));
+        }
+
+        if (loweredBody == null)
+        {
+            throw new ArgumentNullException(nameof(loweredBody));
+        }
+
+        var structType = stateMachine.MaterializeAsStructSymbol();
+        var map = new AsyncStateMachineFieldMap(stateMachine, structType);
+        var hoist = AsyncCaptureWalker.Analyze(loweredBody, stateMachine.KickoffMethod.Parameters);
+        var fields = stateMachine.Fields;
+        var fieldIndex = 2;
+        if (stateMachine.ThisField != null)
+        {
+            fieldIndex++;
+        }
+
+        foreach (var parameter in hoist.Parameters)
+        {
+            map.parameterFields.Add(parameter, RequireField(fields, fieldIndex++, parameter.Name));
+        }
+
+        foreach (var local in hoist.Locals)
+        {
+            map.localFields.Add(local, RequireField(fields, fieldIndex++, null));
+        }
+
+        return map;
+    }
+
+    /// <summary>Gets the hoisted field corresponding to a kickoff parameter.</summary>
+    /// <param name="parameter">The kickoff parameter.</param>
+    /// <returns>The corresponding state-machine field.</returns>
+    public FieldSymbol GetParameterField(ParameterSymbol parameter)
+    {
+        if (parameter == null)
+        {
+            throw new ArgumentNullException(nameof(parameter));
+        }
+
+        return parameterFields.TryGetValue(parameter, out var field)
+            ? field
+            : throw new KeyNotFoundException($"Parameter '{parameter.Name}' is not hoisted into state machine '{StateMachine.Name}'.");
+    }
+
+    /// <summary>Gets the hoisted field corresponding to a user local.</summary>
+    /// <param name="local">The user local.</param>
+    /// <returns>The corresponding state-machine field.</returns>
+    public FieldSymbol GetLocalField(VariableSymbol local)
+    {
+        if (local == null)
+        {
+            throw new ArgumentNullException(nameof(local));
+        }
+
+        return localFields.TryGetValue(local, out var field)
+            ? field
+            : throw new KeyNotFoundException($"Local '{local.Name}' is not hoisted into state machine '{StateMachine.Name}'.");
+    }
+
+    /// <summary>Creates a field read against a state-machine receiver expression.</summary>
+    /// <param name="receiver">The state-machine receiver expression.</param>
+    /// <param name="field">The field to read.</param>
+    /// <returns>A bound field-access expression using the materialized aggregate.</returns>
+    public BoundFieldAccessExpression Read(BoundExpression receiver, FieldSymbol field)
+    {
+        if (receiver == null)
+        {
+            throw new ArgumentNullException(nameof(receiver));
+        }
+
+        if (field == null)
+        {
+            throw new ArgumentNullException(nameof(field));
+        }
+
+        return new BoundFieldAccessExpression(receiver, StructType, field);
+    }
+
+    /// <summary>Creates a field assignment against a state-machine receiver variable.</summary>
+    /// <param name="receiver">The state-machine receiver variable.</param>
+    /// <param name="field">The field to assign.</param>
+    /// <param name="value">The value being stored.</param>
+    /// <returns>A bound field-assignment expression using the materialized aggregate.</returns>
+    public BoundFieldAssignmentExpression Write(VariableSymbol receiver, FieldSymbol field, BoundExpression value)
+    {
+        if (receiver == null)
+        {
+            throw new ArgumentNullException(nameof(receiver));
+        }
+
+        if (field == null)
+        {
+            throw new ArgumentNullException(nameof(field));
+        }
+
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        return new BoundFieldAssignmentExpression(receiver, StructType, field, value);
+    }
+
+    private static FieldSymbol RequireField(System.Collections.Immutable.ImmutableArray<FieldSymbol> fields, int index, string expectedName)
+    {
+        if (index < 0 || index >= fields.Length)
+        {
+            throw new InvalidOperationException("Synthesized state-machine field layout does not match the capture walker output.");
+        }
+
+        var field = fields[index];
+        if (expectedName != null && field.Name != expectedName)
+        {
+            throw new InvalidOperationException("Synthesized state-machine field layout does not match the capture walker output.");
+        }
+
+        return field;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncStateMachineFieldMapTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncStateMachineFieldMapTests.cs
@@ -1,0 +1,115 @@
+// <copyright file="AsyncStateMachineFieldMapTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Lowering.Async;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
+
+public class AsyncStateMachineFieldMapTests
+{
+    private static readonly ReferenceResolver Resolver = ReferenceResolver.Default();
+
+    [Fact]
+    public void Create_MaterializesStateMachineStruct()
+    {
+        var fn = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void) { IsAsync = true };
+        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
+
+        var map = AsyncStateMachineFieldMap.Create(sm, body);
+
+        Assert.Same(sm, map.StateMachine);
+        Assert.Equal(sm.Name, map.StructType.Name);
+        Assert.False(map.StructType.IsClass);
+        Assert.Same(sm.StateField, map.StateField);
+        Assert.Same(sm.BuilderField, map.BuilderField);
+    }
+
+    [Fact]
+    public void Create_MapsParametersByCaptureOrder()
+    {
+        var p1 = new ParameterSymbol("a", TypeSymbol.Int);
+        var p2 = new ParameterSymbol("b", TypeSymbol.String);
+        var fn = new FunctionSymbol("doIt", ImmutableArray.Create(p1, p2), TypeSymbol.Void) { IsAsync = true };
+        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
+
+        var map = AsyncStateMachineFieldMap.Create(sm, body);
+
+        Assert.Equal("a", map.GetParameterField(p1).Name);
+        Assert.Equal(TypeSymbol.Int, map.GetParameterField(p1).Type);
+        Assert.Equal("b", map.GetParameterField(p2).Name);
+        Assert.Equal(TypeSymbol.String, map.GetParameterField(p2).Type);
+    }
+
+    [Fact]
+    public void Create_MapsHoistedLocalsByCaptureOrder()
+    {
+        var fn = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void) { IsAsync = true };
+        var x = new LocalVariableSymbol("x", isReadOnly: false, TypeSymbol.Int);
+        var y = new LocalVariableSymbol("y", isReadOnly: false, TypeSymbol.String);
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(x, new BoundLiteralExpression(1)),
+            new BoundVariableDeclaration(y, new BoundLiteralExpression("hello"))));
+        var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
+
+        var map = AsyncStateMachineFieldMap.Create(sm, body);
+
+        Assert.Equal("<x>5__1", map.GetLocalField(x).Name);
+        Assert.Equal(TypeSymbol.Int, map.GetLocalField(x).Type);
+        Assert.Equal("<y>5__2", map.GetLocalField(y).Name);
+        Assert.Equal(TypeSymbol.String, map.GetLocalField(y).Type);
+    }
+
+    [Fact]
+    public void Read_CreatesExistingFieldAccessNode()
+    {
+        var fn = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void) { IsAsync = true };
+        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
+        var map = AsyncStateMachineFieldMap.Create(sm, body);
+        var receiver = new LocalVariableSymbol("this", isReadOnly: false, map.StructType);
+
+        var access = map.Read(new BoundVariableExpression(receiver), map.StateField);
+
+        Assert.Same(map.StructType, access.StructType);
+        Assert.Same(map.StateField, access.Field);
+        Assert.Equal(TypeSymbol.Int, access.Type);
+    }
+
+    [Fact]
+    public void Write_CreatesExistingFieldAssignmentNode()
+    {
+        var fn = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void) { IsAsync = true };
+        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
+        var map = AsyncStateMachineFieldMap.Create(sm, body);
+        var receiver = new LocalVariableSymbol("this", isReadOnly: false, map.StructType);
+        var value = new BoundLiteralExpression(-1);
+
+        var assignment = map.Write(receiver, map.StateField, value);
+
+        Assert.Same(receiver, assignment.Receiver);
+        Assert.Same(map.StructType, assignment.StructType);
+        Assert.Same(map.StateField, assignment.Field);
+        Assert.Same(value, assignment.Value);
+        Assert.Equal(TypeSymbol.Int, assignment.Type);
+    }
+
+    [Fact]
+    public void Create_FreezesSynthesizedFieldLayout()
+    {
+        var fn = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void) { IsAsync = true };
+        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
+
+        AsyncStateMachineFieldMap.Create(sm, body);
+
+        Assert.Throws<System.InvalidOperationException>(() => sm.AddField(new FieldSymbol("late", TypeSymbol.Int, Accessibility.Public)));
+    }
+}


### PR DESCRIPTION
Refs #52. Builds on #110.

## Why

PR #110 gave `SynthesizedStateMachineType` a stable `StructSymbol` projection. The next state-machine rewriter slice needs a reusable way to consume that projection and produce existing bound nodes for generated `MoveNext` code.

## What changed

Adds `AsyncStateMachineFieldMap`, a pure lowering utility that:

- materializes the synthesized state-machine aggregate as a `StructSymbol`
- uses the same `AsyncCaptureWalker` ordering that populated the synthesized fields
- resolves `<>1__state`, `<>t__builder`, optional `<>4__this`, parameter proxy fields, and hoisted-local fields
- creates existing `BoundFieldAccessExpression` read nodes
- creates existing `BoundFieldAssignmentExpression` write nodes
- freezes the synthesized field layout via materialization so field maps cannot go stale

This does **not** rewrite method bodies or relax `AsyncEmitPrecheck` yet; it is the bridge from the async synthesized-type model to the existing `StructSymbol`-keyed bound/emitter surface.

## Tests

Added `AsyncStateMachineFieldMapTests` covering:

- state-machine struct materialization
- parameter field mapping
- hoisted-local field mapping
- field-read node creation
- field-write node creation
- field-layout freeze after map creation

## Validation

- `dotnet build GSharp.sln -nologo -clp:NoSummary`
- `dotnet test GSharp.sln --no-restore --nologo`

Full suite: 795 passing, 0 warnings.

## Next

The next PR can start `AsyncStateMachineRewriter` / `MoveNextBodyBuilder` scaffolding using this field map for generated state/builder/local/parameter accesses.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>