### PR TITLE
Async emit: scaffold state machine rewriter

### DIFF
--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -201,6 +201,8 @@ public class Compilation
             return new EmitResult(success: false, program.Diagnostics.ToImmutableArray());
         }
 
+        Lowering.Async.AsyncStateMachineRewriter.Rewrite(program, References);
+
         var asyncDiagnostics = Lowering.Async.AsyncEmitPrecheck.Check(program);
         if (asyncDiagnostics.Any())
         {
@@ -255,6 +257,8 @@ public class Compilation
         {
             return new EmitResult(success: false, program.Diagnostics.ToImmutableArray());
         }
+
+        Lowering.Async.AsyncStateMachineRewriter.Rewrite(program, References);
 
         var asyncDiagnostics = Lowering.Async.AsyncEmitPrecheck.Check(program);
         if (asyncDiagnostics.Any())

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriter.cs
@@ -1,0 +1,171 @@
+// <copyright file="AsyncStateMachineRewriter.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// First-stage async state-machine lowering orchestrator.
+/// </summary>
+/// <remarks>
+/// This scaffold wires together the already-landed async emit building blocks:
+/// it creates the synthesized state-machine type, materializes the field map,
+/// allocates deterministic await resume states, and links the kickoff method to
+/// its state machine. It intentionally does not rewrite the kickoff body or
+/// relax <see cref="AsyncEmitPrecheck"/> yet; later slices consume the returned
+/// plans to build the kickoff stub and <c>MoveNext</c> body.
+/// </remarks>
+public static class AsyncStateMachineRewriter
+{
+    /// <summary>
+    /// Builds state-machine plans for every async function in
+    /// <paramref name="program"/>.
+    /// </summary>
+    /// <param name="program">The bound program to inspect.</param>
+    /// <param name="references">The compilation reference resolver.</param>
+    /// <returns>A rewrite result containing the original program and one plan
+    /// per async function whose builder could be resolved.</returns>
+    public static AsyncStateMachineRewriteResult Rewrite(BoundProgram program, ReferenceResolver references)
+    {
+        if (program == null)
+        {
+            throw new ArgumentNullException(nameof(program));
+        }
+
+        var plans = ImmutableArray.CreateBuilder<AsyncStateMachinePlan>();
+        var ordinalsByScopeAndName = new Dictionary<string, int>();
+
+        foreach (var pair in program.Functions.OrderBy(pair => GetFunctionSortKey(program, pair.Key), StringComparer.Ordinal))
+        {
+            var function = pair.Key;
+            if (!function.IsAsync)
+            {
+                continue;
+            }
+
+            var ordinal = AllocateTypeOrdinal(program, function, ordinalsByScopeAndName);
+            var stateMachine = AsyncStateMachineTypeBuilder.Build(function, pair.Value, references, ordinal);
+            if (stateMachine == null)
+            {
+                function.StateMachineType = null;
+                continue;
+            }
+
+            var fieldMap = AsyncStateMachineFieldMap.Create(stateMachine, pair.Value);
+            var awaitStates = AwaitStateCollector.Allocate(pair.Value);
+            function.StateMachineType = stateMachine;
+
+            plans.Add(new AsyncStateMachinePlan(function, pair.Value, stateMachine, fieldMap, awaitStates));
+        }
+
+        return new AsyncStateMachineRewriteResult(program, plans.ToImmutable());
+    }
+
+    private static int AllocateTypeOrdinal(
+        BoundProgram program,
+        FunctionSymbol function,
+        Dictionary<string, int> ordinalsByScopeAndName)
+    {
+        var packageName = function.Package?.Name ?? program.PackageName ?? string.Empty;
+        var key = packageName + ":" + function.Name;
+        ordinalsByScopeAndName.TryGetValue(key, out var ordinal);
+        ordinalsByScopeAndName[key] = ordinal + 1;
+        return ordinal;
+    }
+
+    private static string GetFunctionSortKey(BoundProgram program, FunctionSymbol function)
+    {
+        var packageName = function.Package?.Name ?? program.PackageName ?? string.Empty;
+        var parameterTypes = string.Join(",", function.Parameters.Select(parameter => parameter.Type?.Name ?? string.Empty));
+        return packageName + ":" + function.Name + ":" + function.Parameters.Length + ":" + parameterTypes;
+    }
+
+    private sealed class AwaitStateCollector : BoundTreeRewriter
+    {
+        private readonly ResumableStateAllocator allocator = new ResumableStateAllocator();
+        private readonly ImmutableDictionary<BoundAwaitExpression, int>.Builder states =
+            ImmutableDictionary.CreateBuilder<BoundAwaitExpression, int>();
+
+        public static ImmutableDictionary<BoundAwaitExpression, int> Allocate(BoundStatement body)
+        {
+            var collector = new AwaitStateCollector();
+            collector.RewriteStatement(body);
+            return collector.states.ToImmutable();
+        }
+
+        protected override BoundExpression RewriteAwaitExpression(BoundAwaitExpression node)
+        {
+            states.Add(node, allocator.AllocateAwaitState());
+            return base.RewriteAwaitExpression(node);
+        }
+    }
+}
+
+/// <summary>
+/// Result of running the async state-machine rewriter scaffold.
+/// </summary>
+public sealed class AsyncStateMachineRewriteResult
+{
+    /// <summary>Initializes a new instance of the <see cref="AsyncStateMachineRewriteResult"/> class.</summary>
+    /// <param name="program">The program passed to the rewriter.</param>
+    /// <param name="stateMachines">The synthesized state-machine plans.</param>
+    public AsyncStateMachineRewriteResult(BoundProgram program, ImmutableArray<AsyncStateMachinePlan> stateMachines)
+    {
+        Program = program;
+        StateMachines = stateMachines;
+    }
+
+    /// <summary>Gets the bound program passed to the rewriter.</summary>
+    public BoundProgram Program { get; }
+
+    /// <summary>Gets the synthesized state-machine plans.</summary>
+    public ImmutableArray<AsyncStateMachinePlan> StateMachines { get; }
+}
+
+/// <summary>
+/// Captures the synthesized artifacts for one async kickoff method.
+/// </summary>
+public sealed class AsyncStateMachinePlan
+{
+    /// <summary>Initializes a new instance of the <see cref="AsyncStateMachinePlan"/> class.</summary>
+    /// <param name="kickoffMethod">The original async kickoff method.</param>
+    /// <param name="loweredBody">The lowered body that will become <c>MoveNext</c>.</param>
+    /// <param name="stateMachine">The synthesized state-machine type.</param>
+    /// <param name="fieldMap">The state-machine field map.</param>
+    /// <param name="awaitResumeStates">Resume-state numbers keyed by await expression.</param>
+    public AsyncStateMachinePlan(
+        FunctionSymbol kickoffMethod,
+        BoundBlockStatement loweredBody,
+        SynthesizedStateMachineType stateMachine,
+        AsyncStateMachineFieldMap fieldMap,
+        ImmutableDictionary<BoundAwaitExpression, int> awaitResumeStates)
+    {
+        KickoffMethod = kickoffMethod ?? throw new ArgumentNullException(nameof(kickoffMethod));
+        LoweredBody = loweredBody ?? throw new ArgumentNullException(nameof(loweredBody));
+        StateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
+        FieldMap = fieldMap ?? throw new ArgumentNullException(nameof(fieldMap));
+        AwaitResumeStates = awaitResumeStates ?? ImmutableDictionary<BoundAwaitExpression, int>.Empty;
+    }
+
+    /// <summary>Gets the original async kickoff method.</summary>
+    public FunctionSymbol KickoffMethod { get; }
+
+    /// <summary>Gets the lowered body that will become <c>MoveNext</c>.</summary>
+    public BoundBlockStatement LoweredBody { get; }
+
+    /// <summary>Gets the synthesized state-machine type.</summary>
+    public SynthesizedStateMachineType StateMachine { get; }
+
+    /// <summary>Gets the state-machine field map.</summary>
+    public AsyncStateMachineFieldMap FieldMap { get; }
+
+    /// <summary>Gets await resume-state numbers keyed by await expression.</summary>
+    public ImmutableDictionary<BoundAwaitExpression, int> AwaitResumeStates { get; }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriterTests.cs
@@ -1,0 +1,143 @@
+// <copyright file="AsyncStateMachineRewriterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Lowering.Async;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
+
+public class AsyncStateMachineRewriterTests
+{
+    private static readonly PackageSymbol Package = new PackageSymbol("main", declaration: null);
+    private static readonly ReferenceResolver Resolver = ReferenceResolver.Default();
+
+    [Fact]
+    public void Rewrite_NonAsyncFunction_DoesNotCreatePlan()
+    {
+        var function = new FunctionSymbol("plain", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, package: Package);
+        var body = Block();
+        var program = Program(function, body);
+
+        var result = AsyncStateMachineRewriter.Rewrite(program, Resolver);
+
+        Assert.Same(program, result.Program);
+        Assert.Empty(result.StateMachines);
+        Assert.Null(function.StateMachineType);
+    }
+
+    [Fact]
+    public void Rewrite_AsyncFunction_AttachesSynthesizedStateMachine()
+    {
+        var function = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, package: Package) { IsAsync = true };
+        var body = Block();
+        var program = Program(function, body);
+
+        var result = AsyncStateMachineRewriter.Rewrite(program, Resolver);
+
+        var plan = Assert.Single(result.StateMachines);
+        Assert.Same(function, plan.KickoffMethod);
+        Assert.Same(body, plan.LoweredBody);
+        Assert.Same(plan.StateMachine, function.StateMachineType);
+        Assert.Same(plan.StateMachine, plan.FieldMap.StateMachine);
+        Assert.Equal("<doIt>d__0", plan.StateMachine.Name);
+        Assert.Empty(plan.AwaitResumeStates);
+    }
+
+    [Fact]
+    public void Rewrite_AsyncFunction_MaterializesFieldMap()
+    {
+        var parameter = new ParameterSymbol("value", TypeSymbol.Int);
+        var function = new FunctionSymbol("doIt", ImmutableArray.Create(parameter), TypeSymbol.Void, package: Package) { IsAsync = true };
+        var body = Block(new BoundExpressionStatement(new BoundVariableExpression(parameter)));
+        var program = Program(function, body);
+
+        var result = AsyncStateMachineRewriter.Rewrite(program, Resolver);
+
+        var plan = Assert.Single(result.StateMachines);
+        Assert.Equal(plan.StateMachine.Name, plan.FieldMap.StructType.Name);
+        var parameterField = plan.FieldMap.GetParameterField(parameter);
+        Assert.Equal("value", parameterField.Name);
+        Assert.Equal(TypeSymbol.Int, parameterField.Type);
+        Assert.Throws<System.InvalidOperationException>(() => plan.StateMachine.AddField(new FieldSymbol("late", TypeSymbol.Int, Accessibility.Public)));
+    }
+
+    [Fact]
+    public void Rewrite_AllocatesAwaitResumeStatesInTraversalOrder()
+    {
+        var firstAwait = new BoundAwaitExpression(new BoundLiteralExpression(1), TypeSymbol.Int);
+        var secondAwait = new BoundAwaitExpression(new BoundLiteralExpression(2), TypeSymbol.Int);
+        var function = new FunctionSymbol("compute", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int, package: Package) { IsAsync = true };
+        var body = Block(
+            new BoundExpressionStatement(firstAwait),
+            new BoundExpressionStatement(secondAwait));
+        var program = Program(function, body);
+
+        var result = AsyncStateMachineRewriter.Rewrite(program, Resolver);
+
+        var states = Assert.Single(result.StateMachines).AwaitResumeStates;
+        Assert.Equal(0, states[firstAwait]);
+        Assert.Equal(1, states[secondAwait]);
+    }
+
+    [Fact]
+    public void Rewrite_UsesPerNameOrdinalsForStateMachineTypeNames()
+    {
+        var first = new FunctionSymbol("duplicate", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, package: Package) { IsAsync = true };
+        var second = new FunctionSymbol("duplicate", ImmutableArray.Create(new ParameterSymbol("x", TypeSymbol.Int)), TypeSymbol.Void, package: Package) { IsAsync = true };
+        var program = Program(
+            (first, Block()),
+            (second, Block()));
+
+        var result = AsyncStateMachineRewriter.Rewrite(program, Resolver);
+
+        var names = result.StateMachines.Select(sm => sm.StateMachine.Name).OrderBy(name => name).ToArray();
+        Assert.Equal(new[] { "<duplicate>d__0", "<duplicate>d__1" }, names);
+    }
+
+    [Fact]
+    public void Rewrite_UnresolvableBuilder_LeavesFunctionUnplanned()
+    {
+        var function = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, package: Package) { IsAsync = true };
+        var program = Program(function, Block());
+
+        var result = AsyncStateMachineRewriter.Rewrite(program, references: null);
+
+        Assert.Empty(result.StateMachines);
+        Assert.Null(function.StateMachineType);
+    }
+
+    private static BoundBlockStatement Block(params BoundStatement[] statements)
+    {
+        return new BoundBlockStatement(statements.ToImmutableArray());
+    }
+
+    private static BoundProgram Program(FunctionSymbol function, BoundBlockStatement body)
+    {
+        return Program((function, body));
+    }
+
+    private static BoundProgram Program(params (FunctionSymbol Function, BoundBlockStatement Body)[] functions)
+    {
+        var builder = ImmutableDictionary.CreateBuilder<FunctionSymbol, BoundBlockStatement>();
+        foreach (var pair in functions)
+        {
+            builder.Add(pair.Function, pair.Body);
+        }
+
+        return new BoundProgram(
+            Package,
+            ImmutableArray.Create(Package),
+            ImmutableArray<Diagnostic>.Empty,
+            builder.ToImmutable(),
+            entryPoint: null,
+            statement: Block(),
+            structs: ImmutableArray<StructSymbol>.Empty,
+            interfaces: ImmutableArray<InterfaceSymbol>.Empty);
+    }
+}


### PR DESCRIPTION
## Summary
- add the first AsyncStateMachineRewriter scaffold that plans async methods without changing emitted behavior
- build/materialize synthesized state-machine types, field maps, and await resume-state mappings
- run the scaffold from Compilation.Emit before the existing async emit precheck, keeping the diagnostic gate active

## Tests
- dotnet test GSharp.sln --nologo --filter "FullyQualifiedName~AsyncStateMachineRewriterTests"
- dotnet test GSharp.sln --nologo --filter "FullyQualifiedName~AsyncStateMachineRewriterTests|FullyQualifiedName~AsyncEmitPrecheckTests"
- dotnet build GSharp.sln -nologo -clp:NoSummary
- dotnet test GSharp.sln --no-restore --nologo