### PR TITLE
Async emit: add resumable state allocator

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/ResumableStateAllocator.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/ResumableStateAllocator.cs
@@ -1,0 +1,51 @@
+// <copyright file="ResumableStateAllocator.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Allocates deterministic state numbers for resumable async state-machine
+/// points.
+/// </summary>
+/// <remarks>
+/// Await resume states and async-iterator yield resume states live in separate
+/// numeric ranges. Await states count upward from <c>0</c>; async-iterator
+/// yield states count downward from <c>-4</c>. This mirrors Roslyn's state
+/// numbering and keeps <c>-1</c>, <c>-2</c>, and <c>-3</c> reserved for the
+/// non-resumable states in <see cref="StateMachineStates"/>.
+/// </remarks>
+public sealed class ResumableStateAllocator
+{
+    private int nextAwaitState = StateMachineStates.FirstResumableAsyncState;
+    private int nextYieldState = StateMachineStates.FirstResumableAsyncIteratorState;
+
+    /// <summary>
+    /// Gets the number of await resume states allocated so far.
+    /// </summary>
+    public int AwaitStateCount => nextAwaitState - StateMachineStates.FirstResumableAsyncState;
+
+    /// <summary>
+    /// Gets the number of async-iterator yield resume states allocated so far.
+    /// </summary>
+    public int YieldStateCount => StateMachineStates.FirstResumableAsyncIteratorState - nextYieldState;
+
+    /// <summary>
+    /// Allocates the next state number for a suspending <c>await</c>.
+    /// </summary>
+    /// <returns>The next monotonically increasing await resume state.</returns>
+    public int AllocateAwaitState()
+    {
+        return nextAwaitState++;
+    }
+
+    /// <summary>
+    /// Allocates the next state number for a suspending async-iterator
+    /// <c>yield return</c>.
+    /// </summary>
+    /// <returns>The next monotonically decreasing yield resume state.</returns>
+    public int AllocateYieldState()
+    {
+        return nextYieldState--;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/ResumableStateAllocatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/ResumableStateAllocatorTests.cs
@@ -1,0 +1,96 @@
+// <copyright file="ResumableStateAllocatorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Lowering.Async;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
+
+public class ResumableStateAllocatorTests
+{
+    [Fact]
+    public void AllocateAwaitState_StartsAtFirstResumableAsyncState()
+    {
+        var allocator = new ResumableStateAllocator();
+
+        var state = allocator.AllocateAwaitState();
+
+        Assert.Equal(StateMachineStates.FirstResumableAsyncState, state);
+    }
+
+    [Fact]
+    public void AllocateAwaitState_IncrementsMonotonically()
+    {
+        var allocator = new ResumableStateAllocator();
+
+        var first = allocator.AllocateAwaitState();
+        var second = allocator.AllocateAwaitState();
+        var third = allocator.AllocateAwaitState();
+
+        Assert.Equal(0, first);
+        Assert.Equal(1, second);
+        Assert.Equal(2, third);
+        Assert.Equal(3, allocator.AwaitStateCount);
+    }
+
+    [Fact]
+    public void AllocateYieldState_StartsBelowInitialAsyncIteratorState()
+    {
+        var allocator = new ResumableStateAllocator();
+
+        var state = allocator.AllocateYieldState();
+
+        Assert.Equal(StateMachineStates.InitialAsyncIteratorState - 1, state);
+        Assert.Equal(StateMachineStates.FirstResumableAsyncIteratorState, state);
+    }
+
+    [Fact]
+    public void AllocateYieldState_DecrementsMonotonically()
+    {
+        var allocator = new ResumableStateAllocator();
+
+        var first = allocator.AllocateYieldState();
+        var second = allocator.AllocateYieldState();
+        var third = allocator.AllocateYieldState();
+
+        Assert.Equal(-4, first);
+        Assert.Equal(-5, second);
+        Assert.Equal(-6, third);
+        Assert.Equal(3, allocator.YieldStateCount);
+    }
+
+    [Fact]
+    public void AwaitAndYieldRanges_AreIndependent()
+    {
+        var allocator = new ResumableStateAllocator();
+
+        var await0 = allocator.AllocateAwaitState();
+        var yield0 = allocator.AllocateYieldState();
+        var await1 = allocator.AllocateAwaitState();
+        var yield1 = allocator.AllocateYieldState();
+
+        Assert.Equal(0, await0);
+        Assert.Equal(1, await1);
+        Assert.Equal(-4, yield0);
+        Assert.Equal(-5, yield1);
+        Assert.Equal(2, allocator.AwaitStateCount);
+        Assert.Equal(2, allocator.YieldStateCount);
+    }
+
+    [Fact]
+    public void ReservedStates_DoNotOverlapResumableRanges()
+    {
+        var allocator = new ResumableStateAllocator();
+
+        var awaitState = allocator.AllocateAwaitState();
+        var yieldState = allocator.AllocateYieldState();
+
+        Assert.NotEqual(StateMachineStates.NotStartedOrRunningState, awaitState);
+        Assert.NotEqual(StateMachineStates.FinishedState, awaitState);
+        Assert.NotEqual(StateMachineStates.InitialAsyncIteratorState, awaitState);
+        Assert.NotEqual(StateMachineStates.NotStartedOrRunningState, yieldState);
+        Assert.NotEqual(StateMachineStates.FinishedState, yieldState);
+        Assert.NotEqual(StateMachineStates.InitialAsyncIteratorState, yieldState);
+    }
+}


### PR DESCRIPTION
## Summary
- add deterministic allocator for async await resume states and async-iterator yield resume states
- keep await states increasing from 0 and async-iterator yield states decreasing from -4
- cover reserved-state separation and independent allocator ranges with tests

## Tests
- dotnet test GSharp.sln --nologo --filter "FullyQualifiedName~ResumableStateAllocatorTests"
- dotnet build GSharp.sln -nologo -clp:NoSummary
- dotnet test GSharp.sln --no-restore --nologo