### PR TITLE
Recognise and reject [DllImport] in v1.0 (GS0211)

### DIFF
--- a/docs/adr/0047-attribute-syntax-and-declaration.md
+++ b/docs/adr/0047-attribute-syntax-and-declaration.md
@@ -133,7 +133,7 @@ A small, closed set of attributes drive compiler behaviour today (the binder's h
 | `System.Runtime.CompilerServices.CompilerGeneratedAttribute` | any | Synthesis-only; user-written form is rejected. |
 | `System.ObsoleteAttribute`             | any                             | Diagnostic on uses of the marked symbol (warning by default, error if `IsError` arg is `true`). |
 | `System.Diagnostics.ConditionalAttribute` | method                       | Calls are elided when the named symbol is not defined in the compilation. |
-| `System.Runtime.InteropServices.DllImportAttribute` | method (extern body)    | Recognised but only valid on declarations whose body marker is `extern` (post-v1.0; v1.0 rejects with `ERR_DllImportNotSupported`). |
+| `System.Runtime.InteropServices.DllImportAttribute` | method (extern body)    | Recognised but only valid on declarations whose body marker is `extern` (post-v1.0; v1.0 rejects with `ERR_DllImportNotSupported`, diagnostic `GS0211`). |
 | `System.AttributeUsageAttribute`       | attribute class only            | Validates targets / multi-apply on every subsequent use of the attribute. |
 | `System.Runtime.CompilerServices.NullableAttribute` and `NullableContextAttribute` | any | Read-only; written exclusively by the emitter from ADR-0001 nullability state. User-written form is rejected. |
 | `System.Diagnostics.CodeAnalysis.NotNullWhenAttribute` (and the `MaybeNullWhen` / `MemberNotNull*` family) | parameter / return | Recognised on imported metadata for nullability flow; user-written form is accepted and influences the binder's nullability state machine identically to C#. |

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -156,7 +156,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0194 | Error | Unrecognised escape sequence in character literal. | `'\q'`. |
 | GS0195 | Error | Malformed Unicode escape in character literal. | `'\u00G0'`. |
 
-### Attribute / annotation diagnostics (GS0196–GS0206)
+### Attribute / annotation diagnostics (GS0196–GS0211)
 
 ADR-0047 introduces Kotlin-style attribute syntax (`@Foo(...)`) and the `@Attribute` declaration sugar. The following diagnostics cover parsing, resolution, use-site validation, and the compiler-recognised attribute set.
 
@@ -173,6 +173,7 @@ ADR-0047 introduces Kotlin-style attribute syntax (`@Foo(...)`) and the `@Attrib
 | GS0204 | **Warning** (Error if `IsError=true`) | Reference to a symbol marked `[Obsolete]`. | Calling a function, instantiating a class (`Old(5)`), writing a struct literal (`Old{}`), naming a struct/class/interface/enum in a type clause, reading an obsolete parameter, reading/writing an obsolete `var`/`let`/`const`, reading an obsolete enum member (`Color.Red`), or reading/writing an obsolete struct/class field (`p.Old`) — all declared with `@Obsolete("use Bar")`. Severity is promoted to error when the attribute's second argument is `true`. |
 | GS0205 | Error | Attribute is reserved for compiler synthesis. | `@CompilerGenerated`, `@Extension`, `@AsyncStateMachine`, `@Nullable`, or `@NullableContext` written in user source. |
 | GS0206 | Error | Annotations are only allowed on variable declarations, not on this statement. | `@Obsolete\nreturn` inside a function body — annotations may precede `var`/`let`/`const` but no other statement kind. |
+| GS0211 | Error | Attribute `[DllImport]` is recognised but not supported in v1.0; P/Invoke (extern function bodies) is a post-v1.0 feature. | `@DllImport("user32.dll") func MessageBox() {}` — emit support and the `extern` body marker arrive after v1.0. |
 
 ### Pointer / by-ref diagnostics (GS9001–GS9006)
 

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -6951,6 +6951,17 @@ public sealed class Binder
             return null;
         }
 
+        // 3a.1) Issue #179 / ADR-0047 §6: recognise [DllImport] but reject it in
+        // v1.0. The attribute is only valid on declarations whose body marker is
+        // `extern`, which (together with the underlying P/Invoke metadata emit)
+        // is a post-v1.0 feature. Type-identity recognition prevents aliasing
+        // or shadowing the source-level name from bypassing the rule.
+        if (KnownAttributes.IsDllImport(attrType.ClrType))
+        {
+            Diagnostics.ReportDllImportNotSupported(GetAnnotationNameLocation(annotation), nameText);
+            return null;
+        }
+
         // 3b) Issue #177 / ADR-0047 §6: enforce [AttributeUsage(ValidOn)].
         // For the `Type` target the actual CLR target depends on the kind
         // of type being declared (class/struct/enum/interface), which the

--- a/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
+++ b/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
@@ -52,6 +52,33 @@ internal static class KnownAttributes
 
     /// <summary>
     /// Returns <c>true</c> when <paramref name="clrType"/> is
+    /// <see cref="System.Runtime.InteropServices.DllImportAttribute"/>. ADR-0047 §6
+    /// recognises <c>[DllImport]</c> but only on declarations whose body marker is
+    /// <c>extern</c>, which is post-v1.0; for v1.0 the binder reports
+    /// <c>GS0211</c> (<c>ERR_DllImportNotSupported</c>) on any use in source.
+    /// Recognition is type-identity based so renaming or shadowing the
+    /// source-level name cannot bypass the rule.
+    /// </summary>
+    /// <param name="clrType">The resolved attribute CLR type, or <c>null</c>.</param>
+    /// <returns><c>true</c> when the attribute is <c>[DllImport]</c>.</returns>
+    public static bool IsDllImport(Type clrType)
+    {
+        return clrType == typeof(System.Runtime.InteropServices.DllImportAttribute);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="attribute"/> is
+    /// <see cref="System.Runtime.InteropServices.DllImportAttribute"/>.
+    /// </summary>
+    /// <param name="attribute">A bound attribute application.</param>
+    /// <returns><c>true</c> when the attribute is <c>[DllImport]</c>.</returns>
+    public static bool IsDllImport(BoundAttribute attribute)
+    {
+        return IsDllImport(attribute?.AttributeType?.ClrType);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="clrType"/> is
     /// <see cref="System.Runtime.CompilerServices.EnumeratorCancellationAttribute"/>.
     /// Recognition is type-identity based (ADR-0047 §6 / ADR-0040): the
     /// resolved CLR type — not the source name — selects the behaviour, so a

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1329,6 +1329,19 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0210", $"Duplicate attribute '{attributeName}'; this attribute type does not allow multiple applications (AllowMultiple = false).");
     }
 
+    /// <summary>
+    /// Reports GS0211 when <c>[DllImport]</c> is applied in source. ADR-0047 §6
+    /// recognises <see cref="System.Runtime.InteropServices.DllImportAttribute"/>
+    /// but only on declarations whose body marker is <c>extern</c>; emit of the
+    /// underlying P/Invoke metadata is post-v1.0, so v1.0 rejects every use.
+    /// </summary>
+    /// <param name="location">The source location of the annotation.</param>
+    /// <param name="name">The attribute name as written in source.</param>
+    public void ReportDllImportNotSupported(TextLocation location, string name)
+    {
+        Report(location, "GS0211", $"Attribute '{name}' is recognised but not supported in v1.0; P/Invoke (extern function bodies) is a post-v1.0 feature.");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
@@ -273,6 +273,45 @@ type Point struct {
     }
 
     [Fact]
+    public void DllImport_Attribute_Is_Rejected_In_V1()
+    {
+        // Issue #179 / ADR-0047 §6: v1.0 recognises [DllImport] (suffix rule
+        // resolves @DllImport to System.Runtime.InteropServices.DllImportAttribute)
+        // but rejects it because P/Invoke + extern function bodies are post-v1.0.
+        var source = """
+            import System.Runtime.InteropServices
+
+            @DllImport("user32.dll")
+            func MessageBox() {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        var diag = Assert.Single(GetBinderDiagnostics(globalScope), d => d.Id == "GS0211");
+        Assert.Contains("DllImport", diag.Message);
+
+        var fn = globalScope.Functions.Single(f => f.Name == "MessageBox");
+        Assert.Empty(fn.Attributes);
+    }
+
+    [Fact]
+    public void DllImport_Attribute_Is_Rejected_Even_With_Attribute_Suffix()
+    {
+        // Type-identity check must catch the explicit `DllImportAttribute` name
+        // as well, not just the suffix-resolved short form.
+        var source = """
+            import System.Runtime.InteropServices
+
+            @DllImportAttribute("user32.dll")
+            func MessageBox() {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0211");
+    }
+
+    [Fact]
     public void Obsolete_Warning_Is_Reported_At_Class_Constructor_Call()
     {
         // #175: extend GS0204 to primary-constructor calls on classes.


### PR DESCRIPTION
Closes #179.

ADR-0047 §6 recognises `System.Runtime.InteropServices.DllImportAttribute` but only on declarations whose body marker is `extern`, which together with the underlying P/Invoke metadata emit is post-v1.0. The binder now identifies `[DllImport]` by CLR type identity and reports a new `GS0211` (`ERR_DllImportNotSupported`) on any use in source; the attribute is dropped from the bound list.

### Changes

- **`KnownAttributes`**: add `IsDllImport(Type)` / `IsDllImport(BoundAttribute)` (type-identity, so shadowing or renaming the source-level name cannot bypass the rule).
- **`Binder.BindAttribute`**: reject `[DllImport]` immediately after the reserved-for-compiler check, mirroring the existing pattern.
- **`DiagnosticBag`**: add `ReportDllImportNotSupported` with code `GS0211`.
- **`docs/diagnostics.md`**: extend the attribute-diagnostics range header to `GS0211` and add a row for the new code.
- **`docs/adr/0047-attribute-syntax-and-declaration.md`**: cross-reference `GS0211` from §6.
- **`AttributeBinderTests`**: cover both the suffix-resolved (`@DllImport`) and the explicit (`@DllImportAttribute`) spellings, and assert the attribute is not attached to the function symbol.

### Post-v1.0

Implement `extern` function-body declarations and emit the P/Invoke metadata (`MethodImplAttributes.PreserveSig`, `ImplMap` row, etc.); at that point `GS0211` becomes conditional on the body marker rather than a blanket rejection.

### Validation

- `dotnet build GSharp.sln -nologo -clp:NoSummary` — 0 warnings, 0 errors.
- `dotnet test GSharp.sln --nologo --no-restore` — all suites pass (Core 1149, Compiler 159, Interpreter 32, LanguageServer 17, Sdk 21).