### PR TITLE
Configure build pipeline to produce NuGet packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,12 @@ jobs:
           name: test-results
           path: TestResults/**/*.trx
 
+      - name: Upload NuGet packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages
+          path: out/bin/Release/nupkgs/*.nupkg
+
   e2e:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: dotnet restore GSharp.sln
+
+      - name: Build
+        run: dotnet build GSharp.sln --configuration Release --no-restore -graph
+
+      - name: Test
+        run: dotnet test GSharp.sln --configuration Release --no-build
+
+      - name: Push to NuGet
+        run: dotnet nuget push "out/bin/Release/nupkgs/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
Configures CI to produce and publish NuGet packages:

**build.yml changes:**
- Uploads `.nupkg` files as a build artifact (`nuget-packages`) on every CI run

**New publish.yml workflow:**
- Triggered on GitHub release publication
- Builds, tests, then pushes all `.nupkg` files to nuget.org
- Requires `NUGET_API_KEY` repository secret to be configured

### Setup required before first publish
1. Create an API key at https://www.nuget.org/account/apikeys (scoped to `Gsharp.NET.Sdk` package)
2. Add it as a repository secret named `NUGET_API_KEY`
3. Create a GitHub release (tag like `v0.1.x`) to trigger the publish

Part of #271