### PR TITLE
Phase 1 (#142): TypeSymbol entries + Binder lookup for all primitives

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -441,13 +441,10 @@ public sealed class Binder
         var name = syntax.Identifier.Text;
 
         // Reject shadowing of primitive type names.
-        switch (name)
+        if (IsPrimitiveTypeName(name))
         {
-            case "bool":
-            case "int":
-            case "string":
-                Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
-                return;
+            Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
+            return;
         }
 
         var aliasedType = BindTypeClause(syntax.AliasedType);
@@ -466,13 +463,10 @@ public sealed class Binder
     {
         var name = syntax.Identifier.Text;
 
-        switch (name)
+        if (IsPrimitiveTypeName(name))
         {
-            case "bool":
-            case "int":
-            case "string":
-                Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
-                return;
+            Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
+            return;
         }
 
         var accessibility = ResolveAccessibility(syntax.AccessibilityModifier);
@@ -509,13 +503,10 @@ public sealed class Binder
     {
         var name = syntax.Identifier.Text;
 
-        switch (name)
+        if (IsPrimitiveTypeName(name))
         {
-            case "bool":
-            case "int":
-            case "string":
-                Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
-                return;
+            Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
+            return;
         }
 
         var accessibility = ResolveAccessibility(syntax.AccessibilityModifier);
@@ -1189,7 +1180,31 @@ public sealed class Binder
     }
 
     private static bool IsPrimitiveTypeName(string name)
-        => name == "bool" || name == "int" || name == "string" || name == "float64";
+    {
+        switch (name)
+        {
+            case "bool":
+            case "byte":
+            case "sbyte":
+            case "short":
+            case "ushort":
+            case "int":
+            case "uint":
+            case "long":
+            case "ulong":
+            case "nint":
+            case "nuint":
+            case "float32":
+            case "float64":
+            case "decimal":
+            case "char":
+            case "string":
+            case "object":
+                return true;
+            default:
+                return false;
+        }
+    }
 
     private ImmutableArray<TypeParameterSymbol> BindTypeParameterList(TypeParameterListSyntax syntax)
     {
@@ -6291,10 +6306,38 @@ public sealed class Binder
         {
             case "bool":
                 return TypeSymbol.Bool;
+            case "byte":
+                return TypeSymbol.Byte;
+            case "sbyte":
+                return TypeSymbol.SByte;
+            case "short":
+                return TypeSymbol.Short;
+            case "ushort":
+                return TypeSymbol.UShort;
             case "int":
                 return TypeSymbol.Int;
+            case "uint":
+                return TypeSymbol.UInt;
+            case "long":
+                return TypeSymbol.Long;
+            case "ulong":
+                return TypeSymbol.ULong;
+            case "nint":
+                return TypeSymbol.NInt;
+            case "nuint":
+                return TypeSymbol.NUInt;
+            case "float32":
+                return TypeSymbol.Float32;
+            case "float64":
+                return TypeSymbol.Float64;
+            case "decimal":
+                return TypeSymbol.Decimal;
+            case "char":
+                return TypeSymbol.Char;
             case "string":
                 return TypeSymbol.String;
+            case "object":
+                return TypeSymbol.Object;
         }
 
         if (scope.TryLookupTypeAlias(name, out var aliased))

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -22,14 +22,84 @@ public class TypeSymbol : Symbol
     public static readonly TypeSymbol Bool = new TypeSymbol("bool", typeof(bool));
 
     /// <summary>
+    /// The `byte` symbol (8-bit unsigned integer, <c>System.Byte</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol Byte = new TypeSymbol("byte", typeof(byte));
+
+    /// <summary>
+    /// The `sbyte` symbol (8-bit signed integer, <c>System.SByte</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol SByte = new TypeSymbol("sbyte", typeof(sbyte));
+
+    /// <summary>
+    /// The `short` symbol (16-bit signed integer, <c>System.Int16</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol Short = new TypeSymbol("short", typeof(short));
+
+    /// <summary>
+    /// The `ushort` symbol (16-bit unsigned integer, <c>System.UInt16</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol UShort = new TypeSymbol("ushort", typeof(ushort));
+
+    /// <summary>
     /// The `int` symbol.
     /// </summary>
     public static readonly TypeSymbol Int = new TypeSymbol("int", typeof(int));
 
     /// <summary>
+    /// The `uint` symbol (32-bit unsigned integer, <c>System.UInt32</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol UInt = new TypeSymbol("uint", typeof(uint));
+
+    /// <summary>
+    /// The `long` symbol (64-bit signed integer, <c>System.Int64</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol Long = new TypeSymbol("long", typeof(long));
+
+    /// <summary>
+    /// The `ulong` symbol (64-bit unsigned integer, <c>System.UInt64</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol ULong = new TypeSymbol("ulong", typeof(ulong));
+
+    /// <summary>
+    /// The `nint` symbol (native-width signed integer, <c>System.IntPtr</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol NInt = new TypeSymbol("nint", typeof(nint));
+
+    /// <summary>
+    /// The `nuint` symbol (native-width unsigned integer, <c>System.UIntPtr</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol NUInt = new TypeSymbol("nuint", typeof(nuint));
+
+    /// <summary>
+    /// The `float32` symbol (IEEE 754 binary32, <c>System.Single</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol Float32 = new TypeSymbol("float32", typeof(float));
+
+    /// <summary>
+    /// The `float64` symbol (IEEE 754 binary64, <c>System.Double</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol Float64 = new TypeSymbol("float64", typeof(double));
+
+    /// <summary>
+    /// The `decimal` symbol (128-bit base-10, <c>System.Decimal</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol Decimal = new TypeSymbol("decimal", typeof(decimal));
+
+    /// <summary>
+    /// The `char` symbol (UTF-16 code unit, <c>System.Char</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol Char = new TypeSymbol("char", typeof(char));
+
+    /// <summary>
     /// The `string` symbol.
     /// </summary>
     public static readonly TypeSymbol String = new TypeSymbol("string", typeof(string));
+
+    /// <summary>
+    /// The `object` symbol (universal upper bound, <c>System.Object</c>). Added by ADR-0044 / ADR-0045.
+    /// </summary>
+    public static readonly TypeSymbol Object = new TypeSymbol("object", typeof(object));
 
     /// <summary>
     /// The void type symbol.
@@ -88,24 +158,44 @@ public class TypeSymbol : Symbol
         // Compare by FullName so types loaded from a MetadataLoadContext (carrying the
         // target framework's identity) still map onto the built-in primitive symbols.
         var fullName = clrType.FullName;
-        if (fullName == "System.Boolean")
+        switch (fullName)
         {
-            return Bool;
-        }
-
-        if (fullName == "System.Int32")
-        {
-            return Int;
-        }
-
-        if (fullName == "System.String")
-        {
-            return String;
-        }
-
-        if (fullName == "System.Void")
-        {
-            return Void;
+            case "System.Boolean":
+                return Bool;
+            case "System.Byte":
+                return Byte;
+            case "System.SByte":
+                return SByte;
+            case "System.Int16":
+                return Short;
+            case "System.UInt16":
+                return UShort;
+            case "System.Int32":
+                return Int;
+            case "System.UInt32":
+                return UInt;
+            case "System.Int64":
+                return Long;
+            case "System.UInt64":
+                return ULong;
+            case "System.IntPtr":
+                return NInt;
+            case "System.UIntPtr":
+                return NUInt;
+            case "System.Single":
+                return Float32;
+            case "System.Double":
+                return Float64;
+            case "System.Decimal":
+                return Decimal;
+            case "System.Char":
+                return Char;
+            case "System.String":
+                return String;
+            case "System.Object":
+                return Object;
+            case "System.Void":
+                return Void;
         }
 
         return ImportedTypeSymbol.Get(clrType);

--- a/test/Core.Tests/CodeAnalysis/Binding/TypeAliasTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/TypeAliasTests.cs
@@ -52,6 +52,56 @@ public class TypeAliasTests
             d => d.Message.Contains("already declared", System.StringComparison.OrdinalIgnoreCase));
     }
 
+    [Theory]
+    [InlineData("byte")]
+    [InlineData("sbyte")]
+    [InlineData("short")]
+    [InlineData("ushort")]
+    [InlineData("uint")]
+    [InlineData("long")]
+    [InlineData("ulong")]
+    [InlineData("nint")]
+    [InlineData("nuint")]
+    [InlineData("float32")]
+    [InlineData("float64")]
+    [InlineData("decimal")]
+    [InlineData("char")]
+    [InlineData("object")]
+    public void TypeAlias_Cannot_Shadow_New_Primitives(string primitiveName)
+    {
+        // ADR-0044 / ADR-0045: each primitive added in issue #142 must be
+        // rejected as a redeclaration target, matching the existing
+        // bool/int/string behaviour.
+        var diagnostics = Bind($"type {primitiveName} = string\n");
+        Assert.Contains(
+            diagnostics,
+            d => d.Message.Contains("already declared", System.StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("byte")]
+    [InlineData("sbyte")]
+    [InlineData("short")]
+    [InlineData("ushort")]
+    [InlineData("uint")]
+    [InlineData("long")]
+    [InlineData("ulong")]
+    [InlineData("nint")]
+    [InlineData("nuint")]
+    [InlineData("float32")]
+    [InlineData("float64")]
+    [InlineData("decimal")]
+    [InlineData("char")]
+    [InlineData("object")]
+    public void TypeClause_Resolves_New_Primitive_As_Alias_Target(string primitiveName)
+    {
+        // The new keywords must be reachable from any type-clause position.
+        // A type alias to one of them is the smallest exercise that does not
+        // depend on the Phase 3 conversion table.
+        var diagnostics = Bind($"type X = {primitiveName}\n");
+        Assert.Empty(diagnostics);
+    }
+
     [Fact]
     public void TypeAlias_Duplicate_Reports_Error()
     {

--- a/test/Core.Tests/CodeAnalysis/Symbols/PrimitiveTypeSymbolTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/PrimitiveTypeSymbolTests.cs
@@ -1,0 +1,85 @@
+// <copyright file="PrimitiveTypeSymbolTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#nullable enable
+
+using System;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// ADR-0044 / ADR-0045: built-in primitive type symbols and their
+/// <see cref="TypeSymbol.FromClrType(Type)"/> mapping.
+///
+/// Phase 1 of issue #142 — confirms each new symbol exists, exposes the
+/// correct CLR type, and round-trips through <c>FromClrType</c>.
+/// </summary>
+public class PrimitiveTypeSymbolTests
+{
+    public static TheoryData<TypeSymbol, Type, string> PrimitiveTypeData => new()
+    {
+        { TypeSymbol.Bool, typeof(bool), "bool" },
+        { TypeSymbol.Byte, typeof(byte), "byte" },
+        { TypeSymbol.SByte, typeof(sbyte), "sbyte" },
+        { TypeSymbol.Short, typeof(short), "short" },
+        { TypeSymbol.UShort, typeof(ushort), "ushort" },
+        { TypeSymbol.Int, typeof(int), "int" },
+        { TypeSymbol.UInt, typeof(uint), "uint" },
+        { TypeSymbol.Long, typeof(long), "long" },
+        { TypeSymbol.ULong, typeof(ulong), "ulong" },
+        { TypeSymbol.NInt, typeof(nint), "nint" },
+        { TypeSymbol.NUInt, typeof(nuint), "nuint" },
+        { TypeSymbol.Float32, typeof(float), "float32" },
+        { TypeSymbol.Float64, typeof(double), "float64" },
+        { TypeSymbol.Decimal, typeof(decimal), "decimal" },
+        { TypeSymbol.Char, typeof(char), "char" },
+        { TypeSymbol.String, typeof(string), "string" },
+        { TypeSymbol.Object, typeof(object), "object" },
+        { TypeSymbol.Void, typeof(void), "void" },
+    };
+
+    [Theory]
+    [MemberData(nameof(PrimitiveTypeData))]
+    public void PrimitiveSymbol_HasCanonicalNameAndClrType(TypeSymbol symbol, Type expectedClrType, string expectedName)
+    {
+        Assert.Equal(expectedName, symbol.Name);
+        Assert.Same(expectedClrType, symbol.ClrType);
+    }
+
+    [Theory]
+    [MemberData(nameof(PrimitiveTypeData))]
+    public void FromClrType_MapsBackToCanonicalSymbol(TypeSymbol symbol, Type clrType, string expectedName)
+    {
+        _ = expectedName;
+        Assert.Same(symbol, TypeSymbol.FromClrType(clrType));
+    }
+
+    [Fact]
+    public void FromClrType_NullableValueTypes_LiftThroughEachPrimitive()
+    {
+        // Nullable<T> lifting (ADR-0001) still wraps each new value-type primitive.
+        AssertNullableLifts(typeof(byte?), TypeSymbol.Byte);
+        AssertNullableLifts(typeof(sbyte?), TypeSymbol.SByte);
+        AssertNullableLifts(typeof(short?), TypeSymbol.Short);
+        AssertNullableLifts(typeof(ushort?), TypeSymbol.UShort);
+        AssertNullableLifts(typeof(uint?), TypeSymbol.UInt);
+        AssertNullableLifts(typeof(long?), TypeSymbol.Long);
+        AssertNullableLifts(typeof(ulong?), TypeSymbol.ULong);
+        AssertNullableLifts(typeof(nint?), TypeSymbol.NInt);
+        AssertNullableLifts(typeof(nuint?), TypeSymbol.NUInt);
+        AssertNullableLifts(typeof(float?), TypeSymbol.Float32);
+        AssertNullableLifts(typeof(double?), TypeSymbol.Float64);
+        AssertNullableLifts(typeof(decimal?), TypeSymbol.Decimal);
+        AssertNullableLifts(typeof(char?), TypeSymbol.Char);
+    }
+
+    private static void AssertNullableLifts(Type nullableClrType, TypeSymbol expectedUnderlying)
+    {
+        var sym = TypeSymbol.FromClrType(nullableClrType);
+        var nullable = Assert.IsType<NullableTypeSymbol>(sym);
+        Assert.Same(expectedUnderlying, nullable.UnderlyingType);
+    }
+}


### PR DESCRIPTION
Phase 1 of issue #142 (depends on #157 / ADRs 0044/0045/0046).

Adds `TypeSymbol` entries for every CLR primitive the keyword surface is currently missing, wires them through `TypeSymbol.FromClrType`, and makes them resolvable from any type-clause position via `Binder.LookupType`.

## What changes

### New `TypeSymbol` entries (per ADR-0044)
`Byte`, `SByte`, `Short`, `UShort`, `UInt`, `Long`, `ULong`, `NInt`, `NUInt`, `Float32`, `Float64`, `Decimal`, `Char`, `Object` — each pinned to its `System.*` CLR type.

### `TypeSymbol.FromClrType`
`System.{Byte,SByte,Int16,UInt16,UInt32,Int64,UInt64,IntPtr,UIntPtr,Single,Double,Decimal,Char,Object}` now round-trip to the new built-in symbols rather than wrapping in `ImportedTypeSymbol`. `Nullable<T>` lifting (ADR-0001) still works for each new value-type primitive.

### `Binder.LookupType`
Each new keyword spelling resolves to its `TypeSymbol`; the existing `bool`/`int`/`string`/`float64` cases are preserved.

### `Binder.IsPrimitiveTypeName`
Expanded to cover the full ADR-0044 table. The three shadow-rejection switches in `BindTypeAliasDeclaration` / `BindEnumDeclaration` / `BindStructDeclaration` now share that helper instead of each carrying their own `bool`/`int`/`string` list.

## What is intentionally NOT in this PR

- No literal forms (numeric suffixes, char literals, float syntax) — that's **Phase 2**.
- No new implicit/explicit conversions or `decimal`-ctor lowering — that's **Phase 3**.
- No new operator-table rows or `object` boxing in emit — that's **Phase 4**.
- No interpreter or `Console.WriteLine`-overload work — that's **Phase 5**.

This PR makes the names **reachable** as type clauses (`type X = long`, CLR-typed parameter/field positions); using them with a literal value still requires an explicit cast for now, by design.

## Tests

- **`PrimitiveTypeSymbolTests`** (new): each primitive exposes the right `Name`/`ClrType`; `FromClrType` round-trips; `Nullable<T>` lifts each value-type primitive correctly.
- **`TypeAliasTests`** (extended): `type {primitive} = string` is rejected for each new keyword (parity with the existing `bool`/`int`/`string` check); a type alias **to** each primitive binds with no diagnostics.

## Validation

```
$ dotnet build GSharp.sln -nologo -clp:NoSummary
Build succeeded.
    0 Warning(s)
    0 Error(s)

$ dotnet test GSharp.sln --no-restore --nologo
Passed!  - 21  (Sdk)
Passed!  - 956 (Core, was 891 before this PR)
Passed!  -  91 (Compiler)
Passed!  -   8 (Interpreter)
Passed!  -  17 (LanguageServer)
```

All 1073 tests pass; 65 new tests added by this PR.

Tracks #142 (Phase 1 only; remaining phases tracked under the same issue).
