### PR TITLE
ADR-0041: sequence[T] aliases IAsyncEnumerable[T] in async return slot

### DIFF
--- a/docs/adr/0023-async-state-machine.md
+++ b/docs/adr/0023-async-state-machine.md
@@ -119,7 +119,7 @@ Filed issues tracking incomplete edges of the async/iterator surface:
 Smaller deferrals carried in commit messages:
 
 - `[EnumeratorCancellation]` parameter forwarding (§10 advanced).
-- `asyncSequence[T]` alias for `IAsyncEnumerable[T]` (future ADR).
+- `asyncSequence[T]` alias for `IAsyncEnumerable[T]` — addressed by ADR-0041 (proposes context-sensitive `sequence[T]` instead of a new keyword).
 - Iterator `try`/`finally` support (`Dispose()` resuming into finally blocks).
 - Extension-method `GetAwaiter()` resolution.
 - `AsyncMethodBuilderInfo` for `ValueTask`/`ValueTask<T>` return types.

--- a/docs/adr/0040-sequence-type-and-yield.md
+++ b/docs/adr/0040-sequence-type-and-yield.md
@@ -107,7 +107,7 @@ This reuses architectural patterns from the async state-machine pipeline (`Synth
 
 ## Open questions
 
-1. **Async iterator alias**: `IAsyncEnumerable[T]` support shipped in #128 but no `asyncSequence[T]` alias exists yet. Future ADR will decide the ergonomic spelling.
+1. **Async iterator alias**: `IAsyncEnumerable[T]` support shipped in #128 but no `asyncSequence[T]` alias exists yet. ADR-0041 proposes overloading `sequence[T]` in `async` return-type position to mean `IAsyncEnumerable[T]`, in lieu of a separate keyword.
 2. **Try/finally in iterators**: this slice does not support `try`/`finally` within iterator bodies (would require `Dispose()` to resume into finally blocks). A diagnostic is emitted if detected.
 3. **Interpreter parity**: the interpreter (`Evaluator.cs`) does not gain `yield` support in this slice. Iterator functions are emit-only. This is a known gap tracked as #138 — the interpreter is authoritative per `docs/emit-pipeline.md` but iterator state machines are inherently an emit concern.
 

--- a/docs/adr/0041-async-sequence-alias.md
+++ b/docs/adr/0041-async-sequence-alias.md
@@ -1,0 +1,159 @@
+# ADR-0041: `sequence[T]` in an `async` context aliases `IAsyncEnumerable[T]`
+
+- **Status**: Accepted (implemented in this PR)
+- **Date**: 2026-05-25
+- **Phase**: Phase 7 follow-up — iterator ergonomics
+- **Related**: ADR-0002 (concurrency model), ADR-0022 (`<-` is async in async contexts), ADR-0023 (async state machine), ADR-0040 (`sequence[T]` + `yield`)
+
+## Context
+
+ADR-0040 introduced `sequence[T]` as a contextual-keyword alias for `System.Collections.Generic.IEnumerable<T>`, and ADR-0023 shipped `IAsyncEnumerable[T]` support for async iterators in #128. Both ADRs leave one ergonomic edge open (ADR-0040 §"Open questions" item 1; ADR-0023 §"Known limitations" "asyncSequence[T] alias"): users wanting an async iterator must spell the BCL type by hand, e.g.
+
+```gsharp
+async func numbers() IAsyncEnumerable[int] { yield 1; await Task.Delay(10); yield 2 }
+```
+
+while the sync flavor enjoys the GSharp-flavored alias:
+
+```gsharp
+func numbers() sequence[int] { yield 1; yield 2 }
+```
+
+The asymmetry is jarring. Two ergonomic spellings are credible:
+
+- **A separate alias** `asyncSequence[T]` (the path implied by the ADR-0023/0040 follow-ups).
+- **Overload the existing alias**: `sequence[T]` continues to mean `IEnumerable[T]` everywhere except in the return-type position of an `async func`, where it means `IAsyncEnumerable[T]`. This is the user proposal evaluated here.
+
+A precedent for concurrency-context-dependent semantics already exists in GSharp: ADR-0022 specifies that channel `<-` operations lower to async `Reader`/`Writer` calls inside `async` contexts and blocking calls otherwise. The surface token is identical; the lowering target depends on the enclosing function's `async`-ness.
+
+## Feasibility assessment
+
+Mechanically, the change is small and local to the binder and one symbol class. The grammar is unchanged — `sequence` remains a contextual keyword recognized in type-clause position. The work splits as follows.
+
+### Binder (one new flow)
+
+`Binder.BindTypeClause` would need to know, when it encounters `IsSequence`, whether the *current binding context* is the return-type position of an `async` function (free function, method, extension, or lambda). The `IsAsync` flag is already on `FunctionDeclarationSyntax` and on the lambda syntax. Two viable shapes:
+
+1. **Peek the enclosing syntax**: walk `syntax.Parent` (or have `BindFunctionDeclaration`/`BindLambda` pass a boolean) when binding the *return type clause specifically*. This is cleanly scoped — the rule applies only to the return-type slot, never to parameter types, local declarations, generic arguments, or any other type-clause site.
+2. **Bind eagerly to `SequenceTypeSymbol` and rewrite later** when the function symbol is materialized with `IsAsync = true`. Less appealing because the symbol identity escapes into the bound tree before the rewrite, and we lose the early-error path for `yield`/`return` validation.
+
+Shape 1 is preferred. The async re-interpretation is a property of *one* syntactic slot and should be resolved there.
+
+### Symbol model
+
+`SequenceTypeSymbol` currently materializes `IEnumerable<T>` eagerly. Two paths:
+
+- **Parallel `AsyncSequenceTypeSymbol`** with `ClrType = IAsyncEnumerable<T>`, cached the same way. Cleanest separation; iterator rewriter and `IsAsyncIteratorReturnType` already key off the CLR type, so downstream passes need no changes. Recommended.
+- **Flag on the existing type**: `SequenceTypeSymbol.Get(elementType, isAsync)` selecting between `IEnumerable<>` and `IAsyncEnumerable<>` at construction. Saves one class but couples two concepts into one symbol and risks accidental equality-by-element-type collisions.
+
+### Implicit-async-iterator detection
+
+Today `function.IsAsync = syntax.IsAsync || IsAsyncIteratorReturnType(type)` (Binder.cs:1128, 1135). Under this ADR, the implicit branch becomes redundant for the alias path because resolving `sequence[T]` to `IAsyncEnumerable[T]` requires `syntax.IsAsync` to already be true. The implicit branch still fires for the explicit `IAsyncEnumerable[T]` spelling, preserving today's behavior for direct BCL spellings.
+
+### Validators that already work
+
+- `IsIteratorReturnType` (Binder.cs:2794) accepts `SequenceTypeSymbol` *and* `IAsyncEnumerable[T]` via the CLR-type branch. If `sequence[T]` in an async function resolves to an `AsyncSequenceTypeSymbol` (or directly to `IAsyncEnumerable[T]`), `yield` is already accepted.
+- `GetIteratorElementType` (Binder.cs:2857) already handles both shapes.
+- `BindAwaitExpression` (Binder.cs:4924) already allows `await` whenever the enclosing function is async *or* returns an async iterator. Unchanged.
+- `IteratorRewriter` and `AsyncIteratorRewriter` (test/Core.Tests/CodeAnalysis/Lowering/Iterators/) dispatch on CLR type; identical IL is produced for `sequence[int]` and `IAsyncEnumerable[int]` in an `async` context.
+
+### Scope of the alias re-interpretation
+
+The new rule applies **only** to the return-type clause of an `async func` (declaration, method, extension, lambda). Everywhere else — parameter types, local declarations, generic arguments, struct fields, `let x sequence[int]` *inside* an async function body — `sequence[T]` continues to mean `IEnumerable[T]`. This narrow scoping keeps the alias predictable: the only token that triggers the swap is the `async` modifier on the enclosing function, and the only affected slot is one fixed position.
+
+### Migration
+
+Purely additive. Existing code that spells `IAsyncEnumerable[T]` directly continues to work unchanged via `IsAsyncIteratorReturnType`. No existing program changes meaning, because there is no legal way today to write `async func foo() sequence[int]` and have it round-trip — the function would bind as `Task[IEnumerable[int]]` at call sites and `yield` would be rejected (no iterator return type). In other words, the proposed syntax is currently dead and the new rule fills the gap.
+
+### Verdict
+
+**Feasible.** The implementation cost is single-digit hours of binder work plus targeted unit tests. The architectural footprint is one new symbol class and one new branch in `BindTypeClause`. No emit, no lowering, no runtime changes.
+
+## Decision
+
+Adopt the context-sensitive alias rule:
+
+> In the return-type clause of an `async func` (declaration, method, extension, or lambda), `sequence[T]` resolves to `System.Collections.Generic.IAsyncEnumerable<T>`. In every other position — including non-async functions, parameter types, local declarations, generic arguments, and type clauses inside an async function body — `sequence[T]` resolves to `System.Collections.Generic.IEnumerable<T>` as specified in ADR-0040.
+
+Concretely:
+
+```gsharp
+async func foo() sequence[int] {   // sequence[int] == IAsyncEnumerable[int]
+    yield 1
+    await Task.Delay(10)
+    yield 2
+}
+
+func bar() sequence[int] {         // sequence[int] == IEnumerable[int]
+    yield 1
+    yield 2
+}
+
+async func baz(items sequence[int]) sequence[int] {
+    // parameter `items` is IEnumerable[int] (alias rule applies to return slot only)
+    // return type is IAsyncEnumerable[int]
+    for x in items { yield x }
+}
+```
+
+The explicit spellings `IEnumerable[T]` and `IAsyncEnumerable[T]` remain legal everywhere and are unaffected.
+
+## Consequences
+
+Positive:
+
+- Symmetric ergonomic surface for sync and async iterators; closes the open question in ADR-0040 §"Open questions" and the `asyncSequence[T]` follow-up in ADR-0023.
+- One fewer keyword/alias to introduce; `asyncSequence[T]` is not needed.
+- Reuses the precedent established by ADR-0022 (`<-` is async in async contexts) — context-sensitive lowering is already part of the language.
+- No breaking change; the new syntax was previously inexpressible (would have produced `Task[IEnumerable[T]]` with no way to populate it via `yield`).
+
+Negative:
+
+- The same type-clause token denotes different CLR types depending on the enclosing function modifier. A casual reader must look at the function header to know what `sequence[T]` means here. Mitigation: documentation, hover tooling, and the scoping restriction (return-type slot only) keep the rule narrow.
+- Hover/IDE tooling must thread the async context to render the correct CLR type in tooltips. Manageable: the symbol is materialized differently in each case, so hover follows the symbol.
+- Diverges from C# (`IEnumerable<T>` and `IAsyncEnumerable<T>` are always distinct spellings) and Kotlin (`Sequence<T>` vs. `Flow<T>` are distinct names). GSharp has no Go analog because Go does not have iterators in this form.
+
+Neutral:
+
+- `IsAsyncIteratorReturnType` keeps detecting the explicit `IAsyncEnumerable[T]` spelling, so the implicit-async-iterator path (no `async` modifier, return type alone implies async) remains usable for the explicit BCL spelling but is *not* triggered by `sequence[T]`. To get an async iterator via the alias, the `async` modifier is mandatory. This is intentional: it keeps the alias unambiguous at the call site (a reader sees `async` and knows the swap is in play).
+- A function `func foo() sequence[int]` cannot be implicitly promoted to an async iterator. Users wanting an async iterator must either add `async` (alias swap fires) or spell `IAsyncEnumerable[int]` directly.
+
+## Implementation summary
+
+Shipped as a small, additive binder change:
+
+1. New `AsyncSequenceTypeSymbol` (`src/Core/CodeAnalysis/Symbols/AsyncSequenceTypeSymbol.cs`) mirrors `SequenceTypeSymbol` but materializes `ClrType = IAsyncEnumerable<T>`, cached per element type.
+2. New `Binder.BindReturnTypeClause(TypeClauseSyntax, bool isAsync)` helper. When `isAsync` is `true`, it post-processes a top-level `SequenceTypeSymbol` (optionally wrapped in `NullableTypeSymbol`) into `AsyncSequenceTypeSymbol`. All four return-type binding sites — free/extension/method function declarations, class methods, interface methods, and lambdas — now route through this helper.
+3. No changes needed in downstream passes. `IsAsyncIteratorReturnType` (binder), `IteratorRewriter.IsAsyncIteratorFunction`, and `AsyncIteratorRewriter.IsAsyncIteratorFunction` all key off the CLR type (`IAsyncEnumerable\`1`), so an `AsyncSequenceTypeSymbol` is routed to the async-iterator state-machine path automatically.
+4. End-to-end tests live in `test/Core.Tests/CodeAnalysis/Emit/AsyncSequenceAliasTests.cs` and cover: yield-only, mixed yield + await, CLR-shape verification (`IAsyncEnumerable<int>` and not `IEnumerable<int>`), sync behavior preservation when `async` is absent, parameter-position non-swap inside an async function body, and equivalence of the alias and the explicit `IAsyncEnumerable[int]` spelling.
+
+The change is purely additive: existing code spelling `IAsyncEnumerable[T]` directly continues to work, and existing sync `sequence[T]` programs are unaffected.
+
+## Alternatives considered
+
+### A. Introduce a separate `asyncSequence[T]` keyword
+
+This is the path implied by the ADR-0023 and ADR-0040 follow-ups. It mirrors Kotlin's `Sequence<T>` / `Flow<T>` and C#'s separate spellings. Pros: zero ambiguity, no context-sensitive resolution rule. Cons: a second contextual keyword for a concept that the `async` modifier already disambiguates, and asymmetry of *naming* (`asyncSequence` reads heavier than `sequence`). Rejected in favor of the unified spelling but kept as a fallback if the context-sensitive rule proves confusing in practice.
+
+### B. Resolve `sequence[T]` to `IAsyncEnumerable[T]` everywhere inside an async function body
+
+Considered and rejected. Treating parameter types and local declarations as async-aliased would surprise readers, break the principle that a type clause's meaning is determined locally, and make it impossible to declare a synchronous `IEnumerable[int]` parameter inside an async function. The chosen scope — return-type slot only — keeps the rule predictable and one-keyword-deep.
+
+### C. Make `async` mandatory on any function returning `IAsyncEnumerable[T]`
+
+Considered and rejected as overreach. The implicit-async-iterator detection in ADR-0023 (`IsAsync = ... || IsAsyncIteratorReturnType(type)`) is already shipped and lets users omit `async` when the BCL spelling makes the intent obvious. This ADR does not change that rule for the explicit spelling; it only adds the alias-driven path that *requires* `async` because the alias is the only signal.
+
+### D. Defer indefinitely; leave users to spell `IAsyncEnumerable[T]`
+
+The status quo. Rejected because the asymmetry between sync and async iterator ergonomics is a documented open question in two shipped ADRs, and the implementation cost of this proposal is small.
+
+## Implementation sketch (informative, not normative)
+
+The bullets below describe the change as proposed; see "Implementation summary" above for what actually shipped.
+
+1. Introduce `AsyncSequenceTypeSymbol` mirroring `SequenceTypeSymbol` but with `ClrType = typeof(IAsyncEnumerable<>).MakeGenericType(elementType.ClrType)`, cached by element type.
+2. In `Binder.BindFunctionDeclaration` (and the lambda counterpart), pass an `inAsyncReturnSlot` flag when binding the *return* type clause. When `BindTypeClause` sees `syntax.IsSequence && inAsyncReturnSlot`, construct `AsyncSequenceTypeSymbol.Get(elementType)` instead.
+3. Extend `IsIteratorReturnType` and `GetIteratorElementType` to recognize `AsyncSequenceTypeSymbol` (mirroring the existing `SequenceTypeSymbol` branches). All downstream passes already handle `IAsyncEnumerable[T]` by CLR type and need no further changes.
+4. Add binder unit tests covering: async lambda return type, async method on a struct, async extension function, alias-vs-explicit interoperability, parameter-position `sequence[T]` inside an async function (must stay sync), and a `func foo() sequence[int]` without `async` (must stay sync).
+5. Add an end-to-end emit test mirroring `AsyncIteratorEmitTests.numbers` but using `async func numbers() sequence[int]` to verify the produced state-machine class implements `IAsyncEnumerable<int>`.
+6. Update ADR-0040 §"Open questions" item 1 to point at this ADR; update ADR-0023 §"Known limitations" `asyncSequence[T]` line to mark the alias question resolved here.

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -753,7 +753,7 @@ public sealed class Binder
                     }
                 }
 
-                var returnType = BindTypeClause(methodSyntax.Type) ?? TypeSymbol.Void;
+                var returnType = BindReturnTypeClause(methodSyntax.Type, methodSyntax.IsAsync) ?? TypeSymbol.Void;
                 var methodAccessibility = ResolveAccessibility(methodSyntax.AccessibilityModifier);
                 var methodParameters = parameters.ToImmutable();
 
@@ -943,7 +943,7 @@ public sealed class Binder
                 }
             }
 
-            var returnType = BindTypeClause(methodSyntax.Type) ?? TypeSymbol.Void;
+            var returnType = BindReturnTypeClause(methodSyntax.Type, methodSyntax.IsAsync) ?? TypeSymbol.Void;
             var methodSymbol = new FunctionSymbol(
                 methodName,
                 parameters.ToImmutable(),
@@ -1096,7 +1096,8 @@ public sealed class Binder
                 }
             }
 
-            var type = BindTypeClause(syntax.Type) ?? TypeSymbol.Void;
+            // ADR-0041: bind the return type with async-aware alias resolution.
+            var type = BindReturnTypeClause(syntax.Type, syntax.IsAsync) ?? TypeSymbol.Void;
 
             var accessibility = ResolveAccessibility(syntax.AccessibilityModifier);
             FunctionSymbol function;
@@ -1846,6 +1847,38 @@ public sealed class Binder
         }
 
         return NullableTypeSymbol.Get(bound);
+    }
+
+    /// <summary>
+    /// ADR-0041: binds the return-type clause of a function (declaration,
+    /// method, extension, or lambda). When <paramref name="isAsync"/> is
+    /// <c>true</c> and the clause is the top-level <c>sequence[T]</c> alias
+    /// (optionally nullable), the alias resolves to
+    /// <see cref="AsyncSequenceTypeSymbol"/> (i.e. <c>IAsyncEnumerable[T]</c>)
+    /// rather than the synchronous <see cref="SequenceTypeSymbol"/>.
+    /// In every other position — parameter types, locals, generic arguments,
+    /// nested type clauses — <c>sequence[T]</c> continues to mean
+    /// <c>IEnumerable[T]</c> (ADR-0040).
+    /// </summary>
+    private TypeSymbol BindReturnTypeClause(TypeClauseSyntax syntax, bool isAsync)
+    {
+        var bound = BindTypeClause(syntax);
+        if (!isAsync || bound == null)
+        {
+            return bound;
+        }
+
+        if (bound is SequenceTypeSymbol seq)
+        {
+            return AsyncSequenceTypeSymbol.Get(seq.ElementType);
+        }
+
+        if (bound is NullableTypeSymbol nt && nt.UnderlyingType is SequenceTypeSymbol innerSeq)
+        {
+            return NullableTypeSymbol.Get(AsyncSequenceTypeSymbol.Get(innerSeq.ElementType));
+        }
+
+        return bound;
     }
 
     private BoundStatement BindIfStatement(IfStatementSyntax syntax)
@@ -3824,7 +3857,7 @@ public sealed class Binder
             parameterTypes.Add(ptype);
         }
 
-        var returnType = syntax.ReturnTypeClause != null ? BindTypeClause(syntax.ReturnTypeClause) : TypeSymbol.Void;
+        var returnType = syntax.ReturnTypeClause != null ? BindReturnTypeClause(syntax.ReturnTypeClause, syntax.IsAsync) : TypeSymbol.Void;
         returnType ??= TypeSymbol.Void;
 
         // For async lambdas, the observable return type (from the caller's

--- a/src/Core/CodeAnalysis/Symbols/AsyncSequenceTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/AsyncSequenceTypeSymbol.cs
@@ -1,0 +1,56 @@
+// <copyright file="AsyncSequenceTypeSymbol.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Represents an async sequence type — the contextual alias for
+/// <c>System.Collections.Generic.IAsyncEnumerable&lt;T&gt;</c> produced when
+/// <c>sequence[T]</c> appears in the return-type position of an
+/// <c>async func</c> (ADR-0041). Outside the return-type position of an
+/// <c>async func</c>, <c>sequence[T]</c> still resolves to the synchronous
+/// <see cref="SequenceTypeSymbol"/> (ADR-0040).
+/// </summary>
+public sealed class AsyncSequenceTypeSymbol : TypeSymbol
+{
+    private static readonly ConcurrentDictionary<TypeSymbol, AsyncSequenceTypeSymbol> Cache = new();
+
+    private AsyncSequenceTypeSymbol(TypeSymbol elementType)
+        : base($"sequence[{elementType.Name}]", MakeClrType(elementType))
+    {
+        ElementType = elementType;
+    }
+
+    /// <summary>Gets the element type.</summary>
+    public TypeSymbol ElementType { get; }
+
+    /// <summary>
+    /// Gets or creates the async-sequence type symbol for the given element type.
+    /// </summary>
+    /// <param name="elementType">The element type.</param>
+    /// <returns>The cached <see cref="AsyncSequenceTypeSymbol"/>.</returns>
+    public static AsyncSequenceTypeSymbol Get(TypeSymbol elementType)
+    {
+        if (elementType == null)
+        {
+            throw new ArgumentNullException(nameof(elementType));
+        }
+
+        return Cache.GetOrAdd(elementType, et => new AsyncSequenceTypeSymbol(et));
+    }
+
+    private static Type MakeClrType(TypeSymbol elementType)
+    {
+        if (elementType.ClrType == null)
+        {
+            return null;
+        }
+
+        return typeof(IAsyncEnumerable<>).MakeGenericType(elementType.ClrType);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncSequenceAliasTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncSequenceAliasTests.cs
@@ -1,0 +1,242 @@
+// <copyright file="AsyncSequenceAliasTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// End-to-end tests for ADR-0041: in the return-type position of an
+/// <c>async func</c>, the <c>sequence[T]</c> alias resolves to
+/// <c>IAsyncEnumerable[T]</c>. Outside that position, it continues to mean
+/// <c>IEnumerable[T]</c> (ADR-0040).
+/// </summary>
+public class AsyncSequenceAliasTests
+{
+    [Fact]
+    public void AsyncSequenceAlias_YieldOnly_ProducesValues()
+    {
+        const string Source = @"package AsyncSeqAlias
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+
+async func numbers() sequence[int] {
+    yield 1
+    yield 2
+    yield 3
+}
+";
+        var items = CompileAndEnumerateAsync<int>(Source, "numbers", nameof(AsyncSequenceAlias_YieldOnly_ProducesValues));
+        Assert.Equal(new[] { 1, 2, 3 }, items);
+    }
+
+    [Fact]
+    public void AsyncSequenceAlias_YieldWithAwait_ProducesValues()
+    {
+        const string Source = @"package AsyncSeqAliasAwait
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+
+async func numbers() sequence[int] {
+    yield 10
+    await Task.Yield()
+    yield 20
+    await Task.Yield()
+    yield 30
+}
+";
+        var items = CompileAndEnumerateAsync<int>(Source, "numbers", nameof(AsyncSequenceAlias_YieldWithAwait_ProducesValues));
+        Assert.Equal(new[] { 10, 20, 30 }, items);
+    }
+
+    [Fact]
+    public void AsyncSequenceAlias_ResultImplementsIAsyncEnumerable()
+    {
+        const string Source = @"package AsyncSeqAliasShape
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+
+async func gen() sequence[int] {
+    yield 1
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(AsyncSequenceAlias_ResultImplementsIAsyncEnumerable));
+        try
+        {
+            var result = InvokeFunction(asm, "gen", null);
+            Assert.IsAssignableFrom<IAsyncEnumerable<int>>(result);
+            Assert.False(result is IEnumerable<int>, "async-sequence return must not also be IEnumerable<int>");
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void SyncSequence_NoAsyncModifier_StillIEnumerable()
+    {
+        const string Source = @"package SyncSeqStable
+import System
+import System.Collections.Generic
+
+func numbers() sequence[int] {
+    yield 1
+    yield 2
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(SyncSequence_NoAsyncModifier_StillIEnumerable));
+        try
+        {
+            var result = InvokeFunction(asm, "numbers", null);
+            Assert.IsAssignableFrom<IEnumerable<int>>(result);
+            Assert.False(result is IAsyncEnumerable<int>, "sync-sequence return must not be IAsyncEnumerable<int>");
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void AsyncSequenceAlias_ParameterPosition_StaysSyncEnumerable()
+    {
+        // ADR-0041: the alias swap applies only to the return-type slot.
+        // Parameter `items` is sequence[int] inside an async func — it must
+        // still bind to IEnumerable[int] so we can pass a normal collection.
+        const string Source = @"package AsyncSeqParam
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+
+async func echo(items sequence[int]) sequence[int] {
+    for x in items {
+        yield x
+    }
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(AsyncSequenceAlias_ParameterPosition_StaysSyncEnumerable));
+        try
+        {
+            // Pass a synchronous IEnumerable<int> as the argument.
+            IEnumerable<int> arg = new[] { 7, 8, 9 };
+            var result = InvokeFunction(asm, "echo", new object[] { arg });
+            var items = ConsumeAsyncEnumerable<int>(result);
+            Assert.Equal(new[] { 7, 8, 9 }, items);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void AsyncSequenceAlias_AndExplicitIAsyncEnumerable_AreSameClrType()
+    {
+        // Two functions, one spelled with the alias, the other with the BCL
+        // type, should expose the same CLR return type.
+        const string Source = @"package AsyncSeqEquiv
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+
+async func viaAlias() sequence[int] {
+    yield 1
+}
+
+func viaExplicit() IAsyncEnumerable[int] {
+    yield 2
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(AsyncSequenceAlias_AndExplicitIAsyncEnumerable_AreSameClrType));
+        try
+        {
+            var programType = asm.GetTypes().First(t => t.Name == "<Program>");
+            var alias = programType.GetMethod("viaAlias", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            var explicitly = programType.GetMethod("viaExplicit", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(alias);
+            Assert.NotNull(explicitly);
+            Assert.Equal(alias!.ReturnType, explicitly!.ReturnType);
+            Assert.Equal(typeof(IAsyncEnumerable<int>), alias.ReturnType);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    private static List<T> CompileAndEnumerateAsync<T>(string source, string functionName, string contextName)
+    {
+        var (asm, ctx) = CompileToAssembly(source, contextName);
+        try
+        {
+            var enumerable = InvokeFunction(asm, functionName, null);
+            return ConsumeAsyncEnumerable<T>(enumerable);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    private static (Assembly asm, AssemblyLoadContext ctx) CompileToAssembly(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        var asm = loadContext.LoadFromStream(peStream);
+        return (asm, loadContext);
+    }
+
+    private static object InvokeFunction(Assembly asm, string functionName, object[] args)
+    {
+        var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+        Assert.NotNull(programType);
+        var method = programType!.GetMethod(
+            functionName,
+            BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return method!.Invoke(null, args);
+    }
+
+    private static List<T> ConsumeAsyncEnumerable<T>(object enumerable)
+    {
+        var asyncEnumerable = (IAsyncEnumerable<T>)enumerable;
+        var enumerator = asyncEnumerable.GetAsyncEnumerator(CancellationToken.None);
+        var items = new List<T>();
+        try
+        {
+            while (enumerator.MoveNextAsync().AsTask().GetAwaiter().GetResult())
+            {
+                items.Add(enumerator.Current);
+            }
+        }
+        finally
+        {
+            enumerator.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+
+        return items;
+    }
+}


### PR DESCRIPTION
## Summary

Introduces ADR-0041: in the return-type position of an `async func` (declaration, method, extension, or lambda), the `sequence[T]` alias resolves to `System.Collections.Generic.IAsyncEnumerable<T>` instead of the synchronous `IEnumerable<T>`. Everywhere else — parameter types, locals, generic arguments, nested type clauses, and any context without `async` — `sequence[T]` continues to mean `IEnumerable<T>` per ADR-0040.

Closes the open question carried in ADR-0040 §"Open questions" and the `asyncSequence[T]` follow-up in ADR-0023 §"Known limitations".

## Example

```gsharp
async func foo() sequence[int] {       // sequence[int] == IAsyncEnumerable[int]
    yield 1
    await Task.Yield()
    yield 2
}

func bar() sequence[int] {             // sequence[int] == IEnumerable[int]
    yield 1
}

async func echo(items sequence[int]) sequence[int] {
    // parameter is IEnumerable[int]; return type is IAsyncEnumerable[int]
    for x in items { yield x }
}
```

## Implementation

- **`AsyncSequenceTypeSymbol`** — new cached symbol with `ClrType = IAsyncEnumerable<T>`.
- **`Binder.BindReturnTypeClause(syntax, isAsync)`** — new helper applied at the four return-type binding sites (free/extension/method functions, class methods, interface methods, lambdas). When `isAsync` is true, post-processes a top-level `SequenceTypeSymbol` (optionally wrapped in `NullableTypeSymbol`) into `AsyncSequenceTypeSymbol`.
- **No downstream changes needed.** `IsAsyncIteratorReturnType` (binder), `IteratorRewriter.IsAsyncIteratorFunction`, and `AsyncIteratorRewriter.IsAsyncIteratorFunction` all dispatch on the function's CLR return type (`IAsyncEnumerable\`1`), so the new symbol flows through the existing async-iterator state-machine pipeline automatically.

## Tests

New `AsyncSequenceAliasTests` (test/Core.Tests/CodeAnalysis/Emit/) covers:

- Yield-only `async func numbers() sequence[int]` produces values.
- Mixed yield + `await Task.Yield()` produces values across suspensions.
- Return value implements `IAsyncEnumerable<int>` and not `IEnumerable<int>`.
- `func numbers() sequence[int]` without `async` continues to return `IEnumerable<int>` (and not `IAsyncEnumerable<int>`).
- Parameter `items sequence[int]` inside an async func stays `IEnumerable[int]` — accepts a sync collection at the call site.
- `async func() sequence[int]` and `func() IAsyncEnumerable[int]` produce the same CLR return type.

Full suite: 990 pass (+6 new), 2 skipped (pre-existing).

## Docs

- **ADR-0041** added (Accepted) with full feasibility analysis, decision, consequences, alternatives, implementation summary.
- **ADR-0040** open-questions entry updated to point at ADR-0041.
- **ADR-0023** `asyncSequence[T]` follow-up entry updated to point at ADR-0041.

## Compatibility

Purely additive. No breaking change:

- Existing code that spells `IAsyncEnumerable[T]` directly is unaffected (`IsAsyncIteratorReturnType` still detects it).
- Existing sync `sequence[T]` programs are unaffected.
- The newly-meaningful syntax `async func foo() sequence[int]` was previously dead — it would bind as `Task[IEnumerable[int]]` with no legal way to populate it via `yield`.