### PR TITLE
Populate ImportScope chains from per-file import statements (#217)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -429,7 +429,10 @@ public sealed class Binder
             .Where(g => !g.Name.StartsWith("<>"))
             .ToImmutableArray();
 
-        return new BoundProgram(globalScope.Package, globalScope.Packages, diagnostics.ToImmutable(), functionBodies.ToImmutable(), globalScope.EntryPoint, statement, globalScope.Structs, globalScope.Interfaces, globalScope.Enums, globals);
+        return new BoundProgram(globalScope.Package, globalScope.Packages, diagnostics.ToImmutable(), functionBodies.ToImmutable(), globalScope.EntryPoint, statement, globalScope.Structs, globalScope.Interfaces, globalScope.Enums, globals)
+        {
+            Imports = globalScope.Imports,
+        };
     }
 
     private static BoundScope CreateParentScope(BoundGlobalScope previous, ReferenceResolver references, ImmutableHashSet<string> preprocessorSymbols)

--- a/src/Core/CodeAnalysis/Binding/BoundProgram.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundProgram.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -210,4 +211,13 @@ public sealed class BoundProgram
     /// observable from other assemblies.
     /// </summary>
     public ImmutableArray<GlobalVariableSymbol> Globals { get; }
+
+    /// <summary>
+    /// Gets the explicit (user-written) import symbols declared across all
+    /// syntax trees. Implicit compiler-synthesized imports (e.g. the implicit
+    /// <c>import System</c>) are excluded. Populated by
+    /// <see cref="Binding.Binder.BindProgram"/> from the bound global scope;
+    /// the PDB emitter uses this to produce per-file <c>ImportScope</c> chains.
+    /// </summary>
+    public ImmutableArray<ImportSymbol> Imports { get; internal set; } = ImmutableArray<ImportSymbol>.Empty;
 }

--- a/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
@@ -15,6 +15,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Security.Cryptography;
 using System.Text;
+using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Emit;
@@ -56,10 +57,27 @@ internal sealed class PortablePdbEmitter
     private readonly Dictionary<SyntaxTree, DocumentHandle> documentsByTree = new Dictionary<SyntaxTree, DocumentHandle>();
     private readonly Dictionary<int, RecordedMethod> recordedMethods = new Dictionary<int, RecordedMethod>();
     private readonly DebugInformationOptions options;
+    private IReadOnlyDictionary<SyntaxTree, ImmutableArray<ImportSymbol>> importsPerTree;
 
     public PortablePdbEmitter(DebugInformationOptions options)
     {
         this.options = options ?? new DebugInformationOptions();
+    }
+
+    /// <summary>
+    /// Supplies the per-file explicit imports that will be encoded into
+    /// <c>ImportScope</c> blobs during <see cref="Serialize"/>. Call before
+    /// <see cref="Serialize"/>; may be called at most once. Keys are the
+    /// <see cref="SyntaxTree"/> instances from which each import originates;
+    /// only trees with at least one explicit (non-implicit) import need an
+    /// entry. Implicit compiler-synthesized imports (e.g. the implicit
+    /// <c>import System</c>) should be excluded from the lists — they carry
+    /// a <see langword="null"/> <see cref="ImportSymbol.Declaration"/> and
+    /// therefore have no source-tree anchor.
+    /// </summary>
+    public void SetImportsPerTree(IReadOnlyDictionary<SyntaxTree, ImmutableArray<ImportSymbol>> imports)
+    {
+        this.importsPerTree = imports;
     }
 
     /// <summary>
@@ -126,13 +144,25 @@ internal sealed class PortablePdbEmitter
     /// <paramref name="methodHandle"/> is what later pairs it with its
     /// <c>MethodDebugInformation</c> row in <see cref="Serialize"/>.
     /// </summary>
+    /// <param name="methodHandle">The MethodDef handle for this method.</param>
+    /// <param name="sequencePoints">Sequence points collected during IL emit.</param>
+    /// <param name="locals">Local-variable descriptors for the method.</param>
+    /// <param name="constants">Compile-time constant descriptors for the method.</param>
+    /// <param name="ilCodeSize">IL body size in bytes (used as <c>LocalScope.Length</c>).</param>
+    /// <param name="localSignatureToken">The <c>StandaloneSignature</c> token for the locals blob.</param>
+    /// <param name="syntaxTree">
+    /// The <see cref="SyntaxTree"/> that declared this method, or <see langword="null"/>
+    /// for fully synthesized methods (e.g. async kickoff stubs). The tree is used to
+    /// select the per-file <c>ImportScope</c> when writing <c>LocalScope</c> rows.
+    /// </param>
     public void RecordMethod(
         MethodDefinitionHandle methodHandle,
         IReadOnlyList<SequencePoint> sequencePoints,
         IReadOnlyList<LocalInfo> locals,
         IReadOnlyList<LocalConstantInfo> constants,
         int ilCodeSize,
-        StandaloneSignatureHandle localSignatureToken)
+        StandaloneSignatureHandle localSignatureToken,
+        SyntaxTree syntaxTree = null)
     {
         if (methodHandle.IsNil)
         {
@@ -168,7 +198,8 @@ internal sealed class PortablePdbEmitter
             locals ?? System.Array.Empty<LocalInfo>(),
             constants ?? System.Array.Empty<LocalConstantInfo>(),
             ilCodeSize,
-            localSignatureToken);
+            localSignatureToken,
+            syntaxTree);
     }
 
     /// <summary>
@@ -205,13 +236,38 @@ internal sealed class PortablePdbEmitter
             }
         }
 
-        // Step 2 — Phase 5: root ImportScope (currently always empty; per-file
-        // import information lands once the binder exposes it on the symbol
-        // model). Every LocalScope must reference an ImportScope, so we always
-        // need at least the root row.
+        // Step 2 — Phase 5+: root ImportScope. Every LocalScope must reference
+        // an ImportScope; the root (with no parent and an empty imports blob) is
+        // the fallback for methods with no source-tree anchor. Per-file scopes
+        // are parented here and carry the explicit namespace imports from each
+        // syntax tree (issue #217).
         var rootImportScope = this.pdbMetadata.AddImportScope(
             parentScope: default,
             imports: this.pdbMetadata.GetOrAddBlob(EmptyBlob));
+
+        // Build per-tree ImportScope rows from the explicit imports provided by
+        // SetImportsPerTree. Each tree whose imports list is non-empty gets its
+        // own row parented at rootImportScope; trees without explicit imports
+        // (or not passed at all) fall back to rootImportScope.
+        var importScopeByTree = new Dictionary<SyntaxTree, ImportScopeHandle>();
+        if (this.importsPerTree != null)
+        {
+            foreach (var kv in this.importsPerTree)
+            {
+                var tree = kv.Key;
+                var imports = kv.Value;
+                if (tree is null || imports.IsDefaultOrEmpty)
+                {
+                    continue;
+                }
+
+                var importsBlob = BuildImportsBlob(imports);
+                var treeScope = this.pdbMetadata.AddImportScope(
+                    parentScope: rootImportScope,
+                    imports: importsBlob);
+                importScopeByTree[tree] = treeScope;
+            }
+        }
 
         // Step 3 — Phase 5+6: LocalVariable + LocalConstant + LocalScope rows.
         // The reader walks LocalScope sorted by method, then by startOffset.
@@ -269,9 +325,17 @@ internal sealed class PortablePdbEmitter
                 }
             }
 
+            // Use the per-tree ImportScope when one was built for this method's
+            // source file; fall back to the root scope for synthesized methods.
+            var importScope = rootImportScope;
+            if (rec.SyntaxTree != null && importScopeByTree.TryGetValue(rec.SyntaxTree, out var treeImportScope))
+            {
+                importScope = treeImportScope;
+            }
+
             this.pdbMetadata.AddLocalScope(
                 method: MetadataTokens.MethodDefinitionHandle(rid),
-                importScope: rootImportScope,
+                importScope: importScope,
                 variableList: firstLocal,
                 constantList: MetadataTokens.LocalConstantHandle(firstConstantRid),
                 startOffset: 0,
@@ -324,6 +388,52 @@ internal sealed class PortablePdbEmitter
     }
 
     private static readonly byte[] EmptyBlob = System.Array.Empty<byte>();
+
+    /// <summary>
+    /// Encodes an imports blob for an <c>ImportScope</c> row per the Portable PDB
+    /// spec § "ImportScope". Each import becomes one record in the blob:
+    /// <list type="bullet">
+    ///   <item>Non-alias imports → kind 1 (<c>ImportNamespace</c>): a compressed
+    ///   blob-heap offset of the UTF-8 namespace string.</item>
+    ///   <item>Alias imports → kind 7 (<c>AliasNamespace</c>): compressed blob-heap
+    ///   offset of the alias, then the namespace.</item>
+    /// </list>
+    /// Implicit (compiler-synthesized) imports are silently skipped because they
+    /// have no user-visible declaration.
+    /// </summary>
+    private BlobHandle BuildImportsBlob(ImmutableArray<ImportSymbol> imports)
+    {
+        var blob = new BlobBuilder();
+        foreach (var import in imports)
+        {
+            if (import.IsImplicit)
+            {
+                continue;
+            }
+
+            var nsBytes = Encoding.UTF8.GetBytes(import.Target);
+            var nsHandle = this.pdbMetadata.GetOrAddBlob(nsBytes);
+            var nsOffset = MetadataTokens.GetHeapOffset(nsHandle);
+
+            if (import.IsAlias)
+            {
+                // Kind 7 = AliasNamespace
+                blob.WriteCompressedInteger(7);
+                var aliasBytes = Encoding.UTF8.GetBytes(import.Name);
+                var aliasHandle = this.pdbMetadata.GetOrAddBlob(aliasBytes);
+                blob.WriteCompressedInteger(MetadataTokens.GetHeapOffset(aliasHandle));
+                blob.WriteCompressedInteger(nsOffset);
+            }
+            else
+            {
+                // Kind 1 = ImportNamespace
+                blob.WriteCompressedInteger(1);
+                blob.WriteCompressedInteger(nsOffset);
+            }
+        }
+
+        return this.pdbMetadata.GetOrAddBlob(blob);
+    }
 
     /// <summary>
     /// Writes a single <c>CompilationOptions</c> key/value pair using the
@@ -510,13 +620,15 @@ internal sealed class PortablePdbEmitter
             IReadOnlyList<LocalInfo> locals,
             IReadOnlyList<LocalConstantInfo> constants,
             int ilCodeSize,
-            StandaloneSignatureHandle localSignatureToken)
+            StandaloneSignatureHandle localSignatureToken,
+            SyntaxTree syntaxTree)
         {
             this.Points = points;
             this.Locals = locals;
             this.Constants = constants;
             this.IlCodeSize = ilCodeSize;
             this.LocalSignatureToken = localSignatureToken;
+            this.SyntaxTree = syntaxTree;
         }
 
         public IReadOnlyList<SequencePoint> Points { get; }
@@ -528,6 +640,14 @@ internal sealed class PortablePdbEmitter
         public int IlCodeSize { get; }
 
         public StandaloneSignatureHandle LocalSignatureToken { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Syntax.SyntaxTree"/> that contains this method's
+        /// declaration, or <see langword="null"/> for synthesized methods.
+        /// Used by <see cref="Serialize"/> to pick the per-file
+        /// <c>ImportScope</c> for each <c>LocalScope</c> row.
+        /// </summary>
+        public SyntaxTree SyntaxTree { get; }
     }
 }
 

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -277,6 +277,29 @@ internal sealed class ReflectionMetadataEmitter
         if (needsPdb)
         {
             this.pdb = new PortablePdbEmitter(this.debugInformation);
+
+            // #217: Wire per-file import information so the PDB emitter can
+            // produce per-tree ImportScope rows. Group only the explicit
+            // (user-written) imports — implicit ones have a null Declaration
+            // and therefore no syntax-tree anchor.
+            var importsGrouped = new Dictionary<SyntaxTree, ImmutableArray<ImportSymbol>>();
+            foreach (var import in this.program.Imports)
+            {
+                var tree = import.Declaration?.SyntaxTree;
+                if (tree is null)
+                {
+                    continue;
+                }
+
+                if (!importsGrouped.TryGetValue(tree, out var list))
+                {
+                    list = ImmutableArray<ImportSymbol>.Empty;
+                }
+
+                importsGrouped[tree] = list.Add(import);
+            }
+
+            this.pdb.SetImportsPerTree(importsGrouped);
         }
 
         // 1. Seed Object reference. Resolve from the supplied references so the type-ref
@@ -2666,7 +2689,7 @@ internal sealed class ReflectionMetadataEmitter
         // method post-lowering; sequence points and locals captured here surface
         // in debugger stack traces, locals window, and `step` commands across
         // `await` points.
-        this.pdb?.RecordMethod(moveNextHandle, capturedSequencePoints, capturedLocals, capturedConstants, capturedCodeSize, capturedLocalsSignature);
+        this.pdb?.RecordMethod(moveNextHandle, capturedSequencePoints, capturedLocals, capturedConstants, capturedCodeSize, capturedLocalsSignature, plan.KickoffMethod?.Declaration?.SyntaxTree);
     }
 
     /// <summary>
@@ -3305,7 +3328,7 @@ internal sealed class ReflectionMetadataEmitter
         // async-kickoff path (the kickoff stub is fully synthesised — visible
         // PDB rows for the user's async body land via EmitStateMachineMoveNext
         // below).
-        this.pdb?.RecordMethod(handle, capturedSequencePoints, capturedLocals, capturedConstants, capturedCodeSize, capturedLocalsSignature);
+        this.pdb?.RecordMethod(handle, capturedSequencePoints, capturedLocals, capturedConstants, capturedCodeSize, capturedLocalsSignature, function.Declaration?.SyntaxTree);
 
         // Phase 3 of #141: attach user annotations (method target) to the
         // MethodDef. Issue #170: per-parameter annotations attach to each

--- a/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
@@ -881,3 +881,199 @@ func main() {
         return peReader.ReadDebugDirectory();
     }
 }
+
+/// <summary>
+/// Issue #217: per-file <c>ImportScope</c> chain tests. Verifies that explicit
+/// namespace imports in a GSharp source file are encoded into <c>ImportScope</c>
+/// blobs that debuggers can use to resolve unqualified type names.
+/// </summary>
+public class PortablePdbPhase217Tests
+{
+    private const string ProgramWithImports = @"package main
+
+import System.Collections.Generic
+
+func main() {
+    let x = 1
+    let y = 2
+    let z = x + y
+}
+";
+
+    private const string ProgramWithAliasImport = @"package main
+
+import gen = System.Collections.Generic
+
+func main() {
+    let x = 1
+}
+";
+
+    private const string ProgramWithNoExplicitImports = @"package main
+
+func main() {
+    let x = 1
+}
+";
+
+    [Fact]
+    public void ImportScope_Blob_Contains_Namespace_For_Explicit_Import()
+    {
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(ProgramWithImports, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var reader = provider.GetMetadataReader();
+
+        // Expect at least two ImportScope rows: the root (empty) + one per-file scope.
+        Assert.True(reader.ImportScopes.Count >= 2, $"expected ≥2 ImportScope rows, got {reader.ImportScopes.Count}");
+
+        // At least one non-root scope must decode to a namespace import for System.Collections.Generic.
+        var foundNamespace = false;
+        foreach (var handle in reader.ImportScopes)
+        {
+            var scope = reader.GetImportScope(handle);
+            foreach (var import in scope.GetImports())
+            {
+                if (import.Kind == ImportDefinitionKind.ImportNamespace)
+                {
+                    var ns = Encoding.UTF8.GetString(reader.GetBlobBytes(import.TargetNamespace));
+                    if (ns == "System.Collections.Generic")
+                    {
+                        foundNamespace = true;
+                        break;
+                    }
+                }
+            }
+
+            if (foundNamespace)
+            {
+                break;
+            }
+        }
+
+        Assert.True(foundNamespace, "expected an ImportScope row whose blob contains a namespace import for System.Collections.Generic");
+    }
+
+    [Fact]
+    public void ImportScope_Blob_Contains_Alias_And_Namespace_For_Alias_Import()
+    {
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(ProgramWithAliasImport, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var reader = provider.GetMetadataReader();
+
+        Assert.True(reader.ImportScopes.Count >= 2, $"expected ≥2 ImportScope rows, got {reader.ImportScopes.Count}");
+
+        var foundAlias = false;
+        foreach (var handle in reader.ImportScopes)
+        {
+            var scope = reader.GetImportScope(handle);
+            foreach (var import in scope.GetImports())
+            {
+                if (import.Kind == ImportDefinitionKind.AliasNamespace)
+                {
+                    var alias = Encoding.UTF8.GetString(reader.GetBlobBytes((BlobHandle)import.Alias));
+                    var ns = Encoding.UTF8.GetString(reader.GetBlobBytes(import.TargetNamespace));
+                    if (alias == "gen" && ns == "System.Collections.Generic")
+                    {
+                        foundAlias = true;
+                        break;
+                    }
+                }
+            }
+
+            if (foundAlias)
+            {
+                break;
+            }
+        }
+
+        Assert.True(foundAlias, "expected an ImportScope row whose blob contains AliasNamespace(gen → System.Collections.Generic)");
+    }
+
+    [Fact]
+    public void Every_LocalScope_References_The_Per_Tree_ImportScope()
+    {
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(ProgramWithImports, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var reader = provider.GetMetadataReader();
+
+        // Find the per-file scope (a scope whose parent is not nil).
+        ImportScopeHandle perFileScope = default;
+        foreach (var handle in reader.ImportScopes)
+        {
+            var scope = reader.GetImportScope(handle);
+            if (!scope.Parent.IsNil)
+            {
+                perFileScope = handle;
+                break;
+            }
+        }
+
+        Assert.False(perFileScope.IsNil, "expected at least one per-file ImportScope (with a non-nil parent)");
+
+        // Every LocalScope that references an ImportScope should reference
+        // the per-file scope, not the root.
+        foreach (var lsh in reader.LocalScopes)
+        {
+            var ls = reader.GetLocalScope(lsh);
+            Assert.False(ls.ImportScope.IsNil, "every LocalScope must reference an ImportScope");
+            Assert.Equal(perFileScope, ls.ImportScope);
+        }
+    }
+
+    [Fact]
+    public void Program_With_No_Explicit_Imports_Still_Produces_Root_ImportScope_Only()
+    {
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(ProgramWithNoExplicitImports, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var reader = provider.GetMetadataReader();
+
+        // Without explicit imports there is only the single root scope.
+        Assert.Equal(1, (int)reader.ImportScopes.Count);
+
+        foreach (var lsh in reader.LocalScopes)
+        {
+            var ls = reader.GetLocalScope(lsh);
+            Assert.False(ls.ImportScope.IsNil, "every LocalScope must reference an ImportScope");
+        }
+    }
+}


### PR DESCRIPTION
Closes #217.

## Summary

Wires per-file explicit imports into Portable PDB `ImportScope` rows so debuggers can resolve unqualified type names according to each source file's actual imports.

## Changes

### Symbol model (`BoundProgram`)
- Added `Imports` property (`ImmutableArray<ImportSymbol>`, `internal set`) populated by `Binder.BindProgram` from the global scope. Gives the emitter access to explicit per-file imports without re-walking the scope chain.

### `PortablePdbEmitter`
- `SetImportsPerTree` — accepts a pre-grouped `SyntaxTree → imports` map before `Serialize` is called.
- `BuildImportsBlob` — encodes each explicit import as a Portable PDB import record per spec: kind 1 (`ImportNamespace`) for plain imports, kind 7 (`AliasNamespace`) for aliased imports.
- `RecordMethod` — gains an optional `syntaxTree` parameter stored on `RecordedMethod`.
- `Serialize` — always emits the root `ImportScope` (empty, no parent); builds per-tree scopes (parented at root) from the supplied map; wires each `LocalScope` to its method's tree scope, falling back to root for synthesized methods.

### `ReflectionMetadataEmitter`
- Groups `program.Imports` by `Declaration.SyntaxTree` and calls `pdb.SetImportsPerTree` right after the PDB emitter is created.
- Passes `function.Declaration?.SyntaxTree` to `RecordMethod` for regular functions.
- Passes `plan.KickoffMethod?.Declaration?.SyntaxTree` for async `MoveNext` methods.

## Tests (`PortablePdbPhase217Tests`)

| Test | What it checks |
|------|---------------|
| `ImportScope_Blob_Contains_Namespace_For_Explicit_Import` | `import System.Collections.Generic` → `ImportScope` blob decodes to `ImportNamespace` for that namespace |
| `ImportScope_Blob_Contains_Alias_And_Namespace_For_Alias_Import` | `import gen = System.Collections.Generic` → `AliasNamespace(gen, ...)` |
| `Every_LocalScope_References_The_Per_Tree_ImportScope` | Each `LocalScope` references the per-file scope (not always root) |
| `Program_With_No_Explicit_Imports_Still_Produces_Root_ImportScope_Only` | No regressions when there are no explicit imports |

All 1,420 existing tests continue to pass.