### PR TITLE
Support method-group to delegate conversion (#324)

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -265,6 +265,7 @@ LiteralExpression
 MakeChannelExpression
 MapDeleteExpression
 MapLiteralExpression
+MethodGroupExpression
 NullConditionalAccessExpression
 PatternSwitchArm
 PatternSwitchStatement

--- a/samples/MethodGroupToDelegate.golden
+++ b/samples/MethodGroupToDelegate.golden
@@ -1,0 +1,4 @@
+42
+42
+10
+method groups work

--- a/samples/MethodGroupToDelegate.gs
+++ b/samples/MethodGroupToDelegate.gs
@@ -1,0 +1,41 @@
+// file: MethodGroupToDelegate.gs
+// Issue #324: a named function used as a method group converts directly to a
+// delegate value, mirroring the C#/F# idiom. This sample exercises every
+// supported target shape: a generic `Func[...]`, the native `func(...)` type,
+// passing a method group as a callback argument, and an `Action[...]` (void
+// return). No lambda wrapping is required.
+
+package GSharp.Example.MethodGroupToDelegate
+
+import System
+
+func inc(x int32) int32 {
+    return x + 1
+}
+
+func twice(x int32) int32 {
+    return x * 2
+}
+
+func apply(g func(int32) int32, v int32) int32 {
+    return g(v)
+}
+
+func shout(message string) {
+    Console.WriteLine(message)
+}
+
+// Method group -> generic Func[...] delegate.
+var f Func[int32, int32] = inc
+Console.WriteLine(f.Invoke(41))
+
+// Method group -> native func(...) delegate, invoked directly.
+var nf func(int32) int32 = twice
+Console.WriteLine(nf(21))
+
+// Method group passed as a callback argument.
+Console.WriteLine(apply(inc, 9))
+
+// Method group -> Action[...] delegate (void return).
+var a Action[string] = shout
+a.Invoke("method groups work")

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -5511,9 +5511,27 @@ public sealed class Binder
             return new BoundErrorExpression(null);
         }
 
-        var variable = BindVariableReference(name, syntax.IdentifierToken.Location);
+        var variable = BindVariableReference(name, syntax.IdentifierToken.Location, suppressNotAVariable: true);
         if (variable == null)
         {
+            // Issue #324: a bare identifier naming a free (package-level)
+            // function is a method group. In a value context — e.g. assigning
+            // to a `func(...)` or `Func[...]` slot — it converts to a delegate
+            // over that function. We only synthesize the group here; the
+            // conversion classifier decides whether the surrounding context
+            // actually accepts it (otherwise a cannot-convert is reported).
+            if (TryBindMethodGroup(name, out var methodGroup))
+            {
+                return methodGroup;
+            }
+
+            // Not a method group: surface the suppressed GS0126 (or the
+            // undefined-variable diagnostic already reported).
+            if (scope.TryLookupSymbol(name) is not null and not VariableSymbol)
+            {
+                Diagnostics.ReportNotAVariable(syntax.IdentifierToken.Location, name);
+            }
+
             return new BoundErrorExpression(null);
         }
 
@@ -9457,6 +9475,11 @@ public sealed class Binder
 
     private VariableSymbol BindVariableReference(string name, TextLocation location)
     {
+        return BindVariableReference(name, location, suppressNotAVariable: false);
+    }
+
+    private VariableSymbol BindVariableReference(string name, TextLocation location, bool suppressNotAVariable)
+    {
         switch (scope.TryLookupSymbol(name))
         {
             case VariableSymbol variable:
@@ -9468,9 +9491,52 @@ public sealed class Binder
                 return null;
 
             default:
-                Diagnostics.ReportNotAVariable(location, name);
+                if (!suppressNotAVariable)
+                {
+                    Diagnostics.ReportNotAVariable(location, name);
+                }
+
                 return null;
         }
+    }
+
+    // Issue #324: build a method-group expression for a bare identifier that
+    // names a free (package-level) function. Returns false for anything that
+    // cannot be materialized as a simple `ldftn` over a static method def:
+    // instance methods, generics, variadics, and class statics are excluded.
+    private bool TryBindMethodGroup(string name, out BoundExpression methodGroup)
+    {
+        methodGroup = null;
+
+        if (scope.TryLookupSymbol(name) is not FunctionSymbol function)
+        {
+            return false;
+        }
+
+        if (function.IsInstanceMethod
+            || function.IsGeneric
+            || function.IsExtension
+            || function.IsStatic
+            || function.StaticOwnerType != null
+            || function.Package == null)
+        {
+            return false;
+        }
+
+        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(function.Parameters.Length);
+        foreach (var parameter in function.Parameters)
+        {
+            if (parameter.IsVariadic)
+            {
+                return false;
+            }
+
+            parameterTypes.Add(parameter.Type);
+        }
+
+        var fnType = FunctionTypeSymbol.Get(parameterTypes.MoveToImmutable(), function.Type ?? TypeSymbol.Void);
+        methodGroup = new BoundMethodGroupExpression(null, function, fnType);
+        return true;
     }
 
     // ADR-0047 §6 / #175: if <paramref name="symbol"/> carries an

--- a/src/Core/CodeAnalysis/Binding/BoundMethodGroupExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundMethodGroupExpression.cs
@@ -1,0 +1,38 @@
+// <copyright file="BoundMethodGroupExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+#pragma warning disable CS1591
+#pragma warning disable SA1600
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #324: a bare reference to a named function used in a value context
+/// (C#/F# "method group"). Its type is the <see cref="FunctionTypeSymbol"/>
+/// describing the function's signature, so the existing function-value →
+/// delegate conversion machinery materializes it as a delegate (native
+/// <c>func(...)</c> slots via identity, <c>Func[...]</c>/<c>Action[...]</c>
+/// slots via the function → delegate conversion). The emitter loads the
+/// function's address with <c>ldftn</c> and constructs the delegate directly.
+/// </summary>
+public sealed class BoundMethodGroupExpression : BoundExpression
+{
+    public BoundMethodGroupExpression(SyntaxNode syntax, FunctionSymbol function, FunctionTypeSymbol type)
+        : base(syntax)
+    {
+        Function = function;
+        FunctionType = type;
+    }
+
+    public FunctionSymbol Function { get; }
+
+    public FunctionTypeSymbol FunctionType { get; }
+
+    public override TypeSymbol Type => FunctionType;
+
+    public override BoundNodeKind Kind => BoundNodeKind.MethodGroupExpression;
+}

--- a/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -60,6 +60,7 @@ public enum BoundNodeKind
     TupleLiteralExpression,
     TupleElementAccessExpression,
     FunctionLiteralExpression,
+    MethodGroupExpression,
     IndirectCallExpression,
     ClrConstructorCallExpression,
     ClrPropertyAccessExpression,

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -199,6 +199,9 @@ public static class BoundNodePrinter
             case BoundNodeKind.FunctionLiteralExpression:
                 WriteFunctionLiteralExpression((BoundFunctionLiteralExpression)node, writer);
                 break;
+            case BoundNodeKind.MethodGroupExpression:
+                WriteMethodGroupExpression((BoundMethodGroupExpression)node, writer);
+                break;
             case BoundNodeKind.IndirectCallExpression:
                 WriteIndirectCallExpression((BoundIndirectCallExpression)node, writer);
                 break;
@@ -1398,6 +1401,11 @@ public static class BoundNodePrinter
         writer.WritePunctuation(SyntaxKind.CloseParenthesisToken);
         writer.WriteSpace();
         node.Body.WriteTo(writer);
+    }
+
+    private static void WriteMethodGroupExpression(BoundMethodGroupExpression node, IndentedTextWriter writer)
+    {
+        writer.WriteIdentifier(node.Function.Name);
     }
 
     private static void WriteIndirectCallExpression(BoundIndirectCallExpression node, IndentedTextWriter writer)

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -382,6 +382,8 @@ public abstract class BoundTreeRewriter
                 return RewriteTupleElementAccessExpression((BoundTupleElementAccessExpression)node);
             case BoundNodeKind.FunctionLiteralExpression:
                 return RewriteFunctionLiteralExpression((BoundFunctionLiteralExpression)node);
+            case BoundNodeKind.MethodGroupExpression:
+                return RewriteMethodGroupExpression((BoundMethodGroupExpression)node);
             case BoundNodeKind.IndirectCallExpression:
                 return RewriteIndirectCallExpression((BoundIndirectCallExpression)node);
             case BoundNodeKind.ClrConstructorCallExpression:
@@ -1609,6 +1611,14 @@ public abstract class BoundTreeRewriter
     /// <param name="node">The node to rewrite.</param>
     /// <returns>The rewritten node.</returns>
     protected virtual BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+    {
+        return node;
+    }
+
+    /// <summary>Rewrites a method-group expression (issue #324).</summary>
+    /// <param name="node">The node to rewrite.</param>
+    /// <returns>The rewritten node.</returns>
+    protected virtual BoundExpression RewriteMethodGroupExpression(BoundMethodGroupExpression node)
     {
         return node;
     }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -10344,6 +10344,9 @@ internal sealed class ReflectionMetadataEmitter
                 case BoundFunctionLiteralExpression literal:
                     this.EmitFunctionLiteral(literal);
                     break;
+                case BoundMethodGroupExpression methodGroup:
+                    this.EmitMethodGroup(methodGroup, overrideDelegateType: null);
+                    break;
                 case BoundIndirectCallExpression indirect:
                     this.EmitIndirectCall(indirect);
                     break;
@@ -10473,6 +10476,16 @@ internal sealed class ReflectionMetadataEmitter
             if (source is BoundFunctionLiteralExpression literal)
             {
                 this.EmitFunctionLiteral(literal, overrideDelegateType: targetDelegateType);
+                return;
+            }
+
+            // Issue #324: a method group materializes the same `ldnull / ldftn /
+            // newobj <Delegate>` sequence as a no-capture lambda, but over the
+            // existing named function's MethodDef and bound to the requested
+            // target delegate type.
+            if (source is BoundMethodGroupExpression methodGroup)
+            {
+                this.EmitMethodGroup(methodGroup, overrideDelegateType: targetDelegateType);
                 return;
             }
 
@@ -12909,6 +12922,30 @@ internal sealed class ReflectionMetadataEmitter
             }
 
             var delegateType = overrideDelegateType ?? this.outer.ResolveDelegateClrType(literal.FunctionType);
+            var delegateCtor = delegateType.GetConstructors()[0];
+
+            this.il.OpCode(ILOpCode.Ldnull);
+            this.il.OpCode(ILOpCode.Ldftn);
+            this.il.Token(methodHandle);
+            this.il.OpCode(ILOpCode.Newobj);
+            this.il.Token(this.outer.GetCtorReference(delegateCtor));
+        }
+
+        // Issue #324: emit a named-function method group as a delegate. The
+        // function already has a static MethodDef row in functionHandles, so we
+        // reuse the no-capture lambda sequence: `ldnull; ldftn <method>; newobj
+        // <Delegate>::.ctor(object, IntPtr)`. The delegate type is the target
+        // when one is supplied (a `Func[...]`/`Action[...]` conversion target),
+        // otherwise the native delegate for the function's own signature.
+        private void EmitMethodGroup(BoundMethodGroupExpression methodGroup, Type overrideDelegateType)
+        {
+            if (!this.outer.functionHandles.TryGetValue(methodGroup.Function, out var methodHandle))
+            {
+                throw new InvalidOperationException(
+                    $"Method group '{methodGroup.Function.Name}' has no emitted MethodDef.");
+            }
+
+            var delegateType = overrideDelegateType ?? this.outer.ResolveDelegateClrType(methodGroup.FunctionType);
             var delegateCtor = delegateType.GetConstructors()[0];
 
             this.il.OpCode(ILOpCode.Ldnull);

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -489,6 +489,7 @@ public sealed class Evaluator
                 BoundNodeKind.TupleLiteralExpression => EvaluateTupleLiteralExpression((BoundTupleLiteralExpression)node),
                 BoundNodeKind.TupleElementAccessExpression => EvaluateTupleElementAccessExpression((BoundTupleElementAccessExpression)node),
                 BoundNodeKind.FunctionLiteralExpression => EvaluateFunctionLiteralExpression((BoundFunctionLiteralExpression)node),
+                BoundNodeKind.MethodGroupExpression => EvaluateMethodGroupExpression((BoundMethodGroupExpression)node),
                 BoundNodeKind.IndirectCallExpression => EvaluateIndirectCallExpression((BoundIndirectCallExpression)node),
                 BoundNodeKind.ClrConstructorCallExpression => EvaluateClrConstructorCallExpression((BoundClrConstructorCallExpression)node),
                 BoundNodeKind.ClrPropertyAccessExpression => EvaluateClrPropertyAccessExpression((BoundClrPropertyAccessExpression)node),
@@ -760,6 +761,15 @@ public sealed class Evaluator
         }
 
         return new ClosureValue(node.Function, node.Body, node.FunctionType, captured);
+    }
+
+    private object EvaluateMethodGroupExpression(BoundMethodGroupExpression node)
+    {
+        // Issue #324: a named-function method group behaves like a no-capture
+        // closure over the function's own body, so indirect invocation reuses
+        // the ClosureValue path.
+        var body = program.Functions[node.Function];
+        return new ClosureValue(node.Function, body, node.FunctionType, new Dictionary<VariableSymbol, object>());
     }
 
     private object EvaluateIndirectCallExpression(BoundIndirectCallExpression node)

--- a/test/Core.Tests/CodeAnalysis/Binding/LambdaTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/LambdaTests.cs
@@ -94,6 +94,33 @@ add(1)
         Assert.NotEmpty(result.Diagnostics);
     }
 
+    [Fact]
+    public void MethodGroup_NamedFunction_ConvertsToNativeFuncType()
+    {
+        // Issue #324: a bare function name in a value context expecting a
+        // compatible delegate converts to a method group — no lambda wrapper.
+        var result = Evaluate(@"
+func inc(x int32) int32 { return x + 1 }
+let f func(int32) int32 = inc
+f(41)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void MethodGroup_NamedFunction_PassedAsCallbackArgument()
+    {
+        // Issue #324: a method group flows into a `func(...)`-typed parameter.
+        var result = Evaluate(@"
+func twice(x int32) int32 { return x * 2 }
+func apply(g func(int32) int32, v int32) int32 { return g(v) }
+apply(twice, 21)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var syntaxTree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -266,6 +266,7 @@ LiteralExpression
 MakeChannelExpression
 MapDeleteExpression
 MapLiteralExpression
+MethodGroupExpression
 NullConditionalAccessExpression
 PatternSwitchArm
 PatternSwitchStatement


### PR DESCRIPTION
Fixes #324.

## Problem
A named function used as a method group could not be converted to a delegate value:
```gsharp
func inc(x int32) int32 { return x + 1 }
var f Func[int32, int32] = inc    // GS0126: inc is not a variable
```
The only workaround was wrapping in a lambda.

## Fix
A bare identifier that names a free (package-level) function in a value context is now bound as a **method group** (`BoundMethodGroupExpression`) whose type is the function's `FunctionTypeSymbol`. The existing function→delegate conversion machinery then materializes it for both native `func(...)` slots (identity) and generic `Func[...]`/`Action[...]` slots (function→delegate conversion).

- **Binder**: synthesize the method group; only free functions qualify — instance methods, generics, variadics, extensions, and class statics fall back to the prior `GS0126` diagnostic.
- **Emit**: `ldnull; ldftn <method>; newobj <Delegate>::.ctor` over the function's existing `MethodDef` (reusing the no-capture lambda path).
- **Evaluator**: a method group invokes through the existing `ClosureValue` path.

## Tests
- New conformance sample `samples/MethodGroupToDelegate.gs` (+ golden) exercises `Func[...]`, native `func(...)`, callback-argument, and `Action[...]` targets and asserts runtime output.
- New unit tests in `LambdaTests`.
- `coverage-matrix` golden and `docs/coverage-matrix.md` updated for the new `BoundNodeKind`.

## Scope
Conversion of a **CLR member** method group (e.g. `Console.WriteLine`) is a separate feature and intentionally out of scope for this issue (still reports the existing member diagnostic).

## Validation
Full suite green: Core 1353, Compiler 241, Interpreter 50, Sdk 24, LanguageServer 117 — 0 failures.