### PR TITLE
Fix data struct computed property getter 'this' semantics for value types

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -3840,6 +3840,17 @@ internal sealed class ReflectionMetadataEmitter
                 this.asyncIteratorEmitContexts.TryGetValue(owningSmClass, out aiEmitCtx);
             }
 
+            // For struct instance methods, pass structThisParameter so the
+            // BodyEmitter knows arg0 is already a managed pointer (ref T) and
+            // emits ldarg.0 instead of ldarga.0 when accessing fields via this.
+            ParameterSymbol structThis = null;
+            if (function.IsInstanceMethod
+                && function.ReceiverType is StructSymbol recvStruct
+                && !recvStruct.IsClass)
+            {
+                structThis = function.ThisParameter;
+            }
+
             var emitter = new BodyEmitter(
                 this,
                 il,
@@ -3858,6 +3869,7 @@ internal sealed class ReflectionMetadataEmitter
                 selectStatementSlots,
                 goEnclosingScopes,
                 constValues: constValues,
+                structThisParameter: structThis,
                 asyncIteratorEmitCtx: aiEmitCtx);
             emitter.EmitBlock(body);
 

--- a/test/Compiler.Tests/Emit/PropertyInteropTests.cs
+++ b/test/Compiler.Tests/Emit/PropertyInteropTests.cs
@@ -332,7 +332,7 @@ public class PropertyInteropTests
         Assert.Equal("999", output.Split('\n')[2]);
     }
 
-    [Fact(Skip = "Data struct computed property getter has incorrect 'this' semantics for value types")]
+    [Fact]
     public void CSharp_DataStruct_ComputedProperty_IsAccessible()
     {
         var gsSource = """


### PR DESCRIPTION
## Summary

Fixes #249.

Computed property getters on `data struct` types were producing garbage values because `EmitFunction` did not pass `structThisParameter` to `BodyEmitter` for struct instance methods. This caused `TryLoadVariableAddress` to emit `ldarga.0` (pointer-to-pointer) instead of `ldarg.0` (the managed pointer itself) when accessing fields via `this`.

## Changes

- **`ReflectionMetadataEmitter.cs`** — Detect struct instance methods in `EmitFunction` and pass `structThisParameter` to `BodyEmitter`.
- **`PropertyInteropTests.cs`** — Enable the previously-skipped `CSharp_DataStruct_ComputedProperty_IsAccessible` test.

## Verification

All 1507 tests pass, including the newly-enabled interop test that confirms `Vec2{X:3, Y:4}.LengthSquared == 25`.