### PR TITLE
Emit .cctor for static field initializers (#262)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1380,6 +1380,7 @@ public sealed class Binder
         {
             // Static fields
             var staticFieldsBuilder = ImmutableArray.CreateBuilder<FieldSymbol>();
+            var initializersBuilder = ImmutableDictionary.CreateBuilder<FieldSymbol, BoundExpression>();
             foreach (var fieldSyntax in syntax.SharedBlock.Fields)
             {
                 var fieldName = fieldSyntax.Identifier.Text;
@@ -1408,10 +1409,22 @@ public sealed class Binder
                         System.AttributeTargets.Field));
                 }
 
+                // Issue #262: bind the initializer expression if present.
+                if (fieldSyntax.Initializer != null)
+                {
+                    var boundInit = BindExpression(fieldSyntax.Initializer);
+                    var convertedInit = BindConversion(fieldSyntax.Initializer.Location, boundInit, fieldType);
+                    initializersBuilder[fieldSymbol] = convertedInit;
+                }
+
                 staticFieldsBuilder.Add(fieldSymbol);
             }
 
             structSymbol.SetStaticFields(staticFieldsBuilder.ToImmutable());
+            if (initializersBuilder.Count > 0)
+            {
+                structSymbol.SetStaticFieldInitializers(initializersBuilder.ToImmutable());
+            }
 
             // Static methods
             var staticMethodsBuilder = ImmutableArray.CreateBuilder<FunctionSymbol>();

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -71,6 +71,9 @@ internal sealed class ReflectionMetadataEmitter
     private readonly Dictionary<StructSymbol, MethodDefinitionHandle> classCtorHandles = new Dictionary<StructSymbol, MethodDefinitionHandle>();
     private readonly Dictionary<StructSymbol, MethodDefinitionHandle> classPrimaryCtorHandles = new Dictionary<StructSymbol, MethodDefinitionHandle>();
 
+    // Issue #262: .cctor (type initializer) handles for types with static field initializers.
+    private readonly Dictionary<StructSymbol, MethodDefinitionHandle> cctorHandles = new Dictionary<StructSymbol, MethodDefinitionHandle>();
+
     // Phase 3.B.4: user-defined interface TypeDefs.
     private readonly Dictionary<InterfaceSymbol, TypeDefinitionHandle> interfaceTypeDefs = new Dictionary<InterfaceSymbol, TypeDefinitionHandle>();
 
@@ -661,13 +664,19 @@ internal sealed class ReflectionMetadataEmitter
                     this.methodHandles[m] = handle;
                 }
             }
+
+            // Issue #262: plan .cctor row for classes with static field initializers.
+            if (!c.StaticFieldInitializers.IsEmpty)
+            {
+                this.cctorHandles[c] = MetadataTokens.MethodDefinitionHandle(methodRow++);
+            }
         }
 
         // Plan method rows for non-SM structs.
         var structFirstMethodRows = new Dictionary<StructSymbol, int>();
         foreach (var s in nonSmStructs)
         {
-            if (s.Methods.IsDefaultOrEmpty && !s.IsInline && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty)
+            if (s.Methods.IsDefaultOrEmpty && !s.IsInline && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty && s.StaticFieldInitializers.IsEmpty)
             {
                 continue;
             }
@@ -720,6 +729,12 @@ internal sealed class ReflectionMetadataEmitter
                     aggregateMethodHandles[m] = handle;
                     this.methodHandles[m] = handle;
                 }
+            }
+
+            // Issue #262: plan .cctor row for structs with static field initializers.
+            if (!s.StaticFieldInitializers.IsEmpty)
+            {
+                this.cctorHandles[s] = MetadataTokens.MethodDefinitionHandle(methodRow++);
             }
         }
 
@@ -1080,6 +1095,12 @@ internal sealed class ReflectionMetadataEmitter
                     }
                 }
             }
+
+            // Issue #262: emit .cctor for classes with static field initializers.
+            if (this.cctorHandles.ContainsKey(c))
+            {
+                this.EmitStaticConstructor(c);
+            }
         }
 
         // 4b. Non-SM struct methods.
@@ -1090,7 +1111,7 @@ internal sealed class ReflectionMetadataEmitter
                 this.EmitInlineStructSynthesizedMembers(s);
             }
 
-            if (s.Methods.IsDefaultOrEmpty && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty)
+            if (s.Methods.IsDefaultOrEmpty && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty && s.StaticFieldInitializers.IsEmpty)
             {
                 continue;
             }
@@ -1123,6 +1144,12 @@ internal sealed class ReflectionMetadataEmitter
                         this.methodHandles[m] = emittedHandle;
                     }
                 }
+            }
+
+            // Issue #262: emit .cctor for structs with static field initializers.
+            if (this.cctorHandles.ContainsKey(s))
+            {
+                this.EmitStaticConstructor(s);
             }
         }
 
@@ -3515,6 +3542,120 @@ internal sealed class ReflectionMetadataEmitter
             implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
             name: this.metadata.GetOrAddString(".ctor"),
             signature: this.metadata.GetOrAddBlob(ctorSig),
+            bodyOffset: bodyOffset,
+            parameterList: this.NextParameterHandle());
+    }
+
+    /// <summary>
+    /// Emits a <c>.cctor</c> (type initializer) for a type with static field
+    /// initializers (Issue #262). The body evaluates each initializer expression
+    /// and stores the result into the corresponding static field via <c>stsfld</c>.
+    /// </summary>
+    private void EmitStaticConstructor(StructSymbol typeSym)
+    {
+        int bodyOffset = -1;
+        if (!this.metadataOnly)
+        {
+            // Build a synthetic body: for each field with an initializer,
+            // emit the expression + stsfld.
+            var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+            foreach (var field in typeSym.StaticFields)
+            {
+                if (typeSym.StaticFieldInitializers.TryGetValue(field, out var initExpr))
+                {
+                    // Synthesize: field = initExpr (as an expression statement).
+                    var assignment = new BoundFieldAssignmentExpression(null, null, typeSym, field, initExpr);
+                    statements.Add(new BoundExpressionStatement(null, assignment));
+                }
+            }
+
+            var body = new BoundBlockStatement(null, statements.ToImmutable());
+
+            var il = new InstructionEncoder(new BlobBuilder(), new ControlFlowBuilder());
+            var locals = new Dictionary<VariableSymbol, int>();
+            var labels = new Dictionary<BoundLabel, LabelHandle>();
+            var localTypes = new List<TypeSymbol>();
+            var appendSlots = new Dictionary<BoundAppendExpression, (int Src, int Dst)>();
+            var structLiteralSlots = new Dictionary<BoundStructLiteralExpression, int>();
+            var defaultExpressionSlots = new Dictionary<BoundDefaultExpression, int>();
+            var mapIndexSlots = new Dictionary<BoundIndexExpression, int>();
+            var patternSwitchSlots = new Dictionary<BoundPatternSwitchStatement, int>();
+            var typePatternScratchSlots = new Dictionary<BoundTypePattern, int>();
+            var switchExpressionSlots = new Dictionary<BoundSwitchExpression, (int Result, int Discriminant)>();
+            var channelOpSlots = new Dictionary<BoundNode, (int VT, int TA, int Result, int Spare)>();
+            var scopeFrameSlots = new Dictionary<BoundScopeStatement, (int Tasks, int Cts, int Awaiter)>();
+            var selectStatementSlots = new Dictionary<BoundSelectStatement, SelectSlots>();
+            var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
+            var constValues = new Dictionary<VariableSymbol, object>();
+
+            CollectLocalsAndLabels(
+                body,
+                null,
+                locals,
+                localTypes,
+                labels,
+                appendSlots,
+                structLiteralSlots,
+                defaultExpressionSlots,
+                mapIndexSlots,
+                patternSwitchSlots,
+                typePatternScratchSlots,
+                switchExpressionSlots,
+                channelOpSlots,
+                scopeFrameSlots,
+                selectStatementSlots,
+                goEnclosingScopes,
+                il);
+
+            var parameters = new Dictionary<ParameterSymbol, int>();
+
+            StandaloneSignatureHandle localsSignature = default;
+            if (localTypes.Count > 0)
+            {
+                var localsSigBlob = new BlobBuilder();
+                var encoder = new BlobEncoder(localsSigBlob).LocalVariableSignature(localTypes.Count);
+                foreach (var t in localTypes)
+                {
+                    EncodeTypeSymbol(encoder.AddVariable().Type(), t);
+                }
+
+                localsSignature = this.metadata.AddStandaloneSignature(this.metadata.GetOrAddBlob(localsSigBlob));
+            }
+
+            var emitter = new BodyEmitter(
+                this,
+                il,
+                locals,
+                parameters,
+                labels,
+                appendSlots,
+                structLiteralSlots,
+                defaultExpressionSlots,
+                mapIndexSlots,
+                patternSwitchSlots,
+                typePatternScratchSlots,
+                switchExpressionSlots,
+                channelOpSlots,
+                scopeFrameSlots,
+                selectStatementSlots,
+                goEnclosingScopes,
+                constValues: constValues);
+            emitter.EmitBlock(body);
+            il.OpCode(ILOpCode.Ret);
+
+            bodyOffset = this.methodBodyStream.AddMethodBody(il, localVariablesSignature: localsSignature);
+        }
+
+        var cctorSig = new BlobBuilder();
+        new BlobEncoder(cctorSig).MethodSignature(isInstanceMethod: false)
+            .Parameters(0, r => r.Void(), _ => { });
+
+        this.metadata.AddMethodDefinition(
+            attributes: MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.SpecialName
+                | MethodAttributes.RTSpecialName | MethodAttributes.Static,
+            implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString(".cctor"),
+            signature: this.metadata.GetOrAddBlob(cctorSig),
             bodyOffset: bodyOffset,
             parameterList: this.NextParameterHandle());
     }

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -5,6 +5,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
@@ -207,6 +208,9 @@ public sealed class StructSymbol : TypeSymbol
     /// <summary>Gets the static events declared inside a <c>shared</c> block (ADR-0053). Populated by the binder; defaults to empty.</summary>
     public ImmutableArray<EventSymbol> StaticEvents { get; private set; } = ImmutableArray<EventSymbol>.Empty;
 
+    /// <summary>Gets the bound initializer expressions for static fields with non-default values (Issue #262). Keyed by field symbol.</summary>
+    public ImmutableDictionary<FieldSymbol, BoundExpression> StaticFieldInitializers { get; private set; } = ImmutableDictionary<FieldSymbol, BoundExpression>.Empty;
+
     /// <summary>Gets the type parameters when this is a generic definition (Phase 4.3 / ADR-0020). Empty for non-generic types and for constructed instances.</summary>
     public ImmutableArray<TypeParameterSymbol> TypeParameters { get; private set; } = ImmutableArray<TypeParameterSymbol>.Empty;
 
@@ -283,6 +287,13 @@ public sealed class StructSymbol : TypeSymbol
     public void SetStaticEvents(ImmutableArray<EventSymbol> events)
     {
         StaticEvents = events;
+    }
+
+    /// <summary>Sets <see cref="StaticFieldInitializers"/> after binding shared-block field initializers (Issue #262).</summary>
+    /// <param name="initializers">A mapping from field symbol to its bound initializer expression.</param>
+    public void SetStaticFieldInitializers(ImmutableDictionary<FieldSymbol, BoundExpression> initializers)
+    {
+        StaticFieldInitializers = initializers;
     }
 
     /// <summary>Tries to find a static field by name on this type (ADR-0053).</summary>

--- a/src/Core/CodeAnalysis/Syntax/FieldDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/FieldDeclarationSyntax.cs
@@ -18,17 +18,23 @@ public sealed class FieldDeclarationSyntax : SyntaxNode
     /// <param name="accessibilityModifier">The optional accessibility modifier.</param>
     /// <param name="identifier">The field identifier.</param>
     /// <param name="type">The field type clause.</param>
+    /// <param name="equalsToken">The optional <c>=</c> token preceding the initializer.</param>
+    /// <param name="initializer">The optional initializer expression.</param>
     public FieldDeclarationSyntax(
         SyntaxTree syntaxTree,
         SyntaxToken accessibilityModifier,
         SyntaxToken identifier,
-        TypeClauseSyntax type)
+        TypeClauseSyntax type,
+        SyntaxToken equalsToken = null,
+        ExpressionSyntax initializer = null)
         : base(syntaxTree)
     {
         Annotations = ImmutableArray<AnnotationSyntax>.Empty;
         AccessibilityModifier = accessibilityModifier;
         Identifier = identifier;
         Type = type;
+        EqualsToken = equalsToken;
+        Initializer = initializer;
     }
 
     /// <inheritdoc/>
@@ -53,6 +59,12 @@ public sealed class FieldDeclarationSyntax : SyntaxNode
 
     /// <summary>Gets the field type clause.</summary>
     public TypeClauseSyntax Type { get; }
+
+    /// <summary>Gets the optional <c>=</c> token preceding the initializer (Issue #262).</summary>
+    public SyntaxToken EqualsToken { get; }
+
+    /// <summary>Gets the optional initializer expression (Issue #262).</summary>
+    public ExpressionSyntax Initializer { get; }
 
     /// <summary>Attaches the given annotation list to this field declaration and returns this same instance for fluent parser use.</summary>
     /// <param name="annotations">The annotation list to attach (may be empty).</param>

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -1181,7 +1181,17 @@ public class Parser
 
         var fieldIdentifier = MatchToken(SyntaxKind.IdentifierToken);
         var fieldType = ParseTypeClause();
-        return new FieldDeclarationSyntax(syntaxTree, fieldAccessibility, fieldIdentifier, fieldType);
+
+        // Issue #262: optional initializer for static field declarations.
+        SyntaxToken equalsToken = null;
+        ExpressionSyntax initializer = null;
+        if (Current.Kind == SyntaxKind.EqualsToken)
+        {
+            equalsToken = NextToken();
+            initializer = ParseExpression();
+        }
+
+        return new FieldDeclarationSyntax(syntaxTree, fieldAccessibility, fieldIdentifier, fieldType, equalsToken, initializer);
     }
 
     private MemberSyntax ParseFunctionDeclaration(SyntaxToken accessibilityModifier)

--- a/test/Core.Tests/CodeAnalysis/SharedBlockTests.cs
+++ b/test/Core.Tests/CodeAnalysis/SharedBlockTests.cs
@@ -247,6 +247,106 @@ Console.WriteLine(Factory.create())
     }
 
     // ─────────────────────────────────────────────────────────────────────────
+    // 4. Issue #262: Static field initializers and .cctor emission
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SharedBlock_StaticFieldInitializer_Parses()
+    {
+        var source = @"
+type Counter struct {
+    shared {
+        count int32 = 42
+    }
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void SharedBlock_StaticFieldInitializer_Emit_RoundTrip()
+    {
+        var source = @"package CctorEmit
+import System
+
+type Counter struct {
+    shared {
+        count int32 = 42
+    }
+}
+
+Console.WriteLine(Counter.count)
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "SharedBlock-CctorEmit");
+        Assert.Contains("42", output);
+    }
+
+    [Fact]
+    public void SharedBlock_MultipleStaticFieldInitializers_Emit_RoundTrip()
+    {
+        var source = @"package CctorMulti
+import System
+
+type Config struct {
+    shared {
+        x int32 = 10
+        y int32 = 20
+        name string = ""hello""
+    }
+}
+
+Console.WriteLine(Config.x)
+Console.WriteLine(Config.y)
+Console.WriteLine(Config.name)
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "SharedBlock-CctorMulti");
+        Assert.Contains("10", output);
+        Assert.Contains("20", output);
+        Assert.Contains("hello", output);
+    }
+
+    [Fact]
+    public void SharedBlock_StaticFieldInitializer_ZeroValue_NoCctor()
+    {
+        // A field with default(T) initializer (= 0 for int) should still work.
+        var source = @"package CctorZero
+import System
+
+type Counter struct {
+    shared {
+        count int32 = 0
+        active int32 = 5
+    }
+}
+
+Console.WriteLine(Counter.count)
+Console.WriteLine(Counter.active)
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "SharedBlock-CctorZero");
+        Assert.Contains("0", output);
+        Assert.Contains("5", output);
+    }
+
+    [Fact]
+    public void SharedBlock_StaticFieldInitializer_ClassType_Emit_RoundTrip()
+    {
+        var source = @"package CctorClass
+import System
+
+type Service class {
+    shared {
+        instanceCount int32 = 100
+    }
+}
+
+Console.WriteLine(Service.instanceCount)
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "SharedBlock-CctorClass");
+        Assert.Contains("100", output);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
     // Helpers
     // ─────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Implements Issue #262: when a static field inside a `shared` block has an explicit initializer (e.g. `count int32 = 42`), the compiler now emits a `.cctor` (type initializer) that evaluates the expression and stores the result via `stsfld`.

Previously, non-zero initializers were silently ignored because the CLR only zero-initializes fields by default.

## Changes

| File | Change |
|------|--------|
| `FieldDeclarationSyntax.cs` | Add optional `EqualsToken` + `Initializer` expression |
| `Parser.cs` | Parse `= <expr>` after field type clause in shared blocks |
| `StructSymbol.cs` | Add `StaticFieldInitializers` dictionary + setter |
| `Binder.cs` | Bind initializer expressions during shared-block binding |
| `ReflectionMetadataEmitter.cs` | Plan .cctor method rows; emit MethodDef + body using BodyEmitter with synthesized `BoundFieldAssignmentExpression` nodes |
| `SharedBlockTests.cs` | 5 new tests: parser, struct emit, class emit, multiple fields, zero+non-zero mix |

## Test Plan

All 1545 tests pass (5 new). The new tests verify:
- Parser accepts `fieldName type = expr` syntax
- Single static field with non-zero initializer round-trips through .cctor
- Multiple initializers in one shared block all fire
- Mixed zero/non-zero initializers work correctly
- Class types (not just structs) get a .cctor

Closes #262