### PR TITLE
Phase 2: Add DeclaringSyntax to variable symbols and labels (#95, #50)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -665,7 +665,7 @@ public sealed class Binder
                     continue;
                 }
 
-                ctorBuilder.Add(new ParameterSymbol(paramName, paramType));
+                ctorBuilder.Add(new ParameterSymbol(paramName, paramType, declaringSyntax: paramSyntax.Identifier));
                 fields.Add(new FieldSymbol(paramName, paramType, Accessibility.Public, isReadOnly: syntax.IsInline));
             }
 
@@ -893,7 +893,7 @@ public sealed class Binder
                     }
                     else
                     {
-                        parameters.Add(new ParameterSymbol(parameterName, parameterType));
+                        parameters.Add(new ParameterSymbol(parameterName, parameterType, declaringSyntax: parameterSyntax.Identifier));
                     }
                 }
 
@@ -1089,7 +1089,7 @@ public sealed class Binder
                 }
                 else
                 {
-                    parameters.Add(new ParameterSymbol(parameterName, parameterType));
+                    parameters.Add(new ParameterSymbol(parameterName, parameterType, declaringSyntax: parameterSyntax.Identifier));
                 }
             }
 
@@ -1198,7 +1198,7 @@ public sealed class Binder
                     receiverType = TypeSymbol.Error;
                 }
 
-                explicitReceiverParameter = new ParameterSymbol(recvName, receiverType);
+                explicitReceiverParameter = new ParameterSymbol(recvName, receiverType, declaringSyntax: syntax.Receiver);
                 seenParameterNames.Add(recvName);
                 parameters.Add(explicitReceiverParameter);
 
@@ -1237,7 +1237,7 @@ public sealed class Binder
                         parameterType = SliceTypeSymbol.Get(parameterType);
                     }
 
-                    var parameter = new ParameterSymbol(parameterName, parameterType, isVariadic);
+                    var parameter = new ParameterSymbol(parameterName, parameterType, isVariadic, declaringSyntax: parameterSyntax.Identifier);
                     parameters.Add(parameter);
                     parameterSymbolBySyntax[pIndex] = parameter;
                 }
@@ -2751,7 +2751,7 @@ public sealed class Binder
     private BoundPattern BindTypePattern(TypePatternSyntax syntax, TypeSymbol discriminantType)
     {
         var targetType = BindTypeClause(syntax.Type) ?? TypeSymbol.Error;
-        var variable = new LocalVariableSymbol(syntax.Identifier.Text, isReadOnly: true, targetType);
+        var variable = new LocalVariableSymbol(syntax.Identifier.Text, isReadOnly: true, targetType, declaringSyntax: syntax.Identifier);
         if (!scope.TryDeclareVariable(variable))
         {
             Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, syntax.Identifier.Text);
@@ -3196,7 +3196,7 @@ public sealed class Binder
                 // Introduce a scope so the bound variable is visible only inside
                 // the case body — matches `for v := range` lexical hygiene.
                 scope = new BoundScope(scope);
-                variable = new LocalVariableSymbol(caseSyntax.Identifier.Text, isReadOnly: true, chan.ElementType);
+                variable = new LocalVariableSymbol(caseSyntax.Identifier.Text, isReadOnly: true, chan.ElementType, declaringSyntax: caseSyntax.Identifier);
                 if (!scope.TryDeclareVariable(variable))
                 {
                     Diagnostics.ReportSymbolAlreadyDeclared(caseSyntax.Identifier.Location, caseSyntax.Identifier.Text);
@@ -4380,7 +4380,7 @@ public sealed class Binder
                 Diagnostics.ReportParameterAlreadyDeclared(p.Location, pname);
             }
 
-            parameterSymbols.Add(new ParameterSymbol(pname, ptype));
+            parameterSymbols.Add(new ParameterSymbol(pname, ptype, declaringSyntax: p.Identifier));
             parameterTypes.Add(ptype);
         }
 
@@ -6694,8 +6694,8 @@ public sealed class Binder
         var name = identifier.Text ?? "?";
         var declare = !identifier.IsMissing;
         var variable = function == null
-                            ? (VariableSymbol)new GlobalVariableSymbol(name, isReadOnly, type, accessibility)
-                            : new LocalVariableSymbol(name, isReadOnly, type);
+                            ? (VariableSymbol)new GlobalVariableSymbol(name, isReadOnly, type, accessibility, declaringSyntax: identifier)
+                            : new LocalVariableSymbol(name, isReadOnly, type, declaringSyntax: identifier);
 
         if (declare && !scope.TryDeclareVariable(variable))
         {

--- a/src/Core/CodeAnalysis/Binding/BoundLabel.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundLabel.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -13,15 +15,28 @@ public sealed class BoundLabel
     /// Initializes a new instance of the <see cref="BoundLabel"/> class.
     /// </summary>
     /// <param name="name">The label name.</param>
-    public BoundLabel(string name)
+    /// <param name="declaringSyntax">
+    /// The originating label-declaration syntax (may be <see langword="null"/>
+    /// for compiler-synthesised labels — break/continue/exit anchors emitted by
+    /// the lowering pipeline, async-resume points, etc.). Used by the Portable
+    /// PDB emitter to anchor branch-target sequence points per ADR-0027 §7.7a.
+    /// </param>
+    public BoundLabel(string name, SyntaxNode declaringSyntax = null)
     {
         Name = name;
+        DeclaringSyntax = declaringSyntax;
     }
 
     /// <summary>
     /// Gets the label name.
     /// </summary>
     public string Name { get; }
+
+    /// <summary>
+    /// Gets the originating label-declaration syntax for this label, or
+    /// <see langword="null"/> when the label is compiler-synthesised.
+    /// </summary>
+    public SyntaxNode DeclaringSyntax { get; }
 
     /// <inheritdoc/>
     public override string ToString() => Name;

--- a/src/Core/CodeAnalysis/Symbols/GlobalVariableSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/GlobalVariableSymbol.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
 /// <summary>
@@ -16,8 +18,13 @@ public sealed class GlobalVariableSymbol : VariableSymbol
     /// <param name="isReadOnly">Whether it's read-only or not.</param>
     /// <param name="type">The type of the variable.</param>
     /// <param name="accessibility">The CLR visibility level (defaults to <see cref="Accessibility.Public"/>).</param>
-    public GlobalVariableSymbol(string name, bool isReadOnly, TypeSymbol type, Accessibility accessibility = Accessibility.Public)
-        : base(name, isReadOnly, type)
+    /// <param name="declaringSyntax">
+    /// The originating declaration syntax (may be <see langword="null"/> for
+    /// synthesised globals such as host-package bootstrap state). Used by the
+    /// PDB emitter to anchor field-declaration locations per ADR-0027 §7.7a.
+    /// </param>
+    public GlobalVariableSymbol(string name, bool isReadOnly, TypeSymbol type, Accessibility accessibility = Accessibility.Public, SyntaxNode declaringSyntax = null)
+        : base(name, isReadOnly, type, declaringSyntax)
     {
         Accessibility = accessibility;
     }

--- a/src/Core/CodeAnalysis/Symbols/LocalVariableSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/LocalVariableSymbol.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
 /// <summary>
@@ -15,8 +17,14 @@ public class LocalVariableSymbol : VariableSymbol
     /// <param name="name">The local variable's name.</param>
     /// <param name="isReadOnly">Whether the local variable is read-only or not.</param>
     /// <param name="type">The local variable's type.</param>
-    public LocalVariableSymbol(string name, bool isReadOnly, TypeSymbol type)
-        : base(name, isReadOnly, type)
+    /// <param name="declaringSyntax">
+    /// The originating declaration syntax (may be <see langword="null"/> for
+    /// compiler-synthesised locals — async/iterator state-machine slots,
+    /// lowering temporaries, awaiter cache slots, etc.). Used by the Portable
+    /// PDB emitter to map IL local slots back to source per ADR-0027 §7.7a.
+    /// </param>
+    public LocalVariableSymbol(string name, bool isReadOnly, TypeSymbol type, SyntaxNode declaringSyntax = null)
+        : base(name, isReadOnly, type, declaringSyntax)
     {
     }
 

--- a/src/Core/CodeAnalysis/Symbols/ParameterSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ParameterSymbol.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
 /// <summary>
@@ -15,8 +17,14 @@ public sealed class ParameterSymbol : LocalVariableSymbol
     /// <param name="name">The parameter name.</param>
     /// <param name="type">The parameter type (already wrapped in <c>SliceTypeSymbol</c> if variadic).</param>
     /// <param name="isVariadic">Whether the parameter is variadic (Phase 4.8).</param>
-    public ParameterSymbol(string name, TypeSymbol type, bool isVariadic = false)
-        : base(name, isReadOnly: true, type)
+    /// <param name="declaringSyntax">
+    /// The originating parameter-declaration syntax (may be <see langword="null"/>
+    /// for compiler-synthesised parameters — async kickoff <c>&lt;&gt;sm_this</c>,
+    /// state-machine builder receivers, etc.). Consumed by the PDB emitter for
+    /// arg-display in debuggers.
+    /// </param>
+    public ParameterSymbol(string name, TypeSymbol type, bool isVariadic = false, SyntaxNode declaringSyntax = null)
+        : base(name, isReadOnly: true, type, declaringSyntax)
     {
         IsVariadic = isVariadic;
     }

--- a/src/Core/CodeAnalysis/Symbols/VariableSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/VariableSymbol.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
 /// <summary>
@@ -15,11 +17,19 @@ public abstract class VariableSymbol : Symbol
     /// <param name="name">The variable's name.</param>
     /// <param name="isReadOnly">Whether it's read-only or not.</param>
     /// <param name="type">The variable's type.</param>
-    public VariableSymbol(string name, bool isReadOnly, TypeSymbol type)
+    /// <param name="declaringSyntax">
+    /// The originating declaration syntax (may be <see langword="null"/> for
+    /// compiler-synthesised variables — async/iterator state-machine slots,
+    /// lowering temporaries, etc.). Used by the Portable PDB emitter to map
+    /// IL local slots back to source for stepping and locals display per
+    /// ADR-0027 §7.7a.
+    /// </param>
+    public VariableSymbol(string name, bool isReadOnly, TypeSymbol type, SyntaxNode declaringSyntax = null)
         : base(name)
     {
         IsReadOnly = isReadOnly;
         Type = type;
+        DeclaringSyntax = declaringSyntax;
     }
 
     /// <summary>
@@ -31,4 +41,13 @@ public abstract class VariableSymbol : Symbol
     /// Gets the variable's type.
     /// </summary>
     public TypeSymbol Type { get; }
+
+    /// <summary>
+    /// Gets the originating declaration syntax for this variable, or
+    /// <see langword="null"/> when the variable is compiler-synthesised and
+    /// has no source-level declaration. Consumed by the Portable PDB emitter
+    /// to anchor <c>LocalVariable</c> rows and (for hoisted async/iterator
+    /// state-machine locals) the hoisted-local-scope <c>CustomDebugInformation</c>.
+    /// </summary>
+    public SyntaxNode DeclaringSyntax { get; }
 }


### PR DESCRIPTION
Phase 2 of the Portable PDB emit plan for #95 and #50.

Threads the originating declaration syntax through `VariableSymbol`, `LocalVariableSymbol`, `ParameterSymbol`, `GlobalVariableSymbol`, and `BoundLabel` so the upcoming PDB emitter can later anchor `LocalVariable` / `Parameter` / `Label` rows and the hoisted-local-scope `CustomDebugInformation` for async/iterator state machines (ADR-0027 §7.7a).

### Approach (pragmatic departure from Phase 1)

- Added an optional trailing `SyntaxNode declaringSyntax = null` ctor parameter to each affected type, plus a public `DeclaringSyntax` getter.
- Keeping it optional avoids a mechanical rewrite of ~140 synthesised lowering/test call sites that have no source syntax — those legitimately pass `null` and will later emit hidden (0xfeefee) anchors.
- Threaded real syntax from the Binder wherever a user-visible declaration has it: `BindVariableDeclaration` (global + local), `BindTypePattern`, the channel-receive case binder, primary-constructor parameters, function and method parameter lists, the function-literal parameter list, and the explicit method-receiver parameter.
- Hoisted locals in the async/iterator state machine already key off the original `VariableSymbol` reference (`AsyncStateMachineFieldMap`), so `DeclaringSyntax` flows through to hoisted fields automatically with no extra work in `MoveNextBodyRewriter`.

### No behavior change

Pure data plumbing. Full suite green:

- Sdk: 21
- Core: 1159
- Interpreter: 32
- LanguageServer: 17
- Compiler: 159
- **Total: 1388 passing, 0 failing**

### Next

Phase 3 (`/debug`, `/pdb`, `/sourcelink` real parsing on `gsc` + a `DebugInformation` options record on `Compilation`) will land in a follow-up PR once this merges.

Refs #95 #50 ADR-0027 §7.7a