### PR TITLE
Phase 5 of #141: type-identity recognisers + @Obsolete warning

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -4945,6 +4945,13 @@ public sealed class Binder
             return new BoundErrorExpression();
         }
 
+        // ADR-0047 §6: if the resolved callee is marked [Obsolete], surface
+        // a use-site diagnostic (warning by default, error if IsError=true).
+        if (KnownAttributes.TryGetObsolete(function.Attributes, out var obsoleteMessage, out var obsoleteIsError))
+        {
+            Diagnostics.ReportObsoleteUse(syntax.Identifier.Location, function.Name, obsoleteMessage, obsoleteIsError);
+        }
+
         var isVariadic = function.Parameters.Length > 0 && function.Parameters[function.Parameters.Length - 1].IsVariadic;
         var fixedParamCount = isVariadic ? function.Parameters.Length - 1 : function.Parameters.Length;
 
@@ -6691,6 +6698,17 @@ public sealed class Binder
         {
             var displayName = nameIsExact ? nameText : (nameText + "Attribute");
             Diagnostics.ReportNotAnAttributeType(GetAnnotationNameLocation(annotation), displayName);
+            return null;
+        }
+
+        // 3a) Reject user-written instances of attributes ADR-0047 §6
+        // reserves for compiler synthesis (Extension, AsyncStateMachine,
+        // CompilerGenerated, Nullable, NullableContext). Recognition is
+        // type-identity based on the resolved CLR type so renaming or
+        // shadowing the source-level name cannot bypass the rule.
+        if (KnownAttributes.IsReservedForCompiler(attrType.ClrType))
+        {
+            Diagnostics.ReportAttributeReservedForCompiler(GetAnnotationNameLocation(annotation), nameText);
             return null;
         }
 

--- a/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
+++ b/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
@@ -1,0 +1,94 @@
+// <copyright file="KnownAttributes.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Type-identity recogniser for the closed set of compiler-recognised
+/// attributes (ADR-0047 §6). All checks key off the resolved CLR
+/// <see cref="System.Type"/> on a <see cref="BoundAttribute"/> rather
+/// than a string name, so renaming an attribute type or shadowing it in
+/// user code never breaks compiler semantics.
+/// </summary>
+internal static class KnownAttributes
+{
+    private static readonly HashSet<Type> ReservedForCompilerSet = new()
+    {
+        typeof(System.Runtime.CompilerServices.ExtensionAttribute),
+        typeof(System.Runtime.CompilerServices.AsyncStateMachineAttribute),
+        typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute),
+        typeof(System.Runtime.CompilerServices.NullableAttribute),
+        typeof(System.Runtime.CompilerServices.NullableContextAttribute),
+    };
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="clrType"/> is one of the
+    /// attributes ADR-0047 §6 reserves for compiler synthesis. Users
+    /// must not write these in source.
+    /// </summary>
+    /// <param name="clrType">The resolved attribute CLR type, or <c>null</c>.</param>
+    /// <returns><c>true</c> if the attribute is reserved for the compiler.</returns>
+    public static bool IsReservedForCompiler(Type clrType)
+    {
+        return clrType != null && ReservedForCompilerSet.Contains(clrType);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="attribute"/> is
+    /// <see cref="System.ObsoleteAttribute"/>.
+    /// </summary>
+    /// <param name="attribute">A bound attribute application.</param>
+    /// <returns><c>true</c> when the attribute is <c>[Obsolete]</c>.</returns>
+    public static bool IsObsolete(BoundAttribute attribute)
+    {
+        return attribute?.AttributeType?.ClrType == typeof(System.ObsoleteAttribute);
+    }
+
+    /// <summary>
+    /// Looks for an <c>[Obsolete]</c> attribute in <paramref name="attributes"/>
+    /// and extracts its <c>message</c> and <c>isError</c> arguments.
+    /// </summary>
+    /// <param name="attributes">The attribute list on the symbol.</param>
+    /// <param name="message">The optional user-supplied message, or <c>null</c>.</param>
+    /// <param name="isError">Whether the attribute's <c>error</c> flag is set.</param>
+    /// <returns><c>true</c> if any attribute in the list is <c>[Obsolete]</c>.</returns>
+    public static bool TryGetObsolete(ImmutableArray<BoundAttribute> attributes, out string message, out bool isError)
+    {
+        message = null;
+        isError = false;
+        if (attributes.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        foreach (var attr in attributes)
+        {
+            if (!IsObsolete(attr))
+            {
+                continue;
+            }
+
+            if (!attr.PositionalArguments.IsDefaultOrEmpty)
+            {
+                if (attr.PositionalArguments.Length >= 1 && attr.PositionalArguments[0].Value is string s)
+                {
+                    message = s;
+                }
+
+                if (attr.PositionalArguments.Length >= 2 && attr.PositionalArguments[1].Value is bool b)
+                {
+                    isError = b;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1231,6 +1231,37 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0203", $"Class is tagged @Attribute and cannot also declare an explicit base class '{baseName}'. The @Attribute sugar implies ': System.Attribute'.");
     }
 
+    /// <summary>
+    /// Reports a reference to a symbol marked with
+    /// <see cref="System.ObsoleteAttribute"/>. The diagnostic is a
+    /// warning by default; if the attribute's <c>error</c> flag is set
+    /// it is reported as an error (ADR-0047 §6).
+    /// </summary>
+    /// <param name="location">The source location of the use site.</param>
+    /// <param name="name">The display name of the obsolete symbol.</param>
+    /// <param name="message">The optional user message; may be <c>null</c>.</param>
+    /// <param name="isError">When <c>true</c>, the diagnostic is reported as an error.</param>
+    public void ReportObsoleteUse(TextLocation location, string name, string message, bool isError)
+    {
+        var text = string.IsNullOrEmpty(message)
+            ? $"'{name}' is obsolete."
+            : $"'{name}' is obsolete: '{message}'.";
+        Report(location, "GS0204", text, isError ? DiagnosticSeverity.Error : DiagnosticSeverity.Warning);
+    }
+
+    /// <summary>
+    /// Reports a user-written annotation that names an attribute the
+    /// compiler reserves for its own synthesis (ADR-0047 §6: the
+    /// <c>Extension</c>, <c>AsyncStateMachine</c>, <c>CompilerGenerated</c>,
+    /// <c>Nullable</c>, <c>NullableContext</c> family).
+    /// </summary>
+    /// <param name="location">The source location of the annotation.</param>
+    /// <param name="name">The attribute name as written in source.</param>
+    public void ReportAttributeReservedForCompiler(TextLocation location, string name)
+    {
+        Report(location, "GS0205", $"Attribute '{name}' is reserved for compiler synthesis and cannot be written in source.");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncMethodBuilderInfo.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncMethodBuilderInfo.cs
@@ -237,8 +237,9 @@ public sealed class AsyncMethodBuilderInfo
         }
 
         // 3. Custom task-like via [AsyncMethodBuilder] on the return type.
+        // ADR-0047 §6: recognised by type identity, not string name.
         var attributeType = kickoffReturnClrType.GetCustomAttributesData()
-            .FirstOrDefault(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.AsyncMethodBuilderAttribute");
+            .FirstOrDefault(a => a.AttributeType == typeof(System.Runtime.CompilerServices.AsyncMethodBuilderAttribute));
         if (attributeType != null && attributeType.ConstructorArguments.Count == 1)
         {
             var customBuilder = attributeType.ConstructorArguments[0].Value as Type;

--- a/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
@@ -197,10 +197,88 @@ type Point struct {
         Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0203");
     }
 
+    [Fact]
+    public void Obsolete_Warning_Is_Reported_At_Call_Site()
+    {
+        var source = """
+            @Obsolete("use Bar")
+            func Old() {
+            }
+
+            func Main() {
+                Old()
+            }
+            """;
+
+        var program = BindProgramFromSource(source);
+        var diags = program.Diagnostics.Where(d => d.Id == "GS0204").ToList();
+
+        var obsoleteDiag = Assert.Single(diags);
+        Assert.Equal(GSharp.Core.CodeAnalysis.DiagnosticSeverity.Warning, obsoleteDiag.Severity);
+        Assert.Contains("Old", obsoleteDiag.Message);
+        Assert.Contains("use Bar", obsoleteDiag.Message);
+    }
+
+    [Fact]
+    public void Obsolete_With_IsError_Promotes_To_Error()
+    {
+        var source = """
+            @Obsolete("dead", true)
+            func Old() {
+            }
+
+            func Main() {
+                Old()
+            }
+            """;
+
+        var program = BindProgramFromSource(source);
+        var obsoleteDiag = Assert.Single(program.Diagnostics, d => d.Id == "GS0204");
+        Assert.Equal(GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error, obsoleteDiag.Severity);
+    }
+
+    [Fact]
+    public void Reserved_CompilerGenerated_Attribute_Is_Rejected()
+    {
+        var source = """
+            import System.Runtime.CompilerServices
+
+            @CompilerGenerated
+            func Helper() {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0205");
+
+        var helper = globalScope.Functions.Single(f => f.Name == "Helper");
+        Assert.Empty(helper.Attributes);
+    }
+
+    [Fact]
+    public void Reserved_Extension_Attribute_Is_Rejected()
+    {
+        var source = """
+            import System.Runtime.CompilerServices
+
+            @Extension
+            func Helper() {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0205");
+    }
+
     private static BoundGlobalScope BindSource(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));
         return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+
+    private static BoundProgram BindProgramFromSource(string source)
+    {
+        return Binder.BindProgram(BindSource(source));
     }
 
     private static System.Collections.Generic.IEnumerable<GSharp.Core.CodeAnalysis.Diagnostic> GetBinderDiagnostics(BoundGlobalScope scope)


### PR DESCRIPTION
Part of #141 — see [ADR-0047 §6](../blob/main/docs/adr/0047-attribute-syntax-and-declaration.md). Follow-up to PR #173.

## What this PR does

Wires the user-visible end of the attribute-recognition pipeline using **type identity**, not string names.

### Type-identity recogniser

New `KnownAttributes` helper (`src/Core/CodeAnalysis/Binding/KnownAttributes.cs`) centralises checks against the ADR-0047 §6 closed set:

- `IsReservedForCompiler(Type)` — `Extension`, `AsyncStateMachine`, `CompilerGenerated`, `Nullable`, `NullableContext`.
- `IsObsolete(BoundAttribute)` and `TryGetObsolete(...)` extracting message / IsError.

All checks compare `attr.AttributeType.ClrType == typeof(...)` — renaming or shadowing the source name cannot bypass compiler semantics.

### `@Obsolete` use-site diagnostic (GS0204)

`BindCallExpression` now walks `FunctionSymbol.Attributes` after overload resolution and reports **GS0204** at the call site:

```gs
@Obsolete("use Bar")
func Old() { }

func Main() {
    Old()   // warning GS0204: 'Old' is obsolete: 'use Bar'.
}
```

If the second positional arg (`isError`) is `true`, the diagnostic is promoted to an error.

### Reserved-attribute rejection (GS0205)

`BindAttribute` rejects user-written instances of the synthesis-only attributes from §6:

```gs
@CompilerGenerated   // GS0205: reserved for compiler synthesis
func Helper() { }
```

### String→type-identity migration

`AsyncMethodBuilderInfo.GetBuilderInfo` previously matched `a.AttributeType.FullName == "System.Runtime.CompilerServices.AsyncMethodBuilderAttribute"`. Now uses `AttributeType == typeof(AsyncMethodBuilderAttribute)` per ADR-0047 §6.

## Out of scope (deferred follow-ups)

These remain in the recognised set but are not implemented in this PR:

- `[Obsolete]` on struct/interface/field/property use sites (only function calls today).
- `[Conditional]` call elision.
- `[AttributeUsage]` enforcement of `AllowMultiple` / `ValidOn`.
- `[NotNullWhen]` family flowing into nullability.
- `[DllImport]` rejection with `ERR_DllImportNotSupported`.
- `[EnumeratorCancellation]` validation on `async sequence` parameters.

## Tests

- 4 new `AttributeBinderTests` covering: obsolete warning at call site, IsError → error promotion, `@CompilerGenerated` rejection, `@Extension` rejection.
- Full suite: **1307 tests pass** (was 1303).
