### PR TITLE
ADR-0044/0045/0046: lock decisions for primitive-type coverage (#142, Phase 0)

### DIFF
--- a/docs/adr/0044-numeric-primitive-coverage.md
+++ b/docs/adr/0044-numeric-primitive-coverage.md
@@ -1,0 +1,121 @@
+# ADR-0044: Complete numeric primitive coverage
+
+- **Status**: Accepted
+- **Date**: 2026-05-26
+- **Phase**: Phase 8 — primitive coverage
+- **Related**: issue #142, issue #143 (typeof / nameof), ADR-0001 (null model), ADR-0034 (imported CLR interop), ADR-0037 (numeric tie-breaking)
+
+## Context
+
+GSharp today exposes a strict subset of the CLR's primitive types as keywords:
+
+| Keyword  | CLR type        |
+| -------- | --------------- |
+| `bool`   | `System.Boolean`|
+| `int`    | `System.Int32`  |
+| `string` | `System.String` |
+| `void`   | `System.Void`   |
+
+A `float64` token is referenced in one Binder helper (`Binder.cs:1192`) but no corresponding `TypeSymbol.Float64` exists. Every other CLR primitive — `byte`, `sbyte`, `short`, `ushort`, `uint`, `long`, `ulong`, `nint`/`nuint`, `decimal`, `char`, `float32`/`float64`, and `object` — can only be reached through fully-qualified BCL names after an `import` (`System.Int64`, `System.Decimal`, …). Imported `Console.WriteLine` overloads, for example, are visible but cannot be called with a literal of the right type because the literal's static type cannot be expressed.
+
+Three sub-decisions need to be locked before the implementation work can be split into reviewable PRs:
+
+1. **Canonical spellings** — Go-style (`int64`, `uint32`, `float64`, …) vs. C#-style (`long`, `uint`, `double`, …). GSharp's existing `int` is already aliased to `Int32` (a C#-style choice), but the lone `float64` reference and the broader Go-flavoured design (slices, channels, `:=`, `func`) tilt the floats toward Go.
+2. **Literal type inference** — C#-style (every literal has an intrinsic default type; suffixes widen it) vs. Go-style (untyped constants get their type from the surrounding context).
+3. **Native-width integers** — naming for `System.IntPtr` / `System.UIntPtr`.
+
+Locking these here unblocks Phases 1–6 of the issue #142 plan.
+
+## Decision
+
+### Canonical name table
+
+The following keywords are added to the GSharp lexer and `SyntaxFacts` keyword table, each pinned to the CLR type listed:
+
+| Keyword   | CLR type           | Notes |
+| --------- | ------------------ | ----- |
+| `byte`    | `System.Byte`      | 8-bit unsigned |
+| `sbyte`   | `System.SByte`     | 8-bit signed |
+| `short`   | `System.Int16`     | 16-bit signed |
+| `ushort`  | `System.UInt16`    | 16-bit unsigned |
+| `int`     | `System.Int32`     | unchanged |
+| `uint`    | `System.UInt32`    | 32-bit unsigned |
+| `long`    | `System.Int64`     | 64-bit signed |
+| `ulong`   | `System.UInt64`    | 64-bit unsigned |
+| `nint`    | `System.IntPtr`    | native-width signed |
+| `nuint`   | `System.UIntPtr`   | native-width unsigned |
+| `float32` | `System.Single`    | IEEE 754 binary32 |
+| `float64` | `System.Double`    | IEEE 754 binary64 |
+| `decimal` | `System.Decimal`   | 128-bit base-10 |
+| `char`    | `System.Char`      | UTF-16 code unit |
+| `object`  | `System.Object`    | universal upper bound (see ADR-0045) |
+
+Choices made:
+
+* **Integers and `object` follow C#**. `int`/`uint`/`long`/`ulong`/`short`/`ushort`/`byte`/`sbyte`/`object` keep the C# spellings already implicit in GSharp's existing `int`. C# parity makes interop with imported BCL types (which are everywhere in GSharp) read naturally — `func write(value object)` matches `Console.WriteLine(object)` exactly.
+* **Floats follow Go**. `float32`/`float64` (not `float`/`double`). The width is part of the type name, which is consistent with the rest of the Go-flavoured surface and avoids the C# ambiguity of "what's `float`?". This also locks in the meaning of the `float64` helper that already lives in `Binder.cs:1192`.
+* **Native-width integers use `nint`/`nuint`**. These spellings are unambiguous, match modern C#, and are consistent with the existing `int = int32` precedent (a fixed-width name even though it could have been native-sized).
+
+### Literal type inference: Go-style untyped constants
+
+A numeric literal token is **untyped** in the lexer. Its static type is determined by the *target type* at the point of use:
+
+1. **Direct target type available.** If the literal appears in a position with an annotated target (variable declaration, parameter, explicit cast, operand of an assignment to a typed location, single-overload argument position), the literal acquires the target's type — provided the literal's value is representable in that type. Otherwise: `ReportInvalidNumber` (`literal '258' cannot be represented as 'byte'`).
+2. **No direct target type.** The literal defaults as follows:
+   - Integer literals → `int` (preserving today's behaviour).
+   - Floating-point literals (containing `.`, `e`, or `E`) → `float64`.
+   - Suffixed literals (see below) → the suffix's type.
+3. **Arithmetic between untyped literals** stays untyped: `1 + 2` is an untyped integer until placed in a context. `1 + 1.5` is untyped float64 (the wider category wins among untyped operands). Once one operand becomes typed, the literal acquires that type (range-checked).
+
+This preserves the ergonomics that `let x : long = 1` simply works without `1L` decoration, while keeping today's "unannotated `1` is `int`" default unchanged.
+
+### Optional explicit type-pin suffixes
+
+Suffixes are accepted as an *escape hatch* when the user wants to pin a literal's type without writing a target. They follow C# spellings (case-insensitive):
+
+| Suffix     | Type      |
+| ---------- | --------- |
+| `L`        | `long`    |
+| `UL` / `LU`| `ulong`   |
+| `U`        | `uint`    |
+| `F`        | `float32` |
+| `D`        | `float64` |
+| `M`        | `decimal` |
+
+Suffixes are **never required**. They are only relevant when the surrounding context cannot supply a target. When a suffix is present *and* a target is supplied, the two must be type-compatible (the suffix wins; mismatch reports a diagnostic).
+
+`nint`/`nuint`/`short`/`ushort`/`sbyte`/`byte`/`char` have **no dedicated suffix**. Such typings always come from context or an explicit cast.
+
+### Underscores and existing radix prefixes
+
+The current `0x`/`0o`/`0b` prefixes and `_` digit separators (per `docs/lexical.md`) apply unchanged to every integer type. Suffixes appear *after* the digit body and are not preceded by an underscore (`0xFF_L` is invalid; write `0xFFL`).
+
+### Floating-point literal grammar
+
+The lexer learns the standard float forms:
+
+```
+float_literal = decimal_digits "." [ decimal_digits ] [ exponent ]
+              | "." decimal_digits [ exponent ]
+              | decimal_digits exponent
+exponent      = ( "e" | "E" ) [ "+" | "-" ] decimal_digits
+```
+
+Underscores between digits are allowed everywhere they are allowed in integers. Hex/octal/binary floats are not introduced by this ADR.
+
+## Consequences
+
+* Every CLR primitive that imported BCL APIs already expose becomes spellable in GSharp. `Console.WriteLine(42L)`, `decimal` arithmetic, `byte[]` element types via `nint`-indexed APIs all become first-class.
+* The "untyped literal" rule keeps the surface ergonomic: code that writes `let x : long = 0` continues to look natural, and existing tests that rely on `1 + 2` being `int` still pass because that's still the default in unconstrained position.
+* The lexer's `value` slot now needs to carry more than `int` — typically `long` for integer literals and `double` for float literals, with `decimal` for `M`-suffixed. `BoundLiteralExpression` consumes that wider value and narrows when the target type is known.
+* Suffixes overlap visually with identifiers: `0L` is a long literal, `0Lx` is a syntax error (no valid identifier may immediately follow a number). The lexer's existing "number then identifier" boundary already handles this.
+* `nint`/`nuint` literals only come from context; this is the same restriction C# applied originally and has not been a usability problem in practice.
+* `char` literals are deferred to ADR-0046; this ADR makes `char` *spellable* and addresses range conversions, but does not introduce `'c'` syntax.
+
+## Alternatives considered
+
+* **C#-style floats (`double`, `float`).** Rejected because (a) the existing `float64` reference in the Binder already points the language at Go-style names, and (b) width-in-the-name reads more honestly than `float` (which in C# is 32-bit, but is ambiguous to readers coming from any other language).
+* **C#-style intrinsic literal types with required suffixes.** Rejected because `let x : long = 100` is far more common in GSharp's style than `100L`, and forcing the suffix harms ergonomics for no semantic benefit. The Go rule still allows the suffix as a disambiguator.
+* **Go-style integer names (`int32`, `int64`, `uint64`, …) everywhere.** Rejected because it would break the existing `int = Int32` keyword and the assumption baked into call sites that `int` is the canonical 32-bit integer. The compromise — fixed-width *float* names but C# integer/object names — matches the precedent already in the codebase.
+* **`nativeint` / `unativeint`.** Rejected as verbose; `nint`/`nuint` is the modern C# spelling and reads consistently with `int`/`uint`.
+* **No `object` keyword (force `System.Object`).** Rejected because boxing and the universal upper bound are pervasive enough that requiring an import every time is hostile; see ADR-0045 for the semantic side.

--- a/docs/adr/0045-object-universal-upper-bound.md
+++ b/docs/adr/0045-object-universal-upper-bound.md
@@ -1,0 +1,73 @@
+# ADR-0045: `object` as the universal upper bound
+
+- **Status**: Accepted
+- **Date**: 2026-05-26
+- **Phase**: Phase 8 — primitive coverage
+- **Related**: issue #142, ADR-0001 (null model), ADR-0034 (imported CLR interop), ADR-0044 (numeric primitive coverage)
+
+## Context
+
+ADR-0044 adds `object` to GSharp's keyword table and pins it to `System.Object`. The *spelling* is straightforward; the *semantics* warrant their own ADR because `object` is the seam between GSharp's type system and the CLR's universal upper bound.
+
+Today GSharp has no concept of "every value is assignable to `T`". Reference-type nullability is handled by ADR-0001 (`T?` is the assignable-from-`nil` flavour of `T`), and value types are independently boxed only by the underlying runtime when GSharp calls into imported APIs that take `object`. There is no GSharp-language way to write a variable of type `object`, no GSharp-language assignment that says "box this `int`", no GSharp `is object` pattern, and no GSharp definition of `==` on `object`.
+
+The question is how closely the new `object` keyword matches C# (boxing rules, identity equality, default `ToString` access) vs. how much we trim for GSharp-specific reasons.
+
+## Decision
+
+`object` is the universal upper bound. Specifically:
+
+### Assignment compatibility
+
+* Every reference type is implicitly convertible to `object` (identity reference).
+* Every value type is implicitly convertible to `object` via **boxing**. The emit pipeline inserts a `box` instruction on the underlying CLR value type.
+* The conversion to `object` is **always implicit**; no cast is required.
+
+Nullability follows ADR-0001:
+
+* `object` is the non-nullable reference type. A `nil` may not be assigned to a variable of type `object`.
+* `object?` is the nullable variant; `nil` is assignable, `nil` flows through it, and access requires `?.` / `!`.
+* Boxing a value of a value type into `object` produces a non-`nil` reference, exactly as on the CLR.
+
+### Boxing direction and unboxing
+
+* **Box** (value type → `object`) is implicit, as above.
+* **Unbox** (`object` → value type `T`) requires an explicit `T(expr)` conversion. At runtime this lowers to the CLR `unbox.any T` instruction; a runtime-type mismatch raises `System.InvalidCastException`, matching C#.
+* **Downcast** (`object` → reference type `T`) likewise requires `T(expr)`; this lowers to `castclass T`.
+* The `is` pattern (`x is T`) tests the runtime type without raising; success narrows the local in the matching arm (per the existing `is`-pattern flow).
+
+### Equality
+
+* `==` and `!=` on two operands typed `object` resolve to **reference equality** (CLR `ceq`). This matches C# behaviour and ADR-0037's tie-breaking rule.
+* Equality between an `object`-typed operand and a value-typed operand: the value operand is boxed and reference equality is used. (This is the C# rule for `object == int`.)
+* User-defined `==` operators are not lifted to `object` — to invoke them, both operands must already have the more specific static type.
+
+### Members visible on `object`
+
+`object` exposes the standard `System.Object` instance members imported from the BCL: `ToString()`, `GetHashCode()`, `GetType()`, and `Equals(object)`. These are reached via the existing imported-member pipeline; no GSharp-specific bindings are introduced.
+
+### `nil` and `object`
+
+* `object` cannot hold `nil`; use `object?` for that.
+* `nil is object` is `false` (`nil` does not have a runtime type to test against).
+* Boxing a `T?` whose value is `nil` produces `nil` in `object?` (CLR behaviour: boxing a null `Nullable<T>` yields a null reference).
+
+### `typeof`
+
+`typeof(object)` returns the `Type` instance for `System.Object`, on the same footing as every other primitive (issue #143).
+
+## Consequences
+
+* Imported APIs that take `object` parameters become trivially callable from GSharp: `Console.WriteLine(42)` works because `int` boxes to `object` on the call.
+* Generics involving `T : object` and reflection-heavy APIs become usable without the user having to add a `System.Object` import.
+* The conversion table grows: every value-type primitive added by ADR-0044 must list `object` in its implicit-target set, and the emit side must select `box <T>` when the target is `object`.
+* `==` on `object` is reference equality, even when the runtime values are `int` boxes — this can surprise users coming from Python or JavaScript. The diagnostic system should not warn on this case (it's a well-known CLR semantic), but documentation in `docs/lexical.md` (or a follow-up doc) should call it out.
+* Reference equality means GSharp value-type comparison authors should still use the typed `==` they already define (per ADR-0035 user operator overloads). Boxing-to-`object` to compare is an anti-pattern but is not blocked.
+* No new attribute support is required; nullable annotations for `object`/`object?` flow through ADR-0001's existing mechanism.
+
+## Alternatives considered
+
+* **Treat `object` as just another imported type.** Rejected: forcing `import System` plus the `System.Object` spelling every time the user wants a universal upper bound is hostile and breaks parity with the rest of the keyword table.
+* **Make `object` nullable by default (`object` ⇔ `object?`).** Rejected because it breaks ADR-0001's invariant that bare reference types are non-nullable; `object?` is the explicit nullable spelling and matches every other reference type.
+* **Value-equality for `object == object`.** Rejected as too surprising at the CLR boundary: imported BCL APIs assume CLR semantics, and matching them avoids subtle bugs at the interop seam.
+* **Disallow boxing (force callers to write `(object)x` explicitly).** Rejected because it would make every `Console.WriteLine(42)` call site noisy without preventing a meaningful class of bug.

--- a/docs/adr/0046-char-literal-grammar.md
+++ b/docs/adr/0046-char-literal-grammar.md
@@ -1,0 +1,63 @@
+# ADR-0046: `'c'` character literal grammar
+
+- **Status**: Accepted
+- **Date**: 2026-05-26
+- **Phase**: Phase 8 — primitive coverage
+- **Related**: issue #142, ADR-0044 (numeric primitive coverage), ADR-0011 (string interpolation grammar), ADR-0012 (raw string delimiter)
+
+## Context
+
+ADR-0044 adds `char` (`System.Char`) to GSharp's keyword set, but stops short of introducing a literal form for it. Without one, a user who wants a `char` value must either rely on context inference (`let c : char = 65` — a numeric cast) or borrow from a single-character string (`"A"[0]` — extra runtime work and an unobvious idiom). Both paths exist but read poorly and break parity with imported BCL APIs that overload on `char` vs. `int`.
+
+The question is whether to introduce a dedicated `'c'` literal form and, if so, what its escape grammar looks like.
+
+## Decision
+
+GSharp adds a single-quote character literal. A character literal denotes a value of type `char` and is lexed as `CharacterToken`.
+
+### Grammar
+
+```
+char_literal     = "'" char_content "'"
+char_content     = unicode_value | escape_sequence
+unicode_value    = any Unicode code unit other than "'", "\", and line terminators
+escape_sequence  = "\" ( "'" | "\"" | "\\" | "0" | "a" | "b" | "f" | "n" | "r" | "t" | "v"
+                       | "x" hex_digit{1,4}
+                       | "u" hex_digit{4}
+                       | "U" hex_digit{8} )
+```
+
+* Exactly one Unicode code unit (or one escape) is permitted between the delimiters. An empty literal (`''`) is a diagnostic.
+* `\u` requires exactly four hex digits; `\U` requires exactly eight and must denote a value ≤ `U+FFFF` *or* a value in the supplementary planes — in the latter case the literal is rejected because `char` is a single UTF-16 code unit. Use a string literal plus `string.EnumerateRunes()` for supplementary characters.
+* `\x` accepts one to four hex digits (C# style); the resulting value must fit in a UTF-16 code unit (≤ `0xFFFF`).
+* Line terminators (`\n`, `\r`) inside a literal are diagnostics; use `\n` / `\r` escapes.
+* Surrogate code units are *representable* (e.g. `'\uD83D'`) — this matches `System.Char`'s definition — but the lexer warns that paired surrogates require two `char`s.
+
+### Static type
+
+A character literal's static type is `char`. Unlike integer literals (ADR-0044), it is *not* untyped: `char` already participates in the implicit-conversion table to wider integers (`char → ushort/int/uint/long/…`), so the typed literal flows naturally into integer-typed targets without an explicit cast.
+
+### Interaction with raw strings and interpolation
+
+* Raw strings (ADR-0012) and interpolated strings (ADR-0011) are unaffected — they remain delimited by backticks and `"…"` respectively.
+* A single-quote literal does **not** support interpolation (`'\(x)'` is a lex error). Interpolation is a string concern.
+
+### Reserved future use
+
+The `''` (empty char literal) and any escape sequence not listed above remain reserved. Future ADRs may extend the escape grammar (for example `\e` if a use case appears), but unknown escapes are diagnostics today, not silent fallbacks to the literal character.
+
+## Consequences
+
+* `char`-typed parameters of imported BCL APIs become writable in idiomatic GSharp: `Console.Write('\n')`, `someString.IndexOf('.')`.
+* The lexer learns a new token form. Token-disambiguation between `'…'` and bare identifiers requires lookahead of one character (the opening `'`), already cheap in the current lexer.
+* The full Unicode-aware escape set (`\u`, `\U`, `\x`) matches what GSharp already parses inside string literals (per ADR-0011); reusing the same scanner avoids divergence.
+* Diagnostics expand: empty literal, unterminated literal, multi-codepoint literal, supplementary-plane `\U` literal, and disallowed line terminator each get their own error code.
+* `typeof('a')` returns the `Type` for `System.Char`, on the same footing as the numeric primitives (issue #143).
+* `'c'` is not a possible identifier prefix today, so no existing source breaks.
+
+## Alternatives considered
+
+* **No literal form — only `char(65)` casts and `"A"[0]`.** Rejected because it makes `char`-typed call sites read like an interop afterthought, and it requires an extra runtime indexing step for the string form.
+* **Double-quoted single-character literal with a suffix (`"A"c`).** Rejected as visually clumsy and inconsistent with every other ADR-0044 suffix (which all attach to numeric literals).
+* **Allow `'c'` to denote either a `char` *or* a single-character string by context.** Rejected because the surface ambiguity outweighs the convenience. `'A'` is always a `char`; if the user wants a string, they write `"A"`.
+* **Adopt Go's runes (`'c'` is `int32`).** Rejected because GSharp's runtime is the CLR, where `char` is a 16-bit UTF-16 code unit. Forcing `'c'` to be 32-bit would diverge from every imported BCL signature. Users who want a Unicode rune can write `'A'` and cast it to `int` (the implicit-widening table covers that path).


### PR DESCRIPTION
Phase 0 of issue #142: land the three ADRs that lock the open decisions called out in the issue, so the implementation phases (lexer, type symbols, conversions, operators, interpreter, docs) can each ship as a focused PR against a stable target.

## ADRs

### ADR-0044 — Numeric primitive coverage
- Canonical name table for `byte`, `sbyte`, `short`, `ushort`, `uint`, `long`, `ulong`, `nint`, `nuint`, `float32`, `float64`, `decimal`, `char`, `object` (in addition to the existing `bool`, `int`, `string`, `void`).
- **Go-style untyped-constant inference**: a numeric literal has no intrinsic type until it meets a target type. `let x : long = 1` works without `1L`. No-target default stays `int` (or `float64` for fractional literals) so existing tests are preserved.
- **Optional C#-style type-pin suffixes** (`L`, `UL`, `U`, `F`, `D`, `M`) as an escape hatch for ambiguous contexts.
- **Go-style float names** (`float32` / `float64`) — keeps width visible and matches the existing `float64` hint in `Binder.cs`.
- **C#-style integer/object spellings** — keeps parity with the existing `int = Int32` precedent and reads naturally next to imported BCL APIs.
- **`nint` / `nuint`** for native-width integers.

### ADR-0045 — `object` as universal upper bound
- Every reference type is implicitly convertible to `object`; every value type via boxing.
- Unbox / downcast require an explicit cast (`int(o)`, `Foo(o)`).
- `==` on `object` operands is **reference equality** (CLR semantics).
- ADR-0001 nullability still applies — bare `object` does not hold `nil`; use `object?`.
- `typeof(object)` works (issue #143 parity).

### ADR-0046 — `'c'` character literal grammar
- Single-quote character literal; one Unicode code unit or one escape between delimiters.
- Reuses the existing string-literal escape grammar (`\n`, `\t`, `\\`, `\'`, `\"`, `\u`, `\U`, `\x`).
- Static type is always `char` — flows into wider integer targets via the ADR-0044 implicit-conversion table.
- No interpolation (interpolation remains a string concern).

## Why these three together
The issue explicitly lists these as ADR-required decisions. Until they are locked, any code change implicitly picks one of the alternatives. Landing them as a single docs-only PR keeps the choices visible and reviewable on their own merits.

## Next phases (each its own PR, against the locked ADRs)
- Phase 1 — `TypeSymbol` entries + `Binder.LookupType` + `FromClrType`.
- Phase 2 — Lexer float syntax + optional suffixes + untyped-constant inference in the binder.
- Phase 3 — Full conversion table + `decimal` ctor lowering.
- Phase 4 — Operator tables + `object` boxing/upper-bound + `typeof` parity.
- Phase 5 — Interpreter parity + `Console.WriteLine` overload selection.
- Phase 6 — Docs (`docs/lexical.md`, coverage-matrix golden).

## Validation
Docs-only change; no build or test required. Verified `docs/adr/0044`, `0045`, `0046` render correctly and follow the format of `docs/adr/0000-template.md` and recent ADRs (e.g. `0043-async-func-type-clause.md`).

Tracks #142 (Phase 0 only; remaining phases tracked under the same issue).
