### PR TITLE
Fix #193: emit user-defined enums as CLR enum types

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -312,6 +312,7 @@ public sealed class Binder
         var typeAliases = binder.scope.GetDeclaredTypeAliases();
         var structs = binder.scope.GetDeclaredStructs();
         var interfaces = binder.scope.GetDeclaredInterfaces();
+        var enums = binder.scope.GetDeclaredEnums();
 
         // Entry-point package: the package owning the top-level statements
         // (if any) or the package owning explicit Main (if any) or, lacking
@@ -328,7 +329,7 @@ public sealed class Binder
             diagnostics = diagnostics.InsertRange(0, previous.Diagnostics);
         }
 
-        return new BoundGlobalScope(previous, entryPointPackage, packagesInOrder.ToImmutable(), diagnostics, imports, functions, variables, typeAliases, structs, interfaces, entryPoint, statements.ToImmutable());
+        return new BoundGlobalScope(previous, entryPointPackage, packagesInOrder.ToImmutable(), diagnostics, imports, functions, variables, typeAliases, structs, interfaces, enums, entryPoint, statements.ToImmutable());
     }
 
     /// <summary>
@@ -402,7 +403,7 @@ public sealed class Binder
             functionBodies[globalScope.EntryPoint] = statement;
         }
 
-        return new BoundProgram(globalScope.Package, globalScope.Packages, diagnostics.ToImmutable(), functionBodies.ToImmutable(), globalScope.EntryPoint, statement, globalScope.Structs, globalScope.Interfaces);
+        return new BoundProgram(globalScope.Package, globalScope.Packages, diagnostics.ToImmutable(), functionBodies.ToImmutable(), globalScope.EntryPoint, statement, globalScope.Structs, globalScope.Interfaces, globalScope.Enums);
     }
 
     private static BoundScope CreateParentScope(BoundGlobalScope previous, ReferenceResolver references)

--- a/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
@@ -67,6 +67,40 @@ public sealed class BoundGlobalScope
         ImmutableArray<InterfaceSymbol> interfaces,
         FunctionSymbol entryPoint,
         ImmutableArray<BoundStatement> statements)
+        : this(previous, package, packages, diagnostics, imports, functions, variables, typeAliases, structs, interfaces, ImmutableArray<EnumSymbol>.Empty, entryPoint, statements)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundGlobalScope"/> class with declared enums (#193).
+    /// </summary>
+    /// <param name="previous">Previous compilation global scope.</param>
+    /// <param name="package">The entry-point package for the current compilation.</param>
+    /// <param name="packages">All distinct packages declared in the current compilation, in declaration order.</param>
+    /// <param name="diagnostics">Diagnostics for the current compilation.</param>
+    /// <param name="imports">Imports in the current compilation.</param>
+    /// <param name="functions">Functions in the current compilation.</param>
+    /// <param name="variables">Variables in the current compilation.</param>
+    /// <param name="typeAliases">Type aliases declared in the current compilation.</param>
+    /// <param name="structs">User-defined struct types declared in the current compilation.</param>
+    /// <param name="interfaces">User-defined interface types declared in the current compilation (Phase 3.B.4).</param>
+    /// <param name="enums">User-defined enum types declared in the current compilation (#193).</param>
+    /// <param name="entryPoint">The entry-point function for this compilation, or null if the compilation is a library.</param>
+    /// <param name="statements">Statements in the current compilation.</param>
+    public BoundGlobalScope(
+        BoundGlobalScope previous,
+        PackageSymbol package,
+        ImmutableArray<PackageSymbol> packages,
+        ImmutableArray<Diagnostic> diagnostics,
+        ImmutableArray<ImportSymbol> imports,
+        ImmutableArray<FunctionSymbol> functions,
+        ImmutableArray<VariableSymbol> variables,
+        ImmutableDictionary<string, TypeSymbol> typeAliases,
+        ImmutableArray<StructSymbol> structs,
+        ImmutableArray<InterfaceSymbol> interfaces,
+        ImmutableArray<EnumSymbol> enums,
+        FunctionSymbol entryPoint,
+        ImmutableArray<BoundStatement> statements)
     {
         Previous = previous;
         Package = package;
@@ -78,6 +112,7 @@ public sealed class BoundGlobalScope
         TypeAliases = typeAliases;
         Structs = structs;
         Interfaces = interfaces;
+        Enums = enums;
         EntryPoint = entryPoint;
         Statements = statements;
     }
@@ -168,6 +203,11 @@ public sealed class BoundGlobalScope
     /// Gets the user-defined interface types declared in the current compilation (Phase 3.B.4).
     /// </summary>
     public ImmutableArray<InterfaceSymbol> Interfaces { get; }
+
+    /// <summary>
+    /// Gets the user-defined enum types declared in the current compilation (#193).
+    /// </summary>
+    public ImmutableArray<EnumSymbol> Enums { get; }
 
     /// <summary>
     /// Gets the synthesized or explicit entry-point function for this compilation,

--- a/src/Core/CodeAnalysis/Binding/BoundProgram.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundProgram.cs
@@ -52,6 +52,32 @@ public sealed class BoundProgram
         BoundBlockStatement statement,
         ImmutableArray<StructSymbol> structs,
         ImmutableArray<InterfaceSymbol> interfaces)
+        : this(entryPointPackage, packages, diagnostics, functions, entryPoint, statement, structs, interfaces, ImmutableArray<EnumSymbol>.Empty)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundProgram"/> class with declared enums (#193).
+    /// </summary>
+    /// <param name="entryPointPackage">The entry-point package; its name is exposed via <see cref="PackageName"/> for back-compat.</param>
+    /// <param name="packages">All distinct packages in this program, in declaration order.</param>
+    /// <param name="diagnostics">The diagnostics.</param>
+    /// <param name="functions">The functions. Each <see cref="FunctionSymbol"/> key carries its owning package via <see cref="FunctionSymbol.Package"/>.</param>
+    /// <param name="entryPoint">The entry-point function, or null if the compilation is a library.</param>
+    /// <param name="statement">The statements.</param>
+    /// <param name="structs">User-defined struct types declared in this program, grouped by declaring package.</param>
+    /// <param name="interfaces">User-defined interface types declared in this program (Phase 3.B.4).</param>
+    /// <param name="enums">User-defined enum types declared in this program (#193).</param>
+    public BoundProgram(
+        PackageSymbol entryPointPackage,
+        ImmutableArray<PackageSymbol> packages,
+        ImmutableArray<Diagnostic> diagnostics,
+        ImmutableDictionary<FunctionSymbol, BoundBlockStatement> functions,
+        FunctionSymbol entryPoint,
+        BoundBlockStatement statement,
+        ImmutableArray<StructSymbol> structs,
+        ImmutableArray<InterfaceSymbol> interfaces,
+        ImmutableArray<EnumSymbol> enums)
     {
         EntryPointPackage = entryPointPackage;
         Packages = packages;
@@ -61,6 +87,7 @@ public sealed class BoundProgram
         Statement = statement;
         Structs = structs;
         Interfaces = interfaces;
+        Enums = enums;
     }
 
     /// <summary>
@@ -139,4 +166,10 @@ public sealed class BoundProgram
     /// Gets the user-defined interface types declared in this program (Phase 3.B.4).
     /// </summary>
     public ImmutableArray<InterfaceSymbol> Interfaces { get; }
+
+    /// <summary>
+    /// Gets the user-defined enum types declared in this program (#193).
+    /// Each enum carries its declaring package via <see cref="EnumSymbol.PackageName"/>.
+    /// </summary>
+    public ImmutableArray<EnumSymbol> Enums { get; }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -332,6 +332,15 @@ public sealed class BoundScope
             ? ImmutableArray<InterfaceSymbol>.Empty
             : typeAliases.Values.OfType<InterfaceSymbol>().ToImmutableArray();
 
+    /// <summary>
+    /// Gets the set of declared user-defined enum types in this scope chain (#193).
+    /// </summary>
+    /// <returns>The enums in declaration order.</returns>
+    public ImmutableArray<EnumSymbol> GetDeclaredEnums()
+        => typeAliases == null
+            ? ImmutableArray<EnumSymbol>.Empty
+            : typeAliases.Values.OfType<EnumSymbol>().ToImmutableArray();
+
     private bool TryDeclareSymbol<TSymbol>(TSymbol symbol)
         where TSymbol : Symbol
     {

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -66,6 +66,13 @@ internal sealed class ReflectionMetadataEmitter
     // Phase 3.B.4: user-defined interface TypeDefs.
     private readonly Dictionary<InterfaceSymbol, TypeDefinitionHandle> interfaceTypeDefs = new Dictionary<InterfaceSymbol, TypeDefinitionHandle>();
 
+    // Issue #193: user-defined enum TypeDefs and the per-member literal field rows.
+    // EnumSymbol is emitted as a sealed value type deriving from System.Enum with
+    // a public instance field 'value__' of int32 plus one public static literal
+    // field per EnumMemberSymbol carrying its integer constant.
+    private readonly Dictionary<EnumSymbol, TypeDefinitionHandle> enumTypeDefs = new Dictionary<EnumSymbol, TypeDefinitionHandle>();
+    private readonly Dictionary<EnumMemberSymbol, FieldDefinitionHandle> enumMemberFieldDefs = new Dictionary<EnumMemberSymbol, FieldDefinitionHandle>();
+
     // Phase 3.B.3 sub-step 2b: instance methods on user-defined classes.
     private readonly Dictionary<FunctionSymbol, MethodDefinitionHandle> methodHandles = new Dictionary<FunctionSymbol, MethodDefinitionHandle>();
 
@@ -124,6 +131,7 @@ internal sealed class ReflectionMetadataEmitter
     private Type coreValueType;
     private Type coreSystemType;
     private Type coreRuntimeTypeHandleType;
+    private Type coreEnumType;
     private TypeReferenceHandle objectTypeRef;
     private TypeReferenceHandle valueTypeRef;
     private MemberReferenceHandle objectCtorRef;
@@ -222,6 +230,7 @@ internal sealed class ReflectionMetadataEmitter
         this.coreValueType = this.ResolveCoreType("System.ValueType", typeof(System.ValueType));
         this.coreSystemType = this.ResolveCoreType("System.Type", typeof(System.Type));
         this.coreRuntimeTypeHandleType = this.ResolveCoreType("System.RuntimeTypeHandle", typeof(System.RuntimeTypeHandle));
+        this.coreEnumType = this.ResolveCoreType("System.Enum", typeof(System.Enum));
         this.objectTypeRef = this.GetTypeReference(this.coreObjectType);
         this.valueTypeRef = this.GetTypeReference(this.coreValueType);
         this.objectCtorRef = this.GetObjectDefaultCtorReference();
@@ -353,6 +362,19 @@ internal sealed class ReflectionMetadataEmitter
             nextFieldRow += s.Fields.Length;
         }
 
+        // Issue #193: each user-defined enum contributes 1 instance field
+        // (value__) plus one literal field per member. Enum field rows are
+        // planned right after non-SM struct fields so the enum TypeDef can
+        // be emitted between non-SM struct TypeDefs and <Program> without
+        // violating the monotone fieldList constraint.
+        var enums = this.program.Enums;
+        var enumFirstFieldRow = new Dictionary<EnumSymbol, int>();
+        foreach (var e in enums)
+        {
+            enumFirstFieldRow[e] = nextFieldRow;
+            nextFieldRow += 1 + e.Members.Length;
+        }
+
         int programFirstFieldRow = nextFieldRow;
 
         // SM types get field rows after <Program>'s fieldList pointer.
@@ -475,6 +497,14 @@ internal sealed class ReflectionMetadataEmitter
                 ? firstStructMethodRow
                 : firstPackageCtorRow;
             this.EmitStructTypeDef(s, structFirstFieldRow[s], methodListRow);
+        }
+
+        // Issue #193: emit enum TypeDefs between non-SM structs and <Program>.
+        // Each enum has no methods, so its methodList points at the same row
+        // <Program>'s package ctor will live (firstPackageCtorRow).
+        foreach (var e in enums)
+        {
+            this.EmitEnumTypeDef(e, enumFirstFieldRow[e], firstPackageCtorRow);
         }
 
         // 3. Group functions by their declaring package. One <Program> type
@@ -1088,6 +1118,86 @@ internal sealed class ReflectionMetadataEmitter
             fieldList: firstField,
             methodList: MetadataTokens.MethodDefinitionHandle(methodListRow));
         this.structTypeDefs[structSym] = handle2;
+    }
+
+    /// <summary>
+    /// Issue #193: emits a CLR <c>enum</c> TypeDef for a user-defined GSharp
+    /// <c>type Name enum { ... }</c>. The TypeDef is a sealed value type
+    /// deriving from <c>System.Enum</c> with:
+    ///   * an instance field <c>value__</c> of <c>int32</c> (the underlying
+    ///     type per ADR-0047 §3; widen later if we add explicit underlying
+    ///     -type syntax),
+    ///   * one <c>public static literal</c> field per <see cref="EnumMemberSymbol"/>
+    ///     carrying its integer constant via a <c>HasDefault</c> / Constant row.
+    /// Custom attributes bound onto <c>EnumSymbol.Attributes</c> route
+    /// to the type-def row; per-member attributes route to each literal field.
+    /// </summary>
+    private void EmitEnumTypeDef(EnumSymbol enumSym, int firstFieldRow, int methodListRow)
+    {
+        var enumTypeRef = this.GetTypeReference(this.coreEnumType);
+
+        // Field 1: instance int32 'value__' with SpecialName | RTSpecialName.
+        var valueFieldSigBlob = new BlobBuilder();
+        new BlobEncoder(valueFieldSigBlob).FieldSignature().Int32();
+        var valueFieldHandle = this.metadata.AddFieldDefinition(
+            attributes: FieldAttributes.Public | FieldAttributes.SpecialName | FieldAttributes.RTSpecialName,
+            name: this.metadata.GetOrAddString("value__"),
+            signature: this.metadata.GetOrAddBlob(valueFieldSigBlob));
+
+        // Fields 2..N: one public static literal field per member, signature
+        // is the enum's own typedef (the standard CLR convention for enum
+        // literals). The Constant row is added below after all field rows
+        // have been emitted so they remain in increasing parent-token order.
+        var memberFieldHandles = new List<FieldDefinitionHandle>(enumSym.Members.Length);
+        TypeDefinitionHandle enumTypeDef = default;
+
+        // The literal-field signature references the enum's own TypeDef; we
+        // need to reserve the TypeDef handle first so the FieldSig encoder
+        // can refer to it. AddTypeDefinition is monotone, so the next-row
+        // handle gives us the soon-to-be-emitted handle.
+        var pendingTypeDef = MetadataTokens.TypeDefinitionHandle(this.metadata.GetRowCount(TableIndex.TypeDef) + 1);
+
+        foreach (var member in enumSym.Members)
+        {
+            var memberSigBlob = new BlobBuilder();
+            new BlobEncoder(memberSigBlob).FieldSignature().Type(pendingTypeDef, isValueType: true);
+            var memberFieldHandle = this.metadata.AddFieldDefinition(
+                attributes: FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.Literal | FieldAttributes.HasDefault,
+                name: this.metadata.GetOrAddString(member.Name),
+                signature: this.metadata.GetOrAddBlob(memberSigBlob));
+            memberFieldHandles.Add(memberFieldHandle);
+            this.enumMemberFieldDefs[member] = memberFieldHandle;
+        }
+
+        var typeAttrs = TypeAttributes.Class | TypeAttributes.Sealed
+            | TypeAttributes.AnsiClass | TypeAttributes.AutoLayout
+            | MapTypeAccessibility(enumSym.Accessibility);
+
+        enumTypeDef = this.metadata.AddTypeDefinition(
+            attributes: typeAttrs,
+            @namespace: this.metadata.GetOrAddString(enumSym.PackageName ?? string.Empty),
+            name: this.metadata.GetOrAddString(enumSym.Name),
+            baseType: enumTypeRef,
+            fieldList: valueFieldHandle,
+            methodList: MetadataTokens.MethodDefinitionHandle(methodListRow));
+        this.enumTypeDefs[enumSym] = enumTypeDef;
+
+        // Constant rows must be added in increasing parent FieldDefinition
+        // order; iterating the literal fields in declaration order naturally
+        // satisfies this since AddFieldDefinition is monotone.
+        for (int i = 0; i < enumSym.Members.Length; i++)
+        {
+            this.metadata.AddConstant(parent: memberFieldHandles[i], value: enumSym.Members[i].Value);
+        }
+
+        // Issue #188 (step 3): route any user annotations attached to the
+        // enum type onto the TypeDef row, and per-member annotations onto
+        // each literal-field row.
+        this.EmitUserAttributes(enumTypeDef, enumSym, AttributeTargetKind.Type);
+        for (int i = 0; i < enumSym.Members.Length; i++)
+        {
+            this.EmitUserAttributes(memberFieldHandles[i], enumSym.Members[i], AttributeTargetKind.Field);
+        }
     }
 
     /// <summary>
@@ -4846,6 +4956,11 @@ internal sealed class ReflectionMetadataEmitter
             return td;
         }
 
+        if (element is EnumSymbol enumSym && this.enumTypeDefs.TryGetValue(enumSym, out var etd))
+        {
+            return etd;
+        }
+
         throw new NotSupportedException($"Cannot resolve element type token for '{element.Name}'.");
     }
 
@@ -5408,6 +5523,17 @@ internal sealed class ReflectionMetadataEmitter
 
             encoder.Type(typeDef, isValueType: !structSym.IsClass);
         }
+        else if (type is EnumSymbol enumSym)
+        {
+            // Issue #193: a user-defined enum's signature surface is its
+            // own TypeDef (a sealed value type derived from System.Enum).
+            if (!this.enumTypeDefs.TryGetValue(enumSym, out var enumTypeDef))
+            {
+                throw new InvalidOperationException($"Enum '{enumSym.Name}' has no emitted TypeDef.");
+            }
+
+            encoder.Type(enumTypeDef, isValueType: true);
+        }
         else if (type is InterfaceSymbol ifaceSym)
         {
             // Phase D: user-defined interface as a signature type. The
@@ -5463,6 +5589,15 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         if (type is StructSymbol s && !s.IsClass)
+        {
+            return true;
+        }
+
+        // Issue #193: a user-defined enum is a CLR value type (sealed,
+        // derives from System.Enum). Boundary boxing logic (e.g. generic
+        // argument passing) must treat it as such even though it has no
+        // ClrType on the symbol.
+        if (type is EnumSymbol)
         {
             return true;
         }

--- a/test/Compiler.Tests/Emit/EnumEmitTests.cs
+++ b/test/Compiler.Tests/Emit/EnumEmitTests.cs
@@ -1,0 +1,193 @@
+// <copyright file="EnumEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #193 emit tests. Compiles GSharp sources declaring user-defined enums
+/// and asserts that the resulting PE contains a CLR enum TypeDef (sealed value
+/// type derived from <see cref="System.Enum"/>) with the expected
+/// <c>value__</c> field plus one literal field per member, and that user
+/// annotations on the enum type or its members survive the round-trip as
+/// <c>CustomAttribute</c> rows.
+/// </summary>
+public class EnumEmitTests
+{
+    [Fact]
+    public void Enum_Emits_As_ClrEnum_With_Int_Underlying()
+    {
+        var source = """
+            package P
+            import System
+
+            type Color enum { Red, Green, Blue }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var color = assembly.GetTypes().Single(t => t.Name == "Color");
+
+        Assert.True(color.IsEnum, "Emitted Color must be a CLR enum.");
+        Assert.Equal(typeof(int), Enum.GetUnderlyingType(color));
+        Assert.True(color.IsSealed);
+        Assert.Equal("P", color.Namespace);
+
+        var names = Enum.GetNames(color);
+        Assert.Equal(new[] { "Red", "Green", "Blue" }, names);
+
+        var values = Enum.GetValues(color).Cast<object>().Select(v => Convert.ToInt32(v)).ToArray();
+        Assert.Equal(new[] { 0, 1, 2 }, values);
+    }
+
+    [Fact]
+    public void Enum_Member_Constants_Match_Auto_Numbering()
+    {
+        var source = """
+            package P
+            import System
+
+            type Pri enum { Low, Medium, High }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var pri = assembly.GetTypes().Single(t => t.Name == "Pri");
+
+        // Each member should round-trip as a literal field carrying its int.
+        var literalFields = pri.GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(f => f.IsLiteral)
+            .OrderBy(f => Convert.ToInt32(f.GetRawConstantValue()))
+            .ToArray();
+
+        Assert.Equal(3, literalFields.Length);
+        Assert.Equal("Low", literalFields[0].Name);
+        Assert.Equal(0, Convert.ToInt32(literalFields[0].GetRawConstantValue()));
+        Assert.Equal("Medium", literalFields[1].Name);
+        Assert.Equal(1, Convert.ToInt32(literalFields[1].GetRawConstantValue()));
+        Assert.Equal("High", literalFields[2].Name);
+        Assert.Equal(2, Convert.ToInt32(literalFields[2].GetRawConstantValue()));
+
+        // value__ instance field exists and is int32 with SpecialName / RTSpecialName.
+        var valueField = pri.GetField("value__", BindingFlags.Instance | BindingFlags.Public);
+        Assert.NotNull(valueField);
+        Assert.Equal(typeof(int), valueField.FieldType);
+        Assert.True((valueField.Attributes & FieldAttributes.SpecialName) != 0);
+        Assert.True((valueField.Attributes & FieldAttributes.RTSpecialName) != 0);
+    }
+
+    [Fact]
+    public void Obsolete_On_Enum_Member_Round_Trips_As_CustomAttribute_On_Field()
+    {
+        // Issue #188 / #193: @Obsolete on an enum member must end up as a
+        // CustomAttribute on the literal field row, observable via reflection.
+        var source = """
+            package P
+            import System
+
+            type Color enum {
+                Red,
+                @Obsolete("use Red")
+                Crimson,
+                Blue,
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var color = assembly.GetTypes().Single(t => t.Name == "Color");
+        var crimson = color.GetField("Crimson", BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(crimson);
+
+        var data = crimson.GetCustomAttributesData().Single(d => d.AttributeType.FullName == "System.ObsoleteAttribute");
+        var arg = Assert.Single(data.ConstructorArguments);
+        Assert.Equal("use Red", arg.Value);
+    }
+
+    [Fact]
+    public void Obsolete_On_Enum_Type_Round_Trips_As_CustomAttribute_On_TypeDef()
+    {
+        var source = """
+            package P
+            import System
+
+            @Obsolete("legacy enum")
+            type Color enum { Red, Green }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var color = assembly.GetTypes().Single(t => t.Name == "Color");
+        var data = color.GetCustomAttributesData().Single(d => d.AttributeType.FullName == "System.ObsoleteAttribute");
+        var arg = Assert.Single(data.ConstructorArguments);
+        Assert.Equal("legacy enum", arg.Value);
+    }
+
+    [Fact]
+    public void Enum_Appears_In_Function_Signature_As_TypeDef()
+    {
+        // The public signature surface of `func Pick(c Color) Color` should
+        // reference the enum's TypeDef rather than int32.
+        var source = """
+            package P
+            import System
+
+            type Color enum { Red, Green, Blue }
+
+            func Pick(c Color) Color {
+                return c
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var color = assembly.GetTypes().Single(t => t.Name == "Color");
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var pick = program.GetMethod("Pick", BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(pick);
+
+        var parameters = pick.GetParameters();
+        Assert.Single(parameters);
+        Assert.Equal(color, parameters[0].ParameterType);
+        Assert.Equal(color, pick.ReturnType);
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_enum_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}


### PR DESCRIPTION
Closes #193.

Wires `EnumSymbol` through `BoundGlobalScope` / `BoundProgram` and adds full emit support in `ReflectionMetadataEmitter`.

## What changes

* **Emit**: each `EnumSymbol` becomes a sealed value type derived from `System.Enum` with a public `value__` instance `int32` field plus one public `static literal` field per `EnumMemberSymbol` carrying its integer constant via `HasDefault` / `Constant` rows.
* **Row planning**: enum fields are slotted between non-SM struct fields and `<Program>`'s `fieldList` pointer; enum TypeDefs are emitted between non-SM struct TypeDefs and the per-package `<Program>` TypeDefs so the monotone `fieldList` / `methodList` invariants are preserved.
* **Signature surface**: `EncodeTypeSymbol` and `GetElementTypeToken` now resolve `EnumSymbol` to its TypeDef, so `func Pick(c Color) Color` references the enum rather than `int32` in parameter/return/field signatures. `BoundLiteralExpression(intValue, EnumSymbol)` continues to emit as `ldc.i4` (the CLR represents enum values as their underlying type on the stack).
* **Value-type predicate**: `IsValueTypeSymbol` now recognises `EnumSymbol` so generic boundary boxing matches the CLR.
* **Custom attributes**: `EmitUserAttributes` is routed for both the enum type-def and each member's literal-field row, completing step 3 of #188 by giving `@Obsolete` (or any other annotation) on an enum member a metadata row to attach to.

## Tests

New `EnumEmitTests` covers:

* `type.IsEnum` + `Enum.GetUnderlyingType(type) == typeof(int)`
* member names + values match (`Enum.GetNames` / `Enum.GetValues`)
* literal fields are `Public | Static | Literal | HasDefault` with correct `GetRawConstantValue`
* `value__` has `SpecialName | RTSpecialName` and `FieldType == typeof(int)`
* `@Obsolete` on an enum **member** round-trips as a `CustomAttribute` on the literal field
* `@Obsolete` on an enum **type** round-trips as a `CustomAttribute` on the TypeDef
* parameter and return types of `func Pick(c Color) Color` resolve to the emitted enum TypeDef

Full test suite: 1357 passed (was 1352; +5 new).

## Out of scope (follow-ups)

* Use-site obsolete diagnostics across compilation units (refs item 6.3 of #193) — requires import-side wiring for enum TypeDefs, tracked separately.
* Explicit underlying-type syntax beyond `int` (per ADR-0047 §3).