### PR TITLE
Phase 2 of #141: binder + diagnostics for Kotlin-style annotations

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -206,6 +206,7 @@ AddressOfExpression
 AppendExpression
 ArrayCreationExpression
 AssignmentExpression
+Attribute
 AwaitExpression
 AwaitForRangeStatement
 BinaryExpression

--- a/src/Core/CodeAnalysis/Binding/AttributeTargetKind.cs
+++ b/src/Core/CodeAnalysis/Binding/AttributeTargetKind.cs
@@ -1,0 +1,41 @@
+// <copyright file="AttributeTargetKind.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Closed set of attribute use-site target kinds per ADR-0047 §2.
+/// </summary>
+public enum AttributeTargetKind
+{
+    /// <summary>The annotation targets a field metadata row.</summary>
+    Field,
+
+    /// <summary>The annotation targets a parameter metadata row.</summary>
+    Param,
+
+    /// <summary>The annotation targets a return-value metadata row.</summary>
+    Return,
+
+    /// <summary>The annotation targets a type metadata row.</summary>
+    Type,
+
+    /// <summary>The annotation targets a method metadata row.</summary>
+    Method,
+
+    /// <summary>The annotation targets a property metadata row.</summary>
+    Property,
+
+    /// <summary>The annotation targets an event metadata row.</summary>
+    Event,
+
+    /// <summary>The annotation targets the module metadata row.</summary>
+    Module,
+
+    /// <summary>The annotation targets the assembly metadata row.</summary>
+    Assembly,
+
+    /// <summary>The annotation targets a generic parameter metadata row.</summary>
+    GenericParam,
+}

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -24,6 +24,32 @@ public sealed class Binder
     private readonly List<(StructDeclarationSyntax Syntax, StructSymbol Symbol)> pendingInterfaceImplementationChecks
         = new List<(StructDeclarationSyntax, StructSymbol)>();
 
+    /// <summary>
+    /// Targets permitted on a function declaration (member or free):
+    /// <c>method</c> by default; <c>return</c> via use-site qualifier.
+    /// </summary>
+    private static readonly ImmutableHashSet<AttributeTargetKind> FunctionDeclarationAllowedTargets =
+        ImmutableHashSet.Create(AttributeTargetKind.Method, AttributeTargetKind.Return);
+
+    /// <summary>
+    /// Targets permitted on a parameter: only <c>param</c>.
+    /// </summary>
+    private static readonly ImmutableHashSet<AttributeTargetKind> ParameterAllowedTargets =
+        ImmutableHashSet.Create(AttributeTargetKind.Param);
+
+    /// <summary>
+    /// Targets permitted on a type-shaped declaration
+    /// (<c>struct</c> / <c>interface</c> / <c>enum</c> / type alias).
+    /// </summary>
+    private static readonly ImmutableHashSet<AttributeTargetKind> TypeDeclarationAllowedTargets =
+        ImmutableHashSet.Create(AttributeTargetKind.Type);
+
+    /// <summary>
+    /// Targets permitted on a field declaration: only <c>field</c>.
+    /// </summary>
+    private static readonly ImmutableHashSet<AttributeTargetKind> FieldDeclarationAllowedTargets =
+        ImmutableHashSet.Create(AttributeTargetKind.Field);
+
     private FunctionSymbol function;
 
     private Stack<(BoundLabel BreakLabel, BoundLabel ContinueLabel)> loopStack = new Stack<(BoundLabel BreakLabel, BoundLabel ContinueLabel)>();
@@ -453,6 +479,16 @@ public sealed class Binder
             return;
         }
 
+        // Issue #141 / ADR-0047: type aliases accept annotations syntactically;
+        // since the alias has no dedicated symbol of its own, the resolved
+        // attribute list is reported for diagnostics and otherwise dropped
+        // until v2 introduces a richer alias-symbol shape.
+        BindAttributes(
+            syntax.Annotations,
+            AttributeTargetKind.Type,
+            TypeDeclarationAllowedTargets,
+            "a type alias declaration");
+
         if (!scope.TryDeclareTypeAlias(name, aliasedType))
         {
             Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
@@ -471,6 +507,11 @@ public sealed class Binder
 
         var accessibility = ResolveAccessibility(syntax.AccessibilityModifier);
         var enumSymbol = new EnumSymbol(name, accessibility, package.Name, syntax);
+        enumSymbol.SetAttributes(BindAttributes(
+            syntax.Annotations,
+            AttributeTargetKind.Type,
+            TypeDeclarationAllowedTargets,
+            "an enum declaration"));
 
         var seenMemberNames = new HashSet<string>();
         var members = ImmutableArray.CreateBuilder<EnumMemberSymbol>();
@@ -695,6 +736,12 @@ public sealed class Binder
             structSymbol.SetTypeParameters(typeParameters);
         }
 
+        structSymbol.SetAttributes(BindAttributes(
+            syntax.Annotations,
+            AttributeTargetKind.Type,
+            TypeDeclarationAllowedTargets,
+            syntax.IsClass ? "a class declaration" : "a struct declaration"));
+
         if (!scope.TryDeclareTypeAlias(name, structSymbol))
         {
             Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
@@ -849,6 +896,11 @@ public sealed class Binder
         var name = syntax.Identifier.Text;
         var accessibility = ResolveAccessibility(syntax.AccessibilityModifier);
         var interfaceSymbol = new InterfaceSymbol(name, accessibility, syntax, package.Name);
+        interfaceSymbol.SetAttributes(BindAttributes(
+            syntax.Annotations,
+            AttributeTargetKind.Type,
+            TypeDeclarationAllowedTargets,
+            "an interface declaration"));
 
         // Phase 4.3c / ADR-0020: bind type parameters at declaration time so
         // method-signature binding (which happens later) can resolve them.
@@ -1091,6 +1143,28 @@ public sealed class Binder
             var type = BindReturnTypeClause(syntax.Type, syntax.IsAsync) ?? TypeSymbol.Void;
 
             var accessibility = ResolveAccessibility(syntax.AccessibilityModifier);
+
+            // Issue #141 / ADR-0047: resolve annotation lead-ins for this
+            // declaration. We do this once per function regardless of whether
+            // it is an extension, a method, or a free function — diagnostics
+            // and the resulting bound-attribute list are identical.
+            var functionAttributes = BindAttributes(
+                syntax.Annotations,
+                AttributeTargetKind.Method,
+                FunctionDeclarationAllowedTargets,
+                "a function declaration");
+
+            // Per-parameter annotations: each ParameterSyntax owns its own
+            // annotation list; the default target is `param`.
+            foreach (var parameterSyntax in syntax.Parameters)
+            {
+                BindAttributes(
+                    parameterSyntax.Annotations,
+                    AttributeTargetKind.Param,
+                    ParameterAllowedTargets,
+                    "a parameter declaration");
+            }
+
             FunctionSymbol function;
             if (methodReceiverStruct != null)
             {
@@ -1118,6 +1192,7 @@ public sealed class Binder
                     explicitReceiverParameter);
                 function.TypeParameters = typeParameters;
                 function.IsAsync = syntax.IsAsync || IsAsyncIteratorReturnType(type);
+                function.SetAttributes(functionAttributes);
                 methodReceiverStruct.AddMethods(ImmutableArray.Create(function));
                 return;
             }
@@ -1125,6 +1200,7 @@ public sealed class Binder
             function = new FunctionSymbol(syntax.Identifier.Text, parameters.ToImmutable(), type, syntax, package, accessibility);
             function.TypeParameters = typeParameters;
             function.IsAsync = syntax.IsAsync || IsAsyncIteratorReturnType(type);
+            function.SetAttributes(functionAttributes);
 
             if (syntax.IsExtension)
             {
@@ -6438,6 +6514,232 @@ public sealed class Binder
         return packagesInOrder.Count > 0
             ? packagesInOrder[0]
             : new PackageSymbol("Default", declaration: null);
+    }
+
+    /// <summary>
+    /// Resolves a list of <see cref="AnnotationSyntax"/> nodes against the
+    /// declaring scope and returns the bound attribute list per ADR-0047.
+    /// </summary>
+    /// <param name="annotations">Annotations from the declaration's syntax node.</param>
+    /// <param name="defaultTarget">Default target inferred from the declaration position.</param>
+    /// <param name="allowedTargets">Target kinds permitted at this declaration position.</param>
+    /// <param name="positionDescription">Human-readable position for diagnostics.</param>
+    /// <returns>The resolved attribute list (skipping unresolved entries).</returns>
+    private ImmutableArray<BoundAttribute> BindAttributes(
+        ImmutableArray<AnnotationSyntax> annotations,
+        AttributeTargetKind defaultTarget,
+        ImmutableHashSet<AttributeTargetKind> allowedTargets,
+        string positionDescription)
+    {
+        if (annotations.IsDefaultOrEmpty)
+        {
+            return ImmutableArray<BoundAttribute>.Empty;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<BoundAttribute>(annotations.Length);
+        foreach (var annotation in annotations)
+        {
+            var bound = BindAttribute(annotation, defaultTarget, allowedTargets, positionDescription);
+            if (bound != null)
+            {
+                builder.Add(bound);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private BoundAttribute BindAttribute(
+        AnnotationSyntax annotation,
+        AttributeTargetKind defaultTarget,
+        ImmutableHashSet<AttributeTargetKind> allowedTargets,
+        string positionDescription)
+    {
+        // 1) Resolve target — parser already filtered to canonical kinds; if
+        // the user wrote an unrecognised one a GS0197 was already reported,
+        // but we still need to map a parsed-but-unknown string back to a
+        // sentinel. The closed set keys off ADR-0047 §2.
+        var targetKind = defaultTarget;
+        if (annotation.Target != null)
+        {
+            if (TryParseTargetKind(annotation.Target.KindIdentifier.Text, out var parsedTarget))
+            {
+                targetKind = parsedTarget;
+            }
+            else
+            {
+                // Already reported by the parser; treat as default and continue.
+            }
+
+            if (!allowedTargets.Contains(targetKind))
+            {
+                Diagnostics.ReportAttributeTargetInvalidForPosition(
+                    annotation.Target.KindIdentifier.Location,
+                    annotation.Target.KindIdentifier.Text,
+                    positionDescription);
+            }
+        }
+
+        // 2) Resolve attribute type (C#-style: `Foo` then `FooAttribute`).
+        var nameText = annotation.GetNameText();
+        var attrType = ResolveAttributeType(nameText, annotation, out var nameIsExact);
+        if (attrType == null)
+        {
+            return null;
+        }
+
+        // 3) Validate it derives from System.Attribute.
+        if (!IsAttributeType(attrType))
+        {
+            var displayName = nameIsExact ? nameText : (nameText + "Attribute");
+            Diagnostics.ReportNotAnAttributeType(GetAnnotationNameLocation(annotation), displayName);
+            return null;
+        }
+
+        // 4) Bind arguments — positional + named — restricted to compile-time
+        // constants. Named arguments come back from ParseArguments as
+        // NamedArgumentExpressionSyntax wrappers.
+        var positional = ImmutableArray.CreateBuilder<BoundAttributeArgument>();
+        var named = ImmutableArray.CreateBuilder<BoundAttributeArgument>();
+        if (annotation.Arguments != null)
+        {
+            foreach (var argSyntax in annotation.Arguments)
+            {
+                if (argSyntax is NamedArgumentExpressionSyntax namedArg)
+                {
+                    var bound = TryBindAttributeConstant(namedArg.Expression);
+                    if (bound == null)
+                    {
+                        Diagnostics.ReportAttributeArgumentNotConstant(namedArg.Expression.Location);
+                        continue;
+                    }
+
+                    named.Add(new BoundAttributeArgument(namedArg.NameToken.Text, bound.Value, bound.Type));
+                }
+                else
+                {
+                    var bound = TryBindAttributeConstant(argSyntax);
+                    if (bound == null)
+                    {
+                        Diagnostics.ReportAttributeArgumentNotConstant(argSyntax.Location);
+                        continue;
+                    }
+
+                    positional.Add(new BoundAttributeArgument(name: null, bound.Value, bound.Type));
+                }
+            }
+        }
+
+        return new BoundAttribute(annotation, attrType, targetKind, positional.ToImmutable(), named.ToImmutable());
+    }
+
+    private TypeSymbol ResolveAttributeType(string name, AnnotationSyntax annotation, out bool nameIsExact)
+    {
+        var nameLocation = GetAnnotationNameLocation(annotation);
+        nameIsExact = true;
+
+        // The dotted form (e.g. `System.Obsolete`) is not yet routed through
+        // LookupType — fall back to a CLR walk by full name. v1 keeps
+        // resolution focused on the single-identifier form; dotted names
+        // remain a follow-up.
+        var direct = LookupType(name);
+        TypeSymbol suffixed = null;
+        if (!string.IsNullOrEmpty(name) && !name.EndsWith("Attribute", StringComparison.Ordinal))
+        {
+            suffixed = LookupType(name + "Attribute");
+        }
+
+        if (direct != null && IsAttributeType(direct) && suffixed != null && IsAttributeType(suffixed))
+        {
+            Diagnostics.ReportAmbiguousAttributeName(nameLocation, name);
+            return direct;
+        }
+
+        if (direct != null)
+        {
+            nameIsExact = true;
+            return direct;
+        }
+
+        if (suffixed != null)
+        {
+            nameIsExact = false;
+            return suffixed;
+        }
+
+        Diagnostics.ReportAttributeTypeNotFound(nameLocation, name);
+        return null;
+    }
+
+    private static bool IsAttributeType(TypeSymbol typeSymbol)
+    {
+        var clr = typeSymbol?.ClrType;
+        if (clr == null)
+        {
+            return false;
+        }
+
+        var attributeFullName = typeof(System.Attribute).FullName;
+        for (var t = clr; t != null; t = t.BaseType)
+        {
+            if (t.FullName == attributeFullName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static TextLocation GetAnnotationNameLocation(AnnotationSyntax annotation)
+    {
+        if (!annotation.NameSegments.IsDefaultOrEmpty)
+        {
+            var first = annotation.NameSegments[0];
+            var last = annotation.NameSegments[annotation.NameSegments.Length - 1];
+            var span = TextSpan.FromBounds(first.Span.Start, last.Span.End);
+            return new TextLocation(annotation.SyntaxTree.Text, span);
+        }
+
+        return annotation.Location;
+    }
+
+    private static bool TryParseTargetKind(string text, out AttributeTargetKind kind)
+    {
+        switch (text)
+        {
+            case "field": kind = AttributeTargetKind.Field; return true;
+            case "param": kind = AttributeTargetKind.Param; return true;
+            case "return": kind = AttributeTargetKind.Return; return true;
+            case "type": kind = AttributeTargetKind.Type; return true;
+            case "method": kind = AttributeTargetKind.Method; return true;
+            case "property": kind = AttributeTargetKind.Property; return true;
+            case "event": kind = AttributeTargetKind.Event; return true;
+            case "module": kind = AttributeTargetKind.Module; return true;
+            case "assembly": kind = AttributeTargetKind.Assembly; return true;
+            case "genericparam": kind = AttributeTargetKind.GenericParam; return true;
+            default: kind = AttributeTargetKind.Method; return false;
+        }
+    }
+
+    /// <summary>
+    /// Tries to bind an attribute argument expression as a compile-time
+    /// constant. v1 accepts only direct literal-shaped expressions
+    /// (numbers, strings, chars, bool, nil); broader constant folding —
+    /// <c>typeof(T)</c>, enum member access, array literals, signed
+    /// numeric literals — is a follow-up once the corresponding binder
+    /// paths land in Phase 3 / Phase 5.
+    /// </summary>
+    /// <param name="syntax">The argument expression.</param>
+    /// <returns>The bound literal, or <c>null</c> if not a recognised constant.</returns>
+    private BoundLiteralExpression TryBindAttributeConstant(ExpressionSyntax syntax)
+    {
+        if (syntax is LiteralExpressionSyntax literal)
+        {
+            return BindExpression(literal) as BoundLiteralExpression;
+        }
+
+        return null;
     }
 
     private sealed class CapturedVariableCollector : BoundTreeRewriter

--- a/src/Core/CodeAnalysis/Binding/BoundAttribute.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundAttribute.cs
@@ -1,0 +1,67 @@
+// <copyright file="BoundAttribute.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// A bound attribute application — the result of resolving an
+/// <see cref="AnnotationSyntax"/> against the declaring scope per
+/// ADR-0047 §3.
+/// </summary>
+public sealed class BoundAttribute : BoundNode
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundAttribute"/> class.
+    /// </summary>
+    /// <param name="syntax">The originating syntax node.</param>
+    /// <param name="attributeType">The resolved <see cref="System.Attribute"/>-derived type.</param>
+    /// <param name="target">The use-site target (defaulted from declaration position when omitted).</param>
+    /// <param name="positionalArguments">Positional constructor arguments in source order.</param>
+    /// <param name="namedArguments">Named property/field arguments in source order.</param>
+    public BoundAttribute(
+        AnnotationSyntax syntax,
+        TypeSymbol attributeType,
+        AttributeTargetKind target,
+        ImmutableArray<BoundAttributeArgument> positionalArguments,
+        ImmutableArray<BoundAttributeArgument> namedArguments)
+    {
+        Syntax = syntax;
+        AttributeType = attributeType;
+        Target = target;
+        PositionalArguments = positionalArguments;
+        NamedArguments = namedArguments;
+    }
+
+    /// <inheritdoc/>
+    public override BoundNodeKind Kind => BoundNodeKind.Attribute;
+
+    /// <summary>
+    /// Gets the originating annotation syntax.
+    /// </summary>
+    public AnnotationSyntax Syntax { get; }
+
+    /// <summary>
+    /// Gets the resolved attribute type.
+    /// </summary>
+    public TypeSymbol AttributeType { get; }
+
+    /// <summary>
+    /// Gets the effective use-site target.
+    /// </summary>
+    public AttributeTargetKind Target { get; }
+
+    /// <summary>
+    /// Gets the bound positional arguments in source order.
+    /// </summary>
+    public ImmutableArray<BoundAttributeArgument> PositionalArguments { get; }
+
+    /// <summary>
+    /// Gets the bound named arguments in source order.
+    /// </summary>
+    public ImmutableArray<BoundAttributeArgument> NamedArguments { get; }
+}

--- a/src/Core/CodeAnalysis/Binding/BoundAttributeArgument.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundAttributeArgument.cs
@@ -1,0 +1,45 @@
+// <copyright file="BoundAttributeArgument.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// A single argument to a bound attribute application — either a positional
+/// constructor argument (<see cref="Name"/> is <c>null</c>) or a named
+/// argument that binds to a public field or property on the attribute type.
+/// Per ADR-0047 §3 / ECMA-335 II.23.3 only compile-time constants of the
+/// recognised attribute-argument value space are permitted.
+/// </summary>
+public sealed class BoundAttributeArgument
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundAttributeArgument"/> class.
+    /// </summary>
+    /// <param name="name">Property/field name for named arguments; <c>null</c> for positional.</param>
+    /// <param name="value">The constant value of the argument.</param>
+    /// <param name="type">The static type of the argument.</param>
+    public BoundAttributeArgument(string name, object value, TypeSymbol type)
+    {
+        Name = name;
+        Value = value;
+        Type = type;
+    }
+
+    /// <summary>
+    /// Gets the field or property name for a named argument, or <c>null</c> for a positional argument.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the compile-time constant value of the argument.
+    /// </summary>
+    public object Value { get; }
+
+    /// <summary>
+    /// Gets the static type of the argument.
+    /// </summary>
+    public TypeSymbol Type { get; }
+}

--- a/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -102,6 +102,9 @@ public enum BoundNodeKind
     YieldStatement,
     AwaitYieldPoint,
     AwaitResumePoint,
+
+    // Issue #141 / ADR-0047: attribute application (annotation in source).
+    Attribute,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1160,6 +1160,63 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0197", $"Annotation target '{kind}' is not a recognized use-site kind. Expected one of: field, param, return, type, method, property, event, module, assembly, genericparam.");
     }
 
+    /// <summary>
+    /// Reports an annotation whose name cannot be resolved to any type
+    /// reachable from the declaring scope (ADR-0047 §3).
+    /// </summary>
+    /// <param name="location">The source location of the offending annotation name.</param>
+    /// <param name="name">The unresolved annotation name as written in source.</param>
+    public void ReportAttributeTypeNotFound(TextLocation location, string name)
+    {
+        Report(location, "GS0198", $"Attribute type '{name}' could not be found. Looked up both '{name}' and '{name}Attribute'.");
+    }
+
+    /// <summary>
+    /// Reports an annotation whose name resolves to both <c>Foo</c> and
+    /// <c>FooAttribute</c> in the declaring scope (ADR-0047 §3). The user
+    /// must qualify the name to disambiguate.
+    /// </summary>
+    /// <param name="location">The source location of the offending annotation name.</param>
+    /// <param name="name">The ambiguous annotation name as written in source.</param>
+    public void ReportAmbiguousAttributeName(TextLocation location, string name)
+    {
+        Report(location, "GS0199", $"Attribute name '{name}' is ambiguous between '{name}' and '{name}Attribute'. Qualify the name to disambiguate.");
+    }
+
+    /// <summary>
+    /// Reports an annotation whose resolved type does not derive from
+    /// <c>System.Attribute</c> (ADR-0047 §3).
+    /// </summary>
+    /// <param name="location">The source location of the offending annotation.</param>
+    /// <param name="typeName">The type name that fails the attribute check.</param>
+    public void ReportNotAnAttributeType(TextLocation location, string typeName)
+    {
+        Report(location, "GS0200", $"Type '{typeName}' is not an attribute class (it does not derive from System.Attribute).");
+    }
+
+    /// <summary>
+    /// Reports a use-site target qualifier that is valid in isolation but
+    /// not permitted at the current declaration position (ADR-0047 §4).
+    /// </summary>
+    /// <param name="location">The source location of the offending target.</param>
+    /// <param name="kind">The disallowed target kind text.</param>
+    /// <param name="position">A human-readable description of the declaration position.</param>
+    public void ReportAttributeTargetInvalidForPosition(TextLocation location, string kind, string position)
+    {
+        Report(location, "GS0201", $"Attribute target '{kind}' is not valid on {position}.");
+    }
+
+    /// <summary>
+    /// Reports an attribute argument whose value cannot be reduced to a
+    /// compile-time constant of the recognised attribute-argument value
+    /// space (ADR-0047 §3 / ECMA-335 II.23.3).
+    /// </summary>
+    /// <param name="location">The source location of the offending argument.</param>
+    public void ReportAttributeArgumentNotConstant(TextLocation location)
+    {
+        Report(location, "GS0202", "Attribute arguments must be compile-time constants (primitive, string, typeof, enum, or 1-D array thereof).");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Symbols/Symbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/Symbol.cs
@@ -2,7 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System.Collections.Immutable;
 using System.IO;
+using GSharp.Core.CodeAnalysis.Binding;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
@@ -31,6 +33,12 @@ public abstract class Symbol
     public string Name { get; }
 
     /// <summary>
+    /// Gets the user-written attributes attached to this symbol per ADR-0047.
+    /// Defaults to empty; populated by the binder during declaration binding.
+    /// </summary>
+    public ImmutableArray<BoundAttribute> Attributes { get; private set; } = ImmutableArray<BoundAttribute>.Empty;
+
+    /// <summary>
     /// Writes the symbol to the specified text writer.
     /// </summary>
     /// <param name="writer">The writer to write the symbol to.</param>
@@ -50,5 +58,15 @@ public abstract class Symbol
             WriteTo(writer);
             return writer.ToString();
         }
+    }
+
+    /// <summary>
+    /// Sets the bound-attribute list for this symbol. Called by the binder
+    /// once attribute resolution for the owning declaration completes.
+    /// </summary>
+    /// <param name="attributes">The bound attributes to attach.</param>
+    internal void SetAttributes(ImmutableArray<BoundAttribute> attributes)
+    {
+        Attributes = attributes;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
@@ -1,0 +1,148 @@
+// <copyright file="AttributeBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Tests for ADR-0047 Phase 2 attribute binding: name resolution against the
+/// declaring scope, use-site target validation, and compile-time constant
+/// argument checking. Annotations on type aliases and parameters are bound
+/// for diagnostics; the bound-attribute list itself is asserted via the
+/// owning <see cref="GSharp.Core.CodeAnalysis.Symbols.Symbol.Attributes"/>
+/// slot for functions, structs, and interfaces.
+/// </summary>
+public class AttributeBinderTests
+{
+    [Fact]
+    public void Resolves_Obsolete_With_Attribute_Suffix()
+    {
+        // `@Obsolete` resolves to System.ObsoleteAttribute via the suffix rule.
+        var globalScope = BindSource("@Obsolete\nfunc Helper() {\n}\n");
+        var helper = globalScope.Functions.Single(f => f.Name == "Helper");
+
+        Assert.Single(helper.Attributes);
+        Assert.Equal("System.ObsoleteAttribute", helper.Attributes[0].AttributeType.Name);
+        Assert.Equal(AttributeTargetKind.Method, helper.Attributes[0].Target);
+        Assert.Empty(GetBinderDiagnostics(globalScope));
+    }
+
+    [Fact]
+    public void Resolves_Obsolete_With_Message_Argument()
+    {
+        var globalScope = BindSource("@Obsolete(\"use Bar instead\")\nfunc Foo() {\n}\n");
+        var foo = globalScope.Functions.Single(f => f.Name == "Foo");
+
+        var attr = Assert.Single(foo.Attributes);
+        var posArg = Assert.Single(attr.PositionalArguments);
+        Assert.Equal("use Bar instead", posArg.Value);
+        Assert.Empty(GetBinderDiagnostics(globalScope));
+    }
+
+    [Fact]
+    public void Reports_Unknown_Attribute_Type()
+    {
+        var globalScope = BindSource("@DoesNotExistAnywhere\nfunc Helper() {\n}\n");
+
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0198");
+        var helper = globalScope.Functions.Single(f => f.Name == "Helper");
+        Assert.Empty(helper.Attributes);
+    }
+
+    [Fact]
+    public void Reports_When_Type_Is_Not_An_Attribute()
+    {
+        // `int` resolves but is not a System.Attribute subclass — must report GS0200.
+        var globalScope = BindSource("@int\nfunc Helper() {\n}\n");
+
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0200");
+    }
+
+    [Fact]
+    public void Reports_Invalid_Use_Site_Target_On_Function()
+    {
+        // `@field:` is not valid on a function declaration.
+        var globalScope = BindSource("@field:Obsolete\nfunc Helper() {\n}\n");
+
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0201");
+    }
+
+    [Fact]
+    public void Allows_Return_Use_Site_Target_On_Function()
+    {
+        var globalScope = BindSource("@return:Obsolete\nfunc Helper() {\n}\n");
+
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0201");
+        var helper = globalScope.Functions.Single(f => f.Name == "Helper");
+        var attr = Assert.Single(helper.Attributes);
+        Assert.Equal(AttributeTargetKind.Return, attr.Target);
+    }
+
+    [Fact]
+    public void Reports_Non_Constant_Attribute_Argument()
+    {
+        // A nameof(...) expression isn't a recognised literal-shaped constant
+        // for v1 — it must report GS0202.
+        var globalScope = BindSource("@Obsolete(nameof(Helper))\nfunc Helper() {\n}\n");
+
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0202");
+    }
+
+    [Fact]
+    public void Attaches_Attributes_To_Struct_Symbol()
+    {
+        var source = @"
+@Obsolete
+type Point struct {
+    X int
+    Y int
+}
+";
+        var globalScope = BindSource(source);
+        var point = globalScope.Structs.Single(t => t.Name == "Point");
+
+        Assert.Single(point.Attributes);
+        Assert.Equal(AttributeTargetKind.Type, point.Attributes[0].Target);
+    }
+
+    [Fact]
+    public void Reports_Invalid_Use_Site_Target_On_Struct()
+    {
+        var source = @"
+@method:Obsolete
+type Point struct {
+    X int
+}
+";
+        var globalScope = BindSource(source);
+
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0201");
+    }
+
+    [Fact]
+    public void Binds_Multiple_Stacked_Annotations()
+    {
+        var globalScope = BindSource("@Obsolete\n@Obsolete(\"again\")\nfunc Helper() {\n}\n");
+        var helper = globalScope.Functions.Single(f => f.Name == "Helper");
+
+        Assert.Equal(2, helper.Attributes.Length);
+    }
+
+    private static BoundGlobalScope BindSource(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+
+    private static System.Collections.Generic.IEnumerable<GSharp.Core.CodeAnalysis.Diagnostic> GetBinderDiagnostics(BoundGlobalScope scope)
+    {
+        return scope.Diagnostics;
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -206,6 +206,7 @@ AddressOfExpression
 AppendExpression
 ArrayCreationExpression
 AssignmentExpression
+Attribute
 AwaitExpression
 AwaitForRangeStatement
 AwaitResumePoint


### PR DESCRIPTION
Implements Phase 2 of [ADR-0047](docs/adr/0047-attribute-syntax-and-declaration.md) for #141: the binder now resolves `@`-form annotations against the declaring scope, validates use-site targets, and attaches a bound attribute list to each member symbol. Emit (Phase 3), declaration sugar (Phase 4), recogniser migration (Phase 5), and interpreter parity (Phase 6) follow.

## Scope

- New IR: `BoundAttribute`, `BoundAttributeArgument`
- New `AttributeTargetKind` enum (closed set of 10 kinds per ADR-0047 §2)
- `Symbol.Attributes` slot (`ImmutableArray<BoundAttribute>`, default empty) with internal setter
- `Binder.BindAttributes`:
  - Resolves the annotation name as `Foo` then `FooAttribute` (C# rule)
  - Reports ambiguity if both resolve and both derive from `System.Attribute`
  - Verifies the resolved type derives from `System.Attribute`
  - Validates the use-site target against the declaration position
  - Binds positional + named arguments restricted to literal-shaped compile-time constants
- Wired into binding of:
  - Functions (default `method`; `return` allowed via qualifier)
  - Parameters (default `param`)
  - Structs / classes (default `type`)
  - Interfaces (default `type`)
  - Enums (default `type`)
  - Type aliases (default `type`; bound for diagnostics, list dropped — alias has no own symbol)
- Diagnostics:
  - **GS0198** attribute type not found
  - **GS0199** ambiguous `Foo` vs `FooAttribute`
  - **GS0200** not an attribute class (does not derive from `System.Attribute`)
  - **GS0201** invalid use-site target for the declaration position
  - **GS0202** attribute argument not compile-time constant
- `BoundNodeKind.Attribute` added; coverage matrix golden + `docs/coverage-matrix.md` updated
- 10 new tests in `AttributeBinderTests`

## Out of scope (follow-ups)

- Field-level annotations — `FieldDeclarationSyntax` doesn't yet carry an `Annotations` slot (Phase 1 only added it on `MemberSyntax` and `ParameterSyntax`). Will be picked up in a small follow-up.
- `[Obsolete]` use-site warning — lands together with the recogniser migration in Phase 5.
- Full constructor overload resolution against the resolved attribute type (v1 records args as-typed).
- Dotted attribute names (e.g. `@System.Obsolete`).
- Non-literal compile-time constants (`typeof(T)`, enum members, 1-D array literals) — broader constant binding lands alongside the typeof work in Phase 3.

## Verification

- `dotnet build src/Core -nologo -clp:NoSummary` — clean
- `dotnet test GSharp.sln --no-restore --nologo` — all 1275 tests pass (Core 1098, Compiler 134, Interpreter 26, LanguageServer 17)