### PR TITLE
Bind computed property accessor bodies for interpreter and emitter

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -418,6 +418,48 @@ public sealed class Binder
             }
         }
 
+        // ADR-0051: bind computed property accessor bodies. These are analogous
+        // to method bodies but hang off PropertySymbol.GetterSymbol/SetterSymbol.
+        foreach (var structSym in globalScope.Structs)
+        {
+            if (structSym.Properties.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            foreach (var prop in structSym.Properties)
+            {
+                if (prop.IsAutoProperty)
+                {
+                    continue;
+                }
+
+                if (prop.GetterSymbol != null && prop.GetterBodySyntax != null)
+                {
+                    var binder = new Binder(parentScope, prop.GetterSymbol);
+                    var body = binder.BindStatement(prop.GetterBodySyntax);
+                    var loweredBody = Lowerer.Lower(body);
+
+                    if (!ControlFlowGraph.AllPathsReturn(loweredBody))
+                    {
+                        binder.Diagnostics.ReportAllPathsMustReturn(prop.GetterBodySyntax.OpenBraceToken.Location);
+                    }
+
+                    functionBodies.Add(prop.GetterSymbol, loweredBody);
+                    diagnostics.AddRange(binder.Diagnostics);
+                }
+
+                if (prop.SetterSymbol != null && prop.SetterBodySyntax != null)
+                {
+                    var binder = new Binder(parentScope, prop.SetterSymbol);
+                    var body = binder.BindStatement(prop.SetterBodySyntax);
+                    var loweredBody = Lowerer.Lower(body);
+                    functionBodies.Add(prop.SetterSymbol, loweredBody);
+                    diagnostics.AddRange(binder.Diagnostics);
+                }
+            }
+        }
+
         var statement = Lowerer.Lower(new BoundBlockStatement(null, globalScope.Statements));
 
         // If the entry point is the synthesized top-level function, its body is
@@ -1080,6 +1122,46 @@ public sealed class Binder
                         Accessibility.Private,
                         isReadOnly: !hasSetter);
                     propertySymbol.BackingField = backingField;
+                }
+
+                // Create FunctionSymbols for computed property accessors (ADR-0051).
+                if (!isAutoProperty)
+                {
+                    var getAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsGetter);
+                    var setAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsSetter);
+
+                    if (hasGetter && getAccessor?.Body != null)
+                    {
+                        var getterSymbol = new FunctionSymbol(
+                            $"get_{propName}",
+                            ImmutableArray<ParameterSymbol>.Empty,
+                            propType,
+                            declaration: null,
+                            package,
+                            propAccessibility,
+                            receiverType: structSymbol,
+                            isOpen: isVirtual,
+                            isOverride: isOverride);
+                        propertySymbol.GetterSymbol = getterSymbol;
+                        propertySymbol.GetterBodySyntax = getAccessor.Body;
+                    }
+
+                    if (hasSetter && setAccessor?.Body != null)
+                    {
+                        var setterParam = new ParameterSymbol(setterParamName, propType);
+                        var setterSymbol = new FunctionSymbol(
+                            $"set_{propName}",
+                            ImmutableArray.Create(setterParam),
+                            TypeSymbol.Void,
+                            declaration: null,
+                            package,
+                            propAccessibility,
+                            receiverType: structSymbol,
+                            isOpen: isVirtual,
+                            isOverride: isOverride);
+                        propertySymbol.SetterSymbol = setterSymbol;
+                        propertySymbol.SetterBodySyntax = setAccessor.Body;
+                    }
                 }
 
                 // Bind annotations

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1663,32 +1663,39 @@ internal sealed class ReflectionMetadataEmitter
     /// <summary>
     /// ADR-0051 Phase 6: emits a getter accessor MethodDef (get_PropertyName).
     /// For auto-properties: ldarg.0, ldfld backing, ret.
-    /// For computed properties: throws NotImplementedException (placeholder).
+    /// For computed properties: emits the bound getter body IL.
     /// </summary>
     private MethodDefinitionHandle EmitPropertyGetter(StructSymbol structSym, PropertySymbol prop)
     {
         int bodyOffset = -1;
         if (!this.metadataOnly)
         {
-            var il = new InstructionEncoder(new BlobBuilder());
             if (prop.IsAutoProperty && prop.BackingField != null
                 && this.structFieldDefs.TryGetValue(prop.BackingField, out var backingHandle))
             {
+                var il = new InstructionEncoder(new BlobBuilder());
                 il.LoadArgument(0);
                 il.OpCode(ILOpCode.Ldfld);
                 il.Token(backingHandle);
                 il.OpCode(ILOpCode.Ret);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+            else if (prop.GetterSymbol != null && this.program.Functions.TryGetValue(prop.GetterSymbol, out var getterBody))
+            {
+                // Computed property with bound body: emit using EmitFunction infrastructure.
+                var handle = this.EmitFunction(prop.GetterSymbol, getterBody, isEntryPoint: false);
+                return handle;
             }
             else
             {
-                // Computed property placeholder: throw new NotImplementedException().
+                // Fallback: throw new NotImplementedException().
+                var il = new InstructionEncoder(new BlobBuilder());
                 var nieCtor = this.GetNotImplementedExceptionCtor();
                 il.OpCode(ILOpCode.Newobj);
                 il.Token(nieCtor);
                 il.OpCode(ILOpCode.Throw);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
             }
-
-            bodyOffset = this.methodBodyStream.AddMethodBody(il);
         }
 
         var sigBlob = new BlobBuilder();
@@ -1717,33 +1724,40 @@ internal sealed class ReflectionMetadataEmitter
     /// <summary>
     /// ADR-0051 Phase 6: emits a setter accessor MethodDef (set_PropertyName).
     /// For auto-properties: ldarg.0, ldarg.1, stfld backing, ret.
-    /// For computed properties: throws NotImplementedException (placeholder).
+    /// For computed properties: emits the bound setter body IL.
     /// </summary>
     private MethodDefinitionHandle EmitPropertySetter(StructSymbol structSym, PropertySymbol prop)
     {
         int bodyOffset = -1;
         if (!this.metadataOnly)
         {
-            var il = new InstructionEncoder(new BlobBuilder());
             if (prop.IsAutoProperty && prop.BackingField != null
                 && this.structFieldDefs.TryGetValue(prop.BackingField, out var backingHandle))
             {
+                var il = new InstructionEncoder(new BlobBuilder());
                 il.LoadArgument(0);
                 il.LoadArgument(1);
                 il.OpCode(ILOpCode.Stfld);
                 il.Token(backingHandle);
                 il.OpCode(ILOpCode.Ret);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+            else if (prop.SetterSymbol != null && this.program.Functions.TryGetValue(prop.SetterSymbol, out var setterBody))
+            {
+                // Computed property with bound body: emit using EmitFunction infrastructure.
+                var handle = this.EmitFunction(prop.SetterSymbol, setterBody, isEntryPoint: false);
+                return handle;
             }
             else
             {
-                // Computed property placeholder: throw new NotImplementedException().
+                // Fallback: throw new NotImplementedException().
+                var il = new InstructionEncoder(new BlobBuilder());
                 var nieCtor = this.GetNotImplementedExceptionCtor();
                 il.OpCode(ILOpCode.Newobj);
                 il.Token(nieCtor);
                 il.OpCode(ILOpCode.Throw);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
             }
-
-            bodyOffset = this.methodBodyStream.AddMethodBody(il);
         }
 
         var sigBlob = new BlobBuilder();

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -999,8 +999,19 @@ public sealed class Evaluator
             return DefaultValue(node.Property.Type);
         }
 
-        // Computed property: accessor bodies not yet bound for interpreter evaluation.
-        // Return default value as a safe placeholder.
+        // Computed property: execute the bound getter body.
+        if (node.Property.GetterSymbol != null && program.Functions.TryGetValue(node.Property.GetterSymbol, out var getterBody))
+        {
+            var frame = new Dictionary<Symbols.VariableSymbol, object>
+            {
+                [node.Property.GetterSymbol.ThisParameter] = receiverValue,
+            };
+            locals.Push(frame);
+            var result = EvaluateStatement(getterBody);
+            locals.Pop();
+            return result;
+        }
+
         return DefaultValue(node.Property.Type);
     }
 
@@ -1039,7 +1050,21 @@ public sealed class Evaluator
             return value;
         }
 
-        // Computed property: setter body not yet bound. No-op for now.
+        // Computed property: execute the bound setter body.
+        if (node.Property.SetterSymbol != null && program.Functions.TryGetValue(node.Property.SetterSymbol, out var setterBody))
+        {
+            var receiverValue = EvaluateExpression(node.Receiver);
+            var frame = new Dictionary<Symbols.VariableSymbol, object>
+            {
+                [node.Property.SetterSymbol.ThisParameter] = receiverValue,
+                [node.Property.SetterSymbol.Parameters[0]] = value,
+            };
+            locals.Push(frame);
+            EvaluateStatement(setterBody);
+            locals.Pop();
+            return value;
+        }
+
         return value;
     }
 

--- a/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
@@ -78,4 +78,10 @@ public sealed class PropertySymbol : Symbol
 
     /// <summary>Gets or sets the synthesized setter function symbol.</summary>
     public FunctionSymbol SetterSymbol { get; set; }
+
+    /// <summary>Gets or sets the getter accessor body syntax (for computed properties). Null for auto-properties.</summary>
+    public Syntax.BlockStatementSyntax GetterBodySyntax { get; set; }
+
+    /// <summary>Gets or sets the setter accessor body syntax (for computed properties). Null for auto-properties.</summary>
+    public Syntax.BlockStatementSyntax SetterBodySyntax { get; set; }
 }

--- a/test/Compiler.Tests/Emit/PropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/PropertyEmitTests.cs
@@ -275,6 +275,90 @@ public class PropertyEmitTests
         Assert.Null(result);
     }
 
+    [Fact]
+    public void ComputedProperty_Getter_EmitsCorrectIL()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Rect class {
+                prop Width int32
+                prop Height int32
+                prop Area int32 {
+                    get {
+                        return this.Width * this.Height
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var rectType = assembly.GetTypes().Single(t => t.Name == "Rect");
+        var instance = Activator.CreateInstance(rectType);
+        rectType.GetProperty("Width")!.SetMethod!.Invoke(instance, new object[] { 3 });
+        rectType.GetProperty("Height")!.SetMethod!.Invoke(instance, new object[] { 4 });
+        var area = rectType.GetProperty("Area")!.GetMethod!.Invoke(instance, null);
+        Assert.Equal(12, area);
+    }
+
+    [Fact]
+    public void ComputedProperty_Setter_EmitsCorrectIL()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Counter class {
+                prop raw int32
+                prop Value int32 {
+                    get {
+                        return this.raw * 2
+                    }
+                    set(v) {
+                        this.raw = v
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var counterType = assembly.GetTypes().Single(t => t.Name == "Counter");
+        var instance = Activator.CreateInstance(counterType);
+        counterType.GetProperty("Value")!.SetMethod!.Invoke(instance, new object[] { 5 });
+        var result = counterType.GetProperty("Value")!.GetMethod!.Invoke(instance, null);
+        Assert.Equal(10, result);
+    }
+
+    [Fact]
+    public void ComputedProperty_GetOnly_HasNoSetter()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Greeter class {
+                prop Name string
+                prop Greeting string {
+                    get {
+                        return "Hello, " + this.Name
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var greeterType = assembly.GetTypes().Single(t => t.Name == "Greeter");
+        var instance = Activator.CreateInstance(greeterType);
+        greeterType.GetProperty("Name")!.SetMethod!.Invoke(instance, new object[] { "World" });
+        var greetingProp = greeterType.GetProperty("Greeting");
+        Assert.NotNull(greetingProp);
+        Assert.True(greetingProp!.CanRead);
+        Assert.False(greetingProp.CanWrite);
+        var result = greetingProp.GetMethod!.Invoke(instance, null);
+        Assert.Equal("Hello, World", result);
+    }
+
     private static Assembly CompileToAssembly(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_property_emit_").FullName;

--- a/test/Interpreter.Tests/PropertyInterpreterTests.cs
+++ b/test/Interpreter.Tests/PropertyInterpreterTests.cs
@@ -114,6 +114,74 @@ public class PropertyInterpreterTests
         Assert.Contains("GS0189", output);
     }
 
+    [Fact]
+    public void ComputedProperty_Getter_ReturnsValue()
+    {
+        var source = """
+            type Rect class {
+                prop Width int32
+                prop Height int32
+                prop Area int32 {
+                    get {
+                        return this.Width * this.Height
+                    }
+                }
+            }
+            let r = Rect{}
+            r.Width = 3
+            r.Height = 4
+            r.Area
+            """;
+        var output = RunSubmission(source);
+        Assert.Contains("12", output);
+        Assert.DoesNotContain("error GS", output);
+    }
+
+    [Fact]
+    public void ComputedProperty_Setter_UpdatesBackingState()
+    {
+        var source = """
+            type Counter class {
+                prop raw int32
+                prop Value int32 {
+                    get {
+                        return this.raw * 2
+                    }
+                    set(v) {
+                        this.raw = v
+                    }
+                }
+            }
+            let c = Counter{}
+            c.Value = 5
+            c.Value
+            """;
+        var output = RunSubmission(source);
+        Assert.Contains("10", output);
+        Assert.DoesNotContain("error GS", output);
+    }
+
+    [Fact]
+    public void ComputedProperty_GetOnly_NoSetter()
+    {
+        var source = """
+            type Greeter class {
+                prop Name string
+                prop Greeting string {
+                    get {
+                        return "Hello, " + this.Name
+                    }
+                }
+            }
+            let g = Greeter{}
+            g.Name = "World"
+            g.Greeting
+            """;
+        var output = RunSubmission(source);
+        Assert.Contains("Hello, World", output);
+        Assert.DoesNotContain("error GS", output);
+    }
+
     private static string RunSubmission(string text)
     {
         using var outWriter = new StringWriter();


### PR DESCRIPTION
Closes #244.

## Summary

This PR implements computed property accessor body binding, completing the ADR-0051 property story beyond auto-properties.

### Changes

1. **PropertySymbol** – Added `GetterBodySyntax`/`SetterBodySyntax` to store the accessor `BlockStatementSyntax` for computed properties.

2. **Binder** (type declaration) – For non-auto properties with accessor bodies, creates `FunctionSymbol` instances (`GetterSymbol`/`SetterSymbol`) and stores the body syntax.

3. **Binder** (`BindProgram`) – Walks struct properties and binds computed accessor bodies into `functionBodies`, just like method bodies.

4. **Evaluator** – Executes the bound getter/setter body with a locals frame containing `this` (and the setter parameter) instead of returning defaults/no-op.

5. **Emitter** – Delegates to `EmitFunction` for computed accessor bodies instead of emitting `throw new NotImplementedException()` stubs.

### Tests

- 3 new interpreter tests: getter returns computed value, setter updates backing state, get-only property
- 3 new emitter tests: same scenarios validated via reflection on the compiled assembly