### PR TITLE
Interpreter: support yield in sync and async iterators (#138)

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -25,6 +25,8 @@ public sealed class Evaluator
     private readonly Stack<Dictionary<VariableSymbol, object>> locals = new Stack<Dictionary<VariableSymbol, object>>();
     private readonly object goLock = new object();
     private readonly Stack<ScopeFrame> scopeFrames = new Stack<ScopeFrame>();
+    private readonly Stack<System.Collections.IList> iteratorSinks = new Stack<System.Collections.IList>();
+    private readonly Dictionary<Symbols.FunctionSymbol, bool> iteratorFunctionCache = new Dictionary<Symbols.FunctionSymbol, bool>();
     private Random random;
 
     private object lastValue;
@@ -131,6 +133,10 @@ public sealed class Evaluator
                     break;
                 case BoundNodeKind.AwaitForRangeStatement:
                     EvaluateAwaitForRangeStatement((BoundAwaitForRangeStatement)s);
+                    index++;
+                    break;
+                case BoundNodeKind.YieldStatement:
+                    EvaluateYieldStatement((BoundYieldStatement)s);
                     index++;
                     break;
                 default:
@@ -1149,6 +1155,14 @@ public sealed class Evaluator
             this.locals.Push(locals);
 
             var statement = program.Functions[node.Function];
+
+            if (IsIteratorFunction(node.Function, statement))
+            {
+                var iteratorResult = EvaluateIteratorFunction(node.Function, statement);
+                this.locals.Pop();
+                return iteratorResult;
+            }
+
             var result = EvaluateStatement(statement);
 
             this.locals.Pop();
@@ -1160,6 +1174,92 @@ public sealed class Evaluator
 
             return result;
         }
+    }
+
+    private bool IsIteratorFunction(Symbols.FunctionSymbol function, BoundBlockStatement body)
+    {
+        if (iteratorFunctionCache.TryGetValue(function, out var cached))
+        {
+            return cached;
+        }
+
+        var walker = new YieldFinder();
+        walker.RewriteStatement(body);
+        cached = walker.Found;
+        iteratorFunctionCache[function] = cached;
+        return cached;
+    }
+
+    private object EvaluateIteratorFunction(Symbols.FunctionSymbol function, BoundBlockStatement body)
+    {
+        // ADR-0040: iterator functions (sync `sequence[T]` / `IEnumerable[T]` and
+        // async `IAsyncEnumerable[T]`) are realized eagerly under the interpreter.
+        // We push a yield sink, run the body to completion synchronously (with
+        // `await` modeled by `GetAwaiter().GetResult()` per the existing
+        // single-threaded interp model), then wrap the collected items in a
+        // typed list or an IAsyncEnumerable adapter for `await for` consumers.
+        var elementType = GetIteratorElementClrType(function.Type);
+        var listType = typeof(List<>).MakeGenericType(elementType);
+        var list = (System.Collections.IList)Activator.CreateInstance(listType);
+
+        iteratorSinks.Push(list);
+        try
+        {
+            EvaluateStatement(body);
+        }
+        finally
+        {
+            iteratorSinks.Pop();
+        }
+
+        if (IsAsyncEnumerableReturn(function.Type))
+        {
+            var wrapperType = typeof(InterpAsyncEnumerableBuffer<>).MakeGenericType(elementType);
+            return Activator.CreateInstance(wrapperType, list);
+        }
+
+        return list;
+    }
+
+    private void EvaluateYieldStatement(BoundYieldStatement node)
+    {
+        if (iteratorSinks.Count == 0)
+        {
+            throw new EvaluatorException("'yield' encountered outside of an iterator function.", node);
+        }
+
+        var value = EvaluateExpression(node.Expression);
+        iteratorSinks.Peek().Add(value);
+        lastValue = value;
+    }
+
+    private static Type GetIteratorElementClrType(TypeSymbol type)
+    {
+        if (type is Symbols.SequenceTypeSymbol seq)
+        {
+            return seq.ElementType.ClrType ?? typeof(object);
+        }
+
+        var clr = type?.ClrType;
+        if (clr != null && clr.IsGenericType && !clr.IsGenericTypeDefinition)
+        {
+            return clr.GetGenericArguments()[0];
+        }
+
+        return typeof(object);
+    }
+
+    private static bool IsAsyncEnumerableReturn(TypeSymbol type)
+    {
+        var clr = type?.ClrType;
+        if (clr == null || !clr.IsGenericType || clr.IsGenericTypeDefinition)
+        {
+            return false;
+        }
+
+        var fullName = clr.GetGenericTypeDefinition().FullName;
+        return fullName == "System.Collections.Generic.IAsyncEnumerable`1"
+            || fullName == "System.Collections.Generic.IAsyncEnumerator`1";
     }
 
     private static object WrapAsyncResult(TypeSymbol declaredReturn, object value)
@@ -1858,6 +1958,49 @@ public sealed class Evaluator
         {
             var locals = this.locals.Peek();
             locals[variable] = value;
+        }
+    }
+
+    private sealed class YieldFinder : Binding.BoundTreeRewriter
+    {
+        public bool Found { get; private set; }
+
+        protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
+        {
+            Found = true;
+            return node;
+        }
+    }
+
+    private sealed class InterpAsyncEnumerableBuffer<T> :
+        System.Collections.Generic.IAsyncEnumerable<T>,
+        System.Collections.Generic.IAsyncEnumerator<T>
+    {
+        private readonly System.Collections.Generic.IList<T> items;
+        private int index = -1;
+
+        public InterpAsyncEnumerableBuffer(System.Collections.Generic.IList<T> items)
+        {
+            this.items = items;
+        }
+
+        public T Current => items[index];
+
+        public System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(
+            System.Threading.CancellationToken cancellationToken = default)
+        {
+            return new InterpAsyncEnumerableBuffer<T>(items);
+        }
+
+        public System.Threading.Tasks.ValueTask<bool> MoveNextAsync()
+        {
+            index++;
+            return new System.Threading.Tasks.ValueTask<bool>(index < items.Count);
+        }
+
+        public System.Threading.Tasks.ValueTask DisposeAsync()
+        {
+            return default;
         }
     }
 

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncInterpVsEmitParityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncInterpVsEmitParityTests.cs
@@ -237,7 +237,7 @@ Console.WriteLine(t.Result)
         AssertParity(Source, Expected, nameof(Parity_AsyncAccumulator_MultipleAwaits));
     }
 
-    [Fact(Skip = "Interpreter does not support yield — iterator execution is emit-only")]
+    [Fact]
     public void Parity_SyncIterator_Sequence()
     {
         const string Source = @"package ParitySyncIter
@@ -258,7 +258,7 @@ for x in nums() {
         AssertParity(Source, Expected, nameof(Parity_SyncIterator_Sequence));
     }
 
-    [Fact(Skip = "Interpreter does not support yield — async iterator execution is emit-only")]
+    [Fact(Skip = "Emitter does not yet support `await for` (IAsyncEnumerable consumer side). Interpreter side is covered by AsyncIterator_InterpOnly_ProducesValues.")]
     public void Parity_AsyncIterator_YieldWithAwait()
     {
         const string Source = @"package ParityAsyncIter
@@ -280,6 +280,35 @@ await for x in gen() {
 ";
         const string Expected = "10\n20\n30\n";
         AssertParity(Source, Expected, nameof(Parity_AsyncIterator_YieldWithAwait));
+    }
+
+    [Fact]
+    public void AsyncIterator_InterpOnly_ProducesValues()
+    {
+        // Interpreter-side coverage for #138: yield + await inside an async
+        // iterator function (`IAsyncEnumerable[int]`). The matching parity
+        // test is skipped because the emitter does not yet implement the
+        // `await for` consumer side; this test exercises the interpreter
+        // alone so the producer side does not regress.
+        const string Source = @"package AsyncIterInterp
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+
+func gen() IAsyncEnumerable[int] {
+    yield 10
+    await Task.Delay(1)
+    yield 20
+    await Task.Delay(1)
+    yield 30
+}
+
+await for x in gen() {
+    Console.WriteLine(x)
+}
+";
+        const string Expected = "10\n20\n30\n";
+        Assert.Equal(Expected, RunInterpreter(Source));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #138.

Adds `yield` support to the interpreter so functions returning
`sequence[T]` / `IEnumerable[T]` / `IAsyncEnumerable[T]` evaluate
without throwing on `BoundYieldStatement` from `EvaluateStatement`.

## Approach

Per ADR-0040 the interpreter is the authoritative single-threaded
semantic backend, so iterators are realized **eagerly**:

- A `BoundNodeKind.YieldStatement` case in `EvaluateStatement` pushes the
  evaluated expression onto the active yield sink.
- `EvaluateCallExpression` detects iterator functions (body contains
  `BoundYieldStatement`, cached per `FunctionSymbol`) and routes them to
  a new `EvaluateIteratorFunction` helper that:
  - pushes a yield sink,
  - runs the body to completion synchronously (`await` is already
    realized via `GetAwaiter().GetResult()` — same pragma as Phase 5.1),
  - returns either a typed `List<T>` (sync iterator) or a private
    `InterpAsyncEnumerableBuffer<T>` adapter implementing
    `IAsyncEnumerable<T>` + `IAsyncEnumerator<T>` so `await for`
    consumers can iterate the produced values.

## Tests

- Unskipped `Parity_SyncIterator_Sequence` — now passes interp↔emit
  parity.
- Added `AsyncIterator_InterpOnly_ProducesValues` to cover the
  interpreter side of `yield` + `await` in an `IAsyncEnumerable[int]`
  producer.
- `Parity_AsyncIterator_YieldWithAwait` remains skipped — its
  blocker is no longer the interpreter (this PR fixes that) but the
  **emit-side `await for` consumer** which is still unimplemented
  (see note at `AsyncIteratorEmitTests.cs:22`). The skip reason was
  updated to reflect this; closing the emit-side gap is a separate
  follow-up.

Full suite: **973 passing**, 2 skipped (1 pre-existing unrelated, 1
the await-for-consumer parity test), 0 failures.