### PR TITLE
ADR-0053: Static members on user types via `shared` block

### DIFF
--- a/docs/adr/0053-static-members.md
+++ b/docs/adr/0053-static-members.md
@@ -1,4 +1,4 @@
-# ADR-0053: Static members on user types — `companion object`
+# ADR-0053: Static members on user types — `shared` block
 
 - **Status**: Proposed
 - **Date**: 2026-05-29
@@ -18,36 +18,36 @@ Kotlin uses `companion object` to host static-like members on a class. On the JV
 ### Design goals
 
 1. **CLR round-trip**: static members declared in GSharp must emit as standard CLR `static` FieldDef/MethodDef/PropertyDef rows on the enclosing TypeDef so C#/F#/VB can consume them with zero friction.
-2. **Kotlin-flavored syntax**: use `companion object { … }` as the declaration site, consistent with GSharp's Kotlin/Go hybrid philosophy.
-3. **No hidden nested types**: unlike Kotlin/JVM, no `Companion` nested class is emitted. The `companion object` block is purely syntactic grouping — members lower directly to static CLR members.
-4. **Uniform access**: inside the companion body, other static members of the same type are accessible without qualification. Instance members are not accessible (no `this`).
+2. **Concise grouped syntax**: use a single `shared { … }` block as the declaration site — inspired by Kotlin's companion concept but more concise, consistent with GSharp's preference for brevity.
+3. **No hidden nested types**: unlike Kotlin/JVM, no `Companion` nested class is emitted. The `shared` block is purely syntactic grouping — members lower directly to static CLR members.
+4. **Uniform access**: inside the shared body, other static members of the same type are accessible without qualification. Instance members are not accessible (no `this`).
 
 ## Decision
 
 ### 1. Grammar
 
 ```
-companion_block       = "companion" "object" "{" companion_member* "}"
-companion_member      = field_declaration
+shared_block          = "shared" "{" shared_member* "}"
+shared_member         = field_declaration
                       | function_declaration
                       | property_declaration
                       | event_declaration
                       | const_declaration
 ```
 
-The `companion` and `object` keywords are contextual — recognized only inside a type body immediately preceding `{`. Outside type bodies, both remain valid identifiers.
+The `shared` keyword is contextual — recognized only inside a type body immediately preceding `{`. Outside type bodies, `shared` remains a valid identifier.
 
-A type may contain at most one `companion object` block. The parser reports an error on duplicate companions.
+A type may contain at most one `shared` block. The parser reports an error on duplicates.
 
 ### 2. Placement
 
-The `companion object` block appears inside `struct`, `class`, or `sealed class` bodies:
+The `shared` block appears inside `struct`, `class`, or `sealed class` bodies:
 
 ```gs
 type Counter class {
     value int
 
-    companion object {
+    shared {
         var instanceCount int = 0
 
         func create() Counter {
@@ -60,7 +60,7 @@ type Counter class {
 
 ### 3. Accessibility
 
-Members inside `companion object` inherit the same accessibility modifier rules as regular type members (`public` default, `internal`, `private`). The enclosing `companion object` block itself has no accessibility modifier; all its members are individually annotated.
+Members inside `shared` inherit the same accessibility modifier rules as regular type members (`public` default, `internal`, `private`). The enclosing `shared` block itself has no accessibility modifier; all its members are individually annotated.
 
 ### 4. Member kinds
 
@@ -74,13 +74,13 @@ Members inside `companion object` inherit the same accessibility modifier rules 
 
 ### 5. Binding rules
 
-- Inside a companion body, `this` is not available. Attempting to reference `this` or instance members produces a diagnostic.
+- Inside a shared body, `this` is not available. Attempting to reference `this` or instance members produces a diagnostic.
 - Other static members of the same type are accessible by simple name (no `TypeName.` prefix required).
 - Static members are accessed from outside via `TypeName.member` — reusing the existing `ImportedClassSymbol`-style accessor resolution path extended to user-defined types.
 
 ### 6. Type-level access from GSharp
 
-User-defined types already register in the scope. The binder will extend `BindAccessorExpression` to recognize a user-defined `StructSymbol` on the left side of `.` and look up static members (companion fields/methods/properties) — mirroring the `ImportedClassSymbol` path but for user types.
+User-defined types already register in the scope. The binder will extend `BindAccessorExpression` to recognize a user-defined `StructSymbol` on the left side of `.` and look up static members (shared fields/methods/properties) — mirroring the `ImportedClassSymbol` path but for user types.
 
 ### 7. Static initializers
 
@@ -88,49 +88,49 @@ Static field initializers (`var count int = 0`) emit into a `.cctor` (class cons
 
 ### 8. Static-only types (future extension)
 
-A future follow-up may introduce `type Utils object { … }` syntax (no `companion` — the entire type is the object) for declaring top-level static-only utility types. This parallels Kotlin's `object` declaration. Deferred to a separate ADR; not part of this proposal.
+A future follow-up may introduce `type Utils object { … }` syntax for declaring top-level static-only utility types. This parallels Kotlin's `object` declaration. Deferred to a separate ADR; not part of this proposal.
 
 ## Implementation plan
 
 ### Phase A: Syntax
 
-1. Add contextual keywords `companion` and `object` to `SyntaxKind` (e.g., `CompanionKeyword`, `ObjectKeyword`).
-2. Create `CompanionObjectSyntax` node containing field, function, property, and event declarations.
-3. Extend `StructDeclarationSyntax` to hold an optional `CompanionObjectSyntax`.
-4. Extend the parser to recognize `companion object { … }` inside type bodies.
+1. Add contextual keyword `shared` to `SyntaxKind` (e.g., `SharedKeyword`).
+2. Create `SharedBlockSyntax` node containing field, function, property, and event declarations.
+3. Extend `StructDeclarationSyntax` to hold an optional `SharedBlockSyntax`.
+4. Extend the parser to recognize `shared { … }` inside type bodies.
 
 ### Phase B: Symbols
 
-1. Add `StaticFields`, `StaticMethods`, `StaticProperties`, `StaticEvents` collections to `StructSymbol` (or a unified `CompanionMembers` container).
+1. Add `StaticFields`, `StaticMethods`, `StaticProperties`, `StaticEvents` collections to `StructSymbol` (or a unified `SharedMembers` container).
 2. Mark `FieldSymbol` / `FunctionSymbol` / `PropertySymbol` / `EventSymbol` with an `IsStatic` flag.
 3. Add `SetStaticMembers(…)` setter on `StructSymbol`.
 
 ### Phase C: Binding
 
-1. In `BindStructDeclaration`, detect the `CompanionObjectSyntax` and bind its members as static.
+1. In `BindStructDeclaration`, detect the `SharedBlockSyntax` and bind its members as static.
 2. Extend `BindAccessorExpression` to resolve `UserType.StaticMember` — when the left-side name matches a user-defined type in scope, look up static members before falling through to error.
-3. Inside companion method bodies, push a scope that disallows `this` and exposes sibling static members by simple name.
-4. Emit a diagnostic (`GS0XXX`) for `this` references and instance member access inside companion bodies.
+3. Inside shared method bodies, push a scope that disallows `this` and exposes sibling static members by simple name.
+4. Emit a diagnostic (`GS0XXX`) for `this` references and instance member access inside shared bodies.
 
 ### Phase D: Emit
 
 1. In `EmitStructTypeDef`, emit static FieldDefs with `FieldAttributes.Static`.
-2. Emit static MethodDefs (companion `func` declarations) with `MethodAttributes.Static`.
+2. Emit static MethodDefs (shared `func` declarations) with `MethodAttributes.Static`.
 3. Emit `.cctor` (static constructor) for types that have static field initializers.
 4. Extend property/event emission (ADR-0051/0052 paths) to handle the static case (`MethodAttributes.Static` on accessors).
 
 ### Phase E: Tests
 
-1. Parser tests: `companion object` parses, duplicate rejected.
+1. Parser tests: `shared` block parses, duplicate rejected.
 2. Binder tests: static members resolve via `Type.member`; `this` is rejected; diagnostics fire correctly.
 3. Emit tests: round-trip validation — emit GSharp assembly, load via reflection, verify static members are callable from C#-style reflection invocations.
-4. End-to-end tests: GSharp program declares a type with companion, calls static members, produces correct output.
+4. End-to-end tests: GSharp program declares a type with a shared block, calls static members, produces correct output.
 
 ## Consequences
 
 - User types gain full CLR static member support, enabling GSharp libraries to be consumed from C# without wrapper code.
-- The `companion object` syntax is familiar to Kotlin developers and provides a clear visual grouping for static members — avoiding the C# antipattern of interspersing static and instance members.
-- No ABI impact on existing code: companion support is additive.
+- The `shared` block syntax provides a clear visual grouping for static members — avoiding the C# antipattern of interspersing static and instance members — while being concise (single keyword).
+- No ABI impact on existing code: shared block support is additive.
 - Future `object` declarations (singleton/utility types) can reuse the same infrastructure with minimal additional work.
 
 ## Alternatives considered
@@ -144,9 +144,9 @@ type Counter class {
 }
 ```
 
-Pro: minimal syntax, familiar to C#/Java developers. Con: loses Kotlin-style grouping; interleaving static and instance members reduces readability. Also, introducing a `static` keyword would shadow the existing import path for `System.Reflection.BindingFlags.Static` and similar identifiers, creating ambiguity.
+Pro: minimal syntax, familiar to C#/Java developers. Con: loses grouping; interleaving static and instance members reduces readability. Also, introducing a `static` keyword would shadow the existing import path for `System.Reflection.BindingFlags.Static` and similar identifiers, creating ambiguity.
 
-**Verdict**: rejected for v1 in favor of companion grouping. If community demand arises, a `static` modifier sugar could desugar to companion placement in a future ADR.
+**Verdict**: rejected for v1 in favor of `shared` grouping. If community demand arises, a `static` modifier sugar could desugar to shared placement in a future ADR.
 
 ### A2: Nested `Companion` class (Kotlin/JVM style)
 
@@ -163,3 +163,17 @@ Only support `type Utils object { … }` for static-only types; no static member
 Pro: simple. Con: overly restrictive — common pattern (factory methods, shared counters, caches) require instance + static coexistence.
 
 **Verdict**: deferred as a future complement, not a replacement.
+
+### A4: `companion object { … }` (Kotlin-verbatim)
+
+```gs
+type Counter class {
+    companion object {
+        var count int = 0
+    }
+}
+```
+
+Pro: identical to Kotlin, immediately recognizable to Kotlin developers. Con: two keywords for a single concept is verbose; `object` conflicts with a potential future singleton `type X object { … }` syntax. GSharp already diverges from Kotlin in other areas (e.g., `func` vs `fun`, `struct` vs `data class`), so verbatim Kotlin syntax is not a design goal.
+
+**Verdict**: rejected in favor of the single-keyword `shared`.

--- a/docs/adr/0053-static-members.md
+++ b/docs/adr/0053-static-members.md
@@ -1,0 +1,165 @@
+# ADR-0053: Static members on user types — `companion object`
+
+- **Status**: Proposed
+- **Date**: 2026-05-29
+- **Phase**: Phase 10 — CLR round-trip completeness
+- **Related**: Issue #196; ADR-0003 (OO surface); ADR-0051 (properties); ADR-0052 (events); Kotlin companion objects
+
+## Context
+
+GSharp can *consume* static members on imported CLR types via `ImportedClassSymbol` (e.g., `Guid.NewGuid()`, `Console.WriteLine(…)`, `Int32.MaxValue`). However, user-defined types (`struct`, `class`) cannot *declare* static members. This prevents C# projects from referencing GSharp-authored libraries and calling static factory methods, constants, or shared state — breaking CLR round-trip symmetry.
+
+Issue #196 asks to consider support for CLR static types and members, keeping an eye on how Kotlin operates.
+
+### Kotlin model
+
+Kotlin uses `companion object` to host static-like members on a class. On the JVM, companions compile to a nested `Companion` class with a singleton instance stored in a static field. However, adding `@JvmStatic` causes the Kotlin compiler to also emit a real static method forwarder on the enclosing class — enabling natural Java interop.
+
+### Design goals
+
+1. **CLR round-trip**: static members declared in GSharp must emit as standard CLR `static` FieldDef/MethodDef/PropertyDef rows on the enclosing TypeDef so C#/F#/VB can consume them with zero friction.
+2. **Kotlin-flavored syntax**: use `companion object { … }` as the declaration site, consistent with GSharp's Kotlin/Go hybrid philosophy.
+3. **No hidden nested types**: unlike Kotlin/JVM, no `Companion` nested class is emitted. The `companion object` block is purely syntactic grouping — members lower directly to static CLR members.
+4. **Uniform access**: inside the companion body, other static members of the same type are accessible without qualification. Instance members are not accessible (no `this`).
+
+## Decision
+
+### 1. Grammar
+
+```
+companion_block       = "companion" "object" "{" companion_member* "}"
+companion_member      = field_declaration
+                      | function_declaration
+                      | property_declaration
+                      | event_declaration
+                      | const_declaration
+```
+
+The `companion` and `object` keywords are contextual — recognized only inside a type body immediately preceding `{`. Outside type bodies, both remain valid identifiers.
+
+A type may contain at most one `companion object` block. The parser reports an error on duplicate companions.
+
+### 2. Placement
+
+The `companion object` block appears inside `struct`, `class`, or `sealed class` bodies:
+
+```gs
+type Counter class {
+    value int
+
+    companion object {
+        var instanceCount int = 0
+
+        func create() Counter {
+            instanceCount = instanceCount + 1
+            return Counter { value: instanceCount }
+        }
+    }
+}
+```
+
+### 3. Accessibility
+
+Members inside `companion object` inherit the same accessibility modifier rules as regular type members (`public` default, `internal`, `private`). The enclosing `companion object` block itself has no accessibility modifier; all its members are individually annotated.
+
+### 4. Member kinds
+
+| Kind | Static emission | Notes |
+|------|----------------|-------|
+| `var` / `let` field | `static` FieldDef | Mutable or immutable static field |
+| `const` | `static literal` FieldDef | Compile-time constant |
+| `func` | `static` MethodDef | Static method — no receiver parameter |
+| `prop` | `static` PropertyDef + accessors | Static property (ADR-0051 parallel) |
+| `event` | `static` EventDef + accessors | Static event (ADR-0052 parallel) |
+
+### 5. Binding rules
+
+- Inside a companion body, `this` is not available. Attempting to reference `this` or instance members produces a diagnostic.
+- Other static members of the same type are accessible by simple name (no `TypeName.` prefix required).
+- Static members are accessed from outside via `TypeName.member` — reusing the existing `ImportedClassSymbol`-style accessor resolution path extended to user-defined types.
+
+### 6. Type-level access from GSharp
+
+User-defined types already register in the scope. The binder will extend `BindAccessorExpression` to recognize a user-defined `StructSymbol` on the left side of `.` and look up static members (companion fields/methods/properties) — mirroring the `ImportedClassSymbol` path but for user types.
+
+### 7. Static initializers
+
+Static field initializers (`var count int = 0`) emit into a `.cctor` (class constructor / type initializer). The emitter generates a `beforefieldinit` type with a single `.cctor` that runs all static field initializers in declaration order.
+
+### 8. Static-only types (future extension)
+
+A future follow-up may introduce `type Utils object { … }` syntax (no `companion` — the entire type is the object) for declaring top-level static-only utility types. This parallels Kotlin's `object` declaration. Deferred to a separate ADR; not part of this proposal.
+
+## Implementation plan
+
+### Phase A: Syntax
+
+1. Add contextual keywords `companion` and `object` to `SyntaxKind` (e.g., `CompanionKeyword`, `ObjectKeyword`).
+2. Create `CompanionObjectSyntax` node containing field, function, property, and event declarations.
+3. Extend `StructDeclarationSyntax` to hold an optional `CompanionObjectSyntax`.
+4. Extend the parser to recognize `companion object { … }` inside type bodies.
+
+### Phase B: Symbols
+
+1. Add `StaticFields`, `StaticMethods`, `StaticProperties`, `StaticEvents` collections to `StructSymbol` (or a unified `CompanionMembers` container).
+2. Mark `FieldSymbol` / `FunctionSymbol` / `PropertySymbol` / `EventSymbol` with an `IsStatic` flag.
+3. Add `SetStaticMembers(…)` setter on `StructSymbol`.
+
+### Phase C: Binding
+
+1. In `BindStructDeclaration`, detect the `CompanionObjectSyntax` and bind its members as static.
+2. Extend `BindAccessorExpression` to resolve `UserType.StaticMember` — when the left-side name matches a user-defined type in scope, look up static members before falling through to error.
+3. Inside companion method bodies, push a scope that disallows `this` and exposes sibling static members by simple name.
+4. Emit a diagnostic (`GS0XXX`) for `this` references and instance member access inside companion bodies.
+
+### Phase D: Emit
+
+1. In `EmitStructTypeDef`, emit static FieldDefs with `FieldAttributes.Static`.
+2. Emit static MethodDefs (companion `func` declarations) with `MethodAttributes.Static`.
+3. Emit `.cctor` (static constructor) for types that have static field initializers.
+4. Extend property/event emission (ADR-0051/0052 paths) to handle the static case (`MethodAttributes.Static` on accessors).
+
+### Phase E: Tests
+
+1. Parser tests: `companion object` parses, duplicate rejected.
+2. Binder tests: static members resolve via `Type.member`; `this` is rejected; diagnostics fire correctly.
+3. Emit tests: round-trip validation — emit GSharp assembly, load via reflection, verify static members are callable from C#-style reflection invocations.
+4. End-to-end tests: GSharp program declares a type with companion, calls static members, produces correct output.
+
+## Consequences
+
+- User types gain full CLR static member support, enabling GSharp libraries to be consumed from C# without wrapper code.
+- The `companion object` syntax is familiar to Kotlin developers and provides a clear visual grouping for static members — avoiding the C# antipattern of interspersing static and instance members.
+- No ABI impact on existing code: companion support is additive.
+- Future `object` declarations (singleton/utility types) can reuse the same infrastructure with minimal additional work.
+
+## Alternatives considered
+
+### A1: `static` modifier on individual members
+
+```gs
+type Counter class {
+    static var count int = 0
+    static func create() Counter { … }
+}
+```
+
+Pro: minimal syntax, familiar to C#/Java developers. Con: loses Kotlin-style grouping; interleaving static and instance members reduces readability. Also, introducing a `static` keyword would shadow the existing import path for `System.Reflection.BindingFlags.Static` and similar identifiers, creating ambiguity.
+
+**Verdict**: rejected for v1 in favor of companion grouping. If community demand arises, a `static` modifier sugar could desugar to companion placement in a future ADR.
+
+### A2: Nested `Companion` class (Kotlin/JVM style)
+
+Emit a nested `TypeName.Companion` class with instance methods and a singleton field on the parent. Add `[JvmStatic]`-equivalent forwarders.
+
+Pro: matches Kotlin/JVM. Con: adds hidden types to the assembly metadata; C# consumers see both the forwarder and the nested class; complicates reflection-based tooling.
+
+**Verdict**: rejected. Direct static emission is cleaner for CLR interop.
+
+### A3: Top-level `object` only (no companion)
+
+Only support `type Utils object { … }` for static-only types; no static members on types that also have instances.
+
+Pro: simple. Con: overly restrictive — common pattern (factory methods, shared counters, caches) require instance + static coexistence.
+
+**Verdict**: deferred as a future complement, not a replacement.

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -168,6 +168,7 @@ ShiftLeftEqualsToken
 ShiftLeftToken
 ShiftRightEqualsToken
 ShiftRightToken
+SharedBlock
 SlashEqualsToken
 SlashToken
 StarEqualsToken

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1326,6 +1326,265 @@ public sealed class Binder
             structSymbol.SetEvents(eventsBuilder.ToImmutable());
         }
 
+        // ADR-0053: bind members declared inside the optional `shared { … }` block
+        // as static members on the struct/class symbol.
+        if (syntax.SharedBlock != null)
+        {
+            // Static fields
+            var staticFieldsBuilder = ImmutableArray.CreateBuilder<FieldSymbol>();
+            foreach (var fieldSyntax in syntax.SharedBlock.Fields)
+            {
+                var fieldName = fieldSyntax.Identifier.Text;
+                if (!existingNames.Add(fieldName))
+                {
+                    Diagnostics.ReportSymbolAlreadyDeclared(fieldSyntax.Identifier.Location, fieldName);
+                    continue;
+                }
+
+                var fieldType = BindTypeClause(fieldSyntax.Type);
+                if (fieldType == null)
+                {
+                    continue;
+                }
+
+                var fieldAccessibility = ResolveAccessibility(fieldSyntax.AccessibilityModifier);
+                var fieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: false, isStatic: true);
+
+                if (!fieldSyntax.Annotations.IsDefaultOrEmpty)
+                {
+                    fieldSymbol.SetAttributes(BindAttributes(
+                        fieldSyntax.Annotations,
+                        AttributeTargetKind.Field,
+                        FieldDeclarationAllowedTargets,
+                        "a field declaration",
+                        System.AttributeTargets.Field));
+                }
+
+                staticFieldsBuilder.Add(fieldSymbol);
+            }
+
+            structSymbol.SetStaticFields(staticFieldsBuilder.ToImmutable());
+
+            // Static methods
+            var staticMethodsBuilder = ImmutableArray.CreateBuilder<FunctionSymbol>();
+            foreach (var methodSyntax in syntax.SharedBlock.Methods)
+            {
+                var methodName = methodSyntax.Identifier.Text;
+                if (!existingNames.Add(methodName))
+                {
+                    Diagnostics.ReportSymbolAlreadyDeclared(methodSyntax.Identifier.Location, methodName);
+                    continue;
+                }
+
+                var parameters = ImmutableArray.CreateBuilder<ParameterSymbol>();
+                var seenParameterNames = new HashSet<string>();
+                foreach (var parameterSyntax in methodSyntax.Parameters)
+                {
+                    var parameterName = parameterSyntax.Identifier.Text;
+                    var parameterType = BindTypeClause(parameterSyntax.Type);
+                    if (parameterSyntax.IsVariadic)
+                    {
+                        Diagnostics.ReportVariadicParameterNotSupportedHere(parameterSyntax.Location, parameterName);
+                    }
+
+                    if (!seenParameterNames.Add(parameterName))
+                    {
+                        Diagnostics.ReportParameterAlreadyDeclared(parameterSyntax.Location, parameterName);
+                    }
+                    else
+                    {
+                        parameters.Add(new ParameterSymbol(parameterName, parameterType, declaringSyntax: parameterSyntax.Identifier));
+                    }
+                }
+
+                var returnType = BindReturnTypeClause(methodSyntax.Type, methodSyntax.IsAsync) ?? TypeSymbol.Void;
+                var methodAccessibility = ResolveAccessibility(methodSyntax.AccessibilityModifier);
+
+                var methodSymbol = new FunctionSymbol(
+                    methodName,
+                    parameters.ToImmutable(),
+                    returnType,
+                    methodSyntax,
+                    package,
+                    methodAccessibility,
+                    receiverType: null);
+                methodSymbol.IsStatic = true;
+
+                if (!methodSyntax.Annotations.IsDefaultOrEmpty)
+                {
+                    var methodAttributes = BindAttributes(
+                        methodSyntax.Annotations,
+                        AttributeTargetKind.Method,
+                        FunctionDeclarationAllowedTargets,
+                        "a method declaration",
+                        System.AttributeTargets.Method);
+                    methodSymbol.SetAttributes(methodAttributes);
+                }
+
+                staticMethodsBuilder.Add(methodSymbol);
+            }
+
+            structSymbol.SetStaticMethods(staticMethodsBuilder.ToImmutable());
+
+            // Static properties
+            var staticPropertiesBuilder = ImmutableArray.CreateBuilder<PropertySymbol>();
+            foreach (var propSyntax in syntax.SharedBlock.Properties)
+            {
+                var propName = propSyntax.Identifier.Text;
+                if (!existingNames.Add(propName))
+                {
+                    Diagnostics.ReportSymbolAlreadyDeclared(propSyntax.Identifier.Location, propName);
+                    continue;
+                }
+
+                var propType = BindTypeClause(propSyntax.Type);
+                if (propType == null)
+                {
+                    continue;
+                }
+
+                var propAccessibility = ResolveAccessibility(propSyntax.AccessibilityModifier);
+                bool hasGetter = true;
+                bool hasSetter;
+                bool isAutoProperty;
+                string setterParamName = "value";
+
+                if (propSyntax.OpenBraceToken == null)
+                {
+                    hasSetter = true;
+                    isAutoProperty = true;
+                }
+                else
+                {
+                    var getAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsGetter);
+                    var setAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsSetter);
+                    hasGetter = getAccessor != null || propSyntax.Accessors.IsDefaultOrEmpty;
+                    hasSetter = setAccessor != null;
+
+                    if (setAccessor != null && setAccessor.ParameterIdentifier != null)
+                    {
+                        setterParamName = setAccessor.ParameterIdentifier.Text;
+                    }
+
+                    isAutoProperty = (getAccessor == null || getAccessor.Body == null)
+                                  && (setAccessor == null || setAccessor.Body == null)
+                                  && propSyntax.Accessors.All(a => a.Body == null);
+                }
+
+                var propertySymbol = new PropertySymbol(
+                    propName,
+                    propType,
+                    propAccessibility,
+                    hasGetter,
+                    hasSetter,
+                    isAutoProperty,
+                    isVirtual: false,
+                    isOverride: false,
+                    setterParamName,
+                    isStatic: true);
+
+                if (isAutoProperty)
+                {
+                    var backingField = new FieldSymbol(
+                        $"<{propName}>k__BackingField",
+                        propType,
+                        Accessibility.Private,
+                        isReadOnly: !hasSetter,
+                        isStatic: true);
+                    propertySymbol.BackingField = backingField;
+                }
+
+                if (!propSyntax.Annotations.IsDefaultOrEmpty)
+                {
+                    propertySymbol.SetAttributes(BindAttributes(
+                        propSyntax.Annotations,
+                        AttributeTargetKind.Property,
+                        PropertyDeclarationAllowedTargets,
+                        "a property declaration",
+                        System.AttributeTargets.Property));
+                }
+
+                staticPropertiesBuilder.Add(propertySymbol);
+            }
+
+            structSymbol.SetStaticProperties(staticPropertiesBuilder.ToImmutable());
+
+            // Static events
+            var staticEventsBuilder = ImmutableArray.CreateBuilder<EventSymbol>();
+            foreach (var eventSyntax in syntax.SharedBlock.Events)
+            {
+                var eventName = eventSyntax.Identifier.Text;
+                if (!existingNames.Add(eventName))
+                {
+                    Diagnostics.ReportSymbolAlreadyDeclared(eventSyntax.Identifier.Location, eventName);
+                    continue;
+                }
+
+                var handlerType = BindTypeClause(eventSyntax.Type);
+                if (handlerType == null)
+                {
+                    continue;
+                }
+
+                var eventAccessibility = ResolveAccessibility(eventSyntax.AccessibilityModifier);
+                bool isFieldLike = eventSyntax.OpenBraceToken == null;
+
+                var eventSymbol = new EventSymbol(
+                    eventName,
+                    handlerType,
+                    eventAccessibility,
+                    isFieldLike,
+                    isVirtual: false,
+                    isOverride: false,
+                    isStatic: true);
+
+                if (isFieldLike)
+                {
+                    var backingField = new FieldSymbol(
+                        eventName,
+                        handlerType,
+                        Accessibility.Private,
+                        isReadOnly: false,
+                        isStatic: true);
+                    eventSymbol.BackingField = backingField;
+                }
+
+                var handlerParam = new ParameterSymbol("value", handlerType);
+                eventSymbol.AddMethodSymbol = new FunctionSymbol(
+                    $"add_{eventName}",
+                    ImmutableArray.Create(handlerParam),
+                    TypeSymbol.Void,
+                    declaration: null,
+                    package,
+                    eventAccessibility,
+                    receiverType: null);
+                eventSymbol.AddMethodSymbol.IsStatic = true;
+                eventSymbol.RemoveMethodSymbol = new FunctionSymbol(
+                    $"remove_{eventName}",
+                    ImmutableArray.Create(handlerParam),
+                    TypeSymbol.Void,
+                    declaration: null,
+                    package,
+                    eventAccessibility,
+                    receiverType: null);
+                eventSymbol.RemoveMethodSymbol.IsStatic = true;
+
+                if (!eventSyntax.Annotations.IsDefaultOrEmpty)
+                {
+                    eventSymbol.SetAttributes(BindAttributes(
+                        eventSyntax.Annotations,
+                        AttributeTargetKind.Event,
+                        EventDeclarationAllowedTargets,
+                        "an event declaration",
+                        System.AttributeTargets.Event));
+                }
+
+                staticEventsBuilder.Add(eventSymbol);
+            }
+
+            structSymbol.SetStaticEvents(staticEventsBuilder.ToImmutable());
+        }
+
         // Phase 3.B.4: validate interface implementation. Walks each
         // implemented interface and confirms the class (including inherited
         // methods) provides a same-name, same-signature method. The check
@@ -6724,6 +6983,7 @@ public sealed class Binder
         BoundExpression receiver = null;
         ImportedClassSymbol classSymbol = null;
         EnumSymbol enumSymbol = null;
+        StructSymbol userStructSymbol = null;
 
         if (leftPart is NameExpressionSyntax leftName)
         {
@@ -6766,9 +7026,21 @@ public sealed class Binder
             {
                 classSymbol = importedClass;
             }
-            else if (scope.TryLookupTypeAlias(name, out var typeAlias) && typeAlias is EnumSymbol foundEnum)
+            else if (scope.TryLookupTypeAlias(name, out var typeAlias))
             {
-                enumSymbol = foundEnum;
+                if (typeAlias is EnumSymbol foundEnum)
+                {
+                    enumSymbol = foundEnum;
+                }
+                else if (typeAlias is StructSymbol foundStruct)
+                {
+                    userStructSymbol = foundStruct;
+                }
+                else
+                {
+                    Diagnostics.ReportUnableToFindType(leftName.Location, name);
+                    return new BoundErrorExpression(null);
+                }
             }
             else
             {
@@ -6784,6 +7056,11 @@ public sealed class Binder
         if (enumSymbol != null)
         {
             return BindEnumAccessorStep(enumSymbol, rightPart);
+        }
+
+        if (userStructSymbol != null)
+        {
+            return BindUserTypeStaticAccessorStep(userStructSymbol, rightPart);
         }
 
         return BindAccessorStep(receiver, classSymbol, rightPart);
@@ -6903,6 +7180,88 @@ public sealed class Binder
             default:
                 return new BoundErrorExpression(null);
         }
+    }
+
+    /// <summary>
+    /// Handles <c>TypeName.member</c> and <c>TypeName.method(args)</c> accessor
+    /// resolution for user-defined struct/class static members (ADR-0053).
+    /// </summary>
+    private BoundExpression BindUserTypeStaticAccessorStep(StructSymbol structSym, ExpressionSyntax rightPart)
+    {
+        switch (rightPart)
+        {
+            case AccessorExpressionSyntax nested:
+                var head = BindUserTypeStaticAccessorStep(structSym, nested.LeftPart);
+                if (head is BoundErrorExpression)
+                {
+                    return head;
+                }
+
+                return BindAccessorStep(head, null, nested.RightPart);
+
+            case CallExpressionSyntax ce:
+                return BindUserTypeStaticCall(structSym, ce);
+
+            case NameExpressionSyntax ne:
+                return BindUserTypeStaticMemberAccess(structSym, ne);
+
+            default:
+                return new BoundErrorExpression(null);
+        }
+    }
+
+    private BoundExpression BindUserTypeStaticMemberAccess(StructSymbol structSym, NameExpressionSyntax ne)
+    {
+        var memberName = ne.IdentifierToken.Text;
+
+        if (structSym.TryGetStaticField(memberName, out var field))
+        {
+            return new BoundFieldAccessExpression(null, receiver: null, structSym, field);
+        }
+
+        foreach (var prop in structSym.StaticProperties)
+        {
+            if (prop.Name == memberName)
+            {
+                return new BoundPropertyAccessExpression(null, receiver: null, structSym, prop);
+            }
+        }
+
+        Diagnostics.ReportUnableToFindMember(ne.Location, memberName);
+        return new BoundErrorExpression(null);
+    }
+
+    private BoundExpression BindUserTypeStaticCall(StructSymbol structSym, CallExpressionSyntax ce)
+    {
+        var methodName = ce.Identifier.Text;
+
+        var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>();
+        foreach (var argument in ce.Arguments)
+        {
+            boundArguments.Add(BindExpression(argument));
+        }
+
+        var arguments = boundArguments.ToImmutable();
+
+        if (structSym.TryGetStaticMethod(methodName, out var method))
+        {
+            if (arguments.Length != method.Parameters.Length)
+            {
+                Diagnostics.ReportWrongArgumentCount(ce.Location, method.Name, method.Parameters.Length, arguments.Length);
+                return new BoundErrorExpression(null);
+            }
+
+            var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
+            for (var i = 0; i < arguments.Length; i++)
+            {
+                convertedArgs.Add(BindConversion(ce.Arguments[i].Location, arguments[i], method.Parameters[i].Type));
+            }
+
+            return new BoundCallExpression(null, method, convertedArgs.ToImmutable());
+        }
+
+        Diagnostics.ReportUnableToFindMember(ce.Location, methodName);
+        return new BoundErrorExpression(null);
     }
 
     private BoundExpression BindAccessorStep(BoundExpression receiver, ImportedClassSymbol classSymbol, ExpressionSyntax rightPart)

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -498,6 +498,35 @@ public sealed class Binder
             }
         }
 
+        // ADR-0053 Phase D: bind static method bodies declared in `shared` blocks.
+        foreach (var structSym in globalScope.Structs)
+        {
+            if (structSym.StaticMethods.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            foreach (var method in structSym.StaticMethods)
+            {
+                if (method.Declaration == null)
+                {
+                    continue;
+                }
+
+                var binder = new Binder(parentScope, method);
+                var body = binder.BindStatement(method.Declaration.Body);
+                var loweredBody = Lowerer.Lower(body);
+
+                if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(loweredBody))
+                {
+                    binder.Diagnostics.ReportAllPathsMustReturn(method.Declaration.Identifier.Location);
+                }
+
+                functionBodies.Add(method, loweredBody);
+                diagnostics.AddRange(binder.Diagnostics);
+            }
+        }
+
         var statement = Lowerer.Lower(new BoundBlockStatement(null, globalScope.Statements));
 
         // If the entry point is the synthesized top-level function, its body is

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -5514,6 +5514,26 @@ public sealed class Binder
             return new BoundClrPropertyAssignmentExpression(null, receiver: null, staticMember, staticConverted, TypeSymbol.FromClrType(staticTargetType));
         }
 
+        // ADR-0053: user-defined struct/class type → static field write.
+        if (scope.TryLookupTypeAlias(receiverName, out var typeAlias) && typeAlias is StructSymbol userStruct)
+        {
+            var staticValue = BindExpression(syntax.Value);
+            var fieldName = syntax.FieldIdentifier.Text;
+            if (userStruct.TryGetStaticField(fieldName, out var staticField))
+            {
+                if (staticField.IsReadOnly)
+                {
+                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
+                }
+
+                var staticConverted = BindConversion(syntax.Value.Location, staticValue, staticField.Type);
+                return new BoundFieldAssignmentExpression(null, null, userStruct, staticField, staticConverted);
+            }
+
+            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
+            return new BoundErrorExpression(null);
+        }
+
         var variable = BindVariableReference(receiverName, syntax.Receiver.Location);
         var value = BindExpression(syntax.Value);
         if (variable == null)

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -1281,14 +1281,30 @@ public static class BoundNodePrinter
 
     private static void WriteFieldAccessExpression(BoundFieldAccessExpression node, IndentedTextWriter writer)
     {
-        node.Receiver.WriteTo(writer);
+        if (node.Receiver != null)
+        {
+            node.Receiver.WriteTo(writer);
+        }
+        else
+        {
+            writer.WriteIdentifier(node.StructType.Name);
+        }
+
         writer.WritePunctuation(SyntaxKind.DotToken);
         writer.WriteIdentifier(node.Field.Name);
     }
 
     private static void WriteFieldAssignmentExpression(BoundFieldAssignmentExpression node, IndentedTextWriter writer)
     {
-        writer.WriteIdentifier(node.Receiver.Name);
+        if (node.Receiver != null)
+        {
+            writer.WriteIdentifier(node.Receiver.Name);
+        }
+        else
+        {
+            writer.WriteIdentifier(node.StructType.Name);
+        }
+
         writer.WritePunctuation(SyntaxKind.DotToken);
         writer.WriteIdentifier(node.Field.Name);
         writer.WriteSpace();

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1513,6 +1513,12 @@ public abstract class BoundTreeRewriter
     /// <returns>The rewritten node.</returns>
     protected virtual BoundExpression RewriteFieldAccessExpression(BoundFieldAccessExpression node)
     {
+        // ADR-0053: static field access has no receiver (null).
+        if (node.Receiver == null)
+        {
+            return node;
+        }
+
         var receiver = RewriteExpression(node.Receiver);
         return receiver == node.Receiver ? node : new BoundFieldAccessExpression(null, receiver, node.StructType, node.Field, node.NarrowedType);
     }

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1372,6 +1372,13 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0212", $"Function '{functionName}' is marked '@Conditional' but does not return 'void'; conditional methods must return 'void' because calls may be elided at the call site.");
     }
 
+    /// <summary>GS9007: A type may contain at most one 'shared' block.</summary>
+    /// <param name="location">The text location of the duplicate shared keyword.</param>
+    public void ReportDuplicateSharedBlock(TextLocation location)
+    {
+        Report(location, "GS9007", "A type may contain at most one 'shared' block.");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -8448,7 +8448,8 @@ internal sealed class ReflectionMetadataEmitter
                         }
                     }
 
-                    if (!this.outer.functionHandles.TryGetValue(call.Function, out var fnHandle))
+                    if (!this.outer.functionHandles.TryGetValue(call.Function, out var fnHandle)
+                        && !this.outer.methodHandles.TryGetValue(call.Function, out fnHandle))
                     {
                         throw new InvalidOperationException(
                             $"Call to function '{call.Function.Name}' has no emitted MethodDef.");

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -482,6 +482,12 @@ internal sealed class ReflectionMetadataEmitter
                     nextFieldRow++;
                 }
             }
+
+            // ADR-0053: static fields from shared block.
+            if (!s.StaticFields.IsDefaultOrEmpty)
+            {
+                nextFieldRow += s.StaticFields.Length;
+            }
         }
 
         foreach (var s in nonSmStructs)
@@ -504,6 +510,12 @@ internal sealed class ReflectionMetadataEmitter
                 {
                     nextFieldRow++;
                 }
+            }
+
+            // ADR-0053: static fields from shared block.
+            if (!s.StaticFields.IsDefaultOrEmpty)
+            {
+                nextFieldRow += s.StaticFields.Length;
             }
         }
 
@@ -638,13 +650,24 @@ internal sealed class ReflectionMetadataEmitter
                 var removeHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
                 this.eventAccessorHandles[ev] = (addHandle, removeHandle);
             }
+
+            // ADR-0053: plan method rows for static methods on classes.
+            if (!c.StaticMethods.IsDefaultOrEmpty)
+            {
+                foreach (var m in c.StaticMethods)
+                {
+                    var handle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                    aggregateMethodHandles[m] = handle;
+                    this.methodHandles[m] = handle;
+                }
+            }
         }
 
         // Plan method rows for non-SM structs.
         var structFirstMethodRows = new Dictionary<StructSymbol, int>();
         foreach (var s in nonSmStructs)
         {
-            if (s.Methods.IsDefaultOrEmpty && !s.IsInline && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty)
+            if (s.Methods.IsDefaultOrEmpty && !s.IsInline && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty)
             {
                 continue;
             }
@@ -686,6 +709,17 @@ internal sealed class ReflectionMetadataEmitter
                 var addHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
                 var removeHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
                 this.eventAccessorHandles[ev] = (addHandle, removeHandle);
+            }
+
+            // ADR-0053: plan method rows for static methods on structs.
+            if (!s.StaticMethods.IsDefaultOrEmpty)
+            {
+                foreach (var m in s.StaticMethods)
+                {
+                    var handle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                    aggregateMethodHandles[m] = handle;
+                    this.methodHandles[m] = handle;
+                }
             }
         }
 
@@ -797,6 +831,13 @@ internal sealed class ReflectionMetadataEmitter
             // Class instance methods are owned by their class TypeDef, not by
             // a package's <Program> container.
             if (kvp.Key.IsInstanceMethod)
+            {
+                continue;
+            }
+
+            // ADR-0053: static methods on structs/classes are emitted as part of
+            // their owning TypeDef, not as package-level functions.
+            if (kvp.Key.IsStatic && aggregateMethodHandles.ContainsKey(kvp.Key))
             {
                 continue;
             }
@@ -1026,6 +1067,19 @@ internal sealed class ReflectionMetadataEmitter
 
             // ADR-0052: emit event accessor methods for classes.
             this.EmitEventAccessors(c);
+
+            // ADR-0053: emit static methods for classes.
+            if (!c.StaticMethods.IsDefaultOrEmpty)
+            {
+                foreach (var m in c.StaticMethods)
+                {
+                    if (this.program.Functions.TryGetValue(m, out var staticBody))
+                    {
+                        var emittedHandle = this.EmitFunction(m, staticBody, isEntryPoint: false);
+                        this.methodHandles[m] = emittedHandle;
+                    }
+                }
+            }
         }
 
         // 4b. Non-SM struct methods.
@@ -1036,7 +1090,7 @@ internal sealed class ReflectionMetadataEmitter
                 this.EmitInlineStructSynthesizedMembers(s);
             }
 
-            if (s.Methods.IsDefaultOrEmpty && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty)
+            if (s.Methods.IsDefaultOrEmpty && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty)
             {
                 continue;
             }
@@ -1057,6 +1111,19 @@ internal sealed class ReflectionMetadataEmitter
 
             // ADR-0052: emit event accessor methods for structs.
             this.EmitEventAccessors(s);
+
+            // ADR-0053: emit static methods for structs.
+            if (!s.StaticMethods.IsDefaultOrEmpty)
+            {
+                foreach (var m in s.StaticMethods)
+                {
+                    if (this.program.Functions.TryGetValue(m, out var staticBody))
+                    {
+                        var emittedHandle = this.EmitFunction(m, staticBody, isEntryPoint: false);
+                        this.methodHandles[m] = emittedHandle;
+                    }
+                }
+            }
         }
 
         // Phase 4 emit parity (F2, type-erased): now that every generic
@@ -1661,6 +1728,32 @@ internal sealed class ReflectionMetadataEmitter
             }
 
             this.structFieldDefs[ev.BackingField] = backingHandle;
+        }
+
+        // ADR-0053: emit static field definitions from shared block.
+        if (!structSym.StaticFields.IsDefaultOrEmpty)
+        {
+            foreach (var staticField in structSym.StaticFields)
+            {
+                var sigBlob = new BlobBuilder();
+                this.EncodeTypeSymbol(new BlobEncoder(sigBlob).FieldSignature(), staticField.Type);
+                var attrs = MapFieldAccessibility(staticField.Accessibility) | FieldAttributes.Static;
+                if (staticField.IsReadOnly)
+                {
+                    attrs |= FieldAttributes.InitOnly;
+                }
+
+                var handle = this.metadata.AddFieldDefinition(
+                    attributes: attrs,
+                    name: this.metadata.GetOrAddString(staticField.Name),
+                    signature: this.metadata.GetOrAddBlob(sigBlob));
+                if (firstField.IsNil)
+                {
+                    firstField = handle;
+                }
+
+                this.structFieldDefs[staticField] = handle;
+            }
         }
 
         if (firstField.IsNil)
@@ -6158,7 +6251,11 @@ internal sealed class ReflectionMetadataEmitter
                 WalkForStructLiterals(blockExpr.Expression, sink);
                 break;
             case BoundFieldAccessExpression fa:
-                WalkForStructLiterals(fa.Receiver, sink);
+                if (fa.Receiver != null)
+                {
+                    WalkForStructLiterals(fa.Receiver, sink);
+                }
+
                 break;
             case BoundFieldAssignmentExpression fas:
                 WalkForStructLiterals(fas.Value, sink);
@@ -6677,7 +6774,11 @@ internal sealed class ReflectionMetadataEmitter
                 WalkForNullConditional(conv.Expression, sink);
                 break;
             case BoundFieldAccessExpression fa:
-                WalkForNullConditional(fa.Receiver, sink);
+                if (fa.Receiver != null)
+                {
+                    WalkForNullConditional(fa.Receiver, sink);
+                }
+
                 break;
             case BoundFieldAssignmentExpression fas:
                 WalkForNullConditional(fas.Value, sink);
@@ -10004,6 +10105,14 @@ internal sealed class ReflectionMetadataEmitter
                     $"Struct field '{fa.Field.Name}' has no emitted FieldDef.");
             }
 
+            // ADR-0053: static field access — no receiver, use ldsfld.
+            if (fa.Receiver == null)
+            {
+                this.il.OpCode(ILOpCode.Ldsfld);
+                this.il.Token(fieldHandle);
+                return;
+            }
+
             // Class receivers are references: load the value (the ref) and ldfld.
             // For struct receivers, load by address when the receiver is a
             // simple variable (avoids a copy and is verifier-friendly); fall
@@ -10366,6 +10475,19 @@ internal sealed class ReflectionMetadataEmitter
             {
                 throw new InvalidOperationException(
                     $"Struct field '{fas.Field.Name}' has no emitted FieldDef.");
+            }
+
+            // ADR-0053: static field assignment — no receiver, use stsfld/ldsfld.
+            if (fas.Receiver == null)
+            {
+                this.EmitExpression(fas.Value);
+                this.il.OpCode(ILOpCode.Stsfld);
+                this.il.Token(fieldHandle);
+
+                // Leave the assigned value on the stack as the expression result.
+                this.il.OpCode(ILOpCode.Ldsfld);
+                this.il.Token(fieldHandle);
+                return;
             }
 
             // Class field assignment: load the reference, evaluate the value,
@@ -11123,6 +11245,14 @@ internal sealed class ReflectionMetadataEmitter
             {
                 throw new InvalidOperationException(
                     $"Cannot take address of field '{fa.Field.Name}': no emitted FieldDef.");
+            }
+
+            // ADR-0053: static field address — use ldsflda.
+            if (fa.Receiver == null)
+            {
+                this.il.OpCode(ILOpCode.Ldsflda);
+                this.il.Token(fieldHandle);
+                return;
             }
 
             // Load receiver address, then ldflda.

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -27,6 +27,7 @@ public sealed class Evaluator
     private readonly Stack<ScopeFrame> scopeFrames = new Stack<ScopeFrame>();
     private readonly Stack<System.Collections.IList> iteratorSinks = new Stack<System.Collections.IList>();
     private readonly Dictionary<Symbols.FunctionSymbol, bool> iteratorFunctionCache = new Dictionary<Symbols.FunctionSymbol, bool>();
+    private readonly Dictionary<(Symbols.StructSymbol, Symbols.FieldSymbol), object> staticFields = new Dictionary<(Symbols.StructSymbol, Symbols.FieldSymbol), object>();
     private Random random;
 
     private object lastValue;
@@ -993,6 +994,18 @@ public sealed class Evaluator
 
     private object EvaluateFieldAccessExpression(BoundFieldAccessExpression node)
     {
+        // ADR-0053: static field access — receiver is null; look up in the
+        // static-field storage keyed by (StructType, Field).
+        if (node.Receiver == null)
+        {
+            if (staticFields.TryGetValue((node.StructType, node.Field), out var staticValue))
+            {
+                return staticValue;
+            }
+
+            return DefaultValue(node.Field.Type);
+        }
+
         var receiverValue = EvaluateExpression(node.Receiver);
         if (receiverValue is StructValue sv && sv.Fields.TryGetValue(node.Field.Name, out var value))
         {
@@ -1036,6 +1049,20 @@ public sealed class Evaluator
 
     private object EvaluatePropertyAccessExpression(BoundPropertyAccessExpression node)
     {
+        // ADR-0053: static property access — receiver is null.
+        if (node.Receiver == null)
+        {
+            if (node.Property.IsAutoProperty && node.Property.BackingField != null)
+            {
+                if (staticFields.TryGetValue((node.StructType, node.Property.BackingField), out var staticValue))
+                {
+                    return staticValue;
+                }
+            }
+
+            return DefaultValue(node.Property.Type);
+        }
+
         var receiverValue = EvaluateExpression(node.Receiver);
 
         // Auto-property fallback: access backing field directly.
@@ -2434,6 +2461,13 @@ public sealed class Evaluator
     /// <summary>ADR-0039: Writes back a value into a field after ref/out return.</summary>
     private void WriteBackField(BoundFieldAccessExpression fa, object value)
     {
+        if (fa.Receiver == null)
+        {
+            // ADR-0053: static field write-back.
+            staticFields[(fa.StructType, fa.Field)] = value;
+            return;
+        }
+
         var receiver = EvaluateExpression(fa.Receiver);
         if (receiver is StructValue sv)
         {
@@ -2446,6 +2480,13 @@ public sealed class Evaluator
     {
         if (pa.Property.IsAutoProperty && pa.Property.BackingField != null)
         {
+            if (pa.Receiver == null)
+            {
+                // ADR-0053: static property write-back.
+                staticFields[(pa.StructType, pa.Property.BackingField)] = value;
+                return;
+            }
+
             var receiver = EvaluateExpression(pa.Receiver);
             if (receiver is StructValue sv)
             {

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -1017,6 +1017,15 @@ public sealed class Evaluator
 
     private object EvaluateFieldAssignmentExpression(BoundFieldAssignmentExpression node)
     {
+        // ADR-0053: static field assignment — receiver is null; store in the
+        // static-field storage keyed by (StructType, Field).
+        if (node.Receiver == null)
+        {
+            var value = EvaluateExpression(node.Value);
+            staticFields[(node.StructType, node.Field)] = value;
+            return value;
+        }
+
         var current = node.Receiver.Kind == Symbols.SymbolKind.GlobalVariable
             ? globals[node.Receiver]
             : locals.Peek()[node.Receiver];

--- a/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
@@ -18,13 +18,15 @@ public sealed class EventSymbol : Symbol
     /// <param name="isFieldLike">Whether this is a field-like event (no explicit accessors).</param>
     /// <param name="isVirtual">Whether this event is virtual (open modifier present).</param>
     /// <param name="isOverride">Whether this event overrides a base event.</param>
+    /// <param name="isStatic">Whether this event is declared inside a <c>shared</c> block (ADR-0053).</param>
     public EventSymbol(
         string name,
         TypeSymbol type,
         Accessibility accessibility,
         bool isFieldLike,
         bool isVirtual,
-        bool isOverride)
+        bool isOverride,
+        bool isStatic = false)
         : base(name)
     {
         Type = type;
@@ -32,6 +34,7 @@ public sealed class EventSymbol : Symbol
         IsFieldLike = isFieldLike;
         IsVirtual = isVirtual;
         IsOverride = isOverride;
+        IsStatic = isStatic;
     }
 
     /// <inheritdoc/>
@@ -51,6 +54,9 @@ public sealed class EventSymbol : Symbol
 
     /// <summary>Gets a value indicating whether this event overrides a base event.</summary>
     public bool IsOverride { get; }
+
+    /// <summary>Gets a value indicating whether this event is declared inside a <c>shared</c> block (ADR-0053).</summary>
+    public bool IsStatic { get; }
 
     /// <summary>Gets or sets the synthesized backing delegate field (null for explicit accessors).</summary>
     public FieldSymbol BackingField { get; set; }

--- a/src/Core/CodeAnalysis/Symbols/FieldSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FieldSymbol.cs
@@ -16,12 +16,14 @@ public sealed class FieldSymbol : Symbol
     /// <param name="type">The field type.</param>
     /// <param name="accessibility">The field accessibility.</param>
     /// <param name="isReadOnly">True when the field is init-only after construction.</param>
-    public FieldSymbol(string name, TypeSymbol type, Accessibility accessibility, bool isReadOnly = false)
+    /// <param name="isStatic">True when the field is declared inside a <c>shared</c> block (ADR-0053).</param>
+    public FieldSymbol(string name, TypeSymbol type, Accessibility accessibility, bool isReadOnly = false, bool isStatic = false)
         : base(name)
     {
         Type = type;
         Accessibility = accessibility;
         IsReadOnly = isReadOnly;
+        IsStatic = isStatic;
     }
 
     /// <inheritdoc/>
@@ -35,4 +37,7 @@ public sealed class FieldSymbol : Symbol
 
     /// <summary>Gets a value indicating whether this field is init-only after construction.</summary>
     public bool IsReadOnly { get; }
+
+    /// <summary>Gets a value indicating whether this field is declared inside a <c>shared</c> block (ADR-0053).</summary>
+    public bool IsStatic { get; }
 }

--- a/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -206,6 +206,9 @@ public sealed class FunctionSymbol : Symbol
     /// <summary>Gets a value indicating whether this function declares one or more type parameters (Phase 4.1).</summary>
     public bool IsGeneric => !TypeParameters.IsDefaultOrEmpty;
 
+    /// <summary>Gets or sets a value indicating whether this function is declared inside a <c>shared</c> block (ADR-0053). Static functions have no receiver.</summary>
+    public bool IsStatic { get; set; }
+
     /// <summary>Gets or sets a value indicating whether this function is declared <c>async</c> (Phase 5.1 / ADR-0023). When true, callers observe the function's return as <c>Task[T]</c> (or <c>Task</c> when no return type was declared) and the body may use <c>await</c>.</summary>
     public bool IsAsync { get; set; }
 

--- a/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
@@ -21,6 +21,7 @@ public sealed class PropertySymbol : Symbol
     /// <param name="isVirtual">Whether this property is virtual (open).</param>
     /// <param name="isOverride">Whether this property overrides a base property.</param>
     /// <param name="setterParameterName">The setter parameter name (defaults to "value").</param>
+    /// <param name="isStatic">Whether this property is declared inside a <c>shared</c> block (ADR-0053).</param>
     public PropertySymbol(
         string name,
         TypeSymbol type,
@@ -30,7 +31,8 @@ public sealed class PropertySymbol : Symbol
         bool isAutoProperty,
         bool isVirtual,
         bool isOverride,
-        string setterParameterName = "value")
+        string setterParameterName = "value",
+        bool isStatic = false)
         : base(name)
     {
         Type = type;
@@ -41,6 +43,7 @@ public sealed class PropertySymbol : Symbol
         IsVirtual = isVirtual;
         IsOverride = isOverride;
         SetterParameterName = setterParameterName;
+        IsStatic = isStatic;
     }
 
     /// <inheritdoc/>
@@ -69,6 +72,9 @@ public sealed class PropertySymbol : Symbol
 
     /// <summary>Gets the setter parameter name (defaults to "value").</summary>
     public string SetterParameterName { get; }
+
+    /// <summary>Gets a value indicating whether this property is declared inside a <c>shared</c> block (ADR-0053).</summary>
+    public bool IsStatic { get; }
 
     /// <summary>Gets or sets the synthesized backing field symbol for auto-properties. Null for computed properties.</summary>
     public FieldSymbol BackingField { get; set; }

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -195,6 +195,18 @@ public sealed class StructSymbol : TypeSymbol
     /// <summary>Gets the events declared on this type (ADR-0052). Populated by the binder after the symbol is constructed; defaults to empty.</summary>
     public ImmutableArray<EventSymbol> Events { get; private set; } = ImmutableArray<EventSymbol>.Empty;
 
+    /// <summary>Gets the static fields declared inside a <c>shared</c> block (ADR-0053). Populated by the binder; defaults to empty.</summary>
+    public ImmutableArray<FieldSymbol> StaticFields { get; private set; } = ImmutableArray<FieldSymbol>.Empty;
+
+    /// <summary>Gets the static methods declared inside a <c>shared</c> block (ADR-0053). Populated by the binder; defaults to empty.</summary>
+    public ImmutableArray<FunctionSymbol> StaticMethods { get; private set; } = ImmutableArray<FunctionSymbol>.Empty;
+
+    /// <summary>Gets the static properties declared inside a <c>shared</c> block (ADR-0053). Populated by the binder; defaults to empty.</summary>
+    public ImmutableArray<PropertySymbol> StaticProperties { get; private set; } = ImmutableArray<PropertySymbol>.Empty;
+
+    /// <summary>Gets the static events declared inside a <c>shared</c> block (ADR-0053). Populated by the binder; defaults to empty.</summary>
+    public ImmutableArray<EventSymbol> StaticEvents { get; private set; } = ImmutableArray<EventSymbol>.Empty;
+
     /// <summary>Gets the type parameters when this is a generic definition (Phase 4.3 / ADR-0020). Empty for non-generic types and for constructed instances.</summary>
     public ImmutableArray<TypeParameterSymbol> TypeParameters { get; private set; } = ImmutableArray<TypeParameterSymbol>.Empty;
 
@@ -243,6 +255,78 @@ public sealed class StructSymbol : TypeSymbol
     public void SetEvents(ImmutableArray<EventSymbol> events)
     {
         Events = events;
+    }
+
+    /// <summary>Sets <see cref="StaticFields"/> after binding shared-block field declarations (ADR-0053).</summary>
+    /// <param name="fields">The bound static field symbols owned by this type.</param>
+    public void SetStaticFields(ImmutableArray<FieldSymbol> fields)
+    {
+        StaticFields = fields;
+    }
+
+    /// <summary>Sets <see cref="StaticMethods"/> after binding shared-block method declarations (ADR-0053).</summary>
+    /// <param name="methods">The bound static method symbols owned by this type.</param>
+    public void SetStaticMethods(ImmutableArray<FunctionSymbol> methods)
+    {
+        StaticMethods = methods;
+    }
+
+    /// <summary>Sets <see cref="StaticProperties"/> after binding shared-block property declarations (ADR-0053).</summary>
+    /// <param name="properties">The bound static property symbols owned by this type.</param>
+    public void SetStaticProperties(ImmutableArray<PropertySymbol> properties)
+    {
+        StaticProperties = properties;
+    }
+
+    /// <summary>Sets <see cref="StaticEvents"/> after binding shared-block event declarations (ADR-0053).</summary>
+    /// <param name="events">The bound static event symbols owned by this type.</param>
+    public void SetStaticEvents(ImmutableArray<EventSymbol> events)
+    {
+        StaticEvents = events;
+    }
+
+    /// <summary>Tries to find a static field by name on this type (ADR-0053).</summary>
+    /// <param name="name">The field name.</param>
+    /// <param name="field">The found static field on success.</param>
+    /// <returns>True if found.</returns>
+    public bool TryGetStaticField(string name, out FieldSymbol field)
+    {
+        if (!StaticFields.IsDefaultOrEmpty)
+        {
+            foreach (var f in StaticFields)
+            {
+                if (f.Name == name)
+                {
+                    field = f;
+                    return true;
+                }
+            }
+        }
+
+        field = null;
+        return false;
+    }
+
+    /// <summary>Tries to find a static method by name on this type (ADR-0053).</summary>
+    /// <param name="name">The method name.</param>
+    /// <param name="method">The found static method on success.</param>
+    /// <returns>True if found.</returns>
+    public bool TryGetStaticMethod(string name, out FunctionSymbol method)
+    {
+        if (!StaticMethods.IsDefaultOrEmpty)
+        {
+            foreach (var m in StaticMethods)
+            {
+                if (m.Name == name)
+                {
+                    method = m;
+                    return true;
+                }
+            }
+        }
+
+        method = null;
+        return false;
     }
 
     /// <summary>Appends additional methods after the initial declaration binding pass.</summary>

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -652,6 +652,7 @@ public class Parser
         var properties = ImmutableArray.CreateBuilder<PropertyDeclarationSyntax>();
         var events = ImmutableArray.CreateBuilder<EventDeclarationSyntax>();
         var methods = ImmutableArray.CreateBuilder<FunctionDeclarationSyntax>();
+        SharedBlockSyntax structDecl_sharedBlock = null;
         if (inlineKeyword != null && Current.Kind != SyntaxKind.OpenBraceToken)
         {
             openBrace = new SyntaxToken(syntaxTree, SyntaxKind.OpenBraceToken, Current.Position, "{", null);
@@ -751,6 +752,25 @@ public class Parser
                 eventDecl.WithAnnotations(memberAnnotations);
                 events.Add(eventDecl);
             }
+            else if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "shared" && Peek(1).Kind == SyntaxKind.OpenBraceToken)
+            {
+                // ADR-0053: shared block grouping static member declarations.
+                if (memberAccessibility != null || memberOpenModifier != null || memberOverrideModifier != null)
+                {
+                    var loc = (memberAccessibility ?? memberOpenModifier ?? memberOverrideModifier).Location;
+                    Diagnostics.ReportUnexpectedToken(loc, SyntaxKind.IdentifierToken, SyntaxKind.OpenBraceToken);
+                }
+
+                var sharedBlock = ParseSharedBlock();
+                if (structDecl_sharedBlock != null)
+                {
+                    Diagnostics.ReportDuplicateSharedBlock(sharedBlock.SharedKeyword.Location);
+                }
+                else
+                {
+                    structDecl_sharedBlock = sharedBlock;
+                }
+            }
             else if (Current.Kind == SyntaxKind.FuncKeyword)
             {
                 if (structOrClassKeyword.Kind != SyntaxKind.ClassKeyword)
@@ -780,7 +800,7 @@ public class Parser
         }
 
         var closeBrace = MatchToken(SyntaxKind.CloseBraceToken);
-        return new StructDeclarationSyntax(
+        var structDecl = new StructDeclarationSyntax(
             syntaxTree,
             accessibilityModifier,
             typeKeyword,
@@ -795,6 +815,76 @@ public class Parser
             baseColon,
             baseTypeIdentifier,
             additionalBaseIdentifiers.ToImmutable(),
+            openBrace,
+            fields.ToImmutable(),
+            properties.ToImmutable(),
+            events.ToImmutable(),
+            methods.ToImmutable(),
+            closeBrace);
+        structDecl.SharedBlock = structDecl_sharedBlock;
+        return structDecl;
+    }
+
+    private SharedBlockSyntax ParseSharedBlock()
+    {
+        var sharedKeyword = NextToken(); // consume the contextual "shared" identifier
+        var openBrace = MatchToken(SyntaxKind.OpenBraceToken);
+
+        var fields = ImmutableArray.CreateBuilder<FieldDeclarationSyntax>();
+        var properties = ImmutableArray.CreateBuilder<PropertyDeclarationSyntax>();
+        var events = ImmutableArray.CreateBuilder<EventDeclarationSyntax>();
+        var methods = ImmutableArray.CreateBuilder<FunctionDeclarationSyntax>();
+
+        while (Current.Kind != SyntaxKind.CloseBraceToken && Current.Kind != SyntaxKind.EndOfFileToken)
+        {
+            var startToken = Current;
+
+            SyntaxToken memberAccessibility = null;
+            if (Current.Kind == SyntaxKind.PublicKeyword ||
+                Current.Kind == SyntaxKind.InternalKeyword ||
+                Current.Kind == SyntaxKind.PrivateKeyword)
+            {
+                var ahead = 1;
+                while (Peek(ahead).Kind == SyntaxKind.OpenKeyword || Peek(ahead).Kind == SyntaxKind.OverrideKeyword)
+                {
+                    ahead++;
+                }
+
+                if (Peek(ahead).Kind == SyntaxKind.FuncKeyword ||
+                    (Peek(ahead).Kind == SyntaxKind.IdentifierToken && Peek(ahead).Text == "prop") ||
+                    (Peek(ahead).Kind == SyntaxKind.IdentifierToken && Peek(ahead).Text == "event"))
+                {
+                    memberAccessibility = NextToken();
+                }
+            }
+
+            if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "prop")
+            {
+                properties.Add(ParsePropertyDeclaration(memberAccessibility, null, null));
+            }
+            else if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "event")
+            {
+                events.Add(ParseEventDeclaration(memberAccessibility, null, null));
+            }
+            else if (Current.Kind == SyntaxKind.FuncKeyword)
+            {
+                methods.Add((FunctionDeclarationSyntax)ParseFunctionDeclaration(memberAccessibility, null, null));
+            }
+            else
+            {
+                fields.Add(ParseFieldDeclaration());
+            }
+
+            if (Current == startToken)
+            {
+                NextToken();
+            }
+        }
+
+        var closeBrace = MatchToken(SyntaxKind.CloseBraceToken);
+        return new SharedBlockSyntax(
+            syntaxTree,
+            sharedKeyword,
             openBrace,
             fields.ToImmutable(),
             properties.ToImmutable(),

--- a/src/Core/CodeAnalysis/Syntax/SharedBlockSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/SharedBlockSyntax.cs
@@ -1,0 +1,69 @@
+// <copyright file="SharedBlockSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents a <c>shared { … }</c> block inside a struct/class body (ADR-0053).
+/// Groups static member declarations (fields, properties, events, methods).
+/// </summary>
+public sealed class SharedBlockSyntax : SyntaxNode
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SharedBlockSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="sharedKeyword">The contextual <c>shared</c> identifier token.</param>
+    /// <param name="openBraceToken">The opening brace.</param>
+    /// <param name="fields">The field declarations.</param>
+    /// <param name="properties">The property declarations.</param>
+    /// <param name="events">The event declarations.</param>
+    /// <param name="methods">The method declarations.</param>
+    /// <param name="closeBraceToken">The closing brace.</param>
+    public SharedBlockSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken sharedKeyword,
+        SyntaxToken openBraceToken,
+        ImmutableArray<FieldDeclarationSyntax> fields,
+        ImmutableArray<PropertyDeclarationSyntax> properties,
+        ImmutableArray<EventDeclarationSyntax> events,
+        ImmutableArray<FunctionDeclarationSyntax> methods,
+        SyntaxToken closeBraceToken)
+        : base(syntaxTree)
+    {
+        SharedKeyword = sharedKeyword;
+        OpenBraceToken = openBraceToken;
+        Fields = fields;
+        Properties = properties;
+        Events = events;
+        Methods = methods;
+        CloseBraceToken = closeBraceToken;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.SharedBlock;
+
+    /// <summary>Gets the contextual <c>shared</c> identifier token.</summary>
+    public SyntaxToken SharedKeyword { get; }
+
+    /// <summary>Gets the opening brace.</summary>
+    public SyntaxToken OpenBraceToken { get; }
+
+    /// <summary>Gets the field declarations.</summary>
+    public ImmutableArray<FieldDeclarationSyntax> Fields { get; }
+
+    /// <summary>Gets the property declarations.</summary>
+    public ImmutableArray<PropertyDeclarationSyntax> Properties { get; }
+
+    /// <summary>Gets the event declarations.</summary>
+    public ImmutableArray<EventDeclarationSyntax> Events { get; }
+
+    /// <summary>Gets the method declarations.</summary>
+    public ImmutableArray<FunctionDeclarationSyntax> Methods { get; }
+
+    /// <summary>Gets the closing brace.</summary>
+    public SyntaxToken CloseBraceToken { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/StructDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/StructDeclarationSyntax.cs
@@ -426,4 +426,7 @@ public sealed class StructDeclarationSyntax : MemberSyntax
 
     /// <summary>Gets or sets the optional type-parameter list (Phase 4.3 / ADR-0020), e.g. <c>[T any]</c> in <c>type Box[T any] class { ... }</c>. Assigned by the parser when the declaration is generic; <c>null</c> otherwise.</summary>
     public TypeParameterListSyntax TypeParameterList { get; set; }
+
+    /// <summary>Gets or sets the optional <c>shared { … }</c> block (ADR-0053) grouping static member declarations. Null when the type has no shared block.</summary>
+    public SharedBlockSyntax SharedBlock { get; set; }
 }

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -235,6 +235,9 @@ public enum SyntaxKind
     EventDeclaration,
     PropertyAccessor,
     EventAccessor,
+
+    // ADR-0053: static (shared) members
+    SharedBlock,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/test/Core.Tests/CodeAnalysis/SharedBlockTests.cs
+++ b/test/Core.Tests/CodeAnalysis/SharedBlockTests.cs
@@ -1,0 +1,306 @@
+// <copyright file="SharedBlockTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// ADR-0053 Phase E — comprehensive tests for the <c>shared { … }</c> block feature
+/// covering parser, binder, evaluator, and emit round-trip scenarios.
+/// </summary>
+public class SharedBlockTests
+{
+    // ─────────────────────────────────────────────────────────────────────────
+    // 1. Parser tests
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SharedBlock_Parses_InClass()
+    {
+        var source = @"
+type Counter class {
+    shared {
+        count int32
+    }
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void SharedBlock_Parses_InStruct()
+    {
+        var source = @"
+type Counter struct {
+    shared {
+        count int32
+    }
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void SharedBlock_Parses_WithMethods()
+    {
+        var source = @"
+type Factory struct {
+    shared {
+        func create() int32 {
+            return 42
+        }
+    }
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void SharedBlock_DuplicateSharedBlock_ReportsDiagnostic()
+    {
+        var source = @"
+type Counter struct {
+    shared {
+        x int32
+    }
+    shared {
+        y int32
+    }
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.NotEmpty(tree.Diagnostics);
+        Assert.Contains(tree.Diagnostics, d => d.Message.Contains("shared"));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 2. Binder tests
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SharedBlock_StaticFieldAccess_Binds()
+    {
+        var source = @"
+type Counter struct {
+    shared {
+        count int32
+    }
+}
+
+var x = Counter.count
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void SharedBlock_StaticMethodCall_Binds()
+    {
+        var source = @"
+type Factory struct {
+    shared {
+        func create() int32 {
+            return 42
+        }
+    }
+}
+
+var x = Factory.create()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void SharedBlock_StaticField_AssignmentBinds()
+    {
+        var source = @"
+type Counter struct {
+    shared {
+        count int32
+    }
+}
+
+Counter.count = 5
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 3. Evaluator (interpreter) tests
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SharedBlock_StaticField_ReadWrite()
+    {
+        var source = @"
+type Counter struct {
+    shared {
+        count int32
+    }
+}
+
+Counter.count = 42
+var result = Counter.count
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SharedBlock_StaticMethod_ReturnsValue()
+    {
+        var source = @"
+type Factory struct {
+    shared {
+        func create() int32 {
+            return 99
+        }
+    }
+}
+
+var result = Factory.create()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(99, result.Value);
+    }
+
+    [Fact]
+    public void SharedBlock_StaticField_SharedAcrossInstances()
+    {
+        var source = @"
+type Counter struct {
+    shared {
+        count int32
+    }
+}
+
+Counter.count = 10
+Counter.count = Counter.count + 5
+var result = Counter.count
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(15, result.Value);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 4. Emit (compiled) tests
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SharedBlock_StaticField_Emit_RoundTrip()
+    {
+        var source = @"package SharedFieldEmit
+import System
+
+type Counter struct {
+    shared {
+        count int32
+    }
+}
+
+Counter.count = 77
+Console.WriteLine(Counter.count)
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "SharedBlock-StaticField");
+        Assert.Contains("77", output);
+    }
+
+    [Fact]
+    public void SharedBlock_StaticMethod_Emit_RoundTrip()
+    {
+        var source = @"package SharedMethodEmit
+import System
+
+type Factory struct {
+    shared {
+        func create() int32 {
+            return 123
+        }
+    }
+}
+
+Console.WriteLine(Factory.create())
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "SharedBlock-StaticMethod");
+        Assert.Contains("123", output);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+
+    private static EmitResult Compile(string source, Stream peStream)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Emit(peStream);
+    }
+
+    private static string CompileLoadInvokeCaptureStdout(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var result = Compile(source, peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, parameters: null);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -164,6 +164,7 @@ SelectKeyword
 SelectStatement
 SemicolonToken
 SequenceKeyword
+SharedBlock
 ShiftLeftEqualsToken
 ShiftLeftToken
 ShiftRightEqualsToken


### PR DESCRIPTION
## ADR-0053: Static Members via `shared` Block

Implements [issue #196](https://github.com/DavidObando/gsharp/issues/196) — support for CLR static types and members in GSharp.

### Design

Introduces a `shared { … }` block inside struct/class bodies. Members declared within are emitted as standard CLR static members, enabling full roundtrip interop with C# projects.

```gsharp
type Counter class {
    shared {
        var count int
        func create() Counter {
            Counter.count = Counter.count + 1
            return Counter{}
        }
    }
}

Counter.count = 10
var c = Counter.create()
```

### Implementation Phases

| Phase | Commit | Description |
|-------|--------|-------------|
| A | 625ebf3 | Parser: `shared` contextual keyword, `SharedBlockSyntax` node, GS9007 duplicate diagnostic |
| B | 4eec51e | Symbols: `IsStatic` on Field/Function/Property/Event, static collections on `StructSymbol` |
| C | 51f4d92 | Binder: bind shared members, resolve `TypeName.member` static access/calls/assignments |
| D | 5e77bbd | Emit: `FieldAttributes.Static`, `ldsfld`/`stsfld`/`ldsflda` IL, static method emission |
| E | a45ec10 | Tests: 12 new tests covering parser, binder, evaluator, and emit round-trip |

### Deferred Work

- `.cctor` (type initializer) — CLR zero-inits all fields; explicit initializers deferred
- Static property/event accessors — awaiting full binder support
- Implicit simple-name access inside shared method bodies (must use `TypeName.field` for now)

Design document: `docs/adr/0053-static-members.md`