### PR TITLE
Add sequence[T] type and yield keyword (ADR-0040)

### DIFF
--- a/docs/adr/0040-sequence-type-and-yield.md
+++ b/docs/adr/0040-sequence-type-and-yield.md
@@ -1,0 +1,130 @@
+# ADR-0040: `sequence[T]` type alias and `yield` statement
+
+- **Status**: Proposed
+- **Date**: 2026-05-26
+- **Phase**: Phase 7 follow-up — iterator support
+- **Related**: ADR-0023 (async state machine), ADR-0031 (canonical `for x in collection`), ADR-0034 (imported CLR interop), ADR-0039 (by-ref pointers)
+
+## Context
+
+GSharp already supports consumer-side iteration via `for x in collection` (ADR-0031), which works on arrays, slices, dictionaries, `IEnumerable[T]`, non-generic `IEnumerable`, and pattern-based `GetEnumerator()`. However, there is no producer-side iterator syntax — users cannot define lazy sequences that yield values one at a time. This means custom iteration logic must allocate a full collection up-front or implement the `IEnumerator[T]` interface manually, neither of which is ergonomic.
+
+The async state-machine infrastructure (ADR-0023) has established patterns for synthesized types, field maps, kickoff stubs, and `MoveNext` bodies. The sync iterator pattern is simpler (no builder, no awaiter) and can leverage the same architectural patterns.
+
+Async iterators (`IAsyncEnumerable[T]`) are aspirational but blocked until sync iterators are solid. This ADR covers sync iterators only.
+
+## Decision
+
+### 1. Introduce `sequence[T]` as a type alias for `IEnumerable[T]`
+
+By analogy with `map[K]V` aliasing `Dictionary[K, V]` (Phase 3.A.4), `sequence[T]` is the GSharp-flavored spelling of `System.Collections.Generic.IEnumerable<T>`. Both forms are interchangeable in declarations, parameter types, return types, and assignments. At the CLR metadata level they are the same type — no wrapper, no indirection.
+
+The `sequence` keyword is contextual: it is recognized only in type-annotation position (before `[`), and remains a valid identifier elsewhere.
+
+### 2. Introduce `yield <expr>` statement
+
+`yield <expr>` produces the next value of the enclosing iterator function. It is legal only in functions whose return type is one of:
+- `IEnumerable[T]` (equivalently `sequence[T]`)
+- `IEnumerator[T]`
+- `IEnumerable` (non-generic)
+- `IEnumerator` (non-generic)
+
+A function containing any `yield` statement becomes an *iterator function*. The `<expr>` must be assignable to the element type of the enclosing iterator's return type.
+
+### 3. `yield break` is not supported
+
+This slice does not implement `yield break`. The GSharp answer for early termination of an iterator is plain `return` — running off the end of the function body or executing `return` causes `MoveNext()` to return `false`. This is consistent with Go's approach where `return` is the single exit mechanism, and avoids a two-keyword statement form that has no analog in Go or Kotlin.
+
+### 4. Async iterators deferred
+
+`IAsyncEnumerable[T]` and `await foreach`-style async iteration are a separate future slice. The `sequence[T]` alias is sync-only; an `async_sequence[T]` or equivalent will be designed when that work begins.
+
+## Surface syntax
+
+### `sequence[T]` type
+
+Parses identically to `map[K]V`: the contextual keyword `sequence` followed by `[`, a type clause, and `]`. Example:
+
+```gsharp
+func fib(max: int) sequence[int] {
+    a, b := 0, 1
+    for a <= max {
+        yield a
+        a, b = b, a+b
+    }
+}
+```
+
+### `yield <expr>` statement
+
+Parses as a statement. The keyword `yield` is contextual — it is recognized as a keyword only when it appears as the first token of a statement and is followed by an expression (not a semicolon, `}`, or EOF). The bare identifier `yield` remains legal as a variable name:
+
+```gsharp
+yield := 42          // legal: short variable declaration
+fmt.Println(yield)   // legal: yield as identifier
+yield x + 1          // legal: yield statement in an iterator function
+```
+
+Disambiguation: at statement-start position, if the current token text is `"yield"` and the next token is not `:=`, `++`, `--`, `,`, `.`, `(`, `[`, `=`, or an assignment operator, it is parsed as a yield statement. Otherwise it falls through to expression/assignment parsing where `yield` is treated as an identifier.
+
+## Semantics
+
+The execution model is identical to C#'s iterator state machine:
+
+1. **Lazy**: calling an iterator function returns immediately with an `IEnumerable[T]` instance. No user code runs until the first `MoveNext()`.
+2. **Deferred side-effects**: side effects in the function body execute only when `MoveNext()` is called.
+3. **One-shot per enumeration**: each call to `GetEnumerator()` returns a fresh enumerator that starts from the beginning. The initial instance can serve as both `IEnumerable[T]` and `IEnumerator[T]` for the first enumeration (thread-id optimization).
+4. **Composition with `for x in`**: because iterator functions return `IEnumerable[T]`, they compose naturally with the existing `for x in seq` consumption (ADR-0031).
+
+## Codegen approach
+
+Synthesize a sealed class implementing `IEnumerable<T>`, `IEnumerator<T>`, `IDisposable`:
+
+- **Fields**: `<>1__state` (int), `<>2__current` (T), `<>l__initialThreadId` (int), parameter proxies, hoisted locals.
+- **`MoveNext()`**: state-dispatch switch at entry; each `yield x` becomes `current = x; state = K; return true; resumeK: state = -1;`. End of body: `state = -1; return false;`.
+- **`get_Current`**: returns `<>2__current`.
+- **`Dispose()`**: `state = -1` (no try/finally support this slice).
+- **`Reset()`**: throws `NotSupportedException`.
+- **`GetEnumerator()`**: if `state == -2 && threadId == initialThreadId`, transitions to state 0 and returns `this`; otherwise allocates a fresh instance with parameters copied.
+- **Non-generic `IEnumerator.Current`**: boxes via the generic property.
+
+The original function body is replaced with a kickoff stub: allocate the state machine with `state = -2`, copy parameters, return.
+
+This reuses architectural patterns from the async state-machine pipeline (`SynthesizedStateMachineType`, `ResumableStateAllocator`, etc.) but is a separate, simpler lowering pass since there is no builder or awaiter machinery.
+
+## Interop
+
+`sequence[T]` and `IEnumerable[T]` are the same type at the CLR metadata level. Functions declared with either spelling produce identical IL. Mixing both forms in a single program is well-defined. Values flow freely between GSharp iterators and .NET LINQ, `foreach`, and any other `IEnumerable[T]` consumer.
+
+## Diagnostics
+
+| ID | Message |
+|---|---|
+| GS9101 | `yield` statement is not allowed outside an iterator function |
+| GS9102 | Iterator function must return `IEnumerable[T]`, `IEnumerator[T]`, `IEnumerable`, or `IEnumerator` |
+| GS9103 | Cannot convert yielded expression of type `{actual}` to iterator element type `{expected}` |
+| GS9104 | `yield break` is not supported; use `return` to end iteration |
+
+## Open questions
+
+1. **Async iterators**: `IAsyncEnumerable[T]` support is deferred. Will likely introduce `async_sequence[T]` or reuse `sequence[T]` in async context.
+2. **Try/finally in iterators**: this slice does not support `try`/`finally` within iterator bodies (would require `Dispose()` to resume into finally blocks). A diagnostic is emitted if detected.
+3. **Interpreter parity**: the interpreter (`Evaluator.cs`) does not gain `yield` support in this slice. Iterator functions are emit-only. This is a known gap — the interpreter is authoritative per `docs/emit-pipeline.md` but iterator state machines are inherently an emit concern. Interpreter parity is tracked as follow-up work.
+
+## Alternatives considered
+
+### A. Generator functions with `func*` syntax
+
+A Go-style channel-based generator (`func fib() chan int`) was considered but rejected because it requires goroutine allocation per iteration, has different lifetime semantics, and doesn't compose with LINQ or `foreach`.
+
+### B. Reserved `yield` keyword
+
+Making `yield` a hard keyword was rejected because it would break any existing code using `yield` as a variable name and is inconsistent with the contextual-keyword precedent set by `in` (ADR-0031) and variance markers (ADR-0021).
+
+### C. `yield return` two-keyword form (C# style)
+
+Rejected in favor of bare `yield <expr>` for brevity and Go/Kotlin flavor. The `return` in C#'s `yield return` is vestigial — it aids disambiguation in C#'s grammar but is unnecessary in GSharp where `yield` is unambiguous at statement start.
+
+## Summary
+
+This ADR introduces producer-side iterator support via `sequence[T]` (alias for `IEnumerable[T]`) and `yield <expr>`. The feature uses a synthesized state-machine class following the well-established C# iterator pattern, reuses architectural patterns from the existing async pipeline, and composes naturally with the already-shipped `for x in` consumption syntax. `yield break` is omitted in favor of plain `return`; async iterators are deferred.

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -1,176 +1,309 @@
-# GSharp coverage matrix
+# GSharp coverage-matrix snapshot
+# Generated from SyntaxKind, BoundNodeKind, BoundBinaryOperator,
+# and BoundUnaryOperator. Drift fails CoverageMatrixGoldenTests.
 
-Front-end vs. back-end coverage of every distinct surface-language construct, traced from "lexer produces a token" → "parser builds a syntax node" → "binder lowers to a bound node" → "emitter writes IL" (and the interpreter's `Evaluator`, which `design/Gsharp-design-v0.1.md` declares the semantic source of truth).
+[SyntaxKind]
+AccessorExpression
+AmpersandAmpersandToken
+AmpersandEqualsToken
+AmpersandHatEqualsToken
+AmpersandHatToken
+AmpersandToken
+ArrayCreationExpression
+AssignmentExpression
+AsyncKeyword
+AwaitExpression
+AwaitForRangeStatement
+AwaitKeyword
+BadToken
+BangBangToken
+BangEqualsToken
+BangToken
+BinaryExpression
+BlockStatement
+BreakKeyword
+BreakStatement
+CallExpression
+CaseKeyword
+CatchClause
+CatchKeyword
+ChanKeyword
+ChannelReceiveExpression
+ChannelSendStatement
+ClassKeyword
+CloseBraceToken
+CloseParenthesisToken
+CloseSquareBracketToken
+ColonEqualsToken
+ColonToken
+CommaToken
+CommentToken
+CompilationUnit
+ConstKeyword
+ConstantPattern
+ContinueKeyword
+ContinueStatement
+DefaultKeyword
+DeferKeyword
+DeferStatement
+DiscardPattern
+DotToken
+EllipsisToken
+ElseClause
+ElseKeyword
+EndOfFileToken
+EnumDeclaration
+EnumKeyword
+EnumMember
+EqualsEqualsToken
+EqualsToken
+EventSubscriptionExpression
+ExpressionStatement
+FallthroughKeyword
+FalseKeyword
+FieldAccessExpression
+FieldAssignmentExpression
+FieldDeclaration
+FieldInitializer
+FinallyClause
+FinallyKeyword
+ForClauseStatement
+ForConditionStatement
+ForEllipsisStatement
+ForInfiniteStatement
+ForKeyword
+ForRangeStatement
+FuncKeyword
+FunctionDeclaration
+FunctionLiteralExpression
+GlobalStatement
+GoKeyword
+GoStatement
+GotoKeyword
+GreaterOrEqualsToken
+GreaterToken
+HatEqualsToken
+HatToken
+IdentifierToken
+IfKeyword
+IfStatement
+ImportDeclaration
+ImportKeyword
+IndexAssignmentExpression
+IndexExpression
+InterfaceDeclaration
+InterfaceKeyword
+InternalKeyword
+InterpolatedStringExpression
+InterpolatedStringToken
+IsKeyword
+LeftArrowToken
+LessOrEqualsToken
+LessToken
+LetKeyword
+ListPattern
+LiteralExpression
+MakeChannelExpression
+MapCreationExpression
+MapEntry
+MapKeyword
+MinusEqualsToken
+MinusMinusToken
+MinusToken
+MultiAssignmentStatement
+NameExpression
+NamedArgumentExpression
+NamedDeconstructionField
+NamedDeconstructionStatement
+NilKeyword
+NumberToken
+OpenBraceToken
+OpenKeyword
+OpenParenthesisToken
+OpenSquareBracketToken
+OperatorKeyword
+OverrideKeyword
+PackageDeclaration
+PackageKeyword
+Parameter
+ParenthesizedExpression
+PercentEqualsToken
+PercentToken
+PipeEqualsToken
+PipePipeToken
+PipeToken
+PlusEqualsToken
+PlusPlusToken
+PlusToken
+PrivateKeyword
+PropertyPattern
+PropertyPatternField
+PublicKeyword
+QuestionColonToken
+QuestionDotToken
+QuestionToken
+RangeKeyword
+RelationalPattern
+ReturnKeyword
+ReturnStatement
+RightArrowToken
+ScopeKeyword
+ScopeStatement
+SealedKeyword
+SelectCase
+SelectKeyword
+SelectStatement
+SemicolonToken
+SequenceKeyword
+ShiftLeftEqualsToken
+ShiftLeftToken
+ShiftRightEqualsToken
+ShiftRightToken
+SlashEqualsToken
+SlashToken
+StarEqualsToken
+StarToken
+StringToken
+StructDeclaration
+StructKeyword
+StructLiteralExpression
+SwitchCase
+SwitchExpression
+SwitchExpressionArm
+SwitchKeyword
+SwitchStatement
+ThrowKeyword
+ThrowStatement
+TrueKeyword
+TryKeyword
+TryStatement
+TupleDeconstructionStatement
+TupleLiteralExpression
+TypeAliasDeclaration
+TypeArgumentList
+TypeClause
+TypeKeyword
+TypeParameter
+TypeParameterList
+TypePattern
+UnaryExpression
+UsingKeyword
+UsingStatement
+VarKeyword
+VariableDeclaration
+WhitespaceToken
+WithExpression
+YieldStatement
 
-This file is the **golden** for the coverage-matrix introspection test (`test/Core.Tests/CoverageMatrix/`, execution plan §0.5). A new `SyntaxKind`, `BoundNodeKind`, or `BoundBinaryOperator`/`BoundUnaryOperator` entry that lands without an update here will fail that test on CI. The original prose source is `~/gsharp-gaps.md` §5; this file is the in-repo canonical copy.
+[BoundNodeKind]
+AddressOfExpression
+AppendExpression
+ArrayCreationExpression
+AssignmentExpression
+AwaitExpression
+AwaitForRangeStatement
+BinaryExpression
+BlockExpression
+BlockStatement
+CallExpression
+CapExpression
+ChannelCloseExpression
+ChannelReceiveExpression
+ChannelSendStatement
+ClrBinaryOperatorExpression
+ClrConstructorCallExpression
+ClrConversionCallExpression
+ClrEventSubscriptionExpression
+ClrIndexAssignmentExpression
+ClrIndexExpression
+ClrPropertyAccessExpression
+ClrPropertyAssignmentExpression
+ClrUnaryOperatorExpression
+ConditionalGotoStatement
+ConstantPattern
+ConstructorCallExpression
+ConversionExpression
+DereferenceExpression
+DiscardPattern
+ErrorExpression
+ExpressionStatement
+FieldAccessExpression
+FieldAssignmentExpression
+ForEllipsisStatement
+ForInfiniteStatement
+ForRangeStatement
+FunctionLiteralExpression
+GoStatement
+GotoStatement
+IfStatement
+ImportedCallExpression
+ImportedInstanceCallExpression
+IndexAssignmentExpression
+IndexExpression
+IndirectCallExpression
+LabelStatement
+LenExpression
+ListPattern
+LiteralExpression
+MakeChannelExpression
+MapDeleteExpression
+MapLiteralExpression
+NullConditionalAccessExpression
+PatternSwitchArm
+PatternSwitchStatement
+PropertyPattern
+PropertyPatternField
+RelationalPattern
+ReturnStatement
+ScopeStatement
+SelectStatement
+SpillSequenceExpression
+StateMachineAwaitOnCompleted
+StructLiteralExpression
+SwitchExpression
+SwitchExpressionArm
+ThrowStatement
+TryStatement
+TupleElementAccessExpression
+TupleLiteralExpression
+TypePattern
+UnaryExpression
+UserInstanceCallExpression
+VariableDeclaration
+VariableExpression
+YieldStatement
 
-Findings are based on `src/Core/CodeAnalysis/{Syntax/Lexer.cs, Syntax/Parser.cs, Binding/Binder.cs, Binding/BoundBinaryOperator.cs, Binding/BoundUnaryOperator.cs, Emit/ReflectionMetadataEmitter.cs}`.
+[BoundBinaryOperator]
+AmpersandAmpersandToken LogicalAnd (bool,bool) -> bool
+AmpersandHatToken BitClear (int,int) -> int
+AmpersandToken BitwiseAnd (bool,bool) -> bool
+AmpersandToken BitwiseAnd (int,int) -> int
+BangEqualsToken NotEquals (bool,bool) -> bool
+BangEqualsToken NotEquals (int,int) -> bool
+BangEqualsToken NotEquals (string,string) -> bool
+EqualsEqualsToken Equals (bool,bool) -> bool
+EqualsEqualsToken Equals (int,int) -> bool
+EqualsEqualsToken Equals (string,string) -> bool
+GreaterOrEqualsToken GreaterOrEquals (int,int) -> bool
+GreaterToken Greater (int,int) -> bool
+HatToken BitwiseXor (bool,bool) -> bool
+HatToken BitwiseXor (int,int) -> int
+LessOrEqualsToken LessOrEquals (int,int) -> bool
+LessToken Less (int,int) -> bool
+MinusToken Difference (int,int) -> int
+PercentToken Remainder (int,int) -> int
+PipePipeToken LogicalOr (bool,bool) -> bool
+PipeToken BitwiseOr (bool,bool) -> bool
+PipeToken BitwiseOr (int,int) -> int
+PlusToken Sum (int,int) -> int
+PlusToken Sum (string,string) -> string
+ShiftLeftToken ShiftLeft (int,int) -> int
+ShiftRightToken ShiftRight (int,int) -> int
+SlashToken Quotient (int,int) -> int
+StarToken Product (int,int) -> int
 
-Legend: ✅ = supported end-to-end. 🟡 = partially supported (caveats in the Notes column). ❌ = not implemented. — = not applicable at that layer.
-
-## Tokens
-
-| Token / class | Lexer | Reachable by parser? | Notes |
-| --- | --- | --- | --- |
-| Numeric literal | ✅ | ✅ | Decimal, `0x` hex, `0o` octal, `0b` binary (Phase 1.3); `_` allowed between digits and after the prefix. Floats / Go-style leading-zero octal not yet supported. |
-| String literal (double-quoted) | ✅ | ✅ | Includes Kotlin-style interpolation (`$ident`, `${expr}`) lowered to `+`-chain with `Convert.ToString` (Phase 1.1). `$$` escapes a literal `$`. |
-| Raw string literal (backtick) | ✅ | ✅ | Phase 1.2: contents verbatim, no escapes, CRLF/CR normalized to LF, multi-line allowed; embedded backticks not representable. |
-| Identifier | ✅ | ✅ | Unicode-aware via `char.IsLetter`/`char.IsLetterOrDigit` (categories Lu/Ll/Lt/Lm/Lo/Nl + Nd). Surrogate pairs not yet supported. See `docs/lexical.md`. |
-| `++` / `--` | ✅ | ✅ | Statement-only (Phase 2.2); the parser desugars `i++`/`i--` to `i = i ± 1` so the rest of the pipeline is unchanged. `let y = x++` is rejected at parse time. |
-| Compound assignment (`+=`, `-=`, `*=`, `/=`, `%=`, `^=`, `&=`, `|=`, `&^=`, `<<=`, `>>=`) | ✅ | ✅ | Phase 2.1: the parser desugars `x op= rhs` to `x = x op rhs`; the binder/lowerer/emitter need no per-operator change. |
-| `[` / `]` | ✅ | ❌ | No syntax node consumes them; indexing/slicing unreachable. |
-| `;` | ✅ | ❌ | Only synthesized internally; no statement separator role in source. |
-| `<-` (channel send/recv arrow) | ✅ | ✅ | Phase 5.4 / 5.5 / ADR-0022. Receive `<-ch` parses as a unary expression; the binder special-cases the `<-` token to a `BoundChannelReceiveExpression` typed as the channel element type. Send `ch <- v` is recognised at statement scope (an expression followed by `<-` becomes a `ChannelSendStatementSyntax`) and binds to `BoundChannelSendStatement`. Non-channel operands diagnose. Emit mirrors the interpreter's `ValueTask.AsTask().GetAwaiter().GetResult()` shape and traps `ChannelClosedException` on receive to yield the element zero value (Phase E). |
-| `->` (switch-expression arm arrow) | ✅ | ✅ | Phase 6.1: separates `case` / `default` arms from result expressions in `switch` expressions. |
-| `&^` (Go bit-clear) | ✅ | ✅ | End-to-end for `int` operands; emitter implements as `not; and`. |
-
-## Top-level constructs
-
-| Construct | Parser | Binder | Emit | Interp | Notes |
-| --- | --- | --- | --- | --- | --- |
-| `package A.B.C` | ✅ | ✅ | ✅ | ✅ | Dotted; no aliases. |
-| `import A.B.C` | ✅ | ✅ | ✅ | ✅ | Aliased form `import alias = path` lands in Phase 1.4. Implicit `import System` is on by default (Phase 1.5; opt-out via `gsc /noimplicitimports`). No parenthesized groups, no string-path imports, no per-file `import` blocks. |
-| Top-level statements | ✅ | ✅ | ✅ | ✅ | Entry point synthesized; one file may carry them. |
-| `func name(params) Ret { … }` | ✅ | ✅ | ✅ | ✅ | Single return type only. Accepts optional `public`/`internal`/`private` modifier (Phase 2.8); default is `public` per ADR-0014. |
-| Multiple return values / named returns | ❌ | — | — | — | |
-| Receiver-clause functions `func (r R) M(...)` | ✅ | ✅ | ✅ | ✅ | Phase 3.B.6 + Phase 6.4: Form A is shared. If `R` is declared in the same package and is a `struct` or `class`, the declaration is appended to `R`'s method set and dispatches like an instance method. If `R` is a cross-package, CLR, or primitive type, it remains an extension function with the receiver as parameter 0. Same-package interface/enum/alias receivers diagnose. |
-| Variadic / generic function parameters | ✅ | ✅ | ✅ | ✅ | Variadic `...T` is supported on function declarations and calls; generic function type parameters use `func Name[T any](...)`. |
-| `public` / `internal` / `private` modifiers | ✅ | ✅ | ✅ (func) | — | Phase 2.8 / ADR-0014: allowed on top-level `func`, `type`, `var`, `let`, `const`. Default is `public`. Emitter maps to `MethodAttributes.Public`/`Assembly`/`Private` for functions; global-variable accessibility is recorded for future field emission. |
-
-## Statements
-
-| Statement | Parser | Binder | Emit | Interp | Notes |
-| --- | --- | --- | --- | --- | --- |
-| Block `{ … }` | ✅ | ✅ | ✅ | ✅ | |
-| `var x [T] = e` / `let x [T] = e` / `const x [T] = e` | ✅ | ✅ | ✅ | ✅ | Single identifier; no `var (…)` group. `let` (since Phase 1.6) is an immutable runtime binding — same binder behavior as `const`. |
-| `x := e` | ✅ | ✅ | ✅ | ✅ | Single and multi-target forms (Phase 2.3): `a, b := 1, 2` declares N variables. Call-form `a, b := f()` still waits on Phase 4 multi-return. |
-| `x = e` | ✅ | ✅ | ✅ | ✅ | Single and multi-target forms (Phase 2.3): `a, b = b, a` evaluates every RHS into a fresh temporary before any assignment lands, matching Go's swap semantics. |
-| `if cond stmt [else stmt]` | ✅ | ✅ | ✅ | ✅ | No `if init; cond` form. |
-| `for { }` (infinite) | ✅ | ✅ | ✅ | ✅ | |
-| `for i := lo ... hi { }` | ✅ | ✅ | ✅ | ✅ | GSharp-specific; not Go's `for i := lo; i < hi; i++`. |
-| `for cond { }` (while-style) | ✅ | ✅ | ✅ | ✅ | Lowered in the binder to `goto checkLabel; body; check: if cond goto body`. |
-| `for init; cond; post { }` (C-style) | ✅ | ✅ | ✅ | ✅ | Header parts are all optional; `for ;; { }` is the infinite form. `continue` jumps to `post` then re-evaluates `cond`. |
-| `for v in coll`; legacy `for k, v := range coll` | ✅ | ✅ | ✅ | ✅ | Phase 7.2 / ADR-0031: canonical `for v in coll` and `for k, v in dict` route to the same `BoundForRangeStatement` as the legacy Phase-4 `:= range` spelling, which continues to bind unchanged. Arrays/slices (index-based), CLR `IDictionary[K,V]` (key/value), CLR `IEnumerable[T]` and non-generic `IEnumerable` (element-with-counter), plus pattern-based `GetEnumerator()` with `bool MoveNext()` and `Current` property/field for imported CLR and user-defined types work through the shared lowerer on both interpreter and emit paths. |
-| `break` / `continue` | ✅ | ✅ | ✅ | ✅ | No labels. |
-| `return [e]` | ✅ | ✅ | ✅ | ✅ | Single expr; line-sensitive. |
-| `switch` / `case` / `default` | ✅ | ✅ | ✅ | ✅ | Phase 2.6: statement switch; Phase 6.2 case values now bind as patterns (constant, discard, type, property, relational, list) and the interpreter dispatches a `BoundPatternSwitchStatement`. Phase 6.3 diagnoses non-exhaustive enum and sealed-interface statement switches when no top-level discard/default arm is present; duplicate-covered variants are accepted until unreachable-arm analysis lands. Phase 6.6 ✅ narrows nullable discriminants inside type-pattern and non-nil constant-pattern arms. Each case body is a brace block. Emit lowers a pattern switch statement directly: the discriminant is evaluated once into a temp; each non-default arm gets its own `nextArm` label and pattern dispatch (constant/discard/type/property/relational/list) branches there on failure or falls through to the arm body; the default arm (if present) is emitted last and falls through to the end label. |
-| `fallthrough` | ❌ | — | — | — | ADR-0013 rejects Go-style implicit case fallthrough. The keyword remains reserved; the parser emits a diagnostic if it appears. |
-| `using let/var/const x = e` | ✅ | ✅ | ✅ | ✅ | Phase 3.D.3, converged in Phase 7.1 / ADR-0030: binds the declaration at the point it appears and wraps subsequent statements in the enclosing block in `try/finally { x.Dispose() }`, so disposal is LIFO and exception-safe. |
-| `defer` | ✅ | ✅ | ✅ | ✅ | Phase 7.1 / ADR-0030: `defer <call>` is block-scoped and LIFO. Arguments are captured eagerly into synthesized immutable locals, then the remaining block lowers to nested `try/finally` cleanup calls. Non-call operands diagnose. |
-| `go` (goroutine) | ✅ | ✅ | ✅ | ✅ | Phase 5.3 / ADR-0022. `go <call>` schedules the call on `Task.Run(Action)`. Only call expressions are accepted as operands. The interpreter serializes body execution with a monitor on the evaluator to keep the shared locals/globals stacks safe; concurrency is observational rather than parallel. Phase F emit synthesizes a per-go-site display class so captured variables are snapshotted into fields and the generated `InvokeAction` method can be registered as an `Action`; when lexically inside `scope`, the returned `Task` is appended to the scope frame. |
-| `select` | ✅ | ✅ | ✅ | ✅ | Phase 5.6 / ADR-0022. Arms: `case <-ch { … }` (recv-discard), `case v := <-ch { … }` (recv-bind — declares `v` typed as the channel's element type, visible only in the arm body), `case ch <- v { … }` (send), and at most one `default { … }`. Body uses brace-block (consistent with GSharp's `switch`), not Go's colon-terminator. Empty `select { }` and duplicate `default` arms diagnose; send/receive operand type-checks reuse the existing channel diagnostics. Evaluator and emitter implement the ADR-0022 algorithm: snapshot channels, source-order readiness checks, take `default` if no arm is ready, otherwise block on `Task.WhenAny` of per-arm `WaitToRead/WriteAsync` and retry. Drained-closed receive surfaces as the element type's zero value. Lowerer flattens each arm body so nested `if`/`for`/etc. inside arms work end-to-end. |
-| `async func` / `await e` | ✅ | ✅ | — | ✅ | Phase 5.1+5.2 / ADR-0023 (interpreter). `async` is a `func` modifier; the call-site return type is wrapped as `Task` / `Task[T]`. `await` is an expression that unwraps the awaited element type. The interpreter realizes an async function as `Task.FromResult(body-result)` and `await` blocks via `GetAwaiter().GetResult()`. Emit deferred to Phase 7 (state machine). |
-| `scope { … }` | ✅ | ✅ | ✅ | ✅ | Phase 5.7 / ADR-0022. `scope { … }` opens a structured-concurrency block; the body binds in a fresh lexical scope. `go` statements lexically inside the body have their backing `Task` registered with the innermost scope frame instead of being fire-and-forget. At scope exit the evaluator awaits `Task.WhenAll` on the frame's tasks; on any failure the scope's `CancellationTokenSource` is cancelled (cooperative shut-down of sibling tasks) and the first failure is rethrown — additional failures attach as `AggregateException.InnerExceptions[1..]`. Nested `scope` blocks compose via a stack of frames. Phase F emit preallocates scope frame locals (`List<Task>`, `CancellationTokenSource`, awaiter), registers nested go tasks, waits in a finally, and disposes the CTS. Source-level `ctx` binding and async-aware lowering remain deferred. |
-| `await for v := range stream` | ✅ | ✅ | — | ✅ | Phase 5.8 / ADR-0023 (interpreter). The stream operand must implement `IAsyncEnumerable[T]`; the loop variable is typed as `T`. The interpreter realizes the iteration by reflectively calling `GetAsyncEnumerator(ct)` → looping `MoveNextAsync()` (blocking each `ValueTask` via `.AsTask().GetAwaiter().GetResult()`, the same pragma Phase 5.1 uses for `await`) → assigning `Current` to the loop variable → evaluating the body → `DisposeAsync()` in a `finally`. When the statement is lexically inside a `scope { … }`, the scope's `CancellationTokenSource` is plumbed into `GetAsyncEnumerator`; otherwise `CancellationToken.None`. Operand type-checks surface a dedicated diagnostic. Lowerer flattens the body so nested `if`/`for`/etc. inside the loop work (Phase 5 exit). `break` / `continue` inside the body, the async-aware lowering, and emit are deferred. |
-| `goto` / labels | ❌ | 🟡 | 🟡 | 🟡 | `BoundGotoStatement` / `BoundLabelStatement` exist as **lowering artifacts** for `for`/`if`; not surfaceable from source. |
-| Send statement `ch <- v` / receive `<-ch` | ✅ | ✅ | ✅ | ✅ | Phase 5.4 / 5.5 / ADR-0022. `ch <- v` is a `ChannelSendStatementSyntax` at statement scope; `<-ch` is a unary-form expression. The binder requires a `chan T` operand and infers the element type. Interpreter realizes channels as `System.Threading.Channels.Channel[T]` — send is `Writer.WriteAsync(v).AsTask().GetAwaiter().GetResult()`, receive is `Reader.ReadAsync().AsTask().GetAwaiter().GetResult()` (catches `ChannelClosedException` and returns the element type's zero value). Phase E emit lowers to the same IL shape using per-call-site `ValueTask`/`TaskAwaiter` scratch slots and a `MethodSpec`-encoded `Channel.CreateUnbounded<T>` / `CreateBounded<T>` call site. Two-value receive (`v, ok := <-ch`) and the async-aware lowering remain deferred. |
-| Increment/decrement statement (`i++`, `i--`) | ✅ | ✅ | ✅ | ✅ | Parser desugars to `i = i ± 1` (Phase 2.2). Statement-only — not valid in expression position. |
-| `type` declaration (alias or defined type) | ✅ | ✅ | — | ✅ | Phase 2.7: `type Name = Other` declares an erased alias resolvable anywhere an `int`/`bool`/`string` (or other alias) is. Defined types (with their own identity) and structural types arrive in Phase 3. |
-| `struct` declaration | ✅ | ✅ | ✅ | ✅ | Phase 3.B.1: `type Name struct { Field Type … }` declares a value-typed aggregate. Emitted as a CLR `ValueType` (sealed, sequential layout) under the declaring package's namespace. Composite literal `Name{Field: …}`, field read `p.Field`, and field assignment `p.Field = …` work on both backends with Go-style value semantics (assignment deep-copies). Field assignment receivers are restricted to simple variables for Phase 3.B.1. Phase 6.4 adds top-level Form A methods (`func (p Point) M()`) for same-package structs; they are equivalent to methods in the aggregate method set. |
-| `data struct` declaration | ✅ | ✅ | ✅ | ✅ | Phase 3.B.2 / ADR-0029: `type Name data struct { Field Type … }` is a struct whose values compare with structural equality via `==` / `!=`. `data` is a context-sensitive keyword (only special before `struct`); empty `data struct` is a binder diagnostic. Phase 7.3 / ADR-0032 adds data-struct ergonomics: `.copy(F = v, …)` and `expr with { F = v }` lower through a synthesized single-eval local into `BoundStructLiteralExpression`, and `let (a, b) = data` plus `let { F = a } = data` deconstruct through synthesized locals by field order or name. Emit lowers `==` / `!=` to a boxed call through `Object.Equals(object, object)`, which routes through the inherited `ValueType.Equals` reflection-based field-by-field comparison — same observable semantics as the interpreter's structural `Equals`/`GetHashCode`/`ToString`. Explicit synthesized `Equals(T)` / `GetHashCode` / `op_Equality` / `Deconstruct` methods on the struct's CLR `TypeDef` are a future iteration. |
-| `inline struct` declaration | ✅ | ✅ | ✅ | ✅ | Phase 7.4 / ADR-0033: `type Name inline struct(value T)` declares a readonly single-field value wrapper. `inline` is contextual and only valid before `struct`; it cannot combine with `data`, `record`, or `open`. The binder enforces exactly one field across primary-constructor parameters and body fields, marks the field readonly, permits positional deconstruction, and keeps nominal type identity so two wrappers over the same underlying type are not assignable or comparable. Emit writes a sealed sequential value type with an init-only public field, `IsReadOnlyAttribute`, and synthesized `Equals(object)`, `Equals(Name)`, `GetHashCode`, `ToString`, equality operators, and `Deconstruct`. |
-| `record` declaration alias | ✅ | ✅ | ✅ | ✅ | Phase 6.7 / ADR-0025: `type Name record { Field Type … }` is a pure parse-time alias for `type Name data struct { Field Type … }`. `record` is contextual and only special in a type-declaration header when followed by `{`; elsewhere it remains an ordinary identifier. The bound tree, symbols, emit, equality semantics, and ADR-0029 synthesized-member behavior are identical to `data struct`. `record class`, positional constructor records, record-specific `with` semantics beyond ADR-0032 data-struct sugar, `open record`, and `sealed record` are out of scope. |
-| `type Name enum { A, B, C }` | ✅ | ✅ | — | ✅ | Phase 6.8. Members auto-number from 0. Underlying type is `System.Int32`. `Color.Red` member access; equality only (no ordering). Usable as switch discriminant in both the statement and expression forms. Phase 6.3 exhaustiveness accepts all members covered by constant patterns or a top-level discard/default. Explicit member values (`Red = 5`) and emit are deferred. |
-| `class` declaration | ✅ | ✅ | ✅ | ✅ | Phase 3.B.3 (sub-steps 1 + 2 primary ctor + 2b methods + 3 single inheritance): `type Name class { Field Type … }` declares a reference-typed aggregate; `type Name class(p1 T1, p2 T2) { … }` additionally declares a Kotlin-style primary constructor whose parameters become public fields of the same name (ADR-0017 lock-in). Composite literal `Name{Field: …}` continues to work for any class (uses the implicit parameterless ctor); `Name(arg1, arg2)` invokes the declared primary ctor positionally. Body fields not listed in the primary ctor are zero-initialized. Reference semantics: assignment shares the instance and field writes mutate in place so all references observe the update. Methods inside the body (`func Name(args) Ret { body }`) and Phase 6.4 same-package top-level receiver methods (`func (c C) Name(args) Ret { body }`) are dispatched via `receiver.Method(args)`; a bare identifier `X` inside either body resolves to `this.X` if `X` is a field of the enclosing class (implicit-`this` field access and assignment). Method declarations inside a `struct` body are diagnosed. Single inheritance per ADR-0017: `open class Base { open func F() T { … } }` declares a subclassable class with an overridable method; `class Derived : Base { override func F() T { … } }` extends it. Sealed-by-default — subclassing a non-`open` class diagnoses `Class 'X' is not open; declare 'open class X' to allow subclassing.`. Method-side: `open` (overridable), `override` (sealed override), `open override` (overridable override). Missing `override` when redefining an inherited open method diagnoses `Method 'B.F' is overridable; add 'override' to redefine it.`. Overriding a non-open method, mismatched signatures, or override of an unknown base all diagnose. Derived fields shadow base fields by name; inherited fields are bare-name accessible inside derived methods. Virtual dispatch routes `(base)d.F()` to the derived override at runtime on both backends. Emit lowers a class as a CLR reference type (TypeAttributes.Sealed when not `open`), BaseType pointing at the user base class TypeDef (else `System.Object`); methods are virtual+newslot+final by default, with `open` clearing Final, `override` clearing NewSlot, and `open override` clearing both; derived `.ctor` chains to the base `.ctor`. Forward base references are not supported — base must be declared before derived. |
-
-## Expressions
-
-| Expression | Parser | Binder | Emit | Interp | Notes |
-| --- | --- | --- | --- | --- | --- |
-| Integer / string / bool literal | ✅ | ✅ | ✅ | ✅ | Emitter literal table covers only `int`/`string`/`bool`. |
-| Name | ✅ | ✅ | ✅ | ✅ | |
-| Call `f(args)` | ✅ | ✅ | ✅ | ✅ | |
-| Member access `a.b.c` | ✅ | ✅ | ✅ | ✅ | `AccessorExpressionSyntax`; resolves through `ReferenceResolver` to imported CLR types. |
-| Parenthesized | ✅ | ✅ | ✅ | ✅ | |
-| Assignment expression `x = e` | ✅ | ✅ | ✅ | ✅ | Identifier LHS only. |
-| Indexing `a[i]` | ✅ | ✅ | ✅ | ✅ | Phase 3.A.3: read and write indexing on fixed-length arrays and slices via `IndexExpressionSyntax` and `IndexAssignmentExpressionSyntax`. Phase 3.A.4 extends to `map[K]V` (key-based; missing keys return the value type's zero value — the comma-ok form is deferred). Sliced reads (`a[lo:hi]`, `a[lo:hi:max]`) are not implemented. |
-| Composite literal `[N]T{…}` / `[]T{…}` / `map[K]V{…}` | ✅ | ✅ | ✅ | ✅ | Phase 3.A.1: fixed-length array literal `ArrayCreationExpressionSyntax`; Phase 3.A.2 extends the same node to variable-length slice literals (length omitted). Phase 3.A.4 adds `MapCreationExpressionSyntax` lowered to `Dictionary[K,V]` — emit issues `newobj` + per-entry `set_Item`. |
-| Built-in `len(x)` / `cap(x)` / `append(s, e)` / `delete(m, k)` | ✅ | ✅ | ✅ | ✅ | Phase 3.A.2: `len` on string/array/slice, `cap` on array/slice (aliases length per ADR-0016), `append` on slice (single trailing element only; variadic Go form deferred to Phase 4). Phase 3.A.4 extends `len` to `map[K]V` (emit: `callvirt get_Count`) and adds `delete(m, k)` (emit: `callvirt Remove`, pop bool). |
-| Built-in `make(chan T)` / `make(chan T, cap)` | ✅ | ✅ | ✅ | ✅ | Phase 5.4 / ADR-0022. `make` is contextual (not a keyword) — recognised when it precedes `(chan …)`. Capacity-less form lowers to `Channel.CreateUnbounded[T]()`; the capacity form lowers to `Channel.CreateBounded[T](new BoundedChannelOptions(cap))`. Phase E emit closes the gap via `MethodSpec` instantiation of the generic `CreateUnbounded`/`CreateBounded` factories. |
-| Built-in `close(ch)` | ✅ | ✅ | ✅ | ✅ | Phase 5.4 / ADR-0022. Intrinsic — operand must be a `chan T`. Lowers to `ch.Writer.Complete()`. Subsequent receives drain buffered values, then return the element type's zero value. Phase E emit calls `ChannelWriter<T>.Complete(null)` directly. |
-| Type assertion / conversion (`x.(T)`, `T(x)`) | 🟡 | 🟡 | — | 🟡 | Built-in type names invoked as `int(x)` route through `BindCallExpression` → `BindConversion`; emit currently only handles bool↔int. Go-style `x.(T)` does not exist. |
-| Address-of `&x` / dereference `*x` | 🟡 | ❌ | — | — | Parsed as unary, but no `BoundUnaryOperator` entry → binder rejects. The `Loop.gs` design sample's `*count` is **unimplementable today**. |
-| Channel receive `<-ch` | ✅ | ✅ | — | ✅ | See "Send statement / receive" row above. Phase 5.5 / ADR-0022 (interpreter). |
-| `switch` expression (`let x = switch v { case A -> r1 default -> r2 }`) | ✅ | ✅ | ✅ | ✅ | Phase 6.1 expression form; Phase 6.2 case values now bind as patterns (constant, discard, type, property, relational, list). Phase 6.3 allows enum and sealed-interface discriminants to omit `default` when all variants are covered; non-exhaustive closed discriminants diagnose missing arms. Phase 6.6 ✅ narrows nullable discriminants inside type-pattern and non-nil constant-pattern arm results. Other discriminants still require `default`. Duplicate-covered variants are accepted; unreachable-arm analysis is deferred. All arm result expressions unify to a single type. Interpreter evaluates arms in source order. Emit allocates a result temp plus a discriminant temp per switch expression and reuses the Phase B pattern-dispatch helpers; arm bodies `stloc` the result before branching to the end label, where the temp is loaded to yield the expression's value. |
-| Higher-order call `f()(args)` / function values | ✅ | ✅ | ✅ | ✅ | Phase 4.7 — first-class function types (`func(T) R`), indirect-call expressions, function-typed locals/params/returns. |
-| Function literal / lambda | ✅ | ✅ | ✅ | ✅ | Phase 4.7 (`func(...) {...}` literal); Phase 4.9 adds Kotlin-style trailing-lambda call syntax — `f(args) func(...) {...}` desugars to `f(args, func(...) {...})` at parse time. |
-
-## Patterns
-
-| Pattern | Parser | Binder | Emit | Interp | Notes |
-| --- | --- | --- | --- | --- | --- |
-| Constant pattern (`case 1`) | ✅ | ✅ | ✅ | ✅ | Legacy case expression spelling now wraps as `ConstantPatternSyntax`; equality uses `object.Equals` in the interpreter. Phase 6.6 ✅ narrows a nullable switch discriminant to its underlying type for non-`nil` constants. Emit reuses the standard equality path on the discriminant temp; `nil` constants emit a `ldnull/ceq` check. |
-| Discard pattern (`case _`) | ✅ | ✅ | ✅ | ✅ | Matches any discriminant value; top-level discard behaves like a lenient default arm. Emit is a no-op (falls through to arm body). |
-| Type pattern (`case v is User`) | ✅ | ✅ | ✅ | ✅ | Introduces read-only arm-local binding `v`; interpreter supports GSharp struct/class values and imported CLR instances. Phase 6.6 ✅ also narrows a nullable switch discriminant to the target type within that arm. Emit boxes value-typed discriminants, executes `isinst Target`, stores the result in a scratch local, branches to the next arm on null, and otherwise stores the narrowed value (with `unbox.any` for value targets) into the arm-local. |
-| Property pattern (`case { Name: "x" }`) | ✅ | ✅ | ✅ | ✅ | Applies to GSharp struct/class discriminants; field values recurse into nested patterns. Emit composes a child value-loader closure per field (`ldfld FieldHandle` on the receiver) and recurses into the nested pattern, branching to the arm-fail label on the first mismatch. |
-| Relational pattern (`case > 0`) | ✅ | ✅ | ✅ | ✅ | Operators bind through `BoundBinaryOperator`; `==` / `!=` are accepted. Emit loads the discriminant, evaluates the operand, and uses the standard `ceq/clt/cgt` (plus negation) sequence followed by `brfalse fail`. |
-| List pattern (`case [1, _, 3]`) | ✅ | ✅ | ✅ | ✅ | Applies to arrays/slices with exact length matching; `..` slice patterns are deferred. Emit checks `Ldlen == N` then recurses per element with a `ldelem`-based child loader. |
-
-## Operators (semantic coverage)
-
-`BoundBinaryOperator` and `BoundUnaryOperator` enumerate every operator the binder will accept. The parser otherwise produces all Go tokens.
-
-| Operator | int | bool | string | Imported types |
-| --- | --- | --- | --- | --- |
-| `+` | ✅ | — | ✅ (string concat via `String.Concat`) | ✅ (Stream C: `op_Addition` on either operand's type) |
-| `-` `*` `/` `%` | ✅ | — | — | ✅ (Stream C: `op_Subtraction`, `op_Multiply`, `op_Division`, `op_Modulus`) |
-| `<<` `>>` | ✅ | — | — | ✅ (Stream C: `op_LeftShift`, `op_RightShift`) |
-| `&` `\|` `^` `&^` | ✅ | partial (`&`/`\|`/`^` ✅, `&^` ❌) | — | ✅ for `&` `\|` `^` (`op_BitwiseAnd`, `op_BitwiseOr`, `op_ExclusiveOr`); `&^` is still GSharp-side only |
-| `&&` `\|\|` | — | ✅ | — | ❌ (requires `op_True`/`op_False` lowering — deferred) |
-| `==` `!=` | ✅ | ✅ | ✅ (via `String.Equals`) | ✅ (Stream C: `op_Equality`/`op_Inequality`) |
-| `<` `<=` `>` `>=` | ✅ | — | — | ✅ (Stream C: `op_LessThan`, `op_LessThanOrEqual`, `op_GreaterThan`, `op_GreaterThanOrEqual`) |
-| unary `+` `-` `^` | ✅ | — | — | ✅ for `+`/`-` (`op_UnaryPlus`, `op_UnaryNegation`); `~` (CLR `op_OnesComplement`) currently maps to GSharp `^` |
-| unary `!` | — | ✅ | — | ✅ (`op_LogicalNot`) |
-| unary `*` `&` `<-` | ❌ | ❌ | ❌ | ❌ |
-| Operator-by-name on user types (`func (p Point) plus`) | — | — | — | ❌ Phase 6.5 / ADR-0026 (deferred): Kotlin-style implicit reinterpretation (e.g. a method named `plus` becoming `op_Addition`) is not adopted. |
-| Explicit `operator` keyword on user types (`func (a T) operator +(b T) T`) | ✅ | ✅ | ✅ | ✅ Stream D / ADR-0035: receiver-form binary (`+ - * / % & | ^ << >> == != < <= > >=`) and unary (`+ - ! ~`) operators on `struct` / `data struct` / `class` types. The parser synthesizes an `op_*` identifier; the binder resolves user operators (struct methods then extension functions) ahead of the imported-CLR `op_*` fallback. Value-type `struct` operators bind and run under the interpreter but share the pre-existing value-type-receiver IL-emit limitation (use `class` for compiled scenarios today). Free-function form, `operator implicit` / `operator explicit`, `++` / `--`, and `op_True` / `op_False` are deferred. |
-
-Operator resolution: when neither operand is a built-in, the binder runs the shared `OverloadResolution` over `op_*` candidates collected from both operand types (and their CLR base chains), deduped by identity. Ambiguous matches surface as a binder diagnostic; no first-match fallback. See `ClrOperatorResolution.cs`.
-
-Numeric overload tie-breaking: when two applicable candidates classify identically as `NumericWidening`, `OverloadResolution` applies C# §7.5.3.4 "better conversion target" — the smaller target (the one with an implicit conversion to the other) wins, and a signed integral target beats the corresponding unsigned peer (`sbyte`/`short`/`int`/`long` beat the matching unsigned types). See ADR-0037.
-
-Generic-method type inference (imported open generic methods, ADR-0038): when an imported method candidate is an open generic definition (`Enumerable.Repeat<TResult>(TResult, int)`), `OverloadResolution.TryInferTypeArguments` walks the parameter-to-argument pairs and records bounds on each method type parameter. Inference handles bare type parameters, arrays (`T[]`), byref (`out T` / `ref T`), and recursive instantiation through the argument's base-class chain and interface table (so `List<int>` binds an `IEnumerable<T>` parameter to `T = int`). With all bounds resolved, the resolver constructs the closed method via `MakeGenericMethod` (catching `ArgumentException` for constraint violations) and re-runs applicability + better-function-member on the closed candidate. Inference is first-phase input-type only; lambda/delegate-output inference and second-phase return-type-context inference remain deferred. Both backends already handle closed generic calls — the emitter wraps the open `MemberRef` in a `MethodSpecification` per ECMA-335 II.23.2.15, and the interpreter dispatches through `MethodInfo.Invoke`.
-
-Implicit and explicit conversions: `BindConversion` first runs the built-in `Conversion.Classify` (covers `int ↔ bool`, `nil` → nullable/reference, reference-compatible `T ↔ T?` for reference `T`, `struct → object` boxing, and reference-compatible upcasts to base classes or interfaces). When that returns `!Exists`, Stream E falls back to `ClrOperatorResolution.TryResolveConversion`, which searches public-static `op_Implicit` on the source and target CLR types, then `op_Explicit` when the call site allows explicit conversions. A successful resolution lowers to `BoundClrConversionCallExpression`; both the interpreter (`MethodInfo.Invoke`) and the emitter (`call` to the conversion method) dispatch the node. User-defined implicits also feed `OverloadResolution.UserDefinedImplicitConversionLookup`, so an `op_Implicit` participates in better-function-member tie-breaking for overload resolution.
-
-Reference upcasts (Phase 6 exit, added with `samples/aspirational/ExpressionEval.gs`): a `class` value implicitly converts to any interface it implements and to any of its (transitive) base classes. The interpreter treats the upcast as a no-op (the boxed instance keeps its concrete class identity), so `Lit{Value: 1}` flowing into an `Expr`-typed parameter or composite-literal field works end-to-end on the interpreter. Emit handles both **class → base-class** and **class → interface** upcasts as no-ops via the `IsReferenceCompatible` walk used by `EmitConversion`: the boxed reference already satisfies the target contract on the CLR, and the encoder threads interface TypeDefs through `EncodeTypeSymbol` so interface-typed slots, parameters, and return types all encode correctly.
-
-## Language server coverage
-
-| Capability | Status | Notes |
-| --- | --- | --- |
-| Document sync diagnostics | ✅ | Open/change publish parse + global-scope diagnostics for responsiveness; save publishes the full binding-stage pipeline. |
-| Folding ranges | ✅ | Top-level function bodies. |
-| Hover | ✅ | Markdown signature hovers for variables, functions, structs/classes, enums, fields, enum members, and known types. |
-| Find references | ✅ | Single-document references through the current document cache; cross-file/package references are a future enhancement. |
-| Rename | ✅ | Single-document workspace edits for user-code symbols; invalid identifiers and CLR/built-in symbols are rejected. |
-| Code actions | ✅ | Sort imports refactor is wired through `textDocument/codeAction`. |
-
-## Top-line takeaways
-
-1. **The dominant gap is parser → binder**, not binder → emit. The emitter implements essentially every bound node the binder can currently produce; failures show up as parser-rejections or binder "operator/conversion not supported" diagnostics.
-2. **Two design samples already exceed the implementation.** `samples/Loop.gs` (pre-Phase-0 rewrite) and `design/Gsharp-design-v0.1.md` use C-style `for init; cond; post`, `args[0]` indexing, `i--`, and `*count` — none of which parse today. The Phase-0 rewrite of `samples/Loop.gs` removes those constructs; the v0.1 design Loop section is annotated as aspirational pointing at `design/Gsharp-design-v0.2.md`.
-3. **String interpolation is real (Phase 1.1).** `"Count value: $i"` lexes as an `InterpolatedStringToken`, parses as `InterpolatedStringExpressionSyntax`, and lowers in the binder to a `+`-chain over `Convert.ToString` calls — emitted unchanged.
-4. **The emitter caps literals at `int`/`string`/`bool`.** Adding any new literal kind (float, char/rune, null) requires coordinated lexer + binder + `EmitLiteral` changes.
-5. **`EmitConversion` covers five built-in shapes plus user-defined CLR conversions.** Built-in: `int ↔ bool`, `nil → reference/nullable`, reference-compatible nullable wrap/unwrap (`T ↔ T?` for reference `T`, metadata-only), `struct → object` boxing, and reference-compatible upcasts (`class → base class` and `class → interface`). On top of that, Stream E lowers any unmatched conversion to `BoundClrConversionCallExpression` when an `op_Implicit` or (for explicit casts) `op_Explicit` exists on the source or target type — both backends dispatch through the resolved `MethodInfo`. Numeric widening / narrowing between unrelated CLR numeric types still requires either a built-in conversion shape or an `op_*` on one of the types.
-6. **Phase 5 concurrency emit covers the core surface.** Channels plus synchronous send/receive/close, `go`, `scope`, and `select` now emit (`samples/Channels.gs`, `samples/GoScope.gs`, `samples/Select.gs`). `async` / `await` emits state-machine kickoff and per-await MoveNext dispatch for straight-line code (no await-in-try/catch); `await for` remains interpreter-only.
-7. **Phase 6.1/6.2 switch on both backends.** `switch` statements with pattern arms (Phase B emit) and `switch` expressions (Phase C emit) lower in the emitter to a discriminant temp plus per-arm pattern-test branches; switch expressions additionally allocate a result temp that holds the chosen arm value. The same `EmitPattern` dispatcher handles every pattern flavor in both forms.
-
-## Phase 5 exit-criteria status (concurrency)
-
-| Exit criterion | Status | Evidence |
-| --- | --- | --- |
-| Meaningful concurrent sample fan-out + fan-in + timeout | ✅ both | `samples/PortScan.gs` — chan + go + scope + select with timeout arm; runs on both backends after the Phase A–G emit work and is covered by `SampleConformanceTests` (emit) as well as remaining interpreter unit tests. |
-| Pure async/await sample interoperating with BCL `Task` | ✅ interp | `samples/aspirational/AsyncTask.gs` — `async func` + `await` against `Task.Delay`, driven from a top-level `scope { go ... }`. Emit of `async`/`await` is deferred per ADR-0023. |
-| Coverage matrix ✅ on the entire concurrency section | ✅ interp / ✅ emit (except async) | Channels + go + scope + select all emit; only `async func` / `await` / `await for` remain emit-deferred (ADR-0023 Strategy A multi-month rewrite). |
-
-**Open Phase-5 polish follow-ups** (carried into Phase 6/7):
-
-- `HttpClient` end-to-end interop in a `.gs` sample: constructable imported types ✅ (Phase 4), instance / static member read+write ✅ (Stream B), imported `op_*` ✅ (Stream C), user-defined CLR conversions ✅ (Stream E), event subscription `+=` / `-=` ✅ (Stream B′ / ADR-0036). An `HttpClient`-using sibling to `AsyncTask.gs` is now unblocked end-to-end.
-- Two-value channel receive `v, ok := <-ch` (ADR-0022 §Open follow-ups).
-- `ctx` source binding to expose a scope's CTS to user code (ADR-0022 §scope; deferred from #78).
-- `break` / `continue` inside `await for` body (deferred from #79).
-- Async-aware lowering of `await` and emit of state machines (Phase 7 / ADR-0027).
-- ~~Event subscription (`obj.Click += handler`, `-=`) and multi-segment compound-assignment LHS (`a.b.c += …`) — Stream B′, parser-side work.~~ **Shipped** in Stream B′ / ADR-0036. A generalized `FunctionTypeSymbol → CLR-delegate` conversion (so function literals can be passed to non-event APIs expecting custom delegates) remains a follow-up.
-- ~~`operator` keyword on GSharp-defined types (declaring `operator +` etc.). Tracked as Stream D; superseding ADR-0026 is part of that follow-up PR.~~ **Shipped** in Stream D / ADR-0035 (receiver-form binary and unary operators). Free-function form, conversions, `++` / `--`, and `op_True` / `op_False` short-circuit remain deferred.
-
+[BoundUnaryOperator]
+BangToken LogicalNegation (bool) -> bool
+HatToken OnesComplement (int) -> int
+MinusToken Negation (int) -> int
+PlusToken Identity (int) -> int

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -315,7 +315,7 @@ public sealed class Binder
                 var body = binder.BindStatement(function.Declaration.Body);
                 var loweredBody = Lowerer.Lower(body);
 
-                if (function.Type != TypeSymbol.Void && !ControlFlowGraph.AllPathsReturn(loweredBody))
+                if (function.Type != TypeSymbol.Void && !IsIteratorReturnType(function.Type) && !ControlFlowGraph.AllPathsReturn(loweredBody))
                 {
                     binder.Diagnostics.ReportAllPathsMustReturn(function.Declaration.Identifier.Location);
                 }
@@ -344,7 +344,7 @@ public sealed class Binder
                 var body = binder.BindStatement(method.Declaration.Body);
                 var loweredBody = Lowerer.Lower(body);
 
-                if (method.Type != TypeSymbol.Void && !ControlFlowGraph.AllPathsReturn(loweredBody))
+                if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(loweredBody))
                 {
                     binder.Diagnostics.ReportAllPathsMustReturn(method.Declaration.Identifier.Location);
                 }
@@ -1360,6 +1360,8 @@ public sealed class Binder
                 return BindScopeStatement((ScopeStatementSyntax)syntax);
             case SyntaxKind.AwaitForRangeStatement:
                 return BindAwaitForRangeStatement((AwaitForRangeStatementSyntax)syntax);
+            case SyntaxKind.YieldStatement:
+                return BindYieldStatement((YieldStatementSyntax)syntax);
             case SyntaxKind.TupleDeconstructionStatement:
                 return BindTupleDeconstructionStatement((TupleDeconstructionStatementSyntax)syntax);
             case SyntaxKind.NamedDeconstructionStatement:
@@ -1703,6 +1705,18 @@ public sealed class Binder
             }
 
             return ChannelTypeSymbol.Get(elementType);
+        }
+
+        // ADR-0040: sequence type clause `sequence[T]`.
+        if (syntax.IsSequence)
+        {
+            var elementType = BindTypeClause(syntax.SequenceElementType);
+            if (elementType == null)
+            {
+                return null;
+            }
+
+            return SequenceTypeSymbol.Get(elementType);
         }
 
         // ADR-0039: pointer type clause `*T`.
@@ -2757,6 +2771,88 @@ public sealed class Binder
         return new BoundAwaitForRangeStatement(variable, stream, body);
     }
 
+    private BoundStatement BindYieldStatement(YieldStatementSyntax syntax)
+    {
+        // ADR-0040: `yield <expr>` — only valid in an iterator function.
+        if (function == null || !IsIteratorReturnType(function.Type))
+        {
+            Diagnostics.ReportYieldOutsideIteratorFunction(syntax.YieldKeyword.Location);
+            return new BoundExpressionStatement(new BoundErrorExpression());
+        }
+
+        var elementType = GetIteratorElementType(function.Type);
+        var expression = BindExpression(syntax.Expression);
+        if (expression.Type != null && elementType != null && expression.Type != elementType)
+        {
+            expression = BindConversion(syntax.Expression.Location, expression, elementType);
+        }
+
+        return new BoundYieldStatement(expression);
+    }
+
+    private static bool IsIteratorReturnType(TypeSymbol type)
+    {
+        if (type == null)
+        {
+            return false;
+        }
+
+        if (type is SequenceTypeSymbol)
+        {
+            return true;
+        }
+
+        var clr = type.ClrType;
+        if (clr == null)
+        {
+            return false;
+        }
+
+        if (clr == typeof(System.Collections.IEnumerable) ||
+            clr == typeof(System.Collections.IEnumerator))
+        {
+            return true;
+        }
+
+        if (clr.IsGenericType && !clr.IsGenericTypeDefinition)
+        {
+            var def = clr.GetGenericTypeDefinition();
+            if (def == typeof(System.Collections.Generic.IEnumerable<>) ||
+                def == typeof(System.Collections.Generic.IEnumerator<>))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static TypeSymbol GetIteratorElementType(TypeSymbol type)
+    {
+        if (type is SequenceTypeSymbol seq)
+        {
+            return seq.ElementType;
+        }
+
+        var clr = type?.ClrType;
+        if (clr == null)
+        {
+            return TypeSymbol.FromClrType(typeof(object));
+        }
+
+        if (clr.IsGenericType && !clr.IsGenericTypeDefinition)
+        {
+            var def = clr.GetGenericTypeDefinition();
+            if (def == typeof(System.Collections.Generic.IEnumerable<>) ||
+                def == typeof(System.Collections.Generic.IEnumerator<>))
+            {
+                return TypeSymbol.FromClrType(clr.GetGenericArguments()[0]);
+            }
+        }
+
+        return TypeSymbol.FromClrType(typeof(object));
+    }
+
     private static bool TryGetAsyncEnumerableElementType(TypeSymbol type, out TypeSymbol elementType)
     {
         elementType = null;
@@ -2876,6 +2972,12 @@ public sealed class Binder
                 iterationKind = ForRangeKind.PatternEnumerator;
                 keyType = TypeSymbol.Int;
                 valueType = userElemType;
+                break;
+            case SequenceTypeSymbol seq:
+                // ADR-0040: sequence[T] is IEnumerable[T] — iterate via Enumerable strategy.
+                iterationKind = ForRangeKind.Enumerable;
+                keyType = TypeSymbol.Int;
+                valueType = seq.ElementType;
                 break;
             default:
                 if (collection.Type != TypeSymbol.Error)

--- a/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -93,6 +93,7 @@ public enum BoundNodeKind
     SelectStatement,
     ScopeStatement,
     AwaitForRangeStatement,
+    YieldStatement,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -99,6 +99,9 @@ public static class BoundNodePrinter
             case BoundNodeKind.AwaitForRangeStatement:
                 WriteAwaitForRangeStatement((BoundAwaitForRangeStatement)node, writer);
                 break;
+            case BoundNodeKind.YieldStatement:
+                WriteYieldStatement((BoundYieldStatement)node, writer);
+                break;
             case BoundNodeKind.ErrorExpression:
                 WriteErrorExpression((BoundErrorExpression)node, writer);
                 break;
@@ -823,6 +826,13 @@ public static class BoundNodePrinter
         node.Stream.WriteTo(writer);
         writer.WriteSpace();
         node.Body.WriteTo(writer);
+    }
+
+    private static void WriteYieldStatement(BoundYieldStatement node, IndentedTextWriter writer)
+    {
+        writer.WriteIdentifier("yield");
+        writer.WriteSpace();
+        node.Expression.WriteTo(writer);
     }
 
     private static void WriteMakeChannelExpression(BoundMakeChannelExpression node, IndentedTextWriter writer)

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -59,6 +59,8 @@ public abstract class BoundTreeRewriter
                 return RewriteScopeStatement((BoundScopeStatement)node);
             case BoundNodeKind.AwaitForRangeStatement:
                 return RewriteAwaitForRangeStatement((BoundAwaitForRangeStatement)node);
+            case BoundNodeKind.YieldStatement:
+                return RewriteYieldStatement((BoundYieldStatement)node);
             default:
                 throw new Exception($"Unexpected node: {node.Kind}");
         }
@@ -780,6 +782,20 @@ public abstract class BoundTreeRewriter
         }
 
         return new BoundAwaitForRangeStatement(node.ValueVariable, stream, body);
+    }
+
+    /// <summary>Rewrites a bound yield statement (ADR-0040).</summary>
+    /// <param name="node">The yield statement to rewrite.</param>
+    /// <returns>The rewritten yield statement.</returns>
+    protected virtual BoundStatement RewriteYieldStatement(BoundYieldStatement node)
+    {
+        var expression = RewriteExpression(node.Expression);
+        if (expression == node.Expression)
+        {
+            return node;
+        }
+
+        return new BoundYieldStatement(expression);
     }
 
     /// <summary>Rewrites a bound make-channel expression (Phase 5.4).</summary>

--- a/src/Core/CodeAnalysis/Binding/BoundYieldStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundYieldStatement.cs
@@ -1,0 +1,26 @@
+// <copyright file="BoundYieldStatement.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Bound yield statement — produces the next value in an iterator function (ADR-0040).
+/// </summary>
+public sealed class BoundYieldStatement : BoundStatement
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundYieldStatement"/> class.
+    /// </summary>
+    /// <param name="expression">The expression whose value is yielded.</param>
+    public BoundYieldStatement(BoundExpression expression)
+    {
+        Expression = expression;
+    }
+
+    /// <inheritdoc/>
+    public override BoundNodeKind Kind => BoundNodeKind.YieldStatement;
+
+    /// <summary>Gets the expression whose value is yielded to the caller.</summary>
+    public BoundExpression Expression { get; }
+}

--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -281,6 +281,7 @@ public sealed class ControlFlowGraph
                     case BoundNodeKind.ScopeStatement:
                     case BoundNodeKind.AwaitForRangeStatement:
                     case BoundNodeKind.PatternSwitchStatement:
+                    case BoundNodeKind.YieldStatement:
                         // Treat exception-flow constructs as opaque statements; precise
                         // CFG modeling of catch/finally edges is deferred to a later phase.
                         // GoStatement and ChannelSendStatement fall through to the next

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Emit;
+using GSharp.Core.CodeAnalysis.Lowering.Iterators;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
@@ -202,6 +203,7 @@ public class Compilation
         }
 
         var asyncRewriteResult = Lowering.Async.AsyncStateMachineRewriter.Rewrite(program, References ?? Symbols.ReferenceResolver.Default());
+        var iteratorRewriteResult = IteratorRewriter.Rewrite(program);
 
         var asyncDiagnostics = Lowering.Async.AsyncEmitPrecheck.Check(program);
         if (asyncDiagnostics.Any())
@@ -212,7 +214,7 @@ public class Compilation
         try
         {
             using var stream = File.Create(program.PackageName + ".dll");
-            EmitAssembly(program, stream, References, asyncRewriteResult: asyncRewriteResult);
+            EmitAssembly(program, stream, References, asyncRewriteResult: asyncRewriteResult, iteratorRewriteResult: iteratorRewriteResult);
         }
         catch (Exception ex) when (ex is NotSupportedException || ex is InvalidOperationException)
         {
@@ -259,6 +261,7 @@ public class Compilation
         }
 
         var asyncRewriteResult = Lowering.Async.AsyncStateMachineRewriter.Rewrite(program, References ?? Symbols.ReferenceResolver.Default());
+        var iteratorRewriteResult = IteratorRewriter.Rewrite(program);
 
         var asyncDiagnostics = Lowering.Async.AsyncEmitPrecheck.Check(program);
         if (asyncDiagnostics.Any())
@@ -270,12 +273,12 @@ public class Compilation
         {
             if (peStream is not null)
             {
-                EmitAssembly(program, peStream, References, assemblyName, metadataOnly: false, asyncRewriteResult: asyncRewriteResult);
+                EmitAssembly(program, peStream, References, assemblyName, metadataOnly: false, asyncRewriteResult: asyncRewriteResult, iteratorRewriteResult: iteratorRewriteResult);
             }
 
             if (refStream is not null)
             {
-                EmitAssembly(program, refStream, References, assemblyName, metadataOnly: true, asyncRewriteResult: asyncRewriteResult);
+                EmitAssembly(program, refStream, References, assemblyName, metadataOnly: true, asyncRewriteResult: asyncRewriteResult, iteratorRewriteResult: iteratorRewriteResult);
             }
         }
         catch (Exception ex) when (ex is NotSupportedException || ex is InvalidOperationException)
@@ -288,8 +291,8 @@ public class Compilation
         return new EmitResult(success: true, diagnostics: ImmutableArray<Diagnostic>.Empty);
     }
 
-    private static void EmitAssembly(BoundProgram program, Stream peStream, ReferenceResolver references, string assemblyName = null, bool metadataOnly = false, Lowering.Async.AsyncStateMachineRewriteResult asyncRewriteResult = null)
+    private static void EmitAssembly(BoundProgram program, Stream peStream, ReferenceResolver references, string assemblyName = null, bool metadataOnly = false, Lowering.Async.AsyncStateMachineRewriteResult asyncRewriteResult = null, IteratorRewriteResult iteratorRewriteResult = null)
     {
-        ReflectionMetadataEmitter.Emit(program, peStream, references, assemblyName, metadataOnly, asyncRewriteResult);
+        ReflectionMetadataEmitter.Emit(program, peStream, references, assemblyName, metadataOnly, asyncRewriteResult, iteratorRewriteResult);
     }
 }

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -462,6 +462,16 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Reports that a <c>yield</c> statement was used outside an iterator function (ADR-0040).
+    /// </summary>
+    /// <param name="location">The text location of the yield keyword.</param>
+    public void ReportYieldOutsideIteratorFunction(TextLocation location)
+    {
+        var message = "'yield' statement is not allowed outside an iterator function (a function returning IEnumerable[T] or sequence[T]).";
+        Report(location, message);
+    }
+
+    /// <summary>
     /// Reports that the operand of a <c>go</c> statement is not a call expression (Phase 5.3 / ADR-0022).
     /// </summary>
     /// <param name="location">The text location of the operand.</param>

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -12,7 +12,9 @@ using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Security.Cryptography;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Lowering.Async;
+using GSharp.Core.CodeAnalysis.Lowering.Iterators;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 
@@ -84,10 +86,15 @@ internal sealed class ReflectionMetadataEmitter
     // with an InvokeAction instance method that Task.Run can bind to an Action.
     private readonly Dictionary<BoundGoStatement, ClosureInfo> goClosureInfos = new Dictionary<BoundGoStatement, ClosureInfo>();
     private readonly List<StructSymbol> synthesizedClosureClasses = new List<StructSymbol>();
+    private readonly Dictionary<FunctionSymbol, BoundBlockStatement> iteratorKickoffBodies = new Dictionary<FunctionSymbol, BoundBlockStatement>();
+    private readonly Dictionary<StructSymbol, IteratorStateMachineInfo> iteratorStateMachineInfos = new Dictionary<StructSymbol, IteratorStateMachineInfo>();
     private int closureCounter;
 
     // Async state-machine plans produced by AsyncStateMachineRewriter.
     private ImmutableArray<AsyncStateMachinePlan> asyncStateMachinePlans = ImmutableArray<AsyncStateMachinePlan>.Empty;
+
+    // Iterator state-machine plans produced by IteratorRewriter.
+    private ImmutableArray<IteratorStateMachinePlan> iteratorPlans = ImmutableArray<IteratorStateMachinePlan>.Empty;
 
     private Type coreObjectType;
     private Type coreStringType;
@@ -141,18 +148,28 @@ internal sealed class ReflectionMetadataEmitter
     /// Optional result from the async state-machine rewriter. When non-null,
     /// contains plans for emitting state-machine types and kickoff bodies.
     /// </param>
+    /// <param name="iteratorRewriteResult">
+    /// Optional result from the iterator rewriter. When non-null, contains plans
+    /// for emitting iterator state-machine types and kickoff bodies.
+    /// </param>
     public static void Emit(
         BoundProgram program,
         Stream peStream,
         ReferenceResolver references = null,
         string assemblyName = null,
         bool metadataOnly = false,
-        AsyncStateMachineRewriteResult asyncRewriteResult = null)
+        AsyncStateMachineRewriteResult asyncRewriteResult = null,
+        IteratorRewriteResult iteratorRewriteResult = null)
     {
         var emitter = new ReflectionMetadataEmitter(program, references, assemblyName, metadataOnly);
         if (asyncRewriteResult != null)
         {
             emitter.asyncStateMachinePlans = asyncRewriteResult.StateMachines;
+        }
+
+        if (iteratorRewriteResult != null)
+        {
+            emitter.iteratorPlans = iteratorRewriteResult.Plans;
         }
 
         emitter.EmitCore(peStream);
@@ -196,6 +213,7 @@ internal sealed class ReflectionMetadataEmitter
             ?? (this.program.Packages.IsDefaultOrEmpty ? null : this.program.Packages[0]);
         this.SynthesizeClosures(lambdaLiterals, hostPackageGuess);
         this.SynthesizeGoClosures(goStatements, hostPackageGuess);
+        this.SynthesizeIteratorStateMachines(hostPackageGuess);
 
         // Phase 3.B.4: user-defined interface TypeDefs (planned below).
         // Synthesized closure classes are appended after user aggregates so
@@ -365,6 +383,11 @@ internal sealed class ReflectionMetadataEmitter
                         this.metadata.AddInterfaceImplementation(this.structTypeDefs[c], ifaceHandle);
                     }
                 }
+            }
+
+            if (this.iteratorStateMachineInfos.TryGetValue(c, out var iteratorInfo))
+            {
+                this.AddIteratorInterfaceImplementations(c, iteratorInfo);
             }
         }
 
@@ -1602,6 +1625,11 @@ internal sealed class ReflectionMetadataEmitter
 
     private MethodDefinitionHandle EmitFunction(FunctionSymbol function, BoundBlockStatement body, bool isEntryPoint)
     {
+        if (this.iteratorKickoffBodies.TryGetValue(function, out var iteratorKickoffBody))
+        {
+            body = iteratorKickoffBody;
+        }
+
         // Async kickoff body: replace the user body with the kickoff stub
         // that creates the state machine, initializes it, and calls Start.
         AsyncStateMachinePlan asyncPlan = null;
@@ -2578,6 +2606,121 @@ internal sealed class ReflectionMetadataEmitter
 
             this.goClosureInfos[go] = info;
         }
+    }
+
+    private void SynthesizeIteratorStateMachines(PackageSymbol hostPackage)
+    {
+        if (this.iteratorPlans.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        foreach (var plan in this.iteratorPlans)
+        {
+            var packageName = hostPackage?.Name ?? plan.Function.Package?.Name ?? string.Empty;
+            var stateField = new FieldSymbol("<>1__state", TypeSymbol.Int, Accessibility.Public);
+            var currentField = new FieldSymbol("<>2__current", plan.ElementType, Accessibility.Public);
+            var initialThreadField = new FieldSymbol("<>l__initialThreadId", TypeSymbol.Int, Accessibility.Public);
+            var fields = ImmutableArray.CreateBuilder<FieldSymbol>();
+            fields.Add(stateField);
+            fields.Add(currentField);
+            fields.Add(initialThreadField);
+
+            var fieldMap = new Dictionary<VariableSymbol, FieldSymbol>();
+            var parameterFields = new Dictionary<ParameterSymbol, FieldSymbol>();
+            foreach (var parameter in plan.Function.Parameters)
+            {
+                var field = new FieldSymbol("<>3__" + parameter.Name, parameter.Type, Accessibility.Public);
+                fields.Add(field);
+                fieldMap[parameter] = field;
+                parameterFields[parameter] = field;
+            }
+
+            var hoistedFields = new Dictionary<VariableSymbol, FieldSymbol>();
+            foreach (var local in plan.HoistedLocals)
+            {
+                if (fieldMap.ContainsKey(local))
+                {
+                    continue;
+                }
+
+                var field = new FieldSymbol("<>5__" + local.Name, local.Type, Accessibility.Public);
+                fields.Add(field);
+                fieldMap[local] = field;
+                hoistedFields[local] = field;
+            }
+
+            var smClass = new StructSymbol(
+                name: "<" + plan.Function.Name + ">d__" + System.Threading.Interlocked.Increment(ref this.closureCounter).ToString(System.Globalization.CultureInfo.InvariantCulture),
+                fields: fields.ToImmutable(),
+                accessibility: Accessibility.Internal,
+                declaration: null,
+                packageName: packageName,
+                isData: false,
+                isInline: false,
+                isClass: true);
+
+            var moveNext = new FunctionSymbol("MoveNext", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Bool, null, hostPackage, Accessibility.Public, (TypeSymbol)smClass);
+            var getCurrent = new FunctionSymbol("get_Current", ImmutableArray<ParameterSymbol>.Empty, plan.ElementType, null, hostPackage, Accessibility.Public, (TypeSymbol)smClass);
+            var getCurrentObject = new FunctionSymbol("get_Current", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.FromClrType(typeof(object)), null, hostPackage, Accessibility.Public, (TypeSymbol)smClass);
+            var getEnumeratorType = TypeSymbol.FromClrType(typeof(System.Collections.Generic.IEnumerator<>).MakeGenericType(plan.ElementType.ClrType ?? typeof(object)));
+            var getEnumerator = new FunctionSymbol("GetEnumerator", ImmutableArray<ParameterSymbol>.Empty, getEnumeratorType, null, hostPackage, Accessibility.Public, (TypeSymbol)smClass);
+            var getEnumeratorObject = new FunctionSymbol("GetEnumerator", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.FromClrType(typeof(System.Collections.IEnumerator)), null, hostPackage, Accessibility.Public, (TypeSymbol)smClass);
+            var dispose = new FunctionSymbol("Dispose", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, null, hostPackage, Accessibility.Public, (TypeSymbol)smClass);
+            var reset = new FunctionSymbol("Reset", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, null, hostPackage, Accessibility.Public, (TypeSymbol)smClass);
+            smClass.SetMethods(ImmutableArray.Create(moveNext, getCurrent, getCurrentObject, getEnumerator, getEnumeratorObject, dispose, reset));
+
+            var moveNextBody = IteratorMoveNextBodyBuilder.BuildWithFieldAccess(plan, stateField, currentField, moveNext.ThisParameter, smClass, fieldMap).Body;
+            this.lambdaBodies[moveNext] = moveNextBody;
+            this.lambdaBodies[getCurrent] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+                new BoundReturnStatement(new BoundFieldAccessExpression(new BoundVariableExpression(getCurrent.ThisParameter), smClass, currentField)))));
+            this.lambdaBodies[getCurrentObject] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+                new BoundReturnStatement(new BoundConversionExpression(
+                    TypeSymbol.FromClrType(typeof(object)),
+                    new BoundFieldAccessExpression(new BoundVariableExpression(getCurrentObject.ThisParameter), smClass, currentField))))));
+            this.lambdaBodies[dispose] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(new BoundFieldAssignmentExpression(dispose.ThisParameter, smClass, stateField, new BoundLiteralExpression(-1))),
+                new BoundReturnStatement(null))));
+            this.lambdaBodies[reset] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(new BoundFieldAssignmentExpression(reset.ThisParameter, smClass, stateField, new BoundLiteralExpression(-1))),
+                new BoundReturnStatement(null))));
+            this.lambdaBodies[getEnumerator] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+                new BoundReturnStatement(this.CreateIteratorStateMachineLiteral(smClass, stateField, parameterFields, plan.Function.Parameters, p => new BoundFieldAccessExpression(new BoundVariableExpression(getEnumerator.ThisParameter), smClass, parameterFields[p]))))));
+            this.lambdaBodies[getEnumeratorObject] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+                new BoundReturnStatement(this.CreateIteratorStateMachineLiteral(smClass, stateField, parameterFields, plan.Function.Parameters, p => new BoundFieldAccessExpression(new BoundVariableExpression(getEnumeratorObject.ThisParameter), smClass, parameterFields[p]))))));
+
+            this.iteratorKickoffBodies[plan.Function] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+                new BoundReturnStatement(this.CreateIteratorStateMachineLiteral(smClass, stateField, parameterFields, plan.Function.Parameters, p => new BoundVariableExpression(p))))));
+            this.iteratorStateMachineInfos[smClass] = new IteratorStateMachineInfo(plan, smClass);
+            this.synthesizedClosureClasses.Add(smClass);
+        }
+    }
+
+    private BoundStructLiteralExpression CreateIteratorStateMachineLiteral(
+        StructSymbol smClass,
+        FieldSymbol stateField,
+        Dictionary<ParameterSymbol, FieldSymbol> parameterFields,
+        ImmutableArray<ParameterSymbol> parameters,
+        Func<ParameterSymbol, BoundExpression> parameterValueFactory)
+    {
+        var initializers = ImmutableArray.CreateBuilder<BoundFieldInitializer>();
+        initializers.Add(new BoundFieldInitializer(stateField, new BoundLiteralExpression(0)));
+        foreach (var parameter in parameters)
+        {
+            initializers.Add(new BoundFieldInitializer(parameterFields[parameter], parameterValueFactory(parameter)));
+        }
+
+        return new BoundStructLiteralExpression(smClass, initializers.ToImmutable());
+    }
+
+    private void AddIteratorInterfaceImplementations(StructSymbol smClass, IteratorStateMachineInfo info)
+    {
+        var elementClr = info.Plan.ElementType.ClrType ?? typeof(object);
+        this.metadata.AddInterfaceImplementation(this.structTypeDefs[smClass], this.GetTypeHandleForMember(typeof(System.Collections.Generic.IEnumerable<>).MakeGenericType(elementClr)));
+        this.metadata.AddInterfaceImplementation(this.structTypeDefs[smClass], this.GetTypeHandleForMember(typeof(System.Collections.Generic.IEnumerator<>).MakeGenericType(elementClr)));
+        this.metadata.AddInterfaceImplementation(this.structTypeDefs[smClass], this.GetTypeReference(typeof(System.IDisposable)));
+        this.metadata.AddInterfaceImplementation(this.structTypeDefs[smClass], this.GetTypeReference(typeof(System.Collections.IEnumerable)));
+        this.metadata.AddInterfaceImplementation(this.structTypeDefs[smClass], this.GetTypeReference(typeof(System.Collections.IEnumerator)));
     }
 
     private ClosureInfo SynthesizeDisplayClass(
@@ -3979,6 +4122,19 @@ internal sealed class ReflectionMetadataEmitter
         return hostType;
     }
 
+    private sealed class IteratorStateMachineInfo
+    {
+        public IteratorStateMachineInfo(IteratorStateMachinePlan plan, StructSymbol classSym)
+        {
+            this.Plan = plan;
+            this.ClassSym = classSym;
+        }
+
+        public IteratorStateMachinePlan Plan { get; }
+
+        public StructSymbol ClassSym { get; }
+    }
+
     private sealed class ClosureInfo
     {
         public ClosureInfo(StructSymbol classSym, FunctionSymbol invokeMethod, Dictionary<VariableSymbol, FieldSymbol> captureFields)
@@ -4403,6 +4559,8 @@ internal sealed class ReflectionMetadataEmitter
                 case BoundSelectStatement select:
                     this.EmitSelectStatement(select);
                     break;
+                case BoundYieldStatement:
+                    throw new NotSupportedException("Internal error: yield reached the emitter before iterator lowering.");
                 default:
                     throw new NotSupportedException(
                         $"Bound statement kind '{statement.Kind}' is not yet supported by the emitter.");
@@ -4480,7 +4638,10 @@ internal sealed class ReflectionMetadataEmitter
                 case BoundImportedInstanceCallExpression instCall:
                     this.EmitInstanceReceiver(instCall.Receiver);
                     this.EmitImportedCallArguments(instCall.Arguments, instCall.ArgumentRefKinds);
-                    this.il.Call(this.outer.GetMethodEntityHandle(instCall.Method));
+                    var receiverIsValueType = instCall.Receiver.Type?.ClrType?.IsValueType == true;
+                    var instCallHandle = this.outer.GetMethodEntityHandle(instCall.Method);
+                    this.il.OpCode(receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
+                    this.il.Token(instCallHandle);
                     break;
                 case BoundAddressOfExpression addressOf:
                     this.EmitAddressOf(addressOf);
@@ -4670,10 +4831,10 @@ internal sealed class ReflectionMetadataEmitter
                 return;
             }
 
-            if (from is StructSymbol fromStruct && !fromStruct.IsClass && to?.ClrType == typeof(object))
+            if (to?.ClrType == typeof(object) && IsValueTypeSymbol(from))
             {
                 this.il.OpCode(ILOpCode.Box);
-                this.il.Token(this.outer.GetElementTypeToken(fromStruct));
+                this.il.Token(this.outer.GetElementTypeToken(from));
                 return;
             }
 

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorMoveNextBodyBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorMoveNextBodyBuilder.cs
@@ -1,0 +1,324 @@
+// <copyright file="IteratorMoveNextBodyBuilder.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable SA1611 // Element parameters should be documented
+#pragma warning disable SA1612 // Element parameter documentation should match
+#pragma warning disable SA1572 // Summary documentation should have paramrefs
+#pragma warning disable CS1572 // XML comment has a param tag
+#pragma warning disable CS1573 // Parameter has no matching param tag
+#pragma warning disable SA1512 // Single-line comments should not be followed by blank line
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Iterators;
+
+/// <summary>
+/// Builds the <c>MoveNext()</c> method body for an iterator state machine.
+/// Transforms the original function body by replacing each <c>yield</c> with
+/// a state transition + return true, and adds a state-dispatch switch at entry.
+/// </summary>
+public static class IteratorMoveNextBodyBuilder
+{
+    /// <summary>
+    /// Builds the MoveNext body and returns the lowered block statement.
+    /// </summary>
+    /// <param name="plan">The iterator state machine plan.</param>
+    /// <param name="stateField">The state field symbol (parameter slot for state local).</param>
+    /// <param name="currentField">The current field symbol (parameter slot for current local).</param>
+    /// <param name="thisParameter">The this parameter for the instance method.</param>
+    /// <returns>The lowered MoveNext body and the this parameter.</returns>
+    public static IteratorMoveNextBody BuildWithFieldAccess(
+        IteratorStateMachinePlan plan,
+        FieldSymbol stateField,
+        FieldSymbol currentField,
+        ParameterSymbol thisParameter,
+        StructSymbol smClass,
+        Dictionary<VariableSymbol, FieldSymbol> hoistedFieldMap)
+    {
+        BoundExpression FieldRead(FieldSymbol field) =>
+            new BoundFieldAccessExpression(new BoundVariableExpression(thisParameter), smClass, field);
+
+        BoundExpression FieldWrite(FieldSymbol field, BoundExpression value) =>
+            new BoundFieldAssignmentExpression(thisParameter, smClass, field, value);
+
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+
+        var yieldLabels = new Dictionary<int, BoundLabel>();
+        foreach (var kvp in plan.YieldStates)
+        {
+            var label = new BoundLabel($"$iterResume_{kvp.Value}");
+            yieldLabels[kvp.Value] = label;
+        }
+
+        var startLabel = new BoundLabel("$iterStart");
+        var endLabel = new BoundLabel("$iterEnd");
+
+        statements.Add(new BoundConditionalGotoStatement(
+            startLabel,
+            new BoundBinaryExpression(
+                FieldRead(stateField),
+                BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
+                new BoundLiteralExpression(0)),
+            jumpIfTrue: true));
+
+        foreach (var kvp in plan.YieldStates)
+        {
+            statements.Add(new BoundConditionalGotoStatement(
+                yieldLabels[kvp.Value],
+                new BoundBinaryExpression(
+                    FieldRead(stateField),
+                    BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
+                    new BoundLiteralExpression(kvp.Value)),
+                jumpIfTrue: true));
+        }
+
+        statements.Add(new BoundGotoStatement(endLabel));
+        statements.Add(new BoundLabelStatement(startLabel));
+
+        var rewriter = new FieldAccessYieldRewriter(smClass, thisParameter, stateField, currentField, hoistedFieldMap, yieldLabels, endLabel);
+        var rewrittenBody = rewriter.RewriteStatement(plan.Body);
+        if (rewrittenBody is BoundBlockStatement block)
+        {
+            statements.AddRange(block.Statements);
+        }
+        else
+        {
+            statements.Add(rewrittenBody);
+        }
+
+        statements.Add(new BoundLabelStatement(endLabel));
+        statements.Add(new BoundExpressionStatement(FieldWrite(stateField, new BoundLiteralExpression(-1))));
+        statements.Add(new BoundReturnStatement(new BoundLiteralExpression(false)));
+
+        return new IteratorMoveNextBody(Lowerer.Lower(new BoundBlockStatement(statements.ToImmutable())), thisParameter);
+    }
+
+    public static IteratorMoveNextBody Build(
+        IteratorStateMachinePlan plan,
+        VariableSymbol stateLocal,
+        VariableSymbol currentLocal,
+        ParameterSymbol thisParameter)
+    {
+        // The MoveNext body is:
+        // 1. switch(state) { case 0: goto start; case 1: goto resume1; ... default: goto end; }
+        // 2. start: [user body with yields replaced by: current=x; state=K; return true; resumeK: state=0; ...]
+        // 3. end: state=-1; return false;
+
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+
+        // Create labels for each yield resume point
+        var yieldLabels = new Dictionary<int, BoundLabel>();
+        foreach (var kvp in plan.YieldStates)
+        {
+            var label = new BoundLabel($"$iterResume_{kvp.Value}");
+            yieldLabels[kvp.Value] = label;
+        }
+
+        var startLabel = new BoundLabel("$iterStart");
+        var endLabel = new BoundLabel("$iterEnd");
+
+        // State dispatch: if state == 0 goto start; if state == K goto resumeK; else goto end
+        statements.Add(new BoundConditionalGotoStatement(
+            startLabel,
+            new BoundBinaryExpression(
+                new BoundVariableExpression(stateLocal),
+                BoundBinaryOperator.Bind(Syntax.SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
+                new BoundLiteralExpression(0)),
+            jumpIfTrue: true));
+
+        foreach (var kvp in plan.YieldStates)
+        {
+            statements.Add(new BoundConditionalGotoStatement(
+                yieldLabels[kvp.Value],
+                new BoundBinaryExpression(
+                    new BoundVariableExpression(stateLocal),
+                    BoundBinaryOperator.Bind(Syntax.SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
+                    new BoundLiteralExpression(kvp.Value)),
+                jumpIfTrue: true));
+        }
+
+        // Default: goto end
+        statements.Add(new BoundGotoStatement(endLabel));
+
+        // start:
+        statements.Add(new BoundLabelStatement(startLabel));
+
+        // Rewrite the user body: replace yields with state transitions
+        var rewriter = new YieldReplacer(stateLocal, currentLocal, yieldLabels, endLabel);
+        var rewrittenBody = rewriter.RewriteStatement(plan.Body);
+
+        // Flatten the body into the statement list
+        if (rewrittenBody is BoundBlockStatement block)
+        {
+            statements.AddRange(block.Statements);
+        }
+        else
+        {
+            statements.Add(rewrittenBody);
+        }
+
+        // Fall through to end: state = -1; return false
+        statements.Add(new BoundLabelStatement(endLabel));
+        statements.Add(new BoundExpressionStatement(
+            new BoundAssignmentExpression(stateLocal, new BoundLiteralExpression(-1))));
+        statements.Add(new BoundReturnStatement(new BoundLiteralExpression(false)));
+
+        var body = new BoundBlockStatement(statements.ToImmutable());
+        return new IteratorMoveNextBody(body, thisParameter);
+    }
+
+    private sealed class FieldAccessYieldRewriter : BoundTreeRewriter
+    {
+        private readonly StructSymbol smClass;
+        private readonly ParameterSymbol thisParameter;
+        private readonly FieldSymbol stateField;
+        private readonly FieldSymbol currentField;
+        private readonly Dictionary<VariableSymbol, FieldSymbol> fieldMap;
+        private readonly Dictionary<int, BoundLabel> yieldLabels;
+        private readonly BoundLabel endLabel;
+        private int yieldIndex;
+
+        public FieldAccessYieldRewriter(
+            StructSymbol smClass,
+            ParameterSymbol thisParameter,
+            FieldSymbol stateField,
+            FieldSymbol currentField,
+            Dictionary<VariableSymbol, FieldSymbol> fieldMap,
+            Dictionary<int, BoundLabel> yieldLabels,
+            BoundLabel endLabel)
+        {
+            this.smClass = smClass;
+            this.thisParameter = thisParameter;
+            this.stateField = stateField;
+            this.currentField = currentField;
+            this.fieldMap = fieldMap;
+            this.yieldLabels = yieldLabels;
+            this.endLabel = endLabel;
+        }
+
+        protected override BoundExpression RewriteVariableExpression(BoundVariableExpression node)
+        {
+            if (this.fieldMap.TryGetValue(node.Variable, out var field))
+            {
+                return this.FieldRead(field);
+            }
+
+            return node;
+        }
+
+        protected override BoundExpression RewriteAssignmentExpression(BoundAssignmentExpression node)
+        {
+            if (this.fieldMap.TryGetValue(node.Variable, out var field))
+            {
+                return this.FieldWrite(field, this.RewriteExpression(node.Expression));
+            }
+
+            return base.RewriteAssignmentExpression(node);
+        }
+
+        protected override BoundStatement RewriteVariableDeclaration(BoundVariableDeclaration node)
+        {
+            if (this.fieldMap.TryGetValue(node.Variable, out var field))
+            {
+                return new BoundExpressionStatement(this.FieldWrite(field, this.RewriteExpression(node.Initializer)));
+            }
+
+            return base.RewriteVariableDeclaration(node);
+        }
+
+        protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
+        {
+            this.yieldIndex++;
+            var label = this.yieldLabels[this.yieldIndex];
+            var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+            statements.Add(new BoundExpressionStatement(this.FieldWrite(this.currentField, this.RewriteExpression(node.Expression))));
+            statements.Add(new BoundExpressionStatement(this.FieldWrite(this.stateField, new BoundLiteralExpression(this.yieldIndex))));
+            statements.Add(new BoundReturnStatement(new BoundLiteralExpression(true)));
+            statements.Add(new BoundLabelStatement(label));
+            statements.Add(new BoundExpressionStatement(this.FieldWrite(this.stateField, new BoundLiteralExpression(0))));
+            return new BoundBlockStatement(statements.ToImmutable());
+        }
+
+        protected override BoundStatement RewriteReturnStatement(BoundReturnStatement node)
+        {
+            return new BoundGotoStatement(this.endLabel);
+        }
+
+        private BoundExpression FieldRead(FieldSymbol field) =>
+            new BoundFieldAccessExpression(new BoundVariableExpression(this.thisParameter), this.smClass, field);
+
+        private BoundExpression FieldWrite(FieldSymbol field, BoundExpression value) =>
+            new BoundFieldAssignmentExpression(this.thisParameter, this.smClass, field, value);
+    }
+
+    private sealed class YieldReplacer : BoundTreeRewriter
+    {
+        private readonly VariableSymbol stateLocal;
+        private readonly VariableSymbol currentLocal;
+        private readonly Dictionary<int, BoundLabel> yieldLabels;
+        private readonly BoundLabel endLabel;
+        private int yieldIndex;
+
+        public YieldReplacer(
+            VariableSymbol stateLocal,
+            VariableSymbol currentLocal,
+            Dictionary<int, BoundLabel> yieldLabels,
+            BoundLabel endLabel)
+        {
+            this.stateLocal = stateLocal;
+            this.currentLocal = currentLocal;
+            this.yieldLabels = yieldLabels;
+            this.endLabel = endLabel;
+        }
+
+        protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
+        {
+            yieldIndex++;
+            var label = yieldLabels[yieldIndex];
+
+            // current = expr; state = K; return true; resumeK: state = -1;
+            var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+            statements.Add(new BoundExpressionStatement(
+                new BoundAssignmentExpression(currentLocal, node.Expression)));
+            statements.Add(new BoundExpressionStatement(
+                new BoundAssignmentExpression(stateLocal, new BoundLiteralExpression(yieldIndex))));
+            statements.Add(new BoundReturnStatement(new BoundLiteralExpression(true)));
+            statements.Add(new BoundLabelStatement(label));
+            statements.Add(new BoundExpressionStatement(
+                new BoundAssignmentExpression(stateLocal, new BoundLiteralExpression(-1))));
+
+            return new BoundBlockStatement(statements.ToImmutable());
+        }
+
+        protected override BoundStatement RewriteReturnStatement(BoundReturnStatement node)
+        {
+            // In an iterator, `return` (with or without value) means end iteration.
+            return new BoundGotoStatement(endLabel);
+        }
+    }
+}
+
+/// <summary>
+/// The result of building a MoveNext body.
+/// </summary>
+public sealed class IteratorMoveNextBody
+{
+    /// <summary>Initializes a new instance of the <see cref="IteratorMoveNextBody"/> class.</summary>
+    public IteratorMoveNextBody(BoundBlockStatement body, ParameterSymbol thisParameter)
+    {
+        Body = body;
+        ThisParameter = thisParameter;
+    }
+
+    /// <summary>Gets the lowered MoveNext body.</summary>
+    public BoundBlockStatement Body { get; }
+
+    /// <summary>Gets the this parameter.</summary>
+    public ParameterSymbol ThisParameter { get; }
+}

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
@@ -1,0 +1,221 @@
+// <copyright file="IteratorRewriter.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable SA1201 // Elements should appear in the correct order
+#pragma warning disable SA1611 // Element parameters should be documented
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Iterators;
+
+/// <summary>
+/// Rewrites iterator functions (those containing <c>yield</c> statements) into
+/// state-machine classes implementing <c>IEnumerable&lt;T&gt;</c> and
+/// <c>IEnumerator&lt;T&gt;</c> (ADR-0040).
+/// </summary>
+public static class IteratorRewriter
+{
+    /// <summary>
+    /// Scans the bound program for iterator functions and builds rewrite plans.
+    /// </summary>
+    /// <param name="program">The bound program.</param>
+    /// <returns>The rewrite result containing plans for each iterator function.</returns>
+    public static IteratorRewriteResult Rewrite(BoundProgram program)
+    {
+        if (program == null)
+        {
+            throw new ArgumentNullException(nameof(program));
+        }
+
+        var plans = ImmutableArray.CreateBuilder<IteratorStateMachinePlan>();
+
+        foreach (var pair in program.Functions.OrderBy(p => p.Key.Name, StringComparer.Ordinal))
+        {
+            var function = pair.Key;
+            var body = pair.Value;
+
+            if (!ContainsYield(body))
+            {
+                continue;
+            }
+
+            var elementType = GetIteratorElementType(function.Type);
+            if (elementType == null)
+            {
+                continue;
+            }
+
+            var plan = BuildPlan(function, body, elementType);
+            plans.Add(plan);
+        }
+
+        return new IteratorRewriteResult(program, plans.ToImmutable());
+    }
+
+    private static bool ContainsYield(BoundStatement statement)
+    {
+        var walker = new YieldWalker();
+        walker.RewriteStatement(statement);
+        return walker.Found;
+    }
+
+    private static TypeSymbol GetIteratorElementType(TypeSymbol type)
+    {
+        if (type is SequenceTypeSymbol seq)
+        {
+            return seq.ElementType;
+        }
+
+        var clr = type?.ClrType;
+        if (clr == null)
+        {
+            return null;
+        }
+
+        if (clr.IsGenericType && !clr.IsGenericTypeDefinition)
+        {
+            var def = clr.GetGenericTypeDefinition();
+            if (def == typeof(IEnumerable<>) || def == typeof(IEnumerator<>))
+            {
+                return TypeSymbol.FromClrType(clr.GetGenericArguments()[0]);
+            }
+        }
+
+        if (clr == typeof(System.Collections.IEnumerable) ||
+            clr == typeof(System.Collections.IEnumerator))
+        {
+            return TypeSymbol.FromClrType(typeof(object));
+        }
+
+        return null;
+    }
+
+    private static IteratorStateMachinePlan BuildPlan(
+        FunctionSymbol function,
+        BoundStatement body,
+        TypeSymbol elementType)
+    {
+        // Collect yields and assign states.
+        var yieldCollector = new YieldStateCollector();
+        yieldCollector.RewriteStatement(body);
+        var yieldStates = yieldCollector.States;
+
+        // Collect hoisted locals (locals that are live across yield points).
+        var hoistedLocals = CollectHoistedLocals(body);
+
+        return new IteratorStateMachinePlan(function, body, elementType, yieldStates, hoistedLocals);
+    }
+
+    private static ImmutableArray<VariableSymbol> CollectHoistedLocals(BoundStatement body)
+    {
+        // Simple approach: hoist all locals declared in the body.
+        // A more precise analysis would only hoist those live across yields.
+        var collector = new LocalCollector();
+        collector.RewriteStatement(body);
+        return collector.Locals.ToImmutableArray();
+    }
+
+    private sealed class YieldWalker : BoundTreeRewriter
+    {
+        public bool Found { get; private set; }
+
+        protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
+        {
+            Found = true;
+            return node;
+        }
+    }
+
+    private sealed class YieldStateCollector : BoundTreeRewriter
+    {
+        private int nextState = 1; // State 0 = initial, -1 = finished, -2 = before first enumeration.
+
+        public ImmutableDictionary<BoundYieldStatement, int> States => states.ToImmutable();
+
+        private readonly ImmutableDictionary<BoundYieldStatement, int>.Builder states =
+            ImmutableDictionary.CreateBuilder<BoundYieldStatement, int>();
+
+        protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
+        {
+            states.Add(node, nextState++);
+            return node;
+        }
+    }
+
+    private sealed class LocalCollector : BoundTreeRewriter
+    {
+        public List<VariableSymbol> Locals { get; } = new List<VariableSymbol>();
+
+        protected override BoundStatement RewriteVariableDeclaration(BoundVariableDeclaration node)
+        {
+            if (!Locals.Contains(node.Variable))
+            {
+                Locals.Add(node.Variable);
+            }
+
+            return base.RewriteVariableDeclaration(node);
+        }
+    }
+}
+
+/// <summary>
+/// Result of running the iterator rewriter.
+/// </summary>
+public sealed class IteratorRewriteResult
+{
+    /// <summary>Initializes a new instance of the <see cref="IteratorRewriteResult"/> class.</summary>
+    public IteratorRewriteResult(BoundProgram program, ImmutableArray<IteratorStateMachinePlan> plans)
+    {
+        Program = program;
+        Plans = plans;
+    }
+
+    /// <summary>Gets the original program.</summary>
+    public BoundProgram Program { get; }
+
+    /// <summary>Gets the iterator state machine plans.</summary>
+    public ImmutableArray<IteratorStateMachinePlan> Plans { get; }
+}
+
+/// <summary>
+/// Holds the plan for rewriting a single iterator function into a state machine.
+/// </summary>
+public sealed class IteratorStateMachinePlan
+{
+    /// <summary>Initializes a new instance of the <see cref="IteratorStateMachinePlan"/> class.</summary>
+    public IteratorStateMachinePlan(
+        FunctionSymbol function,
+        BoundStatement body,
+        TypeSymbol elementType,
+        ImmutableDictionary<BoundYieldStatement, int> yieldStates,
+        ImmutableArray<VariableSymbol> hoistedLocals)
+    {
+        Function = function;
+        Body = body;
+        ElementType = elementType;
+        YieldStates = yieldStates;
+        HoistedLocals = hoistedLocals;
+    }
+
+    /// <summary>Gets the original iterator function.</summary>
+    public FunctionSymbol Function { get; }
+
+    /// <summary>Gets the original function body.</summary>
+    public BoundStatement Body { get; }
+
+    /// <summary>Gets the element type produced by this iterator.</summary>
+    public TypeSymbol ElementType { get; }
+
+    /// <summary>Gets the yield statement to state mapping.</summary>
+    public ImmutableDictionary<BoundYieldStatement, int> YieldStates { get; }
+
+    /// <summary>Gets the locals that must be hoisted to state machine fields.</summary>
+    public ImmutableArray<VariableSymbol> HoistedLocals { get; }
+}

--- a/src/Core/CodeAnalysis/Symbols/SequenceTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/SequenceTypeSymbol.cs
@@ -1,0 +1,51 @@
+// <copyright file="SequenceTypeSymbol.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Represents a sequence type <c>sequence[T]</c> — alias for <c>IEnumerable&lt;T&gt;</c> (ADR-0040).
+/// </summary>
+public sealed class SequenceTypeSymbol : TypeSymbol
+{
+    private static readonly ConcurrentDictionary<TypeSymbol, SequenceTypeSymbol> Cache = new();
+
+    private SequenceTypeSymbol(TypeSymbol elementType)
+        : base($"sequence[{elementType.Name}]", MakeClrType(elementType))
+    {
+        ElementType = elementType;
+    }
+
+    /// <summary>Gets the element type.</summary>
+    public TypeSymbol ElementType { get; }
+
+    /// <summary>
+    /// Gets or creates the sequence type symbol for the given element type.
+    /// </summary>
+    /// <param name="elementType">The element type.</param>
+    /// <returns>The cached <see cref="SequenceTypeSymbol"/>.</returns>
+    public static SequenceTypeSymbol Get(TypeSymbol elementType)
+    {
+        if (elementType == null)
+        {
+            throw new ArgumentNullException(nameof(elementType));
+        }
+
+        return Cache.GetOrAdd(elementType, et => new SequenceTypeSymbol(et));
+    }
+
+    private static Type MakeClrType(TypeSymbol elementType)
+    {
+        if (elementType.ClrType == null)
+        {
+            return null;
+        }
+
+        return typeof(IEnumerable<>).MakeGenericType(elementType.ClrType);
+    }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -1015,6 +1015,12 @@ public class Parser
             return ParseChanTypeClause();
         }
 
+        // ADR-0040: sequence type `sequence[T]` — alias for IEnumerable[T].
+        if (Current.Kind == SyntaxKind.SequenceKeyword)
+        {
+            return ParseSequenceTypeClause();
+        }
+
         // ADR-0039: pointer type `*T` in type-annotation position.
         if (Current.Kind == SyntaxKind.StarToken)
         {
@@ -1134,6 +1140,17 @@ public class Parser
         return new TypeClauseSyntax(syntaxTree, chanKeyword, elementType, question);
     }
 
+    private TypeClauseSyntax ParseSequenceTypeClause()
+    {
+        // ADR-0040: sequence type clause `sequence[T]` with optional trailing `?`.
+        var sequenceKeyword = MatchToken(SyntaxKind.SequenceKeyword);
+        var openBracket = MatchToken(SyntaxKind.OpenSquareBracketToken);
+        var elementType = ParseTypeClause();
+        var closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
+        var question = Current.Kind == SyntaxKind.QuestionToken ? MatchToken(SyntaxKind.QuestionToken) : null;
+        return TypeClauseSyntax.CreateSequence(syntaxTree, sequenceKeyword, openBracket, elementType, closeBracket, question);
+    }
+
     private TypeClauseSyntax ParseFunctionTypeClause()
     {
         // Phase 4.7: function type clause `func(T1, T2, ...) R?`. The return
@@ -1176,6 +1193,8 @@ public class Parser
             Current.Kind != SyntaxKind.OpenParenthesisToken &&
             Current.Kind != SyntaxKind.FuncKeyword &&
             Current.Kind != SyntaxKind.MapKeyword &&
+            Current.Kind != SyntaxKind.ChanKeyword &&
+            Current.Kind != SyntaxKind.SequenceKeyword &&
             Current.Kind != SyntaxKind.StarToken)
         {
             return null;
@@ -1261,6 +1280,35 @@ public class Parser
 
                 goto default;
             default:
+                // ADR-0040: contextual `yield` keyword — parse as yield statement
+                // when `yield` appears at statement start and is not followed by
+                // an assignment operator or other identifier-consuming syntax.
+                if (Current.Kind == SyntaxKind.SequenceKeyword &&
+                    Peek(1).Kind != SyntaxKind.ColonEqualsToken &&
+                    Peek(1).Kind != SyntaxKind.PlusPlusToken &&
+                    Peek(1).Kind != SyntaxKind.MinusMinusToken &&
+                    Peek(1).Kind != SyntaxKind.CommaToken &&
+                    Peek(1).Kind != SyntaxKind.DotToken &&
+                    Peek(1).Kind != SyntaxKind.OpenParenthesisToken &&
+                    Peek(1).Kind != SyntaxKind.EqualsToken)
+                {
+                    // "sequence" at statement start is not a yield — fall through.
+                }
+
+                if (Current.Kind == SyntaxKind.IdentifierToken &&
+                    Current.Text == "yield" &&
+                    Peek(1).Kind != SyntaxKind.ColonEqualsToken &&
+                    Peek(1).Kind != SyntaxKind.PlusPlusToken &&
+                    Peek(1).Kind != SyntaxKind.MinusMinusToken &&
+                    Peek(1).Kind != SyntaxKind.CommaToken &&
+                    Peek(1).Kind != SyntaxKind.DotToken &&
+                    Peek(1).Kind != SyntaxKind.OpenParenthesisToken &&
+                    Peek(1).Kind != SyntaxKind.EqualsToken &&
+                    Peek(1).Kind != SyntaxKind.OpenSquareBracketToken)
+                {
+                    return ParseYieldStatement();
+                }
+
                 if (Current.Kind == SyntaxKind.IdentifierToken &&
                     Peek(1).Kind == SyntaxKind.ColonEqualsToken)
                 {
@@ -1853,6 +1901,15 @@ public class Parser
         }
 
         return new ReturnStatementSyntax(syntaxTree, keyword, expression);
+    }
+
+    private StatementSyntax ParseYieldStatement()
+    {
+        // ADR-0040: `yield <expr>` statement. The `yield` token is a contextual
+        // identifier (not a reserved keyword) to preserve source compatibility.
+        var yieldToken = MatchToken(SyntaxKind.IdentifierToken);
+        var expression = ParseExpression();
+        return new YieldStatementSyntax(syntaxTree, yieldToken, expression);
     }
 
     private StatementSyntax ParseSwitchStatement()

--- a/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -199,6 +199,8 @@ public static class SyntaxFacts
                 return SyntaxKind.SealedKeyword;
             case "select":
                 return SyntaxKind.SelectKeyword;
+            case "sequence":
+                return SyntaxKind.SequenceKeyword;
             case "struct":
                 return SyntaxKind.StructKeyword;
             case "switch":
@@ -445,6 +447,8 @@ public static class SyntaxFacts
                 return "scope";
             case SyntaxKind.SelectKeyword:
                 return "select";
+            case SyntaxKind.SequenceKeyword:
+                return "sequence";
             case SyntaxKind.StructKeyword:
                 return "struct";
             case SyntaxKind.SwitchKeyword:

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -119,6 +119,7 @@ public enum SyntaxKind
     SealedKeyword,
     SelectKeyword,
     ScopeKeyword,
+    SequenceKeyword,
     StructKeyword,
     SwitchKeyword,
     ThrowKeyword,
@@ -215,6 +216,7 @@ public enum SyntaxKind
     ScopeStatement,
     AwaitForRangeStatement,
     EventSubscriptionExpression,
+    YieldStatement,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
@@ -193,6 +193,26 @@ public sealed class TypeClauseSyntax : SyntaxNode
     }
 #pragma warning restore SA1642
 
+    /// <summary>Initializes a new instance of the <see cref="TypeClauseSyntax"/> class for a sequence type (ADR-0040).</summary>
+#pragma warning disable SA1642
+    private TypeClauseSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken sequenceKeyword,
+        SyntaxToken openBracketToken,
+        TypeClauseSyntax elementType,
+        SyntaxToken closeBracketToken,
+        SyntaxToken questionToken,
+        bool isSequence)
+        : base(syntaxTree)
+    {
+        SequenceKeyword = sequenceKeyword;
+        SequenceOpenBracketToken = openBracketToken;
+        SequenceElementType = elementType;
+        SequenceCloseBracketToken = closeBracketToken;
+        QuestionToken = questionToken;
+    }
+#pragma warning restore SA1642
+
     /// <inheritdoc/>
     public override SyntaxKind Kind => SyntaxKind.TypeClause;
 
@@ -292,6 +312,21 @@ public sealed class TypeClauseSyntax : SyntaxNode
     /// <summary>Gets a value indicating whether this clause denotes a pointer type <c>*T</c> (ADR-0039).</summary>
     public bool IsPointer => PointerStarToken != null;
 
+    /// <summary>Gets the <c>sequence</c> keyword for sequence types, or <c>null</c> (ADR-0040).</summary>
+    public SyntaxToken SequenceKeyword { get; }
+
+    /// <summary>Gets the <c>[</c> opening the sequence element type, or <c>null</c> (ADR-0040).</summary>
+    public SyntaxToken SequenceOpenBracketToken { get; }
+
+    /// <summary>Gets the sequence element type clause, or <c>null</c> (ADR-0040).</summary>
+    public TypeClauseSyntax SequenceElementType { get; }
+
+    /// <summary>Gets the <c>]</c> closing the sequence element type, or <c>null</c> (ADR-0040).</summary>
+    public SyntaxToken SequenceCloseBracketToken { get; }
+
+    /// <summary>Gets a value indicating whether this clause denotes a sequence type <c>sequence[T]</c> (ADR-0040).</summary>
+    public bool IsSequence => SequenceKeyword != null;
+
     /// <summary>Creates a pointer type clause <c>*T</c> (ADR-0039).</summary>
     /// <param name="syntaxTree">The parent syntax tree.</param>
     /// <param name="starToken">The <c>*</c> prefix token.</param>
@@ -305,5 +340,24 @@ public sealed class TypeClauseSyntax : SyntaxNode
         SyntaxToken questionToken)
     {
         return new TypeClauseSyntax(syntaxTree, starToken, pointeeType, questionToken, isPointer: true);
+    }
+
+    /// <summary>Creates a sequence type clause <c>sequence[T]</c> (ADR-0040).</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="sequenceKeyword">The <c>sequence</c> keyword.</param>
+    /// <param name="openBracketToken">The <c>[</c> token.</param>
+    /// <param name="elementType">The element type clause.</param>
+    /// <param name="closeBracketToken">The <c>]</c> token.</param>
+    /// <param name="questionToken">The optional trailing <c>?</c> nullability marker.</param>
+    /// <returns>A sequence type clause.</returns>
+    public static TypeClauseSyntax CreateSequence(
+        SyntaxTree syntaxTree,
+        SyntaxToken sequenceKeyword,
+        SyntaxToken openBracketToken,
+        TypeClauseSyntax elementType,
+        SyntaxToken closeBracketToken,
+        SyntaxToken questionToken)
+    {
+        return new TypeClauseSyntax(syntaxTree, sequenceKeyword, openBracketToken, elementType, closeBracketToken, questionToken, isSequence: true);
     }
 }

--- a/src/Core/CodeAnalysis/Syntax/YieldStatementSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/YieldStatementSyntax.cs
@@ -1,0 +1,33 @@
+// <copyright file="YieldStatementSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents a <c>yield &lt;expr&gt;</c> statement in an iterator function (ADR-0040).
+/// </summary>
+public sealed class YieldStatementSyntax : StatementSyntax
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="YieldStatementSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="yieldKeyword">The contextual <c>yield</c> keyword token.</param>
+    /// <param name="expression">The expression to yield.</param>
+    public YieldStatementSyntax(SyntaxTree syntaxTree, SyntaxToken yieldKeyword, ExpressionSyntax expression)
+        : base(syntaxTree)
+    {
+        YieldKeyword = yieldKeyword;
+        Expression = expression;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.YieldStatement;
+
+    /// <summary>Gets the contextual <c>yield</c> keyword token.</summary>
+    public SyntaxToken YieldKeyword { get; }
+
+    /// <summary>Gets the expression being yielded.</summary>
+    public ExpressionSyntax Expression { get; }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/IteratorEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/IteratorEmitTests.cs
@@ -1,0 +1,191 @@
+// <copyright file="IteratorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// End-to-end emit tests for iterator functions (ADR-0040: sequence[T] and yield).
+/// </summary>
+public class IteratorEmitTests
+{
+    [Fact]
+    public void Iterator_KickoffOnly_DoesNotThrow()
+    {
+        // Minimal test: call the iterator but don't iterate.
+        // Validates the kickoff body IL is well-formed.
+        var source = @"
+package IterTest
+import System
+import System.Collections.Generic
+
+func numbers() sequence[int] {
+    yield 1
+    yield 2
+    yield 3
+}
+
+var n = numbers()
+Console.WriteLine(""ok"")
+";
+        var output = CompileLoadInvokeCaptureStdout(source, nameof(Iterator_KickoffOnly_DoesNotThrow));
+        Assert.Contains("ok", output);
+    }
+
+    [Fact]
+    public void Iterator_Sequence_EnumeratesYieldedValues()
+    {
+        var source = @"
+package IterTest
+import System
+import System.Collections.Generic
+
+func numbers() sequence[int] {
+    yield 1
+    yield 2
+    yield 3
+}
+
+for x in numbers() {
+    Console.WriteLine(x)
+}
+";
+        var output = CompileLoadInvokeCaptureStdout(source, nameof(Iterator_Sequence_EnumeratesYieldedValues));
+        Assert.Contains("1", output);
+        Assert.Contains("2", output);
+        Assert.Contains("3", output);
+    }
+
+    [Fact]
+    public void Iterator_IEnumerable_EnumeratesYieldedValues()
+    {
+        var source = @"
+package IterTest
+import System
+import System.Collections.Generic
+
+func numbers() IEnumerable[int] {
+    yield 1
+    yield 2
+    yield 3
+}
+
+for x in numbers() {
+    Console.WriteLine(x)
+}
+";
+        var output = CompileLoadInvokeCaptureStdout(source, nameof(Iterator_IEnumerable_EnumeratesYieldedValues));
+        Assert.Contains("1", output);
+        Assert.Contains("2", output);
+        Assert.Contains("3", output);
+    }
+
+    [Fact]
+    public void Iterator_Fib_ProducesExpectedSequence()
+    {
+        var source = @"
+package IterTest
+import System
+import System.Collections.Generic
+
+func fib(max int) sequence[int] {
+    a, b := 0, 1
+    for a <= max {
+        yield a
+        a, b = b, a+b
+    }
+}
+
+for x in fib(20) {
+    Console.Write(x)
+    Console.Write("" "")
+}
+";
+        var output = CompileLoadInvokeCaptureStdout(source, nameof(Iterator_Fib_ProducesExpectedSequence));
+        Assert.Contains("0 1 1 2 3 5 8 13", output);
+    }
+
+    [Fact]
+    public void Iterator_With_Yield_Inside_Conditional_Works()
+    {
+        var source = @"
+package IterTest
+import System
+import System.Collections.Generic
+
+func evens(max int) sequence[int] {
+    i := 0
+    for i <= max {
+        if i % 2 == 0 {
+            yield i
+        }
+        i = i + 1
+    }
+}
+
+for x in evens(10) {
+    Console.Write(x)
+    Console.Write("" "")
+}
+";
+        var output = CompileLoadInvokeCaptureStdout(source, nameof(Iterator_With_Yield_Inside_Conditional_Works));
+        Assert.Contains("0 2 4 6 8 10", output);
+    }
+
+    private static EmitResult Compile(string source, Stream peStream)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Emit(peStream);
+    }
+
+    private static string CompileLoadInvokeCaptureStdout(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var result = Compile(source, peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, parameters: null);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -154,6 +154,7 @@ SelectCase
 SelectKeyword
 SelectStatement
 SemicolonToken
+SequenceKeyword
 ShiftLeftEqualsToken
 ShiftLeftToken
 ShiftRightEqualsToken
@@ -192,6 +193,7 @@ VarKeyword
 VariableDeclaration
 WhitespaceToken
 WithExpression
+YieldStatement
 
 [BoundNodeKind]
 AddressOfExpression
@@ -269,6 +271,7 @@ UnaryExpression
 UserInstanceCallExpression
 VariableDeclaration
 VariableExpression
+YieldStatement
 
 [BoundBinaryOperator]
 AmpersandAmpersandToken LogicalAnd (bool,bool) -> bool


### PR DESCRIPTION
Closes the language gap that GSharp had no producer-side iterator syntax. Adds:

- **`sequence[T]`** — a Go-flavored alias for `System.Collections.Generic.IEnumerable[T]`, mirroring how `map[K]V` aliases `Dictionary[K, V]`. The two forms are interchangeable at declarations, parameter/return types, and conversions; identical metadata.
- **`yield <expr>`** — statement, contextual keyword. Legal only inside iterator functions (return type `IEnumerable[T]` / `IEnumerator[T]` / `sequence[T]`). A function containing any `yield` becomes an iterator function and is rewritten to a synthesized class state machine.
- **No `yield break`** in this slice — use plain `return` to end iteration. Documented in the ADR as a deliberate scope cut.

## Design

ADR-0040 (`docs/adr/0040-sequence-type-and-yield.md`) covers context, decision, syntax/semantics, codegen approach, interop with existing `for x in seq` consumption, and open questions (async iterators / `IAsyncEnumerable[T]` are explicitly deferred).

## Implementation

- Parser: `YieldStatementSyntax`; `sequence[T]` type syntax piggy-backs on the map-style parser.
- Binder: detects iterator functions; checks yield element type; emits new diagnostics for yield-outside-iterator and iterator-return-type mismatch.
- Lowering: `IteratorRewriter` under `src/Core/CodeAnalysis/Lowering/Iterators/` builds a class state machine implementing `IEnumerable[T]`, `IEnumerator[T]`, `IDisposable`, with the standard `<>1__state` / `<>2__current` / `<>l__initialThreadId` fields and a Roslyn-compatible `GetEnumerator()` reuse optimization.
- Emitter: synthesized class state-machine TypeDef materialization extended; yield statement lowering via plain `assign current; assign state; return true; resume label; clear state`.

## Tests
- New end-to-end PE round-trip tests covering: kickoff-only, `sequence[int]` with `for-in`, explicit `IEnumerable[int]` return, **the Fibonacci example from the issue** (`fib(20)` ⇒ `0, 1, 1, 2, 3, 5, 8, 13`), and yield inside a conditional.

## Counts
- Total 897 tests pass: Core 767 · Compiler 84 · LanguageServer 17 · Interpreter 8 · Sdk 21. Verified clean in Debug **and** Release on macOS arm64.

## Follow-ups
- `yield break` (intentional gap).
- Try/finally in iterator bodies.
- Async iterators (`async IAsyncEnumerable[T]`) — separate slice, blocked on this one.
- Interpreter parity for yield-producer functions if missing — verify and either add or document.