### PR TITLE
Fix refasm MVID not recognized by MSBuild

### DIFF
--- a/build/projectref-e2e.sh
+++ b/build/projectref-e2e.sh
@@ -81,10 +81,19 @@ fi
 # Now make a public signature change — add a new public method.
 TS_BEFORE2=$(stat -f %m "$APP_DLL" 2>/dev/null || stat -c %Y "$APP_DLL")
 sleep 1
-cat >> "$SAMPLE/Lib/Greeter.gs" <<'EOF'
+cat > "$SAMPLE/Lib/Greeter.gs" <<'EOF'
+package ProjectRefLib
 
-func Farewell() string {
-    return "Goodbye!"
+import System
+
+type Greeter class(Name string) {
+    func Greet() string {
+        return "Hello, " + Name + "!"
+    }
+
+    func Farewell() string {
+        return "Goodbye!"
+    }
 }
 EOF
 dotnet build "$SAMPLE/App/App.gsproj" --nologo -v:q
@@ -102,5 +111,6 @@ git checkout -- "$SAMPLE/Lib/Greeter.gs" 2>/dev/null || true
 if [[ "$REFASM_GATE_WORKS" == "true" ]]; then
     echo "PASS: cross-project references and refasm incremental rebuild verified."
 else
-    echo "PASS: cross-project references verified (refasm gating needs MVID fix — tracked separately)."
+    echo "FAIL: refasm incremental rebuild gating is not working."
+    exit 1
 fi

--- a/samples/ProjectRef/Lib/Greeter.gs
+++ b/samples/ProjectRef/Lib/Greeter.gs
@@ -7,8 +7,3 @@ type Greeter class(Name string) {
         return "Hello, " + Name + "!"
     }
 }
-// body-only change
-
-func Farewell() string {
-    return "Goodbye!"
-}

--- a/src/Core/CodeAnalysis/Emit/MvidPEBuilder.cs
+++ b/src/Core/CodeAnalysis/Emit/MvidPEBuilder.cs
@@ -1,0 +1,90 @@
+// <copyright file="MvidPEBuilder.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#pragma warning disable SA1100 // base. required — Serialize(BlobBuilder) is inherited, not overridden
+#pragma warning disable SA1118 // multi-line Section ctor is clearest here
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace GSharp.Core.CodeAnalysis.Emit;
+
+/// <summary>
+/// A <see cref="ManagedPEBuilder"/> subclass that adds a <c>.mvid</c> PE section
+/// to the output assembly. MSBuild's <c>CopyRefAssembly</c> task uses a lightweight
+/// reader (<c>MvidReader</c>) that looks for this section to quickly extract the
+/// module version identifier without loading full metadata. Without it, the task
+/// cannot determine whether the public API surface has changed between builds and
+/// falls back to always copying, defeating incremental build gating for downstream
+/// consumers.
+/// </summary>
+internal sealed class MvidPEBuilder : ManagedPEBuilder
+{
+    private const string MvidSectionName = ".mvid";
+    private const int SizeOfGuid = 16;
+
+    private Blob mvidSectionFixup;
+
+    public MvidPEBuilder(
+        PEHeaderBuilder header,
+        MetadataRootBuilder metadataRootBuilder,
+        BlobBuilder ilStream,
+        MethodDefinitionHandle entryPoint,
+        DebugDirectoryBuilder debugDirectoryBuilder,
+        Func<IEnumerable<Blob>, BlobContentId> deterministicIdProvider)
+        : base(
+            header,
+            metadataRootBuilder,
+            ilStream,
+            entryPoint: entryPoint,
+            debugDirectoryBuilder: debugDirectoryBuilder,
+            deterministicIdProvider: deterministicIdProvider)
+    {
+    }
+
+    /// <summary>
+    /// Serializes the PE and returns the <c>.mvid</c> section fixup blob so
+    /// the caller can patch it with the final content-derived GUID.
+    /// </summary>
+    /// <param name="peBlob">Destination blob builder for the PE image.</param>
+    /// <param name="mvidFixup">
+    /// On return, the reserved blob within the <c>.mvid</c> section that the
+    /// caller must overwrite with the deterministic content ID GUID.
+    /// </param>
+    /// <returns>The content identifier derived from the serialized PE.</returns>
+    public BlobContentId Serialize(BlobBuilder peBlob, out Blob mvidFixup)
+    {
+        var result = base.Serialize(peBlob);
+        mvidFixup = this.mvidSectionFixup;
+        return result;
+    }
+
+    protected override ImmutableArray<Section> CreateSections()
+    {
+        var baseSections = base.CreateSections();
+        var builder = ImmutableArray.CreateBuilder<Section>(baseSections.Length + 1);
+
+        builder.Add(new Section(MvidSectionName, SectionCharacteristics.MemRead | SectionCharacteristics.ContainsInitializedData | SectionCharacteristics.MemDiscardable));
+
+        builder.AddRange(baseSections);
+        return builder.MoveToImmutable();
+    }
+
+    protected override BlobBuilder SerializeSection(string name, SectionLocation location)
+    {
+        if (name.Equals(MvidSectionName, StringComparison.Ordinal))
+        {
+            var sectionBuilder = new BlobBuilder();
+            this.mvidSectionFixup = sectionBuilder.ReserveBytes(SizeOfGuid);
+            new BlobWriter(this.mvidSectionFixup).WriteBytes(0, SizeOfGuid);
+            return sectionBuilder;
+        }
+
+        return base.SerializeSection(name, location);
+    }
+}

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1064,19 +1064,39 @@ internal sealed class ReflectionMetadataEmitter
         // 9. Serialize PE deterministically: a SHA-256 of the serialized PE
         // content produces the BlobContentId, which patches both the PE
         // TimeDateStamp and the reserved MVID guid in the metadata heap.
+        // For reference assemblies we use MvidPEBuilder which adds a .mvid
+        // PE section so MSBuild's CopyRefAssembly can efficiently extract
+        // the module version identifier without loading full metadata.
         var peHeaderBuilder = new PEHeaderBuilder(
             imageCharacteristics: entryHandle.IsNil
                 ? Characteristics.Dll | Characteristics.ExecutableImage
                 : Characteristics.ExecutableImage);
-        var peBuilder = new ManagedPEBuilder(
-            header: peHeaderBuilder,
-            metadataRootBuilder: new MetadataRootBuilder(this.metadata),
-            ilStream: this.ilStream,
-            entryPoint: this.metadataOnly ? default : entryHandle,
-            debugDirectoryBuilder: debugDirectory,
-            deterministicIdProvider: ComputeDeterministicContentId);
         var peBlob = new BlobBuilder();
-        var contentId = peBuilder.Serialize(peBlob);
+        BlobContentId contentId;
+        if (this.metadataOnly)
+        {
+            var mvidBuilder = new MvidPEBuilder(
+                header: peHeaderBuilder,
+                metadataRootBuilder: new MetadataRootBuilder(this.metadata),
+                ilStream: this.ilStream,
+                entryPoint: default,
+                debugDirectoryBuilder: debugDirectory,
+                deterministicIdProvider: ComputeDeterministicContentId);
+            contentId = mvidBuilder.Serialize(peBlob, out var mvidSectionFixup);
+            new BlobWriter(mvidSectionFixup).WriteGuid(contentId.Guid);
+        }
+        else
+        {
+            var peBuilder = new ManagedPEBuilder(
+                header: peHeaderBuilder,
+                metadataRootBuilder: new MetadataRootBuilder(this.metadata),
+                ilStream: this.ilStream,
+                entryPoint: entryHandle,
+                debugDirectoryBuilder: debugDirectory,
+                deterministicIdProvider: ComputeDeterministicContentId);
+            contentId = peBuilder.Serialize(peBlob);
+        }
+
         mvidFixup.CreateWriter().WriteGuid(contentId.Guid);
         peBlob.WriteContentTo(peStream);
 

--- a/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
+++ b/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <Target Name="CoreCompile"
-          Inputs="$(MSBuildAllProjects);@(Compile);@(ReferencePath)"
+          Inputs="$(MSBuildAllProjects);@(Compile);@(ReferencePathWithRefAssemblies)"
           Outputs="@(IntermediateAssembly)"
           DependsOnTargets="$(CoreCompileDependsOn)">
 


### PR DESCRIPTION
MSBuild's `CopyRefAssembly` task reads the module version identifier from a dedicated `.mvid` PE section (via its lightweight `MvidReader`) rather than the standard metadata GUID heap. Without this section the task cannot compare MVIDs between builds and always copies the reference assembly, defeating incremental rebuild gating for downstream consumers.

## Changes

- **New: `MvidPEBuilder.cs`** — Subclass of `ManagedPEBuilder` that overrides `CreateSections()`/`SerializeSection()` to emit a `.mvid` PE section containing the deterministic content-derived GUID, matching Roslyn's `ExtendedPEBuilder` convention.
- **`ReflectionMetadataEmitter.cs`** — Uses `MvidPEBuilder` when `metadataOnly=true` (refasm path); patches both the metadata GUID heap and the `.mvid` section.
- **`Gsharp.NET.Core.Sdk.targets`** — Changed `CoreCompile` Inputs from `@(ReferencePath)` to `@(ReferencePathWithRefAssemblies)` so MSBuild tracks stable ref assembly timestamps.
- **`projectref-e2e.sh`** — Fixed public signature test syntax; made test fail-fast.
- **`Greeter.gs`** — Removed leftover test content.

## Verification

```
bash build/projectref-e2e.sh
```

All assertions pass:
- ✅ Body-only Lib change does NOT rebuild downstream App
- ✅ Public signature change DOES rebuild downstream App
- ✅ No more "Could not extract the MVID" MSBuild warning

Fixes #238