### PR TITLE
Support raise accessor and static events on user types

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -449,44 +449,42 @@ public sealed class Binder
         // to method bodies but hang off PropertySymbol.GetterSymbol/SetterSymbol.
         foreach (var structSym in globalScope.Structs)
         {
-            if (structSym.Properties.IsDefaultOrEmpty)
+            if (!structSym.Properties.IsDefaultOrEmpty)
             {
-                continue;
-            }
-
-            foreach (var prop in structSym.Properties)
-            {
-                if (prop.IsAutoProperty)
+                foreach (var prop in structSym.Properties)
                 {
-                    continue;
-                }
-
-                if (prop.GetterSymbol != null && prop.GetterBodySyntax != null)
-                {
-                    var binder = new Binder(parentScope, prop.GetterSymbol);
-                    var body = binder.BindStatement(prop.GetterBodySyntax);
-                    var loweredBody = Lowerer.Lower(body);
-
-                    if (!ControlFlowGraph.AllPathsReturn(loweredBody))
+                    if (prop.IsAutoProperty)
                     {
-                        binder.Diagnostics.ReportAllPathsMustReturn(prop.GetterBodySyntax.OpenBraceToken.Location);
+                        continue;
                     }
 
-                    functionBodies.Add(prop.GetterSymbol, loweredBody);
-                    diagnostics.AddRange(binder.Diagnostics);
-                }
+                    if (prop.GetterSymbol != null && prop.GetterBodySyntax != null)
+                    {
+                        var binder = new Binder(parentScope, prop.GetterSymbol);
+                        var body = binder.BindStatement(prop.GetterBodySyntax);
+                        var loweredBody = Lowerer.Lower(body);
 
-                if (prop.SetterSymbol != null && prop.SetterBodySyntax != null)
-                {
-                    var binder = new Binder(parentScope, prop.SetterSymbol);
-                    var body = binder.BindStatement(prop.SetterBodySyntax);
-                    var loweredBody = Lowerer.Lower(body);
-                    functionBodies.Add(prop.SetterSymbol, loweredBody);
-                    diagnostics.AddRange(binder.Diagnostics);
+                        if (!ControlFlowGraph.AllPathsReturn(loweredBody))
+                        {
+                            binder.Diagnostics.ReportAllPathsMustReturn(prop.GetterBodySyntax.OpenBraceToken.Location);
+                        }
+
+                        functionBodies.Add(prop.GetterSymbol, loweredBody);
+                        diagnostics.AddRange(binder.Diagnostics);
+                    }
+
+                    if (prop.SetterSymbol != null && prop.SetterBodySyntax != null)
+                    {
+                        var binder = new Binder(parentScope, prop.SetterSymbol);
+                        var body = binder.BindStatement(prop.SetterBodySyntax);
+                        var loweredBody = Lowerer.Lower(body);
+                        functionBodies.Add(prop.SetterSymbol, loweredBody);
+                        diagnostics.AddRange(binder.Diagnostics);
+                    }
                 }
             }
 
-            // ADR-0052: bind explicit event accessor bodies (add/remove).
+            // ADR-0052: bind explicit event accessor bodies (add/remove/raise).
             if (!structSym.Events.IsDefaultOrEmpty)
             {
                 foreach (var ev in structSym.Events)
@@ -511,6 +509,16 @@ public sealed class Binder
                         var body = binder.BindStatement(ev.RemoveBodySyntax);
                         var loweredBody = Lowerer.Lower(body);
                         functionBodies.Add(ev.RemoveMethodSymbol, loweredBody);
+                        diagnostics.AddRange(binder.Diagnostics);
+                    }
+
+                    // Issue #257: bind raise accessor body.
+                    if (ev.RaiseMethodSymbol != null && ev.RaiseBodySyntax != null)
+                    {
+                        var binder = new Binder(parentScope, ev.RaiseMethodSymbol);
+                        var body = binder.BindStatement(ev.RaiseBodySyntax);
+                        var loweredBody = Lowerer.Lower(body);
+                        functionBodies.Add(ev.RaiseMethodSymbol, loweredBody);
                         diagnostics.AddRange(binder.Diagnostics);
                     }
                 }
@@ -588,6 +596,16 @@ public sealed class Binder
                     var body = binder.BindStatement(ev.RemoveBodySyntax);
                     var loweredBody = Lowerer.Lower(body);
                     functionBodies.Add(ev.RemoveMethodSymbol, loweredBody);
+                    diagnostics.AddRange(binder.Diagnostics);
+                }
+
+                // Issue #257: bind raise accessor body for static events.
+                if (ev.RaiseMethodSymbol != null && ev.RaiseBodySyntax != null)
+                {
+                    var binder = new Binder(parentScope, ev.RaiseMethodSymbol);
+                    var body = binder.BindStatement(ev.RaiseBodySyntax);
+                    var loweredBody = Lowerer.Lower(body);
+                    functionBodies.Add(ev.RaiseMethodSymbol, loweredBody);
                     diagnostics.AddRange(binder.Diagnostics);
                 }
             }
@@ -1398,6 +1416,7 @@ public sealed class Binder
                     // Explicit accessors — store body syntax
                     var addAccessor = eventSyntax.Accessors.FirstOrDefault(a => a.IsAdd);
                     var removeAccessor = eventSyntax.Accessors.FirstOrDefault(a => a.IsRemove);
+                    var raiseAccessor = eventSyntax.Accessors.FirstOrDefault(a => a.IsRaise);
 
                     if (addAccessor?.Body != null)
                     {
@@ -1407,6 +1426,11 @@ public sealed class Binder
                     if (removeAccessor?.Body != null)
                     {
                         eventSymbol.RemoveBodySyntax = removeAccessor.Body;
+                    }
+
+                    if (raiseAccessor?.Body != null)
+                    {
+                        eventSymbol.RaiseBodySyntax = raiseAccessor.Body;
                     }
                 }
 
@@ -1421,7 +1445,7 @@ public sealed class Binder
                     eventAccessibility,
                     receiverType: structSymbol,
                     isOpen: isVirtual,
-                    isOverride: isOverride);
+                    isOverride: isOverride) { IsSpecialName = true };
                 eventSymbol.RemoveMethodSymbol = new FunctionSymbol(
                     $"remove_{eventName}",
                     ImmutableArray.Create(handlerParam),
@@ -1431,7 +1455,34 @@ public sealed class Binder
                     eventAccessibility,
                     receiverType: structSymbol,
                     isOpen: isVirtual,
-                    isOverride: isOverride);
+                    isOverride: isOverride) { IsSpecialName = true };
+
+                // Issue #257: create raise method symbol if raise accessor is present.
+                if (eventSyntax.Accessors.Any(a => a.IsRaise))
+                {
+                    var raiseParams = ImmutableArray<ParameterSymbol>.Empty;
+                    if (handlerType is FunctionTypeSymbol fnType)
+                    {
+                        var builder = ImmutableArray.CreateBuilder<ParameterSymbol>(fnType.ParameterTypes.Length);
+                        for (int pi = 0; pi < fnType.ParameterTypes.Length; pi++)
+                        {
+                            builder.Add(new ParameterSymbol($"arg{pi}", fnType.ParameterTypes[pi]));
+                        }
+
+                        raiseParams = builder.ToImmutable();
+                    }
+
+                    eventSymbol.RaiseMethodSymbol = new FunctionSymbol(
+                        $"raise_{eventName}",
+                        raiseParams,
+                        TypeSymbol.Void,
+                        declaration: null,
+                        package,
+                        eventAccessibility,
+                        receiverType: structSymbol,
+                        isOpen: isVirtual,
+                        isOverride: isOverride) { IsSpecialName = true };
+                }
 
                 // Bind annotations
                 if (!eventSyntax.Annotations.IsDefaultOrEmpty)
@@ -1726,6 +1777,28 @@ public sealed class Binder
                         isStatic: true);
                     eventSymbol.BackingField = backingField;
                 }
+                else
+                {
+                    // Issue #257: store explicit accessor bodies for static events.
+                    var addAccessor = eventSyntax.Accessors.FirstOrDefault(a => a.IsAdd);
+                    var removeAccessor = eventSyntax.Accessors.FirstOrDefault(a => a.IsRemove);
+                    var raiseAccessor = eventSyntax.Accessors.FirstOrDefault(a => a.IsRaise);
+
+                    if (addAccessor?.Body != null)
+                    {
+                        eventSymbol.AddBodySyntax = addAccessor.Body;
+                    }
+
+                    if (removeAccessor?.Body != null)
+                    {
+                        eventSymbol.RemoveBodySyntax = removeAccessor.Body;
+                    }
+
+                    if (raiseAccessor?.Body != null)
+                    {
+                        eventSymbol.RaiseBodySyntax = raiseAccessor.Body;
+                    }
+                }
 
                 var handlerParam = new ParameterSymbol("value", handlerType);
                 eventSymbol.AddMethodSymbol = new FunctionSymbol(
@@ -1735,7 +1808,7 @@ public sealed class Binder
                     declaration: null,
                     package,
                     eventAccessibility,
-                    receiverType: null);
+                    receiverType: null) { IsSpecialName = true };
                 eventSymbol.AddMethodSymbol.IsStatic = true;
                 eventSymbol.RemoveMethodSymbol = new FunctionSymbol(
                     $"remove_{eventName}",
@@ -1744,8 +1817,34 @@ public sealed class Binder
                     declaration: null,
                     package,
                     eventAccessibility,
-                    receiverType: null);
+                    receiverType: null) { IsSpecialName = true };
                 eventSymbol.RemoveMethodSymbol.IsStatic = true;
+
+                // Issue #257: create raise method symbol if raise accessor is present.
+                if (eventSyntax.Accessors.Any(a => a.IsRaise))
+                {
+                    var raiseParams = ImmutableArray<ParameterSymbol>.Empty;
+                    if (handlerType is FunctionTypeSymbol fnType)
+                    {
+                        var builder = ImmutableArray.CreateBuilder<ParameterSymbol>(fnType.ParameterTypes.Length);
+                        for (int pi = 0; pi < fnType.ParameterTypes.Length; pi++)
+                        {
+                            builder.Add(new ParameterSymbol($"arg{pi}", fnType.ParameterTypes[pi]));
+                        }
+
+                        raiseParams = builder.ToImmutable();
+                    }
+
+                    eventSymbol.RaiseMethodSymbol = new FunctionSymbol(
+                        $"raise_{eventName}",
+                        raiseParams,
+                        TypeSymbol.Void,
+                        declaration: null,
+                        package,
+                        eventAccessibility,
+                        receiverType: null) { IsSpecialName = true };
+                    eventSymbol.RaiseMethodSymbol.IsStatic = true;
+                }
 
                 if (!eventSyntax.Annotations.IsDefaultOrEmpty)
                 {

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -97,7 +97,8 @@ internal sealed class ReflectionMetadataEmitter
     private readonly Dictionary<PropertySymbol, (MethodDefinitionHandle? Getter, MethodDefinitionHandle? Setter)> propertyAccessorHandles = new Dictionary<PropertySymbol, (MethodDefinitionHandle? Getter, MethodDefinitionHandle? Setter)>();
 
     // ADR-0052: event accessor method handles for EventDef + MethodSemantics emission.
-    private readonly Dictionary<EventSymbol, (MethodDefinitionHandle Add, MethodDefinitionHandle Remove)> eventAccessorHandles = new Dictionary<EventSymbol, (MethodDefinitionHandle Add, MethodDefinitionHandle Remove)>();
+    // Issue #257: extended with optional Raise handle.
+    private readonly Dictionary<EventSymbol, (MethodDefinitionHandle Add, MethodDefinitionHandle Remove, MethodDefinitionHandle? Raise)> eventAccessorHandles = new Dictionary<EventSymbol, (MethodDefinitionHandle Add, MethodDefinitionHandle Remove, MethodDefinitionHandle? Raise)>();
 
     // ADR-0051 Phase 6: cached MemberReferenceHandle for NotImplementedException..ctor().
     private MemberReferenceHandle? notImplementedExceptionCtorRef;
@@ -638,7 +639,8 @@ internal sealed class ReflectionMetadataEmitter
             {
                 var addHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
                 var removeHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
-                this.eventAccessorHandles[ev] = (addHandle, removeHandle);
+                MethodDefinitionHandle? raiseHandle = ev.RaiseMethodSymbol != null ? MetadataTokens.MethodDefinitionHandle(methodRow++) : null;
+                this.eventAccessorHandles[ev] = (addHandle, removeHandle, raiseHandle);
             }
         }
 
@@ -687,7 +689,8 @@ internal sealed class ReflectionMetadataEmitter
             {
                 var addHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
                 var removeHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
-                this.eventAccessorHandles[ev] = (addHandle, removeHandle);
+                MethodDefinitionHandle? raiseHandle = ev.RaiseMethodSymbol != null ? MetadataTokens.MethodDefinitionHandle(methodRow++) : null;
+                this.eventAccessorHandles[ev] = (addHandle, removeHandle, raiseHandle);
             }
 
             // ADR-0053: plan method rows for static methods on classes.
@@ -724,7 +727,8 @@ internal sealed class ReflectionMetadataEmitter
             {
                 var addHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
                 var removeHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
-                this.eventAccessorHandles[ev] = (addHandle, removeHandle);
+                MethodDefinitionHandle? raiseHandle = ev.RaiseMethodSymbol != null ? MetadataTokens.MethodDefinitionHandle(methodRow++) : null;
+                this.eventAccessorHandles[ev] = (addHandle, removeHandle, raiseHandle);
             }
 
             // Issue #262: plan .cctor row for classes with static field initializers.
@@ -779,7 +783,8 @@ internal sealed class ReflectionMetadataEmitter
             {
                 var addHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
                 var removeHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
-                this.eventAccessorHandles[ev] = (addHandle, removeHandle);
+                MethodDefinitionHandle? raiseHandle = ev.RaiseMethodSymbol != null ? MetadataTokens.MethodDefinitionHandle(methodRow++) : null;
+                this.eventAccessorHandles[ev] = (addHandle, removeHandle, raiseHandle);
             }
 
             // ADR-0053: plan method rows for static methods on structs.
@@ -816,7 +821,8 @@ internal sealed class ReflectionMetadataEmitter
             {
                 var addHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
                 var removeHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
-                this.eventAccessorHandles[ev] = (addHandle, removeHandle);
+                MethodDefinitionHandle? raiseHandle = ev.RaiseMethodSymbol != null ? MetadataTokens.MethodDefinitionHandle(methodRow++) : null;
+                this.eventAccessorHandles[ev] = (addHandle, removeHandle, raiseHandle);
             }
 
             // Issue #262: plan .cctor row for structs with static field initializers.
@@ -2413,6 +2419,13 @@ internal sealed class ReflectionMetadataEmitter
             // Emit remove_X MethodDef.
             var removeMethod = this.EmitStaticEventRemoveAccessor(structSym, ev);
 
+            // Issue #257: emit raise_X MethodDef if present.
+            MethodDefinitionHandle? raiseMethod = null;
+            if (ev.RaiseMethodSymbol != null)
+            {
+                raiseMethod = this.EmitEventRaiseAccessor(structSym, ev, isStatic: true);
+            }
+
             // Emit EventDef row.
             var eventTypeHandle = this.GetEventTypeHandle(ev.Type);
 
@@ -2429,6 +2442,10 @@ internal sealed class ReflectionMetadataEmitter
             // MethodSemantics rows linking accessor MethodDefs to the EventDef.
             this.metadata.AddMethodSemantics(eventDef, MethodSemanticsAttributes.Adder, addMethod);
             this.metadata.AddMethodSemantics(eventDef, MethodSemanticsAttributes.Remover, removeMethod);
+            if (raiseMethod.HasValue)
+            {
+                this.metadata.AddMethodSemantics(eventDef, MethodSemanticsAttributes.Raiser, raiseMethod.Value);
+            }
         }
 
         // EventMap row: links the TypeDef to its first EventDef.
@@ -2671,6 +2688,13 @@ internal sealed class ReflectionMetadataEmitter
             // Emit remove_X MethodDef.
             var removeMethod = this.EmitEventRemoveAccessor(structSym, ev);
 
+            // Issue #257: emit raise_X MethodDef if present.
+            MethodDefinitionHandle? raiseMethod = null;
+            if (ev.RaiseMethodSymbol != null)
+            {
+                raiseMethod = this.EmitEventRaiseAccessor(structSym, ev, isStatic: false);
+            }
+
             // Emit EventDef row.
             var eventTypeHandle = this.GetEventTypeHandle(ev.Type);
 
@@ -2687,6 +2711,10 @@ internal sealed class ReflectionMetadataEmitter
             // MethodSemantics rows linking accessor MethodDefs to the EventDef.
             this.metadata.AddMethodSemantics(eventDef, MethodSemanticsAttributes.Adder, addMethod);
             this.metadata.AddMethodSemantics(eventDef, MethodSemanticsAttributes.Remover, removeMethod);
+            if (raiseMethod.HasValue)
+            {
+                this.metadata.AddMethodSemantics(eventDef, MethodSemanticsAttributes.Raiser, raiseMethod.Value);
+            }
         }
 
         // EventMap row: links the TypeDef to its first EventDef.
@@ -2878,6 +2906,84 @@ internal sealed class ReflectionMetadataEmitter
             attributes: methodAttrs,
             implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
             name: this.metadata.GetOrAddString($"remove_{ev.Name}"),
+            signature: this.metadata.GetOrAddBlob(sigBlob),
+            bodyOffset: bodyOffset,
+            parameterList: firstParamHandle);
+    }
+
+    /// <summary>
+    /// Issue #257: emits the raise_X accessor MethodDef for an event.
+    /// The raise accessor body is always user-provided (explicit).
+    /// </summary>
+    private MethodDefinitionHandle EmitEventRaiseAccessor(StructSymbol structSym, EventSymbol ev, bool isStatic)
+    {
+        int bodyOffset = -1;
+        if (!this.metadataOnly)
+        {
+            if (ev.RaiseMethodSymbol != null && this.program.Functions.TryGetValue(ev.RaiseMethodSymbol, out var raiseBody))
+            {
+                var handle = this.EmitFunction(ev.RaiseMethodSymbol, raiseBody, isEntryPoint: false);
+                return handle;
+            }
+            else
+            {
+                // Fallback: throw new NotImplementedException().
+                var il = new InstructionEncoder(new BlobBuilder());
+                var nieCtor = this.GetNotImplementedExceptionCtor();
+                il.OpCode(ILOpCode.Newobj);
+                il.Token(nieCtor);
+                il.OpCode(ILOpCode.Throw);
+                bodyOffset = this.methodBodyStream.AddMethodBody(il);
+            }
+        }
+
+        // Build signature: parameters match the handler type's parameters, return void.
+        int paramCount = 0;
+        if (ev.Type is FunctionTypeSymbol fnType)
+        {
+            paramCount = fnType.ParameterTypes.Length;
+        }
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: !isStatic)
+            .Parameters(paramCount, r => r.Void(), ps =>
+            {
+                if (ev.Type is FunctionTypeSymbol fn)
+                {
+                    foreach (var pt in fn.ParameterTypes)
+                    {
+                        this.EncodeTypeSymbol(ps.AddParameter().Type(), pt);
+                    }
+                }
+            });
+
+        var methodAttrs = MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig;
+        if (isStatic)
+        {
+            methodAttrs |= MethodAttributes.Static;
+        }
+        else if (ev.IsVirtual)
+        {
+            methodAttrs |= MethodAttributes.Virtual | MethodAttributes.NewSlot;
+        }
+        else if (ev.IsOverride)
+        {
+            methodAttrs |= MethodAttributes.Virtual;
+        }
+
+        var firstParamHandle = this.NextParameterHandle();
+        for (int i = 0; i < paramCount; i++)
+        {
+            this.metadata.AddParameter(
+                attributes: ParameterAttributes.None,
+                name: this.metadata.GetOrAddString($"arg{i}"),
+                sequenceNumber: i + 1);
+        }
+
+        return this.metadata.AddMethodDefinition(
+            attributes: methodAttrs,
+            implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString($"raise_{ev.Name}"),
             signature: this.metadata.GetOrAddBlob(sigBlob),
             bodyOffset: bodyOffset,
             parameterList: firstParamHandle);
@@ -3969,6 +4075,42 @@ internal sealed class ReflectionMetadataEmitter
             // MethodSemantics rows linking accessor MethodDefs to the EventDef.
             this.metadata.AddMethodSemantics(eventDef, MethodSemanticsAttributes.Adder, emittedAdd);
             this.metadata.AddMethodSemantics(eventDef, MethodSemanticsAttributes.Remover, emittedRemove);
+
+            // Issue #257: emit abstract raise_X MethodDef if present.
+            if (ev.RaiseMethodSymbol != null)
+            {
+                int raiseParamCount = 0;
+                if (ev.Type is FunctionTypeSymbol fnType)
+                {
+                    raiseParamCount = fnType.ParameterTypes.Length;
+                }
+
+                var raiseSigBlob = new BlobBuilder();
+                new BlobEncoder(raiseSigBlob).MethodSignature(isInstanceMethod: true)
+                    .Parameters(raiseParamCount, r => r.Void(), ps =>
+                    {
+                        if (ev.Type is FunctionTypeSymbol fn)
+                        {
+                            foreach (var pt in fn.ParameterTypes)
+                            {
+                                this.EncodeTypeSymbol(ps.AddParameter().Type(), pt);
+                            }
+                        }
+                    });
+
+                var raiseAttrs = MethodAttributes.Public | MethodAttributes.HideBySig
+                    | MethodAttributes.Virtual | MethodAttributes.Abstract
+                    | MethodAttributes.NewSlot | MethodAttributes.SpecialName;
+                var emittedRaise = this.metadata.AddMethodDefinition(
+                    attributes: raiseAttrs,
+                    implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+                    name: this.metadata.GetOrAddString($"raise_{ev.Name}"),
+                    signature: this.metadata.GetOrAddBlob(raiseSigBlob),
+                    bodyOffset: -1,
+                    parameterList: this.NextParameterHandle());
+
+                this.metadata.AddMethodSemantics(eventDef, MethodSemanticsAttributes.Raiser, emittedRaise);
+            }
         }
 
         // EventMap row: links the TypeDef to its first EventDef.
@@ -5196,6 +5338,12 @@ internal sealed class ReflectionMetadataEmitter
         // convention came from `func (a T) operator +(...)` and should round-
         // trip as SpecialName so consumers (e.g. C#) see them as operators.
         if (function.IsExtension && function.Name != null && function.Name.StartsWith("op_"))
+        {
+            methodAttrs |= MethodAttributes.SpecialName;
+        }
+
+        // Issue #257: event accessor methods (add_X, remove_X, raise_X) are marked SpecialName.
+        if (function.IsSpecialName)
         {
             methodAttrs |= MethodAttributes.SpecialName;
         }

--- a/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
@@ -67,9 +67,15 @@ public sealed class EventSymbol : Symbol
     /// <summary>Gets or sets the synthesized remove method symbol.</summary>
     public FunctionSymbol RemoveMethodSymbol { get; set; }
 
+    /// <summary>Gets or sets the synthesized raise method symbol (issue #257). Null when no <c>raise</c> accessor is declared.</summary>
+    public FunctionSymbol RaiseMethodSymbol { get; set; }
+
     /// <summary>Gets or sets the explicit add body syntax (null for field-like events).</summary>
     public Syntax.BlockStatementSyntax AddBodySyntax { get; set; }
 
     /// <summary>Gets or sets the explicit remove body syntax (null for field-like events).</summary>
     public Syntax.BlockStatementSyntax RemoveBodySyntax { get; set; }
+
+    /// <summary>Gets or sets the explicit raise body syntax (issue #257). Null when no <c>raise</c> accessor is declared.</summary>
+    public Syntax.BlockStatementSyntax RaiseBodySyntax { get; set; }
 }

--- a/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -212,6 +212,9 @@ public sealed class FunctionSymbol : Symbol
     /// <summary>Gets or sets the struct/class that owns this static method (ADR-0053 / #261). <c>null</c> for non-static or top-level functions.</summary>
     public StructSymbol StaticOwnerType { get; set; }
 
+    /// <summary>Gets or sets a value indicating whether this function should be emitted with <c>MethodAttributes.SpecialName</c> (e.g., event accessor methods).</summary>
+    public bool IsSpecialName { get; set; }
+
     /// <summary>Gets or sets a value indicating whether this function is declared <c>async</c> (Phase 5.1 / ADR-0023). When true, callers observe the function's return as <c>Task[T]</c> (or <c>Task</c> when no return type was declared) and the body may use <c>await</c>.</summary>
     public bool IsAsync { get; set; }
 

--- a/src/Core/CodeAnalysis/Syntax/EventAccessorSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/EventAccessorSyntax.cs
@@ -45,4 +45,7 @@ public sealed class EventAccessorSyntax : SyntaxNode
 
     /// <summary>Gets a value indicating whether this accessor is a <c>remove</c> accessor.</summary>
     public bool IsRemove => AccessorKeyword?.Text == "remove";
+
+    /// <summary>Gets a value indicating whether this accessor is a <c>raise</c> accessor (issue #257).</summary>
+    public bool IsRaise => AccessorKeyword?.Text == "raise";
 }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -1076,7 +1076,7 @@ public class Parser
             var startToken = Current;
 
             if (Current.Kind == SyntaxKind.IdentifierToken &&
-                (Current.Text == "add" || Current.Text == "remove"))
+                (Current.Text == "add" || Current.Text == "remove" || Current.Text == "raise"))
             {
                 var accessorKeyword = NextToken();
 

--- a/test/Compiler.Tests/Emit/EventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/EventEmitTests.cs
@@ -146,6 +146,150 @@ public class EventEmitTests
         Assert.True(ev.RemoveMethod!.IsAbstract);
     }
 
+    [Fact]
+    public void RaiseAccessor_EmitsRaiseMethod()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Notifier class {
+                public event Changed func() {
+                    add { }
+                    remove { }
+                    raise { }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var notifierType = assembly.GetTypes().Single(t => t.Name == "Notifier");
+        var ev = notifierType.GetEvent("Changed");
+
+        Assert.NotNull(ev);
+        Assert.NotNull(ev!.RaiseMethod);
+        Assert.Equal("raise_Changed", ev.RaiseMethod!.Name);
+        Assert.True(ev.RaiseMethod.IsSpecialName);
+    }
+
+    [Fact]
+    public void RaiseAccessor_MatchesHandlerParams()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Emitter class {
+                public event Notify func(int32, string) {
+                    add { }
+                    remove { }
+                    raise { }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var emitterType = assembly.GetTypes().Single(t => t.Name == "Emitter");
+        var ev = emitterType.GetEvent("Notify");
+
+        Assert.NotNull(ev);
+        Assert.NotNull(ev!.RaiseMethod);
+        var raiseParams = ev.RaiseMethod!.GetParameters();
+        Assert.Equal(2, raiseParams.Length);
+        Assert.Equal(typeof(int), raiseParams[0].ParameterType);
+        Assert.Equal(typeof(string), raiseParams[1].ParameterType);
+    }
+
+    [Fact]
+    public void StaticEvent_EmitsStaticAccessors()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type EventBus class {
+                shared {
+                    public event OnNotify func()
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var busType = assembly.GetTypes().Single(t => t.Name == "EventBus");
+        var ev = busType.GetEvent("OnNotify");
+
+        Assert.NotNull(ev);
+        Assert.NotNull(ev!.AddMethod);
+        Assert.NotNull(ev!.RemoveMethod);
+        Assert.True(ev.AddMethod!.IsStatic);
+        Assert.True(ev.RemoveMethod!.IsStatic);
+    }
+
+    [Fact]
+    public void StaticEvent_AddRemove_WorksAtRuntime()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Bus class {
+                shared {
+                    public event Ping func()
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var busType = assembly.GetTypes().Single(t => t.Name == "Bus");
+        var ev = busType.GetEvent("Ping")!;
+
+        bool invoked = false;
+        Action handler = () => invoked = true;
+        ev.AddMethod!.Invoke(null, new object[] { handler });
+
+        // Read backing field and invoke
+        var backingField = busType.GetField("Ping", BindingFlags.NonPublic | BindingFlags.Static);
+        var del = backingField!.GetValue(null) as Delegate;
+        Assert.NotNull(del);
+        del!.DynamicInvoke();
+        Assert.True(invoked);
+
+        // Remove
+        invoked = false;
+        ev.RemoveMethod!.Invoke(null, new object[] { handler });
+        del = backingField.GetValue(null) as Delegate;
+        Assert.Null(del);
+    }
+
+    [Fact]
+    public void StaticEvent_WithRaiseAccessor_Emits()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Hub class {
+                shared {
+                    public event Alert func() {
+                        add { }
+                        remove { }
+                        raise { }
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var hubType = assembly.GetTypes().Single(t => t.Name == "Hub");
+        var ev = hubType.GetEvent("Alert");
+
+        Assert.NotNull(ev);
+        Assert.NotNull(ev!.RaiseMethod);
+        Assert.Equal("raise_Alert", ev.RaiseMethod!.Name);
+        Assert.True(ev.RaiseMethod.IsStatic);
+        Assert.True(ev.RaiseMethod.IsSpecialName);
+    }
+
     private static Assembly CompileToAssembly(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_event_emit_").FullName;

--- a/test/Core.Tests/CodeAnalysis/Syntax/EventParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/EventParserTests.cs
@@ -73,4 +73,31 @@ public class EventParserTests
         Assert.Equal(SyntaxKind.EventDeclaration, structDecl.Events[0].Kind);
         Assert.Equal("Click", structDecl.Events[0].Identifier.Text);
     }
+
+    [Fact]
+    public void ParsesEvent_WithRaiseAccessor()
+    {
+        const string source = "package P\ntype Foo class {\n  event Changed func() {\n    add { }\n    remove { }\n    raise { }\n  }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var ev = structDecl.Events[0];
+        Assert.Equal(3, ev.Accessors.Length);
+        Assert.True(ev.Accessors[2].IsRaise);
+    }
+
+    [Fact]
+    public void ParsesEvent_RaiseAccessorOnly_WithAddRemove()
+    {
+        const string source = "package P\ntype Foo class {\n  event Notify func(int32) {\n    add { }\n    remove { }\n    raise { }\n  }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var ev = structDecl.Events[0];
+        Assert.Single(ev.Accessors.Where(a => a.IsAdd));
+        Assert.Single(ev.Accessors.Where(a => a.IsRemove));
+        Assert.Single(ev.Accessors.Where(a => a.IsRaise));
+    }
 }


### PR DESCRIPTION
Closes #257

## Summary

Implements the `raise` accessor for events and fixes static events with explicit accessor bodies.

### Changes

**Parser**
- Recognize `raise` keyword in event accessor blocks

**Symbols**
- `EventSymbol`: add `RaiseMethodSymbol` and `RaiseBodySyntax` properties
- `FunctionSymbol`: add `IsSpecialName` property for accessor methods

**Binder**
- Create `raise_X` FunctionSymbol with parameters matching the handler type
- Store explicit accessor bodies (add/remove/raise) for static events
- Fix bug: instance event body binding was skipped when the struct had no properties (the `continue` in the property loop also skipped events)

**Emitter**
- Emit `raise_X` MethodDef with `MethodSemantics.Raiser` row
- Support raise accessor in instance, static, and interface event emission
- Respect `IsSpecialName` flag in `EmitFunction` for accessor methods emitted via the generic path

### Tests
- 2 parser tests for raise accessor syntax
- 6 emitter tests (instance raise, static raise, static events with add/remove/raise)