### PR TITLE
Implement Func/func to System.Delegate widening conversion (#323)

### DIFF
--- a/samples/FuncToSystemDelegate.golden
+++ b/samples/FuncToSystemDelegate.golden
@@ -1,0 +1,2 @@
+<lambda1>
+<lambda2>

--- a/samples/FuncToSystemDelegate.gs
+++ b/samples/FuncToSystemDelegate.gs
@@ -1,0 +1,23 @@
+// file: FuncToSystemDelegate.gs
+//
+// Issue #323: a Func[...] (or native func(...)) value widens implicitly to
+// System.Delegate (the common base of every delegate). This used to fail with
+// `error GS0155`. Both forms are exercised:
+//   * the var form: a named/generic delegate value assigned to a Delegate slot
+//   * the lambda-literal form: a func literal assigned directly to a Delegate
+// The resulting System.Delegate values expose their target method, proving the
+// widening is a correct reference upcast at runtime.
+
+package GSharp.Samples.FuncToSystemDelegate
+
+import System
+
+// var form: a named generic delegate value widens to System.Delegate.
+var f Func[string] = func() string { return "hi" }
+var d Delegate = f
+
+// lambda-literal form: a func literal assigned straight to a Delegate slot.
+var g Delegate = func() string { return "yo" }
+
+Console.WriteLine(d.Method.Name)
+Console.WriteLine(g.Method.Name)

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -184,6 +184,26 @@ public sealed class Conversion
             return Conversion.Implicit;
         }
 
+        // Issue #323: any delegate-typed value widens implicitly to
+        // System.Delegate (and System.MulticastDelegate), since every CLR
+        // delegate derives from those base types. This covers both a GSharp
+        // `func` literal (FunctionTypeSymbol, which materializes as a delegate
+        // instance) and a named/generic CLR delegate value such as
+        // `Func[string]`. At the IL level this is a plain reference upcast,
+        // so EMIT needs no conversion opcode.
+        if (to?.ClrType != null && IsSystemDelegateBaseType(to.ClrType))
+        {
+            if (from is FunctionTypeSymbol)
+            {
+                return Conversion.Implicit;
+            }
+
+            if (from?.ClrType != null && ClrTypeUtilities.IsDelegateType(from.ClrType))
+            {
+                return Conversion.Implicit;
+            }
+        }
+
         // ADR-0044 numeric lattice. Both operands must be CLR primitives in
         // the numeric set; the widening map decides implicit vs. explicit.
         // Decimal narrowings (decimal → int etc.) and signed/unsigned
@@ -328,5 +348,17 @@ public sealed class Conversion
 
         var fnReturnClr = fn.ReturnType.ClrType;
         return fnReturnClr != null && ClrTypeUtilities.IsAssignableByName(invoke.ReturnType, fnReturnClr);
+    }
+
+    /// <summary>
+    /// Determines whether a CLR type is the System.Delegate or
+    /// System.MulticastDelegate base type (the common bases of every delegate),
+    /// using name-based checks so it works under a MetadataLoadContext.
+    /// </summary>
+    private static bool IsSystemDelegateBaseType(Type type)
+    {
+        var fullName = type.FullName;
+        return string.Equals(fullName, "System.Delegate", StringComparison.Ordinal)
+            || string.Equals(fullName, "System.MulticastDelegate", StringComparison.Ordinal);
     }
 }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -10468,7 +10468,14 @@ internal sealed class ReflectionMetadataEmitter
         //    to the target delegate type via `dup / ldvirtftn Invoke / newobj`.
         private void EmitFunctionToDelegateConversion(BoundExpression source, FunctionTypeSymbol sourceFn, Type targetDelegateHostType)
         {
-            var targetDelegateType = this.outer.ResolveTargetDelegateClrType(targetDelegateHostType);
+            // Issue #323: when the target is the abstract System.Delegate /
+            // System.MulticastDelegate base type, there is no concrete delegate
+            // to instantiate. Materialize the function value as its natural
+            // delegate type (Func/Action) instead; the resulting reference is
+            // already a System.Delegate, so the widening is a no-op upcast.
+            var targetDelegateType = IsSystemDelegateHostType(targetDelegateHostType)
+                ? this.outer.ResolveDelegateClrType(sourceFn)
+                : this.outer.ResolveTargetDelegateClrType(targetDelegateHostType);
 
             if (source is BoundFunctionLiteralExpression literal)
             {
@@ -10701,7 +10708,28 @@ internal sealed class ReflectionMetadataEmitter
                 }
             }
 
+            // Issue #323: any delegate-typed value (named/generic CLR delegate
+            // such as Func[string]) widens to System.Delegate /
+            // System.MulticastDelegate as a no-op reference upcast.
+            if (b?.ClrType != null && IsSystemDelegateHostType(b.ClrType)
+                && a?.ClrType != null && ClrTypeUtilities.IsDelegateType(a.ClrType))
+            {
+                return true;
+            }
+
             return false;
+        }
+
+        private static bool IsSystemDelegateHostType(Type type)
+        {
+            if (type == null)
+            {
+                return false;
+            }
+
+            var fullName = type.FullName;
+            return string.Equals(fullName, "System.Delegate", StringComparison.Ordinal)
+                || string.Equals(fullName, "System.MulticastDelegate", StringComparison.Ordinal);
         }
 
         private void EmitUnary(BoundUnaryExpression u)

--- a/test/Core.Tests/CodeAnalysis/Binding/DelegateWideningConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/DelegateWideningConversionTests.cs
@@ -1,0 +1,66 @@
+// <copyright file="DelegateWideningConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #323: a delegate-typed value (a named/generic CLR delegate such as
+/// <c>Func[string]</c> or a GSharp <c>func</c> literal) widens implicitly to
+/// <see cref="System.Delegate"/> and <see cref="System.MulticastDelegate"/>,
+/// the common base types of every delegate. These tests pin
+/// <see cref="Conversion.Classify"/> so the reference-widening rule is not lost
+/// in a future refactor.
+/// </summary>
+public class DelegateWideningConversionTests
+{
+    public static TheoryData<Type> DelegateBaseTypes() => new()
+    {
+        typeof(Delegate),
+        typeof(MulticastDelegate),
+    };
+
+    [Theory]
+    [MemberData(nameof(DelegateBaseTypes))]
+    public void NamedDelegateValueWidensImplicitly(Type baseType)
+    {
+        var from = ImportedTypeSymbol.Get(typeof(Func<string>));
+        var to = ImportedTypeSymbol.Get(baseType);
+
+        var conversion = Conversion.Classify(from, to);
+
+        Assert.True(conversion.Exists);
+        Assert.True(conversion.IsImplicit);
+        Assert.False(conversion.IsIdentity);
+    }
+
+    [Theory]
+    [MemberData(nameof(DelegateBaseTypes))]
+    public void FunctionLiteralTypeWidensImplicitly(Type baseType)
+    {
+        var from = FunctionTypeSymbol.Get(ImmutableArray<TypeSymbol>.Empty, TypeSymbol.String);
+        var to = ImportedTypeSymbol.Get(baseType);
+
+        var conversion = Conversion.Classify(from, to);
+
+        Assert.True(conversion.Exists);
+        Assert.True(conversion.IsImplicit);
+    }
+
+    [Fact]
+    public void NonDelegateValueDoesNotWidenToSystemDelegate()
+    {
+        var from = TypeSymbol.Int32;
+        var to = ImportedTypeSymbol.Get(typeof(Delegate));
+
+        var conversion = Conversion.Classify(from, to);
+
+        Assert.False(conversion.Exists);
+    }
+}


### PR DESCRIPTION
Fixes #323.

## Problem
A `Func[...]` (or native `func(...)`) value did not implicitly convert to `System.Delegate`, yielding `GS0155`:
```gsharp
var f Func[string] = func() string { return "hi" }
var d Delegate = f          // GS0155
```
Both the var form and the lambda-literal form failed.

## Fix
- **`Conversion.Classify`**: any delegate-typed value — a GSharp `func` literal (`FunctionTypeSymbol`) or a named/generic CLR delegate value (e.g. `Func[string]`) — now widens implicitly to `System.Delegate` / `System.MulticastDelegate`, the common base types of every delegate.
- **Emit (`ReflectionMetadataEmitter`)**: the named-delegate → `System.Delegate` case is a no-op reference upcast. For a `func` literal assigned directly to a `Delegate` slot, the natural `Func`/`Action` delegate is materialized first (since `System.Delegate` is abstract) and then upcast.

## Tests
- New conformance sample `samples/FuncToSystemDelegate.gs` (+ golden) covering both the var and lambda-literal forms, asserting runtime output.
- New unit tests `DelegateWideningConversionTests` pinning the `Conversion.Classify` rule for `Delegate` and `MulticastDelegate` targets.
- Full suite passes (Core 1356, Compiler 241, Interpreter 50, LanguageServer 117, Sdk 24).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>