### PR TITLE
Fix #148: emitter support for `await for` (IAsyncEnumerable consumer)

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -502,6 +502,7 @@ public sealed class Evaluator
                 BoundNodeKind.ChannelCloseExpression => EvaluateChannelCloseExpression((BoundChannelCloseExpression)node),
                 BoundNodeKind.AddressOfExpression => EvaluateAddressOfExpression((BoundAddressOfExpression)node),
                 BoundNodeKind.DereferenceExpression => EvaluateDereferenceExpression((BoundDereferenceExpression)node),
+                BoundNodeKind.DefaultExpression => EvaluateDefaultExpression((BoundDefaultExpression)node),
                 _ => throw new EvaluatorException($"Unexpected node {node.Kind}", node),
             };
         }
@@ -1456,24 +1457,54 @@ public sealed class Evaluator
     private object EvaluateAwaitExpression(BoundAwaitExpression node)
     {
         var operand = EvaluateExpression(node.Expression);
-        if (operand is not Task task)
+        if (operand is Task task)
         {
-            throw new EvaluatorException("'await' operand did not evaluate to a Task.", node);
-        }
+            task.GetAwaiter().GetResult();
 
-        task.GetAwaiter().GetResult();
-
-        var taskType = task.GetType();
-        if (taskType.IsGenericType)
-        {
-            var resultProperty = taskType.GetProperty("Result");
-            if (resultProperty != null)
+            var taskType = task.GetType();
+            if (taskType.IsGenericType)
             {
-                return resultProperty.GetValue(task);
+                var resultProperty = taskType.GetProperty("Result");
+                if (resultProperty != null)
+                {
+                    return resultProperty.GetValue(task);
+                }
             }
+
+            return null;
         }
 
-        return null;
+        // Issue #148: `await for` desugaring produces `await __enum.MoveNextAsync()`
+        // and `await __enum.DisposeAsync()`, which return `ValueTask<bool>` /
+        // `ValueTask`. Use the same synchronous-await pragma the await-for
+        // path uses for the underlying enumerator calls.
+        if (operand == null)
+        {
+            throw new EvaluatorException("'await' operand did not evaluate to an awaitable.", node);
+        }
+
+        var operandType = operand.GetType();
+        if (operandType.FullName == "System.Threading.Tasks.ValueTask" ||
+            (operandType.IsGenericType && operandType.GetGenericTypeDefinition().FullName == "System.Threading.Tasks.ValueTask`1"))
+        {
+            return BlockOnValueTask(operand);
+        }
+
+        throw new EvaluatorException("'await' operand did not evaluate to a Task.", node);
+    }
+
+    private static object EvaluateDefaultExpression(BoundDefaultExpression node)
+    {
+        // Issue #148: the `await for` lowering uses `default(CancellationToken)`
+        // for the `GetAsyncEnumerator` token; more generally, BoundDefaultExpression
+        // should produce the type's default value when interpreted.
+        var clr = node.Type?.ClrType;
+        if (clr == null || !clr.IsValueType)
+        {
+            return null;
+        }
+
+        return System.Activator.CreateInstance(clr);
     }
 
     private object EvaluateMakeChannelExpression(BoundMakeChannelExpression node)

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -243,6 +243,144 @@ public sealed class Lowerer : BoundTreeRewriter
         return RewriteStatement(lowered);
     }
 
+    /// <inheritdoc/>
+    protected override BoundStatement RewriteAwaitForRangeStatement(BoundAwaitForRangeStatement node)
+    {
+        // Phase 5.8 / ADR-0023 — issue #148: desugar
+        //   await for v in stream { <body> }
+        // into the equivalent try/finally with an awaiting MoveNextAsync
+        // loop and an awaiting DisposeAsync. After the rewrite, the
+        // AsyncStateMachineRewriter pipeline (AsyncExceptionHandlerRewriter
+        // + SpillSequenceSpiller + MoveNextBodyRewriter) handles the
+        // resulting awaits — including the await inside the finally
+        // (Pattern B in AsyncExceptionHandlerRewriter).
+        //
+        // {
+        //   var __enum = stream.GetAsyncEnumerator(default(CancellationToken))
+        //   try {
+        //     start:
+        //     var __more = await __enum.MoveNextAsync()
+        //     gotoFalse __more, end
+        //     v = __enum.Current
+        //     <body>
+        //     goto start
+        //     end:
+        //   } finally {
+        //     await __enum.DisposeAsync()
+        //   }
+        // }
+        var stream = RewriteExpression(node.Stream);
+        var body = RewriteStatement(node.Body);
+
+        var lowered = LowerAwaitForRange(node.ValueVariable, stream, body);
+        return RewriteStatement(lowered);
+    }
+
+    private BoundStatement LowerAwaitForRange(VariableSymbol valueVariable, BoundExpression stream, BoundStatement body)
+    {
+        var streamClr = stream.Type?.ClrType;
+        if (streamClr == null)
+        {
+            return new BoundExpressionStatement(new BoundErrorExpression());
+        }
+
+        System.Type asyncEnumerableInterface = null;
+        if (streamClr.IsGenericType &&
+            !streamClr.IsGenericTypeDefinition &&
+            streamClr.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IAsyncEnumerable`1")
+        {
+            asyncEnumerableInterface = streamClr;
+        }
+        else
+        {
+            foreach (var iface in streamClr.GetInterfaces())
+            {
+                if (iface.IsGenericType &&
+                    !iface.IsGenericTypeDefinition &&
+                    iface.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IAsyncEnumerable`1")
+                {
+                    asyncEnumerableInterface = iface;
+                    break;
+                }
+            }
+        }
+
+        if (asyncEnumerableInterface == null)
+        {
+            return new BoundExpressionStatement(new BoundErrorExpression());
+        }
+
+        var elementClr = asyncEnumerableInterface.GetGenericArguments()[0];
+        var enumeratorClr = typeof(System.Collections.Generic.IAsyncEnumerator<>).MakeGenericType(elementClr);
+        var valueTaskBoolClr = typeof(System.Threading.Tasks.ValueTask<>).MakeGenericType(typeof(bool));
+
+        var getAsyncEnumerator = asyncEnumerableInterface.GetMethod(
+            "GetAsyncEnumerator",
+            new[] { typeof(System.Threading.CancellationToken) });
+        var moveNextAsync = enumeratorClr.GetMethod("MoveNextAsync", System.Type.EmptyTypes);
+        var currentProperty = enumeratorClr.GetProperty("Current");
+        var disposeAsync = typeof(System.IAsyncDisposable).GetMethod("DisposeAsync", System.Type.EmptyTypes);
+
+        if (getAsyncEnumerator == null || moveNextAsync == null || currentProperty == null || disposeAsync == null)
+        {
+            return new BoundExpressionStatement(new BoundErrorExpression());
+        }
+
+        var cancellationTokenType = TypeSymbol.FromClrType(typeof(System.Threading.CancellationToken));
+        var enumeratorType = TypeSymbol.FromClrType(enumeratorClr);
+        var valueTaskBoolType = TypeSymbol.FromClrType(valueTaskBoolClr);
+        var valueTaskType = TypeSymbol.FromClrType(typeof(System.Threading.Tasks.ValueTask));
+        var currentType = TypeSymbol.FromClrType(currentProperty.PropertyType);
+
+        var enumeratorSymbol = new LocalVariableSymbol("$awaitEnum", isReadOnly: true, type: enumeratorType);
+        var enumeratorExpr = new BoundVariableExpression(enumeratorSymbol);
+        var getEnumCall = new BoundImportedInstanceCallExpression(
+            stream,
+            getAsyncEnumerator,
+            enumeratorType,
+            ImmutableArray.Create<BoundExpression>(new BoundDefaultExpression(cancellationTokenType)));
+        var enumeratorDecl = new BoundVariableDeclaration(enumeratorSymbol, getEnumCall);
+
+        var startLabel = GenerateLabel();
+        var endLabel = GenerateLabel();
+        var moreSymbol = new LocalVariableSymbol("$more", isReadOnly: false, type: TypeSymbol.Bool);
+
+        var moveNextCall = new BoundImportedInstanceCallExpression(
+            enumeratorExpr,
+            moveNextAsync,
+            valueTaskBoolType,
+            ImmutableArray<BoundExpression>.Empty);
+        var moveNextAwait = new BoundAwaitExpression(moveNextCall, TypeSymbol.Bool);
+        var moreDecl = new BoundVariableDeclaration(moreSymbol, moveNextAwait);
+
+        var currentAccess = new BoundClrPropertyAccessExpression(enumeratorExpr, currentProperty, currentType);
+        var assignValue = new BoundExpressionStatement(
+            new BoundAssignmentExpression(valueVariable, currentAccess));
+
+        var tryStatements = ImmutableArray.CreateBuilder<BoundStatement>();
+        tryStatements.Add(new BoundLabelStatement(startLabel));
+        tryStatements.Add(moreDecl);
+        tryStatements.Add(new BoundConditionalGotoStatement(endLabel, new BoundVariableExpression(moreSymbol), jumpIfTrue: false));
+        tryStatements.Add(assignValue);
+        tryStatements.Add(body);
+        tryStatements.Add(new BoundGotoStatement(startLabel));
+        tryStatements.Add(new BoundLabelStatement(endLabel));
+        var tryBlock = new BoundBlockStatement(tryStatements.ToImmutable());
+
+        var disposeCall = new BoundImportedInstanceCallExpression(
+            enumeratorExpr,
+            disposeAsync,
+            valueTaskType,
+            ImmutableArray<BoundExpression>.Empty);
+        var disposeAwait = new BoundAwaitExpression(disposeCall, TypeSymbol.Void);
+        var finallyBlock = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(disposeAwait)));
+
+        var tryStmt = new BoundTryStatement(tryBlock, ImmutableArray<BoundCatchClause>.Empty, finallyBlock);
+
+        return new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(enumeratorDecl, tryStmt));
+    }
+
     private BoundStatement LowerIndexedRange(BoundForRangeStatement node)
     {
         // {
@@ -574,12 +712,6 @@ public sealed class Lowerer : BoundTreeRewriter
                 }
 
                 builder.Add(new BoundSelectStatement(flatCases.ToImmutable()));
-            }
-            else if (current is BoundAwaitForRangeStatement af)
-            {
-                // Phase 5.8: flatten the await-for body so nested if/for/etc. work.
-                var flatAfBody = Flatten(af.Body);
-                builder.Add(new BoundAwaitForRangeStatement(af.ValueVariable, af.Stream, flatAfBody));
             }
             else
             {

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncInterpVsEmitParityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncInterpVsEmitParityTests.cs
@@ -258,7 +258,7 @@ for x in nums() {
         AssertParity(Source, Expected, nameof(Parity_SyncIterator_Sequence));
     }
 
-    [Fact(Skip = "Emitter does not yet support `await for` (IAsyncEnumerable consumer side). Interpreter side is covered by AsyncIterator_InterpOnly_ProducesValues.")]
+    [Fact]
     public void Parity_AsyncIterator_YieldWithAwait()
     {
         const string Source = @"package ParityAsyncIter
@@ -274,9 +274,13 @@ func gen() IAsyncEnumerable[int] {
     yield 30
 }
 
-await for x in gen() {
-    Console.WriteLine(x)
+async func consume() {
+    await for x in gen() {
+        Console.WriteLine(x)
+    }
 }
+
+consume().Wait()
 ";
         const string Expected = "10\n20\n30\n";
         AssertParity(Source, Expected, nameof(Parity_AsyncIterator_YieldWithAwait));

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncIteratorEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncIteratorEmitTests.cs
@@ -19,7 +19,8 @@ namespace GSharp.Core.Tests.CodeAnalysis.Emit;
 
 /// <summary>
 /// End-to-end emit tests for async iterator functions (IAsyncEnumerable/IAsyncEnumerator with yield + await).
-/// Consumer side (await for) is not yet implemented, so tests consume via C# reflection.
+/// Tests consume the produced stream via C# reflection; the consumer-side `await for` lowering is exercised
+/// by <see cref="AsyncInterpVsEmitParityTests"/>.
 /// </summary>
 public class AsyncIteratorEmitTests
 {


### PR DESCRIPTION
Fixes #148.

Desugars `BoundAwaitForRangeStatement` in the `Lowerer` into the canonical try/finally with an awaiting `MoveNextAsync` loop and an awaiting `DisposeAsync`. The resulting awaits flow through the existing async state-machine pipeline (`AsyncExceptionHandlerRewriter` Pattern B for the await in `finally`, `SpillSequenceSpiller`, `MoveNextBodyRewriter`).

Lowered shape:

```
var __enum = stream.GetAsyncEnumerator(default(CancellationToken))
try {
  start:
  var __more = await __enum.MoveNextAsync()
  gotoFalse __more, end
  v = __enum.Current
  <body>
  goto start
  end:
} finally {
  await __enum.DisposeAsync()
}
```

### Changes
- `Lowerer.RewriteAwaitForRangeStatement` + `LowerAwaitForRange`: desugars to `BoundTryStatement` with goto-based loop (uses `BoundConditionalGotoStatement` rather than `BoundIfStatement`, per the lowering invariant).
- `Evaluator.EvaluateAwaitExpression`: also handles `ValueTask` / `ValueTask<T>` via `BlockOnValueTask`, so the interpreter accepts the desugared `MoveNextAsync`/`DisposeAsync` awaits.
- `Evaluator.EvaluateDefaultExpression`: new handler — the lowering emits `default(CancellationToken)` for `GetAsyncEnumerator`.
- Dropped the now-dead `Flatten` branch for `BoundAwaitForRangeStatement`.
- Unskipped `Parity_AsyncIterator_YieldWithAwait`. Wrapped the `await for` in an `async func consume()` and called `consume().Wait()` — top-level await is a separate, unfinished feature and other parity tests follow the same wrapper pattern.
- Dropped the "consumer side not yet implemented" note from `AsyncIteratorEmitTests`.

### Acceptance criteria (from #148)
- [x] `BoundAwaitForRangeStatement` is lowered for emit and integrates with the async state machine rewriter.
- [x] `Parity_AsyncIterator_YieldWithAwait` is unskipped and passes interp↔emit parity.
- [x] The misleading note at `AsyncIteratorEmitTests.cs:22` is removed.

### Tests
`dotnet test GSharp.sln --nologo --no-restore` — all projects pass (Core: 867 passed / 1 skipped; the only remaining skip is the pre-existing parser bug for params + generic return type).