### PR TITLE
PDB Phase 7: PE DebugDirectory wiring (CodeView, PdbChecksum, Reproducible, EmbeddedPortablePdb)

### DIFF
--- a/docs/debug-info.md
+++ b/docs/debug-info.md
@@ -59,21 +59,18 @@ row used by the IL itself.
 
 
 
-The Portable PDB writer is staged. Phases 4–6 (shipped) emit `Document`,
+The Portable PDB writer is staged. Phases 4–7 (shipped) emit `Document`,
 `MethodDebugInformation`, `LocalScope`, `LocalVariable`, a single root
-`ImportScope`, plus `CustomDebugInformation` rows for `EmbeddedSource` (when
-`/embed` is on), `SourceLink` (when `/sourcelink:<file>` is supplied), and
-`CompilationOptions` (always). The following are planned for subsequent
-phases and tracked separately:
+`ImportScope`, `CustomDebugInformation` rows for `EmbeddedSource` /
+`SourceLink` / `CompilationOptions`, and PE-side `DebugDirectory` entries
+(`CodeView`, `PdbChecksum`, `Reproducible`, `EmbeddedPortablePdb`). The
+following are planned for subsequent phases and tracked separately:
 
 * `LocalConstant` rows for `const` bindings — Phase 5.1 (deferred until the
   binder surfaces `BoundLocalConstant` with a compile-time value, see #216).
 * Per-file `ImportScope` chains populated from `import` statements — Phase 5.2
   (#217).
-* `CompilationMetadataReferences` rows — deferred from Phase 6 pending
-  reference-resolver plumbing (filed as a follow-up issue).
-* PE `DebugDirectory` entries (`CodeView`, `PdbChecksum`, `Reproducible`,
-  `EmbeddedPortablePdb`) — Phase 7.
+* `CompilationMetadataReferences` rows — deferred from Phase 6 (#219).
 
 ## Custom debug information (Phase 6)
 
@@ -113,6 +110,22 @@ A sequence of `(utf8 name \0 utf8 value \0)` pairs. The Phase 6 set is:
 | `compiler-version` | `Assembly.GetExecutingAssembly().GetName().Version` of `GSharp.Core` |
 | `language` | `GSharp` |
 | `language-version` | `1.0` (placeholder until a language-version concept lands) |
+
+## PE-side debug directory (Phase 7)
+
+When `/debug` is on, the emitter populates the PE's `IMAGE_DIRECTORY_ENTRY_DEBUG`
+table via `DebugDirectoryBuilder`:
+
+| Entry | When | Payload |
+| --- | --- | --- |
+| `CodeView` | Always (sidecar + embedded) | PDB content id (GUID + age = 1) and the PDB file name. For sidecar emit this is the value of `/pdb:<path>` if supplied, else `<AssemblyName>.pdb`. For embedded emit it is also the conventional bare name (debuggers ignore the path field for embedded PDBs). |
+| `PdbChecksum` | Always | Algorithm `SHA256` plus the 32-byte SHA-256 digest of the serialized Portable PDB blob — same bytes a sidecar `.pdb` would contain. Symbol servers verify PE↔PDB pairing by this checksum. |
+| `Reproducible` | When `/deterministic` is set | Empty payload; marker bit. |
+| `EmbeddedPortablePdb` | When `/debug:embedded` | Deflate-compressed copy of the Portable PDB blob inlined into the PE. No sidecar is written even if a stream is supplied. |
+
+The PDB content id is shared between the in-PE `CodeView.Guid` and the
+Portable PDB metadata header's `Id` field, so a debugger that locates a
+candidate sidecar can verify the pairing without reading the full PE.
 
 ## Compiler flags
 

--- a/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
@@ -172,10 +172,12 @@ internal sealed class PortablePdbEmitter
     /// Walks every MethodDef row in token order and emits a
     /// <c>MethodDebugInformation</c> row for each — rich for methods that
     /// recorded sequence points, empty otherwise. Then assembles the Portable
-    /// PDB blob and writes it to <paramref name="pdbStream"/>.
+    /// PDB blob and returns it together with the <see cref="BlobContentId"/>
+    /// computed by <paramref name="idProvider"/>. The caller is responsible
+    /// for writing the blob to a sidecar stream and/or embedding it in the PE
+    /// debug directory.
     /// </summary>
-    public void Serialize(
-        Stream pdbStream,
+    public (BlobBuilder Blob, BlobContentId ContentId) Serialize(
         ImmutableArray<int> peRowCounts,
         MethodDefinitionHandle entryPoint,
         Func<IEnumerable<Blob>, BlobContentId> idProvider)
@@ -290,8 +292,8 @@ internal sealed class PortablePdbEmitter
             idProvider: idProvider);
 
         var pdbBlob = new BlobBuilder();
-        pdbBuilder.Serialize(pdbBlob);
-        pdbBlob.WriteContentTo(pdbStream);
+        var contentId = pdbBuilder.Serialize(pdbBlob);
+        return (pdbBlob, contentId);
     }
 
     private static readonly byte[] EmptyBlob = System.Array.Empty<byte>();

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -41,6 +41,10 @@ namespace GSharp.Core.CodeAnalysis.Emit;
 /// </remarks>
 internal sealed class ReflectionMetadataEmitter
 {
+    // Portable PDB metadata format version expected by all current readers
+    // (System.Reflection.Metadata, dotnet-symbol, debuggers). 0x0100 = v1.0.
+    private const ushort PortablePdbVersion = 0x0100;
+
     private readonly BoundProgram program;
     private readonly ReferenceResolver references;
     private readonly string assemblyNameOverride;
@@ -262,10 +266,15 @@ internal sealed class ReflectionMetadataEmitter
     {
         // Phase 4 (ADR-0027 §7.7a): instantiate the Portable PDB collaborator
         // before any method body is emitted, but only when the caller asked
-        // for portable PDBs and supplied a destination stream. Leaving `this.pdb`
-        // null in every other configuration is what keeps the legacy emit path
-        // bit-for-bit identical.
-        if (this.debugInformation.Format == DebugInformationFormat.Portable && this.pdbStream != null)
+        // for portable PDBs or for embedded PDBs (Phase 7). Sidecar emission
+        // additionally requires a destination stream; embedded emission does
+        // not because the blob is written into the PE itself. Leaving
+        // `this.pdb` null in every other configuration is what keeps the
+        // legacy emit path bit-for-bit identical.
+        var format = this.debugInformation.Format;
+        var needsPdb = (format == DebugInformationFormat.Portable && this.pdbStream != null)
+            || format == DebugInformationFormat.Embedded;
+        if (needsPdb)
         {
             this.pdb = new PortablePdbEmitter(this.debugInformation);
         }
@@ -961,7 +970,71 @@ internal sealed class ReflectionMetadataEmitter
             this.EmitReferenceAssemblyAttribute(assemblyHandle);
         }
 
-        // 7. Serialize PE deterministically: a SHA-256 of the serialized PE
+        // 7. Build the Portable PDB blob FIRST so we can wire its content id
+        // (CodeView), SHA-256 checksum (PdbChecksum), and — when embedded —
+        // the blob itself into the PE's DebugDirectory. PortablePdbEmitter
+        // does not touch any stream here; we own sidecar / embedded routing.
+        BlobBuilder pdbBlob = null;
+        BlobContentId pdbContentId = default;
+        byte[] pdbChecksum = null;
+        var pdbEnabled = this.pdb != null;
+        if (pdbEnabled)
+        {
+            var peRowCounts = this.metadata.GetRowCounts();
+            (pdbBlob, pdbContentId) = this.pdb.Serialize(
+                peRowCounts,
+                this.metadataOnly ? default : entryHandle,
+                ComputeDeterministicContentId);
+            pdbChecksum = ComputePdbChecksum(pdbBlob);
+        }
+
+        // 8. Construct a DebugDirectoryBuilder when PDB emit is on, so the PE
+        // image gains a real CodeView entry (sidecar discovery), PdbChecksum
+        // entry (PE ↔ PDB pairing), Reproducible entry (deterministic emit),
+        // and — when embedded — an EmbeddedPortablePdb entry containing the
+        // full PDB blob inline. Pass null to ManagedPEBuilder when PDB is off
+        // so the legacy emit path stays bit-for-bit identical.
+        DebugDirectoryBuilder debugDirectory = null;
+        var isEmbedded = this.debugInformation.Format == DebugInformationFormat.Embedded;
+        if (pdbEnabled)
+        {
+            debugDirectory = new DebugDirectoryBuilder();
+
+            // CodeView: identifies the PDB the runtime/debugger should fetch.
+            // For embedded format the path is conventionally just the bare
+            // pdb file name (no directory) because the consumer reads it out
+            // of the PE itself; for sidecar it can be a full path supplied
+            // via /pdb:<path>, else the bare ".pdb" suffix of the PE name.
+            var codeViewPath = !string.IsNullOrEmpty(this.debugInformation.PdbFilePath)
+                ? this.debugInformation.PdbFilePath
+                : (this.assemblyNameOverride ?? this.program.PackageName ?? "module") + ".pdb";
+            debugDirectory.AddCodeViewEntry(
+                pdbPath: codeViewPath,
+                pdbContentId: pdbContentId,
+                portablePdbVersion: PortablePdbVersion);
+
+            // PdbChecksum: always emitted; lets symbol servers verify PE↔PDB
+            // by content hash without trusting the file path.
+            debugDirectory.AddPdbChecksumEntry(
+                algorithmName: "SHA256",
+                checksum: ImmutableArray.Create(pdbChecksum));
+
+            // Reproducible: opt-in marker that this build is byte-deterministic.
+            if (this.debugInformation.Deterministic)
+            {
+                debugDirectory.AddReproducibleEntry();
+            }
+
+            // EmbeddedPortablePdb: only when /debug:embedded was requested.
+            // The blob is compressed inside the PE; readers transparently
+            // inflate via System.Reflection.PortableExecutable.PEReader.
+            if (isEmbedded)
+            {
+                debugDirectory.AddEmbeddedPortablePdbEntry(pdbBlob, PortablePdbVersion);
+            }
+        }
+
+        // 9. Serialize PE deterministically: a SHA-256 of the serialized PE
         // content produces the BlobContentId, which patches both the PE
         // TimeDateStamp and the reserved MVID guid in the metadata heap.
         var peHeaderBuilder = new PEHeaderBuilder(
@@ -973,25 +1046,39 @@ internal sealed class ReflectionMetadataEmitter
             metadataRootBuilder: new MetadataRootBuilder(this.metadata),
             ilStream: this.ilStream,
             entryPoint: this.metadataOnly ? default : entryHandle,
+            debugDirectoryBuilder: debugDirectory,
             deterministicIdProvider: ComputeDeterministicContentId);
         var peBlob = new BlobBuilder();
         var contentId = peBuilder.Serialize(peBlob);
         mvidFixup.CreateWriter().WriteGuid(contentId.Guid);
         peBlob.WriteContentTo(peStream);
 
-        // Phase 4 (ADR-0027 §7.7a) PDB sidecar. Serialized after the PE so the
-        // MethodDef table row count and entry-point handle are stable. We emit
-        // exactly one MethodDebugInformation row per MethodDef (empty when no
-        // sequence points were captured), as required by the Portable PDB spec.
-        if (this.pdb != null)
+        // 10. Phase 4–7 PDB sidecar routing. Embedded format suppresses the
+        // sidecar — the blob already lives in the PE. Portable format writes
+        // to the supplied stream when one was provided (callers that want
+        // only an embedded PDB pass `pdbStream: null`).
+        if (pdbEnabled && !isEmbedded && this.pdbStream != null)
         {
-            var peRowCounts = this.metadata.GetRowCounts();
-            this.pdb.Serialize(
-                this.pdbStream,
-                peRowCounts,
-                this.metadataOnly ? default : entryHandle,
-                ComputeDeterministicContentId);
+            pdbBlob.WriteContentTo(this.pdbStream);
         }
+    }
+
+    /// <summary>
+    /// Computes the SHA-256 checksum of the serialized Portable PDB content,
+    /// matching the algorithm name written into the <c>PdbChecksum</c> debug
+    /// directory entry. Returning a fresh byte array keeps callers from
+    /// having to thread <see cref="IncrementalHash"/> through the call site.
+    /// </summary>
+    private static byte[] ComputePdbChecksum(BlobBuilder pdbBlob)
+    {
+        using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        foreach (var blob in pdbBlob.GetBlobs())
+        {
+            var bytes = blob.GetBytes();
+            sha.AppendData(bytes.Array, bytes.Offset, bytes.Count);
+        }
+
+        return sha.GetHashAndReset();
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
 using System.Security.Cryptography;
 using System.Text;
 using GSharp.Core.CodeAnalysis.Compilation;
@@ -525,5 +526,185 @@ func main() {
         }
 
         return dict;
+    }
+}
+
+public class PortablePdbPhase7Tests
+{
+    private const string SimpleProgram = @"package main
+
+func main() {
+    let x = 1
+}
+";
+
+    [Fact]
+    public void Portable_Writes_CodeView_And_PdbChecksum_Into_PE_DebugDirectory()
+    {
+        var (pe, _) = EmitWith(new DebugInformationOptions { Format = DebugInformationFormat.Portable });
+        var entries = ReadDebugDirectoryEntries(pe);
+
+        Assert.Contains(entries, e => e.Type == DebugDirectoryEntryType.CodeView);
+        Assert.Contains(entries, e => e.Type == DebugDirectoryEntryType.PdbChecksum);
+    }
+
+    [Fact]
+    public void CodeView_PdbPath_Defaults_To_Bare_PdbFileName()
+    {
+        var (pe, _) = EmitWith(new DebugInformationOptions { Format = DebugInformationFormat.Portable });
+        using var peReader = new PEReader(new MemoryStream(pe.ToArray()));
+        var cv = peReader.ReadDebugDirectory()
+            .Single(e => e.Type == DebugDirectoryEntryType.CodeView);
+        var data = peReader.ReadCodeViewDebugDirectoryData(cv);
+
+        // Default path when /pdb:<path> is not set should be "<asm>.pdb".
+        Assert.EndsWith(".pdb", data.Path, StringComparison.Ordinal);
+        Assert.DoesNotContain('/', data.Path);
+        Assert.DoesNotContain('\\', data.Path);
+    }
+
+    [Fact]
+    public void CodeView_Pdb_ContentId_Matches_Sidecar_PdbId()
+    {
+        var (pe, pdbBytes) = EmitWith(new DebugInformationOptions { Format = DebugInformationFormat.Portable });
+
+        using var peReader = new PEReader(new MemoryStream(pe.ToArray()));
+        var cv = peReader.ReadDebugDirectory()
+            .Single(e => e.Type == DebugDirectoryEntryType.CodeView);
+        var data = peReader.ReadCodeViewDebugDirectoryData(cv);
+
+        using var pdbProvider = MetadataReaderProvider.FromPortablePdbStream(new MemoryStream(pdbBytes));
+        var pdbReader = pdbProvider.GetMetadataReader();
+        var pdbId = pdbReader.DebugMetadataHeader.Id;
+
+        // Portable PDB content id layout: first 16 bytes = guid, next 4 = stamp.
+        var pdbGuid = new Guid(pdbId.Slice(0, 16).ToArray());
+        Assert.Equal(pdbGuid, data.Guid);
+    }
+
+    [Fact]
+    public void PdbChecksum_Algorithm_Is_SHA256_And_Matches_Pdb_Content()
+    {
+        var (pe, pdbBytes) = EmitWith(new DebugInformationOptions { Format = DebugInformationFormat.Portable });
+
+        using var peReader = new PEReader(new MemoryStream(pe.ToArray()));
+        var cs = peReader.ReadDebugDirectory()
+            .Single(e => e.Type == DebugDirectoryEntryType.PdbChecksum);
+        var data = peReader.ReadPdbChecksumDebugDirectoryData(cs);
+
+        Assert.Equal("SHA256", data.AlgorithmName);
+
+        using var sha = SHA256.Create();
+        var expected = sha.ComputeHash(pdbBytes);
+        Assert.Equal(expected, data.Checksum.ToArray());
+    }
+
+    [Fact]
+    public void Reproducible_Entry_Is_Present_When_Deterministic_Is_True()
+    {
+        var (pe, _) = EmitWith(new DebugInformationOptions
+        {
+            Format = DebugInformationFormat.Portable,
+            Deterministic = true,
+        });
+
+        var entries = ReadDebugDirectoryEntries(pe);
+        Assert.Contains(entries, e => e.Type == DebugDirectoryEntryType.Reproducible);
+    }
+
+    [Fact]
+    public void Reproducible_Entry_Is_Absent_When_Deterministic_Is_False()
+    {
+        var (pe, _) = EmitWith(new DebugInformationOptions { Format = DebugInformationFormat.Portable });
+        var entries = ReadDebugDirectoryEntries(pe);
+        Assert.DoesNotContain(entries, e => e.Type == DebugDirectoryEntryType.Reproducible);
+    }
+
+    [Fact]
+    public void Pdb_DebugDirectory_Entries_Are_Absent_When_DebugFormat_Is_None()
+    {
+        var peStream = new MemoryStream();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(SimpleProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.None },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: null, refStream: null);
+        Assert.True(result.Success);
+
+        using var peReader = new PEReader(new MemoryStream(peStream.ToArray()));
+        var entries = peReader.ReadDebugDirectory();
+
+        // ManagedPEBuilder may insert a bare Reproducible entry when given a
+        // deterministicIdProvider; what must NOT appear are PDB-pointing
+        // entries since the caller did not request debug info.
+        Assert.DoesNotContain(entries, e => e.Type == DebugDirectoryEntryType.CodeView);
+        Assert.DoesNotContain(entries, e => e.Type == DebugDirectoryEntryType.PdbChecksum);
+        Assert.DoesNotContain(entries, e => e.Type == DebugDirectoryEntryType.EmbeddedPortablePdb);
+    }
+
+    [Fact]
+    public void Embedded_Format_Writes_EmbeddedPortablePdb_Entry_And_Suppresses_Sidecar()
+    {
+        var peStream = new MemoryStream();
+        var pdbStream = new MemoryStream();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(SimpleProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Embedded },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        // Embedded format must not produce sidecar bytes even if the caller
+        // passed a stream — Roslyn behaves the same way.
+        Assert.Equal(0, pdbStream.Length);
+
+        using var peReader = new PEReader(new MemoryStream(peStream.ToArray()));
+        var entries = peReader.ReadDebugDirectory();
+        Assert.Contains(entries, e => e.Type == DebugDirectoryEntryType.EmbeddedPortablePdb);
+        Assert.Contains(entries, e => e.Type == DebugDirectoryEntryType.CodeView);
+        Assert.Contains(entries, e => e.Type == DebugDirectoryEntryType.PdbChecksum);
+    }
+
+    [Fact]
+    public void Embedded_Portable_Pdb_Roundtrips_With_Original_Documents()
+    {
+        var peStream = new MemoryStream();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(SimpleProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Embedded },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: null, refStream: null);
+        Assert.True(result.Success);
+
+        using var peReader = new PEReader(new MemoryStream(peStream.ToArray()));
+        var embed = peReader.ReadDebugDirectory()
+            .Single(e => e.Type == DebugDirectoryEntryType.EmbeddedPortablePdb);
+        using var pdbProvider = peReader.ReadEmbeddedPortablePdbDebugDirectoryData(embed);
+        var pdbReader = pdbProvider.GetMetadataReader();
+
+        Assert.Equal(1, (int)pdbReader.Documents.Count);
+        var doc = pdbReader.GetDocument(pdbReader.Documents.First());
+        Assert.Equal("main.gs", pdbReader.GetString(doc.Name));
+        Assert.Equal(PortablePdbEmitterTestHelpers.GSharpLanguageGuid, pdbReader.GetGuid(doc.Language));
+    }
+
+    private static (MemoryStream Pe, byte[] PdbBytes) EmitWith(DebugInformationOptions options)
+    {
+        var peStream = new MemoryStream();
+        var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(SimpleProgram, "main.gs")))
+        {
+            DebugInformation = options,
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        return (peStream, pdbStream.ToArray());
+    }
+
+    private static System.Collections.Immutable.ImmutableArray<DebugDirectoryEntry> ReadDebugDirectoryEntries(MemoryStream pe)
+    {
+        using var peReader = new PEReader(new MemoryStream(pe.ToArray()));
+        return peReader.ReadDebugDirectory();
     }
 }


### PR DESCRIPTION
Part of #95 / #50 (ADR-0027 §7.7a, debug-info phase 7 of 10).

## What

Wires `DebugDirectoryBuilder` into the existing `ManagedPEBuilder` path so the produced PE actually advertises its PDB to debuggers and symbol servers. With this PR the PE finally carries the four entries every .NET debugger looks for:

| Entry | When | Payload |
| --- | --- | --- |
| `CodeView` | Always under `/debug` | PDB content id (Guid + age = 1) plus a path derived from `/pdb:<path>` or, by default, `<AssemblyName>.pdb`. |
| `PdbChecksum` | Always under `/debug` | `SHA256` digest of the serialized Portable PDB blob — same bytes a sidecar `.pdb` would contain. |
| `Reproducible` | When `/deterministic` | Marker, empty payload. |
| `EmbeddedPortablePdb` | When `/debug:embedded` | Deflate-compressed copy of the PDB inlined into the PE; sidecar is suppressed even when a stream is supplied. |

## How

* `PortablePdbEmitter.Serialize` no longer writes to a stream — it returns `(BlobBuilder, BlobContentId)`. The caller (`ReflectionMetadataEmitter`) owns sidecar vs embedded routing.
* `EmitCore` is restructured: PDB blob is built **before** the PE so the `DebugDirectoryBuilder` can wire its content id (CodeView) and checksum (PdbChecksum) at PE-construction time.
* PDB construction now triggers on `Format == Portable && pdbStream != null` **or** `Format == Embedded` (the latter never needs a sidecar stream).
* Embedded format hard-suppresses sidecar writes, matching csc behaviour and the spec.

## Tests

`PortablePdbPhase7Tests` (9 new tests):

* CodeView + PdbChecksum present under `/debug:portable`.
* CodeView path defaults to a bare `<asm>.pdb` filename (no directory separators).
* CodeView `Guid` round-trips against the Portable PDB metadata header `Id`.
* PdbChecksum algorithm name is `SHA256` and the digest matches `SHA256(pdbBytes)`.
* Reproducible present iff `Deterministic=true`.
* No PDB-pointing entries when `Format=None` (note: `ManagedPEBuilder` may still emit a bare `Reproducible` due to the deterministic id provider; this is benign).
* `Format=Embedded` writes EmbeddedPortablePdb + CodeView + PdbChecksum and produces zero sidecar bytes even when a `pdbStream` is supplied.
* The embedded PDB blob round-trips: `PEReader.ReadEmbeddedPortablePdbDebugDirectoryData` yields a reader that sees the original `Document` rows (`main.gs`, GSharp language GUID).

Full suite: **1429 passing** (1420 baseline + 9 new), 0 failures.

## Docs

`docs/debug-info.md` gains a 'PE-side debug directory (Phase 7)' section documenting each entry, when it appears, and what tooling uses it.

## Refs

* Parent: #95, #50
* ADR: ADR-0027 §7.7a
* Builds on: #220 (Phase 6 — CDIs)
* Deferred follow-ups: #216 (LocalConstant), #217 (per-file ImportScope), #218 (Emit overload ambiguity), #219 (CompilationMetadataReferences)