### PR TITLE
Phase 3 of #142: conversion lattice + primitive-literal emit

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
+using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
@@ -30,6 +32,50 @@ public sealed class Conversion
     /// States that there's an explicit conversion between the given types.
     /// </summary>
     public static readonly Conversion Explicit = new Conversion(exists: true, isIdentity: false, isImplicit: false);
+
+    // ADR-0044 implicit numeric widening lattice, keyed by source CLR full
+    // name → set of target CLR full names. Mirrors C# §6.1.2 plus the
+    // ADR-0044 inclusion of `decimal` as a widening target for every
+    // integral source. Native-width integers (nint/nuint) follow C#'s
+    // rules: nint widens to int64/single/double/decimal; nuint widens to
+    // uint64/single/double/decimal.
+    private static readonly Dictionary<string, HashSet<string>> NumericWideningTargets = new(StringComparer.Ordinal)
+    {
+        ["System.SByte"] = new(StringComparer.Ordinal) { "System.Int16", "System.Int32", "System.Int64", "System.IntPtr", "System.Single", "System.Double", "System.Decimal" },
+        ["System.Byte"] = new(StringComparer.Ordinal) { "System.Int16", "System.UInt16", "System.Int32", "System.UInt32", "System.Int64", "System.UInt64", "System.IntPtr", "System.UIntPtr", "System.Single", "System.Double", "System.Decimal" },
+        ["System.Int16"] = new(StringComparer.Ordinal) { "System.Int32", "System.Int64", "System.IntPtr", "System.Single", "System.Double", "System.Decimal" },
+        ["System.UInt16"] = new(StringComparer.Ordinal) { "System.Int32", "System.UInt32", "System.Int64", "System.UInt64", "System.IntPtr", "System.UIntPtr", "System.Single", "System.Double", "System.Decimal" },
+        ["System.Int32"] = new(StringComparer.Ordinal) { "System.Int64", "System.IntPtr", "System.Single", "System.Double", "System.Decimal" },
+        ["System.UInt32"] = new(StringComparer.Ordinal) { "System.Int64", "System.UInt64", "System.UIntPtr", "System.Single", "System.Double", "System.Decimal" },
+        ["System.Int64"] = new(StringComparer.Ordinal) { "System.Single", "System.Double", "System.Decimal" },
+        ["System.UInt64"] = new(StringComparer.Ordinal) { "System.Single", "System.Double", "System.Decimal" },
+        ["System.IntPtr"] = new(StringComparer.Ordinal) { "System.Int64", "System.Single", "System.Double", "System.Decimal" },
+        ["System.UIntPtr"] = new(StringComparer.Ordinal) { "System.UInt64", "System.Single", "System.Double", "System.Decimal" },
+        ["System.Char"] = new(StringComparer.Ordinal) { "System.UInt16", "System.Int32", "System.UInt32", "System.Int64", "System.UInt64", "System.IntPtr", "System.UIntPtr", "System.Single", "System.Double", "System.Decimal" },
+        ["System.Single"] = new(StringComparer.Ordinal) { "System.Double" },
+    };
+
+    // All numeric primitive CLR full-name set — every pair (source != target)
+    // that isn't an implicit widening is permitted as an explicit narrowing
+    // (per ADR-0044). `char` is included so `(char)<int>` and `(int)<char>`
+    // both work the same way as in C#.
+    private static readonly HashSet<string> NumericClrFullNames = new(StringComparer.Ordinal)
+    {
+        "System.SByte",
+        "System.Byte",
+        "System.Int16",
+        "System.UInt16",
+        "System.Int32",
+        "System.UInt32",
+        "System.Int64",
+        "System.UInt64",
+        "System.IntPtr",
+        "System.UIntPtr",
+        "System.Single",
+        "System.Double",
+        "System.Decimal",
+        "System.Char",
+    };
 
     private Conversion(bool exists, bool isIdentity, bool isImplicit)
     {
@@ -98,6 +144,24 @@ public sealed class Conversion
             return Conversion.None;
         }
 
+        // ADR-0044 numeric lattice. Both operands must be CLR primitives in
+        // the numeric set; the widening map decides implicit vs. explicit.
+        // Decimal narrowings (decimal → int etc.) and signed/unsigned
+        // mismatches at the same width (int ↔ uint) are explicit per C#.
+        var fromClr = from?.ClrType?.FullName;
+        var toClr = to?.ClrType?.FullName;
+        if (fromClr != null && toClr != null
+            && NumericClrFullNames.Contains(fromClr)
+            && NumericClrFullNames.Contains(toClr))
+        {
+            if (NumericWideningTargets.TryGetValue(fromClr, out var targets) && targets.Contains(toClr))
+            {
+                return Conversion.Implicit;
+            }
+
+            return Conversion.Explicit;
+        }
+
         if (from == TypeSymbol.Bool || from == TypeSymbol.Int)
         {
             if (to == TypeSymbol.String)
@@ -120,10 +184,24 @@ public sealed class Conversion
             return Conversion.Explicit;
         }
 
+        // ADR-0045: every value-type primitive (and every user struct)
+        // boxes implicitly to `object`. Reference types convert to
+        // `object` as a plain reference widening.
+        if (to?.ClrType == typeof(object) && from?.ClrType != null)
+        {
+            return Conversion.Implicit;
+        }
+
         // Boxing conversion for user value types to System.Object.
         if (from is StructSymbol fromStruct && !fromStruct.IsClass && to?.ClrType == typeof(object))
         {
             return Conversion.Implicit;
+        }
+
+        // ADR-0045 explicit unbox: `(T)objectValue` for any value-type T.
+        if (from?.ClrType == typeof(object) && to?.ClrType != null && to.ClrType.IsValueType)
+        {
+            return Conversion.Explicit;
         }
 
         // Reference upcast: a class implicitly converts to any interface in

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -5908,10 +5908,26 @@ internal sealed class ReflectionMetadataEmitter
                 return;
             }
 
+            // ADR-0044 numeric conversion lattice. Any pair of numeric CLR
+            // primitives (sbyte/byte/short/ushort/int/uint/long/ulong/nint/
+            // nuint/float/double/decimal/char) gets a typed IL conversion.
+            if (TryEmitNumericConversion(from, to))
+            {
+                return;
+            }
+
             if (to?.ClrType == typeof(object) && IsValueTypeSymbol(from))
             {
                 this.il.OpCode(ILOpCode.Box);
                 this.il.Token(this.outer.GetElementTypeToken(from));
+                return;
+            }
+
+            // ADR-0045 explicit unbox: `(T)objectValue` for a value type T.
+            if (from?.ClrType == typeof(object) && to?.ClrType != null && to.ClrType.IsValueType)
+            {
+                this.il.OpCode(ILOpCode.Unbox_any);
+                this.il.Token(this.outer.GetElementTypeToken(to));
                 return;
             }
 
@@ -5926,6 +5942,171 @@ internal sealed class ReflectionMetadataEmitter
             throw new NotSupportedException(
                 $"Conversion from '{from.Name}' to '{to.Name}' is not yet supported by the emitter.");
         }
+
+        // ADR-0044 numeric conversions. Maps the from/to CLR pair to the
+        // appropriate `conv.*` opcode or, for `decimal`, to the matching
+        // implicit/explicit operator method. Returns true when an emission
+        // was made.
+        private bool TryEmitNumericConversion(TypeSymbol fromSym, TypeSymbol toSym)
+        {
+            var from = fromSym?.ClrType;
+            var to = toSym?.ClrType;
+            if (from is null || to is null)
+            {
+                return false;
+            }
+
+            if (!IsNumericClrType(from) || !IsNumericClrType(to))
+            {
+                return false;
+            }
+
+            // decimal is a value type with no `conv.*` opcode; route through
+            // the BCL's operator methods. `op_Implicit` for widening sources
+            // (every integral type → decimal) and `op_Explicit` otherwise.
+            if (to == typeof(decimal) || from == typeof(decimal))
+            {
+                return TryEmitDecimalConversion(from, to);
+            }
+
+            // Stack-type bookkeeping: anything narrower than i4 is widened to
+            // i4 on the evaluation stack, so the source's stack shape is
+            // determined by `from`'s size only when it's i8, native int, r4,
+            // or r8. We pick the conv opcode that matches the *target*
+            // representation.
+            ILOpCode? op = null;
+            if (to == typeof(sbyte))
+            {
+                op = ILOpCode.Conv_i1;
+            }
+            else if (to == typeof(byte))
+            {
+                op = ILOpCode.Conv_u1;
+            }
+            else if (to == typeof(short))
+            {
+                op = ILOpCode.Conv_i2;
+            }
+            else if (to == typeof(ushort) || to == typeof(char))
+            {
+                op = ILOpCode.Conv_u2;
+            }
+            else if (to == typeof(int))
+            {
+                // From an i4-sized source the value is already i4. From i8,
+                // r4, r8, nint, nuint we must narrow to i4.
+                if (Is32BitOrSmaller(from))
+                {
+                    return true;
+                }
+
+                op = ILOpCode.Conv_i4;
+            }
+            else if (to == typeof(uint))
+            {
+                if (Is32BitOrSmaller(from))
+                {
+                    return true;
+                }
+
+                op = ILOpCode.Conv_u4;
+            }
+            else if (to == typeof(long))
+            {
+                op = ILOpCode.Conv_i8;
+            }
+            else if (to == typeof(ulong))
+            {
+                op = ILOpCode.Conv_u8;
+            }
+            else if (to == typeof(nint))
+            {
+                op = ILOpCode.Conv_i;
+            }
+            else if (to == typeof(nuint))
+            {
+                op = ILOpCode.Conv_u;
+            }
+            else if (to == typeof(float))
+            {
+                op = ILOpCode.Conv_r4;
+            }
+            else if (to == typeof(double))
+            {
+                op = ILOpCode.Conv_r8;
+            }
+
+            if (op == null)
+            {
+                return false;
+            }
+
+            this.il.OpCode(op.Value);
+            return true;
+        }
+
+        private bool TryEmitDecimalConversion(Type from, Type to)
+        {
+            // To decimal: every numeric source has either an `op_Implicit`
+            // (integrals, char) or an `op_Explicit` (float, double).
+            if (to == typeof(decimal))
+            {
+                var op = typeof(decimal).GetMethod("op_Implicit", new[] { from })
+                    ?? typeof(decimal).GetMethod("op_Explicit", new[] { from });
+                if (op == null)
+                {
+                    return false;
+                }
+
+                this.il.Call(this.outer.GetMethodEntityHandle(op));
+                return true;
+            }
+
+            // From decimal: every numeric target has an `op_Explicit`.
+            if (from == typeof(decimal))
+            {
+                var op = typeof(decimal).GetMethod("op_Explicit", new[] { typeof(decimal) });
+                // GetMethod by name+params resolves the conversion that
+                // returns the requested type when overloads disambiguate by
+                // return type; iterate to find the right one.
+                foreach (var m in typeof(decimal).GetMethods())
+                {
+                    if (m.Name == "op_Explicit"
+                        && m.ReturnType == to
+                        && m.GetParameters().Length == 1
+                        && m.GetParameters()[0].ParameterType == typeof(decimal))
+                    {
+                        op = m;
+                        break;
+                    }
+                }
+
+                if (op == null || op.ReturnType != to)
+                {
+                    return false;
+                }
+
+                this.il.Call(this.outer.GetMethodEntityHandle(op));
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsNumericClrType(Type t)
+            => t == typeof(sbyte) || t == typeof(byte)
+                || t == typeof(short) || t == typeof(ushort)
+                || t == typeof(int) || t == typeof(uint)
+                || t == typeof(long) || t == typeof(ulong)
+                || t == typeof(nint) || t == typeof(nuint)
+                || t == typeof(float) || t == typeof(double)
+                || t == typeof(decimal) || t == typeof(char);
+
+        private static bool Is32BitOrSmaller(Type t)
+            => t == typeof(sbyte) || t == typeof(byte)
+                || t == typeof(short) || t == typeof(ushort)
+                || t == typeof(int) || t == typeof(uint)
+                || t == typeof(char) || t == typeof(bool);
 
         private static bool IsReferenceCompatible(TypeSymbol a, TypeSymbol b)
         {
@@ -6229,16 +6410,134 @@ internal sealed class ReflectionMetadataEmitter
                 case string s:
                     this.il.LoadString(this.outer.metadata.GetOrAddUserString(s));
                     break;
+                case bool b:
+                    this.il.LoadConstantI4(b ? 1 : 0);
+                    break;
+                case sbyte sb:
+                    this.il.LoadConstantI4(sb);
+                    break;
+                case byte by:
+                    this.il.LoadConstantI4(by);
+                    break;
+                case short sh:
+                    this.il.LoadConstantI4(sh);
+                    break;
+                case ushort us:
+                    this.il.LoadConstantI4(us);
+                    break;
+                case char ch:
+                    this.il.LoadConstantI4(ch);
+                    break;
                 case int i:
                     this.il.LoadConstantI4(i);
                     break;
-                case bool b:
-                    this.il.LoadConstantI4(b ? 1 : 0);
+                case uint ui:
+                    this.il.LoadConstantI4(unchecked((int)ui));
+                    break;
+                case long lng:
+                    this.il.LoadConstantI8(lng);
+                    break;
+                case ulong ul:
+                    this.il.LoadConstantI8(unchecked((long)ul));
+                    break;
+                case nint ni:
+                    this.il.LoadConstantI8(ni);
+                    this.il.OpCode(ILOpCode.Conv_i);
+                    break;
+                case nuint nu:
+                    this.il.LoadConstantI8(unchecked((long)(ulong)nu));
+                    this.il.OpCode(ILOpCode.Conv_u);
+                    break;
+                case float f:
+                    this.il.LoadConstantR4(f);
+                    break;
+                case double d:
+                    this.il.LoadConstantR8(d);
+                    break;
+                case decimal m:
+                    this.EmitDecimalLiteral(m);
                     break;
                 default:
                     throw new NotSupportedException(
                         $"Literal of CLR type '{literal.Value?.GetType()}' is not yet supported.");
             }
+        }
+
+        // ADR-0044 decimal literal lowering. IL has no `ldc.decimal`, so each
+        // literal is materialised by calling the
+        // `Decimal(int, int, int, bool, byte)` ctor with the bit pattern
+        // returned by `decimal.GetBits`. Common small values (0, 1, -1) and
+        // any value that fits in `int` use the cheaper one-int ctors.
+        private void EmitDecimalLiteral(decimal value)
+        {
+            if (value == decimal.Zero)
+            {
+                this.EmitDecimalStaticField(nameof(decimal.Zero));
+                return;
+            }
+
+            if (value == decimal.One)
+            {
+                this.EmitDecimalStaticField(nameof(decimal.One));
+                return;
+            }
+
+            if (value == decimal.MinusOne)
+            {
+                this.EmitDecimalStaticField(nameof(decimal.MinusOne));
+                return;
+            }
+
+            // Try int ctor for small whole values.
+            if (decimal.Truncate(value) == value && value >= int.MinValue && value <= int.MaxValue)
+            {
+                var asInt = (int)value;
+                this.il.LoadConstantI4(asInt);
+                var ctor = typeof(decimal).GetConstructor(new[] { typeof(int) });
+                this.il.OpCode(ILOpCode.Newobj);
+                this.il.Token(this.outer.GetCtorReference(ctor));
+                return;
+            }
+
+            // Try long ctor.
+            if (decimal.Truncate(value) == value && value >= long.MinValue && value <= long.MaxValue)
+            {
+                var asLong = (long)value;
+                this.il.LoadConstantI8(asLong);
+                var ctor = typeof(decimal).GetConstructor(new[] { typeof(long) });
+                this.il.OpCode(ILOpCode.Newobj);
+                this.il.Token(this.outer.GetCtorReference(ctor));
+                return;
+            }
+
+            // General case: Decimal(int lo, int mid, int hi, bool isNegative, byte scale).
+            var bits = decimal.GetBits(value);
+            var lo = bits[0];
+            var mid = bits[1];
+            var hi = bits[2];
+            var flags = bits[3];
+            var isNegative = (flags & unchecked((int)0x80000000)) != 0;
+            var scale = (byte)((flags >> 16) & 0x7F);
+
+            this.il.LoadConstantI4(lo);
+            this.il.LoadConstantI4(mid);
+            this.il.LoadConstantI4(hi);
+            this.il.LoadConstantI4(isNegative ? 1 : 0);
+            this.il.LoadConstantI4(scale);
+
+            var bigCtor = typeof(decimal).GetConstructor(new[]
+            {
+                typeof(int), typeof(int), typeof(int), typeof(bool), typeof(byte),
+            });
+            this.il.OpCode(ILOpCode.Newobj);
+            this.il.Token(this.outer.GetCtorReference(bigCtor));
+        }
+
+        private void EmitDecimalStaticField(string name)
+        {
+            var field = typeof(decimal).GetField(name);
+            this.il.OpCode(ILOpCode.Ldsfld);
+            this.il.Token(this.outer.GetFieldReference(field));
         }
 
         private void EmitDefault(BoundDefaultExpression node)

--- a/test/Compiler.Tests/Emit/PrimitiveLiteralEmitTests.cs
+++ b/test/Compiler.Tests/Emit/PrimitiveLiteralEmitTests.cs
@@ -1,0 +1,241 @@
+// <copyright file="PrimitiveLiteralEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Phase 3 of #142: end-to-end emit-and-execute coverage for ADR-0044's
+/// expanded primitive set. Each test compiles a tiny GSharp program that
+/// stresses a literal value, an implicit widening, or an explicit
+/// narrowing of one of the new primitive types and asserts that the
+/// printed output matches the BCL's stringification of the same value.
+/// </summary>
+public class PrimitiveLiteralEmitTests
+{
+    [Fact]
+    public void LongLiteral_Suffixed_RoundTripsThroughWriteLine()
+    {
+        var source = """
+            package P
+            import System
+
+            let x = 9999999999L
+            Console.WriteLine(x)
+            """;
+
+        Assert.Equal("9999999999\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Float32Literal_Suffixed_RoundTrips()
+    {
+        var source = """
+            package P
+            import System
+
+            let x = 3.5F
+            Console.WriteLine(x)
+            """;
+
+        Assert.Equal("3.5\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Float64Literal_Default_RoundTrips()
+    {
+        var source = """
+            package P
+            import System
+
+            let x = 2.5
+            Console.WriteLine(x)
+            """;
+
+        Assert.Equal("2.5\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DecimalLiteral_SmallValue_UsesIntCtor()
+    {
+        var source = """
+            package P
+            import System
+
+            let x = 42M
+            Console.WriteLine(x)
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DecimalLiteral_FractionalValue_UsesFiveArgCtor()
+    {
+        var source = """
+            package P
+            import System
+
+            let x = 3.14M
+            Console.WriteLine(x)
+            """;
+
+        Assert.Equal("3.14\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DecimalLiteral_Zero_UsesStaticField()
+    {
+        var source = """
+            package P
+            import System
+
+            let x = 0M
+            Console.WriteLine(x)
+            """;
+
+        Assert.Equal("0\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void UnsuffixedInt_WidensImplicitlyTo_LongTarget()
+    {
+        // ADR-0044: `let x : long = 1` works without `1L`.
+        var source = """
+            package P
+            import System
+
+            let x long = 1
+            Console.WriteLine(x)
+            """;
+
+        Assert.Equal("1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ExplicitNarrowing_LongToInt_Truncates()
+    {
+        var source = """
+            package P
+            import System
+
+            let big = 4294967297L
+            let n = int(big)
+            Console.WriteLine(n)
+            """;
+
+        Assert.Equal("1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ExplicitNarrowing_Float64ToInt_Truncates()
+    {
+        var source = """
+            package P
+            import System
+
+            let f = 3.9
+            let n = int(f)
+            Console.WriteLine(n)
+            """;
+
+        Assert.Equal("3\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Int_To_Object_Boxes_ForObjectParameter()
+    {
+        var source = """
+            package P
+            import System
+
+            let n = 42
+            Console.WriteLine(n)
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void CharLiteral_Prints_AsChar()
+    {
+        var source = """
+            package P
+            import System
+
+            let c = 'A'
+            Console.WriteLine(c)
+            """;
+
+        Assert.Equal("A\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_phase3_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/PrimitiveConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/PrimitiveConversionTests.cs
@@ -1,0 +1,177 @@
+// <copyright file="PrimitiveConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Phase 3 of #142: exercises <see cref="Conversion.Classify"/> across the
+/// full ADR-0044 numeric lattice and the ADR-0045 object boxing/unboxing
+/// rules. Each test pair pins one cell in the conversion matrix so a
+/// future refactor of the table can be caught here rather than via a
+/// downstream emitter or interpreter failure.
+/// </summary>
+public class PrimitiveConversionTests
+{
+    public static TheoryData<TypeSymbol, TypeSymbol> ImplicitNumericWidenings()
+    {
+        var data = new TheoryData<TypeSymbol, TypeSymbol>
+        {
+            { TypeSymbol.SByte, TypeSymbol.Short },
+            { TypeSymbol.SByte, TypeSymbol.Int },
+            { TypeSymbol.SByte, TypeSymbol.Long },
+            { TypeSymbol.SByte, TypeSymbol.Float32 },
+            { TypeSymbol.SByte, TypeSymbol.Float64 },
+            { TypeSymbol.SByte, TypeSymbol.Decimal },
+            { TypeSymbol.Byte, TypeSymbol.Short },
+            { TypeSymbol.Byte, TypeSymbol.UShort },
+            { TypeSymbol.Byte, TypeSymbol.Int },
+            { TypeSymbol.Byte, TypeSymbol.UInt },
+            { TypeSymbol.Byte, TypeSymbol.Long },
+            { TypeSymbol.Byte, TypeSymbol.ULong },
+            { TypeSymbol.Byte, TypeSymbol.Decimal },
+            { TypeSymbol.Short, TypeSymbol.Int },
+            { TypeSymbol.Short, TypeSymbol.Long },
+            { TypeSymbol.Short, TypeSymbol.Float32 },
+            { TypeSymbol.Short, TypeSymbol.Float64 },
+            { TypeSymbol.UShort, TypeSymbol.Int },
+            { TypeSymbol.UShort, TypeSymbol.UInt },
+            { TypeSymbol.UShort, TypeSymbol.Long },
+            { TypeSymbol.Int, TypeSymbol.Long },
+            { TypeSymbol.Int, TypeSymbol.Float32 },
+            { TypeSymbol.Int, TypeSymbol.Float64 },
+            { TypeSymbol.Int, TypeSymbol.Decimal },
+            { TypeSymbol.UInt, TypeSymbol.Long },
+            { TypeSymbol.UInt, TypeSymbol.ULong },
+            { TypeSymbol.UInt, TypeSymbol.Decimal },
+            { TypeSymbol.Long, TypeSymbol.Float64 },
+            { TypeSymbol.Long, TypeSymbol.Decimal },
+            { TypeSymbol.ULong, TypeSymbol.Decimal },
+            { TypeSymbol.Float32, TypeSymbol.Float64 },
+            { TypeSymbol.Char, TypeSymbol.UShort },
+            { TypeSymbol.Char, TypeSymbol.Int },
+            { TypeSymbol.Char, TypeSymbol.UInt },
+            { TypeSymbol.Char, TypeSymbol.Float64 },
+            { TypeSymbol.NInt, TypeSymbol.Long },
+            { TypeSymbol.NInt, TypeSymbol.Float64 },
+            { TypeSymbol.NUInt, TypeSymbol.ULong },
+        };
+        return data;
+    }
+
+    public static TheoryData<TypeSymbol, TypeSymbol> ExplicitNumericNarrowings()
+    {
+        var data = new TheoryData<TypeSymbol, TypeSymbol>
+        {
+            { TypeSymbol.Int, TypeSymbol.Byte },
+            { TypeSymbol.Int, TypeSymbol.SByte },
+            { TypeSymbol.Int, TypeSymbol.Short },
+            { TypeSymbol.Int, TypeSymbol.UShort },
+            { TypeSymbol.Int, TypeSymbol.UInt },
+            { TypeSymbol.Int, TypeSymbol.Char },
+            { TypeSymbol.Long, TypeSymbol.Int },
+            { TypeSymbol.Long, TypeSymbol.UInt },
+            { TypeSymbol.ULong, TypeSymbol.Int },
+            { TypeSymbol.ULong, TypeSymbol.Long },
+            { TypeSymbol.Float64, TypeSymbol.Float32 },
+            { TypeSymbol.Float64, TypeSymbol.Int },
+            { TypeSymbol.Float32, TypeSymbol.Int },
+            { TypeSymbol.Decimal, TypeSymbol.Int },
+            { TypeSymbol.Decimal, TypeSymbol.Long },
+            { TypeSymbol.Decimal, TypeSymbol.Float32 },
+            { TypeSymbol.Decimal, TypeSymbol.Float64 },
+        };
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(ImplicitNumericWidenings))]
+    public void NumericWidening_IsImplicit(TypeSymbol from, TypeSymbol to)
+    {
+        var conv = Conversion.Classify(from, to);
+        Assert.True(conv.Exists, $"expected {from.Name} -> {to.Name} to exist");
+        Assert.True(conv.IsImplicit, $"expected {from.Name} -> {to.Name} to be implicit");
+    }
+
+    [Theory]
+    [MemberData(nameof(ExplicitNumericNarrowings))]
+    public void NumericNarrowing_IsExplicit(TypeSymbol from, TypeSymbol to)
+    {
+        var conv = Conversion.Classify(from, to);
+        Assert.True(conv.Exists, $"expected {from.Name} -> {to.Name} to exist");
+        Assert.True(conv.IsExplicit, $"expected {from.Name} -> {to.Name} to be explicit (got implicit={conv.IsImplicit})");
+    }
+
+    [Theory]
+    [InlineData("Int", "Int")]
+    [InlineData("Long", "Long")]
+    [InlineData("Decimal", "Decimal")]
+    [InlineData("Char", "Char")]
+    public void Identity_IsIdentity(string fromName, string toName)
+    {
+        var from = LookupPrimitive(fromName);
+        var to = LookupPrimitive(toName);
+        var conv = Conversion.Classify(from, to);
+        Assert.True(conv.IsIdentity);
+    }
+
+    [Fact]
+    public void Int_To_UInt_IsExplicit()
+    {
+        // Same width but signed/unsigned: explicit per C# §6.2.1.
+        var conv = Conversion.Classify(TypeSymbol.Int, TypeSymbol.UInt);
+        Assert.True(conv.IsExplicit);
+    }
+
+    [Fact]
+    public void Bool_To_Int_HasNoNumericConversion()
+    {
+        // bool is not in the numeric lattice; no conversion exists in
+        // either direction. (The IL-level bool↔int helpers in the emitter
+        // are reachable only through unrelated paths such as the discarded
+        // result of an equality test.)
+        var conv = Conversion.Classify(TypeSymbol.Bool, TypeSymbol.Int);
+        Assert.False(conv.Exists);
+    }
+
+    [Fact]
+    public void Int_To_Object_IsImplicit_Boxing()
+    {
+        var conv = Conversion.Classify(TypeSymbol.Int, TypeSymbol.Object);
+        Assert.True(conv.IsImplicit, "value-type → object is implicit boxing per ADR-0045");
+    }
+
+    [Fact]
+    public void Decimal_To_Object_IsImplicit_Boxing()
+    {
+        var conv = Conversion.Classify(TypeSymbol.Decimal, TypeSymbol.Object);
+        Assert.True(conv.IsImplicit);
+    }
+
+    [Fact]
+    public void Object_To_Int_IsExplicit_Unbox()
+    {
+        var conv = Conversion.Classify(TypeSymbol.Object, TypeSymbol.Int);
+        Assert.True(conv.IsExplicit, "object → value-type is explicit unboxing per ADR-0045");
+    }
+
+    [Fact]
+    public void String_To_Object_IsImplicit_Reference()
+    {
+        var conv = Conversion.Classify(TypeSymbol.String, TypeSymbol.Object);
+        Assert.True(conv.IsImplicit, "reference type → object is implicit reference conversion");
+    }
+
+    private static TypeSymbol LookupPrimitive(string name) => name switch
+    {
+        "Int" => TypeSymbol.Int,
+        "Long" => TypeSymbol.Long,
+        "Decimal" => TypeSymbol.Decimal,
+        "Char" => TypeSymbol.Char,
+        _ => throw new System.ArgumentException($"unknown primitive '{name}'"),
+    };
+}


### PR DESCRIPTION
Implements ADR-0044's numeric conversion lattice and ADR-0045's object boxing in `Conversion.Classify`, and adds emit support for every CLR primitive literal plus the corresponding numeric conversions in `ReflectionMetadataEmitter`.

## Conversion lattice (`Binding/Conversion.cs`)
- New `NumericWideningTargets` table encoding C# §6.1.2 widenings, plus:
  - `char` widening to `ushort/int/uint/long/ulong/nint/nuint/float32/float64/decimal`.
  - `nint` widens to `long/float32/float64/decimal`; `nuint` widens to `ulong/float32/float64/decimal`.
  - Every integral source has implicit widening to `decimal`; `float32`/`float64` need an explicit cast to `decimal`.
- Same-width signed/unsigned pairs (`int↔uint`, `long↔ulong`, …) are `Explicit`.
- Any value type → `object` is `Implicit` (boxing). `object` → value type is `Explicit` (unbox).

## Emit (`Emit/ReflectionMetadataEmitter.cs`)
- `EmitLiteral` now covers every CLR primitive:
  - `sbyte/byte/short/ushort/int/char` → `ldc.i4`
  - `uint` → `ldc.i4` with unchecked cast for values ≥ 2³¹
  - `long/ulong` → `ldc.i8` (unchecked for ulong)
  - `nint/nuint` → `ldc.i8` + `conv.i`/`conv.u`
  - `float32` → `ldc.r4`; `float64` → `ldc.r8`
  - `decimal` — `Decimal.Zero/One/MinusOne` static fields when applicable, otherwise `Decimal(int)` / `Decimal(long)` / the five-argument `Decimal(int lo, int mid, int hi, bool isNegative, byte scale)` ctor (derived from `decimal.GetBits`).
- `EmitConversion` learned a numeric-conversion dispatch:
  - Primitive ↔ primitive → the appropriate `conv.*` opcode (no-op when both sides fit in an i4 stack slot).
  - Decimal ↔ primitive → `op_Implicit`/`op_Explicit` calls.
  - Value type → `object` → `box`.
  - `object` → value type → `unbox.any`.

## Tests
- **`PrimitiveConversionTests`** (new, Core.Tests) — theory-driven, 64 rows:
  - 38 implicit-widening pairs from the lattice.
  - 17 explicit-narrowing pairs.
  - Identity, same-width signed/unsigned mismatches, object boxing/unboxing, `string` reference-type behaviour.
- **`PrimitiveLiteralEmitTests`** (new, Compiler.Tests) — 11 end-to-end emit-and-execute tests:
  - `long`, `float32`, `float64`, `decimal` (small, fractional, zero), and `char` literals round-trip through `Console.WriteLine`.
  - Implicit `int → long` widening at a typed local (`let x long = 1`).
  - Explicit `long → int` and `float64 → int` narrowing casts produce the expected truncation.

## Verification
- `dotnet build src/Core -nologo -clp:NoSummary` ✅ 0 warnings, 0 errors.
- `dotnet test GSharp.sln --no-restore --nologo` ✅ **1214 passing** (Core 1066, Compiler 102, LanguageServer 17, Interpreter 8, Sdk 21).

Targets `main` per project convention.

Refs #142.