### PR TITLE
Fix #172: emit CustomAttribute rows for return-target annotations

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -2730,7 +2730,23 @@ internal sealed class ReflectionMetadataEmitter
         // so we can attach a CustomAttribute to each one. The first emitted
         // ParameterHandle becomes the MethodDef.parameterList anchor; if the
         // function has no parameters we leave it pointing at the next ordinal.
+        //
+        // Issue #172: when the function carries any `@return:` annotations,
+        // emit a Parameter row with sequence number 0 (ECMA-335 II.22.33) in
+        // front of the source-parameter rows so we can attach return-target
+        // CustomAttribute rows to it.
         var firstParamHandle = this.NextParameterHandle();
+        var hasReturnAttributes = !function.Attributes.IsDefaultOrEmpty
+            && function.Attributes.Any(a => a.Target == AttributeTargetKind.Return);
+        ParameterHandle? returnParamHandle = null;
+        if (hasReturnAttributes)
+        {
+            returnParamHandle = this.metadata.AddParameter(
+                attributes: ParameterAttributes.None,
+                name: default(StringHandle),
+                sequenceNumber: 0);
+        }
+
         var paramHandles = new List<(ParameterSymbol Symbol, ParameterHandle Handle)>();
         var sequenceNumber = 1;
         foreach (var p in function.Parameters)
@@ -2757,8 +2773,14 @@ internal sealed class ReflectionMetadataEmitter
 
         // Phase 3 of #141: attach user annotations (method target) to the
         // MethodDef. Issue #170: per-parameter annotations attach to each
-        // emitted Parameter row. Return-target attributes still pending.
+        // emitted Parameter row. Issue #172: return-target annotations attach
+        // to the synthesised sequence-0 Parameter row.
         this.EmitUserAttributes(handle, function, AttributeTargetKind.Method);
+        if (returnParamHandle is { } retHandle)
+        {
+            this.EmitUserAttributes(retHandle, function, AttributeTargetKind.Return);
+        }
+
         foreach (var (paramSym, paramHandle) in paramHandles)
         {
             this.EmitUserAttributes(paramHandle, paramSym, AttributeTargetKind.Param);

--- a/test/Compiler.Tests/Emit/AttributeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AttributeEmitTests.cs
@@ -314,6 +314,40 @@ public class AttributeEmitTests
             d => d.AttributeType.FullName == "System.ObsoleteAttribute");
     }
 
+    [Fact]
+    public void Emits_Attribute_On_Return_Parameter()
+    {
+        // Issue #172 / ADR-0047 §3: `@return:` annotations attach to the
+        // synthesised sequence-0 Parameter row (ECMA-335 II.22.33), surfacing
+        // through `MethodInfo.ReturnParameter.GetCustomAttributesData()`.
+        var source = """
+            package P
+            import System
+
+            @return:Obsolete("old return")
+            func Foo() int {
+                return 0
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var foo = program.GetMethod("Foo", BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(foo);
+
+        var returnParam = foo.ReturnParameter;
+        Assert.NotNull(returnParam);
+        var data = returnParam.GetCustomAttributesData()
+            .Single(d => d.AttributeType.FullName == "System.ObsoleteAttribute");
+        var arg = Assert.Single(data.ConstructorArguments);
+        Assert.Equal("old return", arg.Value);
+
+        // The MethodDef itself should not carry the return-target attribute.
+        Assert.DoesNotContain(
+            foo.GetCustomAttributesData(),
+            d => d.AttributeType.FullName == "System.ObsoleteAttribute");
+    }
+
     private static Assembly CompileToAssembly(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_attr_emit_").FullName;


### PR DESCRIPTION
Closes #172.

Phase 3 follow-up to #141. Return-target annotations (`@return:Foo`) were bound correctly but silently dropped at emit because no Parameter row existed to anchor them.

## Changes

- `ReflectionMetadataEmitter.EmitFunction`: when the function has any `AttributeTargetKind.Return` attributes, emit a Parameter row with sequence number 0 (ECMA-335 II.22.33) ahead of the source-parameter rows, then call `EmitUserAttributes(returnParamHandle, function, AttributeTargetKind.Return)`.
- New emit test `Emits_Attribute_On_Return_Parameter` verifies `@return:Obsolete("old return") func Foo() int { return 0 }` produces an `ObsoleteAttribute` reachable via `MethodInfo.ReturnParameter.GetCustomAttributesData()` (and is **not** attached to the MethodDef itself).

## Validation

`dotnet test GSharp.sln --nologo --no-restore` — all suites green (Core 1105, Compiler 146, Interpreter 31, LanguageServer 17, Sdk 10).