### PR TITLE
Implement typeof(T) and nameof(expr) operators (#143)

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -112,6 +112,7 @@ MinusMinusToken
 MinusToken
 MultiAssignmentStatement
 NameExpression
+NameOfExpression
 NamedArgumentExpression
 NamedDeconstructionField
 NamedDeconstructionStatement
@@ -183,6 +184,7 @@ TypeAliasDeclaration
 TypeArgumentList
 TypeClause
 TypeKeyword
+TypeOfExpression
 TypeParameter
 TypeParameterList
 TypePattern
@@ -269,6 +271,7 @@ ThrowStatement
 TryStatement
 TupleElementAccessExpression
 TupleLiteralExpression
+TypeOfExpression
 TypePattern
 UnaryExpression
 UserInstanceCallExpression

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2720,6 +2720,70 @@ public sealed class Binder
         return new BoundMakeChannelExpression(chan, capacity);
     }
 
+    private BoundExpression BindTypeOfExpression(TypeOfExpressionSyntax syntax)
+    {
+        // Issue #143: `typeof(T)` returns System.Type for the referenced type.
+        var typeSymbol = BindTypeClause(syntax.TypeClause);
+        if (typeSymbol == null || typeSymbol == TypeSymbol.Error)
+        {
+            return new BoundErrorExpression();
+        }
+
+        var systemType = ImportedTypeSymbol.Get(typeof(Type));
+        return new BoundTypeOfExpression(typeSymbol, systemType);
+    }
+
+    private BoundExpression BindNameOfExpression(NameOfExpressionSyntax syntax)
+    {
+        // Issue #143: `nameof(expr)` is folded to a compile-time string of
+        // the unqualified short name. The argument must be a name reference
+        // (identifier, member access, or type). `nameof(this)` / `nameof(it)`
+        // are rejected to match C# semantics.
+        if (TryExtractNameOfName(syntax.Argument, out var name))
+        {
+            return new BoundLiteralExpression(name);
+        }
+
+        Diagnostics.ReportNameOfRequiresNameReference(syntax.Argument.Location);
+        return new BoundErrorExpression();
+    }
+
+    private static bool TryExtractNameOfName(ExpressionSyntax argument, out string name)
+    {
+        switch (argument)
+        {
+            case NameExpressionSyntax n:
+                {
+                    var ident = n.IdentifierToken.Text;
+                    if (string.IsNullOrEmpty(ident) || ident == "this" || ident == "it")
+                    {
+                        name = null;
+                        return false;
+                    }
+
+                    name = ident;
+                    return true;
+                }
+
+            case AccessorExpressionSyntax acc when !acc.IsNullConditional:
+                return TryExtractNameOfName(acc.RightPart, out name);
+
+            case CallExpressionSyntax call when call.TypeArgumentList != null && call.Arguments.Count == 0:
+                // Generic name like `List[int]` parsed as an empty-arg generic
+                // call site is treated as a type reference whose short name is
+                // the identifier (matches C# `nameof(List<int>)` -> "List").
+                name = call.Identifier.Text;
+                return !string.IsNullOrEmpty(name);
+
+            case ParenthesizedExpressionSyntax p:
+                return TryExtractNameOfName(p.Expression, out name);
+
+            default:
+                name = null;
+                return false;
+        }
+    }
+
     private BoundStatement BindSelectStatement(SelectStatementSyntax syntax)
     {
         // Phase 5.6 / ADR-0022: select statement orchestrating channel ops.
@@ -3488,6 +3552,10 @@ public sealed class Binder
                 return BindSwitchExpression((SwitchExpressionSyntax)syntax);
             case SyntaxKind.MakeChannelExpression:
                 return BindMakeChannelExpression((MakeChannelExpressionSyntax)syntax);
+            case SyntaxKind.TypeOfExpression:
+                return BindTypeOfExpression((TypeOfExpressionSyntax)syntax);
+            case SyntaxKind.NameOfExpression:
+                return BindNameOfExpression((NameOfExpressionSyntax)syntax);
             case SyntaxKind.FieldAssignmentExpression:
                 return BindFieldAssignmentExpression((FieldAssignmentExpressionSyntax)syntax);
             case SyntaxKind.EventSubscriptionExpression:

--- a/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -80,6 +80,9 @@ public enum BoundNodeKind
     DefaultExpression,
     ClrStaticCallExpression,
 
+    // Issue #143: typeof operator
+    TypeOfExpression,
+
     // Patterns
     ConstantPattern,
     DiscardPattern,

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -154,6 +154,9 @@ public static class BoundNodePrinter
             case BoundNodeKind.LenExpression:
                 WriteIntrinsicCall("len", ((BoundLenExpression)node).Operand, writer);
                 break;
+            case BoundNodeKind.TypeOfExpression:
+                WriteTypeOfExpression((BoundTypeOfExpression)node, writer);
+                break;
             case BoundNodeKind.CapExpression:
                 WriteIntrinsicCall("cap", ((BoundCapExpression)node).Operand, writer);
                 break;
@@ -973,6 +976,14 @@ public static class BoundNodePrinter
         writer.WriteIdentifier(name);
         writer.WritePunctuation(SyntaxKind.OpenParenthesisToken);
         operand.WriteTo(writer);
+        writer.WritePunctuation(SyntaxKind.CloseParenthesisToken);
+    }
+
+    private static void WriteTypeOfExpression(BoundTypeOfExpression node, IndentedTextWriter writer)
+    {
+        writer.WriteIdentifier("typeof");
+        writer.WritePunctuation(SyntaxKind.OpenParenthesisToken);
+        writer.WriteIdentifier(node.OperandType.Name);
         writer.WritePunctuation(SyntaxKind.CloseParenthesisToken);
     }
 

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -422,6 +422,8 @@ public abstract class BoundTreeRewriter
                 return RewriteSpillSequenceExpression((BoundSpillSequenceExpression)node);
             case BoundNodeKind.DefaultExpression:
                 return RewriteDefaultExpression((BoundDefaultExpression)node);
+            case BoundNodeKind.TypeOfExpression:
+                return node;
             default:
                 throw new Exception($"Unexpected node: {node.Kind}");
         }

--- a/src/Core/CodeAnalysis/Binding/BoundTypeOfExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTypeOfExpression.cs
@@ -1,0 +1,34 @@
+// <copyright file="BoundTypeOfExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Bound built-in <c>typeof(T)</c> expression (issue #143). Carries the
+/// referenced <see cref="TypeSymbol"/> payload; emits as
+/// <c>ldtoken &lt;T&gt;</c> followed by a call to
+/// <c>System.Type.GetTypeFromHandle</c>. Its result type is <c>System.Type</c>.
+/// </summary>
+public sealed class BoundTypeOfExpression : BoundExpression
+{
+    /// <summary>Initializes a new instance of the <see cref="BoundTypeOfExpression"/> class.</summary>
+    /// <param name="operandType">The type that this <c>typeof</c> references.</param>
+    /// <param name="systemType">The <c>System.Type</c> symbol used as the result type.</param>
+    public BoundTypeOfExpression(TypeSymbol operandType, TypeSymbol systemType)
+    {
+        OperandType = operandType;
+        Type = systemType;
+    }
+
+    /// <inheritdoc/>
+    public override BoundNodeKind Kind => BoundNodeKind.TypeOfExpression;
+
+    /// <inheritdoc/>
+    public override TypeSymbol Type { get; }
+
+    /// <summary>Gets the referenced type symbol.</summary>
+    public TypeSymbol OperandType { get; }
+}

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1074,6 +1074,16 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0189", message);
     }
 
+    /// <summary>
+    /// Reports that a <c>nameof(...)</c> argument is not a valid name
+    /// reference (it must denote an identifier, member access, or type).
+    /// </summary>
+    /// <param name="location">The text location of the argument.</param>
+    public void ReportNameOfRequiresNameReference(TextLocation location)
+    {
+        Report(location, "GS0190", "The argument to 'nameof' must be a name reference: an identifier, member access, or type.");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -122,6 +122,8 @@ internal sealed class ReflectionMetadataEmitter
     private Type coreBooleanType;
     private Type coreArrayType;
     private Type coreValueType;
+    private Type coreSystemType;
+    private Type coreRuntimeTypeHandleType;
     private TypeReferenceHandle objectTypeRef;
     private TypeReferenceHandle valueTypeRef;
     private MemberReferenceHandle objectCtorRef;
@@ -216,6 +218,8 @@ internal sealed class ReflectionMetadataEmitter
         this.coreBooleanType = this.ResolveCoreType("System.Boolean", typeof(bool));
         this.coreArrayType = this.ResolveCoreType("System.Array", typeof(System.Array));
         this.coreValueType = this.ResolveCoreType("System.ValueType", typeof(System.ValueType));
+        this.coreSystemType = this.ResolveCoreType("System.Type", typeof(System.Type));
+        this.coreRuntimeTypeHandleType = this.ResolveCoreType("System.RuntimeTypeHandle", typeof(System.RuntimeTypeHandle));
         this.objectTypeRef = this.GetTypeReference(this.coreObjectType);
         this.valueTypeRef = this.GetTypeReference(this.coreValueType);
         this.objectCtorRef = this.GetObjectDefaultCtorReference();
@@ -3975,6 +3979,8 @@ internal sealed class ReflectionMetadataEmitter
             case BoundLenExpression len:
                 WalkForAppends(len.Operand, sink);
                 break;
+            case BoundTypeOfExpression:
+                break;
             case BoundCapExpression cap:
                 WalkForAppends(cap.Operand, sink);
                 break;
@@ -4291,6 +4297,32 @@ internal sealed class ReflectionMetadataEmitter
         var method = this.coreStringType.GetMethod("get_Length", Type.EmptyTypes)
             ?? throw new InvalidOperationException("String.get_Length is not resolvable from the supplied references.");
         return this.GetMethodReference(method);
+    }
+
+    private MemberReferenceHandle GetTypeFromHandleReference()
+    {
+        // System.Type::GetTypeFromHandle(RuntimeTypeHandle) — backs `typeof(T)`.
+        var method = this.coreSystemType.GetMethod(
+            "GetTypeFromHandle",
+            new[] { this.coreRuntimeTypeHandleType })
+            ?? throw new InvalidOperationException("Type.GetTypeFromHandle(RuntimeTypeHandle) is not resolvable from the supplied references.");
+        return this.GetMethodReference(method);
+    }
+
+    private EntityHandle GetTypeOfToken(TypeSymbol type)
+    {
+        // Issue #143: `typeof(T)` token resolution. `NullableTypeSymbol` over a
+        // value type must surface as `System.Nullable<T>` to match C# semantics
+        // (binder/evaluator collapse the wrapper to its underlying type for
+        // every other purpose — ADR-0001).
+        if (type is NullableTypeSymbol nullable
+            && nullable.UnderlyingType.ClrType is { IsValueType: true } valueClr)
+        {
+            var nullableType = typeof(System.Nullable<>).MakeGenericType(valueClr);
+            return this.GetTypeHandleForMember(nullableType);
+        }
+
+        return this.GetElementTypeToken(type);
     }
 
     private MemberReferenceHandle GetArrayCopyReference()
@@ -5732,6 +5764,9 @@ internal sealed class ReflectionMetadataEmitter
                 case BoundLenExpression len:
                     this.EmitLen(len);
                     break;
+                case BoundTypeOfExpression typeOf:
+                    this.EmitTypeOf(typeOf);
+                    break;
                 case BoundCapExpression cap:
                     this.EmitExpression(cap.Operand);
                     this.il.OpCode(ILOpCode.Ldlen);
@@ -6491,6 +6526,14 @@ internal sealed class ReflectionMetadataEmitter
                 this.il.OpCode(ILOpCode.Ldlen);
                 this.il.OpCode(ILOpCode.Conv_i4);
             }
+        }
+
+        private void EmitTypeOf(BoundTypeOfExpression typeOf)
+        {
+            // Issue #143: `typeof(T)` -> ldtoken <T> ; call Type::GetTypeFromHandle.
+            this.il.OpCode(ILOpCode.Ldtoken);
+            this.il.Token(this.outer.GetTypeOfToken(typeOf.OperandType));
+            this.il.Call(this.outer.GetTypeFromHandleReference());
         }
 
         private void EmitAppend(BoundAppendExpression app)

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -473,6 +473,7 @@ public sealed class Evaluator
                 BoundNodeKind.IndexExpression => EvaluateIndexExpression((BoundIndexExpression)node),
                 BoundNodeKind.IndexAssignmentExpression => EvaluateIndexAssignmentExpression((BoundIndexAssignmentExpression)node),
                 BoundNodeKind.LenExpression => EvaluateLenExpression((BoundLenExpression)node),
+                BoundNodeKind.TypeOfExpression => EvaluateTypeOfExpression((BoundTypeOfExpression)node),
                 BoundNodeKind.CapExpression => EvaluateCapExpression((BoundCapExpression)node),
                 BoundNodeKind.AppendExpression => EvaluateAppendExpression((BoundAppendExpression)node),
                 BoundNodeKind.StructLiteralExpression => EvaluateStructLiteralExpression((BoundStructLiteralExpression)node),
@@ -632,6 +633,20 @@ public sealed class Evaluator
             System.Collections.IDictionary d => d.Count,
             _ => throw new EvaluatorException($"len: unsupported operand of CLR type '{v?.GetType()}'.", node),
         };
+    }
+
+    private static object EvaluateTypeOfExpression(BoundTypeOfExpression node)
+    {
+        // Issue #143: nullable value types resolve to `System.Nullable<T>`;
+        // nullable reference types and every other shape resolve to the
+        // operand's ClrType directly.
+        if (node.OperandType is NullableTypeSymbol nullable
+            && nullable.UnderlyingType.ClrType is { IsValueType: true } valueClr)
+        {
+            return typeof(System.Nullable<>).MakeGenericType(valueClr);
+        }
+
+        return node.OperandType.ClrType ?? typeof(object);
     }
 
     private object EvaluateCapExpression(BoundCapExpression node)

--- a/src/Core/CodeAnalysis/Syntax/NameOfExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/NameOfExpressionSyntax.cs
@@ -1,0 +1,50 @@
+// <copyright file="NameOfExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents the built-in <c>nameof(expr)</c> operator (issue #143).
+/// <c>nameof</c> is recognized as a contextual identifier when followed by
+/// <c>(</c>. The argument must be a name reference (identifier, member access,
+/// or generic type instantiation); the binder lowers it to a compile-time
+/// string literal of the unqualified short name.
+/// </summary>
+public sealed class NameOfExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>Initializes a new instance of the <see cref="NameOfExpressionSyntax"/> class.</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="nameOfIdentifier">The <c>nameof</c> identifier token.</param>
+    /// <param name="openParenthesis">The <c>(</c> token.</param>
+    /// <param name="argument">The argument expression — must reduce to a name reference.</param>
+    /// <param name="closeParenthesis">The <c>)</c> token.</param>
+    public NameOfExpressionSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken nameOfIdentifier,
+        SyntaxToken openParenthesis,
+        ExpressionSyntax argument,
+        SyntaxToken closeParenthesis)
+        : base(syntaxTree)
+    {
+        NameOfIdentifier = nameOfIdentifier;
+        OpenParenthesis = openParenthesis;
+        Argument = argument;
+        CloseParenthesis = closeParenthesis;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.NameOfExpression;
+
+    /// <summary>Gets the <c>nameof</c> identifier token.</summary>
+    public SyntaxToken NameOfIdentifier { get; }
+
+    /// <summary>Gets the opening <c>(</c> token.</summary>
+    public SyntaxToken OpenParenthesis { get; }
+
+    /// <summary>Gets the argument expression.</summary>
+    public ExpressionSyntax Argument { get; }
+
+    /// <summary>Gets the closing <c>)</c> token.</summary>
+    public SyntaxToken CloseParenthesis { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -2709,6 +2709,20 @@ public class Parser
             // Phase 5.4 / ADR-0022: contextual `make(chan T)` / `make(chan T, capacity)`.
             current = ParseMakeChannelExpression();
         }
+        else if (Current.Kind == SyntaxKind.IdentifierToken
+            && Current.Text == "typeof"
+            && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
+        {
+            // Issue #143: contextual `typeof(T)` — argument is a type clause.
+            current = ParseTypeOfExpression();
+        }
+        else if (Current.Kind == SyntaxKind.IdentifierToken
+            && Current.Text == "nameof"
+            && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
+        {
+            // Issue #143: contextual `nameof(expr)` — argument is a name reference.
+            current = ParseNameOfExpression();
+        }
         else if (Current.Kind == SyntaxKind.IdentifierToken && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
         {
             current = ParseCallExpression();
@@ -2938,6 +2952,29 @@ public class Parser
 
         var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
         return new MakeChannelExpressionSyntax(syntaxTree, makeIdentifier, openParen, channelType, comma, capacity, closeParen);
+    }
+
+    private ExpressionSyntax ParseTypeOfExpression()
+    {
+        // Issue #143: `typeof(T)` — the argument is a type clause, not an expression.
+        var typeOfIdentifier = MatchToken(SyntaxKind.IdentifierToken);
+        var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
+        var typeClause = ParseTypeClause();
+        var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+        return new TypeOfExpressionSyntax(syntaxTree, typeOfIdentifier, openParen, typeClause, closeParen);
+    }
+
+    private ExpressionSyntax ParseNameOfExpression()
+    {
+        // Issue #143: `nameof(expr)` — the argument is a name reference. We
+        // parse it as a general expression; the binder validates that it
+        // reduces to a name (identifier / member access / generic name) and
+        // emits a diagnostic otherwise.
+        var nameOfIdentifier = MatchToken(SyntaxKind.IdentifierToken);
+        var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
+        var argument = ParseExpression();
+        var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+        return new NameOfExpressionSyntax(syntaxTree, nameOfIdentifier, openParen, argument, closeParen);
     }
 
     // Phase 4.9: Kotlin-style trailing-lambda call syntax. When a call's

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -217,6 +217,10 @@ public enum SyntaxKind
     AwaitForRangeStatement,
     EventSubscriptionExpression,
     YieldStatement,
+
+    // Issue #143: typeof / nameof contextual operators
+    TypeOfExpression,
+    NameOfExpression,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/src/Core/CodeAnalysis/Syntax/TypeOfExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypeOfExpressionSyntax.cs
@@ -1,0 +1,49 @@
+// <copyright file="TypeOfExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents the built-in <c>typeof(T)</c> operator (issue #143).
+/// <c>typeof</c> is recognized as a contextual identifier when followed by
+/// <c>(</c> and a type clause. The result is a <see cref="System.Type"/>
+/// obtained from the type's metadata token.
+/// </summary>
+public sealed class TypeOfExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>Initializes a new instance of the <see cref="TypeOfExpressionSyntax"/> class.</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="typeOfIdentifier">The <c>typeof</c> identifier token.</param>
+    /// <param name="openParenthesis">The <c>(</c> token.</param>
+    /// <param name="typeClause">The type-clause argument.</param>
+    /// <param name="closeParenthesis">The <c>)</c> token.</param>
+    public TypeOfExpressionSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken typeOfIdentifier,
+        SyntaxToken openParenthesis,
+        TypeClauseSyntax typeClause,
+        SyntaxToken closeParenthesis)
+        : base(syntaxTree)
+    {
+        TypeOfIdentifier = typeOfIdentifier;
+        OpenParenthesis = openParenthesis;
+        TypeClause = typeClause;
+        CloseParenthesis = closeParenthesis;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.TypeOfExpression;
+
+    /// <summary>Gets the <c>typeof</c> identifier token.</summary>
+    public SyntaxToken TypeOfIdentifier { get; }
+
+    /// <summary>Gets the opening <c>(</c> token.</summary>
+    public SyntaxToken OpenParenthesis { get; }
+
+    /// <summary>Gets the type-clause argument.</summary>
+    public TypeClauseSyntax TypeClause { get; }
+
+    /// <summary>Gets the closing <c>)</c> token.</summary>
+    public SyntaxToken CloseParenthesis { get; }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/TypeOfNameOfTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/TypeOfNameOfTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="TypeOfNameOfTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #143: binder and evaluator coverage for the <c>typeof(T)</c> and
+/// <c>nameof(expr)</c> contextual operators.
+/// </summary>
+public class TypeOfNameOfTests
+{
+    [Fact]
+    public void TypeOf_Int_Resolves_To_SystemInt32()
+    {
+        var (eval, vars) = EvaluateWithVariables(@"
+var t = typeof(int)
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.Equal(typeof(int), vars["t"]);
+    }
+
+    [Fact]
+    public void TypeOf_String_Resolves_To_SystemString()
+    {
+        var (eval, vars) = EvaluateWithVariables(@"
+var t = typeof(string)
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.Equal(typeof(string), vars["t"]);
+    }
+
+    [Fact]
+    public void TypeOf_Result_Type_Is_SystemType()
+    {
+        var tree = SyntaxTree.Parse(SourceText.From("var t = typeof(int)\n"));
+        var compilation = new Compilation(tree);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var variable = FindVariable(compilation, "t");
+        Assert.Equal(typeof(System.Type), variable.Type.ClrType);
+    }
+
+    [Fact]
+    public void TypeOf_Slice_Of_Int_Resolves_To_Int_Array()
+    {
+        var (eval, vars) = EvaluateWithVariables(@"
+var t = typeof([]int)
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.Equal(typeof(int[]), vars["t"]);
+    }
+
+    [Fact]
+    public void TypeOf_Nullable_Int_Resolves_To_Nullable_Int32()
+    {
+        var (eval, vars) = EvaluateWithVariables(@"
+var t = typeof(int?)
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.Equal(typeof(int?), vars["t"]);
+    }
+
+    [Fact]
+    public void NameOf_Local_Returns_Identifier()
+    {
+        var (eval, vars) = EvaluateWithVariables(@"
+var counter = 0
+var n = nameof(counter)
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.Equal("counter", vars["n"]);
+    }
+
+    [Fact]
+    public void NameOf_Member_Access_Returns_RightmostName()
+    {
+        var (eval, vars) = EvaluateWithVariables(@"
+import System
+var n = nameof(Console.WriteLine)
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.Equal("WriteLine", vars["n"]);
+    }
+
+    [Fact]
+    public void NameOf_Result_Type_Is_String()
+    {
+        var tree = SyntaxTree.Parse(SourceText.From("var n = nameof(n)\n"));
+        var compilation = new Compilation(tree);
+        var variable = FindVariable(compilation, "n");
+        Assert.Same(TypeSymbol.String, variable.Type);
+    }
+
+    [Fact]
+    public void NameOf_Rejects_Literal_Argument()
+    {
+        var tree = SyntaxTree.Parse(SourceText.From("var n = nameof(123)\n"));
+        var compilation = new Compilation(tree);
+        var diagnostics = compilation.GlobalScope.Diagnostics;
+        Assert.Contains(diagnostics, d => d.Id == "GS0190");
+    }
+
+    [Fact]
+    public void NameOf_Rejects_Arbitrary_Call()
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(@"
+import System
+var n = nameof(Console.WriteLine(""hi""))
+"));
+        var compilation = new Compilation(tree);
+        var diagnostics = compilation.GlobalScope.Diagnostics;
+        Assert.Contains(diagnostics, d => d.Id == "GS0190");
+    }
+
+    private static VariableSymbol FindVariable(Compilation compilation, string name)
+    {
+        foreach (var symbol in compilation.GlobalScope.Variables)
+        {
+            if (symbol.Name == name)
+            {
+                return symbol;
+            }
+        }
+
+        throw new Xunit.Sdk.XunitException($"variable '{name}' not found");
+    }
+
+    private static (EvaluationResult Result, Dictionary<string, object> Variables) EvaluateWithVariables(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var variables = new Dictionary<VariableSymbol, object>();
+        var result = compilation.Evaluate(variables);
+
+        var namedVars = new Dictionary<string, object>();
+        foreach (var kvp in variables)
+        {
+            namedVars[kvp.Key.Name] = kvp.Value;
+        }
+
+        return (result, namedVars);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/TypeOfNameOfEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/TypeOfNameOfEmitTests.cs
@@ -1,0 +1,145 @@
+// <copyright file="TypeOfNameOfEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #143: emit tests for <c>typeof(T)</c> and <c>nameof(expr)</c>.
+/// Compiles a tiny GSharp program, loads the produced PE, invokes the entry
+/// point, and validates that the CLR-visible <see cref="Type"/> /
+/// <see cref="string"/> match expectations.
+/// </summary>
+public class TypeOfNameOfEmitTests
+{
+    [Fact]
+    public void TypeOf_Int_Emits_SystemInt32()
+    {
+        var output = CompileAndRun(@"
+package TypeOfIntTest
+import System
+var t = typeof(int)
+Console.WriteLine(t.FullName)
+", nameof(TypeOf_Int_Emits_SystemInt32));
+        Assert.Contains("System.Int32", output);
+    }
+
+    [Fact]
+    public void TypeOf_String_Emits_SystemString()
+    {
+        var output = CompileAndRun(@"
+package TypeOfStringTest
+import System
+var t = typeof(string)
+Console.WriteLine(t.FullName)
+", nameof(TypeOf_String_Emits_SystemString));
+        Assert.Contains("System.String", output);
+    }
+
+    [Fact]
+    public void TypeOf_NullableInt_Emits_SystemNullable()
+    {
+        var output = CompileAndRun(@"
+package TypeOfNullableTest
+import System
+var t = typeof(int?)
+Console.WriteLine(t.FullName)
+", nameof(TypeOf_NullableInt_Emits_SystemNullable));
+        Assert.Contains("System.Nullable", output);
+        Assert.Contains("System.Int32", output);
+    }
+
+    [Fact]
+    public void TypeOf_SliceOfInt_Emits_IntArray()
+    {
+        var output = CompileAndRun(@"
+package TypeOfSliceTest
+import System
+var t = typeof([]int)
+Console.WriteLine(t.FullName)
+", nameof(TypeOf_SliceOfInt_Emits_IntArray));
+        Assert.Contains("System.Int32[]", output);
+    }
+
+    [Fact]
+    public void NameOf_Local_Emits_Identifier_String()
+    {
+        var output = CompileAndRun(@"
+package NameOfLocalTest
+import System
+var counter = 7
+var n = nameof(counter)
+Console.WriteLine(n)
+", nameof(NameOf_Local_Emits_Identifier_String));
+        Assert.Contains("counter", output);
+    }
+
+    [Fact]
+    public void NameOf_Member_Access_Emits_Rightmost_Name()
+    {
+        var output = CompileAndRun(@"
+package NameOfMemberTest
+import System
+var n = nameof(Console.WriteLine)
+Console.WriteLine(n)
+", nameof(NameOf_Member_Access_Emits_Rightmost_Name));
+        Assert.Contains("WriteLine", output);
+    }
+
+    private static EmitResult Compile(string source, Stream peStream)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Emit(peStream);
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var result = Compile(source, peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, parameters: null);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -112,6 +112,7 @@ MinusMinusToken
 MinusToken
 MultiAssignmentStatement
 NameExpression
+NameOfExpression
 NamedArgumentExpression
 NamedDeconstructionField
 NamedDeconstructionStatement
@@ -183,6 +184,7 @@ TypeAliasDeclaration
 TypeArgumentList
 TypeClause
 TypeKeyword
+TypeOfExpression
 TypeParameter
 TypeParameterList
 TypePattern
@@ -271,6 +273,7 @@ ThrowStatement
 TryStatement
 TupleElementAccessExpression
 TupleLiteralExpression
+TypeOfExpression
 TypePattern
 UnaryExpression
 UserInstanceCallExpression


### PR DESCRIPTION
Closes #143

## Summary
Implements the `typeof(T)` and `nameof(expr)` operators per the issue spec.

- **`typeof(T)`** — contextual parsing (no new keyword); takes a `TypeClauseSyntax` so it supports primitives, slices, arrays, maps, pointers, func types, generic instantiations (`List[int]`), channels, sequences, and nullable types. Emits `ldtoken` + `System.Type.GetTypeFromHandle`, returning `System.Type`. Nullable value types correctly produce `System.Nullable<T>`.
- **`nameof(expr)`** — folds to a compile-time string literal in the binder. Accepts `NameExpression`, non-null-conditional `AccessorExpression` (returns rightmost name), `ParenthesizedExpression`, and zero-arg generic `CallExpression`. Rejects `this`, `it`, and literals with new diagnostic **GS0190**.

## Changes
- New syntax nodes: `TypeOfExpressionSyntax`, `NameOfExpressionSyntax`.
- Parser: contextual recognition in `ParseNameOrCallExpression` (mirrors `make(chan T)`).
- Binder: `BindTypeOfExpression` → `BoundTypeOfExpression`; `BindNameOfExpression` → `BoundLiteralExpression(string)`.
- Emitter: new `EmitTypeOf` using `ldtoken` + `Type.GetTypeFromHandle`; resolves `System.Type` / `System.RuntimeTypeHandle` via `ReferenceResolver` per emit-pipeline conventions.
- Evaluator: `EvaluateTypeOfExpression` (with `Nullable<T>` handling).
- New diagnostic `GS0190`.
- Coverage matrix golden + `docs/coverage-matrix.md` updated.

## Testing
- 10 new binder/evaluator tests + 6 end-to-end IL emit tests — all pass.
- Full suite: **1028 passing, 0 failing** (`dotnet test GSharp.sln --nologo --no-restore`).