### PR TITLE
Phase 5: PDB LocalScope + LocalVariable + ImportScope rows

### DIFF
--- a/docs/debug-info.md
+++ b/docs/debug-info.md
@@ -37,13 +37,40 @@ GSharp anchors sequence points at the *first IL offset emitted for each `BoundSt
 
 This is the same visible/hidden contract Roslyn-emitted assemblies follow, so all standard .NET debuggers (Visual Studio, `vsdbg`, `netcoredbg`, `dotnet-dump`, JetBrains Rider, etc.) work without further configuration.
 
-## Custom debug information
+## Local-scope semantics (Phase 5)
 
-The Portable PDB writer is staged. Phase 4 (this milestone) emits only `Document` and `MethodDebugInformation` rows. The following are planned for subsequent phases and tracked separately:
+GSharp's lowering pipeline flattens all nested `BoundBlockStatement`s into a
+single, top-level block before IL emit, so the compiler currently emits one
+`LocalScope` per method covering the entire body (`StartOffset = 0`,
+`Length = method.GetILBytes().Length`). Every user-declared local is recorded
+as a `LocalVariable` row anchored at its IL slot and tagged with its source
+name; compiler-synthesized locals (names starting with `<`, `$`, or containing
+`$`) are emitted with `LocalVariableAttributes.DebuggerHidden` so debuggers
+keep them out of the locals window.
 
-* `LocalScope`, `LocalVariable`, `LocalConstant`, `ImportScope` — Phase 5.
-* `EmbeddedSource`, `SourceLink`, `CompilationOptions`, `CompilationMetadataReferences` — Phase 6.
-* PE `DebugDirectory` entries (`CodeView`, `PdbChecksum`, `Reproducible`, `EmbeddedPortablePdb`) — Phase 7.
+A single root `ImportScope` row is emitted per assembly and referenced by
+every `LocalScope`. Per-file import chains land in a later phase once the
+binder exposes the resolved `import` set on the symbol model.
+
+The `MethodDebugInformation` sequence-point header now carries the real
+`LocalSignatureToken` for each method body, so debuggers can decode the
+on-stack values at every sequence point against the same `StandAloneSig`
+row used by the IL itself.
+
+
+
+The Portable PDB writer is staged. Phases 4–5 (shipped) emit `Document`,
+`MethodDebugInformation`, `LocalScope`, `LocalVariable`, and a single root
+`ImportScope` row per assembly. The following are planned for subsequent
+phases and tracked separately:
+
+* `LocalConstant` rows for `const` bindings — Phase 5.1 (deferred until the
+  binder surfaces `BoundLocalConstant` with a compile-time value).
+* Per-file `ImportScope` chains populated from `import` statements — Phase 5.2.
+* `EmbeddedSource`, `SourceLink`, `CompilationOptions`,
+  `CompilationMetadataReferences` — Phase 6.
+* PE `DebugDirectory` entries (`CodeView`, `PdbChecksum`, `Reproducible`,
+  `EmbeddedPortablePdb`) — Phase 7.
 
 ## Compiler flags
 

--- a/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
@@ -26,10 +26,12 @@ namespace GSharp.Core.CodeAnalysis.Emit;
 /// the <see cref="ReflectionMetadataEmitter"/> never instantiates one.
 /// </summary>
 /// <remarks>
-/// Phase 4 of the ADR-0027 §7.7a Portable PDB plan. This phase covers the
-/// <c>Document</c> table and one <c>MethodDebugInformation</c> row per
-/// <c>MethodDef</c>. Local-scope rows, custom debug information, and PE-side
-/// <c>DebugDirectory</c> entries are deferred to Phases 5, 6, and 7.
+/// Phase 4 covers the <c>Document</c> table and one
+/// <c>MethodDebugInformation</c> row per <c>MethodDef</c>. Phase 5 layers in
+/// <c>LocalScope</c>, <c>LocalVariable</c>, and a single root
+/// <c>ImportScope</c> so debuggers can resolve user-visible local names. Custom
+/// debug information and PE-side <c>DebugDirectory</c> entries are deferred to
+/// Phases 6 and 7.
 /// </remarks>
 internal sealed class PortablePdbEmitter
 {
@@ -92,35 +94,46 @@ internal sealed class PortablePdbEmitter
     /// <paramref name="methodHandle"/> is what later pairs it with its
     /// <c>MethodDebugInformation</c> row in <see cref="Serialize"/>.
     /// </summary>
-    public void RecordMethod(MethodDefinitionHandle methodHandle, IReadOnlyList<SequencePoint> sequencePoints)
+    public void RecordMethod(
+        MethodDefinitionHandle methodHandle,
+        IReadOnlyList<SequencePoint> sequencePoints,
+        IReadOnlyList<LocalInfo> locals,
+        int ilCodeSize,
+        StandaloneSignatureHandle localSignatureToken)
     {
-        if (methodHandle.IsNil || sequencePoints is null || sequencePoints.Count == 0)
+        if (methodHandle.IsNil)
         {
             return;
         }
 
-        // If every captured point is hidden / document-less, there's nothing
-        // for a debugger to do with this row — fall through to the default
-        // empty MethodDebugInformation row written by Serialize. Phase 5 will
-        // revisit this once local-scope rows give debuggers a reason to anchor
-        // hidden points (e.g. for stepping out of synthesized prologue code).
         var hasUsableDocument = false;
-        foreach (var p in sequencePoints)
+        if (sequencePoints != null)
         {
-            if (!p.Document.IsNil)
+            foreach (var p in sequencePoints)
             {
-                hasUsableDocument = true;
-                break;
+                if (!p.Document.IsNil)
+                {
+                    hasUsableDocument = true;
+                    break;
+                }
             }
         }
 
-        if (!hasUsableDocument)
+        var hasLocals = locals != null && locals.Count > 0;
+
+        // Nothing for a debugger to anchor — skip the row entirely so Serialize
+        // falls through to writing an empty MethodDebugInformation slot.
+        if (!hasUsableDocument && !hasLocals)
         {
             return;
         }
 
         var row = MetadataTokens.GetRowNumber(methodHandle);
-        this.recordedMethods[row] = new RecordedMethod(sequencePoints);
+        this.recordedMethods[row] = new RecordedMethod(
+            sequencePoints ?? System.Array.Empty<SequencePoint>(),
+            locals ?? System.Array.Empty<LocalInfo>(),
+            ilCodeSize,
+            localSignatureToken);
     }
 
     /// <summary>
@@ -137,13 +150,15 @@ internal sealed class PortablePdbEmitter
     {
         var methodDefRowCount = peRowCounts[(int)TableIndex.MethodDef];
 
+        // Step 1 — write MethodDebugInformation rows in MethodDef order (Phase 4
+        // contract: one row per MethodDef, lockstep).
         for (var rid = 1; rid <= methodDefRowCount; rid++)
         {
             if (this.recordedMethods.TryGetValue(rid, out var rec) && rec.Points.Count > 0)
             {
                 var primaryDoc = FindPrimaryDocument(rec.Points);
                 var blobBuilder = new BlobBuilder();
-                EncodeSequencePoints(blobBuilder, rec.Points, primaryDoc);
+                EncodeSequencePoints(blobBuilder, rec.Points, primaryDoc, rec.LocalSignatureToken);
                 var blobHandle = this.pdbMetadata.GetOrAddBlob(blobBuilder);
                 this.pdbMetadata.AddMethodDebugInformation(primaryDoc, blobHandle);
             }
@@ -151,6 +166,55 @@ internal sealed class PortablePdbEmitter
             {
                 this.pdbMetadata.AddMethodDebugInformation(default, default);
             }
+        }
+
+        // Step 2 — Phase 5: root ImportScope (currently always empty; per-file
+        // import information lands once the binder exposes it on the symbol
+        // model). Every LocalScope must reference an ImportScope, so we always
+        // need at least the root row.
+        var rootImportScope = this.pdbMetadata.AddImportScope(
+            parentScope: default,
+            imports: this.pdbMetadata.GetOrAddBlob(EmptyBlob));
+
+        // Step 3 — Phase 5: LocalVariable + LocalScope rows. The reader walks
+        // LocalScope sorted by method, then by startOffset. Within a method,
+        // each scope's variable list is implied by the *next* scope's variable
+        // handle, so we MUST add LocalVariable rows in the same order we add
+        // LocalScope rows. Since Phase 5 only emits a single scope per method
+        // covering the full method body, the ordering is trivially correct.
+        for (var rid = 1; rid <= methodDefRowCount; rid++)
+        {
+            if (!this.recordedMethods.TryGetValue(rid, out var rec) || rec.Locals.Count == 0)
+            {
+                continue;
+            }
+
+            // Add LocalVariable rows for this method. The handle returned by
+            // the *first* AddLocalVariable call becomes the scope's variable
+            // list anchor.
+            LocalVariableHandle firstLocal = default;
+            for (var i = 0; i < rec.Locals.Count; i++)
+            {
+                var l = rec.Locals[i];
+                var handle = this.pdbMetadata.AddLocalVariable(
+                    attributes: l.IsCompilerGenerated
+                        ? LocalVariableAttributes.DebuggerHidden
+                        : LocalVariableAttributes.None,
+                    index: l.SlotIndex,
+                    name: this.pdbMetadata.GetOrAddString(l.Name));
+                if (i == 0)
+                {
+                    firstLocal = handle;
+                }
+            }
+
+            this.pdbMetadata.AddLocalScope(
+                method: MetadataTokens.MethodDefinitionHandle(rid),
+                importScope: rootImportScope,
+                variableList: firstLocal,
+                constantList: MetadataTokens.LocalConstantHandle(1),
+                startOffset: 0,
+                length: rec.IlCodeSize);
         }
 
         var pdbBuilder = new PortablePdbBuilder(
@@ -164,6 +228,8 @@ internal sealed class PortablePdbEmitter
         pdbBlob.WriteContentTo(pdbStream);
     }
 
+    private static readonly byte[] EmptyBlob = System.Array.Empty<byte>();
+
     /// <summary>
     /// Encodes a method's sequence-point blob per Portable PDB spec § "Sequence
     /// points blob". The header writes a zero <c>LocalSignatureToken</c> in
@@ -175,10 +241,14 @@ internal sealed class PortablePdbEmitter
     private static void EncodeSequencePoints(
         BlobBuilder blob,
         IReadOnlyList<SequencePoint> points,
-        DocumentHandle primaryDocument)
+        DocumentHandle primaryDocument,
+        StandaloneSignatureHandle localSignatureToken)
     {
-        // LocalSignatureToken — 0 means "no locals signature recorded".
-        blob.WriteCompressedInteger(0);
+        // LocalSignatureToken — full 32-bit metadata token (0 when the method
+        // has no locals). Phase 5 wires the real value through so the
+        // debugger's locals window can deserialise slot types.
+        var tokenValue = localSignatureToken.IsNil ? 0 : MetadataTokens.GetToken(localSignatureToken);
+        blob.WriteCompressedInteger(tokenValue);
 
         // InitialDocument is omitted because every visible point shares the
         // method's primary document (asserted by the caller). Records follow.
@@ -251,13 +321,48 @@ internal sealed class PortablePdbEmitter
 
     private sealed class RecordedMethod
     {
-        public RecordedMethod(IReadOnlyList<SequencePoint> points)
+        public RecordedMethod(
+            IReadOnlyList<SequencePoint> points,
+            IReadOnlyList<LocalInfo> locals,
+            int ilCodeSize,
+            StandaloneSignatureHandle localSignatureToken)
         {
             this.Points = points;
+            this.Locals = locals;
+            this.IlCodeSize = ilCodeSize;
+            this.LocalSignatureToken = localSignatureToken;
         }
 
         public IReadOnlyList<SequencePoint> Points { get; }
+
+        public IReadOnlyList<LocalInfo> Locals { get; }
+
+        public int IlCodeSize { get; }
+
+        public StandaloneSignatureHandle LocalSignatureToken { get; }
     }
+}
+
+/// <summary>
+/// One local-slot descriptor handed to <see cref="PortablePdbEmitter.RecordMethod"/>.
+/// Compiler-generated locals (synthesized by lowering) flow through with
+/// <see cref="IsCompilerGenerated"/> set so debuggers can hide them from the
+/// locals window.
+/// </summary>
+internal readonly struct LocalInfo
+{
+    public LocalInfo(int slotIndex, string name, bool isCompilerGenerated)
+    {
+        this.SlotIndex = slotIndex;
+        this.Name = name ?? string.Empty;
+        this.IsCompilerGenerated = isCompilerGenerated;
+    }
+
+    public int SlotIndex { get; }
+
+    public string Name { get; }
+
+    public bool IsCompilerGenerated { get; }
 }
 
 /// <summary>

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1045,6 +1045,42 @@ internal sealed class ReflectionMetadataEmitter
         return BlobContentId.FromHash(sha.GetHashAndReset());
     }
 
+    /// <summary>
+    /// Converts the per-method <c>locals</c> dictionary used during IL emit
+    /// into a stable, slot-ordered list suitable for the Portable PDB
+    /// <c>LocalVariable</c> table. Compiler-generated names (synthesized by
+    /// lowering) are reported with <see cref="LocalInfo.IsCompilerGenerated"/>
+    /// set so debuggers can hide them from the locals window.
+    /// </summary>
+    private static IReadOnlyList<LocalInfo> CollectLocalInfo(Dictionary<VariableSymbol, int> locals)
+    {
+        if (locals == null || locals.Count == 0)
+        {
+            return System.Array.Empty<LocalInfo>();
+        }
+
+        var result = new List<LocalInfo>(locals.Count);
+        foreach (var kvp in locals)
+        {
+            var name = kvp.Key.Name ?? string.Empty;
+            var isGenerated = name.Length == 0
+                || name[0] == '<'
+                || name[0] == '$'
+                || name.Contains('$');
+            if (isGenerated && name.Length == 0)
+            {
+                // Anonymous slot — give it a deterministic placeholder so the
+                // PDB row is still valid (debuggers ignore hidden names).
+                name = "<slot" + kvp.Value + ">";
+            }
+
+            result.Add(new LocalInfo(kvp.Value, name, isGenerated));
+        }
+
+        result.Sort((a, b) => a.SlotIndex.CompareTo(b.SlotIndex));
+        return result;
+    }
+
     private void EmitStructTypeDef(StructSymbol structSym, int firstFieldRow, int methodListRow)
     {
         // Phase 4 emit parity (F2, type-erased): generic type definitions
@@ -2329,6 +2365,9 @@ internal sealed class ReflectionMetadataEmitter
 
         int bodyOffset = -1;
         IReadOnlyList<SequencePoint> capturedSequencePoints = null;
+        IReadOnlyList<LocalInfo> capturedLocals = null;
+        int capturedCodeSize = 0;
+        StandaloneSignatureHandle capturedLocalsSignature = default;
         if (!this.metadataOnly)
         {
             var moveNextBody = MoveNextBodyRewriter.Build(plan);
@@ -2413,6 +2452,9 @@ internal sealed class ReflectionMetadataEmitter
 
             bodyOffset = this.methodBodyStream.AddMethodBody(il, localVariablesSignature: localsSignature);
             capturedSequencePoints = emitter.SequencePoints;
+            capturedLocals = CollectLocalInfo(locals);
+            capturedCodeSize = il.Offset;
+            capturedLocalsSignature = localsSignature;
         }
 
         // MoveNext signature: void MoveNext() (instance)
@@ -2429,10 +2471,11 @@ internal sealed class ReflectionMetadataEmitter
             bodyOffset: bodyOffset,
             parameterList: this.NextParameterHandle());
 
-        // Phase 4 (ADR-0027 §7.7a): MoveNext is the visible body for an async
-        // method post-lowering; sequence points captured here are what surface
-        // in debugger stack traces and `step` commands across `await` points.
-        this.pdb?.RecordMethod(moveNextHandle, capturedSequencePoints);
+        // Phase 4/5 (ADR-0027 §7.7a): MoveNext is the visible body for an async
+        // method post-lowering; sequence points and locals captured here surface
+        // in debugger stack traces, locals window, and `step` commands across
+        // `await` points.
+        this.pdb?.RecordMethod(moveNextHandle, capturedSequencePoints, capturedLocals, capturedCodeSize, capturedLocalsSignature);
     }
 
     /// <summary>
@@ -2817,6 +2860,9 @@ internal sealed class ReflectionMetadataEmitter
         // MVAR/VAR encoding and add a MethodSpec at call sites.
         int bodyOffset = -1;
         IReadOnlyList<SequencePoint> capturedSequencePoints = null;
+        IReadOnlyList<LocalInfo> capturedLocals = null;
+        int capturedCodeSize = 0;
+        StandaloneSignatureHandle capturedLocalsSignature = default;
         if (!this.metadataOnly)
         {
             if (asyncPlan != null)
@@ -2932,6 +2978,9 @@ internal sealed class ReflectionMetadataEmitter
 
             bodyOffset = this.methodBodyStream.AddMethodBody(il, localVariablesSignature: localsSignature);
             capturedSequencePoints = emitter.SequencePoints;
+            capturedLocals = CollectLocalInfo(locals);
+            capturedCodeSize = il.Offset;
+            capturedLocalsSignature = localsSignature;
             } // end else (non-async path)
         }
 
@@ -3051,12 +3100,13 @@ internal sealed class ReflectionMetadataEmitter
             bodyOffset: bodyOffset,
             parameterList: firstParamHandle);
 
-        // Phase 4 (ADR-0027 §7.7a): hand the body's sequence points to the PDB
-        // emitter, keyed by the freshly minted MethodDef row number. Skipped
-        // when PDB emit is off (pdb == null) or for the async-kickoff path
-        // (the kickoff stub is fully synthesised — visible PDB rows for the
-        // user's async body land via EmitStateMachineMoveNext below).
-        this.pdb?.RecordMethod(handle, capturedSequencePoints);
+        // Phase 4/5 (ADR-0027 §7.7a): hand the body's sequence points and
+        // locals to the PDB emitter, keyed by the freshly minted MethodDef row
+        // number. Skipped when PDB emit is off (pdb == null) or for the
+        // async-kickoff path (the kickoff stub is fully synthesised — visible
+        // PDB rows for the user's async body land via EmitStateMachineMoveNext
+        // below).
+        this.pdb?.RecordMethod(handle, capturedSequencePoints, capturedLocals, capturedCodeSize, capturedLocalsSignature);
 
         // Phase 3 of #141: attach user annotations (method target) to the
         // MethodDef. Issue #170: per-parameter annotations attach to each

--- a/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
@@ -194,10 +194,155 @@ func main() {
     }
 }
 
+public class PortablePdbPhase5Tests
+{
+    private const string ThreeLocalsProgram = @"package main
+
+func main() {
+    let x = 1
+    let y = 2
+    let z = x + y
+}
+";
+
+    [Fact]
+    public void Method_With_UserLocals_Emits_LocalScope_And_LocalVariable_Rows()
+    {
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(ThreeLocalsProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var reader = provider.GetMetadataReader();
+
+        Assert.True(reader.LocalScopes.Count >= 1, "expected at least one LocalScope row");
+        Assert.True(reader.LocalVariables.Count >= 3, $"expected ≥3 LocalVariable rows for x/y/z, got {reader.LocalVariables.Count}");
+
+        var localNames = new System.Collections.Generic.HashSet<string>();
+        foreach (var lvh in reader.LocalVariables)
+        {
+            var lv = reader.GetLocalVariable(lvh);
+            localNames.Add(reader.GetString(lv.Name));
+        }
+
+        Assert.Contains("x", localNames);
+        Assert.Contains("y", localNames);
+        Assert.Contains("z", localNames);
+    }
+
+    [Fact]
+    public void LocalScope_Length_Equals_Method_Body_Size()
+    {
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(ThreeLocalsProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        using var pe = new System.Reflection.PortableExecutable.PEReader(peStream);
+        var peReader = pe.GetMetadataReader();
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var pdbReader = provider.GetMetadataReader();
+
+        foreach (var lsh in pdbReader.LocalScopes)
+        {
+            var scope = pdbReader.GetLocalScope(lsh);
+            Assert.Equal(0, scope.StartOffset);
+
+            var method = peReader.GetMethodDefinition(scope.Method);
+            var body = pe.GetMethodBody(method.RelativeVirtualAddress);
+            Assert.Equal(body.GetILBytes().Length, scope.Length);
+        }
+    }
+
+    [Fact]
+    public void Every_LocalScope_References_A_Root_ImportScope()
+    {
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(ThreeLocalsProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var reader = provider.GetMetadataReader();
+
+        Assert.True(reader.ImportScopes.Count >= 1, "expected a root ImportScope row");
+
+        foreach (var lsh in reader.LocalScopes)
+        {
+            var scope = reader.GetLocalScope(lsh);
+            Assert.False(scope.ImportScope.IsNil, "every LocalScope must reference an ImportScope");
+        }
+    }
+
+    [Fact]
+    public void SequencePoints_Header_References_Method_LocalSignature()
+    {
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(ThreeLocalsProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        using var pe = new System.Reflection.PortableExecutable.PEReader(peStream);
+        var peReader = pe.GetMetadataReader();
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var pdbReader = provider.GetMetadataReader();
+
+        // Find a method with locals and verify the PDB sequence-point header
+        // identifies the same StandaloneSignature row that the PE method body
+        // points at via localVariablesSignature.
+        var verified = false;
+        foreach (var mdih in pdbReader.MethodDebugInformation)
+        {
+            var mdi = pdbReader.GetMethodDebugInformation(mdih);
+            if (mdi.LocalSignature.IsNil)
+            {
+                continue;
+            }
+
+            var methodHandle = MetadataTokens.MethodDefinitionHandle(MetadataTokens.GetRowNumber(mdih));
+            var method = peReader.GetMethodDefinition(methodHandle);
+            var body = pe.GetMethodBody(method.RelativeVirtualAddress);
+            Assert.Equal(MetadataTokens.GetRowNumber(body.LocalSignature), MetadataTokens.GetRowNumber(mdi.LocalSignature));
+            verified = true;
+        }
+
+        Assert.True(verified, "expected at least one method with a non-nil LocalSignature in the PDB header");
+    }
+}
+
 internal static class PortablePdbEmitterTestHelpers
 {
     // Mirror of PortablePdbEmitter.GSharpLanguageGuid for cross-assembly assertion.
-    // Kept in sync via the unit test below in PortablePdbEmitTests — if the
+    // Kept in sync via the unit test in PortablePdbEmitTests — if the
     // emitter ever reissues the GUID this constant must move with it.
     public static readonly Guid GSharpLanguageGuid = new Guid("4F4D7B6A-0E33-4C2E-A3D7-2E5F8B7F9C00");
 }


### PR DESCRIPTION
Layers per-method local-variable metadata onto the Portable PDB writer landed in Phase 4 (#214), so debuggers can show user-declared locals by their source names and decode on-stack values against the method's `StandAloneSig` row. This is the second of three PDB-writing phases; Phase 6 will add the four `CustomDebugInformation` kinds called out by #95.

## What's in this PR

* **`PortablePdbEmitter.RecordMethod`** now also captures the per-method locals dictionary, the IL code size, and the `StandaloneSignatureHandle` returned by `AddStandaloneSignature`.
* **`PortablePdbEmitter.Serialize`** —
  * Adds one root `ImportScope` row (empty imports blob) shared by every `LocalScope`. Per-file import chains land in a later phase once the binder exposes the resolved `import` set on the symbol model.
  * Walks methods in MethodDef row order. For each method with locals: emits `LocalVariable` rows in slot order (compiler-synthesized names get `LocalVariableAttributes.DebuggerHidden`), then a `LocalScope` row covering `[0, codeSize)` anchored at the first `LocalVariable` handle.
  * `EncodeSequencePoints` now writes the real `LocalSignatureToken` in the blob header instead of `0`, so debuggers can decode locals at every sequence point against the same `StandAloneSig` row used by the IL itself.
* **`ReflectionMetadataEmitter`** — both `BodyEmitter` call sites (user methods + async `MoveNext`) now capture `locals`, `il.Offset` (code size), and the locals signature and pass them through to `RecordMethod`. New `CollectLocalInfo` helper converts the per-method dict into a stable, slot-ordered list and flags compiler-generated names (anything starting with `<`, `$`, or containing `$`).
* **`docs/debug-info.md`** — documents the single-scope-per-method strategy (justified by the lowering pipeline already flattening blocks), the compiler-generated-name heuristic, and the new `LocalSignatureToken` plumbing.

## Tests

Four new acceptance tests in `PortablePdbPhase5Tests`:

1. `Method_With_UserLocals_Emits_LocalScope_And_LocalVariable_Rows` — `let x = 1; let y = 2; let z = x + y` produces ≥3 `LocalVariable` rows whose names contain `x`, `y`, `z`.
2. `LocalScope_Length_Equals_Method_Body_Size` — every `LocalScope` starts at IL offset 0 and its `Length` matches the PE method body's `GetILBytes().Length`.
3. `Every_LocalScope_References_A_Root_ImportScope` — there is at least one `ImportScope` row and every `LocalScope.ImportScope` is non-nil.
4. `SequencePoints_Header_References_Method_LocalSignature` — the row number stored in the `MethodDebugInformation` sequence-point header matches the PE method body's `localVariablesSignature` row.

All Phase 4 tests continue to pass. **Full suite: 1414 passing** (1410 prior baseline + 4 new) via `dotnet test GSharp.sln --no-restore --nologo`.

## Out of scope (deferred)

* `LocalConstant` rows for `const` bindings — deferred until the binder surfaces `BoundLocalConstant` with a compile-time value.
* Per-file `ImportScope` chains populated from `import` statements — deferred to when the binder exposes the resolved imports on the symbol model.
* `EmbeddedSource` / `SourceLink` / `CompilationOptions` / `CompilationMetadataReferences` custom debug info → Phase 6.
* PE `DebugDirectory` entries (`CodeView`, `PdbChecksum`, `Reproducible`, `EmbeddedPortablePdb`) → Phase 7.

Refs #95, #50; ADR-0027 §7.7a.