### PR TITLE
Phase 1 of #141: lexer + parser for Kotlin-style annotations

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -9,9 +9,12 @@ AmpersandEqualsToken
 AmpersandHatEqualsToken
 AmpersandHatToken
 AmpersandToken
+Annotation
+AnnotationTarget
 ArrayCreationExpression
 AssignmentExpression
 AsyncKeyword
+AtToken
 AwaitExpression
 AwaitForRangeStatement
 AwaitKeyword

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1136,6 +1136,30 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0195", "Malformed Unicode escape in character literal.");
     }
 
+    /// <summary>
+    /// Reports an annotation lead-in (<c>@</c>) that is not followed by an
+    /// identifier or a use-site target qualifier (ADR-0047 §1).
+    /// </summary>
+    /// <param name="location">The source location of the offending token.</param>
+    public void ReportAnnotationExpected(TextLocation location)
+    {
+        Report(location, "GS0196", "Annotation name expected after '@'.");
+    }
+
+    /// <summary>
+    /// Reports an annotation use-site target qualifier whose kind is not one
+    /// of the canonical kinds defined in ADR-0047 §2 (<c>field</c>,
+    /// <c>param</c>, <c>return</c>, <c>type</c>, <c>method</c>,
+    /// <c>property</c>, <c>event</c>, <c>module</c>, <c>assembly</c>,
+    /// <c>genericparam</c>).
+    /// </summary>
+    /// <param name="location">The source location of the offending kind identifier.</param>
+    /// <param name="kind">The unrecognized kind text.</param>
+    public void ReportAnnotationTargetInvalid(TextLocation location, string kind)
+    {
+        Report(location, "GS0197", $"Annotation target '{kind}' is not a recognized use-site kind. Expected one of: field, param, return, type, method, property, event, module, assembly, genericparam.");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Syntax/AnnotationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/AnnotationSyntax.cs
@@ -1,0 +1,108 @@
+// <copyright file="AnnotationSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents a Kotlin-style annotation lead-in (ADR-0047): an
+/// <c>@</c> token optionally followed by a use-site target qualifier
+/// (<c>field:</c>, <c>param:</c>, <c>return:</c>, …), a dotted attribute
+/// name, and an optional argument list.
+///
+/// Examples:
+/// <list type="bullet">
+///   <item><description><c>@Serializable</c></description></item>
+///   <item><description><c>@Obsolete("use Bar")</c></description></item>
+///   <item><description><c>@field:NonSerialized</c></description></item>
+///   <item><description><c>@System.Diagnostics.Conditional("DEBUG")</c></description></item>
+/// </list>
+///
+/// Phase 1 / issue #141 only models the surface syntax; the binder (Phase 2)
+/// will resolve the dotted name through the C#-style
+/// <c>Foo</c> / <c>FooAttribute</c> lookup and the emitter (Phase 3) will
+/// write the corresponding <c>CustomAttribute</c> metadata row.
+/// </summary>
+public sealed class AnnotationSyntax : SyntaxNode
+{
+    /// <summary>Initializes a new instance of the <see cref="AnnotationSyntax"/> class.</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="atToken">The leading <c>@</c> token.</param>
+    /// <param name="target">Optional use-site target qualifier (e.g. <c>field:</c>); <c>null</c> when the annotation uses the default target for its declaration position.</param>
+    /// <param name="nameSegments">The dotted attribute-name path. The first segment is the leftmost identifier; dots are interleaved into <paramref name="dotTokens"/>.</param>
+    /// <param name="dotTokens">The <c>.</c> tokens that separate name segments. Always <c>nameSegments.Length - 1</c> entries (possibly empty).</param>
+    /// <param name="openParenthesisToken">Optional opening <c>(</c> token. Non-<c>null</c> iff an argument list was supplied.</param>
+    /// <param name="arguments">The positional / named-argument list (per ADR-0047 §1). Empty when no argument list was supplied.</param>
+    /// <param name="closeParenthesisToken">Optional closing <c>)</c> token. Non-<c>null</c> iff <paramref name="openParenthesisToken"/> is non-<c>null</c>.</param>
+    public AnnotationSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken atToken,
+        AnnotationTargetSyntax target,
+        ImmutableArray<SyntaxToken> nameSegments,
+        ImmutableArray<SyntaxToken> dotTokens,
+        SyntaxToken openParenthesisToken,
+        SeparatedSyntaxList<ExpressionSyntax> arguments,
+        SyntaxToken closeParenthesisToken)
+        : base(syntaxTree)
+    {
+        AtToken = atToken;
+        Target = target;
+        NameSegments = nameSegments;
+        DotTokens = dotTokens;
+        OpenParenthesisToken = openParenthesisToken;
+        Arguments = arguments;
+        CloseParenthesisToken = closeParenthesisToken;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.Annotation;
+
+    /// <summary>Gets the leading <c>@</c> token.</summary>
+    public SyntaxToken AtToken { get; }
+
+    /// <summary>Gets the optional use-site target qualifier; <c>null</c> when none is supplied (annotation uses the default target).</summary>
+    public AnnotationTargetSyntax Target { get; }
+
+    /// <summary>Gets the dotted attribute-name segments (the leftmost identifier is at index 0).</summary>
+    public ImmutableArray<SyntaxToken> NameSegments { get; }
+
+    /// <summary>Gets the <c>.</c> tokens that separate <see cref="NameSegments"/>.</summary>
+    public ImmutableArray<SyntaxToken> DotTokens { get; }
+
+    /// <summary>Gets the optional opening <c>(</c> of the argument list; <c>null</c> when no parenthesised argument list was supplied.</summary>
+    public SyntaxToken OpenParenthesisToken { get; }
+
+    /// <summary>Gets the (possibly empty) annotation argument list.</summary>
+    public SeparatedSyntaxList<ExpressionSyntax> Arguments { get; }
+
+    /// <summary>Gets the optional closing <c>)</c> of the argument list; <c>null</c> when no parenthesised argument list was supplied.</summary>
+    public SyntaxToken CloseParenthesisToken { get; }
+
+    /// <summary>Gets a value indicating whether this annotation carries a parenthesised argument list.</summary>
+    public bool HasArgumentList => OpenParenthesisToken != null;
+
+    /// <summary>Gets the dotted attribute name as a string (e.g. <c>"System.Diagnostics.Conditional"</c>).</summary>
+    /// <returns>The flattened dotted name; segments are joined with <c>.</c>.</returns>
+    public string GetNameText()
+    {
+        if (NameSegments.Length == 1)
+        {
+            return NameSegments[0].Text;
+        }
+
+        var sb = new System.Text.StringBuilder();
+        for (var i = 0; i < NameSegments.Length; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append('.');
+            }
+
+            sb.Append(NameSegments[i].Text);
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/Core/CodeAnalysis/Syntax/AnnotationTargetSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/AnnotationTargetSyntax.cs
@@ -1,0 +1,41 @@
+// <copyright file="AnnotationTargetSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents the optional use-site target qualifier on an annotation
+/// (ADR-0047 §4): the <c>field</c>, <c>param</c>, <c>return</c>, <c>type</c>,
+/// <c>method</c>, <c>property</c>, <c>event</c>, <c>module</c>,
+/// <c>assembly</c>, or <c>genericparam</c> identifier that immediately
+/// follows <c>@</c> and is terminated by <c>:</c>.
+///
+/// The kind keywords are *contextual* — they are ordinary identifiers
+/// everywhere else in the language; the lexer does not promote them.
+/// </summary>
+public sealed class AnnotationTargetSyntax : SyntaxNode
+{
+    /// <summary>Initializes a new instance of the <see cref="AnnotationTargetSyntax"/> class.</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="kindIdentifier">The contextual target-kind identifier (e.g. <c>field</c>).</param>
+    /// <param name="colonToken">The trailing <c>:</c> token.</param>
+    public AnnotationTargetSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken kindIdentifier,
+        SyntaxToken colonToken)
+        : base(syntaxTree)
+    {
+        KindIdentifier = kindIdentifier;
+        ColonToken = colonToken;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.AnnotationTarget;
+
+    /// <summary>Gets the contextual target-kind identifier (its <see cref="SyntaxToken.Text"/> is the canonical kind name).</summary>
+    public SyntaxToken KindIdentifier { get; }
+
+    /// <summary>Gets the trailing <c>:</c> token.</summary>
+    public SyntaxToken ColonToken { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -388,6 +388,10 @@ public sealed class Lexer
             case '\'':
                 ReadCharLiteral();
                 break;
+            case '@':
+                kind = SyntaxKind.AtToken;
+                position++;
+                break;
             case '0':
             case '1':
             case '2':

--- a/src/Core/CodeAnalysis/Syntax/MemberSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/MemberSyntax.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System.Collections.Immutable;
+
 namespace GSharp.Core.CodeAnalysis.Syntax;
 
 /// <summary>
@@ -16,5 +18,29 @@ public abstract class MemberSyntax : SyntaxNode
     protected MemberSyntax(SyntaxTree syntaxTree)
         : base(syntaxTree)
     {
+        Annotations = ImmutableArray<AnnotationSyntax>.Empty;
+    }
+
+    /// <summary>
+    /// Gets the Kotlin-style annotations (ADR-0047) attached to this member
+    /// declaration. Empty when the member has no <c>@</c> lead-ins.
+    /// </summary>
+    /// <remarks>
+    /// Annotations are populated by the parser via <see cref="WithAnnotations"/>
+    /// immediately after the concrete member node is constructed, so that
+    /// existing constructor overloads on derived members do not need to be
+    /// touched. <see cref="SyntaxNode.GetChildren"/> finds the slot
+    /// through reflection on the public <c>IEnumerable&lt;SyntaxNode&gt;</c>
+    /// property.
+    /// </remarks>
+    public ImmutableArray<AnnotationSyntax> Annotations { get; private set; }
+
+    /// <summary>Attaches the given annotation list to this member and returns the same instance for fluent use by the parser.</summary>
+    /// <param name="annotations">The annotation list to attach (may be empty).</param>
+    /// <returns>This same <see cref="MemberSyntax"/>, with <see cref="Annotations"/> updated.</returns>
+    internal MemberSyntax WithAnnotations(ImmutableArray<AnnotationSyntax> annotations)
+    {
+        Annotations = annotations.IsDefault ? ImmutableArray<AnnotationSyntax>.Empty : annotations;
+        return this;
     }
 }

--- a/src/Core/CodeAnalysis/Syntax/ParameterSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/ParameterSyntax.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System.Collections.Immutable;
+
 namespace GSharp.Core.CodeAnalysis.Syntax;
 
 /// <summary>
@@ -22,6 +24,7 @@ public sealed class ParameterSyntax : SyntaxNode
         Identifier = identifier;
         EllipsisToken = ellipsisToken;
         Type = type;
+        Annotations = ImmutableArray<AnnotationSyntax>.Empty;
     }
 
     /// <summary>
@@ -39,6 +42,13 @@ public sealed class ParameterSyntax : SyntaxNode
     public override SyntaxKind Kind => SyntaxKind.Parameter;
 
     /// <summary>
+    /// Gets the Kotlin-style annotations (ADR-0047) attached to this parameter.
+    /// Empty when the parameter has no <c>@</c> lead-ins. Populated by the
+    /// parser via <see cref="WithAnnotations"/>.
+    /// </summary>
+    public ImmutableArray<AnnotationSyntax> Annotations { get; private set; }
+
+    /// <summary>
     /// Gets the parameter identifier.
     /// </summary>
     public SyntaxToken Identifier { get; }
@@ -53,4 +63,13 @@ public sealed class ParameterSyntax : SyntaxNode
 
     /// <summary>Gets a value indicating whether this is a variadic parameter (Phase 4.8).</summary>
     public bool IsVariadic => EllipsisToken != null;
+
+    /// <summary>Attaches the given annotation list to this parameter and returns this same instance for fluent parser use.</summary>
+    /// <param name="annotations">The annotation list to attach (may be empty).</param>
+    /// <returns>This same <see cref="ParameterSyntax"/>, with <see cref="Annotations"/> updated.</returns>
+    internal ParameterSyntax WithAnnotations(ImmutableArray<AnnotationSyntax> annotations)
+    {
+        Annotations = annotations.IsDefault ? ImmutableArray<AnnotationSyntax>.Empty : annotations;
+        return this;
+    }
 }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -150,6 +150,11 @@ public class Parser
 
     private MemberSyntax ParseMember()
     {
+        // ADR-0047 / issue #141: Kotlin-style annotation lead-ins precede any
+        // other modifier on a declaration. We collect them once and then
+        // attach the list to whichever member node ParseMember produces.
+        var annotations = ParseAnnotations();
+
         SyntaxToken accessibilityModifier = null;
         if (Current.Kind == SyntaxKind.PublicKeyword ||
             Current.Kind == SyntaxKind.InternalKeyword ||
@@ -166,37 +171,164 @@ public class Parser
             asyncModifier = NextToken();
         }
 
+        MemberSyntax member;
         if (Current.Kind == SyntaxKind.FuncKeyword)
         {
-            return ParseFunctionDeclaration(accessibilityModifier, openModifier: null, overrideModifier: null, asyncModifier);
+            member = ParseFunctionDeclaration(accessibilityModifier, openModifier: null, overrideModifier: null, asyncModifier);
         }
-
-        if (Current.Kind == SyntaxKind.TypeKeyword)
+        else if (Current.Kind == SyntaxKind.TypeKeyword)
         {
-            return ParseTypeAliasDeclaration(accessibilityModifier);
+            member = ParseTypeAliasDeclaration(accessibilityModifier);
         }
-
-        if (accessibilityModifier != null &&
+        else if (accessibilityModifier != null &&
             (Current.Kind == SyntaxKind.VarKeyword ||
              Current.Kind == SyntaxKind.LetKeyword ||
              Current.Kind == SyntaxKind.ConstKeyword))
         {
             var declaration = ParseVariableDeclaration(accessibilityModifier);
-            return new GlobalStatementSyntax(syntaxTree, declaration);
+            member = new GlobalStatementSyntax(syntaxTree, declaration);
         }
-
-        if (accessibilityModifier != null)
+        else
         {
-            Diagnostics.ReportAccessibilityModifierNotAllowedHere(accessibilityModifier.Location, accessibilityModifier.Text);
+            if (accessibilityModifier != null)
+            {
+                Diagnostics.ReportAccessibilityModifierNotAllowedHere(accessibilityModifier.Location, accessibilityModifier.Text);
+            }
+
+            if (asyncModifier != null)
+            {
+                // `async` not followed by `func` — surface as an unexpected token.
+                Diagnostics.ReportUnexpectedToken(asyncModifier.Location, SyntaxKind.AsyncKeyword, SyntaxKind.FuncKeyword);
+            }
+
+            member = ParseGlobalStatement();
         }
 
-        if (asyncModifier != null)
+        return member.WithAnnotations(annotations);
+    }
+
+    /// <summary>
+    /// Parses zero or more Kotlin-style annotations (ADR-0047) at the current
+    /// position. Stops at the first token that is not <c>@</c>. The returned
+    /// list is empty when no annotation lead-in is present.
+    /// </summary>
+    private ImmutableArray<AnnotationSyntax> ParseAnnotations()
+    {
+        if (Current.Kind != SyntaxKind.AtToken)
         {
-            // `async` not followed by `func` — surface as an unexpected token.
-            Diagnostics.ReportUnexpectedToken(asyncModifier.Location, SyntaxKind.AsyncKeyword, SyntaxKind.FuncKeyword);
+            return ImmutableArray<AnnotationSyntax>.Empty;
         }
 
-        return ParseGlobalStatement();
+        var builder = ImmutableArray.CreateBuilder<AnnotationSyntax>();
+        while (Current.Kind == SyntaxKind.AtToken)
+        {
+            builder.Add(ParseAnnotation());
+        }
+
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Parses a single annotation: <c>@</c> [target-kind <c>:</c>] dotted-name
+    /// [<c>(</c> arguments <c>)</c>]. Pre: <c>Current.Kind == AtToken</c>.
+    /// </summary>
+    private AnnotationSyntax ParseAnnotation()
+    {
+        var atToken = MatchToken(SyntaxKind.AtToken);
+
+        // Optional use-site target: `kind:` where kind is one of the canonical
+        // contextual identifiers in ADR-0047 §2. The colon is what makes the
+        // token mean "target" — without the colon the token is the first
+        // segment of the annotation name. We accept any token kind whose text
+        // matches a canonical kind, so reserved keywords like `type` and
+        // `return` work even though the lexer never demotes them to
+        // identifiers — they are contextual only here.
+        AnnotationTargetSyntax target = null;
+        if (Peek(1).Kind == SyntaxKind.ColonToken &&
+            (Current.Kind == SyntaxKind.IdentifierToken ||
+             IsValidAnnotationTargetKind(Current.Text)))
+        {
+            var kindToken = NextToken();
+            var colonToken = NextToken();
+
+            // Normalize the kind to an IdentifierToken so downstream consumers
+            // can rely on a uniform shape regardless of whether the source
+            // spelled `type:` (keyword) or `field:` (plain identifier).
+            var kindIdentifier = new SyntaxToken(syntaxTree, SyntaxKind.IdentifierToken, kindToken.Position, kindToken.Text, null);
+            target = new AnnotationTargetSyntax(syntaxTree, kindIdentifier, colonToken);
+
+            if (!IsValidAnnotationTargetKind(kindToken.Text))
+            {
+                Diagnostics.ReportAnnotationTargetInvalid(kindToken.Location, kindToken.Text);
+            }
+        }
+
+        // Dotted attribute name. At least one segment must be present.
+        var nameSegments = ImmutableArray.CreateBuilder<SyntaxToken>();
+        var dotTokens = ImmutableArray.CreateBuilder<SyntaxToken>();
+
+        if (Current.Kind != SyntaxKind.IdentifierToken)
+        {
+            Diagnostics.ReportAnnotationExpected(atToken.Location);
+
+            // Synthesize a single bad identifier so downstream consumers
+            // still see a structurally valid annotation node.
+            var bad = MatchToken(SyntaxKind.IdentifierToken);
+            nameSegments.Add(bad);
+        }
+        else
+        {
+            nameSegments.Add(NextToken());
+            while (Current.Kind == SyntaxKind.DotToken && Peek(1).Kind == SyntaxKind.IdentifierToken)
+            {
+                dotTokens.Add(NextToken());
+                nameSegments.Add(NextToken());
+            }
+        }
+
+        // Optional argument list. The opening `(` must appear with no
+        // intervening tokens (we use it to disambiguate "annotation with no
+        // args" from "annotation followed by something that opens a `(`").
+        SyntaxToken openParen = null;
+        SeparatedSyntaxList<ExpressionSyntax> arguments = new SeparatedSyntaxList<ExpressionSyntax>(ImmutableArray<SyntaxNode>.Empty);
+        SyntaxToken closeParen = null;
+        if (Current.Kind == SyntaxKind.OpenParenthesisToken)
+        {
+            openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
+            arguments = ParseArguments();
+            closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+        }
+
+        return new AnnotationSyntax(
+            syntaxTree,
+            atToken,
+            target,
+            nameSegments.ToImmutable(),
+            dotTokens.ToImmutable(),
+            openParen,
+            arguments,
+            closeParen);
+    }
+
+    private static bool IsValidAnnotationTargetKind(string text)
+    {
+        // The closed kind set from ADR-0047 §2.
+        switch (text)
+        {
+            case "field":
+            case "param":
+            case "return":
+            case "type":
+            case "method":
+            case "property":
+            case "event":
+            case "module":
+            case "assembly":
+            case "genericparam":
+                return true;
+            default:
+                return false;
+        }
     }
 
     private MemberSyntax ParseTypeAliasDeclaration(SyntaxToken accessibilityModifier)
@@ -982,6 +1114,9 @@ public class Parser
 
     private ParameterSyntax ParseParameter()
     {
+        // ADR-0047: parameter-level annotations precede the identifier.
+        var annotations = ParseAnnotations();
+
         var identifier = MatchToken(SyntaxKind.IdentifierToken);
         SyntaxToken ellipsis = null;
         if (Current.Kind == SyntaxKind.EllipsisToken)
@@ -990,7 +1125,7 @@ public class Parser
         }
 
         var type = ParseTypeClause();
-        return new ParameterSyntax(syntaxTree, identifier, ellipsis, type);
+        return new ParameterSyntax(syntaxTree, identifier, ellipsis, type).WithAnnotations(annotations);
     }
 
     private TypeClauseSyntax ParseTypeClause()

--- a/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -367,6 +367,8 @@ public static class SyntaxFacts
                 return ">>";
             case SyntaxKind.ShiftRightEqualsToken:
                 return ">>=";
+            case SyntaxKind.AtToken:
+                return "@";
 
             // keywords
             case SyntaxKind.AsyncKeyword:

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -73,6 +73,9 @@ public enum SyntaxKind
     ShiftRightToken,
     ShiftRightEqualsToken,
 
+    // ADR-0047: annotation lead-in token
+    AtToken,
+
     // Built-in type tokens
     StringToken,
     InterpolatedStringToken,
@@ -222,6 +225,10 @@ public enum SyntaxKind
     // Issue #143: typeof / nameof contextual operators
     TypeOfExpression,
     NameOfExpression,
+
+    // Issue #141 / ADR-0047: attribute (annotation) syntax
+    Annotation,
+    AnnotationTarget,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/test/Core.Tests/CodeAnalysis/Syntax/AnnotationParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/AnnotationParserTests.cs
@@ -1,0 +1,272 @@
+// <copyright file="AnnotationParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Phase 1 of issue #141 / ADR-0047: lexer + parser support for Kotlin-style
+/// annotation lead-ins on declarations and parameters. The binder and
+/// emitter consume the parsed nodes in subsequent phases; these tests pin
+/// only the surface syntax.
+/// </summary>
+public class AnnotationParserTests
+{
+    [Fact]
+    public void Parses_Single_Annotation_On_Function_Without_Arguments()
+    {
+        const string source = @"
+package P
+
+@Serializable
+func Foo() {
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        var annotation = Assert.Single(fn.Annotations);
+        Assert.Equal("Serializable", annotation.GetNameText());
+        Assert.False(annotation.HasArgumentList);
+        Assert.Null(annotation.Target);
+    }
+
+    [Fact]
+    public void Parses_Annotation_With_Positional_And_Named_Arguments()
+    {
+        const string source = @"
+package P
+
+@AttributeUsage(AttributeTargets.Method, AllowMultiple = true)
+func Foo() {
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        var annotation = Assert.Single(fn.Annotations);
+        Assert.Equal("AttributeUsage", annotation.GetNameText());
+        Assert.True(annotation.HasArgumentList);
+        Assert.Equal(2, annotation.Arguments.Count);
+        Assert.IsType<NamedArgumentExpressionSyntax>(annotation.Arguments[1]);
+    }
+
+    [Fact]
+    public void Parses_Dotted_Annotation_Name()
+    {
+        const string source = @"
+package P
+
+@System.Diagnostics.Conditional(""DEBUG"")
+func Trace() {
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        var annotation = Assert.Single(fn.Annotations);
+        Assert.Equal("System.Diagnostics.Conditional", annotation.GetNameText());
+        Assert.Equal(3, annotation.NameSegments.Length);
+        Assert.Equal(2, annotation.DotTokens.Length);
+    }
+
+    [Fact]
+    public void Parses_Multiple_Stacked_Annotations()
+    {
+        const string source = @"
+package P
+
+@Obsolete(""use Bar"")
+@Conditional(""DEBUG"")
+func Foo() {
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        Assert.Equal(2, fn.Annotations.Length);
+        Assert.Equal("Obsolete", fn.Annotations[0].GetNameText());
+        Assert.Equal("Conditional", fn.Annotations[1].GetNameText());
+    }
+
+    [Theory]
+    [InlineData("field")]
+    [InlineData("param")]
+    [InlineData("return")]
+    [InlineData("type")]
+    [InlineData("method")]
+    [InlineData("property")]
+    [InlineData("event")]
+    [InlineData("module")]
+    [InlineData("assembly")]
+    [InlineData("genericparam")]
+    public void Parses_All_Canonical_Use_Site_Targets(string kind)
+    {
+        var source = $@"
+package P
+
+@{kind}:Foo
+func F() {{
+}}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        var annotation = Assert.Single(fn.Annotations);
+        Assert.NotNull(annotation.Target);
+        Assert.Equal(kind, annotation.Target.KindIdentifier.Text);
+        Assert.Equal("Foo", annotation.GetNameText());
+    }
+
+    [Fact]
+    public void Reports_Diagnostic_For_Unknown_Use_Site_Target()
+    {
+        const string source = @"
+package P
+
+@receiver:Foo
+func F() {
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Contains(tree.Diagnostics, d => d.Id == "GS0197");
+    }
+
+    [Fact]
+    public void Reports_Diagnostic_When_At_Is_Not_Followed_By_Name()
+    {
+        const string source = @"
+package P
+
+@ 123
+func F() {
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Contains(tree.Diagnostics, d => d.Id == "GS0196");
+    }
+
+    [Fact]
+    public void Parses_Annotation_On_Parameter()
+    {
+        const string source = @"
+package P
+
+func F(@NotNull x int) {
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        var param = fn.Parameters.Single();
+        var annotation = Assert.Single(param.Annotations);
+        Assert.Equal("NotNull", annotation.GetNameText());
+    }
+
+    [Fact]
+    public void Parses_Multiple_Annotations_On_Parameter_Including_Targeted()
+    {
+        const string source = @"
+package P
+
+func F(@param:NotNull @Cool(""yes"") x int) {
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        var param = fn.Parameters.Single();
+        Assert.Equal(2, param.Annotations.Length);
+        Assert.Equal("param", param.Annotations[0].Target.KindIdentifier.Text);
+        Assert.True(param.Annotations[1].HasArgumentList);
+    }
+
+    [Fact]
+    public void Annotation_With_No_Arguments_Equivalent_To_Empty_Parens()
+    {
+        const string source = @"
+package P
+
+@Marker
+@Marker()
+func F() {
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        Assert.Equal(2, fn.Annotations.Length);
+        Assert.False(fn.Annotations[0].HasArgumentList);
+        Assert.True(fn.Annotations[1].HasArgumentList);
+        Assert.Empty(fn.Annotations[1].Arguments);
+    }
+
+    [Fact]
+    public void Annotation_Then_Accessibility_Modifier_Then_Func()
+    {
+        const string source = @"
+package P
+
+@Marker
+public func F() {
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        Assert.Single(fn.Annotations);
+        Assert.NotNull(fn.AccessibilityModifier);
+        Assert.Equal("public", fn.AccessibilityModifier.Text);
+    }
+
+    [Fact]
+    public void Annotation_Allowed_Before_Struct_Declaration()
+    {
+        const string source = @"
+package P
+
+@Serializable
+type Point struct {
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        // `type Point struct { }` lowers in the parser to a
+        // StructDeclarationSyntax (not a TypeAliasDeclarationSyntax), but
+        // either way the annotation must round-trip on the MemberSyntax base.
+        var member = tree.Root.Members.OfType<MemberSyntax>().Single(m => m is StructDeclarationSyntax || m is TypeAliasDeclarationSyntax);
+        Assert.Single(member.Annotations);
+    }
+
+    [Fact]
+    public void Lexer_Produces_AtToken_For_At_Sign()
+    {
+        // Direct lexer check: `@` produces an AtToken with the expected text.
+        var sourceText = GSharp.Core.CodeAnalysis.Text.SourceText.From("@");
+        var tree = SyntaxTree.Parse(sourceText);
+        var token = tree.Root.GetChildren().SelectMany(EnumerateTokens).First(t => t.Text == "@");
+        Assert.Equal(SyntaxKind.AtToken, token.Kind);
+    }
+
+    private static System.Collections.Generic.IEnumerable<SyntaxToken> EnumerateTokens(SyntaxNode node)
+    {
+        if (node is SyntaxToken t)
+        {
+            yield return t;
+            yield break;
+        }
+
+        foreach (var child in node.GetChildren())
+        {
+            foreach (var inner in EnumerateTokens(child))
+            {
+                yield return inner;
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -9,9 +9,12 @@ AmpersandEqualsToken
 AmpersandHatEqualsToken
 AmpersandHatToken
 AmpersandToken
+Annotation
+AnnotationTarget
 ArrayCreationExpression
 AssignmentExpression
 AsyncKeyword
+AtToken
 AwaitExpression
 AwaitForRangeStatement
 AwaitKeyword


### PR DESCRIPTION
Implements Phase 1 of [ADR-0047](docs/adr/0047-attribute-syntax-and-declaration.md) for #141: the surface syntax for `@`-form annotations on members and parameters. The binder, emit, and interpreter remain untouched — annotations are dropped after parsing and will be wired up in subsequent phases.

## Scope

- `SyntaxKind.AtToken`, `Annotation`, `AnnotationTarget`
- Lexer emits `AtToken` for `@`
- New nodes: `AnnotationSyntax`, `AnnotationTargetSyntax`
- `MemberSyntax` and `ParameterSyntax` each carry an `Annotations` slot (set via `WithAnnotations(...)` after construction, so the existing concrete-node constructors don't change)
- Parser:
  - `ParseAnnotations()` runs at the top of `ParseMember` and `ParseParameter`
  - `ParseAnnotation()` handles `@[target:]Name[.Name]*[(args)]` with positional + named args
  - Use-site targets are contextual: `field`, `param`, `return`, `type`, `method`, `property`, `event`, `module`, `assembly`, `genericparam` — including reserved keywords `type` and `return` when followed by `:`
- Diagnostics:
  - **GS0196** annotation name expected after `@`
  - **GS0197** invalid use-site target
- Coverage matrix golden (`coverage-matrix.golden.txt`) and `docs/coverage-matrix.md` updated for the three new `SyntaxKind` values
- 13 parser tests in `AnnotationParserTests`

## Out of scope (follow-up phases)

- Phase 2 — binder lookup + diagnostics
- Phase 3 — emit `CustomAttribute` rows
- Phase 4 — `@Attribute` declaration sugar
- Phase 5 — migrate string-keyed compiler recognisers to type-identity
- Phase 6 — interpreter parity
- Phase 7 — docs

Annotations on Go-style receiver parameters are also deferred — the receiver lookahead is currently identifier-driven, and supporting `@` there cleanly is a self-contained follow-up.

## Verification

- `dotnet build src/Core -nologo -clp:NoSummary` — clean
- `dotnet test GSharp.sln --no-restore --nologo` — all 1265 tests pass (Core 1088, Compiler 134, Interpreter 26, LanguageServer 17)