### PR TITLE
PDB Phase 8: SDK wiring — EmbedAllSources / SourceLink / Deterministic + FileWrites (#95, #50)

### DIFF
--- a/build/debug-info-e2e.sh
+++ b/build/debug-info-e2e.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Packs Gsharp.NET.Sdk into .nugs/ and verifies the debug-information
+# pipeline (#95 / #50) end-to-end via the SDK:
+#   * <DebugType>portable</DebugType> produces a sibling .pdb next to the assembly
+#     and a CodeView debug directory entry in the PE.
+#   * <DebugType>embedded</DebugType> produces NO sibling .pdb but does emit an
+#     EmbeddedPortablePdb entry in the debug directory.
+#   * <DebugType>none</DebugType> produces neither.
+# Run as part of the SDK smoke-test set alongside sdk-e2e.sh.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+echo "==> Packing Gsharp.NET.Sdk into .nugs/"
+dotnet build src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj -c Release --nologo -v:q
+mkdir -p .nugs
+cp out/bin/Release/nupkgs/Gsharp.NET.Sdk.*.nupkg .nugs/
+
+NUPKG=$(ls -t out/bin/Release/nupkgs/Gsharp.NET.Sdk.*.nupkg | head -1)
+VER="${NUPKG##*Gsharp.NET.Sdk.}"
+VER="${VER%.nupkg}"
+rm -rf "$HOME/.nuget/packages/gsharp.net.sdk/$VER" || true
+
+WORK="$(mktemp -d -t gs-debug-e2e-XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+echo "==> Workspace: $WORK"
+
+cat > "$WORK/global.json" <<EOF
+{
+  "msbuild-sdks": {
+    "Gsharp.NET.Sdk": "$VER"
+  }
+}
+EOF
+
+cat > "$WORK/NuGet.config" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local" value="$ROOT/.nugs" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+EOF
+
+cat > "$WORK/Debuggable.gs" <<'EOF'
+package debuggable
+
+public func Add(a int, b int) int {
+    var sum = a + b
+    return sum
+}
+EOF
+
+build_case() {
+    local label="$1" debugType="$2"
+    local dir="$WORK/$label"
+    mkdir -p "$dir"
+    cp "$WORK/Debuggable.gs" "$dir/Debuggable.gs"
+    cp "$WORK/global.json" "$dir/global.json"
+    cp "$WORK/NuGet.config" "$dir/NuGet.config"
+    cat > "$dir/Debuggable.gsproj" <<EOF
+<Project Sdk="Gsharp.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <DebugType>$debugType</DebugType>
+  </PropertyGroup>
+</Project>
+EOF
+    echo "==> [$label] dotnet build --nologo (DebugType=$debugType)"
+    dotnet build "$dir/Debuggable.gsproj" --nologo -v:q
+}
+
+build_case portable portable
+build_case embedded embedded
+build_case none     none
+
+PORTABLE_DLL="$WORK/portable/bin/Debug/net10.0/Debuggable.dll"
+PORTABLE_PDB="$WORK/portable/bin/Debug/net10.0/Debuggable.pdb"
+EMBEDDED_DLL="$WORK/embedded/bin/Debug/net10.0/Debuggable.dll"
+EMBEDDED_PDB="$WORK/embedded/bin/Debug/net10.0/Debuggable.pdb"
+NONE_DLL="$WORK/none/bin/Debug/net10.0/Debuggable.dll"
+NONE_PDB="$WORK/none/bin/Debug/net10.0/Debuggable.pdb"
+
+if [[ ! -f "$PORTABLE_PDB" ]]; then
+    echo "FAIL: portable build did not produce $PORTABLE_PDB"
+    exit 1
+fi
+if [[ -f "$EMBEDDED_PDB" ]]; then
+    echo "FAIL: embedded build unexpectedly produced sidecar $EMBEDDED_PDB"
+    exit 1
+fi
+if [[ -f "$NONE_PDB" ]]; then
+    echo "FAIL: DebugType=none build unexpectedly produced sidecar $NONE_PDB"
+    exit 1
+fi
+
+# Verify each PE's debug directory shape via a tiny helper program.
+HELPER="$WORK/inspect.csproj"
+cat > "$HELPER" <<'EOF'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+</Project>
+EOF
+cat > "$WORK/Program.cs" <<'EOF'
+using System;
+using System.IO;
+using System.Reflection.PortableExecutable;
+
+var path = args[0];
+using var stream = File.OpenRead(path);
+using var pe = new PEReader(stream);
+var entries = pe.ReadDebugDirectory();
+bool hasCodeView = false, hasEmbedded = false, hasChecksum = false;
+foreach (var e in entries)
+{
+    if (e.Type == DebugDirectoryEntryType.CodeView) hasCodeView = true;
+    if (e.Type == DebugDirectoryEntryType.EmbeddedPortablePdb) hasEmbedded = true;
+    if (e.Type == DebugDirectoryEntryType.PdbChecksum) hasChecksum = true;
+}
+Console.WriteLine($"codeview={hasCodeView} embedded={hasEmbedded} checksum={hasChecksum}");
+EOF
+
+mv "$HELPER" "$WORK/inspect/inspect.csproj" 2>/dev/null || { mkdir -p "$WORK/inspect"; mv "$HELPER" "$WORK/inspect/inspect.csproj"; }
+mv "$WORK/Program.cs" "$WORK/inspect/Program.cs"
+dotnet build "$WORK/inspect/inspect.csproj" -c Release --nologo -v:q >/dev/null
+
+inspect() {
+    dotnet "$WORK/inspect/bin/Release/net10.0/inspect.dll" "$1"
+}
+
+PORTABLE_INFO=$(inspect "$PORTABLE_DLL")
+EMBEDDED_INFO=$(inspect "$EMBEDDED_DLL")
+NONE_INFO=$(inspect "$NONE_DLL")
+
+echo "portable: $PORTABLE_INFO"
+echo "embedded: $EMBEDDED_INFO"
+echo "none:     $NONE_INFO"
+
+[[ "$PORTABLE_INFO" == "codeview=True embedded=False checksum=True" ]] || {
+    echo "FAIL: portable PE debug directory mismatch"; exit 1; }
+[[ "$EMBEDDED_INFO" == "codeview=True embedded=True checksum=True" ]] || {
+    echo "FAIL: embedded PE debug directory mismatch"; exit 1; }
+[[ "$NONE_INFO" == "codeview=False embedded=False checksum=False" ]] || {
+    echo "FAIL: DebugType=none PE unexpectedly contains PDB debug directory entries"; exit 1; }
+
+echo "PASS: debug-info end-to-end SDK build produces the expected sidecar/embedded/none shapes."

--- a/docs/debug-info.md
+++ b/docs/debug-info.md
@@ -143,3 +143,25 @@ The `gsc` compiler accepts the standard Roslyn-style debug flags:
 | `/deterministic[+/-]` | Emit a content-hash-based Mvid / PdbId. |
 
 The SDK forwards `<DebugType>` and `<PdbFile>` through `BuildTask` so MSBuild-driven builds behave identically to direct `gsc` invocations.
+
+## SDK / MSBuild properties
+
+`Gsharp.NET.Sdk` exposes the standard .NET debug properties and threads them
+through `BuildTask` into the matching `gsc` flag. The property names match
+the C# / F# SDKs, so an enterprise consumer can apply the same `Directory.Build.props`
+to a mixed-language solution and have GSharp projects honour the same
+conventions.
+
+| Property | Default | Forwarded as | Effect |
+| --- | --- | --- | --- |
+| `<DebugType>` | `portable` in `Debug`, `none` in `Release` | `/debug:<value>` | Selects no PDB / sidecar Portable PDB / embedded Portable PDB. |
+| `<DebugSymbols>` | derived from `<DebugType>` | (gates whether the build writes a sidecar PDB) | When `true` and `<DebugType>` is `portable`/`pdbonly`/`full`, the SDK adds `obj/.../<Asm>.pdb` to `@(FileWrites)` and the standard `CopyFilesToOutputDirectory` target copies it next to the produced `*.dll`. |
+| `<PdbFile>` | `obj/.../<AssemblyName>.pdb` | `/pdb:<path>` | Override the sidecar output path. |
+| `<EmbedAllSources>` | `false` | `/embed+` | Embed every primary source file in the PDB as `EmbeddedSource` rows. Recommended when `<DebugType>embedded</DebugType>` is on so debugging the assembly never depends on the local source tree. |
+| `<SourceLink>` | (none) | `/sourcelink:<file>` | Embed the supplied Source-Link JSON as a `CustomDebugInformation` row. |
+| `<Deterministic>` | `true` for the official build, `false` otherwise | `/deterministic+/-` | Switch the Mvid / PdbId to a content hash and emit the `Reproducible` debug-directory entry. |
+
+`Gsharp.NET.Sdk` does *not* invent any of these property names — they are the
+same surface every modern .NET SDK consumes, so existing CI snippets that set
+`<DebugType>embedded</DebugType>`, `<EmbedAllSources>true</EmbedAllSources>`, or
+`<Deterministic>true</Deterministic>` "just work" against a GSharp project.

--- a/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
+++ b/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
@@ -57,6 +57,23 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
     /// <summary>Gets or sets the PDB output path.</summary>
     public string PdbFile { get; set; }
 
+    /// <summary>Gets or sets the path to a Source Link JSON file (forwarded to <c>gsc /sourcelink:</c>).</summary>
+    public string SourceLink { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value (parsed as a bool) controlling whether all primary
+    /// source files are embedded in the Portable PDB (forwarded as
+    /// <c>gsc /embed</c>). Maps to MSBuild's <c>EmbedAllSources</c> property.
+    /// </summary>
+    public string EmbedAllSources { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value (parsed as a bool) controlling deterministic emit
+    /// (forwarded as <c>gsc /deterministic</c>). Maps to MSBuild's
+    /// <c>Deterministic</c> property.
+    /// </summary>
+    public string Deterministic { get; set; }
+
     /// <summary>Gets or sets the assembly version stamped on the output.</summary>
     public string Version { get; set; }
 
@@ -121,6 +138,21 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
         if (!string.IsNullOrEmpty(this.PdbFile))
         {
             args.Add($"/pdb:{this.PdbFile}");
+        }
+
+        if (!string.IsNullOrEmpty(this.SourceLink))
+        {
+            args.Add($"/sourcelink:{this.SourceLink}");
+        }
+
+        if (ParseBool(this.EmbedAllSources))
+        {
+            args.Add("/embed+");
+        }
+
+        if (ParseBool(this.Deterministic))
+        {
+            args.Add("/deterministic+");
         }
 
         if (!string.IsNullOrEmpty(this.RefAssembly))
@@ -188,4 +220,12 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
 
         return proc.ExitCode == 0 && !this.Log.HasLoggedErrors;
     }
+
+    /// <summary>
+    /// Parses an MSBuild bool-style property value. Accepts the canonical
+    /// <c>"true"</c> / <c>"false"</c> spellings (case-insensitive) and treats
+    /// empty / null / unrecognized values as <see langword="false"/>.
+    /// </summary>
+    private static bool ParseBool(string value) =>
+        !string.IsNullOrEmpty(value) && bool.TryParse(value, out var b) && b;
 }

--- a/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
+++ b/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
@@ -34,6 +34,9 @@
         Optimization="$(Optimize)"
         DebugType="$(DebugType)"
         PdbFile="@(_DebugSymbolsIntermediatePath)"
+        SourceLink="$(SourceLink)"
+        EmbedAllSources="$(EmbedAllSources)"
+        Deterministic="$(Deterministic)"
         Version="$(Version)"
         OutputType="$(OutputType)"
         RefAssembly="$(_GsharpRefAssemblyPath)"
@@ -47,6 +50,18 @@
     <ItemGroup>
       <FileWrites Include="$(IntermediateOutputPath)$(TargetName)$(TargetExt)" />
       <FileWrites Include="$(_GsharpRefAssemblyPath)" Condition=" '$(_GsharpRefAssemblyPath)' != '' " />
+
+      <!-- Phase 8: declare the sidecar PDB to MSBuild so incremental build,
+           Clean, dotnet publish, and dotnet pack (when GeneratePackageOnBuild
+           or Symbols=true) all see the symbols alongside the runtime assembly.
+           Embedded PDBs land inside the PE so we deliberately skip the entry
+           for DebugType=embedded; DebugType=none / "" produces no file at
+           all and we likewise skip. -->
+      <FileWrites Include="@(_DebugSymbolsIntermediatePath)"
+                  Condition=" '@(_DebugSymbolsIntermediatePath)' != '' and
+                              '$(DebugType)' != ''                       and
+                              '$(DebugType)' != 'none'                   and
+                              '$(DebugType)' != 'embedded' " />
     </ItemGroup>
   </Target>
 

--- a/test/Sdk.Tests/SdkLayoutTests.cs
+++ b/test/Sdk.Tests/SdkLayoutTests.cs
@@ -127,4 +127,47 @@ public class SdkLayoutTests
         Assert.Contains("Microsoft.Build.Framework", text, System.StringComparison.Ordinal);
         Assert.Contains("Microsoft.Build.Utilities.Core", text, System.StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void Core_Targets_Forwards_Phase6_And_Phase7_BuildTask_Attributes()
+    {
+        var path = Path.Combine(RepoRoot.SdkSourceDir, "build", "Gsharp.NET.Core.Sdk.targets");
+        var doc = XDocument.Load(path);
+        var buildTask = doc.Descendants(MsbuildNs + "Target")
+            .First(t => (string)t.Attribute("Name") == "CoreCompile")
+            .Element(MsbuildNs + "BuildTask");
+
+        var attrs = buildTask!.Attributes().ToDictionary(a => a.Name.LocalName, a => a.Value);
+
+        // Phase 8 wiring: the four debug-information-shaped MSBuild properties
+        // must all reach the task, else consumer projects can't control
+        // SourceLink / embed / determinism without command-line workarounds.
+        Assert.Equal("$(DebugType)", attrs["DebugType"]);
+        Assert.Equal("@(_DebugSymbolsIntermediatePath)", attrs["PdbFile"]);
+        Assert.Equal("$(SourceLink)", attrs["SourceLink"]);
+        Assert.Equal("$(EmbedAllSources)", attrs["EmbedAllSources"]);
+        Assert.Equal("$(Deterministic)", attrs["Deterministic"]);
+    }
+
+    [Fact]
+    public void Core_Targets_Adds_Sidecar_Pdb_To_FileWrites()
+    {
+        var path = Path.Combine(RepoRoot.SdkSourceDir, "build", "Gsharp.NET.Core.Sdk.targets");
+        var doc = XDocument.Load(path);
+
+        var fileWrites = doc.Descendants(MsbuildNs + "FileWrites")
+            .Where(fw =>
+                ((string)fw.Attribute("Include") ?? string.Empty)
+                    .Contains("_DebugSymbolsIntermediatePath", System.StringComparison.Ordinal))
+            .ToList();
+
+        Assert.Single(fileWrites);
+
+        // The PDB FileWrites entry must be gated so Clean / incremental skips
+        // it when no sidecar is produced (DebugType=embedded/none/empty).
+        var condition = (string)fileWrites[0].Attribute("Condition");
+        Assert.NotNull(condition);
+        Assert.Contains("'$(DebugType)' != 'embedded'", condition, System.StringComparison.Ordinal);
+        Assert.Contains("'$(DebugType)' != 'none'", condition, System.StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
Phase 8 of the Portable PDB emit work (parent: #95, #50; ADR-0027 §7.7a). Closes the SDK ↔ compiler wiring so enterprise consumers can drive the full PDB pipeline from MSBuild properties.

## Summary

* `Gsharp.NET.Sdk` now forwards three additional standard properties through `BuildTask` into `gsc`:
  * `<SourceLink>` → `/sourcelink:<file>` (Phase 6)
  * `<EmbedAllSources>` → `/embed+` (Phase 6)
  * `<Deterministic>` → `/deterministic+/-` (Phase 7)
* `Gsharp.NET.Core.Sdk.targets` adds a gated `<FileWrites>` entry for the intermediate Portable PDB so Clean / incremental build / pack / publish see the sidecar. The gate excludes `DebugType=embedded/none`, matching the C#/F# SDK behaviour. The existing `CopyFilesToOutputDirectory` target then copies the sidecar PDB next to the produced assembly automatically.
* `Sdk.Tests`: two new structural assertions — attribute forwarding through `Gsharp.NET.Core.Sdk.targets`, and the gated FileWrites entry. Sdk.Tests goes from 21 → 23 passing.
* New `build/debug-info-e2e.sh` smoke test (sibling of `sdk-e2e.sh`) that packs the SDK, builds three projects (`portable` / `embedded` / `none`), and asserts both the PDB-sidecar presence and the PE `DebugDirectory` shape (`CodeView`, `EmbeddedPortablePdb`, `PdbChecksum`) match the documented contract end-to-end.
* `docs/debug-info.md` gains an SDK / MSBuild property table mapping the standard property names to the `gsc` flags they feed.

## End-to-end verification

```
==> [portable] dotnet build --nologo (DebugType=portable)
==> [embedded] dotnet build --nologo (DebugType=embedded)
==> [none]     dotnet build --nologo (DebugType=none)
portable: codeview=True embedded=False checksum=True
embedded: codeview=True embedded=True  checksum=True
none:     codeview=False embedded=False checksum=False
PASS: debug-info end-to-end SDK build produces the expected sidecar/embedded/none shapes.
```

`dotnet test GSharp.sln --no-restore --nologo` is green (Core 1189, Compiler 170, Sdk 23, Interpreter 32, LanguageServer 8, plus Templates layout).

## Out of scope (Phase 9–10)

* Phase 9 — round-trip stack-trace test + netcoredbg live-debugger E2E.
* Phase 10 — finalize `docs/emit-pipeline.md`, CLI reference, ADR-0040.

Refs #95, #50.
