### PR TITLE
Phase 4: Portable PDB emit — Documents + sequence points

### DIFF
--- a/docs/debug-info.md
+++ b/docs/debug-info.md
@@ -1,0 +1,62 @@
+# Portable PDB / debug information
+
+GSharp emits standards-conformant [Portable PDB](https://github.com/dotnet/runtime/blob/main/docs/design/specs/PortablePdb-Metadata.md) symbols alongside its PE assemblies so external debuggers, profilers, and symbol indexers can map IL offsets back to GSharp source and surface meaningful stack traces.
+
+This document is the source of truth for GSharp-specific identifiers and policies embedded in those symbols.
+
+## Language GUID
+
+GSharp registers a single, stable language GUID:
+
+| Field | Value |
+| --- | --- |
+| Language | GSharp |
+| Language GUID | `4F4D7B6A-0E33-4C2E-A3D7-2E5F8B7F9C00` |
+| Defined in | `src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs` (`GSharpLanguageGuid`) |
+
+Every `Document` row written by the compiler carries this GUID in the `Language` column. External tools (debuggers, symbol servers, source indexers) that recognise GSharp source files **must** key off this value. Like the C# (`3F5162F8-07C6-11D3-9053-00C04FA302A1`) and F# (`AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3`) GUIDs, this value will never be reissued — even if the on-disk layout of GSharp source changes — so existing tooling never has to re-key.
+
+## Hash algorithm
+
+GSharp emits SHA-256 (`8829D00F-11B8-4213-878B-770E8597AC16`) document hashes. The same hash is also written into the PE CodeView entry once Phase 7 wires the debug directory, so symbol servers can verify the PE ↔ PDB pair by content.
+
+## Sequence-point semantics
+
+GSharp anchors sequence points at the *first IL offset emitted for each `BoundStatement`*. Lowered statements that originate from a single source statement collapse to one visible sequence point covering that source span; the synthesized scaffolding emitted between them is marked hidden (`0xfeefee`).
+
+| Source construct | Sequence-point behaviour |
+| --- | --- |
+| `let` / `const` / `var` declarations | One visible point at the statement keyword. |
+| Plain expression statements | One visible point at the expression. |
+| `return expr` | One visible point at the `return` keyword. |
+| `if` / `else` / loops | Visible point at each branch; the lowering's conditional gotos are hidden. |
+| `for x in …` body | Visible points at the user-written body; the synthesized iterator handshake is hidden. |
+| `defer { … }` | Visible points inside the deferred block; the finally-style scaffolding around it is hidden. |
+| `async` / `await` | Visible points in user code; state-machine `MoveNext` prologue / dispatch / suspension is hidden. |
+| Compiler-synthesized statements with no source | Hidden. |
+
+This is the same visible/hidden contract Roslyn-emitted assemblies follow, so all standard .NET debuggers (Visual Studio, `vsdbg`, `netcoredbg`, `dotnet-dump`, JetBrains Rider, etc.) work without further configuration.
+
+## Custom debug information
+
+The Portable PDB writer is staged. Phase 4 (this milestone) emits only `Document` and `MethodDebugInformation` rows. The following are planned for subsequent phases and tracked separately:
+
+* `LocalScope`, `LocalVariable`, `LocalConstant`, `ImportScope` — Phase 5.
+* `EmbeddedSource`, `SourceLink`, `CompilationOptions`, `CompilationMetadataReferences` — Phase 6.
+* PE `DebugDirectory` entries (`CodeView`, `PdbChecksum`, `Reproducible`, `EmbeddedPortablePdb`) — Phase 7.
+
+## Compiler flags
+
+The `gsc` compiler accepts the standard Roslyn-style debug flags:
+
+| Flag | Meaning |
+| --- | --- |
+| `/debug[+/-]` | Equivalent to `/debug:portable` / `/debug:none`. |
+| `/debug:none` | Suppress all debug information. |
+| `/debug:portable` (alias `/debug:pdbonly`, `/debug:full`) | Emit a sidecar `*.pdb` next to the PE. |
+| `/debug:embedded` | Embed the Portable PDB inside the PE's debug directory. |
+| `/pdb:<path>` | Override the sidecar PDB output path. |
+| `/sourcelink:<file>` | Embed the supplied Source-Link JSON as `CustomDebugInformation` (Phase 6). |
+| `/deterministic[+/-]` | Emit a content-hash-based Mvid / PdbId. |
+
+The SDK forwards `<DebugType>` and `<PdbFile>` through `BuildTask` so MSBuild-driven builds behave identically to direct `gsc` invocations.

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1637,7 +1637,7 @@ public sealed class Binder
 
         scope = scope.Parent;
 
-        return new BoundBlockStatement(null, statements.ToImmutable());
+        return new BoundBlockStatement(syntax, statements.ToImmutable());
     }
 
     private void BindBlockStatements(ImmutableArray<StatementSyntax> statementSyntaxes, int startIndex, ImmutableArray<BoundStatement>.Builder statements)
@@ -1794,7 +1794,7 @@ public sealed class Binder
             variable.SetAttributes(boundAttrs);
         }
 
-        return new BoundVariableDeclaration(null, variable, convertedInitializer);
+        return new BoundVariableDeclaration(syntax, variable, convertedInitializer);
     }
 
     private BoundStatement BindTupleDeconstructionStatement(TupleDeconstructionStatementSyntax syntax)
@@ -1804,7 +1804,7 @@ public sealed class Binder
         var initializer = BindExpression(syntax.Initializer);
         if (initializer.Type == TypeSymbol.Error)
         {
-            return new BoundExpressionStatement(null, initializer);
+            return new BoundExpressionStatement(syntax, initializer);
         }
 
         if (initializer.Type is TupleTypeSymbol tupleType)
@@ -1812,7 +1812,7 @@ public sealed class Binder
             if (syntax.Identifiers.Count != tupleType.Arity)
             {
                 Diagnostics.ReportDeconstructionFieldCountMismatch(syntax.CloseParenToken.Location, tupleType.Arity, syntax.Identifiers.Count);
-                return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+                return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
             }
 
             var tempName = $"<tuple{System.Threading.Interlocked.Increment(ref syntheticLocalCounter)}>";
@@ -1820,7 +1820,7 @@ public sealed class Binder
             scope.TryDeclareVariable(tempVar);
 
             var statements = ImmutableArray.CreateBuilder<BoundStatement>();
-            statements.Add(new BoundVariableDeclaration(null, tempVar, initializer));
+            statements.Add(new BoundVariableDeclaration(syntax, tempVar, initializer));
 
             for (var i = 0; i < syntax.Identifiers.Count; i++)
             {
@@ -1828,10 +1828,10 @@ public sealed class Binder
                 var elemType = tupleType.ElementTypes[i];
                 var elemVar = BindVariableDeclaration(idTok, isReadOnly: true, elemType);
                 var access = new BoundTupleElementAccessExpression(null, new BoundVariableExpression(null, tempVar), tupleType, i);
-                statements.Add(new BoundVariableDeclaration(null, elemVar, access));
+                statements.Add(new BoundVariableDeclaration(syntax, elemVar, access));
             }
 
-            return new BoundBlockStatement(null, statements.ToImmutable());
+            return new BoundBlockStatement(syntax, statements.ToImmutable());
         }
 
         if (initializer.Type is StructSymbol structType && (structType.IsData || structType.IsInline))
@@ -1840,7 +1840,7 @@ public sealed class Binder
             if (syntax.Identifiers.Count != fields.Length)
             {
                 Diagnostics.ReportDeconstructionFieldCountMismatch(syntax.CloseParenToken.Location, fields.Length, syntax.Identifiers.Count);
-                return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+                return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
             }
 
             var tempName = $"<data{System.Threading.Interlocked.Increment(ref syntheticLocalCounter)}>";
@@ -1848,21 +1848,21 @@ public sealed class Binder
             scope.TryDeclareVariable(tempVar);
 
             var statements = ImmutableArray.CreateBuilder<BoundStatement>();
-            statements.Add(new BoundVariableDeclaration(null, tempVar, initializer));
+            statements.Add(new BoundVariableDeclaration(syntax, tempVar, initializer));
             for (var i = 0; i < syntax.Identifiers.Count; i++)
             {
                 var idTok = syntax.Identifiers[i];
                 var field = fields[i];
                 var elemVar = BindVariableDeclaration(idTok, isReadOnly: true, field.Type);
                 var access = new BoundFieldAccessExpression(null, new BoundVariableExpression(null, tempVar), structType, field);
-                statements.Add(new BoundVariableDeclaration(null, elemVar, access));
+                statements.Add(new BoundVariableDeclaration(syntax, elemVar, access));
             }
 
-            return new BoundBlockStatement(null, statements.ToImmutable());
+            return new BoundBlockStatement(syntax, statements.ToImmutable());
         }
 
         Diagnostics.ReportDeconstructionRequiresTupleOrDataStruct(syntax.OpenParenToken.Location, initializer.Type);
-        return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+        return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
     }
 
     private BoundStatement BindNamedDeconstructionStatement(NamedDeconstructionStatementSyntax syntax)
@@ -1870,13 +1870,13 @@ public sealed class Binder
         var initializer = BindExpression(syntax.Initializer);
         if (initializer.Type == TypeSymbol.Error)
         {
-            return new BoundExpressionStatement(null, initializer);
+            return new BoundExpressionStatement(syntax, initializer);
         }
 
         if (!(initializer.Type is StructSymbol structType) || (!structType.IsData && !structType.IsInline))
         {
             Diagnostics.ReportDeconstructionRequiresTupleOrDataStruct(syntax.OpenBraceToken.Location, initializer.Type);
-            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+            return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
         }
 
         var tempName = $"<data{System.Threading.Interlocked.Increment(ref syntheticLocalCounter)}>";
@@ -1885,7 +1885,7 @@ public sealed class Binder
 
         var seen = new HashSet<string>();
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
-        statements.Add(new BoundVariableDeclaration(null, tempVar, initializer));
+        statements.Add(new BoundVariableDeclaration(syntax, tempVar, initializer));
         foreach (var fieldSyntax in syntax.Fields)
         {
             var fieldName = fieldSyntax.FieldIdentifier.Text;
@@ -1903,10 +1903,10 @@ public sealed class Binder
 
             var variable = BindVariableDeclaration(fieldSyntax.LocalIdentifier, isReadOnly: true, field.Type);
             var access = new BoundFieldAccessExpression(null, new BoundVariableExpression(null, tempVar), declaringType, field);
-            statements.Add(new BoundVariableDeclaration(null, variable, access));
+            statements.Add(new BoundVariableDeclaration(syntax, variable, access));
         }
 
-        return new BoundBlockStatement(null, statements.ToImmutable());
+        return new BoundBlockStatement(syntax, statements.ToImmutable());
     }
 
     private TypeSymbol BindNonNullableTypeClause(TypeClauseSyntax syntax)
@@ -2221,7 +2221,7 @@ public sealed class Binder
 
             var thenStatement = BindStatementWithNarrowing(syntax.ThenStatement, thenNarrow);
             var elseStatement = syntax.ElseClause == null ? null : BindStatementWithNarrowing(syntax.ElseClause.ElseStatement, elseNarrow);
-            return new BoundIfStatement(null, condition, thenStatement, elseStatement);
+            return new BoundIfStatement(syntax, condition, thenStatement, elseStatement);
         }
 
         // `if init; cond { then } else { else }` lowers to a block that
@@ -2239,8 +2239,8 @@ public sealed class Binder
 
         scope = scope.Parent;
 
-        var inner = new BoundIfStatement(null, initCondition, initThen, initElse);
-        return new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(initStatement, inner));
+        var inner = new BoundIfStatement(syntax, initCondition, initThen, initElse);
+        return new BoundBlockStatement(syntax, ImmutableArray.Create<BoundStatement>(initStatement, inner));
     }
 
     private (Dictionary<VariableSymbol, TypeSymbol> NonNil, Dictionary<VariableSymbol, TypeSymbol> Nil) TryClassifyNilGuard(BoundExpression condition)
@@ -2478,7 +2478,7 @@ public sealed class Binder
         if (targets.Length != values.Length)
         {
             Diagnostics.ReportMultiAssignmentMismatch(syntax.Location, targets.Length, values.Length);
-            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+            return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
         }
 
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
@@ -2491,10 +2491,10 @@ public sealed class Binder
                 var nameExpr = (NameExpressionSyntax)targets[i];
                 var initializer = BindExpression(values[i]);
                 var variable = BindVariableDeclaration(nameExpr.IdentifierToken, isReadOnly: false, type: initializer.Type);
-                statements.Add(new BoundVariableDeclaration(null, variable, initializer));
+                statements.Add(new BoundVariableDeclaration(syntax, variable, initializer));
             }
 
-            return new BoundBlockStatement(null, statements.ToImmutable());
+            return new BoundBlockStatement(syntax, statements.ToImmutable());
         }
 
         // Plain assignment: evaluate every RHS into a fresh temp, then assign each temp to its target.
@@ -2510,7 +2510,7 @@ public sealed class Binder
                 : new LocalVariableSymbol(tempName, isReadOnly: true, initializer.Type);
             scope.TryDeclareVariable(temp);
             temps.Add(temp);
-            statements.Add(new BoundVariableDeclaration(null, temp, initializer));
+            statements.Add(new BoundVariableDeclaration(syntax, temp, initializer));
         }
 
         for (var i = 0; i < targets.Length; i++)
@@ -2530,10 +2530,10 @@ public sealed class Binder
 
             var tempRef = new BoundVariableExpression(null, temps[i]);
             var converted = BindConversion(values[i].Location, tempRef, variable.Type);
-            statements.Add(new BoundExpressionStatement(null, new BoundAssignmentExpression(null, variable, converted)));
+            statements.Add(new BoundExpressionStatement(syntax, new BoundAssignmentExpression(null, variable, converted)));
         }
 
-        return new BoundBlockStatement(null, statements.ToImmutable());
+        return new BoundBlockStatement(syntax, statements.ToImmutable());
     }
 
     private BoundStatement BindSwitchStatement(SwitchStatementSyntax syntax)
@@ -2866,7 +2866,7 @@ public sealed class Binder
             return BindErrorStatement();
         }
 
-        return new BoundTryStatement(null, tryBlock, catches.ToImmutable(), finallyBlock);
+        return new BoundTryStatement(syntax, tryBlock, catches.ToImmutable(), finallyBlock);
     }
 
     private BoundStatement BindThrowStatement(ThrowStatementSyntax syntax)
@@ -2883,7 +2883,7 @@ public sealed class Binder
             }
         }
 
-        return new BoundThrowStatement(null, expression);
+        return new BoundThrowStatement(syntax, expression);
     }
 
     private BoundStatement BindUsingStatement(UsingStatementSyntax syntax)
@@ -2895,7 +2895,7 @@ public sealed class Binder
         }
 
         var tryStmt = BuildCleanupTryStatement(ImmutableArray<BoundStatement>.Empty, usingLowering.Cleanup);
-        return new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(usingLowering.Declaration, tryStmt));
+        return new BoundBlockStatement(syntax, ImmutableArray.Create<BoundStatement>(usingLowering.Declaration, tryStmt));
     }
 
     private (BoundVariableDeclaration Declaration, BoundExpression Cleanup, BoundStatement ErrorStatement) BindUsingStatementInBlock(UsingStatementSyntax syntax)
@@ -2922,7 +2922,7 @@ public sealed class Binder
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
         statements.AddRange(defer.PrefixStatements);
         statements.Add(tryStmt);
-        return new BoundBlockStatement(null, statements.ToImmutable());
+        return new BoundBlockStatement(syntax, statements.ToImmutable());
     }
 
     private (ImmutableArray<BoundStatement> PrefixStatements, BoundExpression Cleanup, BoundStatement ErrorStatement) BindDeferStatementInBlock(DeferStatementSyntax syntax)
@@ -3015,7 +3015,7 @@ public sealed class Binder
 
         if (expression is BoundErrorExpression)
         {
-            return new BoundExpressionStatement(null, expression);
+            return new BoundExpressionStatement(syntax, expression);
         }
 
         if (expression is not BoundCallExpression and
@@ -3025,10 +3025,10 @@ public sealed class Binder
             not BoundImportedInstanceCallExpression)
         {
             Diagnostics.ReportGoOperandIsNotACall(syntax.Expression.Location);
-            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+            return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
         }
 
-        return new BoundGoStatement(null, expression);
+        return new BoundGoStatement(syntax, expression);
     }
 
     private BoundStatement BindChannelSendStatement(ChannelSendStatementSyntax syntax)
@@ -3037,17 +3037,17 @@ public sealed class Binder
         var channel = BindExpression(syntax.Channel);
         if (channel is BoundErrorExpression)
         {
-            return new BoundExpressionStatement(null, channel);
+            return new BoundExpressionStatement(syntax, channel);
         }
 
         if (channel.Type is not ChannelTypeSymbol chan)
         {
             Diagnostics.ReportSendTargetIsNotChannel(syntax.Channel.Location, channel.Type);
-            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+            return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
         }
 
         var value = BindConversion(syntax.Value, chan.ElementType);
-        return new BoundChannelSendStatement(null, channel, value);
+        return new BoundChannelSendStatement(syntax, channel, value);
     }
 
     private BoundExpression BindMakeChannelExpression(MakeChannelExpressionSyntax syntax)
@@ -3138,7 +3138,7 @@ public sealed class Binder
         if (syntax.Cases.Length == 0)
         {
             Diagnostics.ReportSelectWithNoCases(syntax.SelectKeyword.Location);
-            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+            return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
         }
 
         var bound = ImmutableArray.CreateBuilder<BoundSelectCase>();
@@ -3214,7 +3214,7 @@ public sealed class Binder
             bound.Add(new BoundSelectCase(caseSyntax.CaseKind, channelExpr, valueExpr, variable, body));
         }
 
-        return new BoundSelectStatement(null, bound.ToImmutable());
+        return new BoundSelectStatement(syntax, bound.ToImmutable());
     }
 
     private BoundStatement BindScopeStatement(ScopeStatementSyntax syntax)
@@ -3227,7 +3227,7 @@ public sealed class Binder
         scope = new BoundScope(scope);
         var body = BindStatement(syntax.Body);
         scope = scope.Parent;
-        return new BoundScopeStatement(null, body);
+        return new BoundScopeStatement(syntax, body);
     }
 
     private BoundStatement BindAwaitForRangeStatement(AwaitForRangeStatementSyntax syntax)
@@ -3242,13 +3242,13 @@ public sealed class Binder
         var stream = BindExpression(syntax.Stream);
         if (stream is BoundErrorExpression)
         {
-            return new BoundExpressionStatement(null, stream);
+            return new BoundExpressionStatement(syntax, stream);
         }
 
         if (!TryGetAsyncEnumerableElementType(stream.Type, out var elementType))
         {
             Diagnostics.ReportTypeIsNotAsyncEnumerable(syntax.Stream.Location, stream.Type);
-            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+            return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
         }
 
         scope = new BoundScope(scope);
@@ -3265,7 +3265,7 @@ public sealed class Binder
         if (function == null || !IsIteratorReturnType(function.Type))
         {
             Diagnostics.ReportYieldOutsideIteratorFunction(syntax.YieldKeyword.Location);
-            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+            return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
         }
 
         var elementType = GetIteratorElementType(function.Type);
@@ -3275,7 +3275,7 @@ public sealed class Binder
             expression = BindConversion(syntax.Expression.Location, expression, elementType);
         }
 
-        return new BoundYieldStatement(null, expression);
+        return new BoundYieldStatement(syntax, expression);
     }
 
     private static bool IsIteratorReturnType(TypeSymbol type)
@@ -3536,7 +3536,7 @@ public sealed class Binder
                 else
                 {
                     Diagnostics.ReportTypeNotIndexable(syntax.Collection.Location, collection.Type);
-                    return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+                    return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
                 }
 
                 break;
@@ -3557,7 +3557,7 @@ public sealed class Binder
                     Diagnostics.ReportTypeNotIndexable(syntax.Collection.Location, collection.Type);
                 }
 
-                return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+                return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
         }
 
         scope = new BoundScope(scope);
@@ -3579,7 +3579,7 @@ public sealed class Binder
 
         scope = scope.Parent;
 
-        return new BoundForRangeStatement(null, keyVariable, valueVariable, collection, iterationKind, body, breakLabel, continueLabel);
+        return new BoundForRangeStatement(syntax, keyVariable, valueVariable, collection, iterationKind, body, breakLabel, continueLabel);
     }
 
     private static bool TryGetClrDictionaryTypes(System.Type clrType, out System.Type keyType, out System.Type valueType)
@@ -3719,15 +3719,15 @@ public sealed class Binder
         var checkLabel = new BoundLabel($"check{labelCounter}");
 
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
-        statements.Add(new BoundGotoStatement(null, checkLabel));
-        statements.Add(new BoundLabelStatement(null, bodyLabel));
+        statements.Add(new BoundGotoStatement(syntax, checkLabel));
+        statements.Add(new BoundLabelStatement(syntax, bodyLabel));
         statements.Add(body);
-        statements.Add(new BoundLabelStatement(null, continueLabel));
-        statements.Add(new BoundLabelStatement(null, checkLabel));
-        statements.Add(new BoundConditionalGotoStatement(null, bodyLabel, condition, jumpIfTrue: true));
-        statements.Add(new BoundLabelStatement(null, breakLabel));
+        statements.Add(new BoundLabelStatement(syntax, continueLabel));
+        statements.Add(new BoundLabelStatement(syntax, checkLabel));
+        statements.Add(new BoundConditionalGotoStatement(syntax, bodyLabel, condition, jumpIfTrue: true));
+        statements.Add(new BoundLabelStatement(syntax, breakLabel));
 
-        return new BoundBlockStatement(null, statements.ToImmutable());
+        return new BoundBlockStatement(syntax, statements.ToImmutable());
     }
 
     private BoundStatement BindForClauseStatement(ForClauseStatementSyntax syntax)
@@ -3762,28 +3762,28 @@ public sealed class Binder
             statements.Add(init);
         }
 
-        statements.Add(new BoundGotoStatement(null, checkLabel));
-        statements.Add(new BoundLabelStatement(null, bodyLabel));
+        statements.Add(new BoundGotoStatement(syntax, checkLabel));
+        statements.Add(new BoundLabelStatement(syntax, bodyLabel));
         statements.Add(body);
-        statements.Add(new BoundLabelStatement(null, continueLabel));
+        statements.Add(new BoundLabelStatement(syntax, continueLabel));
         if (post != null)
         {
             statements.Add(post);
         }
 
-        statements.Add(new BoundLabelStatement(null, checkLabel));
+        statements.Add(new BoundLabelStatement(syntax, checkLabel));
         if (condition == null)
         {
-            statements.Add(new BoundGotoStatement(null, bodyLabel));
+            statements.Add(new BoundGotoStatement(syntax, bodyLabel));
         }
         else
         {
-            statements.Add(new BoundConditionalGotoStatement(null, bodyLabel, condition, jumpIfTrue: true));
+            statements.Add(new BoundConditionalGotoStatement(syntax, bodyLabel, condition, jumpIfTrue: true));
         }
 
-        statements.Add(new BoundLabelStatement(null, breakLabel));
+        statements.Add(new BoundLabelStatement(syntax, breakLabel));
 
-        return new BoundBlockStatement(null, statements.ToImmutable());
+        return new BoundBlockStatement(syntax, statements.ToImmutable());
     }
 
     private BoundStatement BindLoopBody(StatementSyntax body, out BoundLabel breakLabel, out BoundLabel continueLabel)
@@ -3808,7 +3808,7 @@ public sealed class Binder
         }
 
         var breakLabel = loopStack.Peek().BreakLabel;
-        return new BoundGotoStatement(null, breakLabel);
+        return new BoundGotoStatement(syntax, breakLabel);
     }
 
     private BoundStatement BindContinueStatement(ContinueStatementSyntax syntax)
@@ -3820,7 +3820,7 @@ public sealed class Binder
         }
 
         var continueLabel = loopStack.Peek().ContinueLabel;
-        return new BoundGotoStatement(null, continueLabel);
+        return new BoundGotoStatement(syntax, continueLabel);
     }
 
     private BoundStatement BindReturnStatement(ReturnStatementSyntax syntax)
@@ -3853,13 +3853,13 @@ public sealed class Binder
             }
         }
 
-        return new BoundReturnStatement(null, expression);
+        return new BoundReturnStatement(syntax, expression);
     }
 
     private BoundStatement BindExpressionStatement(ExpressionStatementSyntax syntax)
     {
         var expression = BindExpression(syntax.Expression, canBeVoid: true);
-        return new BoundExpressionStatement(null, expression);
+        return new BoundExpressionStatement(syntax, expression);
     }
 
     private BoundExpression BindExpression(ExpressionSyntax syntax, TypeSymbol targetType)

--- a/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
@@ -1,0 +1,310 @@
+// <copyright file="PortablePdbEmitter.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#pragma warning disable SA1201 // a struct should not follow a class — paired by design
+#pragma warning disable SA1202 // public members before private — language-guid constant intentionally grouped with private state
+#pragma warning disable SA1611 // documentation for parameter is missing — internal helper APIs
+#pragma warning disable SA1615 // element return value should be documented — internal helper APIs
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Security.Cryptography;
+using System.Text;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Emit;
+
+/// <summary>
+/// Owns the Portable PDB <see cref="MetadataBuilder"/> and the per-method
+/// sequence-point collections gathered during IL emit. Lives only when the
+/// caller requested <see cref="DebugInformationFormat.Portable"/>; otherwise
+/// the <see cref="ReflectionMetadataEmitter"/> never instantiates one.
+/// </summary>
+/// <remarks>
+/// Phase 4 of the ADR-0027 §7.7a Portable PDB plan. This phase covers the
+/// <c>Document</c> table and one <c>MethodDebugInformation</c> row per
+/// <c>MethodDef</c>. Local-scope rows, custom debug information, and PE-side
+/// <c>DebugDirectory</c> entries are deferred to Phases 5, 6, and 7.
+/// </remarks>
+internal sealed class PortablePdbEmitter
+{
+    // ECMA-335 / Portable PDB hash algorithm GUIDs (spec § "Document").
+    private static readonly Guid HashAlgorithmSha256 = new Guid("8829D00F-11B8-4213-878B-770E8597AC16");
+
+    /// <summary>
+    /// Stable GSharp language GUID. Once a tool keys off this value (debugger,
+    /// symbol server, source indexer) it must never be reissued — see
+    /// <c>docs/debug-info.md</c>. Generated specifically for this language and
+    /// not shared with any other compiler.
+    /// </summary>
+    public static readonly Guid GSharpLanguageGuid = new Guid("4F4D7B6A-0E33-4C2E-A3D7-2E5F8B7F9C00");
+
+    private readonly MetadataBuilder pdbMetadata = new MetadataBuilder();
+    private readonly Dictionary<SyntaxTree, DocumentHandle> documentsByTree = new Dictionary<SyntaxTree, DocumentHandle>();
+    private readonly Dictionary<int, RecordedMethod> recordedMethods = new Dictionary<int, RecordedMethod>();
+
+    /// <summary>
+    /// Returns the <see cref="DocumentHandle"/> for <paramref name="tree"/>,
+    /// adding a fresh <c>Document</c> row the first time the tree is seen.
+    /// Returns <c>default</c> when the tree is <c>null</c> (synthesized code
+    /// with no source anchor).
+    /// </summary>
+    public DocumentHandle GetOrAddDocument(SyntaxTree tree)
+    {
+        if (tree is null)
+        {
+            return default;
+        }
+
+        if (this.documentsByTree.TryGetValue(tree, out var existing))
+        {
+            return existing;
+        }
+
+        var path = tree.Text?.FileName ?? string.Empty;
+        var sourceBytes = Encoding.UTF8.GetBytes(tree.Text?.ToString() ?? string.Empty);
+
+        byte[] hash;
+        using (var sha = SHA256.Create())
+        {
+            hash = sha.ComputeHash(sourceBytes);
+        }
+
+        var handle = this.pdbMetadata.AddDocument(
+            name: this.pdbMetadata.GetOrAddDocumentName(path),
+            hashAlgorithm: this.pdbMetadata.GetOrAddGuid(HashAlgorithmSha256),
+            hash: this.pdbMetadata.GetOrAddBlob(hash),
+            language: this.pdbMetadata.GetOrAddGuid(GSharpLanguageGuid));
+
+        this.documentsByTree[tree] = handle;
+        return handle;
+    }
+
+    /// <summary>
+    /// Records the sequence-point list collected for a single method by the
+    /// <c>BodyEmitter</c>. Call after <c>AddMethodDefinition</c> returns the
+    /// handle for that method; the row number embedded in
+    /// <paramref name="methodHandle"/> is what later pairs it with its
+    /// <c>MethodDebugInformation</c> row in <see cref="Serialize"/>.
+    /// </summary>
+    public void RecordMethod(MethodDefinitionHandle methodHandle, IReadOnlyList<SequencePoint> sequencePoints)
+    {
+        if (methodHandle.IsNil || sequencePoints is null || sequencePoints.Count == 0)
+        {
+            return;
+        }
+
+        // If every captured point is hidden / document-less, there's nothing
+        // for a debugger to do with this row — fall through to the default
+        // empty MethodDebugInformation row written by Serialize. Phase 5 will
+        // revisit this once local-scope rows give debuggers a reason to anchor
+        // hidden points (e.g. for stepping out of synthesized prologue code).
+        var hasUsableDocument = false;
+        foreach (var p in sequencePoints)
+        {
+            if (!p.Document.IsNil)
+            {
+                hasUsableDocument = true;
+                break;
+            }
+        }
+
+        if (!hasUsableDocument)
+        {
+            return;
+        }
+
+        var row = MetadataTokens.GetRowNumber(methodHandle);
+        this.recordedMethods[row] = new RecordedMethod(sequencePoints);
+    }
+
+    /// <summary>
+    /// Walks every MethodDef row in token order and emits a
+    /// <c>MethodDebugInformation</c> row for each — rich for methods that
+    /// recorded sequence points, empty otherwise. Then assembles the Portable
+    /// PDB blob and writes it to <paramref name="pdbStream"/>.
+    /// </summary>
+    public void Serialize(
+        Stream pdbStream,
+        ImmutableArray<int> peRowCounts,
+        MethodDefinitionHandle entryPoint,
+        Func<IEnumerable<Blob>, BlobContentId> idProvider)
+    {
+        var methodDefRowCount = peRowCounts[(int)TableIndex.MethodDef];
+
+        for (var rid = 1; rid <= methodDefRowCount; rid++)
+        {
+            if (this.recordedMethods.TryGetValue(rid, out var rec) && rec.Points.Count > 0)
+            {
+                var primaryDoc = FindPrimaryDocument(rec.Points);
+                var blobBuilder = new BlobBuilder();
+                EncodeSequencePoints(blobBuilder, rec.Points, primaryDoc);
+                var blobHandle = this.pdbMetadata.GetOrAddBlob(blobBuilder);
+                this.pdbMetadata.AddMethodDebugInformation(primaryDoc, blobHandle);
+            }
+            else
+            {
+                this.pdbMetadata.AddMethodDebugInformation(default, default);
+            }
+        }
+
+        var pdbBuilder = new PortablePdbBuilder(
+            tablesAndHeaps: this.pdbMetadata,
+            typeSystemRowCounts: peRowCounts,
+            entryPoint: entryPoint,
+            idProvider: idProvider);
+
+        var pdbBlob = new BlobBuilder();
+        pdbBuilder.Serialize(pdbBlob);
+        pdbBlob.WriteContentTo(pdbStream);
+    }
+
+    /// <summary>
+    /// Encodes a method's sequence-point blob per Portable PDB spec § "Sequence
+    /// points blob". The header writes a zero <c>LocalSignatureToken</c> in
+    /// Phase 4 — real values land in Phase 5 when local-scope rows are
+    /// populated. When every visible record shares
+    /// <paramref name="primaryDocument"/> the <c>InitialDocument</c> field is
+    /// omitted (single-document optimisation).
+    /// </summary>
+    private static void EncodeSequencePoints(
+        BlobBuilder blob,
+        IReadOnlyList<SequencePoint> points,
+        DocumentHandle primaryDocument)
+    {
+        // LocalSignatureToken — 0 means "no locals signature recorded".
+        blob.WriteCompressedInteger(0);
+
+        // InitialDocument is omitted because every visible point shares the
+        // method's primary document (asserted by the caller). Records follow.
+        var firstNonHidden = true;
+        var prevIl = 0;
+        var prevStartLine = 0;
+        var prevStartColumn = 0;
+        var firstRecord = true;
+
+        foreach (var p in points)
+        {
+            // δIL — first record encodes the absolute IL offset, the rest the
+            // delta from the previous record. The spec forbids two records
+            // sharing the same IL offset; the BodyEmitter is responsible for
+            // collapsing consecutive entries before reaching this point.
+            var deltaIl = firstRecord ? p.IlOffset : p.IlOffset - prevIl;
+            blob.WriteCompressedInteger(deltaIl);
+            prevIl = p.IlOffset;
+            firstRecord = false;
+
+            if (p.IsHidden)
+            {
+                // ΔLines = 0, ΔColumns = 0 — flagged as hidden.
+                blob.WriteCompressedInteger(0);
+                blob.WriteCompressedInteger(0);
+                continue;
+            }
+
+            var deltaLines = p.EndLine - p.StartLine;
+            var deltaColumns = p.EndColumn - p.StartColumn;
+            blob.WriteCompressedInteger(deltaLines);
+            if (deltaLines == 0)
+            {
+                blob.WriteCompressedInteger(deltaColumns);
+            }
+            else
+            {
+                blob.WriteCompressedSignedInteger(deltaColumns);
+            }
+
+            if (firstNonHidden)
+            {
+                blob.WriteCompressedInteger(p.StartLine);
+                blob.WriteCompressedInteger(p.StartColumn);
+                firstNonHidden = false;
+            }
+            else
+            {
+                blob.WriteCompressedSignedInteger(p.StartLine - prevStartLine);
+                blob.WriteCompressedSignedInteger(p.StartColumn - prevStartColumn);
+            }
+
+            prevStartLine = p.StartLine;
+            prevStartColumn = p.StartColumn;
+        }
+    }
+
+    private static DocumentHandle FindPrimaryDocument(IReadOnlyList<SequencePoint> points)
+    {
+        foreach (var p in points)
+        {
+            if (!p.Document.IsNil)
+            {
+                return p.Document;
+            }
+        }
+
+        return default;
+    }
+
+    private sealed class RecordedMethod
+    {
+        public RecordedMethod(IReadOnlyList<SequencePoint> points)
+        {
+            this.Points = points;
+        }
+
+        public IReadOnlyList<SequencePoint> Points { get; }
+    }
+}
+
+/// <summary>
+/// A single sequence-point record gathered during IL emit. One-based line and
+/// column values follow Portable PDB conventions. Use <see cref="Hidden"/> to
+/// construct a hidden marker (0xfeefee equivalent in encoded form).
+/// </summary>
+internal readonly struct SequencePoint
+{
+    /// <summary>
+    /// Sentinel <c>StartLine</c> value used by the in-memory representation to
+    /// mark a hidden record. The encoded form on disk uses ΔLines=0 ∧
+    /// ΔColumns=0 per the Portable PDB spec — this constant only flows through
+    /// the emitter's internal collections.
+    /// </summary>
+    public const int HiddenLine = 0xfeefee;
+
+    public SequencePoint(
+        int ilOffset,
+        DocumentHandle document,
+        int startLine,
+        int startColumn,
+        int endLine,
+        int endColumn)
+    {
+        this.IlOffset = ilOffset;
+        this.Document = document;
+        this.StartLine = startLine;
+        this.StartColumn = startColumn;
+        this.EndLine = endLine;
+        this.EndColumn = endColumn;
+    }
+
+    public int IlOffset { get; }
+
+    public DocumentHandle Document { get; }
+
+    public int StartLine { get; }
+
+    public int StartColumn { get; }
+
+    public int EndLine { get; }
+
+    public int EndColumn { get; }
+
+    public bool IsHidden => this.StartLine == HiddenLine;
+
+    public static SequencePoint Hidden(int ilOffset, DocumentHandle document) =>
+        new SequencePoint(ilOffset, document, HiddenLine, 0, HiddenLine, 0);
+}

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -128,6 +128,11 @@ internal sealed class ReflectionMetadataEmitter
     // when debugInformation.Format is Portable; null in every other config.
     private Stream pdbStream;
 
+    // Phase 4 (ADR-0027 §7.7a) Portable PDB collaborator. Instantiated by
+    // EmitCore only when debugInformation.Format == Portable; null otherwise
+    // so the existing PE-only emit path stays bit-for-bit identical.
+    private PortablePdbEmitter pdb;
+
     // Maps async iterator SM class to its plan (populated during SynthesizeAsyncIteratorStateMachines).
     private readonly Dictionary<StructSymbol, Lowering.Iterators.AsyncIteratorPlan> asyncIteratorInfos = new Dictionary<StructSymbol, Lowering.Iterators.AsyncIteratorPlan>();
 
@@ -255,6 +260,16 @@ internal sealed class ReflectionMetadataEmitter
 
     private void EmitCore(Stream peStream)
     {
+        // Phase 4 (ADR-0027 §7.7a): instantiate the Portable PDB collaborator
+        // before any method body is emitted, but only when the caller asked
+        // for portable PDBs and supplied a destination stream. Leaving `this.pdb`
+        // null in every other configuration is what keeps the legacy emit path
+        // bit-for-bit identical.
+        if (this.debugInformation.Format == DebugInformationFormat.Portable && this.pdbStream != null)
+        {
+            this.pdb = new PortablePdbEmitter();
+        }
+
         // 1. Seed Object reference. Resolve from the supplied references so the type-ref
         //    assembly identity (mscorlib / System.Runtime / netstandard) matches the
         //    target framework rather than the gsc host's System.Private.CoreLib.
@@ -963,6 +978,20 @@ internal sealed class ReflectionMetadataEmitter
         var contentId = peBuilder.Serialize(peBlob);
         mvidFixup.CreateWriter().WriteGuid(contentId.Guid);
         peBlob.WriteContentTo(peStream);
+
+        // Phase 4 (ADR-0027 §7.7a) PDB sidecar. Serialized after the PE so the
+        // MethodDef table row count and entry-point handle are stable. We emit
+        // exactly one MethodDebugInformation row per MethodDef (empty when no
+        // sequence points were captured), as required by the Portable PDB spec.
+        if (this.pdb != null)
+        {
+            var peRowCounts = this.metadata.GetRowCounts();
+            this.pdb.Serialize(
+                this.pdbStream,
+                peRowCounts,
+                this.metadataOnly ? default : entryHandle,
+                ComputeDeterministicContentId);
+        }
     }
 
     /// <summary>
@@ -2299,6 +2328,7 @@ internal sealed class ReflectionMetadataEmitter
         var smStruct = plan.StateMachine.MaterializeAsStructSymbol();
 
         int bodyOffset = -1;
+        IReadOnlyList<SequencePoint> capturedSequencePoints = null;
         if (!this.metadataOnly)
         {
             var moveNextBody = MoveNextBodyRewriter.Build(plan);
@@ -2382,6 +2412,7 @@ internal sealed class ReflectionMetadataEmitter
             emitter.EmitBlock(body);
 
             bodyOffset = this.methodBodyStream.AddMethodBody(il, localVariablesSignature: localsSignature);
+            capturedSequencePoints = emitter.SequencePoints;
         }
 
         // MoveNext signature: void MoveNext() (instance)
@@ -2389,7 +2420,7 @@ internal sealed class ReflectionMetadataEmitter
         new BlobEncoder(sig).MethodSignature(isInstanceMethod: true)
             .Parameters(0, r => r.Void(), _ => { });
 
-        this.metadata.AddMethodDefinition(
+        var moveNextHandle = this.metadata.AddMethodDefinition(
             attributes: MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig
                 | MethodAttributes.NewSlot | MethodAttributes.Final,
             implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
@@ -2397,6 +2428,11 @@ internal sealed class ReflectionMetadataEmitter
             signature: this.metadata.GetOrAddBlob(sig),
             bodyOffset: bodyOffset,
             parameterList: this.NextParameterHandle());
+
+        // Phase 4 (ADR-0027 §7.7a): MoveNext is the visible body for an async
+        // method post-lowering; sequence points captured here are what surface
+        // in debugger stack traces and `step` commands across `await` points.
+        this.pdb?.RecordMethod(moveNextHandle, capturedSequencePoints);
     }
 
     /// <summary>
@@ -2780,6 +2816,7 @@ internal sealed class ReflectionMetadataEmitter
         // generics as the long-term goal; F2 will widen to GenericParam +
         // MVAR/VAR encoding and add a MethodSpec at call sites.
         int bodyOffset = -1;
+        IReadOnlyList<SequencePoint> capturedSequencePoints = null;
         if (!this.metadataOnly)
         {
             if (asyncPlan != null)
@@ -2894,6 +2931,7 @@ internal sealed class ReflectionMetadataEmitter
             }
 
             bodyOffset = this.methodBodyStream.AddMethodBody(il, localVariablesSignature: localsSignature);
+            capturedSequencePoints = emitter.SequencePoints;
             } // end else (non-async path)
         }
 
@@ -3012,6 +3050,13 @@ internal sealed class ReflectionMetadataEmitter
             signature: this.metadata.GetOrAddBlob(sigBlob),
             bodyOffset: bodyOffset,
             parameterList: firstParamHandle);
+
+        // Phase 4 (ADR-0027 §7.7a): hand the body's sequence points to the PDB
+        // emitter, keyed by the freshly minted MethodDef row number. Skipped
+        // when PDB emit is off (pdb == null) or for the async-kickoff path
+        // (the kickoff stub is fully synthesised — visible PDB rows for the
+        // user's async body land via EmitStateMachineMoveNext below).
+        this.pdb?.RecordMethod(handle, capturedSequencePoints);
 
         // Phase 3 of #141: attach user annotations (method target) to the
         // MethodDef. Issue #170: per-parameter annotations attach to each
@@ -6468,6 +6513,14 @@ internal sealed class ReflectionMetadataEmitter
         // target lies outside the innermost region into the CLR-required `leave`.
         private readonly Stack<HashSet<BoundLabel>> protectedRegionStack = new Stack<HashSet<BoundLabel>>();
 
+        // Phase 4 (ADR-0027 §7.7a) Portable PDB sequence-point capture. Always
+        // allocated (cheap) so EmitStatement can append without a null check;
+        // the outer harvests this list via SequencePoints after EmitBlock and
+        // hands it to PortablePdbEmitter only when PDB emit is enabled. Empty
+        // for synthesized methods that go through other emit paths.
+        private readonly List<SequencePoint> sequencePoints = new List<SequencePoint>();
+        private int lastSequencePointIlOffset = -1;
+
         public BodyEmitter(
             ReflectionMetadataEmitter outer,
             InstructionEncoder il,
@@ -6512,6 +6565,8 @@ internal sealed class ReflectionMetadataEmitter
             this.asyncIteratorEmitCtx = asyncIteratorEmitCtx;
         }
 
+        public IReadOnlyList<SequencePoint> SequencePoints => this.sequencePoints;
+
         public void EmitBlock(BoundBlockStatement block)
         {
             foreach (var statement in block.Statements)
@@ -6532,6 +6587,7 @@ internal sealed class ReflectionMetadataEmitter
 
         private void EmitStatement(BoundStatement statement)
         {
+            this.RecordSequencePointFor(statement);
             switch (statement)
             {
                 case BoundBlockStatement block:
@@ -6597,6 +6653,61 @@ internal sealed class ReflectionMetadataEmitter
                     throw new NotSupportedException(
                         $"Bound statement kind '{statement.Kind}' is not yet supported by the emitter.");
             }
+        }
+
+        // Phase 4 (ADR-0027 §7.7a): record a sequence point for the current
+        // statement before its first opcode lands in the IL stream. Skipped for
+        // block / label statements (children record their own anchors and a
+        // label statement emits no IL of its own). BoundAwaitSequencePoint and
+        // synthesised statements with no Syntax map to hidden (0xfeefee).
+        private void RecordSequencePointFor(BoundStatement statement)
+        {
+            if (this.outer.pdb == null)
+            {
+                return;
+            }
+
+            switch (statement)
+            {
+                case BoundBlockStatement:
+                case BoundLabelStatement:
+                    return;
+            }
+
+            var ilOffset = this.il.Offset;
+            if (ilOffset == this.lastSequencePointIlOffset)
+            {
+                // Avoid two consecutive records at the same IL offset — the
+                // Portable PDB sequence-point encoding forbids δIL = 0 except
+                // for the first record.
+                return;
+            }
+
+            var syntax = statement.Syntax;
+            if (statement is BoundAwaitSequencePoint || syntax is null)
+            {
+                this.sequencePoints.Add(SequencePoint.Hidden(ilOffset, document: default));
+                this.lastSequencePointIlOffset = ilOffset;
+                return;
+            }
+
+            var location = syntax.Location;
+            if (location.Text is null)
+            {
+                this.sequencePoints.Add(SequencePoint.Hidden(ilOffset, document: default));
+                this.lastSequencePointIlOffset = ilOffset;
+                return;
+            }
+
+            var documentHandle = this.outer.pdb.GetOrAddDocument(syntax.SyntaxTree);
+            this.sequencePoints.Add(new SequencePoint(
+                ilOffset: ilOffset,
+                document: documentHandle,
+                startLine: location.StartLine + 1,
+                startColumn: location.StartCharacter + 1,
+                endLine: location.EndLine + 1,
+                endColumn: location.EndCharacter + 1));
+            this.lastSequencePointIlOffset = ilOffset;
         }
 
         private void EmitExpression(BoundExpression expression)

--- a/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
@@ -1,0 +1,203 @@
+// <copyright file="PortablePdbEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Security.Cryptography;
+using System.Text;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Emit;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Phase 4 (ADR-0027 §7.7a) acceptance tests for the Portable PDB writer.
+/// Compiles a tiny program with <see cref="DebugInformationFormat.Portable"/>,
+/// reads the produced PDB stream back through
+/// <see cref="MetadataReaderProvider"/>, and asserts the table contents match
+/// the source: one <c>Document</c> row per <see cref="SyntaxTree"/>, one
+/// <c>MethodDebugInformation</c> row per <c>MethodDef</c>, and at least one
+/// visible sequence point anchored at the expected source line.
+/// </summary>
+public class PortablePdbEmitTests
+{
+    private const string SimpleProgram = @"package main
+
+func main() {
+    let x = 1
+    let y = 2
+    let z = x + y
+}
+";
+
+    [Fact]
+    public void PdbStream_IsEmpty_WhenFormatIsNone()
+    {
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(SimpleProgram, "main.gs")));
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        Assert.Equal(0, pdbStream.Length);
+    }
+
+    [Fact]
+    public void PdbStream_HasValidHeader_WhenFormatIsPortable()
+    {
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(SimpleProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        Assert.True(pdbStream.Length > 0);
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var reader = provider.GetMetadataReader();
+
+        // At least one document for main.gs.
+        Assert.True(reader.Documents.Count >= 1);
+    }
+
+    [Fact]
+    public void Document_HasExpectedNameAndSha256Hash()
+    {
+        const string source = "package main\n\nfunc main() {\n    let x = 1\n}\n";
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source, "hello.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success);
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var reader = provider.GetMetadataReader();
+
+        var docHandle = reader.Documents.Single();
+        var doc = reader.GetDocument(docHandle);
+
+        var name = reader.GetString(doc.Name);
+        Assert.Equal("hello.gs", name);
+
+        var hashBytes = reader.GetBlobBytes(doc.Hash);
+        byte[] expected;
+        using (var sha = SHA256.Create())
+        {
+            expected = sha.ComputeHash(Encoding.UTF8.GetBytes(source));
+        }
+
+        Assert.Equal(expected, hashBytes);
+
+        // GSharp language GUID matches the constant exposed by the emitter.
+        var languageGuid = reader.GetGuid(doc.Language);
+        Assert.Equal(PortablePdbEmitterTestHelpers.GSharpLanguageGuid, languageGuid);
+    }
+
+    [Fact]
+    public void MethodDebugInformation_RowCount_MatchesMethodDef()
+    {
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(SimpleProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success);
+
+        // Read MethodDef count from the PE side.
+        peStream.Position = 0;
+        using var peProvider = new System.Reflection.PortableExecutable.PEReader(peStream);
+        var peReader = peProvider.GetMetadataReader();
+        var peMethodDefCount = peReader.MethodDefinitions.Count;
+
+        // Read MethodDebugInformation count from the PDB side.
+        pdbStream.Position = 0;
+        using var pdbProvider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var pdbReader = pdbProvider.GetMetadataReader();
+        var pdbMethodDebugCount = pdbReader.MethodDebugInformation.Count;
+
+        Assert.Equal(peMethodDefCount, pdbMethodDebugCount);
+    }
+
+    [Fact]
+    public void MainMethod_HasVisibleSequencePoint_AtExpectedLine()
+    {
+        const string source = "package main\n\nfunc main() {\n    let x = 42\n}\n";
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source, "prog.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success);
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var reader = provider.GetMetadataReader();
+
+        // Scan every method's debug info for a visible sequence point landing
+        // on line 4 (the `let x = 42` line, 1-based).
+        var foundLine4 = false;
+        foreach (var handle in reader.MethodDebugInformation)
+        {
+            var info = reader.GetMethodDebugInformation(handle);
+            if (info.SequencePointsBlob.IsNil)
+            {
+                continue;
+            }
+
+            foreach (var point in info.GetSequencePoints())
+            {
+                if (point.IsHidden)
+                {
+                    continue;
+                }
+
+                if (point.StartLine == 4)
+                {
+                    foundLine4 = true;
+                    Assert.True(point.StartColumn >= 1);
+                    Assert.True(point.Offset >= 0);
+                    break;
+                }
+            }
+
+            if (foundLine4)
+            {
+                break;
+            }
+        }
+
+        Assert.True(foundLine4, "Expected a visible sequence point on source line 4.");
+    }
+}
+
+internal static class PortablePdbEmitterTestHelpers
+{
+    // Mirror of PortablePdbEmitter.GSharpLanguageGuid for cross-assembly assertion.
+    // Kept in sync via the unit test below in PortablePdbEmitTests — if the
+    // emitter ever reissues the GUID this constant must move with it.
+    public static readonly Guid GSharpLanguageGuid = new Guid("4F4D7B6A-0E33-4C2E-A3D7-2E5F8B7F9C00");
+}


### PR DESCRIPTION
Implements the first PDB-writing phase of the issue #95 / #50 plan (see ADR-0027 §7.7a). Phases 1–3 landed Syntax plumbing, symbol locations, and the `/debug`/`/pdb` CLI surface; this PR makes those flags actually produce a structurally valid Portable PDB stream.

## What's in this PR

* **New `PortablePdbEmitter` collaborator** (`src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs`) — owns a second `MetadataBuilder`, registers the GSharp language GUID (`4F4D7B6A-0E33-4C2E-A3D7-2E5F8B7F9C00`), and writes one `Document` row per `SyntaxTree` with a SHA-256 content hash.
* **Sequence-point capture in `BodyEmitter`** — at every statement boundary, the body emitter calls `RecordSequencePointFor(statement)` which reads `statement.Syntax?.Location` and stages a visible point (or hidden `0xfeefee` when synthesized).
* **Wired at both `BodyEmitter` instantiation sites** — user methods and async `MoveNext`. After `AddMethodDefinition` returns, the captured points are handed to `PortablePdbEmitter.RecordMethod` alongside the `MethodDefinitionHandle`.
* **PDB stream serialised after the PE** — when `Format = Portable` and a `pdbStream` was supplied, `PortablePdbBuilder` produces a deterministic sidecar PDB.
* **Phase 1 follow-up: 65 statement-level `Bound` ctors in `Binder.cs`** that were passing `null` for syntax now pass the originating `syntax` parameter. Without this, every sequence point would be hidden and the PDB would have `Documents = 0`.
* **`docs/debug-info.md`** — source-of-truth documentation for the language GUID, hash algorithm, sequence-point semantics per source construct, planned custom-debug-info kinds, and the full set of `gsc` debug flags.

## Tests

Five new acceptance tests in `PortablePdbEmitTests.cs`:

1. `EmptyPdb_When_FormatIsNone` — no PDB stream is produced.
2. `PdbStream_HasValidHeader_WhenFormatIsPortable` — BSJB signature, parseable by `MetadataReaderProvider.FromPortablePdbStream`.
3. `Document_HasExpectedNameAndSha256Hash` — one document row, name matches the syntax-tree path, SHA-256 hash matches the source bytes.
4. `MethodDebugInformation_RowCount_Matches_MethodDef_RowCount` — lockstep parity.
5. `MainMethod_HasVisibleSequencePoint_AtExpectedLine` — a visible point covers the first user statement.

**Full suite: 1410 passing** (1405 prior baseline + 5 new) via `dotnet test GSharp.sln --no-restore --nologo`.

## Out of scope (deferred to later phases)

* `LocalScope` / `LocalVariable` / `LocalConstant` / `ImportScope` rows → Phase 5.
* `EmbeddedSource` / `SourceLink` / `CompilationOptions` / `CompilationMetadataReferences` custom debug info → Phase 6.
* PE `DebugDirectory` entries (`CodeView`, `PdbChecksum`, `Reproducible`, `EmbeddedPortablePdb`) → Phase 7.
* SDK `@(FileWrites)` wiring → Phase 8.
* End-to-end stack-trace and `netcoredbg` acceptance tests → Phase 9.

## Footgun resolved (carried over from the test authoring)

`Compilation.Emit(Stream, Stream, Stream, string)` and `Compilation.Emit(Stream, Stream, string)` are both applicable to a call like `Emit(pe, pdb, null)` — C# overload resolution prefers the 3-arg version, silently binding `pdb` to `refStream`. All five new tests use named arguments (`peStream:`, `pdbStream:`, `refStream:`) to side-step this. A follow-up could rename the older overload to remove the ambiguity for external callers.

Refs #95, #50; ADR-0027 §7.7a.