### PR TITLE
Generalize per-overload metadata-load tolerance to all CLR member enumeration (Fixes #338)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -5128,14 +5128,14 @@ public sealed class Binder
 
     private static bool TryGetClrCurrentMemberType(System.Type enumeratorType, out System.Type elementType)
     {
-        var currentProperty = enumeratorType.GetProperty("Current", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+        var currentProperty = ClrTypeUtilities.SafeGetProperty(enumeratorType, "Current", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
         if (currentProperty != null)
         {
             elementType = currentProperty.PropertyType;
             return true;
         }
 
-        var currentField = enumeratorType.GetField("Current", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+        var currentField = ClrTypeUtilities.SafeGetField(enumeratorType, "Current", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
         if (currentField != null)
         {
             elementType = currentField.FieldType;
@@ -6033,13 +6033,13 @@ public sealed class Binder
         {
             var clrReceiverType = variable.Type.ClrType;
             var fieldName = syntax.FieldIdentifier.Text;
-            MemberInfo instanceMember = clrReceiverType.GetProperty(fieldName, BindingFlags.Public | BindingFlags.Instance);
+            MemberInfo instanceMember = ClrTypeUtilities.SafeGetProperty(clrReceiverType, fieldName, BindingFlags.Public | BindingFlags.Instance);
             if (instanceMember is PropertyInfo prop && prop.GetIndexParameters().Length != 0)
             {
                 instanceMember = null;
             }
 
-            instanceMember ??= clrReceiverType.GetField(fieldName, BindingFlags.Public | BindingFlags.Instance);
+            instanceMember ??= ClrTypeUtilities.SafeGetField(clrReceiverType, fieldName, BindingFlags.Public | BindingFlags.Instance);
             if (instanceMember == null)
             {
                 Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
@@ -6179,7 +6179,7 @@ public sealed class Binder
             flags = BindingFlags.Public | BindingFlags.Instance;
         }
 
-        var eventInfo = receiverClrType.GetEvent(eventName, flags);
+        var eventInfo = ClrTypeUtilities.SafeGetEvent(receiverClrType, eventName, flags);
         if (eventInfo == null)
         {
             Diagnostics.ReportUnableToFindMember(eventNameSyntax.Location, eventName);
@@ -7821,7 +7821,7 @@ public sealed class Binder
         // "better function member" resolver. Ambiguity surfaces a hard
         // binder diagnostic and the call falls back to the surrounding
         // pipeline (which will diagnose a missing match).
-        var ctors = clrType.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+        var ctors = ClrTypeUtilities.SafeGetConstructors(clrType, BindingFlags.Public | BindingFlags.Instance);
         var argTypes = new System.Type[boundArguments.Count];
         var argsAllTyped = true;
         for (var i = 0; i < boundArguments.Count; i++)
@@ -8539,13 +8539,13 @@ public sealed class Binder
                     if (structSym.ImportedBaseType?.ClrType is System.Type inheritedBaseClr)
                     {
                         var memberName = ne.IdentifierToken.Text;
-                        var clrProp = inheritedBaseClr.GetProperty(memberName, BindingFlags.Public | BindingFlags.Instance);
+                        var clrProp = ClrTypeUtilities.SafeGetProperty(inheritedBaseClr, memberName, BindingFlags.Public | BindingFlags.Instance);
                         if (clrProp != null && clrProp.GetIndexParameters().Length == 0 && clrProp.CanRead)
                         {
                             return new BoundClrPropertyAccessExpression(null, receiver, clrProp, TypeSymbol.FromClrType(clrProp.PropertyType));
                         }
 
-                        var clrFld = inheritedBaseClr.GetField(memberName, BindingFlags.Public | BindingFlags.Instance);
+                        var clrFld = ClrTypeUtilities.SafeGetField(inheritedBaseClr, memberName, BindingFlags.Public | BindingFlags.Instance);
                         if (clrFld != null)
                         {
                             return new BoundClrPropertyAccessExpression(null, receiver, clrFld, TypeSymbol.FromClrType(clrFld.FieldType));
@@ -8577,13 +8577,13 @@ public sealed class Binder
                     // receivers must be narrowed or use `?.` before this path.
                     var clrReceiverType = receiver.Type.ClrType;
                     var memberName = ne.IdentifierToken.Text;
-                    var prop = clrReceiverType.GetProperty(memberName, BindingFlags.Public | BindingFlags.Instance);
+                    var prop = ClrTypeUtilities.SafeGetProperty(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
                     if (prop != null && prop.GetIndexParameters().Length == 0 && prop.CanRead)
                     {
                         return new BoundClrPropertyAccessExpression(null, receiver, prop, TypeSymbol.FromClrType(prop.PropertyType));
                     }
 
-                    var fld = clrReceiverType.GetField(memberName, BindingFlags.Public | BindingFlags.Instance);
+                    var fld = ClrTypeUtilities.SafeGetField(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
                     if (fld != null)
                     {
                         return new BoundClrPropertyAccessExpression(null, receiver, fld, TypeSymbol.FromClrType(fld.FieldType));
@@ -9630,7 +9630,8 @@ public sealed class Binder
         {
             try
             {
-                var openIndexer = openDefinition.GetProperty(
+                var openIndexer = ClrTypeUtilities.SafeGetProperty(
+                    openDefinition,
                     closedIndexer.Name,
                     BindingFlags.Public | BindingFlags.Instance);
                 if (openIndexer?.PropertyType is System.Type openElement && openElement.IsGenericParameter)
@@ -9662,7 +9663,7 @@ public sealed class Binder
             bound.Add(BindExpression(argSyntaxes[i]));
         }
 
-        foreach (var prop in clrTarget.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        foreach (var prop in ClrTypeUtilities.SafeGetProperties(clrTarget, BindingFlags.Public | BindingFlags.Instance))
         {
             var ps = prop.GetIndexParameters();
             if (ps.Length != bound.Count)
@@ -10016,7 +10017,7 @@ public sealed class Binder
         ImmutableArray<BoundExpression>.Builder boundArguments,
         TextLocation location)
     {
-        var ctors = clrBase.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+        var ctors = ClrTypeUtilities.SafeGetConstructors(clrBase, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             .Where(c => c.IsPublic || c.IsFamily || c.IsFamilyOrAssembly)
             .ToArray();
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -429,22 +429,15 @@ internal static class OverloadResolution
 
     /// <summary>
     /// Determines whether an exception thrown while reflecting over a candidate's
-    /// signature is a metadata/assembly load failure (issue #321). Such failures
-    /// arise when a parameter type cannot be projected under the reference
-    /// <c>MetadataLoadContext</c> — for example a ref-struct type or a type that
-    /// lives in a transitive assembly that was not supplied via <c>/r:</c>. These
-    /// candidates are treated as not applicable rather than aborting the whole
-    /// lookup; any other exception is left to propagate.
+    /// signature is a metadata/assembly load failure (issue #321, generalized in
+    /// issue #338). Delegates to the single shared predicate in
+    /// <see cref="ClrTypeUtilities.IsMetadataLoadFailure(Exception)"/> so every
+    /// CLR member enumeration site classifies load failures identically.
     /// </summary>
     /// <param name="ex">The exception observed while evaluating a candidate.</param>
     /// <returns>Whether the exception represents a tolerable load failure.</returns>
     private static bool IsMetadataLoadFailure(Exception ex) =>
-        ex is System.IO.FileNotFoundException
-            or System.IO.FileLoadException
-            or TypeLoadException
-            or BadImageFormatException
-            or MissingMethodException
-            or NotSupportedException;
+        ClrTypeUtilities.IsMetadataLoadFailure(ex);
 
     /// <summary>
     /// Evaluates a single candidate for applicability against the supplied

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -3,6 +3,9 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
@@ -103,5 +106,240 @@ internal static class ClrTypeUtilities
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Issue #338 (generalizing the #321 fix): determines whether an exception
+    /// thrown while reflecting over a CLR member's signature is a
+    /// metadata/assembly load failure. Such failures arise when a member's
+    /// signature (parameter, return, property, field, or event-handler type)
+    /// references a type that cannot be loaded or projected under the reference
+    /// <see cref="System.Reflection.MetadataLoadContext"/> — for example a
+    /// ref-struct type or a type living in a transitive assembly that was not
+    /// supplied via <c>/r:</c>. Member enumeration sites treat the offending
+    /// member as absent rather than letting the throw sink the whole member set;
+    /// any other exception is left to propagate. This is the single shared
+    /// predicate used by every CLR member enumeration site (overload
+    /// resolution, property/field/event/constructor enumeration, and the
+    /// member-access binding path).
+    /// </summary>
+    /// <param name="ex">The exception observed while evaluating a member.</param>
+    /// <returns>Whether the exception represents a tolerable load failure.</returns>
+    public static bool IsMetadataLoadFailure(Exception ex) =>
+        ex is FileNotFoundException
+            or FileLoadException
+            or TypeLoadException
+            or BadImageFormatException
+            or MissingMethodException
+            or MissingMemberException
+            or NotSupportedException;
+
+    /// <summary>
+    /// Probes whether a member's full signature can be read without triggering a
+    /// metadata-load failure (issue #338). Touching the relevant signature types
+    /// (property/field/event-handler/parameter/return types) forces the
+    /// <see cref="System.Reflection.MetadataLoadContext"/> to resolve them; if
+    /// any cannot be loaded the member is treated as unusable and skipped.
+    /// </summary>
+    /// <param name="member">The reflected member to probe.</param>
+    /// <returns><c>true</c> when the member's signature loads cleanly.</returns>
+    public static bool CanLoadSignature(MemberInfo member)
+    {
+        if (member is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            switch (member)
+            {
+                case PropertyInfo property:
+                    _ = property.PropertyType;
+                    foreach (var indexParameter in property.GetIndexParameters())
+                    {
+                        _ = indexParameter.ParameterType;
+                    }
+
+                    break;
+                case FieldInfo field:
+                    _ = field.FieldType;
+                    break;
+                case EventInfo @event:
+                    _ = @event.EventHandlerType;
+                    break;
+                case MethodBase method:
+                    foreach (var parameter in method.GetParameters())
+                    {
+                        _ = parameter.ParameterType;
+                    }
+
+                    if (method is MethodInfo methodInfo)
+                    {
+                        _ = methodInfo.ReturnType;
+                    }
+
+                    break;
+            }
+
+            return true;
+        }
+        catch (Exception ex) when (IsMetadataLoadFailure(ex))
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Enumerates a type's public properties tolerantly (issue #338): properties
+    /// whose signature cannot be loaded under the reference context are skipped
+    /// instead of sinking the whole set.
+    /// </summary>
+    /// <param name="type">The type to enumerate.</param>
+    /// <param name="flags">The binding flags controlling visibility.</param>
+    /// <returns>The properties whose signatures load cleanly.</returns>
+    public static PropertyInfo[] SafeGetProperties(Type type, BindingFlags flags)
+        => SafeEnumerate(type, t => t.GetProperties(flags));
+
+    /// <summary>
+    /// Enumerates a type's fields tolerantly (issue #338): fields whose type
+    /// cannot be loaded under the reference context are skipped.
+    /// </summary>
+    /// <param name="type">The type to enumerate.</param>
+    /// <param name="flags">The binding flags controlling visibility.</param>
+    /// <returns>The fields whose signatures load cleanly.</returns>
+    public static FieldInfo[] SafeGetFields(Type type, BindingFlags flags)
+        => SafeEnumerate(type, t => t.GetFields(flags));
+
+    /// <summary>
+    /// Enumerates a type's events tolerantly (issue #338): events whose handler
+    /// type cannot be loaded under the reference context are skipped.
+    /// </summary>
+    /// <param name="type">The type to enumerate.</param>
+    /// <param name="flags">The binding flags controlling visibility.</param>
+    /// <returns>The events whose signatures load cleanly.</returns>
+    public static EventInfo[] SafeGetEvents(Type type, BindingFlags flags)
+        => SafeEnumerate(type, t => t.GetEvents(flags));
+
+    /// <summary>
+    /// Enumerates a type's constructors tolerantly (issue #338): constructors
+    /// whose parameter signature cannot be loaded under the reference context
+    /// are skipped instead of sinking the whole overload set.
+    /// </summary>
+    /// <param name="type">The type to enumerate.</param>
+    /// <param name="flags">The binding flags controlling visibility.</param>
+    /// <returns>The constructors whose signatures load cleanly.</returns>
+    public static ConstructorInfo[] SafeGetConstructors(Type type, BindingFlags flags)
+        => SafeEnumerate(type, t => t.GetConstructors(flags));
+
+    /// <summary>
+    /// Enumerates a type's methods tolerantly (issue #338): methods whose
+    /// parameter or return signature cannot be loaded under the reference
+    /// context are skipped instead of sinking the whole candidate set.
+    /// </summary>
+    /// <param name="type">The type to enumerate.</param>
+    /// <param name="flags">The binding flags controlling visibility.</param>
+    /// <returns>The methods whose signatures load cleanly.</returns>
+    public static MethodInfo[] SafeGetMethods(Type type, BindingFlags flags)
+        => SafeEnumerate(type, t => t.GetMethods(flags));
+
+    /// <summary>
+    /// Looks up a single property by name tolerantly (issue #338). When the
+    /// requested member — or an unrelated sibling probed during the lookup —
+    /// references an unloadable type, the direct lookup is retried via a guarded
+    /// enumeration that skips only the offending members.
+    /// </summary>
+    /// <param name="type">The type to search.</param>
+    /// <param name="name">The property name.</param>
+    /// <param name="flags">The binding flags controlling visibility.</param>
+    /// <returns>The matching property, or <c>null</c> when none is usable.</returns>
+    public static PropertyInfo SafeGetProperty(Type type, string name, BindingFlags flags)
+        => SafeGetMember(type, name, flags, (t, f) => t.GetProperty(name, f), SafeGetProperties);
+
+    /// <summary>
+    /// Looks up a single field by name tolerantly (issue #338). See
+    /// <see cref="SafeGetProperty"/> for the tolerance contract.
+    /// </summary>
+    /// <param name="type">The type to search.</param>
+    /// <param name="name">The field name.</param>
+    /// <param name="flags">The binding flags controlling visibility.</param>
+    /// <returns>The matching field, or <c>null</c> when none is usable.</returns>
+    public static FieldInfo SafeGetField(Type type, string name, BindingFlags flags)
+        => SafeGetMember(type, name, flags, (t, f) => t.GetField(name, f), SafeGetFields);
+
+    /// <summary>
+    /// Looks up a single event by name tolerantly (issue #338). See
+    /// <see cref="SafeGetProperty"/> for the tolerance contract.
+    /// </summary>
+    /// <param name="type">The type to search.</param>
+    /// <param name="name">The event name.</param>
+    /// <param name="flags">The binding flags controlling visibility.</param>
+    /// <returns>The matching event, or <c>null</c> when none is usable.</returns>
+    public static EventInfo SafeGetEvent(Type type, string name, BindingFlags flags)
+        => SafeGetMember(type, name, flags, (t, f) => t.GetEvent(name, f), SafeGetEvents);
+
+    private static TMember[] SafeEnumerate<TMember>(Type type, Func<Type, TMember[]> getAll)
+        where TMember : MemberInfo
+    {
+        if (type is null)
+        {
+            return Array.Empty<TMember>();
+        }
+
+        TMember[] all;
+        try
+        {
+            all = getAll(type);
+        }
+        catch (Exception ex) when (IsMetadataLoadFailure(ex))
+        {
+            return Array.Empty<TMember>();
+        }
+
+        var usable = new List<TMember>(all.Length);
+        foreach (var member in all)
+        {
+            if (CanLoadSignature(member))
+            {
+                usable.Add(member);
+            }
+        }
+
+        return usable.ToArray();
+    }
+
+    private static TMember SafeGetMember<TMember>(
+        Type type,
+        string name,
+        BindingFlags flags,
+        Func<Type, BindingFlags, TMember> directLookup,
+        Func<Type, BindingFlags, TMember[]> safeEnumerate)
+        where TMember : MemberInfo
+    {
+        if (type is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var member = directLookup(type, flags);
+            return member != null && CanLoadSignature(member) ? member : null;
+        }
+        catch (Exception ex) when (IsMetadataLoadFailure(ex))
+        {
+            // The direct lookup was poisoned by an unloadable member (the target
+            // or a sibling reflected over during the search). Recover via the
+            // guarded enumeration, which skips only the offending members.
+            foreach (var member in safeEnumerate(type, flags))
+            {
+                if (string.Equals(member.Name, name, StringComparison.Ordinal))
+                {
+                    return member;
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -53,14 +53,14 @@ public sealed class ImportedClassSymbol : Symbol
     public bool TryLookupMember(string text, NameExpressionSyntax ne, out MemberInfo member)
     {
         _ = ne;
-        var property = ClassType.GetProperty(text, BindingFlags.Public | BindingFlags.Static);
+        var property = ClrTypeUtilities.SafeGetProperty(ClassType, text, BindingFlags.Public | BindingFlags.Static);
         if (property != null && property.GetIndexParameters().Length == 0)
         {
             member = property;
             return true;
         }
 
-        var field = ClassType.GetField(text, BindingFlags.Public | BindingFlags.Static);
+        var field = ClrTypeUtilities.SafeGetField(ClassType, text, BindingFlags.Public | BindingFlags.Static);
         if (field != null)
         {
             member = field;
@@ -99,7 +99,7 @@ public sealed class ImportedClassSymbol : Symbol
     {
         function = null;
         isAmbiguous = false;
-        var methods = ClassType.GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public);
+        var methods = ClrTypeUtilities.SafeGetMethods(ClassType, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public);
         var nameMatches = methods.Where(m => m.Name == text).ToList();
         if (nameMatches.Count == 0)
         {

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="GSharp.Core.Tests" />
+    <InternalsVisibleTo Include="GSharp.LanguageServer" />
   </ItemGroup>
 
 </Project>

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -945,7 +945,7 @@ public static class CompletionComputer
 
         var flags = BindingFlags.Public | (staticMembers ? BindingFlags.Static : BindingFlags.Instance);
 
-        foreach (var property in clrType.GetProperties(flags))
+        foreach (var property in ClrTypeUtilities.SafeGetProperties(clrType, flags))
         {
             if (property.GetIndexParameters().Length == 0)
             {
@@ -953,13 +953,13 @@ public static class CompletionComputer
             }
         }
 
-        foreach (var field in clrType.GetFields(flags))
+        foreach (var field in ClrTypeUtilities.SafeGetFields(clrType, flags))
         {
             var kind = field.IsLiteral ? CompletionItemKind.Constant : CompletionItemKind.Field;
             AddItem(items, seen, field.Name, kind, $"{field.Name}: {field.FieldType.Name}");
         }
 
-        foreach (var method in clrType.GetMethods(flags))
+        foreach (var method in ClrTypeUtilities.SafeGetMethods(clrType, flags))
         {
             if (method.IsSpecialName)
             {
@@ -969,7 +969,7 @@ public static class CompletionComputer
             AddItem(items, seen, method.Name, CompletionItemKind.Method, $"{method.Name}(...): {method.ReturnType.Name}");
         }
 
-        foreach (var evt in clrType.GetEvents(flags))
+        foreach (var evt in ClrTypeUtilities.SafeGetEvents(clrType, flags))
         {
             AddItem(items, seen, evt.Name, CompletionItemKind.Event, evt.Name);
         }

--- a/test/Core.Tests/CodeAnalysis/Symbols/ClrTypeUtilitiesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ClrTypeUtilitiesTests.cs
@@ -1,0 +1,228 @@
+// <copyright file="ClrTypeUtilitiesTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #338: the per-overload metadata-load tolerance introduced for #321 is
+/// generalized to every CLR member enumeration site. These tests build a
+/// <see cref="System.Reflection.MetadataLoadContext"/> over a curated reference
+/// set that deliberately omits <c>System.Text.RegularExpressions</c>. The
+/// <see cref="Fixture338"/> type below has one "good" and one "bad" member of
+/// each kind (property, field, event, method, constructor); the bad members'
+/// signatures reference <see cref="Regex"/> / <see cref="MatchEvaluator"/>,
+/// which live in the omitted assembly, so touching their signatures throws a
+/// load failure under the MLC — exactly the situation the binder hits under
+/// <c>/r:</c>. The <c>ClrTypeUtilities.SafeGet*</c> helpers must skip only the
+/// offending member and keep every usable sibling.
+/// </summary>
+public class ClrTypeUtilitiesTests
+{
+    private const BindingFlags InstanceFlags = BindingFlags.Public | BindingFlags.Instance;
+
+    [Theory]
+    [InlineData(typeof(FileNotFoundException))]
+    [InlineData(typeof(FileLoadException))]
+    [InlineData(typeof(TypeLoadException))]
+    [InlineData(typeof(BadImageFormatException))]
+    [InlineData(typeof(MissingMethodException))]
+    [InlineData(typeof(MissingMemberException))]
+    [InlineData(typeof(NotSupportedException))]
+    public void IsMetadataLoadFailure_ClassifiesLoadExceptions(Type exceptionType)
+    {
+        var ex = (Exception)Activator.CreateInstance(exceptionType);
+        Assert.True(ClrTypeUtilities.IsMetadataLoadFailure(ex));
+    }
+
+    [Theory]
+    [InlineData(typeof(InvalidOperationException))]
+    [InlineData(typeof(ArgumentException))]
+    [InlineData(typeof(NullReferenceException))]
+    public void IsMetadataLoadFailure_DoesNotSwallowUnrelatedExceptions(Type exceptionType)
+    {
+        var ex = (Exception)Activator.CreateInstance(exceptionType);
+        Assert.False(ClrTypeUtilities.IsMetadataLoadFailure(ex));
+    }
+
+    [Fact]
+    public void SafeGetProperties_SkipsUnloadableMember_KeepsUsableSiblings()
+    {
+        var fixture = LoadFixtureUnderIncompleteContext();
+
+        var names = ClrTypeUtilities.SafeGetProperties(fixture, InstanceFlags)
+            .Select(p => p.Name)
+            .ToArray();
+
+        Assert.Contains(nameof(Fixture338.GoodProperty), names);
+        Assert.DoesNotContain(nameof(Fixture338.BadProperty), names);
+
+        // Sanity check: the raw reflection call genuinely throws on the bad
+        // member, proving the helper had something to tolerate.
+        var rawBad = fixture.GetProperties(InstanceFlags).Single(p => p.Name == nameof(Fixture338.BadProperty));
+        Assert.False(ClrTypeUtilities.CanLoadSignature(rawBad));
+        Assert.Throws<FileNotFoundException>(() => _ = rawBad.PropertyType);
+    }
+
+    [Fact]
+    public void SafeGetFields_SkipsUnloadableMember_KeepsUsableSiblings()
+    {
+        var fixture = LoadFixtureUnderIncompleteContext();
+
+        var names = ClrTypeUtilities.SafeGetFields(fixture, InstanceFlags)
+            .Select(f => f.Name)
+            .ToArray();
+
+        Assert.Contains(nameof(Fixture338.GoodField), names);
+        Assert.DoesNotContain(nameof(Fixture338.BadField), names);
+    }
+
+    [Fact]
+    public void SafeGetEvents_SkipsUnloadableMember_KeepsUsableSiblings()
+    {
+        var fixture = LoadFixtureUnderIncompleteContext();
+
+        var names = ClrTypeUtilities.SafeGetEvents(fixture, InstanceFlags)
+            .Select(e => e.Name)
+            .ToArray();
+
+        Assert.Contains(nameof(Fixture338.GoodEvent), names);
+        Assert.DoesNotContain(nameof(Fixture338.BadEvent), names);
+    }
+
+    [Fact]
+    public void SafeGetMethods_SkipsUnloadableMembers_KeepsUsableSiblings()
+    {
+        var fixture = LoadFixtureUnderIncompleteContext();
+
+        var names = ClrTypeUtilities.SafeGetMethods(fixture, InstanceFlags)
+            .Select(m => m.Name)
+            .ToArray();
+
+        Assert.Contains(nameof(Fixture338.GoodMethod), names);
+        Assert.DoesNotContain(nameof(Fixture338.BadParameterMethod), names);
+        Assert.DoesNotContain(nameof(Fixture338.BadReturnMethod), names);
+    }
+
+    [Fact]
+    public void SafeGetConstructors_SkipsUnloadableOverload_KeepsUsableSiblings()
+    {
+        var fixture = LoadFixtureUnderIncompleteContext();
+
+        var ctors = ClrTypeUtilities.SafeGetConstructors(fixture, InstanceFlags);
+
+        Assert.Contains(ctors, c => c.GetParameters().Length == 0);
+        Assert.DoesNotContain(ctors, c => c.GetParameters().Length == 1);
+    }
+
+    [Fact]
+    public void SafeGetProperty_ByName_ReturnsUsableMember_NullForUnloadable()
+    {
+        var fixture = LoadFixtureUnderIncompleteContext();
+
+        Assert.NotNull(ClrTypeUtilities.SafeGetProperty(fixture, nameof(Fixture338.GoodProperty), InstanceFlags));
+        Assert.Null(ClrTypeUtilities.SafeGetProperty(fixture, nameof(Fixture338.BadProperty), InstanceFlags));
+    }
+
+    [Fact]
+    public void SafeGetField_ByName_ReturnsUsableMember_NullForUnloadable()
+    {
+        var fixture = LoadFixtureUnderIncompleteContext();
+
+        Assert.NotNull(ClrTypeUtilities.SafeGetField(fixture, nameof(Fixture338.GoodField), InstanceFlags));
+        Assert.Null(ClrTypeUtilities.SafeGetField(fixture, nameof(Fixture338.BadField), InstanceFlags));
+    }
+
+    [Fact]
+    public void SafeGetEvent_ByName_ReturnsUsableMember_NullForUnloadable()
+    {
+        var fixture = LoadFixtureUnderIncompleteContext();
+
+        Assert.NotNull(ClrTypeUtilities.SafeGetEvent(fixture, nameof(Fixture338.GoodEvent), InstanceFlags));
+        Assert.Null(ClrTypeUtilities.SafeGetEvent(fixture, nameof(Fixture338.BadEvent), InstanceFlags));
+    }
+
+    /// <summary>
+    /// Loads <see cref="Fixture338"/> through a MetadataLoadContext whose
+    /// reference set intentionally omits <c>System.Text.RegularExpressions</c>,
+    /// so any signature referencing <see cref="Regex"/> / <see cref="MatchEvaluator"/>
+    /// throws a <see cref="FileNotFoundException"/> when touched.
+    /// </summary>
+    private static Type LoadFixtureUnderIncompleteContext()
+    {
+        var trusted = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? string.Empty)
+            .Split(Path.PathSeparator)
+            .Where(p => !string.IsNullOrEmpty(p))
+            .ToList();
+
+        // Drop the assembly that defines Regex / MatchEvaluator so the bad
+        // members become unresolvable, mirroring a transitive assembly that was
+        // not supplied via /r:.
+        var paths = trusted
+            .Where(p => !string.Equals(Path.GetFileNameWithoutExtension(p), "System.Text.RegularExpressions", StringComparison.OrdinalIgnoreCase))
+            .Append(typeof(ClrTypeUtilitiesTests).Assembly.Location)
+            .Where(p => !string.IsNullOrEmpty(p))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var resolver = new PathAssemblyResolver(paths);
+        var mlc = new MetadataLoadContext(resolver, coreAssemblyName: "System.Private.CoreLib");
+        var assembly = mlc.LoadFromAssemblyPath(typeof(ClrTypeUtilitiesTests).Assembly.Location);
+        var fixture = assembly.GetType(typeof(Fixture338).FullName, throwOnError: true);
+
+        // Guard: the regex assembly really is absent from this context.
+        Assert.DoesNotContain(
+            mlc.GetAssemblies(),
+            a => string.Equals(a.GetName().Name, "System.Text.RegularExpressions", StringComparison.OrdinalIgnoreCase));
+
+        return fixture;
+    }
+}
+
+/// <summary>
+/// Issue #338 reflection fixture. Each member kind has a "good" sibling whose
+/// signature only touches core types and a "bad" sibling whose signature
+/// references <see cref="Regex"/> / <see cref="MatchEvaluator"/> from the
+/// deliberately-omitted <c>System.Text.RegularExpressions</c> assembly.
+/// </summary>
+#pragma warning disable CS0067 // event is never used; only its signature is reflected over.
+#pragma warning disable CS0649 // field is never assigned; only its signature is reflected over.
+internal sealed class Fixture338
+{
+    public Fixture338()
+    {
+    }
+
+    public Fixture338(Regex pattern)
+    {
+        _ = pattern;
+    }
+
+    public event EventHandler GoodEvent;
+
+    public event MatchEvaluator BadEvent;
+
+    public int GoodField;
+
+    public Regex BadField;
+
+    public int GoodProperty { get; set; }
+
+    public Regex BadProperty { get; set; }
+
+    public int GoodMethod() => 0;
+
+    public void BadParameterMethod(Regex pattern) => _ = pattern;
+
+    public Regex BadReturnMethod() => null;
+}
+#pragma warning restore CS0067
+#pragma warning restore CS0649


### PR DESCRIPTION
Fixes #338.

## Problem
The fix for #321 made only the **function-lookup** path tolerant of CLR members whose signature references a type that cannot be loaded/projected under the reference `MetadataLoadContext` (e.g. a ref-struct, or a type in a transitive assembly not supplied via `/r:`). Everywhere else, touching such a member while enumerating a type's members threw a load exception, and that throw sank the **entire** member set — producing a spurious `GS0159`/not-found even though other usable members existed.

## Change
Centralized the "is this a metadata-load failure" predicate and a set of tolerant reflection helpers in `ClrTypeUtilities`, and routed every CLR member enumeration site through them:

- `IsMetadataLoadFailure(Exception)` — single shared predicate (`OverloadResolution` now delegates to it).
- `CanLoadSignature(MemberInfo)` — probes a member's signature types.
- `SafeGetProperties/Fields/Events/Constructors/Methods` — tolerant enumeration; skips only the offending member.
- `SafeGetProperty/Field/Event` — tolerant by-name lookup; recovers via guarded enumeration when a sibling poisons the direct lookup.

### Enumeration sites hardened
- **Properties** — instance member access, inherited CLR base member access, indexer enumeration, open-definition indexer mapping, imported static member lookup.
- **Fields** — instance/inherited/static field access, `foreach`-pattern `Current`, CLR assignment targets.
- **Events** — event-subscription binding.
- **Constructors** — instance `.ctor` overload sets and CLR base-constructor initializers.
- **Methods** — imported static/instance function lookup, hover/completion.
- **Member-access binding path** — CLR receiver member reads in the binder.
- **LanguageServer** hover/completion member enumeration.

## Tests
`ClrTypeUtilitiesTests` builds a `MetadataLoadContext` that deliberately omits `System.Text.RegularExpressions`, so a fixture's `Regex`/`MatchEvaluator`-typed members are unloadable while their siblings are fine. Each `SafeGet*` helper is asserted to skip the offending member and keep the usable ones; the predicate classification is covered too.

## Test results
All projects green: Sdk 24, Interpreter 50, LanguageServer 117, Core 1394 (incl. 18 new), Compiler 246 — **1831 passed, 0 failed, 0 skipped**.

No new SyntaxKind/BoundNodeKind/operator, so no coverage-matrix changes.
