### PR TITLE
Fix MetadataLoadContext crash for async funcs returning value types (#290)

### DIFF
--- a/samples/AsyncValueReturns.golden
+++ b/samples/AsyncValueReturns.golden
@@ -1,0 +1,4 @@
+i = 42
+b = True
+f = 4.5
+done

--- a/samples/AsyncValueReturns.gs
+++ b/samples/AsyncValueReturns.gs
@@ -1,0 +1,44 @@
+// file: AsyncValueReturns.gs
+//
+// Regression coverage for issue #290: `async func`s whose kickoff returns a
+// VALUE type (so the synthesized return is `Task<T>` for a value `T`) must
+// build and run. The bug surfaced only on the SDK build path, where reference
+// assemblies are loaded through a MetadataLoadContext and `Task<T>` had to be
+// constructed with a type argument projected into that same context. This
+// sample exercises int32, bool, and float64 async returns end-to-end.
+
+package GSharp.Samples.AsyncValueReturns
+
+import System
+import System.Threading.Tasks
+
+async func asyncInt() int32 {
+    await Task.Delay(1)
+    return 21 * 2
+}
+
+async func asyncBool() bool {
+    await Task.Delay(1)
+    return true
+}
+
+async func asyncFloat() float64 {
+    await Task.Delay(1)
+    return 3.5 + 1.0
+}
+
+async func driver() int32 {
+    let i = await asyncInt()
+    let b = await asyncBool()
+    let f = await asyncFloat()
+    Console.WriteLine("i = $i")
+    Console.WriteLine("b = $b")
+    Console.WriteLine("f = $f")
+    return i
+}
+
+scope {
+    go driver()
+}
+
+Console.WriteLine("done")

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -6912,7 +6912,12 @@ public sealed class Binder
 
         if (scope.References.TryResolveType("System.Threading.Tasks.Task`1", out var taskOpen))
         {
-            var closed = taskOpen.MakeGenericType(clr);
+            // Route the element CLR type through the SAME resolver as Task`1.
+            // Under the SDK build path the references are loaded via a
+            // MetadataLoadContext, and MakeGenericType requires the type
+            // argument to originate from that same context (issue #290).
+            var elementClr = scope.References.MapClrTypeToReferences(clr);
+            var closed = taskOpen.MakeGenericType(elementClr);
             return ImportedTypeSymbol.Get(closed);
         }
 

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
@@ -204,6 +204,12 @@ public static class AsyncStateMachineTypeBuilder
             return null;
         }
 
+        // Project the element CLR type onto the resolver's reference set before
+        // constructing Task`1. Under the SDK build path Task`1 is loaded via a
+        // MetadataLoadContext, and MakeGenericType requires the type argument to
+        // come from that same context (issue #290).
+        inner = references.MapClrTypeToReferences(inner);
+
         return references.TryResolveType("System.Threading.Tasks.Task`1", out var open)
             ? open.MakeGenericType(inner)
             : null;

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -244,6 +244,67 @@ public sealed class ReferenceResolver
     }
 
     /// <summary>
+    /// Projects a CLR <see cref="Type"/> that may originate from the gsc host
+    /// runtime onto the equivalent <see cref="Type"/> from this resolver's
+    /// reference set (its <see cref="MetadataLoadContext"/> when one is in
+    /// play). This is required before calling
+    /// <see cref="Type.MakeGenericType(Type[])"/> on an open generic obtained
+    /// from <see cref="TryResolveType"/>: <c>MakeGenericType</c> demands that
+    /// every type argument was loaded by the SAME context as the generic
+    /// definition, otherwise it throws
+    /// <see cref="ArgumentException"/> ("was not loaded by the
+    /// MetadataLoadContext that loaded the generic type or method").
+    /// </summary>
+    /// <remarks>
+    /// For the <see cref="Default"/> resolver (no
+    /// <see cref="MetadataLoadContext"/>) the host type is already the right
+    /// identity and is returned unchanged. Arrays and constructed generics are
+    /// projected element-by-element so nested type arguments (e.g.
+    /// <c>List[int]</c>) are mapped too. When a leaf type cannot be resolved by
+    /// name from the references, the original host type is returned as a
+    /// best-effort fallback.
+    /// </remarks>
+    /// <param name="hostType">The CLR type to project; may be <c>null</c>.</param>
+    /// <returns>The projected type, or <c>null</c> when <paramref name="hostType"/> is <c>null</c>.</returns>
+    public Type MapClrTypeToReferences(Type hostType)
+    {
+        if (hostType == null)
+        {
+            return null;
+        }
+
+        // The Default resolver searches host-runtime assemblies, so host types
+        // already share identity with anything TryResolveType returns. No
+        // projection is needed (and attempting one would be wasted work).
+        if (metadataContext == null)
+        {
+            return hostType;
+        }
+
+        if (hostType.IsArray)
+        {
+            var mappedElement = MapClrTypeToReferences(hostType.GetElementType());
+            var rank = hostType.GetArrayRank();
+            return rank == 1 ? mappedElement.MakeArrayType() : mappedElement.MakeArrayType(rank);
+        }
+
+        if (hostType.IsGenericType && !hostType.IsGenericTypeDefinition)
+        {
+            var mappedDefinition = MapClrTypeToReferences(hostType.GetGenericTypeDefinition());
+            var mappedArgs = hostType.GetGenericArguments().Select(MapClrTypeToReferences).ToArray();
+            return mappedDefinition.MakeGenericType(mappedArgs);
+        }
+
+        var fullName = hostType.FullName;
+        if (!string.IsNullOrEmpty(fullName) && TryResolveType(fullName, out var mapped) && mapped != null)
+        {
+            return mapped;
+        }
+
+        return hostType;
+    }
+
+    /// <summary>
     /// Resolves a well-known core CLR type (e.g. <c>System.Object</c>,
     /// <c>System.String</c>) by full name. Used by the emitter so type
     /// references for primitives originate from the target framework's

--- a/test/Compiler.Tests/Emit/AsyncValueReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AsyncValueReturnEmitTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="AsyncValueReturnEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Regression tests for issue #290: an <c>async func</c> that returns a value
+/// type (so the kickoff returns <c>Task&lt;T&gt;</c> for a value <c>T</c>)
+/// crashed <c>gsc</c> under the SDK build path. That path supplies reference
+/// assemblies through a <see cref="System.Reflection.MetadataLoadContext"/>, and
+/// constructing <c>Task&lt;T&gt;</c> with a host-runtime type argument threw
+/// <see cref="ArgumentException"/> ("was not loaded by the MetadataLoadContext
+/// that loaded the generic type or method"). These tests reproduce the SDK path
+/// by compiling with explicit <c>/reference</c> arguments, which forces the
+/// binder onto the MetadataLoadContext-backed resolver.
+/// </summary>
+public class AsyncValueReturnEmitTests
+{
+    [Fact]
+    public void Async_Func_Returning_Value_Types_Compiles_And_Runs_Through_MetadataLoadContext()
+    {
+        // Each async func below forces WrapAsTask / ResolveAsyncReturnClrType to
+        // build Task<T> for a value (or reference) T while the binder is on the
+        // MetadataLoadContext-backed resolver — the exact path that crashed in
+        // #290. The runtime portion only needs to confirm the emitted assembly
+        // loads and runs without the MetadataLoadContext mismatch.
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            async func asyncInt() int32 {
+                await Task.Delay(1)
+                return 21 * 2
+            }
+
+            async func asyncBool() bool {
+                await Task.Delay(1)
+                return true
+            }
+
+            async func asyncFloat() float64 {
+                await Task.Delay(1)
+                return 3.5 + 1.0
+            }
+
+            async func asyncString() string {
+                await Task.Delay(1)
+                return "hi"
+            }
+
+            let ti = asyncInt()
+            let tb = asyncBool()
+            let tf = asyncFloat()
+            let ts = asyncString()
+            Console.WriteLine("done")
+            """;
+
+        var output = CompileAndRunThroughMetadataLoadContext(source);
+
+        Assert.Equal("done\n", output);
+    }
+
+    private static string CompileAndRunThroughMetadataLoadContext(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_async_mlc_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            // Passing /reference paths makes ReferenceResolver load them into an
+            // isolated MetadataLoadContext, exactly as the SDK build does. Using
+            // the host runtime's assemblies keeps the test self-contained.
+            var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+            var references = Directory
+                .EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+                .Where(p => Path.GetFileName(p).StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(Path.GetFileName(p), "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(Path.GetFileName(p), "netstandard.dll", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+
+            Assert.NotEmpty(references);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                var args = new List<string>
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                };
+                args.AddRange(references.Select(r => "/reference:" + r));
+                args.Add(srcPath);
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            Assert.True(File.Exists(outPath), $"expected emitted assembly at {outPath}");
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
@@ -55,4 +55,81 @@ public class ReferenceResolverTests
 
         Assert.True(resolver.TryResolveType("System.Console", out _));
     }
+
+    [Fact]
+    public void Default_MapClrTypeToReferences_Returns_Host_Type_Unchanged()
+    {
+        var resolver = ReferenceResolver.Default();
+
+        // With no MetadataLoadContext the host type already has the right
+        // identity, so the projection is a no-op (reference-equal).
+        Assert.Same(typeof(int), resolver.MapClrTypeToReferences(typeof(int)));
+        Assert.Same(typeof(string), resolver.MapClrTypeToReferences(typeof(string)));
+        Assert.Null(resolver.MapClrTypeToReferences(null));
+    }
+
+    [Theory]
+    [InlineData(typeof(int))]
+    [InlineData(typeof(bool))]
+    [InlineData(typeof(double))]
+    [InlineData(typeof(System.DateTime))]
+    [InlineData(typeof(System.Guid))]
+    [InlineData(typeof(string))]
+    public void MapClrTypeToReferences_Lets_Open_Generic_Construct_Under_MetadataLoadContext(Type elementType)
+    {
+        // Regression for issue #290. When references are loaded through a
+        // MetadataLoadContext (the SDK build path), an open generic resolved
+        // from those references rejects a host-runtime type argument:
+        // MakeGenericType demands every argument come from the SAME context.
+        var resolver = BuildMetadataLoadContextResolver();
+        Assert.True(resolver.TryResolveType("System.Threading.Tasks.Task`1", out var openTask));
+
+        // Sanity check: the bug. A host-runtime type argument is rejected.
+        Assert.Throws<ArgumentException>(() => openTask.MakeGenericType(elementType));
+
+        // The fix: projecting the host type through the resolver yields a
+        // context-compatible argument, so Task<T> constructs successfully.
+        var projected = resolver.MapClrTypeToReferences(elementType);
+        var closed = openTask.MakeGenericType(projected);
+
+        Assert.Equal("System.Threading.Tasks.Task`1", closed.GetGenericTypeDefinition().FullName);
+        Assert.Equal(elementType.FullName, closed.GetGenericArguments()[0].FullName);
+    }
+
+    [Fact]
+    public void MapClrTypeToReferences_Projects_Nested_Generic_Arguments()
+    {
+        // Constructed generics and arrays must be projected element-by-element
+        // so nested type arguments are also pulled into the load context.
+        var resolver = BuildMetadataLoadContextResolver();
+        Assert.True(resolver.TryResolveType("System.Threading.Tasks.Task`1", out var openTask));
+
+        var projectedList = resolver.MapClrTypeToReferences(typeof(System.Collections.Generic.List<int>));
+        var closed = openTask.MakeGenericType(projectedList);
+        Assert.Equal(
+            typeof(System.Collections.Generic.List<int>).FullName,
+            closed.GetGenericArguments()[0].FullName);
+
+        var projectedArray = resolver.MapClrTypeToReferences(typeof(int[]));
+        Assert.True(projectedArray.IsArray);
+        Assert.Equal(typeof(int[]).FullName, projectedArray.FullName);
+    }
+
+    private static ReferenceResolver BuildMetadataLoadContextResolver()
+    {
+        // Supplying explicit assembly paths forces ReferenceResolver to load
+        // them into an isolated MetadataLoadContext, mirroring the SDK build.
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Threading.Tasks.Task<>).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #290. An `async func` returning a **value type** (e.g. `int32`, so the kickoff returns `Task<int32>`) crashed `gsc` under the **SDK build path** with:

```
System.ArgumentException: This type 'System.Int32' was not loaded by the MetadataLoadContext that loaded the generic type or method.
   at System.Reflection.TypeLoading.RoDefinitionType.MakeGenericType(Type[] typeArguments)
   at GSharp.Core.CodeAnalysis.Binding.Binder.WrapAsTask(TypeSymbol element)
```

This manifested **only on the SDK `MetadataLoadContext` path**: the conformance harness drives `gsc` with the host (`Default`) reference resolver and therefore passed for the same source shape (`samples/AsyncTask.gs`), while the SDK build supplies reference assemblies through a `MetadataLoadContext` and crashed.

## Root cause

`WrapAsTask` (`Binder.cs`) and `ResolveAsyncReturnClrType` (`AsyncStateMachineTypeBuilder.cs`) constructed `Task<T>` via `MakeGenericType` using a **host-runtime** CLR type argument (`System.Int32` from the gsc host). When the open `Task<>` definition is loaded through a `MetadataLoadContext`, `MakeGenericType` requires the type argument to come from the **same** context — the two reference-resolution paths diverged.

## Fix

- Added `ReferenceResolver.MapClrTypeToReferences`, which projects a host CLR type onto the resolver's reference set (its `MetadataLoadContext` when present), recursing through arrays and constructed generics. For the `Default` resolver it returns the host type unchanged, so non-SDK paths are unaffected.
- Both async-return call sites now route the element type through it before `MakeGenericType`.

## Regression tests

- **`test/Core.Tests` `ReferenceResolverTests`** — asserts a host type argument is rejected by an MLC-loaded `Task<>` and that the projected type constructs successfully, across `int32`/`bool`/`float64`/`DateTime`/`Guid`/`string` plus nested generics and arrays.
- **`test/Compiler.Tests` `AsyncValueReturnEmitTests`** — compiles async value-returning funcs with explicit `/reference` args (forcing the MLC path) and asserts the emitted assembly builds and runs. Verified to fail before the fix and pass after.
- **`samples/AsyncValueReturns.gs` + `.golden`** — end-to-end conformance sample for async funcs returning `int32`/`bool`/`float64`.

## Validation

- Full solution builds clean.
- Full test suite: **1705 passed, 0 failed** (Sdk 23, Interpreter 50, LanguageServer 117, Core 1298, Compiler 217).
- A temporary SDK consumer project (`<Project Sdk="Gsharp.NET.Sdk/...">` with an `async func` returning `int32`) reproduced the crash before the fix and now **builds and runs** cleanly.

## Notes / scope

User-defined GSharp structs as async return types remain a separate, pre-existing limitation (graceful `GS0190`, tracked by #52) — not the crash addressed here. BCL value structs are covered by the unit tests.
