### PR TITLE
Phase 1 (#95/#50 prereq): thread SyntaxNode through BoundNode constructors

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -410,7 +410,7 @@ public sealed class Binder
             }
         }
 
-        var statement = Lowerer.Lower(new BoundBlockStatement(globalScope.Statements));
+        var statement = Lowerer.Lower(new BoundBlockStatement(null, globalScope.Statements));
 
         // If the entry point is the synthesized top-level function, its body is
         // the lowered top-level statements block. Register it under EntryPoint so
@@ -1561,7 +1561,7 @@ public sealed class Binder
 
     private BoundStatement BindErrorStatement()
     {
-        return new BoundExpressionStatement(new BoundErrorExpression());
+        return new BoundExpressionStatement(null, new BoundErrorExpression(null));
     }
 
     private BoundStatement BindStatement(StatementSyntax syntax)
@@ -1637,7 +1637,7 @@ public sealed class Binder
 
         scope = scope.Parent;
 
-        return new BoundBlockStatement(statements.ToImmutable());
+        return new BoundBlockStatement(null, statements.ToImmutable());
     }
 
     private void BindBlockStatements(ImmutableArray<StatementSyntax> statementSyntaxes, int startIndex, ImmutableArray<BoundStatement>.Builder statements)
@@ -1699,9 +1699,9 @@ public sealed class Binder
 
     private BoundTryStatement BuildCleanupTryStatement(ImmutableArray<BoundStatement> protectedStatements, BoundExpression cleanup)
     {
-        var tryBlock = new BoundBlockStatement(protectedStatements);
-        var finallyBlock = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(new BoundExpressionStatement(cleanup)));
-        return new BoundTryStatement(tryBlock, ImmutableArray<BoundCatchClause>.Empty, finallyBlock);
+        var tryBlock = new BoundBlockStatement(null, protectedStatements);
+        var finallyBlock = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(new BoundExpressionStatement(null, cleanup)));
+        return new BoundTryStatement(null, tryBlock, ImmutableArray<BoundCatchClause>.Empty, finallyBlock);
     }
 
     private void InvalidateNarrowingsForAssignedVariables(SyntaxNode statementSyntax)
@@ -1794,7 +1794,7 @@ public sealed class Binder
             variable.SetAttributes(boundAttrs);
         }
 
-        return new BoundVariableDeclaration(variable, convertedInitializer);
+        return new BoundVariableDeclaration(null, variable, convertedInitializer);
     }
 
     private BoundStatement BindTupleDeconstructionStatement(TupleDeconstructionStatementSyntax syntax)
@@ -1804,7 +1804,7 @@ public sealed class Binder
         var initializer = BindExpression(syntax.Initializer);
         if (initializer.Type == TypeSymbol.Error)
         {
-            return new BoundExpressionStatement(initializer);
+            return new BoundExpressionStatement(null, initializer);
         }
 
         if (initializer.Type is TupleTypeSymbol tupleType)
@@ -1812,7 +1812,7 @@ public sealed class Binder
             if (syntax.Identifiers.Count != tupleType.Arity)
             {
                 Diagnostics.ReportDeconstructionFieldCountMismatch(syntax.CloseParenToken.Location, tupleType.Arity, syntax.Identifiers.Count);
-                return new BoundExpressionStatement(new BoundErrorExpression());
+                return new BoundExpressionStatement(null, new BoundErrorExpression(null));
             }
 
             var tempName = $"<tuple{System.Threading.Interlocked.Increment(ref syntheticLocalCounter)}>";
@@ -1820,18 +1820,18 @@ public sealed class Binder
             scope.TryDeclareVariable(tempVar);
 
             var statements = ImmutableArray.CreateBuilder<BoundStatement>();
-            statements.Add(new BoundVariableDeclaration(tempVar, initializer));
+            statements.Add(new BoundVariableDeclaration(null, tempVar, initializer));
 
             for (var i = 0; i < syntax.Identifiers.Count; i++)
             {
                 var idTok = syntax.Identifiers[i];
                 var elemType = tupleType.ElementTypes[i];
                 var elemVar = BindVariableDeclaration(idTok, isReadOnly: true, elemType);
-                var access = new BoundTupleElementAccessExpression(new BoundVariableExpression(tempVar), tupleType, i);
-                statements.Add(new BoundVariableDeclaration(elemVar, access));
+                var access = new BoundTupleElementAccessExpression(null, new BoundVariableExpression(null, tempVar), tupleType, i);
+                statements.Add(new BoundVariableDeclaration(null, elemVar, access));
             }
 
-            return new BoundBlockStatement(statements.ToImmutable());
+            return new BoundBlockStatement(null, statements.ToImmutable());
         }
 
         if (initializer.Type is StructSymbol structType && (structType.IsData || structType.IsInline))
@@ -1840,7 +1840,7 @@ public sealed class Binder
             if (syntax.Identifiers.Count != fields.Length)
             {
                 Diagnostics.ReportDeconstructionFieldCountMismatch(syntax.CloseParenToken.Location, fields.Length, syntax.Identifiers.Count);
-                return new BoundExpressionStatement(new BoundErrorExpression());
+                return new BoundExpressionStatement(null, new BoundErrorExpression(null));
             }
 
             var tempName = $"<data{System.Threading.Interlocked.Increment(ref syntheticLocalCounter)}>";
@@ -1848,21 +1848,21 @@ public sealed class Binder
             scope.TryDeclareVariable(tempVar);
 
             var statements = ImmutableArray.CreateBuilder<BoundStatement>();
-            statements.Add(new BoundVariableDeclaration(tempVar, initializer));
+            statements.Add(new BoundVariableDeclaration(null, tempVar, initializer));
             for (var i = 0; i < syntax.Identifiers.Count; i++)
             {
                 var idTok = syntax.Identifiers[i];
                 var field = fields[i];
                 var elemVar = BindVariableDeclaration(idTok, isReadOnly: true, field.Type);
-                var access = new BoundFieldAccessExpression(new BoundVariableExpression(tempVar), structType, field);
-                statements.Add(new BoundVariableDeclaration(elemVar, access));
+                var access = new BoundFieldAccessExpression(null, new BoundVariableExpression(null, tempVar), structType, field);
+                statements.Add(new BoundVariableDeclaration(null, elemVar, access));
             }
 
-            return new BoundBlockStatement(statements.ToImmutable());
+            return new BoundBlockStatement(null, statements.ToImmutable());
         }
 
         Diagnostics.ReportDeconstructionRequiresTupleOrDataStruct(syntax.OpenParenToken.Location, initializer.Type);
-        return new BoundExpressionStatement(new BoundErrorExpression());
+        return new BoundExpressionStatement(null, new BoundErrorExpression(null));
     }
 
     private BoundStatement BindNamedDeconstructionStatement(NamedDeconstructionStatementSyntax syntax)
@@ -1870,13 +1870,13 @@ public sealed class Binder
         var initializer = BindExpression(syntax.Initializer);
         if (initializer.Type == TypeSymbol.Error)
         {
-            return new BoundExpressionStatement(initializer);
+            return new BoundExpressionStatement(null, initializer);
         }
 
         if (!(initializer.Type is StructSymbol structType) || (!structType.IsData && !structType.IsInline))
         {
             Diagnostics.ReportDeconstructionRequiresTupleOrDataStruct(syntax.OpenBraceToken.Location, initializer.Type);
-            return new BoundExpressionStatement(new BoundErrorExpression());
+            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
         }
 
         var tempName = $"<data{System.Threading.Interlocked.Increment(ref syntheticLocalCounter)}>";
@@ -1885,7 +1885,7 @@ public sealed class Binder
 
         var seen = new HashSet<string>();
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
-        statements.Add(new BoundVariableDeclaration(tempVar, initializer));
+        statements.Add(new BoundVariableDeclaration(null, tempVar, initializer));
         foreach (var fieldSyntax in syntax.Fields)
         {
             var fieldName = fieldSyntax.FieldIdentifier.Text;
@@ -1902,11 +1902,11 @@ public sealed class Binder
             }
 
             var variable = BindVariableDeclaration(fieldSyntax.LocalIdentifier, isReadOnly: true, field.Type);
-            var access = new BoundFieldAccessExpression(new BoundVariableExpression(tempVar), declaringType, field);
-            statements.Add(new BoundVariableDeclaration(variable, access));
+            var access = new BoundFieldAccessExpression(null, new BoundVariableExpression(null, tempVar), declaringType, field);
+            statements.Add(new BoundVariableDeclaration(null, variable, access));
         }
 
-        return new BoundBlockStatement(statements.ToImmutable());
+        return new BoundBlockStatement(null, statements.ToImmutable());
     }
 
     private TypeSymbol BindNonNullableTypeClause(TypeClauseSyntax syntax)
@@ -2221,7 +2221,7 @@ public sealed class Binder
 
             var thenStatement = BindStatementWithNarrowing(syntax.ThenStatement, thenNarrow);
             var elseStatement = syntax.ElseClause == null ? null : BindStatementWithNarrowing(syntax.ElseClause.ElseStatement, elseNarrow);
-            return new BoundIfStatement(condition, thenStatement, elseStatement);
+            return new BoundIfStatement(null, condition, thenStatement, elseStatement);
         }
 
         // `if init; cond { then } else { else }` lowers to a block that
@@ -2239,8 +2239,8 @@ public sealed class Binder
 
         scope = scope.Parent;
 
-        var inner = new BoundIfStatement(initCondition, initThen, initElse);
-        return new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(initStatement, inner));
+        var inner = new BoundIfStatement(null, initCondition, initThen, initElse);
+        return new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(initStatement, inner));
     }
 
     private (Dictionary<VariableSymbol, TypeSymbol> NonNil, Dictionary<VariableSymbol, TypeSymbol> Nil) TryClassifyNilGuard(BoundExpression condition)
@@ -2478,7 +2478,7 @@ public sealed class Binder
         if (targets.Length != values.Length)
         {
             Diagnostics.ReportMultiAssignmentMismatch(syntax.Location, targets.Length, values.Length);
-            return new BoundExpressionStatement(new BoundErrorExpression());
+            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
         }
 
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
@@ -2491,10 +2491,10 @@ public sealed class Binder
                 var nameExpr = (NameExpressionSyntax)targets[i];
                 var initializer = BindExpression(values[i]);
                 var variable = BindVariableDeclaration(nameExpr.IdentifierToken, isReadOnly: false, type: initializer.Type);
-                statements.Add(new BoundVariableDeclaration(variable, initializer));
+                statements.Add(new BoundVariableDeclaration(null, variable, initializer));
             }
 
-            return new BoundBlockStatement(statements.ToImmutable());
+            return new BoundBlockStatement(null, statements.ToImmutable());
         }
 
         // Plain assignment: evaluate every RHS into a fresh temp, then assign each temp to its target.
@@ -2510,7 +2510,7 @@ public sealed class Binder
                 : new LocalVariableSymbol(tempName, isReadOnly: true, initializer.Type);
             scope.TryDeclareVariable(temp);
             temps.Add(temp);
-            statements.Add(new BoundVariableDeclaration(temp, initializer));
+            statements.Add(new BoundVariableDeclaration(null, temp, initializer));
         }
 
         for (var i = 0; i < targets.Length; i++)
@@ -2528,12 +2528,12 @@ public sealed class Binder
                 Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, name);
             }
 
-            var tempRef = new BoundVariableExpression(temps[i]);
+            var tempRef = new BoundVariableExpression(null, temps[i]);
             var converted = BindConversion(values[i].Location, tempRef, variable.Type);
-            statements.Add(new BoundExpressionStatement(new BoundAssignmentExpression(variable, converted)));
+            statements.Add(new BoundExpressionStatement(null, new BoundAssignmentExpression(null, variable, converted)));
         }
 
-        return new BoundBlockStatement(statements.ToImmutable());
+        return new BoundBlockStatement(null, statements.ToImmutable());
     }
 
     private BoundStatement BindSwitchStatement(SwitchStatementSyntax syntax)
@@ -2558,7 +2558,7 @@ public sealed class Binder
                 }
 
                 hasDefault = true;
-                arms.Add(new BoundPatternSwitchArm(pattern: null, BindBlockStatement(caseSyntax.Body)));
+                arms.Add(new BoundPatternSwitchArm(null, pattern: null, BindBlockStatement(caseSyntax.Body)));
                 continue;
             }
 
@@ -2577,7 +2577,7 @@ public sealed class Binder
             var frame = TryClassifyPatternNarrowing(discriminant, pattern);
             var body = BindStatementWithNarrowing(caseSyntax.Body, frame);
             scope = scope.Parent;
-            arms.Add(new BoundPatternSwitchArm(pattern, body));
+            arms.Add(new BoundPatternSwitchArm(null, pattern, body));
         }
 
         var boundArms = arms.ToImmutable();
@@ -2588,7 +2588,7 @@ public sealed class Binder
             scope.GetDeclaredStructs(),
             Diagnostics);
 
-        return new BoundPatternSwitchStatement(discriminant, boundArms);
+        return new BoundPatternSwitchStatement(null, discriminant, boundArms);
     }
 
     private BoundExpression BindSwitchExpression(SwitchExpressionSyntax syntax)
@@ -2598,7 +2598,7 @@ public sealed class Binder
 
         if (switchType == TypeSymbol.Error)
         {
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         if (syntax.Arms.Length == 0)
@@ -2617,7 +2617,7 @@ public sealed class Binder
                 Diagnostics.ReportSwitchExpressionMissingDefault(syntax.SwitchKeyword.Location);
             }
 
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         var hasDefault = false;
@@ -2675,14 +2675,14 @@ public sealed class Binder
                     Diagnostics.ReportSwitchExpressionArmTypeMismatch(arm.Syntax.Result.Location, result.Type, resultType);
                 }
 
-                result = new BoundErrorExpression();
+                result = new BoundErrorExpression(null);
             }
             else if (!conversion.IsIdentity)
             {
-                result = new BoundConversionExpression(resultType, result);
+                result = new BoundConversionExpression(null, resultType, result);
             }
 
-            arms.Add(new BoundSwitchExpressionArm(arm.Pattern, result));
+            arms.Add(new BoundSwitchExpressionArm(null, arm.Pattern, result));
         }
 
         var boundArms = arms.ToImmutable();
@@ -2693,7 +2693,7 @@ public sealed class Binder
             scope.GetDeclaredStructs(),
             Diagnostics);
 
-        return new BoundSwitchExpression(discriminant, boundArms, resultType);
+        return new BoundSwitchExpression(null, discriminant, boundArms, resultType);
     }
 
     private BoundPattern BindPattern(PatternSyntax syntax, TypeSymbol discriminantType)
@@ -2703,7 +2703,7 @@ public sealed class Binder
             case SyntaxKind.ConstantPattern:
                 return BindConstantPattern((ConstantPatternSyntax)syntax, discriminantType);
             case SyntaxKind.DiscardPattern:
-                return new BoundDiscardPattern(discriminantType);
+                return new BoundDiscardPattern(syntax, discriminantType);
             case SyntaxKind.TypePattern:
                 return BindTypePattern((TypePatternSyntax)syntax, discriminantType);
             case SyntaxKind.PropertyPattern:
@@ -2728,10 +2728,10 @@ public sealed class Binder
                 Diagnostics.ReportSwitchCaseTypeMismatch(syntax.Expression.Location, expression.Type, discriminantType);
             }
 
-            return new BoundConstantPattern(discriminantType, new BoundErrorExpression());
+            return new BoundConstantPattern(syntax, discriminantType, new BoundErrorExpression(syntax));
         }
 
-        var value = conversion.IsIdentity ? expression : new BoundConversionExpression(discriminantType, expression);
+        var value = conversion.IsIdentity ? expression : new BoundConversionExpression(syntax, discriminantType, expression);
         var op = BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, discriminantType, discriminantType);
         if (op == null && discriminantType is NullableTypeSymbol nullable)
         {
@@ -2745,7 +2745,7 @@ public sealed class Binder
             Diagnostics.ReportSwitchCaseTypeMismatch(syntax.Expression.Location, expression.Type, discriminantType);
         }
 
-        return new BoundConstantPattern(discriminantType, value);
+        return new BoundConstantPattern(syntax, discriminantType, value);
     }
 
     private BoundPattern BindTypePattern(TypePatternSyntax syntax, TypeSymbol discriminantType)
@@ -2757,7 +2757,7 @@ public sealed class Binder
             Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, syntax.Identifier.Text);
         }
 
-        return new BoundTypePattern(discriminantType, targetType, variable);
+        return new BoundTypePattern(syntax, discriminantType, targetType, variable);
     }
 
     private BoundPattern BindPropertyPattern(PropertyPatternSyntax syntax, TypeSymbol discriminantType)
@@ -2766,7 +2766,7 @@ public sealed class Binder
         if (discriminantType is not StructSymbol structType)
         {
             Diagnostics.ReportPropertyPatternRequiresStructOrClass(syntax.OpenBraceToken.Location, discriminantType);
-            return new BoundPropertyPattern(discriminantType, fields.ToImmutable());
+            return new BoundPropertyPattern(syntax, discriminantType, fields.ToImmutable());
         }
 
         foreach (var fieldSyntax in syntax.Fields)
@@ -2774,14 +2774,14 @@ public sealed class Binder
             if (!structType.TryGetFieldIncludingInherited(fieldSyntax.Identifier.Text, out var field, out _))
             {
                 Diagnostics.ReportUndefinedFieldOnType(fieldSyntax.Identifier.Location, fieldSyntax.Identifier.Text, discriminantType);
-                fields.Add(new BoundPropertyPatternField(new FieldSymbol(fieldSyntax.Identifier.Text, TypeSymbol.Error, Accessibility.Public), BindPattern(fieldSyntax.Pattern, TypeSymbol.Error)));
+                fields.Add(new BoundPropertyPatternField(syntax, new FieldSymbol(fieldSyntax.Identifier.Text, TypeSymbol.Error, Accessibility.Public), BindPattern(fieldSyntax.Pattern, TypeSymbol.Error)));
                 continue;
             }
 
-            fields.Add(new BoundPropertyPatternField(field, BindPattern(fieldSyntax.Pattern, field.Type)));
+            fields.Add(new BoundPropertyPatternField(syntax, field, BindPattern(fieldSyntax.Pattern, field.Type)));
         }
 
-        return new BoundPropertyPattern(discriminantType, fields.ToImmutable());
+        return new BoundPropertyPattern(syntax, discriminantType, fields.ToImmutable());
     }
 
     private BoundPattern BindRelationalPattern(RelationalPatternSyntax syntax, TypeSymbol discriminantType)
@@ -2794,7 +2794,7 @@ public sealed class Binder
             op = BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int);
         }
 
-        return new BoundRelationalPattern(discriminantType, op, value);
+        return new BoundRelationalPattern(syntax, discriminantType, op, value);
     }
 
     private BoundPattern BindListPattern(ListPatternSyntax syntax, TypeSymbol discriminantType)
@@ -2819,7 +2819,7 @@ public sealed class Binder
             elements.Add(BindPattern(elementSyntax, elementType));
         }
 
-        return new BoundListPattern(discriminantType, elements.ToImmutable(), elementType);
+        return new BoundListPattern(syntax, discriminantType, elements.ToImmutable(), elementType);
     }
 
     private BoundStatement BindTryStatement(TryStatementSyntax syntax)
@@ -2866,7 +2866,7 @@ public sealed class Binder
             return BindErrorStatement();
         }
 
-        return new BoundTryStatement(tryBlock, catches.ToImmutable(), finallyBlock);
+        return new BoundTryStatement(null, tryBlock, catches.ToImmutable(), finallyBlock);
     }
 
     private BoundStatement BindThrowStatement(ThrowStatementSyntax syntax)
@@ -2883,7 +2883,7 @@ public sealed class Binder
             }
         }
 
-        return new BoundThrowStatement(expression);
+        return new BoundThrowStatement(null, expression);
     }
 
     private BoundStatement BindUsingStatement(UsingStatementSyntax syntax)
@@ -2895,7 +2895,7 @@ public sealed class Binder
         }
 
         var tryStmt = BuildCleanupTryStatement(ImmutableArray<BoundStatement>.Empty, usingLowering.Cleanup);
-        return new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(usingLowering.Declaration, tryStmt));
+        return new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(usingLowering.Declaration, tryStmt));
     }
 
     private (BoundVariableDeclaration Declaration, BoundExpression Cleanup, BoundStatement ErrorStatement) BindUsingStatementInBlock(UsingStatementSyntax syntax)
@@ -2922,7 +2922,7 @@ public sealed class Binder
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
         statements.AddRange(defer.PrefixStatements);
         statements.Add(tryStmt);
-        return new BoundBlockStatement(statements.ToImmutable());
+        return new BoundBlockStatement(null, statements.ToImmutable());
     }
 
     private (ImmutableArray<BoundStatement> PrefixStatements, BoundExpression Cleanup, BoundStatement ErrorStatement) BindDeferStatementInBlock(DeferStatementSyntax syntax)
@@ -2930,13 +2930,13 @@ public sealed class Binder
         var expression = BindExpression(syntax.Expression, canBeVoid: true);
         if (expression is BoundErrorExpression)
         {
-            return (ImmutableArray<BoundStatement>.Empty, null, new BoundExpressionStatement(expression));
+            return (ImmutableArray<BoundStatement>.Empty, null, new BoundExpressionStatement(null, expression));
         }
 
         if (!IsDeferableCall(expression))
         {
             Diagnostics.ReportDeferOperandIsNotACall(syntax.Expression.Location);
-            return (ImmutableArray<BoundStatement>.Empty, null, new BoundExpressionStatement(new BoundErrorExpression()));
+            return (ImmutableArray<BoundStatement>.Empty, null, new BoundExpressionStatement(null, new BoundErrorExpression(null)));
         }
 
         var prefix = ImmutableArray.CreateBuilder<BoundStatement>();
@@ -2956,15 +2956,15 @@ public sealed class Binder
         switch (expression)
         {
             case BoundCallExpression call:
-                return new BoundCallExpression(call.Function, CaptureArguments(call.Arguments, prefix), call.ReturnType);
+                return new BoundCallExpression(null, call.Function, CaptureArguments(call.Arguments, prefix), call.ReturnType);
             case BoundIndirectCallExpression call:
-                return new BoundIndirectCallExpression(call.Target, call.FunctionType, CaptureArguments(call.Arguments, prefix));
+                return new BoundIndirectCallExpression(null, call.Target, call.FunctionType, CaptureArguments(call.Arguments, prefix));
             case BoundUserInstanceCallExpression call:
-                return new BoundUserInstanceCallExpression(call.Receiver, call.Method, CaptureArguments(call.Arguments, prefix), call.Type);
+                return new BoundUserInstanceCallExpression(null, call.Receiver, call.Method, CaptureArguments(call.Arguments, prefix), call.Type);
             case BoundImportedCallExpression call:
-                return new BoundImportedCallExpression(call.Function, CaptureArguments(call.Arguments, prefix));
+                return new BoundImportedCallExpression(null, call.Function, CaptureArguments(call.Arguments, prefix));
             case BoundImportedInstanceCallExpression call:
-                return new BoundImportedInstanceCallExpression(call.Receiver, call.Method, call.Type, CaptureArguments(call.Arguments, prefix));
+                return new BoundImportedInstanceCallExpression(null, call.Receiver, call.Method, call.Type, CaptureArguments(call.Arguments, prefix));
             default:
                 throw new InvalidOperationException($"Unexpected deferred expression: {expression.Kind}");
         }
@@ -2982,8 +2982,8 @@ public sealed class Binder
         {
             var variable = new LocalVariableSymbol($"$defer$arg${deferArgumentCounter++}", isReadOnly: true, argument.Type ?? TypeSymbol.Error);
             scope.TryDeclareVariable(variable);
-            prefix.Add(new BoundVariableDeclaration(variable, argument));
-            capturedArguments.Add(new BoundVariableExpression(variable));
+            prefix.Add(new BoundVariableDeclaration(null, variable, argument));
+            capturedArguments.Add(new BoundVariableExpression(null, variable));
         }
 
         return capturedArguments.ToImmutable();
@@ -3005,8 +3005,8 @@ public sealed class Binder
             return null;
         }
 
-        var receiver = new BoundVariableExpression(variable);
-        return new BoundImportedInstanceCallExpression(receiver, disposeMethod, TypeSymbol.Void, ImmutableArray<BoundExpression>.Empty);
+        var receiver = new BoundVariableExpression(null, variable);
+        return new BoundImportedInstanceCallExpression(null, receiver, disposeMethod, TypeSymbol.Void, ImmutableArray<BoundExpression>.Empty);
     }
 
     private BoundStatement BindGoStatement(GoStatementSyntax syntax)
@@ -3015,7 +3015,7 @@ public sealed class Binder
 
         if (expression is BoundErrorExpression)
         {
-            return new BoundExpressionStatement(expression);
+            return new BoundExpressionStatement(null, expression);
         }
 
         if (expression is not BoundCallExpression and
@@ -3025,10 +3025,10 @@ public sealed class Binder
             not BoundImportedInstanceCallExpression)
         {
             Diagnostics.ReportGoOperandIsNotACall(syntax.Expression.Location);
-            return new BoundExpressionStatement(new BoundErrorExpression());
+            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
         }
 
-        return new BoundGoStatement(expression);
+        return new BoundGoStatement(null, expression);
     }
 
     private BoundStatement BindChannelSendStatement(ChannelSendStatementSyntax syntax)
@@ -3037,17 +3037,17 @@ public sealed class Binder
         var channel = BindExpression(syntax.Channel);
         if (channel is BoundErrorExpression)
         {
-            return new BoundExpressionStatement(channel);
+            return new BoundExpressionStatement(null, channel);
         }
 
         if (channel.Type is not ChannelTypeSymbol chan)
         {
             Diagnostics.ReportSendTargetIsNotChannel(syntax.Channel.Location, channel.Type);
-            return new BoundExpressionStatement(new BoundErrorExpression());
+            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
         }
 
         var value = BindConversion(syntax.Value, chan.ElementType);
-        return new BoundChannelSendStatement(channel, value);
+        return new BoundChannelSendStatement(null, channel, value);
     }
 
     private BoundExpression BindMakeChannelExpression(MakeChannelExpressionSyntax syntax)
@@ -3056,7 +3056,7 @@ public sealed class Binder
         var typeSymbol = BindTypeClause(syntax.ChannelTypeClause);
         if (typeSymbol is not ChannelTypeSymbol chan)
         {
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         BoundExpression capacity = null;
@@ -3065,7 +3065,7 @@ public sealed class Binder
             capacity = BindConversion(syntax.Capacity, TypeSymbol.Int);
         }
 
-        return new BoundMakeChannelExpression(chan, capacity);
+        return new BoundMakeChannelExpression(null, chan, capacity);
     }
 
     private BoundExpression BindTypeOfExpression(TypeOfExpressionSyntax syntax)
@@ -3074,11 +3074,11 @@ public sealed class Binder
         var typeSymbol = BindTypeClause(syntax.TypeClause);
         if (typeSymbol == null || typeSymbol == TypeSymbol.Error)
         {
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         var systemType = ImportedTypeSymbol.Get(typeof(Type));
-        return new BoundTypeOfExpression(typeSymbol, systemType);
+        return new BoundTypeOfExpression(null, typeSymbol, systemType);
     }
 
     private BoundExpression BindNameOfExpression(NameOfExpressionSyntax syntax)
@@ -3089,11 +3089,11 @@ public sealed class Binder
         // are rejected to match C# semantics.
         if (TryExtractNameOfName(syntax.Argument, out var name))
         {
-            return new BoundLiteralExpression(name);
+            return new BoundLiteralExpression(null, name);
         }
 
         Diagnostics.ReportNameOfRequiresNameReference(syntax.Argument.Location);
-        return new BoundErrorExpression();
+        return new BoundErrorExpression(null);
     }
 
     private static bool TryExtractNameOfName(ExpressionSyntax argument, out string name)
@@ -3138,7 +3138,7 @@ public sealed class Binder
         if (syntax.Cases.Length == 0)
         {
             Diagnostics.ReportSelectWithNoCases(syntax.SelectKeyword.Location);
-            return new BoundExpressionStatement(new BoundErrorExpression());
+            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
         }
 
         var bound = ImmutableArray.CreateBuilder<BoundSelectCase>();
@@ -3214,7 +3214,7 @@ public sealed class Binder
             bound.Add(new BoundSelectCase(caseSyntax.CaseKind, channelExpr, valueExpr, variable, body));
         }
 
-        return new BoundSelectStatement(bound.ToImmutable());
+        return new BoundSelectStatement(null, bound.ToImmutable());
     }
 
     private BoundStatement BindScopeStatement(ScopeStatementSyntax syntax)
@@ -3227,7 +3227,7 @@ public sealed class Binder
         scope = new BoundScope(scope);
         var body = BindStatement(syntax.Body);
         scope = scope.Parent;
-        return new BoundScopeStatement(body);
+        return new BoundScopeStatement(null, body);
     }
 
     private BoundStatement BindAwaitForRangeStatement(AwaitForRangeStatementSyntax syntax)
@@ -3242,13 +3242,13 @@ public sealed class Binder
         var stream = BindExpression(syntax.Stream);
         if (stream is BoundErrorExpression)
         {
-            return new BoundExpressionStatement(stream);
+            return new BoundExpressionStatement(null, stream);
         }
 
         if (!TryGetAsyncEnumerableElementType(stream.Type, out var elementType))
         {
             Diagnostics.ReportTypeIsNotAsyncEnumerable(syntax.Stream.Location, stream.Type);
-            return new BoundExpressionStatement(new BoundErrorExpression());
+            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
         }
 
         scope = new BoundScope(scope);
@@ -3256,7 +3256,7 @@ public sealed class Binder
         var body = BindStatement(syntax.Body);
         scope = scope.Parent;
 
-        return new BoundAwaitForRangeStatement(variable, stream, body);
+        return new BoundAwaitForRangeStatement(null, variable, stream, body);
     }
 
     private BoundStatement BindYieldStatement(YieldStatementSyntax syntax)
@@ -3265,7 +3265,7 @@ public sealed class Binder
         if (function == null || !IsIteratorReturnType(function.Type))
         {
             Diagnostics.ReportYieldOutsideIteratorFunction(syntax.YieldKeyword.Location);
-            return new BoundExpressionStatement(new BoundErrorExpression());
+            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
         }
 
         var elementType = GetIteratorElementType(function.Type);
@@ -3275,7 +3275,7 @@ public sealed class Binder
             expression = BindConversion(syntax.Expression.Location, expression, elementType);
         }
 
-        return new BoundYieldStatement(expression);
+        return new BoundYieldStatement(null, expression);
     }
 
     private static bool IsIteratorReturnType(TypeSymbol type)
@@ -3475,7 +3475,7 @@ public sealed class Binder
 
         scope = scope.Parent;
 
-        return new BoundForInfiniteStatement(body, breakLabel, continueLabel);
+        return new BoundForInfiniteStatement(null, body, breakLabel, continueLabel);
     }
 
     private BoundStatement BindForEllipsisStatement(ForEllipsisStatementSyntax syntax)
@@ -3490,7 +3490,7 @@ public sealed class Binder
 
         scope = scope.Parent;
 
-        return new BoundForEllipsisStatement(variable, lowerBound, upperBound, body, breakLabel, continueLabel);
+        return new BoundForEllipsisStatement(null, variable, lowerBound, upperBound, body, breakLabel, continueLabel);
     }
 
     private BoundStatement BindForRangeStatement(ForRangeStatementSyntax syntax)
@@ -3536,7 +3536,7 @@ public sealed class Binder
                 else
                 {
                     Diagnostics.ReportTypeNotIndexable(syntax.Collection.Location, collection.Type);
-                    return new BoundExpressionStatement(new BoundErrorExpression());
+                    return new BoundExpressionStatement(null, new BoundErrorExpression(null));
                 }
 
                 break;
@@ -3557,7 +3557,7 @@ public sealed class Binder
                     Diagnostics.ReportTypeNotIndexable(syntax.Collection.Location, collection.Type);
                 }
 
-                return new BoundExpressionStatement(new BoundErrorExpression());
+                return new BoundExpressionStatement(null, new BoundErrorExpression(null));
         }
 
         scope = new BoundScope(scope);
@@ -3579,7 +3579,7 @@ public sealed class Binder
 
         scope = scope.Parent;
 
-        return new BoundForRangeStatement(keyVariable, valueVariable, collection, iterationKind, body, breakLabel, continueLabel);
+        return new BoundForRangeStatement(null, keyVariable, valueVariable, collection, iterationKind, body, breakLabel, continueLabel);
     }
 
     private static bool TryGetClrDictionaryTypes(System.Type clrType, out System.Type keyType, out System.Type valueType)
@@ -3719,15 +3719,15 @@ public sealed class Binder
         var checkLabel = new BoundLabel($"check{labelCounter}");
 
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
-        statements.Add(new BoundGotoStatement(checkLabel));
-        statements.Add(new BoundLabelStatement(bodyLabel));
+        statements.Add(new BoundGotoStatement(null, checkLabel));
+        statements.Add(new BoundLabelStatement(null, bodyLabel));
         statements.Add(body);
-        statements.Add(new BoundLabelStatement(continueLabel));
-        statements.Add(new BoundLabelStatement(checkLabel));
-        statements.Add(new BoundConditionalGotoStatement(bodyLabel, condition, jumpIfTrue: true));
-        statements.Add(new BoundLabelStatement(breakLabel));
+        statements.Add(new BoundLabelStatement(null, continueLabel));
+        statements.Add(new BoundLabelStatement(null, checkLabel));
+        statements.Add(new BoundConditionalGotoStatement(null, bodyLabel, condition, jumpIfTrue: true));
+        statements.Add(new BoundLabelStatement(null, breakLabel));
 
-        return new BoundBlockStatement(statements.ToImmutable());
+        return new BoundBlockStatement(null, statements.ToImmutable());
     }
 
     private BoundStatement BindForClauseStatement(ForClauseStatementSyntax syntax)
@@ -3762,28 +3762,28 @@ public sealed class Binder
             statements.Add(init);
         }
 
-        statements.Add(new BoundGotoStatement(checkLabel));
-        statements.Add(new BoundLabelStatement(bodyLabel));
+        statements.Add(new BoundGotoStatement(null, checkLabel));
+        statements.Add(new BoundLabelStatement(null, bodyLabel));
         statements.Add(body);
-        statements.Add(new BoundLabelStatement(continueLabel));
+        statements.Add(new BoundLabelStatement(null, continueLabel));
         if (post != null)
         {
             statements.Add(post);
         }
 
-        statements.Add(new BoundLabelStatement(checkLabel));
+        statements.Add(new BoundLabelStatement(null, checkLabel));
         if (condition == null)
         {
-            statements.Add(new BoundGotoStatement(bodyLabel));
+            statements.Add(new BoundGotoStatement(null, bodyLabel));
         }
         else
         {
-            statements.Add(new BoundConditionalGotoStatement(bodyLabel, condition, jumpIfTrue: true));
+            statements.Add(new BoundConditionalGotoStatement(null, bodyLabel, condition, jumpIfTrue: true));
         }
 
-        statements.Add(new BoundLabelStatement(breakLabel));
+        statements.Add(new BoundLabelStatement(null, breakLabel));
 
-        return new BoundBlockStatement(statements.ToImmutable());
+        return new BoundBlockStatement(null, statements.ToImmutable());
     }
 
     private BoundStatement BindLoopBody(StatementSyntax body, out BoundLabel breakLabel, out BoundLabel continueLabel)
@@ -3808,7 +3808,7 @@ public sealed class Binder
         }
 
         var breakLabel = loopStack.Peek().BreakLabel;
-        return new BoundGotoStatement(breakLabel);
+        return new BoundGotoStatement(null, breakLabel);
     }
 
     private BoundStatement BindContinueStatement(ContinueStatementSyntax syntax)
@@ -3820,7 +3820,7 @@ public sealed class Binder
         }
 
         var continueLabel = loopStack.Peek().ContinueLabel;
-        return new BoundGotoStatement(continueLabel);
+        return new BoundGotoStatement(null, continueLabel);
     }
 
     private BoundStatement BindReturnStatement(ReturnStatementSyntax syntax)
@@ -3853,13 +3853,13 @@ public sealed class Binder
             }
         }
 
-        return new BoundReturnStatement(expression);
+        return new BoundReturnStatement(null, expression);
     }
 
     private BoundStatement BindExpressionStatement(ExpressionStatementSyntax syntax)
     {
         var expression = BindExpression(syntax.Expression, canBeVoid: true);
-        return new BoundExpressionStatement(expression);
+        return new BoundExpressionStatement(null, expression);
     }
 
     private BoundExpression BindExpression(ExpressionSyntax syntax, TypeSymbol targetType)
@@ -3873,7 +3873,7 @@ public sealed class Binder
         if (!canBeVoid && result.Type == TypeSymbol.Void)
         {
             Diagnostics.ReportExpressionMustHaveValue(syntax.Location);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         return result;
@@ -3933,7 +3933,7 @@ public sealed class Binder
                 return BindWithExpression((WithExpressionSyntax)syntax);
             case SyntaxKind.NamedArgumentExpression:
                 Diagnostics.ReportNamedArgumentOnlyValidForCopy(syntax.Location);
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
             default:
                 throw new Exception($"Unexpected syntax {syntax.Kind}");
         }
@@ -3956,7 +3956,7 @@ public sealed class Binder
             value = 0;
         }
 
-        return new BoundLiteralExpression(value);
+        return new BoundLiteralExpression(null, value);
     }
 
     private BoundExpression BindInterpolatedStringExpression(InterpolatedStringExpressionSyntax syntax)
@@ -3986,13 +3986,13 @@ public sealed class Binder
             }
             else
             {
-                piece = new BoundLiteralExpression(segment.Text ?? string.Empty);
+                piece = new BoundLiteralExpression(null, segment.Text ?? string.Empty);
             }
 
             result = result == null ? piece : Concat(result, piece);
         }
 
-        return result ?? new BoundLiteralExpression(string.Empty);
+        return result ?? new BoundLiteralExpression(null, string.Empty);
     }
 
     private BoundExpression ConvertToString(BoundExpression expression, TextLocation diagnosticLocation)
@@ -4006,7 +4006,7 @@ public sealed class Binder
         if (clrType == null)
         {
             Diagnostics.ReportCannotConvert(diagnosticLocation, expression.Type, TypeSymbol.String);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         // Bind a call to `System.Convert.ToString(<expr.Type>)`. Convert.ToString
@@ -4019,18 +4019,18 @@ public sealed class Binder
         if (method == null)
         {
             Diagnostics.ReportCannotConvert(diagnosticLocation, expression.Type, TypeSymbol.String);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         var importedClass = new ImportedClassSymbol(convertType, declaration: null);
         var importedFn = new ImportedFunctionSymbol(method.Name, importedClass, method, declaration: null);
-        return new BoundImportedCallExpression(importedFn, ImmutableArray.Create(expression));
+        return new BoundImportedCallExpression(null, importedFn, ImmutableArray.Create(expression));
     }
 
     private static BoundExpression Concat(BoundExpression left, BoundExpression right)
     {
         var op = BoundBinaryOperator.Bind(SyntaxKind.PlusToken, TypeSymbol.String, TypeSymbol.String);
-        return new BoundBinaryExpression(left, op, right);
+        return new BoundBinaryExpression(null, left, op, right);
     }
 
     private BoundExpression BindNameExpression(NameExpressionSyntax syntax)
@@ -4040,13 +4040,13 @@ public sealed class Binder
         {
             // This means the token was inserted by the parser. We already
             // reported error so we can just return an error expression.
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         var variable = BindVariableReference(name, syntax.IdentifierToken.Location);
         if (variable == null)
         {
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         if (variable is ImplicitFieldVariableSymbol implicitField)
@@ -4058,12 +4058,13 @@ public sealed class Binder
                 implicitField.Field,
                 $"{implicitField.StructType.Name}.{implicitField.Field.Name}");
             return new BoundFieldAccessExpression(
-                new BoundVariableExpression(implicitField.Receiver),
+                null,
+                new BoundVariableExpression(null, implicitField.Receiver),
                 implicitField.StructType,
                 implicitField.Field);
         }
 
-        return new BoundVariableExpression(variable, TryGetNarrowedType(variable));
+        return new BoundVariableExpression(null, variable, TryGetNarrowedType(variable));
     }
 
     private TypeSymbol TryGetNarrowedType(VariableSymbol variable)
@@ -4107,7 +4108,7 @@ public sealed class Binder
                 $"{implicitField.StructType.Name}.{implicitField.Field.Name}");
 
             var convertedValue = BindConversion(syntax.Expression.Location, boundExpression, implicitField.Field.Type);
-            return new BoundFieldAssignmentExpression(implicitField.Receiver, implicitField.StructType, implicitField.Field, convertedValue);
+            return new BoundFieldAssignmentExpression(null, implicitField.Receiver, implicitField.StructType, implicitField.Field, convertedValue);
         }
 
         if (variable.IsReadOnly)
@@ -4117,7 +4118,7 @@ public sealed class Binder
 
         var convertedExpression = BindConversion(syntax.Expression.Location, boundExpression, variable.Type);
 
-        return new BoundAssignmentExpression(variable, convertedExpression);
+        return new BoundAssignmentExpression(null, variable, convertedExpression);
     }
 
     private BoundExpression BindWithExpression(WithExpressionSyntax syntax)
@@ -4130,13 +4131,13 @@ public sealed class Binder
     {
         if (receiver.Type == TypeSymbol.Error)
         {
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         if (!(receiver.Type is StructSymbol structType) || !structType.IsData)
         {
             Diagnostics.ReportCopyOrWithNotDataStruct(diagnosticLocation, receiver.Type);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         var tempName = "$copy" + System.Threading.Interlocked.Increment(ref syntheticLocalCounter).ToString(System.Globalization.CultureInfo.InvariantCulture);
@@ -4174,14 +4175,14 @@ public sealed class Binder
             }
             else
             {
-                var access = new BoundFieldAccessExpression(new BoundVariableExpression(tempVar), structType, field);
+                var access = new BoundFieldAccessExpression(null, new BoundVariableExpression(null, tempVar), structType, field);
                 initializers.Add(new BoundFieldInitializer(field, access));
             }
         }
 
-        var declaration = new BoundVariableDeclaration(tempVar, receiver);
-        var literal = new BoundStructLiteralExpression(structType, initializers.ToImmutable());
-        return new BoundBlockExpression(ImmutableArray.Create<BoundStatement>(declaration), literal);
+        var declaration = new BoundVariableDeclaration(null, tempVar, receiver);
+        var literal = new BoundStructLiteralExpression(null, structType, initializers.ToImmutable());
+        return new BoundBlockExpression(null, ImmutableArray.Create<BoundStatement>(declaration), literal);
     }
 
     private static bool TryGetCopyOverrides(CallExpressionSyntax call, out SeparatedSyntaxList<FieldInitializerSyntax> overrides)
@@ -4215,7 +4216,7 @@ public sealed class Binder
         if (!scope.TryLookupTypeAlias(typeName, out var resolvedType) || !(resolvedType is StructSymbol structSymbol))
         {
             Diagnostics.ReportUnableToFindType(syntax.TypeIdentifier.Location, typeName);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         // ADR-0047 §6 / #175: struct/class literal `Foo{ ... }` is a
@@ -4239,7 +4240,7 @@ public sealed class Binder
                 if (explicitArgs.Count != tps.Length)
                 {
                     Diagnostics.ReportWrongTypeArgumentCount(syntax.TypeArgumentList.Location, typeName, tps.Length, explicitArgs.Count);
-                    return new BoundErrorExpression();
+                    return new BoundErrorExpression(null);
                 }
 
                 for (var i = 0; i < explicitArgs.Count; i++)
@@ -4247,7 +4248,7 @@ public sealed class Binder
                     var ta = BindTypeClause(explicitArgs[i]);
                     if (ta == null)
                     {
-                        return new BoundErrorExpression();
+                        return new BoundErrorExpression(null);
                     }
 
                     substitution[tps[i]] = ta;
@@ -4274,7 +4275,7 @@ public sealed class Binder
                     if (!substitution.ContainsKey(tp))
                     {
                         Diagnostics.ReportTypeArgumentInferenceFailed(syntax.TypeIdentifier.Location, typeName, tp.Name);
-                        return new BoundErrorExpression();
+                        return new BoundErrorExpression(null);
                     }
                 }
             }
@@ -4289,7 +4290,7 @@ public sealed class Binder
                 if (!SatisfiesConstraint(typeArg, tp))
                 {
                     Diagnostics.ReportTypeArgumentDoesNotSatisfyConstraint(constraintLocation, tp.Name, typeArg, DescribeConstraint(tp));
-                    return new BoundErrorExpression();
+                    return new BoundErrorExpression(null);
                 }
             }
 
@@ -4304,7 +4305,7 @@ public sealed class Binder
         else if (syntax.TypeArgumentList != null)
         {
             Diagnostics.ReportWrongTypeArgumentCount(syntax.TypeArgumentList.Location, typeName, 0, syntax.TypeArgumentList.Arguments.Count);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         var seenFieldNames = new HashSet<string>();
@@ -4329,7 +4330,7 @@ public sealed class Binder
             inits.Add(new BoundFieldInitializer(field, valueExpr));
         }
 
-        return new BoundStructLiteralExpression(structSymbol, inits.ToImmutable());
+        return new BoundStructLiteralExpression(null, structSymbol, inits.ToImmutable());
     }
 
     private BoundExpression BindTupleLiteralExpression(TupleLiteralExpressionSyntax syntax)
@@ -4343,7 +4344,7 @@ public sealed class Binder
             var be = BindExpression(e);
             if (be.Type == TypeSymbol.Error)
             {
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
             }
 
             bound.Add(be);
@@ -4351,7 +4352,7 @@ public sealed class Binder
         }
 
         var tupleType = TupleTypeSymbol.Get(elementTypes.MoveToImmutable());
-        return new BoundTupleLiteralExpression(tupleType, bound.MoveToImmutable());
+        return new BoundTupleLiteralExpression(null, tupleType, bound.MoveToImmutable());
     }
 
     private BoundExpression BindFunctionLiteralExpression(FunctionLiteralExpressionSyntax syntax)
@@ -4420,7 +4421,7 @@ public sealed class Binder
         function = outerFunction;
 
         var captured = CollectCapturedVariables(body, synthetic.Parameters);
-        return new BoundFunctionLiteralExpression(synthetic, fnType, (BoundBlockStatement)body, captured);
+        return new BoundFunctionLiteralExpression(null, synthetic, fnType, (BoundBlockStatement)body, captured);
     }
 
     private static ImmutableArray<VariableSymbol> CollectCapturedVariables(BoundStatement body, ImmutableArray<ParameterSymbol> parameters)
@@ -4446,18 +4447,18 @@ public sealed class Binder
             if (!importedClass.TryLookupMember(syntax.FieldIdentifier.Text, ne: null, out var staticMember))
             {
                 Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
             }
 
             if (!TryGetWritableClrMember(staticMember, out var staticTargetType, out var staticWritable))
             {
                 Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.Text);
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
             }
 
             _ = staticWritable;
             var staticConverted = BindConversion(syntax.Value.Location, staticValue, TypeSymbol.FromClrType(staticTargetType));
-            return new BoundClrPropertyAssignmentExpression(receiver: null, staticMember, staticConverted, TypeSymbol.FromClrType(staticTargetType));
+            return new BoundClrPropertyAssignmentExpression(null, receiver: null, staticMember, staticConverted, TypeSymbol.FromClrType(staticTargetType));
         }
 
         var variable = BindVariableReference(receiverName, syntax.Receiver.Location);
@@ -4482,31 +4483,31 @@ public sealed class Binder
             if (instanceMember == null)
             {
                 Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
             }
 
             if (!TryGetWritableClrMember(instanceMember, out var instTargetType, out var instWritable))
             {
                 Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
             }
 
             _ = instWritable;
-            var instReceiver = new BoundVariableExpression(variable);
+            var instReceiver = new BoundVariableExpression(null, variable);
             var instConverted = BindConversion(syntax.Value.Location, value, TypeSymbol.FromClrType(instTargetType));
-            return new BoundClrPropertyAssignmentExpression(instReceiver, instanceMember, instConverted, TypeSymbol.FromClrType(instTargetType));
+            return new BoundClrPropertyAssignmentExpression(null, instReceiver, instanceMember, instConverted, TypeSymbol.FromClrType(instTargetType));
         }
 
         if (!(variable.Type is StructSymbol structSymbol))
         {
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         if (!structSymbol.TryGetFieldIncludingInherited(syntax.FieldIdentifier.Text, out var field, out _))
         {
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         if (variable.IsReadOnly)
@@ -4527,7 +4528,7 @@ public sealed class Binder
             $"{structSymbol.Name}.{field.Name}");
 
         var converted = BindConversion(syntax.Value.Location, value, field.Type);
-        return new BoundFieldAssignmentExpression(variable, structSymbol, field, converted);
+        return new BoundFieldAssignmentExpression(null, variable, structSymbol, field, converted);
     }
 
     private BoundExpression BindEventSubscriptionExpression(EventSubscriptionExpressionSyntax syntax)
@@ -4537,13 +4538,13 @@ public sealed class Binder
         if (syntax.LeftHandSide is not AccessorExpressionSyntax accessor)
         {
             Diagnostics.ReportUnableToFindMember(syntax.LeftHandSide.Location, syntax.OperatorToken.Text);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         if (accessor.RightPart is not NameExpressionSyntax eventNameSyntax)
         {
             Diagnostics.ReportUnableToFindMember(accessor.RightPart.Location, syntax.OperatorToken.Text);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         var eventName = eventNameSyntax.IdentifierToken.Text;
@@ -4565,14 +4566,14 @@ public sealed class Binder
             boundReceiver = BindExpression(accessor.LeftPart);
             if (boundReceiver.Type == TypeSymbol.Error)
             {
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
             }
 
             receiverClrType = boundReceiver.Type?.ClrType;
             if (receiverClrType == null)
             {
                 Diagnostics.ReportUnableToFindMember(eventNameSyntax.Location, eventName);
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
             }
 
             flags = BindingFlags.Public | BindingFlags.Instance;
@@ -4582,7 +4583,7 @@ public sealed class Binder
         if (eventInfo == null)
         {
             Diagnostics.ReportUnableToFindMember(eventNameSyntax.Location, eventName);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         var handlerType = eventInfo.EventHandlerType;
@@ -4606,7 +4607,7 @@ public sealed class Binder
             convertedHandler = BindConversion(syntax.Value.Location, boundHandler, handlerSymbol);
         }
 
-        return new BoundClrEventSubscriptionExpression(boundReceiver, eventInfo, convertedHandler, isAdd);
+        return new BoundClrEventSubscriptionExpression(null, boundReceiver, eventInfo, convertedHandler, isAdd);
     }
 
     private static bool IsSignatureCompatibleWithDelegate(FunctionTypeSymbol fn, Type delegateType)
@@ -4685,7 +4686,7 @@ public sealed class Binder
 
         if (boundOperand.Type == TypeSymbol.Error)
         {
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         var boundOperator = BoundUnaryOperator.Bind(syntax.OperatorToken.Kind, boundOperand.Type);
@@ -4716,10 +4717,10 @@ public sealed class Binder
                     var convertedOperand = BindConversion(syntax.Operand.Location, boundOperand, userOp.Parameters[0].Type);
                     if (isStructReceiver)
                     {
-                        return new BoundUserInstanceCallExpression(convertedOperand, userOp, ImmutableArray<BoundExpression>.Empty);
+                        return new BoundUserInstanceCallExpression(null, convertedOperand, userOp, ImmutableArray<BoundExpression>.Empty);
                     }
 
-                    return new BoundCallExpression(userOp, ImmutableArray.Create(convertedOperand));
+                    return new BoundCallExpression(null, userOp, ImmutableArray.Create(convertedOperand));
                 }
             }
 
@@ -4730,6 +4731,7 @@ public sealed class Binder
                 && ClrOperatorResolution.TryResolveUnary(syntax.OperatorToken.Kind, boundOperand.Type, out var clrMethod, out ambiguous))
             {
                 return new BoundClrUnaryOperatorExpression(
+                    null,
                     syntax.OperatorToken.Kind,
                     boundOperand,
                     clrMethod,
@@ -4738,14 +4740,14 @@ public sealed class Binder
             else if (ambiguous)
             {
                 Diagnostics.ReportAmbiguousOverload(syntax.OperatorToken.Location, syntax.OperatorToken.Text, candidateCount: 2);
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
             }
 
             Diagnostics.ReportUndefinedUnaryOperator(syntax.OperatorToken.Location, syntax.OperatorToken.Text, boundOperand.Type);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
-        return new BoundUnaryExpression(boundOperator, boundOperand);
+        return new BoundUnaryExpression(null, boundOperator, boundOperand);
     }
 
     /// <summary>ADR-0039: Binds <c>&amp;expr</c> — takes managed pointer to an lvalue.</summary>
@@ -4761,7 +4763,7 @@ public sealed class Binder
         if (operand is BoundVariableExpression bve && bve.Variable.IsReadOnly)
         {
             Diagnostics.ReportCannotTakeAddressOfConstant(syntax.OperatorToken.Location, bve.Variable.Name);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         // Lvalue check.
@@ -4769,10 +4771,10 @@ public sealed class Binder
         {
             var exprText = syntax.Operand.ToString();
             Diagnostics.ReportCannotTakeAddressOfNonLvalue(syntax.OperatorToken.Location, exprText);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
-        return new BoundAddressOfExpression(operand);
+        return new BoundAddressOfExpression(null, operand);
     }
 
     /// <summary>ADR-0039: Binds <c>*expr</c> — dereferences a managed pointer.</summary>
@@ -4787,10 +4789,10 @@ public sealed class Binder
         if (operand.Type is not ByRefTypeSymbol)
         {
             Diagnostics.ReportUndefinedUnaryOperator(syntax.OperatorToken.Location, syntax.OperatorToken.Text, operand.Type);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
-        return new BoundDereferenceExpression(operand);
+        return new BoundDereferenceExpression(null, operand);
     }
 
     /// <summary>ADR-0039: Determines whether an expression is an lvalue (can have its address taken).</summary>
@@ -4891,10 +4893,10 @@ public sealed class Binder
         if (operand.Type is not ChannelTypeSymbol chan)
         {
             Diagnostics.ReportReceiveOperandIsNotChannel(syntax.Operand.Location, operand.Type);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
-        return new BoundChannelReceiveExpression(operand, chan.ElementType);
+        return new BoundChannelReceiveExpression(null, operand, chan.ElementType);
     }
 
     private BoundExpression BindBinaryExpression(BinaryExpressionSyntax syntax)
@@ -4904,7 +4906,7 @@ public sealed class Binder
 
         if (boundLeft.Type == TypeSymbol.Error || boundRight.Type == TypeSymbol.Error)
         {
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         var boundOperator = BoundBinaryOperator.Bind(syntax.OperatorToken.Kind, boundLeft.Type, boundRight.Type);
@@ -4946,15 +4948,15 @@ public sealed class Binder
                     var convertedRight = BindConversion(syntax.Right.Location, boundRight, userOp.Parameters[1].Type);
                     if (leftIsStructReceiver)
                     {
-                        return new BoundUserInstanceCallExpression(convertedLeft, userOp, ImmutableArray.Create(convertedRight));
+                        return new BoundUserInstanceCallExpression(null, convertedLeft, userOp, ImmutableArray.Create(convertedRight));
                     }
 
                     if (rightIsStructReceiver)
                     {
-                        return new BoundUserInstanceCallExpression(convertedRight, userOp, ImmutableArray.Create(convertedLeft));
+                        return new BoundUserInstanceCallExpression(null, convertedRight, userOp, ImmutableArray.Create(convertedLeft));
                     }
 
-                    return new BoundCallExpression(userOp, ImmutableArray.Create(convertedLeft, convertedRight));
+                    return new BoundCallExpression(null, userOp, ImmutableArray.Create(convertedLeft, convertedRight));
                 }
             }
 
@@ -4965,6 +4967,7 @@ public sealed class Binder
                 && ClrOperatorResolution.TryResolveBinary(syntax.OperatorToken.Kind, boundLeft.Type, boundRight.Type, out var clrMethod, out ambiguous))
             {
                 return new BoundClrBinaryOperatorExpression(
+                    null,
                     syntax.OperatorToken.Kind,
                     boundLeft,
                     boundRight,
@@ -4974,14 +4977,14 @@ public sealed class Binder
             else if (ambiguous)
             {
                 Diagnostics.ReportAmbiguousOverload(syntax.OperatorToken.Location, syntax.OperatorToken.Text, candidateCount: 2);
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
             }
 
             Diagnostics.ReportUndefinedBinaryOperator(syntax.OperatorToken.Location, syntax.OperatorToken.Text, boundLeft.Type, boundRight.Type);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
-        return new BoundBinaryExpression(boundLeft, boundOperator, boundRight);
+        return new BoundBinaryExpression(null, boundLeft, boundOperator, boundRight);
     }
 
     private BoundExpression BindConstructorCallExpression(CallExpressionSyntax syntax, StructSymbol classType)
@@ -5007,7 +5010,7 @@ public sealed class Binder
                 if (explicitArgs.Count != tps.Length)
                 {
                     Diagnostics.ReportWrongTypeArgumentCount(syntax.TypeArgumentList.Location, classType.Name, tps.Length, explicitArgs.Count);
-                    return new BoundErrorExpression();
+                    return new BoundErrorExpression(syntax);
                 }
 
                 for (var i = 0; i < explicitArgs.Count; i++)
@@ -5015,7 +5018,7 @@ public sealed class Binder
                     var ta = BindTypeClause(explicitArgs[i]);
                     if (ta == null)
                     {
-                        return new BoundErrorExpression();
+                        return new BoundErrorExpression(syntax);
                     }
 
                     substitution[tps[i]] = ta;
@@ -5035,7 +5038,7 @@ public sealed class Binder
                     if (!substitution.ContainsKey(tp))
                     {
                         Diagnostics.ReportTypeArgumentInferenceFailed(syntax.Identifier.Location, classType.Name, tp.Name);
-                        return new BoundErrorExpression();
+                        return new BoundErrorExpression(syntax);
                     }
                 }
             }
@@ -5049,7 +5052,7 @@ public sealed class Binder
                 if (!SatisfiesConstraint(typeArg, tp))
                 {
                     Diagnostics.ReportTypeArgumentDoesNotSatisfyConstraint(constraintLocation, tp.Name, typeArg, DescribeConstraint(tp));
-                    return new BoundErrorExpression();
+                    return new BoundErrorExpression(syntax);
                 }
             }
 
@@ -5064,7 +5067,7 @@ public sealed class Binder
         else if (syntax.TypeArgumentList != null)
         {
             Diagnostics.ReportWrongTypeArgumentCount(syntax.TypeArgumentList.Location, classType.Name, 0, syntax.TypeArgumentList.Arguments.Count);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(syntax);
         }
 
         var parameters = classType.PrimaryConstructorParameters;
@@ -5098,7 +5101,7 @@ public sealed class Binder
             }
 
             Diagnostics.ReportWrongArgumentCount(new TextLocation(syntax.Location.Text, span), classType.Name, parameters.Length, syntax.Arguments.Count);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(syntax);
         }
 
         var hasErrors = false;
@@ -5120,7 +5123,7 @@ public sealed class Binder
 
         if (hasErrors)
         {
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(syntax);
         }
 
         if (!classType.IsClass)
@@ -5134,10 +5137,10 @@ public sealed class Binder
                 }
             }
 
-            return new BoundStructLiteralExpression(classType, fieldInitializers.ToImmutable());
+            return new BoundStructLiteralExpression(syntax, classType, fieldInitializers.ToImmutable());
         }
 
-        return new BoundConstructorCallExpression(classType, boundArguments.ToImmutable());
+        return new BoundConstructorCallExpression(syntax, classType, boundArguments.ToImmutable());
     }
 
     private BoundExpression BindCallExpression(CallExpressionSyntax syntax)
@@ -5193,7 +5196,7 @@ public sealed class Binder
         if (symbol == null)
         {
             Diagnostics.ReportUndefinedFunction(syntax.Identifier.Location, syntax.Identifier.Text);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         // Phase 4.7: invoking a function-typed variable goes through the
@@ -5204,7 +5207,7 @@ public sealed class Binder
             if (syntax.Arguments.Count != fnType.Arity)
             {
                 Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, variable.Name, fnType.Arity, syntax.Arguments.Count);
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
             }
 
             var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
@@ -5213,14 +5216,14 @@ public sealed class Binder
                 convertedArgs.Add(BindConversion(syntax.Arguments[i].Location, boundArguments[i], fnType.ParameterTypes[i]));
             }
 
-            return new BoundIndirectCallExpression(new BoundVariableExpression(variable), fnType, convertedArgs.MoveToImmutable());
+            return new BoundIndirectCallExpression(null, new BoundVariableExpression(null, variable), fnType, convertedArgs.MoveToImmutable());
         }
 
         var function = symbol as FunctionSymbol;
         if (function == null)
         {
             Diagnostics.ReportNotAFunction(syntax.Identifier.Location, syntax.Identifier.Text);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         ReportObsoleteUseIfApplicable(syntax.Identifier.Location, function, function.Name);
@@ -5233,7 +5236,7 @@ public sealed class Binder
             if (syntax.Arguments.Count < fixedParamCount)
             {
                 Diagnostics.ReportTooFewArgumentsForVariadic(syntax.Identifier.Location, function.Name, fixedParamCount, syntax.Arguments.Count);
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
             }
         }
         else if (syntax.Arguments.Count != function.Parameters.Length)
@@ -5260,7 +5263,7 @@ public sealed class Binder
             }
 
             Diagnostics.ReportWrongArgumentCount(new TextLocation(syntax.Location.Text, span), function.Name, function.Parameters.Length, syntax.Arguments.Count);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         bool hasErrors = false;
@@ -5279,7 +5282,7 @@ public sealed class Binder
                 if (explicitArgs.Count != function.TypeParameters.Length)
                 {
                     Diagnostics.ReportWrongTypeArgumentCount(syntax.TypeArgumentList.Location, function.Name, function.TypeParameters.Length, explicitArgs.Count);
-                    return new BoundErrorExpression();
+                    return new BoundErrorExpression(null);
                 }
 
                 for (var i = 0; i < explicitArgs.Count; i++)
@@ -5287,7 +5290,7 @@ public sealed class Binder
                     var ta = BindTypeClause(explicitArgs[i]);
                     if (ta == null)
                     {
-                        return new BoundErrorExpression();
+                        return new BoundErrorExpression(null);
                     }
 
                     substitution[function.TypeParameters[i]] = ta;
@@ -5305,7 +5308,7 @@ public sealed class Binder
                     if (!substitution.ContainsKey(tp))
                     {
                         Diagnostics.ReportTypeArgumentInferenceFailed(syntax.Identifier.Location, function.Name, tp.Name);
-                        return new BoundErrorExpression();
+                        return new BoundErrorExpression(null);
                     }
                 }
             }
@@ -5321,7 +5324,7 @@ public sealed class Binder
                 if (!SatisfiesConstraint(typeArg, tp))
                 {
                     Diagnostics.ReportTypeArgumentDoesNotSatisfyConstraint(constraintLocation, tp.Name, typeArg, DescribeConstraint(tp));
-                    return new BoundErrorExpression();
+                    return new BoundErrorExpression(null);
                 }
             }
         }
@@ -5376,14 +5379,14 @@ public sealed class Binder
                     finalArgs.Add(boundArguments[i]);
                 }
 
-                finalArgs.Add(new BoundArrayCreationExpression(sliceType, packed.MoveToImmutable()));
+                finalArgs.Add(new BoundArrayCreationExpression(syntax, sliceType, packed.MoveToImmutable()));
                 boundArguments = finalArgs;
             }
         }
 
         if (hasErrors)
         {
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(syntax);
         }
 
         if (substitution != null)
@@ -5424,10 +5427,10 @@ public sealed class Binder
     {
         if (KnownAttributes.IsConditionallyElided(function.Attributes, scope.PreprocessorSymbols))
         {
-            return new BoundCallExpression(function, ImmutableArray<BoundExpression>.Empty, returnType, isConditionalElided: true);
+            return new BoundCallExpression(null, function, ImmutableArray<BoundExpression>.Empty, returnType, isConditionalElided: true);
         }
 
-        return new BoundCallExpression(function, arguments, returnType);
+        return new BoundCallExpression(null, function, arguments, returnType);
     }
 
     private static void InferTypeArguments(TypeSymbol parameterType, TypeSymbol argumentType, Dictionary<TypeParameterSymbol, TypeSymbol> substitution)
@@ -5529,7 +5532,7 @@ public sealed class Binder
         if (function == null || (!function.IsAsync && !IsAsyncIteratorReturnType(function.Type)))
         {
             Diagnostics.ReportAwaitOutsideAsyncFunction(syntax.AwaitKeyword.Location);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         if (operand is BoundErrorExpression)
@@ -5540,10 +5543,10 @@ public sealed class Binder
         if (!TryGetTaskElementType(operand.Type, out var element))
         {
             Diagnostics.ReportTypeIsNotAwaitable(syntax.Expression.Location, operand.Type);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
-        return new BoundAwaitExpression(operand, element);
+        return new BoundAwaitExpression(null, operand, element);
     }
 
     private static TypeSymbol SubstituteType(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> substitution)
@@ -5673,14 +5676,14 @@ public sealed class Binder
                 if (syntax.Arguments.Count != 1)
                 {
                     Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, name, 1, syntax.Arguments.Count);
-                    result = new BoundErrorExpression();
+                    result = new BoundErrorExpression(syntax);
                     return true;
                 }
 
                 var operand = BindExpression(syntax.Arguments[0]);
                 if (operand.Type == TypeSymbol.Error)
                 {
-                    result = new BoundErrorExpression();
+                    result = new BoundErrorExpression(syntax);
                     return true;
                 }
 
@@ -5689,13 +5692,13 @@ public sealed class Binder
                 if (!ok)
                 {
                     Diagnostics.ReportIntrinsicArgumentType(syntax.Arguments[0].Location, name, operand.Type);
-                    result = new BoundErrorExpression();
+                    result = new BoundErrorExpression(syntax);
                     return true;
                 }
 
                 result = name == "len"
-                    ? new BoundLenExpression(operand)
-                    : new BoundCapExpression(operand);
+                    ? new BoundLenExpression(syntax, operand)
+                    : new BoundCapExpression(syntax, operand);
                 return true;
             }
 
@@ -5704,26 +5707,26 @@ public sealed class Binder
                 if (syntax.Arguments.Count != 2)
                 {
                     Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, name, 2, syntax.Arguments.Count);
-                    result = new BoundErrorExpression();
+                    result = new BoundErrorExpression(syntax);
                     return true;
                 }
 
                 var slice = BindExpression(syntax.Arguments[0]);
                 if (slice.Type == TypeSymbol.Error)
                 {
-                    result = new BoundErrorExpression();
+                    result = new BoundErrorExpression(syntax);
                     return true;
                 }
 
                 if (slice.Type is not SliceTypeSymbol sliceType)
                 {
                     Diagnostics.ReportIntrinsicArgumentType(syntax.Arguments[0].Location, name, slice.Type);
-                    result = new BoundErrorExpression();
+                    result = new BoundErrorExpression(syntax);
                     return true;
                 }
 
                 var element = BindConversion(syntax.Arguments[1], sliceType.ElementType);
-                result = new BoundAppendExpression(slice, element, sliceType);
+                result = new BoundAppendExpression(syntax, slice, element, sliceType);
                 return true;
             }
 
@@ -5733,26 +5736,26 @@ public sealed class Binder
                 if (syntax.Arguments.Count != 2)
                 {
                     Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, name, 2, syntax.Arguments.Count);
-                    result = new BoundErrorExpression();
+                    result = new BoundErrorExpression(syntax);
                     return true;
                 }
 
                 var mapExpr = BindExpression(syntax.Arguments[0]);
                 if (mapExpr.Type == TypeSymbol.Error)
                 {
-                    result = new BoundErrorExpression();
+                    result = new BoundErrorExpression(syntax);
                     return true;
                 }
 
                 if (mapExpr.Type is not MapTypeSymbol mapType)
                 {
                     Diagnostics.ReportIntrinsicArgumentType(syntax.Arguments[0].Location, name, mapExpr.Type);
-                    result = new BoundErrorExpression();
+                    result = new BoundErrorExpression(syntax);
                     return true;
                 }
 
                 var keyExpr = BindConversion(syntax.Arguments[1], mapType.KeyType);
-                result = new BoundMapDeleteExpression(mapExpr, keyExpr);
+                result = new BoundMapDeleteExpression(syntax, mapExpr, keyExpr);
                 return true;
             }
 
@@ -5762,25 +5765,25 @@ public sealed class Binder
                 if (syntax.Arguments.Count != 1)
                 {
                     Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, name, 1, syntax.Arguments.Count);
-                    result = new BoundErrorExpression();
+                    result = new BoundErrorExpression(syntax);
                     return true;
                 }
 
                 var chanExpr = BindExpression(syntax.Arguments[0]);
                 if (chanExpr.Type == TypeSymbol.Error)
                 {
-                    result = new BoundErrorExpression();
+                    result = new BoundErrorExpression(syntax);
                     return true;
                 }
 
                 if (chanExpr.Type is not ChannelTypeSymbol)
                 {
                     Diagnostics.ReportCloseOperandIsNotChannel(syntax.Arguments[0].Location, chanExpr.Type);
-                    result = new BoundErrorExpression();
+                    result = new BoundErrorExpression(syntax);
                     return true;
                 }
 
-                result = new BoundChannelCloseExpression(chanExpr);
+                result = new BoundChannelCloseExpression(syntax, chanExpr);
                 return true;
             }
 
@@ -5902,6 +5905,7 @@ public sealed class Binder
         }
 
         result = new BoundClrConstructorCallExpression(
+            syntax,
             clrType,
             bestCtor,
             ctorArgs,
@@ -5949,13 +5953,14 @@ public sealed class Binder
                         implicitField.Field,
                         $"{implicitField.StructType.Name}.{implicitField.Field.Name}");
                     receiver = new BoundFieldAccessExpression(
-                        new BoundVariableExpression(implicitField.Receiver),
+                        null,
+                        new BoundVariableExpression(null, implicitField.Receiver),
                         implicitField.StructType,
                         implicitField.Field);
                 }
                 else
                 {
-                    receiver = new BoundVariableExpression(variable, TryGetNarrowedType(variable));
+                    receiver = new BoundVariableExpression(null, variable, TryGetNarrowedType(variable));
                 }
             }
             else if (scope.TryLookupImport(name, out var matchedImport)
@@ -5974,7 +5979,7 @@ public sealed class Binder
             else
             {
                 Diagnostics.ReportUnableToFindType(leftName.Location, name);
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
             }
         }
         else
@@ -6007,7 +6012,7 @@ public sealed class Binder
         else if (receiverType == TypeSymbol.Null)
         {
             // `nil?.x` is statically nil.
-            return new BoundLiteralExpression(null);
+            return new BoundLiteralExpression(null, null);
         }
         else
         {
@@ -6028,13 +6033,13 @@ public sealed class Binder
         scope = new BoundScope(scope);
         scope.TryDeclareVariable(capture);
 
-        var captureRef = new BoundVariableExpression(capture);
+        var captureRef = new BoundVariableExpression(null, capture);
         var whenNotNull = BindAccessorStep(captureRef, null, syntax.RightPart);
 
         scope = scope.Parent;
 
         var resultType = whenNotNull.Type is NullableTypeSymbol ? whenNotNull.Type : (TypeSymbol)NullableTypeSymbol.Get(whenNotNull.Type);
-        return new BoundNullConditionalAccessExpression(receiver, capture, whenNotNull, resultType);
+        return new BoundNullConditionalAccessExpression(null, receiver, capture, whenNotNull, resultType);
     }
 
     private bool TryBindImportAccessor(ImportSymbol import, ref ExpressionSyntax rightPart, out ImportedClassSymbol importedClass)
@@ -6095,14 +6100,14 @@ public sealed class Binder
                     // member surfaces GS0204 at the member-identifier
                     // location (e.g. `Color.Red`).
                     ReportObsoleteUseIfApplicable(ne.Location, member, $"{enumSymbol.Name}.{member.Name}");
-                    return new BoundLiteralExpression(member.Value, enumSymbol);
+                    return new BoundLiteralExpression(null, member.Value, enumSymbol);
                 }
 
                 Diagnostics.ReportUndefinedEnumMember(ne.Location, memberName, enumSymbol.Name);
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
 
             default:
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
         }
     }
 
@@ -6129,7 +6134,7 @@ public sealed class Binder
                     if (!foundMember)
                     {
                         Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
-                        return new BoundErrorExpression();
+                        return new BoundErrorExpression(null);
                     }
 
                     // Stream B: static field/property read on imported type.
@@ -6138,7 +6143,7 @@ public sealed class Binder
                     // their constant value rather than emit `ldsfld`.
                     if (staticMember is FieldInfo litField && litField.IsLiteral)
                     {
-                        return new BoundLiteralExpression(litField.GetRawConstantValue(), TypeSymbol.FromClrType(litField.FieldType));
+                        return new BoundLiteralExpression(null, litField.GetRawConstantValue(), TypeSymbol.FromClrType(litField.FieldType));
                     }
 
                     var staticType = staticMember switch
@@ -6147,7 +6152,7 @@ public sealed class Binder
                         FieldInfo sf => TypeSymbol.FromClrType(sf.FieldType),
                         _ => TypeSymbol.Error,
                     };
-                    return new BoundClrPropertyAccessExpression(null, staticMember, staticType);
+                    return new BoundClrPropertyAccessExpression(null, null, staticMember, staticType);
                 }
                 else if (receiver != null && receiver.Type is StructSymbol structSym)
                 {
@@ -6159,7 +6164,7 @@ public sealed class Binder
                             // Issue #186 / #175: dotted field read fires
                             // GS0204 if the field carries `@Obsolete`.
                             ReportObsoleteUseIfApplicable(ne.IdentifierToken.Location, field, $"{c.Name}.{field.Name}");
-                            return new BoundFieldAccessExpression(receiver, c, field);
+                            return new BoundFieldAccessExpression(null, receiver, c, field);
                         }
                     }
 
@@ -6173,11 +6178,11 @@ public sealed class Binder
                         && int.TryParse(memberName.Substring(4), out var oneBased)
                         && oneBased >= 1 && oneBased <= tupleSym.Arity)
                     {
-                        return new BoundTupleElementAccessExpression(receiver, tupleSym, oneBased - 1);
+                        return new BoundTupleElementAccessExpression(null, receiver, tupleSym, oneBased - 1);
                     }
 
                     Diagnostics.ReportUnableToFindMember(ne.Location, memberName);
-                    return new BoundErrorExpression();
+                    return new BoundErrorExpression(null);
                 }
                 else if (receiver != null && receiver.Type is not NullableTypeSymbol && receiver.Type.ClrType != null)
                 {
@@ -6191,27 +6196,27 @@ public sealed class Binder
                     var prop = clrReceiverType.GetProperty(memberName, BindingFlags.Public | BindingFlags.Instance);
                     if (prop != null && prop.GetIndexParameters().Length == 0 && prop.CanRead)
                     {
-                        return new BoundClrPropertyAccessExpression(receiver, prop, TypeSymbol.FromClrType(prop.PropertyType));
+                        return new BoundClrPropertyAccessExpression(null, receiver, prop, TypeSymbol.FromClrType(prop.PropertyType));
                     }
 
                     var fld = clrReceiverType.GetField(memberName, BindingFlags.Public | BindingFlags.Instance);
                     if (fld != null)
                     {
-                        return new BoundClrPropertyAccessExpression(receiver, fld, TypeSymbol.FromClrType(fld.FieldType));
+                        return new BoundClrPropertyAccessExpression(null, receiver, fld, TypeSymbol.FromClrType(fld.FieldType));
                     }
 
                     Diagnostics.ReportUnableToFindMember(ne.Location, memberName);
-                    return new BoundErrorExpression();
+                    return new BoundErrorExpression(null);
                 }
                 else
                 {
                     Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
                 }
 
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
 
             default:
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
         }
     }
 
@@ -6227,13 +6232,13 @@ public sealed class Binder
             }
 
             Diagnostics.ReportNamedArgumentOnlyValidForCopy(ce.Location);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         if (hasNamedArguments)
         {
             Diagnostics.ReportNamedArgumentOnlyValidForCopy(ce.Location);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>();
@@ -6250,17 +6255,17 @@ public sealed class Binder
             {
                 var refKinds = ComputeArgumentRefKinds(staticFn.Method.GetParameters());
                 ValidateRefArguments(arguments, refKinds, methodName, ce.Location);
-                return new BoundImportedCallExpression(staticFn, arguments, refKinds);
+                return new BoundImportedCallExpression(null, staticFn, arguments, refKinds);
             }
 
             if (staticAmbiguous)
             {
                 Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, candidateCount: 2);
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
             }
 
             Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         if (receiver == null || receiver.Type?.ClrType == null)
@@ -6296,7 +6301,7 @@ public sealed class Binder
             }
 
             Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         // Prefer a user-defined class method when the receiver is a user
@@ -6336,10 +6341,10 @@ public sealed class Binder
                         var returnType = TypeSymbol.FromClrType(resolution.Best.ReturnType);
                         var instRefKinds = ComputeArgumentRefKinds(resolution.Best.GetParameters());
                         ValidateRefArguments(arguments, instRefKinds, methodName, ce.Location);
-                        return new BoundImportedInstanceCallExpression(receiver, resolution.Best, returnType, arguments, instRefKinds);
+                        return new BoundImportedInstanceCallExpression(null, receiver, resolution.Best, returnType, arguments, instRefKinds);
                     case OverloadResolution.ResolutionOutcome.Ambiguous:
                         Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, resolution.Ambiguous.Length);
-                        return new BoundErrorExpression();
+                        return new BoundErrorExpression(null);
                     default:
                         break;
                 }
@@ -6354,7 +6359,7 @@ public sealed class Binder
         }
 
         Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
-        return new BoundErrorExpression();
+        return new BoundErrorExpression(null);
     }
 
     private BoundExpression BindExtensionFunctionCall(BoundExpression receiver, FunctionSymbol extension, ImmutableArray<BoundExpression> arguments, CallExpressionSyntax ce)
@@ -6365,7 +6370,7 @@ public sealed class Binder
         if (arguments.Length != userParamCount)
         {
             Diagnostics.ReportWrongArgumentCount(ce.Location, extension.Name, userParamCount, arguments.Length);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(extension.Parameters.Length);
@@ -6375,7 +6380,7 @@ public sealed class Binder
             convertedArgs.Add(BindConversion(ce.Arguments[i].Location, arguments[i], extension.Parameters[i + 1].Type));
         }
 
-        return new BoundCallExpression(extension, convertedArgs.MoveToImmutable());
+        return new BoundCallExpression(null, extension, convertedArgs.MoveToImmutable());
     }
 
     private BoundExpression BindUserInstanceCall(BoundExpression receiver, FunctionSymbol method, ImmutableArray<BoundExpression> arguments, CallExpressionSyntax ce)
@@ -6385,7 +6390,7 @@ public sealed class Binder
         if (arguments.Length != callableParameterCount)
         {
             Diagnostics.ReportWrongArgumentCount(ce.Location, method.Name, callableParameterCount, arguments.Length);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         // Phase 4.3b / ADR-0020: if the receiver is a constructed generic
@@ -6408,11 +6413,11 @@ public sealed class Binder
             var substitutedReturn = SubstituteType(method.Type, substitution);
             if (!ReferenceEquals(substitutedReturn, method.Type))
             {
-                return new BoundUserInstanceCallExpression(receiver, method, convertedArgs.ToImmutable(), substitutedReturn);
+                return new BoundUserInstanceCallExpression(null, receiver, method, convertedArgs.ToImmutable(), substitutedReturn);
             }
         }
 
-        return new BoundUserInstanceCallExpression(receiver, method, convertedArgs.ToImmutable());
+        return new BoundUserInstanceCallExpression(null, receiver, method, convertedArgs.ToImmutable());
     }
 
     private static Dictionary<TypeParameterSymbol, TypeSymbol> TryBuildReceiverSubstitution(TypeSymbol receiverType)
@@ -6444,7 +6449,7 @@ public sealed class Binder
         if (elementType == null)
         {
             Diagnostics.ReportUndefinedType(syntax.ElementTypeIdentifier.Location, syntax.ElementTypeIdentifier.Text);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         var elements = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Elements.Count);
@@ -6455,13 +6460,13 @@ public sealed class Binder
 
         if (syntax.LengthToken == null)
         {
-            return new BoundArrayCreationExpression(SliceTypeSymbol.Get(elementType), elements.ToImmutable());
+            return new BoundArrayCreationExpression(null, SliceTypeSymbol.Get(elementType), elements.ToImmutable());
         }
 
         if (!int.TryParse(syntax.LengthToken.Text, out var length) || length < 0)
         {
             Diagnostics.ReportInvalidArrayLength(syntax.LengthToken.Location, syntax.LengthToken.Text);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         if (syntax.Elements.Count != length)
@@ -6469,7 +6474,7 @@ public sealed class Binder
             Diagnostics.ReportArrayLiteralLengthMismatch(syntax.Location, length, syntax.Elements.Count);
         }
 
-        return new BoundArrayCreationExpression(ArrayTypeSymbol.Get(elementType, length), elements.ToImmutable());
+        return new BoundArrayCreationExpression(null, ArrayTypeSymbol.Get(elementType, length), elements.ToImmutable());
     }
 
     private BoundExpression BindMapCreationExpression(MapCreationExpressionSyntax syntax)
@@ -6478,14 +6483,14 @@ public sealed class Binder
         var mapType = BindTypeClause(syntax.TypeClause);
         if (mapType == null)
         {
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         if (mapType is not MapTypeSymbol mts)
         {
             // Defensive — the parser only produces a map type clause here.
             Diagnostics.ReportUndefinedType(syntax.TypeClause.Location, mapType.Name);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         var entries = ImmutableArray.CreateBuilder<BoundMapEntry>(syntax.Entries.Count);
@@ -6496,7 +6501,7 @@ public sealed class Binder
             entries.Add(new BoundMapEntry(key, value));
         }
 
-        return new BoundMapLiteralExpression(mts, entries.ToImmutable());
+        return new BoundMapLiteralExpression(null, mts, entries.ToImmutable());
     }
 
     private BoundExpression BindIndexExpression(IndexExpressionSyntax syntax)
@@ -6510,14 +6515,14 @@ public sealed class Binder
         if (target.Type is MapTypeSymbol mapType)
         {
             var key = BindConversion(syntax.Index, mapType.KeyType);
-            return new BoundIndexExpression(target, key, mapType.ValueType);
+            return new BoundIndexExpression(null, target, key, mapType.ValueType);
         }
 
         var element = GetIndexElementType(target.Type);
         if (element != null)
         {
             var index = BindConversion(syntax.Index, TypeSymbol.Int);
-            return new BoundIndexExpression(target, index, element);
+            return new BoundIndexExpression(null, target, index, element);
         }
 
         // Phase 4 exit: CLR indexer read on an imported reference type
@@ -6526,7 +6531,7 @@ public sealed class Binder
         // matches the single argument by assignability).
         if (target.Type is ImportedTypeSymbol && target.Type.ClrType is System.Type clrTarget && TryResolveClrIndexer(clrTarget, new[] { syntax.Index }, out var idxProp, out var idxArgs))
         {
-            return new BoundClrIndexExpression(target, idxProp, idxArgs, TypeSymbol.FromClrType(idxProp.PropertyType));
+            return new BoundClrIndexExpression(null, target, idxProp, idxArgs, TypeSymbol.FromClrType(idxProp.PropertyType));
         }
 
         if (target.Type != TypeSymbol.Error)
@@ -6534,7 +6539,7 @@ public sealed class Binder
             Diagnostics.ReportTypeNotIndexable(syntax.Target.Location, target.Type);
         }
 
-        return new BoundErrorExpression();
+        return new BoundErrorExpression(null);
     }
 
     private BoundExpression BindIndexAssignmentExpression(IndexAssignmentExpressionSyntax syntax)
@@ -6543,7 +6548,7 @@ public sealed class Binder
         if (scope.TryLookupSymbol(name) is not VariableSymbol variable)
         {
             Diagnostics.ReportUndefinedVariable(syntax.TargetIdentifier.Location, name);
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         var element = GetIndexElementType(variable.Type);
@@ -6551,7 +6556,7 @@ public sealed class Binder
         {
             var index = BindConversion(syntax.Index, TypeSymbol.Int);
             var value = BindConversion(syntax.Value, element);
-            return new BoundIndexAssignmentExpression(variable, index, value, element);
+            return new BoundIndexAssignmentExpression(null, variable, index, value, element);
         }
 
         // Phase 3.A.4: map indexed assignment `m[k] = v` — key bound to K,
@@ -6560,7 +6565,7 @@ public sealed class Binder
         {
             var keyExpr = BindConversion(syntax.Index, mapType.KeyType);
             var valExpr = BindConversion(syntax.Value, mapType.ValueType);
-            return new BoundIndexAssignmentExpression(variable, keyExpr, valExpr, mapType.ValueType);
+            return new BoundIndexAssignmentExpression(null, variable, keyExpr, valExpr, mapType.ValueType);
         }
 
         // Phase 4 exit: CLR indexer write on an imported reference type
@@ -6570,12 +6575,12 @@ public sealed class Binder
             if (!idxProp.CanWrite)
             {
                 Diagnostics.ReportTypeNotIndexable(syntax.TargetIdentifier.Location, variable.Type);
-                return new BoundErrorExpression();
+                return new BoundErrorExpression(null);
             }
 
             var valueType = TypeSymbol.FromClrType(idxProp.PropertyType);
             var boundValue = BindConversion(syntax.Value, valueType);
-            return new BoundClrIndexAssignmentExpression(variable, idxProp, idxArgs, boundValue, valueType);
+            return new BoundClrIndexAssignmentExpression(null, variable, idxProp, idxArgs, boundValue, valueType);
         }
 
         if (variable.Type != TypeSymbol.Error)
@@ -6583,7 +6588,7 @@ public sealed class Binder
             Diagnostics.ReportTypeNotIndexable(syntax.TargetIdentifier.Location, variable.Type);
         }
 
-        return new BoundErrorExpression();
+        return new BoundErrorExpression(null);
     }
 
     private bool TryResolveClrIndexer(System.Type clrTarget, IReadOnlyList<ExpressionSyntax> argSyntaxes, out PropertyInfo indexer, out ImmutableArray<BoundExpression> boundArguments)
@@ -6655,7 +6660,7 @@ public sealed class Binder
                 && ClrOperatorResolution.TryResolveConversion(expression.Type.ClrType, type.ClrType, allowExplicit, out var convMethod, out var isExplicit))
             {
                 _ = isExplicit;
-                return new BoundClrConversionCallExpression(expression, convMethod, type);
+                return new BoundClrConversionCallExpression(null, expression, convMethod, type);
             }
 
             if (expression.Type != TypeSymbol.Error && type != TypeSymbol.Error)
@@ -6663,7 +6668,7 @@ public sealed class Binder
                 Diagnostics.ReportCannotConvert(diagnosticLocation, expression.Type, type);
             }
 
-            return new BoundErrorExpression();
+            return new BoundErrorExpression(null);
         }
 
         if (!allowExplicit && conversion.IsExplicit)
@@ -6676,7 +6681,7 @@ public sealed class Binder
             return expression;
         }
 
-        return new BoundConversionExpression(type, expression);
+        return new BoundConversionExpression(null, type, expression);
     }
 
     private VariableSymbol BindVariableDeclaration(SyntaxToken identifier, bool isReadOnly, TypeSymbol type)

--- a/src/Core/CodeAnalysis/Binding/BoundAddressOfExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundAddressOfExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -15,8 +16,10 @@ public sealed class BoundAddressOfExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundAddressOfExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="operand">The lvalue operand whose address is being taken.</param>
-    public BoundAddressOfExpression(BoundExpression operand)
+    public BoundAddressOfExpression(SyntaxNode syntax, BoundExpression operand)
+        : base(syntax)
     {
         Operand = operand;
         Type = ByRefTypeSymbol.Get(operand.Type);

--- a/src/Core/CodeAnalysis/Binding/BoundAppendExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundAppendExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -17,10 +18,12 @@ public sealed class BoundAppendExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundAppendExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="slice">The slice operand.</param>
     /// <param name="element">The element to append.</param>
     /// <param name="sliceType">The slice type symbol that is also the expression type.</param>
-    public BoundAppendExpression(BoundExpression slice, BoundExpression element, SliceTypeSymbol sliceType)
+    public BoundAppendExpression(SyntaxNode syntax, BoundExpression slice, BoundExpression element, SliceTypeSymbol sliceType)
+        : base(syntax)
     {
         Slice = slice;
         Element = element;

--- a/src/Core/CodeAnalysis/Binding/BoundArrayCreationExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundArrayCreationExpression.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -17,9 +18,11 @@ public sealed class BoundArrayCreationExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundArrayCreationExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="containerType">The array or slice type symbol.</param>
     /// <param name="elements">The bound element initialisers.</param>
-    public BoundArrayCreationExpression(TypeSymbol containerType, ImmutableArray<BoundExpression> elements)
+    public BoundArrayCreationExpression(SyntaxNode syntax, TypeSymbol containerType, ImmutableArray<BoundExpression> elements)
+        : base(syntax)
     {
         ContainerType = containerType ?? throw new ArgumentNullException(nameof(containerType));
         Elements = elements;

--- a/src/Core/CodeAnalysis/Binding/BoundAssignmentExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundAssignmentExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -14,9 +15,11 @@ public sealed class BoundAssignmentExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundAssignmentExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="variable">The variable symbol.</param>
     /// <param name="expression">The expression.</param>
-    public BoundAssignmentExpression(VariableSymbol variable, BoundExpression expression)
+    public BoundAssignmentExpression(SyntaxNode syntax, VariableSymbol variable, BoundExpression expression)
+        : base(syntax)
     {
         Variable = variable;
         Expression = expression;

--- a/src/Core/CodeAnalysis/Binding/BoundAttribute.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundAttribute.cs
@@ -29,8 +29,8 @@ public sealed class BoundAttribute : BoundNode
         AttributeTargetKind target,
         ImmutableArray<BoundAttributeArgument> positionalArguments,
         ImmutableArray<BoundAttributeArgument> namedArguments)
+        : base(syntax)
     {
-        Syntax = syntax;
         AttributeType = attributeType;
         Target = target;
         PositionalArguments = positionalArguments;
@@ -43,7 +43,7 @@ public sealed class BoundAttribute : BoundNode
     /// <summary>
     /// Gets the originating annotation syntax.
     /// </summary>
-    public AnnotationSyntax Syntax { get; }
+    public new AnnotationSyntax Syntax => (AnnotationSyntax)base.Syntax;
 
     /// <summary>
     /// Gets the resolved attribute type.

--- a/src/Core/CodeAnalysis/Binding/BoundAwaitExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundAwaitExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -15,9 +16,11 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundAwaitExpression : BoundExpression
 {
     /// <summary>Initializes a new instance of the <see cref="BoundAwaitExpression"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="expression">The expression being awaited.</param>
     /// <param name="type">The unwrapped type that the await yields.</param>
-    public BoundAwaitExpression(BoundExpression expression, TypeSymbol type)
+    public BoundAwaitExpression(SyntaxNode syntax, BoundExpression expression, TypeSymbol type)
+        : base(syntax)
     {
         Expression = expression;
         Type = type;

--- a/src/Core/CodeAnalysis/Binding/BoundAwaitForRangeStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundAwaitForRangeStatement.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -22,13 +23,16 @@ public sealed class BoundAwaitForRangeStatement : BoundStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundAwaitForRangeStatement"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="valueVariable">The element variable.</param>
     /// <param name="stream">The async-stream expression.</param>
     /// <param name="body">The loop body.</param>
     public BoundAwaitForRangeStatement(
+        SyntaxNode syntax,
         VariableSymbol valueVariable,
         BoundExpression stream,
         BoundStatement body)
+        : base(syntax)
     {
         ValueVariable = valueVariable;
         Stream = stream;

--- a/src/Core/CodeAnalysis/Binding/BoundAwaitSequencePoint.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundAwaitSequencePoint.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -14,9 +16,11 @@ public sealed class BoundAwaitSequencePoint : BoundStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundAwaitSequencePoint"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="kind">Whether this is a yield point or a resume point.</param>
     /// <param name="state">The await state number for PDB round-trip.</param>
-    public BoundAwaitSequencePoint(BoundNodeKind kind, int state)
+    public BoundAwaitSequencePoint(SyntaxNode syntax, BoundNodeKind kind, int state)
+        : base(syntax)
     {
         Kind = kind;
         State = state;

--- a/src/Core/CodeAnalysis/Binding/BoundBinaryExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -14,10 +15,12 @@ public sealed class BoundBinaryExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundBinaryExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="left">The left bound expression.</param>
     /// <param name="op">The bound binary operator.</param>
     /// <param name="right">The right bound expression.</param>
-    public BoundBinaryExpression(BoundExpression left, BoundBinaryOperator op, BoundExpression right)
+    public BoundBinaryExpression(SyntaxNode syntax, BoundExpression left, BoundBinaryOperator op, BoundExpression right)
+        : base(syntax)
     {
         Left = left;
         Op = op;

--- a/src/Core/CodeAnalysis/Binding/BoundBlockExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBlockExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Collections.Immutable;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -13,9 +14,11 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundBlockExpression : BoundExpression
 {
     /// <summary>Initializes a new instance of the <see cref="BoundBlockExpression"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="statements">The synthetic prefix statements.</param>
     /// <param name="expression">The resulting expression.</param>
-    public BoundBlockExpression(ImmutableArray<BoundStatement> statements, BoundExpression expression)
+    public BoundBlockExpression(SyntaxNode syntax, ImmutableArray<BoundStatement> statements, BoundExpression expression)
+        : base(syntax)
     {
         Statements = statements;
         Expression = expression;

--- a/src/Core/CodeAnalysis/Binding/BoundBlockStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBlockStatement.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
 using System.Collections.Immutable;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
@@ -14,8 +15,10 @@ public sealed class BoundBlockStatement : BoundStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundBlockStatement"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="statements">The immutable array of bound statements.</param>
-    public BoundBlockStatement(ImmutableArray<BoundStatement> statements)
+    public BoundBlockStatement(SyntaxNode syntax, ImmutableArray<BoundStatement> statements)
+        : base(syntax)
     {
         Statements = statements;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundCallExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Collections.Immutable;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -15,19 +16,21 @@ public sealed class BoundCallExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundCallExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="function">The function symbol.</param>
     /// <param name="arguments">The provided arguments.</param>
-    public BoundCallExpression(FunctionSymbol function, ImmutableArray<BoundExpression> arguments)
-        : this(function, arguments, returnType: null)
+    public BoundCallExpression(SyntaxNode syntax, FunctionSymbol function, ImmutableArray<BoundExpression> arguments)
+        : this(syntax, function, arguments, returnType: null)
     {
     }
 
     /// <summary>Initializes a new instance of the <see cref="BoundCallExpression"/> class with an explicit (substituted) return type for generic-call sites (Phase 4.1 / ADR-0020).</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="function">The function symbol.</param>
     /// <param name="arguments">The provided arguments.</param>
     /// <param name="returnType">The (already-substituted) call-site return type, or <c>null</c> to use <c>function.Type</c>.</param>
-    public BoundCallExpression(FunctionSymbol function, ImmutableArray<BoundExpression> arguments, TypeSymbol returnType)
-        : this(function, arguments, returnType, isConditionalElided: false)
+    public BoundCallExpression(SyntaxNode syntax, FunctionSymbol function, ImmutableArray<BoundExpression> arguments, TypeSymbol returnType)
+        : this(syntax, function, arguments, returnType, isConditionalElided: false)
     {
     }
 
@@ -39,11 +42,13 @@ public sealed class BoundCallExpression : BoundExpression
     /// list is empty because C# semantics forbid evaluating arguments to a
     /// conditional method whose symbol is undefined.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="function">The function symbol.</param>
     /// <param name="arguments">The provided arguments; empty when elided.</param>
     /// <param name="returnType">The (already-substituted) call-site return type, or <c>null</c> to use <c>function.Type</c>.</param>
     /// <param name="isConditionalElided">When <c>true</c>, the call has been elided per <c>[Conditional]</c> rules.</param>
-    public BoundCallExpression(FunctionSymbol function, ImmutableArray<BoundExpression> arguments, TypeSymbol returnType, bool isConditionalElided)
+    public BoundCallExpression(SyntaxNode syntax, FunctionSymbol function, ImmutableArray<BoundExpression> arguments, TypeSymbol returnType, bool isConditionalElided)
+        : base(syntax)
     {
         Function = function;
         Arguments = arguments;

--- a/src/Core/CodeAnalysis/Binding/BoundCapExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundCapExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -16,8 +17,10 @@ public sealed class BoundCapExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundCapExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="operand">The operand expression.</param>
-    public BoundCapExpression(BoundExpression operand)
+    public BoundCapExpression(SyntaxNode syntax, BoundExpression operand)
+        : base(syntax)
     {
         Operand = operand;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundChannelCloseExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundChannelCloseExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -16,8 +17,10 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundChannelCloseExpression : BoundExpression
 {
     /// <summary>Initializes a new instance of the <see cref="BoundChannelCloseExpression"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="channel">The bound channel expression.</param>
-    public BoundChannelCloseExpression(BoundExpression channel)
+    public BoundChannelCloseExpression(SyntaxNode syntax, BoundExpression channel)
+        : base(syntax)
     {
         Channel = channel;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundChannelReceiveExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundChannelReceiveExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -15,9 +16,11 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundChannelReceiveExpression : BoundExpression
 {
     /// <summary>Initializes a new instance of the <see cref="BoundChannelReceiveExpression"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="channel">The bound channel expression.</param>
     /// <param name="elementType">The channel's element type (the type yielded by the receive).</param>
-    public BoundChannelReceiveExpression(BoundExpression channel, TypeSymbol elementType)
+    public BoundChannelReceiveExpression(SyntaxNode syntax, BoundExpression channel, TypeSymbol elementType)
+        : base(syntax)
     {
         Channel = channel;
         Type = elementType;

--- a/src/Core/CodeAnalysis/Binding/BoundChannelSendStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundChannelSendStatement.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -11,9 +13,11 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundChannelSendStatement : BoundStatement
 {
     /// <summary>Initializes a new instance of the <see cref="BoundChannelSendStatement"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="channel">The bound channel expression.</param>
     /// <param name="value">The bound value expression (converted to the channel's element type).</param>
-    public BoundChannelSendStatement(BoundExpression channel, BoundExpression value)
+    public BoundChannelSendStatement(SyntaxNode syntax, BoundExpression channel, BoundExpression value)
+        : base(syntax)
     {
         Channel = channel;
         Value = value;

--- a/src/Core/CodeAnalysis/Binding/BoundClrBinaryOperatorExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrBinaryOperatorExpression.cs
@@ -20,7 +20,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundClrBinaryOperatorExpression : BoundExpression
 {
-    public BoundClrBinaryOperatorExpression(SyntaxKind operatorKind, BoundExpression left, BoundExpression right, MethodInfo method, TypeSymbol resultType)
+    public BoundClrBinaryOperatorExpression(SyntaxNode syntax, SyntaxKind operatorKind, BoundExpression left, BoundExpression right, MethodInfo method, TypeSymbol resultType)
+        : base(syntax)
     {
         OperatorKind = operatorKind;
         Left = left;

--- a/src/Core/CodeAnalysis/Binding/BoundClrConstructorCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrConstructorCallExpression.cs
@@ -2,9 +2,10 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 using System.Collections.Immutable;
 using System.Reflection;
-using GSharp.Core.CodeAnalysis.Symbols;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -19,7 +20,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundClrConstructorCallExpression : BoundExpression
 {
-    public BoundClrConstructorCallExpression(System.Type clrType, ConstructorInfo constructor, ImmutableArray<BoundExpression> arguments, TypeSymbol resultType, ImmutableArray<RefKind> argumentRefKinds = default)
+    public BoundClrConstructorCallExpression(SyntaxNode syntax, System.Type clrType, ConstructorInfo constructor, ImmutableArray<BoundExpression> arguments, TypeSymbol resultType, ImmutableArray<RefKind> argumentRefKinds = default)
+        : base(syntax)
     {
         ClrType = clrType;
         Constructor = constructor;

--- a/src/Core/CodeAnalysis/Binding/BoundClrConversionCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrConversionCallExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Reflection;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Reflection;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -19,7 +20,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundClrConversionCallExpression : BoundExpression
 {
-    public BoundClrConversionCallExpression(BoundExpression source, MethodInfo method, TypeSymbol resultType)
+    public BoundClrConversionCallExpression(SyntaxNode syntax, BoundExpression source, MethodInfo method, TypeSymbol resultType)
+        : base(syntax)
     {
         Source = source;
         Method = method;

--- a/src/Core/CodeAnalysis/Binding/BoundClrEventSubscriptionExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrEventSubscriptionExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Reflection;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Reflection;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -18,7 +19,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundClrEventSubscriptionExpression : BoundExpression
 {
-    public BoundClrEventSubscriptionExpression(BoundExpression receiver, EventInfo eventInfo, BoundExpression handler, bool isAdd)
+    public BoundClrEventSubscriptionExpression(SyntaxNode syntax, BoundExpression receiver, EventInfo eventInfo, BoundExpression handler, bool isAdd)
+        : base(syntax)
     {
         Receiver = receiver;
         Event = eventInfo;

--- a/src/Core/CodeAnalysis/Binding/BoundClrIndexAssignmentExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrIndexAssignmentExpression.cs
@@ -2,9 +2,10 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 using System.Collections.Immutable;
 using System.Reflection;
-using GSharp.Core.CodeAnalysis.Symbols;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -19,7 +20,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundClrIndexAssignmentExpression : BoundExpression
 {
-    public BoundClrIndexAssignmentExpression(VariableSymbol target, PropertyInfo indexer, ImmutableArray<BoundExpression> arguments, BoundExpression value, TypeSymbol resultType)
+    public BoundClrIndexAssignmentExpression(SyntaxNode syntax, VariableSymbol target, PropertyInfo indexer, ImmutableArray<BoundExpression> arguments, BoundExpression value, TypeSymbol resultType)
+        : base(syntax)
     {
         Target = target;
         Indexer = indexer;

--- a/src/Core/CodeAnalysis/Binding/BoundClrIndexExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrIndexExpression.cs
@@ -2,9 +2,10 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 using System.Collections.Immutable;
 using System.Reflection;
-using GSharp.Core.CodeAnalysis.Symbols;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -18,7 +19,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundClrIndexExpression : BoundExpression
 {
-    public BoundClrIndexExpression(BoundExpression target, PropertyInfo indexer, ImmutableArray<BoundExpression> arguments, TypeSymbol resultType)
+    public BoundClrIndexExpression(SyntaxNode syntax, BoundExpression target, PropertyInfo indexer, ImmutableArray<BoundExpression> arguments, TypeSymbol resultType)
+        : base(syntax)
     {
         Target = target;
         Indexer = indexer;

--- a/src/Core/CodeAnalysis/Binding/BoundClrPropertyAccessExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrPropertyAccessExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Reflection;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Reflection;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -19,7 +20,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundClrPropertyAccessExpression : BoundExpression
 {
-    public BoundClrPropertyAccessExpression(BoundExpression receiver, MemberInfo member, TypeSymbol resultType)
+    public BoundClrPropertyAccessExpression(SyntaxNode syntax, BoundExpression receiver, MemberInfo member, TypeSymbol resultType)
+        : base(syntax)
     {
         Receiver = receiver;
         Member = member;

--- a/src/Core/CodeAnalysis/Binding/BoundClrPropertyAssignmentExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrPropertyAssignmentExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Reflection;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Reflection;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -19,7 +20,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundClrPropertyAssignmentExpression : BoundExpression
 {
-    public BoundClrPropertyAssignmentExpression(BoundExpression receiver, MemberInfo member, BoundExpression value, TypeSymbol resultType)
+    public BoundClrPropertyAssignmentExpression(SyntaxNode syntax, BoundExpression receiver, MemberInfo member, BoundExpression value, TypeSymbol resultType)
+        : base(syntax)
     {
         Receiver = receiver;
         Member = member;

--- a/src/Core/CodeAnalysis/Binding/BoundClrStaticCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrStaticCallExpression.cs
@@ -2,9 +2,10 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 using System.Collections.Immutable;
 using System.Reflection;
-using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -16,10 +17,12 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundClrStaticCallExpression : BoundExpression
 {
     public BoundClrStaticCallExpression(
+        SyntaxNode syntax,
         MethodInfo method,
         TypeSymbol returnType,
         ImmutableArray<BoundExpression> arguments,
         ImmutableArray<RefKind> argumentRefKinds = default)
+        : base(syntax)
     {
         Method = method;
         Type = returnType;

--- a/src/Core/CodeAnalysis/Binding/BoundClrUnaryOperatorExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrUnaryOperatorExpression.cs
@@ -19,7 +19,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundClrUnaryOperatorExpression : BoundExpression
 {
-    public BoundClrUnaryOperatorExpression(SyntaxKind operatorKind, BoundExpression operand, MethodInfo method, TypeSymbol resultType)
+    public BoundClrUnaryOperatorExpression(SyntaxNode syntax, SyntaxKind operatorKind, BoundExpression operand, MethodInfo method, TypeSymbol resultType)
+        : base(syntax)
     {
         OperatorKind = operatorKind;
         Operand = operand;

--- a/src/Core/CodeAnalysis/Binding/BoundConditionalGotoStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundConditionalGotoStatement.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -12,10 +14,12 @@ public sealed class BoundConditionalGotoStatement : BoundStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundConditionalGotoStatement"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="label">The label.</param>
     /// <param name="condition">The condition.</param>
     /// <param name="jumpIfTrue">Whether to jump on true, or on false.</param>
-    public BoundConditionalGotoStatement(BoundLabel label, BoundExpression condition, bool jumpIfTrue = true)
+    public BoundConditionalGotoStatement(SyntaxNode syntax, BoundLabel label, BoundExpression condition, bool jumpIfTrue = true)
+        : base(syntax)
     {
         Label = label;
         Condition = condition;

--- a/src/Core/CodeAnalysis/Binding/BoundConstantPattern.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundConstantPattern.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -10,10 +11,11 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundConstantPattern : BoundPattern
 {
     /// <summary>Initializes a new instance of the <see cref="BoundConstantPattern"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="type">The discriminant type.</param>
     /// <param name="value">The value expression.</param>
-    public BoundConstantPattern(TypeSymbol type, BoundExpression value)
-        : base(type)
+    public BoundConstantPattern(SyntaxNode syntax, TypeSymbol type, BoundExpression value)
+        : base(syntax, type)
     {
         Value = value;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundConstructorCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundConstructorCallExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Collections.Immutable;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -18,7 +19,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundConstructorCallExpression : BoundExpression
 {
-    public BoundConstructorCallExpression(StructSymbol structType, ImmutableArray<BoundExpression> arguments)
+    public BoundConstructorCallExpression(SyntaxNode syntax, StructSymbol structType, ImmutableArray<BoundExpression> arguments)
+        : base(syntax)
     {
         StructType = structType;
         Arguments = arguments;

--- a/src/Core/CodeAnalysis/Binding/BoundConversionExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundConversionExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -14,9 +15,11 @@ public sealed class BoundConversionExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundConversionExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="type">The type symbol.</param>
     /// <param name="expression">The expression to convert.</param>
-    public BoundConversionExpression(TypeSymbol type, BoundExpression expression)
+    public BoundConversionExpression(SyntaxNode syntax, TypeSymbol type, BoundExpression expression)
+        : base(syntax)
     {
         Type = type;
         Expression = expression;

--- a/src/Core/CodeAnalysis/Binding/BoundDefaultExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundDefaultExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -15,8 +16,10 @@ public sealed class BoundDefaultExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundDefaultExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="type">The type whose default value this expression produces.</param>
-    public BoundDefaultExpression(TypeSymbol type)
+    public BoundDefaultExpression(SyntaxNode syntax, TypeSymbol type)
+        : base(syntax)
     {
         Type = type;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundDereferenceExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundDereferenceExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -15,8 +16,10 @@ public sealed class BoundDereferenceExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundDereferenceExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="operand">The pointer expression to dereference.</param>
-    public BoundDereferenceExpression(BoundExpression operand)
+    public BoundDereferenceExpression(SyntaxNode syntax, BoundExpression operand)
+        : base(syntax)
     {
         Operand = operand;
         Type = ((ByRefTypeSymbol)operand.Type).PointeeType;

--- a/src/Core/CodeAnalysis/Binding/BoundDiscardPattern.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundDiscardPattern.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -10,9 +11,10 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundDiscardPattern : BoundPattern
 {
     /// <summary>Initializes a new instance of the <see cref="BoundDiscardPattern"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="type">The discriminant type.</param>
-    public BoundDiscardPattern(TypeSymbol type)
-        : base(type)
+    public BoundDiscardPattern(SyntaxNode syntax, TypeSymbol type)
+        : base(syntax, type)
     {
     }
 

--- a/src/Core/CodeAnalysis/Binding/BoundErrorExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundErrorExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -11,6 +12,15 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundErrorExpression : BoundExpression
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundErrorExpression"/> class.
+    /// </summary>
+    /// <param name="syntax">The originating syntax (may be <see langword="null"/> for synthesised nodes).</param>
+    public BoundErrorExpression(SyntaxNode syntax)
+        : base(syntax)
+    {
+    }
+
     /// <inheritdoc/>
     public override BoundNodeKind Kind => BoundNodeKind.ErrorExpression;
 

--- a/src/Core/CodeAnalysis/Binding/BoundExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -11,6 +12,15 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public abstract class BoundExpression : BoundNode
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundExpression"/> class.
+    /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
+    protected BoundExpression(SyntaxNode syntax)
+        : base(syntax)
+    {
+    }
+
     /// <summary>
     /// Gets the bound expression type.
     /// </summary>

--- a/src/Core/CodeAnalysis/Binding/BoundExpressionStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundExpressionStatement.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -12,8 +14,10 @@ public sealed class BoundExpressionStatement : BoundStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundExpressionStatement"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="expression">The expression.</param>
-    public BoundExpressionStatement(BoundExpression expression)
+    public BoundExpressionStatement(SyntaxNode syntax, BoundExpression expression)
+        : base(syntax)
     {
         Expression = expression;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundFieldAccessExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundFieldAccessExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -14,7 +15,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundFieldAccessExpression : BoundExpression
 {
-    public BoundFieldAccessExpression(BoundExpression receiver, StructSymbol structType, FieldSymbol field)
+    public BoundFieldAccessExpression(SyntaxNode syntax, BoundExpression receiver, StructSymbol structType, FieldSymbol field)
+        : base(syntax)
     {
         Receiver = receiver;
         StructType = structType;

--- a/src/Core/CodeAnalysis/Binding/BoundFieldAssignmentExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundFieldAssignmentExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -16,7 +17,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundFieldAssignmentExpression : BoundExpression
 {
-    public BoundFieldAssignmentExpression(VariableSymbol receiver, StructSymbol structType, FieldSymbol field, BoundExpression value)
+    public BoundFieldAssignmentExpression(SyntaxNode syntax, VariableSymbol receiver, StructSymbol structType, FieldSymbol field, BoundExpression value)
+        : base(syntax)
     {
         Receiver = receiver;
         StructType = structType;

--- a/src/Core/CodeAnalysis/Binding/BoundForEllipsisStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundForEllipsisStatement.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -14,6 +15,7 @@ public sealed class BoundForEllipsisStatement : BoundLoopStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundForEllipsisStatement"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="variable">The variable.</param>
     /// <param name="lowerBound">The lower bound expression.</param>
     /// <param name="upperBound">The upper bound expression.</param>
@@ -21,13 +23,14 @@ public sealed class BoundForEllipsisStatement : BoundLoopStatement
     /// <param name="breakLabel">The break label.</param>
     /// <param name="continueLabel">The continue label.</param>
     public BoundForEllipsisStatement(
+        SyntaxNode syntax,
         VariableSymbol variable,
         BoundExpression lowerBound,
         BoundExpression upperBound,
         BoundStatement body,
         BoundLabel breakLabel,
         BoundLabel continueLabel)
-        : base(breakLabel, continueLabel)
+        : base(syntax, breakLabel, continueLabel)
     {
         Variable = variable;
         LowerBound = lowerBound;

--- a/src/Core/CodeAnalysis/Binding/BoundForInfiniteStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundForInfiniteStatement.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -12,14 +14,16 @@ public sealed class BoundForInfiniteStatement : BoundLoopStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundForInfiniteStatement"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="body">The body.</param>
     /// <param name="breakLabel">The break label.</param>
     /// <param name="continueLabel">The continue label.</param>
     public BoundForInfiniteStatement(
+        SyntaxNode syntax,
         BoundStatement body,
         BoundLabel breakLabel,
         BoundLabel continueLabel)
-        : base(breakLabel, continueLabel)
+        : base(syntax, breakLabel, continueLabel)
     {
         Body = body;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundForRangeStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundForRangeStatement.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -35,6 +36,7 @@ public sealed class BoundForRangeStatement : BoundLoopStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundForRangeStatement"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="keyVariable">The key variable (may be null when no key was declared).</param>
     /// <param name="valueVariable">The value variable.</param>
     /// <param name="collection">The collection expression.</param>
@@ -43,6 +45,7 @@ public sealed class BoundForRangeStatement : BoundLoopStatement
     /// <param name="breakLabel">The break label.</param>
     /// <param name="continueLabel">The continue label.</param>
     public BoundForRangeStatement(
+        SyntaxNode syntax,
         VariableSymbol keyVariable,
         VariableSymbol valueVariable,
         BoundExpression collection,
@@ -50,7 +53,7 @@ public sealed class BoundForRangeStatement : BoundLoopStatement
         BoundStatement body,
         BoundLabel breakLabel,
         BoundLabel continueLabel)
-        : base(breakLabel, continueLabel)
+        : base(syntax, breakLabel, continueLabel)
     {
         KeyVariable = keyVariable;
         ValueVariable = valueVariable;

--- a/src/Core/CodeAnalysis/Binding/BoundFunctionLiteralExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundFunctionLiteralExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Collections.Immutable;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -19,10 +20,12 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundFunctionLiteralExpression : BoundExpression
 {
     public BoundFunctionLiteralExpression(
+        SyntaxNode syntax,
         FunctionSymbol function,
         FunctionTypeSymbol type,
         BoundBlockStatement body,
         ImmutableArray<VariableSymbol> capturedVariables)
+        : base(syntax)
     {
         Function = function;
         FunctionType = type;

--- a/src/Core/CodeAnalysis/Binding/BoundGoStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundGoStatement.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -12,8 +14,10 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundGoStatement : BoundStatement
 {
     /// <summary>Initializes a new instance of the <see cref="BoundGoStatement"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="expression">The bound call expression to dispatch.</param>
-    public BoundGoStatement(BoundExpression expression)
+    public BoundGoStatement(SyntaxNode syntax, BoundExpression expression)
+        : base(syntax)
     {
         Expression = expression;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundGotoStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundGotoStatement.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -12,8 +14,10 @@ public sealed class BoundGotoStatement : BoundStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundGotoStatement"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="label">The label.</param>
-    public BoundGotoStatement(BoundLabel label)
+    public BoundGotoStatement(SyntaxNode syntax, BoundLabel label)
+        : base(syntax)
     {
         Label = label;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundIfStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundIfStatement.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -12,13 +14,16 @@ public sealed class BoundIfStatement : BoundStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundIfStatement"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="condition">The bound if statement condition.</param>
     /// <param name="thenStatement">The then statement.</param>
     /// <param name="elseStatement">The else statement.</param>
     public BoundIfStatement(
+        SyntaxNode syntax,
         BoundExpression condition,
         BoundStatement thenStatement,
         BoundStatement elseStatement)
+        : base(syntax)
     {
         Condition = condition;
         ThenStatement = thenStatement;

--- a/src/Core/CodeAnalysis/Binding/BoundImportedCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundImportedCallExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Collections.Immutable;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -15,10 +16,12 @@ public sealed class BoundImportedCallExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundImportedCallExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="function">The function symbol.</param>
     /// <param name="arguments">The provided arguments.</param>
     /// <param name="argumentRefKinds">Per-argument ref-kind annotations (default all-None).</param>
-    public BoundImportedCallExpression(ImportedFunctionSymbol function, ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> argumentRefKinds = default)
+    public BoundImportedCallExpression(SyntaxNode syntax, ImportedFunctionSymbol function, ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> argumentRefKinds = default)
+        : base(syntax)
     {
         Function = function;
         Arguments = arguments;

--- a/src/Core/CodeAnalysis/Binding/BoundImportedInstanceCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundImportedInstanceCallExpression.cs
@@ -2,9 +2,10 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 using System.Collections.Immutable;
 using System.Reflection;
-using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -17,17 +18,20 @@ public sealed class BoundImportedInstanceCallExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundImportedInstanceCallExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="receiver">The expression that produces the instance.</param>
     /// <param name="method">The <see cref="MethodInfo"/> to invoke.</param>
     /// <param name="returnType">The bound return type.</param>
     /// <param name="arguments">The provided arguments.</param>
     /// <param name="argumentRefKinds">Per-argument ref-kind annotations (default all-None).</param>
     public BoundImportedInstanceCallExpression(
+        SyntaxNode syntax,
         BoundExpression receiver,
         MethodInfo method,
         TypeSymbol returnType,
         ImmutableArray<BoundExpression> arguments,
         ImmutableArray<RefKind> argumentRefKinds = default)
+        : base(syntax)
     {
         Receiver = receiver;
         Method = method;

--- a/src/Core/CodeAnalysis/Binding/BoundIndexAssignmentExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundIndexAssignmentExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -14,15 +15,18 @@ public sealed class BoundIndexAssignmentExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundIndexAssignmentExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="target">The target variable holding the array.</param>
     /// <param name="index">The index expression.</param>
     /// <param name="value">The value expression.</param>
     /// <param name="elementType">The element type of the array.</param>
     public BoundIndexAssignmentExpression(
+        SyntaxNode syntax,
         VariableSymbol target,
         BoundExpression index,
         BoundExpression value,
         TypeSymbol elementType)
+        : base(syntax)
     {
         Target = target;
         Index = index;

--- a/src/Core/CodeAnalysis/Binding/BoundIndexExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundIndexExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -14,10 +15,12 @@ public sealed class BoundIndexExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundIndexExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="target">The target expression (must have an array type).</param>
     /// <param name="index">The index expression (must be int).</param>
     /// <param name="resultType">The element type.</param>
-    public BoundIndexExpression(BoundExpression target, BoundExpression index, TypeSymbol resultType)
+    public BoundIndexExpression(SyntaxNode syntax, BoundExpression target, BoundExpression index, TypeSymbol resultType)
+        : base(syntax)
     {
         Target = target;
         Index = index;

--- a/src/Core/CodeAnalysis/Binding/BoundIndirectCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundIndirectCallExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Collections.Immutable;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -17,7 +18,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundIndirectCallExpression : BoundExpression
 {
-    public BoundIndirectCallExpression(BoundExpression target, FunctionTypeSymbol functionType, ImmutableArray<BoundExpression> arguments)
+    public BoundIndirectCallExpression(SyntaxNode syntax, BoundExpression target, FunctionTypeSymbol functionType, ImmutableArray<BoundExpression> arguments)
+        : base(syntax)
     {
         Target = target;
         FunctionType = functionType;

--- a/src/Core/CodeAnalysis/Binding/BoundLabelStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundLabelStatement.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -12,8 +14,10 @@ public sealed class BoundLabelStatement : BoundStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundLabelStatement"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="label">The label.</param>
-    public BoundLabelStatement(BoundLabel label)
+    public BoundLabelStatement(SyntaxNode syntax, BoundLabel label)
+        : base(syntax)
     {
         Label = label;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundLenExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundLenExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -15,8 +16,10 @@ public sealed class BoundLenExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundLenExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="operand">The operand expression.</param>
-    public BoundLenExpression(BoundExpression operand)
+    public BoundLenExpression(SyntaxNode syntax, BoundExpression operand)
+        : base(syntax)
     {
         Operand = operand;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundListPattern.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundListPattern.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Collections.Immutable;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -11,11 +12,12 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundListPattern : BoundPattern
 {
     /// <summary>Initializes a new instance of the <see cref="BoundListPattern"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="type">The discriminant type.</param>
     /// <param name="elements">The element patterns.</param>
     /// <param name="elementType">The element type.</param>
-    public BoundListPattern(TypeSymbol type, ImmutableArray<BoundPattern> elements, TypeSymbol elementType)
-        : base(type)
+    public BoundListPattern(SyntaxNode syntax, TypeSymbol type, ImmutableArray<BoundPattern> elements, TypeSymbol elementType)
+        : base(syntax, type)
     {
         Elements = elements;
         ElementType = elementType;

--- a/src/Core/CodeAnalysis/Binding/BoundLiteralExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundLiteralExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -15,18 +16,21 @@ public sealed class BoundLiteralExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundLiteralExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="value">The value.</param>
-    public BoundLiteralExpression(object value)
-        : this(value, InferType(value))
+    public BoundLiteralExpression(SyntaxNode syntax, object value)
+        : this(syntax, value, InferType(value))
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundLiteralExpression"/> class with an explicit type.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="value">The runtime value.</param>
     /// <param name="type">The static type.</param>
-    public BoundLiteralExpression(object value, TypeSymbol type)
+    public BoundLiteralExpression(SyntaxNode syntax, object value, TypeSymbol type)
+        : base(syntax)
     {
         Value = value;
         Type = type;

--- a/src/Core/CodeAnalysis/Binding/BoundLoopStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundLoopStatement.cs
@@ -4,6 +4,8 @@
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 /// <summary>
 /// Bound loop statement.
 /// </summary>
@@ -12,9 +14,11 @@ public abstract class BoundLoopStatement : BoundStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundLoopStatement"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="breakLabel">The break label.</param>
     /// <param name="continueLabel">The continue label.</param>
-    protected BoundLoopStatement(BoundLabel breakLabel, BoundLabel continueLabel)
+    protected BoundLoopStatement(SyntaxNode syntax, BoundLabel breakLabel, BoundLabel continueLabel)
+        : base(syntax)
     {
         BreakLabel = breakLabel;
         ContinueLabel = continueLabel;

--- a/src/Core/CodeAnalysis/Binding/BoundMakeChannelExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundMakeChannelExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -15,9 +16,11 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundMakeChannelExpression : BoundExpression
 {
     /// <summary>Initializes a new instance of the <see cref="BoundMakeChannelExpression"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="channelType">The constructed channel type.</param>
     /// <param name="capacity">The optional bounded-channel capacity expression.</param>
-    public BoundMakeChannelExpression(ChannelTypeSymbol channelType, BoundExpression capacity)
+    public BoundMakeChannelExpression(SyntaxNode syntax, ChannelTypeSymbol channelType, BoundExpression capacity)
+        : base(syntax)
     {
         ChannelType = channelType;
         Capacity = capacity;

--- a/src/Core/CodeAnalysis/Binding/BoundMapDeleteExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundMapDeleteExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -16,9 +17,11 @@ public sealed class BoundMapDeleteExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundMapDeleteExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="map">The bound map expression.</param>
     /// <param name="key">The bound key expression.</param>
-    public BoundMapDeleteExpression(BoundExpression map, BoundExpression key)
+    public BoundMapDeleteExpression(SyntaxNode syntax, BoundExpression map, BoundExpression key)
+        : base(syntax)
     {
         Map = map ?? throw new ArgumentNullException(nameof(map));
         Key = key ?? throw new ArgumentNullException(nameof(key));

--- a/src/Core/CodeAnalysis/Binding/BoundMapLiteralExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundMapLiteralExpression.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -17,9 +18,11 @@ public sealed class BoundMapLiteralExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundMapLiteralExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="mapType">The map type symbol.</param>
     /// <param name="entries">The bound key/value entries.</param>
-    public BoundMapLiteralExpression(MapTypeSymbol mapType, ImmutableArray<BoundMapEntry> entries)
+    public BoundMapLiteralExpression(SyntaxNode syntax, MapTypeSymbol mapType, ImmutableArray<BoundMapEntry> entries)
+        : base(syntax)
     {
         MapType = mapType ?? throw new ArgumentNullException(nameof(mapType));
         Entries = entries;

--- a/src/Core/CodeAnalysis/Binding/BoundNode.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNode.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.IO;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -12,9 +13,29 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public abstract class BoundNode
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="BoundNode"/> class.
+    /// </summary>
+    /// <param name="syntax">
+    /// The originating <see cref="SyntaxNode"/> this bound node was produced from, or
+    /// <c>null</c> when the node was synthesised by a lowering pass and has no direct
+    /// source counterpart (in which case the emitter will anchor a hidden
+    /// <c>0xfeefee</c> sequence point on it).
+    /// </param>
+    protected BoundNode(SyntaxNode syntax)
+    {
+        Syntax = syntax;
+    }
+
+    /// <summary>
     /// Gets the kind of bound node for this instance.
     /// </summary>
     public abstract BoundNodeKind Kind { get; }
+
+    /// <summary>
+    /// Gets the originating <see cref="SyntaxNode"/>, or <c>null</c> when this node was
+    /// synthesised by a lowering pass and has no direct source counterpart.
+    /// </summary>
+    public SyntaxNode Syntax { get; }
 
     /// <inheritdoc/>
     public override string ToString()

--- a/src/Core/CodeAnalysis/Binding/BoundNullConditionalAccessExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNullConditionalAccessExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -26,6 +27,7 @@ public sealed class BoundNullConditionalAccessExpression : BoundExpression
     /// Initializes a new instance of the
     /// <see cref="BoundNullConditionalAccessExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="receiver">The nullable receiver expression.</param>
     /// <param name="capture">The synthetic local that the receiver value
     /// is captured into for the duration of <see cref="WhenNotNull"/>.</param>
@@ -34,10 +36,12 @@ public sealed class BoundNullConditionalAccessExpression : BoundExpression
     /// <param name="type">The result type — always a
     /// <see cref="NullableTypeSymbol"/>.</param>
     public BoundNullConditionalAccessExpression(
+        SyntaxNode syntax,
         BoundExpression receiver,
         VariableSymbol capture,
         BoundExpression whenNotNull,
         TypeSymbol type)
+        : base(syntax)
     {
         Receiver = receiver;
         Capture = capture;

--- a/src/Core/CodeAnalysis/Binding/BoundPattern.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundPattern.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -10,8 +11,10 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public abstract class BoundPattern : BoundNode
 {
     /// <summary>Initializes a new instance of the <see cref="BoundPattern"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="type">The discriminant type.</param>
-    protected BoundPattern(TypeSymbol type)
+    protected BoundPattern(SyntaxNode syntax, TypeSymbol type)
+        : base(syntax)
     {
         Type = type;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundPatternSwitchArm.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundPatternSwitchArm.cs
@@ -2,15 +2,19 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>Bound arm for a pattern switch statement.</summary>
 public sealed class BoundPatternSwitchArm : BoundNode
 {
     /// <summary>Initializes a new instance of the <see cref="BoundPatternSwitchArm"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="pattern">The arm pattern, or null for default.</param>
     /// <param name="body">The arm body.</param>
-    public BoundPatternSwitchArm(BoundPattern pattern, BoundStatement body)
+    public BoundPatternSwitchArm(SyntaxNode syntax, BoundPattern pattern, BoundStatement body)
+        : base(syntax)
     {
         Pattern = pattern;
         Body = body;

--- a/src/Core/CodeAnalysis/Binding/BoundPatternSwitchStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundPatternSwitchStatement.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
 using System.Collections.Immutable;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
@@ -10,9 +11,11 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundPatternSwitchStatement : BoundStatement
 {
     /// <summary>Initializes a new instance of the <see cref="BoundPatternSwitchStatement"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="discriminant">The discriminant expression.</param>
     /// <param name="arms">The switch arms.</param>
-    public BoundPatternSwitchStatement(BoundExpression discriminant, ImmutableArray<BoundPatternSwitchArm> arms)
+    public BoundPatternSwitchStatement(SyntaxNode syntax, BoundExpression discriminant, ImmutableArray<BoundPatternSwitchArm> arms)
+        : base(syntax)
     {
         Discriminant = discriminant;
         Arms = arms;

--- a/src/Core/CodeAnalysis/Binding/BoundPropertyPattern.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundPropertyPattern.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Collections.Immutable;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -11,10 +12,11 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundPropertyPattern : BoundPattern
 {
     /// <summary>Initializes a new instance of the <see cref="BoundPropertyPattern"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="type">The discriminant type.</param>
     /// <param name="fields">The field patterns.</param>
-    public BoundPropertyPattern(TypeSymbol type, ImmutableArray<BoundPropertyPatternField> fields)
-        : base(type)
+    public BoundPropertyPattern(SyntaxNode syntax, TypeSymbol type, ImmutableArray<BoundPropertyPatternField> fields)
+        : base(syntax, type)
     {
         Fields = fields;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundPropertyPatternField.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundPropertyPatternField.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -10,9 +11,11 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundPropertyPatternField : BoundNode
 {
     /// <summary>Initializes a new instance of the <see cref="BoundPropertyPatternField"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="field">The matched field.</param>
     /// <param name="pattern">The nested pattern.</param>
-    public BoundPropertyPatternField(FieldSymbol field, BoundPattern pattern)
+    public BoundPropertyPatternField(SyntaxNode syntax, FieldSymbol field, BoundPattern pattern)
+        : base(syntax)
     {
         Field = field;
         Pattern = pattern;

--- a/src/Core/CodeAnalysis/Binding/BoundRelationalPattern.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundRelationalPattern.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -10,11 +11,12 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundRelationalPattern : BoundPattern
 {
     /// <summary>Initializes a new instance of the <see cref="BoundRelationalPattern"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="type">The discriminant type.</param>
     /// <param name="op">The operator.</param>
     /// <param name="value">The right-hand value.</param>
-    public BoundRelationalPattern(TypeSymbol type, BoundBinaryOperator op, BoundExpression value)
-        : base(type)
+    public BoundRelationalPattern(SyntaxNode syntax, TypeSymbol type, BoundBinaryOperator op, BoundExpression value)
+        : base(syntax, type)
     {
         Op = op;
         Value = value;

--- a/src/Core/CodeAnalysis/Binding/BoundReturnStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundReturnStatement.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -12,8 +14,10 @@ public sealed class BoundReturnStatement : BoundStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundReturnStatement"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="expression">The expression to return.</param>
-    public BoundReturnStatement(BoundExpression expression)
+    public BoundReturnStatement(SyntaxNode syntax, BoundExpression expression)
+        : base(syntax)
     {
         Expression = expression;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundScopeStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScopeStatement.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -15,8 +17,10 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundScopeStatement : BoundStatement
 {
     /// <summary>Initializes a new instance of the <see cref="BoundScopeStatement"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="body">The bound body block.</param>
-    public BoundScopeStatement(BoundStatement body)
+    public BoundScopeStatement(SyntaxNode syntax, BoundStatement body)
+        : base(syntax)
     {
         Body = body;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundSelectStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundSelectStatement.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
 using System.Collections.Immutable;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
@@ -14,8 +15,10 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundSelectStatement : BoundStatement
 {
     /// <summary>Initializes a new instance of the <see cref="BoundSelectStatement"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="cases">The arms in source order.</param>
-    public BoundSelectStatement(ImmutableArray<BoundSelectCase> cases)
+    public BoundSelectStatement(SyntaxNode syntax, ImmutableArray<BoundSelectCase> cases)
+        : base(syntax)
     {
         Cases = cases;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundSpillSequenceExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundSpillSequenceExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Collections.Immutable;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -18,13 +19,16 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundSpillSequenceExpression : BoundExpression
 {
     /// <summary>Initializes a new instance of the <see cref="BoundSpillSequenceExpression"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="locals">Spill-temp locals owned by this sequence.</param>
     /// <param name="sideEffects">Statements that must run before the value is observed.</param>
     /// <param name="value">The final value expression.</param>
     public BoundSpillSequenceExpression(
+        SyntaxNode syntax,
         ImmutableArray<LocalVariableSymbol> locals,
         ImmutableArray<BoundStatement> sideEffects,
         BoundExpression value)
+        : base(syntax)
     {
         Locals = locals;
         SideEffects = sideEffects;

--- a/src/Core/CodeAnalysis/Binding/BoundStateMachineAwaitOnCompleted.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundStateMachineAwaitOnCompleted.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -17,10 +18,12 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundStateMachineAwaitOnCompleted : BoundExpression
 {
     /// <summary>Initializes a new instance of the <see cref="BoundStateMachineAwaitOnCompleted"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="awaiterLocal">The local variable holding the awaiter.</param>
     /// <param name="awaiterClrType">The CLR type of the awaiter.</param>
     /// <param name="useCritical">Whether to use <c>AwaitUnsafeOnCompleted</c> (true) or <c>AwaitOnCompleted</c> (false).</param>
-    public BoundStateMachineAwaitOnCompleted(VariableSymbol awaiterLocal, Type awaiterClrType, bool useCritical)
+    public BoundStateMachineAwaitOnCompleted(SyntaxNode syntax, VariableSymbol awaiterLocal, Type awaiterClrType, bool useCritical)
+        : base(syntax)
     {
         AwaiterLocal = awaiterLocal ?? throw new ArgumentNullException(nameof(awaiterLocal));
         AwaiterClrType = awaiterClrType ?? throw new ArgumentNullException(nameof(awaiterClrType));

--- a/src/Core/CodeAnalysis/Binding/BoundStateMachineBuilderMoveNext.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundStateMachineBuilderMoveNext.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -15,7 +16,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 #pragma warning disable CS1591
 public sealed class BoundStateMachineBuilderMoveNext : BoundExpression
 {
-    public BoundStateMachineBuilderMoveNext(FieldSymbol builderField, VariableSymbol thisParameter, StructSymbol smClass)
+    public BoundStateMachineBuilderMoveNext(SyntaxNode syntax, FieldSymbol builderField, VariableSymbol thisParameter, StructSymbol smClass)
+        : base(syntax)
     {
         BuilderField = builderField;
         ThisParameter = thisParameter;

--- a/src/Core/CodeAnalysis/Binding/BoundStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundStatement.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -9,4 +11,12 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public abstract class BoundStatement : BoundNode
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundStatement"/> class.
+    /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
+    protected BoundStatement(SyntaxNode syntax)
+        : base(syntax)
+    {
+    }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundStructLiteralExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundStructLiteralExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Collections.Immutable;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -15,7 +16,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundStructLiteralExpression : BoundExpression
 {
-    public BoundStructLiteralExpression(StructSymbol structType, ImmutableArray<BoundFieldInitializer> initializers)
+    public BoundStructLiteralExpression(SyntaxNode syntax, StructSymbol structType, ImmutableArray<BoundFieldInitializer> initializers)
+        : base(syntax)
     {
         StructType = structType;
         Initializers = initializers;

--- a/src/Core/CodeAnalysis/Binding/BoundSwitchExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundSwitchExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Collections.Immutable;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -15,10 +16,12 @@ public sealed class BoundSwitchExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundSwitchExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="discriminant">The bound discriminant expression.</param>
     /// <param name="arms">The bound switch-expression arms.</param>
     /// <param name="type">The unified result type.</param>
-    public BoundSwitchExpression(BoundExpression discriminant, ImmutableArray<BoundSwitchExpressionArm> arms, TypeSymbol type)
+    public BoundSwitchExpression(SyntaxNode syntax, BoundExpression discriminant, ImmutableArray<BoundSwitchExpressionArm> arms, TypeSymbol type)
+        : base(syntax)
     {
         Discriminant = discriminant;
         Arms = arms;

--- a/src/Core/CodeAnalysis/Binding/BoundSwitchExpressionArm.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundSwitchExpressionArm.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -12,9 +14,11 @@ public sealed class BoundSwitchExpressionArm : BoundNode
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundSwitchExpressionArm"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="pattern">The case pattern, or null for <c>default</c>.</param>
     /// <param name="result">The result expression.</param>
-    public BoundSwitchExpressionArm(BoundPattern pattern, BoundExpression result)
+    public BoundSwitchExpressionArm(SyntaxNode syntax, BoundPattern pattern, BoundExpression result)
+        : base(syntax)
     {
         Pattern = pattern;
         Result = result;

--- a/src/Core/CodeAnalysis/Binding/BoundThrowStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundThrowStatement.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -10,8 +12,10 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundThrowStatement : BoundStatement
 {
     /// <summary>Initializes a new instance of the <see cref="BoundThrowStatement"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="expression">The bound exception expression.</param>
-    public BoundThrowStatement(BoundExpression expression)
+    public BoundThrowStatement(SyntaxNode syntax, BoundExpression expression)
+        : base(syntax)
     {
         Expression = expression;
     }

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -106,7 +106,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundBlockStatement(builder.MoveToImmutable());
+        return new BoundBlockStatement(null, builder.MoveToImmutable());
     }
 
     /// <summary>
@@ -122,7 +122,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundVariableDeclaration(node.Variable, initializer);
+        return new BoundVariableDeclaration(null, node.Variable, initializer);
     }
 
     /// <summary>
@@ -140,7 +140,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundIfStatement(condition, thenStatement, elseStatement);
+        return new BoundIfStatement(null, condition, thenStatement, elseStatement);
     }
 
     /// <summary>
@@ -156,7 +156,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundForInfiniteStatement(body, node.BreakLabel, node.ContinueLabel);
+        return new BoundForInfiniteStatement(null, body, node.BreakLabel, node.ContinueLabel);
     }
 
     /// <summary>
@@ -174,7 +174,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundForEllipsisStatement(node.Variable, lowerBound, upperBound, body, node.BreakLabel, node.ContinueLabel);
+        return new BoundForEllipsisStatement(null, node.Variable, lowerBound, upperBound, body, node.BreakLabel, node.ContinueLabel);
     }
 
     /// <summary>
@@ -191,7 +191,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundForRangeStatement(node.KeyVariable, node.ValueVariable, collection, node.IterationKind, body, node.BreakLabel, node.ContinueLabel);
+        return new BoundForRangeStatement(null, node.KeyVariable, node.ValueVariable, collection, node.IterationKind, body, node.BreakLabel, node.ContinueLabel);
     }
 
     /// <summary>
@@ -227,7 +227,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundConditionalGotoStatement(node.Label, condition, node.JumpIfTrue);
+        return new BoundConditionalGotoStatement(null, node.Label, condition, node.JumpIfTrue);
     }
 
     /// <summary>
@@ -243,7 +243,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundReturnStatement(expression);
+        return new BoundReturnStatement(null, expression);
     }
 
     /// <summary>
@@ -259,7 +259,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundExpressionStatement(expression);
+        return new BoundExpressionStatement(null, expression);
     }
 
     /// <summary>
@@ -294,7 +294,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundTryStatement(tryBlock, rewrittenClauses.ToImmutable(), finallyBlock);
+        return new BoundTryStatement(null, tryBlock, rewrittenClauses.ToImmutable(), finallyBlock);
     }
 
     /// <summary>
@@ -310,7 +310,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundThrowStatement(expression);
+        return new BoundThrowStatement(null, expression);
     }
 
     /// <summary>
@@ -482,7 +482,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundAssignmentExpression(node.Variable, expression);
+        return new BoundAssignmentExpression(null, node.Variable, expression);
     }
 
     /// <summary>
@@ -498,7 +498,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundUnaryExpression(node.Op, operand);
+        return new BoundUnaryExpression(null, node.Op, operand);
     }
 
     /// <summary>
@@ -515,7 +515,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundBinaryExpression(left, node.Op, right);
+        return new BoundBinaryExpression(null, left, node.Op, right);
     }
 
     /// <summary>
@@ -555,7 +555,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundCallExpression(node.Function, builder.MoveToImmutable());
+        return new BoundCallExpression(null, node.Function, builder.MoveToImmutable());
     }
 
     /// <summary>
@@ -571,7 +571,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundConversionExpression(node.Type, expression);
+        return new BoundConversionExpression(null, node.Type, expression);
     }
 
     /// <summary>Rewrites a bound await expression (Phase 5.1).</summary>
@@ -585,7 +585,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundAwaitExpression(expression, node.Type);
+        return new BoundAwaitExpression(null, expression, node.Type);
     }
 
     /// <summary>Rewrites a bound switch expression.</summary>
@@ -610,7 +610,7 @@ public abstract class BoundTreeRewriter
                 }
             }
 
-            builder?.Add(new BoundSwitchExpressionArm(pattern, result));
+            builder?.Add(new BoundSwitchExpressionArm(null, pattern, result));
         }
 
         if (discriminant == node.Discriminant && builder == null)
@@ -618,7 +618,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundSwitchExpression(discriminant, builder?.MoveToImmutable() ?? node.Arms, node.Type);
+        return new BoundSwitchExpression(null, discriminant, builder?.MoveToImmutable() ?? node.Arms, node.Type);
     }
 
     /// <summary>Rewrites a bound pattern switch statement.</summary>
@@ -642,7 +642,7 @@ public abstract class BoundTreeRewriter
                 }
             }
 
-            builder?.Add(new BoundPatternSwitchArm(pattern, body));
+            builder?.Add(new BoundPatternSwitchArm(null, pattern, body));
         }
 
         if (discriminant == node.Discriminant && builder == null)
@@ -650,7 +650,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundPatternSwitchStatement(discriminant, builder?.MoveToImmutable() ?? node.Arms);
+        return new BoundPatternSwitchStatement(null, discriminant, builder?.MoveToImmutable() ?? node.Arms);
     }
 
     /// <summary>Rewrites a bound pattern.</summary>
@@ -663,14 +663,14 @@ public abstract class BoundTreeRewriter
             case BoundNodeKind.ConstantPattern:
                 var constant = (BoundConstantPattern)node;
                 var value = RewriteExpression(constant.Value);
-                return value == constant.Value ? node : new BoundConstantPattern(node.Type, value);
+                return value == constant.Value ? node : new BoundConstantPattern(null, node.Type, value);
             case BoundNodeKind.DiscardPattern:
             case BoundNodeKind.TypePattern:
                 return node;
             case BoundNodeKind.RelationalPattern:
                 var relational = (BoundRelationalPattern)node;
                 var relValue = RewriteExpression(relational.Value);
-                return relValue == relational.Value ? node : new BoundRelationalPattern(node.Type, relational.Op, relValue);
+                return relValue == relational.Value ? node : new BoundRelationalPattern(null, node.Type, relational.Op, relValue);
             case BoundNodeKind.PropertyPattern:
                 var property = (BoundPropertyPattern)node;
                 ImmutableArray<BoundPropertyPatternField>.Builder fieldsBuilder = null;
@@ -687,10 +687,10 @@ public abstract class BoundTreeRewriter
                         }
                     }
 
-                    fieldsBuilder?.Add(new BoundPropertyPatternField(field.Field, pattern));
+                    fieldsBuilder?.Add(new BoundPropertyPatternField(null, field.Field, pattern));
                 }
 
-                return fieldsBuilder == null ? node : new BoundPropertyPattern(node.Type, fieldsBuilder.MoveToImmutable());
+                return fieldsBuilder == null ? node : new BoundPropertyPattern(null, node.Type, fieldsBuilder.MoveToImmutable());
             case BoundNodeKind.ListPattern:
                 var list = (BoundListPattern)node;
                 ImmutableArray<BoundPattern>.Builder elementsBuilder = null;
@@ -709,7 +709,7 @@ public abstract class BoundTreeRewriter
                     elementsBuilder?.Add(element);
                 }
 
-                return elementsBuilder == null ? node : new BoundListPattern(node.Type, elementsBuilder.MoveToImmutable(), list.ElementType);
+                return elementsBuilder == null ? node : new BoundListPattern(null, node.Type, elementsBuilder.MoveToImmutable(), list.ElementType);
             default:
                 throw new Exception($"Unexpected pattern node: {node.Kind}");
         }
@@ -726,7 +726,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundGoStatement(expression);
+        return new BoundGoStatement(null, expression);
     }
 
     /// <summary>Rewrites a bound channel-send statement (Phase 5.5).</summary>
@@ -741,7 +741,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundChannelSendStatement(channel, value);
+        return new BoundChannelSendStatement(null, channel, value);
     }
 
     /// <summary>Rewrites a bound select statement (Phase 5.6).</summary>
@@ -773,7 +773,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundSelectStatement(builder.MoveToImmutable());
+        return new BoundSelectStatement(null, builder.MoveToImmutable());
     }
 
     /// <summary>Rewrites a bound scope statement (Phase 5.7).</summary>
@@ -787,7 +787,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundScopeStatement(body);
+        return new BoundScopeStatement(null, body);
     }
 
     /// <summary>Rewrites a bound <c>await for v := range stream</c> statement (Phase 5.8).</summary>
@@ -802,7 +802,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundAwaitForRangeStatement(node.ValueVariable, stream, body);
+        return new BoundAwaitForRangeStatement(null, node.ValueVariable, stream, body);
     }
 
     /// <summary>Rewrites a bound yield statement (ADR-0040).</summary>
@@ -816,7 +816,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundYieldStatement(expression);
+        return new BoundYieldStatement(null, expression);
     }
 
     /// <summary>Rewrites a bound make-channel expression (Phase 5.4).</summary>
@@ -835,7 +835,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundMakeChannelExpression(node.ChannelType, capacity);
+        return new BoundMakeChannelExpression(null, node.ChannelType, capacity);
     }
 
     /// <summary>Rewrites a bound channel-receive expression (Phase 5.5).</summary>
@@ -849,7 +849,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundChannelReceiveExpression(channel, node.Type);
+        return new BoundChannelReceiveExpression(null, channel, node.Type);
     }
 
     /// <summary>Rewrites a bound channel-close expression (Phase 5.4).</summary>
@@ -863,7 +863,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundChannelCloseExpression(channel);
+        return new BoundChannelCloseExpression(null, channel);
     }
 
     /// <summary>
@@ -879,7 +879,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundAddressOfExpression(operand);
+        return new BoundAddressOfExpression(null, operand);
     }
 
     /// <summary>
@@ -895,7 +895,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundDereferenceExpression(operand);
+        return new BoundDereferenceExpression(null, operand);
     }
 
     /// <summary>
@@ -934,7 +934,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundSpillSequenceExpression(node.Locals, builder.MoveToImmutable(), value);
+        return new BoundSpillSequenceExpression(null, node.Locals, builder.MoveToImmutable(), value);
     }
 
     /// <summary>
@@ -974,7 +974,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundImportedCallExpression(node.Function, builder.MoveToImmutable());
+        return new BoundImportedCallExpression(null, node.Function, builder.MoveToImmutable());
     }
 
     /// <summary>
@@ -1016,7 +1016,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundImportedInstanceCallExpression(newReceiver, node.Method, node.Type, args);
+        return new BoundImportedInstanceCallExpression(null, newReceiver, node.Method, node.Type, args);
     }
 
     /// <summary>Rewrites an array creation expression.</summary>
@@ -1041,7 +1041,7 @@ public abstract class BoundTreeRewriter
             builder?.Add(newEl);
         }
 
-        return builder == null ? node : new BoundArrayCreationExpression(node.ContainerType, builder.MoveToImmutable());
+        return builder == null ? node : new BoundArrayCreationExpression(null, node.ContainerType, builder.MoveToImmutable());
     }
 
     /// <summary>Rewrites a map literal expression.</summary>
@@ -1069,7 +1069,7 @@ public abstract class BoundTreeRewriter
                 : new BoundMapEntry(newKey, newValue));
         }
 
-        return builder == null ? node : new BoundMapLiteralExpression(node.MapType, builder.MoveToImmutable());
+        return builder == null ? node : new BoundMapLiteralExpression(null, node.MapType, builder.MoveToImmutable());
     }
 
     /// <summary>Rewrites a <c>delete(m, k)</c> expression.</summary>
@@ -1084,7 +1084,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundMapDeleteExpression(map, key);
+        return new BoundMapDeleteExpression(null, map, key);
     }
 
     /// <summary>Rewrites an index expression.</summary>
@@ -1099,7 +1099,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundIndexExpression(target, index, node.Type);
+        return new BoundIndexExpression(null, target, index, node.Type);
     }
 
     /// <summary>Rewrites an index assignment expression.</summary>
@@ -1114,7 +1114,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundIndexAssignmentExpression(node.Target, index, value, node.Type);
+        return new BoundIndexAssignmentExpression(null, node.Target, index, value, node.Type);
     }
 
     /// <summary>Rewrites a <c>len(x)</c> expression.</summary>
@@ -1123,7 +1123,7 @@ public abstract class BoundTreeRewriter
     protected virtual BoundExpression RewriteLenExpression(BoundLenExpression node)
     {
         var operand = RewriteExpression(node.Operand);
-        return operand == node.Operand ? node : new BoundLenExpression(operand);
+        return operand == node.Operand ? node : new BoundLenExpression(null, operand);
     }
 
     /// <summary>Rewrites a <c>cap(x)</c> expression.</summary>
@@ -1132,7 +1132,7 @@ public abstract class BoundTreeRewriter
     protected virtual BoundExpression RewriteCapExpression(BoundCapExpression node)
     {
         var operand = RewriteExpression(node.Operand);
-        return operand == node.Operand ? node : new BoundCapExpression(operand);
+        return operand == node.Operand ? node : new BoundCapExpression(null, operand);
     }
 
     /// <summary>Rewrites an <c>append(s, e)</c> expression.</summary>
@@ -1147,7 +1147,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundAppendExpression(slice, element, node.SliceType);
+        return new BoundAppendExpression(null, slice, element, node.SliceType);
     }
 
     /// <summary>Rewrites a struct composite literal.</summary>
@@ -1175,7 +1175,7 @@ public abstract class BoundTreeRewriter
             }
         }
 
-        return builder == null ? node : new BoundStructLiteralExpression(node.StructType, builder.ToImmutable());
+        return builder == null ? node : new BoundStructLiteralExpression(null, node.StructType, builder.ToImmutable());
     }
 
     /// <summary>Rewrites a block expression.</summary>
@@ -1209,7 +1209,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundBlockExpression(statementBuilder?.ToImmutable() ?? node.Statements, expression);
+        return new BoundBlockExpression(null, statementBuilder?.ToImmutable() ?? node.Statements, expression);
     }
 
     /// <summary>Rewrites a class primary-constructor call.</summary>
@@ -1237,7 +1237,7 @@ public abstract class BoundTreeRewriter
             }
         }
 
-        return builder == null ? node : new BoundConstructorCallExpression(node.StructType, builder.ToImmutable());
+        return builder == null ? node : new BoundConstructorCallExpression(null, node.StructType, builder.ToImmutable());
     }
 
     /// <summary>Rewrites a CLR constructor call (Phase 4 exit).</summary>
@@ -1265,7 +1265,7 @@ public abstract class BoundTreeRewriter
             }
         }
 
-        return builder == null ? node : new BoundClrConstructorCallExpression(node.ClrType, node.Constructor, builder.ToImmutable(), node.Type);
+        return builder == null ? node : new BoundClrConstructorCallExpression(null, node.ClrType, node.Constructor, builder.ToImmutable(), node.Type);
     }
 
     /// <summary>Rewrites a CLR static method call expression.</summary>
@@ -1293,7 +1293,7 @@ public abstract class BoundTreeRewriter
             }
         }
 
-        return builder == null ? node : new BoundClrStaticCallExpression(node.Method, node.Type, builder.ToImmutable(), node.ArgumentRefKinds);
+        return builder == null ? node : new BoundClrStaticCallExpression(null, node.Method, node.Type, builder.ToImmutable(), node.ArgumentRefKinds);
     }
 
     /// <summary>Rewrites a CLR property/field access on a CLR receiver.</summary>
@@ -1307,7 +1307,7 @@ public abstract class BoundTreeRewriter
         }
 
         var receiver = RewriteExpression(node.Receiver);
-        return receiver == node.Receiver ? node : new BoundClrPropertyAccessExpression(receiver, node.Member, node.Type);
+        return receiver == node.Receiver ? node : new BoundClrPropertyAccessExpression(null, receiver, node.Member, node.Type);
     }
 
     /// <summary>Rewrites a CLR property/field write (static or instance).</summary>
@@ -1322,7 +1322,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundClrPropertyAssignmentExpression(receiver, node.Member, value, node.Type);
+        return new BoundClrPropertyAssignmentExpression(null, receiver, node.Member, value, node.Type);
     }
 
     /// <summary>Rewrites a CLR event subscription (Stream B′).</summary>
@@ -1337,7 +1337,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundClrEventSubscriptionExpression(receiver, node.Event, handler, node.IsAdd);
+        return new BoundClrEventSubscriptionExpression(null, receiver, node.Event, handler, node.IsAdd);
     }
 
     /// <summary>Rewrites a CLR binary operator call (Stream C).</summary>
@@ -1352,7 +1352,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundClrBinaryOperatorExpression(node.OperatorKind, left, right, node.Method, node.Type);
+        return new BoundClrBinaryOperatorExpression(null, node.OperatorKind, left, right, node.Method, node.Type);
     }
 
     /// <summary>Rewrites a CLR unary operator call (Stream C).</summary>
@@ -1366,7 +1366,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundClrUnaryOperatorExpression(node.OperatorKind, operand, node.Method, node.Type);
+        return new BoundClrUnaryOperatorExpression(null, node.OperatorKind, operand, node.Method, node.Type);
     }
 
     /// <summary>Rewrites a CLR conversion call (Stream E).</summary>
@@ -1380,7 +1380,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundClrConversionCallExpression(source, node.Method, node.Type);
+        return new BoundClrConversionCallExpression(null, source, node.Method, node.Type);
     }
 
     /// <summary>Rewrites a CLR indexer read.</summary>
@@ -1415,7 +1415,7 @@ public abstract class BoundTreeRewriter
         }
 
         var args = builder?.ToImmutable() ?? node.Arguments;
-        return new BoundClrIndexExpression(target, node.Indexer, args, node.Type);
+        return new BoundClrIndexExpression(null, target, node.Indexer, args, node.Type);
     }
 
     /// <summary>Rewrites a CLR indexer write.</summary>
@@ -1450,7 +1450,7 @@ public abstract class BoundTreeRewriter
         }
 
         var args = builder?.ToImmutable() ?? node.Arguments;
-        return new BoundClrIndexAssignmentExpression(node.Target, node.Indexer, args, value, node.Type);
+        return new BoundClrIndexAssignmentExpression(null, node.Target, node.Indexer, args, value, node.Type);
     }
 
     /// <summary>Rewrites an instance-method call on a user-defined class.</summary>
@@ -1484,7 +1484,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundUserInstanceCallExpression(receiver, node.Method, builder?.ToImmutable() ?? node.Arguments);
+        return new BoundUserInstanceCallExpression(null, receiver, node.Method, builder?.ToImmutable() ?? node.Arguments);
     }
 
     /// <summary>Rewrites a field read.</summary>
@@ -1493,7 +1493,7 @@ public abstract class BoundTreeRewriter
     protected virtual BoundExpression RewriteFieldAccessExpression(BoundFieldAccessExpression node)
     {
         var receiver = RewriteExpression(node.Receiver);
-        return receiver == node.Receiver ? node : new BoundFieldAccessExpression(receiver, node.StructType, node.Field);
+        return receiver == node.Receiver ? node : new BoundFieldAccessExpression(null, receiver, node.StructType, node.Field);
     }
 
     /// <summary>Rewrites a field assignment.</summary>
@@ -1502,7 +1502,7 @@ public abstract class BoundTreeRewriter
     protected virtual BoundExpression RewriteFieldAssignmentExpression(BoundFieldAssignmentExpression node)
     {
         var value = RewriteExpression(node.Value);
-        return value == node.Value ? node : new BoundFieldAssignmentExpression(node.Receiver, node.StructType, node.Field, value);
+        return value == node.Value ? node : new BoundFieldAssignmentExpression(null, node.Receiver, node.StructType, node.Field, value);
     }
 
     /// <summary>Rewrites a null-conditional access expression (Phase 3.C.3b).</summary>
@@ -1517,7 +1517,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundNullConditionalAccessExpression(receiver, node.Capture, whenNotNull, node.Type);
+        return new BoundNullConditionalAccessExpression(null, receiver, node.Capture, whenNotNull, node.Type);
     }
 
     /// <summary>Rewrites a tuple literal (Phase 4.5).</summary>
@@ -1542,7 +1542,7 @@ public abstract class BoundTreeRewriter
             builder?.Add(newEl);
         }
 
-        return builder == null ? node : new BoundTupleLiteralExpression(node.TupleType, builder.ToImmutable());
+        return builder == null ? node : new BoundTupleLiteralExpression(null, node.TupleType, builder.ToImmutable());
     }
 
     /// <summary>Rewrites a tuple element access (Phase 4.5).</summary>
@@ -1551,7 +1551,7 @@ public abstract class BoundTreeRewriter
     protected virtual BoundExpression RewriteTupleElementAccessExpression(BoundTupleElementAccessExpression node)
     {
         var receiver = RewriteExpression(node.Receiver);
-        return receiver == node.Receiver ? node : new BoundTupleElementAccessExpression(receiver, node.TupleType, node.Index);
+        return receiver == node.Receiver ? node : new BoundTupleElementAccessExpression(null, receiver, node.TupleType, node.Index);
     }
 
     /// <summary>Rewrites a function literal (Phase 4.7). The body is intentionally not rewritten because it forms a separate lexical scope.</summary>
@@ -1590,6 +1590,6 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundIndirectCallExpression(target, node.FunctionType, builder?.ToImmutable() ?? node.Arguments);
+        return new BoundIndirectCallExpression(null, target, node.FunctionType, builder?.ToImmutable() ?? node.Arguments);
     }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundTryStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTryStatement.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
 using System.Collections.Immutable;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
@@ -12,10 +13,12 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundTryStatement : BoundStatement
 {
     /// <summary>Initializes a new instance of the <see cref="BoundTryStatement"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="tryBlock">The protected block.</param>
     /// <param name="catchClauses">The bound catch clauses (possibly empty).</param>
     /// <param name="finallyBlock">The optional finally block.</param>
-    public BoundTryStatement(BoundStatement tryBlock, ImmutableArray<BoundCatchClause> catchClauses, BoundStatement finallyBlock)
+    public BoundTryStatement(SyntaxNode syntax, BoundStatement tryBlock, ImmutableArray<BoundCatchClause> catchClauses, BoundStatement finallyBlock)
+        : base(syntax)
     {
         TryBlock = tryBlock;
         CatchClauses = catchClauses;

--- a/src/Core/CodeAnalysis/Binding/BoundTupleElementAccessExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTupleElementAccessExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -14,7 +15,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundTupleElementAccessExpression : BoundExpression
 {
-    public BoundTupleElementAccessExpression(BoundExpression receiver, TupleTypeSymbol tupleType, int index)
+    public BoundTupleElementAccessExpression(SyntaxNode syntax, BoundExpression receiver, TupleTypeSymbol tupleType, int index)
+        : base(syntax)
     {
         Receiver = receiver;
         TupleType = tupleType;

--- a/src/Core/CodeAnalysis/Binding/BoundTupleLiteralExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTupleLiteralExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Collections.Immutable;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -18,7 +19,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundTupleLiteralExpression : BoundExpression
 {
-    public BoundTupleLiteralExpression(TupleTypeSymbol tupleType, ImmutableArray<BoundExpression> elements)
+    public BoundTupleLiteralExpression(SyntaxNode syntax, TupleTypeSymbol tupleType, ImmutableArray<BoundExpression> elements)
+        : base(syntax)
     {
         TupleType = tupleType;
         Elements = elements;

--- a/src/Core/CodeAnalysis/Binding/BoundTypeOfExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTypeOfExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -15,9 +16,11 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundTypeOfExpression : BoundExpression
 {
     /// <summary>Initializes a new instance of the <see cref="BoundTypeOfExpression"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="operandType">The type that this <c>typeof</c> references.</param>
     /// <param name="systemType">The <c>System.Type</c> symbol used as the result type.</param>
-    public BoundTypeOfExpression(TypeSymbol operandType, TypeSymbol systemType)
+    public BoundTypeOfExpression(SyntaxNode syntax, TypeSymbol operandType, TypeSymbol systemType)
+        : base(syntax)
     {
         OperandType = operandType;
         Type = systemType;

--- a/src/Core/CodeAnalysis/Binding/BoundTypePattern.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTypePattern.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -10,11 +11,12 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundTypePattern : BoundPattern
 {
     /// <summary>Initializes a new instance of the <see cref="BoundTypePattern"/> class.</summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="type">The discriminant type.</param>
     /// <param name="targetType">The target type.</param>
     /// <param name="variable">The introduced variable.</param>
-    public BoundTypePattern(TypeSymbol type, TypeSymbol targetType, LocalVariableSymbol variable)
-        : base(type)
+    public BoundTypePattern(SyntaxNode syntax, TypeSymbol type, TypeSymbol targetType, LocalVariableSymbol variable)
+        : base(syntax, type)
     {
         TargetType = targetType;
         Variable = variable;

--- a/src/Core/CodeAnalysis/Binding/BoundUnaryExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundUnaryExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -14,9 +15,11 @@ public sealed class BoundUnaryExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundUnaryExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="op">The bound unary operator.</param>
     /// <param name="operand">The bound expression.</param>
-    public BoundUnaryExpression(BoundUnaryOperator op, BoundExpression operand)
+    public BoundUnaryExpression(SyntaxNode syntax, BoundUnaryOperator op, BoundExpression operand)
+        : base(syntax)
     {
         Op = op;
         Operand = operand;

--- a/src/Core/CodeAnalysis/Binding/BoundUserInstanceCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundUserInstanceCallExpression.cs
@@ -2,8 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using System.Collections.Immutable;
 
 #pragma warning disable CS1591
 #pragma warning disable SA1600
@@ -20,12 +21,13 @@ public sealed class BoundUserInstanceCallExpression : BoundExpression
 {
     private readonly TypeSymbol returnTypeOverride;
 
-    public BoundUserInstanceCallExpression(BoundExpression receiver, FunctionSymbol method, ImmutableArray<BoundExpression> arguments)
-        : this(receiver, method, arguments, returnTypeOverride: null)
+    public BoundUserInstanceCallExpression(SyntaxNode syntax, BoundExpression receiver, FunctionSymbol method, ImmutableArray<BoundExpression> arguments)
+        : this(syntax, receiver, method, arguments, returnTypeOverride: null)
     {
     }
 
-    public BoundUserInstanceCallExpression(BoundExpression receiver, FunctionSymbol method, ImmutableArray<BoundExpression> arguments, TypeSymbol returnTypeOverride)
+    public BoundUserInstanceCallExpression(SyntaxNode syntax, BoundExpression receiver, FunctionSymbol method, ImmutableArray<BoundExpression> arguments, TypeSymbol returnTypeOverride)
+        : base(syntax)
     {
         Receiver = receiver;
         Method = method;

--- a/src/Core/CodeAnalysis/Binding/BoundVariableDeclaration.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundVariableDeclaration.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -14,9 +15,11 @@ public sealed class BoundVariableDeclaration : BoundStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundVariableDeclaration"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="variable">The variable symbol.</param>
     /// <param name="initializer">The bound expression.</param>
-    public BoundVariableDeclaration(VariableSymbol variable, BoundExpression initializer)
+    public BoundVariableDeclaration(SyntaxNode syntax, VariableSymbol variable, BoundExpression initializer)
+        : base(syntax)
     {
         Variable = variable;
         Initializer = initializer;

--- a/src/Core/CodeAnalysis/Binding/BoundVariableExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundVariableExpression.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -14,9 +15,10 @@ public sealed class BoundVariableExpression : BoundExpression
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundVariableExpression"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="variable">The variable symbol.</param>
-    public BoundVariableExpression(VariableSymbol variable)
-        : this(variable, narrowedType: null)
+    public BoundVariableExpression(SyntaxNode syntax, VariableSymbol variable)
+        : this(syntax, variable, narrowedType: null)
     {
     }
 
@@ -28,11 +30,13 @@ public sealed class BoundVariableExpression : BoundExpression
     /// underlying symbol identity (so the evaluator still loads from the
     /// original slot).
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="variable">The variable symbol.</param>
     /// <param name="narrowedType">The narrowed type to report from
     /// <see cref="Type"/>. Pass <c>null</c> to use the variable's declared
     /// type.</param>
-    public BoundVariableExpression(VariableSymbol variable, TypeSymbol narrowedType)
+    public BoundVariableExpression(SyntaxNode syntax, VariableSymbol variable, TypeSymbol narrowedType)
+        : base(syntax)
     {
         Variable = variable;
         NarrowedType = narrowedType;

--- a/src/Core/CodeAnalysis/Binding/BoundYieldStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundYieldStatement.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -12,8 +14,10 @@ public sealed class BoundYieldStatement : BoundStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundYieldStatement"/> class.
     /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
     /// <param name="expression">The expression whose value is yielded.</param>
-    public BoundYieldStatement(BoundExpression expression)
+    public BoundYieldStatement(SyntaxNode syntax, BoundExpression expression)
+        : base(syntax)
     {
         Expression = expression;
     }

--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -468,11 +468,11 @@ public sealed class ControlFlowGraph
             if (condition is BoundLiteralExpression literal)
             {
                 var value = (bool)literal.Value;
-                return new BoundLiteralExpression(!value);
+                return new BoundLiteralExpression(null, !value);
             }
 
             var op = BoundUnaryOperator.Bind(SyntaxKind.BangToken, TypeSymbol.Bool);
-            return new BoundUnaryExpression(op, condition);
+            return new BoundUnaryExpression(null, op, condition);
         }
     }
 }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -3780,9 +3780,9 @@ internal sealed class ReflectionMetadataEmitter
             var isAsync = exprClr != null && typeof(System.Threading.Tasks.Task).IsAssignableFrom(exprClr);
             var returnType = isAsync ? TypeSymbol.FromClrType(typeof(System.Threading.Tasks.Task)) : TypeSymbol.Void;
             BoundStatement bodyStatement = isAsync
-                ? new BoundReturnStatement(go.Expression)
-                : new BoundExpressionStatement(go.Expression);
-            var body = new BoundBlockStatement(ImmutableArray.Create(bodyStatement));
+                ? new BoundReturnStatement(null, go.Expression)
+                : new BoundExpressionStatement(null, go.Expression);
+            var body = new BoundBlockStatement(null, ImmutableArray.Create(bodyStatement));
 
             var closureName = "<go_" + System.Threading.Interlocked.Increment(ref this.closureCounter).ToString(System.Globalization.CultureInfo.InvariantCulture) + ">";
             var info = this.SynthesizeDisplayClass(
@@ -3862,25 +3862,34 @@ internal sealed class ReflectionMetadataEmitter
 
             var moveNextBody = IteratorMoveNextBodyBuilder.BuildWithFieldAccess(plan, stateField, currentField, moveNext.ThisParameter, smClass, fieldMap).Body;
             this.lambdaBodies[moveNext] = moveNextBody;
-            this.lambdaBodies[getCurrent] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-                new BoundReturnStatement(new BoundFieldAccessExpression(new BoundVariableExpression(getCurrent.ThisParameter), smClass, currentField)))));
-            this.lambdaBodies[getCurrentObject] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-                new BoundReturnStatement(new BoundConversionExpression(
+            this.lambdaBodies[getCurrent] = Lowerer.Lower(new BoundBlockStatement(null,
+                ImmutableArray.Create<BoundStatement>(
+                new BoundReturnStatement(null, new BoundFieldAccessExpression(null, new BoundVariableExpression(null, getCurrent.ThisParameter), smClass, currentField)))));
+            this.lambdaBodies[getCurrentObject] = Lowerer.Lower(new BoundBlockStatement(null,
+                ImmutableArray.Create<BoundStatement>(
+                new BoundReturnStatement(null,
+                    new BoundConversionExpression(
+                    null,
                     TypeSymbol.FromClrType(typeof(object)),
-                    new BoundFieldAccessExpression(new BoundVariableExpression(getCurrentObject.ThisParameter), smClass, currentField))))));
-            this.lambdaBodies[dispose] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-                new BoundExpressionStatement(new BoundFieldAssignmentExpression(dispose.ThisParameter, smClass, stateField, new BoundLiteralExpression(-1))),
-                new BoundReturnStatement(null))));
-            this.lambdaBodies[reset] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-                new BoundExpressionStatement(new BoundFieldAssignmentExpression(reset.ThisParameter, smClass, stateField, new BoundLiteralExpression(-1))),
-                new BoundReturnStatement(null))));
-            this.lambdaBodies[getEnumerator] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-                new BoundReturnStatement(this.CreateIteratorStateMachineLiteral(smClass, stateField, parameterFields, plan.Function.Parameters, p => new BoundFieldAccessExpression(new BoundVariableExpression(getEnumerator.ThisParameter), smClass, parameterFields[p]))))));
-            this.lambdaBodies[getEnumeratorObject] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-                new BoundReturnStatement(this.CreateIteratorStateMachineLiteral(smClass, stateField, parameterFields, plan.Function.Parameters, p => new BoundFieldAccessExpression(new BoundVariableExpression(getEnumeratorObject.ThisParameter), smClass, parameterFields[p]))))));
+                    new BoundFieldAccessExpression(null, new BoundVariableExpression(null, getCurrentObject.ThisParameter), smClass, currentField))))));
+            this.lambdaBodies[dispose] = Lowerer.Lower(new BoundBlockStatement(null,
+                ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(null, new BoundFieldAssignmentExpression(null, dispose.ThisParameter, smClass, stateField, new BoundLiteralExpression(null, -1))),
+                new BoundReturnStatement(null, null))));
+            this.lambdaBodies[reset] = Lowerer.Lower(new BoundBlockStatement(null,
+                ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(null, new BoundFieldAssignmentExpression(null, reset.ThisParameter, smClass, stateField, new BoundLiteralExpression(null, -1))),
+                new BoundReturnStatement(null, null))));
+            this.lambdaBodies[getEnumerator] = Lowerer.Lower(new BoundBlockStatement(null,
+                ImmutableArray.Create<BoundStatement>(
+                new BoundReturnStatement(null, this.CreateIteratorStateMachineLiteral(smClass, stateField, parameterFields, plan.Function.Parameters, p => new BoundFieldAccessExpression(null, new BoundVariableExpression(null, getEnumerator.ThisParameter), smClass, parameterFields[p]))))));
+            this.lambdaBodies[getEnumeratorObject] = Lowerer.Lower(new BoundBlockStatement(null,
+                ImmutableArray.Create<BoundStatement>(
+                new BoundReturnStatement(null, this.CreateIteratorStateMachineLiteral(smClass, stateField, parameterFields, plan.Function.Parameters, p => new BoundFieldAccessExpression(null, new BoundVariableExpression(null, getEnumeratorObject.ThisParameter), smClass, parameterFields[p]))))));
 
-            this.iteratorKickoffBodies[plan.Function] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-                new BoundReturnStatement(this.CreateIteratorStateMachineLiteral(smClass, stateField, parameterFields, plan.Function.Parameters, p => new BoundVariableExpression(p))))));
+            this.iteratorKickoffBodies[plan.Function] = Lowerer.Lower(new BoundBlockStatement(null,
+                ImmutableArray.Create<BoundStatement>(
+                new BoundReturnStatement(null, this.CreateIteratorStateMachineLiteral(smClass, stateField, parameterFields, plan.Function.Parameters, p => new BoundVariableExpression(null, p))))));
             this.iteratorStateMachineInfos[smClass] = new IteratorStateMachineInfo(plan, smClass);
             this.synthesizedClosureClasses.Add(smClass);
         }
@@ -3894,13 +3903,13 @@ internal sealed class ReflectionMetadataEmitter
         Func<ParameterSymbol, BoundExpression> parameterValueFactory)
     {
         var initializers = ImmutableArray.CreateBuilder<BoundFieldInitializer>();
-        initializers.Add(new BoundFieldInitializer(stateField, new BoundLiteralExpression(0)));
+        initializers.Add(new BoundFieldInitializer(stateField, new BoundLiteralExpression(null, 0)));
         foreach (var parameter in parameters)
         {
             initializers.Add(new BoundFieldInitializer(parameterFields[parameter], parameterValueFactory(parameter)));
         }
 
-        return new BoundStructLiteralExpression(smClass, initializers.ToImmutable());
+        return new BoundStructLiteralExpression(null, smClass, initializers.ToImmutable());
     }
 
     private void AddIteratorInterfaceImplementations(StructSymbol smClass, IteratorStateMachineInfo info)
@@ -4042,8 +4051,9 @@ internal sealed class ReflectionMetadataEmitter
             this.lambdaBodies[moveNext] = Lowerer.Lower(moveNextBody);
 
             // get_Current: return this.<>2__current;
-            this.lambdaBodies[getCurrent] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-                new BoundReturnStatement(new BoundFieldAccessExpression(new BoundVariableExpression(getCurrent.ThisParameter), smClass, currentField)))));
+            this.lambdaBodies[getCurrent] = Lowerer.Lower(new BoundBlockStatement(null,
+                ImmutableArray.Create<BoundStatement>(
+                new BoundReturnStatement(null, new BoundFieldAccessExpression(null, new BoundVariableExpression(null, getCurrent.ThisParameter), smClass, currentField)))));
 
             // MoveNextAsync: reset promise, call builder.MoveNext(ref this), return ValueTask<bool>
             // For simplicity: directly set result. The builder calls MoveNext synchronously first;
@@ -4086,12 +4096,14 @@ internal sealed class ReflectionMetadataEmitter
             this.lambdaBodies[onCompleted] = this.BuildVtsOnCompletedBody(onCompleted, smClass, promiseField);
 
             // IAsyncStateMachine.SetStateMachine: no-op (just return)
-            this.lambdaBodies[setStateMachine] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-                new BoundReturnStatement(null))));
+            this.lambdaBodies[setStateMachine] = Lowerer.Lower(new BoundBlockStatement(null,
+                ImmutableArray.Create<BoundStatement>(
+                new BoundReturnStatement(null, null))));
 
             // Kickoff body: new SM { state = -3, params... }
-            this.iteratorKickoffBodies[plan.Function] = Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-                new BoundReturnStatement(this.CreateAsyncIteratorKickoffLiteral(smClass, stateField, builderField, parameterFields, plan.Function.Parameters)))));
+            this.iteratorKickoffBodies[plan.Function] = Lowerer.Lower(new BoundBlockStatement(null,
+                ImmutableArray.Create<BoundStatement>(
+                new BoundReturnStatement(null, this.CreateAsyncIteratorKickoffLiteral(smClass, stateField, builderField, parameterFields, plan.Function.Parameters)))));
 
             this.asyncIteratorInfos[smClass] = plan;
             this.synthesizedClosureClasses.Add(smClass);
@@ -4117,51 +4129,59 @@ internal sealed class ReflectionMetadataEmitter
         // if (state == -2) return default(ValueTask<bool>); // completed
         var finishedLabel = new BoundLabel("<>mna_notFinished");
         stmts.Add(new BoundConditionalGotoStatement(
+            null,
             finishedLabel,
             new BoundBinaryExpression(
-                new BoundFieldAccessExpression(new BoundVariableExpression(thisParam), smClass, stateField),
+                null,
+                new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisParam), smClass, stateField),
                 BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
-                new BoundLiteralExpression(StateMachineStates.FinishedState)),
+                new BoundLiteralExpression(null, StateMachineStates.FinishedState)),
             jumpIfTrue: false));
         // Return a completed ValueTask<bool>(false)
-        stmts.Add(new BoundReturnStatement(new BoundDefaultExpression(TypeSymbol.FromClrType(typeof(System.Threading.Tasks.ValueTask<bool>)))));
-        stmts.Add(new BoundLabelStatement(finishedLabel));
+        stmts.Add(new BoundReturnStatement(null, new BoundDefaultExpression(null, TypeSymbol.FromClrType(typeof(System.Threading.Tasks.ValueTask<bool>)))));
+        stmts.Add(new BoundLabelStatement(null, finishedLabel));
 
         // promise.Reset();
         var promiseType = typeof(System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>);
         var resetMethod = promiseType.GetMethod("Reset");
         var promiseAddr = new BoundAddressOfExpression(
-            new BoundFieldAccessExpression(new BoundVariableExpression(thisParam), smClass, promiseField));
-        stmts.Add(new BoundExpressionStatement(new BoundImportedInstanceCallExpression(
+            null,
+            new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisParam), smClass, promiseField));
+        stmts.Add(new BoundExpressionStatement(null,
+            new BoundImportedInstanceCallExpression(
+            null,
             promiseAddr, resetMethod, TypeSymbol.Void, ImmutableArray<BoundExpression>.Empty)));
 
         // builder.MoveNext(ref this); — uses marker node for MethodSpec emission
-        stmts.Add(new BoundExpressionStatement(new BoundStateMachineBuilderMoveNext(builderField, thisParam, smClass)));
+        stmts.Add(new BoundExpressionStatement(null, new BoundStateMachineBuilderMoveNext(null, builderField, thisParam, smClass)));
 
         // short version = promise.Version;
         var versionProp = promiseType.GetProperty("Version");
         var versionGetter = versionProp.GetGetMethod();
         var promiseAddr2 = new BoundAddressOfExpression(
-            new BoundFieldAccessExpression(new BoundVariableExpression(thisParam), smClass, promiseField));
+            null,
+            new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisParam), smClass, promiseField));
         var versionCall = new BoundImportedInstanceCallExpression(
+            null,
             promiseAddr2, versionGetter, TypeSymbol.FromClrType(typeof(short)), ImmutableArray<BoundExpression>.Empty);
         var versionLocal = new LocalVariableSymbol("<>version", isReadOnly: false, TypeSymbol.FromClrType(typeof(short)));
-        stmts.Add(new BoundVariableDeclaration(versionLocal, versionCall));
+        stmts.Add(new BoundVariableDeclaration(null, versionLocal, versionCall));
 
         // return new ValueTask<bool>(this, version);
         // The ValueTask<bool>(IValueTaskSource<bool>, short) constructor
         var vtCtor = typeof(System.Threading.Tasks.ValueTask<bool>).GetConstructor(
             new[] { typeof(System.Threading.Tasks.Sources.IValueTaskSource<bool>), typeof(short) });
         var vtConstruct = new BoundClrConstructorCallExpression(
+            null,
             typeof(System.Threading.Tasks.ValueTask<bool>),
             vtCtor,
             ImmutableArray.Create<BoundExpression>(
-                new BoundVariableExpression(thisParam),
-                new BoundVariableExpression(versionLocal)),
+                new BoundVariableExpression(null, thisParam),
+                new BoundVariableExpression(null, versionLocal)),
             TypeSymbol.FromClrType(typeof(System.Threading.Tasks.ValueTask<bool>)));
-        stmts.Add(new BoundReturnStatement(vtConstruct));
+        stmts.Add(new BoundReturnStatement(null, vtConstruct));
 
-        return Lowerer.Lower(new BoundBlockStatement(stmts.ToImmutable()));
+        return Lowerer.Lower(new BoundBlockStatement(null, stmts.ToImmutable()));
     }
 
     private BoundBlockStatement BuildDisposeAsyncBody(
@@ -4178,31 +4198,36 @@ internal sealed class ReflectionMetadataEmitter
 
         // if (state == -2) return default(ValueTask);
         var finishedCheck = new BoundBinaryExpression(
-            new BoundFieldAccessExpression(new BoundVariableExpression(thisParam), smClass, stateField),
+            null,
+            new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisParam), smClass, stateField),
             BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
-            new BoundLiteralExpression(StateMachineStates.FinishedState));
-        var earlyReturn = new BoundReturnStatement(new BoundDefaultExpression(TypeSymbol.FromClrType(typeof(System.Threading.Tasks.ValueTask))));
-        stmts.Add(new BoundIfStatement(finishedCheck, earlyReturn, null));
+            new BoundLiteralExpression(null, StateMachineStates.FinishedState));
+        var earlyReturn = new BoundReturnStatement(null, new BoundDefaultExpression(null, TypeSymbol.FromClrType(typeof(System.Threading.Tasks.ValueTask))));
+        stmts.Add(new BoundIfStatement(null, finishedCheck, earlyReturn, null));
 
         // this.<>w__disposeMode = true;
         stmts.Add(new BoundExpressionStatement(
-            new BoundFieldAssignmentExpression(thisParam, smClass, disposeModeField, new BoundLiteralExpression(true))));
+            null,
+            new BoundFieldAssignmentExpression(null, thisParam, smClass, disposeModeField, new BoundLiteralExpression(null, true))));
 
         // promise.Reset();
         var promiseType = typeof(System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>);
         var resetMethod = promiseType.GetMethod("Reset");
         var promiseAddr = new BoundAddressOfExpression(
-            new BoundFieldAccessExpression(new BoundVariableExpression(thisParam), smClass, promiseField));
-        stmts.Add(new BoundExpressionStatement(new BoundImportedInstanceCallExpression(
+            null,
+            new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisParam), smClass, promiseField));
+        stmts.Add(new BoundExpressionStatement(null,
+            new BoundImportedInstanceCallExpression(
+            null,
             promiseAddr, resetMethod, TypeSymbol.Void, ImmutableArray<BoundExpression>.Empty)));
 
         // builder.MoveNext(ref this); — uses marker node for MethodSpec emission
-        stmts.Add(new BoundExpressionStatement(new BoundStateMachineBuilderMoveNext(builderField, thisParam, smClass)));
+        stmts.Add(new BoundExpressionStatement(null, new BoundStateMachineBuilderMoveNext(null, builderField, thisParam, smClass)));
 
         // Return default ValueTask (completed).
-        stmts.Add(new BoundReturnStatement(new BoundDefaultExpression(TypeSymbol.FromClrType(typeof(System.Threading.Tasks.ValueTask)))));
+        stmts.Add(new BoundReturnStatement(null, new BoundDefaultExpression(null, TypeSymbol.FromClrType(typeof(System.Threading.Tasks.ValueTask)))));
 
-        return Lowerer.Lower(new BoundBlockStatement(stmts.ToImmutable()));
+        return Lowerer.Lower(new BoundBlockStatement(null, stmts.ToImmutable()));
     }
 
     private BoundBlockStatement BuildGetAsyncEnumeratorBody(
@@ -4219,13 +4244,17 @@ internal sealed class ReflectionMetadataEmitter
 
         // this.<>1__state = -1; (running state)
         stmts.Add(new BoundExpressionStatement(
-            new BoundFieldAssignmentExpression(thisParam, smClass, stateField,
-                new BoundLiteralExpression(StateMachineStates.NotStartedOrRunningState))));
+            null,
+            new BoundFieldAssignmentExpression(null,
+                thisParam, smClass, stateField,
+                new BoundLiteralExpression(null, StateMachineStates.NotStartedOrRunningState))));
 
         // this.<>w__disposeMode = false; (reset dispose flag for re-enumeration)
         stmts.Add(new BoundExpressionStatement(
-            new BoundFieldAssignmentExpression(thisParam, smClass, disposeModeField,
-                new BoundLiteralExpression(false))));
+            null,
+            new BoundFieldAssignmentExpression(null,
+                thisParam, smClass, disposeModeField,
+                new BoundLiteralExpression(null, false))));
 
         // Issue #180 / ADR-0040: thread the runtime-supplied cancellation
         // token into the user's @EnumeratorCancellation parameter. The C#
@@ -4262,19 +4291,23 @@ internal sealed class ReflectionMetadataEmitter
                     .GetProperty(nameof(System.Threading.CancellationToken.CanBeCanceled))
                     .GetGetMethod();
                 var canBeCanceledCall = new BoundImportedInstanceCallExpression(
-                    new BoundAddressOfExpression(new BoundVariableExpression(ctParam)),
+                    null,
+                    new BoundAddressOfExpression(null, new BoundVariableExpression(null, ctParam)),
                     canBeCanceledGetter,
                     TypeSymbol.Bool,
                     ImmutableArray<BoundExpression>.Empty);
 
                 var assign = new BoundExpressionStatement(
+                    null,
                     new BoundFieldAssignmentExpression(
+                        null,
                         thisParam, smClass, paramField,
-                        new BoundVariableExpression(ctParam)));
+                        new BoundVariableExpression(null, ctParam)));
 
                 stmts.Add(new BoundIfStatement(
+                    null,
                     canBeCanceledCall,
-                    new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(assign)),
+                    new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(assign)),
                     elseStatement: null));
 
                 // Only one parameter may carry the marker; if a user wrote
@@ -4285,9 +4318,9 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         // return this;
-        stmts.Add(new BoundReturnStatement(new BoundVariableExpression(thisParam)));
+        stmts.Add(new BoundReturnStatement(null, new BoundVariableExpression(null, thisParam)));
 
-        return Lowerer.Lower(new BoundBlockStatement(stmts.ToImmutable()));
+        return Lowerer.Lower(new BoundBlockStatement(null, stmts.ToImmutable()));
     }
 
     private BoundBlockStatement BuildVtsGetStatusBody(FunctionSymbol func, StructSymbol smClass, FieldSymbol promiseField)
@@ -4298,11 +4331,13 @@ internal sealed class ReflectionMetadataEmitter
         var promiseType = typeof(System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>);
         var method = promiseType.GetMethod("GetStatus", new[] { typeof(short) });
         var promiseAddr = new BoundAddressOfExpression(
-            new BoundFieldAccessExpression(new BoundVariableExpression(thisParam), smClass, promiseField));
+            null,
+            new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisParam), smClass, promiseField));
         var call = new BoundImportedInstanceCallExpression(
+            null,
             promiseAddr, method, TypeSymbol.FromClrType(typeof(System.Threading.Tasks.Sources.ValueTaskSourceStatus)),
-            ImmutableArray.Create<BoundExpression>(new BoundVariableExpression(tokenParam)));
-        return Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(new BoundReturnStatement(call))));
+            ImmutableArray.Create<BoundExpression>(new BoundVariableExpression(null, tokenParam)));
+        return Lowerer.Lower(new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(new BoundReturnStatement(null, call))));
     }
 
     private BoundBlockStatement BuildVtsGetResultBody(FunctionSymbol func, StructSymbol smClass, FieldSymbol promiseField)
@@ -4313,11 +4348,13 @@ internal sealed class ReflectionMetadataEmitter
         var promiseType = typeof(System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>);
         var method = promiseType.GetMethod("GetResult", new[] { typeof(short) });
         var promiseAddr = new BoundAddressOfExpression(
-            new BoundFieldAccessExpression(new BoundVariableExpression(thisParam), smClass, promiseField));
+            null,
+            new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisParam), smClass, promiseField));
         var call = new BoundImportedInstanceCallExpression(
+            null,
             promiseAddr, method, TypeSymbol.Bool,
-            ImmutableArray.Create<BoundExpression>(new BoundVariableExpression(tokenParam)));
-        return Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(new BoundReturnStatement(call))));
+            ImmutableArray.Create<BoundExpression>(new BoundVariableExpression(null, tokenParam)));
+        return Lowerer.Lower(new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(new BoundReturnStatement(null, call))));
     }
 
     private BoundBlockStatement BuildVtsOnCompletedBody(FunctionSymbol func, StructSymbol smClass, FieldSymbol promiseField)
@@ -4327,16 +4364,18 @@ internal sealed class ReflectionMetadataEmitter
         var promiseType = typeof(System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>);
         var method = promiseType.GetMethod("OnCompleted");
         var promiseAddr = new BoundAddressOfExpression(
-            new BoundFieldAccessExpression(new BoundVariableExpression(thisParam), smClass, promiseField));
+            null,
+            new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisParam), smClass, promiseField));
         var args = ImmutableArray.Create<BoundExpression>(
-            new BoundVariableExpression(func.Parameters[0]),
-            new BoundVariableExpression(func.Parameters[1]),
-            new BoundVariableExpression(func.Parameters[2]),
-            new BoundVariableExpression(func.Parameters[3]));
-        var call = new BoundImportedInstanceCallExpression(promiseAddr, method, TypeSymbol.Void, args);
-        return Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(call),
-            new BoundReturnStatement(null))));
+            new BoundVariableExpression(null, func.Parameters[0]),
+            new BoundVariableExpression(null, func.Parameters[1]),
+            new BoundVariableExpression(null, func.Parameters[2]),
+            new BoundVariableExpression(null, func.Parameters[3]));
+        var call = new BoundImportedInstanceCallExpression(null, promiseAddr, method, TypeSymbol.Void, args);
+        return Lowerer.Lower(new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, call),
+            new BoundReturnStatement(null, null))));
     }
 
     private BoundBlockStatement BuildVtsGetResultVoidBody(FunctionSymbol func, StructSymbol smClass, FieldSymbol promiseField)
@@ -4347,13 +4386,16 @@ internal sealed class ReflectionMetadataEmitter
         var promiseType = typeof(System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>);
         var method = promiseType.GetMethod("GetResult", new[] { typeof(short) });
         var promiseAddr = new BoundAddressOfExpression(
-            new BoundFieldAccessExpression(new BoundVariableExpression(thisParam), smClass, promiseField));
+            null,
+            new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisParam), smClass, promiseField));
         var call = new BoundImportedInstanceCallExpression(
+            null,
             promiseAddr, method, TypeSymbol.Bool,
-            ImmutableArray.Create<BoundExpression>(new BoundVariableExpression(tokenParam)));
-        return Lowerer.Lower(new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(call),
-            new BoundReturnStatement(null))));
+            ImmutableArray.Create<BoundExpression>(new BoundVariableExpression(null, tokenParam)));
+        return Lowerer.Lower(new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, call),
+            new BoundReturnStatement(null, null))));
     }
 
     private BoundStructLiteralExpression CreateAsyncIteratorKickoffLiteral(
@@ -4364,20 +4406,20 @@ internal sealed class ReflectionMetadataEmitter
         ImmutableArray<ParameterSymbol> parameters)
     {
         var initializers = ImmutableArray.CreateBuilder<BoundFieldInitializer>();
-        initializers.Add(new BoundFieldInitializer(stateField, new BoundLiteralExpression(StateMachineStates.InitialAsyncIteratorState)));
+        initializers.Add(new BoundFieldInitializer(stateField, new BoundLiteralExpression(null, StateMachineStates.InitialAsyncIteratorState)));
 
         // Builder: AsyncIteratorMethodBuilder.Create()
         var createMethod = typeof(System.Runtime.CompilerServices.AsyncIteratorMethodBuilder)
             .GetMethod("Create", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static, null, Type.EmptyTypes, null);
         initializers.Add(new BoundFieldInitializer(builderField,
-            new BoundClrStaticCallExpression(createMethod, TypeSymbol.FromClrType(typeof(System.Runtime.CompilerServices.AsyncIteratorMethodBuilder)), ImmutableArray<BoundExpression>.Empty)));
+            new BoundClrStaticCallExpression(null, createMethod, TypeSymbol.FromClrType(typeof(System.Runtime.CompilerServices.AsyncIteratorMethodBuilder)), ImmutableArray<BoundExpression>.Empty)));
 
         foreach (var parameter in parameters)
         {
-            initializers.Add(new BoundFieldInitializer(parameterFields[parameter], new BoundVariableExpression(parameter)));
+            initializers.Add(new BoundFieldInitializer(parameterFields[parameter], new BoundVariableExpression(null, parameter)));
         }
 
-        return new BoundStructLiteralExpression(smClass, initializers.ToImmutable());
+        return new BoundStructLiteralExpression(null, smClass, initializers.ToImmutable());
     }
 
     private void AddAsyncIteratorInterfaceImplementations(StructSymbol smClass, Lowering.Iterators.AsyncIteratorPlan plan)
@@ -6100,7 +6142,8 @@ internal sealed class ReflectionMetadataEmitter
             if (this.captureFields.TryGetValue(node.Variable, out var field))
             {
                 return new BoundFieldAccessExpression(
-                    new BoundVariableExpression(this.thisParam),
+                    null,
+                    new BoundVariableExpression(null, this.thisParam),
                     this.closureClass,
                     field);
             }
@@ -6113,7 +6156,7 @@ internal sealed class ReflectionMetadataEmitter
             if (this.captureFields.TryGetValue(node.Variable, out var field))
             {
                 var value = this.RewriteExpression(node.Expression);
-                return new BoundFieldAssignmentExpression(this.thisParam, this.closureClass, field, value);
+                return new BoundFieldAssignmentExpression(null, this.thisParam, this.closureClass, field, value);
             }
 
             return base.RewriteAssignmentExpression(node);
@@ -6275,7 +6318,7 @@ internal sealed class ReflectionMetadataEmitter
             this.declared.Add(node.Variable);
             return initializer == node.Initializer
                 ? node
-                : new BoundVariableDeclaration(node.Variable, initializer);
+                : new BoundVariableDeclaration(null, node.Variable, initializer);
         }
 
         private void CaptureIfFree(VariableSymbol variable)
@@ -9067,7 +9110,7 @@ internal sealed class ReflectionMetadataEmitter
                 return;
             }
 
-            this.EmitExpression(new BoundVariableExpression(captured));
+            this.EmitExpression(new BoundVariableExpression(null, captured));
         }
 
         // Phase 4 emit parity (E1): indirect call through a func-typed value.
@@ -9400,7 +9443,7 @@ internal sealed class ReflectionMetadataEmitter
                 }
 
                 this.il.OpCode(ILOpCode.Dup);
-                this.EmitExpression(new BoundVariableExpression(captured));
+                this.EmitExpression(new BoundVariableExpression(null, captured));
                 this.il.OpCode(ILOpCode.Stfld);
                 this.il.Token(fieldHandle);
             }

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
@@ -70,7 +70,7 @@ public static class AsyncExceptionHandlerRewriter
 
         var rewriter = new Rewriter();
         var result = rewriter.RewriteStatement(body);
-        return result as BoundBlockStatement ?? new BoundBlockStatement(ImmutableArray.Create(result));
+        return result as BoundBlockStatement ?? new BoundBlockStatement(null, ImmutableArray.Create(result));
     }
 
     private static BoundLabel MakeLabel(string prefix)
@@ -129,7 +129,7 @@ public static class AsyncExceptionHandlerRewriter
                     return node;
                 }
 
-                return new BoundTryStatement(rewrittenTry, rewrittenClauses.ToImmutable(), rewrittenFinally);
+                return new BoundTryStatement(null, rewrittenTry, rewrittenClauses.ToImmutable(), rewrittenFinally);
             }
 
             // We need to rewrite. Build the output statement list.
@@ -140,7 +140,9 @@ public static class AsyncExceptionHandlerRewriter
             var pendingExLocal = new LocalVariableSymbol(
                 $"<>pending_ex_{localOrdinal++}", isReadOnly: false, nullableExceptionType);
             var pendingExNullInit = new BoundVariableDeclaration(
-                pendingExLocal, new BoundLiteralExpression(null, nullableExceptionType));
+                null,
+                pendingExLocal,
+                new BoundLiteralExpression(null, null, nullableExceptionType));
             statements.Add(pendingExNullInit);
 
             if (needsFinallyLift)
@@ -170,7 +172,7 @@ public static class AsyncExceptionHandlerRewriter
                     exceptionType);
             }
 
-            return new BoundBlockStatement(statements.ToImmutable());
+            return new BoundBlockStatement(null, statements.ToImmutable());
         }
 
         private void RewriteCatchWithAwait(
@@ -193,13 +195,15 @@ public static class AsyncExceptionHandlerRewriter
                 {
                     // Replace body: pendingException = ex;
                     var assignPending = new BoundExpressionStatement(
+                        null,
                         new BoundAssignmentExpression(
+                            null,
                             pendingExLocal,
-                            new BoundVariableExpression(clause.Variable)));
+                            new BoundVariableExpression(null, clause.Variable)));
                     var catchAllClause = new BoundCatchClause(
                         exceptionType,
                         clause.Variable,
-                        new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(assignPending)));
+                        new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(assignPending)));
                     newClauses.Add(catchAllClause);
                     afterTryHandlers.Add((clause, clause.Body));
                 }
@@ -209,16 +213,17 @@ public static class AsyncExceptionHandlerRewriter
                 }
             }
 
-            var tryStmt = new BoundTryStatement(tryBody, newClauses.ToImmutable(), finallyBlock);
+            var tryStmt = new BoundTryStatement(null, tryBody, newClauses.ToImmutable(), finallyBlock);
             statements.Add(tryStmt);
 
             // After the try: if (pendingException != null) { T e = (T)pendingException; handlerBody; }
             foreach (var (original, body) in afterTryHandlers)
             {
                 var endLabel = MakeLabel("catch_end");
-                var pendingExRef = new BoundVariableExpression(pendingExLocal);
-                var nullLit = new BoundLiteralExpression(null, TypeSymbol.Null);
+                var pendingExRef = new BoundVariableExpression(null, pendingExLocal);
+                var nullLit = new BoundLiteralExpression(null, null, TypeSymbol.Null);
                 var condition = new BoundBinaryExpression(
+                    null,
                     pendingExRef,
                     BoundBinaryOperator.Bind(
                         CodeAnalysis.Syntax.SyntaxKind.EqualsEqualsToken,
@@ -227,13 +232,14 @@ public static class AsyncExceptionHandlerRewriter
                     nullLit);
 
                 // Jump past the handler if pendingException == null
-                statements.Add(new BoundConditionalGotoStatement(endLabel, condition, jumpIfTrue: true));
+                statements.Add(new BoundConditionalGotoStatement(null, endLabel, condition, jumpIfTrue: true));
 
                 // Rebind the original catch variable: T e = (T)pendingException;
                 // Since GSharp's catch variable type may be same as Exception, just assign directly.
                 var rebind = new BoundVariableDeclaration(
+                    null,
                     original.Variable,
-                    new BoundVariableExpression(pendingExLocal));
+                    new BoundVariableExpression(null, pendingExLocal));
                 statements.Add(rebind);
 
                 // Emit the handler body
@@ -249,7 +255,7 @@ public static class AsyncExceptionHandlerRewriter
                     statements.Add(body);
                 }
 
-                statements.Add(new BoundLabelStatement(endLabel));
+                statements.Add(new BoundLabelStatement(null, endLabel));
             }
         }
 
@@ -273,13 +279,15 @@ public static class AsyncExceptionHandlerRewriter
                 {
                     // Capture into pending and lift body after finally
                     var assignPending = new BoundExpressionStatement(
+                        null,
                         new BoundAssignmentExpression(
+                            null,
                             pendingExLocal,
-                            new BoundVariableExpression(clause.Variable)));
+                            new BoundVariableExpression(null, clause.Variable)));
                     var captureClause = new BoundCatchClause(
                         exceptionType,
                         clause.Variable,
-                        new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(assignPending)));
+                        new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(assignPending)));
                     innerClauses.Add(captureClause);
                     liftedCatchHandlers.Add((clause, clause.Body));
                 }
@@ -294,23 +302,26 @@ public static class AsyncExceptionHandlerRewriter
             var catchAllVar = new LocalVariableSymbol(
                 $"<>ex_finally_{localOrdinal++}", isReadOnly: false, exceptionType);
             var catchAllAssign = new BoundExpressionStatement(
+                null,
                 new BoundAssignmentExpression(
+                    null,
                     pendingExLocal,
-                    new BoundVariableExpression(catchAllVar)));
-            var catchAllBody = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(catchAllAssign));
+                    new BoundVariableExpression(null, catchAllVar)));
+            var catchAllBody = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(catchAllAssign));
             var catchAllClause = new BoundCatchClause(exceptionType, catchAllVar, catchAllBody);
             innerClauses.Add(catchAllClause);
 
-            var innerTry = new BoundTryStatement(tryBody, innerClauses.ToImmutable(), finallyBlock: null);
+            var innerTry = new BoundTryStatement(null, tryBody, innerClauses.ToImmutable(), finallyBlock: null);
             statements.Add(innerTry);
 
             // Emit lifted catch handlers (for catch-with-await in try/catch/finally)
             foreach (var (original, body) in liftedCatchHandlers)
             {
                 var endLabel = MakeLabel("liftcatch_end");
-                var pendingExRef = new BoundVariableExpression(pendingExLocal);
-                var nullLit = new BoundLiteralExpression(null, TypeSymbol.Null);
+                var pendingExRef = new BoundVariableExpression(null, pendingExLocal);
+                var nullLit = new BoundLiteralExpression(null, null, TypeSymbol.Null);
                 var condition = new BoundBinaryExpression(
+                    null,
                     pendingExRef,
                     BoundBinaryOperator.Bind(
                         CodeAnalysis.Syntax.SyntaxKind.EqualsEqualsToken,
@@ -318,11 +329,12 @@ public static class AsyncExceptionHandlerRewriter
                         TypeSymbol.Null),
                     nullLit);
 
-                statements.Add(new BoundConditionalGotoStatement(endLabel, condition, jumpIfTrue: true));
+                statements.Add(new BoundConditionalGotoStatement(null, endLabel, condition, jumpIfTrue: true));
 
                 var rebind = new BoundVariableDeclaration(
+                    null,
                     original.Variable,
-                    new BoundVariableExpression(pendingExLocal));
+                    new BoundVariableExpression(null, pendingExLocal));
                 statements.Add(rebind);
 
                 if (body is BoundBlockStatement block)
@@ -339,10 +351,12 @@ public static class AsyncExceptionHandlerRewriter
 
                 // Clear pendingException after handling so the rethrow below doesn't fire
                 statements.Add(new BoundExpressionStatement(
+                    null,
                     new BoundAssignmentExpression(
+                        null,
                         pendingExLocal,
-                        new BoundLiteralExpression(null, TypeSymbol.Null))));
-                statements.Add(new BoundLabelStatement(endLabel));
+                        new BoundLiteralExpression(null, null, TypeSymbol.Null))));
+                statements.Add(new BoundLabelStatement(null, endLabel));
             }
 
             // Emit the finally body (now outside any handler region)
@@ -360,9 +374,10 @@ public static class AsyncExceptionHandlerRewriter
 
             // if (pendingException != null) { throw pendingException; }
             var rethrowEndLabel = MakeLabel("rethrow_end");
-            var pendingRef = new BoundVariableExpression(pendingExLocal);
-            var nullLitFinal = new BoundLiteralExpression(null, TypeSymbol.Null);
+            var pendingRef = new BoundVariableExpression(null, pendingExLocal);
+            var nullLitFinal = new BoundLiteralExpression(null, null, TypeSymbol.Null);
             var rethrowCondition = new BoundBinaryExpression(
+                null,
                 pendingRef,
                 BoundBinaryOperator.Bind(
                     CodeAnalysis.Syntax.SyntaxKind.EqualsEqualsToken,
@@ -370,9 +385,9 @@ public static class AsyncExceptionHandlerRewriter
                     TypeSymbol.Null),
                 nullLitFinal);
 
-            statements.Add(new BoundConditionalGotoStatement(rethrowEndLabel, rethrowCondition, jumpIfTrue: true));
-            statements.Add(new BoundThrowStatement(new BoundVariableExpression(pendingExLocal)));
-            statements.Add(new BoundLabelStatement(rethrowEndLabel));
+            statements.Add(new BoundConditionalGotoStatement(null, rethrowEndLabel, rethrowCondition, jumpIfTrue: true));
+            statements.Add(new BoundThrowStatement(null, new BoundVariableExpression(null, pendingExLocal)));
+            statements.Add(new BoundLabelStatement(null, rethrowEndLabel));
         }
 
         private static bool CatchesChanged(

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineFieldMap.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineFieldMap.cs
@@ -133,7 +133,7 @@ public sealed class AsyncStateMachineFieldMap
             throw new ArgumentNullException(nameof(field));
         }
 
-        return new BoundFieldAccessExpression(receiver, StructType, field);
+        return new BoundFieldAccessExpression(null, receiver, StructType, field);
     }
 
     /// <summary>Creates a field assignment against a state-machine receiver variable.</summary>
@@ -158,7 +158,7 @@ public sealed class AsyncStateMachineFieldMap
             throw new ArgumentNullException(nameof(value));
         }
 
-        return new BoundFieldAssignmentExpression(receiver, StructType, field, value);
+        return new BoundFieldAssignmentExpression(null, receiver, StructType, field, value);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
@@ -113,17 +113,17 @@ public static class MoveNextBodyRewriter
             var statements = ImmutableArray.CreateBuilder<BoundStatement>();
 
             // int cachedState = this.<>1__state;
-            statements.Add(new BoundVariableDeclaration(cachedStateLocal, ReadField(plan.FieldMap.StateField)));
+            statements.Add(new BoundVariableDeclaration(null, cachedStateLocal, ReadField(plan.FieldMap.StateField)));
 
             // T retVal = default; (only for Task<T>)
             if (retValLocal != null)
             {
                 var defaultVal = retValLocal.Type == TypeSymbol.Int
-                    ? (BoundExpression)new BoundLiteralExpression(0)
+                    ? (BoundExpression)new BoundLiteralExpression(null, 0)
                     : retValLocal.Type == TypeSymbol.Bool
-                        ? new BoundLiteralExpression(false)
-                        : new BoundLiteralExpression(null);
-                statements.Add(new BoundVariableDeclaration(retValLocal, defaultVal));
+                        ? new BoundLiteralExpression(null, false)
+                        : new BoundLiteralExpression(null, null);
+                statements.Add(new BoundVariableDeclaration(null, retValLocal, defaultVal));
             }
 
             // Pre-pass: locate each await within the user's try-statement nesting
@@ -153,7 +153,7 @@ public static class MoveNextBodyRewriter
             }
 
             // exprReturnLabel: (inside try — target of return-funneling gotos)
-            tryBodyStatements.Add(new BoundLabelStatement(plan.MoveNextPlan.ExpressionReturnLabel));
+            tryBodyStatements.Add(new BoundLabelStatement(null, plan.MoveNextPlan.ExpressionReturnLabel));
 
             // this.<>1__state = -2;
             tryBodyStatements.Add(Stmt(WriteField(plan.FieldMap.StateField, Literal(StateMachineStates.FinishedState))));
@@ -162,23 +162,23 @@ public static class MoveNextBodyRewriter
             tryBodyStatements.Add(Stmt(EmitBuilderSetResult()));
 
             // exitLabel: (inside try — suspension paths jump here to leave)
-            tryBodyStatements.Add(new BoundLabelStatement(plan.MoveNextPlan.ExitLabel));
+            tryBodyStatements.Add(new BoundLabelStatement(null, plan.MoveNextPlan.ExitLabel));
 
-            var tryBody = new BoundBlockStatement(tryBodyStatements.ToImmutable());
+            var tryBody = new BoundBlockStatement(null, tryBodyStatements.ToImmutable());
 
             // catch (Exception ex) { this.<>1__state = -2; builder.SetException(ex); }
             var exLocal = new LocalVariableSymbol("<>ex", isReadOnly: false, TypeSymbol.FromClrType(typeof(Exception)));
             allLocals.Add(exLocal);
             var catchBody = BuildCatchBody(exLocal);
             var catchClause = new BoundCatchClause(TypeSymbol.FromClrType(typeof(Exception)), exLocal, catchBody);
-            var tryStatement = new BoundTryStatement(tryBody, ImmutableArray.Create(catchClause), finallyBlock: null);
+            var tryStatement = new BoundTryStatement(null, tryBody, ImmutableArray.Create(catchClause), finallyBlock: null);
             statements.Add(tryStatement);
 
             // return; (after try/catch — reached via leave from both paths)
-            statements.Add(new BoundReturnStatement(null));
+            statements.Add(new BoundReturnStatement(null, null));
 
             return new MoveNextBody(
-                new BoundBlockStatement(statements.ToImmutable()),
+                new BoundBlockStatement(null, statements.ToImmutable()),
                 allLocals.ToImmutableArray(),
                 thisParameter);
         }
@@ -187,7 +187,7 @@ public static class MoveNextBodyRewriter
             ImmutableArray<BoundStatement>.Builder statements,
             TryDispatchPlan tryDispatch)
         {
-            statements.Add(new BoundLabelStatement(plan.MoveNextPlan.DispatchLabel));
+            statements.Add(new BoundLabelStatement(null, plan.MoveNextPlan.DispatchLabel));
 
             if (plan.MoveNextPlan.AwaitResumePoints.IsEmpty)
             {
@@ -201,10 +201,11 @@ public static class MoveNextBodyRewriter
                 // otherwise jump directly to the resume label.
                 var target = tryDispatch.GetOuterDispatchTarget(rp.State) ?? rp.ResumeLabel;
                 var condition = new BoundBinaryExpression(
-                    new BoundVariableExpression(cachedStateLocal),
+                    null,
+                    new BoundVariableExpression(null, cachedStateLocal),
                     BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
                     Literal(rp.State));
-                statements.Add(new BoundConditionalGotoStatement(target, condition, jumpIfTrue: true));
+                statements.Add(new BoundConditionalGotoStatement(null, target, condition, jumpIfTrue: true));
             }
         }
 
@@ -218,29 +219,36 @@ public static class MoveNextBodyRewriter
             // this.<>t__builder.SetException(ex);
             var builderInfo = plan.StateMachine.BuilderInfo;
             var builderAccess = new BoundFieldAccessExpression(
-                new BoundVariableExpression(thisParameter), structType, plan.FieldMap.BuilderField);
-            var builderAddr = new BoundAddressOfExpression(builderAccess);
+                null,
+                new BoundVariableExpression(null, thisParameter),
+                structType,
+                plan.FieldMap.BuilderField);
+            var builderAddr = new BoundAddressOfExpression(null, builderAccess);
             var setExceptionCall = new BoundImportedInstanceCallExpression(
+                null,
                 builderAddr,
                 builderInfo.SetExceptionMethod,
                 TypeSymbol.Void,
-                ImmutableArray.Create<BoundExpression>(new BoundVariableExpression(exLocal)));
+                ImmutableArray.Create<BoundExpression>(new BoundVariableExpression(null, exLocal)));
             stmts.Add(Stmt(setExceptionCall));
 
-            return new BoundBlockStatement(stmts.ToImmutable());
+            return new BoundBlockStatement(null, stmts.ToImmutable());
         }
 
         private BoundExpression EmitBuilderSetResult()
         {
             var builderInfo = plan.StateMachine.BuilderInfo;
             var builderAccess = new BoundFieldAccessExpression(
-                new BoundVariableExpression(thisParameter), structType, plan.FieldMap.BuilderField);
-            var builderAddr = new BoundAddressOfExpression(builderAccess);
+                null,
+                new BoundVariableExpression(null, thisParameter),
+                structType,
+                plan.FieldMap.BuilderField);
+            var builderAddr = new BoundAddressOfExpression(null, builderAccess);
 
             ImmutableArray<BoundExpression> args;
             if (retValLocal != null)
             {
-                args = ImmutableArray.Create<BoundExpression>(new BoundVariableExpression(retValLocal));
+                args = ImmutableArray.Create<BoundExpression>(new BoundVariableExpression(null, retValLocal));
             }
             else
             {
@@ -248,6 +256,7 @@ public static class MoveNextBodyRewriter
             }
 
             return new BoundImportedInstanceCallExpression(
+                null,
                 builderAddr,
                 builderInfo.SetResultMethod,
                 TypeSymbol.Void,
@@ -257,22 +266,25 @@ public static class MoveNextBodyRewriter
         private BoundExpression ReadField(FieldSymbol field)
         {
             return new BoundFieldAccessExpression(
-                new BoundVariableExpression(thisParameter), structType, field);
+                null,
+                new BoundVariableExpression(null, thisParameter),
+                structType,
+                field);
         }
 
         private BoundExpression WriteField(FieldSymbol field, BoundExpression value)
         {
-            return new BoundFieldAssignmentExpression(thisParameter, structType, field, value);
+            return new BoundFieldAssignmentExpression(null, thisParameter, structType, field, value);
         }
 
         private static BoundExpression Literal(int value)
         {
-            return new BoundLiteralExpression(value);
+            return new BoundLiteralExpression(null, value);
         }
 
         private static BoundExpressionStatement Stmt(BoundExpression expr)
         {
-            return new BoundExpressionStatement(expr);
+            return new BoundExpressionStatement(null, expr);
         }
 
         /// <summary>
@@ -297,11 +309,12 @@ public static class MoveNextBodyRewriter
                 {
                     var rewrittenExpr = RewriteExpression(node.Expression);
                     stmts.Add(new BoundExpressionStatement(
-                        new BoundAssignmentExpression(ctx.retValLocal, rewrittenExpr)));
+                        null,
+                        new BoundAssignmentExpression(null, ctx.retValLocal, rewrittenExpr)));
                 }
 
-                stmts.Add(new BoundGotoStatement(ctx.plan.MoveNextPlan.ExpressionReturnLabel));
-                return new BoundBlockStatement(stmts.ToImmutable());
+                stmts.Add(new BoundGotoStatement(null, ctx.plan.MoveNextPlan.ExpressionReturnLabel));
+                return new BoundBlockStatement(null, stmts.ToImmutable());
             }
 
             protected override BoundStatement RewriteExpressionStatement(BoundExpressionStatement node)
@@ -336,12 +349,12 @@ public static class MoveNextBodyRewriter
                         return Stmt(ctx.WriteField(field, rewrittenInit));
                     }
 
-                    return new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+                    return new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
                 }
 
                 if (rewrittenInit != node.Initializer)
                 {
-                    return new BoundVariableDeclaration(node.Variable, rewrittenInit);
+                    return new BoundVariableDeclaration(null, node.Variable, rewrittenInit);
                 }
 
                 return node;
@@ -368,7 +381,7 @@ public static class MoveNextBodyRewriter
 
                 if (rewrittenValue != node.Expression)
                 {
-                    return new BoundAssignmentExpression(node.Variable, rewrittenValue);
+                    return new BoundAssignmentExpression(null, node.Variable, rewrittenValue);
                 }
 
                 return node;
@@ -384,7 +397,7 @@ public static class MoveNextBodyRewriter
                 // write-through support for captured vars in async lambdas.
                 if (rewrittenValue != node.Value)
                 {
-                    return new BoundFieldAssignmentExpression(node.Receiver, node.StructType, node.Field, rewrittenValue);
+                    return new BoundFieldAssignmentExpression(null, node.Receiver, node.StructType, node.Field, rewrittenValue);
                 }
 
                 return node;
@@ -421,7 +434,7 @@ public static class MoveNextBodyRewriter
                         {
                             var copyToField = Stmt(ctx.WriteField(
                                 field,
-                                new BoundVariableExpression(clause.Variable)));
+                                new BoundVariableExpression(null, clause.Variable)));
                             var stmts = ImmutableArray.CreateBuilder<BoundStatement>();
                             stmts.Add(copyToField);
                             if (clause.Body is BoundBlockStatement block)
@@ -436,7 +449,7 @@ public static class MoveNextBodyRewriter
                             patchedClauses.Add(new BoundCatchClause(
                                 clause.ExceptionType,
                                 clause.Variable,
-                                new BoundBlockStatement(stmts.ToImmutable())));
+                                new BoundBlockStatement(null, stmts.ToImmutable())));
                         }
                         else
                         {
@@ -445,6 +458,7 @@ public static class MoveNextBodyRewriter
                     }
 
                     result = new BoundTryStatement(
+                        null,
                         result.TryBlock,
                         patchedClauses.ToImmutable(),
                         result.FinallyBlock);
@@ -470,10 +484,11 @@ public static class MoveNextBodyRewriter
                     foreach (var entry in dispatchEntries)
                     {
                         var cond = new BoundBinaryExpression(
-                            new BoundVariableExpression(ctx.cachedStateLocal),
+                            null,
+                            new BoundVariableExpression(null, ctx.cachedStateLocal),
                             BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
                             Literal(entry.State));
-                        newTryBodyStmts.Add(new BoundConditionalGotoStatement(entry.Target, cond, jumpIfTrue: true));
+                        newTryBodyStmts.Add(new BoundConditionalGotoStatement(null, entry.Target, cond, jumpIfTrue: true));
                     }
                 }
 
@@ -487,7 +502,8 @@ public static class MoveNextBodyRewriter
                 }
 
                 var rebuiltTry = new BoundTryStatement(
-                    new BoundBlockStatement(newTryBodyStmts.ToImmutable()),
+                    null,
+                    new BoundBlockStatement(null, newTryBodyStmts.ToImmutable()),
                     result.CatchClauses,
                     result.FinallyBlock);
 
@@ -497,8 +513,10 @@ public static class MoveNextBodyRewriter
                 }
 
                 // Place the entry label immediately before the try (outside it).
-                return new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-                    new BoundLabelStatement(entryLabel),
+                return new BoundBlockStatement(
+                    null,
+                    ImmutableArray.Create<BoundStatement>(
+                    new BoundLabelStatement(null, entryLabel),
                     rebuiltTry));
             }
 
@@ -552,8 +570,8 @@ public static class MoveNextBodyRewriter
                     var tempLocal = new LocalVariableSymbol(
                         "<>awaitable_" + resumePoint.State, isReadOnly: false, awaitableTypeSymbol);
                     ctx.allLocals.Add(tempLocal);
-                    stmts.Add(new BoundVariableDeclaration(tempLocal, rewrittenOperand));
-                    getAwaiterReceiver = new BoundAddressOfExpression(new BoundVariableExpression(tempLocal));
+                    stmts.Add(new BoundVariableDeclaration(null, tempLocal, rewrittenOperand));
+                    getAwaiterReceiver = new BoundAddressOfExpression(null, new BoundVariableExpression(null, tempLocal));
                 }
                 else
                 {
@@ -561,44 +579,49 @@ public static class MoveNextBodyRewriter
                 }
 
                 var getAwaiterCall = new BoundImportedInstanceCallExpression(
+                    null,
                     getAwaiterReceiver,
                     shape.GetAwaiterMethod,
                     awaiterTypeSymbol,
                     ImmutableArray<BoundExpression>.Empty);
-                stmts.Add(new BoundVariableDeclaration(awaiterLocal, getAwaiterCall));
+                stmts.Add(new BoundVariableDeclaration(null, awaiterLocal, getAwaiterCall));
 
                 // if (awaiter.IsCompleted) goto resumeAfter;
                 var isCompletedGetter = shape.IsCompletedProperty.GetGetMethod();
                 BoundExpression isCompletedReceiver;
                 if (awaiterClrType.IsValueType)
                 {
-                    isCompletedReceiver = new BoundAddressOfExpression(new BoundVariableExpression(awaiterLocal));
+                    isCompletedReceiver = new BoundAddressOfExpression(null, new BoundVariableExpression(null, awaiterLocal));
                 }
                 else
                 {
-                    isCompletedReceiver = new BoundVariableExpression(awaiterLocal);
+                    isCompletedReceiver = new BoundVariableExpression(null, awaiterLocal);
                 }
 
                 var isCompletedCall = new BoundImportedInstanceCallExpression(
+                    null,
                     isCompletedReceiver,
                     isCompletedGetter,
                     TypeSymbol.Bool,
                     ImmutableArray<BoundExpression>.Empty);
                 stmts.Add(new BoundConditionalGotoStatement(
-                    resumePoint.ResumeAfterLabel, isCompletedCall, jumpIfTrue: true));
+                    null,
+                    resumePoint.ResumeAfterLabel,
+                    isCompletedCall,
+                    jumpIfTrue: true));
 
                 // === Suspension path ===
                 // [AwaitYieldPoint] — hidden sequence point marker before state save.
-                stmts.Add(new BoundAwaitSequencePoint(BoundNodeKind.AwaitYieldPoint, resumePoint.State));
+                stmts.Add(new BoundAwaitSequencePoint(null, BoundNodeKind.AwaitYieldPoint, resumePoint.State));
 
                 // this.<>1__state = K;
                 stmts.Add(Stmt(ctx.WriteField(ctx.plan.FieldMap.StateField, Literal(resumePoint.State))));
 
                 // cachedState = K;
-                stmts.Add(Stmt(new BoundAssignmentExpression(ctx.cachedStateLocal, Literal(resumePoint.State))));
+                stmts.Add(Stmt(new BoundAssignmentExpression(null, ctx.cachedStateLocal, Literal(resumePoint.State))));
 
                 // this.<>u__N = awaiter;
-                BoundExpression awaiterToStore = new BoundVariableExpression(awaiterLocal);
+                BoundExpression awaiterToStore = new BoundVariableExpression(null, awaiterLocal);
                 if (!awaiterClrType.IsValueType)
                 {
                     // Reference awaiters stored as-is (field is object, implicit upcast).
@@ -609,55 +632,59 @@ public static class MoveNextBodyRewriter
                 // builder.AwaitUnsafe/OnCompleted<TAwaiter, TSM>(ref awaiter, ref this);
                 // Use the special marker node.
                 var awaitOnCompletedMarker = new BoundStateMachineAwaitOnCompleted(
-                    awaiterLocal, awaiterClrType, shape.ImplementsCriticalNotifyCompletion);
+                    null,
+                    awaiterLocal,
+                    awaiterClrType,
+                    shape.ImplementsCriticalNotifyCompletion);
                 stmts.Add(Stmt(awaitOnCompletedMarker));
 
                 // goto exitLabel;
-                stmts.Add(new BoundGotoStatement(ctx.plan.MoveNextPlan.ExitLabel));
+                stmts.Add(new BoundGotoStatement(null, ctx.plan.MoveNextPlan.ExitLabel));
 
                 // stateK_resume:
-                stmts.Add(new BoundLabelStatement(resumePoint.ResumeLabel));
+                stmts.Add(new BoundLabelStatement(null, resumePoint.ResumeLabel));
 
                 // [AwaitResumePoint] — hidden sequence point marker after resume dispatch.
-                stmts.Add(new BoundAwaitSequencePoint(BoundNodeKind.AwaitResumePoint, resumePoint.State));
+                stmts.Add(new BoundAwaitSequencePoint(null, BoundNodeKind.AwaitResumePoint, resumePoint.State));
 
                 // awaiter = (TAwaiter)this.<>u__N;
                 BoundExpression reloadedAwaiter = ctx.ReadField(awaiterField);
                 if (!awaiterClrType.IsValueType)
                 {
-                    reloadedAwaiter = new BoundConversionExpression(awaiterTypeSymbol, reloadedAwaiter);
+                    reloadedAwaiter = new BoundConversionExpression(null, awaiterTypeSymbol, reloadedAwaiter);
                 }
 
-                stmts.Add(Stmt(new BoundAssignmentExpression(awaiterLocal, reloadedAwaiter)));
+                stmts.Add(Stmt(new BoundAssignmentExpression(null, awaiterLocal, reloadedAwaiter)));
 
                 // this.<>u__N = default;
                 // Clears the awaiter field to release GC roots. For reference types
                 // this emits ldnull;stfld. For value types the emitter uses the
                 // optimized ldflda+initobj path via BoundDefaultExpression.
-                stmts.Add(Stmt(ctx.WriteField(awaiterField, new BoundDefaultExpression(awaiterTypeSymbol))));
+                stmts.Add(Stmt(ctx.WriteField(awaiterField, new BoundDefaultExpression(null, awaiterTypeSymbol))));
 
                 // this.<>1__state = -1;
                 stmts.Add(Stmt(ctx.WriteField(ctx.plan.FieldMap.StateField, Literal(StateMachineStates.NotStartedOrRunningState))));
 
                 // cachedState = -1;
-                stmts.Add(Stmt(new BoundAssignmentExpression(ctx.cachedStateLocal, Literal(StateMachineStates.NotStartedOrRunningState))));
+                stmts.Add(Stmt(new BoundAssignmentExpression(null, ctx.cachedStateLocal, Literal(StateMachineStates.NotStartedOrRunningState))));
 
                 // stateK_resume_after:
-                stmts.Add(new BoundLabelStatement(resumePoint.ResumeAfterLabel));
+                stmts.Add(new BoundLabelStatement(null, resumePoint.ResumeAfterLabel));
 
                 // result = awaiter.GetResult();
                 BoundExpression getResultReceiver;
                 if (awaiterClrType.IsValueType)
                 {
-                    getResultReceiver = new BoundAddressOfExpression(new BoundVariableExpression(awaiterLocal));
+                    getResultReceiver = new BoundAddressOfExpression(null, new BoundVariableExpression(null, awaiterLocal));
                 }
                 else
                 {
-                    getResultReceiver = new BoundVariableExpression(awaiterLocal);
+                    getResultReceiver = new BoundVariableExpression(null, awaiterLocal);
                 }
 
                 var resultType = awaitExpr.Type ?? TypeSymbol.Void;
                 var getResultCall = new BoundImportedInstanceCallExpression(
+                    null,
                     getResultReceiver,
                     shape.GetResultMethod,
                     resultType,
@@ -673,7 +700,7 @@ public static class MoveNextBodyRewriter
                     }
                     else
                     {
-                        stmts.Add(new BoundVariableDeclaration(resultTarget, getResultCall));
+                        stmts.Add(new BoundVariableDeclaration(null, resultTarget, getResultCall));
                     }
                 }
                 else
@@ -682,7 +709,7 @@ public static class MoveNextBodyRewriter
                     stmts.Add(Stmt(getResultCall));
                 }
 
-                return new BoundBlockStatement(stmts.ToImmutable());
+                return new BoundBlockStatement(null, stmts.ToImmutable());
             }
 
             private bool TryGetHoistedField(VariableSymbol variable, out FieldSymbol field)

--- a/src/Core/CodeAnalysis/Lowering/Async/RefInitializationHoister.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/RefInitializationHoister.cs
@@ -112,7 +112,7 @@ public static class RefInitializationHoister
             // Remove ref local declarations entirely.
             if (node.Variable is LocalVariableSymbol local && refLocals.ContainsKey(local))
             {
-                return new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+                return new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
             }
 
             return base.RewriteVariableDeclaration(node);
@@ -139,7 +139,7 @@ public static class RefInitializationHoister
                 && refLocals.TryGetValue(local, out var operand))
             {
                 var rewrittenOperand = RewriteExpression(operand);
-                return new BoundAddressOfExpression(rewrittenOperand);
+                return new BoundAddressOfExpression(null, rewrittenOperand);
             }
 
             return base.RewriteVariableExpression(node);
@@ -161,7 +161,7 @@ public static class RefInitializationHoister
 
                 // Return a dummy expression (literal 0 cast away) — the statement
                 // wrapping this will be a no-op expression statement.
-                return new BoundLiteralExpression(0);
+                return new BoundLiteralExpression(null, 0);
             }
 
             return base.RewriteAssignmentExpression(node);

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -74,7 +74,7 @@ public static class SpillSequenceSpiller
                 return block;
             }
 
-            return new BoundBlockStatement(builder.ToImmutable());
+            return new BoundBlockStatement(null, builder.ToImmutable());
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ public static class SpillSequenceSpiller
 
             var spilled = SpillExpression(decl.Initializer);
             FlushSideEffects(spilled, builder);
-            builder.Add(new BoundVariableDeclaration(decl.Variable, spilled.Value));
+            builder.Add(new BoundVariableDeclaration(null, decl.Variable, spilled.Value));
             return true;
         }
 
@@ -148,7 +148,7 @@ public static class SpillSequenceSpiller
             FlushSideEffects(spilled, builder);
             if (spilled.Value is not BoundLiteralExpression)
             {
-                builder.Add(new BoundExpressionStatement(spilled.Value));
+                builder.Add(new BoundExpressionStatement(null, spilled.Value));
             }
 
             return true;
@@ -169,7 +169,7 @@ public static class SpillSequenceSpiller
             // would leak an un-rewritten await to the emitter (issue #132).
             var spilled = SpillExpression(ret.Expression);
             FlushSideEffects(spilled, builder);
-            builder.Add(new BoundReturnStatement(spilled.Value));
+            builder.Add(new BoundReturnStatement(null, spilled.Value));
             return true;
         }
 
@@ -191,7 +191,7 @@ public static class SpillSequenceSpiller
             var thenBuilder = ImmutableArray.CreateBuilder<BoundStatement>();
             var thenChanged = RewriteStatementToList(ifStmt.ThenStatement, thenBuilder);
             var thenStmt = thenChanged
-                ? (thenBuilder.Count == 1 ? thenBuilder[0] : new BoundBlockStatement(thenBuilder.ToImmutable()))
+                ? (thenBuilder.Count == 1 ? thenBuilder[0] : new BoundBlockStatement(null, thenBuilder.ToImmutable()))
                 : ifStmt.ThenStatement;
 
             BoundStatement elseStmt = ifStmt.ElseStatement;
@@ -202,7 +202,7 @@ public static class SpillSequenceSpiller
                 elseChanged = RewriteStatementToList(elseStmt, elseBuilder);
                 if (elseChanged)
                 {
-                    elseStmt = elseBuilder.Count == 1 ? elseBuilder[0] : new BoundBlockStatement(elseBuilder.ToImmutable());
+                    elseStmt = elseBuilder.Count == 1 ? elseBuilder[0] : new BoundBlockStatement(null, elseBuilder.ToImmutable());
                 }
             }
 
@@ -212,7 +212,7 @@ public static class SpillSequenceSpiller
                 return false;
             }
 
-            builder.Add(new BoundIfStatement(condition, thenStmt, elseStmt));
+            builder.Add(new BoundIfStatement(null, condition, thenStmt, elseStmt));
             return true;
         }
 
@@ -270,8 +270,8 @@ public static class SpillSequenceSpiller
 
             // Create a spill temp for the await result.
             var spillLocal = MakeSpillTemp(awaitExpr.Type);
-            var awaitNode = new BoundAwaitExpression(innerExpr, awaitExpr.Type);
-            var assignStmt = new BoundVariableDeclaration(spillLocal, awaitNode);
+            var awaitNode = new BoundAwaitExpression(null, innerExpr, awaitExpr.Type);
+            var assignStmt = new BoundVariableDeclaration(null, spillLocal, awaitNode);
 
             var locals = ImmutableArray.CreateBuilder<LocalVariableSymbol>();
             var sideEffects = ImmutableArray.CreateBuilder<BoundStatement>();
@@ -286,9 +286,10 @@ public static class SpillSequenceSpiller
             sideEffects.Add(assignStmt);
 
             return new BoundSpillSequenceExpression(
+                null,
                 locals.ToImmutable(),
                 sideEffects.ToImmutable(),
-                new BoundVariableExpression(spillLocal));
+                new BoundVariableExpression(null, spillLocal));
         }
 
         private BoundSpillSequenceExpression SpillBinary(BoundBinaryExpression binary)
@@ -334,8 +335,8 @@ public static class SpillSequenceSpiller
             {
                 var leftTemp = MakeSpillTemp(left.Type);
                 locals.Add(leftTemp);
-                sideEffects.Add(new BoundVariableDeclaration(leftTemp, left));
-                left = new BoundVariableExpression(leftTemp);
+                sideEffects.Add(new BoundVariableDeclaration(null, leftTemp, left));
+                left = new BoundVariableExpression(null, leftTemp);
             }
 
             BoundExpression right;
@@ -351,7 +352,7 @@ public static class SpillSequenceSpiller
                 right = binary.Right;
             }
 
-            var value = new BoundBinaryExpression(left, binary.Op, right);
+            var value = new BoundBinaryExpression(null, left, binary.Op, right);
 
             if (locals.Count == 0 && sideEffects.Count == 0)
             {
@@ -359,6 +360,7 @@ public static class SpillSequenceSpiller
             }
 
             return new BoundSpillSequenceExpression(
+                null,
                 locals.ToImmutable(),
                 sideEffects.ToImmutable(),
                 value);
@@ -385,30 +387,33 @@ public static class SpillSequenceSpiller
             var endLabel = MakeLabel();
 
             // if (left) goto evalRight
-            sideEffects.Add(new BoundConditionalGotoStatement(evalRightLabel, left, jumpIfTrue: true));
+            sideEffects.Add(new BoundConditionalGotoStatement(null, evalRightLabel, left, jumpIfTrue: true));
 
             // tmp = false; goto end
             sideEffects.Add(new BoundExpressionStatement(
-                new BoundAssignmentExpression(resultLocal, new BoundLiteralExpression(false))));
-            sideEffects.Add(new BoundGotoStatement(endLabel));
+                null,
+                new BoundAssignmentExpression(null, resultLocal, new BoundLiteralExpression(null, false))));
+            sideEffects.Add(new BoundGotoStatement(null, endLabel));
 
             // evalRight: tmp = await b
-            sideEffects.Add(new BoundLabelStatement(evalRightLabel));
+            sideEffects.Add(new BoundLabelStatement(null, evalRightLabel));
             var spilledRight = SpillExpression(binary.Right);
             locals.AddRange(spilledRight.Locals);
             sideEffects.AddRange(spilledRight.SideEffects);
             sideEffects.Add(new BoundExpressionStatement(
-                new BoundAssignmentExpression(resultLocal, spilledRight.Value)));
+                null,
+                new BoundAssignmentExpression(null, resultLocal, spilledRight.Value)));
 
             // end:
-            sideEffects.Add(new BoundLabelStatement(endLabel));
+            sideEffects.Add(new BoundLabelStatement(null, endLabel));
 
             locals.Add(resultLocal);
 
             return new BoundSpillSequenceExpression(
+                null,
                 locals.ToImmutable(),
                 sideEffects.ToImmutable(),
-                new BoundVariableExpression(resultLocal));
+                new BoundVariableExpression(null, resultLocal));
         }
 
         private BoundSpillSequenceExpression SpillLogicalOr(BoundBinaryExpression binary)
@@ -430,31 +435,34 @@ public static class SpillSequenceSpiller
             var endLabel = MakeLabel();
 
             // if (left) { tmp = true; goto end }
-            sideEffects.Add(new BoundConditionalGotoStatement(endLabel, left, jumpIfTrue: true));
+            sideEffects.Add(new BoundConditionalGotoStatement(null, endLabel, left, jumpIfTrue: true));
 
             // else: tmp = await b
             var spilledRight = SpillExpression(binary.Right);
             locals.AddRange(spilledRight.Locals);
             sideEffects.AddRange(spilledRight.SideEffects);
             sideEffects.Add(new BoundExpressionStatement(
-                new BoundAssignmentExpression(resultLocal, spilledRight.Value)));
+                null,
+                new BoundAssignmentExpression(null, resultLocal, spilledRight.Value)));
             var skipTrueLabel = MakeLabel();
-            sideEffects.Add(new BoundGotoStatement(skipTrueLabel));
+            sideEffects.Add(new BoundGotoStatement(null, skipTrueLabel));
 
             // end:  (jumped to when left is true)
-            sideEffects.Add(new BoundLabelStatement(endLabel));
+            sideEffects.Add(new BoundLabelStatement(null, endLabel));
             sideEffects.Add(new BoundExpressionStatement(
-                new BoundAssignmentExpression(resultLocal, new BoundLiteralExpression(true))));
+                null,
+                new BoundAssignmentExpression(null, resultLocal, new BoundLiteralExpression(null, true))));
 
             // skipTrue:
-            sideEffects.Add(new BoundLabelStatement(skipTrueLabel));
+            sideEffects.Add(new BoundLabelStatement(null, skipTrueLabel));
 
             locals.Add(resultLocal);
 
             return new BoundSpillSequenceExpression(
+                null,
                 locals.ToImmutable(),
                 sideEffects.ToImmutable(),
-                new BoundVariableExpression(resultLocal));
+                new BoundVariableExpression(null, resultLocal));
         }
 
         private BoundSpillSequenceExpression SpillCall(BoundCallExpression call)
@@ -466,8 +474,9 @@ public static class SpillSequenceSpiller
                 return Trivial(call);
             }
 
-            var value = new BoundCallExpression(call.Function, args.ToImmutable(), call.ReturnType);
+            var value = new BoundCallExpression(null, call.Function, args.ToImmutable(), call.ReturnType);
             return new BoundSpillSequenceExpression(
+                null,
                 locals.ToImmutable(),
                 sideEffects.ToImmutable(),
                 value);
@@ -482,8 +491,9 @@ public static class SpillSequenceSpiller
                 return Trivial(call);
             }
 
-            var value = new BoundImportedCallExpression(call.Function, args.ToImmutable(), call.ArgumentRefKinds);
+            var value = new BoundImportedCallExpression(null, call.Function, args.ToImmutable(), call.ArgumentRefKinds);
             return new BoundSpillSequenceExpression(
+                null,
                 locals.ToImmutable(),
                 sideEffects.ToImmutable(),
                 value);
@@ -518,8 +528,8 @@ public static class SpillSequenceSpiller
             {
                 var recvTemp = MakeSpillTemp(receiver.Type);
                 locals.Add(recvTemp);
-                sideEffects.Add(new BoundVariableDeclaration(recvTemp, receiver));
-                receiver = new BoundVariableExpression(recvTemp);
+                sideEffects.Add(new BoundVariableDeclaration(null, recvTemp, receiver));
+                receiver = new BoundVariableExpression(null, recvTemp);
             }
 
             var (argLocals, argSideEffects, args) = SpillArgumentList(call.Arguments);
@@ -531,8 +541,9 @@ public static class SpillSequenceSpiller
                 return Trivial(call);
             }
 
-            var value = new BoundImportedInstanceCallExpression(receiver, call.Method, call.Type, args.ToImmutable(), call.ArgumentRefKinds);
+            var value = new BoundImportedInstanceCallExpression(null, receiver, call.Method, call.Type, args.ToImmutable(), call.ArgumentRefKinds);
             return new BoundSpillSequenceExpression(
+                null,
                 locals.ToImmutable(),
                 sideEffects.ToImmutable(),
                 value);
@@ -566,8 +577,8 @@ public static class SpillSequenceSpiller
             {
                 var recvTemp = MakeSpillTemp(receiver.Type);
                 locals.Add(recvTemp);
-                sideEffects.Add(new BoundVariableDeclaration(recvTemp, receiver));
-                receiver = new BoundVariableExpression(recvTemp);
+                sideEffects.Add(new BoundVariableDeclaration(null, recvTemp, receiver));
+                receiver = new BoundVariableExpression(null, recvTemp);
             }
 
             var (argLocals, argSideEffects, args) = SpillArgumentList(call.Arguments);
@@ -579,8 +590,9 @@ public static class SpillSequenceSpiller
                 return Trivial(call);
             }
 
-            var value = new BoundUserInstanceCallExpression(receiver, call.Method, args.ToImmutable());
+            var value = new BoundUserInstanceCallExpression(null, receiver, call.Method, args.ToImmutable());
             return new BoundSpillSequenceExpression(
+                null,
                 locals.ToImmutable(),
                 sideEffects.ToImmutable(),
                 value);
@@ -594,8 +606,9 @@ public static class SpillSequenceSpiller
             }
 
             var spilled = SpillExpression(conv.Expression);
-            var value = new BoundConversionExpression(conv.Type, spilled.Value);
+            var value = new BoundConversionExpression(null, conv.Type, spilled.Value);
             return new BoundSpillSequenceExpression(
+                null,
                 spilled.Locals,
                 spilled.SideEffects,
                 value);
@@ -609,8 +622,9 @@ public static class SpillSequenceSpiller
             }
 
             var spilled = SpillExpression(assign.Expression);
-            var value = new BoundAssignmentExpression(assign.Variable, spilled.Value);
+            var value = new BoundAssignmentExpression(null, assign.Variable, spilled.Value);
             return new BoundSpillSequenceExpression(
+                null,
                 spilled.Locals,
                 spilled.SideEffects,
                 value);
@@ -671,8 +685,8 @@ public static class SpillSequenceSpiller
                     // This arg precedes an await — spill to temp.
                     var temp = MakeSpillTemp(arg.Type);
                     locals.Add(temp);
-                    sideEffects.Add(new BoundVariableDeclaration(temp, arg));
-                    args.Add(new BoundVariableExpression(temp));
+                    sideEffects.Add(new BoundVariableDeclaration(null, temp, arg));
+                    args.Add(new BoundVariableExpression(null, temp));
                 }
                 else if (i > firstAwaitIdx && !IsPureOrConstant(arg))
                 {
@@ -692,8 +706,8 @@ public static class SpillSequenceSpiller
                     {
                         var temp = MakeSpillTemp(arg.Type);
                         locals.Add(temp);
-                        sideEffects.Add(new BoundVariableDeclaration(temp, arg));
-                        args.Add(new BoundVariableExpression(temp));
+                        sideEffects.Add(new BoundVariableDeclaration(null, temp, arg));
+                        args.Add(new BoundVariableExpression(null, temp));
                     }
                     else
                     {
@@ -729,6 +743,7 @@ public static class SpillSequenceSpiller
         private static BoundSpillSequenceExpression Trivial(BoundExpression value)
         {
             return new BoundSpillSequenceExpression(
+                null,
                 ImmutableArray<LocalVariableSymbol>.Empty,
                 ImmutableArray<BoundStatement>.Empty,
                 value);
@@ -753,7 +768,7 @@ public static class SpillSequenceSpiller
 
                 if (!alreadyDeclared)
                 {
-                    builder.Add(new BoundVariableDeclaration(local, GetDefaultValue(local.Type)));
+                    builder.Add(new BoundVariableDeclaration(null, local, GetDefaultValue(local.Type)));
                 }
             }
 
@@ -767,22 +782,22 @@ public static class SpillSequenceSpiller
         {
             if (type == TypeSymbol.Int)
             {
-                return new BoundLiteralExpression(0);
+                return new BoundLiteralExpression(null, 0);
             }
 
             if (type == TypeSymbol.Bool)
             {
-                return new BoundLiteralExpression(false);
+                return new BoundLiteralExpression(null, false);
             }
 
             if (type == TypeSymbol.String)
             {
-                return new BoundLiteralExpression(string.Empty);
+                return new BoundLiteralExpression(null, string.Empty);
             }
 
             // For reference types or unknown types, use default(int) as placeholder.
             // The actual value will be overwritten before use.
-            return new BoundLiteralExpression(0);
+            return new BoundLiteralExpression(null, 0);
         }
     }
 }

--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
@@ -124,13 +124,13 @@ public static class AsyncIteratorMoveNextBodyBuilder
             var catchBody = BuildCatchBody(exLocal);
 
             var catchClause = new BoundCatchClause(TypeSymbol.FromClrType(typeof(Exception)), exLocal, catchBody);
-            var tryStmt = new BoundTryStatement(tryBody, ImmutableArray.Create(catchClause), finallyBlock: null);
+            var tryStmt = new BoundTryStatement(null, tryBody, ImmutableArray.Create(catchClause), finallyBlock: null);
             stmts.Add(tryStmt);
 
             // return; (after try/catch)
-            stmts.Add(new BoundReturnStatement(null));
+            stmts.Add(new BoundReturnStatement(null, null));
 
-            return new BoundBlockStatement(stmts.ToImmutable());
+            return new BoundBlockStatement(null, stmts.ToImmutable());
         }
 
         private BoundBlockStatement BuildTryBody()
@@ -153,14 +153,14 @@ public static class AsyncIteratorMoveNextBodyBuilder
             }
 
             // End of body: state = -2; promise.SetResult(false);
-            stmts.Add(new BoundLabelStatement(endOfBodyLabel));
+            stmts.Add(new BoundLabelStatement(null, endOfBodyLabel));
             stmts.Add(Stmt(WriteField(stateField, Literal(StateMachineStates.FinishedState))));
             stmts.Add(Stmt(EmitPromiseSetResult(false)));
 
             // Exit label (for suspension return paths).
-            stmts.Add(new BoundLabelStatement(exitLabel));
+            stmts.Add(new BoundLabelStatement(null, exitLabel));
 
-            return new BoundBlockStatement(stmts.ToImmutable());
+            return new BoundBlockStatement(null, stmts.ToImmutable());
         }
 
         private void EmitStateDispatch(ImmutableArray<BoundStatement>.Builder stmts)
@@ -172,8 +172,10 @@ public static class AsyncIteratorMoveNextBodyBuilder
             {
                 var state = kvp.Value;
                 stmts.Add(new BoundConditionalGotoStatement(
+                    null,
                     yieldResumeLabels[state],
                     new BoundBinaryExpression(
+                        null,
                         stateRead,
                         BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
                         Literal(state)),
@@ -185,8 +187,10 @@ public static class AsyncIteratorMoveNextBodyBuilder
             {
                 var state = kvp.Value;
                 stmts.Add(new BoundConditionalGotoStatement(
+                    null,
                     awaitResumeLabels[state],
                     new BoundBinaryExpression(
+                        null,
                         ReadField(stateField),
                         BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
                         Literal(state)),
@@ -205,15 +209,17 @@ public static class AsyncIteratorMoveNextBodyBuilder
             var promiseFieldType = typeof(System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>);
             var setExceptionMethod = promiseFieldType.GetMethod("SetException", new[] { typeof(Exception) });
             var promiseAddr = new BoundAddressOfExpression(
-                new BoundFieldAccessExpression(new BoundVariableExpression(thisParameter), smClass, promiseField));
+                null,
+                new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisParameter), smClass, promiseField));
             var call = new BoundImportedInstanceCallExpression(
+                null,
                 promiseAddr,
                 setExceptionMethod,
                 TypeSymbol.Void,
-                ImmutableArray.Create<BoundExpression>(new BoundVariableExpression(exLocal)));
+                ImmutableArray.Create<BoundExpression>(new BoundVariableExpression(null, exLocal)));
             stmts.Add(Stmt(call));
 
-            return new BoundBlockStatement(stmts.ToImmutable());
+            return new BoundBlockStatement(null, stmts.ToImmutable());
         }
 
         private BoundExpression EmitPromiseSetResult(bool value)
@@ -221,27 +227,29 @@ public static class AsyncIteratorMoveNextBodyBuilder
             var promiseFieldType = typeof(System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>);
             var setResultMethod = promiseFieldType.GetMethod("SetResult", new[] { typeof(bool) });
             var promiseAddr = new BoundAddressOfExpression(
-                new BoundFieldAccessExpression(new BoundVariableExpression(thisParameter), smClass, promiseField));
+                null,
+                new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisParameter), smClass, promiseField));
             return new BoundImportedInstanceCallExpression(
+                null,
                 promiseAddr,
                 setResultMethod,
                 TypeSymbol.Void,
-                ImmutableArray.Create<BoundExpression>(new BoundLiteralExpression(value)));
+                ImmutableArray.Create<BoundExpression>(new BoundLiteralExpression(null, value)));
         }
 
         private BoundExpression ReadField(FieldSymbol field)
         {
-            return new BoundFieldAccessExpression(new BoundVariableExpression(thisParameter), smClass, field);
+            return new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisParameter), smClass, field);
         }
 
         private BoundExpression WriteField(FieldSymbol field, BoundExpression value)
         {
-            return new BoundFieldAssignmentExpression(thisParameter, smClass, field, value);
+            return new BoundFieldAssignmentExpression(null, thisParameter, smClass, field, value);
         }
 
-        private static BoundExpression Literal(int value) => new BoundLiteralExpression(value);
+        private static BoundExpression Literal(int value) => new BoundLiteralExpression(null, value);
 
-        private static BoundExpressionStatement Stmt(BoundExpression expr) => new BoundExpressionStatement(expr);
+        private static BoundExpressionStatement Stmt(BoundExpression expr) => new BoundExpressionStatement(null, expr);
 
         /// <summary>
         /// Walks the user body, replacing yields, awaits, variable accesses (hoisted to fields),
@@ -277,7 +285,7 @@ public static class AsyncIteratorMoveNextBodyBuilder
 
                 if (rewrittenValue != node.Expression)
                 {
-                    return new BoundAssignmentExpression(node.Variable, rewrittenValue);
+                    return new BoundAssignmentExpression(null, node.Variable, rewrittenValue);
                 }
 
                 return node;
@@ -298,12 +306,12 @@ public static class AsyncIteratorMoveNextBodyBuilder
                         return Stmt(ctx.WriteField(field, rewrittenInit));
                     }
 
-                    return new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+                    return new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
                 }
 
                 if (rewrittenInit != node.Initializer)
                 {
-                    return new BoundVariableDeclaration(node.Variable, rewrittenInit);
+                    return new BoundVariableDeclaration(null, node.Variable, rewrittenInit);
                 }
 
                 return node;
@@ -353,21 +361,22 @@ public static class AsyncIteratorMoveNextBodyBuilder
                 stmts.Add(Stmt(ctx.EmitPromiseSetResult(true)));
 
                 // return;
-                stmts.Add(new BoundGotoStatement(ctx.exitLabel));
+                stmts.Add(new BoundGotoStatement(null, ctx.exitLabel));
 
                 // yieldResumeK:
-                stmts.Add(new BoundLabelStatement(ctx.yieldResumeLabels[yieldState]));
+                stmts.Add(new BoundLabelStatement(null, ctx.yieldResumeLabels[yieldState]));
 
                 // this.<>1__state = -1;
                 stmts.Add(Stmt(ctx.WriteField(ctx.stateField, Literal(StateMachineStates.NotStartedOrRunningState))));
 
                 // if (<>w__disposeMode) goto endOfBody;
                 stmts.Add(new BoundConditionalGotoStatement(
+                    null,
                     ctx.endOfBodyLabel,
                     ctx.ReadField(ctx.disposeModeField),
                     jumpIfTrue: true));
 
-                return new BoundBlockStatement(stmts.ToImmutable());
+                return new BoundBlockStatement(null, stmts.ToImmutable());
             }
 
             protected override BoundStatement RewriteExpressionStatement(BoundExpressionStatement node)
@@ -394,7 +403,7 @@ public static class AsyncIteratorMoveNextBodyBuilder
             protected override BoundStatement RewriteReturnStatement(BoundReturnStatement node)
             {
                 // In an async iterator, `return` means end iteration.
-                return new BoundGotoStatement(ctx.endOfBodyLabel);
+                return new BoundGotoStatement(null, ctx.endOfBodyLabel);
             }
 
             private BoundBlockStatement EmitPerAwaitSequence(BoundAwaitExpression awaitExpr, VariableSymbol resultTarget)
@@ -435,8 +444,8 @@ public static class AsyncIteratorMoveNextBodyBuilder
                     var awaitableTypeSymbol = TypeSymbol.FromClrType(awaitableClrType);
                     var tempLocal = new LocalVariableSymbol(
                         "<>awaitable_" + awaitState, isReadOnly: false, awaitableTypeSymbol);
-                    stmts.Add(new BoundVariableDeclaration(tempLocal, rewrittenOperand));
-                    getAwaiterReceiver = new BoundAddressOfExpression(new BoundVariableExpression(tempLocal));
+                    stmts.Add(new BoundVariableDeclaration(null, tempLocal, rewrittenOperand));
+                    getAwaiterReceiver = new BoundAddressOfExpression(null, new BoundVariableExpression(null, tempLocal));
                 }
                 else
                 {
@@ -444,6 +453,7 @@ public static class AsyncIteratorMoveNextBodyBuilder
                 }
 
                 var getAwaiterCall = new BoundImportedInstanceCallExpression(
+                    null,
                     getAwaiterReceiver,
                     shape.GetAwaiterMethod,
                     awaiterTypeSymbol,
@@ -451,82 +461,85 @@ public static class AsyncIteratorMoveNextBodyBuilder
 
                 var awaiterLocal = new LocalVariableSymbol(
                     "<>awaiter_" + awaitState, isReadOnly: false, awaiterTypeSymbol);
-                stmts.Add(new BoundVariableDeclaration(awaiterLocal, getAwaiterCall));
+                stmts.Add(new BoundVariableDeclaration(null, awaiterLocal, getAwaiterCall));
 
                 // if (awaiter.IsCompleted) goto resumeAfter;
                 var isCompletedGetter = shape.IsCompletedProperty.GetGetMethod();
                 BoundExpression isCompletedReceiver;
                 if (awaiterClrType.IsValueType)
                 {
-                    isCompletedReceiver = new BoundAddressOfExpression(new BoundVariableExpression(awaiterLocal));
+                    isCompletedReceiver = new BoundAddressOfExpression(null, new BoundVariableExpression(null, awaiterLocal));
                 }
                 else
                 {
-                    isCompletedReceiver = new BoundVariableExpression(awaiterLocal);
+                    isCompletedReceiver = new BoundVariableExpression(null, awaiterLocal);
                 }
 
                 var isCompletedCall = new BoundImportedInstanceCallExpression(
+                    null,
                     isCompletedReceiver,
                     isCompletedGetter,
                     TypeSymbol.Bool,
                     ImmutableArray<BoundExpression>.Empty);
-                stmts.Add(new BoundConditionalGotoStatement(resumeAfterLabel, isCompletedCall, jumpIfTrue: true));
+                stmts.Add(new BoundConditionalGotoStatement(null, resumeAfterLabel, isCompletedCall, jumpIfTrue: true));
 
                 // === Suspension path ===
                 // [AwaitYieldPoint] — hidden sequence point marker before state save.
-                stmts.Add(new BoundAwaitSequencePoint(BoundNodeKind.AwaitYieldPoint, awaitState));
+                stmts.Add(new BoundAwaitSequencePoint(null, BoundNodeKind.AwaitYieldPoint, awaitState));
 
                 // this.<>1__state = awaitState;
                 stmts.Add(Stmt(ctx.WriteField(ctx.stateField, Literal(awaitState))));
 
                 // this.<>u__N = awaiter;
-                stmts.Add(Stmt(ctx.WriteField(awaiterField, new BoundVariableExpression(awaiterLocal))));
+                stmts.Add(Stmt(ctx.WriteField(awaiterField, new BoundVariableExpression(null, awaiterLocal))));
 
                 // builder.AwaitUnsafe/OnCompleted(ref awaiter, ref this);
                 var awaitOnCompletedMarker = new BoundStateMachineAwaitOnCompleted(
+                    null,
                     awaiterLocal, awaiterClrType, shape.ImplementsCriticalNotifyCompletion);
                 stmts.Add(Stmt(awaitOnCompletedMarker));
 
                 // goto exit;
-                stmts.Add(new BoundGotoStatement(ctx.exitLabel));
+                stmts.Add(new BoundGotoStatement(null, ctx.exitLabel));
 
                 // resumeLabel:
-                stmts.Add(new BoundLabelStatement(resumeLabel));
+                stmts.Add(new BoundLabelStatement(null, resumeLabel));
 
                 // [AwaitResumePoint] — hidden sequence point marker after resume dispatch.
-                stmts.Add(new BoundAwaitSequencePoint(BoundNodeKind.AwaitResumePoint, awaitState));
+                stmts.Add(new BoundAwaitSequencePoint(null, BoundNodeKind.AwaitResumePoint, awaitState));
 
                 // awaiter = this.<>u__N;
                 BoundExpression reloadedAwaiter = ctx.ReadField(awaiterField);
                 if (!awaiterClrType.IsValueType)
                 {
-                    reloadedAwaiter = new BoundConversionExpression(awaiterTypeSymbol, reloadedAwaiter);
+                    reloadedAwaiter = new BoundConversionExpression(null, awaiterTypeSymbol, reloadedAwaiter);
                 }
 
-                stmts.Add(Stmt(new BoundAssignmentExpression(awaiterLocal, reloadedAwaiter)));
+                stmts.Add(Stmt(new BoundAssignmentExpression(null, awaiterLocal, reloadedAwaiter)));
 
                 // this.<>u__N = default;
-                stmts.Add(Stmt(ctx.WriteField(awaiterField, new BoundDefaultExpression(awaiterTypeSymbol))));
+                stmts.Add(Stmt(ctx.WriteField(awaiterField, new BoundDefaultExpression(null, awaiterTypeSymbol))));
 
                 // this.<>1__state = -1;
                 stmts.Add(Stmt(ctx.WriteField(ctx.stateField, Literal(StateMachineStates.NotStartedOrRunningState))));
 
                 // resumeAfterLabel:
-                stmts.Add(new BoundLabelStatement(resumeAfterLabel));
+                stmts.Add(new BoundLabelStatement(null, resumeAfterLabel));
 
                 // result = awaiter.GetResult();
                 BoundExpression getResultReceiver;
                 if (awaiterClrType.IsValueType)
                 {
-                    getResultReceiver = new BoundAddressOfExpression(new BoundVariableExpression(awaiterLocal));
+                    getResultReceiver = new BoundAddressOfExpression(null, new BoundVariableExpression(null, awaiterLocal));
                 }
                 else
                 {
-                    getResultReceiver = new BoundVariableExpression(awaiterLocal);
+                    getResultReceiver = new BoundVariableExpression(null, awaiterLocal);
                 }
 
                 var resultType = awaitExpr.Type ?? TypeSymbol.Void;
                 var getResultCall = new BoundImportedInstanceCallExpression(
+                    null,
                     getResultReceiver,
                     shape.GetResultMethod,
                     resultType,
@@ -542,7 +555,7 @@ public static class AsyncIteratorMoveNextBodyBuilder
                     }
                     else
                     {
-                        stmts.Add(new BoundVariableDeclaration(resultTarget, getResultCall));
+                        stmts.Add(new BoundVariableDeclaration(null, resultTarget, getResultCall));
                     }
                 }
                 else
@@ -550,7 +563,7 @@ public static class AsyncIteratorMoveNextBodyBuilder
                     stmts.Add(Stmt(getResultCall));
                 }
 
-                return new BoundBlockStatement(stmts.ToImmutable());
+                return new BoundBlockStatement(null, stmts.ToImmutable());
             }
         }
     }

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorMoveNextBodyBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorMoveNextBodyBuilder.cs
@@ -42,10 +42,10 @@ public static class IteratorMoveNextBodyBuilder
         Dictionary<VariableSymbol, FieldSymbol> hoistedFieldMap)
     {
         BoundExpression FieldRead(FieldSymbol field) =>
-            new BoundFieldAccessExpression(new BoundVariableExpression(thisParameter), smClass, field);
+            new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisParameter), smClass, field);
 
         BoundExpression FieldWrite(FieldSymbol field, BoundExpression value) =>
-            new BoundFieldAssignmentExpression(thisParameter, smClass, field, value);
+            new BoundFieldAssignmentExpression(null, thisParameter, smClass, field, value);
 
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
 
@@ -60,26 +60,30 @@ public static class IteratorMoveNextBodyBuilder
         var endLabel = new BoundLabel("$iterEnd");
 
         statements.Add(new BoundConditionalGotoStatement(
+            null,
             startLabel,
             new BoundBinaryExpression(
+                null,
                 FieldRead(stateField),
                 BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
-                new BoundLiteralExpression(0)),
+                new BoundLiteralExpression(null, 0)),
             jumpIfTrue: true));
 
         foreach (var kvp in plan.YieldStates)
         {
             statements.Add(new BoundConditionalGotoStatement(
+                null,
                 yieldLabels[kvp.Value],
                 new BoundBinaryExpression(
+                    null,
                     FieldRead(stateField),
                     BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
-                    new BoundLiteralExpression(kvp.Value)),
+                    new BoundLiteralExpression(null, kvp.Value)),
                 jumpIfTrue: true));
         }
 
-        statements.Add(new BoundGotoStatement(endLabel));
-        statements.Add(new BoundLabelStatement(startLabel));
+        statements.Add(new BoundGotoStatement(null, endLabel));
+        statements.Add(new BoundLabelStatement(null, startLabel));
 
         var rewriter = new FieldAccessYieldRewriter(smClass, thisParameter, stateField, currentField, hoistedFieldMap, yieldLabels, endLabel);
         var rewrittenBody = rewriter.RewriteStatement(plan.Body);
@@ -92,11 +96,11 @@ public static class IteratorMoveNextBodyBuilder
             statements.Add(rewrittenBody);
         }
 
-        statements.Add(new BoundLabelStatement(endLabel));
-        statements.Add(new BoundExpressionStatement(FieldWrite(stateField, new BoundLiteralExpression(-1))));
-        statements.Add(new BoundReturnStatement(new BoundLiteralExpression(false)));
+        statements.Add(new BoundLabelStatement(null, endLabel));
+        statements.Add(new BoundExpressionStatement(null, FieldWrite(stateField, new BoundLiteralExpression(null, -1))));
+        statements.Add(new BoundReturnStatement(null, new BoundLiteralExpression(null, false)));
 
-        return new IteratorMoveNextBody(Lowerer.Lower(new BoundBlockStatement(statements.ToImmutable())), thisParameter);
+        return new IteratorMoveNextBody(Lowerer.Lower(new BoundBlockStatement(null, statements.ToImmutable())), thisParameter);
     }
 
     public static IteratorMoveNextBody Build(
@@ -125,29 +129,33 @@ public static class IteratorMoveNextBodyBuilder
 
         // State dispatch: if state == 0 goto start; if state == K goto resumeK; else goto end
         statements.Add(new BoundConditionalGotoStatement(
+            null,
             startLabel,
             new BoundBinaryExpression(
-                new BoundVariableExpression(stateLocal),
+                null,
+                new BoundVariableExpression(null, stateLocal),
                 BoundBinaryOperator.Bind(Syntax.SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
-                new BoundLiteralExpression(0)),
+                new BoundLiteralExpression(null, 0)),
             jumpIfTrue: true));
 
         foreach (var kvp in plan.YieldStates)
         {
             statements.Add(new BoundConditionalGotoStatement(
+                null,
                 yieldLabels[kvp.Value],
                 new BoundBinaryExpression(
-                    new BoundVariableExpression(stateLocal),
+                    null,
+                    new BoundVariableExpression(null, stateLocal),
                     BoundBinaryOperator.Bind(Syntax.SyntaxKind.EqualsEqualsToken, TypeSymbol.Int, TypeSymbol.Int),
-                    new BoundLiteralExpression(kvp.Value)),
+                    new BoundLiteralExpression(null, kvp.Value)),
                 jumpIfTrue: true));
         }
 
         // Default: goto end
-        statements.Add(new BoundGotoStatement(endLabel));
+        statements.Add(new BoundGotoStatement(null, endLabel));
 
         // start:
-        statements.Add(new BoundLabelStatement(startLabel));
+        statements.Add(new BoundLabelStatement(null, startLabel));
 
         // Rewrite the user body: replace yields with state transitions
         var rewriter = new YieldReplacer(stateLocal, currentLocal, yieldLabels, endLabel);
@@ -164,12 +172,13 @@ public static class IteratorMoveNextBodyBuilder
         }
 
         // Fall through to end: state = -1; return false
-        statements.Add(new BoundLabelStatement(endLabel));
+        statements.Add(new BoundLabelStatement(null, endLabel));
         statements.Add(new BoundExpressionStatement(
-            new BoundAssignmentExpression(stateLocal, new BoundLiteralExpression(-1))));
-        statements.Add(new BoundReturnStatement(new BoundLiteralExpression(false)));
+            null,
+            new BoundAssignmentExpression(null, stateLocal, new BoundLiteralExpression(null, -1))));
+        statements.Add(new BoundReturnStatement(null, new BoundLiteralExpression(null, false)));
 
-        var body = new BoundBlockStatement(statements.ToImmutable());
+        var body = new BoundBlockStatement(null, statements.ToImmutable());
         return new IteratorMoveNextBody(body, thisParameter);
     }
 
@@ -226,7 +235,7 @@ public static class IteratorMoveNextBodyBuilder
         {
             if (this.fieldMap.TryGetValue(node.Variable, out var field))
             {
-                return new BoundExpressionStatement(this.FieldWrite(field, this.RewriteExpression(node.Initializer)));
+                return new BoundExpressionStatement(null, this.FieldWrite(field, this.RewriteExpression(node.Initializer)));
             }
 
             return base.RewriteVariableDeclaration(node);
@@ -237,24 +246,24 @@ public static class IteratorMoveNextBodyBuilder
             this.yieldIndex++;
             var label = this.yieldLabels[this.yieldIndex];
             var statements = ImmutableArray.CreateBuilder<BoundStatement>();
-            statements.Add(new BoundExpressionStatement(this.FieldWrite(this.currentField, this.RewriteExpression(node.Expression))));
-            statements.Add(new BoundExpressionStatement(this.FieldWrite(this.stateField, new BoundLiteralExpression(this.yieldIndex))));
-            statements.Add(new BoundReturnStatement(new BoundLiteralExpression(true)));
-            statements.Add(new BoundLabelStatement(label));
-            statements.Add(new BoundExpressionStatement(this.FieldWrite(this.stateField, new BoundLiteralExpression(0))));
-            return new BoundBlockStatement(statements.ToImmutable());
+            statements.Add(new BoundExpressionStatement(null, this.FieldWrite(this.currentField, this.RewriteExpression(node.Expression))));
+            statements.Add(new BoundExpressionStatement(null, this.FieldWrite(this.stateField, new BoundLiteralExpression(null, this.yieldIndex))));
+            statements.Add(new BoundReturnStatement(null, new BoundLiteralExpression(null, true)));
+            statements.Add(new BoundLabelStatement(null, label));
+            statements.Add(new BoundExpressionStatement(null, this.FieldWrite(this.stateField, new BoundLiteralExpression(null, 0))));
+            return new BoundBlockStatement(null, statements.ToImmutable());
         }
 
         protected override BoundStatement RewriteReturnStatement(BoundReturnStatement node)
         {
-            return new BoundGotoStatement(this.endLabel);
+            return new BoundGotoStatement(null, this.endLabel);
         }
 
         private BoundExpression FieldRead(FieldSymbol field) =>
-            new BoundFieldAccessExpression(new BoundVariableExpression(this.thisParameter), this.smClass, field);
+            new BoundFieldAccessExpression(null, new BoundVariableExpression(null, this.thisParameter), this.smClass, field);
 
         private BoundExpression FieldWrite(FieldSymbol field, BoundExpression value) =>
-            new BoundFieldAssignmentExpression(this.thisParameter, this.smClass, field, value);
+            new BoundFieldAssignmentExpression(null, this.thisParameter, this.smClass, field, value);
     }
 
     private sealed class YieldReplacer : BoundTreeRewriter
@@ -285,21 +294,24 @@ public static class IteratorMoveNextBodyBuilder
             // current = expr; state = K; return true; resumeK: state = -1;
             var statements = ImmutableArray.CreateBuilder<BoundStatement>();
             statements.Add(new BoundExpressionStatement(
-                new BoundAssignmentExpression(currentLocal, node.Expression)));
+                null,
+                new BoundAssignmentExpression(null, currentLocal, node.Expression)));
             statements.Add(new BoundExpressionStatement(
-                new BoundAssignmentExpression(stateLocal, new BoundLiteralExpression(yieldIndex))));
-            statements.Add(new BoundReturnStatement(new BoundLiteralExpression(true)));
-            statements.Add(new BoundLabelStatement(label));
+                null,
+                new BoundAssignmentExpression(null, stateLocal, new BoundLiteralExpression(null, yieldIndex))));
+            statements.Add(new BoundReturnStatement(null, new BoundLiteralExpression(null, true)));
+            statements.Add(new BoundLabelStatement(null, label));
             statements.Add(new BoundExpressionStatement(
-                new BoundAssignmentExpression(stateLocal, new BoundLiteralExpression(-1))));
+                null,
+                new BoundAssignmentExpression(null, stateLocal, new BoundLiteralExpression(null, -1))));
 
-            return new BoundBlockStatement(statements.ToImmutable());
+            return new BoundBlockStatement(null, statements.ToImmutable());
         }
 
         protected override BoundStatement RewriteReturnStatement(BoundReturnStatement node)
         {
             // In an iterator, `return` (with or without value) means end iteration.
-            return new BoundGotoStatement(endLabel);
+            return new BoundGotoStatement(null, endLabel);
         }
     }
 }

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -48,9 +48,9 @@ public sealed class Lowerer : BoundTreeRewriter
             // <then>
             // end:
             var endLabel = GenerateLabel();
-            var gotoFalse = new BoundConditionalGotoStatement(endLabel, node.Condition, false);
-            var endLabelStatement = new BoundLabelStatement(endLabel);
-            var result = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(gotoFalse, node.ThenStatement, endLabelStatement));
+            var gotoFalse = new BoundConditionalGotoStatement(null, endLabel, node.Condition, false);
+            var endLabelStatement = new BoundLabelStatement(null, endLabel);
+            var result = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(gotoFalse, node.ThenStatement, endLabelStatement));
             return RewriteStatement(result);
         }
         else
@@ -71,11 +71,13 @@ public sealed class Lowerer : BoundTreeRewriter
             var elseLabel = GenerateLabel();
             var endLabel = GenerateLabel();
 
-            var gotoFalse = new BoundConditionalGotoStatement(elseLabel, node.Condition, false);
-            var gotoEndStatement = new BoundGotoStatement(endLabel);
-            var elseLabelStatement = new BoundLabelStatement(elseLabel);
-            var endLabelStatement = new BoundLabelStatement(endLabel);
-            var result = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+            var gotoFalse = new BoundConditionalGotoStatement(null, elseLabel, node.Condition, false);
+            var gotoEndStatement = new BoundGotoStatement(null, endLabel);
+            var elseLabelStatement = new BoundLabelStatement(null, elseLabel);
+            var endLabelStatement = new BoundLabelStatement(null, endLabel);
+            var result = new BoundBlockStatement(
+                null,
+                ImmutableArray.Create<BoundStatement>(
                 gotoFalse,
                 node.ThenStatement,
                 gotoEndStatement,
@@ -100,11 +102,13 @@ public sealed class Lowerer : BoundTreeRewriter
         //     goto continue
         //     break:
         // }
-        var continueLabelStatement = new BoundLabelStatement(node.ContinueLabel);
-        var gotoContinue = new BoundGotoStatement(node.ContinueLabel);
-        var breakLabelStatement = new BoundLabelStatement(node.BreakLabel);
+        var continueLabelStatement = new BoundLabelStatement(null, node.ContinueLabel);
+        var gotoContinue = new BoundGotoStatement(null, node.ContinueLabel);
+        var breakLabelStatement = new BoundLabelStatement(null, node.BreakLabel);
 
-        var result = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+        var result = new BoundBlockStatement(
+            null,
+            ImmutableArray.Create<BoundStatement>(
             continueLabelStatement,
             node.Body,
             gotoContinue,
@@ -136,74 +140,91 @@ public sealed class Lowerer : BoundTreeRewriter
         //     gotoTrue ((step > 0 && lower < upper) || (step < 0 && lower > upper)) body
         //     break:
         // }
-        var variableDeclaration = new BoundVariableDeclaration(node.Variable, node.LowerBound);
+        var variableDeclaration = new BoundVariableDeclaration(null, node.Variable, node.LowerBound);
         var upperBoundSymbol = new LocalVariableSymbol("upperBound", isReadOnly: true, type: TypeSymbol.Int);
-        var upperBoundDeclaration = new BoundVariableDeclaration(upperBoundSymbol, node.UpperBound);
+        var upperBoundDeclaration = new BoundVariableDeclaration(null, upperBoundSymbol, node.UpperBound);
         var stepBoundSymbol = new LocalVariableSymbol("step", isReadOnly: false, type: TypeSymbol.Int);
         var stepBoundDeclaration = new BoundVariableDeclaration(
+            null,
             variable: stepBoundSymbol,
-            initializer: new BoundLiteralExpression(1));
-        var variableExpression = new BoundVariableExpression(node.Variable);
-        var upperBoundExpression = new BoundVariableExpression(upperBoundSymbol);
-        var stepBoundExpression = new BoundVariableExpression(stepBoundSymbol);
+            initializer: new BoundLiteralExpression(null, 1));
+        var variableExpression = new BoundVariableExpression(null, node.Variable);
+        var upperBoundExpression = new BoundVariableExpression(null, upperBoundSymbol);
+        var stepBoundExpression = new BoundVariableExpression(null, stepBoundSymbol);
         var ifLowerIsGreaterThanUpperExpression = new BoundBinaryExpression(
+            null,
             left: variableExpression,
             op: BoundBinaryOperator.Bind(SyntaxKind.GreaterToken, TypeSymbol.Int, TypeSymbol.Int),
             right: upperBoundExpression);
         var stepBoundAssingment = new BoundExpressionStatement(
+            null,
             expression: new BoundAssignmentExpression(
+                null,
                 variable: stepBoundSymbol,
-                expression: new BoundLiteralExpression(-1)));
+                expression: new BoundLiteralExpression(null, -1)));
         var ifLowerIsGreaterThanUpperIfStatement = new BoundIfStatement(
+            null,
             condition: ifLowerIsGreaterThanUpperExpression,
             thenStatement: stepBoundAssingment,
             elseStatement: null);
         var startLabel = GenerateLabel();
-        var gotoStart = new BoundGotoStatement(startLabel);
+        var gotoStart = new BoundGotoStatement(null, startLabel);
         var bodyLabel = GenerateLabel();
-        var bodyLabelStatement = new BoundLabelStatement(bodyLabel);
-        var continueLabelStatement = new BoundLabelStatement(node.ContinueLabel);
+        var bodyLabelStatement = new BoundLabelStatement(null, bodyLabel);
+        var continueLabelStatement = new BoundLabelStatement(null, node.ContinueLabel);
         var increment = new BoundExpressionStatement(
+            null,
             expression: new BoundAssignmentExpression(
+                null,
                 variable: node.Variable,
                 expression: new BoundBinaryExpression(
+                    null,
                     left: variableExpression,
                     op: BoundBinaryOperator.Bind(SyntaxKind.PlusToken, TypeSymbol.Int, TypeSymbol.Int),
                     right: stepBoundExpression)));
-        var startLabelStatement = new BoundLabelStatement(startLabel);
-        var zeroLiteralExpression = new BoundLiteralExpression(0);
+        var startLabelStatement = new BoundLabelStatement(null, startLabel);
+        var zeroLiteralExpression = new BoundLiteralExpression(null, 0);
         var stepGreaterThanZeroExpression = new BoundBinaryExpression(
+            null,
             left: stepBoundExpression,
             op: BoundBinaryOperator.Bind(SyntaxKind.GreaterToken, TypeSymbol.Int, TypeSymbol.Int),
             right: zeroLiteralExpression);
         var lowerLessThanUpperExpression = new BoundBinaryExpression(
+            null,
             left: variableExpression,
             op: BoundBinaryOperator.Bind(SyntaxKind.LessToken, TypeSymbol.Int, TypeSymbol.Int),
             right: upperBoundExpression);
         var positiveStepAndLowerLessThanUpper = new BoundBinaryExpression(
+            null,
             left: stepGreaterThanZeroExpression,
             op: BoundBinaryOperator.Bind(SyntaxKind.AmpersandAmpersandToken, TypeSymbol.Bool, TypeSymbol.Bool),
             right: lowerLessThanUpperExpression);
         var stepLessThanZeroExpression = new BoundBinaryExpression(
+            null,
             left: stepBoundExpression,
             op: BoundBinaryOperator.Bind(SyntaxKind.LessToken, TypeSymbol.Int, TypeSymbol.Int),
             right: zeroLiteralExpression);
         var lowerGreaterThanUpperExpression = new BoundBinaryExpression(
+            null,
             left: variableExpression,
             op: BoundBinaryOperator.Bind(SyntaxKind.GreaterToken, TypeSymbol.Int, TypeSymbol.Int),
             right: upperBoundExpression);
         var negativeStepAndLowerGreaterThanUpper = new BoundBinaryExpression(
+            null,
             left: stepLessThanZeroExpression,
             op: BoundBinaryOperator.Bind(SyntaxKind.AmpersandAmpersandToken, TypeSymbol.Bool, TypeSymbol.Bool),
             right: lowerGreaterThanUpperExpression);
         var condition = new BoundBinaryExpression(
+            null,
             positiveStepAndLowerLessThanUpper,
             BoundBinaryOperator.Bind(SyntaxKind.PipePipeToken, TypeSymbol.Bool, TypeSymbol.Bool),
             negativeStepAndLowerGreaterThanUpper);
-        var gotoTrue = new BoundConditionalGotoStatement(bodyLabel, condition, jumpIfTrue: true);
-        var breakLabelStatement = new BoundLabelStatement(node.BreakLabel);
+        var gotoTrue = new BoundConditionalGotoStatement(null, bodyLabel, condition, jumpIfTrue: true);
+        var breakLabelStatement = new BoundLabelStatement(null, node.BreakLabel);
 
-        var result = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
+        var result = new BoundBlockStatement(
+            null,
+            ImmutableArray.Create<BoundStatement>(
             variableDeclaration,
             upperBoundDeclaration,
             stepBoundDeclaration,
@@ -281,7 +302,7 @@ public sealed class Lowerer : BoundTreeRewriter
         var streamClr = stream.Type?.ClrType;
         if (streamClr == null)
         {
-            return new BoundExpressionStatement(new BoundErrorExpression());
+            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
         }
 
         System.Type asyncEnumerableInterface = null;
@@ -307,7 +328,7 @@ public sealed class Lowerer : BoundTreeRewriter
 
         if (asyncEnumerableInterface == null)
         {
-            return new BoundExpressionStatement(new BoundErrorExpression());
+            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
         }
 
         var elementClr = asyncEnumerableInterface.GetGenericArguments()[0];
@@ -323,7 +344,7 @@ public sealed class Lowerer : BoundTreeRewriter
 
         if (getAsyncEnumerator == null || moveNextAsync == null || currentProperty == null || disposeAsync == null)
         {
-            return new BoundExpressionStatement(new BoundErrorExpression());
+            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
         }
 
         var cancellationTokenType = TypeSymbol.FromClrType(typeof(System.Threading.CancellationToken));
@@ -333,52 +354,58 @@ public sealed class Lowerer : BoundTreeRewriter
         var currentType = TypeSymbol.FromClrType(currentProperty.PropertyType);
 
         var enumeratorSymbol = new LocalVariableSymbol("$awaitEnum", isReadOnly: true, type: enumeratorType);
-        var enumeratorExpr = new BoundVariableExpression(enumeratorSymbol);
+        var enumeratorExpr = new BoundVariableExpression(null, enumeratorSymbol);
         var getEnumCall = new BoundImportedInstanceCallExpression(
+            null,
             stream,
             getAsyncEnumerator,
             enumeratorType,
-            ImmutableArray.Create<BoundExpression>(new BoundDefaultExpression(cancellationTokenType)));
-        var enumeratorDecl = new BoundVariableDeclaration(enumeratorSymbol, getEnumCall);
+            ImmutableArray.Create<BoundExpression>(new BoundDefaultExpression(null, cancellationTokenType)));
+        var enumeratorDecl = new BoundVariableDeclaration(null, enumeratorSymbol, getEnumCall);
 
         var startLabel = GenerateLabel();
         var endLabel = GenerateLabel();
         var moreSymbol = new LocalVariableSymbol("$more", isReadOnly: false, type: TypeSymbol.Bool);
 
         var moveNextCall = new BoundImportedInstanceCallExpression(
+            null,
             enumeratorExpr,
             moveNextAsync,
             valueTaskBoolType,
             ImmutableArray<BoundExpression>.Empty);
-        var moveNextAwait = new BoundAwaitExpression(moveNextCall, TypeSymbol.Bool);
-        var moreDecl = new BoundVariableDeclaration(moreSymbol, moveNextAwait);
+        var moveNextAwait = new BoundAwaitExpression(null, moveNextCall, TypeSymbol.Bool);
+        var moreDecl = new BoundVariableDeclaration(null, moreSymbol, moveNextAwait);
 
-        var currentAccess = new BoundClrPropertyAccessExpression(enumeratorExpr, currentProperty, currentType);
+        var currentAccess = new BoundClrPropertyAccessExpression(null, enumeratorExpr, currentProperty, currentType);
         var assignValue = new BoundExpressionStatement(
-            new BoundAssignmentExpression(valueVariable, currentAccess));
+            null,
+            new BoundAssignmentExpression(null, valueVariable, currentAccess));
 
         var tryStatements = ImmutableArray.CreateBuilder<BoundStatement>();
-        tryStatements.Add(new BoundLabelStatement(startLabel));
+        tryStatements.Add(new BoundLabelStatement(null, startLabel));
         tryStatements.Add(moreDecl);
-        tryStatements.Add(new BoundConditionalGotoStatement(endLabel, new BoundVariableExpression(moreSymbol), jumpIfTrue: false));
+        tryStatements.Add(new BoundConditionalGotoStatement(null, endLabel, new BoundVariableExpression(null, moreSymbol), jumpIfTrue: false));
         tryStatements.Add(assignValue);
         tryStatements.Add(body);
-        tryStatements.Add(new BoundGotoStatement(startLabel));
-        tryStatements.Add(new BoundLabelStatement(endLabel));
-        var tryBlock = new BoundBlockStatement(tryStatements.ToImmutable());
+        tryStatements.Add(new BoundGotoStatement(null, startLabel));
+        tryStatements.Add(new BoundLabelStatement(null, endLabel));
+        var tryBlock = new BoundBlockStatement(null, tryStatements.ToImmutable());
 
         var disposeCall = new BoundImportedInstanceCallExpression(
+            null,
             enumeratorExpr,
             disposeAsync,
             valueTaskType,
             ImmutableArray<BoundExpression>.Empty);
-        var disposeAwait = new BoundAwaitExpression(disposeCall, TypeSymbol.Void);
-        var finallyBlock = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(disposeAwait)));
+        var disposeAwait = new BoundAwaitExpression(null, disposeCall, TypeSymbol.Void);
+        var finallyBlock = new BoundBlockStatement(
+            null,
+            ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, disposeAwait)));
 
-        var tryStmt = new BoundTryStatement(tryBlock, ImmutableArray<BoundCatchClause>.Empty, finallyBlock);
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray<BoundCatchClause>.Empty, finallyBlock);
 
-        return new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(enumeratorDecl, tryStmt));
+        return new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(enumeratorDecl, tryStmt));
     }
 
     private BoundStatement LowerIndexedRange(BoundForRangeStatement node)
@@ -398,12 +425,12 @@ public sealed class Lowerer : BoundTreeRewriter
         //   break:
         // }
         var collectionSymbol = new LocalVariableSymbol("$coll", isReadOnly: true, type: node.Collection.Type);
-        var collectionDecl = new BoundVariableDeclaration(collectionSymbol, node.Collection);
-        var collectionExpr = new BoundVariableExpression(collectionSymbol);
+        var collectionDecl = new BoundVariableDeclaration(null, collectionSymbol, node.Collection);
+        var collectionExpr = new BoundVariableExpression(null, collectionSymbol);
 
         var indexSymbol = new LocalVariableSymbol("$i", isReadOnly: false, type: TypeSymbol.Int);
-        var indexDecl = new BoundVariableDeclaration(indexSymbol, new BoundLiteralExpression(0));
-        var indexExpr = new BoundVariableExpression(indexSymbol);
+        var indexDecl = new BoundVariableDeclaration(null, indexSymbol, new BoundLiteralExpression(null, 0));
+        var indexExpr = new BoundVariableExpression(null, indexSymbol);
 
         var startLabel = GenerateLabel();
         var bodyLabel = GenerateLabel();
@@ -411,40 +438,45 @@ public sealed class Lowerer : BoundTreeRewriter
         var perIterationStatements = ImmutableArray.CreateBuilder<BoundStatement>();
         if (node.KeyVariable != null)
         {
-            perIterationStatements.Add(new BoundVariableDeclaration(node.KeyVariable, indexExpr));
+            perIterationStatements.Add(new BoundVariableDeclaration(null, node.KeyVariable, indexExpr));
         }
 
         perIterationStatements.Add(new BoundVariableDeclaration(
+            null,
             node.ValueVariable,
-            new BoundIndexExpression(collectionExpr, indexExpr, node.ValueVariable.Type)));
+            new BoundIndexExpression(null, collectionExpr, indexExpr, node.ValueVariable.Type)));
 
         perIterationStatements.Add(node.Body);
 
         var increment = new BoundExpressionStatement(
+            null,
             new BoundAssignmentExpression(
+                null,
                 indexSymbol,
                 new BoundBinaryExpression(
+                    null,
                     indexExpr,
                     BoundBinaryOperator.Bind(SyntaxKind.PlusToken, TypeSymbol.Int, TypeSymbol.Int),
-                    new BoundLiteralExpression(1))));
+                    new BoundLiteralExpression(null, 1))));
 
         var hasMore = new BoundBinaryExpression(
+            null,
             indexExpr,
             BoundBinaryOperator.Bind(SyntaxKind.LessToken, TypeSymbol.Int, TypeSymbol.Int),
-            new BoundLenExpression(collectionExpr));
+            new BoundLenExpression(null, collectionExpr));
 
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
         statements.Add(collectionDecl);
         statements.Add(indexDecl);
-        statements.Add(new BoundGotoStatement(startLabel));
-        statements.Add(new BoundLabelStatement(bodyLabel));
+        statements.Add(new BoundGotoStatement(null, startLabel));
+        statements.Add(new BoundLabelStatement(null, bodyLabel));
         statements.AddRange(perIterationStatements);
-        statements.Add(new BoundLabelStatement(node.ContinueLabel));
+        statements.Add(new BoundLabelStatement(null, node.ContinueLabel));
         statements.Add(increment);
-        statements.Add(new BoundLabelStatement(startLabel));
-        statements.Add(new BoundConditionalGotoStatement(bodyLabel, hasMore, jumpIfTrue: true));
-        statements.Add(new BoundLabelStatement(node.BreakLabel));
-        return new BoundBlockStatement(statements.ToImmutable());
+        statements.Add(new BoundLabelStatement(null, startLabel));
+        statements.Add(new BoundConditionalGotoStatement(null, bodyLabel, hasMore, jumpIfTrue: true));
+        statements.Add(new BoundLabelStatement(null, node.BreakLabel));
+        return new BoundBlockStatement(null, statements.ToImmutable());
     }
 
     private BoundStatement LowerCollectionRange(BoundForRangeStatement node, bool isDictionary)
@@ -467,17 +499,17 @@ public sealed class Lowerer : BoundTreeRewriter
         {
             // Defensive: bail out unchanged if we can't resolve. The
             // binder already validated this case, so this shouldn't fire.
-            return new BoundExpressionStatement(new BoundErrorExpression());
+            return new BoundExpressionStatement(node.Syntax, new BoundErrorExpression(node.Syntax));
         }
 
         if (!TryBuildMoveNextAndCurrent(enumeratorType, out var moveNextCallFactory, out var currentAccessFactory))
         {
-            return new BoundExpressionStatement(new BoundErrorExpression());
+            return new BoundExpressionStatement(node.Syntax, new BoundErrorExpression(node.Syntax));
         }
 
         var enumeratorSymbol = new LocalVariableSymbol("$enum", isReadOnly: true, type: enumeratorType);
-        var enumeratorDecl = new BoundVariableDeclaration(enumeratorSymbol, getEnumCall);
-        var enumeratorExpr = new BoundVariableExpression(enumeratorSymbol);
+        var enumeratorDecl = new BoundVariableDeclaration(node.Syntax, enumeratorSymbol, getEnumCall);
+        var enumeratorExpr = new BoundVariableExpression(node.Syntax, enumeratorSymbol);
 
         var startLabel = GenerateLabel();
         var bodyLabel = GenerateLabel();
@@ -489,11 +521,11 @@ public sealed class Lowerer : BoundTreeRewriter
         if (!isDictionary && node.KeyVariable != null)
         {
             indexSymbol = new LocalVariableSymbol("$i", isReadOnly: false, type: TypeSymbol.Int);
-            statements.Add(new BoundVariableDeclaration(indexSymbol, new BoundLiteralExpression(0)));
+            statements.Add(new BoundVariableDeclaration(node.Syntax, indexSymbol, new BoundLiteralExpression(node.Syntax, 0)));
         }
 
-        statements.Add(new BoundGotoStatement(startLabel));
-        statements.Add(new BoundLabelStatement(bodyLabel));
+        statements.Add(new BoundGotoStatement(node.Syntax, startLabel));
+        statements.Add(new BoundLabelStatement(node.Syntax, bodyLabel));
 
         var currentAccess = currentAccessFactory(enumeratorExpr);
 
@@ -503,49 +535,54 @@ public sealed class Lowerer : BoundTreeRewriter
             var keyProp = kvpClr.GetProperty("Key");
             var valueProp = kvpClr.GetProperty("Value");
             var kvpSymbol = new LocalVariableSymbol("$kvp", isReadOnly: true, type: TypeSymbol.FromClrType(kvpClr));
-            statements.Add(new BoundVariableDeclaration(kvpSymbol, currentAccess));
-            var kvpExpr = new BoundVariableExpression(kvpSymbol);
+            statements.Add(new BoundVariableDeclaration(node.Syntax, kvpSymbol, currentAccess));
+            var kvpExpr = new BoundVariableExpression(node.Syntax, kvpSymbol);
 
             if (node.KeyVariable != null)
             {
                 statements.Add(new BoundVariableDeclaration(
+                    node.Syntax,
                     node.KeyVariable,
-                    new BoundClrPropertyAccessExpression(kvpExpr, keyProp, TypeSymbol.FromClrType(keyProp.PropertyType))));
+                    new BoundClrPropertyAccessExpression(node.Syntax, kvpExpr, keyProp, TypeSymbol.FromClrType(keyProp.PropertyType))));
             }
 
             statements.Add(new BoundVariableDeclaration(
+                node.Syntax,
                 node.ValueVariable,
-                new BoundClrPropertyAccessExpression(kvpExpr, valueProp, TypeSymbol.FromClrType(valueProp.PropertyType))));
+                new BoundClrPropertyAccessExpression(node.Syntax, kvpExpr, valueProp, TypeSymbol.FromClrType(valueProp.PropertyType))));
         }
         else
         {
             if (node.KeyVariable != null)
             {
-                statements.Add(new BoundVariableDeclaration(node.KeyVariable, new BoundVariableExpression(indexSymbol)));
+                statements.Add(new BoundVariableDeclaration(node.Syntax, node.KeyVariable, new BoundVariableExpression(node.Syntax, indexSymbol)));
             }
 
-            statements.Add(new BoundVariableDeclaration(node.ValueVariable, currentAccess));
+            statements.Add(new BoundVariableDeclaration(node.Syntax, node.ValueVariable, currentAccess));
         }
 
         statements.Add(node.Body);
-        statements.Add(new BoundLabelStatement(node.ContinueLabel));
+        statements.Add(new BoundLabelStatement(node.Syntax, node.ContinueLabel));
 
         if (indexSymbol != null)
         {
-            var indexExpr = new BoundVariableExpression(indexSymbol);
+            var indexExpr = new BoundVariableExpression(node.Syntax, indexSymbol);
             statements.Add(new BoundExpressionStatement(
+                node.Syntax,
                 new BoundAssignmentExpression(
+                    node.Syntax,
                     indexSymbol,
                     new BoundBinaryExpression(
+                        node.Syntax,
                         indexExpr,
                         BoundBinaryOperator.Bind(SyntaxKind.PlusToken, TypeSymbol.Int, TypeSymbol.Int),
-                        new BoundLiteralExpression(1)))));
+                        new BoundLiteralExpression(node.Syntax, 1)))));
         }
 
-        statements.Add(new BoundLabelStatement(startLabel));
-        statements.Add(new BoundConditionalGotoStatement(bodyLabel, moveNextCallFactory(enumeratorExpr), jumpIfTrue: true));
-        statements.Add(new BoundLabelStatement(node.BreakLabel));
-        return new BoundBlockStatement(statements.ToImmutable());
+        statements.Add(new BoundLabelStatement(node.Syntax, startLabel));
+        statements.Add(new BoundConditionalGotoStatement(node.Syntax, bodyLabel, moveNextCallFactory(enumeratorExpr), jumpIfTrue: true));
+        statements.Add(new BoundLabelStatement(node.Syntax, node.BreakLabel));
+        return new BoundBlockStatement(node.Syntax, statements.ToImmutable());
     }
 
     private static bool TryBuildGetEnumeratorCall(
@@ -566,6 +603,7 @@ public sealed class Lowerer : BoundTreeRewriter
             {
                 enumeratorType = TypeSymbol.FromClrType(getEnumerator.ReturnType);
                 getEnumeratorCall = new BoundImportedInstanceCallExpression(
+                    null,
                     collection,
                     getEnumerator,
                     enumeratorType,
@@ -580,6 +618,7 @@ public sealed class Lowerer : BoundTreeRewriter
         {
             enumeratorType = userGetEnumerator.Type;
             getEnumeratorCall = new BoundUserInstanceCallExpression(
+                null,
                 collection,
                 userGetEnumerator,
                 ImmutableArray<BoundExpression>.Empty);
@@ -614,11 +653,13 @@ public sealed class Lowerer : BoundTreeRewriter
             if (moveNext != null && currentMember != null)
             {
                 moveNextCallFactory = receiver => new BoundImportedInstanceCallExpression(
+                    null,
                     receiver,
                     moveNext,
                     TypeSymbol.Bool,
                     ImmutableArray<BoundExpression>.Empty);
                 currentAccessFactory = receiver => new BoundClrPropertyAccessExpression(
+                    null,
                     receiver,
                     currentMember,
                     GetClrMemberType(currentMember));
@@ -633,10 +674,11 @@ public sealed class Lowerer : BoundTreeRewriter
             userEnumerator.TryGetField("Current", out var currentField))
         {
             moveNextCallFactory = receiver => new BoundUserInstanceCallExpression(
+                null,
                 receiver,
                 userMoveNext,
                 ImmutableArray<BoundExpression>.Empty);
-            currentAccessFactory = receiver => new BoundFieldAccessExpression(receiver, userEnumerator, currentField);
+            currentAccessFactory = receiver => new BoundFieldAccessExpression(null, receiver, userEnumerator, currentField);
             return true;
         }
 
@@ -682,24 +724,24 @@ public sealed class Lowerer : BoundTreeRewriter
                 }
 
                 var flatFinally = t.FinallyBlock == null ? null : (BoundStatement)Flatten(t.FinallyBlock);
-                builder.Add(new BoundTryStatement(flatTry, flatCatches.ToImmutable(), flatFinally));
+                builder.Add(new BoundTryStatement(null, flatTry, flatCatches.ToImmutable(), flatFinally));
             }
             else if (current is BoundScopeStatement scope)
             {
                 // Phase 5.7: flatten the scope body so the evaluator's flat-statement
                 // walker sees lowered gotos/conditionals instead of nested blocks.
                 var flatScopeBody = Flatten(scope.Body);
-                builder.Add(new BoundScopeStatement(flatScopeBody));
+                builder.Add(new BoundScopeStatement(null, flatScopeBody));
             }
             else if (current is BoundPatternSwitchStatement ps)
             {
                 var flatArms = ImmutableArray.CreateBuilder<BoundPatternSwitchArm>(ps.Arms.Length);
                 foreach (var arm in ps.Arms)
                 {
-                    flatArms.Add(new BoundPatternSwitchArm(arm.Pattern, Flatten(arm.Body)));
+                    flatArms.Add(new BoundPatternSwitchArm(null, arm.Pattern, Flatten(arm.Body)));
                 }
 
-                builder.Add(new BoundPatternSwitchStatement(ps.Discriminant, flatArms.ToImmutable()));
+                builder.Add(new BoundPatternSwitchStatement(null, ps.Discriminant, flatArms.ToImmutable()));
             }
             else if (current is BoundSelectStatement sel)
             {
@@ -711,7 +753,7 @@ public sealed class Lowerer : BoundTreeRewriter
                     flatCases.Add(new BoundSelectCase(arm.CaseKind, arm.Channel, arm.Value, arm.Variable, flatArmBody));
                 }
 
-                builder.Add(new BoundSelectStatement(flatCases.ToImmutable()));
+                builder.Add(new BoundSelectStatement(null, flatCases.ToImmutable()));
             }
             else
             {
@@ -719,7 +761,7 @@ public sealed class Lowerer : BoundTreeRewriter
             }
         }
 
-        return new BoundBlockStatement(builder.ToImmutable());
+        return new BoundBlockStatement(null, builder.ToImmutable());
     }
 
     private BoundLabel GenerateLabel()

--- a/test/Core.Tests/CodeAnalysis/Binding/BoundDefaultExpressionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/BoundDefaultExpressionTests.cs
@@ -17,7 +17,7 @@ public class BoundDefaultExpressionTests
     public void BoundDefaultExpression_Has_Expected_Kind_And_Type()
     {
         var type = TypeSymbol.Int;
-        var expr = new BoundDefaultExpression(type);
+        var expr = new BoundDefaultExpression(null, type);
 
         Assert.Equal(BoundNodeKind.DefaultExpression, expr.Kind);
         Assert.Same(type, expr.Type);
@@ -27,7 +27,7 @@ public class BoundDefaultExpressionTests
     public void BoundDefaultExpression_With_ReferenceType_Has_Correct_Kind()
     {
         var type = TypeSymbol.String;
-        var expr = new BoundDefaultExpression(type);
+        var expr = new BoundDefaultExpression(null, type);
 
         Assert.Equal(BoundNodeKind.DefaultExpression, expr.Kind);
         Assert.Same(type, expr.Type);
@@ -37,7 +37,7 @@ public class BoundDefaultExpressionTests
     public void BoundDefaultExpression_With_ClrType_Preserves_Type()
     {
         var type = TypeSymbol.FromClrType(typeof(System.TimeSpan));
-        var expr = new BoundDefaultExpression(type);
+        var expr = new BoundDefaultExpression(null, type);
 
         Assert.Equal(BoundNodeKind.DefaultExpression, expr.Kind);
         Assert.Equal(typeof(System.TimeSpan), expr.Type.ClrType);

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncBoundTreeQueriesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncBoundTreeQueriesTests.cs
@@ -15,24 +15,24 @@ public class AsyncBoundTreeQueriesTests
     [Fact]
     public void HasAwait_OnExpressionStatementWithAwait_ReturnsTrue()
     {
-        var literal = new BoundLiteralExpression(0);
-        var await = new BoundAwaitExpression(literal, TypeSymbol.Int);
-        var stmt = new BoundExpressionStatement(await);
+        var literal = new BoundLiteralExpression(null, 0);
+        var await = new BoundAwaitExpression(null, literal, TypeSymbol.Int);
+        var stmt = new BoundExpressionStatement(null, await);
         Assert.True(AsyncBoundTreeQueries.HasAwait(stmt));
     }
 
     [Fact]
     public void HasAwait_OnPlainBlock_ReturnsFalse()
     {
-        var stmt = new BoundExpressionStatement(new BoundLiteralExpression(42));
+        var stmt = new BoundExpressionStatement(null, new BoundLiteralExpression(null, 42));
         Assert.False(AsyncBoundTreeQueries.HasAwait(stmt));
     }
 
     [Fact]
     public void HasAwait_OnNestedBlockWithAwait_ReturnsTrue()
     {
-        var inner = new BoundExpressionStatement(new BoundAwaitExpression(new BoundLiteralExpression(1), TypeSymbol.Int));
-        var outer = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(inner));
+        var inner = new BoundExpressionStatement(null, new BoundAwaitExpression(null, new BoundLiteralExpression(null, 1), TypeSymbol.Int));
+        var outer = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(inner));
         Assert.True(AsyncBoundTreeQueries.HasAwait(outer));
     }
 

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncCaptureWalkerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncCaptureWalkerTests.cs
@@ -16,7 +16,7 @@ public class AsyncCaptureWalkerTests
     [Fact]
     public void Analyze_EmptyBody_NoLocals()
     {
-        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var body = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
         var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
 
         Assert.Empty(result.Parameters);
@@ -27,8 +27,9 @@ public class AsyncCaptureWalkerTests
     public void Analyze_DeclaredLocal_IsHoisted()
     {
         var local = new LocalVariableSymbol("x", isReadOnly: false, TypeSymbol.Int);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundVariableDeclaration(local, new BoundLiteralExpression(0))));
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(null, local, new BoundLiteralExpression(null, 0))));
 
         var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
 
@@ -40,8 +41,9 @@ public class AsyncCaptureWalkerTests
     public void Analyze_ReferencedLocal_IsHoisted()
     {
         var local = new LocalVariableSymbol("y", isReadOnly: false, TypeSymbol.Int);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(new BoundVariableExpression(local))));
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, new BoundVariableExpression(null, local))));
 
         var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
 
@@ -53,10 +55,11 @@ public class AsyncCaptureWalkerTests
     public void Analyze_SameLocalReferencedTwice_AppearsOnce()
     {
         var local = new LocalVariableSymbol("x", isReadOnly: false, TypeSymbol.Int);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundVariableDeclaration(local, new BoundLiteralExpression(1)),
-            new BoundExpressionStatement(new BoundVariableExpression(local)),
-            new BoundExpressionStatement(new BoundVariableExpression(local))));
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(null, local, new BoundLiteralExpression(null, 1)),
+            new BoundExpressionStatement(null, new BoundVariableExpression(null, local)),
+            new BoundExpressionStatement(null, new BoundVariableExpression(null, local))));
 
         var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
 
@@ -70,11 +73,12 @@ public class AsyncCaptureWalkerTests
         var second = new LocalVariableSymbol("second", isReadOnly: false, TypeSymbol.Int);
         var third = new LocalVariableSymbol("third", isReadOnly: false, TypeSymbol.Int);
 
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundVariableDeclaration(first, new BoundLiteralExpression(1)),
-            new BoundExpressionStatement(new BoundVariableExpression(second)),
-            new BoundVariableDeclaration(third, new BoundLiteralExpression(3)),
-            new BoundExpressionStatement(new BoundVariableExpression(first))));
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(null, first, new BoundLiteralExpression(null, 1)),
+            new BoundExpressionStatement(null, new BoundVariableExpression(null, second)),
+            new BoundVariableDeclaration(null, third, new BoundLiteralExpression(null, 3)),
+            new BoundExpressionStatement(null, new BoundVariableExpression(null, first))));
 
         var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
 
@@ -87,9 +91,10 @@ public class AsyncCaptureWalkerTests
         var userLocal = new LocalVariableSymbol("x", isReadOnly: false, TypeSymbol.Int);
         var spillTemp = new LocalVariableSymbol(GeneratedNames.SpillTempField(0), isReadOnly: false, TypeSymbol.Int);
 
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundVariableDeclaration(userLocal, new BoundLiteralExpression(1)),
-            new BoundVariableDeclaration(spillTemp, new BoundLiteralExpression(2))));
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(null, userLocal, new BoundLiteralExpression(null, 1)),
+            new BoundVariableDeclaration(null, spillTemp, new BoundLiteralExpression(null, 2))));
 
         var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
 
@@ -102,7 +107,7 @@ public class AsyncCaptureWalkerTests
     {
         var p1 = new ParameterSymbol("a", TypeSymbol.Int);
         var p2 = new ParameterSymbol("b", TypeSymbol.String);
-        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var body = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
 
         var result = AsyncCaptureWalker.Analyze(body, ImmutableArray.Create(p1, p2));
 
@@ -115,8 +120,9 @@ public class AsyncCaptureWalkerTests
     public void Analyze_ParameterReferencedInBody_NotDuplicatedIntoLocals()
     {
         var p1 = new ParameterSymbol("a", TypeSymbol.Int);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(new BoundVariableExpression(p1))));
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, new BoundVariableExpression(null, p1))));
 
         var result = AsyncCaptureWalker.Analyze(body, ImmutableArray.Create(p1));
 

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriterTests.cs
@@ -24,12 +24,14 @@ public class AsyncExceptionHandlerRewriterTests
     {
         // Arrange: try { x = 1 } finally { x = 2 } — no await anywhere
         var x = new LocalVariableSymbol("x", false, TypeSymbol.Int);
-        var tryBlock = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(new BoundAssignmentExpression(x, new BoundLiteralExpression(1)))));
-        var finallyBlock = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(new BoundAssignmentExpression(x, new BoundLiteralExpression(2)))));
-        var tryStmt = new BoundTryStatement(tryBlock, ImmutableArray<BoundCatchClause>.Empty, finallyBlock);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(tryStmt));
+        var tryBlock = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 1)))));
+        var finallyBlock = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 2)))));
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray<BoundCatchClause>.Empty, finallyBlock);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
 
         // Act
         var result = AsyncExceptionHandlerRewriter.Rewrite(body);
@@ -43,13 +45,15 @@ public class AsyncExceptionHandlerRewriterTests
     {
         // Arrange: try { x = 1 } finally { await ... }
         var x = new LocalVariableSymbol("x", false, TypeSymbol.Int);
-        var tryBlock = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(new BoundAssignmentExpression(x, new BoundLiteralExpression(1)))));
-        var awaitExpr = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
-        var finallyBlock = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(awaitExpr)));
-        var tryStmt = new BoundTryStatement(tryBlock, ImmutableArray<BoundCatchClause>.Empty, finallyBlock);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(tryStmt));
+        var tryBlock = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 1)))));
+        var awaitExpr = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int);
+        var finallyBlock = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, awaitExpr)));
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray<BoundCatchClause>.Empty, finallyBlock);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
 
         // Act
         var result = AsyncExceptionHandlerRewriter.Rewrite(body);
@@ -86,13 +90,15 @@ public class AsyncExceptionHandlerRewriterTests
         // Arrange: try { x = 1 } catch (e Exception) { x = 2 } — no await
         var x = new LocalVariableSymbol("x", false, TypeSymbol.Int);
         var e = new LocalVariableSymbol("e", false, ExceptionType);
-        var tryBlock = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(new BoundAssignmentExpression(x, new BoundLiteralExpression(1)))));
-        var catchBody = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(new BoundAssignmentExpression(x, new BoundLiteralExpression(2)))));
+        var tryBlock = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 1)))));
+        var catchBody = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 2)))));
         var catchClause = new BoundCatchClause(ExceptionType, e, catchBody);
-        var tryStmt = new BoundTryStatement(tryBlock, ImmutableArray.Create(catchClause), null);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(tryStmt));
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray.Create(catchClause), null);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
 
         // Act
         var result = AsyncExceptionHandlerRewriter.Rewrite(body);
@@ -107,15 +113,17 @@ public class AsyncExceptionHandlerRewriterTests
         // Arrange: try { x = 1 } catch (e Exception) { await ...; x = 2 }
         var x = new LocalVariableSymbol("x", false, TypeSymbol.Int);
         var e = new LocalVariableSymbol("e", false, ExceptionType);
-        var tryBlock = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(new BoundAssignmentExpression(x, new BoundLiteralExpression(1)))));
-        var awaitExpr = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
-        var catchBody = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(awaitExpr),
-            new BoundExpressionStatement(new BoundAssignmentExpression(x, new BoundLiteralExpression(2)))));
+        var tryBlock = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 1)))));
+        var awaitExpr = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int);
+        var catchBody = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, awaitExpr),
+            new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 2)))));
         var catchClause = new BoundCatchClause(ExceptionType, e, catchBody);
-        var tryStmt = new BoundTryStatement(tryBlock, ImmutableArray.Create(catchClause), null);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(tryStmt));
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray.Create(catchClause), null);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
 
         // Act
         var result = AsyncExceptionHandlerRewriter.Rewrite(body);
@@ -151,17 +159,20 @@ public class AsyncExceptionHandlerRewriterTests
         // Arrange: try { x = 1 } catch (e) { await a } finally { await b }
         var x = new LocalVariableSymbol("x", false, TypeSymbol.Int);
         var e = new LocalVariableSymbol("e", false, ExceptionType);
-        var tryBlock = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(new BoundAssignmentExpression(x, new BoundLiteralExpression(1)))));
-        var awaitA = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
-        var catchBody = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(awaitA)));
+        var tryBlock = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 1)))));
+        var awaitA = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int);
+        var catchBody = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, awaitA)));
         var catchClause = new BoundCatchClause(ExceptionType, e, catchBody);
-        var awaitB = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
-        var finallyBlock = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(awaitB)));
-        var tryStmt = new BoundTryStatement(tryBlock, ImmutableArray.Create(catchClause), finallyBlock);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(tryStmt));
+        var awaitB = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int);
+        var finallyBlock = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, awaitB)));
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray.Create(catchClause), finallyBlock);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
 
         // Act
         var result = AsyncExceptionHandlerRewriter.Rewrite(body);
@@ -185,8 +196,8 @@ public class AsyncExceptionHandlerRewriterTests
     {
         // A body with no await should pass through unchanged
         var x = new LocalVariableSymbol("x", false, TypeSymbol.Int);
-        var stmt = new BoundExpressionStatement(new BoundAssignmentExpression(x, new BoundLiteralExpression(42)));
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(stmt));
+        var stmt = new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 42)));
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(stmt));
 
         var result = AsyncExceptionHandlerRewriter.Rewrite(body);
 
@@ -199,16 +210,18 @@ public class AsyncExceptionHandlerRewriterTests
         // Arrange: try { throw new Exception() } catch (e) { await ...; throw e; }
         // After rewrite, the throw should reference the pendingException variable.
         var e = new LocalVariableSymbol("e", false, ExceptionType);
-        var throwExpr = new BoundThrowStatement(new BoundVariableExpression(e));
-        var awaitExpr = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
-        var catchBody = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(awaitExpr),
+        var throwExpr = new BoundThrowStatement(null, new BoundVariableExpression(null, e));
+        var awaitExpr = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int);
+        var catchBody = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, awaitExpr),
             throwExpr));
         var catchClause = new BoundCatchClause(ExceptionType, e, catchBody);
-        var tryBlock = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundThrowStatement(new BoundLiteralExpression("test", TypeSymbol.String))));
-        var tryStmt = new BoundTryStatement(tryBlock, ImmutableArray.Create(catchClause), null);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(tryStmt));
+        var tryBlock = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundThrowStatement(null, new BoundLiteralExpression(null, "test", TypeSymbol.String))));
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray.Create(catchClause), null);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
 
         // Act
         var result = AsyncExceptionHandlerRewriter.Rewrite(body);
@@ -232,13 +245,15 @@ public class AsyncExceptionHandlerRewriterTests
         // process the finally-with-await pattern; the return inside the try body
         // will pass through (it's handled by MoveNextBodyRewriter's exit label).
         var x = new LocalVariableSymbol("x", false, TypeSymbol.Int);
-        var tryBlock = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundReturnStatement(new BoundLiteralExpression(42))));
-        var awaitExpr = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
-        var finallyBlock = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundExpressionStatement(awaitExpr)));
-        var tryStmt = new BoundTryStatement(tryBlock, ImmutableArray<BoundCatchClause>.Empty, finallyBlock);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(tryStmt));
+        var tryBlock = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundReturnStatement(null, new BoundLiteralExpression(null, 42))));
+        var awaitExpr = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int);
+        var finallyBlock = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, awaitExpr)));
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray<BoundCatchClause>.Empty, finallyBlock);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
 
         // Act: should not throw; should rewrite
         var result = AsyncExceptionHandlerRewriter.Rewrite(body);

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncStateMachineFieldMapTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncStateMachineFieldMapTests.cs
@@ -18,7 +18,7 @@ public class AsyncStateMachineFieldMapTests
     public void Create_MaterializesStateMachineStruct()
     {
         var fn = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void) { IsAsync = true };
-        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var body = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
         var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
 
         var map = AsyncStateMachineFieldMap.Create(sm, body);
@@ -36,7 +36,7 @@ public class AsyncStateMachineFieldMapTests
         var p1 = new ParameterSymbol("a", TypeSymbol.Int);
         var p2 = new ParameterSymbol("b", TypeSymbol.String);
         var fn = new FunctionSymbol("doIt", ImmutableArray.Create(p1, p2), TypeSymbol.Void) { IsAsync = true };
-        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var body = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
         var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
 
         var map = AsyncStateMachineFieldMap.Create(sm, body);
@@ -53,9 +53,10 @@ public class AsyncStateMachineFieldMapTests
         var fn = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void) { IsAsync = true };
         var x = new LocalVariableSymbol("x", isReadOnly: false, TypeSymbol.Int);
         var y = new LocalVariableSymbol("y", isReadOnly: false, TypeSymbol.String);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundVariableDeclaration(x, new BoundLiteralExpression(1)),
-            new BoundVariableDeclaration(y, new BoundLiteralExpression("hello"))));
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(null, x, new BoundLiteralExpression(null, 1)),
+            new BoundVariableDeclaration(null, y, new BoundLiteralExpression(null, "hello"))));
         var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
 
         var map = AsyncStateMachineFieldMap.Create(sm, body);
@@ -70,12 +71,12 @@ public class AsyncStateMachineFieldMapTests
     public void Read_CreatesExistingFieldAccessNode()
     {
         var fn = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void) { IsAsync = true };
-        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var body = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
         var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
         var map = AsyncStateMachineFieldMap.Create(sm, body);
         var receiver = new LocalVariableSymbol("this", isReadOnly: false, map.StructType);
 
-        var access = map.Read(new BoundVariableExpression(receiver), map.StateField);
+        var access = map.Read(new BoundVariableExpression(null, receiver), map.StateField);
 
         Assert.Same(map.StructType, access.StructType);
         Assert.Same(map.StateField, access.Field);
@@ -86,11 +87,11 @@ public class AsyncStateMachineFieldMapTests
     public void Write_CreatesExistingFieldAssignmentNode()
     {
         var fn = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void) { IsAsync = true };
-        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var body = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
         var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
         var map = AsyncStateMachineFieldMap.Create(sm, body);
         var receiver = new LocalVariableSymbol("this", isReadOnly: false, map.StructType);
-        var value = new BoundLiteralExpression(-1);
+        var value = new BoundLiteralExpression(null, -1);
 
         var assignment = map.Write(receiver, map.StateField, value);
 
@@ -105,7 +106,7 @@ public class AsyncStateMachineFieldMapTests
     public void Create_FreezesSynthesizedFieldLayout()
     {
         var fn = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void) { IsAsync = true };
-        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var body = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
         var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
 
         AsyncStateMachineFieldMap.Create(sm, body);

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriterTests.cs
@@ -59,7 +59,7 @@ public class AsyncStateMachineRewriterTests
     {
         var parameter = new ParameterSymbol("value", TypeSymbol.Int);
         var function = new FunctionSymbol("doIt", ImmutableArray.Create(parameter), TypeSymbol.Void, package: Package) { IsAsync = true };
-        var body = Block(new BoundExpressionStatement(new BoundVariableExpression(parameter)));
+        var body = Block(new BoundExpressionStatement(null, new BoundVariableExpression(null, parameter)));
         var program = Program(function, body);
 
         var result = AsyncStateMachineRewriter.Rewrite(program, Resolver);
@@ -75,12 +75,12 @@ public class AsyncStateMachineRewriterTests
     [Fact]
     public void Rewrite_AllocatesAwaitResumeStatesInTraversalOrder()
     {
-        var firstAwait = new BoundAwaitExpression(new BoundLiteralExpression(1), TypeSymbol.Int);
-        var secondAwait = new BoundAwaitExpression(new BoundLiteralExpression(2), TypeSymbol.Int);
+        var firstAwait = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 1), TypeSymbol.Int);
+        var secondAwait = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 2), TypeSymbol.Int);
         var function = new FunctionSymbol("compute", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int, package: Package) { IsAsync = true };
         var body = Block(
-            new BoundExpressionStatement(firstAwait),
-            new BoundExpressionStatement(secondAwait));
+            new BoundExpressionStatement(null, firstAwait),
+            new BoundExpressionStatement(null, secondAwait));
         var program = Program(function, body);
 
         var result = AsyncStateMachineRewriter.Rewrite(program, Resolver);
@@ -131,24 +131,26 @@ public class AsyncStateMachineRewriterTests
         // We bind a program with try/catch around an await + an await in an expression,
         // run Rewrite, and assert the resulting plan demonstrates all passes ran.
         var awaitInTry = new BoundAwaitExpression(
-            new BoundLiteralExpression(null, TypeSymbol.FromClrType(typeof(System.Threading.Tasks.Task))),
+            null,
+            new BoundLiteralExpression(null, null, TypeSymbol.FromClrType(typeof(System.Threading.Tasks.Task))),
             TypeSymbol.Void);
         var awaitInExpr = new BoundAwaitExpression(
-            new BoundLiteralExpression(null, TypeSymbol.FromClrType(typeof(System.Threading.Tasks.Task<int>))),
+            null,
+            new BoundLiteralExpression(null, null, TypeSymbol.FromClrType(typeof(System.Threading.Tasks.Task<int>))),
             TypeSymbol.Int);
 
         // try { await ...; } catch(Exception e) { }
         var catchVar = new LocalVariableSymbol("e", false, TypeSymbol.FromClrType(typeof(System.Exception)));
-        var tryBlock = Block(new BoundExpressionStatement(awaitInTry));
+        var tryBlock = Block(new BoundExpressionStatement(null, awaitInTry));
         var catchBody = Block();
         var catchClause = new BoundCatchClause(TypeSymbol.FromClrType(typeof(System.Exception)), catchVar, catchBody);
-        var tryStmt = new BoundTryStatement(tryBlock, ImmutableArray.Create(catchClause), finallyBlock: null);
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray.Create(catchClause), finallyBlock: null);
 
         // x = await Task<int>
         var x = new LocalVariableSymbol("x", false, TypeSymbol.Int);
         var body = Block(
             tryStmt,
-            new BoundVariableDeclaration(x, awaitInExpr));
+            new BoundVariableDeclaration(null, x, awaitInExpr));
 
         var function = new FunctionSymbol("pipeline", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int, package: Package) { IsAsync = true };
         var program = Program(function, body);
@@ -197,7 +199,7 @@ public class AsyncStateMachineRewriterTests
 
         protected override BoundExpression RewriteBinaryExpression(BoundBinaryExpression node)
         {
-            if (AsyncBoundTreeQueries.HasAwait(new BoundExpressionStatement(node)))
+            if (AsyncBoundTreeQueries.HasAwait(new BoundExpressionStatement(null, node)))
             {
                 Found = true;
             }
@@ -208,7 +210,7 @@ public class AsyncStateMachineRewriterTests
 
     private static BoundBlockStatement Block(params BoundStatement[] statements)
     {
-        return new BoundBlockStatement(statements.ToImmutableArray());
+        return new BoundBlockStatement(null, statements.ToImmutableArray());
     }
 
     private static BoundProgram Program(FunctionSymbol function, BoundBlockStatement body)

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilderTests.cs
@@ -20,7 +20,7 @@ public class AsyncStateMachineTypeBuilderTests
     public void Build_NonAsyncKickoff_Throws()
     {
         var fn = new FunctionSymbol("foo", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void);
-        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var body = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
 
         Assert.Throws<ArgumentException>(() => AsyncStateMachineTypeBuilder.Build(fn, body, Resolver));
     }
@@ -29,7 +29,7 @@ public class AsyncStateMachineTypeBuilderTests
     public void Build_VoidAsyncKickoff_BindsTaskBuilder()
     {
         var fn = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void) { IsAsync = true };
-        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var body = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
 
         var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
 
@@ -44,7 +44,7 @@ public class AsyncStateMachineTypeBuilderTests
     public void Build_IntAsyncKickoff_BindsGenericTaskBuilder()
     {
         var fn = new FunctionSymbol("compute", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int) { IsAsync = true };
-        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var body = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
 
         var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
 
@@ -57,7 +57,7 @@ public class AsyncStateMachineTypeBuilderTests
     public void Build_PopulatesStateAndBuilderFields_InOrder()
     {
         var fn = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void) { IsAsync = true };
-        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var body = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
 
         var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
 
@@ -76,7 +76,7 @@ public class AsyncStateMachineTypeBuilderTests
         var p1 = new ParameterSymbol("a", TypeSymbol.Int);
         var p2 = new ParameterSymbol("b", TypeSymbol.String);
         var fn = new FunctionSymbol("doIt", ImmutableArray.Create(p1, p2), TypeSymbol.Void) { IsAsync = true };
-        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var body = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
 
         var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
 
@@ -94,9 +94,10 @@ public class AsyncStateMachineTypeBuilderTests
         var fn = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void) { IsAsync = true };
         var x = new LocalVariableSymbol("x", isReadOnly: false, TypeSymbol.Int);
         var y = new LocalVariableSymbol("y", isReadOnly: false, TypeSymbol.String);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundVariableDeclaration(x, new BoundLiteralExpression(1)),
-            new BoundVariableDeclaration(y, new BoundLiteralExpression("hello"))));
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(null, x, new BoundLiteralExpression(null, 1)),
+            new BoundVariableDeclaration(null, y, new BoundLiteralExpression(null, "hello"))));
 
         var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
 
@@ -116,7 +117,7 @@ public class AsyncStateMachineTypeBuilderTests
 
         var elem = TypeSymbol.FromClrType(typeof(int));
         var fn = new FunctionSymbol("stream", ImmutableArray<ParameterSymbol>.Empty, elem) { IsAsync = true };
-        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var body = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
 
         var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
 
@@ -129,7 +130,7 @@ public class AsyncStateMachineTypeBuilderTests
     public void Build_OrdinalAffectsTypeName()
     {
         var fn = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void) { IsAsync = true };
-        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var body = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
 
         var sm0 = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver, ordinal: 0);
         var sm3 = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver, ordinal: 3);
@@ -142,7 +143,7 @@ public class AsyncStateMachineTypeBuilderTests
     public void Build_PopulatedTypeIs_BackLinkable_FromFunctionSymbol()
     {
         var fn = new FunctionSymbol("doIt", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void) { IsAsync = true };
-        var body = new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty);
+        var body = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
 
         var sm = AsyncStateMachineTypeBuilder.Build(fn, body, Resolver);
         fn.StateMachineType = sm;

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/KickoffBodyBuilderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/KickoffBodyBuilderTests.cs
@@ -199,6 +199,6 @@ public class KickoffBodyBuilderTests
 
     private static BoundBlockStatement Block(params BoundStatement[] statements)
     {
-        return new BoundBlockStatement(statements.ToImmutableArray());
+        return new BoundBlockStatement(null, statements.ToImmutableArray());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/MoveNextBodyBuilderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/MoveNextBodyBuilderTests.cs
@@ -29,11 +29,11 @@ public class MoveNextBodyBuilderTests
     [Fact]
     public void Build_AwaitStates_CreatesResumeLabelsOrderedByState()
     {
-        var firstAwait = new BoundAwaitExpression(new BoundLiteralExpression(1), TypeSymbol.Int);
-        var secondAwait = new BoundAwaitExpression(new BoundLiteralExpression(2), TypeSymbol.Int);
+        var firstAwait = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 1), TypeSymbol.Int);
+        var secondAwait = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 2), TypeSymbol.Int);
         var body = Block(
-            new BoundExpressionStatement(secondAwait),
-            new BoundExpressionStatement(firstAwait));
+            new BoundExpressionStatement(null, secondAwait),
+            new BoundExpressionStatement(null, firstAwait));
         var states = ImmutableDictionary.CreateRange(new[]
         {
             new System.Collections.Generic.KeyValuePair<BoundAwaitExpression, int>(secondAwait, 1),
@@ -78,6 +78,6 @@ public class MoveNextBodyBuilderTests
 
     private static BoundBlockStatement Block(params BoundStatement[] statements)
     {
-        return new BoundBlockStatement(statements.ToImmutableArray());
+        return new BoundBlockStatement(null, statements.ToImmutableArray());
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/MoveNextBodyRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/MoveNextBodyRewriterTests.cs
@@ -28,7 +28,7 @@ public class MoveNextBodyRewriterTests
     {
         // Arrange: async body with no awaits
         var function = new FunctionSymbol("noAwait", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, package: Package) { IsAsync = true };
-        var body = Block(new BoundExpressionStatement(new BoundLiteralExpression(42)));
+        var body = Block(new BoundExpressionStatement(null, new BoundLiteralExpression(null, 42)));
         var plan = BuildPlan(function, body);
 
         // Act
@@ -79,7 +79,7 @@ public class MoveNextBodyRewriterTests
         // Arrange: async body with one await
         var awaitExpr = MakeTaskAwait();
         var function = new FunctionSymbol("oneAwait", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, package: Package) { IsAsync = true };
-        var body = Block(new BoundExpressionStatement(awaitExpr));
+        var body = Block(new BoundExpressionStatement(null, awaitExpr));
         var plan = BuildPlan(function, body);
 
         // Act
@@ -127,8 +127,8 @@ public class MoveNextBodyRewriterTests
         var await2 = MakeTaskAwait();
         var function = new FunctionSymbol("twoAwaits", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, package: Package) { IsAsync = true };
         var body = Block(
-            new BoundExpressionStatement(await1),
-            new BoundExpressionStatement(await2));
+            new BoundExpressionStatement(null, await1),
+            new BoundExpressionStatement(null, await2));
         var plan = BuildPlan(function, body);
 
         // Act
@@ -155,7 +155,7 @@ public class MoveNextBodyRewriterTests
         var awaitExpr = MakeTaskIntAwait();
         var x = new LocalVariableSymbol("x", false, TypeSymbol.Int);
         var function = new FunctionSymbol("initAwait", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, package: Package) { IsAsync = true };
-        var body = Block(new BoundVariableDeclaration(x, awaitExpr));
+        var body = Block(new BoundVariableDeclaration(null, x, awaitExpr));
         var plan = BuildPlan(function, body);
 
         // Act
@@ -178,8 +178,8 @@ public class MoveNextBodyRewriterTests
         var x = new LocalVariableSymbol("x", false, TypeSymbol.Int);
         var function = new FunctionSymbol("assignAwait", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, package: Package) { IsAsync = true };
         var body = Block(
-            new BoundVariableDeclaration(x, new BoundLiteralExpression(0)),
-            new BoundExpressionStatement(new BoundAssignmentExpression(x, awaitExpr)));
+            new BoundVariableDeclaration(null, x, new BoundLiteralExpression(null, 0)),
+            new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, awaitExpr)));
         var plan = BuildPlan(function, body);
 
         // Act
@@ -199,7 +199,7 @@ public class MoveNextBodyRewriterTests
         // Arrange: body with single await — both markers must share state number
         var awaitExpr = MakeTaskAwait();
         var function = new FunctionSymbol("markers", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, package: Package) { IsAsync = true };
-        var body = Block(new BoundExpressionStatement(awaitExpr));
+        var body = Block(new BoundExpressionStatement(null, awaitExpr));
         var plan = BuildPlan(function, body);
 
         // Act
@@ -221,7 +221,7 @@ public class MoveNextBodyRewriterTests
     {
         // Arrange: async function returning int with explicit return
         var function = new FunctionSymbol("retVal", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int, package: Package) { IsAsync = true };
-        var body = Block(new BoundReturnStatement(new BoundLiteralExpression(99)));
+        var body = Block(new BoundReturnStatement(null, new BoundLiteralExpression(null, 99)));
         var plan = BuildPlan(function, body);
 
         // Act
@@ -247,9 +247,9 @@ public class MoveNextBodyRewriterTests
         var function = new FunctionSymbol("hoisted", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, package: Package) { IsAsync = true };
         // x := 5; await ...; use x
         var body = Block(
-            new BoundVariableDeclaration(x, new BoundLiteralExpression(5)),
-            new BoundExpressionStatement(awaitExpr),
-            new BoundExpressionStatement(new BoundVariableExpression(x)));
+            new BoundVariableDeclaration(null, x, new BoundLiteralExpression(null, 5)),
+            new BoundExpressionStatement(null, awaitExpr),
+            new BoundExpressionStatement(null, new BoundVariableExpression(null, x)));
         var plan = BuildPlan(function, body);
 
         // Act
@@ -293,14 +293,15 @@ public class MoveNextBodyRewriterTests
 
     private static BoundBlockStatement Block(params BoundStatement[] statements)
     {
-        return new BoundBlockStatement(statements.ToImmutableArray());
+        return new BoundBlockStatement(null, statements.ToImmutableArray());
     }
 
     private static BoundAwaitExpression MakeTaskAwait()
     {
         // Await on a Task (void result) — use Task type so AwaitableShape resolves
         return new BoundAwaitExpression(
-            new BoundLiteralExpression(null, TypeSymbol.FromClrType(typeof(Task))),
+            null,
+            new BoundLiteralExpression(null, null, TypeSymbol.FromClrType(typeof(Task))),
             TypeSymbol.Void);
     }
 
@@ -308,7 +309,8 @@ public class MoveNextBodyRewriterTests
     {
         // Await on a Task<int> — result type is int
         return new BoundAwaitExpression(
-            new BoundLiteralExpression(null, TypeSymbol.FromClrType(typeof(Task<int>))),
+            null,
+            new BoundLiteralExpression(null, null, TypeSymbol.FromClrType(typeof(Task<int>))),
             TypeSymbol.Int);
     }
 

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/RefInitializationHoisterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/RefInitializationHoisterTests.cs
@@ -25,12 +25,15 @@ public class RefInitializationHoisterTests
 
         // var x = 42
         // var y = x + 1
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(
-            new BoundVariableDeclaration(x, new BoundLiteralExpression(42)),
-            new BoundVariableDeclaration(y, new BoundBinaryExpression(
-                new BoundVariableExpression(x),
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(null, x, new BoundLiteralExpression(null, 42)),
+            new BoundVariableDeclaration(null,
+y, new BoundBinaryExpression(
+                null,
+                new BoundVariableExpression(null, x),
                 BoundBinaryOperator.Bind(Core.CodeAnalysis.Syntax.SyntaxKind.PlusToken, TypeSymbol.Int, TypeSymbol.Int),
-                new BoundLiteralExpression(1)))));
+                new BoundLiteralExpression(null, 1)))));
 
         var result = RefInitializationHoister.Rewrite(body);
 
@@ -48,14 +51,14 @@ public class RefInitializationHoisterTests
         var x = new LocalVariableSymbol("x", isReadOnly: false, TypeSymbol.Int);
         var slot = new LocalVariableSymbol("slot", isReadOnly: false, ByRefTypeSymbol.Get(TypeSymbol.Int));
 
-        var declX = new BoundVariableDeclaration(x, new BoundLiteralExpression(10));
-        var declSlot = new BoundVariableDeclaration(slot, new BoundAddressOfExpression(new BoundVariableExpression(x)));
+        var declX = new BoundVariableDeclaration(null, x, new BoundLiteralExpression(null, 10));
+        var declSlot = new BoundVariableDeclaration(null, slot, new BoundAddressOfExpression(null, new BoundVariableExpression(null, x)));
 
         // Use: *slot (dereference)
-        var deref = new BoundDereferenceExpression(new BoundVariableExpression(slot));
-        var useStmt = new BoundExpressionStatement(deref);
+        var deref = new BoundDereferenceExpression(null, new BoundVariableExpression(null, slot));
+        var useStmt = new BoundExpressionStatement(null, deref);
 
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(declX, declSlot, useStmt));
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(declX, declSlot, useStmt));
 
         var result = RefInitializationHoister.Rewrite(body);
 
@@ -91,15 +94,16 @@ public class RefInitializationHoisterTests
         var slot = new LocalVariableSymbol("slot", isReadOnly: false, ByRefTypeSymbol.Get(TypeSymbol.Int));
 
         var indexExpr = new BoundIndexExpression(
-            new BoundVariableExpression(arr),
-            new BoundVariableExpression(i),
+            null,
+            new BoundVariableExpression(null, arr),
+            new BoundVariableExpression(null, i),
             TypeSymbol.Int);
-        var declSlot = new BoundVariableDeclaration(slot, new BoundAddressOfExpression(indexExpr));
+        var declSlot = new BoundVariableDeclaration(null, slot, new BoundAddressOfExpression(null, indexExpr));
 
-        var deref = new BoundDereferenceExpression(new BoundVariableExpression(slot));
-        var useStmt = new BoundExpressionStatement(deref);
+        var deref = new BoundDereferenceExpression(null, new BoundVariableExpression(null, slot));
+        var useStmt = new BoundExpressionStatement(null, deref);
 
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(declSlot, useStmt));
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(declSlot, useStmt));
 
         var result = RefInitializationHoister.Rewrite(body);
         var stmts = result.Statements;
@@ -129,13 +133,14 @@ public class RefInitializationHoisterTests
         var slot = new LocalVariableSymbol("slot", isReadOnly: false, ByRefTypeSymbol.Get(TypeSymbol.Int));
 
         var fieldAccess = new BoundFieldAccessExpression(
-            new BoundVariableExpression(obj), structType, field);
-        var declSlot = new BoundVariableDeclaration(slot, new BoundAddressOfExpression(fieldAccess));
+            null,
+            new BoundVariableExpression(null, obj), structType, field);
+        var declSlot = new BoundVariableDeclaration(null, slot, new BoundAddressOfExpression(null, fieldAccess));
 
-        var deref = new BoundDereferenceExpression(new BoundVariableExpression(slot));
-        var useStmt = new BoundExpressionStatement(deref);
+        var deref = new BoundDereferenceExpression(null, new BoundVariableExpression(null, slot));
+        var useStmt = new BoundExpressionStatement(null, deref);
 
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(declSlot, useStmt));
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(declSlot, useStmt));
 
         var result = RefInitializationHoister.Rewrite(body);
         var stmts = result.Statements;
@@ -164,13 +169,13 @@ public class RefInitializationHoisterTests
         var x = new LocalVariableSymbol("x", isReadOnly: false, TypeSymbol.Int);
         var slot = new LocalVariableSymbol("slot", isReadOnly: false, ByRefTypeSymbol.Get(TypeSymbol.Int));
 
-        var declX = new BoundVariableDeclaration(x, new BoundLiteralExpression(10));
-        var declSlot = new BoundVariableDeclaration(slot, new BoundAddressOfExpression(new BoundVariableExpression(x)));
+        var declX = new BoundVariableDeclaration(null, x, new BoundLiteralExpression(null, 10));
+        var declSlot = new BoundVariableDeclaration(null, slot, new BoundAddressOfExpression(null, new BoundVariableExpression(null, x)));
 
         // Bare usage of slot (not dereferenced)
-        var bareUse = new BoundExpressionStatement(new BoundVariableExpression(slot));
+        var bareUse = new BoundExpressionStatement(null, new BoundVariableExpression(null, slot));
 
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(declX, declSlot, bareUse));
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(declX, declSlot, bareUse));
 
         var result = RefInitializationHoister.Rewrite(body);
         var stmts = result.Statements;

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/SpillSequenceSpillerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/SpillSequenceSpillerTests.cs
@@ -32,12 +32,13 @@ public class SpillSequenceSpillerTests
     {
         // Arrange: left is a call (not pure), right is await
         var leftCall = MakeCall("sideEffect", TypeSymbol.Int);
-        var rightAwait = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
-        var binary = new BoundBinaryExpression(leftCall, AddOp, rightAwait);
+        var rightAwait = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int);
+        var binary = new BoundBinaryExpression(null, leftCall, AddOp, rightAwait);
         var decl = new BoundVariableDeclaration(
+            null,
             new LocalVariableSymbol("x", false, TypeSymbol.Int),
             binary);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(decl));
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(decl));
 
         // Act
         var result = SpillSequenceSpiller.Rewrite(body);
@@ -59,13 +60,14 @@ public class SpillSequenceSpillerTests
     public void Pure_BinaryExpression_With_AwaitOnRight_OfPureLeft_DoesNotSpillLeft()
     {
         // Arrange: left is a literal (pure constant), right is await
-        var left = new BoundLiteralExpression(10);
-        var rightAwait = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
-        var binary = new BoundBinaryExpression(left, AddOp, rightAwait);
+        var left = new BoundLiteralExpression(null, 10);
+        var rightAwait = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int);
+        var binary = new BoundBinaryExpression(null, left, AddOp, rightAwait);
         var decl = new BoundVariableDeclaration(
+            null,
             new LocalVariableSymbol("x", false, TypeSymbol.Int),
             binary);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(decl));
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(decl));
 
         // Act
         var result = SpillSequenceSpiller.Rewrite(body);
@@ -94,11 +96,11 @@ public class SpillSequenceSpillerTests
     public void LogicalAnd_With_Await_OnRight_LowersToIf()
     {
         // Arrange: left && (await right)
-        var left = new BoundVariableExpression(new LocalVariableSymbol("a", true, TypeSymbol.Bool));
-        var rightAwait = new BoundAwaitExpression(new BoundLiteralExpression(true), TypeSymbol.Bool);
-        var binary = new BoundBinaryExpression(left, LogicalAndOp, rightAwait);
-        var stmt = new BoundExpressionStatement(binary);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(stmt));
+        var left = new BoundVariableExpression(null, new LocalVariableSymbol("a", true, TypeSymbol.Bool));
+        var rightAwait = new BoundAwaitExpression(null, new BoundLiteralExpression(null, true), TypeSymbol.Bool);
+        var binary = new BoundBinaryExpression(null, left, LogicalAndOp, rightAwait);
+        var stmt = new BoundExpressionStatement(null, binary);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(stmt));
 
         // Act
         var result = SpillSequenceSpiller.Rewrite(body);
@@ -122,11 +124,11 @@ public class SpillSequenceSpillerTests
     public void LogicalOr_With_Await_OnRight_LowersToIf()
     {
         // Arrange: left || (await right)
-        var left = new BoundVariableExpression(new LocalVariableSymbol("a", true, TypeSymbol.Bool));
-        var rightAwait = new BoundAwaitExpression(new BoundLiteralExpression(false), TypeSymbol.Bool);
-        var binary = new BoundBinaryExpression(left, LogicalOrOp, rightAwait);
-        var stmt = new BoundExpressionStatement(binary);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(stmt));
+        var left = new BoundVariableExpression(null, new LocalVariableSymbol("a", true, TypeSymbol.Bool));
+        var rightAwait = new BoundAwaitExpression(null, new BoundLiteralExpression(null, false), TypeSymbol.Bool);
+        var binary = new BoundBinaryExpression(null, left, LogicalOrOp, rightAwait);
+        var stmt = new BoundExpressionStatement(null, binary);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(stmt));
 
         // Act
         var result = SpillSequenceSpiller.Rewrite(body);
@@ -151,13 +153,15 @@ public class SpillSequenceSpillerTests
     {
         // Arrange: f(sideEffect(), await task)
         var arg0 = MakeCall("sideEffect", TypeSymbol.Int);
-        var arg1 = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
+        var arg1 = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int);
         var call = new BoundCallExpression(
+            null,
             MakeFunction("f", TypeSymbol.Int, TypeSymbol.Int, TypeSymbol.Int),
             ImmutableArray.Create<BoundExpression>(arg0, arg1));
         var decl = new BoundVariableDeclaration(
+            null,
             new LocalVariableSymbol("r", false, TypeSymbol.Int), call);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(decl));
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(decl));
 
         // Act
         var result = SpillSequenceSpiller.Rewrite(body);
@@ -176,14 +180,16 @@ public class SpillSequenceSpillerTests
     {
         // Arrange: receiver.Method(await task)
         var receiver = MakeCall("getObj", TypeSymbol.String);
-        var arg = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
+        var arg = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int);
         var method = typeof(string).GetMethod("Substring", new[] { typeof(int) });
         var call = new BoundImportedInstanceCallExpression(
+            null,
             receiver, method, TypeSymbol.String,
             ImmutableArray.Create<BoundExpression>(arg));
         var decl = new BoundVariableDeclaration(
+            null,
             new LocalVariableSymbol("s", false, TypeSymbol.String), call);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(decl));
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(decl));
 
         // Act
         var result = SpillSequenceSpiller.Rewrite(body);
@@ -210,12 +216,13 @@ public class SpillSequenceSpillerTests
     public void Nested_Await_In_Binary_BothSidesAwait_BothSpilled()
     {
         // Arrange: (await t1) + (await t2)
-        var awaitLeft = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
-        var awaitRight = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
-        var binary = new BoundBinaryExpression(awaitLeft, AddOp, awaitRight);
+        var awaitLeft = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int);
+        var awaitRight = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int);
+        var binary = new BoundBinaryExpression(null, awaitLeft, AddOp, awaitRight);
         var decl = new BoundVariableDeclaration(
+            null,
             new LocalVariableSymbol("x", false, TypeSymbol.Int), binary);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(decl));
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(decl));
 
         // Act
         var result = SpillSequenceSpiller.Rewrite(body);
@@ -239,9 +246,9 @@ public class SpillSequenceSpillerTests
     public void Await_AlreadyAt_TopLevel_NotSpilled()
     {
         // Arrange: await task (expression statement)
-        var awaitExpr = new BoundAwaitExpression(new BoundLiteralExpression(0), TypeSymbol.Int);
-        var stmt = new BoundExpressionStatement(awaitExpr);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(stmt));
+        var awaitExpr = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int);
+        var stmt = new BoundExpressionStatement(null, awaitExpr);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(stmt));
 
         // Act
         var result = SpillSequenceSpiller.Rewrite(body);
@@ -254,10 +261,11 @@ public class SpillSequenceSpillerTests
     public void NonAsync_Function_NotProcessed()
     {
         // Arrange: a body without any await
-        var literal = new BoundLiteralExpression(42);
+        var literal = new BoundLiteralExpression(null, 42);
         var decl = new BoundVariableDeclaration(
+            null,
             new LocalVariableSymbol("x", false, TypeSymbol.Int), literal);
-        var body = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(decl));
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(decl));
 
         // Act
         var result = SpillSequenceSpiller.Rewrite(body);
@@ -272,7 +280,7 @@ public class SpillSequenceSpillerTests
             name,
             ImmutableArray<ParameterSymbol>.Empty,
             returnType);
-        return new BoundCallExpression(func, ImmutableArray<BoundExpression>.Empty);
+        return new BoundCallExpression(null, func, ImmutableArray<BoundExpression>.Empty);
     }
 
     private static FunctionSymbol MakeFunction(string name, TypeSymbol returnType, params TypeSymbol[] paramTypes)

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/SynthesizedStateMachineTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/SynthesizedStateMachineTypeTests.cs
@@ -150,7 +150,7 @@ public class SynthesizedStateMachineTypeTests
         var projected = sm.MaterializeAsStructSymbol();
         var thisLocal = new LocalVariableSymbol("this", isReadOnly: false, projected);
 
-        var access = new BoundFieldAccessExpression(new BoundVariableExpression(thisLocal), projected, field);
+        var access = new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisLocal), projected, field);
 
         Assert.Same(projected, access.StructType);
         Assert.Same(field, access.Field);

--- a/test/Core.Tests/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriterTests.cs
@@ -31,7 +31,7 @@ public class AsyncIteratorRewriterTests
         // Arrange: async iterator function with one yield
         var asyncEnumerableType = TypeSymbol.FromClrType(typeof(IAsyncEnumerable<int>));
         var function = new FunctionSymbol("asyncGen", ImmutableArray<ParameterSymbol>.Empty, asyncEnumerableType, package: Package);
-        var yieldStmt = new BoundYieldStatement(new BoundLiteralExpression(42));
+        var yieldStmt = new BoundYieldStatement(null, new BoundLiteralExpression(null, 42));
         var body = Block(yieldStmt);
         var program = MakeProgram(function, body);
 
@@ -51,8 +51,8 @@ public class AsyncIteratorRewriterTests
         // Arrange: two yields
         var asyncEnumerableType = TypeSymbol.FromClrType(typeof(IAsyncEnumerable<int>));
         var function = new FunctionSymbol("multiYield", ImmutableArray<ParameterSymbol>.Empty, asyncEnumerableType, package: Package);
-        var yield1 = new BoundYieldStatement(new BoundLiteralExpression(1));
-        var yield2 = new BoundYieldStatement(new BoundLiteralExpression(2));
+        var yield1 = new BoundYieldStatement(null, new BoundLiteralExpression(null, 1));
+        var yield2 = new BoundYieldStatement(null, new BoundLiteralExpression(null, 2));
         var body = Block(yield1, yield2);
         var program = MakeProgram(function, body);
 
@@ -73,15 +73,17 @@ public class AsyncIteratorRewriterTests
         var asyncEnumerableType = TypeSymbol.FromClrType(typeof(IAsyncEnumerable<int>));
         var function = new FunctionSymbol("awaitGen", ImmutableArray<ParameterSymbol>.Empty, asyncEnumerableType, package: Package);
         var await1 = new BoundAwaitExpression(
-            new BoundLiteralExpression(null, TypeSymbol.FromClrType(typeof(Task))),
+            null,
+            new BoundLiteralExpression(null, null, TypeSymbol.FromClrType(typeof(Task))),
             TypeSymbol.Void);
         var await2 = new BoundAwaitExpression(
-            new BoundLiteralExpression(null, TypeSymbol.FromClrType(typeof(Task))),
+            null,
+            new BoundLiteralExpression(null, null, TypeSymbol.FromClrType(typeof(Task))),
             TypeSymbol.Void);
         var body = Block(
-            new BoundExpressionStatement(await1),
-            new BoundExpressionStatement(await2),
-            new BoundYieldStatement(new BoundLiteralExpression(99)));
+            new BoundExpressionStatement(null, await1),
+            new BoundExpressionStatement(null, await2),
+            new BoundYieldStatement(null, new BoundLiteralExpression(null, 99)));
         var program = MakeProgram(function, body);
 
         // Act
@@ -102,11 +104,12 @@ public class AsyncIteratorRewriterTests
         var asyncEnumerableType = TypeSymbol.FromClrType(typeof(IAsyncEnumerable<int>));
         var function = new FunctionSymbol("mixed", ImmutableArray<ParameterSymbol>.Empty, asyncEnumerableType, package: Package);
         var awaitExpr = new BoundAwaitExpression(
-            new BoundLiteralExpression(null, TypeSymbol.FromClrType(typeof(Task))),
+            null,
+            new BoundLiteralExpression(null, null, TypeSymbol.FromClrType(typeof(Task))),
             TypeSymbol.Void);
-        var yieldStmt = new BoundYieldStatement(new BoundLiteralExpression(7));
+        var yieldStmt = new BoundYieldStatement(null, new BoundLiteralExpression(null, 7));
         var body = Block(
-            new BoundExpressionStatement(awaitExpr),
+            new BoundExpressionStatement(null, awaitExpr),
             yieldStmt);
         var program = MakeProgram(function, body);
 
@@ -132,11 +135,12 @@ public class AsyncIteratorRewriterTests
         var asyncEnumerableType = TypeSymbol.FromClrType(typeof(IAsyncEnumerable<int>));
         var function = new FunctionSymbol("awaiterTypes", ImmutableArray<ParameterSymbol>.Empty, asyncEnumerableType, package: Package);
         var awaitExpr = new BoundAwaitExpression(
-            new BoundLiteralExpression(null, TypeSymbol.FromClrType(typeof(Task))),
+            null,
+            new BoundLiteralExpression(null, null, TypeSymbol.FromClrType(typeof(Task))),
             TypeSymbol.Void);
         var body = Block(
-            new BoundExpressionStatement(awaitExpr),
-            new BoundYieldStatement(new BoundLiteralExpression(1)));
+            new BoundExpressionStatement(null, awaitExpr),
+            new BoundYieldStatement(null, new BoundLiteralExpression(null, 1)));
         var program = MakeProgram(function, body);
 
         // Act
@@ -152,7 +156,7 @@ public class AsyncIteratorRewriterTests
     {
         // Arrange: plain async function (not returning IAsyncEnumerable)
         var function = new FunctionSymbol("notIterator", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, package: Package) { IsAsync = true };
-        var body = Block(new BoundExpressionStatement(new BoundLiteralExpression(1)));
+        var body = Block(new BoundExpressionStatement(null, new BoundLiteralExpression(null, 1)));
         var program = MakeProgram(function, body);
 
         // Act
@@ -168,7 +172,7 @@ public class AsyncIteratorRewriterTests
         // Arrange
         var asyncEnumerableType = TypeSymbol.FromClrType(typeof(IAsyncEnumerable<int>));
         var function = new FunctionSymbol("enumerable", ImmutableArray<ParameterSymbol>.Empty, asyncEnumerableType, package: Package);
-        var body = Block(new BoundYieldStatement(new BoundLiteralExpression(1)));
+        var body = Block(new BoundYieldStatement(null, new BoundLiteralExpression(null, 1)));
         var program = MakeProgram(function, body);
 
         // Act
@@ -183,7 +187,7 @@ public class AsyncIteratorRewriterTests
 
     private static BoundBlockStatement Block(params BoundStatement[] statements)
     {
-        return new BoundBlockStatement(statements.ToImmutableArray());
+        return new BoundBlockStatement(null, statements.ToImmutableArray());
     }
 
     private static BoundProgram MakeProgram(FunctionSymbol function, BoundBlockStatement body)

--- a/test/Core.Tests/CodeAnalysis/Lowering/Iterators/IteratorRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Iterators/IteratorRewriterTests.cs
@@ -29,7 +29,7 @@ public class IteratorRewriterTests
         var elementType = TypeSymbol.Int;
         var seqType = SequenceTypeSymbol.Get(elementType);
         var function = new FunctionSymbol("gen", ImmutableArray<ParameterSymbol>.Empty, seqType, package: Package);
-        var yieldStmt = new BoundYieldStatement(new BoundLiteralExpression(42));
+        var yieldStmt = new BoundYieldStatement(null, new BoundLiteralExpression(null, 42));
         var body = Block(yieldStmt);
         var program = MakeProgram(function, body);
 
@@ -50,9 +50,9 @@ public class IteratorRewriterTests
         // Arrange: function with three yields
         var seqType = SequenceTypeSymbol.Get(TypeSymbol.Int);
         var function = new FunctionSymbol("multi", ImmutableArray<ParameterSymbol>.Empty, seqType, package: Package);
-        var yield1 = new BoundYieldStatement(new BoundLiteralExpression(1));
-        var yield2 = new BoundYieldStatement(new BoundLiteralExpression(2));
-        var yield3 = new BoundYieldStatement(new BoundLiteralExpression(3));
+        var yield1 = new BoundYieldStatement(null, new BoundLiteralExpression(null, 1));
+        var yield2 = new BoundYieldStatement(null, new BoundLiteralExpression(null, 2));
+        var yield3 = new BoundYieldStatement(null, new BoundLiteralExpression(null, 3));
         var body = Block(yield1, yield2, yield3);
         var program = MakeProgram(function, body);
 
@@ -73,7 +73,7 @@ public class IteratorRewriterTests
         // Arrange: non-iterator function
         var seqType = SequenceTypeSymbol.Get(TypeSymbol.Int);
         var function = new FunctionSymbol("plain", ImmutableArray<ParameterSymbol>.Empty, seqType, package: Package);
-        var body = Block(new BoundExpressionStatement(new BoundLiteralExpression(1)));
+        var body = Block(new BoundExpressionStatement(null, new BoundLiteralExpression(null, 1)));
         var program = MakeProgram(function, body);
 
         // Act
@@ -91,8 +91,8 @@ public class IteratorRewriterTests
         var function = new FunctionSymbol("withLocal", ImmutableArray<ParameterSymbol>.Empty, seqType, package: Package);
         var localVar = new LocalVariableSymbol("temp", false, TypeSymbol.Int);
         var body = Block(
-            new BoundVariableDeclaration(localVar, new BoundLiteralExpression(10)),
-            new BoundYieldStatement(new BoundVariableExpression(localVar)));
+            new BoundVariableDeclaration(null, localVar, new BoundLiteralExpression(null, 10)),
+            new BoundYieldStatement(null, new BoundVariableExpression(null, localVar)));
         var program = MakeProgram(function, body);
 
         // Act
@@ -110,7 +110,7 @@ public class IteratorRewriterTests
         var stringType = TypeSymbol.FromClrType(typeof(string));
         var enumerableType = TypeSymbol.FromClrType(typeof(IEnumerable<string>));
         var function = new FunctionSymbol("strings", ImmutableArray<ParameterSymbol>.Empty, enumerableType, package: Package);
-        var body = Block(new BoundYieldStatement(new BoundLiteralExpression("hello")));
+        var body = Block(new BoundYieldStatement(null, new BoundLiteralExpression(null, "hello")));
         var program = MakeProgram(function, body);
 
         // Act
@@ -128,7 +128,7 @@ public class IteratorRewriterTests
         var asyncEnumerableType = TypeSymbol.FromClrType(
             typeof(IAsyncEnumerable<int>));
         var function = new FunctionSymbol("asyncGen", ImmutableArray<ParameterSymbol>.Empty, asyncEnumerableType, package: Package);
-        var body = Block(new BoundYieldStatement(new BoundLiteralExpression(1)));
+        var body = Block(new BoundYieldStatement(null, new BoundLiteralExpression(null, 1)));
         var program = MakeProgram(function, body);
 
         // Act
@@ -142,7 +142,7 @@ public class IteratorRewriterTests
 
     private static BoundBlockStatement Block(params BoundStatement[] statements)
     {
-        return new BoundBlockStatement(statements.ToImmutableArray());
+        return new BoundBlockStatement(null, statements.ToImmutableArray());
     }
 
     private static BoundProgram MakeProgram(FunctionSymbol function, BoundBlockStatement body)


### PR DESCRIPTION
## Summary

Adds `public SyntaxNode Syntax { get; }` to the `BoundNode` base class and threads it through every concrete `Bound*` constructor and call site (Roslyn-style). This is the cross-cutting prerequisite for the rest of the Portable PDB work tracked by #95 and #50, both explicitly v1.0-blocking per ADR-0027 §7.7a.

**No behaviour change.** All 1388 tests pass; `dotnet build GSharp.sln` produces 0 warnings, 0 errors.

## Why now

The emitter cannot map IL offsets back to `(tree, line, column)` without each `BoundNode` knowing its originating syntax. Today there's no such reference; the pre-existing `BoundAwaitSequencePoint` exists as a placeholder but currently emits a `nop` with no PDB anchor. This PR closes that gap as pure plumbing so subsequent phases can stay small and focused.

## What changed

- `BoundNode` / `BoundExpression` / `BoundStatement` / `BoundPattern` accept and forward `SyntaxNode syntax`.
- 81 concrete `Bound*.cs` files updated to thread `syntax` to base.
- `BoundAttribute` keeps its typed `AnnotationSyntax Syntax` via a `new` shadowing accessor over `base.Syntax`.
- `BoundLoopStatement` (abstract base) updated; `BoundErrorExpression` gains an explicit ctor.
- ~765 call sites updated in `Binder`, `Lowerer`, async / iterator rewriters, and `ReflectionMetadataEmitter`.
- ~192 call sites updated in `Core.Tests` test helpers.
- `BoundMapEntry` and `BoundAttribute` excluded from the rewrite where they already accept syntax themselves.

## Synthesised nodes

Compiler-synthesised lowering nodes (state-machine scaffolding, hoisted locals, etc.) explicitly pass `null`. Phase 4 will emit hidden `0xfeefee` sequence points for those, matching the standard portable-PDB convention.

## What's next (separate PRs)

This is Phase 1 of 10. Subsequent phases (per the approved plan):
2. Locations on `LocalVariableSymbol` / `LocalConstantSymbol` / `LabelSymbol`.
3. `/debug` / `/pdb` / `/sourcelink` parsing on `gsc`; `DebugInformation` options on `Compilation`.
4. `Document` table + `MethodDebugInformation` (sequence points).
5. `LocalScope` / `LocalVariable` / `LocalConstant` / `ImportScope`.
6. `CustomDebugInformation` (EmbeddedSource, SourceLink, CompilationOptions, CompilationMetadataReferences).
7. PE-side `DebugDirectory` / CodeView / PDB checksum / deterministic IDs.
8. SDK wiring (`@(FileWrites)` for the produced `.pdb`).
9. Acceptance tests: round-trip stack-trace + `netcoredbg` E2E.
10. Docs + ADR-0040.

Related: #95, #50, ADR-0027 §7.7a