### PR TITLE
Resolve non-System imports inside function and method bodies

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -394,10 +394,17 @@ public sealed class Binder
     /// Produces a bound program from the specified global scope.
     /// </summary>
     /// <param name="globalScope">The global scope.</param>
+    /// <param name="references">
+    /// The reference resolver used to resolve imported CLR types inside function and
+    /// method bodies. When omitted, function-body scopes fall back to
+    /// <see cref="ReferenceResolver.Default"/>, which only carries core/System
+    /// assemblies — causing imports of non-System namespaces (e.g. types from
+    /// referenced libraries or third-party packages) to fail inside bodies.
+    /// </param>
     /// <returns>A bound program.</returns>
-    public static BoundProgram BindProgram(BoundGlobalScope globalScope)
+    public static BoundProgram BindProgram(BoundGlobalScope globalScope, ReferenceResolver references = null)
     {
-        var parentScope = CreateParentScope(globalScope, references: null, preprocessorSymbols: globalScope?.PreprocessorSymbols);
+        var parentScope = CreateParentScope(globalScope, references, preprocessorSymbols: globalScope?.PreprocessorSymbols);
 
         var functionBodies = ImmutableDictionary.CreateBuilder<FunctionSymbol, BoundBlockStatement>();
         var diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -157,7 +157,7 @@ public class Compilation
             return new EvaluationResult(diagnostics, null);
         }
 
-        var program = Binder.BindProgram(GlobalScope);
+        var program = Binder.BindProgram(GlobalScope, References);
 
         var appPath = Environment.GetCommandLineArgs()[0];
         var appDirectory = Path.GetDirectoryName(appPath);
@@ -208,7 +208,7 @@ public class Compilation
     /// <param name="writer">The writer.</param>
     public void EmitTree(TextWriter writer)
     {
-        var program = Binder.BindProgram(GlobalScope);
+        var program = Binder.BindProgram(GlobalScope, References);
 
         if (program.Statement.Statements.Any())
         {
@@ -244,7 +244,7 @@ public class Compilation
             return new EmitResult(success: false, syntaxDiagnostics);
         }
 
-        var program = Binder.BindProgram(GlobalScope);
+        var program = Binder.BindProgram(GlobalScope, References);
         if (program.Diagnostics.Any(d => d.IsError))
         {
             return new EmitResult(success: false, program.Diagnostics.ToImmutableArray());
@@ -308,7 +308,7 @@ public class Compilation
             return new EmitResult(success: false, syntaxDiagnostics);
         }
 
-        var program = Binder.BindProgram(GlobalScope);
+        var program = Binder.BindProgram(GlobalScope, References);
         if (program.Diagnostics.Any(d => d.IsError))
         {
             return new EmitResult(success: false, program.Diagnostics.ToImmutableArray());

--- a/test/Core.Tests/CodeAnalysis/Binding/ImportedTypeInFunctionBodyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ImportedTypeInFunctionBodyTests.cs
@@ -1,0 +1,81 @@
+// <copyright file="ImportedTypeInFunctionBodyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Core.Tests.Fixtures;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests: imports of non-<c>System.*</c> namespaces must resolve
+/// inside function and method bodies, not only in top-level statements.
+/// <para>
+/// Previously <see cref="Binder.BindProgram(BoundGlobalScope, ReferenceResolver)"/>
+/// rebuilt the function-body parent scope with <c>references: null</c>, so those
+/// scopes fell back to <see cref="ReferenceResolver.Default"/> (core/System
+/// assemblies only). Types from referenced libraries or third-party packages
+/// (e.g. <c>Xunit.Assert</c>) therefore failed to resolve inside bodies even
+/// though they resolved at top level. The resolver is now threaded through.
+/// </para>
+/// </summary>
+public class ImportedTypeInFunctionBodyTests
+{
+    private static ReferenceResolver FixtureResolver()
+    {
+        var fixturePath = typeof(ImportedGreeter).Assembly.Location;
+        return ReferenceResolver.WithReferences(new[] { fixturePath });
+    }
+
+    private static ImmutableArray<Diagnostic> BindBodies(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(
+            previous: null,
+            ImmutableArray.Create(tree),
+            FixtureResolver());
+        var program = Binder.BindProgram(globalScope, FixtureResolver());
+        return globalScope.Diagnostics.AddRange(program.Diagnostics);
+    }
+
+    [Fact]
+    public void ImportedType_Constructed_In_FreeFunction_Body_Resolves()
+    {
+        var source = """
+            package Demo
+            import GSharp.Core.Tests.Fixtures
+
+            func Run() string {
+                var g = ImportedGreeter()
+                return g.Greet("world")
+            }
+            """;
+
+        Assert.Empty(BindBodies(source));
+    }
+
+    [Fact]
+    public void ImportedType_Constructed_In_Class_Method_Body_Resolves()
+    {
+        var source = """
+            package Demo
+            import GSharp.Core.Tests.Fixtures
+
+            type Host class {
+                func Run() string {
+                    var g = ImportedGreeter()
+                    return g.Greet("world")
+                }
+            }
+            """;
+
+        Assert.Empty(BindBodies(source));
+    }
+}

--- a/test/Core.Tests/Fixtures/ImportedAttributeFixtures.cs
+++ b/test/Core.Tests/Fixtures/ImportedAttributeFixtures.cs
@@ -27,3 +27,21 @@ public sealed class ImportedMarkerAttribute : Attribute
 public sealed class ImportedDefaultAttribute : Attribute
 {
 }
+
+/// <summary>
+/// A plain reference-assembly class used to verify that imports of non-System
+/// namespaces resolve inside function and method bodies — not just in top-level
+/// statements. Constructing this type or calling its members from within a
+/// <c>func</c> body forces the function-body binder scope to use the
+/// compilation's <see cref="System.Reflection.Assembly"/> references rather than
+/// falling back to the core-only default resolver.
+/// </summary>
+public sealed class ImportedGreeter
+{
+    /// <summary>
+    /// Greets the supplied name.
+    /// </summary>
+    /// <param name="name">The name to greet.</param>
+    /// <returns>A greeting string.</returns>
+    public string Greet(string name) => $"Hello, {name}!";
+}


### PR DESCRIPTION
## Problem

Imported types from non-`System.*` namespaces resolved in top-level statements but failed inside `func`/method bodies, producing `GS0157 Cannot find type` / `GS0130 Function doesn't exist`. `System.*` types kept working, which masked the issue.

This blocks writing G# code (e.g. test methods using `Xunit.Assert`) that must live inside a class/function and reference a type from a referenced assembly.

## Root cause

`Binder.BindProgram` rebuilt the function-body parent scope via `CreateParentScope(globalScope, references: null)`. With a null resolver, `BoundScope` falls back to `ReferenceResolver.Default()`, which only carries core/System assemblies. Top-level statements bind in phase 1 with the real resolver, so only function/method **bodies** lost the references.

## Fix

Thread the compilation's `ReferenceResolver` through `BindProgram` into the function-body scopes. All four `Compilation` call sites now pass `References`.

## Tests

Adds `ImportedTypeInFunctionBodyTests` covering construction and member access of an imported non-System type (`GSharp.Core.Tests.Fixtures.ImportedGreeter`) inside both a free function and a class method body. Full suite passes (1313 Core tests + all projects).