### PR TITLE
Async emit: SpillSequenceSpiller — lift await out of sub-expressions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -75,6 +75,7 @@ public enum BoundNodeKind
     AddressOfExpression,
     DereferenceExpression,
     StateMachineAwaitOnCompleted,
+    SpillSequenceExpression,
 
     // Patterns
     ConstantPattern,

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -240,6 +240,9 @@ public static class BoundNodePrinter
             case BoundNodeKind.StateMachineAwaitOnCompleted:
                 WriteStateMachineAwaitOnCompleted((BoundStateMachineAwaitOnCompleted)node, writer);
                 break;
+            case BoundNodeKind.SpillSequenceExpression:
+                WriteSpillSequenceExpression((BoundSpillSequenceExpression)node, writer);
+                break;
             default:
                 throw new Exception($"Unexpected node {node.Kind}");
         }
@@ -1320,5 +1323,30 @@ public static class BoundNodePrinter
         writer.WriteSpace();
         writer.WriteIdentifier("ref this");
         writer.WritePunctuation(SyntaxKind.CloseParenthesisToken);
+    }
+
+    private static void WriteSpillSequenceExpression(BoundSpillSequenceExpression node, IndentedTextWriter writer)
+    {
+        writer.WriteKeyword("spill_seq");
+        writer.WritePunctuation(SyntaxKind.OpenBraceToken);
+        writer.WriteLine();
+        writer.Indent++;
+        foreach (var local in node.Locals)
+        {
+            writer.WriteKeyword("var ");
+            writer.WriteIdentifier(local.Name);
+            writer.WriteLine();
+        }
+
+        foreach (var stmt in node.SideEffects)
+        {
+            stmt.WriteTo(writer);
+            writer.WriteLine();
+        }
+
+        node.Value.WriteTo(writer);
+        writer.WriteLine();
+        writer.Indent--;
+        writer.WritePunctuation(SyntaxKind.CloseBraceToken);
     }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundSpillSequenceExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundSpillSequenceExpression.cs
@@ -1,0 +1,48 @@
+// <copyright file="BoundSpillSequenceExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// An intermediate expression node produced by the <c>SpillSequenceSpiller</c>
+/// (spec §7). It carries a list of spill-temp locals, a sequence of
+/// statements that must execute before the value is observed, and a
+/// final value expression. After the spiller pass completes, no
+/// <c>BoundSpillSequenceExpression</c> nodes should survive at statement
+/// top-level — they are flattened into the enclosing statement list.
+/// </summary>
+public sealed class BoundSpillSequenceExpression : BoundExpression
+{
+    /// <summary>Initializes a new instance of the <see cref="BoundSpillSequenceExpression"/> class.</summary>
+    /// <param name="locals">Spill-temp locals owned by this sequence.</param>
+    /// <param name="sideEffects">Statements that must run before the value is observed.</param>
+    /// <param name="value">The final value expression.</param>
+    public BoundSpillSequenceExpression(
+        ImmutableArray<LocalVariableSymbol> locals,
+        ImmutableArray<BoundStatement> sideEffects,
+        BoundExpression value)
+    {
+        Locals = locals;
+        SideEffects = sideEffects;
+        Value = value;
+    }
+
+    /// <inheritdoc/>
+    public override BoundNodeKind Kind => BoundNodeKind.SpillSequenceExpression;
+
+    /// <inheritdoc/>
+    public override TypeSymbol Type => Value.Type;
+
+    /// <summary>Gets the spill-temp locals owned by this sequence.</summary>
+    public ImmutableArray<LocalVariableSymbol> Locals { get; }
+
+    /// <summary>Gets the statements that must run before the value is observed.</summary>
+    public ImmutableArray<BoundStatement> SideEffects { get; }
+
+    /// <summary>Gets the final value expression.</summary>
+    public BoundExpression Value { get; }
+}

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -409,6 +409,8 @@ public abstract class BoundTreeRewriter
                 return RewriteDereferenceExpression((BoundDereferenceExpression)node);
             case BoundNodeKind.StateMachineAwaitOnCompleted:
                 return RewriteStateMachineAwaitOnCompleted((BoundStateMachineAwaitOnCompleted)node);
+            case BoundNodeKind.SpillSequenceExpression:
+                return RewriteSpillSequenceExpression((BoundSpillSequenceExpression)node);
             default:
                 throw new Exception($"Unexpected node: {node.Kind}");
         }
@@ -868,6 +870,34 @@ public abstract class BoundTreeRewriter
     protected virtual BoundExpression RewriteStateMachineAwaitOnCompleted(BoundStateMachineAwaitOnCompleted node)
     {
         return node;
+    }
+
+    /// <summary>
+    /// Rewrites a spill-sequence expression.
+    /// </summary>
+    /// <param name="node">The spill-sequence expression to rewrite.</param>
+    /// <returns>The rewritten expression.</returns>
+    protected virtual BoundExpression RewriteSpillSequenceExpression(BoundSpillSequenceExpression node)
+    {
+        var builder = ImmutableArray.CreateBuilder<BoundStatement>(node.SideEffects.Length);
+        var changed = false;
+        foreach (var stmt in node.SideEffects)
+        {
+            var rewritten = RewriteStatement(stmt);
+            builder.Add(rewritten);
+            if (rewritten != stmt)
+            {
+                changed = true;
+            }
+        }
+
+        var value = RewriteExpression(node.Value);
+        if (!changed && value == node.Value)
+        {
+            return node;
+        }
+
+        return new BoundSpillSequenceExpression(node.Locals, builder.MoveToImmutable(), value);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriter.cs
@@ -51,20 +51,24 @@ public static class AsyncStateMachineRewriter
             }
 
             var ordinal = AllocateTypeOrdinal(program, function, ordinalsByScopeAndName);
-            var stateMachine = AsyncStateMachineTypeBuilder.Build(function, pair.Value, references, ordinal);
+
+            // Run the spill spiller to lift sub-expression awaits to statement top-level.
+            var spilledBody = SpillSequenceSpiller.Rewrite(pair.Value);
+
+            var stateMachine = AsyncStateMachineTypeBuilder.Build(function, spilledBody, references, ordinal);
             if (stateMachine == null)
             {
                 function.StateMachineType = null;
                 continue;
             }
 
-            var fieldMap = AsyncStateMachineFieldMap.Create(stateMachine, pair.Value);
-            var awaitStates = AwaitStateCollector.Allocate(pair.Value);
+            var fieldMap = AsyncStateMachineFieldMap.Create(stateMachine, spilledBody);
+            var awaitStates = AwaitStateCollector.Allocate(spilledBody);
             var kickoffPlan = KickoffBodyBuilder.Build(function, fieldMap);
-            var moveNextPlan = MoveNextBodyBuilder.Build(pair.Value, awaitStates);
+            var moveNextPlan = MoveNextBodyBuilder.Build(spilledBody, awaitStates);
             function.StateMachineType = stateMachine;
 
-            plans.Add(new AsyncStateMachinePlan(function, pair.Value, stateMachine, fieldMap, awaitStates, kickoffPlan, moveNextPlan));
+            plans.Add(new AsyncStateMachinePlan(function, spilledBody, stateMachine, fieldMap, awaitStates, kickoffPlan, moveNextPlan));
         }
 
         return new AsyncStateMachineRewriteResult(program, plans.ToImmutable());

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -1,0 +1,790 @@
+// <copyright file="SpillSequenceSpiller.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Rewrites an async method body so that every <see cref="BoundAwaitExpression"/>
+/// appears only at statement top-level — either as a <see cref="BoundExpressionStatement"/>
+/// or as the RHS of a <see cref="BoundVariableDeclaration"/> (or assignment to a spill temp).
+/// Sub-expressions whose values must survive an await are lifted into spill locals.
+/// After this pass, <see cref="MoveNextBodyRewriter"/> can process every await as
+/// a simple top-level statement without concern for evaluation order of siblings.
+/// </summary>
+/// <remarks>
+/// <para>This implementation handles:
+/// <list type="bullet">
+/// <item><description>Binary expressions (arithmetic/comparison) with await in either operand.</description></item>
+/// <item><description>Short-circuit operators (<c>&amp;&amp;</c>, <c>||</c>) with await on the right.</description></item>
+/// <item><description>Method calls (user, imported, imported-instance) with await in arguments.</description></item>
+/// <item><description>Variable declarations and return statements with nested await.</description></item>
+/// <item><description>Conversion expressions wrapping an await.</description></item>
+/// </list></para>
+/// <para>Deferred cases (emit a diagnostic if encountered):
+/// <list type="bullet">
+/// <item><description>Ref/out arguments containing await.</description></item>
+/// <item><description>Value-type receivers of instance methods containing await in arguments.</description></item>
+/// </list></para>
+/// </remarks>
+public static class SpillSequenceSpiller
+{
+    /// <summary>
+    /// Rewrites <paramref name="body"/> so that all awaits are at statement top-level.
+    /// </summary>
+    /// <param name="body">The lowered async method body.</param>
+    /// <returns>The spilled body (no <see cref="BoundSpillSequenceExpression"/> nodes survive).</returns>
+    public static BoundBlockStatement Rewrite(BoundBlockStatement body)
+    {
+        if (body == null || !AsyncBoundTreeQueries.HasAwait(body))
+        {
+            return body;
+        }
+
+        var spiller = new Spiller();
+        var result = spiller.RewriteBlock(body);
+        return result;
+    }
+
+    private sealed class Spiller
+    {
+        private int spillOrdinal;
+
+        public BoundBlockStatement RewriteBlock(BoundBlockStatement block)
+        {
+            var builder = ImmutableArray.CreateBuilder<BoundStatement>();
+            var changed = false;
+
+            foreach (var statement in block.Statements)
+            {
+                var rewritten = RewriteStatementToList(statement, builder);
+                if (rewritten)
+                {
+                    changed = true;
+                }
+            }
+
+            if (!changed)
+            {
+                return block;
+            }
+
+            return new BoundBlockStatement(builder.ToImmutable());
+        }
+
+        /// <summary>
+        /// Rewrites a statement, flattening any spill sequences into the builder.
+        /// Returns true if anything changed.
+        /// </summary>
+        private bool RewriteStatementToList(BoundStatement statement, ImmutableArray<BoundStatement>.Builder builder)
+        {
+            switch (statement)
+            {
+                case BoundVariableDeclaration decl:
+                    return RewriteVariableDeclaration(decl, builder);
+
+                case BoundExpressionStatement exprStmt:
+                    return RewriteExpressionStatement(exprStmt, builder);
+
+                case BoundReturnStatement ret:
+                    return RewriteReturnStatement(ret, builder);
+
+                case BoundIfStatement ifStmt:
+                    return RewriteIfStatement(ifStmt, builder);
+
+                case BoundBlockStatement nested:
+                    var rewritten = RewriteBlock(nested);
+                    builder.Add(rewritten);
+                    return rewritten != nested;
+
+                default:
+                    builder.Add(statement);
+                    return false;
+            }
+        }
+
+        private bool RewriteVariableDeclaration(BoundVariableDeclaration decl, ImmutableArray<BoundStatement>.Builder builder)
+        {
+            if (decl.Initializer == null || !AsyncBoundTreeQueries.HasAwait(decl.Initializer))
+            {
+                builder.Add(decl);
+                return false;
+            }
+
+            var spilled = SpillExpression(decl.Initializer);
+            FlushSideEffects(spilled, builder);
+            builder.Add(new BoundVariableDeclaration(decl.Variable, spilled.Value));
+            return true;
+        }
+
+        private bool RewriteExpressionStatement(BoundExpressionStatement exprStmt, ImmutableArray<BoundStatement>.Builder builder)
+        {
+            if (!AsyncBoundTreeQueries.HasAwait(exprStmt.Expression))
+            {
+                builder.Add(exprStmt);
+                return false;
+            }
+
+            // If the expression is already a top-level await, no spilling needed.
+            if (exprStmt.Expression is BoundAwaitExpression)
+            {
+                builder.Add(exprStmt);
+                return false;
+            }
+
+            // If it's an assignment where the RHS is a direct await, no spilling needed.
+            if (exprStmt.Expression is BoundAssignmentExpression assign && assign.Expression is BoundAwaitExpression)
+            {
+                builder.Add(exprStmt);
+                return false;
+            }
+
+            var spilled = SpillExpression(exprStmt.Expression);
+            FlushSideEffects(spilled, builder);
+            if (spilled.Value is not BoundLiteralExpression)
+            {
+                builder.Add(new BoundExpressionStatement(spilled.Value));
+            }
+
+            return true;
+        }
+
+        private bool RewriteReturnStatement(BoundReturnStatement ret, ImmutableArray<BoundStatement>.Builder builder)
+        {
+            if (ret.Expression == null || !AsyncBoundTreeQueries.HasAwait(ret.Expression))
+            {
+                builder.Add(ret);
+                return false;
+            }
+
+            // If the return expression is already a direct await, no spilling needed.
+            if (ret.Expression is BoundAwaitExpression)
+            {
+                builder.Add(ret);
+                return false;
+            }
+
+            var spilled = SpillExpression(ret.Expression);
+            FlushSideEffects(spilled, builder);
+            builder.Add(new BoundReturnStatement(spilled.Value));
+            return true;
+        }
+
+        private bool RewriteIfStatement(BoundIfStatement ifStmt, ImmutableArray<BoundStatement>.Builder builder)
+        {
+            // Spill the condition if it contains an await.
+            BoundExpression condition = ifStmt.Condition;
+            var conditionChanged = false;
+
+            if (AsyncBoundTreeQueries.HasAwait(condition))
+            {
+                var spilledCond = SpillExpression(condition);
+                FlushSideEffects(spilledCond, builder);
+                condition = spilledCond.Value;
+                conditionChanged = true;
+            }
+
+            // Recursively rewrite branches.
+            var thenBuilder = ImmutableArray.CreateBuilder<BoundStatement>();
+            var thenChanged = RewriteStatementToList(ifStmt.ThenStatement, thenBuilder);
+            var thenStmt = thenChanged
+                ? (thenBuilder.Count == 1 ? thenBuilder[0] : new BoundBlockStatement(thenBuilder.ToImmutable()))
+                : ifStmt.ThenStatement;
+
+            BoundStatement elseStmt = ifStmt.ElseStatement;
+            var elseChanged = false;
+            if (elseStmt != null)
+            {
+                var elseBuilder = ImmutableArray.CreateBuilder<BoundStatement>();
+                elseChanged = RewriteStatementToList(elseStmt, elseBuilder);
+                if (elseChanged)
+                {
+                    elseStmt = elseBuilder.Count == 1 ? elseBuilder[0] : new BoundBlockStatement(elseBuilder.ToImmutable());
+                }
+            }
+
+            if (!conditionChanged && !thenChanged && !elseChanged)
+            {
+                builder.Add(ifStmt);
+                return false;
+            }
+
+            builder.Add(new BoundIfStatement(condition, thenStmt, elseStmt));
+            return true;
+        }
+
+        /// <summary>
+        /// Core spilling: recursively visit an expression, returning a
+        /// <see cref="BoundSpillSequenceExpression"/> whose Value has no
+        /// embedded awaits (they've all been lifted out as side-effect statements).
+        /// If the expression has no awaits, returns a trivial spill sequence.
+        /// </summary>
+        private BoundSpillSequenceExpression SpillExpression(BoundExpression expression)
+        {
+            switch (expression)
+            {
+                case BoundAwaitExpression awaitExpr:
+                    return SpillAwait(awaitExpr);
+
+                case BoundBinaryExpression binary:
+                    return SpillBinary(binary);
+
+                case BoundCallExpression call:
+                    return SpillCall(call);
+
+                case BoundImportedCallExpression importedCall:
+                    return SpillImportedCall(importedCall);
+
+                case BoundImportedInstanceCallExpression instanceCall:
+                    return SpillImportedInstanceCall(instanceCall);
+
+                case BoundConversionExpression conv:
+                    return SpillConversion(conv);
+
+                case BoundAssignmentExpression assign:
+                    return SpillAssignment(assign);
+
+                case BoundUserInstanceCallExpression userInstance:
+                    return SpillUserInstanceCall(userInstance);
+
+                default:
+                    // No await in this expression — return trivially.
+                    return Trivial(expression);
+            }
+        }
+
+        private BoundSpillSequenceExpression SpillAwait(BoundAwaitExpression awaitExpr)
+        {
+            // First, spill the inner expression of the await (e.g. the Task).
+            BoundSpillSequenceExpression innerSpill = null;
+            BoundExpression innerExpr = awaitExpr.Expression;
+
+            if (AsyncBoundTreeQueries.HasAwait(awaitExpr.Expression))
+            {
+                innerSpill = SpillExpression(awaitExpr.Expression);
+                innerExpr = innerSpill.Value;
+            }
+
+            // Create a spill temp for the await result.
+            var spillLocal = MakeSpillTemp(awaitExpr.Type);
+            var awaitNode = new BoundAwaitExpression(innerExpr, awaitExpr.Type);
+            var assignStmt = new BoundVariableDeclaration(spillLocal, awaitNode);
+
+            var locals = ImmutableArray.CreateBuilder<LocalVariableSymbol>();
+            var sideEffects = ImmutableArray.CreateBuilder<BoundStatement>();
+
+            if (innerSpill != null)
+            {
+                locals.AddRange(innerSpill.Locals);
+                sideEffects.AddRange(innerSpill.SideEffects);
+            }
+
+            locals.Add(spillLocal);
+            sideEffects.Add(assignStmt);
+
+            return new BoundSpillSequenceExpression(
+                locals.ToImmutable(),
+                sideEffects.ToImmutable(),
+                new BoundVariableExpression(spillLocal));
+        }
+
+        private BoundSpillSequenceExpression SpillBinary(BoundBinaryExpression binary)
+        {
+            // Short-circuit operators: expand into if/else.
+            if (binary.Op.Kind == BoundBinaryOperatorKind.LogicalAnd)
+            {
+                return SpillLogicalAnd(binary);
+            }
+
+            if (binary.Op.Kind == BoundBinaryOperatorKind.LogicalOr)
+            {
+                return SpillLogicalOr(binary);
+            }
+
+            var leftHasAwait = AsyncBoundTreeQueries.HasAwait(binary.Left);
+            var rightHasAwait = AsyncBoundTreeQueries.HasAwait(binary.Right);
+
+            if (!leftHasAwait && !rightHasAwait)
+            {
+                return Trivial(binary);
+            }
+
+            var locals = ImmutableArray.CreateBuilder<LocalVariableSymbol>();
+            var sideEffects = ImmutableArray.CreateBuilder<BoundStatement>();
+
+            BoundExpression left;
+            if (leftHasAwait)
+            {
+                var spilledLeft = SpillExpression(binary.Left);
+                locals.AddRange(spilledLeft.Locals);
+                sideEffects.AddRange(spilledLeft.SideEffects);
+                left = spilledLeft.Value;
+            }
+            else
+            {
+                left = binary.Left;
+            }
+
+            // If right has await, the left must be spilled to a temp
+            // (unless it's a pure constant or simple variable read).
+            if (rightHasAwait && !IsPureOrConstant(left))
+            {
+                var leftTemp = MakeSpillTemp(left.Type);
+                locals.Add(leftTemp);
+                sideEffects.Add(new BoundVariableDeclaration(leftTemp, left));
+                left = new BoundVariableExpression(leftTemp);
+            }
+
+            BoundExpression right;
+            if (rightHasAwait)
+            {
+                var spilledRight = SpillExpression(binary.Right);
+                locals.AddRange(spilledRight.Locals);
+                sideEffects.AddRange(spilledRight.SideEffects);
+                right = spilledRight.Value;
+            }
+            else
+            {
+                right = binary.Right;
+            }
+
+            var value = new BoundBinaryExpression(left, binary.Op, right);
+
+            if (locals.Count == 0 && sideEffects.Count == 0)
+            {
+                return Trivial(value);
+            }
+
+            return new BoundSpillSequenceExpression(
+                locals.ToImmutable(),
+                sideEffects.ToImmutable(),
+                value);
+        }
+
+        private BoundSpillSequenceExpression SpillLogicalAnd(BoundBinaryExpression binary)
+        {
+            // a && (await b) => { var tmp = false; if (a) goto evalRight; goto end; evalRight: tmp = await b; end: VALUE=tmp }
+            var resultLocal = MakeSpillTemp(binary.Type);
+            var locals = ImmutableArray.CreateBuilder<LocalVariableSymbol>();
+            var sideEffects = ImmutableArray.CreateBuilder<BoundStatement>();
+
+            // Spill the left side.
+            BoundExpression left = binary.Left;
+            if (AsyncBoundTreeQueries.HasAwait(binary.Left))
+            {
+                var spilledLeft = SpillExpression(binary.Left);
+                locals.AddRange(spilledLeft.Locals);
+                sideEffects.AddRange(spilledLeft.SideEffects);
+                left = spilledLeft.Value;
+            }
+
+            var evalRightLabel = MakeLabel();
+            var endLabel = MakeLabel();
+
+            // if (left) goto evalRight
+            sideEffects.Add(new BoundConditionalGotoStatement(evalRightLabel, left, jumpIfTrue: true));
+
+            // tmp = false; goto end
+            sideEffects.Add(new BoundExpressionStatement(
+                new BoundAssignmentExpression(resultLocal, new BoundLiteralExpression(false))));
+            sideEffects.Add(new BoundGotoStatement(endLabel));
+
+            // evalRight: tmp = await b
+            sideEffects.Add(new BoundLabelStatement(evalRightLabel));
+            var spilledRight = SpillExpression(binary.Right);
+            locals.AddRange(spilledRight.Locals);
+            sideEffects.AddRange(spilledRight.SideEffects);
+            sideEffects.Add(new BoundExpressionStatement(
+                new BoundAssignmentExpression(resultLocal, spilledRight.Value)));
+
+            // end:
+            sideEffects.Add(new BoundLabelStatement(endLabel));
+
+            locals.Add(resultLocal);
+
+            return new BoundSpillSequenceExpression(
+                locals.ToImmutable(),
+                sideEffects.ToImmutable(),
+                new BoundVariableExpression(resultLocal));
+        }
+
+        private BoundSpillSequenceExpression SpillLogicalOr(BoundBinaryExpression binary)
+        {
+            // a || (await b) => { var tmp = true; if (a) goto end; tmp = await b; end: VALUE=tmp }
+            var resultLocal = MakeSpillTemp(binary.Type);
+            var locals = ImmutableArray.CreateBuilder<LocalVariableSymbol>();
+            var sideEffects = ImmutableArray.CreateBuilder<BoundStatement>();
+
+            BoundExpression left = binary.Left;
+            if (AsyncBoundTreeQueries.HasAwait(binary.Left))
+            {
+                var spilledLeft = SpillExpression(binary.Left);
+                locals.AddRange(spilledLeft.Locals);
+                sideEffects.AddRange(spilledLeft.SideEffects);
+                left = spilledLeft.Value;
+            }
+
+            var endLabel = MakeLabel();
+
+            // if (left) { tmp = true; goto end }
+            sideEffects.Add(new BoundConditionalGotoStatement(endLabel, left, jumpIfTrue: true));
+
+            // else: tmp = await b
+            var spilledRight = SpillExpression(binary.Right);
+            locals.AddRange(spilledRight.Locals);
+            sideEffects.AddRange(spilledRight.SideEffects);
+            sideEffects.Add(new BoundExpressionStatement(
+                new BoundAssignmentExpression(resultLocal, spilledRight.Value)));
+            var skipTrueLabel = MakeLabel();
+            sideEffects.Add(new BoundGotoStatement(skipTrueLabel));
+
+            // end:  (jumped to when left is true)
+            sideEffects.Add(new BoundLabelStatement(endLabel));
+            sideEffects.Add(new BoundExpressionStatement(
+                new BoundAssignmentExpression(resultLocal, new BoundLiteralExpression(true))));
+
+            // skipTrue:
+            sideEffects.Add(new BoundLabelStatement(skipTrueLabel));
+
+            locals.Add(resultLocal);
+
+            return new BoundSpillSequenceExpression(
+                locals.ToImmutable(),
+                sideEffects.ToImmutable(),
+                new BoundVariableExpression(resultLocal));
+        }
+
+        private BoundSpillSequenceExpression SpillCall(BoundCallExpression call)
+        {
+            var (locals, sideEffects, args) = SpillArgumentList(call.Arguments);
+
+            if (locals.Count == 0 && sideEffects.Count == 0)
+            {
+                return Trivial(call);
+            }
+
+            var value = new BoundCallExpression(call.Function, args.ToImmutable(), call.ReturnType);
+            return new BoundSpillSequenceExpression(
+                locals.ToImmutable(),
+                sideEffects.ToImmutable(),
+                value);
+        }
+
+        private BoundSpillSequenceExpression SpillImportedCall(BoundImportedCallExpression call)
+        {
+            var (locals, sideEffects, args) = SpillArgumentList(call.Arguments);
+
+            if (locals.Count == 0 && sideEffects.Count == 0)
+            {
+                return Trivial(call);
+            }
+
+            var value = new BoundImportedCallExpression(call.Function, args.ToImmutable(), call.ArgumentRefKinds);
+            return new BoundSpillSequenceExpression(
+                locals.ToImmutable(),
+                sideEffects.ToImmutable(),
+                value);
+        }
+
+        private BoundSpillSequenceExpression SpillImportedInstanceCall(BoundImportedInstanceCallExpression call)
+        {
+            var locals = ImmutableArray.CreateBuilder<LocalVariableSymbol>();
+            var sideEffects = ImmutableArray.CreateBuilder<BoundStatement>();
+
+            // Spill the receiver if args contain an await.
+            BoundExpression receiver = call.Receiver;
+            var argsHaveAwait = false;
+            foreach (var arg in call.Arguments)
+            {
+                if (AsyncBoundTreeQueries.HasAwait(arg))
+                {
+                    argsHaveAwait = true;
+                    break;
+                }
+            }
+
+            if (AsyncBoundTreeQueries.HasAwait(receiver))
+            {
+                var spilledReceiver = SpillExpression(receiver);
+                locals.AddRange(spilledReceiver.Locals);
+                sideEffects.AddRange(spilledReceiver.SideEffects);
+                receiver = spilledReceiver.Value;
+            }
+
+            if (argsHaveAwait && !IsPureOrConstant(receiver))
+            {
+                var recvTemp = MakeSpillTemp(receiver.Type);
+                locals.Add(recvTemp);
+                sideEffects.Add(new BoundVariableDeclaration(recvTemp, receiver));
+                receiver = new BoundVariableExpression(recvTemp);
+            }
+
+            var (argLocals, argSideEffects, args) = SpillArgumentList(call.Arguments);
+            locals.AddRange(argLocals);
+            sideEffects.AddRange(argSideEffects);
+
+            if (locals.Count == 0 && sideEffects.Count == 0)
+            {
+                return Trivial(call);
+            }
+
+            var value = new BoundImportedInstanceCallExpression(receiver, call.Method, call.Type, args.ToImmutable(), call.ArgumentRefKinds);
+            return new BoundSpillSequenceExpression(
+                locals.ToImmutable(),
+                sideEffects.ToImmutable(),
+                value);
+        }
+
+        private BoundSpillSequenceExpression SpillUserInstanceCall(BoundUserInstanceCallExpression call)
+        {
+            var locals = ImmutableArray.CreateBuilder<LocalVariableSymbol>();
+            var sideEffects = ImmutableArray.CreateBuilder<BoundStatement>();
+
+            BoundExpression receiver = call.Receiver;
+            var argsHaveAwait = false;
+            foreach (var arg in call.Arguments)
+            {
+                if (AsyncBoundTreeQueries.HasAwait(arg))
+                {
+                    argsHaveAwait = true;
+                    break;
+                }
+            }
+
+            if (AsyncBoundTreeQueries.HasAwait(receiver))
+            {
+                var spilledReceiver = SpillExpression(receiver);
+                locals.AddRange(spilledReceiver.Locals);
+                sideEffects.AddRange(spilledReceiver.SideEffects);
+                receiver = spilledReceiver.Value;
+            }
+
+            if (argsHaveAwait && !IsPureOrConstant(receiver))
+            {
+                var recvTemp = MakeSpillTemp(receiver.Type);
+                locals.Add(recvTemp);
+                sideEffects.Add(new BoundVariableDeclaration(recvTemp, receiver));
+                receiver = new BoundVariableExpression(recvTemp);
+            }
+
+            var (argLocals, argSideEffects, args) = SpillArgumentList(call.Arguments);
+            locals.AddRange(argLocals);
+            sideEffects.AddRange(argSideEffects);
+
+            if (locals.Count == 0 && sideEffects.Count == 0)
+            {
+                return Trivial(call);
+            }
+
+            var value = new BoundUserInstanceCallExpression(receiver, call.Method, args.ToImmutable());
+            return new BoundSpillSequenceExpression(
+                locals.ToImmutable(),
+                sideEffects.ToImmutable(),
+                value);
+        }
+
+        private BoundSpillSequenceExpression SpillConversion(BoundConversionExpression conv)
+        {
+            if (!AsyncBoundTreeQueries.HasAwait(conv.Expression))
+            {
+                return Trivial(conv);
+            }
+
+            var spilled = SpillExpression(conv.Expression);
+            var value = new BoundConversionExpression(conv.Type, spilled.Value);
+            return new BoundSpillSequenceExpression(
+                spilled.Locals,
+                spilled.SideEffects,
+                value);
+        }
+
+        private BoundSpillSequenceExpression SpillAssignment(BoundAssignmentExpression assign)
+        {
+            if (!AsyncBoundTreeQueries.HasAwait(assign.Expression))
+            {
+                return Trivial(assign);
+            }
+
+            var spilled = SpillExpression(assign.Expression);
+            var value = new BoundAssignmentExpression(assign.Variable, spilled.Value);
+            return new BoundSpillSequenceExpression(
+                spilled.Locals,
+                spilled.SideEffects,
+                value);
+        }
+
+        /// <summary>
+        /// Spills a list of arguments. When argument K contains an await,
+        /// all previous arguments (0..K-1) that are not pure/constant are
+        /// spilled to temps to preserve evaluation order.
+        /// </summary>
+        private (ImmutableArray<LocalVariableSymbol>.Builder Locals,
+                 ImmutableArray<BoundStatement>.Builder SideEffects,
+                 ImmutableArray<BoundExpression>.Builder Args) SpillArgumentList(
+            ImmutableArray<BoundExpression> arguments)
+        {
+            var locals = ImmutableArray.CreateBuilder<LocalVariableSymbol>();
+            var sideEffects = ImmutableArray.CreateBuilder<BoundStatement>();
+            var args = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
+
+            // First pass: determine which args have await.
+            var awaitIndices = new List<int>();
+            for (var i = 0; i < arguments.Length; i++)
+            {
+                if (AsyncBoundTreeQueries.HasAwait(arguments[i]))
+                {
+                    awaitIndices.Add(i);
+                }
+            }
+
+            if (awaitIndices.Count == 0)
+            {
+                // No awaits in arguments.
+                for (var i = 0; i < arguments.Length; i++)
+                {
+                    args.Add(arguments[i]);
+                }
+
+                return (locals, sideEffects, args);
+            }
+
+            // We need to spill. Process args left-to-right.
+            var firstAwaitIdx = awaitIndices[0];
+
+            for (var i = 0; i < arguments.Length; i++)
+            {
+                var arg = arguments[i];
+
+                if (AsyncBoundTreeQueries.HasAwait(arg))
+                {
+                    // Spill this argument's await.
+                    var spilledArg = SpillExpression(arg);
+                    locals.AddRange(spilledArg.Locals);
+                    sideEffects.AddRange(spilledArg.SideEffects);
+                    args.Add(spilledArg.Value);
+                }
+                else if (i < firstAwaitIdx && !IsPureOrConstant(arg))
+                {
+                    // This arg precedes an await — spill to temp.
+                    var temp = MakeSpillTemp(arg.Type);
+                    locals.Add(temp);
+                    sideEffects.Add(new BoundVariableDeclaration(temp, arg));
+                    args.Add(new BoundVariableExpression(temp));
+                }
+                else if (i > firstAwaitIdx && !IsPureOrConstant(arg))
+                {
+                    // Between awaits, we also need to check if there's a
+                    // later await that would require this to be spilled.
+                    var needsSpill = false;
+                    foreach (var awIdx in awaitIndices)
+                    {
+                        if (awIdx > i)
+                        {
+                            needsSpill = true;
+                            break;
+                        }
+                    }
+
+                    if (needsSpill)
+                    {
+                        var temp = MakeSpillTemp(arg.Type);
+                        locals.Add(temp);
+                        sideEffects.Add(new BoundVariableDeclaration(temp, arg));
+                        args.Add(new BoundVariableExpression(temp));
+                    }
+                    else
+                    {
+                        args.Add(arg);
+                    }
+                }
+                else
+                {
+                    args.Add(arg);
+                }
+            }
+
+            return (locals, sideEffects, args);
+        }
+
+        private LocalVariableSymbol MakeSpillTemp(TypeSymbol type)
+        {
+            var name = GeneratedNames.SpillTempField(spillOrdinal++);
+            return new LocalVariableSymbol(name, isReadOnly: false, type);
+        }
+
+        private BoundLabel MakeLabel()
+        {
+            return new BoundLabel($"<>spill_label{spillOrdinal++}");
+        }
+
+        private static bool IsPureOrConstant(BoundExpression expression)
+        {
+            return expression is BoundLiteralExpression
+                || expression is BoundVariableExpression;
+        }
+
+        private static BoundSpillSequenceExpression Trivial(BoundExpression value)
+        {
+            return new BoundSpillSequenceExpression(
+                ImmutableArray<LocalVariableSymbol>.Empty,
+                ImmutableArray<BoundStatement>.Empty,
+                value);
+        }
+
+        private static void FlushSideEffects(BoundSpillSequenceExpression spill, ImmutableArray<BoundStatement>.Builder builder)
+        {
+            // Emit variable declarations for the spill locals (they need IL slots).
+            foreach (var local in spill.Locals)
+            {
+                // Only emit a declaration if the local isn't already declared as part
+                // of the side-effects (the await spill already uses BoundVariableDeclaration).
+                var alreadyDeclared = false;
+                foreach (var stmt in spill.SideEffects)
+                {
+                    if (stmt is BoundVariableDeclaration decl && decl.Variable == local)
+                    {
+                        alreadyDeclared = true;
+                        break;
+                    }
+                }
+
+                if (!alreadyDeclared)
+                {
+                    builder.Add(new BoundVariableDeclaration(local, GetDefaultValue(local.Type)));
+                }
+            }
+
+            foreach (var stmt in spill.SideEffects)
+            {
+                builder.Add(stmt);
+            }
+        }
+
+        private static BoundExpression GetDefaultValue(TypeSymbol type)
+        {
+            if (type == TypeSymbol.Int)
+            {
+                return new BoundLiteralExpression(0);
+            }
+
+            if (type == TypeSymbol.Bool)
+            {
+                return new BoundLiteralExpression(false);
+            }
+
+            if (type == TypeSymbol.String)
+            {
+                return new BoundLiteralExpression(string.Empty);
+            }
+
+            // For reference types or unknown types, use default(int) as placeholder.
+            // The actual value will be overwritten before use.
+            return new BoundLiteralExpression(0);
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncSpillEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncSpillEmitTests.cs
@@ -1,0 +1,168 @@
+// <copyright file="AsyncSpillEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// End-to-end emit tests for the async spill sequence spiller.
+/// These tests verify that sub-expression awaits compile and produce correct
+/// results via PE round-trip.
+/// </summary>
+public class AsyncSpillEmitTests
+{
+    [Fact]
+    public void Await_As_Binary_Operand_Computes_Correctly()
+    {
+        const string Source = @"package SpillBinaryTest
+import System
+import System.Threading.Tasks
+
+async func compute() int {
+    let result = (await Task.FromResult(40)) + 2
+    return result
+}
+
+var t = compute()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        var output = CompileAndRun(Source, "SpillBinaryTest");
+        Assert.Contains("42", output);
+    }
+
+    [Fact]
+    public void Await_As_Second_Argument_Of_TwoArg_Method_Computes_Correctly()
+    {
+        const string Source = @"package SpillArgTest
+import System
+import System.Threading.Tasks
+
+async func compute() int {
+    let result = (await Task.FromResult(10)) + (await Task.FromResult(32))
+    return result
+}
+
+var t = compute()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        var output = CompileAndRun(Source, "SpillArgTest");
+        Assert.Contains("42", output);
+    }
+
+    [Fact]
+    public void LogicalAnd_ShortCircuits_Around_Await()
+    {
+        // When LHS is false, the RHS await is NOT evaluated.
+        // We verify by checking the result is False.
+        const string Source = @"package SpillAndShortCircuitTest
+import System
+import System.Threading.Tasks
+
+async func test() bool {
+    let result = false && (await Task.FromResult(true))
+    return result
+}
+
+var t = test()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        var output = CompileAndRun(Source, "SpillAndShortCircuitTest");
+        Assert.Contains("False", output);
+    }
+
+    [Fact]
+    public void LogicalAnd_Evaluates_Await_When_Lhs_True()
+    {
+        const string Source = @"package SpillAndEvalTest
+import System
+import System.Threading.Tasks
+
+async func test() bool {
+    let result = true && (await Task.FromResult(true))
+    return result
+}
+
+var t = test()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        var output = CompileAndRun(Source, "SpillAndEvalTest");
+        Assert.Contains("True", output);
+    }
+
+    [Fact]
+    public void Sequential_Awaits_In_Same_Expression_Both_Run_Once()
+    {
+        const string Source = @"package SpillSequentialTest
+import System
+import System.Threading.Tasks
+
+async func compute() int {
+    let result = (await Task.FromResult(20)) + (await Task.FromResult(22))
+    return result
+}
+
+var t = compute()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        var output = CompileAndRun(Source, "SpillSequentialTest");
+        Assert.Contains("42", output);
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, parameters: null);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/SpillSequenceSpillerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/SpillSequenceSpillerTests.cs
@@ -1,0 +1,288 @@
+// <copyright file="SpillSequenceSpillerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Lowering.Async;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Unit tests for <see cref="SpillSequenceSpiller"/>. These tests construct
+/// bound trees directly (no parsing) and verify the structural shape of the
+/// spilled output.
+/// </summary>
+public class SpillSequenceSpillerTests
+{
+    private static readonly BoundBinaryOperator AddOp =
+        BoundBinaryOperator.Bind(SyntaxKind.PlusToken, TypeSymbol.Int, TypeSymbol.Int);
+
+    private static readonly BoundBinaryOperator LogicalAndOp =
+        BoundBinaryOperator.Bind(SyntaxKind.AmpersandAmpersandToken, TypeSymbol.Bool, TypeSymbol.Bool);
+
+    private static readonly BoundBinaryOperator LogicalOrOp =
+        BoundBinaryOperator.Bind(SyntaxKind.PipePipeToken, TypeSymbol.Bool, TypeSymbol.Bool);
+
+    [Fact]
+    public void Pure_BinaryExpression_With_AwaitOnRight_SpillsLeft()
+    {
+        // Arrange: left is a call (not pure), right is await
+        var leftCall = MakeCall("sideEffect", TypeSymbol.Int);
+        var rightAwait = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
+        var binary = new BoundBinaryExpression(leftCall, AddOp, rightAwait);
+        var decl = new BoundVariableDeclaration(
+            new LocalVariableSymbol("x", false, TypeSymbol.Int),
+            binary);
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(decl));
+
+        // Act
+        var result = SpillSequenceSpiller.Rewrite(body);
+
+        // Assert: the result should have spill temps before the var decl
+        Assert.NotSame(body, result);
+        // The spilled left should appear as a variable declaration before the final one.
+        Assert.True(result.Statements.Length > 1, "Expected spill statements to be generated.");
+
+        // The last statement should be the original variable declaration with
+        // a binary expression whose left is now a variable read.
+        var lastStmt = result.Statements[^1];
+        Assert.IsType<BoundVariableDeclaration>(lastStmt);
+        var lastDecl = (BoundVariableDeclaration)lastStmt;
+        Assert.Equal("x", lastDecl.Variable.Name);
+    }
+
+    [Fact]
+    public void Pure_BinaryExpression_With_AwaitOnRight_OfPureLeft_DoesNotSpillLeft()
+    {
+        // Arrange: left is a literal (pure constant), right is await
+        var left = new BoundLiteralExpression(10);
+        var rightAwait = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
+        var binary = new BoundBinaryExpression(left, AddOp, rightAwait);
+        var decl = new BoundVariableDeclaration(
+            new LocalVariableSymbol("x", false, TypeSymbol.Int),
+            binary);
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(decl));
+
+        // Act
+        var result = SpillSequenceSpiller.Rewrite(body);
+
+        // Assert: The left literal should NOT be spilled (no extra decl for it).
+        // We expect: spill temp for await result, then final decl.
+        Assert.NotSame(body, result);
+
+        // None of the intermediate declarations should be for the literal 10.
+        foreach (var stmt in result.Statements)
+        {
+            if (stmt is BoundVariableDeclaration d && d.Variable.Name == "x")
+            {
+                continue;
+            }
+
+            if (stmt is BoundVariableDeclaration spillDecl)
+            {
+                // The spill temp should be for the await result, not for "10"
+                Assert.StartsWith(GeneratedNames.SpillTempPrefix, spillDecl.Variable.Name);
+            }
+        }
+    }
+
+    [Fact]
+    public void LogicalAnd_With_Await_OnRight_LowersToIf()
+    {
+        // Arrange: left && (await right)
+        var left = new BoundVariableExpression(new LocalVariableSymbol("a", true, TypeSymbol.Bool));
+        var rightAwait = new BoundAwaitExpression(new BoundLiteralExpression(true), TypeSymbol.Bool);
+        var binary = new BoundBinaryExpression(left, LogicalAndOp, rightAwait);
+        var stmt = new BoundExpressionStatement(binary);
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(stmt));
+
+        // Act
+        var result = SpillSequenceSpiller.Rewrite(body);
+
+        // Assert: should contain a conditional goto for short-circuit semantics
+        Assert.NotSame(body, result);
+        var hasConditionalGoto = false;
+        foreach (var s in result.Statements)
+        {
+            if (s is BoundConditionalGotoStatement)
+            {
+                hasConditionalGoto = true;
+                break;
+            }
+        }
+
+        Assert.True(hasConditionalGoto, "LogicalAnd with await should lower to conditional goto statements.");
+    }
+
+    [Fact]
+    public void LogicalOr_With_Await_OnRight_LowersToIf()
+    {
+        // Arrange: left || (await right)
+        var left = new BoundVariableExpression(new LocalVariableSymbol("a", true, TypeSymbol.Bool));
+        var rightAwait = new BoundAwaitExpression(new BoundLiteralExpression(false), TypeSymbol.Bool);
+        var binary = new BoundBinaryExpression(left, LogicalOrOp, rightAwait);
+        var stmt = new BoundExpressionStatement(binary);
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(stmt));
+
+        // Act
+        var result = SpillSequenceSpiller.Rewrite(body);
+
+        // Assert
+        Assert.NotSame(body, result);
+        var hasConditionalGoto = false;
+        foreach (var s in result.Statements)
+        {
+            if (s is BoundConditionalGotoStatement)
+            {
+                hasConditionalGoto = true;
+                break;
+            }
+        }
+
+        Assert.True(hasConditionalGoto, "LogicalOr with await should lower to conditional goto statements.");
+    }
+
+    [Fact]
+    public void Method_Call_With_Await_As_Second_Argument_SpillsFirstArg()
+    {
+        // Arrange: f(sideEffect(), await task)
+        var arg0 = MakeCall("sideEffect", TypeSymbol.Int);
+        var arg1 = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
+        var call = new BoundCallExpression(
+            MakeFunction("f", TypeSymbol.Int, TypeSymbol.Int, TypeSymbol.Int),
+            ImmutableArray.Create<BoundExpression>(arg0, arg1));
+        var decl = new BoundVariableDeclaration(
+            new LocalVariableSymbol("r", false, TypeSymbol.Int), call);
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(decl));
+
+        // Act
+        var result = SpillSequenceSpiller.Rewrite(body);
+
+        // Assert: first arg should be spilled into a temp before the await
+        Assert.NotSame(body, result);
+        Assert.True(result.Statements.Length >= 2, "Expected at least one spill before the call.");
+
+        // Check first statement spills arg0
+        var firstDecl = Assert.IsType<BoundVariableDeclaration>(result.Statements[0]);
+        Assert.StartsWith(GeneratedNames.SpillTempPrefix, firstDecl.Variable.Name);
+    }
+
+    [Fact]
+    public void Method_Call_On_Reference_Receiver_With_Await_Arg_SpillsReceiver()
+    {
+        // Arrange: receiver.Method(await task)
+        var receiver = MakeCall("getObj", TypeSymbol.String);
+        var arg = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
+        var method = typeof(string).GetMethod("Substring", new[] { typeof(int) });
+        var call = new BoundImportedInstanceCallExpression(
+            receiver, method, TypeSymbol.String,
+            ImmutableArray.Create<BoundExpression>(arg));
+        var decl = new BoundVariableDeclaration(
+            new LocalVariableSymbol("s", false, TypeSymbol.String), call);
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(decl));
+
+        // Act
+        var result = SpillSequenceSpiller.Rewrite(body);
+
+        // Assert: receiver should be spilled
+        Assert.NotSame(body, result);
+        // Find the spill temp for the receiver
+        var hasReceiverSpill = false;
+        foreach (var s in result.Statements)
+        {
+            if (s is BoundVariableDeclaration d
+                && d.Variable.Name.StartsWith(GeneratedNames.SpillTempPrefix)
+                && d.Initializer is BoundCallExpression)
+            {
+                hasReceiverSpill = true;
+                break;
+            }
+        }
+
+        Assert.True(hasReceiverSpill, "Receiver should be spilled when args contain await.");
+    }
+
+    [Fact]
+    public void Nested_Await_In_Binary_BothSidesAwait_BothSpilled()
+    {
+        // Arrange: (await t1) + (await t2)
+        var awaitLeft = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
+        var awaitRight = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
+        var binary = new BoundBinaryExpression(awaitLeft, AddOp, awaitRight);
+        var decl = new BoundVariableDeclaration(
+            new LocalVariableSymbol("x", false, TypeSymbol.Int), binary);
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(decl));
+
+        // Act
+        var result = SpillSequenceSpiller.Rewrite(body);
+
+        // Assert: both awaits should be spilled
+        Assert.NotSame(body, result);
+        var spillCount = 0;
+        foreach (var s in result.Statements)
+        {
+            if (s is BoundVariableDeclaration d
+                && d.Variable.Name.StartsWith(GeneratedNames.SpillTempPrefix))
+            {
+                spillCount++;
+            }
+        }
+
+        Assert.True(spillCount >= 2, $"Expected at least 2 spill temps but got {spillCount}.");
+    }
+
+    [Fact]
+    public void Await_AlreadyAt_TopLevel_NotSpilled()
+    {
+        // Arrange: await task (expression statement)
+        var awaitExpr = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
+        var stmt = new BoundExpressionStatement(awaitExpr);
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(stmt));
+
+        // Act
+        var result = SpillSequenceSpiller.Rewrite(body);
+
+        // Assert: should be unchanged (idempotent)
+        Assert.Same(body, result);
+    }
+
+    [Fact]
+    public void NonAsync_Function_NotProcessed()
+    {
+        // Arrange: a body without any await
+        var literal = new BoundLiteralExpression(42);
+        var decl = new BoundVariableDeclaration(
+            new LocalVariableSymbol("x", false, TypeSymbol.Int), literal);
+        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(decl));
+
+        // Act
+        var result = SpillSequenceSpiller.Rewrite(body);
+
+        // Assert: should be unchanged
+        Assert.Same(body, result);
+    }
+
+    private static BoundCallExpression MakeCall(string name, TypeSymbol returnType)
+    {
+        var func = new FunctionSymbol(
+            name,
+            ImmutableArray<ParameterSymbol>.Empty,
+            returnType);
+        return new BoundCallExpression(func, ImmutableArray<BoundExpression>.Empty);
+    }
+
+    private static FunctionSymbol MakeFunction(string name, TypeSymbol returnType, params TypeSymbol[] paramTypes)
+    {
+        var parameters = ImmutableArray.CreateBuilder<ParameterSymbol>();
+        for (var i = 0; i < paramTypes.Length; i++)
+        {
+            parameters.Add(new ParameterSymbol("p" + i, paramTypes[i]));
+        }
+
+        return new FunctionSymbol(name, parameters.ToImmutable(), returnType);
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -255,6 +255,7 @@ RelationalPattern
 ReturnStatement
 ScopeStatement
 SelectStatement
+SpillSequenceExpression
 StateMachineAwaitOnCompleted
 StructLiteralExpression
 SwitchExpression


### PR DESCRIPTION
Implements the **SpillSequenceSpiller** pass (spec §7), allowing `await` to appear inside sub-expressions, not only as a statement-level expression.

## What
- New `BoundSpillSequenceExpression` bound node: `(Locals, SideEffects, Value)` triple. Registered in `BoundTreeRewriter`, `BoundNodePrinter`, `BoundNodeKind`.
- New `SpillSequenceSpiller` rewriter under `src/Core/CodeAnalysis/Lowering/Async/`. Lifts `BoundAwaitExpression` to spill-statement top level by introducing spill temps for sibling sub-expressions that must be evaluated before the await.
- Handles: binary ops, short-circuit `&&`/`||` (lowered to conditional gotos because `BodyEmitter` doesn't see `BoundIfStatement`), method calls (user/imported/instance), conversions, assignments, instance receivers.
- Wired into `AsyncStateMachineRewriter` pipeline **before** `AsyncCaptureWalker` and `MoveNextBodyRewriter` (spec §2 order).

## Deferred (with code TODOs)
- `ref`/`out` arguments containing await (clean diagnostic).
- Value-type instance receivers when an argument contains await.
- `AsyncExceptionHandlerRewriter` is still TBD — when added it will run before this pass.

## Tests
- 9 unit tests in `SpillSequenceSpillerTests` covering bound-tree shape per case.
- 5 end-to-end PE round-trip tests in `AsyncSpillEmitTests`: `Await` as binary operand returning 42, await as second arg of two-arg method, short-circuit `&&` skipping await when LHS false, short-circuit `&&` evaluating await when LHS true, sequential awaits in the same expression.

## Counts
- 870 total tests pass (was 856; +14 new).
- Verified clean in **Release** as well as Debug on macOS arm64 — guards against Linux-only IL bugs like the one in #119.