### PR TITLE
Validate @EnumeratorCancellation on async sequence parameters (#180)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1262,6 +1262,33 @@ public sealed class Binder
                 if (parameterSymbol != null && !paramAttrs.IsDefaultOrEmpty)
                 {
                     parameterSymbol.SetAttributes(paramAttrs);
+
+                    // Issue #180 / ADR-0040: validate @EnumeratorCancellation.
+                    // The attribute marks the cancellation-token parameter that
+                    // the async-sequence rewriter threads through, so it is
+                    // only meaningful when (a) the parameter's type is
+                    // System.Threading.CancellationToken and (b) the enclosing
+                    // function returns IAsyncEnumerable[T] (an `async sequence`).
+                    // Diagnostics are reported per offending attribute; the
+                    // attribute is still attached so downstream tooling can
+                    // observe the user's intent.
+                    var ecAttr = KnownAttributes.FindEnumeratorCancellation(paramAttrs);
+                    if (ecAttr != null)
+                    {
+                        if (parameterSymbol.Type?.ClrType != typeof(System.Threading.CancellationToken))
+                        {
+                            Diagnostics.ReportEnumeratorCancellationWrongType(
+                                parameterSyntax.Location,
+                                parameterSymbol.Name,
+                                parameterSymbol.Type?.Name ?? "?");
+                        }
+                        else if (!IsAsyncSequenceReturnType(type))
+                        {
+                            Diagnostics.ReportEnumeratorCancellationNotAsyncSequence(
+                                parameterSyntax.Location,
+                                parameterSymbol.Name);
+                        }
+                    }
                 }
             }
 
@@ -3207,6 +3234,27 @@ public sealed class Binder
         var fullName = def?.FullName;
         return fullName == "System.Collections.Generic.IAsyncEnumerable`1"
             || fullName == "System.Collections.Generic.IAsyncEnumerator`1";
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="type"/> denotes an
+    /// <c>async sequence</c> — i.e. <c>IAsyncEnumerable&lt;T&gt;</c>. Used
+    /// by the <c>@EnumeratorCancellation</c> binder check (ADR-0040 /
+    /// issue #180): only sequences expose
+    /// <c>GetAsyncEnumerator(CancellationToken)</c> so threading a token
+    /// through a marked parameter is only meaningful here, not on a bare
+    /// <c>IAsyncEnumerator&lt;T&gt;</c>.
+    /// </summary>
+    private static bool IsAsyncSequenceReturnType(TypeSymbol type)
+    {
+        var clr = type?.ClrType;
+        if (clr == null || !clr.IsGenericType || clr.IsGenericTypeDefinition)
+        {
+            return false;
+        }
+
+        var def = clr.GetGenericTypeDefinition();
+        return def?.FullName == "System.Collections.Generic.IAsyncEnumerable`1";
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
+++ b/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
@@ -50,6 +50,55 @@ internal static class KnownAttributes
     }
 
     /// <summary>
+    /// Returns <c>true</c> when <paramref name="clrType"/> is
+    /// <see cref="System.Runtime.CompilerServices.EnumeratorCancellationAttribute"/>.
+    /// Recognition is type-identity based (ADR-0047 §6 / ADR-0040): the
+    /// resolved CLR type — not the source name — selects the behaviour, so a
+    /// renamed or shadowed alias cannot bypass the validation rules.
+    /// </summary>
+    /// <param name="clrType">The resolved attribute CLR type, or <c>null</c>.</param>
+    /// <returns><c>true</c> when the attribute is <c>[EnumeratorCancellation]</c>.</returns>
+    public static bool IsEnumeratorCancellation(Type clrType)
+    {
+        return clrType == typeof(System.Runtime.CompilerServices.EnumeratorCancellationAttribute);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="attribute"/> is
+    /// <see cref="System.Runtime.CompilerServices.EnumeratorCancellationAttribute"/>.
+    /// </summary>
+    /// <param name="attribute">A bound attribute application.</param>
+    /// <returns><c>true</c> when the attribute is <c>[EnumeratorCancellation]</c>.</returns>
+    public static bool IsEnumeratorCancellation(BoundAttribute attribute)
+    {
+        return IsEnumeratorCancellation(attribute?.AttributeType?.ClrType);
+    }
+
+    /// <summary>
+    /// Returns the first <c>[EnumeratorCancellation]</c> attribute in
+    /// <paramref name="attributes"/>, or <c>null</c> if none is present.
+    /// </summary>
+    /// <param name="attributes">The attribute list on a parameter symbol.</param>
+    /// <returns>The matching attribute, or <c>null</c>.</returns>
+    public static BoundAttribute FindEnumeratorCancellation(ImmutableArray<BoundAttribute> attributes)
+    {
+        if (attributes.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        foreach (var attr in attributes)
+        {
+            if (IsEnumeratorCancellation(attr))
+            {
+                return attr;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Looks for an <c>[Obsolete]</c> attribute in <paramref name="attributes"/>
     /// and extracts its <c>message</c> and <c>isError</c> arguments.
     /// </summary>

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1274,6 +1274,36 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0206", "Annotations are only allowed on variable declarations (var/let/const), not on this statement.");
     }
 
+    /// <summary>
+    /// Reports GS0207 when <c>@EnumeratorCancellation</c> is applied to a
+    /// parameter whose type is not <see cref="System.Threading.CancellationToken"/>
+    /// (ADR-0047 §6 / ADR-0040: <c>EnumeratorCancellationAttribute</c> marks
+    /// the cancellation-token parameter that the async-sequence rewriter
+    /// threads through; non-token parameters cannot be threaded).
+    /// </summary>
+    /// <param name="location">The source location of the parameter declaration.</param>
+    /// <param name="parameterName">The parameter's declared name.</param>
+    /// <param name="actualTypeName">The parameter's declared type (display string).</param>
+    public void ReportEnumeratorCancellationWrongType(TextLocation location, string parameterName, string actualTypeName)
+    {
+        Report(location, "GS0207", $"Parameter '{parameterName}' is annotated '@EnumeratorCancellation' but has type '{actualTypeName}'; only 'System.Threading.CancellationToken' parameters can carry this annotation.");
+    }
+
+    /// <summary>
+    /// Reports GS0208 when <c>@EnumeratorCancellation</c> is applied to a
+    /// parameter on a function whose return type is not an
+    /// <c>async sequence</c> (i.e. <see cref="System.Collections.Generic.IAsyncEnumerable{T}"/>).
+    /// The runtime only threads the per-enumerator cancellation token through
+    /// <c>IAsyncEnumerable.GetAsyncEnumerator(CancellationToken)</c>, so the
+    /// attribute is meaningless elsewhere (ADR-0040).
+    /// </summary>
+    /// <param name="location">The source location of the parameter declaration.</param>
+    /// <param name="parameterName">The parameter's declared name.</param>
+    public void ReportEnumeratorCancellationNotAsyncSequence(TextLocation location, string parameterName)
+    {
+        Report(location, "GS0208", $"Parameter '{parameterName}' is annotated '@EnumeratorCancellation' but its enclosing function is not an async sequence (does not return 'IAsyncEnumerable[T]').");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -4072,7 +4072,8 @@ internal sealed class ReflectionMetadataEmitter
             if (getAsyncEnumerator != null)
             {
                 this.lambdaBodies[getAsyncEnumerator] = this.BuildGetAsyncEnumeratorBody(
-                    getAsyncEnumerator, smClass, stateField, disposeModeField);
+                    getAsyncEnumerator, smClass, stateField, disposeModeField,
+                    plan.Function.Parameters, parameterFields);
             }
 
             // IValueTaskSource<bool>.GetStatus(short token): return promise.GetStatus(token);
@@ -4208,9 +4209,12 @@ internal sealed class ReflectionMetadataEmitter
         FunctionSymbol getAsyncEnumerator,
         StructSymbol smClass,
         FieldSymbol stateField,
-        FieldSymbol disposeModeField)
+        FieldSymbol disposeModeField,
+        ImmutableArray<ParameterSymbol> userParameters,
+        Dictionary<ParameterSymbol, FieldSymbol> parameterFields)
     {
         var thisParam = getAsyncEnumerator.ThisParameter;
+        var ctParam = getAsyncEnumerator.Parameters[0];
         var stmts = ImmutableArray.CreateBuilder<BoundStatement>();
 
         // this.<>1__state = -1; (running state)
@@ -4222,6 +4226,63 @@ internal sealed class ReflectionMetadataEmitter
         stmts.Add(new BoundExpressionStatement(
             new BoundFieldAssignmentExpression(thisParam, smClass, disposeModeField,
                 new BoundLiteralExpression(false))));
+
+        // Issue #180 / ADR-0040: thread the runtime-supplied cancellation
+        // token into the user's @EnumeratorCancellation parameter. The C#
+        // semantics combine the original kickoff token with the per-enumerator
+        // token via CancellationTokenSource.CreateLinkedTokenSource; for this
+        // slice we adopt the conservative "override when meaningful" rule:
+        // if the caller passed a real (cancellable) token via WithCancellation,
+        // assign it to the parameter field; otherwise keep the kickoff value.
+        //     if (cancellationToken.CanBeCanceled) {
+        //         this.<param> = cancellationToken;
+        //     }
+        if (!userParameters.IsDefaultOrEmpty)
+        {
+            foreach (var userParam in userParameters)
+            {
+                var ecAttr = KnownAttributes.FindEnumeratorCancellation(userParam.Attributes);
+                if (ecAttr == null)
+                {
+                    continue;
+                }
+
+                if (userParam.Type?.ClrType != typeof(System.Threading.CancellationToken))
+                {
+                    // Binder already reported GS0207; skip emit-time threading.
+                    continue;
+                }
+
+                if (!parameterFields.TryGetValue(userParam, out var paramField))
+                {
+                    continue;
+                }
+
+                var canBeCanceledGetter = typeof(System.Threading.CancellationToken)
+                    .GetProperty(nameof(System.Threading.CancellationToken.CanBeCanceled))
+                    .GetGetMethod();
+                var canBeCanceledCall = new BoundImportedInstanceCallExpression(
+                    new BoundAddressOfExpression(new BoundVariableExpression(ctParam)),
+                    canBeCanceledGetter,
+                    TypeSymbol.Bool,
+                    ImmutableArray<BoundExpression>.Empty);
+
+                var assign = new BoundExpressionStatement(
+                    new BoundFieldAssignmentExpression(
+                        thisParam, smClass, paramField,
+                        new BoundVariableExpression(ctParam)));
+
+                stmts.Add(new BoundIfStatement(
+                    canBeCanceledCall,
+                    new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(assign)),
+                    elseStatement: null));
+
+                // Only one parameter may carry the marker; if a user wrote
+                // multiple, the binder accepts the first and downstream emit
+                // honours that same parameter.
+                break;
+            }
+        }
 
         // return this;
         stmts.Add(new BoundReturnStatement(new BoundVariableExpression(thisParam)));

--- a/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
@@ -732,6 +732,90 @@ type Point struct {
         Assert.Contains(program.Diagnostics, d => d.Id == "GS0204" && d.Message.Contains("Box.Value"));
     }
 
+    [Fact]
+    public void EnumeratorCancellation_On_CancellationToken_In_AsyncSequence_Is_Accepted()
+    {
+        // ADR-0040 / issue #180: a CancellationToken parameter on a function
+        // returning IAsyncEnumerable[T] is the only valid place for the
+        // attribute. No diagnostics should be reported.
+        var source = """
+            import System.Collections.Generic
+            import System.Runtime.CompilerServices
+            import System.Threading
+
+            func numbers(@EnumeratorCancellation ct CancellationToken) IAsyncEnumerable[int] {
+                yield 1
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0207");
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0208");
+
+        var numbers = globalScope.Functions.Single(f => f.Name == "numbers");
+        var ct = numbers.Parameters.Single();
+        var attr = Assert.Single(ct.Attributes);
+        Assert.Equal(
+            "System.Runtime.CompilerServices.EnumeratorCancellationAttribute",
+            attr.AttributeType.Name);
+    }
+
+    [Fact]
+    public void EnumeratorCancellation_On_NonToken_Parameter_Reports_GS0207()
+    {
+        // ADR-0040: ERR_EnumeratorCancellationWrongType — the attribute is
+        // valid only on a CancellationToken parameter.
+        var source = """
+            import System.Collections.Generic
+            import System.Runtime.CompilerServices
+
+            func numbers(@EnumeratorCancellation n int) IAsyncEnumerable[int] {
+                yield n
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0207");
+    }
+
+    [Fact]
+    public void EnumeratorCancellation_On_NonAsyncSequence_Reports_GS0208()
+    {
+        // ADR-0040: the runtime threads the per-enumerator token only through
+        // IAsyncEnumerable.GetAsyncEnumerator, so applying the attribute on a
+        // plain function (or an iterator/enumerator return) is an error.
+        var source = """
+            import System.Threading
+            import System.Runtime.CompilerServices
+
+            func noop(@EnumeratorCancellation ct CancellationToken) {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0208");
+    }
+
+    [Fact]
+    public void EnumeratorCancellation_On_AsyncEnumerator_Return_Reports_GS0208()
+    {
+        // IAsyncEnumerator[T] is *not* an `async sequence` — it has no
+        // GetAsyncEnumerator(CancellationToken) overload to thread the token
+        // through, so the attribute is rejected.
+        var source = """
+            import System.Collections.Generic
+            import System.Runtime.CompilerServices
+            import System.Threading
+
+            func numbers(@EnumeratorCancellation ct CancellationToken) IAsyncEnumerator[int] {
+                yield 1
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0208");
+    }
+
     private static BoundGlobalScope BindSource(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncIteratorEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncIteratorEmitTests.cs
@@ -167,6 +167,60 @@ func delayed() IAsyncEnumerable[int] {
         Assert.Equal(new[] { 100, 200, 300 }, items);
     }
 
+    [Fact]
+    public async Task AsyncIterator_EnumeratorCancellation_RuntimeTokenIsThreaded()
+    {
+        // Issue #180 / ADR-0040: a CancellationToken parameter annotated
+        // @EnumeratorCancellation on an `async sequence` receives the token
+        // supplied at GetAsyncEnumerator(ct) time. We verify by passing
+        // an already-cancelled token; the iterator's first await on
+        // Task.Delay(token) must observe the cancellation and throw.
+        const string Source = @"package AsyncIterEC
+import System
+import System.Collections.Generic
+import System.Runtime.CompilerServices
+import System.Threading
+import System.Threading.Tasks
+
+func numbers(@EnumeratorCancellation ct CancellationToken) IAsyncEnumerable[int] {
+    yield 1
+    await Task.Delay(1000, ct)
+    yield 2
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(AsyncIterator_EnumeratorCancellation_RuntimeTokenIsThreaded));
+        try
+        {
+            // Kickoff with default token; runtime token comes via GetAsyncEnumerator.
+            var enumerable = (IAsyncEnumerable<int>)InvokeFunction(asm, "numbers", new object[] { default(CancellationToken) });
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var enumerator = enumerable.GetAsyncEnumerator(cts.Token);
+            try
+            {
+                // First MoveNextAsync should produce the first yielded value.
+                Assert.True(await enumerator.MoveNextAsync());
+                Assert.Equal(1, enumerator.Current);
+
+                // Second MoveNextAsync awaits Task.Delay(..., ct); since the
+                // runtime-supplied token (already cancelled) was threaded into
+                // the user parameter, the delay throws OperationCanceledException.
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                    async () => await enumerator.MoveNextAsync());
+            }
+            finally
+            {
+                await enumerator.DisposeAsync();
+            }
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
     private static List<T> CompileAndEnumerate<T>(string source, string functionName, string contextName)
     {
         return CompileAndEnumerateWithArgs<T>(source, functionName, null, contextName);


### PR DESCRIPTION
Closes #180. Phase 5 follow-up to #141 / ADR-0047 §6 / ADR-0040.

## What this PR does

### Type-identity recogniser
- `KnownAttributes.IsEnumeratorCancellation(Type)` /
  `IsEnumeratorCancellation(BoundAttribute)` /
  `FindEnumeratorCancellation(ImmutableArray<BoundAttribute>)` —
  checks key off the resolved CLR type so a renamed or shadowed alias
  cannot bypass validation.

### Binder validation
After per-parameter attribute binding, the function-declaration binder
inspects each parameter's attribute list for `@EnumeratorCancellation`:

- **GS0207** — `ERR_EnumeratorCancellationWrongType`: the parameter's
  declared type is not `System.Threading.CancellationToken`.
- **GS0208** — the enclosing function is not an *async sequence*
  (return type is not `IAsyncEnumerable[T]`). `IAsyncEnumerator[T]` is
  rejected too — it exposes no `GetAsyncEnumerator(CancellationToken)`
  overload to thread the token through.

The bound attribute is still attached to the `ParameterSymbol` so the
emitter and downstream tooling can observe the user's intent.

### Emitter wiring
`BuildGetAsyncEnumeratorBody` now scans the user-function parameters
for an `@EnumeratorCancellation`-marked `CancellationToken` and emits

```
if (cancellationToken.CanBeCanceled) {
    this.<param> = cancellationToken;
}
```

before returning `this`. This is the conservative "override when
meaningful" rule: callers using `WithCancellation(...)` drive
cancellation into the user parameter; callers passing
`CancellationToken.None` leave the kickoff value intact.

## Tests

- `AttributeBinderTests` — accept on `CancellationToken` +
  `IAsyncEnumerable[T]`; reject GS0207 on non-token; GS0208 on void
  and on `IAsyncEnumerator[T]` returns.
- `AsyncIteratorEmitTests.AsyncIterator_EnumeratorCancellation_RuntimeTokenIsThreaded` —
  emits + runs an iterator, calls `GetAsyncEnumerator(cancelledToken)`,
  and asserts the awaited `Task.Delay(..., ct)` observes the
  runtime-supplied cancellation (`OperationCanceledException`).