### PR TITLE
Address #175: extend [Obsolete] use-site warnings beyond function calls

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -170,7 +170,7 @@ ADR-0047 introduces Kotlin-style attribute syntax (`@Foo(...)`) and the `@Attrib
 | GS0201 | Error | Attribute target is not valid at this position. | `@field:Obsolete func Foo() {}` — `field` is not allowed on a function. |
 | GS0202 | Error | Attribute arguments must be compile-time constants. | `@Trace(myVar)` — argument is not a primitive, string, `typeof`, enum, or 1-D array thereof. |
 | GS0203 | Error | Class tagged `@Attribute` cannot also declare an explicit base class. | `@Attribute type Trace class : Other {}` — the `@Attribute` sugar implies `: System.Attribute`. |
-| GS0204 | **Warning** (Error if `IsError=true`) | Reference to a symbol marked `[Obsolete]`. | Calling a function declared with `@Obsolete("use Bar")`. Severity is promoted to error when the attribute's second argument is `true`. |
+| GS0204 | **Warning** (Error if `IsError=true`) | Reference to a symbol marked `[Obsolete]`. | Calling a function, instantiating a class (`Old(5)`), writing a struct literal (`Old{}`), naming a struct/class/interface/enum in a type clause, or reading an obsolete parameter — all declared with `@Obsolete("use Bar")`. Severity is promoted to error when the attribute's second argument is `true`. |
 | GS0205 | Error | Attribute is reserved for compiler synthesis. | `@CompilerGenerated`, `@Extension`, `@AsyncStateMachine`, `@Nullable`, or `@NullableContext` written in user source. |
 
 ### Pointer / by-ref diagnostics (GS9001–GS9006)

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1959,6 +1959,12 @@ public sealed class Binder
             return null;
         }
 
+        // ADR-0047 §6 / #175: report obsolete-use for any named struct,
+        // class, interface, or enum reference appearing in type position
+        // (parameter types, return types, field types, generic-argument
+        // positions, type aliases, etc.).
+        ReportObsoleteUseIfApplicable(syntax.Identifier.Location, element, element.Name);
+
         // Phase 4.3c / ADR-0020: handle generic type construction `Foo[T1, T2]` in
         // type position (currently interfaces; structs follow up later).
         if (syntax.HasTypeArguments)
@@ -3974,6 +3980,10 @@ public sealed class Binder
             return new BoundErrorExpression();
         }
 
+        // ADR-0047 §6 / #175: struct/class literal `Foo{ ... }` is a
+        // use of the named type.
+        ReportObsoleteUseIfApplicable(syntax.TypeIdentifier.Location, structSymbol, structSymbol.Name);
+
         // Phase 4.3 / ADR-0020: if the declared struct is generic, build a
         // type-argument substitution (explicit or inferred from initializers)
         // and construct a closed StructSymbol to bind against. Constructed
@@ -4731,6 +4741,10 @@ public sealed class Binder
 
     private BoundExpression BindConstructorCallExpression(CallExpressionSyntax syntax, StructSymbol classType)
     {
+        // ADR-0047 §6 / #175: primary-constructor call `Foo(...)` is a
+        // use of the class type itself.
+        ReportObsoleteUseIfApplicable(syntax.Identifier.Location, classType, classType.Name);
+
         // Phase 4.3b / ADR-0020: a primary-constructor call on a generic
         // class definition (`Box(5)` or `Box[int](5)`) builds a type-argument
         // substitution before resolving the parameter list against the
@@ -4902,6 +4916,9 @@ public sealed class Binder
             // ctor call instead.
             if (!(type is StructSymbol singleArgStruct && (singleArgStruct.IsClass || singleArgStruct.IsInline) && singleArgStruct.HasPrimaryConstructor))
             {
+                // ADR-0047 §6 / #175: `Type(x)` as an explicit conversion
+                // is still a use of the named type.
+                ReportObsoleteUseIfApplicable(syntax.Identifier.Location, type, type.Name);
                 return BindConversion(syntax.Arguments[0], type, allowExplicit: true);
             }
         }
@@ -4961,12 +4978,7 @@ public sealed class Binder
             return new BoundErrorExpression();
         }
 
-        // ADR-0047 §6: if the resolved callee is marked [Obsolete], surface
-        // a use-site diagnostic (warning by default, error if IsError=true).
-        if (KnownAttributes.TryGetObsolete(function.Attributes, out var obsoleteMessage, out var obsoleteIsError))
-        {
-            Diagnostics.ReportObsoleteUse(syntax.Identifier.Location, function.Name, obsoleteMessage, obsoleteIsError);
-        }
+        ReportObsoleteUseIfApplicable(syntax.Identifier.Location, function, function.Name);
 
         var isVariadic = function.Parameters.Length > 0 && function.Parameters[function.Parameters.Length - 1].IsVariadic;
         var fixedParamCount = isVariadic ? function.Parameters.Length - 1 : function.Parameters.Length;
@@ -6411,6 +6423,7 @@ public sealed class Binder
         switch (scope.TryLookupSymbol(name))
         {
             case VariableSymbol variable:
+                ReportObsoleteUseIfApplicable(location, variable, variable.Name);
                 return variable;
 
             case null:
@@ -6420,6 +6433,24 @@ public sealed class Binder
             default:
                 Diagnostics.ReportNotAVariable(location, name);
                 return null;
+        }
+    }
+
+    // ADR-0047 §6 / #175: if <paramref name="symbol"/> carries an
+    // [Obsolete] attribute, surface a use-site diagnostic at
+    // <paramref name="location"/>. Severity is Warning by default,
+    // promoted to Error when the attribute's second positional
+    // argument (IsError) is true.
+    private void ReportObsoleteUseIfApplicable(TextLocation location, Symbol symbol, string displayName)
+    {
+        if (symbol == null)
+        {
+            return;
+        }
+
+        if (KnownAttributes.TryGetObsolete(symbol.Attributes, out var message, out var isError))
+        {
+            Diagnostics.ReportObsoleteUse(location, displayName, message, isError);
         }
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
@@ -270,6 +270,141 @@ type Point struct {
         Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0205");
     }
 
+    [Fact]
+    public void Obsolete_Warning_Is_Reported_At_Class_Constructor_Call()
+    {
+        // #175: extend GS0204 to primary-constructor calls on classes.
+        var source = """
+            @Obsolete("retired")
+            type Old class (value int) {
+            }
+
+            func Main() {
+                let x = Old(5)
+            }
+            """;
+
+        var program = BindProgramFromSource(source);
+        var diag = Assert.Single(program.Diagnostics, d => d.Id == "GS0204");
+        Assert.Equal(GSharp.Core.CodeAnalysis.DiagnosticSeverity.Warning, diag.Severity);
+        Assert.Contains("Old", diag.Message);
+        Assert.Contains("retired", diag.Message);
+    }
+
+    [Fact]
+    public void Obsolete_Warning_Is_Reported_At_Struct_Literal()
+    {
+        // #175: extend GS0204 to struct/class literal expressions.
+        var source = """
+            @Obsolete
+            type Point data struct {
+                X int
+                Y int
+            }
+
+            func Main() {
+                let p = Point{ X: 1, Y: 2 }
+            }
+            """;
+
+        var program = BindProgramFromSource(source);
+        var diag = Assert.Single(program.Diagnostics, d => d.Id == "GS0204");
+        Assert.Equal(GSharp.Core.CodeAnalysis.DiagnosticSeverity.Warning, diag.Severity);
+        Assert.Contains("Point", diag.Message);
+    }
+
+    [Fact]
+    public void Obsolete_Warning_Is_Reported_At_Type_Clause_Reference()
+    {
+        // #175: extend GS0204 to named type references in type position.
+        // Marking a struct obsolete and naming it as a parameter type
+        // surfaces the diagnostic at the parameter's type clause. Such
+        // diagnostics are produced during declaration binding, so they
+        // live on the global-scope diagnostic bag rather than per-body.
+        var source = """
+            @Obsolete("legacy")
+            type Old data struct {
+                Value int
+            }
+
+            func Consume(o Old) {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0204" && d.Message.Contains("Old") && d.Message.Contains("legacy"));
+    }
+
+    [Fact]
+    public void Obsolete_Warning_Is_Reported_At_Interface_Type_Reference()
+    {
+        // #175: extend GS0204 to interface type references.
+        var source = """
+            @Obsolete
+            type IOld interface {
+            }
+
+            func Consume(o IOld) {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0204" && d.Message.Contains("IOld"));
+    }
+
+    [Fact]
+    public void Obsolete_Warning_Is_Reported_At_Enum_Type_Reference()
+    {
+        // #175: extend GS0204 to enum type references.
+        var source = """
+            @Obsolete
+            type Mode enum { A, B }
+
+            func Pick(m Mode) {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0204" && d.Message.Contains("Mode"));
+    }
+
+    [Fact]
+    public void Obsolete_Warning_Is_Reported_At_Parameter_Use_Site()
+    {
+        // #175: parameters that carry @Obsolete surface GS0204 at every
+        // read or write site (parameters already carry attribute storage
+        // per #170).
+        var source = """
+            func Foo(@Obsolete("dead") x int) int {
+                return x + 1
+            }
+            """;
+
+        var program = BindProgramFromSource(source);
+        var diag = Assert.Single(program.Diagnostics, d => d.Id == "GS0204");
+        Assert.Equal(GSharp.Core.CodeAnalysis.DiagnosticSeverity.Warning, diag.Severity);
+        Assert.Contains("x", diag.Message);
+        Assert.Contains("dead", diag.Message);
+    }
+
+    [Fact]
+    public void Obsolete_With_IsError_On_Class_Promotes_To_Error()
+    {
+        var source = """
+            @Obsolete("gone", true)
+            type Old class (value int) {
+            }
+
+            func Main() {
+                let x = Old(5)
+            }
+            """;
+
+        var program = BindProgramFromSource(source);
+        var diag = Assert.Single(program.Diagnostics, d => d.Id == "GS0204");
+        Assert.Equal(GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error, diag.Severity);
+    }
+
     private static BoundGlobalScope BindSource(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
Fixes #175.

ADR-0047 §6 says `[Obsolete]` applies to *any* symbol use, but PR #174 wired GS0204 only at `BindCallExpression` for function calls. This PR extends the diagnostic to every binding site where attribute storage already exists.

## New GS0204 sites

* **Type clauses** — named struct/class/interface/enum references in parameter types, return types, field types, generic arguments, type aliases. Reported once from `BindNonNullableTypeClause` right after a successful `LookupType`.
* **Primary-constructor calls** — `Foo(arg1, arg2)` on a class with a primary constructor. Reported from `BindConstructorCallExpression`.
* **Struct/class literals** — `Foo{ X: 1 }`. Reported from `BindStructLiteralExpression`.
* **Explicit conversion calls** — `T(x)` where `T` is a named type. Reported in the conversion path of `BindCallExpression`.
* **Parameter use sites** — reading or writing an `@Obsolete` parameter. Reported from `BindVariableReference` so every reference surfaces the warning.

A single private helper `ReportObsoleteUseIfApplicable(location, symbol, displayName)` centralises the `KnownAttributes.TryGetObsolete` + `Diagnostics.ReportObsoleteUse` pattern. The existing function-call site is refactored to use it.

## Out of scope (tracked separately)

The issue also mentions fields, properties, enum members, and `var`/`let`/`const` bindings. These need syntax-level annotation storage first; `FieldDeclarationSyntax`, `EnumMemberSyntax`, and `VariableDeclarationSyntax` currently have no `Annotations` slot. Filed follow-ups:

* #186 — Allow @-annotations on field declarations
* #187 — Allow @-annotations on var/let/const variable declarations
* #188 — Allow @-annotations on enum members

Once any of those land, the `ReportObsoleteUseIfApplicable` helper can be wired into the corresponding bind sites (`BoundFieldAccessExpression`, `BoundFieldAssignmentExpression`, enum-member references, etc.) with one-line additions.

## Tests

`AttributeBinderTests` gains seven new cases covering each new site plus the IsError → Error promotion on a class. Full suite (1327 tests) passes.