### PR TITLE
Track [MemberNotNull]/[MemberNotNullWhen] field postconditions in nullable flow analysis (closes #208)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -945,6 +945,18 @@ public sealed class Binder
                     isOpen: methodSyntax.IsOpen,
                     isOverride: methodSyntax.IsOverride);
                 methodSymbol.OverriddenMethod = overriddenMethod;
+
+                if (!methodSyntax.Annotations.IsDefaultOrEmpty)
+                {
+                    var methodAttributes = BindAttributes(
+                        methodSyntax.Annotations,
+                        AttributeTargetKind.Method,
+                        FunctionDeclarationAllowedTargets,
+                        "a method declaration",
+                        System.AttributeTargets.Method);
+                    methodSymbol.SetAttributes(methodAttributes);
+                }
+
                 methodsBuilder.Add(methodSymbol);
             }
 
@@ -1645,58 +1657,154 @@ public sealed class Binder
 
     private void BindBlockStatements(ImmutableArray<StatementSyntax> statementSyntaxes, int startIndex, ImmutableArray<BoundStatement>.Builder statements)
     {
-        for (var i = startIndex; i < statementSyntaxes.Length; i++)
+        // Issue #208: push a persistent narrowing frame for this statement list.
+        // After each call statement whose method carries [MemberNotNull], the
+        // named fields are added to this frame and remain narrowed for all
+        // subsequent statements in the block (until assignment invalidates them).
+        var memberNotNullFrame = new Dictionary<VariableSymbol, TypeSymbol>();
+        narrowedVariables.Add(memberNotNullFrame);
+        try
         {
-            var statementSyntax = statementSyntaxes[i];
-
-            if (statementSyntax is DeferStatementSyntax deferSyntax)
+            for (var i = startIndex; i < statementSyntaxes.Length; i++)
             {
-                var defer = BindDeferStatementInBlock(deferSyntax);
-                statements.AddRange(defer.PrefixStatements);
-                if (defer.Cleanup == null)
+                var statementSyntax = statementSyntaxes[i];
+
+                if (statementSyntax is DeferStatementSyntax deferSyntax)
                 {
-                    statements.Add(defer.ErrorStatement);
+                    var defer = BindDeferStatementInBlock(deferSyntax);
+                    statements.AddRange(defer.PrefixStatements);
+                    if (defer.Cleanup == null)
+                    {
+                        statements.Add(defer.ErrorStatement);
+                        InvalidateNarrowingsForAssignedVariables(statementSyntax);
+                        continue;
+                    }
+
                     InvalidateNarrowingsForAssignedVariables(statementSyntax);
-                    continue;
+                    var innerStatements = ImmutableArray.CreateBuilder<BoundStatement>();
+                    BindBlockStatements(statementSyntaxes, i + 1, innerStatements);
+                    statements.Add(BuildCleanupTryStatement(innerStatements.ToImmutable(), defer.Cleanup));
+                    return;
                 }
 
-                InvalidateNarrowingsForAssignedVariables(statementSyntax);
-                var innerStatements = ImmutableArray.CreateBuilder<BoundStatement>();
-                BindBlockStatements(statementSyntaxes, i + 1, innerStatements);
-                statements.Add(BuildCleanupTryStatement(innerStatements.ToImmutable(), defer.Cleanup));
-                return;
-            }
-
-            if (statementSyntax is UsingStatementSyntax usingSyntax)
-            {
-                var usingLowering = BindUsingStatementInBlock(usingSyntax);
-                if (usingLowering.Declaration != null)
+                if (statementSyntax is UsingStatementSyntax usingSyntax)
                 {
-                    statements.Add(usingLowering.Declaration);
-                }
+                    var usingLowering = BindUsingStatementInBlock(usingSyntax);
+                    if (usingLowering.Declaration != null)
+                    {
+                        statements.Add(usingLowering.Declaration);
+                    }
 
-                if (usingLowering.Cleanup == null)
-                {
-                    statements.Add(usingLowering.ErrorStatement);
+                    if (usingLowering.Cleanup == null)
+                    {
+                        statements.Add(usingLowering.ErrorStatement);
+                        InvalidateNarrowingsForAssignedVariables(statementSyntax);
+                        continue;
+                    }
+
                     InvalidateNarrowingsForAssignedVariables(statementSyntax);
-                    continue;
+                    var innerStatements = ImmutableArray.CreateBuilder<BoundStatement>();
+                    BindBlockStatements(statementSyntaxes, i + 1, innerStatements);
+                    statements.Add(BuildCleanupTryStatement(innerStatements.ToImmutable(), usingLowering.Cleanup));
+                    return;
                 }
 
+                var statement = BindStatement(statementSyntax);
+                statements.Add(statement);
+
+                // Issue #208: after binding a call statement, apply any
+                // [MemberNotNull] post-condition narrowings to the persistent frame.
+                ApplyMemberNotNullNarrowings(statement, memberNotNullFrame);
+
+                // Phase 3.C.4: mutation invalidates the narrowing. After binding
+                // a statement that writes to a narrowed variable, drop its
+                // narrowing from the current frame so subsequent reads in this
+                // block see the variable at its declared (nullable) type again.
                 InvalidateNarrowingsForAssignedVariables(statementSyntax);
-                var innerStatements = ImmutableArray.CreateBuilder<BoundStatement>();
-                BindBlockStatements(statementSyntaxes, i + 1, innerStatements);
-                statements.Add(BuildCleanupTryStatement(innerStatements.ToImmutable(), usingLowering.Cleanup));
-                return;
             }
+        }
+        finally
+        {
+            narrowedVariables.RemoveAt(narrowedVariables.Count - 1);
+        }
+    }
 
-            var statement = BindStatement(statementSyntax);
-            statements.Add(statement);
+    /// <summary>
+    /// If <paramref name="statement"/> is a call expression statement whose
+    /// called function carries <c>[MemberNotNull("_f", …)]</c>, narrows each
+    /// named field (via its <see cref="ImplicitFieldVariableSymbol"/>) to its
+    /// underlying non-nullable type in <paramref name="frame"/>.
+    /// </summary>
+    private void ApplyMemberNotNullNarrowings(BoundStatement statement, Dictionary<VariableSymbol, TypeSymbol> frame)
+    {
+        BoundExpression callExpr = null;
+        if (statement is BoundExpressionStatement exprStmt)
+        {
+            callExpr = exprStmt.Expression;
+        }
 
-            // Phase 3.C.4: mutation invalidates the narrowing. After binding
-            // a statement that writes to a narrowed variable, drop its
-            // narrowing from the current frame so subsequent reads in this
-            // block see the variable at its declared (nullable) type again.
-            InvalidateNarrowingsForAssignedVariables(statementSyntax);
+        if (callExpr == null)
+        {
+            return;
+        }
+
+        ImmutableArray<string> memberNames;
+        switch (callExpr)
+        {
+            case BoundCallExpression userCall:
+                if (!KnownAttributes.TryGetMemberNotNullMembers(userCall.Function.Attributes, out memberNames))
+                {
+                    return;
+                }
+
+                break;
+
+            case BoundImportedCallExpression importedCall:
+                if (!ClrNullability.TryGetMemberNotNullMembers(importedCall.Function.Method, out memberNames))
+                {
+                    return;
+                }
+
+                break;
+
+            case BoundImportedInstanceCallExpression instanceCall:
+                if (!ClrNullability.TryGetMemberNotNullMembers(instanceCall.Method, out memberNames))
+                {
+                    return;
+                }
+
+                break;
+
+            case BoundUserInstanceCallExpression userInstanceCall:
+                if (!KnownAttributes.TryGetMemberNotNullMembers(userInstanceCall.Method.Attributes, out memberNames))
+                {
+                    return;
+                }
+
+                break;
+
+            default:
+                return;
+        }
+
+        foreach (var name in memberNames)
+        {
+            NarrowFieldIfNullable(name, frame);
+        }
+    }
+
+    /// <summary>
+    /// Looks up <paramref name="fieldName"/> in the current scope. If it
+    /// resolves to an <see cref="ImplicitFieldVariableSymbol"/> whose declared
+    /// type is nullable, adds a narrowing entry to <paramref name="frame"/>
+    /// that maps the symbol to its underlying non-nullable type.
+    /// </summary>
+    private void NarrowFieldIfNullable(string fieldName, Dictionary<VariableSymbol, TypeSymbol> frame)
+    {
+        if (scope.TryLookupSymbol(fieldName) is ImplicitFieldVariableSymbol fieldVar
+            && fieldVar.Type is NullableTypeSymbol nullable)
+        {
+            frame[fieldVar] = nullable.UnderlyingType;
         }
     }
 
@@ -1714,12 +1822,6 @@ public sealed class Binder
             return;
         }
 
-        var top = narrowedVariables[narrowedVariables.Count - 1];
-        if (top.Count == 0)
-        {
-            return;
-        }
-
         var assignedNames = new HashSet<string>();
         CollectAssignedNames(statementSyntax, assignedNames);
         if (assignedNames.Count == 0)
@@ -1728,15 +1830,21 @@ public sealed class Binder
         }
 
         // Resolve each name through the current scope and drop any matching
-        // narrowing. We don't need to be conservative about scope shadowing:
-        // the narrowed variable lives in an outer scope, so an inner
-        // shadowing declaration with the same name will resolve to a
+        // narrowing from ALL active frames. We don't need to be conservative
+        // about scope shadowing: the narrowed variable lives in an outer scope,
+        // so an inner shadowing declaration with the same name will resolve to a
         // different symbol, and the narrowing will simply not be triggered.
+        // Issue #208: iterate ALL frames (not just the top) because the
+        // memberNotNullFrame sits above the if-condition frames; dropping from
+        // only the top would miss narrowings added by if-condition analysis.
         foreach (var name in assignedNames)
         {
-            if (scope.TryLookupSymbol(name) is VariableSymbol v && top.ContainsKey(v))
+            if (scope.TryLookupSymbol(name) is VariableSymbol v)
             {
-                top.Remove(v);
+                for (var i = narrowedVariables.Count - 1; i >= 0; i--)
+                {
+                    narrowedVariables[i].Remove(v);
+                }
             }
         }
     }
@@ -2308,20 +2416,81 @@ public sealed class Binder
 
         if (inner is BoundImportedCallExpression importedCall && importedCall.Type == TypeSymbol.Bool)
         {
-            return ClassifyImportedBoolCallNarrowing(importedCall, negate);
+            var (thenFrame, elseFrame) = ClassifyImportedBoolCallNarrowing(importedCall, negate);
+            MergeClrMemberNotNullWhenNarrowings(importedCall.Function.Method, negate, ref thenFrame, ref elseFrame);
+            return (thenFrame, elseFrame);
         }
 
         if (inner is BoundImportedInstanceCallExpression importedInstanceCall && importedInstanceCall.Type == TypeSymbol.Bool)
         {
-            return ClassifyImportedMethodBoolCallNarrowing(importedInstanceCall.Method.GetParameters(), importedInstanceCall.Arguments, negate);
+            var (thenFrame, elseFrame) = ClassifyImportedMethodBoolCallNarrowing(importedInstanceCall.Method.GetParameters(), importedInstanceCall.Arguments, negate);
+            MergeClrMemberNotNullWhenNarrowings(importedInstanceCall.Method, negate, ref thenFrame, ref elseFrame);
+            return (thenFrame, elseFrame);
         }
 
         if (inner is BoundCallExpression userCall && userCall.Type == TypeSymbol.Bool)
         {
-            return ClassifyUserBoolCallNarrowing(userCall, negate);
+            var (thenFrame, elseFrame) = ClassifyUserBoolCallNarrowing(userCall, negate);
+            MergeUserMemberNotNullWhenNarrowings(userCall.Function.Attributes, negate, ref thenFrame, ref elseFrame);
+            return (thenFrame, elseFrame);
+        }
+
+        if (inner is BoundUserInstanceCallExpression userInstanceCall && userInstanceCall.Type == TypeSymbol.Bool)
+        {
+            var (thenFrame, elseFrame) = (default(Dictionary<VariableSymbol, TypeSymbol>), default(Dictionary<VariableSymbol, TypeSymbol>));
+            MergeUserMemberNotNullWhenNarrowings(userInstanceCall.Method.Attributes, negate, ref thenFrame, ref elseFrame);
+            return (thenFrame, elseFrame);
         }
 
         return (null, null);
+    }
+
+    // Issue #208: merge [MemberNotNullWhen] field narrowings from a CLR-imported method.
+    private void MergeClrMemberNotNullWhenNarrowings(
+        System.Reflection.MethodInfo method,
+        bool negate,
+        ref Dictionary<VariableSymbol, TypeSymbol> thenFrame,
+        ref Dictionary<VariableSymbol, TypeSymbol> elseFrame)
+    {
+        if (!ClrNullability.TryGetMemberNotNullWhenData(method, out var returnValue, out var members))
+        {
+            return;
+        }
+
+        var narrowThen = returnValue != negate;
+        var frame = narrowThen ? (thenFrame ??= new Dictionary<VariableSymbol, TypeSymbol>()) : (elseFrame ??= new Dictionary<VariableSymbol, TypeSymbol>());
+        foreach (var name in members)
+        {
+            NarrowFieldIfNullable(name, frame);
+        }
+    }
+
+    // Issue #208: merge [MemberNotNullWhen] field narrowings from a user-declared method.
+    private void MergeUserMemberNotNullWhenNarrowings(
+        ImmutableArray<BoundAttribute> attributes,
+        bool negate,
+        ref Dictionary<VariableSymbol, TypeSymbol> thenFrame,
+        ref Dictionary<VariableSymbol, TypeSymbol> elseFrame)
+    {
+        if (attributes.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        foreach (var attr in attributes)
+        {
+            if (!KnownAttributes.TryGetMemberNotNullWhenData(attr, out var returnValue, out var members))
+            {
+                continue;
+            }
+
+            var narrowThen = returnValue != negate;
+            var frame = narrowThen ? (thenFrame ??= new Dictionary<VariableSymbol, TypeSymbol>()) : (elseFrame ??= new Dictionary<VariableSymbol, TypeSymbol>());
+            foreach (var name in members)
+            {
+                NarrowFieldIfNullable(name, frame);
+            }
+        }
     }
 
     private static (Dictionary<VariableSymbol, TypeSymbol> Then, Dictionary<VariableSymbol, TypeSymbol> Else) ClassifyImportedBoolCallNarrowing(BoundImportedCallExpression call, bool negate)
@@ -4105,11 +4274,17 @@ public sealed class Binder
                 syntax.IdentifierToken.Location,
                 implicitField.Field,
                 $"{implicitField.StructType.Name}.{implicitField.Field.Name}");
+
+            // Issue #208: apply any [MemberNotNull] post-call narrowing so that
+            // `field.Member` accesses after a [MemberNotNull] helper call are
+            // accepted without a nil-guard.
+            var narrowedFieldType = TryGetNarrowedType(implicitField);
             return new BoundFieldAccessExpression(
                 null,
                 new BoundVariableExpression(null, implicitField.Receiver),
                 implicitField.StructType,
-                implicitField.Field);
+                implicitField.Field,
+                narrowedFieldType);
         }
 
         return new BoundVariableExpression(null, variable, TryGetNarrowedType(variable));
@@ -6000,11 +6175,16 @@ public sealed class Binder
                         leftName.IdentifierToken.Location,
                         implicitField.Field,
                         $"{implicitField.StructType.Name}.{implicitField.Field.Name}");
+
+                    // Issue #208: apply any [MemberNotNull] narrowing so that
+                    // chained access like `_name.Length` after a [MemberNotNull]
+                    // call is accepted without a nil-guard.
                     receiver = new BoundFieldAccessExpression(
                         null,
                         new BoundVariableExpression(null, implicitField.Receiver),
                         implicitField.StructType,
-                        implicitField.Field);
+                        implicitField.Field,
+                        TryGetNarrowedType(implicitField));
                 }
                 else
                 {

--- a/src/Core/CodeAnalysis/Binding/BoundFieldAccessExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundFieldAccessExpression.cs
@@ -16,11 +16,30 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundFieldAccessExpression : BoundExpression
 {
     public BoundFieldAccessExpression(SyntaxNode syntax, BoundExpression receiver, StructSymbol structType, FieldSymbol field)
+        : this(syntax, receiver, structType, field, narrowedType: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundFieldAccessExpression"/>
+    /// class with a narrowed type. Issue #208: used by smart-cast flow analysis
+    /// to surface a non-nullable view of a nullable field inside a block where
+    /// a <c>[MemberNotNull]</c> call has been observed, without changing the
+    /// underlying field symbol identity (so the emitter still uses the same
+    /// field handle).
+    /// </summary>
+    /// <param name="syntax">The originating syntax, or <c>null</c> for synthesized nodes.</param>
+    /// <param name="receiver">The expression that produces the struct/class instance.</param>
+    /// <param name="structType">The declaring struct/class type.</param>
+    /// <param name="field">The field to read.</param>
+    /// <param name="narrowedType">The narrowed type to surface, or <c>null</c> to use <paramref name="field"/>'s declared type.</param>
+    public BoundFieldAccessExpression(SyntaxNode syntax, BoundExpression receiver, StructSymbol structType, FieldSymbol field, TypeSymbol narrowedType)
         : base(syntax)
     {
         Receiver = receiver;
         StructType = structType;
         Field = field;
+        NarrowedType = narrowedType;
     }
 
     public BoundExpression Receiver { get; }
@@ -29,7 +48,16 @@ public sealed class BoundFieldAccessExpression : BoundExpression
 
     public FieldSymbol Field { get; }
 
-    public override TypeSymbol Type => Field.Type;
+    /// <summary>
+    /// Gets the narrowed type for flow-analysis smart-cast, or <c>null</c> to
+    /// use the field's declared type. When non-null the binder reports this
+    /// type to callers so that member-access and type-compatibility checks see
+    /// the narrowed (non-nullable) view; the emitter always uses
+    /// <see cref="Field"/> for the actual field handle.
+    /// </summary>
+    public TypeSymbol NarrowedType { get; }
+
+    public override TypeSymbol Type => NarrowedType ?? Field.Type;
 
     public override BoundNodeKind Kind => BoundNodeKind.FieldAccessExpression;
 }

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1493,7 +1493,7 @@ public abstract class BoundTreeRewriter
     protected virtual BoundExpression RewriteFieldAccessExpression(BoundFieldAccessExpression node)
     {
         var receiver = RewriteExpression(node.Receiver);
-        return receiver == node.Receiver ? node : new BoundFieldAccessExpression(null, receiver, node.StructType, node.Field);
+        return receiver == node.Receiver ? node : new BoundFieldAccessExpression(null, receiver, node.StructType, node.Field, node.NarrowedType);
     }
 
     /// <summary>Rewrites a field assignment.</summary>

--- a/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
+++ b/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
@@ -200,6 +200,93 @@ internal static class KnownAttributes
     }
 
     /// <summary>
+    /// Collects all member names from every <c>[MemberNotNull("_f1", "_f2", …)]</c>
+    /// attribute in <paramref name="attributes"/>. Issue #208: the post-call
+    /// postcondition lists which fields are non-null after the annotated method
+    /// returns. Multiple attributes and multiple string arguments per attribute
+    /// are both supported.
+    /// </summary>
+    /// <param name="attributes">The attribute list on a function symbol.</param>
+    /// <param name="members">Receives the collected member names.</param>
+    /// <returns><c>true</c> when at least one name was collected.</returns>
+    public static bool TryGetMemberNotNullMembers(ImmutableArray<BoundAttribute> attributes, out ImmutableArray<string> members)
+    {
+        members = ImmutableArray<string>.Empty;
+        if (attributes.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        ImmutableArray<string>.Builder builder = null;
+        foreach (var attr in attributes)
+        {
+            if (!IsMemberNotNull(attr) || attr.PositionalArguments.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            foreach (var arg in attr.PositionalArguments)
+            {
+                if (arg.Value is string s && !string.IsNullOrEmpty(s))
+                {
+                    (builder ??= ImmutableArray.CreateBuilder<string>()).Add(s);
+                }
+            }
+        }
+
+        if (builder == null)
+        {
+            return false;
+        }
+
+        members = builder.ToImmutable();
+        return true;
+    }
+
+    /// <summary>
+    /// Extracts the <c>returnValue</c> boolean and field names from a single
+    /// <c>[MemberNotNullWhen(returnValue, "_f1", "_f2", …)]</c> attribute.
+    /// Issue #208: on the arm where the call returns <paramref name="returnValue"/>
+    /// the named fields are guaranteed non-null.
+    /// </summary>
+    /// <param name="attribute">A bound attribute application.</param>
+    /// <param name="returnValue">Receives the <c>returnValue</c> argument.</param>
+    /// <param name="members">Receives the member names.</param>
+    /// <returns><c>true</c> when <paramref name="attribute"/> is a valid
+    /// <c>[MemberNotNullWhen]</c> with at least one string member.</returns>
+    public static bool TryGetMemberNotNullWhenData(BoundAttribute attribute, out bool returnValue, out ImmutableArray<string> members)
+    {
+        returnValue = false;
+        members = ImmutableArray<string>.Empty;
+
+        if (!IsMemberNotNullWhen(attribute)
+            || attribute.PositionalArguments.IsDefaultOrEmpty
+            || attribute.PositionalArguments.Length < 2
+            || attribute.PositionalArguments[0].Value is not bool rv)
+        {
+            return false;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<string>();
+        for (var i = 1; i < attribute.PositionalArguments.Length; i++)
+        {
+            if (attribute.PositionalArguments[i].Value is string s && !string.IsNullOrEmpty(s))
+            {
+                builder.Add(s);
+            }
+        }
+
+        if (builder.Count == 0)
+        {
+            return false;
+        }
+
+        returnValue = rv;
+        members = builder.ToImmutable();
+        return true;
+    }
+
+    /// <summary>
     /// Returns <c>true</c> when <paramref name="clrType"/> is
     /// <see cref="System.Runtime.CompilerServices.EnumeratorCancellationAttribute"/>.
     /// Recognition is type-identity based (ADR-0047 §6 / ADR-0040): the

--- a/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 
@@ -23,6 +24,8 @@ public static class ClrNullability
     private const string NullableContextAttributeFullName = "System.Runtime.CompilerServices.NullableContextAttribute";
     private const string NotNullWhenAttributeFullName = "System.Diagnostics.CodeAnalysis.NotNullWhenAttribute";
     private const string MaybeNullWhenAttributeFullName = "System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute";
+    private const string MemberNotNullAttributeFullName = "System.Diagnostics.CodeAnalysis.MemberNotNullAttribute";
+    private const string MemberNotNullWhenAttributeFullName = "System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute";
 
     /// <summary>
     /// Returns the GSharp <see cref="TypeSymbol"/> for a method's return
@@ -59,6 +62,95 @@ public static class ClrNullability
     internal static bool TryGetMaybeNullWhen(ParameterInfo parameter, out bool returnValue)
     {
         return TryGetBoolAttributeValue(parameter, MaybeNullWhenAttributeFullName, out returnValue);
+    }
+
+    /// <summary>
+    /// Collects all member names from every <c>[MemberNotNull]</c> attribute
+    /// on <paramref name="method"/>. Issue #208: used to apply unconditional
+    /// field post-condition narrowing at call sites.
+    /// </summary>
+    /// <param name="method">The method to inspect.</param>
+    /// <param name="members">Receives the collected member names.</param>
+    /// <returns><c>true</c> when at least one name was collected.</returns>
+    internal static bool TryGetMemberNotNullMembers(MethodInfo method, out ImmutableArray<string> members)
+    {
+        members = ImmutableArray<string>.Empty;
+        var attrs = SafeGetCustomAttributesData(method);
+        if (attrs == null)
+        {
+            return false;
+        }
+
+        ImmutableArray<string>.Builder builder = null;
+        foreach (var ad in attrs)
+        {
+            if (ad.AttributeType?.FullName != MemberNotNullAttributeFullName || ad.ConstructorArguments.Count == 0)
+            {
+                continue;
+            }
+
+            foreach (var arg in ad.ConstructorArguments)
+            {
+                CollectStringOrArray(arg, ref builder);
+            }
+        }
+
+        if (builder == null)
+        {
+            return false;
+        }
+
+        members = builder.ToImmutable();
+        return true;
+    }
+
+    /// <summary>
+    /// Extracts the <c>returnValue</c> boolean and field names from a
+    /// <c>[MemberNotNullWhen]</c> attribute on <paramref name="method"/>.
+    /// Issue #208: used to apply conditional field post-condition narrowing.
+    /// Returns the first valid occurrence found.
+    /// </summary>
+    /// <param name="method">The method to inspect.</param>
+    /// <param name="returnValue">Receives the <c>returnValue</c> argument.</param>
+    /// <param name="members">Receives the member names.</param>
+    /// <returns><c>true</c> when a valid <c>[MemberNotNullWhen]</c> was found.</returns>
+    internal static bool TryGetMemberNotNullWhenData(MethodInfo method, out bool returnValue, out ImmutableArray<string> members)
+    {
+        returnValue = false;
+        members = ImmutableArray<string>.Empty;
+        var attrs = SafeGetCustomAttributesData(method);
+        if (attrs == null)
+        {
+            return false;
+        }
+
+        foreach (var ad in attrs)
+        {
+            if (ad.AttributeType?.FullName != MemberNotNullWhenAttributeFullName || ad.ConstructorArguments.Count < 2)
+            {
+                continue;
+            }
+
+            if (ad.ConstructorArguments[0].Value is not bool rv)
+            {
+                continue;
+            }
+
+            ImmutableArray<string>.Builder builder = null;
+            for (var i = 1; i < ad.ConstructorArguments.Count; i++)
+            {
+                CollectStringOrArray(ad.ConstructorArguments[i], ref builder);
+            }
+
+            if (builder != null && builder.Count > 0)
+            {
+                returnValue = rv;
+                members = builder.ToImmutable();
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static TypeSymbol ApplyReferenceNullability(TypeSymbol baseSymbol, Type clrType, ICustomAttributeProvider declaration, MemberInfo enclosingMember)
@@ -159,6 +251,27 @@ public static class ClrNullability
 
         value = false;
         return false;
+    }
+
+    // Helper: add a single string or expand a params-array argument into the builder.
+    private static void CollectStringOrArray(
+        CustomAttributeTypedArgument arg,
+        ref ImmutableArray<string>.Builder builder)
+    {
+        if (arg.Value is string s && !string.IsNullOrEmpty(s))
+        {
+            (builder ??= ImmutableArray.CreateBuilder<string>()).Add(s);
+        }
+        else if (arg.Value is System.Collections.ObjectModel.ReadOnlyCollection<CustomAttributeTypedArgument> arr)
+        {
+            foreach (var elem in arr)
+            {
+                if (elem.Value is string es && !string.IsNullOrEmpty(es))
+                {
+                    (builder ??= ImmutableArray.CreateBuilder<string>()).Add(es);
+                }
+            }
+        }
     }
 
     private static System.Collections.Generic.IList<CustomAttributeData> SafeGetCustomAttributesData(ICustomAttributeProvider provider)

--- a/test/Core.Tests/CodeAnalysis/Binding/NullableFlowAnalysisTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NullableFlowAnalysisTests.cs
@@ -356,6 +356,230 @@ if !dict.TryGetValue(""key"", &value) {
         Assert.Empty(result.Diagnostics);
     }
 
+    // Issue #208 — [MemberNotNull] / [MemberNotNullWhen] field postconditions
+
+    [Fact]
+    public void MemberNotNull_AfterHelperCall_FieldNarrowedToNonNullable()
+    {
+        // EnsureInit() carries [MemberNotNull("_name")]. After the call, bare
+        // name access _name.Length must succeed without a nil-guard.
+        var result = Evaluate(@"
+import System.Diagnostics.CodeAnalysis
+
+type Box class {
+    _name string?
+
+    func EnsureInit() {
+        _name = ""default""
+    }
+
+    @MemberNotNull(""_name"")
+    func EnsureInitAnnotated() {
+        _name = ""default""
+    }
+
+    func Run() int {
+        this.EnsureInitAnnotated()
+        return _name.Length
+    }
+}
+
+var b = Box{}
+b.Run()
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void MemberNotNull_WithoutHelperCall_FieldRemainsNullable()
+    {
+        // Without calling the [MemberNotNull] helper, _name stays nullable and
+        // .Length access must be rejected.
+        var result = Evaluate(@"
+import System.Diagnostics.CodeAnalysis
+
+type Box class {
+    _name string?
+
+    @MemberNotNull(""_name"")
+    func EnsureInit() {
+        _name = ""hello""
+    }
+
+    func Run() int {
+        return _name.Length
+    }
+}
+
+var b = Box{}
+b.Run()
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot find member Length.", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void MemberNotNull_AfterHelperCall_FieldInvalidatedBySubsequentAssignment()
+    {
+        // After the [MemberNotNull] helper call, assigning nil to _name must
+        // invalidate the narrowing so a subsequent .Length access is rejected.
+        var result = Evaluate(@"
+import System.Diagnostics.CodeAnalysis
+
+type Box class {
+    _name string?
+
+    @MemberNotNull(""_name"")
+    func EnsureInit() {
+        _name = ""hello""
+    }
+
+    func Run() int {
+        this.EnsureInit()
+        _name = nil
+        return _name.Length
+    }
+}
+
+var b = Box{}
+b.Run()
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot find member Length.", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void MemberNotNullWhen_ThenArm_FieldNarrowedOnMatchingReturn()
+    {
+        // TryGet() returns true when _name is non-null per [MemberNotNullWhen(true,"_name")].
+        // The then-arm must see _name narrowed and .Length must succeed.
+        var result = Evaluate(@"
+import System.Diagnostics.CodeAnalysis
+
+type Box class {
+    _name string?
+
+    @MemberNotNullWhen(true, ""_name"")
+    func TryGet() bool {
+        return _name != nil
+    }
+
+    func Run() int {
+        if this.TryGet() {
+            return _name.Length
+        }
+        return 0
+    }
+}
+
+var b = Box{}
+b._name = ""hello""
+b.Run()
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void MemberNotNullWhen_ElseArm_FieldRemainsNullableOnNonMatchingReturn()
+    {
+        // In the else-arm TryGet() returned false, so _name is still nullable
+        // and .Length must be rejected.
+        var result = Evaluate(@"
+import System.Diagnostics.CodeAnalysis
+
+type Box class {
+    _name string?
+
+    @MemberNotNullWhen(true, ""_name"")
+    func TryGet() bool {
+        return _name != nil
+    }
+
+    func Run() int {
+        if this.TryGet() {
+        } else {
+            return _name.Length
+        }
+        return 0
+    }
+}
+
+var b = Box{}
+b.Run()
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot find member Length.", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void MemberNotNullWhen_NegatedCall_ElseArmNarrowed()
+    {
+        // !TryGet() is true when TryGet() returned false — so the then-arm is
+        // the failure arm. The else-arm sees the true-return and _name is narrowed.
+        var result = Evaluate(@"
+import System.Diagnostics.CodeAnalysis
+
+type Box class {
+    _name string?
+
+    @MemberNotNullWhen(true, ""_name"")
+    func TryGet() bool {
+        return _name != nil
+    }
+
+    func Run() int {
+        if !this.TryGet() {
+        } else {
+            return _name.Length
+        }
+        return 0
+    }
+}
+
+var b = Box{}
+b._name = ""world""
+b.Run()
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void MemberNotNull_MultipleFields_BothNarrowed()
+    {
+        // [MemberNotNull("_a", "_b")] should narrow both fields after the call.
+        var result = Evaluate(@"
+import System.Diagnostics.CodeAnalysis
+
+type Pair class {
+    _a string?
+    _b string?
+
+    @MemberNotNull(""_a"", ""_b"")
+    func Init() {
+        _a = ""hello""
+        _b = ""world""
+    }
+
+    func Run() int {
+        this.Init()
+        return _a.Length + _b.Length
+    }
+}
+
+var p = Pair{}
+p.Run()
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(10, result.Value);
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var syntaxTree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
## Summary

Implements issue #208: calling a method annotated with `@MemberNotNull("_field")` now marks the named field as non-null in the post-state. `@MemberNotNullWhen(rv, "_field")` marks fields non-null on the matching boolean arm of an if/switch.

## Changes

### New API recognition
- `KnownAttributes.TryGetMemberNotNullMembers` / `TryGetMemberNotNullWhenData` — extract member names from user-annotated methods
- `ClrNullability.TryGetMemberNotNullMembers` / `TryGetMemberNotNullWhenData` — same for imported CLR methods

### BoundFieldAccessExpression narrowing
- Added `NarrowedType` property (parallel to `BoundVariableExpression`); `Type` returns `NarrowedType ?? Field.Type`
- Updated `BoundTreeRewriter` to preserve `NarrowedType`

### Binder changes
- **`BindBlockStatements`**: pushes a persistent `memberNotNullFrame` onto `narrowedVariables`; calls `ApplyMemberNotNullNarrowings` after each statement to narrow fields listed by `[MemberNotNull]`
- **`BindAccessorExpression`**: fixed to pass `TryGetNarrowedType(implicitField)` when building `BoundFieldAccessExpression` for bare-field receivers — this was the key bug causing `_name.Length` to fail even after the frame was populated
- **`InvalidateNarrowingsForAssignedVariables`**: now removes from *all* active frames (not just the top) so mutations correctly invalidate narrowings in both if-condition frames and `memberNotNull` frames
- **`BindStructDeclarationBody`**: binds method-level annotations so user class methods have their `Attributes` populated during body binding
- **`TryClassifyBoolCallNarrowing`**: extended to handle `BoundUserInstanceCallExpression` and apply `[MemberNotNullWhen]` narrowings

### Tests (7 new)
- `MemberNotNull_AfterHelperCall_FieldNarrowedToNonNullable` — basic narrowing works
- `MemberNotNull_WithoutHelperCall_FieldRemainsNullable` — no narrowing without the call
- `MemberNotNull_AfterHelperCall_FieldInvalidatedBySubsequentAssignment` — mutation drops narrowing
- `MemberNotNull_MultipleFields_BothNarrowed` — multi-field annotation
- `MemberNotNullWhen_ThenArm_FieldNarrowedOnMatchingReturn` — then-arm narrowing
- `MemberNotNullWhen_ElseArm_FieldRemainsNullableOnNonMatchingReturn` — else-arm stays nullable
- `MemberNotNullWhen_NegatedCall_ElseArmNarrowed` — negated condition flips arms