### PR TITLE
Phase 6 of #141: interpreter parity for Kotlin-style attributes

### DIFF
--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -112,7 +112,7 @@ public class Compilation
     {
         var parseDiagnostics = SyntaxTrees.SelectMany(st => st.Diagnostics);
         var diagnostics = parseDiagnostics.Concat(GlobalScope.Diagnostics).ToImmutableArray();
-        if (diagnostics.Any())
+        if (diagnostics.Any(d => d.IsError))
         {
             return new EvaluationResult(diagnostics, null);
         }
@@ -131,16 +131,24 @@ public class Compilation
             cfg.WriteTo(streamWriter);
         }
 
-        if (program.Diagnostics.Any())
+        // ADR-0047 Phase 6 / #141: combine all non-error diagnostics (warnings,
+        // info) collected so far so they surface to the REPL alongside the
+        // evaluated value, mirroring the emit pipeline's IsError filter.
+        var allWarnings = diagnostics
+            .Concat(program.Diagnostics)
+            .Where(d => !d.IsError)
+            .ToImmutableArray();
+
+        if (program.Diagnostics.Any(d => d.IsError))
         {
-            return new EvaluationResult(program.Diagnostics.ToImmutableArray(), null);
+            return new EvaluationResult(allWarnings.Concat(program.Diagnostics.Where(d => d.IsError)).ToImmutableArray(), null);
         }
 
         var evaluator = new Evaluator(program, variables);
         try
         {
             var value = evaluator.Evaluate();
-            return new EvaluationResult(ImmutableArray<Diagnostic>.Empty, value);
+            return new EvaluationResult(allWarnings, value);
         }
         catch (EvaluatorException ex)
         {
@@ -150,7 +158,7 @@ public class Compilation
             var location = new TextLocation(sourceText, new TextSpan(0, sourceText.Length));
             var message = ex.Message;
             var diagnostic = new Diagnostic(location, "GS9999", DiagnosticSeverity.Error, message);
-            return new EvaluationResult(ImmutableArray.Create(diagnostic), null);
+            return new EvaluationResult(allWarnings.Add(diagnostic), null);
         }
     }
 

--- a/src/Interpreter/GSharpRepl.cs
+++ b/src/Interpreter/GSharpRepl.cs
@@ -48,7 +48,17 @@ public class GSharpRepl : Repl
 
         var result = compilation.Evaluate(variables);
 
-        if (!result.Diagnostics.Any())
+        // ADR-0047 Phase 6 / #141: a non-empty Diagnostics list no longer
+        // implies failure — warnings (e.g. GS0204 [Obsolete]) coexist with a
+        // valid value. Print any diagnostics first, then the value, and treat
+        // the compilation as successful unless an error severity is present.
+        if (result.Diagnostics.Any())
+        {
+            Console.Out.WriteDiagnostics(result.Diagnostics);
+        }
+
+        var hasError = result.Diagnostics.Any(d => d.IsError);
+        if (!hasError)
         {
             if (result.Value != null)
             {
@@ -58,10 +68,6 @@ public class GSharpRepl : Repl
             }
 
             previous = compilation;
-        }
-        else
-        {
-            Console.Out.WriteDiagnostics(result.Diagnostics);
         }
     }
 

--- a/test/Interpreter.Tests/AttributeInterpreterTests.cs
+++ b/test/Interpreter.Tests/AttributeInterpreterTests.cs
@@ -1,0 +1,87 @@
+// <copyright file="AttributeInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Phase 6 of #141: interpreter parity for ADR-0047 Kotlin-style attribute
+/// syntax. The interpreter shares Core's parser/binder, so accepting the
+/// syntax is automatic; these tests pin that down and verify that the
+/// new GS0204 (<c>[Obsolete]</c>) warning from Phase 5 surfaces without
+/// blocking evaluation.
+/// </summary>
+public class AttributeInterpreterTests
+{
+    [Fact]
+    public void Interpreter_Accepts_Obsolete_Annotation_On_Function()
+    {
+        // @Obsolete on the declaration parses and binds; calling Helper()
+        // is a use site so the GS0204 warning fires, but the value still
+        // evaluates and prints (warnings do not block evaluation).
+        var source = "@Obsolete\nfunc Helper() int {\n  return 42\n}\nHelper()";
+        var output = RunSubmission(source);
+        Assert.Contains("42", output);
+        Assert.Contains("warning GS0204", output);
+        Assert.DoesNotContain("error GS", output);
+    }
+
+    [Fact]
+    public void Interpreter_Reports_Obsolete_Warning_At_Call_Site_And_Continues()
+    {
+        var source = "@Obsolete(\"use Bar\")\nfunc Old() int {\n  return 7\n}\nOld()";
+        var output = RunSubmission(source);
+
+        Assert.Contains("GS0204", output);
+        Assert.Contains("use Bar", output);
+        Assert.Contains("7", output);
+    }
+
+    [Fact]
+    public void Interpreter_Reports_Obsolete_Error_When_IsError_Is_True()
+    {
+        var source = "@Obsolete(\"dead\", true)\nfunc Old() int {\n  return 1\n}\nOld()";
+        var output = RunSubmission(source);
+
+        Assert.Contains("GS0204", output);
+        Assert.Contains("error GS0204", output);
+    }
+
+    [Fact]
+    public void Interpreter_Rejects_Reserved_CompilerGenerated_Attribute()
+    {
+        var source = "import System.Runtime.CompilerServices\n@CompilerGenerated\nfunc Helper() {\n}\n";
+        var output = RunSubmission(source);
+        Assert.Contains("GS0205", output);
+    }
+
+    [Fact]
+    public void Interpreter_Accepts_AttributeSugar_Class_Declaration()
+    {
+        var source = "import System\n@Attribute\ntype Trace class {\n}\n";
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString();
+    }
+}


### PR DESCRIPTION
Part of #141 — follow-up to PR #174. Phase 6 of the [ADR-0047](../blob/main/docs/adr/0047-attribute-syntax-and-declaration.md) plan.

## Summary

The interpreter shares the Core parser and binder, so accepting the Kotlin-style attribute syntax from Phases 1–4 is automatic. Phase 5 added GS0204 (`[Obsolete]` warning at call sites) and GS0205 (reserved-attribute rejection). This PR closes the parity loop:

### Bug fixed

`Compilation.Evaluate` previously bailed on **any** diagnostic. With Phase 5, that meant calling a `@Obsolete`-marked function returned a "failed" evaluation with no value — even though the warning shouldn't block execution. The emit pipeline already filters on `d.IsError`; `Evaluate` now does the same. `EvaluationResult.Diagnostics` carries the surviving warnings alongside the value.

`GSharpRepl.EvaluateSubmission` prints diagnostics first, then the value when no diagnostic is an error.

### Tests

New `AttributeInterpreterTests`:

1. `Interpreter_Accepts_Obsolete_Annotation_On_Function` — `@Obsolete func ...` parses, binds, calling it yields the value **and** the GS0204 warning.
2. `Interpreter_Reports_Obsolete_Warning_At_Call_Site_And_Continues` — value (`7`) printed alongside warning.
3. `Interpreter_Reports_Obsolete_Error_When_IsError_Is_True` — `@Obsolete("dead", true)` blocks evaluation.
4. `Interpreter_Rejects_Reserved_CompilerGenerated_Attribute` — GS0205 in REPL.
5. `Interpreter_Accepts_AttributeSugar_Class_Declaration` — `@Attribute type Trace class {}` binds cleanly.

Full suite: **1312 / 1312 passing** (was 1307).