### PR TITLE
Phase 3: DebugInformation options + gsc /debug, /pdb, /sourcelink, /deterministic (#95, #50)

### DIFF
--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Emit;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.IO;
@@ -77,6 +78,13 @@ public class Program
         var compilation = new Compilation(references, syntaxTrees.ToArray())
         {
             ImplicitSystemImport = parsed.ImplicitSystemImport,
+            DebugInformation =
+            {
+                Format = parsed.DebugFormat,
+                PdbFilePath = parsed.PdbPath,
+                SourceLinkFilePath = parsed.SourceLinkPath,
+                Deterministic = parsed.Deterministic,
+            },
         };
 
         if (parsed.OutputPath is null)
@@ -125,11 +133,33 @@ public class Program
             }
         }
 
+        // Phase 3 / ADR-0027 §7.7a: when Portable PDB is requested, open the
+        // sidecar stream alongside the PE. If the caller did not supply an
+        // explicit /pdb:<path>, default to "<PE>.pdb" (csc.exe convention).
+        // Embedded format keeps the PDB content inside the PE — no sidecar.
+        string pdbOutputPath = null;
+        if (compilation.DebugInformation.Format == DebugInformationFormat.Portable)
+        {
+            pdbOutputPath = compilation.DebugInformation.PdbFilePath;
+            if (string.IsNullOrEmpty(pdbOutputPath))
+            {
+                pdbOutputPath = Path.ChangeExtension(outputPath, ".pdb");
+                compilation.DebugInformation.PdbFilePath = pdbOutputPath;
+            }
+
+            var pdbDir = Path.GetDirectoryName(pdbOutputPath);
+            if (!string.IsNullOrEmpty(pdbDir))
+            {
+                Directory.CreateDirectory(pdbDir);
+            }
+        }
+
         EmitResult result;
         using (var peStream = File.Create(outputPath))
         using (var refStream = string.IsNullOrEmpty(refOutputPath) ? null : File.Create(refOutputPath))
+        using (var pdbStream = pdbOutputPath is null ? null : File.Create(pdbOutputPath))
         {
-            result = compilation.Emit(peStream, refStream, args.AssemblyName);
+            result = compilation.Emit(peStream, pdbStream, refStream, args.AssemblyName);
         }
 
         // Apply /nowarn, /warnaserror filtering.
@@ -149,6 +179,11 @@ public class Program
             if (!string.IsNullOrEmpty(refOutputPath))
             {
                 TryDelete(refOutputPath);
+            }
+
+            if (!string.IsNullOrEmpty(pdbOutputPath))
+            {
+                TryDelete(pdbOutputPath);
             }
 
             Console.Error.WriteLine("Failed.");
@@ -368,8 +403,58 @@ public class Program
                         break;
 
                     case "debug":
+                        result.DebugFormat = ParseDebugValue(value);
+                        result.DebugFlagSeen = true;
+                        break;
+
+                    case "debug+":
+                        // /debug+ is an alias for /debug with no value: enable portable.
+                        result.DebugFormat = DebugInformationFormat.Portable;
+                        result.DebugFlagSeen = true;
+                        break;
+
+                    case "debug-":
+                        // /debug- explicitly disables debug emit, overriding any earlier /debug.
+                        result.DebugFormat = DebugInformationFormat.None;
+                        result.DebugFlagSeen = true;
+                        break;
+
                     case "pdb":
-                        // Accepted for SDK compatibility; debug info emit is Phase 2.
+                        // /pdb:<path> sets the sidecar PDB path. Only meaningful with
+                        // a Portable format — if no /debug flag has been seen yet we
+                        // imply Portable here, matching csc.exe behaviour.
+                        if (string.IsNullOrEmpty(value))
+                        {
+                            throw new CommandLineException("/pdb requires a path: /pdb:<file>.");
+                        }
+
+                        result.PdbPath = value;
+                        if (!result.DebugFlagSeen)
+                        {
+                            result.DebugFormat = DebugInformationFormat.Portable;
+                        }
+
+                        break;
+
+                    case "sourcelink":
+                        if (string.IsNullOrEmpty(value))
+                        {
+                            throw new CommandLineException("/sourcelink requires a path: /sourcelink:<file>.");
+                        }
+
+                        result.SourceLinkPath = value;
+                        break;
+
+                    case "deterministic":
+                        result.Deterministic = ParseBoolFlag(value, defaultIfEmpty: true);
+                        break;
+
+                    case "deterministic+":
+                        result.Deterministic = true;
+                        break;
+
+                    case "deterministic-":
+                        result.Deterministic = false;
                         break;
 
                     case "?":
@@ -452,6 +537,25 @@ public class Program
         }
 
         return result;
+    }
+
+    private static DebugInformationFormat ParseDebugValue(string value)
+    {
+        // /debug, /debug+, /debug:portable, /debug:full → Portable
+        // /debug:embedded → Embedded
+        // /debug:none, /debug- → None
+        if (string.IsNullOrEmpty(value))
+        {
+            return DebugInformationFormat.Portable;
+        }
+
+        return value.ToLowerInvariant() switch
+        {
+            "none" => DebugInformationFormat.None,
+            "portable" or "full" or "pdbonly" => DebugInformationFormat.Portable,
+            "embedded" => DebugInformationFormat.Embedded,
+            _ => throw new CommandLineException($"Unsupported /debug value: {value}. Expected one of: none, portable, full, pdbonly, embedded."),
+        };
     }
 
     private static bool ParseBoolFlag(string value, bool defaultIfEmpty)
@@ -540,6 +644,21 @@ public class Program
 
         /// <summary>Gets the set of diagnostic IDs that should remain as warnings (from /warnaserror-:&lt;ids&gt;), overriding /warnaserror.</summary>
         public HashSet<string> WarnNotAsErrorIds { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Gets or sets the requested PDB emit format (from /debug, /debug:&lt;value&gt;, /debug+/-). Defaults to None.</summary>
+        public DebugInformationFormat DebugFormat { get; set; } = DebugInformationFormat.None;
+
+        /// <summary>Gets or sets a value indicating whether a /debug, /debug+, or /debug- switch was observed on the command line. Used so that a bare /pdb:&lt;path&gt; can default the format to Portable without overriding a later /debug-.</summary>
+        public bool DebugFlagSeen { get; set; }
+
+        /// <summary>Gets or sets the explicit sidecar PDB path (from /pdb:&lt;path&gt;). Null means "default to {OutputPath}.pdb".</summary>
+        public string PdbPath { get; set; }
+
+        /// <summary>Gets or sets the path to a Source Link JSON file (from /sourcelink:&lt;path&gt;).</summary>
+        public string SourceLinkPath { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether the emit should be deterministic (from /deterministic, /deterministic+/-).</summary>
+        public bool Deterministic { get; set; }
     }
 
     private sealed class CommandLineException : Exception

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -25,6 +25,7 @@ public class Compilation
 {
     private BoundGlobalScope globalScope;
     private ImmutableHashSet<string> preprocessorSymbols = ImmutableHashSet<string>.Empty;
+    private DebugInformationOptions debugInformation = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Compilation"/> class.
@@ -53,6 +54,7 @@ public class Compilation
         References = references ?? previous?.References;
         ImplicitSystemImport = previous?.ImplicitSystemImport ?? true;
         PreprocessorSymbols = previous?.PreprocessorSymbols ?? ImmutableHashSet<string>.Empty;
+        debugInformation = CloneDebugInformation(previous?.DebugInformation);
     }
 
     /// <summary>
@@ -94,6 +96,23 @@ public class Compilation
     {
         get => preprocessorSymbols;
         set => preprocessorSymbols = value ?? ImmutableHashSet<string>.Empty;
+    }
+
+    /// <summary>
+    /// Gets or sets the PDB-related emit options. Defaults to a fresh
+    /// <see cref="DebugInformationOptions"/> instance with
+    /// <see cref="DebugInformationOptions.Format"/> set to
+    /// <see cref="DebugInformationFormat.None"/>, so callers that do not
+    /// opt in produce bit-for-bit identical PE output. Inherits from
+    /// <see cref="Previous"/> when chained, mirroring
+    /// <see cref="ImplicitSystemImport"/> / <see cref="PreprocessorSymbols"/>.
+    /// Setting <see langword="null"/> is normalised to a fresh default
+    /// instance.
+    /// </summary>
+    public DebugInformationOptions DebugInformation
+    {
+        get => debugInformation;
+        set => debugInformation = value ?? new DebugInformationOptions();
     }
 
     /// <summary>
@@ -246,7 +265,7 @@ public class Compilation
         try
         {
             using var stream = File.Create(program.PackageName + ".dll");
-            EmitAssembly(program, stream, References, asyncRewriteResult: lowered.AsyncRewriteResult, iteratorRewriteResult: lowered.IteratorRewriteResult, asyncIteratorRewriteResult: lowered.AsyncIteratorRewriteResult);
+            EmitAssembly(program, stream, References, asyncRewriteResult: lowered.AsyncRewriteResult, iteratorRewriteResult: lowered.IteratorRewriteResult, asyncIteratorRewriteResult: lowered.AsyncIteratorRewriteResult, debugInformation: DebugInformation, pdbStream: null);
         }
         catch (Exception ex) when (ex is NotSupportedException || ex is InvalidOperationException)
         {
@@ -266,6 +285,70 @@ public class Compilation
     /// <param name="peStream">Destination stream for the PE bytes.</param>
     /// <returns>An emit result.</returns>
     public EmitResult Emit(Stream peStream) => Emit(peStream, refStream: null, assemblyName: null);
+
+    /// <summary>
+    /// Compiles the current syntax tree and writes the resulting assembly to
+    /// <paramref name="peStream"/>, optionally writing a Portable PDB stream
+    /// to <paramref name="pdbStream"/> when <see cref="DebugInformation"/>
+    /// requests a sidecar format. When <paramref name="refStream"/> is
+    /// supplied, also writes a metadata-only sibling assembly to it.
+    /// </summary>
+    /// <param name="peStream">Destination stream for the PE bytes. May be <c>null</c> when only a reference assembly is desired.</param>
+    /// <param name="pdbStream">Destination stream for the Portable PDB sidecar. Only consumed when <see cref="DebugInformation"/>'s <see cref="DebugInformationOptions.Format"/> is <see cref="DebugInformationFormat.Portable"/>. May be <c>null</c> in all other cases.</param>
+    /// <param name="refStream">Optional destination stream for the metadata-only reference assembly.</param>
+    /// <param name="assemblyName">Optional override for the assembly identity. When null, the entry-point package name is used.</param>
+    /// <returns>An emit result.</returns>
+    public EmitResult Emit(Stream peStream, Stream pdbStream, Stream refStream, string assemblyName = null)
+    {
+        var parseDiagnostics = SyntaxTrees.SelectMany(st => st.Diagnostics);
+        var syntaxDiagnostics = parseDiagnostics.Concat(GlobalScope.Diagnostics).ToImmutableArray();
+        if (syntaxDiagnostics.Any(d => d.IsError))
+        {
+            return new EmitResult(success: false, syntaxDiagnostics);
+        }
+
+        var program = Binder.BindProgram(GlobalScope);
+        if (program.Diagnostics.Any(d => d.IsError))
+        {
+            return new EmitResult(success: false, program.Diagnostics.ToImmutableArray());
+        }
+
+        var (lowered, lowerDiagnostics) = LowerForEmit(program, References ?? Symbols.ReferenceResolver.Default());
+        if (lowerDiagnostics.Any(d => d.IsError))
+        {
+            return new EmitResult(success: false, lowerDiagnostics);
+        }
+
+        var allWarnings = syntaxDiagnostics
+            .Concat(program.Diagnostics)
+            .Concat(lowerDiagnostics)
+            .Where(d => !d.IsError)
+            .ToImmutableArray();
+
+        try
+        {
+            if (peStream is not null)
+            {
+                EmitAssembly(program, peStream, References, assemblyName, metadataOnly: false, asyncRewriteResult: lowered.AsyncRewriteResult, iteratorRewriteResult: lowered.IteratorRewriteResult, asyncIteratorRewriteResult: lowered.AsyncIteratorRewriteResult, debugInformation: DebugInformation, pdbStream: pdbStream);
+            }
+
+            if (refStream is not null)
+            {
+                // Reference assemblies never carry debug info — pass an explicit
+                // None override so we don't accidentally write a CodeView entry
+                // pointing at a sidecar that doesn't describe this PE.
+                EmitAssembly(program, refStream, References, assemblyName, metadataOnly: true, asyncRewriteResult: lowered.AsyncRewriteResult, iteratorRewriteResult: lowered.IteratorRewriteResult, asyncIteratorRewriteResult: lowered.AsyncIteratorRewriteResult, debugInformation: null, pdbStream: null);
+            }
+        }
+        catch (Exception ex) when (ex is NotSupportedException || ex is InvalidOperationException)
+        {
+            var location = new TextLocation(SourceText.From(string.Empty), new TextSpan(0, 0));
+            var diagnostic = new Diagnostic(location, "GS9998", DiagnosticSeverity.Error, ex.Message);
+            return new EmitResult(success: false, ImmutableArray.Create(diagnostic));
+        }
+
+        return new EmitResult(success: true, diagnostics: allWarnings);
+    }
 
     /// <summary>
     /// Compiles the current syntax tree and writes the resulting assembly to
@@ -308,12 +391,12 @@ public class Compilation
         {
             if (peStream is not null)
             {
-                EmitAssembly(program, peStream, References, assemblyName, metadataOnly: false, asyncRewriteResult: lowered.AsyncRewriteResult, iteratorRewriteResult: lowered.IteratorRewriteResult, asyncIteratorRewriteResult: lowered.AsyncIteratorRewriteResult);
+                EmitAssembly(program, peStream, References, assemblyName, metadataOnly: false, asyncRewriteResult: lowered.AsyncRewriteResult, iteratorRewriteResult: lowered.IteratorRewriteResult, asyncIteratorRewriteResult: lowered.AsyncIteratorRewriteResult, debugInformation: DebugInformation, pdbStream: null);
             }
 
             if (refStream is not null)
             {
-                EmitAssembly(program, refStream, References, assemblyName, metadataOnly: true, asyncRewriteResult: lowered.AsyncRewriteResult, iteratorRewriteResult: lowered.IteratorRewriteResult, asyncIteratorRewriteResult: lowered.AsyncIteratorRewriteResult);
+                EmitAssembly(program, refStream, References, assemblyName, metadataOnly: true, asyncRewriteResult: lowered.AsyncRewriteResult, iteratorRewriteResult: lowered.IteratorRewriteResult, asyncIteratorRewriteResult: lowered.AsyncIteratorRewriteResult, debugInformation: null, pdbStream: null);
             }
         }
         catch (Exception ex) when (ex is NotSupportedException || ex is InvalidOperationException)
@@ -357,9 +440,25 @@ public class Compilation
         return (lowered, diagnostics);
     }
 
-    private static void EmitAssembly(BoundProgram program, Stream peStream, ReferenceResolver references, string assemblyName = null, bool metadataOnly = false, Lowering.Async.AsyncStateMachineRewriteResult asyncRewriteResult = null, IteratorRewriteResult iteratorRewriteResult = null, AsyncIteratorRewriteResult asyncIteratorRewriteResult = null)
+    private static DebugInformationOptions CloneDebugInformation(DebugInformationOptions source)
     {
-        ReflectionMetadataEmitter.Emit(program, peStream, references, assemblyName, metadataOnly, asyncRewriteResult, iteratorRewriteResult, asyncIteratorRewriteResult);
+        if (source is null)
+        {
+            return new DebugInformationOptions();
+        }
+
+        return new DebugInformationOptions
+        {
+            Format = source.Format,
+            PdbFilePath = source.PdbFilePath,
+            SourceLinkFilePath = source.SourceLinkFilePath,
+            Deterministic = source.Deterministic,
+        };
+    }
+
+    private static void EmitAssembly(BoundProgram program, Stream peStream, ReferenceResolver references, string assemblyName = null, bool metadataOnly = false, Lowering.Async.AsyncStateMachineRewriteResult asyncRewriteResult = null, IteratorRewriteResult iteratorRewriteResult = null, AsyncIteratorRewriteResult asyncIteratorRewriteResult = null, DebugInformationOptions debugInformation = null, Stream pdbStream = null)
+    {
+        ReflectionMetadataEmitter.Emit(program, peStream, references, assemblyName, metadataOnly, asyncRewriteResult, iteratorRewriteResult, asyncIteratorRewriteResult, debugInformation, pdbStream);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/DebugInformationFormat.cs
+++ b/src/Core/CodeAnalysis/Emit/DebugInformationFormat.cs
@@ -1,0 +1,38 @@
+// <copyright file="DebugInformationFormat.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Emit;
+
+/// <summary>
+/// Selects how debug information is emitted alongside the compiled PE.
+/// Mirrors the C# / Roslyn nomenclature so SDK consumers can use the same
+/// MSBuild semantics. The full PDB pipeline is implemented across Phases
+/// 4–7 of ADR-0027 §7.7; this Phase 3 enum is the option surface that
+/// downstream phases consume.
+/// </summary>
+public enum DebugInformationFormat
+{
+    /// <summary>
+    /// Do not emit any debug information. The PE still goes out, but no
+    /// PDB sidecar is produced and no <c>Debug</c> directory entries
+    /// describing a PDB are written. Equivalent to <c>/debug-</c>.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Emit a Portable PDB sidecar file next to the PE. The PE's
+    /// <c>Debug</c> directory carries a <c>CodeView</c> entry pointing at
+    /// the sidecar by name and a matching <c>PdbChecksum</c> entry.
+    /// Equivalent to <c>/debug</c>, <c>/debug+</c>, <c>/debug:portable</c>,
+    /// and <c>/debug:full</c>.
+    /// </summary>
+    Portable = 1,
+
+    /// <summary>
+    /// Emit the Portable PDB stream embedded directly into the PE via an
+    /// <c>EmbeddedPortablePdb</c> debug-directory entry — no sidecar file
+    /// is produced. Equivalent to <c>/debug:embedded</c>.
+    /// </summary>
+    Embedded = 2,
+}

--- a/src/Core/CodeAnalysis/Emit/DebugInformationOptions.cs
+++ b/src/Core/CodeAnalysis/Emit/DebugInformationOptions.cs
@@ -1,0 +1,66 @@
+// <copyright file="DebugInformationOptions.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Emit;
+
+/// <summary>
+/// PDB-related emit options consumed by the <see cref="ReflectionMetadataEmitter"/>.
+/// Hung off <see cref="Compilation.Compilation.DebugInformation"/> so embedders
+/// (gsc, the SDK <c>BuildTask</c>, language-service hosts) can configure debug
+/// emit in one place.
+/// </summary>
+/// <remarks>
+/// Phase 3 of the ADR-0027 §7.7a Portable PDB plan: defines the option surface
+/// only. The actual PDB stream production lands across Phases 4 (Document /
+/// MethodDebugInformation), 5 (LocalScope / LocalVariable / LocalConstant /
+/// ImportScope), 6 (CustomDebugInformation: EmbeddedSource, SourceLink,
+/// CompilationOptions, CompilationMetadataReferences), and 7 (PE
+/// <c>DebugDirectory</c> entries: CodeView, PdbChecksum, Reproducible,
+/// EmbeddedPortablePdb).
+/// </remarks>
+public sealed class DebugInformationOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DebugInformationOptions"/>
+    /// class with sensible defaults: <see cref="DebugInformationFormat.None"/>,
+    /// non-deterministic output, no Source Link file.
+    /// </summary>
+    public DebugInformationOptions()
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the requested debug information format. Defaults to
+    /// <see cref="DebugInformationFormat.None"/> so existing emit paths that
+    /// do not opt in remain bit-for-bit identical with Phase 1/2 output.
+    /// </summary>
+    public DebugInformationFormat Format { get; set; } = DebugInformationFormat.None;
+
+    /// <summary>
+    /// Gets or sets the explicit sidecar PDB path. Only meaningful when
+    /// <see cref="Format"/> is <see cref="DebugInformationFormat.Portable"/>.
+    /// When <see langword="null"/>, the emitter chooses a default of
+    /// <c>{PE}.pdb</c> next to the PE; when set, this value is recorded
+    /// verbatim into the PE's <c>CodeView</c> debug-directory entry as
+    /// the PDB path string.
+    /// </summary>
+    public string PdbFilePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path of a Source Link JSON file (
+    /// <see href="https://github.com/dotnet/sourcelink"/>). When set, the
+    /// file's bytes are read at emit time and recorded as the PDB
+    /// <c>SourceLink</c> <c>CustomDebugInformation</c> blob, enabling
+    /// debuggers to fetch matching source from the URL substitution map.
+    /// </summary>
+    public string SourceLinkFilePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the emit must be
+    /// deterministic. When <see langword="true"/>, the emitter writes a
+    /// content-derived <c>Mvid</c> and <c>PdbId</c> instead of fresh GUIDs
+    /// and adds a <c>Reproducible</c> debug-directory entry to the PE.
+    /// </summary>
+    public bool Deterministic { get; set; }
+}

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -119,6 +119,15 @@ internal sealed class ReflectionMetadataEmitter
     // Async iterator state-machine plans produced by AsyncIteratorRewriter.
     private ImmutableArray<Lowering.Iterators.AsyncIteratorPlan> asyncIteratorPlans = ImmutableArray<Lowering.Iterators.AsyncIteratorPlan>.Empty;
 
+    // Phase 3 (ADR-0027 §7.7a) Portable PDB options. Defaults to a None-format
+    // instance so the existing PE-only emit path stays bit-for-bit identical
+    // until Phases 4-7 light up the actual PDB pipeline.
+    private DebugInformationOptions debugInformation = new();
+
+    // Phase 3 (ADR-0027 §7.7a) Portable PDB destination stream. Only consumed
+    // when debugInformation.Format is Portable; null in every other config.
+    private Stream pdbStream;
+
     // Maps async iterator SM class to its plan (populated during SynthesizeAsyncIteratorStateMachines).
     private readonly Dictionary<StructSymbol, Lowering.Iterators.AsyncIteratorPlan> asyncIteratorInfos = new Dictionary<StructSymbol, Lowering.Iterators.AsyncIteratorPlan>();
 
@@ -194,6 +203,22 @@ internal sealed class ReflectionMetadataEmitter
     /// Optional result from the async iterator rewriter. When non-null, contains plans
     /// for emitting async iterator state-machine types and kickoff bodies.
     /// </param>
+    /// <param name="debugInformation">
+    /// Phase 3 (ADR-0027 §7.7a) PDB-related emit options. When <see langword="null"/>
+    /// or when <see cref="DebugInformationOptions.Format"/> is
+    /// <see cref="DebugInformationFormat.None"/> the emitter behaves exactly as
+    /// it did before Phase 3 (no PDB sidecar, no <c>DebugDirectory</c> entries).
+    /// The actual production of PDB content lands across Phases 4–7; Phase 3
+    /// only plumbs the option onto the emitter so subsequent phases can consume
+    /// it without further signature churn.
+    /// </param>
+    /// <param name="pdbStream">
+    /// Optional destination for the Portable PDB sidecar stream. Only consumed
+    /// when <paramref name="debugInformation"/> requests
+    /// <see cref="DebugInformationFormat.Portable"/>; ignored in every other
+    /// configuration. Plumbed here so callers can open the file once and have
+    /// the emitter write to it directly without intermediate buffering.
+    /// </param>
     public static void Emit(
         BoundProgram program,
         Stream peStream,
@@ -202,7 +227,9 @@ internal sealed class ReflectionMetadataEmitter
         bool metadataOnly = false,
         AsyncStateMachineRewriteResult asyncRewriteResult = null,
         IteratorRewriteResult iteratorRewriteResult = null,
-        Lowering.Iterators.AsyncIteratorRewriteResult asyncIteratorRewriteResult = null)
+        Lowering.Iterators.AsyncIteratorRewriteResult asyncIteratorRewriteResult = null,
+        DebugInformationOptions debugInformation = null,
+        Stream pdbStream = null)
     {
         var emitter = new ReflectionMetadataEmitter(program, references, assemblyName, metadataOnly);
         if (asyncRewriteResult != null)
@@ -219,6 +246,9 @@ internal sealed class ReflectionMetadataEmitter
         {
             emitter.asyncIteratorPlans = asyncIteratorRewriteResult.Plans;
         }
+
+        emitter.debugInformation = debugInformation ?? new DebugInformationOptions();
+        emitter.pdbStream = pdbStream;
 
         emitter.EmitCore(peStream);
     }

--- a/test/Compiler.Tests/ProgramTests.cs
+++ b/test/Compiler.Tests/ProgramTests.cs
@@ -314,4 +314,105 @@ public class ProgramTests
             try { File.Delete(sample); } catch { }
         }
     }
+
+    [Theory]
+    [InlineData("/debug", true)]
+    [InlineData("/debug+", true)]
+    [InlineData("/debug:portable", true)]
+    [InlineData("/debug:full", true)]
+    [InlineData("/debug:pdbonly", true)]
+    [InlineData("/debug:embedded", false)]
+    [InlineData("/debug:none", false)]
+    [InlineData("/debug-", false)]
+    public void Main_DebugFlag_CreatesPdbWhenPortable(string debugFlag, bool expectPdb)
+    {
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package DbgLib\n");
+        var tempDir = Directory.CreateTempSubdirectory("gsc_dbg_").FullName;
+        var outPath = Path.Combine(tempDir, "DbgLib.dll");
+        try
+        {
+            var exit = Program.Main(new[] { "/out:" + outPath, "/target:library", debugFlag, sample });
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(outPath));
+            var pdbPath = Path.ChangeExtension(outPath, ".pdb");
+            Assert.Equal(expectPdb, File.Exists(pdbPath));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Main_PdbFlag_ImpliesPortableAndUsesExplicitPath()
+    {
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package DbgPath\n");
+        var tempDir = Directory.CreateTempSubdirectory("gsc_pdb_").FullName;
+        var outPath = Path.Combine(tempDir, "DbgPath.dll");
+        var pdbPath = Path.Combine(tempDir, "custom-name.pdb");
+        try
+        {
+            var exit = Program.Main(new[] { "/out:" + outPath, "/target:library", "/pdb:" + pdbPath, sample });
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(outPath));
+            Assert.True(File.Exists(pdbPath), "explicit /pdb:<path> sidecar should exist");
+            // The default {PE}.pdb should NOT have been written when /pdb redirected it.
+            Assert.False(File.Exists(Path.ChangeExtension(outPath, ".pdb")));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Main_DebugMinusOverridesPdbFlag()
+    {
+        // /debug- should win over an earlier /pdb:<path>: no PDB written.
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package DbgOff\n");
+        var tempDir = Directory.CreateTempSubdirectory("gsc_off_").FullName;
+        var outPath = Path.Combine(tempDir, "DbgOff.dll");
+        var pdbPath = Path.Combine(tempDir, "DbgOff.pdb");
+        try
+        {
+            var exit = Program.Main(new[] { "/out:" + outPath, "/target:library", "/pdb:" + pdbPath, "/debug-", sample });
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(outPath));
+            Assert.False(File.Exists(pdbPath));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Main_UnknownDebugValue_ReturnsErrorExitCode()
+    {
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package P\n");
+        var tempDir = Directory.CreateTempSubdirectory("gsc_bad_").FullName;
+        var outPath = Path.Combine(tempDir, "P.dll");
+        using var errWriter = new StringWriter();
+        var prevErr = Console.Error;
+        Console.SetError(errWriter);
+        try
+        {
+            var exit = Program.Main(new[] { "/out:" + outPath, "/target:library", "/debug:bogus", sample });
+            Assert.NotEqual(0, exit);
+            Assert.Contains("/debug", errWriter.ToString());
+        }
+        finally
+        {
+            Console.SetError(prevErr);
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
 }

--- a/test/Core.Tests/CodeAnalysis/Emit/DebugInformationOptionsTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/DebugInformationOptionsTests.cs
@@ -1,0 +1,137 @@
+// <copyright file="DebugInformationOptionsTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Emit;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Phase 3 (ADR-0027 §7.7a) tests covering the <see cref="DebugInformationOptions"/>
+/// surface on <see cref="Compilation"/>: defaults, inheritance through
+/// <see cref="Compilation.ContinueWith"/>, null normalisation, and that
+/// the option set does not change PE output until later phases light up
+/// the actual PDB writer.
+/// </summary>
+public class DebugInformationOptionsTests
+{
+    [Fact]
+    public void DebugInformation_HasNoneDefault()
+    {
+        var compilation = new Compilation(SyntaxTree.Parse("package P\n"));
+
+        Assert.NotNull(compilation.DebugInformation);
+        Assert.Equal(DebugInformationFormat.None, compilation.DebugInformation.Format);
+        Assert.Null(compilation.DebugInformation.PdbFilePath);
+        Assert.Null(compilation.DebugInformation.SourceLinkFilePath);
+        Assert.False(compilation.DebugInformation.Deterministic);
+    }
+
+    [Fact]
+    public void DebugInformation_NullAssignmentNormalisesToDefault()
+    {
+        var compilation = new Compilation(SyntaxTree.Parse("package P\n"))
+        {
+            DebugInformation = null,
+        };
+
+        Assert.NotNull(compilation.DebugInformation);
+        Assert.Equal(DebugInformationFormat.None, compilation.DebugInformation.Format);
+    }
+
+    [Fact]
+    public void DebugInformation_AssignsValuesIndependently()
+    {
+        var compilation = new Compilation(SyntaxTree.Parse("package P\n"))
+        {
+            DebugInformation = new DebugInformationOptions
+            {
+                Format = DebugInformationFormat.Portable,
+                PdbFilePath = "/tmp/x.pdb",
+                SourceLinkFilePath = "/tmp/sourcelink.json",
+                Deterministic = true,
+            },
+        };
+
+        Assert.Equal(DebugInformationFormat.Portable, compilation.DebugInformation.Format);
+        Assert.Equal("/tmp/x.pdb", compilation.DebugInformation.PdbFilePath);
+        Assert.Equal("/tmp/sourcelink.json", compilation.DebugInformation.SourceLinkFilePath);
+        Assert.True(compilation.DebugInformation.Deterministic);
+    }
+
+    [Fact]
+    public void DebugInformation_IsClonedThroughContinueWith()
+    {
+        var initial = new Compilation(SyntaxTree.Parse("package P\n"))
+        {
+            DebugInformation = new DebugInformationOptions
+            {
+                Format = DebugInformationFormat.Embedded,
+                Deterministic = true,
+            },
+        };
+
+        var next = initial.ContinueWith(SyntaxTree.Parse("package P\n"));
+
+        Assert.Equal(DebugInformationFormat.Embedded, next.DebugInformation.Format);
+        Assert.True(next.DebugInformation.Deterministic);
+
+        // The chained compilation gets its own copy: mutating the new one
+        // does not bleed back to the previous one.
+        next.DebugInformation.Format = DebugInformationFormat.None;
+        Assert.Equal(DebugInformationFormat.Embedded, initial.DebugInformation.Format);
+    }
+
+    [Fact]
+    public void Emit_WithDebugInformationNone_ProducesIdenticalPeAsBefore()
+    {
+        // Phase 3 is pure plumbing: requesting None must not perturb PE bytes.
+        var src = "package P\nimport System\nfunc Main() { Console.WriteLine(\"hi\") }\n";
+
+        var baseline = new Compilation(SyntaxTree.Parse(src));
+        var withOptions = new Compilation(SyntaxTree.Parse(src))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.None },
+        };
+
+        using var baselineStream = new MemoryStream();
+        using var withOptionsStream = new MemoryStream();
+
+        var baselineResult = baseline.Emit(baselineStream);
+        var withOptionsResult = withOptions.Emit(withOptionsStream);
+
+        Assert.True(baselineResult.Success);
+        Assert.True(withOptionsResult.Success);
+        Assert.Equal(baselineStream.ToArray(), withOptionsStream.ToArray());
+    }
+
+    [Fact]
+    public void Emit_WithPdbStreamOverload_ProducesPe()
+    {
+        // Phase 3 only plumbs the pdbStream parameter — the emitter currently
+        // ignores it. Future phases (4-7) will actually write content. This
+        // test pins the surface so callers (SDK BuildTask, gsc) can adopt
+        // it now without a follow-up signature break.
+        var src = "package P\nfunc Main() { }\n";
+        var compilation = new Compilation(SyntaxTree.Parse(src))
+        {
+            DebugInformation = new DebugInformationOptions
+            {
+                Format = DebugInformationFormat.Portable,
+                PdbFilePath = "P.pdb",
+            },
+        };
+
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var result = compilation.Emit(peStream, pdbStream, refStream: null);
+
+        Assert.True(result.Success);
+        Assert.True(peStream.Length > 0, "PE stream should have content");
+    }
+}


### PR DESCRIPTION
Phase 3 of the Portable PDB emit plan for #95 and #50.

Defines the option surface that downstream PDB phases consume, replaces the gsc `/debug` + `/pdb` no-op switches with real parsing, and threads the options through to `ReflectionMetadataEmitter.Emit`. **No PDB bytes are written yet** — that lands across Phases 4–7. Per ADR-0027 §7.7a.

### New public surface (`src/Core/CodeAnalysis/Emit`)

- `DebugInformationFormat` enum: `None | Portable | Embedded`.
- `DebugInformationOptions`: `{ Format, PdbFilePath, SourceLinkFilePath, Deterministic }`.

### `Compilation`

- New `DebugInformation` property with a non-null default (`Format=None`) so existing emit paths are bit-for-bit identical until callers opt in. Inherited and **cloned** through `ContinueWith` so chained compilations get an independent copy.
- New `Emit(peStream, pdbStream, refStream, assemblyName)` overload that also opens a sidecar stream when `Format=Portable`.
- Existing two- and three-arg `Emit` overloads thread `DebugInformation` through to the emitter with unchanged behaviour.

### `ReflectionMetadataEmitter.Emit`

Two new optional trailing params: `DebugInformationOptions debugInformation` and `Stream pdbStream`. Both `null` in legacy call sites. Phase 3 stores them on the emitter instance; Phases 4–7 actually consume them.

### gsc CLI (`src/Compiler/Program.cs`)

- `/debug`, `/debug+`, `/debug-` → `Portable` / `None`.
- `/debug:none|portable|full|pdbonly|embedded`.
- `/pdb:<path>` implies `Portable` when no `/debug` flag has been seen yet (matches `csc.exe`). `/debug-` after `/pdb` still wins (last-write).
- `/sourcelink:<path>`, `/deterministic[+/-]`.
- Unknown `/debug` value now returns a `CommandLineException` instead of silently no-oping.
- When `Portable` is requested without `/pdb`, the sidecar defaults to `<PE>.pdb` (`csc.exe` convention).
- The PDB sidecar is opened alongside the PE and the new `Emit` overload is invoked. Failed emits `TryDelete` the `.pdb` in addition to the `.dll`.

### Tests

Full suite green: **1405 passing, 0 failing** (Sdk 21, Core 1165 +6, Interpreter 32, LanguageServer 17, Compiler 170 +11).

- `test/Core.Tests/.../DebugInformationOptionsTests.cs` (6 cases): defaults, null normalisation, value assignment, `ContinueWith` cloning, `Emit(None)` producing identical bytes to the no-options baseline, `Emit(peStream, pdbStream, refStream)` success.
- `test/Compiler.Tests/ProgramTests.cs` (11 new cases): `/debug` variants matrix, `/pdb:<custom-path>` redirection, `/debug-` overriding `/pdb`, `/debug:bogus` error path.

### Next

Phase 4 introduces a `PortablePdbEmitter` collaborator and starts populating the `Document` table + `MethodDebugInformation` sequence points from the `BoundNode.Syntax` data that Phases 1–2 threaded in.

Refs #95 #50 ADR-0027 §7.7a