### PR TITLE
Phase 1 (#142): TypeSymbol entries + Binder lookup for all primitives (re-target to main)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -441,13 +441,10 @@ public sealed class Binder
         var name = syntax.Identifier.Text;
 
         // Reject shadowing of primitive type names.
-        switch (name)
+        if (IsPrimitiveTypeName(name))
         {
-            case "bool":
-            case "int":
-            case "string":
-                Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
-                return;
+            Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
+            return;
         }
 
         var aliasedType = BindTypeClause(syntax.AliasedType);
@@ -466,13 +463,10 @@ public sealed class Binder
     {
         var name = syntax.Identifier.Text;
 
-        switch (name)
+        if (IsPrimitiveTypeName(name))
         {
-            case "bool":
-            case "int":
-            case "string":
-                Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
-                return;
+            Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
+            return;
         }
 
         var accessibility = ResolveAccessibility(syntax.AccessibilityModifier);
@@ -509,13 +503,10 @@ public sealed class Binder
     {
         var name = syntax.Identifier.Text;
 
-        switch (name)
+        if (IsPrimitiveTypeName(name))
         {
-            case "bool":
-            case "int":
-            case "string":
-                Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
-                return;
+            Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
+            return;
         }
 
         var accessibility = ResolveAccessibility(syntax.AccessibilityModifier);
@@ -1189,7 +1180,31 @@ public sealed class Binder
     }
 
     private static bool IsPrimitiveTypeName(string name)
-        => name == "bool" || name == "int" || name == "string" || name == "float64";
+    {
+        switch (name)
+        {
+            case "bool":
+            case "byte":
+            case "sbyte":
+            case "short":
+            case "ushort":
+            case "int":
+            case "uint":
+            case "long":
+            case "ulong":
+            case "nint":
+            case "nuint":
+            case "float32":
+            case "float64":
+            case "decimal":
+            case "char":
+            case "string":
+            case "object":
+                return true;
+            default:
+                return false;
+        }
+    }
 
     private ImmutableArray<TypeParameterSymbol> BindTypeParameterList(TypeParameterListSyntax syntax)
     {
@@ -6291,10 +6306,38 @@ public sealed class Binder
         {
             case "bool":
                 return TypeSymbol.Bool;
+            case "byte":
+                return TypeSymbol.Byte;
+            case "sbyte":
+                return TypeSymbol.SByte;
+            case "short":
+                return TypeSymbol.Short;
+            case "ushort":
+                return TypeSymbol.UShort;
             case "int":
                 return TypeSymbol.Int;
+            case "uint":
+                return TypeSymbol.UInt;
+            case "long":
+                return TypeSymbol.Long;
+            case "ulong":
+                return TypeSymbol.ULong;
+            case "nint":
+                return TypeSymbol.NInt;
+            case "nuint":
+                return TypeSymbol.NUInt;
+            case "float32":
+                return TypeSymbol.Float32;
+            case "float64":
+                return TypeSymbol.Float64;
+            case "decimal":
+                return TypeSymbol.Decimal;
+            case "char":
+                return TypeSymbol.Char;
             case "string":
                 return TypeSymbol.String;
+            case "object":
+                return TypeSymbol.Object;
         }
 
         if (scope.TryLookupTypeAlias(name, out var aliased))

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -22,14 +22,84 @@ public class TypeSymbol : Symbol
     public static readonly TypeSymbol Bool = new TypeSymbol("bool", typeof(bool));
 
     /// <summary>
+    /// The `byte` symbol (8-bit unsigned integer, <c>System.Byte</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol Byte = new TypeSymbol("byte", typeof(byte));
+
+    /// <summary>
+    /// The `sbyte` symbol (8-bit signed integer, <c>System.SByte</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol SByte = new TypeSymbol("sbyte", typeof(sbyte));
+
+    /// <summary>
+    /// The `short` symbol (16-bit signed integer, <c>System.Int16</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol Short = new TypeSymbol("short", typeof(short));
+
+    /// <summary>
+    /// The `ushort` symbol (16-bit unsigned integer, <c>System.UInt16</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol UShort = new TypeSymbol("ushort", typeof(ushort));
+
+    /// <summary>
     /// The `int` symbol.
     /// </summary>
     public static readonly TypeSymbol Int = new TypeSymbol("int", typeof(int));
 
     /// <summary>
+    /// The `uint` symbol (32-bit unsigned integer, <c>System.UInt32</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol UInt = new TypeSymbol("uint", typeof(uint));
+
+    /// <summary>
+    /// The `long` symbol (64-bit signed integer, <c>System.Int64</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol Long = new TypeSymbol("long", typeof(long));
+
+    /// <summary>
+    /// The `ulong` symbol (64-bit unsigned integer, <c>System.UInt64</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol ULong = new TypeSymbol("ulong", typeof(ulong));
+
+    /// <summary>
+    /// The `nint` symbol (native-width signed integer, <c>System.IntPtr</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol NInt = new TypeSymbol("nint", typeof(nint));
+
+    /// <summary>
+    /// The `nuint` symbol (native-width unsigned integer, <c>System.UIntPtr</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol NUInt = new TypeSymbol("nuint", typeof(nuint));
+
+    /// <summary>
+    /// The `float32` symbol (IEEE 754 binary32, <c>System.Single</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol Float32 = new TypeSymbol("float32", typeof(float));
+
+    /// <summary>
+    /// The `float64` symbol (IEEE 754 binary64, <c>System.Double</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol Float64 = new TypeSymbol("float64", typeof(double));
+
+    /// <summary>
+    /// The `decimal` symbol (128-bit base-10, <c>System.Decimal</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol Decimal = new TypeSymbol("decimal", typeof(decimal));
+
+    /// <summary>
+    /// The `char` symbol (UTF-16 code unit, <c>System.Char</c>). Added by ADR-0044.
+    /// </summary>
+    public static readonly TypeSymbol Char = new TypeSymbol("char", typeof(char));
+
+    /// <summary>
     /// The `string` symbol.
     /// </summary>
     public static readonly TypeSymbol String = new TypeSymbol("string", typeof(string));
+
+    /// <summary>
+    /// The `object` symbol (universal upper bound, <c>System.Object</c>). Added by ADR-0044 / ADR-0045.
+    /// </summary>
+    public static readonly TypeSymbol Object = new TypeSymbol("object", typeof(object));
 
     /// <summary>
     /// The void type symbol.
@@ -88,24 +158,44 @@ public class TypeSymbol : Symbol
         // Compare by FullName so types loaded from a MetadataLoadContext (carrying the
         // target framework's identity) still map onto the built-in primitive symbols.
         var fullName = clrType.FullName;
-        if (fullName == "System.Boolean")
+        switch (fullName)
         {
-            return Bool;
-        }
-
-        if (fullName == "System.Int32")
-        {
-            return Int;
-        }
-
-        if (fullName == "System.String")
-        {
-            return String;
-        }
-
-        if (fullName == "System.Void")
-        {
-            return Void;
+            case "System.Boolean":
+                return Bool;
+            case "System.Byte":
+                return Byte;
+            case "System.SByte":
+                return SByte;
+            case "System.Int16":
+                return Short;
+            case "System.UInt16":
+                return UShort;
+            case "System.Int32":
+                return Int;
+            case "System.UInt32":
+                return UInt;
+            case "System.Int64":
+                return Long;
+            case "System.UInt64":
+                return ULong;
+            case "System.IntPtr":
+                return NInt;
+            case "System.UIntPtr":
+                return NUInt;
+            case "System.Single":
+                return Float32;
+            case "System.Double":
+                return Float64;
+            case "System.Decimal":
+                return Decimal;
+            case "System.Char":
+                return Char;
+            case "System.String":
+                return String;
+            case "System.Object":
+                return Object;
+            case "System.Void":
+                return Void;
         }
 
         return ImportedTypeSymbol.Get(clrType);

--- a/test/Core.Tests/CodeAnalysis/Binding/TypeAliasTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/TypeAliasTests.cs
@@ -52,6 +52,56 @@ public class TypeAliasTests
             d => d.Message.Contains("already declared", System.StringComparison.OrdinalIgnoreCase));
     }
 
+    [Theory]
+    [InlineData("byte")]
+    [InlineData("sbyte")]
+    [InlineData("short")]
+    [InlineData("ushort")]
+    [InlineData("uint")]
+    [InlineData("long")]
+    [InlineData("ulong")]
+    [InlineData("nint")]
+    [InlineData("nuint")]
+    [InlineData("float32")]
+    [InlineData("float64")]
+    [InlineData("decimal")]
+    [InlineData("char")]
+    [InlineData("object")]
+    public void TypeAlias_Cannot_Shadow_New_Primitives(string primitiveName)
+    {
+        // ADR-0044 / ADR-0045: each primitive added in issue #142 must be
+        // rejected as a redeclaration target, matching the existing
+        // bool/int/string behaviour.
+        var diagnostics = Bind($"type {primitiveName} = string\n");
+        Assert.Contains(
+            diagnostics,
+            d => d.Message.Contains("already declared", System.StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("byte")]
+    [InlineData("sbyte")]
+    [InlineData("short")]
+    [InlineData("ushort")]
+    [InlineData("uint")]
+    [InlineData("long")]
+    [InlineData("ulong")]
+    [InlineData("nint")]
+    [InlineData("nuint")]
+    [InlineData("float32")]
+    [InlineData("float64")]
+    [InlineData("decimal")]
+    [InlineData("char")]
+    [InlineData("object")]
+    public void TypeClause_Resolves_New_Primitive_As_Alias_Target(string primitiveName)
+    {
+        // The new keywords must be reachable from any type-clause position.
+        // A type alias to one of them is the smallest exercise that does not
+        // depend on the Phase 3 conversion table.
+        var diagnostics = Bind($"type X = {primitiveName}\n");
+        Assert.Empty(diagnostics);
+    }
+
     [Fact]
     public void TypeAlias_Duplicate_Reports_Error()
     {

--- a/test/Core.Tests/CodeAnalysis/Symbols/PrimitiveTypeSymbolTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/PrimitiveTypeSymbolTests.cs
@@ -1,0 +1,85 @@
+// <copyright file="PrimitiveTypeSymbolTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#nullable enable
+
+using System;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// ADR-0044 / ADR-0045: built-in primitive type symbols and their
+/// <see cref="TypeSymbol.FromClrType(Type)"/> mapping.
+///
+/// Phase 1 of issue #142 — confirms each new symbol exists, exposes the
+/// correct CLR type, and round-trips through <c>FromClrType</c>.
+/// </summary>
+public class PrimitiveTypeSymbolTests
+{
+    public static TheoryData<TypeSymbol, Type, string> PrimitiveTypeData => new()
+    {
+        { TypeSymbol.Bool, typeof(bool), "bool" },
+        { TypeSymbol.Byte, typeof(byte), "byte" },
+        { TypeSymbol.SByte, typeof(sbyte), "sbyte" },
+        { TypeSymbol.Short, typeof(short), "short" },
+        { TypeSymbol.UShort, typeof(ushort), "ushort" },
+        { TypeSymbol.Int, typeof(int), "int" },
+        { TypeSymbol.UInt, typeof(uint), "uint" },
+        { TypeSymbol.Long, typeof(long), "long" },
+        { TypeSymbol.ULong, typeof(ulong), "ulong" },
+        { TypeSymbol.NInt, typeof(nint), "nint" },
+        { TypeSymbol.NUInt, typeof(nuint), "nuint" },
+        { TypeSymbol.Float32, typeof(float), "float32" },
+        { TypeSymbol.Float64, typeof(double), "float64" },
+        { TypeSymbol.Decimal, typeof(decimal), "decimal" },
+        { TypeSymbol.Char, typeof(char), "char" },
+        { TypeSymbol.String, typeof(string), "string" },
+        { TypeSymbol.Object, typeof(object), "object" },
+        { TypeSymbol.Void, typeof(void), "void" },
+    };
+
+    [Theory]
+    [MemberData(nameof(PrimitiveTypeData))]
+    public void PrimitiveSymbol_HasCanonicalNameAndClrType(TypeSymbol symbol, Type expectedClrType, string expectedName)
+    {
+        Assert.Equal(expectedName, symbol.Name);
+        Assert.Same(expectedClrType, symbol.ClrType);
+    }
+
+    [Theory]
+    [MemberData(nameof(PrimitiveTypeData))]
+    public void FromClrType_MapsBackToCanonicalSymbol(TypeSymbol symbol, Type clrType, string expectedName)
+    {
+        _ = expectedName;
+        Assert.Same(symbol, TypeSymbol.FromClrType(clrType));
+    }
+
+    [Fact]
+    public void FromClrType_NullableValueTypes_LiftThroughEachPrimitive()
+    {
+        // Nullable<T> lifting (ADR-0001) still wraps each new value-type primitive.
+        AssertNullableLifts(typeof(byte?), TypeSymbol.Byte);
+        AssertNullableLifts(typeof(sbyte?), TypeSymbol.SByte);
+        AssertNullableLifts(typeof(short?), TypeSymbol.Short);
+        AssertNullableLifts(typeof(ushort?), TypeSymbol.UShort);
+        AssertNullableLifts(typeof(uint?), TypeSymbol.UInt);
+        AssertNullableLifts(typeof(long?), TypeSymbol.Long);
+        AssertNullableLifts(typeof(ulong?), TypeSymbol.ULong);
+        AssertNullableLifts(typeof(nint?), TypeSymbol.NInt);
+        AssertNullableLifts(typeof(nuint?), TypeSymbol.NUInt);
+        AssertNullableLifts(typeof(float?), TypeSymbol.Float32);
+        AssertNullableLifts(typeof(double?), TypeSymbol.Float64);
+        AssertNullableLifts(typeof(decimal?), TypeSymbol.Decimal);
+        AssertNullableLifts(typeof(char?), TypeSymbol.Char);
+    }
+
+    private static void AssertNullableLifts(Type nullableClrType, TypeSymbol expectedUnderlying)
+    {
+        var sym = TypeSymbol.FromClrType(nullableClrType);
+        var nullable = Assert.IsType<NullableTypeSymbol>(sym);
+        Assert.Same(expectedUnderlying, nullable.UnderlyingType);
+    }
+}


### PR DESCRIPTION
Re-targets Phase 1 of #142 to `main`. The original PR (#158) was stacked on the Phase 0 ADR branch (#157) and was merged into that branch rather than into `main`, so although both PRs show as MERGED, `main` only carries the ADR docs and is missing the Phase 1 type-symbol code. This PR brings the code over.

Content is identical to #158 — see that PR for the full description. Summary:

- New `TypeSymbol` entries: `Byte`, `SByte`, `Short`, `UShort`, `UInt`, `Long`, `ULong`, `NInt`, `NUInt`, `Float32`, `Float64`, `Decimal`, `Char`, `Object` (per ADR-0044 / ADR-0045).
- `TypeSymbol.FromClrType` maps each `System.*` primitive to the new built-in symbols (preserves `Nullable<T>` lifting from ADR-0001).
- `Binder.LookupType` resolves each new keyword; `IsPrimitiveTypeName` expanded; three shadow-rejection switches consolidated against the new helper.
- 65 new tests in `PrimitiveTypeSymbolTests` and extended `TypeAliasTests`.

Verified locally: `dotnet build GSharp.sln` succeeds with 0 warnings/0 errors; full test suite passes.

Closes the gap left by the misrouted #158 merge. Tracks #142 (Phase 1; remaining phases queued).
