### PR TITLE
Fix #136 #137: async try/catch and try/finally around await

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -5462,6 +5462,12 @@ internal sealed class ReflectionMetadataEmitter
         private readonly Lowering.Async.AsyncStateMachinePlan asyncPlan;
         private readonly AsyncIteratorEmitContext asyncIteratorEmitCtx;
 
+        // Stack of currently-active protected regions; each entry holds the set of
+        // bound labels defined lexically within that region (including nested
+        // protected sub-regions). Used to translate goto/conditional-goto whose
+        // target lies outside the innermost region into the CLR-required `leave`.
+        private readonly Stack<HashSet<BoundLabel>> protectedRegionStack = new Stack<HashSet<BoundLabel>>();
+
         public BodyEmitter(
             ReflectionMetadataEmitter outer,
             InstructionEncoder il,
@@ -5555,11 +5561,10 @@ internal sealed class ReflectionMetadataEmitter
                     this.il.MarkLabel(this.labels[lbl.Label]);
                     break;
                 case BoundGotoStatement g:
-                    this.il.Branch(ILOpCode.Br, this.labels[g.Label]);
+                    this.EmitBranch(g.Label, conditional: null, jumpIfTrue: false);
                     break;
                 case BoundConditionalGotoStatement cg:
-                    this.EmitExpression(cg.Condition);
-                    this.il.Branch(cg.JumpIfTrue ? ILOpCode.Brtrue : ILOpCode.Brfalse, this.labels[cg.Label]);
+                    this.EmitBranch(cg.Label, conditional: cg.Condition, jumpIfTrue: cg.JumpIfTrue);
                     break;
                 case BoundTryStatement tryStmt:
                     this.EmitTryStatement(tryStmt);
@@ -6305,7 +6310,7 @@ internal sealed class ReflectionMetadataEmitter
 
                 this.il.MarkLabel(outerTryStart);
                 this.il.MarkLabel(innerTryStart);
-                this.EmitBlock((BoundBlockStatement)node.TryBlock);
+                this.EmitProtectedRegion((BoundBlockStatement)node.TryBlock);
                 var innerTryEnd = this.il.DefineLabel();
                 this.il.Branch(ILOpCode.Leave, endLabel);
                 this.il.MarkLabel(innerTryEnd);
@@ -6313,7 +6318,7 @@ internal sealed class ReflectionMetadataEmitter
                 this.EmitCatchClauses(node.CatchClauses, innerTryStart, innerTryEnd, leaveTarget: endLabel);
 
                 this.il.MarkLabel(finallyStart);
-                this.EmitBlock((BoundBlockStatement)node.FinallyBlock);
+                this.EmitProtectedRegion((BoundBlockStatement)node.FinallyBlock);
                 this.il.OpCode(ILOpCode.Endfinally);
                 this.il.MarkLabel(finallyEnd);
 
@@ -6323,7 +6328,7 @@ internal sealed class ReflectionMetadataEmitter
             {
                 var tryStart = this.il.DefineLabel();
                 this.il.MarkLabel(tryStart);
-                this.EmitBlock((BoundBlockStatement)node.TryBlock);
+                this.EmitProtectedRegion((BoundBlockStatement)node.TryBlock);
                 var tryEnd = this.il.DefineLabel();
                 this.il.Branch(ILOpCode.Leave, endLabel);
                 this.il.MarkLabel(tryEnd);
@@ -6338,11 +6343,11 @@ internal sealed class ReflectionMetadataEmitter
                 var finallyEnd = this.il.DefineLabel();
 
                 this.il.MarkLabel(tryStart);
-                this.EmitBlock((BoundBlockStatement)node.TryBlock);
+                this.EmitProtectedRegion((BoundBlockStatement)node.TryBlock);
                 this.il.Branch(ILOpCode.Leave, finallyEnd);
 
                 this.il.MarkLabel(finallyStart);
-                this.EmitBlock((BoundBlockStatement)node.FinallyBlock);
+                this.EmitProtectedRegion((BoundBlockStatement)node.FinallyBlock);
                 this.il.OpCode(ILOpCode.Endfinally);
                 this.il.MarkLabel(finallyEnd);
 
@@ -6368,13 +6373,100 @@ internal sealed class ReflectionMetadataEmitter
                 // Stack contains the caught exception; store into the catch variable.
                 this.EmitStoreVariable(clause.Variable);
 
-                this.EmitBlock((BoundBlockStatement)clause.Body);
+                this.EmitProtectedRegion((BoundBlockStatement)clause.Body);
                 this.il.Branch(ILOpCode.Leave, leaveTarget);
                 this.il.MarkLabel(handlerEnd);
 
                 var catchTypeHandle = (EntityHandle)this.outer.GetTypeReference(clause.ExceptionType.ClrType);
                 this.il.ControlFlowBuilder.AddCatchRegion(tryStart, tryEnd, handlerStart, handlerEnd, catchTypeHandle);
             }
+        }
+
+        // Emits a block as a protected region: pushes the lexical label set so
+        // gotos targeting labels outside the region are translated to `leave`.
+        private void EmitProtectedRegion(BoundBlockStatement block)
+        {
+            var labelSet = new HashSet<BoundLabel>();
+            CollectLabels(block, labelSet);
+            this.protectedRegionStack.Push(labelSet);
+            try
+            {
+                this.EmitBlock(block);
+            }
+            finally
+            {
+                this.protectedRegionStack.Pop();
+            }
+        }
+
+        private static void CollectLabels(BoundStatement statement, HashSet<BoundLabel> sink)
+        {
+            switch (statement)
+            {
+                case null:
+                    return;
+                case BoundLabelStatement lbl:
+                    sink.Add(lbl.Label);
+                    return;
+                case BoundBlockStatement block:
+                    foreach (var s in block.Statements)
+                    {
+                        CollectLabels(s, sink);
+                    }
+
+                    return;
+                case BoundTryStatement t:
+                    CollectLabels(t.TryBlock, sink);
+                    foreach (var c in t.CatchClauses)
+                    {
+                        CollectLabels(c.Body, sink);
+                    }
+
+                    if (t.FinallyBlock != null)
+                    {
+                        CollectLabels(t.FinallyBlock, sink);
+                    }
+
+                    return;
+                case BoundScopeStatement sc:
+                    CollectLabels(sc.Body, sink);
+                    return;
+                default:
+                    // All other structured statements (if/for/while/...) are
+                    // flattened to BoundGotoStatement/BoundConditionalGotoStatement
+                    // by Lowerer before reaching the emitter, so there are no
+                    // hidden BoundLabelStatements to discover.
+                    return;
+            }
+        }
+
+        private void EmitBranch(BoundLabel target, BoundExpression conditional, bool jumpIfTrue)
+        {
+            var targetHandle = this.labels[target];
+            var crossesRegion = this.protectedRegionStack.Count > 0
+                && !this.protectedRegionStack.Peek().Contains(target);
+
+            if (conditional == null)
+            {
+                this.il.Branch(crossesRegion ? ILOpCode.Leave : ILOpCode.Br, targetHandle);
+                return;
+            }
+
+            if (!crossesRegion)
+            {
+                this.EmitExpression(conditional);
+                this.il.Branch(jumpIfTrue ? ILOpCode.Brtrue : ILOpCode.Brfalse, targetHandle);
+                return;
+            }
+
+            // Conditional goto that crosses a protected region boundary:
+            // `leave` is not conditional, so emit the inverse branch over a
+            // `leave` to the target.
+            var skipLabel = this.il.DefineLabel();
+            this.EmitExpression(conditional);
+            this.il.Branch(jumpIfTrue ? ILOpCode.Brfalse : ILOpCode.Brtrue, skipLabel);
+            this.il.Branch(ILOpCode.Leave, targetHandle);
+            this.il.MarkLabel(skipLabel);
         }
 
         private void EmitLen(BoundLenExpression len)

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
@@ -108,9 +108,22 @@ public static class AsyncExceptionHandlerRewriter
 
             bool finallyHasAwait = rewrittenFinally != null && AsyncBoundTreeQueries.HasAwait(rewrittenFinally);
 
-            if (!anyCatchHasAwait && !finallyHasAwait)
+            // The finally must be lifted out of the protected region in either
+            // of two cases:
+            //   1) The finally itself contains an await (the CLR forbids await
+            //      inside a finally handler).
+            //   2) The try body contains an await. Without lifting, the IL
+            //      `leave` emitted for async suspension would execute the
+            //      finally on every yield, which is semantically wrong (the
+            //      finally should run only when the try completes normally,
+            //      exceptionally, or via early exit — not on async suspension).
+            bool tryBodyHasAwait = AsyncBoundTreeQueries.HasAwait(rewrittenTry);
+            bool needsFinallyLift = rewrittenFinally != null && (finallyHasAwait || tryBodyHasAwait);
+
+            if (!anyCatchHasAwait && !needsFinallyLift)
             {
-                // No await in any handler — pass through (possibly with rewritten children).
+                // No handler-await and no need to lift the finally — pass
+                // through (possibly with rewritten children).
                 if (rewrittenTry == node.TryBlock && !CatchesChanged(node.CatchClauses, rewrittenClauses) && rewrittenFinally == node.FinallyBlock)
                 {
                     return node;
@@ -130,7 +143,7 @@ public static class AsyncExceptionHandlerRewriter
                 pendingExLocal, new BoundLiteralExpression(null, nullableExceptionType));
             statements.Add(pendingExNullInit);
 
-            if (finallyHasAwait)
+            if (needsFinallyLift)
             {
                 // Pattern B: try/finally with await in finally
                 // Also handles try/catch/finally where finally has await:

--- a/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
@@ -126,14 +126,22 @@ public static class MoveNextBodyRewriter
                 statements.Add(new BoundVariableDeclaration(retValLocal, defaultVal));
             }
 
+            // Pre-pass: locate each await within the user's try-statement nesting
+            // so we can route the resume dispatch around protected regions.
+            // `br` and `brtrue`/`brfalse` cannot enter a CLR protected region;
+            // instead we route entry to a label placed immediately before the
+            // outermost user try, then have each user-try's internal dispatch
+            // route further (to either a resume label or a nested entry label).
+            var tryDispatch = TryDispatchPlanner.Plan(plan.LoweredBody, awaitResumeMap);
+
             // Build the try-body: state dispatch + user body + SetResult path.
             // Everything that targets exprReturnLabel must be INSIDE the try
             // because br cannot leave a protected region.
             var tryBodyStatements = ImmutableArray.CreateBuilder<BoundStatement>();
-            EmitStateDispatch(tryBodyStatements);
+            EmitStateDispatch(tryBodyStatements, tryDispatch);
 
             // Rewritten user body.
-            var rewriter = new InnerRewriter(this);
+            var rewriter = new InnerRewriter(this, tryDispatch);
             var rewrittenBody = rewriter.RewriteStatement(plan.LoweredBody);
             if (rewrittenBody is BoundBlockStatement block)
             {
@@ -175,7 +183,9 @@ public static class MoveNextBodyRewriter
                 thisParameter);
         }
 
-        private void EmitStateDispatch(ImmutableArray<BoundStatement>.Builder statements)
+        private void EmitStateDispatch(
+            ImmutableArray<BoundStatement>.Builder statements,
+            TryDispatchPlan tryDispatch)
         {
             statements.Add(new BoundLabelStatement(plan.MoveNextPlan.DispatchLabel));
 
@@ -186,11 +196,15 @@ public static class MoveNextBodyRewriter
 
             foreach (var rp in plan.MoveNextPlan.AwaitResumePoints)
             {
+                // If this await is inside a user try, route to the outermost
+                // containing try's entry label (placed just before that try);
+                // otherwise jump directly to the resume label.
+                var target = tryDispatch.GetOuterDispatchTarget(rp.State) ?? rp.ResumeLabel;
                 var condition = new BoundBinaryExpression(
                     new BoundVariableExpression(cachedStateLocal),
                     BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
                     Literal(rp.State));
-                statements.Add(new BoundConditionalGotoStatement(rp.ResumeLabel, condition, jumpIfTrue: true));
+                statements.Add(new BoundConditionalGotoStatement(target, condition, jumpIfTrue: true));
             }
         }
 
@@ -267,10 +281,12 @@ public static class MoveNextBodyRewriter
         private sealed class InnerRewriter : BoundTreeRewriter
         {
             private readonly RewriteContext ctx;
+            private readonly TryDispatchPlan tryDispatch;
 
-            public InnerRewriter(RewriteContext ctx)
+            public InnerRewriter(RewriteContext ctx, TryDispatchPlan tryDispatch)
             {
                 this.ctx = ctx;
+                this.tryDispatch = tryDispatch;
             }
 
             protected override BoundStatement RewriteReturnStatement(BoundReturnStatement node)
@@ -385,56 +401,105 @@ public static class MoveNextBodyRewriter
                 // catch variables.
                 var result = (BoundTryStatement)base.RewriteTryStatement(node);
 
-                var needsPatch = false;
+                // Patch hoisted catch variables.
+                var needsCatchPatch = false;
                 foreach (var clause in result.CatchClauses)
                 {
                     if (TryGetHoistedField(clause.Variable, out _))
                     {
-                        needsPatch = true;
+                        needsCatchPatch = true;
                         break;
                     }
                 }
 
-                if (!needsPatch)
+                if (needsCatchPatch)
+                {
+                    var patchedClauses = ImmutableArray.CreateBuilder<BoundCatchClause>();
+                    foreach (var clause in result.CatchClauses)
+                    {
+                        if (TryGetHoistedField(clause.Variable, out var field))
+                        {
+                            var copyToField = Stmt(ctx.WriteField(
+                                field,
+                                new BoundVariableExpression(clause.Variable)));
+                            var stmts = ImmutableArray.CreateBuilder<BoundStatement>();
+                            stmts.Add(copyToField);
+                            if (clause.Body is BoundBlockStatement block)
+                            {
+                                stmts.AddRange(block.Statements);
+                            }
+                            else
+                            {
+                                stmts.Add(clause.Body);
+                            }
+
+                            patchedClauses.Add(new BoundCatchClause(
+                                clause.ExceptionType,
+                                clause.Variable,
+                                new BoundBlockStatement(stmts.ToImmutable())));
+                        }
+                        else
+                        {
+                            patchedClauses.Add(clause);
+                        }
+                    }
+
+                    result = new BoundTryStatement(
+                        result.TryBlock,
+                        patchedClauses.ToImmutable(),
+                        result.FinallyBlock);
+                }
+
+                // If this user try contains awaits in its body, prepend a
+                // state-dispatch at the top of the try body (legal because
+                // dispatch and resume labels are both inside the same
+                // protected region) and mark the position immediately before
+                // the try with the synthesized entry label that the outer
+                // dispatch (or an enclosing try's dispatch) routes to.
+                var dispatchEntries = tryDispatch.GetInternalDispatchEntries(node);
+                var entryLabel = tryDispatch.GetEntryLabel(node);
+
+                if (dispatchEntries.IsDefaultOrEmpty && entryLabel == null)
                 {
                     return result;
                 }
 
-                var newClauses = ImmutableArray.CreateBuilder<BoundCatchClause>();
-                foreach (var clause in result.CatchClauses)
+                var newTryBodyStmts = ImmutableArray.CreateBuilder<BoundStatement>();
+                if (!dispatchEntries.IsDefaultOrEmpty)
                 {
-                    if (TryGetHoistedField(clause.Variable, out var field))
+                    foreach (var entry in dispatchEntries)
                     {
-                        // Prepend: this.<field> = clause.Variable (load from local slot)
-                        var copyToField = Stmt(ctx.WriteField(
-                            field,
-                            new BoundVariableExpression(clause.Variable)));
-                        var stmts = ImmutableArray.CreateBuilder<BoundStatement>();
-                        stmts.Add(copyToField);
-                        if (clause.Body is BoundBlockStatement block)
-                        {
-                            stmts.AddRange(block.Statements);
-                        }
-                        else
-                        {
-                            stmts.Add(clause.Body);
-                        }
-
-                        newClauses.Add(new BoundCatchClause(
-                            clause.ExceptionType,
-                            clause.Variable,
-                            new BoundBlockStatement(stmts.ToImmutable())));
-                    }
-                    else
-                    {
-                        newClauses.Add(clause);
+                        var cond = new BoundBinaryExpression(
+                            new BoundVariableExpression(ctx.cachedStateLocal),
+                            BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
+                            Literal(entry.State));
+                        newTryBodyStmts.Add(new BoundConditionalGotoStatement(entry.Target, cond, jumpIfTrue: true));
                     }
                 }
 
-                return new BoundTryStatement(
-                    result.TryBlock,
-                    newClauses.ToImmutable(),
+                if (result.TryBlock is BoundBlockStatement existingBlock)
+                {
+                    newTryBodyStmts.AddRange(existingBlock.Statements);
+                }
+                else
+                {
+                    newTryBodyStmts.Add(result.TryBlock);
+                }
+
+                var rebuiltTry = new BoundTryStatement(
+                    new BoundBlockStatement(newTryBodyStmts.ToImmutable()),
+                    result.CatchClauses,
                     result.FinallyBlock);
+
+                if (entryLabel == null)
+                {
+                    return rebuiltTry;
+                }
+
+                // Place the entry label immediately before the try (outside it).
+                return new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+                    new BoundLabelStatement(entryLabel),
+                    rebuiltTry));
             }
 
             protected override BoundExpression RewriteAwaitExpression(BoundAwaitExpression node)

--- a/src/Core/CodeAnalysis/Lowering/Async/TryDispatchEntry.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/TryDispatchEntry.cs
@@ -1,0 +1,26 @@
+// <copyright file="TryDispatchEntry.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Binding;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>One entry in a user try's internal state dispatch.</summary>
+internal readonly struct TryDispatchEntry
+{
+    /// <summary>Initializes a new instance of the <see cref="TryDispatchEntry"/> struct.</summary>
+    /// <param name="state">The await state number.</param>
+    /// <param name="target">The dispatch target label.</param>
+    public TryDispatchEntry(int state, BoundLabel target)
+    {
+        State = state;
+        Target = target;
+    }
+
+    /// <summary>Gets the await state number.</summary>
+    public int State { get; }
+
+    /// <summary>Gets the dispatch target label.</summary>
+    public BoundLabel Target { get; }
+}

--- a/src/Core/CodeAnalysis/Lowering/Async/TryDispatchPlanner.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/TryDispatchPlanner.cs
@@ -1,0 +1,283 @@
+// <copyright file="TryDispatchPlanner.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Pre-pass walker that builds a <see cref="TryDispatchPlan"/> from the
+/// lowered async body by locating each await within the lexical nesting
+/// of user try statements.
+/// </summary>
+/// <remarks>
+/// <para>The CLR forbids branching <c>br</c>/<c>brtrue</c>/<c>brfalse</c>
+/// into a protected (try) region from outside. The outer MoveNext state
+/// dispatch therefore cannot jump directly to a resume label that lies
+/// inside a user try. Instead, a synthesized <i>entry label</i> is placed
+/// immediately before each user try with awaits, and the outer dispatch
+/// routes there. Inside that try a second dispatch then either routes
+/// further (to a nested try's entry label) or to a resume label for an
+/// await directly in that try.</para>
+///
+/// <para>For nested user trys, dispatch chains through each level: outer
+/// dispatch → outermost try's entry → outermost try's internal dispatch →
+/// next-deeper try's entry → ... → resume label.</para>
+/// </remarks>
+internal static class TryDispatchPlanner
+{
+    /// <summary>
+    /// Builds a dispatch plan for the given async body.
+    /// </summary>
+    /// <param name="body">The lowered async body to scan.</param>
+    /// <param name="awaitResumeMap">The await-expression to resume-point map produced by <see cref="MoveNextBodyBuilder"/>.</param>
+    /// <returns>A plan describing how to route the outer and per-try dispatches.</returns>
+    public static TryDispatchPlan Plan(
+        BoundStatement body,
+        IReadOnlyDictionary<BoundAwaitExpression, AwaitResumePoint> awaitResumeMap)
+    {
+        var walker = new Walker(awaitResumeMap);
+        walker.Walk(body);
+        return walker.Build();
+    }
+
+    private sealed class Walker
+    {
+        private readonly IReadOnlyDictionary<BoundAwaitExpression, AwaitResumePoint> awaitResumeMap;
+        private readonly Stack<BoundTryStatement> tryStack = new Stack<BoundTryStatement>();
+        private readonly Dictionary<BoundTryStatement, BoundLabel> entryLabels = new Dictionary<BoundTryStatement, BoundLabel>();
+        private readonly Dictionary<int, BoundLabel> outerDispatch = new Dictionary<int, BoundLabel>();
+        private readonly Dictionary<BoundTryStatement, List<TryDispatchEntry>> internalDispatch = new Dictionary<BoundTryStatement, List<TryDispatchEntry>>();
+        private int entryOrdinal;
+
+        public Walker(IReadOnlyDictionary<BoundAwaitExpression, AwaitResumePoint> awaitResumeMap)
+        {
+            this.awaitResumeMap = awaitResumeMap;
+        }
+
+        public TryDispatchPlan Build()
+        {
+            return new TryDispatchPlan(
+                outerDispatch.ToImmutableDictionary(),
+                entryLabels.ToImmutableDictionary(),
+                internalDispatch.ToImmutableDictionary(
+                    kv => kv.Key,
+                    kv => kv.Value.ToImmutableArray()));
+        }
+
+        public void Walk(BoundNode node)
+        {
+            switch (node)
+            {
+                case null:
+                    return;
+                case BoundAwaitExpression aw:
+                    if (awaitResumeMap.TryGetValue(aw, out var rp))
+                    {
+                        RecordAwait(rp);
+                    }
+
+                    if (aw.Expression != null)
+                    {
+                        Walk(aw.Expression);
+                    }
+
+                    return;
+                case BoundTryStatement t:
+                    tryStack.Push(t);
+                    Walk(t.TryBlock);
+                    foreach (var c in t.CatchClauses)
+                    {
+                        // Catches and finallies should not contain awaits at
+                        // this point (AsyncExceptionHandlerRewriter lifts them
+                        // out). Walk for safety but do not record those awaits
+                        // as needing entry routing for this try.
+                        Walk(c.Body);
+                    }
+
+                    if (t.FinallyBlock != null)
+                    {
+                        Walk(t.FinallyBlock);
+                    }
+
+                    tryStack.Pop();
+                    return;
+                case BoundBlockStatement block:
+                    foreach (var s in block.Statements)
+                    {
+                        Walk(s);
+                    }
+
+                    return;
+                case BoundExpressionStatement es:
+                    Walk(es.Expression);
+                    return;
+                case BoundVariableDeclaration vd:
+                    Walk(vd.Initializer);
+                    return;
+                case BoundReturnStatement ret:
+                    Walk(ret.Expression);
+                    return;
+                case BoundIfStatement ifs:
+                    Walk(ifs.Condition);
+                    Walk(ifs.ThenStatement);
+                    Walk(ifs.ElseStatement);
+                    return;
+                case BoundConditionalGotoStatement cg:
+                    Walk(cg.Condition);
+                    return;
+                case BoundThrowStatement th:
+                    Walk(th.Expression);
+                    return;
+                case BoundScopeStatement sc:
+                    Walk(sc.Body);
+                    return;
+                case BoundAssignmentExpression a:
+                    Walk(a.Expression);
+                    return;
+                case BoundBinaryExpression b:
+                    Walk(b.Left);
+                    Walk(b.Right);
+                    return;
+                case BoundUnaryExpression u:
+                    Walk(u.Operand);
+                    return;
+                case BoundConversionExpression cv:
+                    Walk(cv.Expression);
+                    return;
+                case BoundCallExpression call:
+                    foreach (var arg in call.Arguments)
+                    {
+                        Walk(arg);
+                    }
+
+                    return;
+                case BoundImportedCallExpression ic:
+                    foreach (var arg in ic.Arguments)
+                    {
+                        Walk(arg);
+                    }
+
+                    return;
+                case BoundImportedInstanceCallExpression iic:
+                    Walk(iic.Receiver);
+                    foreach (var arg in iic.Arguments)
+                    {
+                        Walk(arg);
+                    }
+
+                    return;
+                default:
+                    return;
+            }
+        }
+
+        private void RecordAwait(AwaitResumePoint rp)
+        {
+            if (tryStack.Count == 0)
+            {
+                return;
+            }
+
+            // The outer dispatch routes to the OUTERMOST containing try's entry.
+            var stackArr = tryStack.ToArray(); // top-of-stack first → innermost first
+            var outermost = stackArr[stackArr.Length - 1];
+            outerDispatch[rp.State] = GetOrCreateEntryLabel(outermost);
+
+            // Each enclosing try (from outermost inward) gets an internal
+            // dispatch entry. For the try at index idx, the target is either
+            // the entry label of the next-deeper try (idx-1), or the resume
+            // label itself when this try is the innermost containing one.
+            for (int idx = stackArr.Length - 1; idx >= 0; idx--)
+            {
+                var tryAtLevel = stackArr[idx];
+                BoundLabel target = idx == 0 ? rp.ResumeLabel : GetOrCreateEntryLabel(stackArr[idx - 1]);
+
+                if (!internalDispatch.TryGetValue(tryAtLevel, out var list))
+                {
+                    list = new List<TryDispatchEntry>();
+                    internalDispatch[tryAtLevel] = list;
+                }
+
+                list.Add(new TryDispatchEntry(rp.State, target));
+            }
+        }
+
+        private BoundLabel GetOrCreateEntryLabel(BoundTryStatement tryStmt)
+        {
+            if (!entryLabels.TryGetValue(tryStmt, out var lbl))
+            {
+                lbl = new BoundLabel("<>sm_user_try_entry_" + entryOrdinal++);
+                entryLabels[tryStmt] = lbl;
+            }
+
+            return lbl;
+        }
+    }
+}
+
+/// <summary>
+/// Result of <see cref="TryDispatchPlanner.Plan"/>: per-state outer
+/// dispatch routing, per-try entry labels, and per-try internal dispatch
+/// entries.
+/// </summary>
+internal sealed class TryDispatchPlan
+{
+    private readonly ImmutableDictionary<int, BoundLabel> outerDispatchTargets;
+    private readonly ImmutableDictionary<BoundTryStatement, BoundLabel> entryLabels;
+    private readonly ImmutableDictionary<BoundTryStatement, ImmutableArray<TryDispatchEntry>> internalDispatch;
+
+    /// <summary>Initializes a new instance of the <see cref="TryDispatchPlan"/> class.</summary>
+    /// <param name="outerDispatchTargets">Map from await state to outer-dispatch target label.</param>
+    /// <param name="entryLabels">Map from user try statement to its synthesized entry label.</param>
+    /// <param name="internalDispatch">Map from user try statement to its internal dispatch entries.</param>
+    public TryDispatchPlan(
+        ImmutableDictionary<int, BoundLabel> outerDispatchTargets,
+        ImmutableDictionary<BoundTryStatement, BoundLabel> entryLabels,
+        ImmutableDictionary<BoundTryStatement, ImmutableArray<TryDispatchEntry>> internalDispatch)
+    {
+        this.outerDispatchTargets = outerDispatchTargets;
+        this.entryLabels = entryLabels;
+        this.internalDispatch = internalDispatch;
+    }
+
+    /// <summary>
+    /// Gets the label the outer dispatch should branch to for the given
+    /// await state, or <see langword="null"/> if the await is not inside
+    /// any user try (in which case the caller should jump directly to the
+    /// resume label).
+    /// </summary>
+    /// <param name="state">The await suspension state number.</param>
+    /// <returns>The entry-label target, or null.</returns>
+    public BoundLabel GetOuterDispatchTarget(int state)
+    {
+        return outerDispatchTargets.TryGetValue(state, out var lbl) ? lbl : null;
+    }
+
+    /// <summary>
+    /// Gets the entry label placed immediately before the given user try,
+    /// or <see langword="null"/> if the try contains no awaits and needs
+    /// no entry routing.
+    /// </summary>
+    /// <param name="tryStmt">The user try statement (pre-rewrite identity).</param>
+    /// <returns>The synthesized entry label, or null.</returns>
+    public BoundLabel GetEntryLabel(BoundTryStatement tryStmt)
+    {
+        return entryLabels.TryGetValue(tryStmt, out var lbl) ? lbl : null;
+    }
+
+    /// <summary>
+    /// Gets the internal dispatch entries to prepend to the given user
+    /// try's body. Each entry pairs an await state with the label control
+    /// should jump to (either a resume label or a nested try's entry).
+    /// </summary>
+    /// <param name="tryStmt">The user try statement (pre-rewrite identity).</param>
+    /// <returns>The dispatch entries; empty if this try has no awaits inside.</returns>
+    public ImmutableArray<TryDispatchEntry> GetInternalDispatchEntries(BoundTryStatement tryStmt)
+    {
+        return internalDispatch.TryGetValue(tryStmt, out var entries) ? entries : default;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncInterpVsEmitParityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncInterpVsEmitParityTests.cs
@@ -69,7 +69,99 @@ run().Wait()
         AssertParity(Source, Expected, nameof(Parity_RealSuspension_TaskDelay));
     }
 
-    [Fact(Skip = "Emitter produces InvalidProgramException for async state machine with try/catch — tracked as follow-up")]
+    [Fact]
+    public void Parity_AsyncWithMultipleAwaitsInTry()
+    {
+        const string Source = @"package ParityMultiAwaitTry
+import System
+import System.Threading.Tasks
+
+async func run() int {
+    var s = 0
+    try {
+        await Task.Delay(1)
+        s = s + 1
+        await Task.Delay(1)
+        s = s + 2
+        await Task.Delay(1)
+        s = s + 4
+    } catch(ex) {
+        s = -1
+    }
+    return s
+}
+
+var t = run()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        const string Expected = "7\n";
+        AssertParity(Source, Expected, nameof(Parity_AsyncWithMultipleAwaitsInTry));
+    }
+
+    [Fact]
+    public void Parity_AsyncWithNestedTryAroundAwait()
+    {
+        const string Source = @"package ParityNestedTry
+import System
+import System.Threading.Tasks
+
+async func run() int {
+    var s = 0
+    try {
+        await Task.Delay(1)
+        try {
+            await Task.Delay(1)
+            s = s + 10
+        } catch(inner) {
+            s = -2
+        }
+        s = s + 1
+    } catch(ex) {
+        s = -1
+    }
+    return s
+}
+
+var t = run()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        const string Expected = "11\n";
+        AssertParity(Source, Expected, nameof(Parity_AsyncWithNestedTryAroundAwait));
+    }
+
+    [Fact]
+    public void Parity_AsyncTryFinally_RunsOnceOnNormalCompletion()
+    {
+        // Regression for #137: with the IL `leave` fix, the finally must run
+        // exactly once (after the try body completes), not on every async
+        // suspension.
+        const string Source = @"package ParityFinallyOnce
+import System
+import System.Threading.Tasks
+
+async func run() int {
+    var count = 0
+    try {
+        await Task.Delay(1)
+        await Task.Delay(1)
+        await Task.Delay(1)
+    } finally {
+        count = count + 1
+    }
+    return count
+}
+
+var t = run()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        const string Expected = "1\n";
+        AssertParity(Source, Expected, nameof(Parity_AsyncTryFinally_RunsOnceOnNormalCompletion));
+    }
+
+    [Fact]
     public void Parity_AsyncWithTryCatch_AroundAwait()
     {
         const string Source = @"package ParityTryCatch
@@ -95,7 +187,7 @@ Console.WriteLine(t.Result)
         AssertParity(Source, Expected, nameof(Parity_AsyncWithTryCatch_AroundAwait));
     }
 
-    [Fact(Skip = "Emitter produces InvalidProgramException for async state machine with try/finally — tracked as follow-up")]
+    [Fact]
     public void Parity_AsyncWithTryFinally_AroundAwait()
     {
         const string Source = @"package ParityTryFinally


### PR DESCRIPTION
Fixes #136 and #137.

## Root cause

An async function with `try { await E; ... } catch/finally { ... }` produced `InvalidProgramException` at first invocation. Three CLR rules were being violated by the emitted IL:

1. The per-await suspension sequence emitted by `MoveNextBodyRewriter` placed `goto exitLabel` (suspension exit) and the `resumeLabel:` inside the user try. A plain `br` cannot cross a protected-region boundary in either direction.
2. The outer MoveNext state dispatch emitted `goto resumeLabel` from outside the user try, branching *into* the protected region — also illegal.
3. For try/finally, simply switching the suspension branch to `leave` would execute the finally on every async yield, not only on completion.

## Fix

- **IL emitter** (`ReflectionMetadataEmitter.BodyEmitter`): track a stack of label sets for open protected regions. When a `BoundGotoStatement`/`BoundConditionalGotoStatement` targets a label outside the innermost open region, emit `leave` (or, for the conditional case, inverse-branch over a `leave`).

- **`MoveNextBodyRewriter` + new `TryDispatchPlanner`**: for each user try whose body contains awaits, synthesize an *entry label* placed immediately before the try, plus an internal state dispatch at the top of the try body. The outer MoveNext dispatch routes each await to the outermost containing user try's entry label; that try's internal dispatch then routes to either the resume label (await directly in this try) or the next-deeper try's entry label, chaining through arbitrary nesting.

- **`AsyncExceptionHandlerRewriter`**: extend the Pattern B (finally-lift) trigger to fire whenever the try body contains an await — not only when the finally itself contains one. Lifting the finally outside the protected region ensures the IL `leave` for async suspension does not execute it.

## Tests

- Unskipped the two existing parity tests `Parity_AsyncWithTryCatch_AroundAwait` (#136) and `Parity_AsyncWithTryFinally_AroundAwait` (#137).
- Added `Parity_AsyncWithMultipleAwaitsInTry`, `Parity_AsyncWithNestedTryAroundAwait`, and `Parity_AsyncTryFinally_RunsOnceOnNormalCompletion` to lock in nested-try and finally-once behavior.
- Full suite: 982 passing, 3 unrelated skips.