### PR TITLE
PDB Phase 11: LocalConstant rows for const bindings (closes #216)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1794,7 +1794,17 @@ public sealed class Binder
             variable.SetAttributes(boundAttrs);
         }
 
-        return new BoundVariableDeclaration(syntax, variable, convertedInitializer);
+        // Issue #216: a `const` declaration whose converted initializer is a
+        // literal expression carries a compile-time ConstantValue. The emitter
+        // uses this to skip IL slot allocation and emit a LocalConstant PDB row.
+        object constValue = null;
+        if (syntax.Keyword?.Kind == SyntaxKind.ConstKeyword
+            && convertedInitializer is BoundLiteralExpression litExpr)
+        {
+            constValue = litExpr.Value;
+        }
+
+        return new BoundVariableDeclaration(syntax, variable, convertedInitializer, constValue);
     }
 
     private BoundStatement BindTupleDeconstructionStatement(TupleDeconstructionStatementSyntax syntax)

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -122,7 +122,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundVariableDeclaration(null, node.Variable, initializer);
+        return new BoundVariableDeclaration(null, node.Variable, initializer, node.ConstantValue);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/BoundVariableDeclaration.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundVariableDeclaration.cs
@@ -18,11 +18,19 @@ public sealed class BoundVariableDeclaration : BoundStatement
     /// <param name="syntax">The originating syntax.</param>
     /// <param name="variable">The variable symbol.</param>
     /// <param name="initializer">The bound expression.</param>
-    public BoundVariableDeclaration(SyntaxNode syntax, VariableSymbol variable, BoundExpression initializer)
+    /// <param name="constantValue">
+    /// The compile-time constant value when this is a <c>const</c> declaration
+    /// whose initializer folds to a literal; <see langword="null"/> otherwise.
+    /// When non-null the emitter will not allocate an IL slot for the variable
+    /// and will instead inline the value at every read site, emitting a
+    /// <c>LocalConstant</c> row in the Portable PDB.
+    /// </param>
+    public BoundVariableDeclaration(SyntaxNode syntax, VariableSymbol variable, BoundExpression initializer, object constantValue = null)
         : base(syntax)
     {
         Variable = variable;
         Initializer = initializer;
+        ConstantValue = constantValue;
     }
 
     /// <inheritdoc/>
@@ -37,4 +45,14 @@ public sealed class BoundVariableDeclaration : BoundStatement
     /// Gets the bound expression.
     /// </summary>
     public BoundExpression Initializer { get; }
+
+    /// <summary>
+    /// Gets the compile-time constant value for this declaration, or
+    /// <see langword="null"/> when the declaration is not a compile-time
+    /// constant (i.e. it was declared with <c>var</c> or <c>let</c>, or the
+    /// <c>const</c> initializer is not a literal expression). When non-null,
+    /// no IL local slot is allocated and the value is inlined at every read
+    /// site, with a <c>LocalConstant</c> row emitted in the Portable PDB.
+    /// </summary>
+    public object ConstantValue { get; }
 }

--- a/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
@@ -130,6 +130,7 @@ internal sealed class PortablePdbEmitter
         MethodDefinitionHandle methodHandle,
         IReadOnlyList<SequencePoint> sequencePoints,
         IReadOnlyList<LocalInfo> locals,
+        IReadOnlyList<LocalConstantInfo> constants,
         int ilCodeSize,
         StandaloneSignatureHandle localSignatureToken)
     {
@@ -152,10 +153,11 @@ internal sealed class PortablePdbEmitter
         }
 
         var hasLocals = locals != null && locals.Count > 0;
+        var hasConstants = constants != null && constants.Count > 0;
 
         // Nothing for a debugger to anchor — skip the row entirely so Serialize
         // falls through to writing an empty MethodDebugInformation slot.
-        if (!hasUsableDocument && !hasLocals)
+        if (!hasUsableDocument && !hasLocals && !hasConstants)
         {
             return;
         }
@@ -164,6 +166,7 @@ internal sealed class PortablePdbEmitter
         this.recordedMethods[row] = new RecordedMethod(
             sequencePoints ?? System.Array.Empty<SequencePoint>(),
             locals ?? System.Array.Empty<LocalInfo>(),
+            constants ?? System.Array.Empty<LocalConstantInfo>(),
             ilCodeSize,
             localSignatureToken);
     }
@@ -210,15 +213,23 @@ internal sealed class PortablePdbEmitter
             parentScope: default,
             imports: this.pdbMetadata.GetOrAddBlob(EmptyBlob));
 
-        // Step 3 — Phase 5: LocalVariable + LocalScope rows. The reader walks
-        // LocalScope sorted by method, then by startOffset. Within a method,
-        // each scope's variable list is implied by the *next* scope's variable
-        // handle, so we MUST add LocalVariable rows in the same order we add
-        // LocalScope rows. Since Phase 5 only emits a single scope per method
-        // covering the full method body, the ordering is trivially correct.
+        // Step 3 — Phase 5+6: LocalVariable + LocalConstant + LocalScope rows.
+        // The reader walks LocalScope sorted by method, then by startOffset.
+        // Within a method, variable/constant lists are implied by the *next*
+        // scope's handles, so we MUST add rows in the same order as scopes.
+        // We maintain a running nextConstantRid so that empty-constant methods
+        // still produce a correct constantList anchor.
+        int nextConstantRid = 1;
         for (var rid = 1; rid <= methodDefRowCount; rid++)
         {
-            if (!this.recordedMethods.TryGetValue(rid, out var rec) || rec.Locals.Count == 0)
+            if (!this.recordedMethods.TryGetValue(rid, out var rec))
+            {
+                continue;
+            }
+
+            var hasLocals = rec.Locals.Count > 0;
+            var hasConstants = rec.Constants.Count > 0;
+            if (!hasLocals && !hasConstants)
             {
                 continue;
             }
@@ -242,11 +253,27 @@ internal sealed class PortablePdbEmitter
                 }
             }
 
+            // Add LocalConstant rows for this method. Track the first RID so
+            // AddLocalScope gets a correct constantList anchor.
+            var firstConstantRid = nextConstantRid;
+            for (var i = 0; i < rec.Constants.Count; i++)
+            {
+                var c = rec.Constants[i];
+                var sigBlob = EncodeLocalConstantSignature(c.Value);
+                if (!sigBlob.IsNil)
+                {
+                    this.pdbMetadata.AddLocalConstant(
+                        name: this.pdbMetadata.GetOrAddString(c.Name),
+                        signature: sigBlob);
+                    nextConstantRid++;
+                }
+            }
+
             this.pdbMetadata.AddLocalScope(
                 method: MetadataTokens.MethodDefinitionHandle(rid),
                 importScope: rootImportScope,
                 variableList: firstLocal,
-                constantList: MetadataTokens.LocalConstantHandle(1),
+                constantList: MetadataTokens.LocalConstantHandle(firstConstantRid),
                 startOffset: 0,
                 length: rec.IlCodeSize);
         }
@@ -399,16 +426,95 @@ internal sealed class PortablePdbEmitter
         return default;
     }
 
+    /// <summary>
+    /// Encodes a LocalConstant blob per Portable PDB spec §II.23.2.
+    /// Returns a <see cref="BlobHandle"/> for the encoded signature, or
+    /// <see langword="default"/> when the value type is unsupported.
+    /// </summary>
+    private BlobHandle EncodeLocalConstantSignature(object value)
+    {
+        var blob = new BlobBuilder();
+        switch (value)
+        {
+            case bool b:
+                blob.WriteByte(0x02); // ELEMENT_TYPE_BOOLEAN
+                blob.WriteByte(b ? (byte)1 : (byte)0);
+                break;
+            case char ch:
+                blob.WriteByte(0x03); // ELEMENT_TYPE_CHAR
+                blob.WriteInt16((short)ch);
+                break;
+            case sbyte sb:
+                blob.WriteByte(0x04); // ELEMENT_TYPE_I1
+                blob.WriteSByte(sb);
+                break;
+            case byte by:
+                blob.WriteByte(0x05); // ELEMENT_TYPE_U1
+                blob.WriteByte(by);
+                break;
+            case short s:
+                blob.WriteByte(0x06); // ELEMENT_TYPE_I2
+                blob.WriteInt16(s);
+                break;
+            case ushort us:
+                blob.WriteByte(0x07); // ELEMENT_TYPE_U2
+                blob.WriteUInt16(us);
+                break;
+            case int i:
+                blob.WriteByte(0x08); // ELEMENT_TYPE_I4
+                blob.WriteInt32(i);
+                break;
+            case uint ui:
+                blob.WriteByte(0x09); // ELEMENT_TYPE_U4
+                blob.WriteUInt32(ui);
+                break;
+            case long l:
+                blob.WriteByte(0x0A); // ELEMENT_TYPE_I8
+                blob.WriteInt64(l);
+                break;
+            case ulong ul:
+                blob.WriteByte(0x0B); // ELEMENT_TYPE_U8
+                blob.WriteUInt64(ul);
+                break;
+            case float f:
+                blob.WriteByte(0x0C); // ELEMENT_TYPE_R4
+                blob.WriteUInt32(BitConverter.SingleToUInt32Bits(f));
+                break;
+            case double d:
+                blob.WriteByte(0x0D); // ELEMENT_TYPE_R8
+                blob.WriteUInt64(BitConverter.DoubleToUInt64Bits(d));
+                break;
+            case string str:
+                blob.WriteByte(0x0E); // ELEMENT_TYPE_STRING
+                if (str is null)
+                {
+                    blob.WriteByte(0xFF);
+                }
+                else
+                {
+                    blob.WriteBytes(Encoding.Unicode.GetBytes(str));
+                }
+
+                break;
+            default:
+                return default;
+        }
+
+        return this.pdbMetadata.GetOrAddBlob(blob);
+    }
+
     private sealed class RecordedMethod
     {
         public RecordedMethod(
             IReadOnlyList<SequencePoint> points,
             IReadOnlyList<LocalInfo> locals,
+            IReadOnlyList<LocalConstantInfo> constants,
             int ilCodeSize,
             StandaloneSignatureHandle localSignatureToken)
         {
             this.Points = points;
             this.Locals = locals;
+            this.Constants = constants;
             this.IlCodeSize = ilCodeSize;
             this.LocalSignatureToken = localSignatureToken;
         }
@@ -416,6 +522,8 @@ internal sealed class PortablePdbEmitter
         public IReadOnlyList<SequencePoint> Points { get; }
 
         public IReadOnlyList<LocalInfo> Locals { get; }
+
+        public IReadOnlyList<LocalConstantInfo> Constants { get; }
 
         public int IlCodeSize { get; }
 
@@ -443,6 +551,25 @@ internal readonly struct LocalInfo
     public string Name { get; }
 
     public bool IsCompilerGenerated { get; }
+}
+
+/// <summary>
+/// A compile-time constant binding handed to
+/// <see cref="PortablePdbEmitter.RecordMethod"/>. The emitter encodes
+/// <see cref="Value"/> into a <c>LocalConstant</c> signature blob per
+/// Portable PDB spec §II.23.2.
+/// </summary>
+internal readonly struct LocalConstantInfo
+{
+    public LocalConstantInfo(string name, object value)
+    {
+        this.Name = name ?? string.Empty;
+        this.Value = value;
+    }
+
+    public string Name { get; }
+
+    public object Value { get; }
 }
 
 /// <summary>

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1285,6 +1285,102 @@ internal sealed class ReflectionMetadataEmitter
     /// <see cref="EmitStructTypeDef"/> but uses <c>NestedPrivate</c> visibility
     /// and an empty namespace (nested types have no namespace in metadata).
     /// </summary>
+    /// <summary>
+    /// Converts the per-method <c>constValues</c> dictionary into a list of
+    /// <see cref="LocalConstantInfo"/> descriptors for the Portable PDB
+    /// <c>LocalConstant</c> table. Each entry corresponds to one compile-time
+    /// <c>const</c> binding that occupied no IL slot.
+    /// </summary>
+    private static IReadOnlyList<LocalConstantInfo> CollectLocalConstantInfo(Dictionary<VariableSymbol, object> constValues)
+    {
+        if (constValues == null || constValues.Count == 0)
+        {
+            return System.Array.Empty<LocalConstantInfo>();
+        }
+
+        var result = new List<LocalConstantInfo>(constValues.Count);
+        foreach (var kvp in constValues)
+        {
+            result.Add(new LocalConstantInfo(kvp.Key.Name ?? string.Empty, kvp.Value));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Pre-scans <paramref name="body"/> and populates
+    /// <paramref name="constValues"/> with every <c>const</c>-declared local
+    /// that has a compile-time <see cref="BoundVariableDeclaration.ConstantValue"/>.
+    /// Called once before <see cref="CollectLocalsAndLabels"/> so that
+    /// <see cref="BodyEmitter"/> can inline those values instead of loading
+    /// from a slot.
+    /// </summary>
+    private static void CollectConstValues(BoundStatement body, Dictionary<VariableSymbol, object> constValues)
+    {
+        WalkStmtsForConsts(body, constValues);
+    }
+
+    private static void WalkStmtsForConsts(BoundStatement stmt, Dictionary<VariableSymbol, object> result)
+    {
+        switch (stmt)
+        {
+            case BoundVariableDeclaration vd when vd.ConstantValue != null:
+                result[vd.Variable] = vd.ConstantValue;
+                break;
+            case BoundBlockStatement block:
+                foreach (var s in block.Statements)
+                {
+                    WalkStmtsForConsts(s, result);
+                }
+
+                break;
+            case BoundIfStatement ifs:
+                WalkStmtsForConsts(ifs.ThenStatement, result);
+                if (ifs.ElseStatement != null)
+                {
+                    WalkStmtsForConsts(ifs.ElseStatement, result);
+                }
+
+                break;
+            case BoundTryStatement t:
+                WalkStmtsForConsts(t.TryBlock, result);
+                foreach (var clause in t.CatchClauses)
+                {
+                    WalkStmtsForConsts(clause.Body, result);
+                }
+
+                if (t.FinallyBlock != null)
+                {
+                    WalkStmtsForConsts(t.FinallyBlock, result);
+                }
+
+                break;
+            case BoundPatternSwitchStatement ps:
+                foreach (var arm in ps.Arms)
+                {
+                    if (arm.Body != null)
+                    {
+                        WalkStmtsForConsts(arm.Body, result);
+                    }
+                }
+
+                break;
+            case BoundScopeStatement sc:
+                WalkStmtsForConsts(sc.Body, result);
+                break;
+            case BoundSelectStatement sel:
+                foreach (var arm in sel.Cases)
+                {
+                    if (arm.Body != null)
+                    {
+                        WalkStmtsForConsts(arm.Body, result);
+                    }
+                }
+
+                break;
+        }
+    }
+
     private void EmitNestedStructTypeDef(StructSymbol structSym, int firstFieldRow, int methodListRow)
     {
         if (!structSym.TypeArguments.IsDefaultOrEmpty)
@@ -2453,6 +2549,7 @@ internal sealed class ReflectionMetadataEmitter
         int bodyOffset = -1;
         IReadOnlyList<SequencePoint> capturedSequencePoints = null;
         IReadOnlyList<LocalInfo> capturedLocals = null;
+        IReadOnlyList<LocalConstantInfo> capturedConstants = null;
         int capturedCodeSize = 0;
         StandaloneSignatureHandle capturedLocalsSignature = default;
         if (!this.metadataOnly)
@@ -2477,6 +2574,11 @@ internal sealed class ReflectionMetadataEmitter
             var scopeFrameSlots = new Dictionary<BoundScopeStatement, (int Tasks, int Cts, int Awaiter)>();
             var selectStatementSlots = new Dictionary<BoundSelectStatement, SelectSlots>();
             var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
+
+            // Issue #216: collect compile-time const bindings before slot allocation.
+            var constValues = new Dictionary<VariableSymbol, object>();
+            CollectConstValues(body, constValues);
+
             CollectLocalsAndLabels(
                 body,
                 null,
@@ -2532,6 +2634,7 @@ internal sealed class ReflectionMetadataEmitter
                 scopeFrameSlots,
                 selectStatementSlots,
                 goEnclosingScopes,
+                constValues: constValues,
                 structThisParameter: moveNextBody.ThisParameter,
                 asyncFieldMap: plan.FieldMap,
                 asyncPlan: plan);
@@ -2540,6 +2643,7 @@ internal sealed class ReflectionMetadataEmitter
             bodyOffset = this.methodBodyStream.AddMethodBody(il, localVariablesSignature: localsSignature);
             capturedSequencePoints = emitter.SequencePoints;
             capturedLocals = CollectLocalInfo(locals);
+            capturedConstants = CollectLocalConstantInfo(constValues);
             capturedCodeSize = il.Offset;
             capturedLocalsSignature = localsSignature;
         }
@@ -2562,7 +2666,7 @@ internal sealed class ReflectionMetadataEmitter
         // method post-lowering; sequence points and locals captured here surface
         // in debugger stack traces, locals window, and `step` commands across
         // `await` points.
-        this.pdb?.RecordMethod(moveNextHandle, capturedSequencePoints, capturedLocals, capturedCodeSize, capturedLocalsSignature);
+        this.pdb?.RecordMethod(moveNextHandle, capturedSequencePoints, capturedLocals, capturedConstants, capturedCodeSize, capturedLocalsSignature);
     }
 
     /// <summary>
@@ -2948,6 +3052,7 @@ internal sealed class ReflectionMetadataEmitter
         int bodyOffset = -1;
         IReadOnlyList<SequencePoint> capturedSequencePoints = null;
         IReadOnlyList<LocalInfo> capturedLocals = null;
+        IReadOnlyList<LocalConstantInfo> capturedConstants = null;
         int capturedCodeSize = 0;
         StandaloneSignatureHandle capturedLocalsSignature = default;
         if (!this.metadataOnly)
@@ -2975,6 +3080,11 @@ internal sealed class ReflectionMetadataEmitter
             var scopeFrameSlots = new Dictionary<BoundScopeStatement, (int Tasks, int Cts, int Awaiter)>();
             var selectStatementSlots = new Dictionary<BoundSelectStatement, SelectSlots>();
             var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
+
+            // Issue #216: collect compile-time const bindings before slot allocation.
+            var constValues = new Dictionary<VariableSymbol, object>();
+            CollectConstValues(body, constValues);
+
             CollectLocalsAndLabels(
                 body,
                 function,
@@ -3054,6 +3164,7 @@ internal sealed class ReflectionMetadataEmitter
                 scopeFrameSlots,
                 selectStatementSlots,
                 goEnclosingScopes,
+                constValues: constValues,
                 asyncIteratorEmitCtx: aiEmitCtx);
             emitter.EmitBlock(body);
 
@@ -3066,6 +3177,7 @@ internal sealed class ReflectionMetadataEmitter
             bodyOffset = this.methodBodyStream.AddMethodBody(il, localVariablesSignature: localsSignature);
             capturedSequencePoints = emitter.SequencePoints;
             capturedLocals = CollectLocalInfo(locals);
+            capturedConstants = CollectLocalConstantInfo(constValues);
             capturedCodeSize = il.Offset;
             capturedLocalsSignature = localsSignature;
             } // end else (non-async path)
@@ -3193,7 +3305,7 @@ internal sealed class ReflectionMetadataEmitter
         // async-kickoff path (the kickoff stub is fully synthesised — visible
         // PDB rows for the user's async body land via EmitStateMachineMoveNext
         // below).
-        this.pdb?.RecordMethod(handle, capturedSequencePoints, capturedLocals, capturedCodeSize, capturedLocalsSignature);
+        this.pdb?.RecordMethod(handle, capturedSequencePoints, capturedLocals, capturedConstants, capturedCodeSize, capturedLocalsSignature);
 
         // Phase 3 of #141: attach user annotations (method target) to the
         // MethodDef. Issue #170: per-parameter annotations attach to each
@@ -3407,7 +3519,8 @@ internal sealed class ReflectionMetadataEmitter
                         {
                             foreach (var inner in armBlock.Statements)
                             {
-                                if (inner is BoundVariableDeclaration decl && !locals.ContainsKey(decl.Variable))
+                                // Issue #216: const decls have no IL slot.
+                                if (inner is BoundVariableDeclaration decl && decl.ConstantValue == null && !locals.ContainsKey(decl.Variable))
                                 {
                                     locals[decl.Variable] = localTypes.Count;
                                     localTypes.Add(decl.Variable.Type);
@@ -3458,7 +3571,8 @@ internal sealed class ReflectionMetadataEmitter
                 WalkExpressionForSwitches(es.Expression, locals, localTypes, patternSwitchSlots, typePatternScratchSlots, switchExpressionSlots, channelOpSlots, scopeFrameSlots, selectStatementSlots, goEnclosingScopes, currentScope);
                 break;
             case BoundVariableDeclaration vd:
-                if (!locals.ContainsKey(vd.Variable))
+                // Issue #216: compile-time const bindings are inlined — no IL slot.
+                if (vd.ConstantValue == null && !locals.ContainsKey(vd.Variable))
                 {
                     locals[vd.Variable] = localTypes.Count;
                     localTypes.Add(vd.Variable.Type);
@@ -4949,6 +5063,13 @@ internal sealed class ReflectionMetadataEmitter
                         // FieldDef stores into <Program>'s static field via
                         // stsfld; do not also allocate a local slot for it.
                         if (decl.Variable is GlobalVariableSymbol gv && this.globalFieldDefs.ContainsKey(gv))
+                        {
+                            break;
+                        }
+
+                        // Issue #216: compile-time const bindings are inlined at
+                        // every read site — no IL slot is needed.
+                        if (decl.ConstantValue != null)
                         {
                             break;
                         }
@@ -6530,7 +6651,7 @@ internal sealed class ReflectionMetadataEmitter
             this.declared.Add(node.Variable);
             return initializer == node.Initializer
                 ? node
-                : new BoundVariableDeclaration(null, node.Variable, initializer);
+                : new BoundVariableDeclaration(null, node.Variable, initializer, node.ConstantValue);
         }
 
         private void CaptureIfFree(VariableSymbol variable)
@@ -6643,6 +6764,7 @@ internal sealed class ReflectionMetadataEmitter
         private readonly Lowering.Async.AsyncStateMachineFieldMap asyncFieldMap;
         private readonly Lowering.Async.AsyncStateMachinePlan asyncPlan;
         private readonly AsyncIteratorEmitContext asyncIteratorEmitCtx;
+        private readonly Dictionary<VariableSymbol, object> constValues;
 
         // Stack of currently-active protected regions; each entry holds the set of
         // bound labels defined lexically within that region (including nested
@@ -6678,7 +6800,8 @@ internal sealed class ReflectionMetadataEmitter
             ParameterSymbol structThisParameter = null,
             Lowering.Async.AsyncStateMachineFieldMap asyncFieldMap = null,
             Lowering.Async.AsyncStateMachinePlan asyncPlan = null,
-            AsyncIteratorEmitContext asyncIteratorEmitCtx = null)
+            AsyncIteratorEmitContext asyncIteratorEmitCtx = null,
+            Dictionary<VariableSymbol, object> constValues = null)
         {
             this.outer = outer;
             this.il = il;
@@ -6700,6 +6823,7 @@ internal sealed class ReflectionMetadataEmitter
             this.asyncFieldMap = asyncFieldMap;
             this.asyncPlan = asyncPlan;
             this.asyncIteratorEmitCtx = asyncIteratorEmitCtx;
+            this.constValues = constValues;
         }
 
         public IReadOnlyList<SequencePoint> SequencePoints => this.sequencePoints;
@@ -6747,6 +6871,11 @@ internal sealed class ReflectionMetadataEmitter
                     this.il.OpCode(ILOpCode.Ret);
                     break;
                 case BoundVariableDeclaration decl:
+                    if (decl.ConstantValue != null)
+                    {
+                        break; // value inlined at read sites; initializer is a side-effect-free literal
+                    }
+
                     this.EmitExpression(decl.Initializer);
                     this.EmitStoreVariable(decl.Variable);
                     break;
@@ -7721,6 +7850,13 @@ internal sealed class ReflectionMetadataEmitter
 
         private void EmitLoadVariable(VariableSymbol variable)
         {
+            // Issue #216: const bindings have no IL slot — inline the literal value.
+            if (this.constValues != null && this.constValues.TryGetValue(variable, out var cv))
+            {
+                this.EmitLiteral(new BoundLiteralExpression(null, cv, variable.Type));
+                return;
+            }
+
             if (variable is ParameterSymbol ps && this.parameters.TryGetValue(ps, out var argIndex))
             {
                 this.il.LoadArgument(argIndex);

--- a/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
@@ -340,6 +340,179 @@ func main() {
     }
 }
 
+/// <summary>
+/// Phase 6 (issue #216) acceptance tests for <c>LocalConstant</c> PDB rows.
+/// A <c>const</c>-declared binding with a literal initializer must produce a
+/// <c>LocalConstant</c> row in the Portable PDB and must NOT occupy an IL slot.
+/// </summary>
+public class PortablePdbLocalConstantTests
+{
+    private const string ConstFloatProgram = @"package main
+
+func main() {
+    const PI = 3.14
+    let x = PI + 1.0
+}
+";
+
+    private const string MultipleConstsProgram = @"package main
+
+func main() {
+    const A = 1
+    const B = true
+    const C = ""hello""
+    let x = A
+}
+";
+
+    [Fact]
+    public void Const_Float_Produces_LocalConstant_Row()
+    {
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(ConstFloatProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var reader = provider.GetMetadataReader();
+
+        Assert.True(reader.LocalConstants.Count >= 1, $"expected ≥1 LocalConstant row, got {reader.LocalConstants.Count}");
+
+        // Find the PI constant row.
+        string piName = null;
+        byte[] piBlob = null;
+        foreach (var handle in reader.LocalConstants)
+        {
+            var lc = reader.GetLocalConstant(handle);
+            var name = reader.GetString(lc.Name);
+            if (name == "PI")
+            {
+                piName = name;
+                piBlob = reader.GetBlobBytes(lc.Signature);
+                break;
+            }
+        }
+
+        Assert.NotNull(piName);
+        Assert.NotNull(piBlob);
+
+        // Blob[0] must be ELEMENT_TYPE_R8 (0x0D), followed by 8 bytes of the value.
+        Assert.True(piBlob.Length >= 9, $"expected ≥9 blob bytes for R8 constant, got {piBlob.Length}");
+        Assert.Equal(0x0D, piBlob[0]);
+        var encodedValue = BitConverter.ToDouble(piBlob, 1);
+        Assert.Equal(3.14, encodedValue, precision: 10);
+    }
+
+    [Fact]
+    public void Const_Does_Not_Allocate_IL_Slot()
+    {
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(ConstFloatProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        pdbStream.Position = 0;
+        using var pdbProvider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var pdbReader = pdbProvider.GetMetadataReader();
+
+        // PI must not appear in LocalVariables (it has no IL slot).
+        foreach (var handle in pdbReader.LocalVariables)
+        {
+            var lv = pdbReader.GetLocalVariable(handle);
+            Assert.NotEqual("PI", pdbReader.GetString(lv.Name));
+        }
+    }
+
+    [Fact]
+    public void LocalScope_ConstantList_Anchors_Constant_Range()
+    {
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(ConstFloatProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var reader = provider.GetMetadataReader();
+
+        // There must be a LocalScope whose constantList points at a valid constant row.
+        bool found = false;
+        foreach (var handle in reader.LocalScopes)
+        {
+            var scope = reader.GetLocalScope(handle);
+            var constantHandle = scope.GetLocalConstants();
+            if (!constantHandle.GetEnumerator().MoveNext())
+            {
+                continue;
+            }
+
+            // Scope has at least one constant — verify the PI row is reachable.
+            foreach (var ch in scope.GetLocalConstants())
+            {
+                var lc = reader.GetLocalConstant(ch);
+                var name = reader.GetString(lc.Name);
+                if (name == "PI")
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (found)
+            {
+                break;
+            }
+        }
+
+        Assert.True(found, "expected a LocalScope whose constantList contains the PI LocalConstant row");
+    }
+
+    [Fact]
+    public void Multiple_Const_Types_All_Produce_Rows()
+    {
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(MultipleConstsProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var reader = provider.GetMetadataReader();
+
+        var names = new System.Collections.Generic.HashSet<string>();
+        foreach (var handle in reader.LocalConstants)
+        {
+            var lc = reader.GetLocalConstant(handle);
+            names.Add(reader.GetString(lc.Name));
+        }
+
+        Assert.Contains("A", names);
+        Assert.Contains("B", names);
+        Assert.Contains("C", names);
+    }
+}
+
 internal static class PortablePdbEmitterTestHelpers
 {
     // Mirror of PortablePdbEmitter.GSharpLanguageGuid for cross-assembly assertion.


### PR DESCRIPTION
## Summary

Implements [issue #216](https://github.com/DavidObando/gsharp/issues/216): emit `LocalConstant` rows in the Portable PDB for compile-time `const` bindings with literal initializers.

A `const PI = 3.14` declaration now:
1. Produces a `LocalConstant` PDB row with ELEMENT_TYPE_R8 encoding and the correct value
2. Does **not** allocate an IL slot (the value is inlined at read sites)
3. Has its `LocalScope.constantList` correctly anchored

## Changes

### Binding layer
- `BoundVariableDeclaration`: new optional `ConstantValue` property set when `const` keyword + literal initializer
- `Binder.BindVariableDeclaration`: extracts literal value and passes it to `BoundVariableDeclaration`
- `BoundTreeRewriter`: propagates `ConstantValue` through rewrites

### Emit layer
- `ReflectionMetadataEmitter`: pre-scans body for const values; skips IL slot allocation; inlines values at load sites; threads constants to `RecordMethod`
- `PortablePdbEmitter`: new `LocalConstantInfo` struct; `RecordMethod` accepts constants; `Serialize` emits `LocalConstant` rows with correct `constantList` anchoring via running `nextConstantRid` counter; `EncodeLocalConstantSignature` encodes all primitive CLR types + string per Portable PDB spec §II.23.2

### Tests
4 new acceptance tests in `PortablePdbLocalConstantTests`:
- R8 constant row for `const PI = 3.14`
- No IL slot allocated for const binding
- `LocalScope.constantList` anchors the row correctly
- Multiple const types (int, bool, string) all produce rows

## Test results
All 1,439 tests pass (no regressions).