### PR TITLE
Fix: async func trailing lambda not handled by MaybeAppendTrailingLambda (#235)

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -3195,11 +3195,15 @@ public class Parser
     private SeparatedSyntaxList<ExpressionSyntax> MaybeAppendTrailingLambda(
         SeparatedSyntaxList<ExpressionSyntax> arguments)
     {
-        // Only `func(...) {...}` (a function LITERAL) attaches as a trailing
-        // lambda; `func Name(...)` (a function DECLARATION) must stay as the
-        // following statement-level declaration.
-        if (Current.Kind != SyntaxKind.FuncKeyword
-            || Peek(1).Kind != SyntaxKind.OpenParenthesisToken)
+        // Only `func(...) {...}` or `async func(...) {...}` (function LITERALS)
+        // attach as a trailing lambda; `func Name(...)` (a function DECLARATION)
+        // must stay as the following statement-level declaration.
+        var isSyncLiteral = Current.Kind == SyntaxKind.FuncKeyword
+                            && Peek(1).Kind == SyntaxKind.OpenParenthesisToken;
+        var isAsyncLiteral = Current.Kind == SyntaxKind.AsyncKeyword
+                             && Peek(1).Kind == SyntaxKind.FuncKeyword
+                             && Peek(2).Kind == SyntaxKind.OpenParenthesisToken;
+        if (!isSyncLiteral && !isAsyncLiteral)
         {
             return arguments;
         }

--- a/test/Core.Tests/CodeAnalysis/Binding/TrailingLambdaTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/TrailingLambdaTests.cs
@@ -96,6 +96,31 @@ takesInt(1) func() int32 { return 0 }
         Assert.NotEmpty(result.Diagnostics);
     }
 
+    [Fact]
+    public void TrailingLambda_AsyncSoleArgument_BindsWithoutDiagnostics()
+    {
+        // Verify the parser attaches `async func(...)` as a trailing lambda
+        // (previously it misread `async` as an unexpected keyword and dropped
+        // the literal from the argument list entirely).
+        var result = Evaluate(@"
+async func computeAsync() int32 { return 42 }
+func runIt(f async func() int32) { f() }
+runIt() async func() int32 { return await computeAsync() }
+");
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void TrailingLambda_AsyncWithPrecedingArgs_BindsWithoutDiagnostics()
+    {
+        var result = Evaluate(@"
+async func double(x int32) int32 { return x * 2 }
+func combine(seed int32, f async func(int32) int32) { f(seed) }
+combine(10) async func(x int32) int32 { return await double(x) }
+");
+        Assert.Empty(result.Diagnostics);
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var syntaxTree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
## Summary

Fixes #235.

`MaybeAppendTrailingLambda` only fired when the next token was `func`. This caused `call() async func() T { ... }` to be misparsed — `async` was reported as an unexpected keyword, and the literal fell through as a top-level declaration.

## Changes

**`Parser.cs`** — Extended the guard to also accept the `async func(` prefix:

```csharp
var isSyncLiteral  = Current.Kind == SyntaxKind.FuncKeyword
                     && Peek(1).Kind == SyntaxKind.OpenParenthesisToken;
var isAsyncLiteral = Current.Kind == SyntaxKind.AsyncKeyword
                     && Peek(1).Kind == SyntaxKind.FuncKeyword
                     && Peek(2).Kind == SyntaxKind.OpenParenthesisToken;
if (!isSyncLiteral && !isAsyncLiteral)
    return arguments;
```

`ParseFunctionLiteralExpression` already handles the `async` modifier, so no binder or emitter changes are needed.

**`TrailingLambdaTests.cs`** — Added two new binding-level tests:
- `TrailingLambda_AsyncSoleArgument_BindsWithoutDiagnostics`
- `TrailingLambda_AsyncWithPrecedingArgs_BindsWithoutDiagnostics`