### PR TITLE
Address #178: wire [NotNullWhen]/[MaybeNullWhen] family into the nullability state machine

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2264,11 +2264,21 @@ public sealed class Binder
             inner = unary.Operand;
         }
 
-        if (inner is not BoundImportedCallExpression call || call.Type != TypeSymbol.Bool)
+        if (inner is BoundImportedCallExpression importedCall && importedCall.Type == TypeSymbol.Bool)
         {
-            return (null, null);
+            return ClassifyImportedBoolCallNarrowing(importedCall, negate);
         }
 
+        if (inner is BoundCallExpression userCall && userCall.Type == TypeSymbol.Bool)
+        {
+            return ClassifyUserBoolCallNarrowing(userCall, negate);
+        }
+
+        return (null, null);
+    }
+
+    private static (Dictionary<VariableSymbol, TypeSymbol> Then, Dictionary<VariableSymbol, TypeSymbol> Else) ClassifyImportedBoolCallNarrowing(BoundImportedCallExpression call, bool negate)
+    {
         var parameters = call.Function.Method.GetParameters();
         Dictionary<VariableSymbol, TypeSymbol> thenFrame = null;
         Dictionary<VariableSymbol, TypeSymbol> elseFrame = null;
@@ -2285,6 +2295,63 @@ public sealed class Binder
 
             if (!ClrNullability.TryGetNotNullWhen(parameter, out var returnValue)
                 || call.Arguments[i] is not BoundVariableExpression variableExpression
+                || variableExpression.Variable.Type is not NullableTypeSymbol nullable)
+            {
+                continue;
+            }
+
+            var narrowThen = returnValue != negate;
+            var frame = narrowThen ? (thenFrame ??= new Dictionary<VariableSymbol, TypeSymbol>()) : (elseFrame ??= new Dictionary<VariableSymbol, TypeSymbol>());
+            frame[variableExpression.Variable] = nullable.UnderlyingType;
+        }
+
+        return (thenFrame, elseFrame);
+    }
+
+    private static (Dictionary<VariableSymbol, TypeSymbol> Then, Dictionary<VariableSymbol, TypeSymbol> Else) ClassifyUserBoolCallNarrowing(BoundCallExpression call, bool negate)
+    {
+        // Issue #178 / ADR-0047 §6: a user-declared function may carry the
+        // same [NotNullWhen] / [MaybeNullWhen] postconditions C# uses.
+        // Recognition is type-identity based via KnownAttributes so renaming
+        // or shadowing the source name cannot bypass the narrowing rule.
+        var parameters = call.Function.Parameters;
+        Dictionary<VariableSymbol, TypeSymbol> thenFrame = null;
+        Dictionary<VariableSymbol, TypeSymbol> elseFrame = null;
+        var count = Math.Min(parameters.Length, call.Arguments.Length);
+        for (var i = 0; i < count; i++)
+        {
+            var parameter = parameters[i];
+            var attributes = parameter.Attributes;
+            if (attributes.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            var hasMaybeNullWhen = false;
+            bool? notNullWhenReturnValue = null;
+            foreach (var attribute in attributes)
+            {
+                if (KnownAttributes.TryGetNotNullWhenReturnValue(attribute, out var rv))
+                {
+                    notNullWhenReturnValue = rv;
+                }
+                else if (KnownAttributes.IsMaybeNullWhen(attribute))
+                {
+                    hasMaybeNullWhen = true;
+                }
+            }
+
+            // [MaybeNullWhen] alone only weakens postconditions; it cannot
+            // prove non-nullness on its own, so a parameter carrying only
+            // [MaybeNullWhen] is intentionally not narrowed (matches the
+            // imported-metadata path above).
+            if (notNullWhenReturnValue is not bool returnValue)
+            {
+                _ = hasMaybeNullWhen;
+                continue;
+            }
+
+            if (call.Arguments[i] is not BoundVariableExpression variableExpression
                 || variableExpression.Variable.Type is not NullableTypeSymbol nullable)
             {
                 continue;

--- a/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
+++ b/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
@@ -79,6 +79,128 @@ internal static class KnownAttributes
 
     /// <summary>
     /// Returns <c>true</c> when <paramref name="clrType"/> is
+    /// <see cref="System.Diagnostics.CodeAnalysis.NotNullWhenAttribute"/>.
+    /// ADR-0047 §6 / issue #178: recognised on imported metadata and on
+    /// user-written annotations alike; type-identity based so renaming or
+    /// shadowing the source-level name cannot bypass the rule.
+    /// </summary>
+    /// <param name="clrType">The resolved attribute CLR type, or <c>null</c>.</param>
+    /// <returns><c>true</c> when the attribute is <c>[NotNullWhen]</c>.</returns>
+    public static bool IsNotNullWhen(Type clrType)
+    {
+        return clrType == typeof(System.Diagnostics.CodeAnalysis.NotNullWhenAttribute);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="attribute"/> is
+    /// <see cref="System.Diagnostics.CodeAnalysis.NotNullWhenAttribute"/>.
+    /// </summary>
+    /// <param name="attribute">A bound attribute application.</param>
+    /// <returns><c>true</c> when the attribute is <c>[NotNullWhen]</c>.</returns>
+    public static bool IsNotNullWhen(BoundAttribute attribute)
+    {
+        return IsNotNullWhen(attribute?.AttributeType?.ClrType);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="clrType"/> is
+    /// <see cref="System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute"/>.
+    /// </summary>
+    /// <param name="clrType">The resolved attribute CLR type, or <c>null</c>.</param>
+    /// <returns><c>true</c> when the attribute is <c>[MaybeNullWhen]</c>.</returns>
+    public static bool IsMaybeNullWhen(Type clrType)
+    {
+        return clrType == typeof(System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="attribute"/> is
+    /// <see cref="System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute"/>.
+    /// </summary>
+    /// <param name="attribute">A bound attribute application.</param>
+    /// <returns><c>true</c> when the attribute is <c>[MaybeNullWhen]</c>.</returns>
+    public static bool IsMaybeNullWhen(BoundAttribute attribute)
+    {
+        return IsMaybeNullWhen(attribute?.AttributeType?.ClrType);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="clrType"/> is
+    /// <see cref="System.Diagnostics.CodeAnalysis.MemberNotNullAttribute"/>.
+    /// Recognised so it round-trips through the attribute pipeline; field
+    /// post-condition tracking is a follow-up.
+    /// </summary>
+    /// <param name="clrType">The resolved attribute CLR type, or <c>null</c>.</param>
+    /// <returns><c>true</c> when the attribute is <c>[MemberNotNull]</c>.</returns>
+    public static bool IsMemberNotNull(Type clrType)
+    {
+        return clrType == typeof(System.Diagnostics.CodeAnalysis.MemberNotNullAttribute);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="attribute"/> is
+    /// <see cref="System.Diagnostics.CodeAnalysis.MemberNotNullAttribute"/>.
+    /// </summary>
+    /// <param name="attribute">A bound attribute application.</param>
+    /// <returns><c>true</c> when the attribute is <c>[MemberNotNull]</c>.</returns>
+    public static bool IsMemberNotNull(BoundAttribute attribute)
+    {
+        return IsMemberNotNull(attribute?.AttributeType?.ClrType);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="clrType"/> is
+    /// <see cref="System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute"/>.
+    /// </summary>
+    /// <param name="clrType">The resolved attribute CLR type, or <c>null</c>.</param>
+    /// <returns><c>true</c> when the attribute is <c>[MemberNotNullWhen]</c>.</returns>
+    public static bool IsMemberNotNullWhen(Type clrType)
+    {
+        return clrType == typeof(System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="attribute"/> is
+    /// <see cref="System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute"/>.
+    /// </summary>
+    /// <param name="attribute">A bound attribute application.</param>
+    /// <returns><c>true</c> when the attribute is <c>[MemberNotNullWhen]</c>.</returns>
+    public static bool IsMemberNotNullWhen(BoundAttribute attribute)
+    {
+        return IsMemberNotNullWhen(attribute?.AttributeType?.ClrType);
+    }
+
+    /// <summary>
+    /// Extracts the <c>returnValue</c> boolean from a <c>[NotNullWhen(...)]</c>
+    /// application. The single positional argument is the boolean trigger
+    /// (issue #178 / ADR-0047 §6): when the method's <c>bool</c> return
+    /// matches this value, the annotated parameter is known non-null in the
+    /// caller's post-state.
+    /// </summary>
+    /// <param name="attribute">A bound attribute application.</param>
+    /// <param name="returnValue">Receives the <c>returnValue</c> argument.</param>
+    /// <returns><c>true</c> when <paramref name="attribute"/> is <c>[NotNullWhen]</c> and the argument is a constant <see cref="bool"/>.</returns>
+    public static bool TryGetNotNullWhenReturnValue(BoundAttribute attribute, out bool returnValue)
+    {
+        returnValue = false;
+        return IsNotNullWhen(attribute) && TryGetSingleBoolArgument(attribute, out returnValue);
+    }
+
+    /// <summary>
+    /// Extracts the <c>returnValue</c> boolean from a <c>[MaybeNullWhen(...)]</c>
+    /// application — the inverse postcondition to <see cref="TryGetNotNullWhenReturnValue"/>.
+    /// </summary>
+    /// <param name="attribute">A bound attribute application.</param>
+    /// <param name="returnValue">Receives the <c>returnValue</c> argument.</param>
+    /// <returns><c>true</c> when <paramref name="attribute"/> is <c>[MaybeNullWhen]</c> and the argument is a constant <see cref="bool"/>.</returns>
+    public static bool TryGetMaybeNullWhenReturnValue(BoundAttribute attribute, out bool returnValue)
+    {
+        returnValue = false;
+        return IsMaybeNullWhen(attribute) && TryGetSingleBoolArgument(attribute, out returnValue);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="clrType"/> is
     /// <see cref="System.Runtime.CompilerServices.EnumeratorCancellationAttribute"/>.
     /// Recognition is type-identity based (ADR-0047 §6 / ADR-0040): the
     /// resolved CLR type — not the source name — selects the behaviour, so a
@@ -271,5 +393,22 @@ internal static class KnownAttributes
             case AttributeTargets at: result = (int)at; return true;
             default: result = 0; return false;
         }
+    }
+
+    private static bool TryGetSingleBoolArgument(BoundAttribute attribute, out bool value)
+    {
+        value = false;
+        if (attribute == null || attribute.PositionalArguments.IsDefaultOrEmpty || attribute.PositionalArguments.Length < 1)
+        {
+            return false;
+        }
+
+        if (attribute.PositionalArguments[0].Value is bool b)
+        {
+            value = b;
+            return true;
+        }
+
+        return false;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/NullableFlowAnalysisTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NullableFlowAnalysisTests.cs
@@ -109,6 +109,87 @@ len
         Assert.Equal(5, result.Value);
     }
 
+    [Fact]
+    public void If_UserDefinedNotNullWhenTrue_NarrowsThenArm()
+    {
+        var result = Evaluate(@"
+import System.Diagnostics.CodeAnalysis
+
+func TryFetch(@NotNullWhen(true) s string?) bool {
+    return s != nil
+}
+
+let v string? = ""hello""
+if TryFetch(v) {
+    var len = v.Length
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_NegatedUserDefinedNotNullWhenTrue_NarrowsElseArm()
+    {
+        var result = Evaluate(@"
+import System.Diagnostics.CodeAnalysis
+
+func TryFetch(@NotNullWhen(true) s string?) bool {
+    return s != nil
+}
+
+let v string? = ""hello""
+if !TryFetch(v) {
+} else {
+    var len = v.Length
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_UserDefinedNotNullWhenFalse_NarrowsElseArm()
+    {
+        var result = Evaluate(@"
+import System.Diagnostics.CodeAnalysis
+
+func IsMissing(@NotNullWhen(false) s string?) bool {
+    return s == nil
+}
+
+let v string? = ""hello""
+if IsMissing(v) {
+} else {
+    var len = v.Length
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_UserDefinedMaybeNullWhen_DoesNotNarrow()
+    {
+        // [MaybeNullWhen] only weakens postconditions; it cannot prove an
+        // argument is non-null, so the then-arm body should still see the
+        // parameter as nullable and accessing .Length must error.
+        var result = Evaluate(@"
+import System.Diagnostics.CodeAnalysis
+
+func Probe(@MaybeNullWhen(false) s string?) bool {
+    return s != nil
+}
+
+let v string? = ""hello""
+if Probe(v) {
+    var len = v.Length
+}
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot find member Length.", System.StringComparison.Ordinal));
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var syntaxTree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
Closes #178.

Follow-up to PR #174 (Phase 5 of #141).

## Summary
- Adds `KnownAttributes` recognisers for the four-attribute family from `System.Diagnostics.CodeAnalysis`: `NotNullWhen`, `MaybeNullWhen`, `MemberNotNull`, `MemberNotNullWhen`. Recognition is type-identity based on the resolved CLR type so renaming or shadowing the source name cannot bypass the rule (matches the convention used by other ADR-0047 §6 recognisers).
- Adds `TryGetNotNullWhenReturnValue` / `TryGetMaybeNullWhenReturnValue` to extract the boolean trigger argument from a bound application.
- Extends the bool-call narrowing path in the binder (`TryClassifyBoolCallNarrowing`) so it now handles `BoundCallExpression` (user-declared functions) alongside the existing `BoundImportedCallExpression` path. Parameters carrying `@NotNullWhen(...)` now narrow the corresponding argument variable on the matching arm — the canonical `Try*` pattern works identically to C#.
- `@MaybeNullWhen` on its own only weakens postconditions; it does not prove non-nullness, so it is intentionally not narrowed (matches the existing imported-metadata behaviour).
- `@MemberNotNull` / `@MemberNotNullWhen` are recognised but field-state flow tracking is left as a follow-up; GSharp's current nullable flow only narrows variable slots.

## Tests
Adds four new tests under `NullableFlowAnalysisTests` covering the user-written form:
- `@NotNullWhen(true)` narrows the then-arm (`Try*` pattern).
- Negated `@NotNullWhen(true)` narrows the else-arm.
- `@NotNullWhen(false)` narrows the else-arm.
- `@MaybeNullWhen(false)` does not narrow (the body still sees the parameter as nullable).

Full suite (`dotnet test GSharp.sln --nologo --no-restore`) passes.