### PR TITLE
Async emit: add MoveNext body plan

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriter.cs
@@ -60,9 +60,10 @@ public static class AsyncStateMachineRewriter
 
             var fieldMap = AsyncStateMachineFieldMap.Create(stateMachine, pair.Value);
             var awaitStates = AwaitStateCollector.Allocate(pair.Value);
+            var moveNextPlan = MoveNextBodyBuilder.Build(pair.Value, awaitStates);
             function.StateMachineType = stateMachine;
 
-            plans.Add(new AsyncStateMachinePlan(function, pair.Value, stateMachine, fieldMap, awaitStates));
+            plans.Add(new AsyncStateMachinePlan(function, pair.Value, stateMachine, fieldMap, awaitStates, moveNextPlan));
         }
 
         return new AsyncStateMachineRewriteResult(program, plans.ToImmutable());
@@ -140,18 +141,21 @@ public sealed class AsyncStateMachinePlan
     /// <param name="stateMachine">The synthesized state-machine type.</param>
     /// <param name="fieldMap">The state-machine field map.</param>
     /// <param name="awaitResumeStates">Resume-state numbers keyed by await expression.</param>
+    /// <param name="moveNextPlan">The planned <c>MoveNext</c> body shape.</param>
     public AsyncStateMachinePlan(
         FunctionSymbol kickoffMethod,
         BoundBlockStatement loweredBody,
         SynthesizedStateMachineType stateMachine,
         AsyncStateMachineFieldMap fieldMap,
-        ImmutableDictionary<BoundAwaitExpression, int> awaitResumeStates)
+        ImmutableDictionary<BoundAwaitExpression, int> awaitResumeStates,
+        MoveNextBodyPlan moveNextPlan)
     {
         KickoffMethod = kickoffMethod ?? throw new ArgumentNullException(nameof(kickoffMethod));
         LoweredBody = loweredBody ?? throw new ArgumentNullException(nameof(loweredBody));
         StateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
         FieldMap = fieldMap ?? throw new ArgumentNullException(nameof(fieldMap));
         AwaitResumeStates = awaitResumeStates ?? ImmutableDictionary<BoundAwaitExpression, int>.Empty;
+        MoveNextPlan = moveNextPlan ?? throw new ArgumentNullException(nameof(moveNextPlan));
     }
 
     /// <summary>Gets the original async kickoff method.</summary>
@@ -168,4 +172,7 @@ public sealed class AsyncStateMachinePlan
 
     /// <summary>Gets await resume-state numbers keyed by await expression.</summary>
     public ImmutableDictionary<BoundAwaitExpression, int> AwaitResumeStates { get; }
+
+    /// <summary>Gets the planned <c>MoveNext</c> body shape.</summary>
+    public MoveNextBodyPlan MoveNextPlan { get; }
 }

--- a/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyBuilder.cs
@@ -1,0 +1,140 @@
+// <copyright file="MoveNextBodyBuilder.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Plans the canonical <c>MoveNext</c> body shape for an async state machine.
+/// </summary>
+/// <remarks>
+/// This is the first behavior-safe slice of <c>MoveNext</c> construction: it
+/// defines the labels and await-resume dispatch map that later lowering will
+/// consume when replacing each <see cref="BoundAwaitExpression"/> with the
+/// Roslyn-compatible suspension sequence. It does not emit a rewritten body yet.
+/// </remarks>
+public static class MoveNextBodyBuilder
+{
+    /// <summary>
+    /// Builds the label and resume-state plan for one async state-machine
+    /// <c>MoveNext</c> body.
+    /// </summary>
+    /// <param name="loweredBody">The lowered async method body.</param>
+    /// <param name="awaitResumeStates">Await expressions and their allocated state numbers.</param>
+    /// <returns>The planned <c>MoveNext</c> body shape.</returns>
+    public static MoveNextBodyPlan Build(
+        BoundBlockStatement loweredBody,
+        ImmutableDictionary<BoundAwaitExpression, int> awaitResumeStates)
+    {
+        if (loweredBody == null)
+        {
+            throw new ArgumentNullException(nameof(loweredBody));
+        }
+
+        awaitResumeStates ??= ImmutableDictionary<BoundAwaitExpression, int>.Empty;
+
+        var resumePoints = awaitResumeStates
+            .OrderBy(pair => pair.Value)
+            .Select(pair => new AwaitResumePoint(
+                pair.Key,
+                pair.Value,
+                Label("await_resume_" + pair.Value),
+                Label("await_resume_after_" + pair.Value)))
+            .ToImmutableArray();
+
+        return new MoveNextBodyPlan(
+            loweredBody,
+            Label("dispatch"),
+            Label("expr_return"),
+            Label("exit"),
+            resumePoints);
+    }
+
+    private static BoundLabel Label(string name)
+    {
+        return new BoundLabel("<>sm_" + name);
+    }
+}
+
+/// <summary>
+/// Planned labels and resume points for a synthesized <c>MoveNext</c> body.
+/// </summary>
+public sealed class MoveNextBodyPlan
+{
+    /// <summary>Initializes a new instance of the <see cref="MoveNextBodyPlan"/> class.</summary>
+    /// <param name="loweredBody">The lowered body that will be rewritten into <c>MoveNext</c>.</param>
+    /// <param name="dispatchLabel">The label used by the initial state dispatch.</param>
+    /// <param name="expressionReturnLabel">The label used by async-return funneling.</param>
+    /// <param name="exitLabel">The label used when leaving <c>MoveNext</c>, including suspension exits.</param>
+    /// <param name="awaitResumePoints">The await resume-point map.</param>
+    public MoveNextBodyPlan(
+        BoundBlockStatement loweredBody,
+        BoundLabel dispatchLabel,
+        BoundLabel expressionReturnLabel,
+        BoundLabel exitLabel,
+        ImmutableArray<AwaitResumePoint> awaitResumePoints)
+    {
+        LoweredBody = loweredBody ?? throw new ArgumentNullException(nameof(loweredBody));
+        DispatchLabel = dispatchLabel ?? throw new ArgumentNullException(nameof(dispatchLabel));
+        ExpressionReturnLabel = expressionReturnLabel ?? throw new ArgumentNullException(nameof(expressionReturnLabel));
+        ExitLabel = exitLabel ?? throw new ArgumentNullException(nameof(exitLabel));
+        AwaitResumePoints = awaitResumePoints.IsDefault
+            ? ImmutableArray<AwaitResumePoint>.Empty
+            : awaitResumePoints;
+    }
+
+    /// <summary>Gets the lowered body that will be rewritten into <c>MoveNext</c>.</summary>
+    public BoundBlockStatement LoweredBody { get; }
+
+    /// <summary>Gets the label used by the initial state dispatch.</summary>
+    public BoundLabel DispatchLabel { get; }
+
+    /// <summary>Gets the label used by async-return funneling.</summary>
+    public BoundLabel ExpressionReturnLabel { get; }
+
+    /// <summary>Gets the label used when leaving <c>MoveNext</c>.</summary>
+    public BoundLabel ExitLabel { get; }
+
+    /// <summary>Gets await resume points ordered by state number.</summary>
+    public ImmutableArray<AwaitResumePoint> AwaitResumePoints { get; }
+}
+
+/// <summary>
+/// Planned labels for one suspending await in <c>MoveNext</c>.
+/// </summary>
+public sealed class AwaitResumePoint
+{
+    /// <summary>Initializes a new instance of the <see cref="AwaitResumePoint"/> class.</summary>
+    /// <param name="awaitExpression">The await expression in the lowered body.</param>
+    /// <param name="state">The state assigned to this suspension point.</param>
+    /// <param name="resumeLabel">The state-dispatch target used on re-entry.</param>
+    /// <param name="resumeAfterLabel">The label shared by synchronous and resumed completion paths.</param>
+    public AwaitResumePoint(
+        BoundAwaitExpression awaitExpression,
+        int state,
+        BoundLabel resumeLabel,
+        BoundLabel resumeAfterLabel)
+    {
+        AwaitExpression = awaitExpression ?? throw new ArgumentNullException(nameof(awaitExpression));
+        State = state;
+        ResumeLabel = resumeLabel ?? throw new ArgumentNullException(nameof(resumeLabel));
+        ResumeAfterLabel = resumeAfterLabel ?? throw new ArgumentNullException(nameof(resumeAfterLabel));
+    }
+
+    /// <summary>Gets the await expression in the lowered body.</summary>
+    public BoundAwaitExpression AwaitExpression { get; }
+
+    /// <summary>Gets the state assigned to this suspension point.</summary>
+    public int State { get; }
+
+    /// <summary>Gets the state-dispatch target used on re-entry.</summary>
+    public BoundLabel ResumeLabel { get; }
+
+    /// <summary>Gets the label shared by synchronous and resumed completion paths.</summary>
+    public BoundLabel ResumeAfterLabel { get; }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriterTests.cs
@@ -47,6 +47,8 @@ public class AsyncStateMachineRewriterTests
         Assert.Same(plan.StateMachine, plan.FieldMap.StateMachine);
         Assert.Equal("<doIt>d__0", plan.StateMachine.Name);
         Assert.Empty(plan.AwaitResumeStates);
+        Assert.Same(body, plan.MoveNextPlan.LoweredBody);
+        Assert.Empty(plan.MoveNextPlan.AwaitResumePoints);
     }
 
     [Fact]
@@ -83,6 +85,12 @@ public class AsyncStateMachineRewriterTests
         var states = Assert.Single(result.StateMachines).AwaitResumeStates;
         Assert.Equal(0, states[firstAwait]);
         Assert.Equal(1, states[secondAwait]);
+
+        var resumePoints = Assert.Single(result.StateMachines).MoveNextPlan.AwaitResumePoints;
+        Assert.Collection(
+            resumePoints,
+            point => Assert.Same(firstAwait, point.AwaitExpression),
+            point => Assert.Same(secondAwait, point.AwaitExpression));
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/MoveNextBodyBuilderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/MoveNextBodyBuilderTests.cs
@@ -1,0 +1,83 @@
+// <copyright file="MoveNextBodyBuilderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Lowering.Async;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
+
+public class MoveNextBodyBuilderTests
+{
+    [Fact]
+    public void Build_NoAwaits_CreatesCoreLabels()
+    {
+        var body = Block();
+
+        var plan = MoveNextBodyBuilder.Build(body, ImmutableDictionary<BoundAwaitExpression, int>.Empty);
+
+        Assert.Same(body, plan.LoweredBody);
+        Assert.Equal("<>sm_dispatch", plan.DispatchLabel.Name);
+        Assert.Equal("<>sm_expr_return", plan.ExpressionReturnLabel.Name);
+        Assert.Equal("<>sm_exit", plan.ExitLabel.Name);
+        Assert.Empty(plan.AwaitResumePoints);
+    }
+
+    [Fact]
+    public void Build_AwaitStates_CreatesResumeLabelsOrderedByState()
+    {
+        var firstAwait = new BoundAwaitExpression(new BoundLiteralExpression(1), TypeSymbol.Int);
+        var secondAwait = new BoundAwaitExpression(new BoundLiteralExpression(2), TypeSymbol.Int);
+        var body = Block(
+            new BoundExpressionStatement(secondAwait),
+            new BoundExpressionStatement(firstAwait));
+        var states = ImmutableDictionary.CreateRange(new[]
+        {
+            new System.Collections.Generic.KeyValuePair<BoundAwaitExpression, int>(secondAwait, 1),
+            new System.Collections.Generic.KeyValuePair<BoundAwaitExpression, int>(firstAwait, 0),
+        });
+
+        var plan = MoveNextBodyBuilder.Build(body, states);
+
+        Assert.Collection(
+            plan.AwaitResumePoints,
+            point =>
+            {
+                Assert.Same(firstAwait, point.AwaitExpression);
+                Assert.Equal(0, point.State);
+                Assert.Equal("<>sm_await_resume_0", point.ResumeLabel.Name);
+                Assert.Equal("<>sm_await_resume_after_0", point.ResumeAfterLabel.Name);
+            },
+            point =>
+            {
+                Assert.Same(secondAwait, point.AwaitExpression);
+                Assert.Equal(1, point.State);
+                Assert.Equal("<>sm_await_resume_1", point.ResumeLabel.Name);
+                Assert.Equal("<>sm_await_resume_after_1", point.ResumeAfterLabel.Name);
+            });
+    }
+
+    [Fact]
+    public void Build_NullAwaitStates_TreatsAsEmpty()
+    {
+        var body = Block();
+
+        var plan = MoveNextBodyBuilder.Build(body, awaitResumeStates: null);
+
+        Assert.Empty(plan.AwaitResumePoints);
+    }
+
+    [Fact]
+    public void Build_NullBody_Throws()
+    {
+        Assert.Throws<System.ArgumentNullException>(() => MoveNextBodyBuilder.Build(null, ImmutableDictionary<BoundAwaitExpression, int>.Empty));
+    }
+
+    private static BoundBlockStatement Block(params BoundStatement[] statements)
+    {
+        return new BoundBlockStatement(statements.ToImmutableArray());
+    }
+}


### PR DESCRIPTION
## Summary
- add MoveNextBodyBuilder planning for dispatch, async return, exit, and per-await resume labels
- attach the MoveNext plan to each AsyncStateMachinePlan
- cover deterministic await-resume ordering and rewriter integration with tests

## Tests
- dotnet test GSharp.sln --nologo --filter "FullyQualifiedName~MoveNextBodyBuilderTests|FullyQualifiedName~AsyncStateMachineRewriterTests"
- dotnet build GSharp.sln -nologo -clp:NoSummary
- dotnet test GSharp.sln --no-restore --nologo