### PR TITLE
Allow calling CLR delegate-typed variables with call syntax (#325)

### DIFF
--- a/samples/DelegateCallSyntax.golden
+++ b/samples/DelegateCallSyntax.golden
@@ -1,0 +1,7 @@
+42
+42
+True
+False
+hello from Action
+10
+10

--- a/samples/DelegateCallSyntax.gs
+++ b/samples/DelegateCallSyntax.gs
@@ -1,0 +1,33 @@
+// file: DelegateCallSyntax.gs
+//
+// Issue #325: a variable whose type is a CLR delegate (e.g. `Func[...]`,
+// `Predicate[...]`, `Action`) is invocable with call syntax `f(x)`, exactly
+// like a native G# func-typed variable. Previously this required the explicit
+// `.Invoke(...)` form and `f(x)` failed with `GS0131: 'f' is not a function`.
+// Each delegate below is invoked through call syntax to prove the lowering to
+// `Invoke` is correct at runtime.
+
+package GSharp.Samples.DelegateCallSyntax
+
+import System
+
+// Generic Func delegate invoked via call syntax.
+var increment Func[int32, int32] = func(x int32) int32 { return x + 1 }
+Console.WriteLine(increment(41))
+
+// Two-argument Func delegate invoked via call syntax.
+var add Func[int32, int32, int32] = func(a int32, b int32) int32 { return a + b }
+Console.WriteLine(add(20, 22))
+
+// Predicate delegate invoked via call syntax.
+var isBig Predicate[int32] = func(x int32) bool { return x > 2 }
+Console.WriteLine(isBig(5))
+Console.WriteLine(isBig(1))
+
+// Parameterless Action delegate invoked via call syntax.
+var greet Action = func() { Console.WriteLine("hello from Action") }
+greet()
+
+// Call syntax and Invoke produce the same result.
+Console.WriteLine(increment(9))
+Console.WriteLine(increment.Invoke(9))

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -6866,6 +6866,33 @@ public sealed class Binder
             return new BoundIndirectCallExpression(null, new BoundVariableExpression(null, variable), fnType, convertedArgs.MoveToImmutable());
         }
 
+        // #325: a variable whose type is a CLR delegate (e.g. `Func[int32,
+        // int32]`, `RequestDelegate`) is callable with call syntax `f(x)`,
+        // mirroring native func-typed variables. Lower the call to an
+        // invocation of the delegate's `Invoke` method, identical in behavior
+        // to the explicit `f.Invoke(x)` form.
+        if (symbol is VariableSymbol delegateVar
+            && delegateVar.Type?.ClrType is System.Type delegateClrType
+            && ClrTypeUtilities.IsDelegateType(delegateClrType))
+        {
+            var receiver = new BoundVariableExpression(null, delegateVar);
+            if (TryBindInheritedClrInstanceCall(receiver, delegateClrType, "Invoke", boundArguments.ToImmutable(), syntax, out var invokeCall))
+            {
+                return invokeCall;
+            }
+
+            var invoke = delegateClrType.GetMethod("Invoke");
+            var expectedArity = invoke?.GetParameters().Length ?? 0;
+            if (syntax.Arguments.Count != expectedArity)
+            {
+                Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, delegateVar.Name, expectedArity, syntax.Arguments.Count);
+                return new BoundErrorExpression(null);
+            }
+
+            Diagnostics.ReportNotAFunction(syntax.Identifier.Location, syntax.Identifier.Text);
+            return new BoundErrorExpression(null);
+        }
+
         var function = symbol as FunctionSymbol;
         if (function == null)
         {


### PR DESCRIPTION
Fixes #325

## Problem
A variable whose type is a CLR delegate (e.g. `Func[...]`, `Predicate[...]`, `Action`, `RequestDelegate`) could not be invoked with call syntax `f(x)` — it failed with `GS0131: 'f' is not a function` and required the explicit `.Invoke(...)` form. Native G# `func`-typed variables already support `f(x)`, so the asymmetry was surprising.

## Fix
`BindCallExpression` (src/Core/CodeAnalysis/Binding/Binder.cs) now recognizes a variable whose type is a CLR delegate type (`ClrTypeUtilities.IsDelegateType`) and lowers the call to an invocation of the delegate's `Invoke` method via the existing imported-instance-call machinery (`TryBindInheritedClrInstanceCall`). This makes `f(x)` behave identically to `f.Invoke(x)`. Argument-count mismatches report `GS0118` (wrong argument count) against the delegate's `Invoke` arity.

## Tests
- New conformance sample `samples/DelegateCallSyntax.gs` (+ `.golden`) invoking `Func`, `Predicate`, and `Action` delegate-typed variables through call syntax, asserting runtime output, and confirming `f(x)` == `f.Invoke(x)`.
- Full suite passes: Core 1351, Compiler 241, Interpreter 50, LanguageServer 117, Sdk 24 — 0 failures.

## Status
Fully fixed, no deferred work.