### PR TITLE
Fix crash binding imported attributes (MetadataLoadContext)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
+++ b/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
@@ -484,7 +484,9 @@ internal static class KnownAttributes
     /// §6 / issue #177: an <c>@AttributeUsage(...)</c> annotation on a
     /// user-declared <c>@Attribute</c> class supplies <c>ValidOn</c> and
     /// <c>AllowMultiple</c>; CLR-imported attribute types are read via
-    /// reflection. When the attribute carries no <c>AttributeUsage</c> the
+    /// <see cref="System.Reflection.CustomAttributeData"/> so they work for
+    /// types loaded through a <c>MetadataLoadContext</c>. When the attribute
+    /// carries no <c>AttributeUsage</c> the
     /// C# defaults apply: <see cref="AttributeTargets.All"/> /
     /// <c>AllowMultiple = false</c>.
     /// </summary>
@@ -518,12 +520,94 @@ internal static class KnownAttributes
             return;
         }
 
-        var usage = (AttributeUsageAttribute)Attribute.GetCustomAttribute(clr, typeof(AttributeUsageAttribute), inherit: true);
-        if (usage != null)
+        // Attribute types may be loaded through a MetadataLoadContext (reference
+        // assemblies), where runtime-reflection Attribute.GetCustomAttribute(s)
+        // throws InvalidOperationException. Read the [AttributeUsage] data via
+        // CustomAttributeData instead, which works for both runtime and
+        // metadata-loaded types. Walk the base-type chain to honour inherited
+        // usage, matching Attribute.GetCustomAttribute(..., inherit: true).
+        if (TryReadAttributeUsageFromClr(clr, out var clrValidOn, out var clrAllowMultiple))
         {
-            validOn = usage.ValidOn;
-            allowMultiple = usage.AllowMultiple;
+            validOn = clrValidOn;
+            allowMultiple = clrAllowMultiple;
         }
+    }
+
+    private static bool TryReadAttributeUsageFromClr(Type clr, out AttributeTargets validOn, out bool allowMultiple)
+    {
+        validOn = AttributeTargets.All;
+        allowMultiple = false;
+
+        var current = clr;
+        var isSelf = true;
+        while (current != null && current != typeof(object))
+        {
+            IList<System.Reflection.CustomAttributeData> data;
+            try
+            {
+                data = current.GetCustomAttributesData();
+            }
+            catch
+            {
+                return false;
+            }
+
+            foreach (var cad in data)
+            {
+                if (cad.AttributeType?.FullName != typeof(AttributeUsageAttribute).FullName)
+                {
+                    continue;
+                }
+
+                var inheritedForBase = true;
+                var localValidOn = AttributeTargets.All;
+                var localAllowMultiple = false;
+
+                if (cad.ConstructorArguments != null
+                    && cad.ConstructorArguments.Count >= 1
+                    && TryConvertToInt32(cad.ConstructorArguments[0].Value, out var raw))
+                {
+                    localValidOn = (AttributeTargets)raw;
+                }
+
+                if (cad.NamedArguments != null)
+                {
+                    foreach (var named in cad.NamedArguments)
+                    {
+                        if (named.MemberName == "AllowMultiple" && named.TypedValue.Value is bool b)
+                        {
+                            localAllowMultiple = b;
+                        }
+                        else if (named.MemberName == "Inherited" && named.TypedValue.Value is bool inh)
+                        {
+                            inheritedForBase = inh;
+                        }
+                    }
+                }
+
+                // For the attribute type itself any usage applies. For an
+                // ancestor the usage is only inherited when Inherited != false.
+                if (isSelf || inheritedForBase)
+                {
+                    validOn = localValidOn;
+                    allowMultiple = localAllowMultiple;
+                    return true;
+                }
+            }
+
+            try
+            {
+                current = current.BaseType;
+            }
+            catch
+            {
+                return false;
+            }
+
+            isSelf = false;
+        }
+
+        return false;
     }
 
     private static bool TryReadAttributeUsageFromBound(ImmutableArray<BoundAttribute> attributes, out AttributeTargets validOn, out bool allowMultiple)

--- a/test/Core.Tests/CodeAnalysis/Binding/ImportedAttributeBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ImportedAttributeBindingTests.cs
@@ -1,0 +1,105 @@
+// <copyright file="ImportedAttributeBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Core.Tests.Fixtures;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests for issue #288: applying an attribute defined in a
+/// referenced/imported assembly must not crash binding. Attribute types loaded
+/// through a <see cref="System.Reflection.MetadataLoadContext"/> cannot be read
+/// with runtime reflection (<c>Attribute.GetCustomAttribute</c> throws
+/// <see cref="System.InvalidOperationException"/>), so
+/// <see cref="KnownAttributes.GetAttributeUsage"/> must read
+/// <c>[AttributeUsage]</c> via <see cref="System.Reflection.CustomAttributeData"/>.
+/// </summary>
+public class ImportedAttributeBindingTests
+{
+    private static ReferenceResolver FixtureResolver()
+    {
+        // Supplying a real reference path forces the compiler to load attribute
+        // types through a MetadataLoadContext, reproducing the issue #288 crash.
+        var fixturePath = typeof(ImportedMarkerAttribute).Assembly.Location;
+        return ReferenceResolver.WithReferences(new[] { fixturePath });
+    }
+
+    private static BoundGlobalScope BindWithFixtures(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), FixtureResolver());
+    }
+
+    [Fact]
+    public void Imported_Attribute_With_Usage_Binds_Without_Crash()
+    {
+        var source = """
+            package Demo
+            import GSharp.Core.Tests.Fixtures
+
+            @ImportedMarker
+            type Hello class {
+            }
+            """;
+
+        var globalScope = BindWithFixtures(source);
+
+        var hello = globalScope.Structs.Single(s => s.Name == "Hello");
+        var attr = Assert.Single(hello.Attributes);
+        Assert.Equal("GSharp.Core.Tests.Fixtures.ImportedMarkerAttribute", attr.AttributeType.Name);
+        Assert.Equal(AttributeTargetKind.Type, attr.Target);
+
+        // The attribute's [AttributeUsage] permits Class targets, so there must
+        // be no invalid-use-site (GS0201) diagnostic.
+        Assert.DoesNotContain(globalScope.Diagnostics, d => d.Id == "GS0201");
+    }
+
+    [Fact]
+    public void Imported_Attribute_On_Method_Binds_Without_Crash()
+    {
+        var source = """
+            package Demo
+            import GSharp.Core.Tests.Fixtures
+
+            type Hello class {
+                @ImportedMarker
+                func Index() string {
+                    return "hi"
+                }
+            }
+            """;
+
+        var globalScope = BindWithFixtures(source);
+
+        Assert.DoesNotContain(globalScope.Diagnostics, d => d.Id == "GS0201");
+    }
+
+    [Fact]
+    public void Imported_Attribute_Without_Usage_Defaults_To_All()
+    {
+        // ImportedDefaultAttribute carries no [AttributeUsage]; the CLR default
+        // (AttributeTargets.All) must apply, so applying it to a type is valid.
+        var source = """
+            package Demo
+            import GSharp.Core.Tests.Fixtures
+
+            @ImportedDefault
+            type Hello class {
+            }
+            """;
+
+        var globalScope = BindWithFixtures(source);
+
+        var hello = globalScope.Structs.Single(s => s.Name == "Hello");
+        Assert.Single(hello.Attributes);
+        Assert.DoesNotContain(globalScope.Diagnostics, d => d.Id == "GS0201");
+    }
+}

--- a/test/Core.Tests/Fixtures/ImportedAttributeFixtures.cs
+++ b/test/Core.Tests/Fixtures/ImportedAttributeFixtures.cs
@@ -1,0 +1,29 @@
+// <copyright file="ImportedAttributeFixtures.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace GSharp.Core.Tests.Fixtures;
+
+/// <summary>
+/// A user-defined attribute carrying an explicit <see cref="AttributeUsageAttribute"/>.
+/// Regression fixture for issue #288: when this assembly is supplied as a
+/// reference, the compiler loads the type through a <c>MetadataLoadContext</c>,
+/// so reading its <c>[AttributeUsage]</c> must use
+/// <see cref="System.Reflection.CustomAttributeData"/> rather than runtime
+/// reflection.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+public sealed class ImportedMarkerAttribute : Attribute
+{
+}
+
+/// <summary>
+/// A user-defined attribute with no explicit <see cref="AttributeUsageAttribute"/>.
+/// Exercises the CLR default fallback (AttributeTargets.All / AllowMultiple =
+/// false) for metadata-loaded attribute types.
+/// </summary>
+public sealed class ImportedDefaultAttribute : Attribute
+{
+}


### PR DESCRIPTION
## Summary
Applying an attribute defined in a referenced/imported assembly crashed `gsc` during binding, blocking `@`-annotations like `@ApiController` and `@HttpGet("/")`.

```
System.InvalidOperationException: The requested operation cannot be used on objects loaded by a MetadataLoadContext. Use CustomAttributeData instead.
   at GSharp.Core.CodeAnalysis.Binding.KnownAttributes.GetAttributeUsage(...)
```

## Root cause
`KnownAttributes.GetAttributeUsage` read the attribute's `[AttributeUsage]` via runtime reflection (`Attribute.GetCustomAttribute(clr, ..., inherit: true)`). The compiler loads reference assemblies through a `MetadataLoadContext`, where runtime-reflection `GetCustomAttribute(s)` throws.

## Fix
Read attribute usage via `Type.GetCustomAttributesData()`, locating the `System.AttributeUsageAttribute` row by full name and extracting:
- `ValidOn` from the constructor argument,
- `AllowMultiple` / `Inherited` from named arguments.

The base-type chain is walked to honour inherited usage. When the attribute has no explicit `[AttributeUsage]`, the CLR defaults apply (`AttributeTargets.All`, `AllowMultiple = false`, `Inherited = true`).

## Regression test
`test/Core.Tests/CodeAnalysis/Binding/ImportedAttributeBindingTests.cs` binds GS programs applying a user-defined attribute (`test/Core.Tests/Fixtures/ImportedAttributeFixtures.cs`) supplied as a metadata-loaded reference. The tests reproduce the crash before the fix and pass after it, covering: explicit `[AttributeUsage]` on a type and on a method, and the no-`[AttributeUsage]` default fallback.

## Validation
- `dotnet build GSharp.sln` — succeeds.
- Full suite: **1698 passed, 0 failed** (Core 1293, Compiler 215, LanguageServer 117, Interpreter 50, Sdk 23).

Fixes #288
