### PR TITLE
Fix #170: emit CustomAttribute rows for parameter-target annotations

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -6723,25 +6723,23 @@ public sealed class Binder
             {
                 if (argSyntax is NamedArgumentExpressionSyntax namedArg)
                 {
-                    var bound = TryBindAttributeConstant(namedArg.Expression);
-                    if (bound == null)
+                    if (!TryBindAttributeArgument(namedArg.Expression, out var value, out var valueType))
                     {
                         Diagnostics.ReportAttributeArgumentNotConstant(namedArg.Expression.Location);
                         continue;
                     }
 
-                    named.Add(new BoundAttributeArgument(namedArg.NameToken.Text, bound.Value, bound.Type));
+                    named.Add(new BoundAttributeArgument(namedArg.NameToken.Text, value, valueType));
                 }
                 else
                 {
-                    var bound = TryBindAttributeConstant(argSyntax);
-                    if (bound == null)
+                    if (!TryBindAttributeArgument(argSyntax, out var value, out var valueType))
                     {
                         Diagnostics.ReportAttributeArgumentNotConstant(argSyntax.Location);
                         continue;
                     }
 
-                    positional.Add(new BoundAttributeArgument(name: null, bound.Value, bound.Type));
+                    positional.Add(new BoundAttributeArgument(name: null, value, valueType));
                 }
             }
         }
@@ -6840,22 +6838,118 @@ public sealed class Binder
 
     /// <summary>
     /// Tries to bind an attribute argument expression as a compile-time
-    /// constant. v1 accepts only direct literal-shaped expressions
-    /// (numbers, strings, chars, bool, nil); broader constant folding —
-    /// <c>typeof(T)</c>, enum member access, array literals, signed
-    /// numeric literals — is a follow-up once the corresponding binder
-    /// paths land in Phase 3 / Phase 5.
+    /// constant value of one of the shapes permitted by ECMA-335 II.23.3 /
+    /// ADR-0047 §3: literal (numeric, char, string, bool, nil), a
+    /// <c>typeof(T)</c> expression (carried as the resolved CLR
+    /// <see cref="Type"/>), or a single-dimensional array literal of any
+    /// supported element shape. Returns <c>false</c> for any expression the
+    /// emitter cannot serialise.
     /// </summary>
     /// <param name="syntax">The argument expression.</param>
-    /// <returns>The bound literal, or <c>null</c> if not a recognised constant.</returns>
-    private BoundLiteralExpression TryBindAttributeConstant(ExpressionSyntax syntax)
+    /// <param name="value">The extracted compile-time value when the method returns <c>true</c>.</param>
+    /// <param name="type">The static type carried by the argument when the method returns <c>true</c>.</param>
+    /// <returns><c>true</c> if the expression maps to a supported attribute constant; otherwise <c>false</c>.</returns>
+    private bool TryBindAttributeArgument(ExpressionSyntax syntax, out object value, out TypeSymbol type)
     {
-        if (syntax is LiteralExpressionSyntax literal)
+        value = null;
+        type = null;
+
+        switch (syntax)
         {
-            return BindExpression(literal) as BoundLiteralExpression;
+            case LiteralExpressionSyntax literal:
+                if (BindExpression(literal) is BoundLiteralExpression bl)
+                {
+                    value = bl.Value;
+                    type = bl.Type;
+                    return true;
+                }
+
+                return false;
+
+            case TypeOfExpressionSyntax typeOfSyntax:
+                if (BindTypeOfExpression(typeOfSyntax) is BoundTypeOfExpression bt
+                    && bt.OperandType?.ClrType is { } clr)
+                {
+                    value = clr;
+                    type = bt.Type;
+                    return true;
+                }
+
+                return false;
+
+            case ArrayCreationExpressionSyntax arraySyntax:
+                return TryBindAttributeArrayArgument(arraySyntax, out value, out type);
         }
 
-        return null;
+        return false;
+    }
+
+    private bool TryBindAttributeArrayArgument(
+        ArrayCreationExpressionSyntax syntax,
+        out object value,
+        out TypeSymbol type)
+    {
+        value = null;
+        type = null;
+
+        if (BindArrayCreationExpression(syntax) is not BoundArrayCreationExpression bound)
+        {
+            return false;
+        }
+
+        // Attribute arrays must be a serialisable SZARRAY (1-D) shape per
+        // ECMA-335 II.23.3. Both `[]T{...}` (slice) and `[N]T{...}` (array)
+        // produce a CLR `T[]` for the element type clause.
+        var clrArrayType = bound.Type?.ClrType;
+        if (clrArrayType == null || !clrArrayType.IsArray || clrArrayType.GetArrayRank() != 1)
+        {
+            return false;
+        }
+
+        var elementClrType = clrArrayType.GetElementType();
+        if (elementClrType == null)
+        {
+            return false;
+        }
+
+        var result = Array.CreateInstance(elementClrType, syntax.Elements.Count);
+        for (int i = 0; i < syntax.Elements.Count; i++)
+        {
+            if (!TryBindAttributeArgument(syntax.Elements[i], out var elementValue, out _))
+            {
+                return false;
+            }
+
+            try
+            {
+                result.SetValue(CoerceAttributeElement(elementValue, elementClrType), i);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        value = result;
+        type = bound.Type;
+        return true;
+    }
+
+    private static object CoerceAttributeElement(object value, Type elementType)
+    {
+        if (value == null || elementType.IsInstanceOfType(value))
+        {
+            return value;
+        }
+
+        if (elementType.IsEnum)
+        {
+            var underlying = Enum.GetUnderlyingType(elementType);
+            return Convert.ChangeType(value, underlying, System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        // Numeric / char widening between primitives (e.g. int → long).
+        return Convert.ChangeType(value, elementType, System.Globalization.CultureInfo.InvariantCulture);
     }
 
     private sealed class CapturedVariableCollector : BoundTreeRewriter

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1137,8 +1137,13 @@ public sealed class Binder
                 }
             }
 
-            foreach (var parameterSyntax in syntax.Parameters)
+            // Tracks the bound ParameterSymbol corresponding to each parameter
+            // syntax position (null for duplicates) so per-parameter annotations
+            // can be attached to the right symbol below.
+            var parameterSymbolBySyntax = new ParameterSymbol[syntax.Parameters.Count];
+            for (var pIndex = 0; pIndex < syntax.Parameters.Count; pIndex++)
             {
+                var parameterSyntax = syntax.Parameters[pIndex];
                 var parameterName = parameterSyntax.Identifier.Text;
                 var parameterType = BindTypeClause(parameterSyntax.Type);
                 if (!seenParameterNames.Add(parameterName))
@@ -1158,6 +1163,7 @@ public sealed class Binder
 
                     var parameter = new ParameterSymbol(parameterName, parameterType, isVariadic);
                     parameters.Add(parameter);
+                    parameterSymbolBySyntax[pIndex] = parameter;
                 }
             }
 
@@ -1186,14 +1192,24 @@ public sealed class Binder
                 "a function declaration");
 
             // Per-parameter annotations: each ParameterSyntax owns its own
-            // annotation list; the default target is `param`.
-            foreach (var parameterSyntax in syntax.Parameters)
+            // annotation list; the default target is `param`. Issue #170 /
+            // ADR-0047 §3: the bound list is stored on the ParameterSymbol so
+            // the emitter can emit a `CustomAttribute` row keyed to the
+            // corresponding `Parameter` metadata handle.
+            for (var pIndex = 0; pIndex < syntax.Parameters.Count; pIndex++)
             {
-                BindAttributes(
+                var parameterSyntax = syntax.Parameters[pIndex];
+                var paramAttrs = BindAttributes(
                     parameterSyntax.Annotations,
                     AttributeTargetKind.Param,
                     ParameterAllowedTargets,
                     "a parameter declaration");
+
+                var parameterSymbol = parameterSymbolBySyntax[pIndex];
+                if (parameterSymbol != null && !paramAttrs.IsDefaultOrEmpty)
+                {
+                    parameterSymbol.SetAttributes(paramAttrs);
+                }
             }
 
             FunctionSymbol function;

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1171,6 +1171,17 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
+    /// <summary>
+    /// Returns the next <see cref="ParameterHandle"/> that will be assigned by
+    /// the next call to <see cref="MetadataBuilder.AddParameter"/>. Issue #170:
+    /// every <c>AddMethodDefinition</c> call must thread this value into its
+    /// <c>parameterList</c> argument so the Param table's per-method runs stay
+    /// monotone — methods that emit no parameter rows must share the same
+    /// "next" handle, and methods that emit N rows anchor the run that follows.
+    /// </summary>
+    private ParameterHandle NextParameterHandle()
+        => MetadataTokens.ParameterHandle(this.metadata.GetRowCount(TableIndex.Param) + 1);
+
     private void EmitBoundAttribute(EntityHandle parent, BoundAttribute attr)
     {
         var clrType = attr.AttributeType.ClrType;
@@ -1669,7 +1680,7 @@ internal sealed class ReflectionMetadataEmitter
             name: this.metadata.GetOrAddString(method.Name),
             signature: this.metadata.GetOrAddBlob(sigBlob),
             bodyOffset: -1,
-            parameterList: MetadataTokens.ParameterHandle(1));
+            parameterList: this.NextParameterHandle());
     }
 
     /// <summary>
@@ -1703,7 +1714,7 @@ internal sealed class ReflectionMetadataEmitter
             name: this.metadata.GetOrAddString(".ctor"),
             signature: this.metadata.GetOrAddBlob(ctorSig),
             bodyOffset: bodyOffset,
-            parameterList: MetadataTokens.ParameterHandle(1));
+            parameterList: this.NextParameterHandle());
     }
 
     /// <summary>Resolves the <c>.ctor()</c> token a derived class's ctor should chain to: either the base class's default ctor (already emitted) or <see cref="objectCtorRef"/>.</summary>
@@ -1820,7 +1831,7 @@ internal sealed class ReflectionMetadataEmitter
             name: this.metadata.GetOrAddString(".ctor"),
             signature: this.metadata.GetOrAddBlob(ctorSig),
             bodyOffset: bodyOffset,
-            parameterList: MetadataTokens.ParameterHandle(1));
+            parameterList: this.NextParameterHandle());
     }
 
     private static TypeAttributes MapTypeAccessibility(Accessibility accessibility)
@@ -1915,7 +1926,7 @@ internal sealed class ReflectionMetadataEmitter
 
         var sig = new BlobBuilder();
         new BlobEncoder(sig).MethodSignature(isInstanceMethod: true).Parameters(1, r => r.Type().Boolean(), ps => ps.AddParameter().Type().Object());
-        this.metadata.AddMethodDefinition(MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig, MethodImplAttributes.IL | MethodImplAttributes.Managed, this.metadata.GetOrAddString("Equals"), this.metadata.GetOrAddBlob(sig), this.FinishInlineBody(il), MetadataTokens.ParameterHandle(1));
+        this.metadata.AddMethodDefinition(MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig, MethodImplAttributes.IL | MethodImplAttributes.Managed, this.metadata.GetOrAddString("Equals"), this.metadata.GetOrAddBlob(sig), this.FinishInlineBody(il), this.NextParameterHandle());
     }
 
     private void EmitInlineEqualsTyped(StructSymbol structSym, FieldSymbol field, FieldDefinitionHandle fieldHandle)
@@ -1937,7 +1948,7 @@ internal sealed class ReflectionMetadataEmitter
 
         var sig = new BlobBuilder();
         new BlobEncoder(sig).MethodSignature(isInstanceMethod: true).Parameters(1, r => r.Type().Boolean(), ps => this.EncodeTypeSymbol(ps.AddParameter().Type(), structSym));
-        this.metadata.AddMethodDefinition(MethodAttributes.Public | MethodAttributes.HideBySig, MethodImplAttributes.IL | MethodImplAttributes.Managed, this.metadata.GetOrAddString("Equals"), this.metadata.GetOrAddBlob(sig), this.FinishInlineBody(il), MetadataTokens.ParameterHandle(1));
+        this.metadata.AddMethodDefinition(MethodAttributes.Public | MethodAttributes.HideBySig, MethodImplAttributes.IL | MethodImplAttributes.Managed, this.metadata.GetOrAddString("Equals"), this.metadata.GetOrAddBlob(sig), this.FinishInlineBody(il), this.NextParameterHandle());
     }
 
     private void EmitInlineGetHashCode(StructSymbol structSym, FieldSymbol field, FieldDefinitionHandle fieldHandle)
@@ -1956,7 +1967,7 @@ internal sealed class ReflectionMetadataEmitter
 
         var sig = new BlobBuilder();
         new BlobEncoder(sig).MethodSignature(isInstanceMethod: true).Parameters(0, r => r.Type().Int32(), _ => { });
-        this.metadata.AddMethodDefinition(MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig, MethodImplAttributes.IL | MethodImplAttributes.Managed, this.metadata.GetOrAddString("GetHashCode"), this.metadata.GetOrAddBlob(sig), this.FinishInlineBody(il), MetadataTokens.ParameterHandle(1));
+        this.metadata.AddMethodDefinition(MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig, MethodImplAttributes.IL | MethodImplAttributes.Managed, this.metadata.GetOrAddString("GetHashCode"), this.metadata.GetOrAddBlob(sig), this.FinishInlineBody(il), this.NextParameterHandle());
     }
 
     private void EmitInlineToString(StructSymbol structSym, FieldSymbol field, FieldDefinitionHandle fieldHandle)
@@ -1979,7 +1990,7 @@ internal sealed class ReflectionMetadataEmitter
 
         var sig = new BlobBuilder();
         new BlobEncoder(sig).MethodSignature(isInstanceMethod: true).Parameters(0, r => r.Type().String(), _ => { });
-        this.metadata.AddMethodDefinition(MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig, MethodImplAttributes.IL | MethodImplAttributes.Managed, this.metadata.GetOrAddString("ToString"), this.metadata.GetOrAddBlob(sig), this.FinishInlineBody(il), MetadataTokens.ParameterHandle(1));
+        this.metadata.AddMethodDefinition(MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig, MethodImplAttributes.IL | MethodImplAttributes.Managed, this.metadata.GetOrAddString("ToString"), this.metadata.GetOrAddBlob(sig), this.FinishInlineBody(il), this.NextParameterHandle());
     }
 
     private void EmitInlineEqualityOperator(StructSymbol structSym, FieldSymbol field, FieldDefinitionHandle fieldHandle, bool isInequality)
@@ -2015,7 +2026,7 @@ internal sealed class ReflectionMetadataEmitter
                     this.EncodeTypeSymbol(ps.AddParameter().Type(), structSym);
                     this.EncodeTypeSymbol(ps.AddParameter().Type(), structSym);
                 });
-        this.metadata.AddMethodDefinition(MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.SpecialName | MethodAttributes.HideBySig, MethodImplAttributes.IL | MethodImplAttributes.Managed, this.metadata.GetOrAddString(isInequality ? "op_Inequality" : "op_Equality"), this.metadata.GetOrAddBlob(sig), this.FinishInlineBody(il), MetadataTokens.ParameterHandle(1));
+        this.metadata.AddMethodDefinition(MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.SpecialName | MethodAttributes.HideBySig, MethodImplAttributes.IL | MethodImplAttributes.Managed, this.metadata.GetOrAddString(isInequality ? "op_Inequality" : "op_Equality"), this.metadata.GetOrAddBlob(sig), this.FinishInlineBody(il), this.NextParameterHandle());
     }
 
     private void EmitInlineDeconstruct(StructSymbol structSym, FieldSymbol field, FieldDefinitionHandle fieldHandle)
@@ -2034,7 +2045,7 @@ internal sealed class ReflectionMetadataEmitter
 
         var sig = new BlobBuilder();
         new BlobEncoder(sig).MethodSignature(isInstanceMethod: true).Parameters(1, r => r.Void(), ps => this.EncodeTypeSymbol(ps.AddParameter().Type(isByRef: true), field.Type));
-        this.metadata.AddMethodDefinition(MethodAttributes.Public | MethodAttributes.HideBySig, MethodImplAttributes.IL | MethodImplAttributes.Managed, this.metadata.GetOrAddString("Deconstruct"), this.metadata.GetOrAddBlob(sig), this.FinishInlineBody(il), MetadataTokens.ParameterHandle(1));
+        this.metadata.AddMethodDefinition(MethodAttributes.Public | MethodAttributes.HideBySig, MethodImplAttributes.IL | MethodImplAttributes.Managed, this.metadata.GetOrAddString("Deconstruct"), this.metadata.GetOrAddBlob(sig), this.FinishInlineBody(il), this.NextParameterHandle());
     }
 
     /// <summary>
@@ -2143,7 +2154,7 @@ internal sealed class ReflectionMetadataEmitter
             name: this.metadata.GetOrAddString("MoveNext"),
             signature: this.metadata.GetOrAddBlob(sig),
             bodyOffset: bodyOffset,
-            parameterList: MetadataTokens.ParameterHandle(1));
+            parameterList: this.NextParameterHandle());
     }
 
     /// <summary>
@@ -2175,7 +2186,7 @@ internal sealed class ReflectionMetadataEmitter
             name: this.metadata.GetOrAddString("SetStateMachine"),
             signature: this.metadata.GetOrAddBlob(sig),
             bodyOffset: bodyOffset,
-            parameterList: MetadataTokens.ParameterHandle(1));
+            parameterList: this.NextParameterHandle());
     }
 
     /// <summary>
@@ -2494,7 +2505,7 @@ internal sealed class ReflectionMetadataEmitter
             name: this.metadata.GetOrAddString(".ctor"),
             signature: this.metadata.GetOrAddBlob(ctorSig),
             bodyOffset: bodyOffset,
-            parameterList: MetadataTokens.ParameterHandle(1));
+            parameterList: this.NextParameterHandle());
     }
 
     private MethodDefinitionHandle EmitFunction(FunctionSymbol function, BoundBlockStatement body, bool isEntryPoint)
@@ -2715,18 +2726,43 @@ internal sealed class ReflectionMetadataEmitter
             methodAttrs |= MethodAttributes.Static;
         }
 
+        // Issue #170 / ADR-0047 §3: emit a Parameter row per source parameter
+        // so we can attach a CustomAttribute to each one. The first emitted
+        // ParameterHandle becomes the MethodDef.parameterList anchor; if the
+        // function has no parameters we leave it pointing at the next ordinal.
+        var firstParamHandle = this.NextParameterHandle();
+        var paramHandles = new List<(ParameterSymbol Symbol, ParameterHandle Handle)>();
+        var sequenceNumber = 1;
+        foreach (var p in function.Parameters)
+        {
+            if (ReferenceEquals(p, function.ThisParameter))
+            {
+                continue;
+            }
+
+            var paramHandle = this.metadata.AddParameter(
+                attributes: ParameterAttributes.None,
+                name: this.metadata.GetOrAddString(p.Name ?? string.Empty),
+                sequenceNumber: sequenceNumber++);
+            paramHandles.Add((p, paramHandle));
+        }
+
         var handle = this.metadata.AddMethodDefinition(
             attributes: methodAttrs,
             implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
             name: this.metadata.GetOrAddString(methodName),
             signature: this.metadata.GetOrAddBlob(sigBlob),
             bodyOffset: bodyOffset,
-            parameterList: MetadataTokens.ParameterHandle(1));
+            parameterList: firstParamHandle);
 
         // Phase 3 of #141: attach user annotations (method target) to the
-        // MethodDef. Return / param targets are wired alongside their
-        // respective handles in a follow-up.
+        // MethodDef. Issue #170: per-parameter annotations attach to each
+        // emitted Parameter row. Return-target attributes still pending.
         this.EmitUserAttributes(handle, function, AttributeTargetKind.Method);
+        foreach (var (paramSym, paramHandle) in paramHandles)
+        {
+            this.EmitUserAttributes(paramHandle, paramSym, AttributeTargetKind.Param);
+        }
 
         return handle;
     }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1201,7 +1201,7 @@ internal sealed class ReflectionMetadataEmitter
                 {
                     foreach (var p in ctorParams)
                     {
-                        EncodeClrTypeForCtorSig(ps.AddParameter().Type(), p.ParameterType);
+                        this.EncodeClrTypeForCtorSig(ps.AddParameter().Type(), p.ParameterType);
                     }
                 });
 
@@ -1257,7 +1257,8 @@ internal sealed class ReflectionMetadataEmitter
                 }
                 else if (!paramType.IsInstanceOfType(supplied))
                 {
-                    // Allow numeric widening (int → long, etc.) and char → int.
+                    // Allow numeric widening (int → long, etc.), char → int,
+                    // and source-array → target-array element widening.
                     if (!IsTriviallyConvertible(supplied.GetType(), paramType))
                     {
                         match = false;
@@ -1287,10 +1288,15 @@ internal sealed class ReflectionMetadataEmitter
             return from == Enum.GetUnderlyingType(to);
         }
 
+        if (from.IsArray && to.IsArray && from.GetArrayRank() == 1 && to.GetArrayRank() == 1)
+        {
+            return IsTriviallyConvertible(from.GetElementType()!, to.GetElementType()!);
+        }
+
         return false;
     }
 
-    private static void EncodeClrTypeForCtorSig(SignatureTypeEncoder enc, Type t)
+    private void EncodeClrTypeForCtorSig(SignatureTypeEncoder enc, Type t)
     {
         if (t == typeof(bool))
         {
@@ -1351,6 +1357,16 @@ internal sealed class ReflectionMetadataEmitter
         else if (t.IsEnum)
         {
             EncodeClrTypeForCtorSig(enc, Enum.GetUnderlyingType(t));
+        }
+        else if (t.IsArray && t.GetArrayRank() == 1)
+        {
+            // ECMA-335 II.23.2.12: SZARRAY element-type for a single-dimensional array parameter.
+            this.EncodeClrTypeForCtorSig(enc.SZArray(), t.GetElementType()!);
+        }
+        else if (typeof(Type).IsAssignableFrom(t))
+        {
+            // System.Type parameter: encoded as a CLASS type reference in the ctor signature.
+            enc.Type(this.GetTypeReference(t), isValueType: false);
         }
         else
         {
@@ -1419,11 +1435,67 @@ internal sealed class ReflectionMetadataEmitter
         {
             bb.WriteSerializedString((string)value);
         }
+        else if (typeof(Type).IsAssignableFrom(paramType))
+        {
+            // ECMA-335 II.23.3: a System.Type argument is encoded as a
+            // SerString carrying the canonical type-name. A null Type
+            // serialises as the SerString null marker (0xFF).
+            bb.WriteSerializedString(value is Type t ? GetSerializedTypeName(t) : null);
+        }
+        else if (paramType.IsArray && paramType.GetArrayRank() == 1)
+        {
+            WriteCustomAttributeArrayArg(bb, paramType.GetElementType()!, value);
+        }
+        else if (paramType == typeof(object))
+        {
+            // ECMA-335 II.23.3: boxed object argument carries the
+            // FieldOrPropType tag of the runtime type then the value.
+            if (value == null)
+            {
+                // Null object: encode as STRING null marker per common practice.
+                WriteCustomAttributeFieldOrPropertyType(bb, typeof(string));
+                bb.WriteSerializedString(null);
+            }
+            else
+            {
+                var runtimeType = value.GetType();
+                WriteCustomAttributeFieldOrPropertyType(bb, runtimeType);
+                WriteCustomAttributeFixedArg(bb, runtimeType, value);
+            }
+        }
         else
         {
             // Fallback: serialise as string round-trip (best-effort).
             bb.WriteSerializedString(value?.ToString());
         }
+    }
+
+    private static void WriteCustomAttributeArrayArg(BlobBuilder bb, Type elementType, object value)
+    {
+        // ECMA-335 II.23.3: an SZARRAY argument is encoded as an Int32 length
+        // (or 0xFFFFFFFF for a null array) followed by length elements of
+        // FixedArg(elementType).
+        if (value == null)
+        {
+            bb.WriteUInt32(0xFFFFFFFFu);
+            return;
+        }
+
+        var array = (Array)value;
+        bb.WriteInt32(array.Length);
+        for (int i = 0; i < array.Length; i++)
+        {
+            WriteCustomAttributeFixedArg(bb, elementType, array.GetValue(i));
+        }
+    }
+
+    private static string GetSerializedTypeName(Type t)
+    {
+        // ECMA-335 II.23.3 + I.8.5.2: the canonical serialised form is the
+        // assembly-qualified name; types from mscorlib / System.Private.CoreLib
+        // may omit the assembly portion. We always emit the assembly-qualified
+        // form so the consumer can unambiguously rebind the type.
+        return t.AssemblyQualifiedName ?? t.FullName ?? t.Name;
     }
 
     private static void WriteCustomAttributeNamedArg(BlobBuilder bb, Type attributeType, BoundAttributeArgument arg)
@@ -1511,11 +1583,28 @@ internal sealed class ReflectionMetadataEmitter
         {
             bb.WriteByte(0x0E);
         }
+        else if (typeof(Type).IsAssignableFrom(t))
+        {
+            // 0x50 — System.Type (no payload byte; the FixedArg holds the SerString).
+            bb.WriteByte(0x50);
+        }
+        else if (t == typeof(object))
+        {
+            // 0x51 — boxed object. The FixedArg writer prefixes the runtime
+            // type tag and value when emitting the argument body.
+            bb.WriteByte(0x51);
+        }
+        else if (t.IsArray && t.GetArrayRank() == 1)
+        {
+            // 0x1D SZARRAY followed by the element type's FieldOrPropType byte.
+            bb.WriteByte(0x1D);
+            WriteCustomAttributeFieldOrPropertyType(bb, t.GetElementType()!);
+        }
         else if (t.IsEnum)
         {
             // 0x55 then serialised type name (assembly-qualified).
             bb.WriteByte(0x55);
-            bb.WriteSerializedString(t.AssemblyQualifiedName);
+            bb.WriteSerializedString(GetSerializedTypeName(t));
         }
         else
         {

--- a/test/Compiler.Tests/Emit/AttributeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AttributeEmitTests.cs
@@ -282,6 +282,38 @@ public class AttributeEmitTests
         Assert.StartsWith("System.Int32", typeName ?? string.Empty);
     }
 
+    [Fact]
+    public void Emits_Attribute_On_Parameter()
+    {
+        // Issue #170 / ADR-0047 §3: per-parameter annotations attach to the
+        // Parameter metadata row, round-tripping through
+        // `MethodInfo.GetParameters()[i].GetCustomAttributesData()`.
+        var source = """
+            package P
+            import System
+
+            func Foo(@Obsolete("old name") name string) {
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var foo = program.GetMethod("Foo", BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(foo);
+        var parameters = foo.GetParameters();
+        var nameParam = Assert.Single(parameters);
+        Assert.Equal("name", nameParam.Name);
+
+        var data = nameParam.GetCustomAttributesData().Single(d => d.AttributeType.FullName == "System.ObsoleteAttribute");
+        var arg = Assert.Single(data.ConstructorArguments);
+        Assert.Equal("old name", arg.Value);
+
+        // The MethodDef itself should not carry the parameter-target attribute.
+        Assert.DoesNotContain(
+            foo.GetCustomAttributesData(),
+            d => d.AttributeType.FullName == "System.ObsoleteAttribute");
+    }
+
     private static Assembly CompileToAssembly(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_attr_emit_").FullName;

--- a/test/Compiler.Tests/Emit/AttributeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AttributeEmitTests.cs
@@ -100,6 +100,188 @@ public class AttributeEmitTests
         Assert.True(typeof(System.Attribute).IsAssignableFrom(trace));
     }
 
+    [Fact]
+    public void Emits_Typeof_Argument_On_Function()
+    {
+        // System.Diagnostics.DebuggerTypeProxyAttribute(Type) — exercises the
+        // ECMA-335 II.23.3 element-type 0x50 (SerString type-name) encoding.
+        var source = """
+            package P
+            import System
+            import System.Diagnostics
+
+            @DebuggerTypeProxy(typeof(int))
+            type Box data struct {
+                Value int
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var box = assembly.GetTypes().Single(t => t.Name == "Box");
+        var data = box
+            .GetCustomAttributesData()
+            .Single(d => d.AttributeType.FullName == "System.Diagnostics.DebuggerTypeProxyAttribute");
+        var arg = Assert.Single(data.ConstructorArguments);
+        Assert.Equal(typeof(Type), arg.ArgumentType);
+
+        // The CLR rehydrates the SerString into either a System.Type or its
+        // canonical string name depending on whether the type resolves —
+        // accept either, but assert it identifies System.Int32.
+        var typeName = arg.Value switch
+        {
+            Type t => t.FullName,
+            string s => s,
+            _ => null,
+        };
+        Assert.StartsWith("System.Int32", typeName ?? string.Empty);
+    }
+
+    [Fact]
+    public void Emits_Typeof_Named_Argument()
+    {
+        // DebuggerDisplayAttribute exposes a settable `Target` property of
+        // type System.Type — verifies named-arg encoding of the 0x50 tag.
+        var source = """
+            package P
+            import System
+            import System.Diagnostics
+
+            @DebuggerDisplay("{Value}", Target = typeof(string))
+            type Holder data struct {
+                Value int
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var holder = assembly.GetTypes().Single(t => t.Name == "Holder");
+        var data = holder
+            .GetCustomAttributesData()
+            .Single(d => d.AttributeType.FullName == "System.Diagnostics.DebuggerDisplayAttribute");
+
+        var targetNamed = Assert.Single(data.NamedArguments, n => n.MemberName == "Target");
+        Assert.Equal(typeof(Type), targetNamed.TypedValue.ArgumentType);
+        var typeName = targetNamed.TypedValue.Value switch
+        {
+            Type t => t.FullName,
+            string s => s,
+            _ => null,
+        };
+        Assert.StartsWith("System.String", typeName ?? string.Empty);
+    }
+
+    [Fact]
+    public void Emits_Object_Argument_Carrying_Boxed_Int()
+    {
+        // DefaultValueAttribute(object) is the canonical boxed-object ctor —
+        // the emitter must precede the FixedArg with the runtime type tag
+        // (ECMA-335 II.23.3 element-type 0x51).
+        var source = """
+            package P
+            import System
+            import System.ComponentModel
+
+            @DefaultValue(42)
+            type Counter data struct {
+                Value int
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var counter = assembly.GetTypes().Single(t => t.Name == "Counter");
+        var data = counter
+            .GetCustomAttributesData()
+            .Single(d => d.AttributeType.FullName == "System.ComponentModel.DefaultValueAttribute");
+        var arg = Assert.Single(data.ConstructorArguments);
+        // CustomAttributeData unboxes a 0x51-wrapped value to its runtime element type.
+        Assert.Equal(typeof(int), arg.ArgumentType);
+        Assert.Equal(42, arg.Value);
+    }
+
+    [Fact]
+    public void Emits_Object_Argument_Carrying_String()
+    {
+        var source = """
+            package P
+            import System
+            import System.ComponentModel
+
+            @DefaultValue("hello")
+            type Greeter data struct {
+                Value int
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var greeter = assembly.GetTypes().Single(t => t.Name == "Greeter");
+        var data = greeter
+            .GetCustomAttributesData()
+            .Single(d => d.AttributeType.FullName == "System.ComponentModel.DefaultValueAttribute");
+        var arg = Assert.Single(data.ConstructorArguments);
+        Assert.Equal(typeof(string), arg.ArgumentType);
+        Assert.Equal("hello", arg.Value);
+    }
+
+    [Fact]
+    public void Emits_Array_Argument()
+    {
+        // TupleElementNamesAttribute(string[]) — exercises the ECMA-335
+        // II.23.3 SZARRAY (0x1D) encoding for a string-array positional arg.
+        var source = """
+            package P
+            import System
+            import System.Runtime.CompilerServices
+
+            @TupleElementNames([]string{"first", "second"})
+            type Pair data struct {
+                A int
+                B int
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var pair = assembly.GetTypes().Single(t => t.Name == "Pair");
+        var data = pair
+            .GetCustomAttributesData()
+            .Single(d => d.AttributeType.FullName == "System.Runtime.CompilerServices.TupleElementNamesAttribute");
+        var arg = Assert.Single(data.ConstructorArguments);
+        var values = ((System.Collections.ObjectModel.ReadOnlyCollection<System.Reflection.CustomAttributeTypedArgument>)arg.Value)
+            .Select(v => (string)v.Value)
+            .ToArray();
+        Assert.Equal(new[] { "first", "second" }, values);
+    }
+
+    [Fact]
+    public void Emits_Object_Argument_Carrying_Type()
+    {
+        // DefaultValueAttribute(object) carrying a `typeof(T)` — verifies the
+        // recursive 0x51-boxed encoding nests a 0x50 type-name SerString.
+        var source = """
+            package P
+            import System
+            import System.ComponentModel
+
+            @DefaultValue(typeof(int))
+            type Holder data struct {
+                Value int
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var holder = assembly.GetTypes().Single(t => t.Name == "Holder");
+        var data = holder
+            .GetCustomAttributesData()
+            .Single(d => d.AttributeType.FullName == "System.ComponentModel.DefaultValueAttribute");
+        var arg = Assert.Single(data.ConstructorArguments);
+        Assert.Equal(typeof(Type), arg.ArgumentType);
+        var typeName = arg.Value switch
+        {
+            Type t => t.FullName,
+            string s => s,
+            _ => null,
+        };
+        Assert.StartsWith("System.Int32", typeName ?? string.Empty);
+    }
+
     private static Assembly CompileToAssembly(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_attr_emit_").FullName;


### PR DESCRIPTION
Closes #170. Phase 3 follow-up for ADR-0047 §3.

## Changes

- **Binder** (`Binder.cs`): per-parameter `BindAttributes` results are now stored on the corresponding `ParameterSymbol` via `SetAttributes` rather than being discarded after diagnostics. A parallel `ParameterSymbol[]` keyed by syntax index threads each bound list to the right symbol (duplicates are still skipped).
- **Emitter** (`ReflectionMetadataEmitter.cs`): `EmitFunction` now emits a `Parameter` metadata row per source parameter (sequence numbers start at 1, skipping the `this` receiver), anchors `MethodDef.parameterList` at the first new handle, and calls `EmitUserAttributes(paramHandle, paramSym, AttributeTargetKind.Param)` for each one.
- **`NextParameterHandle()` helper**: since the Param table is no longer empty, every `AddMethodDefinition` call site that previously hard-coded `MetadataTokens.ParameterHandle(1)` (synthesized `Equals`/`GetHashCode`/`ToString`/`Deconstruct`/`op_Equality`/abstract interface methods/etc.) now resolves to the next Param row so the table's per-method runs stay monotone per ECMA-335 II.22.26.
- **Test**: `Emits_Attribute_On_Parameter` round-trips `@Obsolete("old name")` on a parameter via `MethodInfo.GetParameters()[i].GetCustomAttributesData()` and confirms the MethodDef itself does **not** carry the param-target attribute.

## Validation

`dotnet test GSharp.sln --nologo --no-restore --no-build`: **1319 / 1319 passing**.