### PR TITLE
Fix Compilation.Emit overload ambiguity (issue #218)

### DIFF
--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -284,7 +284,7 @@ public class Compilation
     /// </summary>
     /// <param name="peStream">Destination stream for the PE bytes.</param>
     /// <returns>An emit result.</returns>
-    public EmitResult Emit(Stream peStream) => Emit(peStream, refStream: null, assemblyName: null);
+    public EmitResult Emit(Stream peStream) => Emit(peStream, pdbStream: null, refStream: null, assemblyName: null);
 
     /// <summary>
     /// Compiles the current syntax tree and writes the resulting assembly to
@@ -358,56 +358,9 @@ public class Compilation
     /// </summary>
     /// <param name="peStream">Destination stream for the PE bytes. May be <c>null</c> when only a reference assembly is desired.</param>
     /// <param name="refStream">Optional destination stream for the metadata-only reference assembly.</param>
-    /// <param name="assemblyName">Optional override for the assembly identity. When null, the entry-point package name is used.</param>
     /// <returns>An emit result.</returns>
-    public EmitResult Emit(Stream peStream, Stream refStream, string assemblyName = null)
-    {
-        var parseDiagnostics = SyntaxTrees.SelectMany(st => st.Diagnostics);
-        var syntaxDiagnostics = parseDiagnostics.Concat(GlobalScope.Diagnostics).ToImmutableArray();
-        if (syntaxDiagnostics.Any(d => d.IsError))
-        {
-            return new EmitResult(success: false, syntaxDiagnostics);
-        }
-
-        var program = Binder.BindProgram(GlobalScope);
-        if (program.Diagnostics.Any(d => d.IsError))
-        {
-            return new EmitResult(success: false, program.Diagnostics.ToImmutableArray());
-        }
-
-        var (lowered, lowerDiagnostics) = LowerForEmit(program, References ?? Symbols.ReferenceResolver.Default());
-        if (lowerDiagnostics.Any(d => d.IsError))
-        {
-            return new EmitResult(success: false, lowerDiagnostics);
-        }
-
-        var allWarnings = syntaxDiagnostics
-            .Concat(program.Diagnostics)
-            .Concat(lowerDiagnostics)
-            .Where(d => !d.IsError)
-            .ToImmutableArray();
-
-        try
-        {
-            if (peStream is not null)
-            {
-                EmitAssembly(program, peStream, References, assemblyName, metadataOnly: false, asyncRewriteResult: lowered.AsyncRewriteResult, iteratorRewriteResult: lowered.IteratorRewriteResult, asyncIteratorRewriteResult: lowered.AsyncIteratorRewriteResult, debugInformation: DebugInformation, pdbStream: null);
-            }
-
-            if (refStream is not null)
-            {
-                EmitAssembly(program, refStream, References, assemblyName, metadataOnly: true, asyncRewriteResult: lowered.AsyncRewriteResult, iteratorRewriteResult: lowered.IteratorRewriteResult, asyncIteratorRewriteResult: lowered.AsyncIteratorRewriteResult, debugInformation: null, pdbStream: null);
-            }
-        }
-        catch (Exception ex) when (ex is NotSupportedException || ex is InvalidOperationException)
-        {
-            var location = new TextLocation(SourceText.From(string.Empty), new TextSpan(0, 0));
-            var diagnostic = new Diagnostic(location, "GS9998", DiagnosticSeverity.Error, ex.Message);
-            return new EmitResult(success: false, ImmutableArray.Create(diagnostic));
-        }
-
-        return new EmitResult(success: true, diagnostics: allWarnings);
-    }
+    public EmitResult Emit(Stream peStream, Stream refStream) =>
+        Emit(peStream, pdbStream: null, refStream, assemblyName: null);
 
     /// <summary>
     /// The canonical async/iterator lowering pipeline. Runs all rewriter

--- a/test/Core.Tests/CodeAnalysis/Emit/DebugInformationOptionsTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/DebugInformationOptionsTests.cs
@@ -129,7 +129,7 @@ public class DebugInformationOptionsTests
         using var peStream = new MemoryStream();
         using var pdbStream = new MemoryStream();
 
-        var result = compilation.Emit(peStream, pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
 
         Assert.True(result.Success);
         Assert.True(peStream.Length > 0, "PE stream should have content");

--- a/test/Core.Tests/CodeAnalysis/Emit/LoweringPipelineTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/LoweringPipelineTests.cs
@@ -58,7 +58,7 @@ Console.WriteLine(""ok"")
         using var pe2 = new MemoryStream();
         var tree2 = SyntaxTree.Parse(SourceText.From(Source));
         var comp2 = new Compilation(tree2);
-        var result2 = comp2.Emit(pe2, refStream: null, assemblyName: null);
+        var result2 = comp2.Emit(pe2, pdbStream: null, refStream: null, assemblyName: null);
         Assert.True(result2.Success, "Emit(pe, ref, name) failed: " + string.Join("; ", result2.Diagnostics.Select(d => d.Message)));
 
         // Both assemblies should have the same method definitions
@@ -90,7 +90,7 @@ Console.WriteLine(""hi"")
         using var refStream = new MemoryStream();
         var tree = SyntaxTree.Parse(SourceText.From(Source));
         var comp = new Compilation(tree);
-        var result = comp.Emit(peStream, refStream, assemblyName: "RefParity");
+        var result = comp.Emit(peStream, pdbStream: null, refStream, assemblyName: "RefParity");
 
         Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
 

--- a/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
@@ -45,7 +45,7 @@ func main() {
         using var pdbStream = new MemoryStream();
 
         var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(SimpleProgram, "main.gs")));
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
 
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
         Assert.Equal(0, pdbStream.Length);
@@ -61,7 +61,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
 
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
         Assert.True(pdbStream.Length > 0);
@@ -85,7 +85,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success);
 
         pdbStream.Position = 0;
@@ -122,7 +122,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success);
 
         // Read MethodDef count from the PE side.
@@ -151,7 +151,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success);
 
         pdbStream.Position = 0;
@@ -216,7 +216,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
 
         pdbStream.Position = 0;
@@ -248,7 +248,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
 
         peStream.Position = 0;
@@ -280,7 +280,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
 
         pdbStream.Position = 0;
@@ -306,7 +306,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
 
         peStream.Position = 0;
@@ -375,7 +375,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
 
         pdbStream.Position = 0;
@@ -419,7 +419,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
 
         pdbStream.Position = 0;
@@ -444,7 +444,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
 
         pdbStream.Position = 0;
@@ -493,7 +493,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
 
         pdbStream.Position = 0;
@@ -648,7 +648,7 @@ func main() {
         {
             DebugInformation = options,
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
 
         pdbStream.Position = 0;
@@ -801,7 +801,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.None },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: null, refStream: null);
+        var result = compilation.Emit(peStream, null, null);
         Assert.True(result.Success);
 
         using var peReader = new PEReader(new MemoryStream(peStream.ToArray()));
@@ -824,7 +824,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Embedded },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
 
         // Embedded format must not produce sidecar bytes even if the caller
@@ -846,7 +846,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Embedded },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: null, refStream: null);
+        var result = compilation.Emit(peStream, null, null);
         Assert.True(result.Success);
 
         using var peReader = new PEReader(new MemoryStream(peStream.ToArray()));
@@ -870,7 +870,7 @@ func main() {
         {
             DebugInformation = options,
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
         return (peStream, pdbStream.ToArray());
     }
@@ -926,7 +926,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
 
         pdbStream.Position = 0;
@@ -973,7 +973,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
 
         pdbStream.Position = 0;
@@ -1019,7 +1019,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
 
         pdbStream.Position = 0;
@@ -1060,7 +1060,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
 
         pdbStream.Position = 0;
@@ -1170,7 +1170,7 @@ func main() {
         {
             DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
         };
-        var result = compilation.Emit(peStream: peStream, pdbStream: pdbStream, refStream: null);
+        var result = compilation.Emit(peStream, pdbStream, null);
         Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
 
         pdbStream.Position = 0;


### PR DESCRIPTION
Fixes #218.

## Problem

`Compilation` had two overloads that both matched a 3-positional-arg call:

```csharp
Emit(Stream peStream, Stream pdbStream, Stream refStream, string assemblyName = null);  // 4-arg
Emit(Stream peStream, Stream refStream, string assemblyName = null);                    // 3-arg
```

C# overload resolution prefers the shorter (3-arg) form, so `compilation.Emit(pe, pdb, null)` silently bound `pdb` to `refStream` and produced no PDB — a serious footgun.

## Fix

Replace `Emit(Stream peStream, Stream refStream, string assemblyName = null)` with `Emit(Stream peStream, Stream refStream)` — a thin wrapper that delegates to the canonical 4-arg form with `pdbStream: null`. Removing the optional `assemblyName` parameter from the 2-arg shorthand eliminates all 3-arg ambiguity.

`Emit(Stream peStream)` is also updated to delegate directly to the 4-arg form.

Callers that needed `assemblyName` via the old shorthand now use the fully explicit 4-arg overload.

## Acceptance check

`compilation.Emit(pe, pdb, null)` now unambiguously resolves to the 4-arg overload (`pdb` → `pdbStream`). The Phase 4 tests in `PortablePdbEmitTests` and `DebugInformationOptionsTests` are switched back to positional args as a sanity check.