### PR TITLE
Extend bool-call narrowing to BoundImportedInstanceCallExpression (#229)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2311,6 +2311,11 @@ public sealed class Binder
             return ClassifyImportedBoolCallNarrowing(importedCall, negate);
         }
 
+        if (inner is BoundImportedInstanceCallExpression importedInstanceCall && importedInstanceCall.Type == TypeSymbol.Bool)
+        {
+            return ClassifyImportedMethodBoolCallNarrowing(importedInstanceCall.Method.GetParameters(), importedInstanceCall.Arguments, negate);
+        }
+
         if (inner is BoundCallExpression userCall && userCall.Type == TypeSymbol.Bool)
         {
             return ClassifyUserBoolCallNarrowing(userCall, negate);
@@ -2320,11 +2325,16 @@ public sealed class Binder
     }
 
     private static (Dictionary<VariableSymbol, TypeSymbol> Then, Dictionary<VariableSymbol, TypeSymbol> Else) ClassifyImportedBoolCallNarrowing(BoundImportedCallExpression call, bool negate)
+        => ClassifyImportedMethodBoolCallNarrowing(call.Function.Method.GetParameters(), call.Arguments, negate);
+
+    private static (Dictionary<VariableSymbol, TypeSymbol> Then, Dictionary<VariableSymbol, TypeSymbol> Else) ClassifyImportedMethodBoolCallNarrowing(
+        ParameterInfo[] parameters,
+        ImmutableArray<BoundExpression> arguments,
+        bool negate)
     {
-        var parameters = call.Function.Method.GetParameters();
         Dictionary<VariableSymbol, TypeSymbol> thenFrame = null;
         Dictionary<VariableSymbol, TypeSymbol> elseFrame = null;
-        var count = Math.Min(parameters.Length, call.Arguments.Length);
+        var count = Math.Min(parameters.Length, arguments.Length);
         for (var i = 0; i < count; i++)
         {
             var parameter = parameters[i];
@@ -2335,7 +2345,7 @@ public sealed class Binder
             // (&var) when the CLR parameter is declared `out T`.
             if (ClrNullability.TryGetMaybeNullWhen(parameter, out var maybeNullWhenReturnValue))
             {
-                var rawArg = call.Arguments[i];
+                var rawArg = arguments[i];
                 var widenArg = rawArg is BoundAddressOfExpression addrOf ? addrOf.Operand : rawArg;
                 if (widenArg is BoundVariableExpression widenVarExpr
                     && widenVarExpr.Variable.Type is not NullableTypeSymbol
@@ -2352,7 +2362,7 @@ public sealed class Binder
             }
 
             if (!ClrNullability.TryGetNotNullWhen(parameter, out var returnValue)
-                || call.Arguments[i] is not BoundVariableExpression variableExpression
+                || arguments[i] is not BoundVariableExpression variableExpression
                 || variableExpression.Variable.Type is not NullableTypeSymbol nullable)
             {
                 continue;

--- a/test/Core.Tests/CodeAnalysis/Binding/NullableFlowAnalysisTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NullableFlowAnalysisTests.cs
@@ -275,6 +275,87 @@ if !TryGet(v) {
         Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot find member Length.", System.StringComparison.Ordinal));
     }
 
+    // Issue #229 — BoundImportedInstanceCallExpression narrowing
+
+    [Fact]
+    public void If_DictionaryTryGetValue_SuccessArm_OutParamConfirmedNonNullable()
+    {
+        // dict.TryGetValue carries [NotNullWhen(true)] on the out parameter.
+        // In the then-arm (true return), `value` must be narrowed to non-nullable
+        // and .Length access must succeed.
+        var result = Evaluate(@"
+import System.Collections.Generic
+
+var dict = Dictionary[string, string]()
+dict[""key""] = ""hello""
+var value = """"
+if dict.TryGetValue(""key"", &value) {
+    var len = value.Length
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_DictionaryTryGetValue_FailureArm_OutParamWidenedToNullable()
+    {
+        // dict.TryGetValue carries [MaybeNullWhen(false)] on the out parameter.
+        // In the else-arm (false return), `value` must be widened to string?
+        // and .Length access must be rejected.
+        var result = Evaluate(@"
+import System.Collections.Generic
+
+var dict = Dictionary[string, string]()
+var value = """"
+if dict.TryGetValue(""key"", &value) {
+} else {
+    var len = value.Length
+}
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot find member Length.", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void If_NegatedDictionaryTryGetValue_SuccessArm_OutParamNotWidened()
+    {
+        // !dict.TryGetValue(...) is true when the call returned false, so the
+        // then-arm is the failure arm: value must be widened to string? and
+        // .Length access must be rejected.
+        var result = Evaluate(@"
+import System.Collections.Generic
+
+var dict = Dictionary[string, string]()
+var value = """"
+if !dict.TryGetValue(""key"", &value) {
+    var len = value.Length
+}
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot find member Length.", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void If_NegatedDictionaryTryGetValue_ElseArm_OutParamIsNonNullable()
+    {
+        // !dict.TryGetValue(...) else-arm is the success arm: value must be
+        // narrowed to non-nullable and .Length access must succeed.
+        var result = Evaluate(@"
+import System.Collections.Generic
+
+var dict = Dictionary[string, string]()
+dict[""key""] = ""hello""
+var value = """"
+if !dict.TryGetValue(""key"", &value) {
+} else {
+    var len = value.Length
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var syntaxTree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
## Summary

Closes #229.

### Problem

`TryClassifyBoolCallNarrowing` in `Binder.cs` handled two call shapes — `BoundImportedCallExpression` (imported static methods) and `BoundCallExpression` (user functions) — but silently skipped `BoundImportedInstanceCallExpression` (imported CLR instance methods such as `dict.TryGetValue`). As a result, `[NotNullWhen]`/`[MaybeNullWhen]` contracts on BCL try-pattern methods were not applied.

### Solution

- Extracted the attribute-reading logic from `ClassifyImportedBoolCallNarrowing` into a new private helper `ClassifyImportedMethodBoolCallNarrowing(ParameterInfo[], ImmutableArray\<BoundExpression\>, bool)`.
- `ClassifyImportedBoolCallNarrowing` now delegates to the helper (no behavioral change).
- Added a new arm in `TryClassifyBoolCallNarrowing` for `BoundImportedInstanceCallExpression` that calls the same helper via `call.Method.GetParameters()`.

### Tests

Four new tests in `NullableFlowAnalysisTests` using `Dictionary[string,string].TryGetValue`:
1. Success arm (`[NotNullWhen(true)]`): `.Length` on the out-param is allowed.
2. Failure arm (`[MaybeNullWhen(false)]`): `.Length` on the out-param is rejected.
3. Negated / success arm: `.Length` is rejected in the then-arm.
4. Negated / failure arm: `.Length` is allowed in the else-arm.