### PR TITLE
Async emitter epic: docs milestone (ADR-0023 → Shipped)

### DIFF
--- a/docs/adr/0023-async-state-machine.md
+++ b/docs/adr/0023-async-state-machine.md
@@ -1,9 +1,9 @@
 # ADR-0023: `async func` / `await` — state-machine strategy
 
-- **Status**: Accepted (interpreter); deferred (emit)
-- **Date**: 2026-05-23
+- **Status**: Shipped (interpreter and emit)
+- **Date**: 2026-05-25
 - **Phase**: Phase 5 (lock before 5.1)
-- **Related**: ADR-0002 (concurrency model), ADR-0022 (go/chan/select lowering); execution plan §§5.1 – 5.2, 5.8; issue #51 (Roslyn-fork option)
+- **Related**: ADR-0002 (concurrency model), ADR-0022 (go/chan/select lowering), ADR-0040 (`sequence[T]` + `yield`); execution plan §§5.1 – 5.2, 5.8; issue #51 (Roslyn-fork option)
 
 ## Context
 
@@ -44,19 +44,87 @@ This pragma keeps the interpreter simple and avoids implementing a continuation-
 
 ### Emit
 
-Emit is **deferred** out of this PR. The work splits into two strategies; we commit to the choice in Phase 7 alongside the broader Roslyn-fork question (ADR-0027).
+The emit backend implements **Strategy A — bespoke state-machine emit** from the original framing. The async rewriter operates on the bound tree (`BoundTreeRewriter`) without any Roslyn runtime dependency, producing IL that follows the canonical `IAsyncStateMachine` contract: a struct state machine with a builder field, state field, hoisted locals, and a `MoveNext()` dispatch loop. The pipeline lives inside `Compilation.LowerForEmit` and runs after binding but before `EmitAssembly`.
 
-**Strategy A — bespoke state-machine emit.** Replicate Roslyn's `AsyncMethodToStateMachineRewriter` against our `BoundTreeRewriter`. Multi-month effort. Owns the long-tail of edge cases (try/catch around awaits, finally with awaits, loops with awaits, structured locals across await points).
+Key architectural choices:
 
-**Strategy B — Roslyn-borrowed lowering.** Re-host Roslyn's async rewriter on our bound tree (the project already vendors a Roslyn submodule under `src/Roslyn/`). Risk: tight coupling to Roslyn's BoundNode shape; ongoing maintenance against upstream churn.
+- **Struct state machines** for async methods and async lambdas (value-type allocation, boxed only on first incomplete await — matching Roslyn's optimization).
+- **Class state machines** for sync iterators (`IEnumerable[T]`) and async iterators (`IAsyncEnumerable[T]`), following the C# pattern where the iterator object itself serves as both enumerable and enumerator for the initial thread.
+- Lowering passes run in a fixed order: `AsyncExceptionHandlerRewriter` → `SpillSequenceSpiller` → `RefInitializationHoister` → `AsyncCaptureWalker` → state-machine rewriter (with MoveNext body rewriter as a sub-pass).
+- Synthesized state-machine types nest privately inside the declaring type (`<Program>` for top-level functions; closure class for capture-bearing lambdas), matching the Roslyn convention for debugger/reflection discovery.
+- Sequence-point markers (`AwaitYieldPoint` / `AwaitResumePoint`) are emitted as `nop` bytes today, awaiting a future PDB writer.
+- Awaitable-shape resolution is duck-typed: any type exposing a compatible `GetAwaiter()` pattern (including `Task.Yield()`, `ValueTask`, and structural awaitables) is accepted.
 
-The deciding inputs we expect to have by Phase 7:
+See `docs/emit-pipeline.md` for the full pass-ordering diagram and typedef layout.
 
-- Real-world async sample volume (Phase 5 samples + Phase 6/7 user testing).
-- Whether the bespoke emitter has hosted enough lowering features by then to make Strategy A's incremental cost feel finite.
-- The Phase 7 ADR-0027 outcome on issue #51.
+## Implementation summary
 
-Until then the interpreter is the only conformance backend for `async`/`await`. The coverage matrix and conformance harness record this explicitly (✅ interp, ❌ emit) so the gap is visible.
+The async emitter shipped end-to-end across PRs #106–#135, building on the interpreter-side work from the original acceptance and the pre-async gap closure in #98.
+
+### Foundations
+
+- **#98** — interpreter↔emitter gap closure (Phases A–G); async deferred per this ADR.
+- **#106** — foundational lowering scaffolding (ADR-0023 Strategy A).
+- **#107** — `AsyncCaptureWalker` (hoist-set analysis).
+- **#108** — `AsyncStateMachineTypeBuilder` factory.
+- **#109** — `AsyncEmitPrecheck` (clean diagnostic instead of bad IL).
+- **#110** — struct materialization for synthesized state machines.
+- **#111** — state-machine field map.
+- **#112** — resumable state allocator.
+- **#113** — state-machine rewriter scaffold.
+- **#114** — MoveNext body plan.
+- **#115** — kickoff body plan.
+- **#116** — kickoff operation ordering.
+- **#118** — kickoff body emission.
+- **#119** — MoveNext per-await dispatch (straight-line).
+
+### Lowering passes
+
+- **#121** — `SpillSequenceSpiller` (lift await out of sub-expressions).
+- **#122** — `AsyncExceptionHandlerRewriter` (spec §8).
+- **#123** — `RefInitializationHoister` (decompose ref locals across await).
+
+### Producer-side iterators
+
+- **ADR-0040 + #124** — `sequence[T]` type alias and `yield` keyword (sync iterators).
+- **#128** — `IAsyncEnumerable[T]` with mixed `yield` + `await` (async iterators).
+
+### Feature surface
+
+- **#125** — `BoundDefaultExpression` + `initobj` (value-type awaiter clear).
+- **#126** — awaitable-shape generalization (`Task.Yield()` / `ValueTask` / structural awaitables).
+- **#127** — async lambdas.
+
+### Polish
+
+- **#129** — sequence-point markers (§9: `AwaitYieldPoint` / `AwaitResumePoint`).
+- **#130** — `LowerForEmit` consolidation (extract pipeline helper; deduplicate Emit overloads).
+- **#131** — precheck cleanup + reflection invariants.
+- **#133** — nested-private state-machine types (Roslyn convention parity).
+
+### Verification
+
+- **#134** — white-box unit tests for async/iterator lowering rewriter passes.
+- **#135** — interp↔emit parity harness + `AsyncTask.gs` conformance promotion + `go`-on-async fix.
+
+## Known limitations / follow-ups
+
+Filed issues tracking incomplete edges of the async/iterator surface:
+
+- **#132** — `return await X` leaks un-rewritten `BoundAwaitExpression` to emitter.
+- **#136** — async `try`/`catch` around `await` → `InvalidProgramException` at runtime.
+- **#137** — async `try`/`finally` around `await` → `InvalidProgramException` at runtime.
+- **#138** — interpreter lacks `yield` (sync and async iterators); blocks parity for any iterator-using program.
+
+Smaller deferrals carried in commit messages:
+
+- `[EnumeratorCancellation]` parameter forwarding (§10 advanced).
+- `asyncSequence[T]` alias for `IAsyncEnumerable[T]` (future ADR).
+- Iterator `try`/`finally` support (`Dispose()` resuming into finally blocks).
+- Extension-method `GetAwaiter()` resolution.
+- `AsyncMethodBuilderInfo` for `ValueTask`/`ValueTask<T>` return types.
+- Pre-existing parser bug — generic return type + params combo.
+- User-facing `default` syntax (`BoundDefaultExpression` is internal-only today).
 
 ## Consequences
 
@@ -64,7 +132,7 @@ Until then the interpreter is the only conformance backend for `async`/`await`. 
 - New bound forms: `BoundAwaitExpression`. (`async` itself flows through `FunctionSymbol.IsAsync` and does not need its own bound node.)
 - Binder rules: `await` only inside async context; an `async func` declared `T` is callable as `Task[T]` everywhere; `await` is the only legal way to consume a `Task[T]` for its value (other than `.Result` via CLR interop, which we accept as an escape hatch).
 - Interpreter takes a synchronous-blocking `await`. Tests must therefore not assert thread-id continuity across `await`; document the constraint in the conformance harness header.
-- Emit gap is recorded explicitly. Phase 5 exit criterion drops the "both backends" half for async-bearing samples and notes the matrix gap.
+- Both backends (interpreter and emit) now cover `async`/`await`. The coverage matrix reflects ✅ interp, ✅ emit for async-method and async-lambda surfaces. Iterator surfaces are emit-only pending #138.
 
 ## Alternatives considered
 
@@ -74,6 +142,6 @@ Until then the interpreter is the only conformance backend for `async`/`await`. 
 
 ## Open follow-ups
 
-- Async lambdas (`async func(x int) int { … }`) — included in the interpreter pass; emit follow-up tracks them with the rest.
-- `ValueTask` / `ValueTask[T]` — duck-typed via `GetAwaiter()`; explicit support TBD when usage demands.
-- Cancellation token plumbing into `await for` — interpreter uses the enclosing `scope { }`'s CTS when present; standalone `await for` uses `CancellationToken.None`. Revisit in Phase 7.
+- Async lambdas (`async func(x int) int { … }`) — shipped in #127 for both interpreter and emit.
+- `ValueTask` / `ValueTask[T]` — duck-typed via `GetAwaiter()` and accepted at the language level (#126); `AsyncMethodBuilderInfo` for native `ValueTask` return (avoiding the Task wrapper) is deferred.
+- Cancellation token plumbing into `await for` — interpreter uses the enclosing `scope { }`'s CTS when present; standalone `await for` uses `CancellationToken.None`. `[EnumeratorCancellation]` forwarding is deferred.

--- a/docs/adr/0039-byref-pointers-and-clr-interop.md
+++ b/docs/adr/0039-byref-pointers-and-clr-interop.md
@@ -3,7 +3,7 @@
 - **Status**: Proposed
 - **Date**: 2026-05-25
 - **Phase**: Phase 7 follow-up — async emitter milestone (state-machine kickoff / MoveNext); also closes CLR interop gaps tracked since ADR-0034
-- **Related**: ADR-0023 (async state machine — deferred emit), ADR-0034 (imported CLR interop), ADR-0035 (user operator overloads), ADR-0038 (generic method inference); async emitter plan (field-map, kickoff, MoveNext)
+- **Related**: ADR-0023 (async state machine), ADR-0034 (imported CLR interop), ADR-0035 (user operator overloads), ADR-0038 (generic method inference); async emitter plan (field-map, kickoff, MoveNext)
 
 ## Context
 

--- a/docs/adr/0040-sequence-type-and-yield.md
+++ b/docs/adr/0040-sequence-type-and-yield.md
@@ -1,7 +1,7 @@
 # ADR-0040: `sequence[T]` type alias and `yield` statement
 
-- **Status**: Proposed
-- **Date**: 2026-05-26
+- **Status**: Shipped (sync iterators); async iterators shipped in #128
+- **Date**: 2026-05-25
 - **Phase**: Phase 7 follow-up — iterator support
 - **Related**: ADR-0023 (async state machine), ADR-0031 (canonical `for x in collection`), ADR-0034 (imported CLR interop), ADR-0039 (by-ref pointers)
 
@@ -35,9 +35,9 @@ A function containing any `yield` statement becomes an *iterator function*. The 
 
 This slice does not implement `yield break`. The GSharp answer for early termination of an iterator is plain `return` — running off the end of the function body or executing `return` causes `MoveNext()` to return `false`. This is consistent with Go's approach where `return` is the single exit mechanism, and avoids a two-keyword statement form that has no analog in Go or Kotlin.
 
-### 4. Async iterators deferred
+### 4. Async iterators
 
-`IAsyncEnumerable[T]` and `await foreach`-style async iteration are a separate future slice. The `sequence[T]` alias is sync-only; an `async_sequence[T]` or equivalent will be designed when that work begins.
+`IAsyncEnumerable[T]` with mixed `yield` + `await` shipped in #128 as part of the ADR-0023 async emitter rollout. The `asyncSequence[T]` alias is deferred to a future ADR; users spell the type as `IAsyncEnumerable[T]` directly today.
 
 ## Surface syntax
 
@@ -107,9 +107,9 @@ This reuses architectural patterns from the async state-machine pipeline (`Synth
 
 ## Open questions
 
-1. **Async iterators**: `IAsyncEnumerable[T]` support is deferred. Will likely introduce `async_sequence[T]` or reuse `sequence[T]` in async context.
+1. **Async iterator alias**: `IAsyncEnumerable[T]` support shipped in #128 but no `asyncSequence[T]` alias exists yet. Future ADR will decide the ergonomic spelling.
 2. **Try/finally in iterators**: this slice does not support `try`/`finally` within iterator bodies (would require `Dispose()` to resume into finally blocks). A diagnostic is emitted if detected.
-3. **Interpreter parity**: the interpreter (`Evaluator.cs`) does not gain `yield` support in this slice. Iterator functions are emit-only. This is a known gap — the interpreter is authoritative per `docs/emit-pipeline.md` but iterator state machines are inherently an emit concern. Interpreter parity is tracked as follow-up work.
+3. **Interpreter parity**: the interpreter (`Evaluator.cs`) does not gain `yield` support in this slice. Iterator functions are emit-only. This is a known gap tracked as #138 — the interpreter is authoritative per `docs/emit-pipeline.md` but iterator state machines are inherently an emit concern.
 
 ## Alternatives considered
 
@@ -127,4 +127,4 @@ Rejected in favor of bare `yield <expr>` for brevity and Go/Kotlin flavor. The `
 
 ## Summary
 
-This ADR introduces producer-side iterator support via `sequence[T]` (alias for `IEnumerable[T]`) and `yield <expr>`. The feature uses a synthesized state-machine class following the well-established C# iterator pattern, reuses architectural patterns from the existing async pipeline, and composes naturally with the already-shipped `for x in` consumption syntax. `yield break` is omitted in favor of plain `return`; async iterators are deferred.
+This ADR introduces producer-side iterator support via `sequence[T]` (alias for `IEnumerable[T]`) and `yield <expr>`. The feature uses a synthesized state-machine class following the well-established C# iterator pattern, reuses architectural patterns from the existing async pipeline, and composes naturally with the already-shipped `for x in` consumption syntax. `yield break` is omitted in favor of plain `return`. Async iterators (`IAsyncEnumerable[T]` with mixed `yield` + `await`) shipped in #128 as a follow-on to this ADR.

--- a/docs/emit-pipeline.md
+++ b/docs/emit-pipeline.md
@@ -31,6 +31,55 @@ GSharp has two execution backends. The interpreter (`Evaluator`) walks the bound
 | Compiler driver | `gsc` (`src/Compiler`) | Parse command-line args (`/out`, `/r`, `/target`, `/targetframework`, response files), produce the PE, and write `<name>.runtimeconfig.json` for executable outputs. |
 | MSBuild SDK | `Gsharp.NET.Sdk` | Wire `CoreCompile` into `Microsoft.NET.Sdk` so `.gsproj` files participate in the standard build pipeline. The SDK's task DLL is `netstandard2.0`; the compiler payload is `net10.0` invoked as `dotnet gsc.dll`. |
 
+## Async / iterator lowering pipeline
+
+Async methods, async lambdas, sync iterators (`sequence[T]`), and async iterators (`IAsyncEnumerable[T]`) require a state-machine transformation before IL emission. This lowering runs inside `Compilation.LowerForEmit`, after binding and before `EmitAssembly`. The entry point is `AsyncStateMachineRewriter.Rewrite` (for async methods/lambdas) or the sibling `IteratorRewriter` / `AsyncIteratorRewriter` (for sync/async iterators respectively).
+
+### Pass ordering (async methods and async lambdas)
+
+Inside `AsyncStateMachineRewriter.Rewrite`, the bound body is transformed through a fixed sequence of passes:
+
+1. **`AsyncExceptionHandlerRewriter`** — rewrites `try`/`catch`/`finally` blocks containing `await` into a form the state machine can resume into (spec §8).
+2. **`SpillSequenceSpiller`** — lifts `await` expressions out of compound sub-expressions into spill-sequence temporaries, ensuring each await is at statement level.
+3. **`RefInitializationHoister`** — decomposes `ref` locals that span await points into addressable fields.
+4. **`AsyncCaptureWalker`** — walks the rewritten body to compute the hoist set (locals and parameters that live across await points).
+5. **State-machine rewriter** — synthesizes the `IAsyncStateMachine` struct, builder field, state field, hoisted-local fields, and the `MoveNext()` body. The **MoveNext body rewriter** is a sub-pass that converts each `await` into a yield/resume pair with state transitions, and inserts sequence-point markers.
+
+### Sync and async iterators
+
+`IteratorRewriter` (sync) and `AsyncIteratorRewriter` (async) run as siblings of the async-state-machine rewriter in `LowerForEmit`. They produce **class** state machines (not structs) because the iterator object serves as both `IEnumerable[T]` and `IEnumerator[T]` for the first enumeration. Each `yield` statement becomes a `current = value; state = K; return true` transition in the generated `MoveNext()`.
+
+### Sequence-point markers
+
+The MoveNext body rewriter inserts `AwaitYieldPoint` (before suspending) and `AwaitResumePoint` (at the resume label) markers. Today these emit as single `nop` IL bytes — placeholders for a future PDB writer that will map them to source-level sequence points for debugger step-through.
+
+### Nested-type layout
+
+All synthesized state-machine types nest privately inside their kickoff method's declaring type, following the Roslyn convention for debugger and reflection discovery:
+
+- Top-level functions: state machine nests inside `<Program>`.
+- Lambdas with captures: state machine nests inside the closure class.
+
+The typedef ordering within the module is:
+
+```
+<Module>
+├── Interfaces
+├── Classes
+│   ├── <Program>
+│   │   └── <async-method-SM>d__N (struct, nested)
+│   ├── SyncIterator_SM (class, nested in declaring type)
+│   └── AsyncIterator_SM (class, nested in declaring type)
+├── Structs
+│   └── (async-lambda struct SMs nested in closure class)
+└── Nested SMs follow their enclosing type's row
+```
+
+### Design references
+
+- [ADR-0023](adr/0023-async-state-machine.md) — async state-machine strategy and implementation summary.
+- [ADR-0040](adr/0040-sequence-type-and-yield.md) — `sequence[T]` type alias and `yield` statement.
+
 ## Entry-point synthesis
 
 GSharp supports C# 9-style top-level statements. The binder lowers a file's top-level statements into a single hidden `MethodSymbol` (logically `<TopLevel>$.<Main>$(string[] args)`). The emitter marks that method as the assembly entry point. An explicit `func Main()` is supported and takes precedence; mixing both in the same compilation is an error. See [`Gsharp-design-v0.1.md`](../design/Gsharp-design-v0.1.md) for the language-level contract.

--- a/samples/aspirational/README.md
+++ b/samples/aspirational/README.md
@@ -8,7 +8,7 @@ A sibling test, `test/Core.Tests/LanguageConformance/AspirationalSamplesTests`, 
 
 | Sample | Demonstrates |
 | --- | --- |
-| `AsyncTask.gs` | `async func`, `await`, BCL `Task.Delay` interop, `scope { go asyncEntry() }` driver pattern for top-level async. Emit of `async`/`await` is the only remaining Phase 5 surface that does not yet route through the emit backend (ADR-0023 Strategy A — multi-month bespoke `IAsyncStateMachine` rewrite). |
+| *(AsyncTask.gs was promoted to top-level `samples/` in #135 after async emit shipped end-to-end — see ADR-0023.)* | |
 
 Other Phase 5 samples (`PortScan.gs` exercising `chan` + `go` + `scope` + `select`, and `Patterns.gs` / `SwitchExpression.gs` exercising pattern matching) now live under top-level `samples/` and run on both backends after the Phase A–G emit work.
 


### PR DESCRIPTION
## Async emitter epic — docs milestone

Final docs-only slice closing the async emitter epic (#52). Implementation shipped end-to-end across PRs #98–#135; this PR brings the docs in line with the shipped reality.

### Changes

- **`docs/adr/0023-async-state-machine.md`** — Status flipped to `Shipped (interpreter and emit)`. Emit subsection rewritten to describe **Strategy A — bespoke state-machine emit** as the chosen path. Added `Implementation summary` subsection cross-referencing every PR in the rollout (grouped by foundations / lowering passes / iterators / feature surface / polish / verification). Added `Known limitations / follow-ups` subsection tracking #132, #136, #137, #138 plus the smaller deferrals.
- **`docs/emit-pipeline.md`** — New `Async / iterator lowering pipeline` section documenting the pass ordering inside `AsyncStateMachineRewriter.Rewrite` (ExceptionHandler → SpillSpiller → RefInitHoister → CaptureWalker → state-machine rewriter → MoveNext body rewriter), the sibling iterator rewriters, sequence-point markers (#129), and the nested-private typedef layout (#133).
- **`docs/adr/0040-sequence-type-and-yield.md`** — Status flipped to Shipped; §4 reflects #128 async iterator landing; open questions updated.
- **`docs/adr/0039-byref-pointers-and-clr-interop.md`** — Removed stale "— deferred emit" from Related line.
- **`samples/aspirational/README.md`** — Notes `AsyncTask.gs` promotion to conformance per #135.

### Verification

- `dotnet build src/Core -nologo -clp:NoSummary` — clean (0 warnings, 0 errors)
- `dotnet test GSharp.sln --no-restore --nologo` — Core 844 ✓ / 5 skip, Compiler 85 ✓
- `dotnet test test/Core.Tests --configuration Release --nologo` — 844 ✓ / 5 skip
- Coverage-matrix golden test passes (no drift)
- Markdown convention: all continuous prose on single lines

Closes the docs portion of #52. Async emitter epic is now feature-complete; remaining work tracked in #132, #136, #137, #138.
