### PR TITLE
Fix F5 debugging: absolute PDB paths and disk-faithful source checksums

### DIFF
--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -69,7 +69,13 @@ public class Program
                 return Error;
             }
 
-            syntaxTrees.Add(SyntaxTree.Load(path));
+            // Resolve to an absolute path so the document name recorded in the
+            // PDB is rooted. Debuggers (vsdbg/coreclr) match on-disk breakpoints
+            // against the PDB document name; a relative name leaves source
+            // unresolvable, which surfaces as a phantom tab with
+            // "Could not load source ...: Incorrect format of 'source' message."
+            var fullPath = Path.GetFullPath(path);
+            syntaxTrees.Add(SyntaxTree.Load(fullPath));
         }
 
         var references = parsed.References.Count > 0

--- a/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
@@ -111,7 +111,15 @@ internal sealed class PortablePdbEmitter
         }
 
         var path = tree.Text?.FileName ?? string.Empty;
-        var sourceBytes = Encoding.UTF8.GetBytes(tree.Text?.ToString() ?? string.Empty);
+
+        // Prefer the exact on-disk bytes for both the checksum and embedded
+        // source. Debuggers (vsdbg/coreclr) compute the document checksum over
+        // the raw file bytes — including any byte-order mark — and refuse to
+        // bind breakpoints in an on-disk file whose hash does not match,
+        // falling back to a source request that surfaces as a phantom tab.
+        // Re-encoding the decoded text would drop the BOM and mismatch.
+        var sourceBytes = tree.Text?.RawBytes
+            ?? Encoding.UTF8.GetBytes(tree.Text?.ToString() ?? string.Empty);
 
         byte[] hash;
         using (var sha = SHA256.Create())

--- a/src/Core/CodeAnalysis/Syntax/SyntaxTree.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxTree.cs
@@ -49,8 +49,9 @@ public class SyntaxTree
     /// <returns>A parsed syntax tree.</returns>
     public static SyntaxTree Load(string filePath)
     {
+        var rawBytes = File.ReadAllBytes(filePath);
         var text = File.ReadAllText(filePath);
-        var sourceText = SourceText.From(text, filePath);
+        var sourceText = SourceText.From(text, filePath, rawBytes);
         return Parse(sourceText);
     }
 

--- a/src/Core/CodeAnalysis/Text/SourceText.cs
+++ b/src/Core/CodeAnalysis/Text/SourceText.cs
@@ -13,12 +13,22 @@ public sealed class SourceText
 {
     private readonly string text;
 
-    private SourceText(string text, string fileName)
+    private SourceText(string text, string fileName, byte[] rawBytes)
     {
         this.text = text;
         FileName = fileName;
+        RawBytes = rawBytes;
         Lines = ParseLines(this, text);
     }
+
+    /// <summary>
+    /// Gets the exact bytes this document was loaded from on disk, when it was
+    /// loaded from a file; otherwise <c>null</c>. Debuggers compute the source
+    /// checksum over these raw bytes (including any byte-order mark), so the PDB
+    /// document hash must be derived from them — not from a re-encoded copy of
+    /// the decoded text — for on-disk source resolution to succeed.
+    /// </summary>
+    public byte[] RawBytes { get; }
 
     /// <summary>
     /// Gets the set of lines contained by this document.
@@ -47,10 +57,15 @@ public sealed class SourceText
     /// </summary>
     /// <param name="text">The string to wrap with a source text.</param>
     /// <param name="fileName">Optional. The file name associated to this source text.</param>
+    /// <param name="rawBytes">
+    /// Optional. The exact on-disk bytes the text was decoded from. Supplied when
+    /// the document originates from a file so the PDB source checksum matches the
+    /// bytes a debugger hashes.
+    /// </param>
     /// <returns>A hydrated source text instance.</returns>
-    public static SourceText From(string text, string fileName = "")
+    public static SourceText From(string text, string fileName = "", byte[] rawBytes = null)
     {
-        return new SourceText(text, fileName);
+        return new SourceText(text, fileName, rawBytes);
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
@@ -113,6 +113,53 @@ func main() {
     }
 
     [Fact]
+    public void Document_HashMatchesRawFileBytes_IncludingBom()
+    {
+        // A debugger computes the source checksum over the exact on-disk bytes
+        // (BOM included). The PDB document hash must match those raw bytes — not
+        // a re-encoded copy of the decoded text — or on-disk source resolution
+        // fails and breakpoints never bind. Use a UTF-8 BOM, which File.ReadAllText
+        // strips from the decoded text, to guard the regression.
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_pdbhash_{Guid.NewGuid():N}.gs");
+        var rawBytes = Encoding.UTF8.GetPreamble()
+            .Concat(Encoding.UTF8.GetBytes("package main\n\nfunc main() {\n    let x = 1\n}\n"))
+            .ToArray();
+        File.WriteAllBytes(sample, rawBytes);
+
+        try
+        {
+            using var peStream = new MemoryStream();
+            using var pdbStream = new MemoryStream();
+
+            var compilation = new Compilation(SyntaxTree.Load(sample))
+            {
+                DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+            };
+            var result = compilation.Emit(peStream, pdbStream, null);
+            Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+            pdbStream.Position = 0;
+            using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+            var reader = provider.GetMetadataReader();
+
+            var doc = reader.GetDocument(reader.Documents.Single());
+            var pdbHash = reader.GetBlobBytes(doc.Hash);
+
+            byte[] expected;
+            using (var sha = SHA256.Create())
+            {
+                expected = sha.ComputeHash(File.ReadAllBytes(sample));
+            }
+
+            Assert.Equal(expected, pdbHash);
+        }
+        finally
+        {
+            File.Delete(sample);
+        }
+    }
+
+    [Fact]
     public void MethodDebugInformation_RowCount_MatchesMethodDef()
     {
         using var peStream = new MemoryStream();


### PR DESCRIPTION
## Problem

Debugging a GSharp program with F5 (coreclr/vsdbg) never hit breakpoints. Instead, a second tab opened with the same file name containing:

> Could not load source 'Program.gs': Incorrect format of 'source' message.

The call stack mapped the correct line (`Program.gs:7`), but source could not be loaded and breakpoints never bound.

## Root causes

Both in the Portable PDB emitted by the compiler:

1. **Relative document path.** The SDK passes sources to `gsc` as relative `@(Compile)` ItemSpecs, so the PDB `Document` name was a relative path (`Program.gs`). vsdbg cannot resolve a relative document to an on-disk file.

2. **Checksum over re-encoded text.** The `Document` hash was `SHA256(Encoding.UTF8.GetBytes(text))`, which strips the BOM / original encoding. vsdbg hashes the **raw on-disk bytes**, so the two disagreed (verified: a UTF-8 BOM flips the hash). On a checksum mismatch vsdbg considers the source stale, refuses to bind breakpoints, and issues a `source` request — the phantom tab.

## Fixes

- `gsc` resolves each source file to an absolute path via `Path.GetFullPath` before parsing (mirrors `csc`).
- `SyntaxTree.Load` captures the exact on-disk bytes onto a new `SourceText.RawBytes` property.
- `PortablePdbEmitter` hashes (and embeds) those raw bytes when available, falling back to UTF-8 of the decoded text for in-memory trees (preserves existing behavior/tests).

## Verification

- New regression test `Document_HashMatchesRawFileBytes_IncludingBom` asserts the PDB `Document` hash equals `SHA256` of the raw file bytes for a BOM'd source.
- End-to-end: a `.gsproj` built via `dotnet build` (SDK → gsc) with a BOM'd `Program.gs` now produces a PDB whose document name is absolute and whose hash matches the on-disk bytes; F5 binds breakpoints and the phantom tab is gone.
- Full suite passes: Core, Compiler, Interpreter, LanguageServer, Sdk.
