### PR TITLE
Fix #132: spill 'return await X' to enable MoveNextBodyRewriter handling

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -162,13 +162,11 @@ public static class SpillSequenceSpiller
                 return false;
             }
 
-            // If the return expression is already a direct await, no spilling needed.
-            if (ret.Expression is BoundAwaitExpression)
-            {
-                builder.Add(ret);
-                return false;
-            }
-
+            // Always spill: even a direct `return await X` must be lifted into
+            // `var __tmp = await X; return __tmp` so MoveNextBodyRewriter can
+            // recognize the await as a top-level variable-declaration shape.
+            // Leaving a BoundAwaitExpression as the direct return expression
+            // would leak an un-rewritten await to the emitter (issue #132).
             var spilled = SpillExpression(ret.Expression);
             FlushSideEffects(spilled, builder);
             builder.Add(new BoundReturnStatement(spilled.Value));

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncSpillEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncSpillEmitTests.cs
@@ -123,6 +123,49 @@ Console.WriteLine(t.Result)
         Assert.Contains("42", output);
     }
 
+    [Fact]
+    public void Return_Direct_Await_FromResult_Returns_Value()
+    {
+        // Regression for issue #132: `return await X` used to leak an
+        // un-rewritten BoundAwaitExpression to the emitter.
+        const string Source = @"package ReturnAwaitTest
+import System
+import System.Threading.Tasks
+
+async func getVal() int {
+    return await Task.FromResult(42)
+}
+
+var t = getVal()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        var output = CompileAndRun(Source, "ReturnAwaitTest");
+        Assert.Contains("42", output);
+    }
+
+    [Fact]
+    public void Return_Direct_Await_TaskDelay_RealSuspension_Returns_Value()
+    {
+        // Regression for issue #132: verify the real-suspension path through
+        // `return await` works, not just the fast (FromResult) path.
+        const string Source = @"package ReturnAwaitDelayTest
+import System
+import System.Threading.Tasks
+
+async func getVal() int {
+    await Task.Delay(1)
+    return await Task.FromResult(42)
+}
+
+var t = getVal()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        var output = CompileAndRun(Source, "ReturnAwaitDelayTest");
+        Assert.Contains("42", output);
+    }
+
     private static string CompileAndRun(string source, string contextName)
     {
         using var peStream = new MemoryStream();


### PR DESCRIPTION
Fixes #132.

## Problem
`SpillSequenceSpiller.RewriteReturnStatement` short-circuited when the return expression was a direct `BoundAwaitExpression`, leaving the un-rewritten await for `MoveNextBodyRewriter`. That rewriter only recognizes awaits at three top-level shapes — expression statement, assignment expression statement, and variable declaration. A return with a direct await isn't among them, so the `BoundAwaitExpression` leaked all the way to `ReflectionMetadataEmitter` and emit failed.

## Fix
Always spill in `RewriteReturnStatement`:
```
return await X
```
becomes
```
var __tmp = await X
return __tmp
```
which matches the variable-declaration shape `MoveNextBodyRewriter` already handles. Option 1 from the issue (spiller-side, single point of normalization).

## Tests
Two new end-to-end emit regression tests in `AsyncSpillEmitTests`:
* `Return_Direct_Await_FromResult_Returns_Value` — fast (synchronous) path.
* `Return_Direct_Await_TaskDelay_RealSuspension_Returns_Value` — real suspension/resume path.

Full suite passes (846 Core + 85 Compiler + 17 LanguageServer + Interpreter + Sdk, 0 failures).