### PR TITLE
Address #187: allow @-annotations on var/let/const variable declarations

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -156,7 +156,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0194 | Error | Unrecognised escape sequence in character literal. | `'\q'`. |
 | GS0195 | Error | Malformed Unicode escape in character literal. | `'\u00G0'`. |
 
-### Attribute / annotation diagnostics (GS0196–GS0205)
+### Attribute / annotation diagnostics (GS0196–GS0206)
 
 ADR-0047 introduces Kotlin-style attribute syntax (`@Foo(...)`) and the `@Attribute` declaration sugar. The following diagnostics cover parsing, resolution, use-site validation, and the compiler-recognised attribute set.
 
@@ -170,8 +170,9 @@ ADR-0047 introduces Kotlin-style attribute syntax (`@Foo(...)`) and the `@Attrib
 | GS0201 | Error | Attribute target is not valid at this position. | `@field:Obsolete func Foo() {}` — `field` is not allowed on a function. |
 | GS0202 | Error | Attribute arguments must be compile-time constants. | `@Trace(myVar)` — argument is not a primitive, string, `typeof`, enum, or 1-D array thereof. |
 | GS0203 | Error | Class tagged `@Attribute` cannot also declare an explicit base class. | `@Attribute type Trace class : Other {}` — the `@Attribute` sugar implies `: System.Attribute`. |
-| GS0204 | **Warning** (Error if `IsError=true`) | Reference to a symbol marked `[Obsolete]`. | Calling a function, instantiating a class (`Old(5)`), writing a struct literal (`Old{}`), naming a struct/class/interface/enum in a type clause, or reading an obsolete parameter — all declared with `@Obsolete("use Bar")`. Severity is promoted to error when the attribute's second argument is `true`. |
+| GS0204 | **Warning** (Error if `IsError=true`) | Reference to a symbol marked `[Obsolete]`. | Calling a function, instantiating a class (`Old(5)`), writing a struct literal (`Old{}`), naming a struct/class/interface/enum in a type clause, reading an obsolete parameter, or reading/writing an obsolete `var`/`let`/`const` — all declared with `@Obsolete("use Bar")`. Severity is promoted to error when the attribute's second argument is `true`. |
 | GS0205 | Error | Attribute is reserved for compiler synthesis. | `@CompilerGenerated`, `@Extension`, `@AsyncStateMachine`, `@Nullable`, or `@NullableContext` written in user source. |
+| GS0206 | Error | Annotations are only allowed on variable declarations, not on this statement. | `@Obsolete\nreturn` inside a function body — annotations may precede `var`/`let`/`const` but no other statement kind. |
 
 ### Pointer / by-ref diagnostics (GS9001–GS9006)
 

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -50,6 +50,17 @@ public sealed class Binder
     private static readonly ImmutableHashSet<AttributeTargetKind> FieldDeclarationAllowedTargets =
         ImmutableHashSet.Create(AttributeTargetKind.Field);
 
+    /// <summary>
+    /// Targets permitted on a <c>var</c>/<c>let</c>/<c>const</c> variable
+    /// declaration. ADR-0047 §2 assigns the default target <c>field</c> to
+    /// these declarations (both at top level — where the variable becomes a
+    /// CLR static field — and in local scope — where the attribute carries
+    /// compiler-recognised semantics like <c>@Obsolete</c> for use-site
+    /// diagnostics).
+    /// </summary>
+    private static readonly ImmutableHashSet<AttributeTargetKind> VariableDeclarationAllowedTargets =
+        ImmutableHashSet.Create(AttributeTargetKind.Field);
+
     private FunctionSymbol function;
 
     private Stack<(BoundLabel BreakLabel, BoundLabel ContinueLabel)> loopStack = new Stack<(BoundLabel BreakLabel, BoundLabel ContinueLabel)>();
@@ -1656,6 +1667,25 @@ public sealed class Binder
         var accessibility = ResolveAccessibility(syntax.AccessibilityModifier);
         var variable = BindVariableDeclaration(syntax.Identifier, isReadOnly, variableType, accessibility);
         var convertedInitializer = BindConversion(syntax.Initializer.Location, initializer, variableType);
+
+        // Issue #187 / ADR-0047 §3: bind any `@Foo` annotations and attach
+        // them to the variable symbol so #175 use-site diagnostics
+        // (e.g. `@Obsolete`) fire when the variable is read or written.
+        // Globals (`GlobalVariableSymbol`) will eventually round-trip these
+        // to CLR `CustomAttribute` rows on their backing static field; for
+        // locals the attributes carry compiler-recognised semantics only.
+        if (variable != null && !syntax.Annotations.IsDefaultOrEmpty)
+        {
+            var positionDescription = variable is GlobalVariableSymbol
+                ? "a top-level variable declaration"
+                : "a local variable declaration";
+            var boundAttrs = BindAttributes(
+                syntax.Annotations,
+                AttributeTargetKind.Field,
+                VariableDeclarationAllowedTargets,
+                positionDescription);
+            variable.SetAttributes(boundAttrs);
+        }
 
         return new BoundVariableDeclaration(variable, convertedInitializer);
     }

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1262,6 +1262,18 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0205", $"Attribute '{name}' is reserved for compiler synthesis and cannot be written in source.");
     }
 
+    /// <summary>
+    /// Reports GS0206 when an annotation lead-in (<c>@Name</c>) precedes a
+    /// statement that does not accept annotations (only local
+    /// <c>var</c>/<c>let</c>/<c>const</c> declarations do — see ADR-0047 §2
+    /// and issue #187).
+    /// </summary>
+    /// <param name="location">The source location of the leading <c>@</c>.</param>
+    public void ReportAnnotationsNotAllowedOnStatement(TextLocation location)
+    {
+        Report(location, "GS0206", "Annotations are only allowed on variable declarations (var/let/const), not on this statement.");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -186,6 +186,19 @@ public class Parser
              Current.Kind == SyntaxKind.ConstKeyword))
         {
             var declaration = ParseVariableDeclaration(accessibilityModifier);
+
+            // Issue #187: annotations on a top-level `var`/`let`/`const`
+            // belong to the variable declaration itself (default target
+            // `field` per ADR-0047 §2), not to the wrapping GlobalStatement.
+            // Forward the parsed annotations onto the declaration and clear
+            // the local so the trailing `member.WithAnnotations(annotations)`
+            // does not double-attach.
+            if (declaration is VariableDeclarationSyntax variableDeclaration)
+            {
+                variableDeclaration.WithAnnotations(annotations);
+                annotations = ImmutableArray<AnnotationSyntax>.Empty;
+            }
+
             member = new GlobalStatementSyntax(syntaxTree, declaration);
         }
         else
@@ -202,6 +215,19 @@ public class Parser
             }
 
             member = ParseGlobalStatement();
+
+            // Issue #187: a top-level `var`/`let`/`const` without an
+            // accessibility modifier is parsed through ParseGlobalStatement →
+            // ParseStatement, which has no awareness of member-level
+            // annotations. Forward them onto the inner variable declaration
+            // so the binder picks them up via VariableDeclarationSyntax.
+            if (!annotations.IsDefaultOrEmpty &&
+                member is GlobalStatementSyntax wrappingGlobal &&
+                wrappingGlobal.Statement is VariableDeclarationSyntax forwardingDeclaration)
+            {
+                forwardingDeclaration.WithAnnotations(annotations);
+                annotations = ImmutableArray<AnnotationSyntax>.Empty;
+            }
         }
 
         return member.WithAnnotations(annotations);
@@ -1442,6 +1468,30 @@ public class Parser
 
     private StatementSyntax ParseStatement()
     {
+        // Issue #187 / ADR-0047 §2: a local `var`/`let`/`const` can be
+        // preceded by Kotlin-style `@` annotations (default target `field`).
+        // Other statement kinds do not accept annotations — for those we
+        // still parse the leading `@...` (to drive a normal binder
+        // diagnostic against the synthesized declaration) but fall through
+        // to the regular dispatch and drop the annotations on the floor
+        // after reporting via ReportAnnotationsNotAllowedOnStatement.
+        ImmutableArray<AnnotationSyntax> leadingAnnotations = ImmutableArray<AnnotationSyntax>.Empty;
+        if (Current.Kind == SyntaxKind.AtToken)
+        {
+            leadingAnnotations = ParseAnnotations();
+            if (Current.Kind != SyntaxKind.ConstKeyword &&
+                Current.Kind != SyntaxKind.LetKeyword &&
+                Current.Kind != SyntaxKind.VarKeyword)
+            {
+                if (leadingAnnotations.Length > 0)
+                {
+                    Diagnostics.ReportAnnotationsNotAllowedOnStatement(leadingAnnotations[0].AtToken.Location);
+                }
+
+                leadingAnnotations = ImmutableArray<AnnotationSyntax>.Empty;
+            }
+        }
+
         switch (Current.Kind)
         {
             case SyntaxKind.OpenBraceToken:
@@ -1449,7 +1499,14 @@ public class Parser
             case SyntaxKind.ConstKeyword:
             case SyntaxKind.LetKeyword:
             case SyntaxKind.VarKeyword:
-                return ParseVariableDeclaration();
+                var declaration = ParseVariableDeclaration();
+                if (declaration is VariableDeclarationSyntax variableDeclaration &&
+                    !leadingAnnotations.IsDefaultOrEmpty)
+                {
+                    variableDeclaration.WithAnnotations(leadingAnnotations);
+                }
+
+                return declaration;
             case SyntaxKind.IfKeyword:
                 return ParseIfStatement();
             case SyntaxKind.ForKeyword:

--- a/src/Core/CodeAnalysis/Syntax/VariableDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/VariableDeclarationSyntax.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System.Collections.Immutable;
+
 namespace GSharp.Core.CodeAnalysis.Syntax;
 
 /// <summary>
@@ -55,10 +57,21 @@ public sealed class VariableDeclarationSyntax : StatementSyntax
         TypeClause = typeClause;
         EqualsToken = equalsToken;
         Initializer = initializer;
+        Annotations = ImmutableArray<AnnotationSyntax>.Empty;
     }
 
     /// <inheritdoc/>
     public override SyntaxKind Kind => SyntaxKind.VariableDeclaration;
+
+    /// <summary>
+    /// Gets the Kotlin-style annotations (ADR-0047) attached to this variable
+    /// declaration. Empty when no <c>@</c> lead-ins are present. Populated by
+    /// the parser via <see cref="WithAnnotations"/> so existing constructor
+    /// overloads do not need to be touched. Declared first so that
+    /// <see cref="SyntaxNode.GetChildren"/> visits annotations before the
+    /// remaining tokens — keeping spans and first/last-token lookups stable.
+    /// </summary>
+    public ImmutableArray<AnnotationSyntax> Annotations { get; private set; }
 
     /// <summary>
     /// Gets the optional accessibility modifier token. Only meaningful for top-level declarations.
@@ -89,4 +102,13 @@ public sealed class VariableDeclarationSyntax : StatementSyntax
     /// Gets the initializer expression.
     /// </summary>
     public ExpressionSyntax Initializer { get; }
+
+    /// <summary>Attaches the given annotation list to this variable declaration and returns this same instance for fluent parser use.</summary>
+    /// <param name="annotations">The annotation list to attach (may be empty).</param>
+    /// <returns>This same <see cref="VariableDeclarationSyntax"/>, with <see cref="Annotations"/> updated.</returns>
+    internal VariableDeclarationSyntax WithAnnotations(ImmutableArray<AnnotationSyntax> annotations)
+    {
+        Annotations = annotations.IsDefault ? ImmutableArray<AnnotationSyntax>.Empty : annotations;
+        return this;
+    }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
@@ -405,6 +405,107 @@ type Point struct {
         Assert.Equal(GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error, diag.Severity);
     }
 
+    [Fact]
+    public void Attaches_Attributes_To_Global_Variable_Symbol()
+    {
+        // Issue #187: a top-level `var`/`let`/`const` accepts annotations
+        // (default target `field`). Verify the attributes flow onto the
+        // GlobalVariableSymbol regardless of whether an accessibility
+        // modifier is present.
+        var source = """
+            @Obsolete("retired")
+            let limit = 10
+
+            @Obsolete
+            public var counter = 0
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Empty(GetBinderDiagnostics(globalScope));
+
+        var limit = globalScope.Variables.Single(v => v.Name == "limit");
+        var counter = globalScope.Variables.Single(v => v.Name == "counter");
+
+        Assert.Single(limit.Attributes);
+        Assert.Equal("System.ObsoleteAttribute", limit.Attributes[0].AttributeType.Name);
+        Assert.Equal(AttributeTargetKind.Field, limit.Attributes[0].Target);
+
+        Assert.Single(counter.Attributes);
+        Assert.Equal(AttributeTargetKind.Field, counter.Attributes[0].Target);
+    }
+
+    [Fact]
+    public void Attaches_Attributes_To_Local_Variable_Symbol_For_Use_Site_Diagnostics()
+    {
+        // Issue #187: locals also accept annotations; the binder must
+        // populate the LocalVariableSymbol.Attributes slot so #175 use-site
+        // diagnostics fire on subsequent reads / writes.
+        var source = """
+            func Main() {
+                @Obsolete("dead local")
+                let x = 1
+                let y = x + 1
+                _ = y
+            }
+            """;
+
+        var program = BindProgramFromSource(source);
+        var diag = Assert.Single(program.Diagnostics, d => d.Id == "GS0204");
+        Assert.Equal(GSharp.Core.CodeAnalysis.DiagnosticSeverity.Warning, diag.Severity);
+        Assert.Contains("x", diag.Message);
+        Assert.Contains("dead local", diag.Message);
+    }
+
+    [Fact]
+    public void Obsolete_Warning_Fires_On_Global_Variable_Read_And_Write()
+    {
+        // Issue #187 + #175: every read or write of an `@Obsolete` global
+        // surfaces GS0204.
+        var source = """
+            @Obsolete("dead global")
+            var counter = 0
+
+            func Main() {
+                counter = counter + 1
+            }
+            """;
+
+        var program = BindProgramFromSource(source);
+        var obsoleteDiags = program.Diagnostics.Where(d => d.Id == "GS0204").ToList();
+        Assert.Equal(2, obsoleteDiags.Count);
+        Assert.All(obsoleteDiags, d => Assert.Contains("counter", d.Message));
+        Assert.All(obsoleteDiags, d => Assert.Contains("dead global", d.Message));
+    }
+
+    [Fact]
+    public void Reports_Invalid_Use_Site_Target_On_Variable()
+    {
+        // `@method:` is not a valid target on a variable declaration.
+        var source = """
+            @method:Obsolete
+            let x = 1
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0201");
+    }
+
+    [Fact]
+    public void Reports_Annotations_Not_Allowed_On_Non_Variable_Statement()
+    {
+        // Issue #187: an `@` lead-in on a statement that is not a variable
+        // declaration surfaces GS0206.
+        var source = """
+            func Main() {
+                @Obsolete
+                return
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        Assert.Contains(tree.Diagnostics, d => d.Id == "GS0206");
+    }
+
     private static BoundGlobalScope BindSource(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Syntax/AnnotationParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/AnnotationParserTests.cs
@@ -253,6 +253,88 @@ type Point struct {
         Assert.Equal(SyntaxKind.AtToken, token.Kind);
     }
 
+    [Fact]
+    public void Parses_Annotation_On_Top_Level_Variable_With_Accessibility()
+    {
+        // Issue #187: a `@`-led annotation precedes `public var` at top
+        // level and lands on the underlying VariableDeclarationSyntax, not
+        // on the wrapping GlobalStatementSyntax.
+        const string source = @"
+package P
+
+@Obsolete(""dead"")
+public var counter = 0
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var member = tree.Root.Members.OfType<GlobalStatementSyntax>().Single();
+        var decl = Assert.IsType<VariableDeclarationSyntax>(member.Statement);
+        var annotation = Assert.Single(decl.Annotations);
+        Assert.Equal("Obsolete", annotation.GetNameText());
+        Assert.Empty(member.Annotations);
+    }
+
+    [Fact]
+    public void Parses_Annotation_On_Top_Level_Variable_Without_Accessibility()
+    {
+        // Issue #187: same as above but with no accessibility modifier;
+        // ParseGlobalStatement → ParseStatement path must still forward the
+        // member-level annotations onto the VariableDeclarationSyntax.
+        const string source = @"
+package P
+
+@Obsolete
+let limit = 10
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var member = tree.Root.Members.OfType<GlobalStatementSyntax>().Single();
+        var decl = Assert.IsType<VariableDeclarationSyntax>(member.Statement);
+        Assert.Single(decl.Annotations);
+        Assert.Empty(member.Annotations);
+    }
+
+    [Fact]
+    public void Parses_Annotation_On_Local_Variable_Declaration()
+    {
+        // Issue #187: locals accept the same `@` lead-in surface syntax.
+        const string source = @"
+package P
+
+func Main() {
+    @Obsolete(""dead local"")
+    let x = 1
+    _ = x
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        var block = Assert.IsType<BlockStatementSyntax>(fn.Body);
+        var decl = block.Statements.OfType<VariableDeclarationSyntax>().Single();
+        var annotation = Assert.Single(decl.Annotations);
+        Assert.Equal("Obsolete", annotation.GetNameText());
+    }
+
+    [Fact]
+    public void Reports_GS0206_On_Annotation_Before_Non_Variable_Statement()
+    {
+        // Issue #187: `@` before a non-variable statement reports GS0206.
+        const string source = @"
+package P
+
+func Main() {
+    @Obsolete
+    return
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Contains(tree.Diagnostics, d => d.Id == "GS0206");
+    }
+
     private static System.Collections.Generic.IEnumerable<SyntaxToken> EnumerateTokens(SyntaxNode node)
     {
         if (node is SyntaxToken t)


### PR DESCRIPTION
Closes #187.

Extends Kotlin-style `@Foo` annotations (ADR-0047) to `var`/`let`/`const` declarations at both top-level and local scope, so attributes such as `@Obsolete` can be attached to a variable binding and surface use-site diagnostics on reads and writes (issue #175 plumbing).

## Parser

- Add `Annotations` slot + `WithAnnotations` to `VariableDeclarationSyntax` (mirrors the `ParameterSyntax` pattern).
- `ParseMember` forwards member-level annotations onto the underlying `VariableDeclarationSyntax` for both the accessibility-modifier path and the `ParseGlobalStatement` → `ParseStatement` path, instead of leaving them on the wrapping `GlobalStatementSyntax`.
- `ParseStatement` accepts a leading `@`-annotation list on local `var`/`let`/`const` declarations. Reports new **GS0206** when an annotation precedes any other statement kind.

## Binder

- Bind `syntax.Annotations` in `BindVariableDeclaration` with default target `field` (ADR-0047 §2) using the new `VariableDeclarationAllowedTargets` set (`{field}`).
- Store the result via `VariableSymbol.SetAttributes` — the existing `BindVariableReference` path automatically reports the **GS0204** use-site diagnostic from #175 on `@Obsolete` reads and writes.

## Diagnostics

- Add **GS0206** (`'annotations are only allowed on variable declarations'`).
- Document **GS0196–GS0206** in `docs/diagnostics.md`; updated **GS0204** description to mention obsolete `var`/`let`/`const` reads and writes.

## Tests

- `AnnotationParserTests`: annotations on top-level vars with and without accessibility, on locals, and the **GS0206** negative case.
- `AttributeBinderTests`: attributes flow onto global and local variable symbols, **GS0204** fires on every read or write of an obsolete global, **GS0201** fires on invalid use-site targets (e.g. `@method:`), and **GS0206** surfaces through the parser.

Full suite: **1121** Core.Tests, **146** Compiler.Tests, **31** Interpreter.Tests, **17** LanguageServer.Tests, **21** Sdk.Tests — all passing.

### Emit note

Globals are currently lowered to locals in the synthesized package initializer and do not yet round-trip to CLR static fields, so no `CustomAttribute` rows are emitted yet. Once globals become real static fields, the `BindVariableDeclaration` storage added here will flow directly through the existing `EmitUserAttributes` path. End-to-end `gsc` compilation of `@Obsolete` globals already works and surfaces **GS0204** on every read/write.