### PR TITLE
Nullable flow: widen non-null args on [MaybeNullWhen] matching arm

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2328,10 +2328,26 @@ public sealed class Binder
         for (var i = 0; i < count; i++)
         {
             var parameter = parameters[i];
-            if (ClrNullability.TryGetMaybeNullWhen(parameter, out _))
+
+            // [MaybeNullWhen(rv)] on a non-nullable argument widens the caller's
+            // variable to its nullable counterpart on the arm where the call returns
+            // rv. The argument may be a plain variable or an address-of expression
+            // (&var) when the CLR parameter is declared `out T`.
+            if (ClrNullability.TryGetMaybeNullWhen(parameter, out var maybeNullWhenReturnValue))
             {
-                // [MaybeNullWhen] only weakens postconditions; it cannot prove
-                // an argument is non-null, so it is intentionally not narrowed.
+                var rawArg = call.Arguments[i];
+                var widenArg = rawArg is BoundAddressOfExpression addrOf ? addrOf.Operand : rawArg;
+                if (widenArg is BoundVariableExpression widenVarExpr
+                    && widenVarExpr.Variable.Type is not NullableTypeSymbol
+                    && widenVarExpr.Variable.Type != TypeSymbol.Null)
+                {
+                    var widenThen = maybeNullWhenReturnValue != negate;
+                    var widenFrame = widenThen
+                        ? (thenFrame ??= new Dictionary<VariableSymbol, TypeSymbol>())
+                        : (elseFrame ??= new Dictionary<VariableSymbol, TypeSymbol>());
+                    widenFrame[widenVarExpr.Variable] = NullableTypeSymbol.Get(widenVarExpr.Variable.Type);
+                }
+
                 continue;
             }
 
@@ -2369,39 +2385,48 @@ public sealed class Binder
                 continue;
             }
 
-            var hasMaybeNullWhen = false;
-            bool? notNullWhenReturnValue = null;
+            var notNullWhenReturnValue = (bool?)null;
+            var maybeNullWhenReturnValue = (bool?)null;
             foreach (var attribute in attributes)
             {
                 if (KnownAttributes.TryGetNotNullWhenReturnValue(attribute, out var rv))
                 {
                     notNullWhenReturnValue = rv;
                 }
-                else if (KnownAttributes.IsMaybeNullWhen(attribute))
+                else if (KnownAttributes.TryGetMaybeNullWhenReturnValue(attribute, out var mrv))
                 {
-                    hasMaybeNullWhen = true;
+                    maybeNullWhenReturnValue = mrv;
                 }
             }
 
-            // [MaybeNullWhen] alone only weakens postconditions; it cannot
-            // prove non-nullness on its own, so a parameter carrying only
-            // [MaybeNullWhen] is intentionally not narrowed (matches the
-            // imported-metadata path above).
-            if (notNullWhenReturnValue is not bool returnValue)
+            var argExpr = call.Arguments[i];
+
+            // [NotNullWhen(rv)]: narrow a nullable argument to its underlying
+            // non-nullable type on the arm where the call returns rv.
+            if (notNullWhenReturnValue is bool returnValue
+                && argExpr is BoundVariableExpression narrowVarExpr
+                && narrowVarExpr.Variable.Type is NullableTypeSymbol nullable)
             {
-                _ = hasMaybeNullWhen;
-                continue;
+                var narrowThen = returnValue != negate;
+                var frame = narrowThen
+                    ? (thenFrame ??= new Dictionary<VariableSymbol, TypeSymbol>())
+                    : (elseFrame ??= new Dictionary<VariableSymbol, TypeSymbol>());
+                frame[narrowVarExpr.Variable] = nullable.UnderlyingType;
             }
 
-            if (call.Arguments[i] is not BoundVariableExpression variableExpression
-                || variableExpression.Variable.Type is not NullableTypeSymbol nullable)
+            // [MaybeNullWhen(rv)]: widen a non-nullable argument to its nullable
+            // counterpart on the arm where the call returns rv.
+            if (maybeNullWhenReturnValue is bool widenReturnValue
+                && argExpr is BoundVariableExpression widenVarExpr
+                && widenVarExpr.Variable.Type is not NullableTypeSymbol
+                && widenVarExpr.Variable.Type != TypeSymbol.Null)
             {
-                continue;
+                var widenThen = widenReturnValue != negate;
+                var widenFrame = widenThen
+                    ? (thenFrame ??= new Dictionary<VariableSymbol, TypeSymbol>())
+                    : (elseFrame ??= new Dictionary<VariableSymbol, TypeSymbol>());
+                widenFrame[widenVarExpr.Variable] = NullableTypeSymbol.Get(widenVarExpr.Variable.Type);
             }
-
-            var narrowThen = returnValue != negate;
-            var frame = narrowThen ? (thenFrame ??= new Dictionary<VariableSymbol, TypeSymbol>()) : (elseFrame ??= new Dictionary<VariableSymbol, TypeSymbol>());
-            frame[variableExpression.Variable] = nullable.UnderlyingType;
         }
 
         return (thenFrame, elseFrame);

--- a/test/Core.Tests/CodeAnalysis/Binding/NullableFlowAnalysisTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NullableFlowAnalysisTests.cs
@@ -171,9 +171,8 @@ if IsMissing(v) {
     [Fact]
     public void If_UserDefinedMaybeNullWhen_DoesNotNarrow()
     {
-        // [MaybeNullWhen] only weakens postconditions; it cannot prove an
-        // argument is non-null, so the then-arm body should still see the
-        // parameter as nullable and accessing .Length must error.
+        // [MaybeNullWhen(false)] on a nullable string? arg cannot prove non-nullness
+        // in the then-arm, so accessing .Length must still error there.
         var result = Evaluate(@"
 import System.Diagnostics.CodeAnalysis
 
@@ -183,6 +182,92 @@ func Probe(@MaybeNullWhen(false) s string?) bool {
 
 let v string? = ""hello""
 if Probe(v) {
+    var len = v.Length
+}
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot find member Length.", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void If_UserDefinedMaybeNullWhenFalse_OnNonNullArg_WidensElseArm()
+    {
+        // [MaybeNullWhen(false)] on a non-nullable string arg must widen the
+        // caller's variable to string? in the else arm (where the call returned false).
+        var result = Evaluate(@"
+import System.Diagnostics.CodeAnalysis
+
+func TryGet(@MaybeNullWhen(false) s string) bool {
+    return s.Length > 0
+}
+
+let v = ""hello""
+if TryGet(v) {
+} else {
+    var len = v.Length
+}
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot find member Length.", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void If_UserDefinedMaybeNullWhenFalse_OnNonNullArg_DoesNotWidenThenArm()
+    {
+        // [MaybeNullWhen(false)] fires on false, so the then-arm (true return)
+        // must leave the variable as non-nullable — .Length access must succeed.
+        var result = Evaluate(@"
+import System.Diagnostics.CodeAnalysis
+
+func TryGet(@MaybeNullWhen(false) s string) bool {
+    return s.Length > 0
+}
+
+let v = ""hello""
+if TryGet(v) {
+    var len = v.Length
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_UserDefinedMaybeNullWhenTrue_OnNonNullArg_WidensThenArm()
+    {
+        // [MaybeNullWhen(true)] fires on true, so the then-arm must see the
+        // variable widened to string? — .Length access must fail.
+        var result = Evaluate(@"
+import System.Diagnostics.CodeAnalysis
+
+func IsEmpty(@MaybeNullWhen(true) s string) bool {
+    return false
+}
+
+let v = ""hello""
+if IsEmpty(v) {
+    var len = v.Length
+}
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot find member Length.", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void If_NegatedUserDefinedMaybeNullWhenFalse_OnNonNullArg_WidensThenArm()
+    {
+        // Negating the call flips the arm: !TryGet(v) is true exactly when
+        // TryGet returned false, so the then-arm now sees the [MaybeNullWhen(false)]
+        // widening and .Length must fail.
+        var result = Evaluate(@"
+import System.Diagnostics.CodeAnalysis
+
+func TryGet(@MaybeNullWhen(false) s string) bool {
+    return s.Length > 0
+}
+
+let v = ""hello""
+if !TryGet(v) {
     var len = v.Length
 }
 ");


### PR DESCRIPTION
Closes #207.

## What changed

### `ClassifyImportedBoolCallNarrowing`

Previously the `[MaybeNullWhen]` branch extracted nothing and immediately `continue`d. It now:

1. Reads `returnValue` from `ClrNullability.TryGetMaybeNullWhen`.
2. Unwraps `BoundAddressOfExpression` so `out T` arguments (`&var` syntax) are handled alongside plain variable arguments.
3. Inserts the variable into the appropriate arm frame with type `NullableTypeSymbol.Get(variable.Type)` when the caller's variable is currently non-nullable.

### `ClassifyUserBoolCallNarrowing`

The dead `hasMaybeNullWhen` sentinel is removed and replaced with a proper `TryGetMaybeNullWhenReturnValue` call. The `[NotNullWhen]` and `[MaybeNullWhen]` paths are now two separate, non-exclusive `if`-blocks so a parameter carrying both attributes is handled correctly.

## Tests

Four new facts added to `NullableFlowAnalysisTests`:

| Test | What it verifies |
|------|-----------------|
| `If_UserDefinedMaybeNullWhenFalse_OnNonNullArg_WidensElseArm` | `.Length` on the widened variable in the else arm raises a diagnostic |
| `If_UserDefinedMaybeNullWhenFalse_OnNonNullArg_DoesNotWidenThenArm` | `.Length` in the then arm (where the attribute does not fire) succeeds |
| `If_UserDefinedMaybeNullWhenTrue_OnNonNullArg_WidensThenArm` | `[MaybeNullWhen(true)]` widens the then arm |
| `If_NegatedUserDefinedMaybeNullWhenFalse_OnNonNullArg_WidensThenArm` | Negating the call correctly flips the widened arm |

The existing `If_UserDefinedMaybeNullWhen_DoesNotNarrow` test (which verifies that `[MaybeNullWhen(false)]` on a `string?` arg does *not* widen an already-nullable variable) continues to pass unchanged.

## Out of scope

BCL instance methods such as `Dictionary<K,V>.TryGetValue` reach `BoundImportedInstanceCallExpression`, which `TryClassifyBoolCallNarrowing` does not currently inspect. Extending narrowing classification to instance-method calls is left for a follow-up issue.