### PR TITLE
ADR-0042: `async sequence[T]` as a type-clause spelling for IAsyncEnumerable[T]

### DIFF
--- a/docs/adr/0042-async-sequence-type-clause.md
+++ b/docs/adr/0042-async-sequence-type-clause.md
@@ -1,0 +1,120 @@
+# ADR-0042: `async sequence[T]` as a type-clause spelling for `IAsyncEnumerable[T]`
+
+- **Status**: Accepted (implemented in this PR)
+- **Date**: 2026-05-25
+- **Phase**: Phase 7 follow-up — iterator ergonomics
+- **Related**: ADR-0023 (async state machine), ADR-0040 (`sequence[T]` + `yield`), ADR-0041 (`sequence[T]` aliases `IAsyncEnumerable[T]` in async return slot), issue #150 (`async func(P) R` as a function-type clause)
+
+## Context
+
+ADR-0040 introduced `sequence[T]` as a contextual-keyword alias for `IEnumerable<T>`. ADR-0041 made `sequence[T]` resolve to `IAsyncEnumerable<T>` *only* in the return-type slot of an `async func`. That covers the common producer case but leaves a gap: there is no GSharp-flavored spelling for `IAsyncEnumerable[T]` in any other type-clause position. Users must drop to the BCL spelling everywhere else:
+
+```gsharp
+// Today (post-ADR-0041)
+async func gen() sequence[int] { yield 1 }      // OK — alias swap
+func consume(s IAsyncEnumerable[int]) { ... }   // BCL spelling required
+let stream IAsyncEnumerable[int] = gen()        // BCL spelling required
+data Pipeline { items IAsyncEnumerable[int] }   // BCL spelling required
+```
+
+The asymmetry is visible at every consumer site. This ADR closes the gap by extending the `async` modifier — already used on function declarations and lambdas — into a *type-clause prefix* that may appear before `sequence[T]`.
+
+The grammar admits this cleanly because `async` is already a hard keyword (`SyntaxFacts.GetKeywordKind` maps `"async"` unconditionally to `AsyncKeyword`), so it is not a legal identifier or type name in any existing program. Adding `async` to the type-clause-start set introduces no parsing ambiguity and no breaking change.
+
+## Decision
+
+In any type-clause position, `async sequence[T]` is a spelling for `System.Collections.Generic.IAsyncEnumerable<T>`. The two-token form is the only legal use of `async` as a type-clause prefix in this slice; `async X` for any other `X` is a parse-time error (with one carved-out exception under design in issue #150 for `async func(P) R`).
+
+Concretely:
+
+```gsharp
+// Parameter
+func consume(stream async sequence[int]) { await for x in stream { ... } }
+
+// Local
+let stream async sequence[int] = gen()
+
+// Struct/class field
+data Pipeline { items async sequence[int] }
+
+// Generic argument
+let cbs List[async sequence[int]] = ...
+
+// Tuple element
+let pair (string, async sequence[int]) = ("a", gen())
+
+// Function-type clause (return slot)
+let factory func() async sequence[int] = gen
+
+// Pointer pointee, map value, chan element, nullable wrap
+let opt async sequence[int]? = nil
+let m map[string]async sequence[int]
+```
+
+All of the above resolve to the same `AsyncSequenceTypeSymbol` and therefore the same CLR type as the explicit `IAsyncEnumerable[T]` spelling and the ADR-0041 implicit-swap form.
+
+### Interaction with ADR-0041
+
+After this ADR, an async iterator's return type may be spelled three equivalent ways:
+
+```gsharp
+async func a() sequence[int] { ... }              // ADR-0041 implicit swap
+async func b() async sequence[int] { ... }        // explicit modifier form
+async func c() IAsyncEnumerable[int] { ... }      // BCL spelling
+```
+
+All three produce identical IL and identical symbols. The implicit swap remains the recommended common-case spelling because the `async` modifier is already on the function header; the explicit modifier form is available for users who prefer maximum local clarity in long signatures or in non-return positions; the BCL spelling is always available for interop documentation.
+
+### Restriction: `async` is only valid before `sequence` in type-clause position
+
+`async` as a type-clause prefix is reserved for the iterator alias. `async map[K]V`, `async chan T`, `async []T`, `async *T`, etc. are explicitly rejected with a diagnostic. Generalizing the modifier to function-type clauses (`async func(P) R` ≡ `func(P) Task[R]`) is the subject of issue #150 and a future ADR; this ADR leaves the door open without committing.
+
+## Consequences
+
+Positive:
+
+- Closes the asymmetry between sync and async iterator type-clause spellings everywhere a type may appear.
+- Single grammar rule, single binder branch, zero downstream changes — all consumer sites (`await for`, iterator rewriter, async-iterator rewriter, emit) already key off the CLR type produced by `AsyncSequenceTypeSymbol` (shipped with ADR-0041).
+- Reuses the existing `async` keyword; no new reserved word; reads consistently with `async func` declarations and lambdas.
+- Future-proofs the modifier for issue #150 (`async func(P) R`) without committing to it now.
+
+Negative:
+
+- Introduces a *two-token* type-clause shape (`async sequence[T]`) — a small departure from GSharp's existing single-prefix type forms (`*T`, `[]T`, `chan T`, `sequence[T]`, `map[K]V`). Mitigation: the parallel with `async func` makes the shape immediately recognizable.
+- Three legal spellings exist for the same async-iterator return type. Style guidance picks one canonical form; the language remains permissive.
+
+Neutral:
+
+- `asyncSequence[T]` as a single-token keyword (mentioned as an open question in ADR-0040 §"Open questions") is foreclosed by this ADR. The two-token modifier form strictly dominates it: no new reserved word, parallels `async func`, reads naturally with nullable and generic positions.
+- Tooling hover currently renders `AsyncSequenceTypeSymbol.Name` as `"sequence[T]"`. Polishing the hover to render `"async sequence[T]"` or the BCL spelling when the source used the explicit modifier form is a nice-to-have; the symbol identity is unchanged either way.
+
+## Alternatives considered
+
+### A. Introduce a single-token `asyncSequence[T]` keyword
+
+The path implied by the ADR-0040 §"Open questions" entry. Rejected: requires a new reserved word, reads less naturally than the modifier form in nullable and generic positions (`asyncSequence[int]?` vs `async sequence[int]?`), and does not generalize to other possible `async` type forms.
+
+### B. Restrict `async sequence[T]` to a subset of type-clause positions (e.g. only locals and parameters)
+
+Rejected: the grammar change (single parser branch) is the same regardless of how many positions accept it, and restricting the alias surface would re-introduce the very asymmetry this ADR closes.
+
+### C. Defer indefinitely
+
+The status quo after ADR-0041. Rejected: the parameter/local/field asymmetry is visible in every consumer-side declaration and the implementation cost is small.
+
+### D. Generalize `async` to all type-clause prefixes in this ADR (`async map[K]V`, `async chan T`, etc.)
+
+Rejected as overreach. None of the other forms have an existing BCL counterpart, and conflating the modifier across unrelated shapes would erode its meaning. Function-type clauses (`async func(P) R`) are tracked separately in issue #150.
+
+## Implementation summary
+
+Shipped in this PR as a strictly additive change. No existing program changes meaning; no existing test changes behavior.
+
+1. **Parser** (`src/Core/CodeAnalysis/Syntax/Parser.cs`):
+   - `ParseTypeClause` gains a leading branch on `AsyncKeyword`. It consumes `async`, then requires the next token to be `sequence` (reporting a clean diagnostic otherwise), then delegates to the existing sequence-type-clause path tagged with an `IsAsync` flag.
+   - `ParseOptionalTypeClause`'s type-clause-start whitelist gains `AsyncKeyword`.
+2. **Syntax model** (`src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs`): the existing sequence type-clause shape carries a new optional `AsyncModifier` token. `IsAsyncSequence` returns true when the modifier is present.
+3. **Binder** (`src/Core/CodeAnalysis/Binding/Binder.cs`): the `IsSequence` branch in `BindNonNullableTypeClause` constructs `AsyncSequenceTypeSymbol.Get(elementType)` when `syntax.IsAsyncSequence` is true, and `SequenceTypeSymbol.Get(elementType)` otherwise. ADR-0041's `BindReturnTypeClause` swap path continues to apply to the unmodified sync alias; it does not need to fire for the explicit modifier form because the binder already produces the async symbol directly.
+4. **Diagnostics**: new "the `async` modifier in a type clause is only valid before `sequence[T]`" diagnostic emitted by the parser when `async` is followed by any token other than `sequence`.
+
+No changes to lowering, emit, iterator rewriters, await-for binding, or any symbol code outside `AsyncSequenceTypeSymbol` (introduced in ADR-0041 / PR #149).

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1710,12 +1710,21 @@ public sealed class Binder
         }
 
         // ADR-0040: sequence type clause `sequence[T]`.
+        // ADR-0042: `async sequence[T]` resolves to IAsyncEnumerable[T] in any
+        // type-clause position; the unmodified `sequence[T]` stays IEnumerable[T]
+        // (with the ADR-0041 implicit swap applied separately at function
+        // return-type binding sites).
         if (syntax.IsSequence)
         {
             var elementType = BindTypeClause(syntax.SequenceElementType);
             if (elementType == null)
             {
                 return null;
+            }
+
+            if (syntax.IsAsyncSequence)
+            {
+                return AsyncSequenceTypeSymbol.Get(elementType);
             }
 
             return SequenceTypeSymbol.Get(elementType);

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -462,6 +462,18 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Reports that the <c>async</c> modifier was used in a type-clause position
+    /// without being followed by <c>sequence</c> (ADR-0042).
+    /// </summary>
+    /// <param name="location">The text location of the <c>async</c> modifier.</param>
+    /// <param name="actualKind">The kind of the token actually following <c>async</c>.</param>
+    public void ReportAsyncModifierInTypeClauseRequiresSequence(TextLocation location, SyntaxKind actualKind)
+    {
+        var message = $"The 'async' modifier in a type clause is only valid before 'sequence[T]'; found '<{actualKind}>'.";
+        Report(location, message);
+    }
+
+    /// <summary>
     /// Reports that a <c>yield</c> statement was used outside an iterator function (ADR-0040).
     /// </summary>
     /// <param name="location">The text location of the yield keyword.</param>

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -1021,6 +1021,12 @@ public class Parser
             return ParseSequenceTypeClause();
         }
 
+        // ADR-0042: `async sequence[T]` — alias for IAsyncEnumerable[T] in any type-clause position.
+        if (Current.Kind == SyntaxKind.AsyncKeyword)
+        {
+            return ParseAsyncSequenceTypeClause();
+        }
+
         // ADR-0039: pointer type `*T` in type-annotation position.
         if (Current.Kind == SyntaxKind.StarToken)
         {
@@ -1151,6 +1157,25 @@ public class Parser
         return TypeClauseSyntax.CreateSequence(syntaxTree, sequenceKeyword, openBracket, elementType, closeBracket, question);
     }
 
+    private TypeClauseSyntax ParseAsyncSequenceTypeClause()
+    {
+        // ADR-0042: `async sequence[T]` — the `async` modifier in a type clause
+        // is only valid before `sequence[T]` today (other modifier forms such as
+        // `async func(P) R` are tracked separately, see issue #150).
+        var asyncModifier = MatchToken(SyntaxKind.AsyncKeyword);
+        if (Current.Kind != SyntaxKind.SequenceKeyword)
+        {
+            Diagnostics.ReportAsyncModifierInTypeClauseRequiresSequence(asyncModifier.Location, Current.Kind);
+        }
+
+        var sequenceKeyword = MatchToken(SyntaxKind.SequenceKeyword);
+        var openBracket = MatchToken(SyntaxKind.OpenSquareBracketToken);
+        var elementType = ParseTypeClause();
+        var closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
+        var question = Current.Kind == SyntaxKind.QuestionToken ? MatchToken(SyntaxKind.QuestionToken) : null;
+        return TypeClauseSyntax.CreateAsyncSequence(syntaxTree, asyncModifier, sequenceKeyword, openBracket, elementType, closeBracket, question);
+    }
+
     private TypeClauseSyntax ParseFunctionTypeClause()
     {
         // Phase 4.7: function type clause `func(T1, T2, ...) R?`. The return
@@ -1195,6 +1220,7 @@ public class Parser
             Current.Kind != SyntaxKind.MapKeyword &&
             Current.Kind != SyntaxKind.ChanKeyword &&
             Current.Kind != SyntaxKind.SequenceKeyword &&
+            Current.Kind != SyntaxKind.AsyncKeyword &&
             Current.Kind != SyntaxKind.StarToken)
         {
             return null;

--- a/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
@@ -193,10 +193,11 @@ public sealed class TypeClauseSyntax : SyntaxNode
     }
 #pragma warning restore SA1642
 
-    /// <summary>Initializes a new instance of the <see cref="TypeClauseSyntax"/> class for a sequence type (ADR-0040).</summary>
+    /// <summary>Initializes a new instance of the <see cref="TypeClauseSyntax"/> class for a sequence type (ADR-0040) — optionally prefixed by the <c>async</c> modifier per ADR-0042.</summary>
 #pragma warning disable SA1642
     private TypeClauseSyntax(
         SyntaxTree syntaxTree,
+        SyntaxToken asyncModifier,
         SyntaxToken sequenceKeyword,
         SyntaxToken openBracketToken,
         TypeClauseSyntax elementType,
@@ -205,6 +206,7 @@ public sealed class TypeClauseSyntax : SyntaxNode
         bool isSequence)
         : base(syntaxTree)
     {
+        AsyncModifier = asyncModifier;
         SequenceKeyword = sequenceKeyword;
         SequenceOpenBracketToken = openBracketToken;
         SequenceElementType = elementType;
@@ -327,6 +329,12 @@ public sealed class TypeClauseSyntax : SyntaxNode
     /// <summary>Gets a value indicating whether this clause denotes a sequence type <c>sequence[T]</c> (ADR-0040).</summary>
     public bool IsSequence => SequenceKeyword != null;
 
+    /// <summary>Gets the optional <c>async</c> modifier preceding a sequence type clause (ADR-0042), or <c>null</c>.</summary>
+    public SyntaxToken AsyncModifier { get; }
+
+    /// <summary>Gets a value indicating whether this clause denotes an async sequence type <c>async sequence[T]</c> (ADR-0042).</summary>
+    public bool IsAsyncSequence => SequenceKeyword != null && AsyncModifier != null;
+
     /// <summary>Creates a pointer type clause <c>*T</c> (ADR-0039).</summary>
     /// <param name="syntaxTree">The parent syntax tree.</param>
     /// <param name="starToken">The <c>*</c> prefix token.</param>
@@ -358,6 +366,27 @@ public sealed class TypeClauseSyntax : SyntaxNode
         SyntaxToken closeBracketToken,
         SyntaxToken questionToken)
     {
-        return new TypeClauseSyntax(syntaxTree, sequenceKeyword, openBracketToken, elementType, closeBracketToken, questionToken, isSequence: true);
+        return new TypeClauseSyntax(syntaxTree, asyncModifier: null, sequenceKeyword, openBracketToken, elementType, closeBracketToken, questionToken, isSequence: true);
+    }
+
+    /// <summary>Creates an async sequence type clause <c>async sequence[T]</c> (ADR-0042).</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="asyncModifier">The <c>async</c> modifier token.</param>
+    /// <param name="sequenceKeyword">The <c>sequence</c> keyword.</param>
+    /// <param name="openBracketToken">The <c>[</c> token.</param>
+    /// <param name="elementType">The element type clause.</param>
+    /// <param name="closeBracketToken">The <c>]</c> token.</param>
+    /// <param name="questionToken">The optional trailing <c>?</c> nullability marker.</param>
+    /// <returns>An async sequence type clause.</returns>
+    public static TypeClauseSyntax CreateAsyncSequence(
+        SyntaxTree syntaxTree,
+        SyntaxToken asyncModifier,
+        SyntaxToken sequenceKeyword,
+        SyntaxToken openBracketToken,
+        TypeClauseSyntax elementType,
+        SyntaxToken closeBracketToken,
+        SyntaxToken questionToken)
+    {
+        return new TypeClauseSyntax(syntaxTree, asyncModifier, sequenceKeyword, openBracketToken, elementType, closeBracketToken, questionToken, isSequence: true);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncSequenceTypeClauseTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncSequenceTypeClauseTests.cs
@@ -1,0 +1,209 @@
+// <copyright file="AsyncSequenceTypeClauseTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// End-to-end tests for ADR-0042: <c>async sequence[T]</c> as a type-clause
+/// spelling for <c>IAsyncEnumerable[T]</c> in any type-clause position
+/// (parameters, locals, fields, generic arguments, function-type return
+/// slots, etc.). Most of the verification is via reflection on emitted
+/// metadata, because GSharp marks any function returning
+/// <c>IAsyncEnumerable[T]</c> as an async iterator (ADR-0041) regardless of
+/// whether the body yields.
+/// </summary>
+public class AsyncSequenceTypeClauseTests
+{
+    [Fact]
+    public void AsyncSequenceTypeClause_ParameterPosition_HasAsyncEnumerableClrType()
+    {
+        // A sync function that accepts `async sequence[int]` and forwards it
+        // to another sink. We only verify the parameter type at the metadata
+        // level — the body is `return null` to keep the iterator rewriter
+        // from interfering with the call site.
+        const string Source = @"package AsyncSeqParam
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+
+func describe(stream async sequence[int]) {
+    Console.Out.WriteLine(""ok"")
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(AsyncSequenceTypeClause_ParameterPosition_HasAsyncEnumerableClrType));
+        try
+        {
+            var method = GetProgramMethod(asm, "describe");
+            var parameters = method.GetParameters();
+            Assert.Single(parameters);
+            Assert.Equal(typeof(IAsyncEnumerable<int>), parameters[0].ParameterType);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void AsyncSequenceTypeClause_LocalDeclaration_BindsToAsyncEnumerable()
+    {
+        // A local typed `async sequence[int]` is hoisted to a state-machine
+        // field when used inside an async function. We verify via reflection
+        // that the field exists with the expected CLR type, which proves the
+        // local's type clause bound to IAsyncEnumerable[int].
+        const string Source = @"package AsyncSeqLocal
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+
+async func source() sequence[int] {
+    yield 1
+}
+
+async func consume() int {
+    let stream async sequence[int] = source()
+    await Task.Yield()
+    return 0
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(AsyncSequenceTypeClause_LocalDeclaration_BindsToAsyncEnumerable));
+        try
+        {
+            // Look at every type in the assembly for a field whose type is
+            // IAsyncEnumerable<int>; the hoisted local should be exactly that.
+            var hasField = asm.GetTypes()
+                .SelectMany(t => t.GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+                .Any(f => f.FieldType == typeof(IAsyncEnumerable<int>));
+            Assert.True(
+                hasField,
+                "Expected at least one emitted field of type IAsyncEnumerable<int> from the hoisted local.");
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void AsyncSequenceTypeClause_AndExplicitIAsyncEnumerable_AreSameClrType()
+    {
+        // Explicit modifier `async sequence[int]` and the BCL spelling
+        // `IAsyncEnumerable[int]` must produce identical CLR signatures.
+        const string Source = @"package AsyncSeqEquiv
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+
+func viaModifier(s async sequence[int]) {
+}
+
+func viaBcl(s IAsyncEnumerable[int]) {
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(AsyncSequenceTypeClause_AndExplicitIAsyncEnumerable_AreSameClrType));
+        try
+        {
+            var viaModifier = GetProgramMethod(asm, "viaModifier");
+            var viaBcl = GetProgramMethod(asm, "viaBcl");
+            Assert.Equal(typeof(IAsyncEnumerable<int>), viaModifier.GetParameters()[0].ParameterType);
+            Assert.Equal(typeof(IAsyncEnumerable<int>), viaBcl.GetParameters()[0].ParameterType);
+            Assert.Equal(viaModifier.GetParameters()[0].ParameterType, viaBcl.GetParameters()[0].ParameterType);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void AsyncSequenceTypeClause_DiagnosticWhenAsyncIsNotFollowedBySequence()
+    {
+        // `async` as a type-clause prefix is reserved for `sequence` today.
+        const string Source = @"package AsyncSeqInvalid
+import System
+
+func bad(s async int) {
+}
+";
+        var tree = SyntaxTree.Parse(SourceText.From(Source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Message.Contains("'async' modifier in a type clause is only valid before 'sequence[T]'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void AsyncSequenceTypeClause_InReturnSlot_MatchesAdr0041Swap()
+    {
+        // ADR-0041: `async func foo() sequence[int]` implicitly swaps to
+        // IAsyncEnumerable[int].
+        // ADR-0042: `async func foo() async sequence[int]` says it explicitly.
+        // Both should produce the same return type.
+        const string Source = @"package AsyncSeqReturn
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+
+async func implicitSwap() sequence[int] {
+    yield 1
+}
+
+async func explicitModifier() async sequence[int] {
+    yield 2
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(AsyncSequenceTypeClause_InReturnSlot_MatchesAdr0041Swap));
+        try
+        {
+            var implicitSwap = GetProgramMethod(asm, "implicitSwap");
+            var explicitModifier = GetProgramMethod(asm, "explicitModifier");
+            Assert.Equal(typeof(IAsyncEnumerable<int>), implicitSwap.ReturnType);
+            Assert.Equal(typeof(IAsyncEnumerable<int>), explicitModifier.ReturnType);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    private static MethodInfo GetProgramMethod(Assembly asm, string name)
+    {
+        var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+        Assert.NotNull(programType);
+        var method = programType!.GetMethod(name, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return method!;
+    }
+
+    private static (Assembly asm, AssemblyLoadContext ctx) CompileToAssembly(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        var asm = loadContext.LoadFromStream(peStream);
+        return (asm, loadContext);
+    }
+}


### PR DESCRIPTION
## Summary

Implements [ADR-0042](docs/adr/0042-async-sequence-type-clause.md), generalizing ADR-0041 (PR #149). The `async` modifier may now precede `sequence[T]` in **any** type-clause position — parameters, locals, fields, generic arguments, lambda parameter/return types, function return slots — to spell `IAsyncEnumerable[T]` explicitly.

The unmodified `sequence[T]` alias continues to mean `IEnumerable[T]` (ADR-0040), and the implicit return-slot swap from ADR-0041 still applies when no modifier is given. The three return-slot spellings are equivalent:

```gsharp
async func a() sequence[int] { ... }          // ADR-0041 implicit swap
async func b() async sequence[int] { ... }    // ADR-0042 explicit
async func c() IAsyncEnumerable[int] { ... }  // BCL direct
```

## What changed

- **ADR-0042** added under `docs/adr/0042-async-sequence-type-clause.md` (Accepted).
- **`TypeClauseSyntax`**: extended sequence shape with an optional `AsyncModifier` token; added `IsAsyncSequence` and `CreateAsyncSequence` factory.
- **`Parser`**: `ParseTypeClause` now recognizes `AsyncKeyword` in type-start position and routes to a new `ParseAsyncSequenceTypeClause`. `AsyncKeyword` added to the `ParseOptionalTypeClause` whitelist so optional type clauses work too.
- **`DiagnosticBag`**: new `ReportAsyncModifierInTypeClauseRequiresSequence` for diagnostics when `async` appears in a type clause but is not followed by `sequence`.
- **`Binder`**: `BindNonNullableTypeClause` sequence branch dispatches on `IsAsyncSequence` and returns `AsyncSequenceTypeSymbol` when the modifier is present. All downstream passes already dispatch on CLR type (`IAsyncEnumerable<T>`), so no other changes are required.

## Tests

5 new end-to-end tests in `AsyncSequenceTypeClauseTests`:
- Parameter position binds to `IAsyncEnumerable<int>`.
- Local declaration is hoisted to a state-machine field of the right type.
- Explicit modifier and BCL spelling produce identical CLR signatures.
- Diagnostic fires when `async` precedes a non-`sequence` type clause.
- Implicit ADR-0041 swap and explicit ADR-0042 spelling are equivalent in the return slot.

Full suite green: `dotnet test GSharp.sln --nologo --no-restore` → 864 Core / 85 Compiler / 17 LanguageServer / 8 Interpreter tests pass.

## Related

- Builds on PR #149 (ADR-0041).
- Closes the ADR-0040 open question about an `asyncSequence[T]` alias — we picked the two-token modifier form instead.
- Tracks alongside #150 for the broader `async func(P) R` function-type direction (independent work).
