### PR TITLE
ADR-0043: `async func(P) R` as a function-type clause (#150)

### DIFF
--- a/docs/adr/0042-async-sequence-type-clause.md
+++ b/docs/adr/0042-async-sequence-type-clause.md
@@ -67,7 +67,7 @@ All three produce identical IL and identical symbols. The implicit swap remains 
 
 ### Restriction: `async` is only valid before `sequence` in type-clause position
 
-`async` as a type-clause prefix is reserved for the iterator alias. `async map[K]V`, `async chan T`, `async []T`, `async *T`, etc. are explicitly rejected with a diagnostic. Generalizing the modifier to function-type clauses (`async func(P) R` ≡ `func(P) Task[R]`) is the subject of issue #150 and a future ADR; this ADR leaves the door open without committing.
+`async` as a type-clause prefix is reserved for the iterator alias. `async map[K]V`, `async chan T`, `async []T`, `async *T`, etc. are explicitly rejected with a diagnostic. Generalizing the modifier to function-type clauses (`async func(P) R` ≡ `func(P) Task[R]`) is the subject of ADR-0043; this ADR leaves the door open without committing.
 
 ## Consequences
 
@@ -76,7 +76,7 @@ Positive:
 - Closes the asymmetry between sync and async iterator type-clause spellings everywhere a type may appear.
 - Single grammar rule, single binder branch, zero downstream changes — all consumer sites (`await for`, iterator rewriter, async-iterator rewriter, emit) already key off the CLR type produced by `AsyncSequenceTypeSymbol` (shipped with ADR-0041).
 - Reuses the existing `async` keyword; no new reserved word; reads consistently with `async func` declarations and lambdas.
-- Future-proofs the modifier for issue #150 (`async func(P) R`) without committing to it now.
+- Future-proofs the modifier for ADR-0043 (`async func(P) R`).
 
 Negative:
 
@@ -104,7 +104,7 @@ The status quo after ADR-0041. Rejected: the parameter/local/field asymmetry is 
 
 ### D. Generalize `async` to all type-clause prefixes in this ADR (`async map[K]V`, `async chan T`, etc.)
 
-Rejected as overreach. None of the other forms have an existing BCL counterpart, and conflating the modifier across unrelated shapes would erode its meaning. Function-type clauses (`async func(P) R`) are tracked separately in issue #150.
+Rejected as overreach. None of the other forms have an existing BCL counterpart, and conflating the modifier across unrelated shapes would erode its meaning. Function-type clauses (`async func(P) R`) are tracked separately in ADR-0043.
 
 ## Implementation summary
 

--- a/docs/adr/0043-async-func-type-clause.md
+++ b/docs/adr/0043-async-func-type-clause.md
@@ -1,0 +1,117 @@
+# ADR-0043: `async func(P) R` as a type-clause spelling for `func(P) Task[R]`
+
+- **Status**: Accepted (implemented in this PR)
+- **Date**: 2026-05-26
+- **Phase**: Phase 7 follow-up — async ergonomics
+- **Related**: ADR-0023 (async state machine), ADR-0042 (`async sequence[T]` type clause), issue #150
+
+## Context
+
+ADR-0023 establishes the rule that an `async func foo() R` declaration is callable as `Task[R]` (or `Task` when `R` is omitted). The `async` modifier is also legal on lambda expressions. In every other position the modifier was rejected by the parser (`Parser.cs:196`) — including type-clause positions — so users had to spell the wrapped `Task[T]` explicitly whenever they wrote a function-typed parameter, local, field, or generic argument:
+
+```gsharp
+// Before this ADR — the Task wrap leaks into the type clause.
+func runEach(items []int, cb func(int) Task[int]) { ... }
+let handler func(int) Task[int] = async func(x int) int { return x + 1 }
+data Pipeline { transform func(int) Task[int] }
+```
+
+ADR-0042 already generalised the `async` modifier to one type-clause shape (`async sequence[T]` ⇒ `IAsyncEnumerable[T]`) and explicitly reserved the function-clause generalisation for issue #150. This ADR closes that gap.
+
+## Decision
+
+In any type-clause position, `async func(P1, P2, ...) R` is a spelling for `func(P1, P2, ...) Task[R]`. The alias resolves to the existing `FunctionTypeSymbol` — the two spellings denote the *same* type, not two distinct types (the same equality discipline used by ADR-0042 / ADR-0040).
+
+```gsharp
+// Local
+let handler async func(int) int = async func(x int) int { return x + 1 }
+
+// Parameter
+func runEach(items []int, cb async func(int) int) {
+    for x in items { _ = cb(x) }
+}
+
+// Struct field
+data Pipeline {
+    transform async func(int) int
+}
+
+// Generic argument / collection element
+let cbs []async func(int) int = ...
+
+// Outer function-type return slot
+func factory() async func(int) int { ... }
+```
+
+### Return-slot transformations
+
+The return-slot rules of an `async func(P) R` type clause exactly mirror the declaration-site rules (ADR-0023):
+
+| `R` (as written)                       | Resolved return slot         |
+| -------------------------------------- | ---------------------------- |
+| *(omitted)*                            | `Task`                       |
+| `T` (any non-Task, non-iterator type)  | `Task[T]`                    |
+| `sequence[T]`                          | `IAsyncEnumerable[T]` (iterator carve-out, ADR-0041) |
+| `async sequence[T]` (ADR-0042)         | `IAsyncEnumerable[T]`        |
+| `IAsyncEnumerable[T]` / `IAsyncEnumerator[T]` | unchanged (iterator carve-out) |
+| `Task` / `Task[X]` / `ValueTask` / `ValueTask[X]` | **diagnostic GS0189** — explicit Task wrap is disallowed because the modifier already implies it |
+
+The double-wrap diagnostic mirrors how an `async func foo() Task[X]` *declaration* would be ill-formed (the declaration site never asks the user to spell `Task` themselves).
+
+### Equality / assignment compatibility
+
+`async func(int) int` and `func(int) Task[int]` are the same `FunctionTypeSymbol` — the same CLR delegate, the same overload-resolution candidate, freely assignable in either direction. There is no new conversion rule and no variance change.
+
+### Restriction: `async` in type-clause position accepts only `func` or `sequence`
+
+The `async` type-clause prefix now has exactly two legal successors:
+
+- `async sequence[T]` (ADR-0042) → `IAsyncEnumerable[T]`
+- `async func(...) R`  (this ADR) → `func(...) Task[R]` (with carve-outs above)
+
+Any other follower (`async int`, `async map[K]V`, `async chan T`, `async []T`, `async *T`, etc.) is rejected by the parser with diagnostic **GS0135** ("the `async` modifier in a type clause is only valid before `sequence[T]` or `func(...)`").
+
+## Consequences
+
+Positive:
+
+- Eliminates the asymmetry between declarations (`async func foo() R`) and types (`func(...) Task[R]`). All consumer sites — parameters, locals, fields, return slots — can now read the same modifier the declaration writes.
+- Zero downstream change: the resolved `FunctionTypeSymbol` is structurally identical to the explicit `Task[R]` spelling, so lowering, emit, the async state machine, overload resolution, and conversion rules see nothing new.
+- Reuses the existing `async` keyword and the ADR-0042 parser entrypoint; no new reserved word, no new syntactic shape.
+
+Negative:
+
+- Two spellings exist for the same delegate type. Style guidance picks one canonical form; the language remains permissive.
+- A user who *wants* to spell `Task[X]` explicitly inside an `async func(...)` type clause must remove either the `async` modifier or the explicit `Task` wrap. The GS0189 diagnostic makes the choice obvious.
+
+Neutral:
+
+- Tooling hover currently renders the resolved `FunctionTypeSymbol` with the `Task[R]` return type even when the source used the modifier spelling. Polishing the hover to render `async func(...) R` when that was the source form is nice-to-have; symbol identity is unchanged either way.
+
+## Alternatives considered
+
+### A. Defer indefinitely
+
+The status quo. Rejected because the asymmetry is visible at every function-typed declaration site and the implementation cost is small (one parser branch + one binder branch).
+
+### B. Permit explicit `Task[X]` return inside `async func(...)` (silently double-wrapping or silently no-opping)
+
+Rejected. Silent double-wrap (`Task[Task[X]]`) is almost never what the user means and creates a subtle trap. Silently no-opping (treating `Task[X]` as already-wrapped) hides intent and makes the modifier meaningless. The diagnostic forces the user to pick a single spelling.
+
+### C. Generalise the modifier to all type-clause prefixes (`async map[K]V`, `async chan T`, etc.)
+
+Rejected as overreach, for the same reasons as ADR-0042 §Alternatives D. None of the other shapes have an established BCL-side Task or AsyncEnumerable counterpart, and the modifier would lose its meaning.
+
+## Implementation summary
+
+Shipped in this PR as a strictly additive change. No existing program changes meaning; no existing test changes behaviour.
+
+1. **Parser** (`src/Core/CodeAnalysis/Syntax/Parser.cs`):
+   - `ParseAsyncSequenceTypeClause` is generalised to `ParseAsyncPrefixedTypeClause`. After consuming `async`, it dispatches on the next token: `func` → `ParseAsyncFunctionTypeClause`; `sequence` → the existing sequence-clause path tagged with the modifier; anything else → diagnostic GS0135 and best-effort recovery.
+2. **Syntax model** (`src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs`): the function-type constructor now records an optional `AsyncModifier` token. A new `IsAsyncFunction` property mirrors `IsAsyncSequence`, and `CreateAsyncFunction` is the corresponding factory.
+3. **Binder** (`src/Core/CodeAnalysis/Binding/Binder.cs`): the `IsFunction` branch of `BindNonNullableTypeClause` applies the ADR-0023 return-slot transformations (`WrapAsTask`, iterator carve-out via `IsAsyncIteratorReturnType`) when `syntax.IsAsyncFunction` is set. A new `IsTaskShapedReturn` helper detects explicit Task/ValueTask wraps and emits diagnostic GS0189.
+4. **Diagnostics**:
+   - **GS0135** (existing) — message updated to mention `func(...)` alongside `sequence[T]`; helper renamed to `ReportAsyncModifierInTypeClauseRequiresSequenceOrFunc`.
+   - **GS0189** (new) — "the return type of an `async func(...)` type clause is implicitly wrapped in `Task`; do not write `Task[…]` explicitly".
+
+No changes to lowering, emit, the async state machine, lambda inference, or any symbol code.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -45,7 +45,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0004 | Error | Invalid number literal. | `9999999999999999999` is out of range for `int`. |
 | GS0005 | Error | Unexpected token. | Parser expected one token kind but found another (e.g. missing `)` or `;`). |
 
-### Binder / semantic diagnostics (GS0100–GS0188)
+### Binder / semantic diagnostics (GS0100–GS0189)
 
 | ID | Severity | Description | Example trigger |
 |----|----------|-------------|-----------------|
@@ -84,7 +84,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0132 | Error | `await` outside an `async func`. | `await someTask` in a regular (non-async) function. |
 | GS0133 | Error | Expression is not awaitable. | `await 42` — `int` is not a `Task` or `Task[T]`. |
 | GS0134 | Error | Expression is not async-enumerable. | `await for x in 42` — `int` does not implement `IAsyncEnumerable[T]`. |
-| GS0135 | Error | `async` modifier in a type clause is only valid before `sequence[T]`. | `async int` in a type position. |
+| GS0135 | Error | `async` modifier in a type clause is only valid before `sequence[T]` or `func(...)`. | `async int` in a type position. |
 | GS0136 | Error | `yield` outside an iterator function. | `yield return 1` in a function that returns `int`, not `sequence[int]`. |
 | GS0137 | Error | `go` operand is not a call expression. | `go x + 1` — only function calls may follow `go`. |
 | GS0138 | Error | `defer` operand is not a call expression. | `defer x + 1`. |
@@ -138,6 +138,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0186 | Error | Interface method may not have a body. | A method declared inside an `interface` has an implementation block. |
 | GS0187 | Error | Class does not implement interface method. | A class claims to implement an interface but a required method is absent. |
 | GS0188 | Error | Class cannot implement a sealed interface from a different package. | Implementing a `sealed interface` defined outside the current package. |
+| GS0189 | Error | The return type of an `async func(...)` type clause is implicitly wrapped in `Task`; do not write `Task[…]` explicitly. | `async func(int) Task[int]` in a type position (ADR-0043). |
 
 ### Async state-machine diagnostics (GS0190)
 

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1644,6 +1644,8 @@ public sealed class Binder
         if (syntax.IsFunction)
         {
             // Phase 4.7: function-type clause `func(T1, T2, ...) R?`.
+            // ADR-0043: `async func(P) R` aliases to `func(P) Task[R]` (with
+            // carve-outs for void → Task and IAsyncEnumerable[T] → unchanged).
             var paramTypes = ImmutableArray.CreateBuilder<TypeSymbol>(syntax.FunctionParameterTypes.Count);
             for (var i = 0; i < syntax.FunctionParameterTypes.Count; i++)
             {
@@ -1657,6 +1659,37 @@ public sealed class Binder
             }
 
             var ret = syntax.ReturnTypeClause != null ? BindTypeClause(syntax.ReturnTypeClause) : TypeSymbol.Void;
+            if (ret == null)
+            {
+                return null;
+            }
+
+            if (syntax.IsAsyncFunction)
+            {
+                if (IsTaskShapedReturn(ret))
+                {
+                    Diagnostics.ReportAsyncFunctionTypeClauseHasExplicitTaskReturn(
+                        syntax.ReturnTypeClause.Location,
+                        ret.Name);
+                    return null;
+                }
+
+                // ADR-0041 iterator carve-out — same logic as
+                // BindReturnTypeClause(isAsync=true) at function declarations.
+                if (ret is SequenceTypeSymbol seq)
+                {
+                    ret = AsyncSequenceTypeSymbol.Get(seq.ElementType);
+                }
+                else if (ret is NullableTypeSymbol nt && nt.UnderlyingType is SequenceTypeSymbol innerSeq)
+                {
+                    ret = NullableTypeSymbol.Get(AsyncSequenceTypeSymbol.Get(innerSeq.ElementType));
+                }
+                else if (!IsAsyncIteratorReturnType(ret))
+                {
+                    ret = WrapAsTask(ret);
+                }
+            }
+
             return FunctionTypeSymbol.Get(paramTypes.MoveToImmutable(), ret ?? TypeSymbol.Void);
         }
 
@@ -2896,6 +2929,36 @@ public sealed class Binder
             || fullName == "System.Collections.Generic.IAsyncEnumerator`1";
     }
 
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="type"/> already denotes a
+    /// Task-shaped awaitable (Task, Task[T], ValueTask, or ValueTask[T]).
+    /// Used by the <c>async func(...)</c> type-clause binder (ADR-0043) to
+    /// reject explicit Task wrapping where the modifier already implies it.
+    /// </summary>
+    private static bool IsTaskShapedReturn(TypeSymbol type)
+    {
+        var clr = type?.ClrType;
+        if (clr == null)
+        {
+            return false;
+        }
+
+        string fullName;
+        if (clr.IsGenericType && !clr.IsGenericTypeDefinition)
+        {
+            fullName = clr.GetGenericTypeDefinition()?.FullName;
+        }
+        else
+        {
+            fullName = clr.FullName;
+        }
+
+        return fullName == "System.Threading.Tasks.Task"
+            || fullName == "System.Threading.Tasks.Task`1"
+            || fullName == "System.Threading.Tasks.ValueTask"
+            || fullName == "System.Threading.Tasks.ValueTask`1";
+    }
+
     private static TypeSymbol GetIteratorElementType(TypeSymbol type)
     {
         if (type is SequenceTypeSymbol seq)
@@ -3870,9 +3933,11 @@ public sealed class Binder
         returnType ??= TypeSymbol.Void;
 
         // For async lambdas, the observable return type (from the caller's
-        // perspective) is Task or Task<T>, matching top-level async functions.
+        // perspective) is Task or Task<T>, matching top-level async functions —
+        // with the iterator carve-out (ADR-0041): an async iterator lambda
+        // returning IAsyncEnumerable[T] does not get a Task wrap.
         var observableReturnType = returnType;
-        if (syntax.IsAsync)
+        if (syntax.IsAsync && !IsAsyncIteratorReturnType(returnType))
         {
             observableReturnType = WrapAsTask(returnType);
         }

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -463,13 +463,13 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
 
     /// <summary>
     /// Reports that the <c>async</c> modifier was used in a type-clause position
-    /// without being followed by <c>sequence</c> (ADR-0042).
+    /// without being followed by <c>sequence</c> or <c>func</c> (ADR-0042 / ADR-0043).
     /// </summary>
     /// <param name="location">The text location of the <c>async</c> modifier.</param>
     /// <param name="actualKind">The kind of the token actually following <c>async</c>.</param>
-    public void ReportAsyncModifierInTypeClauseRequiresSequence(TextLocation location, SyntaxKind actualKind)
+    public void ReportAsyncModifierInTypeClauseRequiresSequenceOrFunc(TextLocation location, SyntaxKind actualKind)
     {
-        var message = $"The 'async' modifier in a type clause is only valid before 'sequence[T]'; found '<{actualKind}>'.";
+        var message = $"The 'async' modifier in a type clause is only valid before 'sequence[T]' or 'func(...)'; found '<{actualKind}>'.";
         Report(location, "GS0135", message);
     }
 
@@ -1058,6 +1058,20 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     public void ReportPointerTypeCannotBeFieldType(TextLocation location, string typeName)
     {
         Report(location, "GS9006", $"Pointer type '{typeName}' cannot be used as a field type.");
+    }
+
+    /// <summary>
+    /// Reports that an <c>async func(...)</c> type clause has an explicit
+    /// <c>Task[…]</c> (or other Task-shaped) return type. The <c>async</c>
+    /// modifier already implies a Task wrap, so the explicit wrap is
+    /// disallowed (ADR-0043).
+    /// </summary>
+    /// <param name="location">The text location of the offending return-type clause.</param>
+    /// <param name="returnTypeName">The name of the explicit return type.</param>
+    public void ReportAsyncFunctionTypeClauseHasExplicitTaskReturn(TextLocation location, string returnTypeName)
+    {
+        var message = $"The return type of an 'async func(...)' type clause is implicitly wrapped in 'Task'; do not write '{returnTypeName}' explicitly.";
+        Report(location, "GS0189", message);
     }
 
     private static string FormatMissingNames(IEnumerable<string> missingNames)

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -1021,10 +1021,13 @@ public class Parser
             return ParseSequenceTypeClause();
         }
 
-        // ADR-0042: `async sequence[T]` — alias for IAsyncEnumerable[T] in any type-clause position.
+        // ADR-0042 / ADR-0043: `async` as a type-clause prefix is reserved for
+        // `async sequence[T]` (alias for IAsyncEnumerable[T]) and
+        // `async func(P) R` (alias for func(P) Task[R]). All other forms are
+        // rejected with a diagnostic.
         if (Current.Kind == SyntaxKind.AsyncKeyword)
         {
-            return ParseAsyncSequenceTypeClause();
+            return ParseAsyncPrefixedTypeClause();
         }
 
         // ADR-0039: pointer type `*T` in type-annotation position.
@@ -1157,15 +1160,21 @@ public class Parser
         return TypeClauseSyntax.CreateSequence(syntaxTree, sequenceKeyword, openBracket, elementType, closeBracket, question);
     }
 
-    private TypeClauseSyntax ParseAsyncSequenceTypeClause()
+    private TypeClauseSyntax ParseAsyncPrefixedTypeClause()
     {
-        // ADR-0042: `async sequence[T]` — the `async` modifier in a type clause
-        // is only valid before `sequence[T]` today (other modifier forms such as
-        // `async func(P) R` are tracked separately, see issue #150).
+        // ADR-0042: `async sequence[T]` — alias for IAsyncEnumerable[T].
+        // ADR-0043: `async func(P) R` — alias for func(P) Task[R].
+        // No other form is legal as an `async`-prefixed type clause.
         var asyncModifier = MatchToken(SyntaxKind.AsyncKeyword);
+
+        if (Current.Kind == SyntaxKind.FuncKeyword)
+        {
+            return ParseAsyncFunctionTypeClause(asyncModifier);
+        }
+
         if (Current.Kind != SyntaxKind.SequenceKeyword)
         {
-            Diagnostics.ReportAsyncModifierInTypeClauseRequiresSequence(asyncModifier.Location, Current.Kind);
+            Diagnostics.ReportAsyncModifierInTypeClauseRequiresSequenceOrFunc(asyncModifier.Location, Current.Kind);
         }
 
         var sequenceKeyword = MatchToken(SyntaxKind.SequenceKeyword);
@@ -1174,6 +1183,42 @@ public class Parser
         var closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
         var question = Current.Kind == SyntaxKind.QuestionToken ? MatchToken(SyntaxKind.QuestionToken) : null;
         return TypeClauseSyntax.CreateAsyncSequence(syntaxTree, asyncModifier, sequenceKeyword, openBracket, elementType, closeBracket, question);
+    }
+
+    private TypeClauseSyntax ParseAsyncFunctionTypeClause(SyntaxToken asyncModifier)
+    {
+        // ADR-0043: `async func(P) R` is a synonym for `func(P) Task[R]`
+        // (with carve-outs for void → Task and IAsyncEnumerable[T] → unchanged).
+        var funcKeyword = MatchToken(SyntaxKind.FuncKeyword);
+        var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
+        var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+
+        while (Current.Kind != SyntaxKind.CloseParenthesisToken &&
+               Current.Kind != SyntaxKind.EndOfFileToken)
+        {
+            nodesAndSeparators.Add(ParseTypeClause());
+            if (Current.Kind == SyntaxKind.CommaToken)
+            {
+                nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+        var returnTypeClause = ParseOptionalTypeClause();
+        var question = Current.Kind == SyntaxKind.QuestionToken ? MatchToken(SyntaxKind.QuestionToken) : null;
+        return TypeClauseSyntax.CreateAsyncFunction(
+            syntaxTree,
+            asyncModifier,
+            funcKeyword,
+            openParen,
+            new SeparatedSyntaxList<TypeClauseSyntax>(nodesAndSeparators.ToImmutable()),
+            closeParen,
+            returnTypeClause,
+            question);
     }
 
     private TypeClauseSyntax ParseFunctionTypeClause()

--- a/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
@@ -134,7 +134,7 @@ public sealed class TypeClauseSyntax : SyntaxNode
         QuestionToken = questionToken;
     }
 
-    /// <summary>Initializes a new instance of the <see cref="TypeClauseSyntax"/> class for a function type <c>func(T1, T2, ...) R?</c> (Phase 4.7).</summary>
+    /// <summary>Initializes a new instance of the <see cref="TypeClauseSyntax"/> class for a function type <c>func(T1, T2, ...) R?</c> (Phase 4.7), optionally prefixed by the <c>async</c> modifier per ADR-0043.</summary>
     /// <param name="syntaxTree">The parent syntax tree.</param>
     /// <param name="funcKeyword">The <c>func</c> keyword.</param>
     /// <param name="openParenToken">The opening <c>(</c> token.</param>
@@ -150,14 +150,8 @@ public sealed class TypeClauseSyntax : SyntaxNode
         SyntaxToken closeParenToken,
         TypeClauseSyntax returnTypeClause,
         SyntaxToken questionToken)
-        : base(syntaxTree)
+        : this(syntaxTree, asyncModifier: null, funcKeyword, openParenToken, functionParameterTypes, closeParenToken, returnTypeClause, questionToken, isFunction: true)
     {
-        FuncKeyword = funcKeyword;
-        OpenParenToken = openParenToken;
-        FunctionParameterTypes = functionParameterTypes;
-        CloseParenToken = closeParenToken;
-        ReturnTypeClause = returnTypeClause;
-        QuestionToken = questionToken;
     }
 
     /// <summary>Initializes a new instance of the <see cref="TypeClauseSyntax"/> class for a channel type <c>chan T?</c> (Phase 5.4 / ADR-0022).</summary>
@@ -211,6 +205,30 @@ public sealed class TypeClauseSyntax : SyntaxNode
         SequenceOpenBracketToken = openBracketToken;
         SequenceElementType = elementType;
         SequenceCloseBracketToken = closeBracketToken;
+        QuestionToken = questionToken;
+    }
+#pragma warning restore SA1642
+
+    /// <summary>Initializes a new instance of the <see cref="TypeClauseSyntax"/> class for an (optionally <c>async</c>-modified) function type clause (ADR-0043).</summary>
+#pragma warning disable SA1642
+    private TypeClauseSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken asyncModifier,
+        SyntaxToken funcKeyword,
+        SyntaxToken openParenToken,
+        SeparatedSyntaxList<TypeClauseSyntax> functionParameterTypes,
+        SyntaxToken closeParenToken,
+        TypeClauseSyntax returnTypeClause,
+        SyntaxToken questionToken,
+        bool isFunction)
+        : base(syntaxTree)
+    {
+        AsyncModifier = asyncModifier;
+        FuncKeyword = funcKeyword;
+        OpenParenToken = openParenToken;
+        FunctionParameterTypes = functionParameterTypes;
+        CloseParenToken = closeParenToken;
+        ReturnTypeClause = returnTypeClause;
         QuestionToken = questionToken;
     }
 #pragma warning restore SA1642
@@ -335,6 +353,9 @@ public sealed class TypeClauseSyntax : SyntaxNode
     /// <summary>Gets a value indicating whether this clause denotes an async sequence type <c>async sequence[T]</c> (ADR-0042).</summary>
     public bool IsAsyncSequence => SequenceKeyword != null && AsyncModifier != null;
 
+    /// <summary>Gets a value indicating whether this clause denotes an async function type <c>async func(...) R?</c> (ADR-0043).</summary>
+    public bool IsAsyncFunction => FuncKeyword != null && AsyncModifier != null;
+
     /// <summary>Creates a pointer type clause <c>*T</c> (ADR-0039).</summary>
     /// <param name="syntaxTree">The parent syntax tree.</param>
     /// <param name="starToken">The <c>*</c> prefix token.</param>
@@ -388,5 +409,28 @@ public sealed class TypeClauseSyntax : SyntaxNode
         SyntaxToken questionToken)
     {
         return new TypeClauseSyntax(syntaxTree, asyncModifier, sequenceKeyword, openBracketToken, elementType, closeBracketToken, questionToken, isSequence: true);
+    }
+
+    /// <summary>Creates an async function type clause <c>async func(P) R?</c> (ADR-0043).</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="asyncModifier">The leading <c>async</c> modifier token.</param>
+    /// <param name="funcKeyword">The <c>func</c> keyword.</param>
+    /// <param name="openParenToken">The opening <c>(</c> token.</param>
+    /// <param name="functionParameterTypes">The comma-separated parameter-type clauses.</param>
+    /// <param name="closeParenToken">The closing <c>)</c> token.</param>
+    /// <param name="returnTypeClause">The optional return-type clause; <c>null</c> for void.</param>
+    /// <param name="questionToken">The optional trailing <c>?</c> nullability marker.</param>
+    /// <returns>An async function type clause.</returns>
+    public static TypeClauseSyntax CreateAsyncFunction(
+        SyntaxTree syntaxTree,
+        SyntaxToken asyncModifier,
+        SyntaxToken funcKeyword,
+        SyntaxToken openParenToken,
+        SeparatedSyntaxList<TypeClauseSyntax> functionParameterTypes,
+        SyntaxToken closeParenToken,
+        TypeClauseSyntax returnTypeClause,
+        SyntaxToken questionToken)
+    {
+        return new TypeClauseSyntax(syntaxTree, asyncModifier, funcKeyword, openParenToken, functionParameterTypes, closeParenToken, returnTypeClause, questionToken, isFunction: true);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncFunctionTypeClauseTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncFunctionTypeClauseTests.cs
@@ -1,0 +1,254 @@
+// <copyright file="AsyncFunctionTypeClauseTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// End-to-end tests for ADR-0043: <c>async func(P) R</c> as a type-clause
+/// spelling for <c>func(P) Task[R]</c> in any type-clause position
+/// (parameters, locals, fields, generic arguments, function-type return
+/// slots, etc.).
+/// </summary>
+public class AsyncFunctionTypeClauseTests
+{
+    [Fact]
+    public void AsyncFunctionTypeClause_Parameter_BindsToFuncReturningTaskOfInt()
+    {
+        const string Source = @"package AsyncFuncParam
+import System
+import System.Threading.Tasks
+
+func runEach(cb async func(int) int) {
+    Console.Out.WriteLine(""ok"")
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(AsyncFunctionTypeClause_Parameter_BindsToFuncReturningTaskOfInt));
+        try
+        {
+            var method = GetProgramMethod(asm, "runEach");
+            var parameters = method.GetParameters();
+            Assert.Single(parameters);
+
+            // The parameter is a delegate type (Func<int, Task<int>>) — verify the
+            // Invoke method shape rather than depending on the exact CLR delegate
+            // shape GSharp's emitter chose.
+            var paramType = parameters[0].ParameterType;
+            var invoke = paramType.GetMethod("Invoke");
+            Assert.NotNull(invoke);
+            Assert.Equal(typeof(Task<int>), invoke!.ReturnType);
+            Assert.Single(invoke.GetParameters());
+            Assert.Equal(typeof(int), invoke.GetParameters()[0].ParameterType);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void AsyncFunctionTypeClause_VoidReturn_AliasesToFuncReturningPlainTask()
+    {
+        const string Source = @"package AsyncFuncVoid
+import System
+import System.Threading.Tasks
+
+func runVoid(cb async func(int)) {
+    Console.Out.WriteLine(""ok"")
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(AsyncFunctionTypeClause_VoidReturn_AliasesToFuncReturningPlainTask));
+        try
+        {
+            var method = GetProgramMethod(asm, "runVoid");
+            var paramType = method.GetParameters()[0].ParameterType;
+            var invoke = paramType.GetMethod("Invoke");
+            Assert.NotNull(invoke);
+            Assert.Equal(typeof(Task), invoke!.ReturnType);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void AsyncFunctionTypeClause_AndExplicitTaskWrap_AreSameType()
+    {
+        // `async func(int) int` and `func(int) Task[int]` must resolve to the
+        // exact same FunctionTypeSymbol — i.e., the same CLR parameter type.
+        const string Source = @"package AsyncFuncEquiv
+import System
+import System.Threading.Tasks
+
+func viaModifier(cb async func(int) int) {
+}
+
+func viaTaskWrap(cb func(int) Task[int]) {
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(AsyncFunctionTypeClause_AndExplicitTaskWrap_AreSameType));
+        try
+        {
+            var viaModifier = GetProgramMethod(asm, "viaModifier");
+            var viaTaskWrap = GetProgramMethod(asm, "viaTaskWrap");
+            Assert.Equal(
+                viaModifier.GetParameters()[0].ParameterType,
+                viaTaskWrap.GetParameters()[0].ParameterType);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void AsyncFunctionTypeClause_InReturnSlot_OfOuterFunction()
+    {
+        // The outer function `factory` returns `async func() int` — i.e.,
+        // `func() Task[int]`. Verify the outer return type's delegate-Invoke
+        // shape via reflection.
+        const string Source = @"package AsyncFuncReturn
+import System
+import System.Threading.Tasks
+
+func factory() async func(int) int {
+    return async func(x int) int { return x + 1 }
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(AsyncFunctionTypeClause_InReturnSlot_OfOuterFunction));
+        try
+        {
+            var factory = GetProgramMethod(asm, "factory");
+            var returnType = factory.ReturnType;
+            var invoke = returnType.GetMethod("Invoke");
+            Assert.NotNull(invoke);
+            Assert.Equal(typeof(Task<int>), invoke!.ReturnType);
+            Assert.Single(invoke.GetParameters());
+            Assert.Equal(typeof(int), invoke.GetParameters()[0].ParameterType);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void AsyncFunctionTypeClause_AsyncSequenceReturn_KeepsIAsyncEnumerableUnwrapped()
+    {
+        // Iterator carve-out: `async func() sequence[int]` and
+        // `async func() async sequence[int]` parameter types both resolve to
+        // `func() IAsyncEnumerable[int]` — no Task wrap.
+        const string Source = @"package AsyncFuncIterReturn
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+
+func acceptImplicit(cb async func() sequence[int]) {
+}
+
+func acceptExplicit(cb async func() async sequence[int]) {
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(AsyncFunctionTypeClause_AsyncSequenceReturn_KeepsIAsyncEnumerableUnwrapped));
+        try
+        {
+            var acceptImplicit = GetProgramMethod(asm, "acceptImplicit");
+            var acceptExplicit = GetProgramMethod(asm, "acceptExplicit");
+
+            var implicitParamType = acceptImplicit.GetParameters()[0].ParameterType;
+            var explicitParamType = acceptExplicit.GetParameters()[0].ParameterType;
+            var implicitInvoke = implicitParamType.GetMethod("Invoke");
+            var explicitInvoke = explicitParamType.GetMethod("Invoke");
+            Assert.NotNull(implicitInvoke);
+            Assert.NotNull(explicitInvoke);
+            Assert.Equal(typeof(IAsyncEnumerable<int>), implicitInvoke!.ReturnType);
+            Assert.Equal(typeof(IAsyncEnumerable<int>), explicitInvoke!.ReturnType);
+            Assert.Equal(implicitParamType, explicitParamType);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void AsyncFunctionTypeClause_ExplicitTaskReturn_IsRejected()
+    {
+        // ADR-0043 rejects `async func(...) Task[X]` because the `async`
+        // modifier already implies the Task wrap.
+        const string Source = @"package AsyncFuncDoubleWrap
+import System
+import System.Threading.Tasks
+
+func bad(cb async func(int) Task[int]) {
+}
+";
+        var tree = SyntaxTree.Parse(SourceText.From(Source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Message.Contains("implicitly wrapped in 'Task'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void AsyncPrefix_FollowedByNonFuncNonSequence_IsRejected()
+    {
+        // After ADR-0043 the legal followers are `func` and `sequence` only.
+        const string Source = @"package AsyncBadPrefix
+import System
+
+func bad(s async int) {
+}
+";
+        var tree = SyntaxTree.Parse(SourceText.From(Source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Message.Contains("'async' modifier in a type clause is only valid before 'sequence[T]' or 'func(...)'", StringComparison.Ordinal));
+    }
+
+    private static MethodInfo GetProgramMethod(Assembly asm, string name)
+    {
+        var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+        Assert.NotNull(programType);
+        var method = programType!.GetMethod(name, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return method!;
+    }
+
+    private static (Assembly asm, AssemblyLoadContext ctx) CompileToAssembly(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        var asm = loadContext.LoadFromStream(peStream);
+        return (asm, loadContext);
+    }
+}


### PR DESCRIPTION
Closes #150.

Generalises the `async` modifier — already legal on function declarations and lambda expressions — to **function-type clauses**, so `async func(P) R` is a spelling for `func(P) Task[R]` in any type-clause position (parameters, locals, fields, generic arguments, function-type return slots, …).

Mirrors the ADR-0023 declaration rule and the ADR-0042 `async sequence[T]` generalisation. The alias resolves to the existing `FunctionTypeSymbol` — `async func(int) int` and `func(int) Task[int]` are the *same* type, freely assignable in either direction.

## Examples

```gsharp
// Local
let handler async func(int) int = async func(x int) int { return x + 1 }

// Parameter
func runEach(items []int, cb async func(int) int) {
    for x in items { _ = cb(x) }
}

// Struct field
data Pipeline { transform async func(int) int }

// Outer return slot
func factory() async func(int) int { ... }
```

## Return-slot rules

| `R` as written | Resolved |
|---|---|
| *(omitted)* | `Task` |
| `T` (non-Task, non-iterator) | `Task[T]` |
| `sequence[T]` | `IAsyncEnumerable[T]` (ADR-0041 carve-out) |
| `async sequence[T]` | `IAsyncEnumerable[T]` |
| `IAsyncEnumerable[T]` / `IAsyncEnumerator[T]` | unchanged |
| `Task` / `Task[X]` / `ValueTask` / `ValueTask[X]` | **GS0189** (no double-wrap) |

## Changes

- `Parser.cs` — generalised `ParseAsyncSequenceTypeClause` → `ParseAsyncPrefixedTypeClause` that dispatches on `func` vs `sequence`.
- `TypeClauseSyntax.cs` — added `CreateAsyncFunction` factory + `IsAsyncFunction` property; the function-type constructor now carries an optional `AsyncModifier` token.
- `Binder.cs` — `BindNonNullableTypeClause` IsFunction branch applies the ADR-0023/0041 return-slot transformation (Task wrap, void→Task, iterator carve-out, sequence→async-sequence swap) when `IsAsyncFunction`. Also tightens `BindFunctionLiteralExpression` to skip the Task wrap when the async lambda's return type is an async iterator (pre-existing missing carve-out, surfaced by the new tests).
- `DiagnosticBag.cs` — GS0135 message updated to mention `func(...)`; new GS0189 for explicit `Task[…]` double-wrap.
- `docs/adr/0043-async-func-type-clause.md` — new ADR.
- `docs/adr/0042-async-sequence-type-clause.md` — back-references updated from "issue #150" to "ADR-0043".
- `docs/diagnostics.md` — GS0135 / GS0189 entries updated.

## Tests

7 new tests in `AsyncFunctionTypeClauseTests`:

1. Parameter binds to `Func<int, Task<int>>` shape.
2. Void return aliases to `func() Task`.
3. `async func(int) int` and `func(int) Task[int]` are the same type.
4. Async-modifier return slot of an outer function works end-to-end.
5. Iterator carve-out: both `async func() sequence[int]` and `async func() async sequence[int]` resolve to `func() IAsyncEnumerable[int]` (no Task wrap).
6. GS0189 fires for `async func(int) Task[int]`.
7. GS0135 fires for `async int` (and the message now lists both `sequence[T]` and `func(...)`).

Full suite: 1020/1020 passing.