### PR TITLE
feat: static property and event accessor support in shared blocks

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -517,6 +517,82 @@ public sealed class Binder
             }
         }
 
+        // Issue #263: bind static property accessor bodies declared in `shared` blocks.
+        foreach (var structSym in globalScope.Structs)
+        {
+            if (structSym.StaticProperties.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            foreach (var prop in structSym.StaticProperties)
+            {
+                if (prop.IsAutoProperty)
+                {
+                    continue;
+                }
+
+                if (prop.GetterSymbol != null && prop.GetterBodySyntax != null)
+                {
+                    var binder = new Binder(parentScope, prop.GetterSymbol);
+                    var body = binder.BindStatement(prop.GetterBodySyntax);
+                    var loweredBody = Lowerer.Lower(body);
+
+                    if (!ControlFlowGraph.AllPathsReturn(loweredBody))
+                    {
+                        binder.Diagnostics.ReportAllPathsMustReturn(prop.GetterBodySyntax.OpenBraceToken.Location);
+                    }
+
+                    functionBodies.Add(prop.GetterSymbol, loweredBody);
+                    diagnostics.AddRange(binder.Diagnostics);
+                }
+
+                if (prop.SetterSymbol != null && prop.SetterBodySyntax != null)
+                {
+                    var binder = new Binder(parentScope, prop.SetterSymbol);
+                    var body = binder.BindStatement(prop.SetterBodySyntax);
+                    var loweredBody = Lowerer.Lower(body);
+                    functionBodies.Add(prop.SetterSymbol, loweredBody);
+                    diagnostics.AddRange(binder.Diagnostics);
+                }
+            }
+        }
+
+        // Issue #263: bind static event accessor bodies declared in `shared` blocks.
+        foreach (var structSym in globalScope.Structs)
+        {
+            if (structSym.StaticEvents.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            foreach (var ev in structSym.StaticEvents)
+            {
+                if (ev.IsFieldLike)
+                {
+                    continue;
+                }
+
+                if (ev.AddMethodSymbol != null && ev.AddBodySyntax != null)
+                {
+                    var binder = new Binder(parentScope, ev.AddMethodSymbol);
+                    var body = binder.BindStatement(ev.AddBodySyntax);
+                    var loweredBody = Lowerer.Lower(body);
+                    functionBodies.Add(ev.AddMethodSymbol, loweredBody);
+                    diagnostics.AddRange(binder.Diagnostics);
+                }
+
+                if (ev.RemoveMethodSymbol != null && ev.RemoveBodySyntax != null)
+                {
+                    var binder = new Binder(parentScope, ev.RemoveMethodSymbol);
+                    var body = binder.BindStatement(ev.RemoveBodySyntax);
+                    var loweredBody = Lowerer.Lower(body);
+                    functionBodies.Add(ev.RemoveMethodSymbol, loweredBody);
+                    diagnostics.AddRange(binder.Diagnostics);
+                }
+            }
+        }
+
         // ADR-0053 Phase D: bind static method bodies declared in `shared` blocks.
         foreach (var structSym in globalScope.Structs)
         {
@@ -1554,6 +1630,46 @@ public sealed class Binder
                         isReadOnly: !hasSetter,
                         isStatic: true);
                     propertySymbol.BackingField = backingField;
+                }
+
+                // Issue #263: create FunctionSymbols for computed static property accessors.
+                if (!isAutoProperty)
+                {
+                    var getAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsGetter);
+                    var setAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsSetter);
+
+                    if (hasGetter && getAccessor?.Body != null)
+                    {
+                        var getterSymbol = new FunctionSymbol(
+                            $"get_{propName}",
+                            ImmutableArray<ParameterSymbol>.Empty,
+                            propType,
+                            declaration: null,
+                            package,
+                            propAccessibility,
+                            receiverType: null);
+                        getterSymbol.IsStatic = true;
+                        getterSymbol.StaticOwnerType = structSymbol;
+                        propertySymbol.GetterSymbol = getterSymbol;
+                        propertySymbol.GetterBodySyntax = getAccessor.Body;
+                    }
+
+                    if (hasSetter && setAccessor?.Body != null)
+                    {
+                        var setterParam = new ParameterSymbol(setterParamName, propType);
+                        var setterSymbol = new FunctionSymbol(
+                            $"set_{propName}",
+                            ImmutableArray.Create(setterParam),
+                            TypeSymbol.Void,
+                            declaration: null,
+                            package,
+                            propAccessibility,
+                            receiverType: null);
+                        setterSymbol.IsStatic = true;
+                        setterSymbol.StaticOwnerType = structSymbol;
+                        propertySymbol.SetterSymbol = setterSymbol;
+                        propertySymbol.SetterBodySyntax = setAccessor.Body;
+                    }
                 }
 
                 if (!propSyntax.Annotations.IsDefaultOrEmpty)
@@ -5595,6 +5711,22 @@ public sealed class Binder
                 return new BoundFieldAssignmentExpression(null, null, userStruct, staticField, staticConverted);
             }
 
+            // Issue #263: static property assignment.
+            foreach (var prop in userStruct.StaticProperties)
+            {
+                if (prop.Name == fieldName)
+                {
+                    if (!prop.HasSetter)
+                    {
+                        Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
+                        return new BoundErrorExpression(null);
+                    }
+
+                    var propConverted = BindConversion(syntax.Value.Location, staticValue, prop.Type);
+                    return new BoundPropertyAssignmentExpression(null, receiver: null, userStruct, prop, propConverted);
+                }
+            }
+
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
             return new BoundErrorExpression(null);
         }
@@ -5711,6 +5843,22 @@ public sealed class Binder
         {
             receiverClrType = importedClass.ClassType;
             flags = BindingFlags.Public | BindingFlags.Static;
+        }
+        else if (accessor.LeftPart is NameExpressionSyntax staticLeftName
+            && scope.TryLookupTypeAlias(staticLeftName.IdentifierToken.Text, out var staticTypeAlias)
+            && staticTypeAlias is StructSymbol staticStruct
+            && !staticStruct.StaticEvents.IsDefaultOrEmpty)
+        {
+            // Issue #263: static event subscription on a user-defined type.
+            var ev = staticStruct.StaticEvents.FirstOrDefault(e => e.Name == eventName);
+            if (ev != null)
+            {
+                var userHandler = BindExpression(syntax.Value);
+                return new BoundEventSubscriptionExpression(null, receiver: null, staticStruct, ev, userHandler, isAdd);
+            }
+
+            Diagnostics.ReportUnableToFindMember(eventNameSyntax.Location, eventName);
+            return new BoundErrorExpression(null);
         }
         else
         {

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -1315,15 +1315,33 @@ public static class BoundNodePrinter
 
     private static void WritePropertyAccessExpression(BoundPropertyAccessExpression node, IndentedTextWriter writer)
     {
-        node.Receiver.WriteTo(writer);
-        writer.WritePunctuation(SyntaxKind.DotToken);
+        if (node.Receiver != null)
+        {
+            node.Receiver.WriteTo(writer);
+            writer.WritePunctuation(SyntaxKind.DotToken);
+        }
+        else
+        {
+            writer.WriteIdentifier(node.StructType.Name);
+            writer.WritePunctuation(SyntaxKind.DotToken);
+        }
+
         writer.WriteIdentifier(node.Property.Name);
     }
 
     private static void WritePropertyAssignmentExpression(BoundPropertyAssignmentExpression node, IndentedTextWriter writer)
     {
-        node.Receiver.WriteTo(writer);
-        writer.WritePunctuation(SyntaxKind.DotToken);
+        if (node.Receiver != null)
+        {
+            node.Receiver.WriteTo(writer);
+            writer.WritePunctuation(SyntaxKind.DotToken);
+        }
+        else
+        {
+            writer.WriteIdentifier(node.StructType.Name);
+            writer.WritePunctuation(SyntaxKind.DotToken);
+        }
+
         writer.WriteIdentifier(node.Property.Name);
         writer.WriteSpace();
         writer.WritePunctuation(SyntaxKind.EqualsToken);

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1537,6 +1537,11 @@ public abstract class BoundTreeRewriter
     /// <returns>The rewritten node.</returns>
     protected virtual BoundExpression RewritePropertyAccessExpression(BoundPropertyAccessExpression node)
     {
+        if (node.Receiver == null)
+        {
+            return node;
+        }
+
         var receiver = RewriteExpression(node.Receiver);
         return receiver == node.Receiver ? node : new BoundPropertyAccessExpression(null, receiver, node.StructType, node.Property);
     }
@@ -1546,7 +1551,7 @@ public abstract class BoundTreeRewriter
     /// <returns>The rewritten node.</returns>
     protected virtual BoundExpression RewritePropertyAssignmentExpression(BoundPropertyAssignmentExpression node)
     {
-        var receiver = RewriteExpression(node.Receiver);
+        var receiver = node.Receiver != null ? RewriteExpression(node.Receiver) : null;
         var value = RewriteExpression(node.Value);
         return receiver == node.Receiver && value == node.Value ? node : new BoundPropertyAssignmentExpression(null, receiver, node.StructType, node.Property, value);
     }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -491,6 +491,24 @@ internal sealed class ReflectionMetadataEmitter
             {
                 nextFieldRow += s.StaticFields.Length;
             }
+
+            // Issue #263: backing fields for static auto-properties.
+            foreach (var p in s.StaticProperties)
+            {
+                if (p.IsAutoProperty && p.BackingField != null)
+                {
+                    nextFieldRow++;
+                }
+            }
+
+            // Issue #263: backing fields for static field-like events.
+            foreach (var ev in s.StaticEvents)
+            {
+                if (ev.IsFieldLike && ev.BackingField != null)
+                {
+                    nextFieldRow++;
+                }
+            }
         }
 
         foreach (var s in nonSmStructs)
@@ -519,6 +537,24 @@ internal sealed class ReflectionMetadataEmitter
             if (!s.StaticFields.IsDefaultOrEmpty)
             {
                 nextFieldRow += s.StaticFields.Length;
+            }
+
+            // Issue #263: backing fields for static auto-properties.
+            foreach (var p in s.StaticProperties)
+            {
+                if (p.IsAutoProperty && p.BackingField != null)
+                {
+                    nextFieldRow++;
+                }
+            }
+
+            // Issue #263: backing fields for static field-like events.
+            foreach (var ev in s.StaticEvents)
+            {
+                if (ev.IsFieldLike && ev.BackingField != null)
+                {
+                    nextFieldRow++;
+                }
             }
         }
 
@@ -665,6 +701,32 @@ internal sealed class ReflectionMetadataEmitter
                 }
             }
 
+            // Issue #263: plan accessor method rows for static properties on classes.
+            foreach (var prop in c.StaticProperties)
+            {
+                MethodDefinitionHandle? getterHandle = null;
+                MethodDefinitionHandle? setterHandle = null;
+                if (prop.HasGetter)
+                {
+                    getterHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                }
+
+                if (prop.HasSetter)
+                {
+                    setterHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                }
+
+                this.propertyAccessorHandles[prop] = (getterHandle, setterHandle);
+            }
+
+            // Issue #263: plan accessor method rows for static events on classes.
+            foreach (var ev in c.StaticEvents)
+            {
+                var addHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                var removeHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                this.eventAccessorHandles[ev] = (addHandle, removeHandle);
+            }
+
             // Issue #262: plan .cctor row for classes with static field initializers.
             if (!c.StaticFieldInitializers.IsEmpty)
             {
@@ -676,7 +738,7 @@ internal sealed class ReflectionMetadataEmitter
         var structFirstMethodRows = new Dictionary<StructSymbol, int>();
         foreach (var s in nonSmStructs)
         {
-            if (s.Methods.IsDefaultOrEmpty && !s.IsInline && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty && s.StaticFieldInitializers.IsEmpty)
+            if (s.Methods.IsDefaultOrEmpty && !s.IsInline && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty && s.StaticProperties.IsDefaultOrEmpty && s.StaticEvents.IsDefaultOrEmpty && s.StaticFieldInitializers.IsEmpty)
             {
                 continue;
             }
@@ -729,6 +791,32 @@ internal sealed class ReflectionMetadataEmitter
                     aggregateMethodHandles[m] = handle;
                     this.methodHandles[m] = handle;
                 }
+            }
+
+            // Issue #263: plan accessor method rows for static properties on structs.
+            foreach (var prop in s.StaticProperties)
+            {
+                MethodDefinitionHandle? getterHandle = null;
+                MethodDefinitionHandle? setterHandle = null;
+                if (prop.HasGetter)
+                {
+                    getterHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                }
+
+                if (prop.HasSetter)
+                {
+                    setterHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                }
+
+                this.propertyAccessorHandles[prop] = (getterHandle, setterHandle);
+            }
+
+            // Issue #263: plan accessor method rows for static events on structs.
+            foreach (var ev in s.StaticEvents)
+            {
+                var addHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                var removeHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                this.eventAccessorHandles[ev] = (addHandle, removeHandle);
             }
 
             // Issue #262: plan .cctor row for structs with static field initializers.
@@ -1096,6 +1184,12 @@ internal sealed class ReflectionMetadataEmitter
                 }
             }
 
+            // Issue #263: emit static property accessor methods for classes.
+            this.EmitStaticPropertyAccessors(c);
+
+            // Issue #263: emit static event accessor methods for classes.
+            this.EmitStaticEventAccessors(c);
+
             // Issue #262: emit .cctor for classes with static field initializers.
             if (this.cctorHandles.ContainsKey(c))
             {
@@ -1111,7 +1205,7 @@ internal sealed class ReflectionMetadataEmitter
                 this.EmitInlineStructSynthesizedMembers(s);
             }
 
-            if (s.Methods.IsDefaultOrEmpty && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty && s.StaticFieldInitializers.IsEmpty)
+            if (s.Methods.IsDefaultOrEmpty && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty && s.StaticProperties.IsDefaultOrEmpty && s.StaticEvents.IsDefaultOrEmpty && s.StaticFieldInitializers.IsEmpty)
             {
                 continue;
             }
@@ -1145,6 +1239,12 @@ internal sealed class ReflectionMetadataEmitter
                     }
                 }
             }
+
+            // Issue #263: emit static property accessor methods for structs.
+            this.EmitStaticPropertyAccessors(s);
+
+            // Issue #263: emit static event accessor methods for structs.
+            this.EmitStaticEventAccessors(s);
 
             // Issue #262: emit .cctor for structs with static field initializers.
             if (this.cctorHandles.ContainsKey(s))
@@ -1783,6 +1883,50 @@ internal sealed class ReflectionMetadataEmitter
             }
         }
 
+        // Issue #263: emit backing FieldDefs for static auto-properties.
+        foreach (var prop in structSym.StaticProperties)
+        {
+            if (!prop.IsAutoProperty || prop.BackingField == null)
+            {
+                continue;
+            }
+
+            var sigBlob = new BlobBuilder();
+            this.EncodeTypeSymbol(new BlobEncoder(sigBlob).FieldSignature(), prop.Type);
+            var backingHandle = this.metadata.AddFieldDefinition(
+                attributes: FieldAttributes.Assembly | FieldAttributes.Static,
+                name: this.metadata.GetOrAddString($"<{prop.Name}>k__BackingField"),
+                signature: this.metadata.GetOrAddBlob(sigBlob));
+            if (firstField.IsNil)
+            {
+                firstField = backingHandle;
+            }
+
+            this.structFieldDefs[prop.BackingField] = backingHandle;
+        }
+
+        // Issue #263: emit backing FieldDefs for static field-like events.
+        foreach (var ev in structSym.StaticEvents)
+        {
+            if (!ev.IsFieldLike || ev.BackingField == null)
+            {
+                continue;
+            }
+
+            var sigBlob = new BlobBuilder();
+            this.EncodeTypeSymbol(new BlobEncoder(sigBlob).FieldSignature(), ev.Type);
+            var backingHandle = this.metadata.AddFieldDefinition(
+                attributes: FieldAttributes.Private | FieldAttributes.Static,
+                name: this.metadata.GetOrAddString(ev.BackingField.Name),
+                signature: this.metadata.GetOrAddBlob(sigBlob));
+            if (firstField.IsNil)
+            {
+                firstField = backingHandle;
+            }
+
+            this.structFieldDefs[ev.BackingField] = backingHandle;
+        }
+
         if (firstField.IsNil)
         {
             // Empty struct: no field rows added; point at next row, which is
@@ -2057,6 +2201,361 @@ internal sealed class ReflectionMetadataEmitter
             attributes: methodAttrs,
             implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
             name: this.metadata.GetOrAddString($"set_{prop.Name}"),
+            signature: this.metadata.GetOrAddBlob(sigBlob),
+            bodyOffset: bodyOffset,
+            parameterList: firstParamHandle);
+    }
+
+    /// <summary>
+    /// Issue #263: emits accessor MethodDefs, PropertyDef rows, PropertyMap,
+    /// and MethodSemantics rows for static properties declared in a shared block.
+    /// </summary>
+    private void EmitStaticPropertyAccessors(StructSymbol structSym)
+    {
+        if (structSym.StaticProperties.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        if (!this.structTypeDefs.TryGetValue(structSym, out var typeDefHandle))
+        {
+            return;
+        }
+
+        PropertyDefinitionHandle firstPropDef = default;
+        foreach (var prop in structSym.StaticProperties)
+        {
+            if (!this.propertyAccessorHandles.TryGetValue(prop, out var accessorHandles))
+            {
+                continue;
+            }
+
+            // Emit getter MethodDef.
+            MethodDefinitionHandle? emittedGetter = null;
+            if (prop.HasGetter && accessorHandles.Getter.HasValue)
+            {
+                emittedGetter = this.EmitStaticPropertyGetter(structSym, prop);
+            }
+
+            // Emit setter MethodDef.
+            MethodDefinitionHandle? emittedSetter = null;
+            if (prop.HasSetter && accessorHandles.Setter.HasValue)
+            {
+                emittedSetter = this.EmitStaticPropertySetter(structSym, prop);
+            }
+
+            // Emit PropertyDef row.
+            var propertySignature = new BlobBuilder();
+            new BlobEncoder(propertySignature)
+                .PropertySignature(isInstanceProperty: false)
+                .Parameters(0, returnType => this.EncodeTypeSymbol(returnType.Type(), prop.Type), parameters => { });
+
+            var propDef = this.metadata.AddProperty(
+                attributes: PropertyAttributes.None,
+                name: this.metadata.GetOrAddString(prop.Name),
+                signature: this.metadata.GetOrAddBlob(propertySignature));
+
+            if (firstPropDef.IsNil)
+            {
+                firstPropDef = propDef;
+            }
+
+            // MethodSemantics rows linking accessor MethodDefs to the PropertyDef.
+            if (emittedGetter.HasValue)
+            {
+                this.metadata.AddMethodSemantics(propDef, MethodSemanticsAttributes.Getter, emittedGetter.Value);
+            }
+
+            if (emittedSetter.HasValue)
+            {
+                this.metadata.AddMethodSemantics(propDef, MethodSemanticsAttributes.Setter, emittedSetter.Value);
+            }
+        }
+
+        // PropertyMap row: links the TypeDef to its first PropertyDef.
+        // Only add if no instance properties already created a PropertyMap for this type.
+        if (!firstPropDef.IsNil && structSym.Properties.IsDefaultOrEmpty)
+        {
+            this.metadata.AddPropertyMap(typeDefHandle, firstPropDef);
+        }
+    }
+
+    /// <summary>
+    /// Issue #263: emits a static getter accessor MethodDef (get_PropertyName).
+    /// </summary>
+    private MethodDefinitionHandle EmitStaticPropertyGetter(StructSymbol structSym, PropertySymbol prop)
+    {
+        int bodyOffset = -1;
+        if (!this.metadataOnly)
+        {
+            if (prop.IsAutoProperty && prop.BackingField != null
+                && this.structFieldDefs.TryGetValue(prop.BackingField, out var backingHandle))
+            {
+                var il = new InstructionEncoder(new BlobBuilder());
+                il.OpCode(ILOpCode.Ldsfld);
+                il.Token(backingHandle);
+                il.OpCode(ILOpCode.Ret);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+            else if (prop.GetterSymbol != null && this.program.Functions.TryGetValue(prop.GetterSymbol, out var getterBody))
+            {
+                var handle = this.EmitFunction(prop.GetterSymbol, getterBody, isEntryPoint: false);
+                return handle;
+            }
+            else
+            {
+                var il = new InstructionEncoder(new BlobBuilder());
+                var nieCtor = this.GetNotImplementedExceptionCtor();
+                il.OpCode(ILOpCode.Newobj);
+                il.Token(nieCtor);
+                il.OpCode(ILOpCode.Throw);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+        }
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: false)
+            .Parameters(0, r => this.EncodeTypeSymbol(r.Type(), prop.Type), _ => { });
+
+        var methodAttrs = MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig | MethodAttributes.Static;
+
+        return this.metadata.AddMethodDefinition(
+            attributes: methodAttrs,
+            implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString($"get_{prop.Name}"),
+            signature: this.metadata.GetOrAddBlob(sigBlob),
+            bodyOffset: bodyOffset,
+            parameterList: this.NextParameterHandle());
+    }
+
+    /// <summary>
+    /// Issue #263: emits a static setter accessor MethodDef (set_PropertyName).
+    /// </summary>
+    private MethodDefinitionHandle EmitStaticPropertySetter(StructSymbol structSym, PropertySymbol prop)
+    {
+        int bodyOffset = -1;
+        if (!this.metadataOnly)
+        {
+            if (prop.IsAutoProperty && prop.BackingField != null
+                && this.structFieldDefs.TryGetValue(prop.BackingField, out var backingHandle))
+            {
+                var il = new InstructionEncoder(new BlobBuilder());
+                il.LoadArgument(0);
+                il.OpCode(ILOpCode.Stsfld);
+                il.Token(backingHandle);
+                il.OpCode(ILOpCode.Ret);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+            else if (prop.SetterSymbol != null && this.program.Functions.TryGetValue(prop.SetterSymbol, out var setterBody))
+            {
+                var handle = this.EmitFunction(prop.SetterSymbol, setterBody, isEntryPoint: false);
+                return handle;
+            }
+            else
+            {
+                var il = new InstructionEncoder(new BlobBuilder());
+                var nieCtor = this.GetNotImplementedExceptionCtor();
+                il.OpCode(ILOpCode.Newobj);
+                il.Token(nieCtor);
+                il.OpCode(ILOpCode.Throw);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+        }
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: false)
+            .Parameters(1, r => r.Void(), ps => this.EncodeTypeSymbol(ps.AddParameter().Type(), prop.Type));
+
+        var methodAttrs = MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig | MethodAttributes.Static;
+
+        var firstParamHandle = this.NextParameterHandle();
+        this.metadata.AddParameter(
+            attributes: ParameterAttributes.None,
+            name: this.metadata.GetOrAddString(prop.SetterParameterName ?? "value"),
+            sequenceNumber: 1);
+
+        return this.metadata.AddMethodDefinition(
+            attributes: methodAttrs,
+            implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString($"set_{prop.Name}"),
+            signature: this.metadata.GetOrAddBlob(sigBlob),
+            bodyOffset: bodyOffset,
+            parameterList: firstParamHandle);
+    }
+
+    /// <summary>
+    /// Issue #263: emits add/remove accessor MethodDefs, EventDef rows, EventMap,
+    /// and MethodSemantics rows for static events declared in a shared block.
+    /// </summary>
+    private void EmitStaticEventAccessors(StructSymbol structSym)
+    {
+        if (structSym.StaticEvents.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        if (!this.structTypeDefs.TryGetValue(structSym, out var typeDefHandle))
+        {
+            return;
+        }
+
+        EventDefinitionHandle firstEventDef = default;
+        foreach (var ev in structSym.StaticEvents)
+        {
+            if (!this.eventAccessorHandles.TryGetValue(ev, out var accessorHandles))
+            {
+                continue;
+            }
+
+            // Emit add_X MethodDef.
+            var addMethod = this.EmitStaticEventAddAccessor(structSym, ev);
+
+            // Emit remove_X MethodDef.
+            var removeMethod = this.EmitStaticEventRemoveAccessor(structSym, ev);
+
+            // Emit EventDef row.
+            var eventTypeHandle = this.GetEventTypeHandle(ev.Type);
+
+            var eventDef = this.metadata.AddEvent(
+                attributes: EventAttributes.None,
+                name: this.metadata.GetOrAddString(ev.Name),
+                type: eventTypeHandle);
+
+            if (firstEventDef.IsNil)
+            {
+                firstEventDef = eventDef;
+            }
+
+            // MethodSemantics rows linking accessor MethodDefs to the EventDef.
+            this.metadata.AddMethodSemantics(eventDef, MethodSemanticsAttributes.Adder, addMethod);
+            this.metadata.AddMethodSemantics(eventDef, MethodSemanticsAttributes.Remover, removeMethod);
+        }
+
+        // EventMap row: links the TypeDef to its first EventDef.
+        // Only add if no instance events already created an EventMap for this type.
+        if (!firstEventDef.IsNil && structSym.Events.IsDefaultOrEmpty)
+        {
+            this.metadata.AddEventMap(typeDefHandle, firstEventDef);
+        }
+    }
+
+    /// <summary>
+    /// Issue #263: emits a static add_X accessor MethodDef for a static event.
+    /// </summary>
+    private MethodDefinitionHandle EmitStaticEventAddAccessor(StructSymbol structSym, EventSymbol ev)
+    {
+        int bodyOffset = -1;
+        if (!this.metadataOnly)
+        {
+            if (ev.IsFieldLike && ev.BackingField != null
+                && this.structFieldDefs.TryGetValue(ev.BackingField, out var backingHandle))
+            {
+                var il = new InstructionEncoder(new BlobBuilder());
+                il.OpCode(ILOpCode.Ldsfld);
+                il.Token(backingHandle);
+                il.LoadArgument(0);
+                il.OpCode(ILOpCode.Call);
+                il.Token(this.GetDelegateCombineRef());
+                il.OpCode(ILOpCode.Castclass);
+                il.Token(this.GetEventTypeHandle(ev.Type));
+                il.OpCode(ILOpCode.Stsfld);
+                il.Token(backingHandle);
+                il.OpCode(ILOpCode.Ret);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+            else if (ev.AddMethodSymbol != null && this.program.Functions.TryGetValue(ev.AddMethodSymbol, out var addBody))
+            {
+                var handle = this.EmitFunction(ev.AddMethodSymbol, addBody, isEntryPoint: false);
+                return handle;
+            }
+            else
+            {
+                var il = new InstructionEncoder(new BlobBuilder());
+                var nieCtor = this.GetNotImplementedExceptionCtor();
+                il.OpCode(ILOpCode.Newobj);
+                il.Token(nieCtor);
+                il.OpCode(ILOpCode.Throw);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+        }
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: false)
+            .Parameters(1, r => r.Void(), ps => this.EncodeTypeSymbol(ps.AddParameter().Type(), ev.Type));
+
+        var methodAttrs = MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig | MethodAttributes.Static;
+
+        var firstParamHandle = this.NextParameterHandle();
+        this.metadata.AddParameter(
+            attributes: ParameterAttributes.None,
+            name: this.metadata.GetOrAddString("value"),
+            sequenceNumber: 1);
+
+        return this.metadata.AddMethodDefinition(
+            attributes: methodAttrs,
+            implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString($"add_{ev.Name}"),
+            signature: this.metadata.GetOrAddBlob(sigBlob),
+            bodyOffset: bodyOffset,
+            parameterList: firstParamHandle);
+    }
+
+    /// <summary>
+    /// Issue #263: emits a static remove_X accessor MethodDef for a static event.
+    /// </summary>
+    private MethodDefinitionHandle EmitStaticEventRemoveAccessor(StructSymbol structSym, EventSymbol ev)
+    {
+        int bodyOffset = -1;
+        if (!this.metadataOnly)
+        {
+            if (ev.IsFieldLike && ev.BackingField != null
+                && this.structFieldDefs.TryGetValue(ev.BackingField, out var backingHandle))
+            {
+                var il = new InstructionEncoder(new BlobBuilder());
+                il.OpCode(ILOpCode.Ldsfld);
+                il.Token(backingHandle);
+                il.LoadArgument(0);
+                il.OpCode(ILOpCode.Call);
+                il.Token(this.GetDelegateRemoveRef());
+                il.OpCode(ILOpCode.Castclass);
+                il.Token(this.GetEventTypeHandle(ev.Type));
+                il.OpCode(ILOpCode.Stsfld);
+                il.Token(backingHandle);
+                il.OpCode(ILOpCode.Ret);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+            else if (ev.RemoveMethodSymbol != null && this.program.Functions.TryGetValue(ev.RemoveMethodSymbol, out var removeBody))
+            {
+                var handle = this.EmitFunction(ev.RemoveMethodSymbol, removeBody, isEntryPoint: false);
+                return handle;
+            }
+            else
+            {
+                var il = new InstructionEncoder(new BlobBuilder());
+                var nieCtor = this.GetNotImplementedExceptionCtor();
+                il.OpCode(ILOpCode.Newobj);
+                il.Token(nieCtor);
+                il.OpCode(ILOpCode.Throw);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+        }
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: false)
+            .Parameters(1, r => r.Void(), ps => this.EncodeTypeSymbol(ps.AddParameter().Type(), ev.Type));
+
+        var methodAttrs = MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig | MethodAttributes.Static;
+
+        var firstParamHandle = this.NextParameterHandle();
+        this.metadata.AddParameter(
+            attributes: ParameterAttributes.None,
+            name: this.metadata.GetOrAddString("value"),
+            sequenceNumber: 1);
+
+        return this.metadata.AddMethodDefinition(
+            attributes: methodAttrs,
+            implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString($"remove_{ev.Name}"),
             signature: this.metadata.GetOrAddBlob(sigBlob),
             bodyOffset: bodyOffset,
             parameterList: firstParamHandle);
@@ -10711,6 +11210,14 @@ internal sealed class ReflectionMetadataEmitter
                     $"Property '{access.Property.Name}' has no emitted getter MethodDef.");
             }
 
+            // Issue #263: static property access — no receiver to load.
+            if (access.Receiver == null)
+            {
+                this.il.OpCode(ILOpCode.Call);
+                this.il.Token(handles.Getter.Value);
+                return;
+            }
+
             // Load receiver.
             var receiverIsClass = access.Receiver.Type is StructSymbol rs && rs.IsClass;
             if (!receiverIsClass && access.Receiver is BoundVariableExpression bv && this.TryLoadVariableAddress(bv.Variable))
@@ -10733,6 +11240,19 @@ internal sealed class ReflectionMetadataEmitter
             {
                 throw new InvalidOperationException(
                     $"Property '{assn.Property.Name}' has no emitted setter MethodDef.");
+            }
+
+            // Issue #263: static property assignment — no receiver.
+            if (assn.Receiver == null)
+            {
+                this.EmitExpression(assn.Value);
+                this.il.OpCode(ILOpCode.Call);
+                this.il.Token(handles.Setter.Value);
+
+                // Re-load the assigned value as the expression result via the getter.
+                this.il.OpCode(ILOpCode.Call);
+                this.il.Token(handles.Getter.Value);
+                return;
             }
 
             // Load receiver, emit value, call setter.
@@ -10911,13 +11431,18 @@ internal sealed class ReflectionMetadataEmitter
         private void EmitUserEventSubscription(BoundEventSubscriptionExpression node)
         {
             // ADR-0052: user-defined event subscription — call add_X or remove_X accessor.
-            this.EmitInstanceReceiver(node.Receiver);
+            if (node.Receiver != null)
+            {
+                this.EmitInstanceReceiver(node.Receiver);
+            }
+
             this.EmitExpression(node.Handler);
 
             if (this.outer.eventAccessorHandles.TryGetValue(node.Event, out var accessorHandles))
             {
                 var accessorHandle = node.IsAdd ? accessorHandles.Add : accessorHandles.Remove;
-                bool isVirtual = node.Event.IsVirtual || node.Event.IsOverride;
+                bool isStatic = node.Receiver == null;
+                bool isVirtual = !isStatic && (node.Event.IsVirtual || node.Event.IsOverride);
                 this.il.OpCode(isVirtual ? ILOpCode.Callvirt : ILOpCode.Call);
                 this.il.Token(accessorHandle);
             }

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -1068,6 +1068,15 @@ public sealed class Evaluator
                     return staticValue;
                 }
             }
+            else if (node.Property.GetterSymbol != null && program.Functions.TryGetValue(node.Property.GetterSymbol, out var staticGetterBody))
+            {
+                // Issue #263: computed static property getter — no 'this' parameter.
+                var frame = new Dictionary<Symbols.VariableSymbol, object>();
+                locals.Push(frame);
+                var result = EvaluateStatement(staticGetterBody);
+                locals.Pop();
+                return result;
+            }
 
             return DefaultValue(node.Property.Type);
         }
@@ -1104,6 +1113,27 @@ public sealed class Evaluator
     private object EvaluatePropertyAssignmentExpression(BoundPropertyAssignmentExpression node)
     {
         var value = EvaluateExpression(node.Value);
+
+        // Issue #263: static property assignment (receiver is null).
+        if (node.Receiver == null)
+        {
+            if (node.Property.IsAutoProperty && node.Property.BackingField != null)
+            {
+                staticFields[(node.StructType, node.Property.BackingField)] = value;
+            }
+            else if (node.Property.SetterSymbol != null && program.Functions.TryGetValue(node.Property.SetterSymbol, out var staticSetterBody))
+            {
+                var frame = new Dictionary<Symbols.VariableSymbol, object>
+                {
+                    [node.Property.SetterSymbol.Parameters[0]] = value,
+                };
+                locals.Push(frame);
+                EvaluateStatement(staticSetterBody);
+                locals.Pop();
+            }
+
+            return value;
+        }
 
         // Auto-property fallback: store to backing field.
         if (node.Property.IsAutoProperty && node.Property.BackingField != null)

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -319,6 +319,12 @@ public sealed class Lowerer : BoundTreeRewriter
         {
             var value = RewriteExpression(node.Value);
 
+            // Issue #263: static auto-property assignment — lower to static field assignment.
+            if (node.Receiver == null)
+            {
+                return new BoundFieldAssignmentExpression(null, receiver: null, node.StructType, node.Property.BackingField, value);
+            }
+
             if (node.Receiver is BoundVariableExpression varExpr)
             {
                 return new BoundFieldAssignmentExpression(null, varExpr.Variable, node.StructType, node.Property.BackingField, value);

--- a/test/Core.Tests/CodeAnalysis/SharedBlockTests.cs
+++ b/test/Core.Tests/CodeAnalysis/SharedBlockTests.cs
@@ -513,4 +513,156 @@ var result = Foo.bar(7)
         Assert.Empty(result.Diagnostics);
         Assert.Equal(7, result.Value);
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 6. Issue #263: Static property accessor support in shared blocks
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SharedBlock_StaticAutoProperty_ReadWrite()
+    {
+        var source = @"
+type Config class {
+    shared {
+        prop name string
+    }
+}
+
+Config.name = ""hello""
+var result = Config.name
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("hello", result.Value);
+    }
+
+    [Fact]
+    public void SharedBlock_StaticComputedProperty_Getter()
+    {
+        var source = @"
+type Counter class {
+    shared {
+        count int32
+        prop doubled int32 {
+            get { return count * 2 }
+        }
+    }
+}
+
+Counter.count = 21
+var result = Counter.doubled
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SharedBlock_StaticComputedProperty_GetterSetter()
+    {
+        var source = @"
+type Config class {
+    shared {
+        _value int32
+        prop value int32 {
+            get { return _value }
+            set(v) { _value = v }
+        }
+    }
+}
+
+Config.value = 99
+var result = Config.value
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(99, result.Value);
+    }
+
+    [Fact]
+    public void SharedBlock_StaticAutoProperty_Emit_RoundTrip()
+    {
+        var source = @"package StaticAutoPropEmit
+import System
+
+type Config class {
+    shared {
+        prop name string
+    }
+}
+
+Config.name = ""world""
+Console.WriteLine(Config.name)
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "SharedBlock-StaticAutoProp");
+        Assert.Contains("world", output);
+    }
+
+    [Fact]
+    public void SharedBlock_StaticComputedProperty_Emit_RoundTrip()
+    {
+        var source = @"package StaticComputedPropEmit
+import System
+
+type Counter class {
+    shared {
+        count int32
+        prop doubled int32 {
+            get { return count * 2 }
+        }
+    }
+}
+
+Counter.count = 21
+Console.WriteLine(Counter.doubled)
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "SharedBlock-StaticComputedProp");
+        Assert.Contains("42", output);
+    }
+
+    [Fact]
+    public void SharedBlock_StaticComputedPropertyGetSet_Emit_RoundTrip()
+    {
+        var source = @"package StaticComputedPropGetSetEmit
+import System
+
+type Config class {
+    shared {
+        _value int32
+        prop value int32 {
+            get { return _value }
+            set(v) { _value = v }
+        }
+    }
+}
+
+Config.value = 77
+Console.WriteLine(Config.value)
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "SharedBlock-StaticComputedPropGetSet");
+        Assert.Contains("77", output);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 7. Issue #263: Static event accessor support in shared blocks
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SharedBlock_StaticFieldLikeEvent_Emit_RoundTrip()
+    {
+        var source = @"package StaticEventEmit
+import System
+
+type EventBus class {
+    shared {
+        event onNotify Action
+    }
+}
+
+EventBus.onNotify += func() { }
+Console.WriteLine(""subscribed"")
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "SharedBlock-StaticEvent");
+        Assert.Contains("subscribed", output);
+    }
 }


### PR DESCRIPTION
Closes #263

Implements the full pipeline (binder → lowerer → evaluator → emitter) for static properties (auto and computed) and static events declared in `shared { … }` blocks.

## Changes

### Binder
- Create `GetterSymbol`/`SetterSymbol` for computed static properties (marked `IsStatic`)
- Bind static property/event accessor bodies
- Bind static property assignment (`Type.prop = value`)
- Bind static event subscription (`Type.event += handler`)

### Lowerer
- Lower static auto-property assignment to `BoundFieldAssignmentExpression` with null receiver

### Evaluator
- Evaluate computed static property getters/setters in the interpreter

### Emitter
- Plan field rows for static auto-property and event backing fields (`Assembly | Static` visibility for cross-type access)
- Plan method rows for static property/event accessors
- Emit `get_`/`set_` accessor method bodies for static properties
- Emit `add_`/`remove_` accessor method bodies for static events
- Emit PropertyMap/EventMap metadata rows
- Handle null receiver in `EmitPropertyAccess`, `EmitPropertyAssignment`, `EmitUserEventSubscription`

### BoundTreeRewriter / BoundNodePrinter
- Null-guard receiver on property access/assignment expressions

### Tests
- 7 new round-trip tests covering static auto-properties, computed properties, and field-like events (interpreter + emitter paths)

All 1552 tests pass.