### PR TITLE
Phase 4 of #141: @Attribute declaration sugar

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -657,6 +657,12 @@ public sealed class Binder
             }
         }
 
+        // Phase 4 of #141 / ADR-0047 §5: detect the `@Attribute` declaration
+        // sugar marker before resolving the base clause so we can tolerate
+        // an explicit `: System.Attribute` (redundant restatement) and reject
+        // any conflicting explicit base.
+        var hasAttributeSugar = HasAttributeSugarMarker(syntax.Annotations);
+
         // Phase 3.B.3 sub-step 3 + 3.B.4: resolve the optional `: X, Y, Z` clause.
         // Each identifier is either the (single) base class or an interface
         // implemented by this class. A base class, if present, must be the
@@ -683,6 +689,16 @@ public sealed class Binder
                 {
                     var token = allBaseTokens[i];
                     var baseName = token.Text;
+
+                    // Phase 4 of #141: tolerate an explicit `: Attribute` on an
+                    // @Attribute-marked class (redundant restatement). The
+                    // System.Attribute base is supplied by the emitter.
+                    if (hasAttributeSugar && i == 0
+                        && (baseName == "Attribute" || baseName == "System.Attribute"))
+                    {
+                        continue;
+                    }
+
                     if (!scope.TryLookupTypeAlias(baseName, out var resolved))
                     {
                         Diagnostics.ReportUnableToFindType(token.Location, baseName);
@@ -700,6 +716,14 @@ public sealed class Binder
                         if (i != 0)
                         {
                             Diagnostics.ReportUnableToFindType(token.Location, baseName);
+                            continue;
+                        }
+
+                        if (hasAttributeSugar)
+                        {
+                            // Phase 4 of #141 / ADR-0047 §5: @Attribute sugar
+                            // forces System.Attribute as the base; conflict.
+                            Diagnostics.ReportAttributeClassExplicitBase(token.Location, baseName);
                             continue;
                         }
 
@@ -741,6 +765,13 @@ public sealed class Binder
             AttributeTargetKind.Type,
             TypeDeclarationAllowedTargets,
             syntax.IsClass ? "a class declaration" : "a struct declaration"));
+
+        if (hasAttributeSugar && syntax.IsClass)
+        {
+            // Phase 4 of #141 / ADR-0047 §5: tag the class so the emitter
+            // overrides its CLR base type to System.Attribute.
+            structSymbol.SetIsAttributeClass();
+        }
 
         if (!scope.TryDeclareTypeAlias(name, structSymbol))
         {
@@ -6517,6 +6548,64 @@ public sealed class Binder
     }
 
     /// <summary>
+    /// Phase 4 of #141 / ADR-0047 §5: returns true if any annotation in the
+    /// list is the bare <c>@Attribute</c> sugar marker (single-segment name
+    /// <c>Attribute</c>, no use-site target qualifier).
+    /// </summary>
+    /// <param name="annotations">Annotations from the declaration's syntax node.</param>
+    /// <returns>True if the marker is present.</returns>
+    private static bool HasAttributeSugarMarker(ImmutableArray<AnnotationSyntax> annotations)
+    {
+        if (annotations.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        foreach (var annotation in annotations)
+        {
+            // ADR-0047 §5: the sugar marker is exactly `@Attribute` (no
+            // use-site target qualifier; no arguments; single-segment name).
+            if (annotation.Target != null)
+            {
+                continue;
+            }
+
+            if (annotation.NameSegments.Length != 1)
+            {
+                continue;
+            }
+
+            if (annotation.NameSegments[0].Text == "Attribute")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Phase 4 of #141 / ADR-0047 §5: returns true if <paramref name="annotation"/>
+    /// is the bare <c>@Attribute</c> sugar marker.
+    /// </summary>
+    /// <param name="annotation">The annotation node to test.</param>
+    /// <returns>True for the marker.</returns>
+    private static bool IsAttributeSugarMarker(AnnotationSyntax annotation)
+    {
+        if (annotation == null || annotation.Target != null)
+        {
+            return false;
+        }
+
+        if (annotation.NameSegments.Length != 1)
+        {
+            return false;
+        }
+
+        return annotation.NameSegments[0].Text == "Attribute";
+    }
+
+    /// <summary>
     /// Resolves a list of <see cref="AnnotationSyntax"/> nodes against the
     /// declaring scope and returns the bound attribute list per ADR-0047.
     /// </summary>
@@ -6539,6 +6628,15 @@ public sealed class Binder
         var builder = ImmutableArray.CreateBuilder<BoundAttribute>(annotations.Length);
         foreach (var annotation in annotations)
         {
+            // Phase 4 of #141 / ADR-0047 §5: the `@Attribute` marker on a
+            // class declaration is sugar — it does NOT participate in the
+            // emitted CustomAttribute table. The struct binder consumes it
+            // separately via HasAttributeSugarMarker.
+            if (defaultTarget == AttributeTargetKind.Type && IsAttributeSugarMarker(annotation))
+            {
+                continue;
+            }
+
             var bound = BindAttribute(annotation, defaultTarget, allowedTargets, positionDescription);
             if (bound != null)
             {

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1217,6 +1217,20 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0202", "Attribute arguments must be compile-time constants (primitive, string, typeof, enum, or 1-D array thereof).");
     }
 
+    /// <summary>
+    /// Reports a class declaration tagged with the <c>@Attribute</c>
+    /// declaration sugar (ADR-0047 §5) that already declares an explicit
+    /// base class other than <c>System.Attribute</c>. The implicit
+    /// <c>System.Attribute</c> base imposed by the sugar conflicts with
+    /// the user-supplied base.
+    /// </summary>
+    /// <param name="location">The location of the offending base-class identifier.</param>
+    /// <param name="baseName">The user-supplied base-class name.</param>
+    public void ReportAttributeClassExplicitBase(TextLocation location, string baseName)
+    {
+        Report(location, "GS0203", $"Class is tagged @Attribute and cannot also declare an explicit base class '{baseName}'. The @Attribute sugar implies ': System.Attribute'.");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -133,6 +133,8 @@ internal sealed class ReflectionMetadataEmitter
     private MemberReferenceHandle objectInstanceToStringRef;
     private MemberReferenceHandle objectInstanceGetHashCodeRef;
     private MemberReferenceHandle nullRefExceptionCtorRef;
+    private EntityHandle? systemAttributeTypeRef;
+    private MemberReferenceHandle? systemAttributeCtorRef;
 
     private ReflectionMetadataEmitter(BoundProgram program, ReferenceResolver references, string assemblyName, bool metadataOnly)
     {
@@ -965,7 +967,13 @@ internal sealed class ReflectionMetadataEmitter
             }
 
             typeAttrs = classAttrs;
-            if (structSym.BaseClass != null && this.structTypeDefs.TryGetValue(structSym.BaseClass, out var baseHandle))
+            if (structSym.IsAttributeClass)
+            {
+                // Phase 4 of #141 / ADR-0047 §5: @Attribute sugar — base is
+                // System.Attribute, regardless of any other resolution.
+                baseType = this.GetSystemAttributeTypeRef();
+            }
+            else if (structSym.BaseClass != null && this.structTypeDefs.TryGetValue(structSym.BaseClass, out var baseHandle))
             {
                 baseType = baseHandle;
             }
@@ -1617,7 +1625,45 @@ internal sealed class ReflectionMetadataEmitter
             return baseCtor;
         }
 
+        if (classSym.IsAttributeClass)
+        {
+            // Phase 4 of #141 / ADR-0047 §5: chain to System.Attribute..ctor()
+            // since the base type was overridden away from System.Object.
+            return this.GetSystemAttributeCtorRef();
+        }
+
         return this.objectCtorRef;
+    }
+
+    private EntityHandle GetSystemAttributeTypeRef()
+    {
+        if (!this.systemAttributeTypeRef.HasValue)
+        {
+            var t = this.references.TryResolveType("System.Attribute", out var resolved)
+                ? resolved
+                : typeof(System.Attribute);
+            this.systemAttributeTypeRef = this.GetTypeReference(t);
+        }
+
+        return this.systemAttributeTypeRef.Value;
+    }
+
+    private MemberReferenceHandle GetSystemAttributeCtorRef()
+    {
+        if (!this.systemAttributeCtorRef.HasValue)
+        {
+            var attrTypeRef = this.GetSystemAttributeTypeRef();
+            var ctorSig = new BlobBuilder();
+            new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
+                .Parameters(0, r => r.Void(), _ => { });
+
+            this.systemAttributeCtorRef = this.metadata.AddMemberReference(
+                attrTypeRef,
+                this.metadata.GetOrAddString(".ctor"),
+                this.metadata.GetOrAddBlob(ctorSig));
+        }
+
+        return this.systemAttributeCtorRef.Value;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -201,6 +201,16 @@ public sealed class StructSymbol : TypeSymbol
     /// <summary>Gets the original generic definition when this is a constructed instance; otherwise <c>this</c>.</summary>
     public StructSymbol Definition { get; private set; }
 
+    /// <summary>
+    /// Gets a value indicating whether this class is sugar-marked as a
+    /// <see cref="System.Attribute"/>-derived type via the
+    /// <c>@Attribute</c> declaration sugar from ADR-0047 §5. When true, the
+    /// emitter overrides the CLR base type from <c>System.Object</c> to
+    /// <see cref="System.Attribute"/> and chains the class's constructors
+    /// to <c>System.Attribute..ctor()</c>.
+    /// </summary>
+    public bool IsAttributeClass { get; private set; }
+
     /// <summary>Sets <see cref="Interfaces"/> after binding. Intended to be called exactly once by the binder during <c>BindStructDeclaration</c>.</summary>
     /// <param name="interfaces">The interfaces this class implements directly.</param>
     public void SetInterfaces(ImmutableArray<InterfaceSymbol> interfaces)
@@ -232,6 +242,17 @@ public sealed class StructSymbol : TypeSymbol
     public void SetTypeParameters(ImmutableArray<TypeParameterSymbol> typeParameters)
     {
         TypeParameters = typeParameters;
+    }
+
+    /// <summary>
+    /// Marks this class as an <c>@Attribute</c>-sugar attribute type per
+    /// ADR-0047 §5. Intended to be called once by the binder after
+    /// <see cref="Symbol.SetAttributes"/> when the bound annotation list
+    /// contains the <c>@Attribute</c> marker.
+    /// </summary>
+    public void SetIsAttributeClass()
+    {
+        IsAttributeClass = true;
     }
 
     /// <summary>Walks the base chain looking for a method with the given name. Returns the most-derived overridable definition (the binder narrows further on overload match).</summary>

--- a/test/Compiler.Tests/Emit/AttributeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AttributeEmitTests.cs
@@ -81,6 +81,25 @@ public class AttributeEmitTests
         Assert.Equal("legacy", arg.Value);
     }
 
+    [Fact]
+    public void AttributeSugar_Emits_Class_With_SystemAttribute_Base()
+    {
+        var source = """
+            package P
+            import System
+
+            @Attribute
+            type Trace class {
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var trace = assembly.GetTypes().Single(t => t.Name == "Trace");
+
+        Assert.Equal("System.Attribute", trace.BaseType?.FullName);
+        Assert.True(typeof(System.Attribute).IsAssignableFrom(trace));
+    }
+
     private static Assembly CompileToAssembly(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_attr_emit_").FullName;

--- a/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
@@ -135,6 +135,68 @@ type Point struct {
         Assert.Equal(2, helper.Attributes.Length);
     }
 
+    [Fact]
+    public void AttributeSugar_Marks_Class_As_AttributeClass_And_Does_Not_Emit_Marker_Attribute()
+    {
+        var source = """
+            package P
+            import System
+
+            @Attribute
+            type Trace class {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        var trace = globalScope.Structs.Single(s => s.Name == "Trace");
+
+        Assert.True(trace.IsAttributeClass);
+
+        // The @Attribute marker is sugar — it must NOT appear in Symbol.Attributes
+        // (since System.Attribute is not itself an applicable attribute).
+        Assert.Empty(trace.Attributes);
+        Assert.Empty(GetBinderDiagnostics(globalScope));
+    }
+
+    [Fact]
+    public void AttributeSugar_Tolerates_Explicit_System_Attribute_Base()
+    {
+        var source = """
+            package P
+            import System
+
+            @Attribute
+            type Trace class : Attribute {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        var trace = globalScope.Structs.Single(s => s.Name == "Trace");
+
+        Assert.True(trace.IsAttributeClass);
+        Assert.Empty(GetBinderDiagnostics(globalScope));
+    }
+
+    [Fact]
+    public void AttributeSugar_Reports_Conflict_With_Other_Explicit_Base()
+    {
+        var source = """
+            package P
+            import System
+
+            open type Other class {
+            }
+
+            @Attribute
+            type Trace class : Other {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0203");
+    }
+
     private static BoundGlobalScope BindSource(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
Implements ADR-0047 §5: a class declaration prefixed with the bare `@Attribute` marker is sugar for "this class derives from `System.Attribute`". Follows up on #169 (Phase 3 emit).

## Changes

- **Binder** (`Binder.cs`)
  - New helpers `HasAttributeSugarMarker` / `IsAttributeSugarMarker` recognise the bare `@Attribute` annotation on a class.
  - When present on a `type ... class { ... }` declaration:
    - The class's `StructSymbol` is tagged via `SetIsAttributeClass()`.
    - An explicit `: Attribute` / `: System.Attribute` base is tolerated as a redundant restatement.
    - Any other explicit base class is rejected with new diagnostic **GS0203** (`ReportAttributeClassExplicitBase`).
    - The marker is filtered out of the symbol's bound-attribute list so it does not become a real `CustomAttribute` application.
- **Symbol** (`StructSymbol.cs`)
  - New `IsAttributeClass` slot + `SetIsAttributeClass()` setter, following the established `SetInterfaces` / `SetMethods` pattern.
- **Emitter** (`ReflectionMetadataEmitter.cs`)
  - When `StructSymbol.IsAttributeClass`, the TypeDef's base type is rewritten from `System.Object` to `System.Attribute`, and the implicit ctor chain target is rewritten from `System.Object..ctor()` to `System.Attribute..ctor()`. Both references are lazily cached.

## Tests

- `AttributeBinderTests`: marker tagging, sugar suppression, redundant explicit base toleration, GS0203 conflict diagnostic.
- `AttributeEmitTests`: round-trip via `Assembly.Load` asserts that `@Attribute type Trace class { }` produces a CLR type whose `BaseType` is `System.Attribute` and is assignable to `System.Attribute`.

Full suite: 1303 tests, all passing.

Refs #141. Phase 5 (string→type-identity migration of compiler-recognised attributes) is next.