### PR TITLE
feat: event declarations on user types (#140)

### DIFF
--- a/docs/adr/0052-event-declarations.md
+++ b/docs/adr/0052-event-declarations.md
@@ -1,0 +1,163 @@
+# ADR-0052: Event declarations on user types — `event` keyword
+
+- **Status**: Proposed
+- **Date**: 2026-05-29
+- **Phase**: Phase 9 — language depth (post-primitive)
+- **Related**: ADR-0036 (CLR event subscription — consumption side); ADR-0047 (attribute syntax — `@event:` target kind); ADR-0051 (property declarations — parallel `prop` pattern); issue #140
+
+## Context
+
+GSharp can consume CLR events on imported types via `+=` / `-=` (ADR-0036), but user-defined types cannot declare events. This breaks CLR round-trip: C# consumers cannot subscribe to notifications from GSharp-authored libraries, and GSharp types cannot implement interfaces that require events (e.g., `INotifyPropertyChanged`).
+
+Issue #140 requests support for declaring events with the same metadata shape that a C# `event` declaration produces — `EventDefinition` row + `add_X`/`remove_X` specialname methods — so that downstream C#/F# consumers see standard CLR events.
+
+### The delegate question
+
+GSharp has no `delegate` keyword. First-class function types (`func(T1, T2) R`) lower to `Action<…>`/`Func<…>` BCL delegates (via `FunctionTypeSymbol`). CLR events carry a *named* delegate type, but nothing prevents using `Action<…>` as the handler type — it produces valid, subscribable events from C#.
+
+Custom delegate types (`EventHandler<T>`, `PropertyChangedEventHandler`, etc.) would require a separate `delegate` declaration. This ADR defers that to a follow-up: for v1, events carry `Action<…>`/`Func<…>` handler types. If interop demand arises, a future ADR will introduce `type MyHandler = delegate func(sender Object, e MyEventArgs)` syntax.
+
+## Decision
+
+Introduce a contextual keyword **`event`** for declaring CLR events inside `struct`, `class`, and `interface` bodies. The design parallels `prop` (ADR-0051) closely — same accessibility/annotation surface, same accessor-body pattern.
+
+### 1. Grammar
+
+```
+event_declaration    = annotations? accessibility_modifier? open_modifier? override_modifier?
+                       "event" identifier type_clause event_body?
+event_body           = "{" event_accessor_list "}"
+event_accessor_list  = add_accessor remove_accessor | remove_accessor add_accessor
+add_accessor         = "add" ( block | ";" )
+remove_accessor      = "remove" ( block | ";" )
+```
+
+The `event` keyword is contextual — recognized only inside a type body. Outside type bodies, `event` remains a valid identifier.
+
+The `type_clause` must resolve to a function type (`func(…) …`) which maps to an `Action<…>` or `Func<…>` delegate at the CLR level.
+
+### 2. Forms
+
+#### Field-like event (most common)
+
+```gs
+type MyButton struct {
+    public event Click func(sender Object, e EventArgs)
+}
+```
+
+No body — the compiler synthesizes:
+- A private backing field: `Action<object, EventArgs> Click` (the multicast delegate)
+- Method: `public void add_Click(Action<object, EventArgs> value)` — calls `Delegate.Combine`
+- Method: `public void remove_Click(Action<object, EventArgs> value)` — calls `Delegate.Remove`
+- `EventDefinition` metadata row linking the event name to the add/remove accessors
+
+The add/remove methods use the standard `Delegate.Combine`/`Delegate.Remove` pattern (not the thread-safe `Interlocked.CompareExchange` loop — simplicity over lock-freedom for v1).
+
+#### Event with explicit accessors
+
+```gs
+type ObservableList struct {
+    private var handlers []func(sender Object, e EventArgs)
+
+    public event CollectionChanged func(sender Object, e EventArgs) {
+        add { handlers = append(handlers, value) }
+        remove { /* custom removal logic */ }
+    }
+}
+```
+
+When an explicit body is present, the compiler does **not** synthesize a backing field. The `add` and `remove` blocks have an implicit `value` parameter of the handler type. Both must be present — omitting either is an error.
+
+#### Interface event
+
+```gs
+type INotifyPropertyChanged interface {
+    event PropertyChanged func(sender Object, e PropertyChangedEventArgs)
+}
+```
+
+No body, no accessibility modifier. The interface emits abstract `add_PropertyChanged`/`remove_PropertyChanged` methods and an `EventDefinition` row. Implementing types must declare the matching event.
+
+### 3. Raising events
+
+Events are raised by invoking the backing delegate directly from within the declaring type:
+
+```gs
+func (b *MyButton) OnClick() {
+    if b.Click != nil {
+        b.Click(b, EventArgs.Empty)
+    }
+}
+```
+
+The backing field is accessible by name inside the declaring type (like C#). Outside the type, only `+=` / `-=` are permitted — direct invocation or assignment is an error. This access restriction is enforced by the binder.
+
+### 4. Annotations and use-site targets
+
+Per ADR-0047, the `@event:` use-site target directs an annotation to the event metadata:
+
+```gs
+@event:Obsolete("Use ClickV2 instead")
+@field:NonSerialized
+public event Click func(sender Object, e EventArgs)
+```
+
+- Default target for annotations on an event declaration: `event`
+- `@field:` targets the synthesized backing field (field-like events only)
+- `@method:` on an event is ambiguous (add or remove?) — disallowed; use explicit accessors with annotations per-accessor instead
+
+### 5. Interaction with `open` / `override`
+
+Events follow the same virtuality model as methods (ADR-0017):
+
+```gs
+type Base class {
+    public open event Changed func(sender Object, e EventArgs)
+}
+
+type Derived class {
+    public override event Changed func(sender Object, e EventArgs)
+}
+```
+
+An `open` event emits virtual `add_X`/`remove_X` accessors. An `override` event emits override accessors. The default (no modifier) emits non-virtual accessors.
+
+### 6. CLR metadata shape
+
+For a field-like event `public event Click func(sender Object, e EventArgs)` on type `MyButton`:
+
+| Metadata row | Content |
+|-------------|---------|
+| FieldDef | `private Action<Object, EventArgs> Click` (backing field) |
+| MethodDef | `public hidebysig specialname void add_Click(Action<Object, EventArgs> value)` |
+| MethodDef | `public hidebysig specialname void remove_Click(Action<Object, EventArgs> value)` |
+| EventDef | Name=`Click`, EventType=`Action<Object, EventArgs>`, AddOn=`add_Click`, RemoveOn=`remove_Click` |
+
+This matches exactly what a C# `public event Action<object, EventArgs> Click;` produces.
+
+## Alternatives considered
+
+1. **`@event` annotation instead of keyword.** Rejected — annotations should not alter the fundamental member kind. An event has different binding semantics (no direct assignment from outside) and emits different metadata. A keyword is warranted.
+
+2. **Go channel-based pub/sub.** GSharp already has channels (`chan`). We could model events as channels. Rejected — this would not produce CLR-compatible metadata, breaking the interop promise.
+
+3. **Require delegate types for events.** Rejected for v1 — adds unnecessary complexity. `Action<…>` is the pragmatic default. Custom delegates can follow in a future ADR.
+
+4. **Kotlin `val onClick: ((Object, EventArgs) -> Unit)?` with `by` delegation.** Rejected — GSharp doesn't use Kotlin's `->` syntax or `by` delegation. The `event` keyword is more explicit and matches Go's philosophy of one obvious way.
+
+## Consequences
+
+- User types can declare CLR events that C# consumers subscribe to with standard `+=` / `-=`.
+- GSharp types can implement interfaces requiring events (e.g., `INotifyPropertyChanged`).
+- The `event` keyword becomes contextual inside type bodies (non-breaking — it was not previously valid there).
+- Raising events uses standard null-check + invoke — no special `raise` keyword.
+- Thread-safe event accessors (Interlocked pattern) are deferred to explicit-accessor usage.
+- Custom delegate types are deferred — events use `Action<…>`/`Func<…>` for v1.
+
+## Follow-up work (out of scope)
+
+- `type MyHandler = delegate func(…)` syntax for named delegate types
+- Thread-safe field-like event accessors (Interlocked.CompareExchange pattern)
+- `raise` accessor support (C#-style, rarely used)
+- Static events on user types

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -61,6 +61,8 @@ EnumKeyword
 EnumMember
 EqualsEqualsToken
 EqualsToken
+EventAccessor
+EventDeclaration
 EventSubscriptionExpression
 ExpressionStatement
 FallthroughKeyword

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -466,6 +466,36 @@ public sealed class Binder
                     diagnostics.AddRange(binder.Diagnostics);
                 }
             }
+
+            // ADR-0052: bind explicit event accessor bodies (add/remove).
+            if (!structSym.Events.IsDefaultOrEmpty)
+            {
+                foreach (var ev in structSym.Events)
+                {
+                    if (ev.IsFieldLike)
+                    {
+                        continue;
+                    }
+
+                    if (ev.AddMethodSymbol != null && ev.AddBodySyntax != null)
+                    {
+                        var binder = new Binder(parentScope, ev.AddMethodSymbol);
+                        var body = binder.BindStatement(ev.AddBodySyntax);
+                        var loweredBody = Lowerer.Lower(body);
+                        functionBodies.Add(ev.AddMethodSymbol, loweredBody);
+                        diagnostics.AddRange(binder.Diagnostics);
+                    }
+
+                    if (ev.RemoveMethodSymbol != null && ev.RemoveBodySyntax != null)
+                    {
+                        var binder = new Binder(parentScope, ev.RemoveMethodSymbol);
+                        var body = binder.BindStatement(ev.RemoveBodySyntax);
+                        var loweredBody = Lowerer.Lower(body);
+                        functionBodies.Add(ev.RemoveMethodSymbol, loweredBody);
+                        diagnostics.AddRange(binder.Diagnostics);
+                    }
+                }
+            }
         }
 
         var statement = Lowerer.Lower(new BoundBlockStatement(null, globalScope.Statements));

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -5317,6 +5317,17 @@ public sealed class Binder
                 return new BoundErrorExpression(null);
             }
 
+            // Check for user-defined event on a StructSymbol before falling through to CLR reflection.
+            if (boundReceiver.Type is StructSymbol userStruct && !userStruct.Events.IsDefaultOrEmpty)
+            {
+                var ev = userStruct.Events.FirstOrDefault(e => e.Name == eventName);
+                if (ev != null)
+                {
+                    var userHandler = BindExpression(syntax.Value);
+                    return new BoundEventSubscriptionExpression(null, boundReceiver, userStruct, ev, userHandler, isAdd);
+                }
+            }
+
             receiverClrType = boundReceiver.Type?.ClrType;
             if (receiverClrType == null)
             {

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -59,6 +59,14 @@ public sealed class Binder
         ImmutableHashSet.Create(AttributeTargetKind.Property, AttributeTargetKind.Field, AttributeTargetKind.Method);
 
     /// <summary>
+    /// Targets permitted on an event declaration (ADR-0052):
+    /// <c>event</c> by default; <c>field</c> for the backing field;
+    /// <c>method</c> for the synthesized add/remove accessors.
+    /// </summary>
+    private static readonly ImmutableHashSet<AttributeTargetKind> EventDeclarationAllowedTargets =
+        ImmutableHashSet.Create(AttributeTargetKind.Event, AttributeTargetKind.Field, AttributeTargetKind.Method);
+
+    /// <summary>
     /// Targets permitted on a <c>var</c>/<c>let</c>/<c>const</c> variable
     /// declaration. ADR-0047 §2 assigns the default target <c>field</c> to
     /// these declarations (both at top level — where the variable becomes a
@@ -1181,6 +1189,113 @@ public sealed class Binder
             structSymbol.SetProperties(propertiesBuilder.ToImmutable());
         }
 
+        // ADR-0052: bind event declarations.
+        if (!syntax.Events.IsDefaultOrEmpty)
+        {
+            var eventsBuilder = ImmutableArray.CreateBuilder<EventSymbol>();
+            foreach (var eventSyntax in syntax.Events)
+            {
+                var eventName = eventSyntax.Identifier.Text;
+
+                // Check for duplicate names
+                if (!existingNames.Add(eventName))
+                {
+                    Diagnostics.ReportSymbolAlreadyDeclared(eventSyntax.Identifier.Location, eventName);
+                    continue;
+                }
+
+                var handlerType = BindTypeClause(eventSyntax.Type);
+                if (handlerType == null)
+                {
+                    continue;
+                }
+
+                var eventAccessibility = ResolveAccessibility(eventSyntax.AccessibilityModifier);
+                bool isFieldLike = eventSyntax.OpenBraceToken == null;
+                bool isVirtual = eventSyntax.OpenModifier != null;
+                bool isOverride = eventSyntax.OverrideModifier != null;
+
+                // Validate: open only on open class
+                if (isVirtual && !structSymbol.IsOpen)
+                {
+                    Diagnostics.ReportOpenMemberInNonOpenClass(eventSyntax.OpenModifier.Location, eventName);
+                }
+
+                var eventSymbol = new EventSymbol(
+                    eventName,
+                    handlerType,
+                    eventAccessibility,
+                    isFieldLike,
+                    isVirtual,
+                    isOverride);
+
+                // Create backing field for field-like events
+                if (isFieldLike)
+                {
+                    var backingField = new FieldSymbol(
+                        eventName,
+                        handlerType,
+                        Accessibility.Private,
+                        isReadOnly: false);
+                    eventSymbol.BackingField = backingField;
+                }
+                else
+                {
+                    // Explicit accessors — store body syntax
+                    var addAccessor = eventSyntax.Accessors.FirstOrDefault(a => a.IsAdd);
+                    var removeAccessor = eventSyntax.Accessors.FirstOrDefault(a => a.IsRemove);
+
+                    if (addAccessor?.Body != null)
+                    {
+                        eventSymbol.AddBodySyntax = addAccessor.Body;
+                    }
+
+                    if (removeAccessor?.Body != null)
+                    {
+                        eventSymbol.RemoveBodySyntax = removeAccessor.Body;
+                    }
+                }
+
+                // Create add/remove method symbols
+                var handlerParam = new ParameterSymbol("value", handlerType);
+                eventSymbol.AddMethodSymbol = new FunctionSymbol(
+                    $"add_{eventName}",
+                    ImmutableArray.Create(handlerParam),
+                    TypeSymbol.Void,
+                    declaration: null,
+                    package,
+                    eventAccessibility,
+                    receiverType: structSymbol,
+                    isOpen: isVirtual,
+                    isOverride: isOverride);
+                eventSymbol.RemoveMethodSymbol = new FunctionSymbol(
+                    $"remove_{eventName}",
+                    ImmutableArray.Create(handlerParam),
+                    TypeSymbol.Void,
+                    declaration: null,
+                    package,
+                    eventAccessibility,
+                    receiverType: structSymbol,
+                    isOpen: isVirtual,
+                    isOverride: isOverride);
+
+                // Bind annotations
+                if (!eventSyntax.Annotations.IsDefaultOrEmpty)
+                {
+                    eventSymbol.SetAttributes(BindAttributes(
+                        eventSyntax.Annotations,
+                        AttributeTargetKind.Event,
+                        EventDeclarationAllowedTargets,
+                        "an event declaration",
+                        System.AttributeTargets.Event));
+                }
+
+                eventsBuilder.Add(eventSymbol);
+            }
+
+            structSymbol.SetEvents(eventsBuilder.ToImmutable());
+        }
+
         // Phase 3.B.4: validate interface implementation. Walks each
         // implemented interface and confirms the class (including inherited
         // methods) provides a same-name, same-signature method. The check
@@ -1454,6 +1569,39 @@ public sealed class Binder
             }
 
             interfaceSymbol.SetProperties(propertiesBuilder.ToImmutable());
+        }
+
+        // ADR-0052: bind interface event declarations.
+        if (!syntax.Events.IsDefaultOrEmpty)
+        {
+            var eventsBuilder = ImmutableArray.CreateBuilder<EventSymbol>();
+            foreach (var eventSyntax in syntax.Events)
+            {
+                var eventName = eventSyntax.Identifier.Text;
+                if (!seenNames.Add(eventName))
+                {
+                    Diagnostics.ReportSymbolAlreadyDeclared(eventSyntax.Identifier.Location, eventName);
+                    continue;
+                }
+
+                var handlerType = BindTypeClause(eventSyntax.Type);
+                if (handlerType == null)
+                {
+                    continue;
+                }
+
+                var eventSymbol = new EventSymbol(
+                    eventName,
+                    handlerType,
+                    Accessibility.Public,
+                    isFieldLike: false,
+                    isVirtual: false,
+                    isOverride: false);
+
+                eventsBuilder.Add(eventSymbol);
+            }
+
+            interfaceSymbol.SetEvents(eventsBuilder.ToImmutable());
         }
 
         // Phase 4.3c / ADR-0021: variance position checking. Walk each method's

--- a/src/Core/CodeAnalysis/Binding/BoundEventSubscriptionExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundEventSubscriptionExpression.cs
@@ -1,0 +1,47 @@
+// <copyright file="BoundEventSubscriptionExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+#pragma warning disable CS1591
+#pragma warning disable SA1600
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Represents a += / -= subscription to a user-defined event (ADR-0052).
+/// </summary>
+public sealed class BoundEventSubscriptionExpression : BoundExpression
+{
+    public BoundEventSubscriptionExpression(
+        SyntaxNode syntax,
+        BoundExpression receiver,
+        StructSymbol structType,
+        EventSymbol eventSymbol,
+        BoundExpression handler,
+        bool isAdd)
+        : base(syntax)
+    {
+        Receiver = receiver;
+        StructType = structType;
+        Event = eventSymbol;
+        Handler = handler;
+        IsAdd = isAdd;
+    }
+
+    public BoundExpression Receiver { get; }
+
+    public StructSymbol StructType { get; }
+
+    public EventSymbol Event { get; }
+
+    public BoundExpression Handler { get; }
+
+    public bool IsAdd { get; }
+
+    public override TypeSymbol Type => TypeSymbol.Void;
+
+    public override BoundNodeKind Kind => BoundNodeKind.EventSubscriptionExpression;
+}

--- a/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -70,6 +70,7 @@ public enum BoundNodeKind
     ClrIndexExpression,
     ClrIndexAssignmentExpression,
     ClrEventSubscriptionExpression,
+    EventSubscriptionExpression,
     AwaitExpression,
     SwitchExpression,
     SwitchExpressionArm,

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -214,6 +214,9 @@ public static class BoundNodePrinter
             case BoundNodeKind.ClrEventSubscriptionExpression:
                 WriteClrEventSubscriptionExpression((BoundClrEventSubscriptionExpression)node, writer);
                 break;
+            case BoundNodeKind.EventSubscriptionExpression:
+                WriteEventSubscriptionExpression((BoundEventSubscriptionExpression)node, writer);
+                break;
             case BoundNodeKind.ClrBinaryOperatorExpression:
                 WriteClrBinaryOperatorExpression((BoundClrBinaryOperatorExpression)node, writer);
                 break;
@@ -1164,6 +1167,25 @@ public static class BoundNodePrinter
         else if (node.Event.DeclaringType != null)
         {
             writer.WriteIdentifier(node.Event.DeclaringType.Name);
+        }
+
+        writer.WritePunctuation(SyntaxKind.DotToken);
+        writer.WriteIdentifier(node.Event.Name);
+        writer.WriteSpace();
+        writer.WritePunctuation(node.IsAdd ? SyntaxKind.PlusEqualsToken : SyntaxKind.MinusEqualsToken);
+        writer.WriteSpace();
+        node.Handler.WriteTo(writer);
+    }
+
+    private static void WriteEventSubscriptionExpression(BoundEventSubscriptionExpression node, IndentedTextWriter writer)
+    {
+        if (node.Receiver != null)
+        {
+            node.Receiver.WriteTo(writer);
+        }
+        else
+        {
+            writer.WriteIdentifier(node.StructType.Name);
         }
 
         writer.WritePunctuation(SyntaxKind.DotToken);

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -394,6 +394,8 @@ public abstract class BoundTreeRewriter
                 return RewriteClrPropertyAssignmentExpression((BoundClrPropertyAssignmentExpression)node);
             case BoundNodeKind.ClrEventSubscriptionExpression:
                 return RewriteClrEventSubscriptionExpression((BoundClrEventSubscriptionExpression)node);
+            case BoundNodeKind.EventSubscriptionExpression:
+                return RewriteEventSubscriptionExpression((BoundEventSubscriptionExpression)node);
             case BoundNodeKind.ClrBinaryOperatorExpression:
                 return RewriteClrBinaryOperatorExpression((BoundClrBinaryOperatorExpression)node);
             case BoundNodeKind.ClrUnaryOperatorExpression:
@@ -1342,6 +1344,21 @@ public abstract class BoundTreeRewriter
         }
 
         return new BoundClrEventSubscriptionExpression(null, receiver, node.Event, handler, node.IsAdd);
+    }
+
+    /// <summary>Rewrites a user-defined event subscription expression (ADR-0052).</summary>
+    /// <param name="node">The node to rewrite.</param>
+    /// <returns>The rewritten node.</returns>
+    protected virtual BoundExpression RewriteEventSubscriptionExpression(BoundEventSubscriptionExpression node)
+    {
+        var receiver = node.Receiver == null ? null : RewriteExpression(node.Receiver);
+        var handler = RewriteExpression(node.Handler);
+        if (receiver == node.Receiver && handler == node.Handler)
+        {
+            return node;
+        }
+
+        return new BoundEventSubscriptionExpression(null, receiver, node.StructType, node.Event, handler, node.IsAdd);
     }
 
     /// <summary>Rewrites a CLR binary operator call (Stream C).</summary>

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -93,8 +93,15 @@ internal sealed class ReflectionMetadataEmitter
     // ADR-0051 Phase 6: property accessor method handles for PropertyDef + MethodSemantics emission.
     private readonly Dictionary<PropertySymbol, (MethodDefinitionHandle? Getter, MethodDefinitionHandle? Setter)> propertyAccessorHandles = new Dictionary<PropertySymbol, (MethodDefinitionHandle? Getter, MethodDefinitionHandle? Setter)>();
 
+    // ADR-0052: event accessor method handles for EventDef + MethodSemantics emission.
+    private readonly Dictionary<EventSymbol, (MethodDefinitionHandle Add, MethodDefinitionHandle Remove)> eventAccessorHandles = new Dictionary<EventSymbol, (MethodDefinitionHandle Add, MethodDefinitionHandle Remove)>();
+
     // ADR-0051 Phase 6: cached MemberReferenceHandle for NotImplementedException..ctor().
     private MemberReferenceHandle? notImplementedExceptionCtorRef;
+
+    // ADR-0052: cached MemberReferenceHandles for Delegate.Combine and Delegate.Remove.
+    private MemberReferenceHandle? delegateCombineRef;
+    private MemberReferenceHandle? delegateRemoveRef;
 
     // Phase 4 emit parity (E1): synthesized lambda bodies (no captures).
     // Populated by a pre-pass walker over every user function/entry body.
@@ -466,6 +473,15 @@ internal sealed class ReflectionMetadataEmitter
                     nextFieldRow++;
                 }
             }
+
+            // ADR-0052: backing fields for field-like events.
+            foreach (var ev in s.Events)
+            {
+                if (ev.IsFieldLike && ev.BackingField != null)
+                {
+                    nextFieldRow++;
+                }
+            }
         }
 
         foreach (var s in nonSmStructs)
@@ -476,6 +492,15 @@ internal sealed class ReflectionMetadataEmitter
             foreach (var p in s.Properties)
             {
                 if (p.IsAutoProperty && p.BackingField != null)
+                {
+                    nextFieldRow++;
+                }
+            }
+
+            // ADR-0052: backing fields for field-like events.
+            foreach (var ev in s.Events)
+            {
+                if (ev.IsFieldLike && ev.BackingField != null)
                 {
                     nextFieldRow++;
                 }
@@ -556,6 +581,14 @@ internal sealed class ReflectionMetadataEmitter
 
                 this.propertyAccessorHandles[prop] = (getterHandle, setterHandle);
             }
+
+            // ADR-0052: plan accessor method rows for interface events.
+            foreach (var ev in i.Events)
+            {
+                var addHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                var removeHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                this.eventAccessorHandles[ev] = (addHandle, removeHandle);
+            }
         }
 
         // Plan method rows for non-SM class ctors + instance methods.
@@ -597,13 +630,21 @@ internal sealed class ReflectionMetadataEmitter
 
                 this.propertyAccessorHandles[prop] = (getterHandle, setterHandle);
             }
+
+            // ADR-0052: plan accessor method rows for class events.
+            foreach (var ev in c.Events)
+            {
+                var addHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                var removeHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                this.eventAccessorHandles[ev] = (addHandle, removeHandle);
+            }
         }
 
         // Plan method rows for non-SM structs.
         var structFirstMethodRows = new Dictionary<StructSymbol, int>();
         foreach (var s in nonSmStructs)
         {
-            if (s.Methods.IsDefaultOrEmpty && !s.IsInline && s.Properties.IsDefaultOrEmpty)
+            if (s.Methods.IsDefaultOrEmpty && !s.IsInline && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty)
             {
                 continue;
             }
@@ -637,6 +678,14 @@ internal sealed class ReflectionMetadataEmitter
                 }
 
                 this.propertyAccessorHandles[prop] = (getterHandle, setterHandle);
+            }
+
+            // ADR-0052: plan accessor method rows for struct events.
+            foreach (var ev in s.Events)
+            {
+                var addHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                var removeHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                this.eventAccessorHandles[ev] = (addHandle, removeHandle);
             }
         }
 
@@ -941,6 +990,9 @@ internal sealed class ReflectionMetadataEmitter
 
             // Issue #248: emit abstract accessor MethodDefs + PropertyDef rows for interface properties.
             this.EmitInterfacePropertyAccessors(i);
+
+            // ADR-0052: emit abstract accessor MethodDefs + EventDef rows for interface events.
+            this.EmitInterfaceEventAccessors(i);
         }
 
         // B2. Non-SM class ctors + instance methods.
@@ -971,6 +1023,9 @@ internal sealed class ReflectionMetadataEmitter
 
             // ADR-0051 Phase 6: emit property accessor methods for classes.
             this.EmitPropertyAccessors(c);
+
+            // ADR-0052: emit event accessor methods for classes.
+            this.EmitEventAccessors(c);
         }
 
         // 4b. Non-SM struct methods.
@@ -981,7 +1036,7 @@ internal sealed class ReflectionMetadataEmitter
                 this.EmitInlineStructSynthesizedMembers(s);
             }
 
-            if (s.Methods.IsDefaultOrEmpty && s.Properties.IsDefaultOrEmpty)
+            if (s.Methods.IsDefaultOrEmpty && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty)
             {
                 continue;
             }
@@ -999,6 +1054,9 @@ internal sealed class ReflectionMetadataEmitter
 
             // ADR-0051 Phase 6: emit property accessor methods for structs.
             this.EmitPropertyAccessors(s);
+
+            // ADR-0052: emit event accessor methods for structs.
+            this.EmitEventAccessors(s);
         }
 
         // Phase 4 emit parity (F2, type-erased): now that every generic
@@ -1583,6 +1641,28 @@ internal sealed class ReflectionMetadataEmitter
             this.structFieldDefs[prop.BackingField] = backingHandle;
         }
 
+        // ADR-0052: emit backing FieldDefs for field-like events.
+        foreach (var ev in structSym.Events)
+        {
+            if (!ev.IsFieldLike || ev.BackingField == null)
+            {
+                continue;
+            }
+
+            var sigBlob = new BlobBuilder();
+            this.EncodeTypeSymbol(new BlobEncoder(sigBlob).FieldSignature(), ev.Type);
+            var backingHandle = this.metadata.AddFieldDefinition(
+                attributes: FieldAttributes.Private,
+                name: this.metadata.GetOrAddString(ev.BackingField.Name),
+                signature: this.metadata.GetOrAddBlob(sigBlob));
+            if (firstField.IsNil)
+            {
+                firstField = backingHandle;
+            }
+
+            this.structFieldDefs[ev.BackingField] = backingHandle;
+        }
+
         if (firstField.IsNil)
         {
             // Empty struct: no field rows added; point at next row, which is
@@ -1910,6 +1990,318 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// ADR-0052: determines whether an event on a class/struct implicitly implements
+    /// an interface event (same name on any implemented interface).
+    /// </summary>
+    private bool EventImplicitlyImplementsInterface(StructSymbol structSym, EventSymbol ev)
+    {
+        if (structSym.Interfaces.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        foreach (var iface in structSym.Interfaces)
+        {
+            if (iface.Events.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            foreach (var ifaceEvent in iface.Events)
+            {
+                if (ifaceEvent.Name == ev.Name)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// ADR-0052: emits add/remove accessor MethodDefs, EventDef rows, EventMap,
+    /// and MethodSemantics rows for all events declared on a type.
+    /// </summary>
+    private void EmitEventAccessors(StructSymbol structSym)
+    {
+        if (structSym.Events.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        if (!this.structTypeDefs.TryGetValue(structSym, out var typeDefHandle))
+        {
+            return;
+        }
+
+        EventDefinitionHandle firstEventDef = default;
+        foreach (var ev in structSym.Events)
+        {
+            if (!this.eventAccessorHandles.TryGetValue(ev, out var accessorHandles))
+            {
+                continue;
+            }
+
+            // Emit add_X MethodDef.
+            var addMethod = this.EmitEventAddAccessor(structSym, ev);
+
+            // Emit remove_X MethodDef.
+            var removeMethod = this.EmitEventRemoveAccessor(structSym, ev);
+
+            // Emit EventDef row.
+            var eventTypeHandle = this.GetEventTypeHandle(ev.Type);
+
+            var eventDef = this.metadata.AddEvent(
+                attributes: EventAttributes.None,
+                name: this.metadata.GetOrAddString(ev.Name),
+                type: eventTypeHandle);
+
+            if (firstEventDef.IsNil)
+            {
+                firstEventDef = eventDef;
+            }
+
+            // MethodSemantics rows linking accessor MethodDefs to the EventDef.
+            this.metadata.AddMethodSemantics(eventDef, MethodSemanticsAttributes.Adder, addMethod);
+            this.metadata.AddMethodSemantics(eventDef, MethodSemanticsAttributes.Remover, removeMethod);
+        }
+
+        // EventMap row: links the TypeDef to its first EventDef.
+        if (!firstEventDef.IsNil)
+        {
+            this.metadata.AddEventMap(typeDefHandle, firstEventDef);
+        }
+    }
+
+    /// <summary>
+    /// ADR-0052: resolves the EntityHandle for the event handler type used in the EventDef row.
+    /// </summary>
+    private EntityHandle GetEventTypeHandle(TypeSymbol type)
+    {
+        if (type is FunctionTypeSymbol fnType)
+        {
+            var clrType = fnType.ClrType;
+            if (clrType != null)
+            {
+                return this.GetTypeHandleForMember(clrType);
+            }
+        }
+
+        if (type.ClrType != null)
+        {
+            return this.GetTypeHandleForMember(type.ClrType);
+        }
+
+        if (type is StructSymbol structSym && this.structTypeDefs.TryGetValue(structSym, out var td))
+        {
+            return td;
+        }
+
+        if (type is InterfaceSymbol ifaceSym && this.interfaceTypeDefs.TryGetValue(ifaceSym, out var ifaceDef))
+        {
+            return ifaceDef;
+        }
+
+        // Fallback: encode as System.Delegate.
+        return this.GetTypeReference(typeof(System.Delegate));
+    }
+
+    /// <summary>
+    /// ADR-0052: emits the add_X accessor MethodDef for an event.
+    /// </summary>
+    private MethodDefinitionHandle EmitEventAddAccessor(StructSymbol structSym, EventSymbol ev)
+    {
+        int bodyOffset = -1;
+        if (!this.metadataOnly)
+        {
+            if (ev.IsFieldLike && ev.BackingField != null
+                && this.structFieldDefs.TryGetValue(ev.BackingField, out var backingHandle))
+            {
+                var il = new InstructionEncoder(new BlobBuilder());
+                il.LoadArgument(0);
+                il.LoadArgument(0);
+                il.OpCode(ILOpCode.Ldfld);
+                il.Token(backingHandle);
+                il.LoadArgument(1);
+                il.OpCode(ILOpCode.Call);
+                il.Token(this.GetDelegateCombineRef());
+                il.OpCode(ILOpCode.Castclass);
+                il.Token(this.GetEventTypeHandle(ev.Type));
+                il.OpCode(ILOpCode.Stfld);
+                il.Token(backingHandle);
+                il.OpCode(ILOpCode.Ret);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+            else
+            {
+                // Fallback: throw new NotImplementedException().
+                var il = new InstructionEncoder(new BlobBuilder());
+                var nieCtor = this.GetNotImplementedExceptionCtor();
+                il.OpCode(ILOpCode.Newobj);
+                il.Token(nieCtor);
+                il.OpCode(ILOpCode.Throw);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+        }
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(1, r => r.Void(), ps => this.EncodeTypeSymbol(ps.AddParameter().Type(), ev.Type));
+
+        var methodAttrs = MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig;
+        if (ev.IsVirtual)
+        {
+            methodAttrs |= MethodAttributes.Virtual | MethodAttributes.NewSlot;
+        }
+        else if (ev.IsOverride)
+        {
+            methodAttrs |= MethodAttributes.Virtual;
+        }
+        else if (this.EventImplicitlyImplementsInterface(structSym, ev))
+        {
+            methodAttrs |= MethodAttributes.Virtual | MethodAttributes.NewSlot;
+        }
+
+        var firstParamHandle = this.NextParameterHandle();
+        this.metadata.AddParameter(
+            attributes: ParameterAttributes.None,
+            name: this.metadata.GetOrAddString("value"),
+            sequenceNumber: 1);
+
+        return this.metadata.AddMethodDefinition(
+            attributes: methodAttrs,
+            implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString($"add_{ev.Name}"),
+            signature: this.metadata.GetOrAddBlob(sigBlob),
+            bodyOffset: bodyOffset,
+            parameterList: firstParamHandle);
+    }
+
+    /// <summary>
+    /// ADR-0052: emits the remove_X accessor MethodDef for an event.
+    /// </summary>
+    private MethodDefinitionHandle EmitEventRemoveAccessor(StructSymbol structSym, EventSymbol ev)
+    {
+        int bodyOffset = -1;
+        if (!this.metadataOnly)
+        {
+            if (ev.IsFieldLike && ev.BackingField != null
+                && this.structFieldDefs.TryGetValue(ev.BackingField, out var backingHandle))
+            {
+                var il = new InstructionEncoder(new BlobBuilder());
+                il.LoadArgument(0);
+                il.LoadArgument(0);
+                il.OpCode(ILOpCode.Ldfld);
+                il.Token(backingHandle);
+                il.LoadArgument(1);
+                il.OpCode(ILOpCode.Call);
+                il.Token(this.GetDelegateRemoveRef());
+                il.OpCode(ILOpCode.Castclass);
+                il.Token(this.GetEventTypeHandle(ev.Type));
+                il.OpCode(ILOpCode.Stfld);
+                il.Token(backingHandle);
+                il.OpCode(ILOpCode.Ret);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+            else
+            {
+                // Fallback: throw new NotImplementedException().
+                var il = new InstructionEncoder(new BlobBuilder());
+                var nieCtor = this.GetNotImplementedExceptionCtor();
+                il.OpCode(ILOpCode.Newobj);
+                il.Token(nieCtor);
+                il.OpCode(ILOpCode.Throw);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+        }
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(1, r => r.Void(), ps => this.EncodeTypeSymbol(ps.AddParameter().Type(), ev.Type));
+
+        var methodAttrs = MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig;
+        if (ev.IsVirtual)
+        {
+            methodAttrs |= MethodAttributes.Virtual | MethodAttributes.NewSlot;
+        }
+        else if (ev.IsOverride)
+        {
+            methodAttrs |= MethodAttributes.Virtual;
+        }
+        else if (this.EventImplicitlyImplementsInterface(structSym, ev))
+        {
+            methodAttrs |= MethodAttributes.Virtual | MethodAttributes.NewSlot;
+        }
+
+        var firstParamHandle = this.NextParameterHandle();
+        this.metadata.AddParameter(
+            attributes: ParameterAttributes.None,
+            name: this.metadata.GetOrAddString("value"),
+            sequenceNumber: 1);
+
+        return this.metadata.AddMethodDefinition(
+            attributes: methodAttrs,
+            implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString($"remove_{ev.Name}"),
+            signature: this.metadata.GetOrAddBlob(sigBlob),
+            bodyOffset: bodyOffset,
+            parameterList: firstParamHandle);
+    }
+
+    /// <summary>ADR-0052: resolves a MemberReferenceHandle for Delegate.Combine(Delegate, Delegate).</summary>
+    private MemberReferenceHandle GetDelegateCombineRef()
+    {
+        if (this.delegateCombineRef.HasValue)
+        {
+            return this.delegateCombineRef.Value;
+        }
+
+        var delegateTypeRef = this.GetTypeReference(typeof(System.Delegate));
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
+            .Parameters(2,
+                r => r.Type().Type(delegateTypeRef, isValueType: false),
+                ps =>
+                {
+                    ps.AddParameter().Type().Type(delegateTypeRef, isValueType: false);
+                    ps.AddParameter().Type().Type(delegateTypeRef, isValueType: false);
+                });
+
+        this.delegateCombineRef = this.metadata.AddMemberReference(
+            delegateTypeRef,
+            this.metadata.GetOrAddString("Combine"),
+            this.metadata.GetOrAddBlob(sig));
+        return this.delegateCombineRef.Value;
+    }
+
+    /// <summary>ADR-0052: resolves a MemberReferenceHandle for Delegate.Remove(Delegate, Delegate).</summary>
+    private MemberReferenceHandle GetDelegateRemoveRef()
+    {
+        if (this.delegateRemoveRef.HasValue)
+        {
+            return this.delegateRemoveRef.Value;
+        }
+
+        var delegateTypeRef = this.GetTypeReference(typeof(System.Delegate));
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
+            .Parameters(2,
+                r => r.Type().Type(delegateTypeRef, isValueType: false),
+                ps =>
+                {
+                    ps.AddParameter().Type().Type(delegateTypeRef, isValueType: false);
+                    ps.AddParameter().Type().Type(delegateTypeRef, isValueType: false);
+                });
+
+        this.delegateRemoveRef = this.metadata.AddMemberReference(
+            delegateTypeRef,
+            this.metadata.GetOrAddString("Remove"),
+            this.metadata.GetOrAddBlob(sig));
+        return this.delegateRemoveRef.Value;
     }
 
     /// <summary>
@@ -2871,6 +3263,87 @@ internal sealed class ReflectionMetadataEmitter
         if (!firstPropDef.IsNil)
         {
             this.metadata.AddPropertyMap(typeDefHandle, firstPropDef);
+        }
+    }
+
+    /// <summary>
+    /// ADR-0052: emits abstract add/remove accessor MethodDefs, EventDef rows, EventMap,
+    /// and MethodSemantics rows for all events declared on an interface.
+    /// </summary>
+    private void EmitInterfaceEventAccessors(InterfaceSymbol ifaceSym)
+    {
+        if (ifaceSym.Events.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        if (!this.interfaceTypeDefs.TryGetValue(ifaceSym, out var typeDefHandle))
+        {
+            return;
+        }
+
+        EventDefinitionHandle firstEventDef = default;
+        foreach (var ev in ifaceSym.Events)
+        {
+            if (!this.eventAccessorHandles.TryGetValue(ev, out var accessorHandles))
+            {
+                continue;
+            }
+
+            // Emit abstract add_X MethodDef.
+            var addSigBlob = new BlobBuilder();
+            new BlobEncoder(addSigBlob).MethodSignature(isInstanceMethod: true)
+                .Parameters(1, r => r.Void(), ps => this.EncodeTypeSymbol(ps.AddParameter().Type(), ev.Type));
+
+            var addAttrs = MethodAttributes.Public | MethodAttributes.HideBySig
+                | MethodAttributes.Virtual | MethodAttributes.Abstract
+                | MethodAttributes.NewSlot | MethodAttributes.SpecialName;
+            var emittedAdd = this.metadata.AddMethodDefinition(
+                attributes: addAttrs,
+                implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+                name: this.metadata.GetOrAddString($"add_{ev.Name}"),
+                signature: this.metadata.GetOrAddBlob(addSigBlob),
+                bodyOffset: -1,
+                parameterList: this.NextParameterHandle());
+
+            // Emit abstract remove_X MethodDef.
+            var removeSigBlob = new BlobBuilder();
+            new BlobEncoder(removeSigBlob).MethodSignature(isInstanceMethod: true)
+                .Parameters(1, r => r.Void(), ps => this.EncodeTypeSymbol(ps.AddParameter().Type(), ev.Type));
+
+            var removeAttrs = MethodAttributes.Public | MethodAttributes.HideBySig
+                | MethodAttributes.Virtual | MethodAttributes.Abstract
+                | MethodAttributes.NewSlot | MethodAttributes.SpecialName;
+            var emittedRemove = this.metadata.AddMethodDefinition(
+                attributes: removeAttrs,
+                implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+                name: this.metadata.GetOrAddString($"remove_{ev.Name}"),
+                signature: this.metadata.GetOrAddBlob(removeSigBlob),
+                bodyOffset: -1,
+                parameterList: this.NextParameterHandle());
+
+            // Emit EventDef row.
+            var eventTypeHandle = this.GetEventTypeHandle(ev.Type);
+
+            var eventDef = this.metadata.AddEvent(
+                attributes: EventAttributes.None,
+                name: this.metadata.GetOrAddString(ev.Name),
+                type: eventTypeHandle);
+
+            if (firstEventDef.IsNil)
+            {
+                firstEventDef = eventDef;
+            }
+
+            // MethodSemantics rows linking accessor MethodDefs to the EventDef.
+            this.metadata.AddMethodSemantics(eventDef, MethodSemanticsAttributes.Adder, emittedAdd);
+            this.metadata.AddMethodSemantics(eventDef, MethodSemanticsAttributes.Remover, emittedRemove);
+        }
+
+        // EventMap row: links the TypeDef to its first EventDef.
+        if (!firstEventDef.IsNil)
+        {
+            this.metadata.AddEventMap(typeDefHandle, firstEventDef);
         }
     }
 

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -2136,6 +2136,12 @@ internal sealed class ReflectionMetadataEmitter
                 il.OpCode(ILOpCode.Ret);
                 bodyOffset = this.methodBodyStream.AddMethodBody(il);
             }
+            else if (ev.AddMethodSymbol != null && this.program.Functions.TryGetValue(ev.AddMethodSymbol, out var addBody))
+            {
+                // Explicit accessor with bound body: emit using EmitFunction infrastructure.
+                var handle = this.EmitFunction(ev.AddMethodSymbol, addBody, isEntryPoint: false);
+                return handle;
+            }
             else
             {
                 // Fallback: throw new NotImplementedException().
@@ -2206,6 +2212,12 @@ internal sealed class ReflectionMetadataEmitter
                 il.Token(backingHandle);
                 il.OpCode(ILOpCode.Ret);
                 bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+            else if (ev.RemoveMethodSymbol != null && this.program.Functions.TryGetValue(ev.RemoveMethodSymbol, out var removeBody))
+            {
+                // Explicit accessor with bound body: emit using EmitFunction infrastructure.
+                var handle = this.EmitFunction(ev.RemoveMethodSymbol, removeBody, isEntryPoint: false);
+                return handle;
             }
             else
             {

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -8488,6 +8488,9 @@ internal sealed class ReflectionMetadataEmitter
                 case BoundClrEventSubscriptionExpression clrEventSub:
                     this.EmitClrEventSubscription(clrEventSub);
                     break;
+                case BoundEventSubscriptionExpression userEventSub:
+                    this.EmitUserEventSubscription(userEventSub);
+                    break;
                 case BoundClrBinaryOperatorExpression clrBinOp:
                     this.EmitClrBinaryOperator(clrBinOp);
                     break;
@@ -10627,6 +10630,21 @@ internal sealed class ReflectionMetadataEmitter
 
             this.il.OpCode(isStatic || receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
             this.il.Token(this.outer.GetMethodReference(accessor));
+        }
+
+        private void EmitUserEventSubscription(BoundEventSubscriptionExpression node)
+        {
+            // ADR-0052: user-defined event subscription — call add_X or remove_X accessor.
+            this.EmitInstanceReceiver(node.Receiver);
+            this.EmitExpression(node.Handler);
+
+            if (this.outer.eventAccessorHandles.TryGetValue(node.Event, out var accessorHandles))
+            {
+                var accessorHandle = node.IsAdd ? accessorHandles.Add : accessorHandles.Remove;
+                bool isVirtual = node.Event.IsVirtual || node.Event.IsOverride;
+                this.il.OpCode(isVirtual ? ILOpCode.Callvirt : ILOpCode.Call);
+                this.il.Token(accessorHandle);
+            }
         }
 
         private void EmitClrBinaryOperator(BoundClrBinaryOperatorExpression op)

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -493,6 +493,7 @@ public sealed class Evaluator
                 BoundNodeKind.ClrPropertyAccessExpression => EvaluateClrPropertyAccessExpression((BoundClrPropertyAccessExpression)node),
                 BoundNodeKind.ClrPropertyAssignmentExpression => EvaluateClrPropertyAssignmentExpression((BoundClrPropertyAssignmentExpression)node),
                 BoundNodeKind.ClrEventSubscriptionExpression => EvaluateClrEventSubscriptionExpression((BoundClrEventSubscriptionExpression)node),
+                BoundNodeKind.EventSubscriptionExpression => EvaluateEventSubscriptionExpression((BoundEventSubscriptionExpression)node),
                 BoundNodeKind.ClrBinaryOperatorExpression => EvaluateClrBinaryOperatorExpression((BoundClrBinaryOperatorExpression)node),
                 BoundNodeKind.ClrUnaryOperatorExpression => EvaluateClrUnaryOperatorExpression((BoundClrUnaryOperatorExpression)node),
                 BoundNodeKind.ClrConversionCallExpression => EvaluateClrConversionCallExpression((BoundClrConversionCallExpression)node),
@@ -888,6 +889,29 @@ public sealed class Evaluator
         else
         {
             node.Event.RemoveEventHandler(receiver, handler);
+        }
+
+        return null;
+    }
+
+    private object EvaluateEventSubscriptionExpression(BoundEventSubscriptionExpression node)
+    {
+        var receiverValue = EvaluateExpression(node.Receiver);
+        var handlerValue = EvaluateExpression(node.Handler) as Delegate;
+
+        if (receiverValue is StructValue sv && node.Event.BackingField != null)
+        {
+            var fieldName = node.Event.BackingField.Name;
+            var existing = sv.Fields.TryGetValue(fieldName, out var current) ? current as Delegate : null;
+
+            if (node.IsAdd)
+            {
+                sv.Fields[fieldName] = existing == null ? handlerValue : Delegate.Combine(existing, handlerValue);
+            }
+            else
+            {
+                sv.Fields[fieldName] = existing == null ? null : Delegate.Remove(existing, handlerValue);
+            }
         }
 
         return null;

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -899,6 +899,32 @@ public sealed class Evaluator
         var receiverValue = EvaluateExpression(node.Receiver);
         var handlerValue = EvaluateExpression(node.Handler) as Delegate;
 
+        // Explicit accessor bodies: execute the bound add/remove body.
+        if (!node.Event.IsFieldLike)
+        {
+            var methodSymbol = node.IsAdd ? node.Event.AddMethodSymbol : node.Event.RemoveMethodSymbol;
+            if (methodSymbol != null && program.Functions.TryGetValue(methodSymbol, out var body))
+            {
+                var frame = new Dictionary<Symbols.VariableSymbol, object>();
+                if (methodSymbol.ThisParameter != null)
+                {
+                    frame[methodSymbol.ThisParameter] = receiverValue;
+                }
+
+                if (methodSymbol.Parameters.Length > 0)
+                {
+                    frame[methodSymbol.Parameters[0]] = handlerValue;
+                }
+
+                locals.Push(frame);
+                EvaluateStatement(body);
+                locals.Pop();
+            }
+
+            return null;
+        }
+
+        // Field-like event: use Delegate.Combine/Remove on the backing field.
         if (receiverValue is StructValue sv && node.Event.BackingField != null)
         {
             var fieldName = node.Event.BackingField.Name;

--- a/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
@@ -1,0 +1,69 @@
+// <copyright file="EventSymbol.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Represents an event declared on a user-defined type (ADR-0052).
+/// </summary>
+public sealed class EventSymbol : Symbol
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventSymbol"/> class.
+    /// </summary>
+    /// <param name="name">The event name.</param>
+    /// <param name="type">The event handler type (should be a FunctionTypeSymbol).</param>
+    /// <param name="accessibility">The event accessibility.</param>
+    /// <param name="isFieldLike">Whether this is a field-like event (no explicit accessors).</param>
+    /// <param name="isVirtual">Whether this event is virtual (open modifier present).</param>
+    /// <param name="isOverride">Whether this event overrides a base event.</param>
+    public EventSymbol(
+        string name,
+        TypeSymbol type,
+        Accessibility accessibility,
+        bool isFieldLike,
+        bool isVirtual,
+        bool isOverride)
+        : base(name)
+    {
+        Type = type;
+        Accessibility = accessibility;
+        IsFieldLike = isFieldLike;
+        IsVirtual = isVirtual;
+        IsOverride = isOverride;
+    }
+
+    /// <inheritdoc/>
+    public override SymbolKind Kind => SymbolKind.Event;
+
+    /// <summary>Gets the event handler type.</summary>
+    public TypeSymbol Type { get; }
+
+    /// <summary>Gets the event accessibility.</summary>
+    public Accessibility Accessibility { get; }
+
+    /// <summary>Gets a value indicating whether this is a field-like event (no explicit accessors).</summary>
+    public bool IsFieldLike { get; }
+
+    /// <summary>Gets a value indicating whether this event is virtual (open modifier present).</summary>
+    public bool IsVirtual { get; }
+
+    /// <summary>Gets a value indicating whether this event overrides a base event.</summary>
+    public bool IsOverride { get; }
+
+    /// <summary>Gets or sets the synthesized backing delegate field (null for explicit accessors).</summary>
+    public FieldSymbol BackingField { get; set; }
+
+    /// <summary>Gets or sets the synthesized add method symbol.</summary>
+    public FunctionSymbol AddMethodSymbol { get; set; }
+
+    /// <summary>Gets or sets the synthesized remove method symbol.</summary>
+    public FunctionSymbol RemoveMethodSymbol { get; set; }
+
+    /// <summary>Gets or sets the explicit add body syntax (null for field-like events).</summary>
+    public Syntax.BlockStatementSyntax AddBodySyntax { get; set; }
+
+    /// <summary>Gets or sets the explicit remove body syntax (null for field-like events).</summary>
+    public Syntax.BlockStatementSyntax RemoveBodySyntax { get; set; }
+}

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -68,6 +68,9 @@ public sealed class InterfaceSymbol : TypeSymbol
     /// <summary>Gets the property signatures declared on this interface (ADR-0051). Populated by the binder via <see cref="SetProperties"/>.</summary>
     public ImmutableArray<PropertySymbol> Properties { get; private set; } = ImmutableArray<PropertySymbol>.Empty;
 
+    /// <summary>Gets the event signatures declared on this interface (ADR-0052). Populated by the binder via <see cref="SetEvents"/>.</summary>
+    public ImmutableArray<EventSymbol> Events { get; private set; } = ImmutableArray<EventSymbol>.Empty;
+
     /// <summary>Gets the type parameters when this is a generic definition (Phase 4.3c / ADR-0020).</summary>
     public ImmutableArray<TypeParameterSymbol> TypeParameters { get; private set; } = ImmutableArray<TypeParameterSymbol>.Empty;
 
@@ -92,6 +95,13 @@ public sealed class InterfaceSymbol : TypeSymbol
     public void SetProperties(ImmutableArray<PropertySymbol> properties)
     {
         Properties = properties;
+    }
+
+    /// <summary>Sets <see cref="Events"/>. Intended to be called once by the binder (ADR-0052).</summary>
+    /// <param name="events">The bound event signatures.</param>
+    public void SetEvents(ImmutableArray<EventSymbol> events)
+    {
+        Events = events;
     }
 
     /// <summary>Sets <see cref="TypeParameters"/> on a generic definition (Phase 4.3c). Intended to be called once by the binder.</summary>

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -192,6 +192,9 @@ public sealed class StructSymbol : TypeSymbol
     /// <summary>Gets the properties declared on this type (ADR-0051). Populated by the binder after the symbol is constructed; defaults to empty.</summary>
     public ImmutableArray<PropertySymbol> Properties { get; private set; } = ImmutableArray<PropertySymbol>.Empty;
 
+    /// <summary>Gets the events declared on this type (ADR-0052). Populated by the binder after the symbol is constructed; defaults to empty.</summary>
+    public ImmutableArray<EventSymbol> Events { get; private set; } = ImmutableArray<EventSymbol>.Empty;
+
     /// <summary>Gets the type parameters when this is a generic definition (Phase 4.3 / ADR-0020). Empty for non-generic types and for constructed instances.</summary>
     public ImmutableArray<TypeParameterSymbol> TypeParameters { get; private set; } = ImmutableArray<TypeParameterSymbol>.Empty;
 
@@ -233,6 +236,13 @@ public sealed class StructSymbol : TypeSymbol
     public void SetProperties(ImmutableArray<PropertySymbol> properties)
     {
         Properties = properties;
+    }
+
+    /// <summary>Sets <see cref="Events"/> after binding event declarations (ADR-0052).</summary>
+    /// <param name="events">The bound event symbols owned by this type.</param>
+    public void SetEvents(ImmutableArray<EventSymbol> events)
+    {
+        Events = events;
     }
 
     /// <summary>Appends additional methods after the initial declaration binding pass.</summary>

--- a/src/Core/CodeAnalysis/Symbols/SymbolKind.cs
+++ b/src/Core/CodeAnalysis/Symbols/SymbolKind.cs
@@ -68,4 +68,9 @@ public enum SymbolKind
     /// The symbol is a property on a struct or class.
     /// </summary>
     Property,
+
+    /// <summary>
+    /// The symbol is an event on a struct or class (ADR-0052).
+    /// </summary>
+    Event,
 }

--- a/src/Core/CodeAnalysis/Syntax/EventAccessorSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/EventAccessorSyntax.cs
@@ -1,0 +1,48 @@
+// <copyright file="EventAccessorSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents a single <c>add</c> or <c>remove</c> accessor inside an event body (ADR-0052).
+/// </summary>
+public sealed class EventAccessorSyntax : SyntaxNode
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventAccessorSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="accessorKeyword">The <c>add</c> or <c>remove</c> identifier token.</param>
+    /// <param name="body">The optional block body.</param>
+    /// <param name="semicolonToken">The optional semicolon (for shorthand <c>add;</c> / <c>remove;</c>).</param>
+    public EventAccessorSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken accessorKeyword,
+        BlockStatementSyntax body,
+        SyntaxToken semicolonToken)
+        : base(syntaxTree)
+    {
+        AccessorKeyword = accessorKeyword;
+        Body = body;
+        SemicolonToken = semicolonToken;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.EventAccessor;
+
+    /// <summary>Gets the <c>add</c> or <c>remove</c> identifier token.</summary>
+    public SyntaxToken AccessorKeyword { get; }
+
+    /// <summary>Gets the optional block body. Null for bare <c>add;</c> / <c>remove;</c> accessors.</summary>
+    public BlockStatementSyntax Body { get; }
+
+    /// <summary>Gets the optional semicolon token (present for <c>add;</c> / <c>remove;</c> shorthand).</summary>
+    public SyntaxToken SemicolonToken { get; }
+
+    /// <summary>Gets a value indicating whether this accessor is an <c>add</c> accessor.</summary>
+    public bool IsAdd => AccessorKeyword?.Text == "add";
+
+    /// <summary>Gets a value indicating whether this accessor is a <c>remove</c> accessor.</summary>
+    public bool IsRemove => AccessorKeyword?.Text == "remove";
+}

--- a/src/Core/CodeAnalysis/Syntax/EventDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/EventDeclarationSyntax.cs
@@ -1,0 +1,96 @@
+// <copyright file="EventDeclarationSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents an <c>event Name Type</c> declaration inside a type body (ADR-0052).
+/// </summary>
+public sealed class EventDeclarationSyntax : SyntaxNode
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventDeclarationSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="accessibilityModifier">The optional accessibility modifier.</param>
+    /// <param name="openModifier">The optional <c>open</c> contextual keyword.</param>
+    /// <param name="overrideModifier">The optional <c>override</c> contextual keyword.</param>
+    /// <param name="eventKeyword">The identifier token whose text is <c>event</c>.</param>
+    /// <param name="identifier">The event name.</param>
+    /// <param name="type">The event handler type clause.</param>
+    /// <param name="openBraceToken">The optional opening brace.</param>
+    /// <param name="accessors">The add/remove accessor list.</param>
+    /// <param name="closeBraceToken">The optional closing brace.</param>
+    public EventDeclarationSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken accessibilityModifier,
+        SyntaxToken openModifier,
+        SyntaxToken overrideModifier,
+        SyntaxToken eventKeyword,
+        SyntaxToken identifier,
+        TypeClauseSyntax type,
+        SyntaxToken openBraceToken,
+        ImmutableArray<EventAccessorSyntax> accessors,
+        SyntaxToken closeBraceToken)
+        : base(syntaxTree)
+    {
+        Annotations = ImmutableArray<AnnotationSyntax>.Empty;
+        AccessibilityModifier = accessibilityModifier;
+        OpenModifier = openModifier;
+        OverrideModifier = overrideModifier;
+        EventKeyword = eventKeyword;
+        Identifier = identifier;
+        Type = type;
+        OpenBraceToken = openBraceToken;
+        Accessors = accessors;
+        CloseBraceToken = closeBraceToken;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.EventDeclaration;
+
+    /// <summary>
+    /// Gets the Kotlin-style annotations (ADR-0047) attached to this event declaration.
+    /// Empty when no <c>@</c> lead-ins are present.
+    /// </summary>
+    public ImmutableArray<AnnotationSyntax> Annotations { get; private set; }
+
+    /// <summary>Gets the optional accessibility modifier token.</summary>
+    public SyntaxToken AccessibilityModifier { get; }
+
+    /// <summary>Gets the optional <c>open</c> contextual keyword.</summary>
+    public SyntaxToken OpenModifier { get; }
+
+    /// <summary>Gets the optional <c>override</c> contextual keyword.</summary>
+    public SyntaxToken OverrideModifier { get; }
+
+    /// <summary>Gets the identifier token whose text is <c>event</c>.</summary>
+    public SyntaxToken EventKeyword { get; }
+
+    /// <summary>Gets the event name identifier.</summary>
+    public SyntaxToken Identifier { get; }
+
+    /// <summary>Gets the event handler type clause.</summary>
+    public TypeClauseSyntax Type { get; }
+
+    /// <summary>Gets the optional opening brace token.</summary>
+    public SyntaxToken OpenBraceToken { get; }
+
+    /// <summary>Gets the add/remove accessor list. Empty for field-like events.</summary>
+    public ImmutableArray<EventAccessorSyntax> Accessors { get; }
+
+    /// <summary>Gets the optional closing brace token.</summary>
+    public SyntaxToken CloseBraceToken { get; }
+
+    /// <summary>Attaches the given annotation list to this event declaration and returns this same instance for fluent parser use.</summary>
+    /// <param name="annotations">The annotation list to attach (may be empty).</param>
+    /// <returns>This same <see cref="EventDeclarationSyntax"/>, with <see cref="Annotations"/> updated.</returns>
+    internal EventDeclarationSyntax WithAnnotations(ImmutableArray<AnnotationSyntax> annotations)
+    {
+        Annotations = annotations.IsDefault ? ImmutableArray<AnnotationSyntax>.Empty : annotations;
+        return this;
+    }
+}

--- a/src/Core/CodeAnalysis/Syntax/InterfaceDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/InterfaceDeclarationSyntax.cs
@@ -63,6 +63,36 @@ public sealed class InterfaceDeclarationSyntax : MemberSyntax
         ImmutableArray<PropertyDeclarationSyntax> properties,
         ImmutableArray<FunctionDeclarationSyntax> methods,
         SyntaxToken closeBraceToken)
+        : this(syntaxTree, accessibilityModifier, typeKeyword, identifier, typeParameterList, sealedKeyword, interfaceKeyword, openBraceToken, properties, ImmutableArray<EventDeclarationSyntax>.Empty, methods, closeBraceToken)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="InterfaceDeclarationSyntax"/> class with property and event declarations (ADR-0051 / ADR-0052).</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="accessibilityModifier">The optional accessibility modifier.</param>
+    /// <param name="typeKeyword">The <c>type</c> keyword.</param>
+    /// <param name="identifier">The interface identifier.</param>
+    /// <param name="typeParameterList">The optional type-parameter list (Phase 4.3c / ADR-0020).</param>
+    /// <param name="sealedKeyword">The optional <c>sealed</c> contextual keyword (Phase 3.B.5).</param>
+    /// <param name="interfaceKeyword">The <c>interface</c> keyword.</param>
+    /// <param name="openBraceToken">The opening brace of the body.</param>
+    /// <param name="properties">The property declarations inside the interface body (ADR-0051).</param>
+    /// <param name="events">The event declarations inside the interface body (ADR-0052).</param>
+    /// <param name="methods">The method signatures declared inside the interface body.</param>
+    /// <param name="closeBraceToken">The closing brace.</param>
+    public InterfaceDeclarationSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken accessibilityModifier,
+        SyntaxToken typeKeyword,
+        SyntaxToken identifier,
+        TypeParameterListSyntax typeParameterList,
+        SyntaxToken sealedKeyword,
+        SyntaxToken interfaceKeyword,
+        SyntaxToken openBraceToken,
+        ImmutableArray<PropertyDeclarationSyntax> properties,
+        ImmutableArray<EventDeclarationSyntax> events,
+        ImmutableArray<FunctionDeclarationSyntax> methods,
+        SyntaxToken closeBraceToken)
         : base(syntaxTree)
     {
         AccessibilityModifier = accessibilityModifier;
@@ -73,6 +103,7 @@ public sealed class InterfaceDeclarationSyntax : MemberSyntax
         InterfaceKeyword = interfaceKeyword;
         OpenBraceToken = openBraceToken;
         Properties = properties;
+        Events = events;
         Methods = methods;
         CloseBraceToken = closeBraceToken;
     }
@@ -152,6 +183,9 @@ public sealed class InterfaceDeclarationSyntax : MemberSyntax
 
     /// <summary>Gets the property declarations inside the interface body (ADR-0051). Empty when no properties are declared.</summary>
     public ImmutableArray<PropertyDeclarationSyntax> Properties { get; }
+
+    /// <summary>Gets the event declarations inside the interface body (ADR-0052). Empty when no events are declared.</summary>
+    public ImmutableArray<EventDeclarationSyntax> Events { get; }
 
     /// <summary>Gets the method signatures (Body is always null on these, per ADR-0018).</summary>
     public ImmutableArray<FunctionDeclarationSyntax> Methods { get; }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -650,6 +650,7 @@ public class Parser
         SyntaxToken openBrace;
         var fields = ImmutableArray.CreateBuilder<FieldDeclarationSyntax>();
         var properties = ImmutableArray.CreateBuilder<PropertyDeclarationSyntax>();
+        var events = ImmutableArray.CreateBuilder<EventDeclarationSyntax>();
         var methods = ImmutableArray.CreateBuilder<FunctionDeclarationSyntax>();
         if (inlineKeyword != null && Current.Kind != SyntaxKind.OpenBraceToken)
         {
@@ -673,6 +674,7 @@ public class Parser
                 openBrace,
                 fields.ToImmutable(),
                 properties.ToImmutable(),
+                events.ToImmutable(),
                 methods.ToImmutable(),
                 syntheticCloseBrace);
         }
@@ -699,7 +701,7 @@ public class Parser
                 Current.Kind == SyntaxKind.PrivateKeyword)
             {
                 // Accessibility modifier may be followed by an optional
-                // `open`/`override` and then `func` or `prop`.
+                // `open`/`override` and then `func`, `prop`, or `event`.
                 var ahead = 1;
                 while (Peek(ahead).Kind == SyntaxKind.OpenKeyword || Peek(ahead).Kind == SyntaxKind.OverrideKeyword)
                 {
@@ -707,7 +709,8 @@ public class Parser
                 }
 
                 if (Peek(ahead).Kind == SyntaxKind.FuncKeyword ||
-                    (Peek(ahead).Kind == SyntaxKind.IdentifierToken && Peek(ahead).Text == "prop"))
+                    (Peek(ahead).Kind == SyntaxKind.IdentifierToken && Peek(ahead).Text == "prop") ||
+                    (Peek(ahead).Kind == SyntaxKind.IdentifierToken && Peek(ahead).Text == "event"))
                 {
                     memberAccessibility = NextToken();
                 }
@@ -741,6 +744,12 @@ public class Parser
                 var property = ParsePropertyDeclaration(memberAccessibility, memberOpenModifier, memberOverrideModifier);
                 property.WithAnnotations(memberAnnotations);
                 properties.Add(property);
+            }
+            else if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "event")
+            {
+                var eventDecl = ParseEventDeclaration(memberAccessibility, memberOpenModifier, memberOverrideModifier);
+                eventDecl.WithAnnotations(memberAnnotations);
+                events.Add(eventDecl);
             }
             else if (Current.Kind == SyntaxKind.FuncKeyword)
             {
@@ -789,6 +798,7 @@ public class Parser
             openBrace,
             fields.ToImmutable(),
             properties.ToImmutable(),
+            events.ToImmutable(),
             methods.ToImmutable(),
             closeBrace);
     }
@@ -804,6 +814,7 @@ public class Parser
         var openBrace = MatchToken(SyntaxKind.OpenBraceToken);
 
         var properties = ImmutableArray.CreateBuilder<PropertyDeclarationSyntax>();
+        var events = ImmutableArray.CreateBuilder<EventDeclarationSyntax>();
         var methods = ImmutableArray.CreateBuilder<FunctionDeclarationSyntax>();
         while (Current.Kind != SyntaxKind.CloseBraceToken && Current.Kind != SyntaxKind.EndOfFileToken)
         {
@@ -811,10 +822,15 @@ public class Parser
 
             // Per ADR-0018, interface members are method signatures only.
             // ADR-0051 extends this to also allow property declarations.
+            // ADR-0052 extends this to also allow event declarations.
             // No accessibility / open / override modifiers are accepted.
             if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "prop")
             {
                 properties.Add(ParsePropertyDeclaration(accessibilityModifier: null, openModifier: null, overrideModifier: null));
+            }
+            else if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "event")
+            {
+                events.Add(ParseEventDeclaration(accessibilityModifier: null, openModifier: null, overrideModifier: null));
             }
             else if (Current.Kind == SyntaxKind.FuncKeyword)
             {
@@ -843,6 +859,7 @@ public class Parser
             interfaceKeyword,
             openBrace,
             properties.ToImmutable(),
+            events.ToImmutable(),
             methods.ToImmutable(),
             closeBrace);
     }
@@ -917,6 +934,88 @@ public class Parser
             openBraceToken: null,
             accessors: ImmutableArray<PropertyAccessorSyntax>.Empty,
             closeBraceToken: null);
+    }
+
+    private EventDeclarationSyntax ParseEventDeclaration(
+        SyntaxToken accessibilityModifier,
+        SyntaxToken openModifier,
+        SyntaxToken overrideModifier)
+    {
+        var eventKeyword = MatchToken(SyntaxKind.IdentifierToken); // consumes "event"
+        var identifier = MatchToken(SyntaxKind.IdentifierToken);
+        var type = ParseTypeClause();
+
+        if (Current.Kind == SyntaxKind.OpenBraceToken)
+        {
+            var openBrace = MatchToken(SyntaxKind.OpenBraceToken);
+            var accessors = ParseEventAccessors();
+            var closeBrace = MatchToken(SyntaxKind.CloseBraceToken);
+            return new EventDeclarationSyntax(
+                syntaxTree,
+                accessibilityModifier,
+                openModifier,
+                overrideModifier,
+                eventKeyword,
+                identifier,
+                type,
+                openBrace,
+                accessors,
+                closeBrace);
+        }
+
+        // Field-like event: event Name Type
+        return new EventDeclarationSyntax(
+            syntaxTree,
+            accessibilityModifier,
+            openModifier,
+            overrideModifier,
+            eventKeyword,
+            identifier,
+            type,
+            openBraceToken: null,
+            accessors: ImmutableArray<EventAccessorSyntax>.Empty,
+            closeBraceToken: null);
+    }
+
+    private ImmutableArray<EventAccessorSyntax> ParseEventAccessors()
+    {
+        var accessors = ImmutableArray.CreateBuilder<EventAccessorSyntax>();
+
+        while (Current.Kind != SyntaxKind.CloseBraceToken && Current.Kind != SyntaxKind.EndOfFileToken)
+        {
+            var startToken = Current;
+
+            if (Current.Kind == SyntaxKind.IdentifierToken &&
+                (Current.Text == "add" || Current.Text == "remove"))
+            {
+                var accessorKeyword = NextToken();
+
+                BlockStatementSyntax body = null;
+                SyntaxToken semicolon = null;
+                if (Current.Kind == SyntaxKind.OpenBraceToken)
+                {
+                    body = ParseBlockStatement();
+                }
+                else if (Current.Kind == SyntaxKind.SemicolonToken)
+                {
+                    semicolon = NextToken();
+                }
+
+                accessors.Add(new EventAccessorSyntax(syntaxTree, accessorKeyword, body, semicolon));
+            }
+            else
+            {
+                Diagnostics.ReportUnexpectedToken(Current.Location, Current.Kind, SyntaxKind.IdentifierToken);
+                NextToken();
+            }
+
+            if (Current == startToken)
+            {
+                NextToken();
+            }
+        }
+
+        return accessors.ToImmutable();
     }
 
     private ImmutableArray<PropertyAccessorSyntax> ParsePropertyAccessors()

--- a/src/Core/CodeAnalysis/Syntax/StructDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/StructDeclarationSyntax.cs
@@ -257,6 +257,72 @@ public sealed class StructDeclarationSyntax : MemberSyntax
         ImmutableArray<PropertyDeclarationSyntax> properties,
         ImmutableArray<FunctionDeclarationSyntax> methods,
         SyntaxToken closeBraceToken)
+        : this(
+            syntaxTree,
+            accessibilityModifier,
+            typeKeyword,
+            identifier,
+            dataKeyword,
+            inlineKeyword,
+            openModifier,
+            structKeyword,
+            primaryConstructorOpenParen,
+            primaryConstructorParameters,
+            primaryConstructorCloseParen,
+            baseColonToken,
+            baseTypeIdentifier,
+            additionalBaseTypeIdentifiers,
+            openBraceToken,
+            fields,
+            properties,
+            ImmutableArray<EventDeclarationSyntax>.Empty,
+            methods,
+            closeBraceToken)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="StructDeclarationSyntax"/> class (ADR-0052 — with event declarations).</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="accessibilityModifier">The optional accessibility modifier.</param>
+    /// <param name="typeKeyword">The <c>type</c> keyword.</param>
+    /// <param name="identifier">The aggregate identifier.</param>
+    /// <param name="dataKeyword">The optional <c>data</c> contextual keyword.</param>
+    /// <param name="inlineKeyword">The optional <c>inline</c> contextual keyword.</param>
+    /// <param name="openModifier">The optional <c>open</c> contextual keyword (classes only).</param>
+    /// <param name="structKeyword">The <c>struct</c> or <c>class</c> keyword.</param>
+    /// <param name="primaryConstructorOpenParen">The optional opening paren of a primary constructor.</param>
+    /// <param name="primaryConstructorParameters">The primary constructor parameter list.</param>
+    /// <param name="primaryConstructorCloseParen">The optional closing paren of the primary constructor.</param>
+    /// <param name="baseColonToken">The optional <c>:</c> token introducing a base/interface clause.</param>
+    /// <param name="baseTypeIdentifier">The first identifier in the base/interface clause.</param>
+    /// <param name="additionalBaseTypeIdentifiers">Subsequent comma-separated identifiers in the base/interface clause (Phase 3.B.4).</param>
+    /// <param name="openBraceToken">The opening brace of the body.</param>
+    /// <param name="fields">The body field declarations.</param>
+    /// <param name="properties">The property declarations in the body (ADR-0051).</param>
+    /// <param name="events">The event declarations in the body (ADR-0052).</param>
+    /// <param name="methods">The method declarations in the body.</param>
+    /// <param name="closeBraceToken">The closing brace.</param>
+    public StructDeclarationSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken accessibilityModifier,
+        SyntaxToken typeKeyword,
+        SyntaxToken identifier,
+        SyntaxToken dataKeyword,
+        SyntaxToken inlineKeyword,
+        SyntaxToken openModifier,
+        SyntaxToken structKeyword,
+        SyntaxToken primaryConstructorOpenParen,
+        SeparatedSyntaxList<ParameterSyntax> primaryConstructorParameters,
+        SyntaxToken primaryConstructorCloseParen,
+        SyntaxToken baseColonToken,
+        SyntaxToken baseTypeIdentifier,
+        ImmutableArray<SyntaxToken> additionalBaseTypeIdentifiers,
+        SyntaxToken openBraceToken,
+        ImmutableArray<FieldDeclarationSyntax> fields,
+        ImmutableArray<PropertyDeclarationSyntax> properties,
+        ImmutableArray<EventDeclarationSyntax> events,
+        ImmutableArray<FunctionDeclarationSyntax> methods,
+        SyntaxToken closeBraceToken)
         : base(syntaxTree)
     {
         AccessibilityModifier = accessibilityModifier;
@@ -275,6 +341,7 @@ public sealed class StructDeclarationSyntax : MemberSyntax
         OpenBraceToken = openBraceToken;
         Fields = fields;
         Properties = properties;
+        Events = events;
         Methods = methods;
         CloseBraceToken = closeBraceToken;
     }
@@ -347,6 +414,9 @@ public sealed class StructDeclarationSyntax : MemberSyntax
 
     /// <summary>Gets the property declarations in the body (ADR-0051). Empty for types that declare no properties.</summary>
     public ImmutableArray<PropertyDeclarationSyntax> Properties { get; }
+
+    /// <summary>Gets the event declarations in the body (ADR-0052). Empty for types that declare no events.</summary>
+    public ImmutableArray<EventDeclarationSyntax> Events { get; }
 
     /// <summary>Gets the method declarations declared inside the body (Phase 3.B.3 sub-step 2b — classes only). Empty for struct types and for bodyless declarations.</summary>
     public ImmutableArray<FunctionDeclarationSyntax> Methods { get; }

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -232,7 +232,9 @@ public enum SyntaxKind
 
     // ADR-0051: property declarations
     PropertyDeclaration,
+    EventDeclaration,
     PropertyAccessor,
+    EventAccessor,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/test/Compiler.Tests/Emit/EventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/EventEmitTests.cs
@@ -1,0 +1,186 @@
+// <copyright file="EventEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// ADR-0052: compiler emit tests for event declarations.
+/// </summary>
+public class EventEmitTests
+{
+    [Fact]
+    public void FieldLikeEvent_EmitsEventDef()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type MyButton class {
+                public event Click func(Object, EventArgs)
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var button = assembly.GetTypes().Single(t => t.Name == "MyButton");
+        var ev = button.GetEvent("Click");
+
+        Assert.NotNull(ev);
+        Assert.Equal("Click", ev!.Name);
+        Assert.NotNull(ev.AddMethod);
+        Assert.NotNull(ev.RemoveMethod);
+        Assert.Equal("add_Click", ev.AddMethod!.Name);
+        Assert.Equal("remove_Click", ev.RemoveMethod!.Name);
+        Assert.True(ev.AddMethod.IsSpecialName);
+        Assert.True(ev.RemoveMethod.IsSpecialName);
+    }
+
+    [Fact]
+    public void FieldLikeEvent_HasBackingField()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type MyButton class {
+                public event Click func(Object, EventArgs)
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var button = assembly.GetTypes().Single(t => t.Name == "MyButton");
+        var backingField = button.GetField("Click", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(backingField);
+        Assert.True(backingField!.IsPrivate);
+    }
+
+    [Fact]
+    public void FieldLikeEvent_AddRemove_WorksAtRuntime()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Notifier class {
+                public event Changed func()
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var notifierType = assembly.GetTypes().Single(t => t.Name == "Notifier");
+        var instance = Activator.CreateInstance(notifierType)!;
+        var ev = notifierType.GetEvent("Changed")!;
+
+        bool invoked = false;
+        Action handler = () => invoked = true;
+        ev.AddEventHandler(instance, handler);
+
+        // Raise by reading the backing field and invoking
+        var backingField = notifierType.GetField("Changed", BindingFlags.NonPublic | BindingFlags.Instance);
+        var del = backingField!.GetValue(instance) as Delegate;
+        Assert.NotNull(del);
+        del!.DynamicInvoke();
+        Assert.True(invoked);
+
+        // Remove handler
+        invoked = false;
+        ev.RemoveEventHandler(instance, handler);
+        del = backingField.GetValue(instance) as Delegate;
+        Assert.Null(del);
+    }
+
+    [Fact]
+    public void Event_MultipleHandlers()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Emitter class {
+                public event Ping func()
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var emitterType = assembly.GetTypes().Single(t => t.Name == "Emitter");
+        var instance = Activator.CreateInstance(emitterType)!;
+        var ev = emitterType.GetEvent("Ping")!;
+
+        int count = 0;
+        Action h1 = () => count++;
+        Action h2 = () => count += 10;
+        ev.AddEventHandler(instance, h1);
+        ev.AddEventHandler(instance, h2);
+
+        var backingField = emitterType.GetField("Ping", BindingFlags.NonPublic | BindingFlags.Instance);
+        var del = backingField!.GetValue(instance) as Delegate;
+        del!.DynamicInvoke();
+        Assert.Equal(11, count);
+    }
+
+    [Fact]
+    public void InterfaceEvent_EmitsAbstractAccessors()
+    {
+        var source = """
+            package MyLib
+
+            type IObservable interface {
+                event Changed func()
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var iface = assembly.GetTypes().Single(t => t.Name == "IObservable");
+        var ev = iface.GetEvent("Changed");
+
+        Assert.NotNull(ev);
+        Assert.NotNull(ev!.AddMethod);
+        Assert.NotNull(ev!.RemoveMethod);
+        Assert.True(ev.AddMethod!.IsAbstract);
+        Assert.True(ev.RemoveMethod!.IsAbstract);
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_event_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/EventParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/EventParserTests.cs
@@ -1,0 +1,76 @@
+// <copyright file="EventParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// ADR-0052: parser tests for event declaration syntax.
+/// </summary>
+public class EventParserTests
+{
+    [Fact]
+    public void ParsesFieldLikeEvent()
+    {
+        const string source = "package P\nimport System\ntype Foo class {\n  event Click func(Object, EventArgs)\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void ParsesFieldLikeEvent_WithAccessibility()
+    {
+        const string source = "package P\nimport System\ntype Foo class {\n  public event Click func(Object, EventArgs)\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void ParsesEvent_WithExplicitAccessors()
+    {
+        const string source = "package P\nimport System\ntype Foo class {\n  event Changed func() {\n    add { }\n    remove { }\n  }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void ParsesEvent_OnInterface()
+    {
+        const string source = "package P\ntype INotify interface {\n  event Changed func()\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void ParsesEvent_WithOpenModifier()
+    {
+        const string source = "package P\ntype Base open class {\n  public open event Notify func()\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void ParsesMultipleEvents()
+    {
+        const string source = "package P\ntype Foo class {\n  event A func()\n  event B func(int32)\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void EventDeclaration_HasCorrectSyntaxKind()
+    {
+        const string source = "package P\ntype Foo class {\n  event Click func()\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        Assert.Single(structDecl.Events);
+        Assert.Equal(SyntaxKind.EventDeclaration, structDecl.Events[0].Kind);
+        Assert.Equal("Click", structDecl.Events[0].Identifier.Text);
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -61,6 +61,8 @@ EnumKeyword
 EnumMember
 EqualsEqualsToken
 EqualsToken
+EventAccessor
+EventDeclaration
 EventSubscriptionExpression
 ExpressionStatement
 FallthroughKeyword

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -241,6 +241,7 @@ DefaultExpression
 DereferenceExpression
 DiscardPattern
 ErrorExpression
+EventSubscriptionExpression
 ExpressionStatement
 FieldAccessExpression
 FieldAssignmentExpression

--- a/test/Interpreter.Tests/EventInterpreterTests.cs
+++ b/test/Interpreter.Tests/EventInterpreterTests.cs
@@ -1,0 +1,65 @@
+// <copyright file="EventInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// ADR-0052: interpreter tests for event declarations.
+/// </summary>
+public class EventInterpreterTests
+{
+    [Fact]
+    public void FieldLikeEvent_ParsesWithoutError()
+    {
+        var source = "import System\ntype Foo class {\n  public event Click func()\n}\n";
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+    }
+
+    [Fact]
+    public void FieldLikeEvent_OnClass_WithEventArgs()
+    {
+        var source = "import System\ntype MyBtn class {\n  public event Click func(Object, EventArgs)\n}\n";
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+    }
+
+    [Fact]
+    public void MultipleEvents_ParseWithoutError()
+    {
+        var source = "import System\ntype Foo class {\n  public event A func()\n  public event B func(int32)\n}\n";
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+    }
+
+    [Fact]
+    public void InterfaceEvent_ParsesWithoutError()
+    {
+        var source = "type INotify interface {\n  event Changed func()\n}\n";
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString();
+    }
+}


### PR DESCRIPTION
## Summary

Implements [#140](https://github.com/DavidObando/gsharp/issues/140) — declaring events on user-defined types (struct/class/interface).

## Syntax

```gs
type MyButton struct {
    // Field-like event (most common)
    public event Click func(sender Object, e EventArgs)

    // Explicit accessors
    public event PropertyChanged func(sender Object, e PropertyChangedEventArgs) {
        add { /* custom add logic */ }
        remove { /* custom remove logic */ }
    }
}

// Interface events
type INotifyPropertyChanged interface {
    event PropertyChanged func(sender Object, e PropertyChangedEventArgs)
}
```

## What's included

| Phase | Description |
|-------|-------------|
| ADR-0052 | Design document covering syntax, CLR metadata shape, alternatives |
| Syntax | `EventDeclarationSyntax`, `EventAccessorSyntax`, parser support |
| Binding | `EventSymbol`, duplicate checking, backing field synthesis, annotation support |
| Emit | `EventDefinition` rows, `add_X`/`remove_X` methods with Delegate.Combine/Remove IL, interface abstract accessors |
| Interpreter | Evaluator support for user-defined event subscription/unsubscription |
| Explicit accessors | Bound accessor bodies (paralleling property computed accessors) |
| Tests | 16 new tests across parser, emitter, and interpreter |

## CLR Metadata

Field-like events emit:
- Private backing field (`Action<...>`/`Func<...>`)
- Public `add_X`/`remove_X` specialname methods
- `EventDefinition` + `EventMap` + `MethodSemantics` metadata rows

## Follow-up issues filed

- #255 — Named delegate types (`type MyHandler = delegate func(...)`)
- #256 — Thread-safe accessors (Interlocked.CompareExchange CAS loop)
- #257 — `raise` accessor + static events

## Test results

All **1,546 tests pass** (16 new tests added).

Closes #140