### PR TITLE
Emit CompilationMetadataReferences CustomDebugInformation (#219)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
@@ -44,6 +44,7 @@ internal sealed class PortablePdbEmitter
     private static readonly Guid EmbeddedSourceKind = new Guid("0E8A571B-6926-466E-B4AD-8AB04611F5FE");
     private static readonly Guid SourceLinkKind = new Guid("CC110556-A091-4D38-9FEC-25AB9A351A6A");
     private static readonly Guid CompilationOptionsKind = new Guid("B5FEEC05-8CD0-4A83-96DA-466284BB4BD8");
+    private static readonly Guid CompilationMetadataReferencesKind = new Guid("7E4D4708-096E-4C5C-AEDA-CB10BA6A740D");
 
     /// <summary>
     /// Stable GSharp language GUID. Once a tool keys off this value (debugger,
@@ -58,6 +59,7 @@ internal sealed class PortablePdbEmitter
     private readonly Dictionary<int, RecordedMethod> recordedMethods = new Dictionary<int, RecordedMethod>();
     private readonly DebugInformationOptions options;
     private IReadOnlyDictionary<SyntaxTree, ImmutableArray<ImportSymbol>> importsPerTree;
+    private ImmutableArray<ReferenceInfo> referenceInfos;
 
     public PortablePdbEmitter(DebugInformationOptions options)
     {
@@ -78,6 +80,16 @@ internal sealed class PortablePdbEmitter
     public void SetImportsPerTree(IReadOnlyDictionary<SyntaxTree, ImmutableArray<ImportSymbol>> imports)
     {
         this.importsPerTree = imports;
+    }
+
+    /// <summary>
+    /// Supplies the per-reference metadata that will be encoded into the
+    /// <c>CompilationMetadataReferences</c> <c>CustomDebugInformation</c> blob
+    /// during <see cref="Serialize"/>. Call before <see cref="Serialize"/>.
+    /// </summary>
+    public void SetReferenceInfos(ImmutableArray<ReferenceInfo> infos)
+    {
+        this.referenceInfos = infos;
     }
 
     /// <summary>
@@ -375,6 +387,30 @@ internal sealed class PortablePdbEmitter
             parent: moduleHandle,
             kind: this.pdbMetadata.GetOrAddGuid(CompilationOptionsKind),
             value: this.pdbMetadata.GetOrAddBlob(optionsBlob));
+
+        // CompilationMetadataReferences: one record per file-backed reference.
+        // Blob layout per spec § "CompilationMetadataReferences":
+        //   (FileName \0  Aliases \0  Flags:byte  TimeStamp:uint32  FileSize:uint32  MVID:guid)*
+        if (!this.referenceInfos.IsDefaultOrEmpty)
+        {
+            var refsBlob = new BlobBuilder();
+            foreach (var info in this.referenceInfos)
+            {
+                refsBlob.WriteUTF8(info.FileName);
+                refsBlob.WriteByte(0);
+                refsBlob.WriteUTF8(info.Aliases ?? string.Empty);
+                refsBlob.WriteByte(0);
+                refsBlob.WriteByte(info.Flags);
+                refsBlob.WriteUInt32(info.TimeStamp);
+                refsBlob.WriteUInt32(info.FileSize);
+                refsBlob.WriteBytes(info.Mvid.ToByteArray());
+            }
+
+            this.pdbMetadata.AddCustomDebugInformation(
+                parent: moduleHandle,
+                kind: this.pdbMetadata.GetOrAddGuid(CompilationMetadataReferencesKind),
+                value: this.pdbMetadata.GetOrAddBlob(refsBlob));
+        }
 
         var pdbBuilder = new PortablePdbBuilder(
             tablesAndHeaps: this.pdbMetadata,

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -300,6 +300,10 @@ internal sealed class ReflectionMetadataEmitter
             }
 
             this.pdb.SetImportsPerTree(importsGrouped);
+
+            // Wire per-reference metadata so the PDB emitter can produce the
+            // CompilationMetadataReferences CDI blob (issue #219).
+            this.pdb.SetReferenceInfos(this.references.GetReferenceInfos());
         }
 
         // 1. Seed Object reference. Resolve from the supplied references so the type-ref

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -2,12 +2,16 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+#pragma warning disable SA1201 // a struct should not follow a class — ReferenceInfo is paired with ReferenceResolver by design
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
@@ -137,6 +141,65 @@ public sealed class ReferenceResolver
         }
 
         return new ReferenceResolver(builder.ToImmutable(), mlc);
+    }
+
+    /// <summary>
+    /// Returns per-reference metadata needed to emit a
+    /// <c>CompilationMetadataReferences</c> <c>CustomDebugInformation</c> blob
+    /// per the Portable PDB spec. Each entry corresponds to one assembly in
+    /// <see cref="Assemblies"/> that can be read from disk; references with no
+    /// file on disk (in-memory, dynamic) are silently skipped.
+    /// </summary>
+    /// <returns>
+    /// An immutable array of <see cref="ReferenceInfo"/> values, one per
+    /// resolvable file-backed reference.
+    /// </returns>
+    public ImmutableArray<ReferenceInfo> GetReferenceInfos()
+    {
+        var builder = ImmutableArray.CreateBuilder<ReferenceInfo>();
+        foreach (var asm in this.assemblies)
+        {
+            var location = asm.Location;
+            if (string.IsNullOrEmpty(location) || !File.Exists(location))
+            {
+                continue;
+            }
+
+            try
+            {
+                var fileSize = (uint)new FileInfo(location).Length;
+                uint timeStamp = 0;
+                var mvid = Guid.Empty;
+
+                using (var fs = new FileStream(location, FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (var peReader = new PEReader(fs))
+                {
+                    timeStamp = (uint)peReader.PEHeaders.CoffHeader.TimeDateStamp;
+                    var mdReader = peReader.GetMetadataReader();
+                    var module = mdReader.GetModuleDefinition();
+                    mvid = mdReader.GetGuid(module.Mvid);
+                }
+
+                // Flags per Portable PDB spec § CompilationMetadataReferences:
+                //   bit 0 = EmbedInteropTypes (COM interop embed, false for normal refs)
+                //   bit 1 = MetadataImageKind.Assembly (true for .dll assemblies)
+                const byte flags = 0x02;
+
+                builder.Add(new ReferenceInfo(
+                    fileName: Path.GetFileName(location),
+                    aliases: string.Empty,
+                    flags: flags,
+                    timeStamp: timeStamp,
+                    fileSize: fileSize,
+                    mvid: mvid));
+            }
+            catch (Exception)
+            {
+                // Skip references that cannot be read (locked, corrupt, etc.).
+            }
+        }
+
+        return builder.ToImmutable();
     }
 
     /// <summary>
@@ -277,4 +340,64 @@ public sealed class ReferenceResolver
         return tpa.Split(Path.PathSeparator)
                   .Where(p => !string.IsNullOrWhiteSpace(p) && File.Exists(p));
     }
+}
+
+/// <summary>
+/// Per-reference metadata record used to emit a
+/// <c>CompilationMetadataReferences</c> <c>CustomDebugInformation</c> blob
+/// per the Portable PDB spec § "CompilationMetadataReferences".
+/// </summary>
+public readonly struct ReferenceInfo
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReferenceInfo"/> struct.
+    /// </summary>
+    /// <param name="fileName">File name (no directory) of the reference PE, e.g. <c>System.Console.dll</c>.</param>
+    /// <param name="aliases">Comma-separated extern alias list; empty string when there are no aliases.</param>
+    /// <param name="flags">Flags byte: bit 0 = EmbedInteropTypes; bit 1 = MetadataImageKind.Assembly.</param>
+    /// <param name="timeStamp">PE COFF header <c>TimeDateStamp</c> of the reference file.</param>
+    /// <param name="fileSize">Length of the reference file in bytes.</param>
+    /// <param name="mvid">Module version id read from the reference's PE metadata.</param>
+    public ReferenceInfo(string fileName, string aliases, byte flags, uint timeStamp, uint fileSize, Guid mvid)
+    {
+        FileName = fileName;
+        Aliases = aliases;
+        Flags = flags;
+        TimeStamp = timeStamp;
+        FileSize = fileSize;
+        Mvid = mvid;
+    }
+
+    /// <summary>
+    /// Gets the file name (no directory) of the reference PE, e.g.
+    /// <c>System.Console.dll</c>.
+    /// </summary>
+    public string FileName { get; }
+
+    /// <summary>
+    /// Gets the comma-separated extern alias list. Empty string for the
+    /// common case of no aliases.
+    /// </summary>
+    public string Aliases { get; }
+
+    /// <summary>
+    /// Gets the flags byte.
+    /// Bit 0 = EmbedInteropTypes; bit 1 = MetadataImageKind.Assembly.
+    /// </summary>
+    public byte Flags { get; }
+
+    /// <summary>
+    /// Gets the PE COFF header <c>TimeDateStamp</c> of the reference file.
+    /// </summary>
+    public uint TimeStamp { get; }
+
+    /// <summary>
+    /// Gets the length of the reference file in bytes.
+    /// </summary>
+    public uint FileSize { get; }
+
+    /// <summary>
+    /// Gets the module version id (MVID) read from the reference's PE metadata.
+    /// </summary>
+    public Guid Mvid { get; }
 }

--- a/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
@@ -1077,3 +1077,163 @@ func main() {
         }
     }
 }
+
+/// <summary>
+/// Issue #219: <c>CompilationMetadataReferences</c>
+/// <c>CustomDebugInformation</c> acceptance tests. Verifies that a CDI row
+/// keyed on <c>7E4D4708-096E-4C5C-AEDA-CB10BA6A740D</c> is written at the
+/// module level, and that the blob contains one record per file-backed
+/// reference with the expected layout and correct MVID.
+/// </summary>
+public class PortablePdbPhase219Tests
+{
+    public static readonly Guid CompilationMetadataReferencesKind = new Guid("7E4D4708-096E-4C5C-AEDA-CB10BA6A740D");
+
+    private const string SimpleProgram = @"package main
+
+func main() {
+    let x = 1
+}
+";
+
+    [Fact]
+    public void CompilationMetadataReferences_CDI_Is_Emitted_As_Module_Level_Row()
+    {
+        var (_, pdb) = EmitWithDefault();
+        var rows = FindCdi(pdb, CompilationMetadataReferencesKind);
+
+        Assert.NotEmpty(rows);
+        Assert.All(rows, row => Assert.Equal(HandleKind.ModuleDefinition, row.Parent.Kind));
+    }
+
+    [Fact]
+    public void CompilationMetadataReferences_Blob_Contains_SystemConsole_With_Matching_Mvid()
+    {
+        // System.Console is always loaded by the Default() resolver via
+        // WellKnownBclAssemblyNames. Skip the test on environments where the
+        // assembly has no on-disk location (e.g. single-file publish).
+        var consolePath = typeof(Console).Assembly.Location;
+        if (string.IsNullOrEmpty(consolePath) || !File.Exists(consolePath))
+        {
+            return;
+        }
+
+        var (_, pdb) = EmitWithDefault();
+        var rows = FindCdi(pdb, CompilationMetadataReferencesKind);
+        Assert.NotEmpty(rows);
+
+        var blob = pdb.GetBlobBytes(rows[0].Value);
+        var records = DecodeReferenceRecords(blob);
+
+        // The blob must contain a record for System.Console.dll.
+        var consoleRecord = records.FirstOrDefault(r =>
+            r.FileName.EndsWith("System.Console.dll", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(consoleRecord.FileName);
+
+        // Its MVID must match the MVID read directly from the PE file.
+        Guid expectedMvid;
+        using (var fs = new FileStream(consolePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+        using (var peReader = new PEReader(fs))
+        {
+            var mdReader = peReader.GetMetadataReader();
+            var module = mdReader.GetModuleDefinition();
+            expectedMvid = mdReader.GetGuid(module.Mvid);
+        }
+
+        Assert.Equal(expectedMvid, consoleRecord.Mvid);
+    }
+
+    [Fact]
+    public void CompilationMetadataReferences_Record_Flags_Mark_Assembly_Kind()
+    {
+        var consolePath = typeof(Console).Assembly.Location;
+        if (string.IsNullOrEmpty(consolePath) || !File.Exists(consolePath))
+        {
+            return;
+        }
+
+        var (_, pdb) = EmitWithDefault();
+        var rows = FindCdi(pdb, CompilationMetadataReferencesKind);
+        var blob = pdb.GetBlobBytes(rows[0].Value);
+        var records = DecodeReferenceRecords(blob);
+
+        // Every record must have bit 1 set (MetadataImageKind.Assembly = 0x02).
+        Assert.All(records, r => Assert.Equal(0x02, r.Flags & 0x02));
+    }
+
+    private static (MemoryStream Pe, MetadataReader Pdb) EmitWithDefault()
+    {
+        var peStream = new MemoryStream();
+        var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(SimpleProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        pdbStream.Position = 0;
+        var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        return (peStream, provider.GetMetadataReader());
+    }
+
+    private static System.Collections.Generic.List<(EntityHandle Parent, BlobHandle Value)> FindCdi(
+        MetadataReader reader, Guid kind)
+    {
+        var matches = new System.Collections.Generic.List<(EntityHandle, BlobHandle)>();
+        foreach (var handle in reader.CustomDebugInformation)
+        {
+            var cdi = reader.GetCustomDebugInformation(handle);
+            if (reader.GetGuid(cdi.Kind) == kind)
+            {
+                matches.Add((cdi.Parent, cdi.Value));
+            }
+        }
+
+        return matches;
+    }
+
+    private static System.Collections.Generic.List<RefRecord> DecodeReferenceRecords(byte[] blob)
+    {
+        var records = new System.Collections.Generic.List<RefRecord>();
+        var i = 0;
+        while (i < blob.Length)
+        {
+            var fileName = ReadNullTerminatedUtf8(blob, ref i);
+            var aliases = ReadNullTerminatedUtf8(blob, ref i);
+            var flags = blob[i++];
+            var timeStamp = System.BitConverter.ToUInt32(blob, i);
+            i += 4;
+            var fileSize = System.BitConverter.ToUInt32(blob, i);
+            i += 4;
+            var mvidBytes = new byte[16];
+            System.Buffer.BlockCopy(blob, i, mvidBytes, 0, 16);
+            i += 16;
+            records.Add(new RefRecord(fileName, aliases, flags, timeStamp, fileSize, new Guid(mvidBytes)));
+        }
+
+        return records;
+    }
+
+    private static string ReadNullTerminatedUtf8(byte[] blob, ref int i)
+    {
+        var start = i;
+        while (i < blob.Length && blob[i] != 0)
+        {
+            i++;
+        }
+
+        var s = System.Text.Encoding.UTF8.GetString(blob, start, i - start);
+        i++; // skip null terminator
+        return s;
+    }
+
+    private readonly record struct RefRecord(
+        string FileName,
+        string Aliases,
+        byte Flags,
+        uint TimeStamp,
+        uint FileSize,
+        Guid Mvid);
+}


### PR DESCRIPTION
Closes #219

## Summary

Implements the deferred Phase 6 item: emit a `CompilationMetadataReferences` `CustomDebugInformation` row per the [Portable PDB spec](https://github.com/dotnet/runtime/blob/main/docs/design/specs/PortablePdb-Metadata.md#compilation-metadata-references-c-and-vb-compilers).

## Changes

**`ReferenceResolver`** — new `ReferenceInfo` struct (FileName, Aliases, Flags, TimeStamp, FileSize, Mvid) and `GetReferenceInfos()` method that reads each file-backed assembly's PE COFF timestamp and MVID via `PEReader`, surfacing all six spec fields without reopening any file redundantly.

**`PortablePdbEmitter`** — adds the `CompilationMetadataReferencesKind` GUID (`7E4D4708-...`), `SetReferenceInfos()` setter, and blob emission inside `Serialize()` immediately after the existing `CompilationOptions` CDI row. The CDI row is parented on `EntityHandle.ModuleDefinition` (RID 1), matching debugger and symbol-server expectations.

**`ReflectionMetadataEmitter`** — wires `pdb.SetReferenceInfos(this.references.GetReferenceInfos())` alongside the existing `SetImportsPerTree()` call during PDB setup.

**`PortablePdbEmitTests`** — new `PortablePdbPhase219Tests` class with three acceptance tests:
- CDI row is present and parented on the module handle
- `System.Console.dll` record appears and its MVID matches the MVID read directly from the PE file
- Every record's Flags byte has bit 1 set (MetadataImageKind.Assembly)