### PR TITLE
feat: implicit simple-name access to sibling static members inside shared methods

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -145,6 +145,25 @@ public sealed class Binder
                 }
             }
 
+            // Issue #261 / ADR-0053: expose sibling static fields as bare names
+            // inside shared method bodies so `x` resolves without requiring
+            // `TypeName.x`. Skip fields whose name collides with a parameter
+            // so that parameters shadow static fields naturally.
+            if (function.IsStatic && function.StaticOwnerType is StructSymbol ownerStruct)
+            {
+                if (!ownerStruct.StaticFields.IsDefaultOrEmpty)
+                {
+                    var paramNames = new HashSet<string>(function.Parameters.Select(p => p.Name));
+                    foreach (var fld in ownerStruct.StaticFields)
+                    {
+                        if (!paramNames.Contains(fld.Name))
+                        {
+                            scope.TryDeclareVariable(new ImplicitStaticFieldVariableSymbol(ownerStruct, fld));
+                        }
+                    }
+                }
+            }
+
             foreach (var p in function.Parameters)
             {
                 if (ReferenceEquals(p, function.ThisParameter))
@@ -1438,6 +1457,7 @@ public sealed class Binder
                     methodAccessibility,
                     receiverType: null);
                 methodSymbol.IsStatic = true;
+                methodSymbol.StaticOwnerType = structSymbol;
 
                 if (!methodSyntax.Annotations.IsDefaultOrEmpty)
                 {
@@ -5117,6 +5137,21 @@ public sealed class Binder
                 narrowedFieldType);
         }
 
+        // Issue #261: bare static field name inside a shared method body.
+        if (variable is ImplicitStaticFieldVariableSymbol implicitStaticField)
+        {
+            ReportObsoleteUseIfApplicable(
+                syntax.IdentifierToken.Location,
+                implicitStaticField.Field,
+                $"{implicitStaticField.StructType.Name}.{implicitStaticField.Field.Name}");
+
+            return new BoundFieldAccessExpression(
+                null,
+                receiver: null,
+                implicitStaticField.StructType,
+                implicitStaticField.Field);
+        }
+
         return new BoundVariableExpression(null, variable, TryGetNarrowedType(variable));
     }
 
@@ -5162,6 +5197,23 @@ public sealed class Binder
 
             var convertedValue = BindConversion(syntax.Expression.Location, boundExpression, implicitField.Field.Type);
             return new BoundFieldAssignmentExpression(null, implicitField.Receiver, implicitField.StructType, implicitField.Field, convertedValue);
+        }
+
+        // Issue #261: bare static field assignment inside a shared method body.
+        if (variable is ImplicitStaticFieldVariableSymbol implicitStaticField)
+        {
+            if (implicitStaticField.Field.IsReadOnly)
+            {
+                Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, name);
+            }
+
+            ReportObsoleteUseIfApplicable(
+                syntax.IdentifierToken.Location,
+                implicitStaticField.Field,
+                $"{implicitStaticField.StructType.Name}.{implicitStaticField.Field.Name}");
+
+            var convertedValue = BindConversion(syntax.Expression.Location, boundExpression, implicitStaticField.Field.Type);
+            return new BoundFieldAssignmentExpression(null, null, implicitStaticField.StructType, implicitStaticField.Field, convertedValue);
         }
 
         if (variable.IsReadOnly)
@@ -7060,6 +7112,21 @@ public sealed class Binder
                         implicitField.StructType,
                         implicitField.Field,
                         TryGetNarrowedType(implicitField));
+                }
+                else if (variable is ImplicitStaticFieldVariableSymbol implicitStaticField)
+                {
+                    // Issue #261: bare static field name as accessor receiver
+                    // inside a shared method body.
+                    ReportObsoleteUseIfApplicable(
+                        leftName.IdentifierToken.Location,
+                        implicitStaticField.Field,
+                        $"{implicitStaticField.StructType.Name}.{implicitStaticField.Field.Name}");
+
+                    receiver = new BoundFieldAccessExpression(
+                        null,
+                        receiver: null,
+                        implicitStaticField.StructType,
+                        implicitStaticField.Field);
                 }
                 else
                 {

--- a/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -209,6 +209,9 @@ public sealed class FunctionSymbol : Symbol
     /// <summary>Gets or sets a value indicating whether this function is declared inside a <c>shared</c> block (ADR-0053). Static functions have no receiver.</summary>
     public bool IsStatic { get; set; }
 
+    /// <summary>Gets or sets the struct/class that owns this static method (ADR-0053 / #261). <c>null</c> for non-static or top-level functions.</summary>
+    public StructSymbol StaticOwnerType { get; set; }
+
     /// <summary>Gets or sets a value indicating whether this function is declared <c>async</c> (Phase 5.1 / ADR-0023). When true, callers observe the function's return as <c>Task[T]</c> (or <c>Task</c> when no return type was declared) and the body may use <c>await</c>.</summary>
     public bool IsAsync { get; set; }
 

--- a/src/Core/CodeAnalysis/Symbols/ImplicitStaticFieldVariableSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImplicitStaticFieldVariableSymbol.cs
@@ -1,0 +1,36 @@
+// <copyright file="ImplicitStaticFieldVariableSymbol.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// A binder-internal pseudo-variable representing a static field made
+/// visible by name inside a shared method body (Issue #261 / ADR-0053).
+/// Resolving a bare identifier <c>x</c> to one of these triggers the binder
+/// to emit a <c>BoundFieldAccessExpression</c> with a <c>null</c> receiver
+/// (static access). Never appears in the bound tree itself.
+/// </summary>
+public sealed class ImplicitStaticFieldVariableSymbol : VariableSymbol
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImplicitStaticFieldVariableSymbol"/> class.
+    /// </summary>
+    /// <param name="structType">The class that owns the static field.</param>
+    /// <param name="field">The underlying static field.</param>
+    public ImplicitStaticFieldVariableSymbol(StructSymbol structType, FieldSymbol field)
+        : base(field.Name, isReadOnly: field.IsReadOnly, type: field.Type)
+    {
+        StructType = structType;
+        Field = field;
+    }
+
+    /// <inheritdoc/>
+    public override SymbolKind Kind => SymbolKind.LocalVariable;
+
+    /// <summary>Gets the class that owns the static field.</summary>
+    public StructSymbol StructType { get; }
+
+    /// <summary>Gets the static field symbol.</summary>
+    public FieldSymbol Field { get; }
+}

--- a/test/Core.Tests/CodeAnalysis/SharedBlockTests.cs
+++ b/test/Core.Tests/CodeAnalysis/SharedBlockTests.cs
@@ -303,4 +303,114 @@ Console.WriteLine(Factory.create())
             loadContext.Unload();
         }
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 5. Issue #261: Implicit bare-name access to sibling static members
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SharedBlock_ImplicitStaticFieldRead_InSharedMethod()
+    {
+        var source = @"
+type Foo class {
+    shared {
+        x int32
+        func bar() int32 {
+            return x
+        }
+    }
+}
+
+Foo.x = 42
+var result = Foo.bar()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SharedBlock_ImplicitStaticFieldWrite_InSharedMethod()
+    {
+        var source = @"
+type Foo class {
+    shared {
+        x int32
+        func setX(val int32) {
+            x = val
+        }
+    }
+}
+
+Foo.setX(99)
+var result = Foo.x
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(99, result.Value);
+    }
+
+    [Fact]
+    public void SharedBlock_ImplicitStaticFieldReadWrite_InSharedMethod()
+    {
+        var source = @"
+type Counter class {
+    shared {
+        count int32
+        func increment() int32 {
+            count = count + 1
+            return count
+        }
+    }
+}
+
+Counter.count = 10
+var result = Counter.increment()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(11, result.Value);
+    }
+
+    [Fact]
+    public void SharedBlock_ImplicitStaticFieldAccess_ChainedMemberAccess()
+    {
+        var source = @"
+type Holder class {
+    shared {
+        name string
+        func getLen() int32 {
+            return len(name)
+        }
+    }
+}
+
+Holder.name = ""hello""
+var result = Holder.getLen()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void SharedBlock_ParameterShadowsStaticField()
+    {
+        var source = @"
+type Foo class {
+    shared {
+        x int32
+        func bar(x int32) int32 {
+            return x
+        }
+    }
+}
+
+Foo.x = 100
+var result = Foo.bar(7)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
 }


### PR DESCRIPTION
Inside a `shared` method body, bare identifiers now resolve to sibling static fields on the same type without requiring the fully qualified `TypeName.member` syntax.

**Example (now works):**
```gsharp
type Foo class {
    shared {
        x int32
        func bar() int32 {
            return x  // no longer requires Foo.x
        }
    }
}
```

**Implementation:**
- Add `ImplicitStaticFieldVariableSymbol` (mirrors `ImplicitFieldVariableSymbol` for instance fields)
- Add `FunctionSymbol.StaticOwnerType` set during shared block binding
- In `Binder` constructor, declare implicit static field symbols in scope for static methods (parameters shadow them naturally)
- Handle `ImplicitStaticFieldVariableSymbol` in `BindNameExpression`, `BindAssignmentExpression`, and `BindAccessorExpression`

**Tests added:** 5 new tests covering read, write, read+write, function-call with implicit field arg, and parameter shadowing.

Closes #261