### PR TITLE
Support general func -> delegate conversion in all positions (#295)

### DIFF
--- a/samples/FuncToDelegate.golden
+++ b/samples/FuncToDelegate.golden
@@ -1,0 +1,5 @@
+42
+True
+False
+hello from Action
+101

--- a/samples/FuncToDelegate.gs
+++ b/samples/FuncToDelegate.gs
@@ -1,0 +1,35 @@
+// file: FuncToDelegate.gs
+//
+// Issue #295 (related to #255): a GSharp function value converts to a
+// compatible CLR delegate type in ALL positions, not only as a direct call
+// argument. This sample exercises the previously-rejected assignment and
+// return positions (which used to fail with `error GS0155`), plus a
+// func-typed value adapted to a named delegate type. The resulting delegates
+// are invoked to prove the materialization is correct at runtime.
+
+package GSharp.Samples.FuncToDelegate
+
+import System
+
+// Return position: a factory that RETURNS a delegate built from a func literal.
+func makeDoubler() Func[int32, int32] {
+    return func(x int32) int32 { return x * 2 }
+}
+
+// Assignment position: a func literal assigned to a named generic delegate.
+var isBig Predicate[int32] = func(x int32) bool { return x > 2 }
+
+// Assignment position: a func literal assigned to a parameterless delegate.
+var greet Action = func() { Console.WriteLine("hello from Action") }
+
+// A func-typed value adapted to a named delegate type (delegate adaptation).
+var raw = func(x int32) int32 { return x + 100 }
+var bump Func[int32, int32] = raw
+
+var doubler = makeDoubler()
+
+Console.WriteLine(doubler.Invoke(21))
+Console.WriteLine(isBig.Invoke(5))
+Console.WriteLine(isBig.Invoke(1))
+greet.Invoke()
+Console.WriteLine(bump.Invoke(1))

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -144,6 +144,20 @@ public sealed class Conversion
             return Conversion.None;
         }
 
+        // Issue #295: a GSharp function value (a `func` literal or any
+        // function-typed value) implicitly converts to ANY compatible CLR
+        // delegate type — one deriving from System.MulticastDelegate whose
+        // `Invoke` signature is assignment-compatible. This lifts the
+        // materialization that previously only happened in argument position
+        // into a general rule, so assignment, return, and cast positions all
+        // accept func → delegate conversions (Action/Func/Predicate and named
+        // delegate types alike).
+        if (from is FunctionTypeSymbol fnSource && to?.ClrType != null
+            && IsFunctionToDelegateConvertible(fnSource, to.ClrType))
+        {
+            return Conversion.Implicit;
+        }
+
         // ADR-0044 numeric lattice. Both operands must be CLR primitives in
         // the numeric set; the widening map decides implicit vs. explicit.
         // Decimal narrowings (decimal → int etc.) and signed/unsigned
@@ -238,5 +252,55 @@ public sealed class Conversion
         }
 
         return Conversion.None;
+    }
+
+    /// <summary>
+    /// Determines whether a GSharp function type is convertible to a CLR
+    /// delegate type by matching parameter arity / assignability and the
+    /// return type. Uses metadata-safe (name-based) checks so it works for
+    /// delegate types loaded through a MetadataLoadContext.
+    /// </summary>
+    private static bool IsFunctionToDelegateConvertible(FunctionTypeSymbol fn, Type delegateType)
+    {
+        if (!ClrTypeUtilities.IsDelegateType(delegateType))
+        {
+            return false;
+        }
+
+        var invoke = delegateType.GetMethod("Invoke");
+        if (invoke == null)
+        {
+            return false;
+        }
+
+        var parms = invoke.GetParameters();
+        if (parms.Length != fn.ParameterTypes.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < parms.Length; i++)
+        {
+            var fnParamClr = fn.ParameterTypes[i]?.ClrType;
+            if (fnParamClr == null || !ClrTypeUtilities.IsAssignableByName(parms[i].ParameterType, fnParamClr))
+            {
+                return false;
+            }
+        }
+
+        var invokeReturnIsVoid = invoke.ReturnType == null
+            || string.Equals(invoke.ReturnType.FullName, "System.Void", StringComparison.Ordinal);
+        if (fn.ReturnType == TypeSymbol.Void || fn.ReturnType == null)
+        {
+            return invokeReturnIsVoid;
+        }
+
+        if (invokeReturnIsVoid)
+        {
+            return false;
+        }
+
+        var fnReturnClr = fn.ReturnType.ClrType;
+        return fnReturnClr != null && ClrTypeUtilities.IsAssignableByName(invoke.ReturnType, fnReturnClr);
     }
 }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -8700,6 +8700,43 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
+    /// <summary>
+    /// Issue #295: map an arbitrary CLR delegate type (named or generic, e.g.
+    /// <c>System.Predicate&lt;int&gt;</c>, <c>RequestDelegate</c>,
+    /// <c>System.EventHandler</c>) from the host runtime onto the emitter's
+    /// reference (MetadataLoadContext) types, reconstructing constructed
+    /// generics from a reference open definition so the produced TypeSpec /
+    /// MemberRef binds to the target framework assemblies. Falls back to the
+    /// host type when no reference mapping is available.
+    /// </summary>
+    private Type ResolveTargetDelegateClrType(Type hostDelegate)
+    {
+        if (hostDelegate == null)
+        {
+            return null;
+        }
+
+        if (hostDelegate.IsConstructedGenericType)
+        {
+            var openName = hostDelegate.GetGenericTypeDefinition().FullName;
+            if (openName != null && this.references.TryResolveType(openName, out var openRef))
+            {
+                var hostArgs = hostDelegate.GetGenericArguments();
+                var refArgs = new Type[hostArgs.Length];
+                for (var i = 0; i < hostArgs.Length; i++)
+                {
+                    refArgs[i] = this.MapToReferenceClrType(hostArgs[i]) ?? hostArgs[i];
+                }
+
+                return openRef.MakeGenericType(refArgs);
+            }
+
+            return hostDelegate;
+        }
+
+        return this.MapToReferenceClrType(hostDelegate) ?? hostDelegate;
+    }
+
     // Phase 4 emit parity (E1): resolve the BCL delegate type backing a
     // GSharp function type. The default ClrType on FunctionTypeSymbol uses
     // host-runtime `typeof(Func<,>)` (which lives in System.Private.CoreLib);
@@ -9645,6 +9682,19 @@ internal sealed class ReflectionMetadataEmitter
 
         private void EmitConversion(BoundConversionExpression conv)
         {
+            // Issue #295: GSharp function value → CLR delegate. This is the
+            // general materialization that previously only happened in
+            // argument position; routing it through EmitConversion makes
+            // assignment, return, and cast positions emit the same delegate
+            // instantiation IL.
+            if (conv.Expression.Type is FunctionTypeSymbol sourceFn
+                && conv.Type?.ClrType != null
+                && ClrTypeUtilities.IsDelegateType(conv.Type.ClrType))
+            {
+                this.EmitFunctionToDelegateConversion(conv.Expression, sourceFn, conv.Type.ClrType);
+                return;
+            }
+
             this.EmitExpression(conv.Expression);
             var from = conv.Expression.Type;
             var to = conv.Type;
@@ -9722,6 +9772,42 @@ internal sealed class ReflectionMetadataEmitter
 
             throw new NotSupportedException(
                 $"Conversion from '{from.Name}' to '{to.Name}' is not yet supported by the emitter.");
+        }
+
+        // Issue #295: emit a GSharp function value materialized as a CLR
+        // delegate of the (possibly named / generic) target delegate type.
+        //
+        //  * For a `func` literal we reuse EmitFunctionLiteral with the target
+        //    delegate as the override type, so it emits the exact same
+        //    `ldnull / ldftn / newobj <Delegate>::.ctor` sequence the
+        //    argument-position path uses, but bound to the requested delegate.
+        //  * For any other function-typed value (a func-typed variable, call
+        //    result, etc.) the runtime value is already a delegate; adapt it
+        //    to the target delegate type via `dup / ldvirtftn Invoke / newobj`.
+        private void EmitFunctionToDelegateConversion(BoundExpression source, FunctionTypeSymbol sourceFn, Type targetDelegateHostType)
+        {
+            var targetDelegateType = this.outer.ResolveTargetDelegateClrType(targetDelegateHostType);
+
+            if (source is BoundFunctionLiteralExpression literal)
+            {
+                this.EmitFunctionLiteral(literal, overrideDelegateType: targetDelegateType);
+                return;
+            }
+
+            // Delegate-to-delegate adaptation: wrap the existing delegate's
+            // Invoke method in a new delegate of the target type.
+            var sourceDelegateType = this.outer.ResolveDelegateClrType(sourceFn);
+            var sourceInvoke = sourceDelegateType.GetMethod("Invoke")
+                ?? throw new InvalidOperationException(
+                    $"Delegate type '{sourceDelegateType.FullName}' has no Invoke method.");
+            var targetCtor = targetDelegateType.GetConstructors()[0];
+
+            this.EmitExpression(source);
+            this.il.OpCode(ILOpCode.Dup);
+            this.il.OpCode(ILOpCode.Ldvirtftn);
+            this.il.Token(this.outer.GetMethodReference(sourceInvoke));
+            this.il.OpCode(ILOpCode.Newobj);
+            this.il.Token(this.outer.GetCtorReference(targetCtor));
         }
 
         // ADR-0044 numeric conversions. Maps the from/to CLR pair to the

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -80,4 +80,28 @@ internal static class ClrTypeUtilities
 
         return false;
     }
+
+    /// <summary>
+    /// Returns whether <paramref name="type"/> is a CLR delegate type, i.e. it
+    /// (transitively) derives from <c>System.MulticastDelegate</c> /
+    /// <c>System.Delegate</c>. Walks the base-type chain by name so it is safe
+    /// for types loaded through a <see cref="System.Reflection.MetadataLoadContext"/>,
+    /// where <c>typeof(Delegate).IsAssignableFrom</c> would throw.
+    /// </summary>
+    /// <param name="type">The candidate type.</param>
+    /// <returns><c>true</c> when the type is a delegate type.</returns>
+    public static bool IsDelegateType(Type type)
+    {
+        for (var t = type; t != null; t = t.BaseType)
+        {
+            var fullName = t.FullName;
+            if (string.Equals(fullName, "System.MulticastDelegate", StringComparison.Ordinal)
+                || string.Equals(fullName, "System.Delegate", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #295 (related to #255 "Consider supporting named delegate types").

Previously a GSharp function value materialized into a CLR delegate **only** in direct call-argument position. Converting a function literal to a delegate in **return** or **variable-assignment** position was rejected with `error GS0155: Cannot convert type 'func(...)...' to '...<DelegateType>'`. This blocked assigning a handler to a delegate-typed variable and middleware factories that **return** a delegate.

### Root cause
`Conversion.Classify` / `BindConversion` had no general "function-type -> delegate" conversion rule — only special-cased positions (event subscription, direct call arguments) materialized the delegate.

### Fix
Added a **general** conversion rule so a GSharp function value converts to **any** compatible delegate type (a type deriving from `System.MulticastDelegate` whose `Invoke` signature matches) in **all** positions:

- **`Conversion.Classify`** — classifies func-type -> delegate-type as an *implicit* conversion when the delegate's `Invoke` signature is assignment-compatible (param arity/assignability + return assignability). Uses metadata-safe, name-based checks so it works for types loaded via `MetadataLoadContext`.
- **`ClrTypeUtilities.IsDelegateType`** — metadata-safe delegate detection by walking the base-type chain (avoids `typeof(Delegate).IsAssignableFrom`, which throws across reflection contexts).
- **`EmitConversion`** — lifts the argument-position materialization into the general conversion emit: a **func literal** reuses `EmitFunctionLiteral` with the target delegate as the override type (the exact `ldnull / ldftn / newobj <Delegate>::.ctor` IL the argument path emits); any other **function-typed value** is adapted to the target delegate via `dup / ldvirtftn Invoke / newobj`.

### Positions / shapes now converting
- Assignment: `var p Predicate[int32] = func(x int32) bool { return x > 2 }`
- Return: `func makeDoubler() Func[int32,int32] { return func(x int32) int32 { return x*2 } }`
- Argument (user functions taking named delegate params)
- Cast (non-generic delegate types, e.g. `Action(func() { ... })`)
- Func / Action / Predicate and named generic delegate types
- Func literals **and** func-typed values (delegate adaptation)

## Regression sample
Added `samples/FuncToDelegate.gs` + `.golden`, auto-discovered by the conformance harness. It exercises **assignment** and **return** positions plus func-typed-value adaptation and **invokes** the resulting delegates to prove runtime correctness. The assignment/return shapes failed with `GS0155` before this change.

## Testing
Full solution build + full test suite green: Core.Tests 1290, Compiler.Tests (incl. new sample) 216, LanguageServer.Tests 117, Interpreter.Tests 50, Sdk.Tests 23 — **1696 passed, 0 failed, 0 skipped**.

## Notes / scope
- Generic-delegate **cast** syntax (e.g. `Predicate[int32](...)`) is an orthogonal, pre-existing limitation of cast-expression parsing for generic type applications; non-generic delegate casts work. Conversion to generic delegate types works in assignment/return/argument positions.
- Bare top-level function names are not expressions in the language today; this PR fully supports "named function references" in the sense of func-typed values/variables. Introducing method-group expressions is a separate language feature.
