### PR TITLE
Surface inner-position generic type argument nullability (#209)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -3731,6 +3731,36 @@ public sealed class Binder
                 keyType = TypeSymbol.Int;
                 valueType = slice.ElementType;
                 break;
+
+            // Issue #209: NullabilityAnnotatedTypeSymbol carries inner-position nullable
+            // flags; extract element/key/value types using those flags so that
+            // `for k, v := range dict` sees the proper nullable types.
+            case NullabilityAnnotatedTypeSymbol annotated when annotated.ClrType != null:
+                if (TryGetClrDictionaryTypes(annotated.ClrType, out var aDKey, out var aDVal))
+                {
+                    iterationKind = ForRangeKind.Dictionary;
+                    keyType = annotated.GetTypeArgumentSymbolForClrType(aDKey);
+                    valueType = annotated.GetTypeArgumentSymbolForClrType(aDVal);
+                }
+                else if (TryGetClrEnumerableElementType(annotated.ClrType, out var aElemType))
+                {
+                    iterationKind = ForRangeKind.Enumerable;
+                    keyType = TypeSymbol.Int;
+                    valueType = annotated.GetTypeArgumentSymbolForClrType(aElemType);
+                }
+                else if (TryGetClrPatternEnumerableElementType(annotated.ClrType, out var aPatternElemType))
+                {
+                    iterationKind = ForRangeKind.PatternEnumerator;
+                    keyType = TypeSymbol.Int;
+                    valueType = TypeSymbol.FromClrType(aPatternElemType);
+                }
+                else
+                {
+                    Diagnostics.ReportTypeNotIndexable(syntax.Collection.Location, collection.Type);
+                    return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
+                }
+
+                break;
             case ImportedTypeSymbol imp when imp.ClrType != null:
                 if (TryGetClrDictionaryTypes(imp.ClrType, out var dKey, out var dVal))
                 {
@@ -6757,6 +6787,14 @@ public sealed class Binder
         // (e.g. `d["k"]` on Dictionary[string, int]). Pick a public
         // instance indexer (a `PropertyInfo` whose `GetIndexParameters()`
         // matches the single argument by assignability).
+        // Issue #209: when the target carries inner-position nullable flags,
+        // use them to type the element correctly (e.g., `list[0]` on `List<string?>` → `string?`).
+        if (target.Type is NullabilityAnnotatedTypeSymbol annotIdx && annotIdx.ClrType is System.Type clrAnnotIdx && TryResolveClrIndexer(clrAnnotIdx, new[] { syntax.Index }, out var idxPropAnnot, out var idxArgsAnnot))
+        {
+            var elemTypeAnnot = annotIdx.GetTypeArgumentSymbolForClrType(idxPropAnnot.PropertyType);
+            return new BoundClrIndexExpression(null, target, idxPropAnnot, idxArgsAnnot, elemTypeAnnot);
+        }
+
         if (target.Type is ImportedTypeSymbol && target.Type.ClrType is System.Type clrTarget && TryResolveClrIndexer(clrTarget, new[] { syntax.Index }, out var idxProp, out var idxArgs))
         {
             return new BoundClrIndexExpression(null, target, idxProp, idxArgs, TypeSymbol.FromClrType(idxProp.PropertyType));
@@ -6798,6 +6836,20 @@ public sealed class Binder
 
         // Phase 4 exit: CLR indexer write on an imported reference type
         // (e.g. `d["k"] = 1` on Dictionary[string, int]).
+        // Issue #209: honour inner-position nullable flags when present.
+        if (variable.Type is NullabilityAnnotatedTypeSymbol annotWr && variable.Type.ClrType is System.Type clrAnnotWr && TryResolveClrIndexer(clrAnnotWr, new[] { syntax.Index }, out var idxPropAnnotWr, out var idxArgsAnnotWr))
+        {
+            if (!idxPropAnnotWr.CanWrite)
+            {
+                Diagnostics.ReportTypeNotIndexable(syntax.TargetIdentifier.Location, variable.Type);
+                return new BoundErrorExpression(null);
+            }
+
+            var valueTypeAnnotWr = annotWr.GetTypeArgumentSymbolForClrType(idxPropAnnotWr.PropertyType);
+            var boundValueAnnotWr = BindConversion(syntax.Value, valueTypeAnnotWr);
+            return new BoundClrIndexAssignmentExpression(null, variable, idxPropAnnotWr, idxArgsAnnotWr, boundValueAnnotWr, valueTypeAnnotWr);
+        }
+
         if (variable.Type is ImportedTypeSymbol && variable.Type.ClrType is System.Type clrTarget && TryResolveClrIndexer(clrTarget, new[] { syntax.Index }, out var idxProp, out var idxArgs))
         {
             if (!idxProp.CanWrite)

--- a/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
@@ -10,13 +10,14 @@ using System.Reflection;
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
 /// <summary>
-/// Phase 3.C.5 / ADR-0001: helpers for reading C# nullable-reference-types
+/// Phase 3.C.5 / ADR-0001 / issue #209: helpers for reading C# nullable-reference-types
 /// metadata (<c>[NullableAttribute]</c> / <c>[NullableContextAttribute]</c>)
 /// from members loaded through a <see cref="MetadataLoadContext"/>.
 ///
-/// We only inspect the top-level nullability byte (index 0 of the
-/// <c>NullableAttribute</c> byte-array, or the scalar argument when present).
-/// Generic-type-argument nullability is not yet surfaced.
+/// Both top-level and inner-position (generic type argument) nullability are
+/// surfaced. Inner positions are carried via <see cref="NullabilityAnnotatedTypeSymbol"/>
+/// so that code paths such as <c>for range</c> iteration and CLR indexer access
+/// can recover the element-type nullability at bind time.
 /// </summary>
 public static class ClrNullability
 {
@@ -30,7 +31,9 @@ public static class ClrNullability
     /// <summary>
     /// Returns the GSharp <see cref="TypeSymbol"/> for a method's return
     /// type, wrapping it in <see cref="NullableTypeSymbol"/> when the
-    /// underlying CLR type is a reference type annotated as nullable.
+    /// underlying CLR type is a reference type annotated as nullable, and
+    /// in <see cref="NullabilityAnnotatedTypeSymbol"/> when the type has
+    /// generic arguments with inner-position nullability (issue #209).
     /// Value-type nullability (<c>Nullable&lt;T&gt;</c>) is handled inside
     /// <see cref="TypeSymbol.FromClrType(Type)"/>.
     /// </summary>
@@ -39,19 +42,20 @@ public static class ClrNullability
     public static TypeSymbol GetReturnTypeSymbol(MethodInfo method)
     {
         var baseSymbol = TypeSymbol.FromClrType(method.ReturnType);
-        return ApplyReferenceNullability(baseSymbol, method.ReturnType, method.ReturnParameter, method);
+        return ApplyReferenceNullabilityFull(baseSymbol, method.ReturnType, method.ReturnParameter, method);
     }
 
     /// <summary>
     /// Returns the GSharp <see cref="TypeSymbol"/> for a parameter, with
-    /// reference-type nullability applied.
+    /// reference-type nullability applied (both top-level and inner generic
+    /// argument positions — issue #209).
     /// </summary>
     /// <param name="parameter">The parameter to inspect.</param>
     /// <returns>The mapped type symbol.</returns>
     public static TypeSymbol GetParameterTypeSymbol(ParameterInfo parameter)
     {
         var baseSymbol = TypeSymbol.FromClrType(parameter.ParameterType);
-        return ApplyReferenceNullability(baseSymbol, parameter.ParameterType, parameter, parameter.Member);
+        return ApplyReferenceNullabilityFull(baseSymbol, parameter.ParameterType, parameter, parameter.Member);
     }
 
     internal static bool TryGetNotNullWhen(ParameterInfo parameter, out bool returnValue)
@@ -153,61 +157,53 @@ public static class ClrNullability
         return false;
     }
 
-    private static TypeSymbol ApplyReferenceNullability(TypeSymbol baseSymbol, Type clrType, ICustomAttributeProvider declaration, MemberInfo enclosingMember)
-    {
-        if (baseSymbol is NullableTypeSymbol)
-        {
-            return baseSymbol;
-        }
-
-        if (clrType == null || clrType.IsValueType)
-        {
-            return baseSymbol;
-        }
-
-        if (!TryGetTopLevelNullableFlag(declaration, enclosingMember, out var flag))
-        {
-            return baseSymbol;
-        }
-
-        // 2 == annotated (i.e. T?). 1 == not-annotated. 0 == oblivious.
-        return flag == 2 ? (TypeSymbol)NullableTypeSymbol.Get(baseSymbol) : baseSymbol;
-    }
-
-    private static bool TryGetTopLevelNullableFlag(ICustomAttributeProvider declaration, MemberInfo enclosingMember, out byte flag)
+    /// <summary>
+    /// Reads the full <c>[NullableAttribute]</c> byte array for a declaration,
+    /// falling back to a single-element array derived from the surrounding
+    /// <c>[NullableContextAttribute]</c> when no explicit <c>[Nullable]</c> is
+    /// present. Returns an empty array when no annotation is found at all.
+    /// </summary>
+    /// <param name="declaration">The attribute provider to inspect (parameter, return parameter, etc.).</param>
+    /// <param name="enclosingMember">The enclosing member used to walk up to <c>[NullableContext]</c>.</param>
+    /// <returns>The full byte array, or an empty array when no annotation is available.</returns>
+    internal static ImmutableArray<byte> ReadNullableFlags(ICustomAttributeProvider declaration, MemberInfo enclosingMember)
     {
         var attrs = SafeGetCustomAttributesData(declaration);
         if (attrs != null)
         {
             foreach (var ad in attrs)
             {
-                if (ad.AttributeType?.FullName != NullableAttributeFullName)
-                {
-                    continue;
-                }
-
-                if (ad.ConstructorArguments.Count != 1)
+                if (ad.AttributeType?.FullName != NullableAttributeFullName || ad.ConstructorArguments.Count != 1)
                 {
                     continue;
                 }
 
                 var arg = ad.ConstructorArguments[0];
+
+                // Single-byte scalar form: [Nullable(1)] or [Nullable(2)]
                 if (arg.Value is byte b)
                 {
-                    flag = b;
-                    return true;
+                    return ImmutableArray.Create(b);
                 }
 
-                if (arg.Value is System.Collections.ObjectModel.ReadOnlyCollection<CustomAttributeTypedArgument> arr && arr.Count > 0 && arr[0].Value is byte first)
+                // Array form: [Nullable(new byte[] { 1, 1, 2 })]
+                if (arg.Value is System.Collections.ObjectModel.ReadOnlyCollection<CustomAttributeTypedArgument> arr)
                 {
-                    flag = first;
-                    return true;
+                    var builder = ImmutableArray.CreateBuilder<byte>(arr.Count);
+                    foreach (var elem in arr)
+                    {
+                        if (elem.Value is byte eb)
+                        {
+                            builder.Add(eb);
+                        }
+                    }
+
+                    return builder.Count > 0 ? builder.ToImmutable() : ImmutableArray<byte>.Empty;
                 }
             }
         }
 
-        // Fall back to the surrounding NullableContextAttribute on the
-        // method, the declaring type, and then any enclosing types.
+        // Fall back to the surrounding NullableContextAttribute.
         for (var member = enclosingMember; member != null; member = member.DeclaringType)
         {
             var contextAttrs = SafeGetCustomAttributesData(member);
@@ -222,14 +218,119 @@ public static class ClrNullability
                     && ad.ConstructorArguments.Count == 1
                     && ad.ConstructorArguments[0].Value is byte ctxByte)
                 {
-                    flag = ctxByte;
-                    return true;
+                    return ImmutableArray.Create(ctxByte);
                 }
             }
         }
 
-        flag = 0;
-        return false;
+        return ImmutableArray<byte>.Empty;
+    }
+
+    /// <summary>
+    /// Counts the number of bytes the C# compiler emits for <paramref name="type"/>
+    /// in a <c>[NullableAttribute]</c> byte array. The count equals the number of
+    /// reference-type positions in a DFS pre-order traversal of the type tree.
+    /// Value types themselves contribute 0 bytes; their reference-type generic
+    /// arguments still contribute.
+    /// </summary>
+    /// <param name="type">The CLR type to measure.</param>
+    /// <returns>The number of nullability bytes this type occupies.</returns>
+    internal static int CountNullabilityBytes(Type type)
+    {
+        if (type == null)
+        {
+            return 0;
+        }
+
+        int count = type.IsValueType ? 0 : 1;
+
+        if (type.IsGenericType && !type.IsGenericTypeDefinition)
+        {
+            foreach (var arg in type.GetGenericArguments())
+            {
+                count += CountNullabilityBytes(arg);
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Constructs a <see cref="TypeSymbol"/> for <paramref name="clrType"/> by
+    /// reading the nullability byte at <paramref name="offset"/> within
+    /// <paramref name="flags"/>, and (for generic types with further inner bytes)
+    /// wrapping the result in a <see cref="NullabilityAnnotatedTypeSymbol"/>.
+    /// </summary>
+    /// <param name="clrType">The CLR type to map.</param>
+    /// <param name="flags">The full nullable-flags byte array.</param>
+    /// <param name="offset">The index within <paramref name="flags"/> where this type's byte lives.</param>
+    /// <returns>The appropriately-nullified <see cref="TypeSymbol"/>.</returns>
+    internal static TypeSymbol SymbolFromFlagsOffset(Type clrType, ImmutableArray<byte> flags, int offset)
+    {
+        var baseSymbol = TypeSymbol.FromClrType(clrType);
+
+        if (clrType.IsValueType)
+        {
+            // Value types carry no reference-nullability byte for themselves.
+            // But a generic value type (e.g., ValueTuple<string, …>) may still
+            // have inner reference-type arguments.
+            if (clrType.IsGenericType && !clrType.IsGenericTypeDefinition && flags.Length > offset)
+            {
+                return new NullabilityAnnotatedTypeSymbol(baseSymbol, flags.Skip(offset).ToImmutableArray());
+            }
+
+            return baseSymbol;
+        }
+
+        byte flag = offset < flags.Length ? flags[offset] : (byte)0;
+        bool isNullable = flag == 2;
+        TypeSymbol result = isNullable ? NullableTypeSymbol.Get(baseSymbol) : baseSymbol;
+
+        // Propagate inner flags when the type is a closed generic.
+        if (clrType.IsGenericType && !clrType.IsGenericTypeDefinition && flags.Length > offset + 1)
+        {
+            // Slice from `offset` so that NullabilityAnnotatedTypeSymbol.NullableFlags[0]
+            // is the byte for this type itself, matching the layout convention.
+            var slicedFlags = flags.Skip(offset).ToImmutableArray();
+            var annotationBase = isNullable ? baseSymbol : result;
+            var annotated = new NullabilityAnnotatedTypeSymbol(annotationBase, slicedFlags);
+            result = isNullable ? (TypeSymbol)NullableTypeSymbol.Get(annotated) : annotated;
+        }
+
+        return result;
+    }
+
+    private static TypeSymbol ApplyReferenceNullabilityFull(TypeSymbol baseSymbol, Type clrType, ICustomAttributeProvider declaration, MemberInfo enclosingMember)
+    {
+        if (baseSymbol is NullableTypeSymbol)
+        {
+            // Already a value-type Nullable<T> — no further annotation needed.
+            return baseSymbol;
+        }
+
+        if (clrType == null || clrType.IsValueType)
+        {
+            return baseSymbol;
+        }
+
+        var flags = ReadNullableFlags(declaration, enclosingMember);
+
+        // Determine the top-level flag (byte 0 of the array, or the context fallback).
+        byte topFlag = flags.Length > 0 ? flags[0] : (byte)0;
+
+        // Wrap top-level nullability.
+        TypeSymbol result = topFlag == 2 ? (TypeSymbol)NullableTypeSymbol.Get(baseSymbol) : baseSymbol;
+
+        // If there are inner-position bytes, wrap with NullabilityAnnotatedTypeSymbol so
+        // that callers (for-range, CLR indexers …) can recover element-type nullability.
+        if (flags.Length > 1 && clrType.IsGenericType && !clrType.IsGenericTypeDefinition)
+        {
+            var annotationBase = topFlag == 2 ? baseSymbol : result;
+            var annotated = new NullabilityAnnotatedTypeSymbol(annotationBase, flags);
+            result = topFlag == 2 ? (TypeSymbol)NullableTypeSymbol.Get(annotated) : annotated;
+        }
+
+        return result;
     }
 
     private static bool TryGetBoolAttributeValue(ParameterInfo parameter, string attributeFullName, out bool value)
@@ -253,7 +354,6 @@ public static class ClrNullability
         return false;
     }
 
-    // Helper: add a single string or expand a params-array argument into the builder.
     private static void CollectStringOrArray(
         CustomAttributeTypedArgument arg,
         ref ImmutableArray<string>.Builder builder)

--- a/src/Core/CodeAnalysis/Symbols/NullabilityAnnotatedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullabilityAnnotatedTypeSymbol.cs
@@ -1,0 +1,120 @@
+// <copyright file="NullabilityAnnotatedTypeSymbol.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// A <see cref="TypeSymbol"/> that wraps an imported CLR generic type and carries
+/// the full <c>[NullableAttribute]</c> byte array so that inner-position
+/// generic-argument nullability (issue #209) can be recovered when the type is
+/// later used as a collection element, dictionary value, etc.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <see cref="NullableFlags"/> array follows the C# compiler's DFS pre-order
+/// layout: byte 0 belongs to the outer type itself (always a reference type when
+/// this wrapper is created), and subsequent bytes belong to each generic type
+/// argument in order — recursively, for nested generics — skipping value-type
+/// positions (which carry no reference-nullability byte).
+/// </para>
+/// <para>
+/// Example — <c>Dictionary&lt;string, string?&gt;</c>:<br/>
+/// flags = { 1 (Dictionary non-null), 1 (string key non-null), 2 (string? value nullable) }.
+/// </para>
+/// </remarks>
+public sealed class NullabilityAnnotatedTypeSymbol : TypeSymbol
+{
+    internal NullabilityAnnotatedTypeSymbol(TypeSymbol baseType, ImmutableArray<byte> nullableFlags)
+        : base(baseType.Name, baseType.ClrType)
+    {
+        BaseType = baseType;
+        NullableFlags = nullableFlags;
+    }
+
+    /// <summary>Gets the underlying non-annotated type symbol.</summary>
+    public TypeSymbol BaseType { get; }
+
+    /// <summary>
+    /// Gets the full <c>[NullableAttribute]</c> byte array for this type, starting
+    /// at the outer type's own byte (index 0).
+    /// </summary>
+    public ImmutableArray<byte> NullableFlags { get; }
+
+    /// <summary>
+    /// Returns the <see cref="TypeSymbol"/> for the generic type argument at
+    /// <paramref name="argIndex"/> (0-based), with reference nullability applied
+    /// from <see cref="NullableFlags"/>.
+    /// </summary>
+    /// <param name="argIndex">0-based index into the outer CLR type's generic arguments.</param>
+    /// <returns>
+    /// The properly-nullified symbol, or <see cref="TypeSymbol.Error"/> when the
+    /// outer CLR type is not a closed generic.
+    /// </returns>
+    public TypeSymbol GetTypeArgumentSymbol(int argIndex)
+    {
+        var clr = ClrType;
+        if (clr == null || !clr.IsGenericType || clr.IsGenericTypeDefinition)
+        {
+            return TypeSymbol.Error;
+        }
+
+        var args = clr.GetGenericArguments();
+        if ((uint)argIndex >= (uint)args.Length)
+        {
+            return TypeSymbol.Error;
+        }
+
+        // Byte 0 belongs to the outer type itself (a reference type).
+        int offset = 1;
+        for (int i = 0; i < argIndex; i++)
+        {
+            offset += ClrNullability.CountNullabilityBytes(args[i]);
+        }
+
+        return ClrNullability.SymbolFromFlagsOffset(args[argIndex], NullableFlags, offset);
+    }
+
+    /// <summary>
+    /// Searches the outer type's generic arguments for one whose resolved CLR type
+    /// matches <paramref name="targetClrType"/> and returns a properly-nullified
+    /// <see cref="TypeSymbol"/> for it. Falls back to a plain
+    /// <see cref="TypeSymbol.FromClrType"/> result when no matching argument is found.
+    /// </summary>
+    /// <param name="targetClrType">The CLR element type to locate.</param>
+    /// <returns>The nullified symbol for the first matching argument.</returns>
+    public TypeSymbol GetTypeArgumentSymbolForClrType(Type targetClrType)
+    {
+        if (targetClrType == null)
+        {
+            return TypeSymbol.Error;
+        }
+
+        var clr = ClrType;
+        if (clr == null || !clr.IsGenericType || clr.IsGenericTypeDefinition)
+        {
+            return TypeSymbol.FromClrType(targetClrType);
+        }
+
+        var args = clr.GetGenericArguments();
+        int offset = 1; // byte 0 = outer type
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+
+            // Compare by FullName so MetadataLoadContext types match runtime types.
+            if (arg == targetClrType || (!arg.IsGenericParameter && arg.FullName == targetClrType.FullName))
+            {
+                return ClrNullability.SymbolFromFlagsOffset(arg, NullableFlags, offset);
+            }
+
+            offset += ClrNullability.CountNullabilityBytes(arg);
+        }
+
+        return TypeSymbol.FromClrType(targetClrType);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Symbols/ClrNullabilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ClrNullabilityTests.cs
@@ -4,17 +4,20 @@
 
 #nullable enable
 
+using System;
+using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Symbols;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
 
 /// <summary>
-/// Phase 3.C.5 / ADR-0001: BCL nullable interop.
+/// Phase 3.C.5 / ADR-0001 / issue #209: BCL nullable interop.
 ///
 /// Covers value-type lift (<c>Nullable&lt;T&gt;</c> on the CLR side becomes
 /// <see cref="NullableTypeSymbol"/> on the GSharp side) and reference-type
-/// surfacing via <c>[NullableContext]</c> / <c>[Nullable]</c> attributes.
+/// surfacing via <c>[NullableContext]</c> / <c>[Nullable]</c> attributes,
+/// including inner-position generic-type-argument nullability.
 /// </summary>
 public class ClrNullabilityTests
 {
@@ -40,7 +43,7 @@ public class ClrNullabilityTests
         // Sample.AnnotatedReturn is annotated `string?` so the binder should
         // see NullableTypeSymbol(String).
         var method = typeof(Sample).GetMethod(nameof(Sample.AnnotatedReturn));
-        var sym = ClrNullability.GetReturnTypeSymbol(method);
+        var sym = ClrNullability.GetReturnTypeSymbol(method!);
         var nullable = Assert.IsType<NullableTypeSymbol>(sym);
         Assert.Same(TypeSymbol.String, nullable.UnderlyingType);
     }
@@ -49,8 +52,144 @@ public class ClrNullabilityTests
     public void ReferenceTypeNonNullAnnotation_StaysFlat()
     {
         var method = typeof(Sample).GetMethod(nameof(Sample.NonNullReturn));
-        var sym = ClrNullability.GetReturnTypeSymbol(method);
+        var sym = ClrNullability.GetReturnTypeSymbol(method!);
         Assert.Same(TypeSymbol.String, sym);
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #209: inner-position (generic type argument) nullability
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Dictionary_ValueAnnotatedNullable_SurfacesInnerNullability()
+    {
+        // Sample.GetDictionary returns Dictionary<string, string?>.
+        // The NullableAttribute byte array is {1, 1, 2}:
+        //   [0] = 1 → Dictionary itself is non-null
+        //   [1] = 1 → string key is non-null
+        //   [2] = 2 → string? value is nullable
+        var method = typeof(Sample).GetMethod(nameof(Sample.GetDictionary));
+        var sym = ClrNullability.GetReturnTypeSymbol(method!);
+
+        // Top level: Dictionary is non-nullable → NullabilityAnnotatedTypeSymbol (not NullableTypeSymbol)
+        var annotated = Assert.IsType<NullabilityAnnotatedTypeSymbol>(sym);
+        Assert.Equal(typeof(Dictionary<string, string>), annotated.ClrType);
+
+        // Key type (arg 0): string — non-nullable
+        var keyType = annotated.GetTypeArgumentSymbol(0);
+        Assert.Same(TypeSymbol.String, keyType);
+        Assert.IsNotType<NullableTypeSymbol>(keyType);
+
+        // Value type (arg 1): string? — nullable
+        var valueType = annotated.GetTypeArgumentSymbol(1);
+        var nullableValue = Assert.IsType<NullableTypeSymbol>(valueType);
+        Assert.Same(TypeSymbol.String, nullableValue.UnderlyingType);
+    }
+
+    [Fact]
+    public void Dictionary_ValueAnnotatedNullable_GetTypeArgumentSymbolForClrType_Works()
+    {
+        var method = typeof(Sample).GetMethod(nameof(Sample.GetDictionary));
+        var sym = ClrNullability.GetReturnTypeSymbol(method!);
+        var annotated = Assert.IsType<NullabilityAnnotatedTypeSymbol>(sym);
+
+        // Lookup by CLR type: string key
+        var keyType = annotated.GetTypeArgumentSymbolForClrType(typeof(string));
+
+        // The first string arg (key) is non-nullable.
+        Assert.Same(TypeSymbol.String, keyType);
+        Assert.IsNotType<NullableTypeSymbol>(keyType);
+    }
+
+    [Fact]
+    public void List_ElementAnnotatedNullable_SurfacesInnerNullability()
+    {
+        // Sample.GetList returns List<string?>.
+        // NullableAttribute byte array: {1, 2}
+        //   [0] = 1 → List is non-null
+        //   [1] = 2 → string? element is nullable
+        var method = typeof(Sample).GetMethod(nameof(Sample.GetList));
+        var sym = ClrNullability.GetReturnTypeSymbol(method!);
+
+        var annotated = Assert.IsType<NullabilityAnnotatedTypeSymbol>(sym);
+        Assert.Equal(typeof(List<string>), annotated.ClrType);
+
+        // Element type (arg 0): string? — nullable
+        var elemType = annotated.GetTypeArgumentSymbol(0);
+        var nullableElem = Assert.IsType<NullableTypeSymbol>(elemType);
+        Assert.Same(TypeSymbol.String, nullableElem.UnderlyingType);
+    }
+
+    [Fact]
+    public void List_ElementAnnotatedNullable_GetTypeArgumentSymbolForClrType_Works()
+    {
+        var method = typeof(Sample).GetMethod(nameof(Sample.GetList));
+        var sym = ClrNullability.GetReturnTypeSymbol(method!);
+        var annotated = Assert.IsType<NullabilityAnnotatedTypeSymbol>(sym);
+
+        var elemType = annotated.GetTypeArgumentSymbolForClrType(typeof(string));
+        var nullableElem = Assert.IsType<NullableTypeSymbol>(elemType);
+        Assert.Same(TypeSymbol.String, nullableElem.UnderlyingType);
+    }
+
+    [Fact]
+    public void FuncParameter_WithNullableFirstArg_SurfacesInnerNullability()
+    {
+        // Sample.AcceptFunc takes a Func<string?, int> parameter.
+        // NullableAttribute byte array on that parameter: {1, 2}
+        //   [0] = 1 → Func is non-null
+        //   [1] = 2 → string? first arg is nullable
+        // (int is a value type — contributes no byte)
+        var method = typeof(Sample).GetMethod(nameof(Sample.AcceptFunc));
+        var parameter = method!.GetParameters()[0];
+        var sym = ClrNullability.GetParameterTypeSymbol(parameter);
+
+        var annotated = Assert.IsType<NullabilityAnnotatedTypeSymbol>(sym);
+        Assert.Equal(typeof(Func<string, int>), annotated.ClrType);
+
+        // First type argument (string?): nullable
+        var arg0 = annotated.GetTypeArgumentSymbol(0);
+        var nullableArg = Assert.IsType<NullableTypeSymbol>(arg0);
+        Assert.Same(TypeSymbol.String, nullableArg.UnderlyingType);
+    }
+
+    [Fact]
+    public void CountNullabilityBytes_SimpleRefType_Returns1()
+    {
+        Assert.Equal(1, ClrNullability.CountNullabilityBytes(typeof(string)));
+    }
+
+    [Fact]
+    public void CountNullabilityBytes_ValueType_Returns0()
+    {
+        Assert.Equal(0, ClrNullability.CountNullabilityBytes(typeof(int)));
+    }
+
+    [Fact]
+    public void CountNullabilityBytes_GenericRefType_IncludesArgs()
+    {
+        // Dictionary<string, string>: 1 (Dict) + 1 (string key) + 1 (string value) = 3
+        Assert.Equal(3, ClrNullability.CountNullabilityBytes(typeof(Dictionary<string, string>)));
+    }
+
+    [Fact]
+    public void CountNullabilityBytes_GenericMixedArgs_SkipsValueType()
+    {
+        // Dictionary<int, string>: 1 (Dict) + 0 (int key) + 1 (string value) = 2
+        Assert.Equal(2, ClrNullability.CountNullabilityBytes(typeof(Dictionary<int, string>)));
+    }
+
+    [Fact]
+    public void NonAnnotated_List_NoInnerFlags_StaysFlat()
+    {
+        // A method with no nullable annotation and no NullableContext → no annotation
+        var method = typeof(ObliviousContainer).GetMethod(nameof(ObliviousContainer.GetList));
+        var sym = ClrNullability.GetReturnTypeSymbol(method!);
+
+        // No NullabilityAnnotatedTypeSymbol when there are no nullable flags at all,
+        // or when the context implies oblivious (flag == 0).
+        // With #nullable disable the compiler emits no [NullableContext] → flat symbol.
+        Assert.IsNotType<NullabilityAnnotatedTypeSymbol>(sym);
     }
 
     /// <summary>
@@ -72,5 +211,38 @@ public class ClrNullabilityTests
         {
             return string.Empty;
         }
+
+        public Dictionary<string, string?> GetDictionary()
+        {
+            return new Dictionary<string, string?>();
+        }
+
+        public List<string?> GetList()
+        {
+            return new List<string?>();
+        }
+
+        public int AcceptFunc(Func<string?, int> f)
+        {
+            return f(null);
+        }
     }
+
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+#pragma warning disable SA1649 // File name should match first type name
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable CS8601 // Possible null reference assignment
+    /// <summary>Simulates a pre-nullable-annotation (oblivious) type.</summary>
+    public class ObliviousContainer
+    {
+        // No #nullable context here — compiler emits no NullableContextAttribute.
+#pragma warning disable CS8603
+        public List<string> GetList() => null;
+#pragma warning restore CS8603
+    }
+#pragma warning restore CS8632
+#pragma warning restore SA1649
+#pragma warning restore SA1402
+#pragma warning restore CS8601
 }
+


### PR DESCRIPTION
Closes #209.

## Summary

Previously `ClrNullability` only read byte 0 of the `[NullableAttribute]` byte array, losing nullability for generic type arguments. This PR reads the full DFS pre-order byte array and surfaces inner positions through a new `NullabilityAnnotatedTypeSymbol` wrapper.

## Changes

### New: `NullabilityAnnotatedTypeSymbol`
A sealed `TypeSymbol` subclass that wraps a base type + carries the full `ImmutableArray<byte> NullableFlags` array. Provides:
- `GetTypeArgumentSymbol(int argIndex)` — offset arithmetic via `CountNullabilityBytes`
- `GetTypeArgumentSymbolForClrType(Type)` — lookup by CLR FullName (handles MetadataLoadContext vs runtime types)

### Updated: `ClrNullability`
- `ReadNullableFlags` — reads full byte array (scalar or array form), falls back to `NullableContextAttribute`
- `CountNullabilityBytes` — DFS byte counter, skipping value types
- `SymbolFromFlagsOffset` — constructs the correct symbol at a position in the flags array
- `ApplyReferenceNullabilityFull` — replaces old single-byte logic; wraps in `NullabilityAnnotatedTypeSymbol` when inner flags exist

### Updated: `Binder`
Added `NullabilityAnnotatedTypeSymbol` handling before the existing `ImportedTypeSymbol` cases in:
- `BindForRangeStatement` — for-range over annotated collections uses `GetTypeArgumentSymbolForClrType`
- `BindIndexExpression` — CLR indexer read path
- `BindIndexAssignmentExpression` — CLR indexer write path

### New tests: `ClrNullabilityTests`
- `Dictionary<string, string?>` — inner value is `NullableTypeSymbol(String)`
- `List<string?>` — element is `NullableTypeSymbol(String)`
- `Func<string?, int>` — first argument via `GetParameterTypeSymbol`
- `CountNullabilityBytes` — edge cases for value types, mixed-args generics
- Oblivious context (no annotation) stays flat