### PR TITLE
Enforce [AttributeUsage] on attribute classes (#177)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -508,7 +508,8 @@ public sealed class Binder
             syntax.Annotations,
             AttributeTargetKind.Type,
             TypeDeclarationAllowedTargets,
-            "a type alias declaration");
+            "a type alias declaration",
+            System.AttributeTargets.Class);
 
         if (!scope.TryDeclareTypeAlias(name, aliasedType))
         {
@@ -532,7 +533,8 @@ public sealed class Binder
             syntax.Annotations,
             AttributeTargetKind.Type,
             TypeDeclarationAllowedTargets,
-            "an enum declaration"));
+            "an enum declaration",
+            System.AttributeTargets.Enum));
 
         var seenMemberNames = new HashSet<string>();
         var members = ImmutableArray.CreateBuilder<EnumMemberSymbol>();
@@ -558,7 +560,8 @@ public sealed class Binder
                     memberSyntax.Annotations,
                     AttributeTargetKind.Field,
                     VariableDeclarationAllowedTargets,
-                    "an enum member declaration"));
+                    "an enum member declaration",
+                    System.AttributeTargets.Field));
             }
 
             members.Add(memberSymbol);
@@ -681,7 +684,8 @@ public sealed class Binder
                     fieldSyntax.Annotations,
                     AttributeTargetKind.Field,
                     FieldDeclarationAllowedTargets,
-                    "a field declaration"));
+                    "a field declaration",
+                    System.AttributeTargets.Field));
             }
 
             fields.Add(fieldSymbol);
@@ -817,7 +821,8 @@ public sealed class Binder
             syntax.Annotations,
             AttributeTargetKind.Type,
             TypeDeclarationAllowedTargets,
-            syntax.IsClass ? "a class declaration" : "a struct declaration"));
+            syntax.IsClass ? "a class declaration" : "a struct declaration",
+            syntax.IsClass ? System.AttributeTargets.Class : System.AttributeTargets.Struct));
 
         if (hasAttributeSugar && syntax.IsClass)
         {
@@ -984,7 +989,8 @@ public sealed class Binder
             syntax.Annotations,
             AttributeTargetKind.Type,
             TypeDeclarationAllowedTargets,
-            "an interface declaration"));
+            "an interface declaration",
+            System.AttributeTargets.Interface));
 
         // Phase 4.3c / ADR-0020: bind type parameters at declaration time so
         // method-signature binding (which happens later) can resolve them.
@@ -1242,7 +1248,8 @@ public sealed class Binder
                 syntax.Annotations,
                 AttributeTargetKind.Method,
                 FunctionDeclarationAllowedTargets,
-                "a function declaration");
+                "a function declaration",
+                System.AttributeTargets.Method);
 
             // Per-parameter annotations: each ParameterSyntax owns its own
             // annotation list; the default target is `param`. Issue #170 /
@@ -1256,7 +1263,8 @@ public sealed class Binder
                     parameterSyntax.Annotations,
                     AttributeTargetKind.Param,
                     ParameterAllowedTargets,
-                    "a parameter declaration");
+                    "a parameter declaration",
+                    System.AttributeTargets.Parameter);
 
                 var parameterSymbol = parameterSymbolBySyntax[pIndex];
                 if (parameterSymbol != null && !paramAttrs.IsDefaultOrEmpty)
@@ -1752,7 +1760,8 @@ public sealed class Binder
                 syntax.Annotations,
                 AttributeTargetKind.Field,
                 VariableDeclarationAllowedTargets,
-                positionDescription);
+                positionDescription,
+                System.AttributeTargets.Field);
             variable.SetAttributes(boundAttrs);
         }
 
@@ -6820,12 +6829,16 @@ public sealed class Binder
     /// <param name="defaultTarget">Default target inferred from the declaration position.</param>
     /// <param name="allowedTargets">Target kinds permitted at this declaration position.</param>
     /// <param name="positionDescription">Human-readable position for diagnostics.</param>
+    /// <param name="defaultSystemTarget">CLR-side <see cref="System.AttributeTargets"/>
+    /// value used when validating <c>[AttributeUsage(ValidOn)]</c> for the
+    /// <c>Type</c> kind, which is ambiguous in source.</param>
     /// <returns>The resolved attribute list (skipping unresolved entries).</returns>
     private ImmutableArray<BoundAttribute> BindAttributes(
         ImmutableArray<AnnotationSyntax> annotations,
         AttributeTargetKind defaultTarget,
         ImmutableHashSet<AttributeTargetKind> allowedTargets,
-        string positionDescription)
+        string positionDescription,
+        System.AttributeTargets defaultSystemTarget)
     {
         if (annotations.IsDefaultOrEmpty)
         {
@@ -6833,6 +6846,13 @@ public sealed class Binder
         }
 
         var builder = ImmutableArray.CreateBuilder<BoundAttribute>(annotations.Length);
+
+        // Track applications per (attribute-type identity, effective target)
+        // so we can fire GS0210 when AllowMultiple = false. We key on the
+        // resolved TypeSymbol (reference identity is sufficient — each
+        // attribute class has a single Symbol instance).
+        var applications = new Dictionary<(TypeSymbol Type, AttributeTargetKind Target), int>();
+
         foreach (var annotation in annotations)
         {
             // Phase 4 of #141 / ADR-0047 §5: the `@Attribute` marker on a
@@ -6844,9 +6864,27 @@ public sealed class Binder
                 continue;
             }
 
-            var bound = BindAttribute(annotation, defaultTarget, allowedTargets, positionDescription);
+            var bound = BindAttribute(annotation, defaultTarget, allowedTargets, positionDescription, defaultSystemTarget);
             if (bound != null)
             {
+                var key = (bound.AttributeType, bound.Target);
+                if (applications.TryGetValue(key, out var count))
+                {
+                    KnownAttributes.GetAttributeUsage(bound.AttributeType, out _, out var allowMultiple);
+                    if (!allowMultiple)
+                    {
+                        Diagnostics.ReportAttributeUsageDuplicate(
+                            GetAnnotationNameLocation(annotation),
+                            annotation.GetNameText());
+                    }
+
+                    applications[key] = count + 1;
+                }
+                else
+                {
+                    applications[key] = 1;
+                }
+
                 builder.Add(bound);
             }
         }
@@ -6858,7 +6896,8 @@ public sealed class Binder
         AnnotationSyntax annotation,
         AttributeTargetKind defaultTarget,
         ImmutableHashSet<AttributeTargetKind> allowedTargets,
-        string positionDescription)
+        string positionDescription,
+        System.AttributeTargets defaultSystemTarget)
     {
         // 1) Resolve target — parser already filtered to canonical kinds; if
         // the user wrote an unrecognised one a GS0197 was already reported,
@@ -6909,6 +6948,24 @@ public sealed class Binder
         if (KnownAttributes.IsReservedForCompiler(attrType.ClrType))
         {
             Diagnostics.ReportAttributeReservedForCompiler(GetAnnotationNameLocation(annotation), nameText);
+            return null;
+        }
+
+        // 3b) Issue #177 / ADR-0047 §6: enforce [AttributeUsage(ValidOn)].
+        // For the `Type` target the actual CLR target depends on the kind
+        // of type being declared (class/struct/enum/interface), which the
+        // caller passes via defaultSystemTarget. For all other targets the
+        // effective CLR target is derived directly from targetKind, since
+        // any use-site qualifier (`@return:` etc.) already narrows it.
+        var effectiveSystemTarget = MapToSystemAttributeTargets(targetKind, defaultSystemTarget);
+        KnownAttributes.GetAttributeUsage(attrType, out var validOn, out _);
+        if ((validOn & effectiveSystemTarget) == 0)
+        {
+            Diagnostics.ReportAttributeUsageInvalidTarget(
+                GetAnnotationNameLocation(annotation),
+                nameText,
+                positionDescription,
+                validOn);
             return null;
         }
 
@@ -6987,6 +7044,11 @@ public sealed class Binder
 
     private static bool IsAttributeType(TypeSymbol typeSymbol)
     {
+        if (typeSymbol is StructSymbol structSym && structSym.IsAttributeClass)
+        {
+            return true;
+        }
+
         var clr = typeSymbol?.ClrType;
         if (clr == null)
         {
@@ -7018,6 +7080,17 @@ public sealed class Binder
         return annotation.Location;
     }
 
+    private static bool IsEnumLikeType(TypeSymbol type)
+    {
+        if (type is EnumSymbol)
+        {
+            return true;
+        }
+
+        var clr = type?.ClrType;
+        return clr != null && clr.IsEnum;
+    }
+
     private static bool TryParseTargetKind(string text, out AttributeTargetKind kind)
     {
         switch (text)
@@ -7033,6 +7106,32 @@ public sealed class Binder
             case "assembly": kind = AttributeTargetKind.Assembly; return true;
             case "genericparam": kind = AttributeTargetKind.GenericParam; return true;
             default: kind = AttributeTargetKind.Method; return false;
+        }
+    }
+
+    /// <summary>
+    /// Issue #177: maps a GSharp <see cref="AttributeTargetKind"/> to the
+    /// corresponding CLR <see cref="System.AttributeTargets"/> flag used by
+    /// <see cref="System.AttributeUsageAttribute"/>. The <c>Type</c> kind
+    /// is intentionally ambiguous in GSharp (class/struct/enum/interface
+    /// share a single source-level position), so the caller supplies the
+    /// concrete CLR target via <paramref name="typePositionFallback"/>.
+    /// </summary>
+    private static System.AttributeTargets MapToSystemAttributeTargets(AttributeTargetKind kind, System.AttributeTargets typePositionFallback)
+    {
+        switch (kind)
+        {
+            case AttributeTargetKind.Field: return System.AttributeTargets.Field;
+            case AttributeTargetKind.Param: return System.AttributeTargets.Parameter;
+            case AttributeTargetKind.Return: return System.AttributeTargets.ReturnValue;
+            case AttributeTargetKind.Method: return System.AttributeTargets.Method;
+            case AttributeTargetKind.Property: return System.AttributeTargets.Property;
+            case AttributeTargetKind.Event: return System.AttributeTargets.Event;
+            case AttributeTargetKind.Module: return System.AttributeTargets.Module;
+            case AttributeTargetKind.Assembly: return System.AttributeTargets.Assembly;
+            case AttributeTargetKind.GenericParam: return System.AttributeTargets.GenericParameter;
+            case AttributeTargetKind.Type: return typePositionFallback;
+            default: return System.AttributeTargets.All;
         }
     }
 
@@ -7079,6 +7178,21 @@ public sealed class Binder
 
             case ArrayCreationExpressionSyntax arraySyntax:
                 return TryBindAttributeArrayArgument(arraySyntax, out value, out type);
+        }
+
+        // Issue #177: accept BoundLiteralExpression whose static type is an
+        // enum (e.g. `AttributeTargets.Method`) — required by [AttributeUsage]
+        // and other enum-valued attribute arguments. The emitter serialises
+        // the underlying primitive per ECMA-335 II.23.3. Other expressions
+        // that incidentally fold to a constant (e.g. `nameof(...)`) remain
+        // out of scope here; they go through GS0202.
+        if (BindExpression(syntax) is BoundLiteralExpression lit
+            && lit.Value != null
+            && IsEnumLikeType(lit.Type))
+        {
+            value = lit.Value;
+            type = lit.Type;
+            return true;
         }
 
         return false;

--- a/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
+++ b/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -139,5 +140,109 @@ internal static class KnownAttributes
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Resolves the effective <see cref="AttributeUsageAttribute"/> for the
+    /// candidate attribute class <paramref name="attributeType"/>. ADR-0047
+    /// §6 / issue #177: an <c>@AttributeUsage(...)</c> annotation on a
+    /// user-declared <c>@Attribute</c> class supplies <c>ValidOn</c> and
+    /// <c>AllowMultiple</c>; CLR-imported attribute types are read via
+    /// reflection. When the attribute carries no <c>AttributeUsage</c> the
+    /// C# defaults apply: <see cref="AttributeTargets.All"/> /
+    /// <c>AllowMultiple = false</c>.
+    /// </summary>
+    /// <param name="attributeType">The resolved attribute type symbol.</param>
+    /// <param name="validOn">Receives the <c>ValidOn</c> flag set.</param>
+    /// <param name="allowMultiple">Receives the <c>AllowMultiple</c> flag.</param>
+    public static void GetAttributeUsage(TypeSymbol attributeType, out AttributeTargets validOn, out bool allowMultiple)
+    {
+        validOn = AttributeTargets.All;
+        allowMultiple = false;
+
+        if (attributeType == null)
+        {
+            return;
+        }
+
+        if (attributeType is StructSymbol structSym && structSym.IsAttributeClass)
+        {
+            if (TryReadAttributeUsageFromBound(structSym.Attributes, out var v, out var am))
+            {
+                validOn = v;
+                allowMultiple = am;
+            }
+
+            return;
+        }
+
+        var clr = attributeType.ClrType;
+        if (clr == null)
+        {
+            return;
+        }
+
+        var usage = (AttributeUsageAttribute)Attribute.GetCustomAttribute(clr, typeof(AttributeUsageAttribute), inherit: true);
+        if (usage != null)
+        {
+            validOn = usage.ValidOn;
+            allowMultiple = usage.AllowMultiple;
+        }
+    }
+
+    private static bool TryReadAttributeUsageFromBound(ImmutableArray<BoundAttribute> attributes, out AttributeTargets validOn, out bool allowMultiple)
+    {
+        validOn = AttributeTargets.All;
+        allowMultiple = false;
+        if (attributes.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        foreach (var attr in attributes)
+        {
+            if (attr?.AttributeType?.ClrType != typeof(AttributeUsageAttribute))
+            {
+                continue;
+            }
+
+            if (!attr.PositionalArguments.IsDefaultOrEmpty
+                && attr.PositionalArguments.Length >= 1
+                && TryConvertToInt32(attr.PositionalArguments[0].Value, out var raw))
+            {
+                validOn = (AttributeTargets)raw;
+            }
+
+            if (!attr.NamedArguments.IsDefaultOrEmpty)
+            {
+                foreach (var named in attr.NamedArguments)
+                {
+                    if (named.Name == "AllowMultiple" && named.Value is bool b)
+                    {
+                        allowMultiple = b;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryConvertToInt32(object value, out int result)
+    {
+        switch (value)
+        {
+            case int i: result = i; return true;
+            case short s: result = s; return true;
+            case byte by: result = by; return true;
+            case sbyte sb: result = sb; return true;
+            case ushort us: result = us; return true;
+            case uint ui: result = (int)ui; return true;
+            case long l: result = (int)l; return true;
+            case AttributeTargets at: result = (int)at; return true;
+            default: result = 0; return false;
+        }
     }
 }

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1304,6 +1304,31 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0208", $"Parameter '{parameterName}' is annotated '@EnumeratorCancellation' but its enclosing function is not an async sequence (does not return 'IAsyncEnumerable[T]').");
     }
 
+    /// <summary>
+    /// Reports GS0209 when an attribute is applied to a declaration whose CLR
+    /// target is excluded by the attribute's <c>[AttributeUsage(ValidOn)]</c>.
+    /// </summary>
+    /// <param name="location">The annotation name location.</param>
+    /// <param name="attributeName">The source-form attribute name.</param>
+    /// <param name="position">A human description of the use-site declaration.</param>
+    /// <param name="validOn">The flag set declared on the attribute class.</param>
+    public void ReportAttributeUsageInvalidTarget(TextLocation location, string attributeName, string position, System.AttributeTargets validOn)
+    {
+        Report(location, "GS0209", $"Attribute '{attributeName}' is not valid on {position}; its [AttributeUsage] permits only: {validOn}.");
+    }
+
+    /// <summary>
+    /// Reports GS0210 when an attribute is applied more than once to the
+    /// same target and its <c>[AttributeUsage(AllowMultiple = false)]</c>
+    /// (the C# default) forbids duplicates.
+    /// </summary>
+    /// <param name="location">The location of the duplicate annotation.</param>
+    /// <param name="attributeName">The source-form attribute name.</param>
+    public void ReportAttributeUsageDuplicate(TextLocation location, string attributeName)
+    {
+        Report(location, "GS0210", $"Duplicate attribute '{attributeName}'; this attribute type does not allow multiple applications (AllowMultiple = false).");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/test/Compiler.Tests/Emit/AttributeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AttributeEmitTests.cs
@@ -288,11 +288,13 @@ public class AttributeEmitTests
         // Issue #170 / ADR-0047 §3: per-parameter annotations attach to the
         // Parameter metadata row, round-tripping through
         // `MethodInfo.GetParameters()[i].GetCustomAttributesData()`.
+        // Uses `[Description]` because its [AttributeUsage(All)] permits the
+        // Parameter target (issue #177 enforces ValidOn).
         var source = """
             package P
-            import System
+            import System.ComponentModel
 
-            func Foo(@Obsolete("old name") name string) {
+            func Foo(@Description("old name") name string) {
             }
             """;
 
@@ -304,14 +306,14 @@ public class AttributeEmitTests
         var nameParam = Assert.Single(parameters);
         Assert.Equal("name", nameParam.Name);
 
-        var data = nameParam.GetCustomAttributesData().Single(d => d.AttributeType.FullName == "System.ObsoleteAttribute");
+        var data = nameParam.GetCustomAttributesData().Single(d => d.AttributeType.FullName == "System.ComponentModel.DescriptionAttribute");
         var arg = Assert.Single(data.ConstructorArguments);
         Assert.Equal("old name", arg.Value);
 
         // The MethodDef itself should not carry the parameter-target attribute.
         Assert.DoesNotContain(
             foo.GetCustomAttributesData(),
-            d => d.AttributeType.FullName == "System.ObsoleteAttribute");
+            d => d.AttributeType.FullName == "System.ComponentModel.DescriptionAttribute");
     }
 
     [Fact]
@@ -320,11 +322,13 @@ public class AttributeEmitTests
         // Issue #172 / ADR-0047 §3: `@return:` annotations attach to the
         // synthesised sequence-0 Parameter row (ECMA-335 II.22.33), surfacing
         // through `MethodInfo.ReturnParameter.GetCustomAttributesData()`.
+        // Uses `[Description]` because its [AttributeUsage(All)] permits the
+        // ReturnValue target (issue #177 enforces ValidOn).
         var source = """
             package P
-            import System
+            import System.ComponentModel
 
-            @return:Obsolete("old return")
+            @return:Description("old return")
             func Foo() int {
                 return 0
             }
@@ -338,14 +342,14 @@ public class AttributeEmitTests
         var returnParam = foo.ReturnParameter;
         Assert.NotNull(returnParam);
         var data = returnParam.GetCustomAttributesData()
-            .Single(d => d.AttributeType.FullName == "System.ObsoleteAttribute");
+            .Single(d => d.AttributeType.FullName == "System.ComponentModel.DescriptionAttribute");
         var arg = Assert.Single(data.ConstructorArguments);
         Assert.Equal("old return", arg.Value);
 
         // The MethodDef itself should not carry the return-target attribute.
         Assert.DoesNotContain(
             foo.GetCustomAttributesData(),
-            d => d.AttributeType.FullName == "System.ObsoleteAttribute");
+            d => d.AttributeType.FullName == "System.ComponentModel.DescriptionAttribute");
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
@@ -77,7 +77,9 @@ public class AttributeBinderTests
     [Fact]
     public void Allows_Return_Use_Site_Target_On_Function()
     {
-        var globalScope = BindSource("@return:Obsolete\nfunc Helper() {\n}\n");
+        // `[Description]` carries `[AttributeUsage(All)]`, which includes
+        // ReturnValue (issue #177).
+        var globalScope = BindSource("import System.ComponentModel\n@return:Description(\"x\")\nfunc Helper() int {\nreturn 0\n}\n");
 
         Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0201");
         var helper = globalScope.Functions.Single(f => f.Name == "Helper");
@@ -369,22 +371,24 @@ type Point struct {
     }
 
     [Fact]
-    public void Obsolete_Warning_Is_Reported_At_Parameter_Use_Site()
+    public void Obsolete_On_Parameter_Reports_GS0209()
     {
-        // #175: parameters that carry @Obsolete surface GS0204 at every
-        // read or write site (parameters already carry attribute storage
-        // per #170).
+        // Issue #177: `[Obsolete]`'s [AttributeUsage] excludes Parameter,
+        // so applying `@Obsolete` to a parameter is rejected at the
+        // declaration site (and never propagates to the parameter's
+        // attribute list, so the #175 GS0204 use-site warning cannot
+        // fire on the parameter).
         var source = """
             func Foo(@Obsolete("dead") x int) int {
                 return x + 1
             }
             """;
 
-        var program = BindProgramFromSource(source);
-        var diag = Assert.Single(program.Diagnostics, d => d.Id == "GS0204");
-        Assert.Equal(GSharp.Core.CodeAnalysis.DiagnosticSeverity.Warning, diag.Severity);
-        Assert.Contains("x", diag.Message);
-        Assert.Contains("dead", diag.Message);
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0209");
+
+        var program = Binder.BindProgram(globalScope);
+        Assert.DoesNotContain(program.Diagnostics, d => d.Id == "GS0204");
     }
 
     [Fact]
@@ -814,6 +818,124 @@ type Point struct {
 
         var globalScope = BindSource(source);
         Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0208");
+    }
+
+    [Fact]
+    public void AttributeUsage_Obsolete_On_Parameter_Reports_GS0209()
+    {
+        // Issue #177: `[Obsolete]`'s [AttributeUsage] does NOT include
+        // AttributeTargets.Parameter, so applying `@Obsolete` to a parameter
+        // must be rejected.
+        var source = """
+            import System
+
+            func Foo(@Obsolete("x") name string) {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0209" && d.Message.Contains("Obsolete"));
+    }
+
+    [Fact]
+    public void AttributeUsage_Obsolete_On_Return_Reports_GS0209()
+    {
+        // Issue #177: `[Obsolete]`'s [AttributeUsage] excludes
+        // AttributeTargets.ReturnValue, so `@return:Obsolete` is rejected.
+        var source = """
+            import System
+
+            @return:Obsolete("x")
+            func Foo() int {
+                return 0
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0209" && d.Message.Contains("Obsolete"));
+    }
+
+    [Fact]
+    public void AttributeUsage_DuplicateObsolete_On_Function_Reports_GS0210()
+    {
+        // Issue #177: `[Obsolete]`'s [AttributeUsage(AllowMultiple = false)]
+        // — applying it twice to the same declaration is an error.
+        var source = """
+            @Obsolete("first")
+            @Obsolete("second")
+            func Foo() {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0210" && d.Message.Contains("Obsolete"));
+    }
+
+    [Fact]
+    public void AttributeUsage_AllowMultiple_True_Permits_Duplicates()
+    {
+        // Issue #177: `[Conditional]` carries
+        // `[AttributeUsage(Method, AllowMultiple = true)]`, so two
+        // applications on the same method must NOT report GS0210.
+        var source = """
+            import System.Diagnostics
+
+            @Conditional("DEBUG")
+            @Conditional("TRACE")
+            func Log() {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0210");
+    }
+
+    [Fact]
+    public void AttributeUsage_UserAttribute_With_ValidOn_Method_On_Field_Reports_GS0209()
+    {
+        // Issue #177: a user-declared `@Attribute` class whose
+        // `@AttributeUsage(AttributeTargets.Method)` excludes Field must be
+        // rejected when applied to a field.
+        var source = """
+            import System
+
+            @Attribute
+            @AttributeUsage(AttributeTargets.Method)
+            type MethodOnly class {
+            }
+
+            type Box class {
+                @MethodOnly
+                Value int
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0209" && d.Message.Contains("MethodOnly"));
+    }
+
+    [Fact]
+    public void AttributeUsage_UserAttribute_AllowMultiple_True_Permits_Duplicates()
+    {
+        // Issue #177: a user-declared `@Attribute` class whose
+        // `@AttributeUsage(All, AllowMultiple := true)` opts into multiple
+        // applications — two applications must NOT report GS0210.
+        var source = """
+            import System
+
+            @Attribute
+            @AttributeUsage(AttributeTargets.All, AllowMultiple := true)
+            type Tag class {
+            }
+
+            @Tag
+            @Tag
+            func Foo() {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0210");
     }
 
     private static BoundGlobalScope BindSource(string source)


### PR DESCRIPTION
Closes #177. Follow-up to #174 (Phase 5 of #141).

ADR-0047 §6: `System.AttributeUsageAttribute` — "validates targets / multi-apply on every subsequent use of the attribute."

## What this PR does

When an attribute class carries an `@AttributeUsage(...)` annotation (or, for CLR-imported attribute types, a `[AttributeUsage]`), the binder now parses `ValidOn` (`AttributeTargets` flags) and `AllowMultiple` and enforces them at every use site.

### `KnownAttributes.GetAttributeUsage(TypeSymbol, out AttributeTargets validOn, out bool allowMultiple)`

Resolves the effective `AttributeUsageAttribute` for a candidate attribute type:

* For user `@Attribute` classes (`StructSymbol` with `IsAttributeClass`), reads the bound `@AttributeUsage(...)` from `StructSymbol.Attributes`.
* For CLR-imported attribute types, reads via reflection.
* Falls back to the C# defaults — `AttributeTargets.All` / `AllowMultiple = false` — when no `AttributeUsage` is present.

### `Binder.BindAttribute`

* New step 3b runs after type resolution / reserved-attribute rejection.
* The use-site target is mapped to the corresponding `System.AttributeTargets` flag. The GSharp `Type` kind is intentionally ambiguous (class/struct/enum/interface share a single position), so each `BindAttributes` caller passes its concrete CLR target via a new parameter.
* **GS0209**: reported when `(validOn & effectiveTarget) == 0`. The attribute is dropped (returns `null`).

### `Binder.BindAttributes`

* Tracks applications by `(AttributeType, effective AttributeTargetKind)` so that two `@Obsolete` annotations targeting different metadata rows (e.g. method + return) don't collide.
* **GS0210**: reported on the second and further annotations when `AllowMultiple = false`.

### Side improvements

* `IsAttributeType` now accepts user-declared `@Attribute` classes (their `StructSymbol.ClrType` is `null`), so user attribute classes can finally be applied to other declarations and exercise the new validation pipeline.
* `TryBindAttributeArgument` accepts `BoundLiteralExpression` whose static type is an enum — covers `AttributeTargets.Method` etc., required by the `[AttributeUsage]` argument shape.

## Example diagnostics

```gs
import System

func Foo(@Obsolete("x") name string) {     // GS0209: Attribute 'Obsolete' is not valid on a parameter declaration; its [AttributeUsage] permits only: ...
}

@Obsolete("a")
@Obsolete("b")                              // GS0210: Duplicate attribute 'Obsolete'; this attribute type does not allow multiple applications.
func Bar() { }
```

```gs
import System

@Attribute
@AttributeUsage(AttributeTargets.Method)
type MethodOnly class { }

type Box class {
    @MethodOnly                              // GS0209: Attribute 'MethodOnly' is not valid on a field declaration; its [AttributeUsage] permits only: Method.
    Value int
}
```

## Test updates

* New `AttributeBinderTests` cover GS0209 and GS0210 for both built-in (`[Obsolete]`, `[Conditional]`) and user-declared attribute classes, plus `AllowMultiple = true` paths.
* Existing tests that applied `@Obsolete` to a parameter or return value have been updated: C#'s `[Obsolete]` doesn't permit those targets either, so those scenarios now correctly fire GS0209. The emission tests that exercised the parameter / return-value attribute machinery now use `@Description` (whose `AttributeUsage(All)` permits both targets).

## Validation

`dotnet build src/Core -nologo -clp:NoSummary` → 0 warnings, 0 errors.
`dotnet test GSharp.sln --nologo --no-restore` → 1376 passing (Sdk 21 / Core 1147 / Compiler 159 / Interpreter 32 / LanguageServer 17).