### PR TITLE
Support generic extension functions (#326)

### DIFF
--- a/samples/GenericExtensionFunctions.golden
+++ b/samples/GenericExtensionFunctions.golden
@@ -1,0 +1,6 @@
+42
+hello
+7
+world
+99
+kept

--- a/samples/GenericExtensionFunctions.gs
+++ b/samples/GenericExtensionFunctions.gs
@@ -1,0 +1,34 @@
+// file: GenericExtensionFunctions.gs
+// Issue #326: extension functions can declare type parameters. A Go-style
+// receiver clause `func (recv R) Name[T](args) ret { ... }` combines the
+// extension-function form (Phase 3.B.6 / ADR-0019) with generic type
+// parameters (Phase 4.1 / ADR-0020). Type arguments are resolved either by
+// inference from the call-site arguments or from an explicit `[T]` list.
+
+package GSharp.Example.GenericExtensionFunctions
+
+import System
+
+// Single type parameter, inferred or explicit.
+func (value int32) Echo[T](item T) T {
+    return item
+}
+
+// The receiver is ignored; the second argument's type is dropped.
+func (value int32) PickFirst[T, U](a T, b U) T {
+    return a
+}
+
+var n = 5
+
+// Inference from the argument type.
+Console.WriteLine(n.Echo(42))
+Console.WriteLine(n.Echo("hello"))
+
+// Explicit type arguments.
+Console.WriteLine(n.Echo[int32](7))
+Console.WriteLine(n.Echo[string]("world"))
+
+// Multiple type parameters, inferred.
+Console.WriteLine(n.PickFirst(99, "ignored"))
+Console.WriteLine(n.PickFirst[string, int32]("kept", 0))

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -8743,11 +8743,104 @@ public sealed class Binder
             return new BoundErrorExpression(null);
         }
 
+        // Issue #326: a generic extension function
+        // `func (r R) Name[T](item T) T` resolves its type parameters either
+        // from an explicit `[T1, T2]` type-argument list at the call site or by
+        // left-to-right inference from the receiver and argument types matched
+        // against the declared parameter types. Mirrors the free-function
+        // generic path (Phase 4.1 / ADR-0020).
+        Dictionary<TypeParameterSymbol, TypeSymbol> substitution = null;
+        if (extension.IsGeneric)
+        {
+            substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>();
+            if (ce.TypeArgumentList != null)
+            {
+                var explicitArgs = ce.TypeArgumentList.Arguments;
+                if (explicitArgs.Count != extension.TypeParameters.Length)
+                {
+                    Diagnostics.ReportWrongTypeArgumentCount(ce.TypeArgumentList.Location, extension.Name, extension.TypeParameters.Length, explicitArgs.Count);
+                    return new BoundErrorExpression(null);
+                }
+
+                for (var i = 0; i < explicitArgs.Count; i++)
+                {
+                    var ta = BindTypeClause(explicitArgs[i]);
+                    if (ta == null)
+                    {
+                        return new BoundErrorExpression(null);
+                    }
+
+                    substitution[extension.TypeParameters[i]] = ta;
+                }
+            }
+            else
+            {
+                // The receiver lines up against parameters[0]; user arguments
+                // against parameters[1..]. Inferring from the receiver too lets
+                // a generic receiver type (e.g. `func (s []T) ...`) bind T.
+                if (receiver?.Type != null)
+                {
+                    InferTypeArguments(extension.Parameters[0].Type, receiver.Type, substitution);
+                }
+
+                for (var i = 0; i < arguments.Length; i++)
+                {
+                    if (arguments[i].Type != null)
+                    {
+                        InferTypeArguments(extension.Parameters[i + 1].Type, arguments[i].Type, substitution);
+                    }
+                }
+
+                foreach (var tp in extension.TypeParameters)
+                {
+                    if (!substitution.ContainsKey(tp))
+                    {
+                        Diagnostics.ReportTypeArgumentInferenceFailed(ce.Identifier.Location, extension.Name, tp.Name);
+                        return new BoundErrorExpression(null);
+                    }
+                }
+            }
+
+            // Phase 4.2 / ADR-0020: each substituted type argument must satisfy
+            // its type parameter's declared constraint.
+            var constraintLocation = ce.TypeArgumentList != null
+                ? ce.TypeArgumentList.Location
+                : ce.Identifier.Location;
+            foreach (var tp in extension.TypeParameters)
+            {
+                var typeArg = substitution[tp];
+                if (!SatisfiesConstraint(typeArg, tp))
+                {
+                    Diagnostics.ReportTypeArgumentDoesNotSatisfyConstraint(constraintLocation, tp.Name, typeArg, DescribeConstraint(tp));
+                    return new BoundErrorExpression(null);
+                }
+            }
+        }
+
         var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(extension.Parameters.Length);
-        convertedArgs.Add(BindConversion(ce.Location, receiver, extension.Parameters[0].Type));
+        var receiverParamType = substitution != null ? SubstituteType(extension.Parameters[0].Type, substitution) : extension.Parameters[0].Type;
+        convertedArgs.Add(BindConversion(ce.Location, receiver, receiverParamType));
         for (var i = 0; i < arguments.Length; i++)
         {
-            convertedArgs.Add(BindConversion(ce.Arguments[i].Location, arguments[i], extension.Parameters[i + 1].Type));
+            var paramType = extension.Parameters[i + 1].Type;
+            if (substitution != null && TypeSymbol.ContainsTypeParameter(paramType))
+            {
+                // A parameter typed as an open T is encoded as System.Object in
+                // the emitted signature; pass the argument unconverted so the
+                // emitter inserts box / unbox.any around the erased boundary.
+                convertedArgs.Add(arguments[i]);
+            }
+            else
+            {
+                var expectedType = substitution != null ? SubstituteType(paramType, substitution) : paramType;
+                convertedArgs.Add(BindConversion(ce.Arguments[i].Location, arguments[i], expectedType));
+            }
+        }
+
+        if (substitution != null)
+        {
+            var returnType = SubstituteType(extension.Type, substitution);
+            return new BoundCallExpression(null, extension, convertedArgs.MoveToImmutable(), returnType);
         }
 
         return new BoundCallExpression(null, extension, convertedArgs.MoveToImmutable());

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -1549,7 +1549,10 @@ public class Parser
                 && Peek(ahead + 1).Kind == SyntaxKind.OpenParenthesisToken;
         }
 
-        return Peek(ahead).Kind == SyntaxKind.OpenParenthesisToken;
+        // The parameter list opens with `(`, or — for a generic extension
+        // function — a type-parameter list `[T]` precedes it (Phase 4.1).
+        return Peek(ahead).Kind == SyntaxKind.OpenParenthesisToken
+            || Peek(ahead).Kind == SyntaxKind.OpenSquareBracketToken;
     }
 
     private SeparatedSyntaxList<ParameterSyntax> ParseParameterList()

--- a/test/Core.Tests/CodeAnalysis/Binding/ExtensionFunctionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ExtensionFunctionTests.cs
@@ -125,6 +125,69 @@ n.Foo()
         Assert.Equal(5, result.Value);
     }
 
+    [Fact]
+    public void Extension_Generic_InfersTypeArgument_FromArgument()
+    {
+        var source = @"
+func (value int32) Echo[T](item T) T {
+    return item
+}
+
+var n = 5
+n.Echo(42)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void Extension_Generic_ExplicitTypeArgument_Binds()
+    {
+        var source = @"
+func (value int32) Echo[T](item T) T {
+    return item
+}
+
+var n = 5
+n.Echo[string](""hello"")
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("hello", result.Value);
+    }
+
+    [Fact]
+    public void Extension_Generic_MultipleTypeParameters_Bind()
+    {
+        var source = @"
+func (value int32) PickFirst[T, U](a T, b U) T {
+    return a
+}
+
+var n = 5
+n.PickFirst(99, ""ignored"")
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(99, result.Value);
+    }
+
+    [Fact]
+    public void Extension_Generic_WrongExplicitTypeArgumentCount_Diagnoses()
+    {
+        var source = @"
+func (value int32) Echo[T](item T) T {
+    return item
+}
+
+var n = 5
+n.Echo[int32, string](42)
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var syntaxTree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
Fixes #326.

Extension functions could not declare type parameters; the parser rejected the receiver + generic form:

```gsharp
func (value int32) Wrap[T](item T) T { return item }   // parse error (GS0113 / GS0005)
```

## Root cause
- **Parser**: `LooksLikeReceiverClause` only treated a clause as a receiver when the name was followed by `(` (the parameter list). For a generic extension the name is followed by `[` (the type-parameter list), so the receiver clause was never consumed.
- **Binder**: `BindExtensionFunctionCall` bound arguments directly against the declared parameter types — which are open type parameters `T` for a generic extension — with no inference/substitution, so calls failed (`Cannot convert int32 to T`).

## Fix
- Parser: accept `[` as well as `(` after the name in `LooksLikeReceiverClause`. (The declaration node and `ParseOptionalTypeParameterList` already supported type params on the receiver path.)
- Binder: `BindExtensionFunctionCall` now resolves type parameters from an explicit `[T]` list or by inference from the receiver and argument types, validates constraints, passes `T`-typed args unconverted (the emitter boxes/unboxes across the type-erased boundary), and returns a call carrying the substituted return type. This mirrors the existing generic free-function path.
- Emit needed no changes: extension functions already emit as static methods with the receiver as the first parameter, and generic functions already emit type-erased with call-site box/unbox.

## Tests
- New conformance sample `samples/GenericExtensionFunctions.gs` (+ golden) covering inference, explicit type args, and multiple type parameters.
- New binder/interpreter unit tests in `ExtensionFunctionTests` (inference, explicit type arg, multiple type params, wrong-type-argument-count diagnostic).
- Full suite passes: Core 1355, Compiler 241, Interpreter 50, LanguageServer 117, Sdk 24.

Verified runtime output for `recv.Wrap(42)`, `recv.Wrap[string]("x")`, and multi-type-param forms.