### PR TITLE
PDB Phase 6: EmbeddedSource, SourceLink, CompilationOptions CDIs

### DIFF
--- a/docs/debug-info.md
+++ b/docs/debug-info.md
@@ -59,18 +59,60 @@ row used by the IL itself.
 
 
 
-The Portable PDB writer is staged. Phases 4–5 (shipped) emit `Document`,
-`MethodDebugInformation`, `LocalScope`, `LocalVariable`, and a single root
-`ImportScope` row per assembly. The following are planned for subsequent
+The Portable PDB writer is staged. Phases 4–6 (shipped) emit `Document`,
+`MethodDebugInformation`, `LocalScope`, `LocalVariable`, a single root
+`ImportScope`, plus `CustomDebugInformation` rows for `EmbeddedSource` (when
+`/embed` is on), `SourceLink` (when `/sourcelink:<file>` is supplied), and
+`CompilationOptions` (always). The following are planned for subsequent
 phases and tracked separately:
 
 * `LocalConstant` rows for `const` bindings — Phase 5.1 (deferred until the
-  binder surfaces `BoundLocalConstant` with a compile-time value).
-* Per-file `ImportScope` chains populated from `import` statements — Phase 5.2.
-* `EmbeddedSource`, `SourceLink`, `CompilationOptions`,
-  `CompilationMetadataReferences` — Phase 6.
+  binder surfaces `BoundLocalConstant` with a compile-time value, see #216).
+* Per-file `ImportScope` chains populated from `import` statements — Phase 5.2
+  (#217).
+* `CompilationMetadataReferences` rows — deferred from Phase 6 pending
+  reference-resolver plumbing (filed as a follow-up issue).
 * PE `DebugDirectory` entries (`CodeView`, `PdbChecksum`, `Reproducible`,
   `EmbeddedPortablePdb`) — Phase 7.
+
+## Custom debug information (Phase 6)
+
+GSharp emits the following `CustomDebugInformation` kinds:
+
+| Kind | Kind GUID | Parent | When emitted |
+| --- | --- | --- | --- |
+| `EmbeddedSource` | `0E8A571B-6926-466E-B4AD-8AB04611F5FE` | `Document` row | `/embed[+/-]` / `EmbedAllSources=true` |
+| `SourceLink` | `CC110556-A091-4D38-9FEC-25AB9A351A6A` | `Module` row | `/sourcelink:<file>` supplied and file exists |
+| `CompilationOptions` | `B5FEEC05-8CD0-4A83-96DA-466284BB4BD8` | `Module` row | Always (cheap; ~80 bytes) |
+
+### `EmbeddedSource` blob layout
+
+```
+formatMarker : int32 (little-endian)
+bytes        : remainder of blob
+```
+
+`formatMarker == 0` ⇒ the bytes are the raw UTF-8 source. `formatMarker > 0`
+⇒ the bytes are `Deflate`-compressed and `formatMarker` is the uncompressed
+size. Phase 6 always writes uncompressed (`formatMarker = 0`); deflate
+compression is a future size optimisation that does not require a reader
+change.
+
+### `SourceLink` blob layout
+
+The raw bytes of the Source-Link JSON file as passed to `/sourcelink:<file>`,
+unmodified. The PDB spec does not transform or re-encode the payload.
+
+### `CompilationOptions` blob layout
+
+A sequence of `(utf8 name \0 utf8 value \0)` pairs. The Phase 6 set is:
+
+| Name | Value |
+| --- | --- |
+| `compiler-name` | `gsc` |
+| `compiler-version` | `Assembly.GetExecutingAssembly().GetName().Version` of `GSharp.Core` |
+| `language` | `GSharp` |
+| `language-version` | `1.0` (placeholder until a language-version concept lands) |
 
 ## Compiler flags
 
@@ -83,7 +125,8 @@ The `gsc` compiler accepts the standard Roslyn-style debug flags:
 | `/debug:portable` (alias `/debug:pdbonly`, `/debug:full`) | Emit a sidecar `*.pdb` next to the PE. |
 | `/debug:embedded` | Embed the Portable PDB inside the PE's debug directory. |
 | `/pdb:<path>` | Override the sidecar PDB output path. |
-| `/sourcelink:<file>` | Embed the supplied Source-Link JSON as `CustomDebugInformation` (Phase 6). |
+| `/sourcelink:<file>` | Embed the supplied Source-Link JSON as `CustomDebugInformation`. |
+| `/embed[+/-]` | Embed every primary source file as an `EmbeddedSource` row (recommended with `/debug:embedded`). |
 | `/deterministic[+/-]` | Emit a content-hash-based Mvid / PdbId. |
 
 The SDK forwards `<DebugType>` and `<PdbFile>` through `BuildTask` so MSBuild-driven builds behave identically to direct `gsc` invocations.

--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -84,6 +84,7 @@ public class Program
                 PdbFilePath = parsed.PdbPath,
                 SourceLinkFilePath = parsed.SourceLinkPath,
                 Deterministic = parsed.Deterministic,
+                EmbedAllSources = parsed.EmbedAllSources,
             },
         };
 
@@ -457,6 +458,20 @@ public class Program
                         result.Deterministic = false;
                         break;
 
+                    case "embed":
+                        // /embed[+/-] embeds all primary sources in the PDB.
+                        // Bare /embed defaults to on, matching csc semantics.
+                        result.EmbedAllSources = ParseBoolFlag(value, defaultIfEmpty: true);
+                        break;
+
+                    case "embed+":
+                        result.EmbedAllSources = true;
+                        break;
+
+                    case "embed-":
+                        result.EmbedAllSources = false;
+                        break;
+
                     case "?":
                     case "help":
                         result.ShowHelp = true;
@@ -659,6 +674,9 @@ public class Program
 
         /// <summary>Gets or sets a value indicating whether the emit should be deterministic (from /deterministic, /deterministic+/-).</summary>
         public bool Deterministic { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether all primary source files are embedded in the Portable PDB (from /embed, /embed+/-).</summary>
+        public bool EmbedAllSources { get; set; }
     }
 
     private sealed class CommandLineException : Exception

--- a/src/Core/CodeAnalysis/Emit/DebugInformationOptions.cs
+++ b/src/Core/CodeAnalysis/Emit/DebugInformationOptions.cs
@@ -63,4 +63,16 @@ public sealed class DebugInformationOptions
     /// and adds a <c>Reproducible</c> debug-directory entry to the PE.
     /// </summary>
     public bool Deterministic { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether all primary source files
+    /// referenced by the compilation are embedded inside the Portable PDB
+    /// as <c>EmbeddedSource</c> <c>CustomDebugInformation</c> blobs. Defaults
+    /// to <see langword="false"/>. Enabling this lets debuggers reconstruct
+    /// source even when the original files have moved on disk, at the cost of
+    /// a larger PDB. The Portable PDB spec recommends pairing this with
+    /// <see cref="DebugInformationFormat.Embedded"/> for fully self-contained
+    /// binaries.
+    /// </summary>
+    public bool EmbedAllSources { get; set; }
 }

--- a/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
@@ -26,17 +26,23 @@ namespace GSharp.Core.CodeAnalysis.Emit;
 /// the <see cref="ReflectionMetadataEmitter"/> never instantiates one.
 /// </summary>
 /// <remarks>
-/// Phase 4 covers the <c>Document</c> table and one
-/// <c>MethodDebugInformation</c> row per <c>MethodDef</c>. Phase 5 layers in
+/// Phases 4–5 cover <c>Document</c>, <c>MethodDebugInformation</c>,
 /// <c>LocalScope</c>, <c>LocalVariable</c>, and a single root
-/// <c>ImportScope</c> so debuggers can resolve user-visible local names. Custom
-/// debug information and PE-side <c>DebugDirectory</c> entries are deferred to
-/// Phases 6 and 7.
+/// <c>ImportScope</c>. Phase 6 adds <c>CustomDebugInformation</c> blobs:
+/// <c>EmbeddedSource</c> (per document), <c>SourceLink</c> (one per module),
+/// and <c>CompilationOptions</c> (one per module). PE-side
+/// <c>DebugDirectory</c> entries land in Phase 7.
 /// </remarks>
 internal sealed class PortablePdbEmitter
 {
     // ECMA-335 / Portable PDB hash algorithm GUIDs (spec § "Document").
     private static readonly Guid HashAlgorithmSha256 = new Guid("8829D00F-11B8-4213-878B-770E8597AC16");
+
+    // Portable PDB CustomDebugInformation kind GUIDs
+    // (spec § "CustomDebugInformation").
+    private static readonly Guid EmbeddedSourceKind = new Guid("0E8A571B-6926-466E-B4AD-8AB04611F5FE");
+    private static readonly Guid SourceLinkKind = new Guid("CC110556-A091-4D38-9FEC-25AB9A351A6A");
+    private static readonly Guid CompilationOptionsKind = new Guid("B5FEEC05-8CD0-4A83-96DA-466284BB4BD8");
 
     /// <summary>
     /// Stable GSharp language GUID. Once a tool keys off this value (debugger,
@@ -49,6 +55,12 @@ internal sealed class PortablePdbEmitter
     private readonly MetadataBuilder pdbMetadata = new MetadataBuilder();
     private readonly Dictionary<SyntaxTree, DocumentHandle> documentsByTree = new Dictionary<SyntaxTree, DocumentHandle>();
     private readonly Dictionary<int, RecordedMethod> recordedMethods = new Dictionary<int, RecordedMethod>();
+    private readonly DebugInformationOptions options;
+
+    public PortablePdbEmitter(DebugInformationOptions options)
+    {
+        this.options = options ?? new DebugInformationOptions();
+    }
 
     /// <summary>
     /// Returns the <see cref="DocumentHandle"/> for <paramref name="tree"/>,
@@ -84,6 +96,26 @@ internal sealed class PortablePdbEmitter
             language: this.pdbMetadata.GetOrAddGuid(GSharpLanguageGuid));
 
         this.documentsByTree[tree] = handle;
+
+        // Phase 6: embed the source file as a CustomDebugInformation row
+        // anchored on this Document. Format per spec § "EmbeddedSource":
+        //   4-byte little-endian int formatMarker, then bytes.
+        // formatMarker == 0  → raw, no compression.
+        // formatMarker  > 0  → uncompressed size of deflate-compressed payload.
+        // Phase 6 always emits uncompressed; deflate compression is a
+        // size-only optimisation we can layer in later without breaking
+        // readers.
+        if (this.options.EmbedAllSources && sourceBytes.Length > 0)
+        {
+            var embedBlob = new BlobBuilder();
+            embedBlob.WriteInt32(0);
+            embedBlob.WriteBytes(sourceBytes);
+            this.pdbMetadata.AddCustomDebugInformation(
+                parent: handle,
+                kind: this.pdbMetadata.GetOrAddGuid(EmbeddedSourceKind),
+                value: this.pdbMetadata.GetOrAddBlob(embedBlob));
+        }
+
         return handle;
     }
 
@@ -217,6 +249,40 @@ internal sealed class PortablePdbEmitter
                 length: rec.IlCodeSize);
         }
 
+        // Step 4 — Phase 6: module-level CustomDebugInformation rows. These
+        // are written *before* the PortablePdbBuilder consumes the metadata
+        // builder. Parent is the singleton Module row (RID 1); this is the
+        // anchor that debuggers and symbol servers query against the module
+        // identity rather than any particular method.
+        var moduleHandle = MetadataTokens.EntityHandle(TableIndex.Module, 1);
+
+        if (!string.IsNullOrEmpty(this.options.SourceLinkFilePath) &&
+            File.Exists(this.options.SourceLinkFilePath))
+        {
+            // SourceLink blob is the raw bytes of the JSON file as-is; the
+            // PDB spec does not transform it.
+            var sourceLinkBytes = File.ReadAllBytes(this.options.SourceLinkFilePath);
+            this.pdbMetadata.AddCustomDebugInformation(
+                parent: moduleHandle,
+                kind: this.pdbMetadata.GetOrAddGuid(SourceLinkKind),
+                value: this.pdbMetadata.GetOrAddBlob(sourceLinkBytes));
+        }
+
+        // CompilationOptions: name/value UTF-8 pairs, each terminated by a
+        // null byte. Always emit so that downstream tooling can identify how
+        // a binary was produced; the set is intentionally minimal in Phase 6
+        // and may grow as more compiler knobs become observable.
+        var optionsBlob = new BlobBuilder();
+        var compilerVersion = typeof(PortablePdbEmitter).Assembly.GetName().Version?.ToString() ?? "0.0.0.0";
+        WriteCompilationOption(optionsBlob, "compiler-name", "gsc");
+        WriteCompilationOption(optionsBlob, "compiler-version", compilerVersion);
+        WriteCompilationOption(optionsBlob, "language", "GSharp");
+        WriteCompilationOption(optionsBlob, "language-version", "1.0");
+        this.pdbMetadata.AddCustomDebugInformation(
+            parent: moduleHandle,
+            kind: this.pdbMetadata.GetOrAddGuid(CompilationOptionsKind),
+            value: this.pdbMetadata.GetOrAddBlob(optionsBlob));
+
         var pdbBuilder = new PortablePdbBuilder(
             tablesAndHeaps: this.pdbMetadata,
             typeSystemRowCounts: peRowCounts,
@@ -229,6 +295,18 @@ internal sealed class PortablePdbEmitter
     }
 
     private static readonly byte[] EmptyBlob = System.Array.Empty<byte>();
+
+    /// <summary>
+    /// Writes a single <c>CompilationOptions</c> key/value pair using the
+    /// spec's null-terminated UTF-8 layout: <c>name \0 value \0</c>.
+    /// </summary>
+    private static void WriteCompilationOption(BlobBuilder builder, string name, string value)
+    {
+        builder.WriteUTF8(name);
+        builder.WriteByte(0);
+        builder.WriteUTF8(value ?? string.Empty);
+        builder.WriteByte(0);
+    }
 
     /// <summary>
     /// Encodes a method's sequence-point blob per Portable PDB spec § "Sequence

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -267,7 +267,7 @@ internal sealed class ReflectionMetadataEmitter
         // bit-for-bit identical.
         if (this.debugInformation.Format == DebugInformationFormat.Portable && this.pdbStream != null)
         {
-            this.pdb = new PortablePdbEmitter();
+            this.pdb = new PortablePdbEmitter(this.debugInformation);
         }
 
         // 1. Seed Object reference. Resolve from the supplied references so the type-ref

--- a/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
@@ -345,4 +345,185 @@ internal static class PortablePdbEmitterTestHelpers
     // Kept in sync via the unit test in PortablePdbEmitTests — if the
     // emitter ever reissues the GUID this constant must move with it.
     public static readonly Guid GSharpLanguageGuid = new Guid("4F4D7B6A-0E33-4C2E-A3D7-2E5F8B7F9C00");
+
+    // Mirror of PortablePdbEmitter's CustomDebugInformation kind GUIDs;
+    // used by Phase 6 acceptance tests to look up specific CDI rows.
+    public static readonly Guid EmbeddedSourceKind = new Guid("0E8A571B-6926-466E-B4AD-8AB04611F5FE");
+    public static readonly Guid SourceLinkKind = new Guid("CC110556-A091-4D38-9FEC-25AB9A351A6A");
+    public static readonly Guid CompilationOptionsKind = new Guid("B5FEEC05-8CD0-4A83-96DA-466284BB4BD8");
+}
+
+public class PortablePdbPhase6Tests
+{
+    private const string SimpleProgram = @"package main
+
+func main() {
+    let x = 1
+}
+";
+
+    [Fact]
+    public void EmbeddedSource_IsAbsent_When_EmbedAllSources_Is_False()
+    {
+        var (_, pdb) = EmitWith(new DebugInformationOptions { Format = DebugInformationFormat.Portable });
+        Assert.Empty(FindCdi(pdb, PortablePdbEmitterTestHelpers.EmbeddedSourceKind));
+    }
+
+    [Fact]
+    public void EmbeddedSource_IsPresent_When_EmbedAllSources_Is_True()
+    {
+        var (_, pdb) = EmitWith(new DebugInformationOptions
+        {
+            Format = DebugInformationFormat.Portable,
+            EmbedAllSources = true,
+        });
+
+        var rows = FindCdi(pdb, PortablePdbEmitterTestHelpers.EmbeddedSourceKind);
+        Assert.NotEmpty(rows);
+
+        // Decode the first embedded-source blob: int32 formatMarker, then bytes.
+        var blob = pdb.GetBlobBytes(rows[0].Value);
+        Assert.True(blob.Length > 4);
+        var formatMarker = blob[0] | (blob[1] << 8) | (blob[2] << 16) | (blob[3] << 24);
+        Assert.Equal(0, formatMarker); // Phase 6: uncompressed
+        var sourceBytes = new byte[blob.Length - 4];
+        System.Buffer.BlockCopy(blob, 4, sourceBytes, 0, sourceBytes.Length);
+        var sourceText = System.Text.Encoding.UTF8.GetString(sourceBytes);
+        Assert.Contains("func main()", sourceText);
+    }
+
+    [Fact]
+    public void EmbeddedSource_Parent_Is_A_Document_Row()
+    {
+        var (_, pdb) = EmitWith(new DebugInformationOptions
+        {
+            Format = DebugInformationFormat.Portable,
+            EmbedAllSources = true,
+        });
+
+        var rows = FindCdi(pdb, PortablePdbEmitterTestHelpers.EmbeddedSourceKind);
+        Assert.NotEmpty(rows);
+        foreach (var (parent, _) in rows)
+        {
+            Assert.Equal(HandleKind.Document, parent.Kind);
+        }
+    }
+
+    [Fact]
+    public void SourceLink_BlobMatches_File_Contents()
+    {
+        var sourceLinkPath = Path.Combine(Path.GetTempPath(), $"sl-{Guid.NewGuid():N}.json");
+        var json = @"{ ""documents"": { ""*"": ""https://example.com/raw/*"" } }";
+        File.WriteAllText(sourceLinkPath, json);
+
+        try
+        {
+            var (_, pdb) = EmitWith(new DebugInformationOptions
+            {
+                Format = DebugInformationFormat.Portable,
+                SourceLinkFilePath = sourceLinkPath,
+            });
+
+            var rows = FindCdi(pdb, PortablePdbEmitterTestHelpers.SourceLinkKind);
+            Assert.Single(rows);
+            var blob = pdb.GetBlobBytes(rows[0].Value);
+            Assert.Equal(File.ReadAllBytes(sourceLinkPath), blob);
+
+            // SourceLink CDI must be parented on the Module row.
+            Assert.Equal(HandleKind.ModuleDefinition, rows[0].Parent.Kind);
+        }
+        finally
+        {
+            File.Delete(sourceLinkPath);
+        }
+    }
+
+    [Fact]
+    public void SourceLink_IsAbsent_When_No_File_Configured()
+    {
+        var (_, pdb) = EmitWith(new DebugInformationOptions { Format = DebugInformationFormat.Portable });
+        Assert.Empty(FindCdi(pdb, PortablePdbEmitterTestHelpers.SourceLinkKind));
+    }
+
+    [Fact]
+    public void CompilationOptions_Always_Emitted_With_Compiler_And_Language_Identifiers()
+    {
+        var (_, pdb) = EmitWith(new DebugInformationOptions { Format = DebugInformationFormat.Portable });
+        var rows = FindCdi(pdb, PortablePdbEmitterTestHelpers.CompilationOptionsKind);
+        Assert.Single(rows);
+
+        var blob = pdb.GetBlobBytes(rows[0].Value);
+        var options = DecodeCompilationOptions(blob);
+
+        Assert.Equal("gsc", options["compiler-name"]);
+        Assert.Equal("GSharp", options["language"]);
+        Assert.Equal("1.0", options["language-version"]);
+        Assert.True(options.ContainsKey("compiler-version"));
+        Assert.False(string.IsNullOrWhiteSpace(options["compiler-version"]));
+
+        // CompilationOptions CDI must be parented on the Module row.
+        Assert.Equal(HandleKind.ModuleDefinition, rows[0].Parent.Kind);
+    }
+
+    private static (MemoryStream Pe, MetadataReader Pdb) EmitWith(DebugInformationOptions options)
+    {
+        var peStream = new MemoryStream();
+        var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(SimpleProgram, "main.gs")))
+        {
+            DebugInformation = options,
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        pdbStream.Position = 0;
+        var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        return (peStream, provider.GetMetadataReader());
+    }
+
+    private static System.Collections.Generic.List<(EntityHandle Parent, BlobHandle Value)> FindCdi(
+        MetadataReader reader, Guid kind)
+    {
+        var matches = new System.Collections.Generic.List<(EntityHandle, BlobHandle)>();
+        foreach (var handle in reader.CustomDebugInformation)
+        {
+            var cdi = reader.GetCustomDebugInformation(handle);
+            if (reader.GetGuid(cdi.Kind) == kind)
+            {
+                matches.Add((cdi.Parent, cdi.Value));
+            }
+        }
+
+        return matches;
+    }
+
+    private static System.Collections.Generic.Dictionary<string, string> DecodeCompilationOptions(byte[] blob)
+    {
+        // Format: (utf8 name \0 utf8 value \0)*
+        var dict = new System.Collections.Generic.Dictionary<string, string>(System.StringComparer.Ordinal);
+        var i = 0;
+        while (i < blob.Length)
+        {
+            var nameStart = i;
+            while (i < blob.Length && blob[i] != 0)
+            {
+                i++;
+            }
+
+            var name = System.Text.Encoding.UTF8.GetString(blob, nameStart, i - nameStart);
+            i++; // skip null
+            var valueStart = i;
+            while (i < blob.Length && blob[i] != 0)
+            {
+                i++;
+            }
+
+            var value = System.Text.Encoding.UTF8.GetString(blob, valueStart, i - valueStart);
+            i++; // skip null
+            dict[name] = value;
+        }
+
+        return dict;
+    }
 }


### PR DESCRIPTION
Part of #95 / #50 (ADR-0027 §7.7a, debug-info phase 6 of 10).

## What

Adds three of the four `CustomDebugInformation` kinds called out by #95 to the Portable PDB writer:

| Kind | Parent | Trigger |
| --- | --- | --- |
| `EmbeddedSource` (`0E8A571B-…`) | `Document` | new `/embed[+/-]` flag → `DebugInformationOptions.EmbedAllSources` |
| `SourceLink` (`CC110556-…`) | `Module` | existing `/sourcelink:<file>` (file now actually read) |
| `CompilationOptions` (`B5FEEC05-…`) | `Module` | always (cheap; ~80 bytes) |

`CompilationMetadataReferences` is split out to **#219** because it needs `ReferenceResolver` to surface per-ref `TimeStamp` / `FileSize` / `MVID`.

## Blob layouts

**EmbeddedSource:** `formatMarker:int32(LE)` followed by source bytes. Phase 6 always writes `formatMarker=0` (uncompressed UTF-8). Deflate compression can be layered in later without breaking readers.

**SourceLink:** raw bytes of the JSON file as-is, per spec.

**CompilationOptions:** `(utf8 name \0 utf8 value \0)*` pairs. Current set: `compiler-name`, `compiler-version`, `language`, `language-version`.

## How

* `DebugInformationOptions.EmbedAllSources` (new bool, default false).
* `PortablePdbEmitter` ctor now takes `DebugInformationOptions` so it can honour SourceLink + embed without reaching back through the emitter.
* `GetOrAddDocument` writes the EmbeddedSource CDI inline when embedding is on.
* `Serialize` writes the module-level CDIs immediately before constructing `PortablePdbBuilder`.
* `gsc` accepts `/embed`, `/embed+`, `/embed-`. Mirrors csc semantics (bare `/embed` ⇒ on).

## Tests

`PortablePdbPhase6Tests` (6 new tests) covers:
* EmbeddedSource absent by default; present + decodable when enabled; parented on a Document row.
* SourceLink blob == file bytes; parented on Module; absent when no file configured.
* CompilationOptions always emitted, parented on Module, contains all four expected keys.

Full suite: **1420 passing** (1414 baseline + 6 new), 0 failures.

## Docs

`docs/debug-info.md` updated with a CDI section documenting the three blob formats and the value set chosen for `CompilationOptions`. `/embed` is added to the gsc flag table.

## Footguns

Still routes around #218 by passing `peStream:`, `pdbStream:`, `refStream: null` as named args in all Phase 6 tests.

## Refs

* Parent: #95, #50
* ADR: ADR-0027 §7.7a
* Deferred: #219 (CompilationMetadataReferences), #216 (LocalConstant), #217 (per-file ImportScope), #218 (Emit overload ambiguity)