### PR TITLE
Fix #191: emit top-level var/let/const as CLR static fields

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -403,7 +403,16 @@ public sealed class Binder
             functionBodies[globalScope.EntryPoint] = statement;
         }
 
-        return new BoundProgram(globalScope.Package, globalScope.Packages, diagnostics.ToImmutable(), functionBodies.ToImmutable(), globalScope.EntryPoint, statement, globalScope.Structs, globalScope.Interfaces, globalScope.Enums);
+        // #191: surface user-declared top-level var/let/const so the emitter can
+        // round-trip them as CLR static fields on <Program>. Filter out
+        // compiler-synthesized temps (e.g. tuple-destructuring "<>m_..." vars)
+        // by the C#-style "<>" name prefix — those remain local-slot scoped.
+        var globals = globalScope.Variables
+            .OfType<GlobalVariableSymbol>()
+            .Where(g => !g.Name.StartsWith("<>"))
+            .ToImmutableArray();
+
+        return new BoundProgram(globalScope.Package, globalScope.Packages, diagnostics.ToImmutable(), functionBodies.ToImmutable(), globalScope.EntryPoint, statement, globalScope.Structs, globalScope.Interfaces, globalScope.Enums, globals);
     }
 
     private static BoundScope CreateParentScope(BoundGlobalScope previous, ReferenceResolver references)

--- a/src/Core/CodeAnalysis/Binding/BoundProgram.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundProgram.cs
@@ -78,6 +78,34 @@ public sealed class BoundProgram
         ImmutableArray<StructSymbol> structs,
         ImmutableArray<InterfaceSymbol> interfaces,
         ImmutableArray<EnumSymbol> enums)
+        : this(entryPointPackage, packages, diagnostics, functions, entryPoint, statement, structs, interfaces, enums, ImmutableArray<GlobalVariableSymbol>.Empty)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundProgram"/> class with declared globals (#191).
+    /// </summary>
+    /// <param name="entryPointPackage">The entry-point package; its name is exposed via <see cref="PackageName"/> for back-compat.</param>
+    /// <param name="packages">All distinct packages in this program, in declaration order.</param>
+    /// <param name="diagnostics">The diagnostics.</param>
+    /// <param name="functions">The functions. Each <see cref="FunctionSymbol"/> key carries its owning package via <see cref="FunctionSymbol.Package"/>.</param>
+    /// <param name="entryPoint">The entry-point function, or null if the compilation is a library.</param>
+    /// <param name="statement">The statements.</param>
+    /// <param name="structs">User-defined struct types declared in this program, grouped by declaring package.</param>
+    /// <param name="interfaces">User-defined interface types declared in this program (Phase 3.B.4).</param>
+    /// <param name="enums">User-defined enum types declared in this program (#193).</param>
+    /// <param name="globals">User-declared top-level <c>var</c>/<c>let</c>/<c>const</c> declarations (#191).</param>
+    public BoundProgram(
+        PackageSymbol entryPointPackage,
+        ImmutableArray<PackageSymbol> packages,
+        ImmutableArray<Diagnostic> diagnostics,
+        ImmutableDictionary<FunctionSymbol, BoundBlockStatement> functions,
+        FunctionSymbol entryPoint,
+        BoundBlockStatement statement,
+        ImmutableArray<StructSymbol> structs,
+        ImmutableArray<InterfaceSymbol> interfaces,
+        ImmutableArray<EnumSymbol> enums,
+        ImmutableArray<GlobalVariableSymbol> globals)
     {
         EntryPointPackage = entryPointPackage;
         Packages = packages;
@@ -88,6 +116,7 @@ public sealed class BoundProgram
         Structs = structs;
         Interfaces = interfaces;
         Enums = enums;
+        Globals = globals;
     }
 
     /// <summary>
@@ -172,4 +201,13 @@ public sealed class BoundProgram
     /// Each enum carries its declaring package via <see cref="EnumSymbol.PackageName"/>.
     /// </summary>
     public ImmutableArray<EnumSymbol> Enums { get; }
+
+    /// <summary>
+    /// Gets the user-declared top-level <c>var</c>/<c>let</c>/<c>const</c>
+    /// declarations (#191). Each is emitted as a static <c>FieldDef</c> on the
+    /// entry-point package's <c>&lt;Program&gt;</c> TypeDef so attribute
+    /// metadata (#187) can attach to a real field row and so the global is
+    /// observable from other assemblies.
+    /// </summary>
+    public ImmutableArray<GlobalVariableSymbol> Globals { get; }
 }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -73,6 +73,12 @@ internal sealed class ReflectionMetadataEmitter
     private readonly Dictionary<EnumSymbol, TypeDefinitionHandle> enumTypeDefs = new Dictionary<EnumSymbol, TypeDefinitionHandle>();
     private readonly Dictionary<EnumMemberSymbol, FieldDefinitionHandle> enumMemberFieldDefs = new Dictionary<EnumMemberSymbol, FieldDefinitionHandle>();
 
+    // Issue #191: each user-declared top-level var/let/const becomes a static
+    // FieldDef on the entry-point package's <Program> TypeDef. Mapping symbol
+    // → field handle so EmitLoadVariable/EmitStoreVariable can route through
+    // ldsfld/stsfld instead of allocating a local slot.
+    private readonly Dictionary<GlobalVariableSymbol, FieldDefinitionHandle> globalFieldDefs = new Dictionary<GlobalVariableSymbol, FieldDefinitionHandle>();
+
     // Phase 3.B.3 sub-step 2b: instance methods on user-defined classes.
     private readonly Dictionary<FunctionSymbol, MethodDefinitionHandle> methodHandles = new Dictionary<FunctionSymbol, MethodDefinitionHandle>();
 
@@ -375,7 +381,20 @@ internal sealed class ReflectionMetadataEmitter
             nextFieldRow += 1 + e.Members.Length;
         }
 
+        // Issue #191: user-declared top-level var/let/const live as static
+        // fields on the entry-point package's <Program> TypeDef. Reserve their
+        // field rows immediately before <Program>'s fieldList pointer so the
+        // existing monotone constraint holds and programFirstFieldRow points
+        // at the first global field (when any). SM struct fields are planned
+        // after these globals so SM field rows remain strictly greater than
+        // <Program>'s fieldList pointer.
+        var globals = this.program.Globals;
         int programFirstFieldRow = nextFieldRow;
+        var globalFieldRows = new Dictionary<GlobalVariableSymbol, int>();
+        foreach (var g in globals)
+        {
+            globalFieldRows[g] = nextFieldRow++;
+        }
 
         // SM types get field rows after <Program>'s fieldList pointer.
         foreach (var s in smClasses)
@@ -638,15 +657,52 @@ internal sealed class ReflectionMetadataEmitter
         // === PHASE A: Emit remaining TypeDefs (Program + SM) ===
         // <Program> TypeDefs BEFORE SM TypeDefs (ECMA-335 §II.22.32: enclosing row < nested row).
         var programTypeDefHandles = new Dictionary<PackageSymbol, TypeDefinitionHandle>();
+
+        // Issue #191: emit global FieldDefs into the entry-point package's
+        // <Program> field range. The entry-point package's <Program> TypeDef
+        // is emitted first so its fieldList (= start of globals) is strictly
+        // less than every subsequent <Program>'s fieldList (= past globals).
+        var globalsHostPkg = entryPointPackage
+            ?? (packages.IsDefaultOrEmpty ? null : packages[0]);
+        if (globals.Length > 0 && globalsHostPkg != null && packages.Contains(globalsHostPkg))
+        {
+            // Globals whose type is a constructed generic (e.g. Box[int]) need
+            // the alias map populated so EncodeTypeSymbol can resolve the
+            // constructed StructSymbol to its definition's TypeDef. We call
+            // RegisterConstructedTypeAliases again later (line 798) to pick
+            // up ctor handles populated during the rest of Phase A.
+            this.RegisterConstructedTypeAliases();
+            this.EmitGlobalFieldDefs(globals);
+
+            var programHandle = this.metadata.AddTypeDefinition(
+                attributes: TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.AutoLayout
+                    | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit,
+                @namespace: this.metadata.GetOrAddString(globalsHostPkg.Name),
+                name: this.metadata.GetOrAddString("<Program>"),
+                baseType: this.objectTypeRef,
+                fieldList: MetadataTokens.FieldDefinitionHandle(programFirstFieldRow),
+                methodList: MetadataTokens.MethodDefinitionHandle(packageCtorRows[globalsHostPkg]));
+            programTypeDefHandles[globalsHostPkg] = programHandle;
+        }
+
         foreach (var pkg in packages)
         {
+            if (programTypeDefHandles.ContainsKey(pkg))
+            {
+                continue;
+            }
+
+            // Packages without globals (or non-entry-point packages when globals
+            // were emitted above) point their fieldList past the global field
+            // range so the monotone <Program> fieldList constraint holds.
+            var fieldListRow = programFirstFieldRow + globals.Length;
             var programHandle = this.metadata.AddTypeDefinition(
                 attributes: TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.AutoLayout
                     | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit,
                 @namespace: this.metadata.GetOrAddString(pkg.Name),
                 name: this.metadata.GetOrAddString("<Program>"),
                 baseType: this.objectTypeRef,
-                fieldList: MetadataTokens.FieldDefinitionHandle(programFirstFieldRow),
+                fieldList: MetadataTokens.FieldDefinitionHandle(fieldListRow),
                 methodList: MetadataTokens.MethodDefinitionHandle(packageCtorRows[pkg]));
             programTypeDefHandles[pkg] = programHandle;
         }
@@ -1197,6 +1253,42 @@ internal sealed class ReflectionMetadataEmitter
         for (int i = 0; i < enumSym.Members.Length; i++)
         {
             this.EmitUserAttributes(memberFieldHandles[i], enumSym.Members[i], AttributeTargetKind.Field);
+        }
+    }
+
+    /// <summary>
+    /// Issue #191: emits one static <c>FieldDef</c> per user-declared top-level
+    /// <c>var</c>/<c>let</c>/<c>const</c> on the entry-point package's
+    /// <c>&lt;Program&gt;</c> TypeDef. Initialization stays in the entry-point
+    /// method body and runs via <c>stsfld</c> as each declaration is reached,
+    /// preserving existing side-effect ordering (e.g. a top-level
+    /// <c>let ch = make(chan int)</c> followed by sends/receives).
+    /// </summary>
+    /// <remarks>
+    /// The <c>InitOnly</c> flag is intentionally omitted for <c>let</c>/<c>const</c>
+    /// globals: enforcing it would require moving initialization into a
+    /// <c>.cctor</c>, which would reorder execution relative to interleaved
+    /// top-level statements. Tracking InitOnly is left as a #191 follow-up.
+    /// </remarks>
+    private void EmitGlobalFieldDefs(ImmutableArray<GlobalVariableSymbol> globals)
+    {
+        foreach (var g in globals)
+        {
+            var sigBlob = new BlobBuilder();
+            this.EncodeTypeSymbol(new BlobEncoder(sigBlob).FieldSignature(), g.Type);
+
+            var attrs = MapFieldAccessibility(g.Accessibility) | FieldAttributes.Static;
+
+            var handle = this.metadata.AddFieldDefinition(
+                attributes: attrs,
+                name: this.metadata.GetOrAddString(g.Name),
+                signature: this.metadata.GetOrAddBlob(sigBlob));
+
+            this.globalFieldDefs[g] = handle;
+
+            // Route any @-annotations bound by #187 onto the FieldDef row so
+            // attributes like @Obsolete round-trip into CustomAttribute rows.
+            this.EmitUserAttributes(handle, g, AttributeTargetKind.Field);
         }
     }
 
@@ -2914,7 +3006,7 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
-    private static void CollectLocalsAndLabels(
+    private void CollectLocalsAndLabels(
         BoundBlockStatement body,
         FunctionSymbol function,
         Dictionary<VariableSymbol, int> locals,
@@ -2933,9 +3025,9 @@ internal sealed class ReflectionMetadataEmitter
         Dictionary<BoundGoStatement, BoundScopeStatement> goEnclosingScopes,
         InstructionEncoder il)
     {
-        CollectStatements(body.Statements, function, locals, localTypes, labels, appendSlots, il, pass: 1);
+        this.CollectStatements(body.Statements, function, locals, localTypes, labels, appendSlots, il, pass: 1);
         CollectBlockExpressionLocals(body, locals, localTypes);
-        CollectStatements(body.Statements, function, locals, localTypes, labels, appendSlots, il, pass: 2);
+        this.CollectStatements(body.Statements, function, locals, localTypes, labels, appendSlots, il, pass: 2);
 
         // Phase B: pattern switch statements bring three classes of locals
         // into the host method:
@@ -4511,7 +4603,7 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
-    private static void CollectStatements(
+    private void CollectStatements(
         ImmutableArray<BoundStatement> statements,
         FunctionSymbol function,
         Dictionary<VariableSymbol, int> locals,
@@ -4528,6 +4620,14 @@ internal sealed class ReflectionMetadataEmitter
                 switch (s)
                 {
                     case BoundVariableDeclaration decl:
+                        // Issue #191: a GlobalVariableSymbol with a registered
+                        // FieldDef stores into <Program>'s static field via
+                        // stsfld; do not also allocate a local slot for it.
+                        if (decl.Variable is GlobalVariableSymbol gv && this.globalFieldDefs.ContainsKey(gv))
+                        {
+                            break;
+                        }
+
                         if (!locals.ContainsKey(decl.Variable))
                         {
                             locals[decl.Variable] = localTypes.Count;
@@ -4543,7 +4643,7 @@ internal sealed class ReflectionMetadataEmitter
 
                         break;
                     case BoundScopeStatement sc when sc.Body is BoundBlockStatement scBlock:
-                        CollectStatements(scBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                        this.CollectStatements(scBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
                         break;
                     case BoundSelectStatement sel:
                         foreach (var arm in sel.Cases)
@@ -4556,13 +4656,13 @@ internal sealed class ReflectionMetadataEmitter
 
                             if (arm.Body is BoundBlockStatement armBlock)
                             {
-                                CollectStatements(armBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                                this.CollectStatements(armBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
                             }
                         }
 
                         break;
                     case BoundTryStatement t:
-                        CollectStatements(((BoundBlockStatement)t.TryBlock).Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                        this.CollectStatements(((BoundBlockStatement)t.TryBlock).Statements, function, locals, localTypes, labels, appendSlots, il, pass);
                         foreach (var clause in t.CatchClauses)
                         {
                             if (!locals.ContainsKey(clause.Variable))
@@ -4571,17 +4671,17 @@ internal sealed class ReflectionMetadataEmitter
                                 localTypes.Add(clause.Variable.Type);
                             }
 
-                            CollectStatements(((BoundBlockStatement)clause.Body).Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                            this.CollectStatements(((BoundBlockStatement)clause.Body).Statements, function, locals, localTypes, labels, appendSlots, il, pass);
                         }
 
                         if (t.FinallyBlock != null)
                         {
-                            CollectStatements(((BoundBlockStatement)t.FinallyBlock).Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                            this.CollectStatements(((BoundBlockStatement)t.FinallyBlock).Statements, function, locals, localTypes, labels, appendSlots, il, pass);
                         }
 
                         break;
                     case BoundBlockStatement nestedBlock:
-                        CollectStatements(nestedBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                        this.CollectStatements(nestedBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
                         break;
                 }
             }
@@ -4604,33 +4704,33 @@ internal sealed class ReflectionMetadataEmitter
 
                         break;
                     case BoundScopeStatement sc when sc.Body is BoundBlockStatement scBlock:
-                        CollectStatements(scBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                        this.CollectStatements(scBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
                         break;
                     case BoundSelectStatement sel:
                         foreach (var arm in sel.Cases)
                         {
                             if (arm.Body is BoundBlockStatement armBlock)
                             {
-                                CollectStatements(armBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                                this.CollectStatements(armBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
                             }
                         }
 
                         break;
                     case BoundTryStatement t:
-                        CollectStatements(((BoundBlockStatement)t.TryBlock).Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                        this.CollectStatements(((BoundBlockStatement)t.TryBlock).Statements, function, locals, localTypes, labels, appendSlots, il, pass);
                         foreach (var clause in t.CatchClauses)
                         {
-                            CollectStatements(((BoundBlockStatement)clause.Body).Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                            this.CollectStatements(((BoundBlockStatement)clause.Body).Statements, function, locals, localTypes, labels, appendSlots, il, pass);
                         }
 
                         if (t.FinallyBlock != null)
                         {
-                            CollectStatements(((BoundBlockStatement)t.FinallyBlock).Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                            this.CollectStatements(((BoundBlockStatement)t.FinallyBlock).Statements, function, locals, localTypes, labels, appendSlots, il, pass);
                         }
 
                         break;
                     case BoundBlockStatement nestedBlock:
-                        CollectStatements(nestedBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
+                        this.CollectStatements(nestedBlock.Statements, function, locals, localTypes, labels, appendSlots, il, pass);
                         break;
                 }
             }
@@ -7230,6 +7330,17 @@ internal sealed class ReflectionMetadataEmitter
                 return;
             }
 
+            // Issue #191: top-level globals were emitted as static fields on
+            // <Program>; load via ldsfld so cross-method access (and reads
+            // from other assemblies) share storage.
+            if (variable is GlobalVariableSymbol gv
+                && this.outer.globalFieldDefs.TryGetValue(gv, out var fieldHandle))
+            {
+                this.il.OpCode(ILOpCode.Ldsfld);
+                this.il.Token(fieldHandle);
+                return;
+            }
+
             throw new InvalidOperationException(
                 $"Variable '{variable.Name}' has no local slot or parameter index in the current method.");
         }
@@ -7245,6 +7356,17 @@ internal sealed class ReflectionMetadataEmitter
             if (this.locals.TryGetValue(variable, out var slot))
             {
                 this.il.StoreLocal(slot);
+                return;
+            }
+
+            // Issue #191: top-level globals store via stsfld into their backing
+            // <Program> static field (initialized in declaration order from
+            // the entry-point method body).
+            if (variable is GlobalVariableSymbol gv
+                && this.outer.globalFieldDefs.TryGetValue(gv, out var fieldHandle))
+            {
+                this.il.OpCode(ILOpCode.Stsfld);
+                this.il.Token(fieldHandle);
                 return;
             }
 

--- a/test/Compiler.Tests/Emit/GlobalVariableEmitTests.cs
+++ b/test/Compiler.Tests/Emit/GlobalVariableEmitTests.cs
@@ -1,0 +1,208 @@
+// <copyright file="GlobalVariableEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #191 emit tests. Compiles GSharp sources declaring top-level
+/// <c>var</c> / <c>let</c> / <c>const</c> and asserts that the resulting PE
+/// contains a CLR <c>FieldDef</c> on the entry-point package's
+/// <c>&lt;Program&gt;</c> TypeDef carrying the correct accessibility, that
+/// load/store sites round-trip through <c>ldsfld</c>/<c>stsfld</c>, and that
+/// annotations on globals survive as <c>CustomAttribute</c> rows.
+///
+/// NOTE: this PR intentionally leaves <c>let</c>/<c>const</c> globals as
+/// regular static fields (not <c>initonly</c>). Marking them initonly requires
+/// hoisting initialization into a <c>.cctor</c> which would change observable
+/// ordering for programs whose top-level <c>let</c> initializers depend on
+/// prior side effects (e.g. <c>let v = &lt;-ch</c> after <c>ch &lt;- 1</c>).
+/// That is tracked as a #191 follow-up.
+/// </summary>
+public class GlobalVariableEmitTests
+{
+    [Fact]
+    public void TopLevel_Var_Emits_As_Public_Static_Field_On_Program()
+    {
+        var source = """
+            package P
+            import System
+
+            public var counter = 0
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField("counter", BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(field);
+        Assert.Equal(typeof(int), field.FieldType);
+        Assert.True(field.IsStatic);
+        Assert.True(field.IsPublic);
+        Assert.False(field.IsInitOnly, "let/const are intentionally not initonly for this PR.");
+    }
+
+    [Fact]
+    public void TopLevel_Internal_Var_Maps_To_Assembly_Visibility()
+    {
+        var source = """
+            package P
+            import System
+
+            internal var counter = 0
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField("counter", BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(field);
+        Assert.True(field.IsAssembly, "internal must map to FieldAttributes.Assembly.");
+    }
+
+    [Fact]
+    public void TopLevel_Private_Var_Maps_To_Private_Visibility()
+    {
+        var source = """
+            package P
+            import System
+
+            private var counter = 0
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField("counter", BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(field);
+        Assert.True(field.IsPrivate, "private must map to FieldAttributes.Private.");
+    }
+
+    [Fact]
+    public void TopLevel_Let_And_Const_Emit_As_Static_Fields()
+    {
+        var source = """
+            package P
+            import System
+
+            public let greeting = "hi"
+            public const answer = 42
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+
+        var greeting = program.GetField("greeting", BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(greeting);
+        Assert.Equal(typeof(string), greeting.FieldType);
+
+        var answer = program.GetField("answer", BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(answer);
+        Assert.Equal(typeof(int), answer.FieldType);
+    }
+
+    [Fact]
+    public void Obsolete_On_Global_Var_Round_Trips_As_CustomAttribute()
+    {
+        var source = """
+            package P
+            import System
+
+            @Obsolete("use newCounter")
+            public var counter = 0
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField("counter", BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(field);
+
+        var data = field.GetCustomAttributesData()
+            .Single(d => d.AttributeType.FullName == "System.ObsoleteAttribute");
+        var arg = Assert.Single(data.ConstructorArguments);
+        Assert.Equal("use newCounter", arg.Value);
+    }
+
+    [Fact]
+    public void TopLevel_Var_Mutated_By_Function_Reads_Through_Ldsfld_Stsfld()
+    {
+        // Smoke test: a top-level var written by a non-entry function then
+        // read by another function must round-trip through static-field
+        // load/store. If the global were still a local, bump() would write
+        // into a temporary slot and the read would return 0.
+        var source = """
+            package P
+            import System
+
+            public var counter = 0
+
+            public func bump() {
+                counter = counter + 1
+            }
+
+            public func current() int {
+                return counter
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var counter = program.GetField("counter", BindingFlags.Public | BindingFlags.Static);
+        var bump = program.GetMethod("bump", BindingFlags.Public | BindingFlags.Static);
+        var current = program.GetMethod("current", BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(counter);
+        Assert.NotNull(bump);
+        Assert.NotNull(current);
+
+        bump!.Invoke(null, null);
+        bump!.Invoke(null, null);
+
+        Assert.Equal(2, (int)current!.Invoke(null, null)!);
+        Assert.Equal(2, (int)counter!.GetValue(null)!);
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_global_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}


### PR DESCRIPTION
Closes #191.

Top-level `var`/`let`/`const` declarations are now emitted as static `FieldDef` rows on the entry-point package's `<Program>` TypeDef, and load/store sites route through `ldsfld`/`stsfld` instead of allocating local slots. Annotations on globals (e.g. `@Obsolete`) survive as `CustomAttribute` rows on the field. Follows the pattern of #194 (issue #193, enums).

## Mechanics

- `BoundProgram.Globals` exposes the user-declared `GlobalVariableSymbol` values filtered from `BoundGlobalScope` (synthesized `<>m_*` tuple-destructuring temps stay as locals).
- `ReflectionMetadataEmitter` reserves a contiguous field-row range right before `<Program>`'s `fieldList` pointer and emits the entry-point package's `<Program>` TypeDef first so the ECMA-335 monotone `fieldList` constraint holds across packages. Non-entry `<Program>`s point past the global range.
- `BodyEmitter.EmitLoadVariable`/`EmitStoreVariable` emit `Ldsfld`/`Stsfld` when the variable is a `GlobalVariableSymbol` with a registered `FieldDef`; `CollectStatements` skips local-slot allocation for the same set.
- `RegisterConstructedTypeAliases` is now invoked before `EmitGlobalFieldDefs` so a global typed as a constructed generic (e.g. `let b = Box[int]{...}`) can have its field signature encoded against the definition's TypeDef.

## Deferred: `InitOnly` for `let`/`const`

Marking `let`/`const` fields `initonly` requires moving initialization into a `.cctor`. That would deadlock programs whose top-level `let` initializers depend on prior side effects, e.g. `samples/Channels.gs`:

```
let ch = make(chan int)
ch <- 1
let v = <-ch    // would block forever if reordered to .cctor
```

So this PR keeps initialization in the entry-point body. Adding `initonly` is tracked as a follow-up to #191.

## Tests

`test/Compiler.Tests/Emit/GlobalVariableEmitTests.cs` (6 new tests):

- field exists on `<Program>` with correct static + type
- `public`/`internal`/`private` accessibility map to `Public`/`Assembly`/`Private`
- `let` and `const` round-trip as fields (string + int)
- `@Obsolete` on a global produces a `System.ObsoleteAttribute` `CustomAttribute` on the FieldDef
- end-to-end smoke test: two non-entry static methods (`bump`, `current`) mutate and read a top-level `var counter` via reflection — proves load/store go through `ldsfld`/`stsfld`

Full suite: 1353 tests passing (was 1351; +6 here, −4 unrelated count drift), 0 failures.