### PR TITLE
Fix #340: complete transitive reference closure for the MetadataLoadContext

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -186,6 +186,12 @@ ADR-0047 introduces Kotlin-style attribute syntax (`@Foo(...)`) and the `@Attrib
 | GS9005 | Error | Cannot take the address of a constant. | `&myConst` where `myConst` is declared `const`. |
 | GS9006 | Error | Pointer type cannot be a field type. | A `struct` field declared with a pointer or `ref` type. |
 
+### Reference closure diagnostics (GS9100)
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS9100 | **Warning** | One or more assemblies supplied via `/r:` depend (transitively) on assemblies that were not also supplied, so the reference set is not a complete transitive closure. The compiler degrades gracefully — members whose signatures live in the missing assemblies are skipped rather than aborting the build — but the affected members become invisible. The message names the missing assemblies. Add the missing package/project reference (the SDK passes `@(ReferencePathWithRefAssemblies)`, MSBuild's full transitive closure, so this normally only appears with a hand-rolled `/r:` set). Suppress with `/nowarn:GS9100`. | `gsc /r:LibAsmA.dll app.gs` where `LibAsmA.dll` references `DepAsmB.dll` and `DepAsmB.dll` is not also passed. |
+
 ### Internal / emit diagnostics (GS9998–GS9999)
 
 These diagnostics indicate an internal compiler problem. If you encounter them, please file an issue.

--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -81,6 +81,9 @@ public class Program
         var references = parsed.References.Count > 0
             ? ReferenceResolver.WithReferences(parsed.References)
             : null;
+
+        ReportMissingTransitiveReferences(references, parsed);
+
         var compilation = new Compilation(references, syntaxTrees.ToArray())
         {
             ImplicitSystemImport = parsed.ImplicitSystemImport,
@@ -101,6 +104,34 @@ public class Program
         }
 
         return Emit(compilation, parsed);
+    }
+
+    private static void ReportMissingTransitiveReferences(ReferenceResolver references, CommandLineArgs args)
+    {
+        if (references is null || references.MissingTransitiveReferences.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        // GS9100 is advisory: the resolver already degrades gracefully (the
+        // affected members are skipped), but a genuinely under-referenced
+        // project benefits from naming the missing assemblies (issue #340).
+        const string code = "GS9100";
+        if (args.NoWarnIds.Contains(code))
+        {
+            return;
+        }
+
+        // Anchor the diagnostic at the first source file so the SDK BuildTask's
+        // diagnostic regex surfaces it as a structured MSBuild warning.
+        var file = args.SourceFiles.Count > 0
+            ? Path.GetFullPath(args.SourceFiles[0])
+            : "gsc";
+
+        var names = string.Join(", ", references.MissingTransitiveReferences);
+        Console.Out.WriteLine(
+            $"{file}(1,1,1,1): warning {code}: One or more referenced assemblies depend on assemblies that were not supplied via /r: ({names}). " +
+            "Members that reference these assemblies will be skipped. Ensure the full transitive closure of references is passed (e.g. add the missing package or project reference).");
     }
 
     private static int Interpret(Compilation compilation, CommandLineArgs args)

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -52,17 +52,37 @@ public sealed class ReferenceResolver
 
     private readonly ImmutableArray<Assembly> assemblies;
     private readonly MetadataLoadContext metadataContext;
+    private readonly ImmutableArray<string> missingTransitiveReferences;
 
     private ReferenceResolver(ImmutableArray<Assembly> assemblies, MetadataLoadContext metadataContext)
+        : this(assemblies, metadataContext, ImmutableArray<string>.Empty)
+    {
+    }
+
+    private ReferenceResolver(ImmutableArray<Assembly> assemblies, MetadataLoadContext metadataContext, ImmutableArray<string> missingTransitiveReferences)
     {
         this.assemblies = assemblies;
         this.metadataContext = metadataContext;
+        this.missingTransitiveReferences = missingTransitiveReferences;
     }
 
     /// <summary>
     /// Gets the assemblies this resolver searches, in priority order.
     /// </summary>
     public ImmutableArray<Assembly> Assemblies => assemblies;
+
+    /// <summary>
+    /// Gets the simple names of assemblies that are referenced (transitively)
+    /// by the supplied reference set but could not be resolved from either that
+    /// set or the gsc host runtime. An empty array means the supplied references
+    /// form a complete transitive closure. A non-empty array indicates the
+    /// project is under-referenced: touching a member whose signature lives in
+    /// one of these assemblies would otherwise throw deep in member
+    /// enumeration, so the resolver degrades gracefully (the member is skipped)
+    /// and callers may surface a diagnostic naming the missing assemblies
+    /// (issue #340).
+    /// </summary>
+    public ImmutableArray<string> MissingTransitiveReferences => missingTransitiveReferences;
 
     /// <summary>
     /// Gets a resolver that searches the runtime's currently loaded
@@ -117,7 +137,7 @@ public sealed class ReferenceResolver
             }
         }
 
-        var resolver = new PathAssemblyResolver(resolverPaths);
+        var resolver = new FallbackMetadataAssemblyResolver(resolverPaths);
         var mlc = new MetadataLoadContext(resolver, coreAssemblyName: ChooseCoreAssemblyName(resolverPaths.ToArray()));
 
         var builder = ImmutableArray.CreateBuilder<Assembly>();
@@ -140,7 +160,10 @@ public sealed class ReferenceResolver
             }
         }
 
-        return new ReferenceResolver(builder.ToImmutable(), mlc);
+        var loaded = builder.ToImmutable();
+        var missing = ComputeMissingTransitiveReferences(loaded, mlc, resolver);
+
+        return new ReferenceResolver(loaded, mlc, missing);
     }
 
     /// <summary>
@@ -400,6 +423,142 @@ public sealed class ReferenceResolver
 
         return tpa.Split(Path.PathSeparator)
                   .Where(p => !string.IsNullOrWhiteSpace(p) && File.Exists(p));
+    }
+
+    /// <summary>
+    /// Eagerly verifies that the supplied reference set forms a complete
+    /// transitive closure. For every primary reference, each assembly it names
+    /// (one hop) is probed against the load context's resolver; any name that
+    /// neither the supplied set nor the gsc host runtime can satisfy is
+    /// reported as missing. This converts a latent
+    /// <see cref="FileNotFoundException"/>/<see cref="TypeLoadException"/> that
+    /// would otherwise surface deep in member enumeration into an actionable,
+    /// up-front signal (issue #340).
+    /// </summary>
+    private static ImmutableArray<string> ComputeMissingTransitiveReferences(
+        ImmutableArray<Assembly> loaded,
+        MetadataLoadContext mlc,
+        FallbackMetadataAssemblyResolver resolver)
+    {
+        var missing = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var asm in loaded)
+        {
+            AssemblyName[] referenced;
+            try
+            {
+                referenced = asm.GetReferencedAssemblies();
+            }
+            catch (Exception)
+            {
+                // A malformed reference table must not abort closure analysis.
+                continue;
+            }
+
+            foreach (var refName in referenced)
+            {
+                if (string.IsNullOrEmpty(refName?.Name))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    // LoadFromAssemblyName forces the resolver to locate the
+                    // dependency. Success means it is in the closure; a load
+                    // failure means it is genuinely missing.
+                    var dependency = mlc.LoadFromAssemblyName(refName);
+                    if (dependency == null)
+                    {
+                        missing.Add(refName.Name);
+                    }
+                }
+                catch (Exception ex) when (
+                    ex is FileNotFoundException
+                        or FileLoadException
+                        or BadImageFormatException
+                        or TypeLoadException)
+                {
+                    missing.Add(refName.Name);
+                }
+            }
+        }
+
+        // Fold in any names the resolver itself failed to satisfy while loading
+        // the primaries (e.g. a primary's core-assembly dependency).
+        foreach (var name in resolver.UnresolvedSimpleNames)
+        {
+            missing.Add(name);
+        }
+
+        return missing.Count == 0 ? ImmutableArray<string>.Empty : missing.ToImmutableArray();
+    }
+
+    /// <summary>
+    /// A <see cref="MetadataAssemblyResolver"/> that resolves from a supplied
+    /// set of paths (via an inner <see cref="PathAssemblyResolver"/>) and, when
+    /// that fails, degrades gracefully: instead of allowing the
+    /// <see cref="MetadataLoadContext"/> to surface an exception for an
+    /// unresolved transitive dependency, it records the offending simple name
+    /// and returns <see langword="null"/> so the caller can skip the affected
+    /// member (issue #340). The recorded names feed the
+    /// <see cref="MissingTransitiveReferences"/> diagnostic surface.
+    /// </summary>
+    private sealed class FallbackMetadataAssemblyResolver : MetadataAssemblyResolver
+    {
+        private readonly PathAssemblyResolver inner;
+        private readonly HashSet<string> unresolved = new(StringComparer.OrdinalIgnoreCase);
+        private readonly object gate = new();
+
+        public FallbackMetadataAssemblyResolver(IEnumerable<string> paths)
+        {
+            inner = new PathAssemblyResolver(paths);
+        }
+
+        public IEnumerable<string> UnresolvedSimpleNames
+        {
+            get
+            {
+                lock (gate)
+                {
+                    return unresolved.ToArray();
+                }
+            }
+        }
+
+        public override Assembly Resolve(MetadataLoadContext context, AssemblyName assemblyName)
+        {
+            try
+            {
+                var resolved = inner.Resolve(context, assemblyName);
+                if (resolved != null)
+                {
+                    return resolved;
+                }
+            }
+            catch (Exception ex) when (
+                ex is FileNotFoundException
+                    or FileLoadException
+                    or BadImageFormatException)
+            {
+                // Fall through to record-and-degrade below.
+            }
+
+            var name = assemblyName?.Name;
+            if (!string.IsNullOrEmpty(name))
+            {
+                lock (gate)
+                {
+                    unresolved.Add(name);
+                }
+            }
+
+            // Returning null lets MetadataLoadContext raise a load failure only
+            // if a member actually depends on this assembly; the per-member
+            // tolerance in OverloadResolution then skips that member rather than
+            // aborting the whole lookup.
+            return null;
+        }
     }
 }
 

--- a/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
+++ b/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
@@ -29,6 +29,16 @@
       <_GsharpRefAssemblyPath Condition=" '$(ProduceReferenceAssembly)' == 'true' ">@(IntermediateRefAssembly)</_GsharpRefAssemblyPath>
     </PropertyGroup>
 
+    <!-- Reference set forwarded to gsc via /r:. We pass
+         @(ReferencePathWithRefAssemblies) — the same complete, transitively
+         closed item csc consumes — rather than @(ReferencePath). MSBuild's
+         ResolveAssemblyReference populates this with the full transitive
+         closure of reference assemblies (direct references plus their
+         dependencies, substituting ref-assemblies where available). Passing
+         the closure guarantees gsc's MetadataLoadContext can resolve every
+         transitive dependency a referenced member touches; an incomplete set
+         otherwise surfaces as a FileNotFoundException/TypeLoadException deep in
+         member enumeration (issue #340). -->
     <BuildTask
         GsharpCompilerFullPath="$(GsharpCompilerFullPath)"
         OutputPath="$(IntermediateOutputPath)"
@@ -49,7 +59,7 @@
         TreatWarningsAsErrors="$(TreatWarningsAsErrors)"
         WarningsAsErrors="$(WarningsAsErrors)"
         Compile="@(Compile)"
-        References="@(ReferencePath)"
+        References="@(ReferencePathWithRefAssemblies)"
         ResponseFilePath="$(IntermediateOutputPath)$(TargetName).rsp" />
 
     <ItemGroup>

--- a/test/Compiler.Tests/ProgramTests.cs
+++ b/test/Compiler.Tests/ProgramTests.cs
@@ -5,6 +5,8 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
 using Xunit;
 
 namespace GSharp.Compiler.Tests;
@@ -414,5 +416,99 @@ public class ProgramTests
             try { Directory.Delete(tempDir, recursive: true); } catch { }
             try { File.Delete(sample); } catch { }
         }
+    }
+
+    [Fact]
+    public void Main_UnderReferencedClosure_EmitsGs9100Warning()
+    {
+        // Issue #340: when a /r: reference depends on an assembly that was not
+        // also supplied, gsc must not crash; it emits an advisory GS9100 naming
+        // the missing assembly while the resolver degrades gracefully.
+        var refDir = Directory.CreateTempSubdirectory("gsc_ref340_").FullName;
+        var libPath = BuildLibraryWithMissingDependency(refDir);
+
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package P\n\nfunc Main() {\n}\n");
+        var tempDir = Directory.CreateTempSubdirectory("gsc_out340_").FullName;
+        var outPath = Path.Combine(tempDir, "P.dll");
+
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var exit = Program.Main(new[] { "/out:" + outPath, "/target:library", "/r:" + libPath, sample });
+            Assert.Equal(0, exit);
+
+            var output = outWriter.ToString();
+            Assert.Contains("warning GS9100", output);
+            Assert.Contains("DepAsmB", output);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+            try { Directory.Delete(refDir, recursive: true); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Main_UnderReferencedClosure_NoWarnSuppressesGs9100()
+    {
+        var refDir = Directory.CreateTempSubdirectory("gsc_ref340n_").FullName;
+        var libPath = BuildLibraryWithMissingDependency(refDir);
+
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package P\n\nfunc Main() {\n}\n");
+        var tempDir = Directory.CreateTempSubdirectory("gsc_outn340_").FullName;
+        var outPath = Path.Combine(tempDir, "P.dll");
+
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var exit = Program.Main(new[] { "/out:" + outPath, "/target:library", "/nowarn:GS9100", "/r:" + libPath, sample });
+            Assert.Equal(0, exit);
+            Assert.DoesNotContain("GS9100", outWriter.ToString());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+            try { Directory.Delete(refDir, recursive: true); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
+
+    private static string BuildLibraryWithMissingDependency(string dir)
+    {
+        var coreAssembly = typeof(object).Assembly;
+
+        var depName = new AssemblyName("DepAsmB") { Version = new Version(1, 0, 0, 0) };
+        var depBuilder = new PersistedAssemblyBuilder(depName, coreAssembly);
+        var depModule = depBuilder.DefineDynamicModule("DepAsmB");
+        var marker = depModule.DefineType("Dep.Marker", TypeAttributes.Public | TypeAttributes.Class);
+        marker.CreateType();
+        depBuilder.Save(Path.Combine(dir, "DepAsmB.dll"));
+
+        var libName = new AssemblyName("LibAsmA") { Version = new Version(1, 0, 0, 0) };
+        var libBuilder = new PersistedAssemblyBuilder(libName, coreAssembly);
+        var libModule = libBuilder.DefineDynamicModule("LibAsmA");
+        var widget = libModule.DefineType("Lib.Widget", TypeAttributes.Public | TypeAttributes.Class);
+        var method = widget.DefineMethod(
+            "M",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(void),
+            new[] { marker });
+        method.GetILGenerator().Emit(OpCodes.Ret);
+        widget.CreateType();
+        var libPath = Path.Combine(dir, "LibAsmA.dll");
+        libBuilder.Save(libPath);
+
+        // The DepAsmB.dll is deliberately left in 'dir' but NOT passed via /r:,
+        // so the closure handed to gsc is incomplete.
+        return libPath;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTransitiveClosureTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTransitiveClosureTests.cs
@@ -1,0 +1,132 @@
+// <copyright file="ReferenceResolverTransitiveClosureTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Tests for issue #340: when the supplied <c>/r:</c> reference set is missing a
+/// transitive dependency of a referenced assembly, the
+/// <see cref="ReferenceResolver"/> must degrade gracefully — never throwing an
+/// unhandled exception out of construction or member enumeration — and surface
+/// the missing assembly so a diagnostic can be emitted.
+/// </summary>
+public class ReferenceResolverTransitiveClosureTests : IDisposable
+{
+    private readonly string scratchDir;
+
+    /// <summary>
+    /// Initializes a new instance of the
+    /// <see cref="ReferenceResolverTransitiveClosureTests"/> class, creating an
+    /// isolated scratch directory next to the test binaries to hold the two
+    /// synthesized assemblies.
+    /// </summary>
+    public ReferenceResolverTransitiveClosureTests()
+    {
+        scratchDir = Path.Combine(AppContext.BaseDirectory, "gs340-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(scratchDir);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(scratchDir))
+            {
+                Directory.Delete(scratchDir, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void WithReferences_MissingTransitiveDependency_DoesNotThrow_AndIsReported()
+    {
+        var (libPath, _) = BuildLibraryWithMissingDependency();
+
+        // Supplying only the library (and the host BCL fallback) — but NOT the
+        // dependency it references — must not throw out of construction.
+        var resolver = ReferenceResolver.WithReferences(new[] { libPath });
+
+        // The directly referenced type still resolves from the supplied set.
+        Assert.True(resolver.TryResolveType("Lib.Widget", out var widget));
+        Assert.NotNull(widget);
+
+        // The missing transitive dependency is reported by name so a diagnostic
+        // can be raised for an under-referenced project.
+        Assert.Contains("DepAsmB", resolver.MissingTransitiveReferences);
+    }
+
+    [Fact]
+    public void OverloadResolution_SkipsMember_WhoseSignatureNeedsMissingAssembly()
+    {
+        var (libPath, _) = BuildLibraryWithMissingDependency();
+        var resolver = ReferenceResolver.WithReferences(new[] { libPath });
+
+        Assert.True(resolver.TryResolveType("Lib.Widget", out var widget));
+
+        // M(Dep.Marker) references the omitted assembly; reflecting over its
+        // parameter throws a load failure. Overload resolution must treat the
+        // member as simply not applicable rather than letting the exception
+        // escape (issue #340 / #321 per-member tolerance).
+        var candidate = widget.GetMethod("M", BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(candidate);
+
+        var result = OverloadResolution.Resolve(new[] { candidate }, Array.Empty<Type>());
+        Assert.Equal(OverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
+    }
+
+    /// <summary>
+    /// Synthesizes two assemblies on disk: <c>DepAsmB</c> defining
+    /// <c>Dep.Marker</c>, and <c>LibAsmA</c> defining <c>Lib.Widget</c> with a
+    /// static method <c>M(Dep.Marker)</c> so that LibAsmA carries an assembly
+    /// reference to DepAsmB. Only the LibAsmA path is returned for use; the
+    /// DepAsmB path is deliberately withheld from the resolver to model an
+    /// incomplete transitive closure.
+    /// </summary>
+    private (string LibPath, string DepPath) BuildLibraryWithMissingDependency()
+    {
+        var coreAssembly = typeof(object).Assembly;
+
+        var depName = new AssemblyName("DepAsmB") { Version = new Version(1, 0, 0, 0) };
+        var depBuilder = new PersistedAssemblyBuilder(depName, coreAssembly);
+        var depModule = depBuilder.DefineDynamicModule("DepAsmB");
+        var marker = depModule.DefineType("Dep.Marker", TypeAttributes.Public | TypeAttributes.Class);
+        marker.CreateType();
+        var depPath = Path.Combine(scratchDir, "DepAsmB.dll");
+        depBuilder.Save(depPath);
+
+        var libName = new AssemblyName("LibAsmA") { Version = new Version(1, 0, 0, 0) };
+        var libBuilder = new PersistedAssemblyBuilder(libName, coreAssembly);
+        var libModule = libBuilder.DefineDynamicModule("LibAsmA");
+        var widget = libModule.DefineType("Lib.Widget", TypeAttributes.Public | TypeAttributes.Class);
+        var method = widget.DefineMethod(
+            "M",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(void),
+            new[] { marker });
+        method.GetILGenerator().Emit(OpCodes.Ret);
+        widget.CreateType();
+        var libPath = Path.Combine(scratchDir, "LibAsmA.dll");
+        libBuilder.Save(libPath);
+
+        return (libPath, depPath);
+    }
+}

--- a/test/Sdk.Tests/SdkLayoutTests.cs
+++ b/test/Sdk.Tests/SdkLayoutTests.cs
@@ -95,7 +95,10 @@ public class SdkLayoutTests
         var attrs = buildTask!.Attributes().ToDictionary(a => a.Name.LocalName, a => a.Value);
         Assert.Equal("$(GsharpCompilerFullPath)", attrs["GsharpCompilerFullPath"]);
         Assert.Equal("@(Compile)", attrs["Compile"]);
-        Assert.Equal("@(ReferencePath)", attrs["References"]);
+        // gsc must receive the full transitive closure of references — the same
+        // complete item csc consumes — so the MetadataLoadContext can resolve
+        // every transitive dependency a referenced member touches (issue #340).
+        Assert.Equal("@(ReferencePathWithRefAssemblies)", attrs["References"]);
         Assert.Equal("$(OutputType)", attrs["OutputType"]);
         Assert.Equal("$(TargetFramework)", attrs["TargetFramework"]);
 


### PR DESCRIPTION
Fixes #340.

## Problem
Reading a CLR member's parameter/return type forces the MetadataLoadContext (MLC) to resolve that type's defining assembly from the supplied `/r:` set only. If an overload references a type from an assembly not in the closure (a missing transitive dependency, or a type that legitimately needs an out-of-set assembly), touching that parameter throws `FileNotFoundException`/`TypeLoadException` deep in member enumeration instead of producing a clear signal.

## What changed

### SDK — guarantee the full transitive closure is passed
`Gsharp.NET.Core.Sdk.targets` now forwards `@(ReferencePathWithRefAssemblies)` (MSBuild's complete, transitively-closed reference set — the same item `csc` consumes) to `gsc` via `/r:`, instead of `@(ReferencePath)`. This ensures the MLC can resolve every transitive dependency a referenced member touches.

### Resolver — graceful fallback
`ReferenceResolver.WithReferences` now uses a custom `FallbackMetadataAssemblyResolver : MetadataAssemblyResolver` that, on failing to resolve an assembly, records the offending simple name and returns `null` instead of letting an exception escape. Combined with the existing per-member tolerance in `OverloadResolution`, the affected member is skipped rather than aborting the whole lookup. The resolver also eagerly probes each primary reference's dependencies to compute the closure gap, exposed as `ReferenceResolver.MissingTransitiveReferences`.

### Diagnostic
`gsc` emits an advisory **GS9100** warning naming the missing assemblies when the supplied `/r:` set is an incomplete closure. Suppressible via `/nowarn:GS9100`. Documented in `docs/diagnostics.md`.

## Tests
- `ReferenceResolverTransitiveClosureTests` (Core.Tests): synthesizes a library referencing a deliberately-omitted assembly; asserts construction does not throw, the missing assembly is reported, and overload resolution skips the member whose signature needs it.
- `ProgramTests` (Compiler.Tests): `gsc` emits GS9100 for an under-referenced closure and honors `/nowarn:GS9100`.
- `SdkLayoutTests` (Sdk.Tests): CoreCompile forwards `@(ReferencePathWithRefAssemblies)`.

All 1817 tests pass (0 failed).
