### PR TITLE
Implement [Conditional] call elision (#176)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -188,8 +188,23 @@ public sealed class Binder
     /// <param name="implicitSystemImport">When <c>true</c>, an implicit <c>import System</c> is seeded before user imports are processed.</param>
     /// <returns>The new chained bound global scope.</returns>
     public static BoundGlobalScope BindGlobalScope(BoundGlobalScope previous, ImmutableArray<SyntaxTree> syntaxTrees, ReferenceResolver references, bool implicitSystemImport)
+        => BindGlobalScope(previous, syntaxTrees, references, implicitSystemImport, preprocessorSymbols: null);
+
+    /// <summary>
+    /// Binds a set of syntax trees to the previous global scope, with full
+    /// control over implicit-import seeding and the active preprocessor
+    /// symbol set used by <c>[Conditional("SYMBOL")]</c> call-site elision
+    /// (ADR-0047 §6 / issue #176).
+    /// </summary>
+    /// <param name="previous">The previous global scope.</param>
+    /// <param name="syntaxTrees">The new syntax trees.</param>
+    /// <param name="references">The reference resolver; <c>null</c> selects <see cref="ReferenceResolver.Default"/>.</param>
+    /// <param name="implicitSystemImport">When <c>true</c>, an implicit <c>import System</c> is seeded before user imports are processed.</param>
+    /// <param name="preprocessorSymbols">The active preprocessor symbol set; <c>null</c> means the empty set.</param>
+    /// <returns>The new chained bound global scope.</returns>
+    public static BoundGlobalScope BindGlobalScope(BoundGlobalScope previous, ImmutableArray<SyntaxTree> syntaxTrees, ReferenceResolver references, bool implicitSystemImport, ImmutableHashSet<string> preprocessorSymbols)
     {
-        var parentScope = CreateParentScope(previous, references);
+        var parentScope = CreateParentScope(previous, references, preprocessorSymbols);
         var binder = new Binder(parentScope, function: null);
 
         if (implicitSystemImport && previous == null)
@@ -329,7 +344,9 @@ public sealed class Binder
             diagnostics = diagnostics.InsertRange(0, previous.Diagnostics);
         }
 
-        return new BoundGlobalScope(previous, entryPointPackage, packagesInOrder.ToImmutable(), diagnostics, imports, functions, variables, typeAliases, structs, interfaces, enums, entryPoint, statements.ToImmutable());
+        var result = new BoundGlobalScope(previous, entryPointPackage, packagesInOrder.ToImmutable(), diagnostics, imports, functions, variables, typeAliases, structs, interfaces, enums, entryPoint, statements.ToImmutable());
+        result.PreprocessorSymbols = preprocessorSymbols ?? ImmutableHashSet<string>.Empty;
+        return result;
     }
 
     /// <summary>
@@ -339,7 +356,7 @@ public sealed class Binder
     /// <returns>A bound program.</returns>
     public static BoundProgram BindProgram(BoundGlobalScope globalScope)
     {
-        var parentScope = CreateParentScope(globalScope, references: null);
+        var parentScope = CreateParentScope(globalScope, references: null, preprocessorSymbols: globalScope?.PreprocessorSymbols);
 
         var functionBodies = ImmutableDictionary.CreateBuilder<FunctionSymbol, BoundBlockStatement>();
         var diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
@@ -415,7 +432,7 @@ public sealed class Binder
         return new BoundProgram(globalScope.Package, globalScope.Packages, diagnostics.ToImmutable(), functionBodies.ToImmutable(), globalScope.EntryPoint, statement, globalScope.Structs, globalScope.Interfaces, globalScope.Enums, globals);
     }
 
-    private static BoundScope CreateParentScope(BoundGlobalScope previous, ReferenceResolver references)
+    private static BoundScope CreateParentScope(BoundGlobalScope previous, ReferenceResolver references, ImmutableHashSet<string> preprocessorSymbols)
     {
         var stack = new Stack<BoundGlobalScope>();
         while (previous != null)
@@ -424,7 +441,7 @@ public sealed class Binder
             previous = previous.Previous;
         }
 
-        var parent = CreateRootScope(references);
+        var parent = CreateRootScope(references, preprocessorSymbols);
 
         while (stack.Count > 0)
         {
@@ -457,9 +474,9 @@ public sealed class Binder
         return parent;
     }
 
-    private static BoundScope CreateRootScope(ReferenceResolver references)
+    private static BoundScope CreateRootScope(ReferenceResolver references, ImmutableHashSet<string> preprocessorSymbols)
     {
-        var result = new BoundScope(parent: null, references: references);
+        var result = new BoundScope(parent: null, references: references, preprocessorSymbols: preprocessorSymbols);
 
         foreach (var f in BuiltinFunctions.GetAll())
         {
@@ -1250,6 +1267,18 @@ public sealed class Binder
                 FunctionDeclarationAllowedTargets,
                 "a function declaration",
                 System.AttributeTargets.Method);
+
+            // Issue #176 / ADR-0047 §6: a function marked `@Conditional`
+            // must return void. The CLR rule (matching C# CS0578) is that
+            // conditional-method calls may be elided at the call site, which
+            // is incompatible with a non-void result feeding the surrounding
+            // expression. The attribute is still attached to the function
+            // symbol so downstream tools see the user's intent and so the
+            // call site still elides; the diagnostic is per-declaration.
+            if (KnownAttributes.HasConditional(functionAttributes) && type != TypeSymbol.Void)
+            {
+                Diagnostics.ReportConditionalMethodMustReturnVoid(syntax.Identifier.Location, syntax.Identifier.Text);
+            }
 
             // Per-parameter annotations: each ParameterSyntax owns its own
             // annotation list; the default target is `param`. Issue #170 /
@@ -5365,16 +5394,40 @@ public sealed class Binder
                 returnType = WrapAsTask(returnType);
             }
 
-            return new BoundCallExpression(function, boundArguments.ToImmutable(), returnType);
+            return CreatePossiblyElidedCall(function, boundArguments.ToImmutable(), returnType);
         }
 
         if (function.IsAsync && !IsAsyncIteratorReturnType(function.Type))
         {
             var asyncReturn = WrapAsTask(function.Type);
-            return new BoundCallExpression(function, boundArguments.ToImmutable(), asyncReturn);
+            return CreatePossiblyElidedCall(function, boundArguments.ToImmutable(), asyncReturn);
         }
 
-        return new BoundCallExpression(function, boundArguments.ToImmutable());
+        return CreatePossiblyElidedCall(function, boundArguments.ToImmutable(), returnType: null);
+    }
+
+    /// <summary>
+    /// Constructs a <see cref="BoundCallExpression"/> for a direct function
+    /// call, applying ADR-0047 §6 / issue #176 <c>[Conditional]</c> call-site
+    /// elision. When elision applies, the resulting call carries an empty
+    /// argument list (C# semantics: arguments to a conditional method are
+    /// not evaluated when the symbol is undefined) and the
+    /// <see cref="BoundCallExpression.IsConditionalElided"/> flag is set so
+    /// the emitter and interpreter skip both argument evaluation and the
+    /// method invocation. The validation that the function returns
+    /// <c>void</c> was performed at declaration time (GS0212), so callers
+    /// can rely on the elided call being a no-op of type <c>void</c>.
+    /// Argument binding still ran above so wrong-type diagnostics on the
+    /// elided arguments are reported normally.
+    /// </summary>
+    private BoundExpression CreatePossiblyElidedCall(FunctionSymbol function, ImmutableArray<BoundExpression> arguments, TypeSymbol returnType)
+    {
+        if (KnownAttributes.IsConditionallyElided(function.Attributes, scope.PreprocessorSymbols))
+        {
+            return new BoundCallExpression(function, ImmutableArray<BoundExpression>.Empty, returnType, isConditionalElided: true);
+        }
+
+        return new BoundCallExpression(function, arguments, returnType);
     }
 
     private static void InferTypeArguments(TypeSymbol parameterType, TypeSymbol argumentType, Dictionary<TypeParameterSymbol, TypeSymbol> substitution)

--- a/src/Core/CodeAnalysis/Binding/BoundCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundCallExpression.cs
@@ -27,10 +27,28 @@ public sealed class BoundCallExpression : BoundExpression
     /// <param name="arguments">The provided arguments.</param>
     /// <param name="returnType">The (already-substituted) call-site return type, or <c>null</c> to use <c>function.Type</c>.</param>
     public BoundCallExpression(FunctionSymbol function, ImmutableArray<BoundExpression> arguments, TypeSymbol returnType)
+        : this(function, arguments, returnType, isConditionalElided: false)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundCallExpression"/>
+    /// class, optionally marking it as a <c>[Conditional]</c>-elided call
+    /// (ADR-0047 §6 / issue #176). When elided the emitter and interpreter
+    /// emit / evaluate no IL or behaviour at the call site, and the argument
+    /// list is empty because C# semantics forbid evaluating arguments to a
+    /// conditional method whose symbol is undefined.
+    /// </summary>
+    /// <param name="function">The function symbol.</param>
+    /// <param name="arguments">The provided arguments; empty when elided.</param>
+    /// <param name="returnType">The (already-substituted) call-site return type, or <c>null</c> to use <c>function.Type</c>.</param>
+    /// <param name="isConditionalElided">When <c>true</c>, the call has been elided per <c>[Conditional]</c> rules.</param>
+    public BoundCallExpression(FunctionSymbol function, ImmutableArray<BoundExpression> arguments, TypeSymbol returnType, bool isConditionalElided)
     {
         Function = function;
         Arguments = arguments;
         ReturnType = returnType;
+        IsConditionalElided = isConditionalElided;
     }
 
     /// <inheritdoc/>
@@ -51,4 +69,13 @@ public sealed class BoundCallExpression : BoundExpression
 
     /// <summary>Gets the call-site (post-substitution) return type for generic-function calls, or <c>null</c> for non-generic calls. Phase 4.1 / ADR-0020.</summary>
     public TypeSymbol ReturnType { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this call has been elided by
+    /// <c>[Conditional]</c> processing (ADR-0047 §6 / issue #176). When
+    /// <c>true</c>, the emitter and interpreter must not evaluate the
+    /// receiver, the arguments, or invoke the target method; the call is a
+    /// no-op of type <c>void</c> at the call site.
+    /// </summary>
+    public bool IsConditionalElided { get; }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
@@ -219,4 +219,14 @@ public sealed class BoundGlobalScope
     /// Gets the statements in the current compilation.
     /// </summary>
     public ImmutableArray<BoundStatement> Statements { get; }
+
+    /// <summary>
+    /// Gets the active preprocessor symbol set used by
+    /// <c>[Conditional("SYMBOL")]</c> call-site elision (ADR-0047 §6 /
+    /// issue #176). Threaded onto the bound global scope so that
+    /// <see cref="Binder.BindProgram"/> — which builds its own scope chain
+    /// from this snapshot — can rehydrate the same symbol set when binding
+    /// function bodies. Defaults to <see cref="ImmutableHashSet{T}.Empty"/>.
+    /// </summary>
+    public ImmutableHashSet<string> PreprocessorSymbols { get; internal set; } = ImmutableHashSet<string>.Empty;
 }

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -26,7 +26,7 @@ public sealed class BoundScope
     /// </summary>
     /// <param name="parent">The parent scope.</param>
     public BoundScope(BoundScope parent)
-        : this(parent, references: null)
+        : this(parent, references: null, preprocessorSymbols: null)
     {
     }
 
@@ -38,11 +38,26 @@ public sealed class BoundScope
     /// <param name="parent">The parent scope.</param>
     /// <param name="references">The reference resolver; defaults to the parent's resolver, or <see cref="ReferenceResolver.Default"/> if none.</param>
     public BoundScope(BoundScope parent, ReferenceResolver references)
+        : this(parent, references, preprocessorSymbols: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundScope"/> class with
+    /// an explicit reference resolver and an active preprocessor-symbol set
+    /// (ADR-0047 §6 / issue #176). Child scopes inherit both from the parent
+    /// when not supplied.
+    /// </summary>
+    /// <param name="parent">The parent scope.</param>
+    /// <param name="references">The reference resolver; defaults to the parent's resolver, or <see cref="ReferenceResolver.Default"/> if none.</param>
+    /// <param name="preprocessorSymbols">The active preprocessor symbol set; defaults to the parent's set, or an empty set if none.</param>
+    public BoundScope(BoundScope parent, ReferenceResolver references, ImmutableHashSet<string> preprocessorSymbols)
     {
         Parent = parent;
         imports = parent?.imports ?? new List<ImportSymbol>();
         typeAliases = parent?.typeAliases ?? new Dictionary<string, TypeSymbol>();
         References = references ?? parent?.References ?? ReferenceResolver.Default();
+        PreprocessorSymbols = preprocessorSymbols ?? parent?.PreprocessorSymbols ?? ImmutableHashSet<string>.Empty;
     }
 
     /// <summary>
@@ -54,6 +69,14 @@ public sealed class BoundScope
     /// Gets the reference resolver used to look up imported CLR types.
     /// </summary>
     public ReferenceResolver References { get; }
+
+    /// <summary>
+    /// Gets the active preprocessor symbol set (ADR-0047 §6 / issue #176).
+    /// Empty by default. <c>[Conditional("SYMBOL")]</c> call-site elision
+    /// keys off this set: a call is elided when *none* of the symbols named
+    /// by the function's <c>[Conditional]</c> applications is in this set.
+    /// </summary>
+    public ImmutableHashSet<string> PreprocessorSymbols { get; }
 
     /// <summary>
     /// Tries to add an import to this scope.

--- a/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
+++ b/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
@@ -249,6 +249,106 @@ internal static class KnownAttributes
     }
 
     /// <summary>
+    /// Returns <c>true</c> when <paramref name="clrType"/> is
+    /// <see cref="System.Diagnostics.ConditionalAttribute"/>. ADR-0047 §6 /
+    /// issue #176: calls to a method carrying one or more
+    /// <c>[Conditional("SYMBOL")]</c> applications are elided at every call
+    /// site at which none of the named symbols is in the active preprocessor
+    /// symbol set. Recognition is type-identity based so renaming or shadowing
+    /// the source-level name cannot bypass the rule.
+    /// </summary>
+    /// <param name="clrType">The resolved attribute CLR type, or <c>null</c>.</param>
+    /// <returns><c>true</c> when the attribute is <c>[Conditional]</c>.</returns>
+    public static bool IsConditional(Type clrType)
+    {
+        return clrType == typeof(System.Diagnostics.ConditionalAttribute);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="attribute"/> is
+    /// <see cref="System.Diagnostics.ConditionalAttribute"/>.
+    /// </summary>
+    /// <param name="attribute">A bound attribute application.</param>
+    /// <returns><c>true</c> when the attribute is <c>[Conditional]</c>.</returns>
+    public static bool IsConditional(BoundAttribute attribute)
+    {
+        return IsConditional(attribute?.AttributeType?.ClrType);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when any attribute in <paramref name="attributes"/>
+    /// is <see cref="System.Diagnostics.ConditionalAttribute"/>. Used by the
+    /// function-declaration binder to drive the void-return validation
+    /// (ADR-0047 §6 / issue #176).
+    /// </summary>
+    /// <param name="attributes">The attribute list on a function symbol.</param>
+    /// <returns><c>true</c> when at least one <c>[Conditional]</c> is present.</returns>
+    public static bool HasConditional(ImmutableArray<BoundAttribute> attributes)
+    {
+        if (attributes.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        foreach (var attr in attributes)
+        {
+            if (IsConditional(attr))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="attributes"/> contains at
+    /// least one <c>[Conditional("SYMBOL")]</c> application and *none* of the
+    /// named symbols is present in <paramref name="preprocessorSymbols"/>. In
+    /// that case the call site must be elided per ADR-0047 §6 / issue #176.
+    /// Returns <c>false</c> when no <c>[Conditional]</c> attribute is present
+    /// (so the caller emits the call normally) or when at least one named
+    /// symbol is defined (the C# rule is "any defined symbol keeps the call").
+    /// Attributes whose positional argument is missing or not a string are
+    /// ignored for the purpose of elision; they were already reported as
+    /// invalid by attribute argument binding.
+    /// </summary>
+    /// <param name="attributes">The attribute list on the called function.</param>
+    /// <param name="preprocessorSymbols">The active preprocessor symbol set; never <c>null</c>.</param>
+    /// <returns><c>true</c> when the call should be elided.</returns>
+    public static bool IsConditionallyElided(ImmutableArray<BoundAttribute> attributes, System.Collections.Generic.ICollection<string> preprocessorSymbols)
+    {
+        if (attributes.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        var sawConditional = false;
+        foreach (var attr in attributes)
+        {
+            if (!IsConditional(attr))
+            {
+                continue;
+            }
+
+            sawConditional = true;
+            if (attr.PositionalArguments.IsDefaultOrEmpty || attr.PositionalArguments.Length < 1)
+            {
+                continue;
+            }
+
+            if (attr.PositionalArguments[0].Value is string symbol
+                && preprocessorSymbols != null
+                && preprocessorSymbols.Contains(symbol))
+            {
+                return false;
+            }
+        }
+
+        return sawConditional;
+    }
+
+    /// <summary>
     /// Looks for an <c>[Obsolete]</c> attribute in <paramref name="attributes"/>
     /// and extracts its <c>message</c> and <c>isError</c> arguments.
     /// </summary>

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -24,6 +24,7 @@ namespace GSharp.Core.CodeAnalysis.Compilation;
 public class Compilation
 {
     private BoundGlobalScope globalScope;
+    private ImmutableHashSet<string> preprocessorSymbols = ImmutableHashSet<string>.Empty;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Compilation"/> class.
@@ -51,6 +52,7 @@ public class Compilation
         SyntaxTrees = syntaxTrees.ToImmutableArray();
         References = references ?? previous?.References;
         ImplicitSystemImport = previous?.ImplicitSystemImport ?? true;
+        PreprocessorSymbols = previous?.PreprocessorSymbols ?? ImmutableHashSet<string>.Empty;
     }
 
     /// <summary>
@@ -76,6 +78,25 @@ public class Compilation
     public bool ImplicitSystemImport { get; set; }
 
     /// <summary>
+    /// Gets or sets the active preprocessor symbol set used by
+    /// <c>[Conditional("SYMBOL")]</c> call-site elision (ADR-0047 §6 /
+    /// issue #176). A call to a function marked
+    /// <c>[Conditional("SYMBOL")]</c> is elided when *none* of the named
+    /// symbols is in this set; if any named symbol is present, the call is
+    /// emitted normally. Defaults to <see cref="ImmutableHashSet{T}.Empty"/>
+    /// — equivalent to "no preprocessor symbols defined" — so
+    /// conditional methods are elided by default unless the embedder opts
+    /// in. Setting <c>null</c> is normalised to the empty set. Inherits
+    /// from <see cref="Previous"/> when chained, matching the inheritance
+    /// shape of <see cref="ImplicitSystemImport"/>.
+    /// </summary>
+    public ImmutableHashSet<string> PreprocessorSymbols
+    {
+        get => preprocessorSymbols;
+        set => preprocessorSymbols = value ?? ImmutableHashSet<string>.Empty;
+    }
+
+    /// <summary>
     /// Gets the global scope.
     /// </summary>
     public BoundGlobalScope GlobalScope
@@ -84,7 +105,7 @@ public class Compilation
         {
             if (globalScope == null)
             {
-                var globalScope = Binder.BindGlobalScope(Previous?.GlobalScope, SyntaxTrees, References, ImplicitSystemImport);
+                var globalScope = Binder.BindGlobalScope(Previous?.GlobalScope, SyntaxTrees, References, ImplicitSystemImport, PreprocessorSymbols);
                 Interlocked.CompareExchange(ref this.globalScope, globalScope, null);
             }
 

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1342,6 +1342,20 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0211", $"Attribute '{name}' is recognised but not supported in v1.0; P/Invoke (extern function bodies) is a post-v1.0 feature.");
     }
 
+    /// <summary>
+    /// Reports GS0212 when <c>[Conditional("SYMBOL")]</c> is applied to a
+    /// function whose return type is not <c>void</c>. The CLR rule
+    /// (matching C# <c>CS0578</c>) is that conditional-method calls may be
+    /// elided at the call site, which is incompatible with a non-void result
+    /// flowing into the surrounding expression. ADR-0047 §6 / issue #176.
+    /// </summary>
+    /// <param name="location">The source location of the function declaration.</param>
+    /// <param name="functionName">The function's declared name.</param>
+    public void ReportConditionalMethodMustReturnVoid(TextLocation location, string functionName)
+    {
+        Report(location, "GS0212", $"Function '{functionName}' is marked '@Conditional' but does not return 'void'; conditional methods must return 'void' because calls may be elided at the call site.");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -6548,6 +6548,17 @@ internal sealed class ReflectionMetadataEmitter
                     this.EmitBinary(b);
                     break;
                 case BoundCallExpression call:
+                    // ADR-0047 §6 / issue #176: a [Conditional("SYMBOL")] call
+                    // whose symbol is undefined is elided at the call site —
+                    // emit no IL for arguments or the call itself. The call
+                    // is a no-op of type void; the enclosing
+                    // BoundExpressionStatement already skips the Pop because
+                    // call.Type == Void.
+                    if (call.IsConditionalElided)
+                    {
+                        break;
+                    }
+
                     for (int i = 0; i < call.Arguments.Length; i++)
                     {
                         var arg = call.Arguments[i];

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -1381,6 +1381,14 @@ public sealed class Evaluator
 
     private object EvaluateCallExpression(BoundCallExpression node)
     {
+        // ADR-0047 §6 / issue #176: a [Conditional("SYMBOL")] call whose
+        // symbol is undefined is elided — neither the arguments nor the
+        // target function body are evaluated.
+        if (node.IsConditionalElided)
+        {
+            return null;
+        }
+
         if (node.Function == BuiltinFunctions.Input)
         {
             return Console.ReadLine();

--- a/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
@@ -977,6 +977,172 @@ type Point struct {
         Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0210");
     }
 
+    [Fact]
+    public void Conditional_On_Non_Void_Function_Reports_GS0212()
+    {
+        // Issue #176 / ADR-0047 §6: `[Conditional]` requires a void return
+        // type because the call may be elided at the call site.
+        var source = """
+            import System.Diagnostics
+
+            @Conditional("DEBUG")
+            func DebugLog() int {
+                return 1
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        var diag = Assert.Single(GetBinderDiagnostics(globalScope), d => d.Id == "GS0212");
+        Assert.Contains("DebugLog", diag.Message);
+        Assert.Equal(GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error, diag.Severity);
+    }
+
+    [Fact]
+    public void Conditional_On_Void_Function_Does_Not_Report_GS0212()
+    {
+        var source = """
+            import System.Diagnostics
+
+            @Conditional("DEBUG")
+            func DebugLog() {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0212");
+
+        var trace = globalScope.Functions.Single(f => f.Name == "DebugLog");
+        Assert.Single(trace.Attributes);
+        Assert.Equal("System.Diagnostics.ConditionalAttribute", trace.Attributes[0].AttributeType.Name);
+    }
+
+    [Fact]
+    public void Conditional_Call_Is_Elided_When_Symbol_Not_Defined()
+    {
+        // Issue #176 / ADR-0047 §6: when no preprocessor symbol matches any
+        // of the function's `[Conditional("SYMBOL")]` applications, the call
+        // is replaced by a no-op and argument evaluation is suppressed.
+        var source = """
+            import System.Diagnostics
+
+            @Conditional("DEBUG")
+            func DebugLog(message string) {
+            }
+
+            func Main() {
+                DebugLog("hello")
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        var program = Binder.BindProgram(globalScope);
+
+        var main = program.Functions.Keys.Single(f => f.Name == "Main" && f.Declaration != null);
+        var call = FindCalls(program.Functions[main]).Single();
+        Assert.True(call.IsConditionalElided);
+        Assert.Empty(call.Arguments);
+    }
+
+    [Fact]
+    public void Conditional_Call_Is_Kept_When_Symbol_Defined()
+    {
+        var source = """
+            import System.Diagnostics
+
+            @Conditional("DEBUG")
+            func DebugLog(message string) {
+            }
+
+            func Main() {
+                DebugLog("hello")
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var preprocessorSymbols = ImmutableHashSet.Create("DEBUG");
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), references: null, implicitSystemImport: true, preprocessorSymbols);
+        var program = Binder.BindProgram(globalScope);
+
+        var main = program.Functions.Keys.Single(f => f.Name == "Main");
+        var call = FindCalls(program.Functions[main]).Single();
+        Assert.False(call.IsConditionalElided);
+        Assert.Single(call.Arguments);
+    }
+
+    [Fact]
+    public void Conditional_Call_Is_Kept_When_Any_Of_Multiple_Symbols_Defined()
+    {
+        // Issue #176 / ADR-0047 §6 / C# CS0578 semantics: multiple
+        // `[Conditional]` applications are combined disjunctively — the call
+        // is emitted if *any* named symbol is defined.
+        var source = """
+            import System.Diagnostics
+
+            @Conditional("DEBUG")
+            @Conditional("TRACE")
+            func DebugLog() {
+            }
+
+            func Main() {
+                DebugLog()
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var preprocessorSymbols = ImmutableHashSet.Create("TRACE");
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), references: null, implicitSystemImport: true, preprocessorSymbols);
+        var program = Binder.BindProgram(globalScope);
+
+        var main = program.Functions.Keys.Single(f => f.Name == "Main");
+        var call = FindCalls(program.Functions[main]).Single();
+        Assert.False(call.IsConditionalElided);
+    }
+
+    [Fact]
+    public void Conditional_Call_Is_Elided_When_None_Of_Multiple_Symbols_Defined()
+    {
+        var source = """
+            import System.Diagnostics
+
+            @Conditional("DEBUG")
+            @Conditional("TRACE")
+            func DebugLog() {
+            }
+
+            func Main() {
+                DebugLog()
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var preprocessorSymbols = ImmutableHashSet.Create("PROFILE");
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), references: null, implicitSystemImport: true, preprocessorSymbols);
+        var program = Binder.BindProgram(globalScope);
+
+        var main = program.Functions.Keys.Single(f => f.Name == "Main");
+        var call = FindCalls(program.Functions[main]).Single();
+        Assert.True(call.IsConditionalElided);
+    }
+
+    private static System.Collections.Generic.IEnumerable<BoundCallExpression> FindCalls(BoundStatement node)
+    {
+        var collector = new CallCollector();
+        collector.RewriteStatement(node);
+        return collector.Calls;
+    }
+
+    private sealed class CallCollector : BoundTreeRewriter
+    {
+        public System.Collections.Generic.List<BoundCallExpression> Calls { get; } = new();
+
+        protected override BoundExpression RewriteCallExpression(BoundCallExpression node)
+        {
+            Calls.Add(node);
+            return base.RewriteCallExpression(node);
+        }
+    }
+
     private static BoundGlobalScope BindSource(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
Closes #176.

Implements `[Conditional]` call elision per ADR-0047 §6.

## Summary
- Recognize `System.Diagnostics.ConditionalAttribute` by type identity (`KnownAttributes.IsConditional` / `HasConditional` / `IsConditionallyElided`).
- Plumb an active preprocessor-symbol set through `Compilation.PreprocessorSymbols` → `BindGlobalScope` → `BoundGlobalScope` → `BindProgram` → `BoundScope`.
- At each call site in `BindCallExpression`, when the target function is `[Conditional]` and **none** of the named symbols is defined, produce a `BoundCallExpression` with empty arguments and `IsConditionalElided = true`. Multiple `[Conditional]` applications combine disjunctively (matches C# CS0578).
- Report new diagnostic **GS0212** (error) when `[Conditional]` is applied to a non-void function.
- `ReflectionMetadataEmitter` and `Evaluator` skip elided calls entirely; arguments are not evaluated.

## Tests
Added six tests in `AttributeBinderTests` covering:
- GS0212 reported on non-void conditional method.
- No GS0212 on void conditional method (attribute still attached).
- Call elided when symbol not defined.
- Call kept when symbol defined.
- Multi-`[Conditional]` disjunction: kept if any symbol defined, elided when none match.

Full suite: **1367 / 1367 passing**.