### PR TITLE
docs(#141): attribute/annotation diagnostics and `@` lead-in (Phase 7)

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -146,6 +146,33 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 |----|----------|-------------|-----------------|
 | GS0190 | Error | Async state machine unavailable for this function. | An `async func` uses a language feature that the GSharp async emitter does not yet support (e.g. `await` inside a nested `try` block). |
 
+### Character literal diagnostics (GS0191–GS0195)
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0191 | Error | Unterminated character literal. | A `'` that has no closing `'` before end-of-line. |
+| GS0192 | Error | Empty character literal; a character literal must contain exactly one code unit or escape. | `''` with nothing inside. |
+| GS0193 | Error | Character literal contains more than one code unit; use a string literal instead. | `'ab'`. |
+| GS0194 | Error | Unrecognised escape sequence in character literal. | `'\q'`. |
+| GS0195 | Error | Malformed Unicode escape in character literal. | `'\u00G0'`. |
+
+### Attribute / annotation diagnostics (GS0196–GS0205)
+
+ADR-0047 introduces Kotlin-style attribute syntax (`@Foo(...)`) and the `@Attribute` declaration sugar. The following diagnostics cover parsing, resolution, use-site validation, and the compiler-recognised attribute set.
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0196 | Error | Annotation name expected after `@`. | `@ func Foo() {}` — bare `@` with no identifier. |
+| GS0197 | Error | Annotation target is not a recognized use-site kind. | `@bogus:Foo func Bar() {}` — must be one of `field`, `param`, `return`, `type`, `method`, `property`, `event`, `module`, `assembly`, `genericparam`. |
+| GS0198 | Error | Attribute type could not be found. | `@DoesNotExist func Foo() {}` — neither `DoesNotExist` nor `DoesNotExistAttribute` resolves to a type. |
+| GS0199 | Error | Attribute name is ambiguous between `Foo` and `FooAttribute`. | Both types are in scope; qualify to disambiguate. |
+| GS0200 | Error | Type is not an attribute class (it does not derive from `System.Attribute`). | `@int func Foo() {}`. |
+| GS0201 | Error | Attribute target is not valid at this position. | `@field:Obsolete func Foo() {}` — `field` is not allowed on a function. |
+| GS0202 | Error | Attribute arguments must be compile-time constants. | `@Trace(myVar)` — argument is not a primitive, string, `typeof`, enum, or 1-D array thereof. |
+| GS0203 | Error | Class tagged `@Attribute` cannot also declare an explicit base class. | `@Attribute type Trace class : Other {}` — the `@Attribute` sugar implies `: System.Attribute`. |
+| GS0204 | **Warning** (Error if `IsError=true`) | Reference to a symbol marked `[Obsolete]`. | Calling a function declared with `@Obsolete("use Bar")`. Severity is promoted to error when the attribute's second argument is `true`. |
+| GS0205 | Error | Attribute is reserved for compiler synthesis. | `@CompilerGenerated`, `@Extension`, `@AsyncStateMachine`, `@Nullable`, or `@NullableContext` written in user source. |
+
 ### Pointer / by-ref diagnostics (GS9001–GS9006)
 
 | ID | Severity | Description | Example trigger |

--- a/docs/lexical.md
+++ b/docs/lexical.md
@@ -103,6 +103,10 @@ GSharp has two string forms:
 
 Single-line comments start with `//` and run to the end of the line. (Block-comment syntax is not yet implemented; see the execution plan.)
 
+## Annotation lead-ins
+
+A leading `@` (the `AtToken`) introduces a Kotlin-style annotation per ADR-0047: `@Foo`, `@Foo("msg")`, `@Foo("msg", true)`, or `@target:Foo`. The `@` is a punctuation token used only by the annotation parser; it has no other syntactic role in expressions. The annotation list itself is part of the declaration grammar — see `docs/adr/0047-attribute-syntax-and-declaration.md`.
+
 ## Whitespace and line terminators
 
 Spaces, tabs, and line terminators are insignificant outside of string literals.
@@ -115,3 +119,4 @@ Spaces, tabs, and line terminators are insignificant outside of string literals.
 * `docs/adr/0044-numeric-primitive-coverage.md` — primitive-type lattice and numeric suffix grammar.
 * `docs/adr/0045-object-universal-upper-bound.md` — `object` as the universal upper bound.
 * `docs/adr/0046-char-literal-grammar.md` — `char` literals and escape grammar.
+* `docs/adr/0047-attribute-syntax-and-declaration.md` — Kotlin-style attribute syntax (`@Foo(...)`) and `@Attribute` declaration sugar.


### PR DESCRIPTION
Phase 7 (final) of #141 — documentation only.

## Changes

- **`docs/diagnostics.md`**
  - Adds a previously-missing **Character literal diagnostics** section (GS0191–GS0195).
  - Adds an **Attribute / annotation diagnostics** section (GS0196–GS0205) covering parser, binder, use-site, reserved-attribute, and the GS0204 obsolete-warning entry. GS0204 is the only non-uniform-severity diagnostic in the catalogue (Warning by default, Error when ` + "`IsError=true`" + `).
- **`docs/lexical.md`**
  - New 'Annotation lead-ins' subsection describing ` + "`@`" + ` as a punctuation token used only by the annotation parser.
  - Adds an ADR-0047 link to the See-also list.

` + "`docs/coverage-matrix.md`" + ` is regenerated by ` + "`CoverageMatrixGoldenTests`" + ` and already contains ` + "`AtToken`/`Annotation`/`AnnotationTarget`/`Attribute`" + ` (no hand-edit).

## Verification

` + "`dotnet test GSharp.sln --no-restore --nologo`" + ` → all 1291 tests pass (Core 1105, Compiler 138, Interpreter 31, LSP 17).

## Plan status

This is the last of the 7 phases of #141. Prior PRs: #166 (ADR), #167, #168, #169, #173, #174, #181. With this PR merged, ADR-0047 is fully landed; remaining follow-ups are tracked in #170, #171, #172, #175, #176, #177, #178, #179, #180.

Closes #141.