### PR TITLE
Fix #337: CLR member method-group to delegate conversion

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -231,6 +231,7 @@ ClrConversionCallExpression
 ClrEventSubscriptionExpression
 ClrIndexAssignmentExpression
 ClrIndexExpression
+ClrMethodGroupExpression
 ClrPropertyAccessExpression
 ClrPropertyAssignmentExpression
 ClrStaticCallExpression

--- a/samples/ClrMethodGroupToDelegate.golden
+++ b/samples/ClrMethodGroupToDelegate.golden
@@ -1,0 +1,3 @@
+hello from a static method group
+42
+instance method group

--- a/samples/ClrMethodGroupToDelegate.gs
+++ b/samples/ClrMethodGroupToDelegate.gs
@@ -1,0 +1,31 @@
+// file: ClrMethodGroupToDelegate.gs
+// Issue #337: a CLR member method group converts directly to a delegate value,
+// mirroring the named-function method-group support from #324/#332. This
+// sample exercises every supported shape:
+//   * a static member group on an imported type (Console.WriteLine, Int32.Parse),
+//   * an instance member group that captures its receiver (StringBuilder.Append),
+//   * overload selection driven by the target delegate signature.
+
+package GSharp.Example.ClrMethodGroupToDelegate
+
+import System
+import System.Text
+
+// Static member method group -> Action[string] (void return). Overload
+// selection picks WriteLine(string) among Console.WriteLine's many overloads.
+var write Action[string] = Console.WriteLine
+write.Invoke("hello from a static method group")
+
+// Static member method group -> Func[string, int32]. Int32.Parse(string) is
+// selected by the target signature.
+var parse Func[string, int32] = Int32.Parse
+Console.WriteLine(parse.Invoke("41") + 1)
+
+// Instance member method group -> Func[string, StringBuilder]. The receiver
+// `sb` is captured as the delegate target; Append(string) is selected.
+var sb = StringBuilder()
+var append Func[string, StringBuilder] = sb.Append
+append.Invoke("instance ")
+append.Invoke("method ")
+append.Invoke("group")
+Console.WriteLine(sb.ToString())

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -8486,6 +8486,16 @@ public sealed class Binder
                     var foundMember = classSymbol.TryLookupMember(ne.IdentifierToken.Text, ne, out var staticMember);
                     if (!foundMember)
                     {
+                        // Issue #337: a static member name that resolves to a
+                        // method (not a field/property) is a method group. In a
+                        // delegate-conversion context it materializes as a
+                        // delegate over the selected overload; the conversion
+                        // classifier decides which overload (if any) applies.
+                        if (TryBindClrMethodGroup(receiver: null, classSymbol.ClassType, wantStatic: true, ne.IdentifierToken.Text, out var staticGroup))
+                        {
+                            return staticGroup;
+                        }
+
                         Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
                         return new BoundErrorExpression(null);
                     }
@@ -8587,6 +8597,16 @@ public sealed class Binder
                     if (fld != null)
                     {
                         return new BoundClrPropertyAccessExpression(null, receiver, fld, TypeSymbol.FromClrType(fld.FieldType));
+                    }
+
+                    // Issue #337: an instance member name that resolves to a
+                    // method (not a field/property) is a method group bound to
+                    // this receiver. In a delegate-conversion context it captures
+                    // the receiver as the delegate target over the selected
+                    // overload.
+                    if (TryBindClrMethodGroup(receiver, clrReceiverType, wantStatic: false, memberName, out var instanceGroup))
+                    {
+                        return instanceGroup;
                     }
 
                     Diagnostics.ReportUnableToFindMember(ne.Location, memberName);
@@ -9710,6 +9730,14 @@ public sealed class Binder
 
     private BoundExpression BindConversion(TextLocation diagnosticLocation, BoundExpression expression, TypeSymbol type, bool allowExplicit = false)
     {
+        // Issue #337: a CLR member method group has no fixed type until the
+        // target delegate signature drives overload selection. Resolve it here,
+        // where the expected type is known, before classifying conversions.
+        if (expression is BoundClrMethodGroupExpression { ResolvedMethod: null } clrMethodGroup)
+        {
+            return BindClrMethodGroupConversion(diagnosticLocation, clrMethodGroup, type);
+        }
+
         var conversion = Conversion.Classify(expression.Type, type);
 
         if (!conversion.Exists)
@@ -9829,6 +9857,137 @@ public sealed class Binder
         var fnType = FunctionTypeSymbol.Get(parameterTypes.MoveToImmutable(), function.Type ?? TypeSymbol.Void);
         methodGroup = new BoundMethodGroupExpression(null, function, fnType);
         return true;
+    }
+
+    // Issue #337: build an (unresolved) CLR member method-group expression for a
+    // member name that resolves to a method on an imported static type or a CLR
+    // instance receiver. Collects every accessible name-matching overload of the
+    // requested static-ness; overload selection happens later in BindConversion
+    // once the target delegate signature is known. Returns false when the type
+    // exposes no method of that name (so the caller surfaces the member
+    // diagnostic).
+    private bool TryBindClrMethodGroup(BoundExpression receiver, Type declaringType, bool wantStatic, string name, out BoundExpression methodGroup)
+    {
+        methodGroup = null;
+
+        if (declaringType == null)
+        {
+            return false;
+        }
+
+        var flags = BindingFlags.Public | (wantStatic ? BindingFlags.Static : BindingFlags.Instance);
+        var candidates = ImmutableArray.CreateBuilder<MethodInfo>();
+        foreach (var method in declaringType.GetMethods(flags))
+        {
+            if (!string.Equals(method.Name, name, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Open generic methods and special-name accessors (property/event
+            // get_/set_/add_/remove_) are not directly convertible method-group
+            // members.
+            if (method.IsGenericMethodDefinition || method.IsSpecialName)
+            {
+                continue;
+            }
+
+            candidates.Add(method);
+        }
+
+        if (candidates.Count == 0)
+        {
+            return false;
+        }
+
+        methodGroup = new BoundClrMethodGroupExpression(null, receiver, declaringType, name, candidates.ToImmutable());
+        return true;
+    }
+
+    // Issue #337: resolve an unresolved CLR method group against an expected
+    // target type. The target must be a CLR delegate type; the group's overloads
+    // are filtered by signature compatibility with the delegate's Invoke method
+    // (arity + return-type compatibility), then C#-style overload resolution
+    // picks the single best candidate using the delegate's parameter types as
+    // the "argument" types. On success the resolved method-group node carries the
+    // selected MethodInfo and target delegate type; on failure a GS0218 is
+    // reported.
+    private BoundExpression BindClrMethodGroupConversion(TextLocation diagnosticLocation, BoundClrMethodGroupExpression group, TypeSymbol targetType)
+    {
+        var delegateClr = targetType?.ClrType;
+        if (delegateClr == null || !ClrTypeUtilities.IsDelegateType(delegateClr))
+        {
+            // A non-delegate target (e.g. `var x int32 = Console.WriteLine`) or
+            // an already-errored target: report unless the target itself is an
+            // error type (which already produced a diagnostic).
+            if (targetType != null && targetType != TypeSymbol.Error)
+            {
+                Diagnostics.ReportCannotConvertMethodGroup(diagnosticLocation, group.MethodName, targetType);
+            }
+
+            return new BoundErrorExpression(null);
+        }
+
+        var invoke = delegateClr.GetMethod("Invoke");
+        if (invoke == null)
+        {
+            Diagnostics.ReportCannotConvertMethodGroup(diagnosticLocation, group.MethodName, targetType);
+            return new BoundErrorExpression(null);
+        }
+
+        var invokeParams = invoke.GetParameters();
+        var argTypes = new Type[invokeParams.Length];
+        for (var i = 0; i < invokeParams.Length; i++)
+        {
+            argTypes[i] = invokeParams[i].ParameterType;
+        }
+
+        var applicable = new List<MethodInfo>();
+        foreach (var candidate in group.Candidates)
+        {
+            if (candidate.GetParameters().Length != invokeParams.Length)
+            {
+                continue;
+            }
+
+            if (!IsMethodGroupReturnCompatible(candidate.ReturnType, invoke.ReturnType))
+            {
+                continue;
+            }
+
+            applicable.Add(candidate);
+        }
+
+        if (applicable.Count > 0)
+        {
+            var resolution = OverloadResolution.Resolve(applicable, argTypes);
+            if (resolution.Outcome == OverloadResolution.ResolutionOutcome.Resolved)
+            {
+                return new BoundClrMethodGroupExpression(group.Syntax, group.Receiver, resolution.Best, targetType);
+            }
+        }
+
+        Diagnostics.ReportCannotConvertMethodGroup(diagnosticLocation, group.MethodName, targetType);
+        return new BoundErrorExpression(null);
+    }
+
+    // Issue #337: a method-group overload's return type is compatible with a
+    // delegate's Invoke return type when both are void, or when the method's
+    // (non-void) return is identity / implicitly reference- or value-convertible
+    // (by name, MetadataLoadContext-safe) to the delegate's (non-void) return.
+    private static bool IsMethodGroupReturnCompatible(Type methodReturn, Type invokeReturn)
+    {
+        var invokeVoid = invokeReturn == null
+            || string.Equals(invokeReturn.FullName, "System.Void", StringComparison.Ordinal);
+        var methodVoid = methodReturn == null
+            || string.Equals(methodReturn.FullName, "System.Void", StringComparison.Ordinal);
+
+        if (invokeVoid || methodVoid)
+        {
+            return invokeVoid && methodVoid;
+        }
+
+        return ClrTypeUtilities.IsAssignableByName(invokeReturn, methodReturn);
     }
 
     // ADR-0047 §6 / #175: if <paramref name="symbol"/> carries an

--- a/src/Core/CodeAnalysis/Binding/BoundClrMethodGroupExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrMethodGroupExpression.cs
@@ -1,0 +1,88 @@
+// <copyright file="BoundClrMethodGroupExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+#pragma warning disable CS1591
+#pragma warning disable SA1600
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #337: a bare reference to a CLR member method (a method group on an
+/// imported static type — e.g. <c>Console.WriteLine</c>, <c>Int32.Parse</c> —
+/// or on a CLR instance receiver — e.g. <c>sb.Append</c>) used in a value
+/// context. Unlike a named G# function group (<see cref="BoundMethodGroupExpression"/>),
+/// the target overload cannot be selected until the expected delegate signature
+/// is known, so the binder first produces the <em>unresolved</em> form carrying
+/// every name-matching overload, then <c>BindConversion</c> picks the single
+/// best <see cref="MethodInfo"/> against the target delegate's <c>Invoke</c>
+/// signature and produces the <em>resolved</em> form. The emitter materializes
+/// the resolved form as <c>ldnull/ldftn</c> (static) or
+/// <c>[dup] ldftn/ldvirtftn</c> over the captured receiver (instance), followed
+/// by a <c>newobj</c> of the target delegate.
+/// </summary>
+public sealed class BoundClrMethodGroupExpression : BoundExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundClrMethodGroupExpression"/>
+    /// class in its <em>unresolved</em> form: a name-matched set of overload
+    /// candidates awaiting overload selection against a target delegate type.
+    /// </summary>
+    /// <param name="syntax">The originating syntax node.</param>
+    /// <param name="receiver">The instance receiver, or <see langword="null"/> for a static group.</param>
+    /// <param name="declaringType">The CLR type declaring the candidates.</param>
+    /// <param name="methodName">The method-group name.</param>
+    /// <param name="candidates">All name-matching overloads.</param>
+    public BoundClrMethodGroupExpression(SyntaxNode syntax, BoundExpression receiver, Type declaringType, string methodName, ImmutableArray<MethodInfo> candidates)
+        : base(syntax)
+    {
+        Receiver = receiver;
+        DeclaringType = declaringType;
+        MethodName = methodName;
+        Candidates = candidates;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundClrMethodGroupExpression"/>
+    /// class in its <em>resolved</em> form: a single overload selected for a
+    /// concrete target delegate type.
+    /// </summary>
+    /// <param name="syntax">The originating syntax node.</param>
+    /// <param name="receiver">The instance receiver, or <see langword="null"/> for a static group.</param>
+    /// <param name="resolvedMethod">The selected overload.</param>
+    /// <param name="delegateType">The target delegate type symbol.</param>
+    public BoundClrMethodGroupExpression(SyntaxNode syntax, BoundExpression receiver, MethodInfo resolvedMethod, TypeSymbol delegateType)
+        : base(syntax)
+    {
+        Receiver = receiver;
+        DeclaringType = resolvedMethod.DeclaringType;
+        MethodName = resolvedMethod.Name;
+        Candidates = ImmutableArray.Create(resolvedMethod);
+        ResolvedMethod = resolvedMethod;
+        DelegateType = delegateType;
+    }
+
+    public BoundExpression Receiver { get; }
+
+    public Type DeclaringType { get; }
+
+    public string MethodName { get; }
+
+    public ImmutableArray<MethodInfo> Candidates { get; }
+
+    /// <summary>Gets the overload selected for the target delegate, or <see langword="null"/> while unresolved.</summary>
+    public MethodInfo ResolvedMethod { get; }
+
+    /// <summary>Gets the target delegate type symbol once resolved, or <see langword="null"/> while unresolved.</summary>
+    public TypeSymbol DelegateType { get; }
+
+    public override TypeSymbol Type => DelegateType ?? TypeSymbol.Error;
+
+    public override BoundNodeKind Kind => BoundNodeKind.ClrMethodGroupExpression;
+}

--- a/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -61,6 +61,7 @@ public enum BoundNodeKind
     TupleElementAccessExpression,
     FunctionLiteralExpression,
     MethodGroupExpression,
+    ClrMethodGroupExpression,
     IndirectCallExpression,
     ClrConstructorCallExpression,
     ClrPropertyAccessExpression,

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -202,6 +202,9 @@ public static class BoundNodePrinter
             case BoundNodeKind.MethodGroupExpression:
                 WriteMethodGroupExpression((BoundMethodGroupExpression)node, writer);
                 break;
+            case BoundNodeKind.ClrMethodGroupExpression:
+                WriteClrMethodGroupExpression((BoundClrMethodGroupExpression)node, writer);
+                break;
             case BoundNodeKind.IndirectCallExpression:
                 WriteIndirectCallExpression((BoundIndirectCallExpression)node, writer);
                 break;
@@ -1406,6 +1409,17 @@ public static class BoundNodePrinter
     private static void WriteMethodGroupExpression(BoundMethodGroupExpression node, IndentedTextWriter writer)
     {
         writer.WriteIdentifier(node.Function.Name);
+    }
+
+    private static void WriteClrMethodGroupExpression(BoundClrMethodGroupExpression node, IndentedTextWriter writer)
+    {
+        if (node.Receiver != null)
+        {
+            node.Receiver.WriteTo(writer);
+            writer.WritePunctuation(".");
+        }
+
+        writer.WriteIdentifier(node.MethodName);
     }
 
     private static void WriteIndirectCallExpression(BoundIndirectCallExpression node, IndentedTextWriter writer)

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -384,6 +384,8 @@ public abstract class BoundTreeRewriter
                 return RewriteFunctionLiteralExpression((BoundFunctionLiteralExpression)node);
             case BoundNodeKind.MethodGroupExpression:
                 return RewriteMethodGroupExpression((BoundMethodGroupExpression)node);
+            case BoundNodeKind.ClrMethodGroupExpression:
+                return RewriteClrMethodGroupExpression((BoundClrMethodGroupExpression)node);
             case BoundNodeKind.IndirectCallExpression:
                 return RewriteIndirectCallExpression((BoundIndirectCallExpression)node);
             case BoundNodeKind.ClrConstructorCallExpression:
@@ -1621,6 +1623,27 @@ public abstract class BoundTreeRewriter
     protected virtual BoundExpression RewriteMethodGroupExpression(BoundMethodGroupExpression node)
     {
         return node;
+    }
+
+    /// <summary>Rewrites a CLR method-group expression (issue #337).</summary>
+    /// <param name="node">The node to rewrite.</param>
+    /// <returns>The rewritten node.</returns>
+    protected virtual BoundExpression RewriteClrMethodGroupExpression(BoundClrMethodGroupExpression node)
+    {
+        if (node.Receiver == null)
+        {
+            return node;
+        }
+
+        var receiver = RewriteExpression(node.Receiver);
+        if (receiver == node.Receiver)
+        {
+            return node;
+        }
+
+        return node.ResolvedMethod != null
+            ? new BoundClrMethodGroupExpression(node.Syntax, receiver, node.ResolvedMethod, node.DelegateType)
+            : new BoundClrMethodGroupExpression(node.Syntax, receiver, node.DeclaringType, node.MethodName, node.Candidates);
     }
 
     /// <summary>Rewrites an indirect call (Phase 4.7).</summary>

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -691,6 +691,20 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Issue #337: reports that a CLR member method group cannot be converted to
+    /// the expected target type (it is not a compatible delegate type, or no
+    /// overload matches the delegate signature).
+    /// </summary>
+    /// <param name="location">The text location where the error was found.</param>
+    /// <param name="methodName">The method-group name.</param>
+    /// <param name="toType">The expected target type.</param>
+    public void ReportCannotConvertMethodGroup(TextLocation location, string methodName, TypeSymbol toType)
+    {
+        var message = $"Cannot convert method group '{methodName}' to '{toType}'. No overload matches the target delegate signature.";
+        Report(location, "GS0218", message);
+    }
+
+    /// <summary>
     /// Reports that we couldn't find the specified type.
     /// </summary>
     /// <param name="location">The text location where the error was found.</param>

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -10380,6 +10380,9 @@ internal sealed class ReflectionMetadataEmitter
                 case BoundMethodGroupExpression methodGroup:
                     this.EmitMethodGroup(methodGroup, overrideDelegateType: null);
                     break;
+                case BoundClrMethodGroupExpression clrMethodGroup:
+                    this.EmitClrMethodGroup(clrMethodGroup);
+                    break;
                 case BoundIndirectCallExpression indirect:
                     this.EmitIndirectCall(indirect);
                     break;
@@ -13012,6 +13015,54 @@ internal sealed class ReflectionMetadataEmitter
             this.il.OpCode(ILOpCode.Ldnull);
             this.il.OpCode(ILOpCode.Ldftn);
             this.il.Token(methodHandle);
+            this.il.OpCode(ILOpCode.Newobj);
+            this.il.Token(this.outer.GetCtorReference(delegateCtor));
+        }
+
+        // Issue #337: emit a resolved CLR member method group as a delegate over
+        // the selected overload. Static groups load a null target and the method
+        // address (`ldnull; ldftn`); instance groups evaluate the receiver and
+        // load its (virtual) address (`<recv>; [dup; ldvirtftn] / ldftn`),
+        // capturing the receiver as the delegate target. The constructed
+        // delegate is the resolved target type (`Func[...]`/`Action[...]` or a
+        // named delegate), resolved onto the emitter's reference context.
+        private void EmitClrMethodGroup(BoundClrMethodGroupExpression methodGroup)
+        {
+            var method = methodGroup.ResolvedMethod
+                ?? throw new InvalidOperationException(
+                    $"CLR method group '{methodGroup.MethodName}' reached emit without overload resolution.");
+
+            var hostDelegate = methodGroup.DelegateType?.ClrType
+                ?? throw new InvalidOperationException(
+                    $"CLR method group '{methodGroup.MethodName}' has no resolved target delegate type.");
+
+            var delegateType = this.outer.ResolveTargetDelegateClrType(hostDelegate);
+            var delegateCtor = delegateType.GetConstructors()[0];
+            var methodRef = this.outer.GetMethodReference(method);
+
+            if (method.IsStatic)
+            {
+                this.il.OpCode(ILOpCode.Ldnull);
+                this.il.OpCode(ILOpCode.Ldftn);
+                this.il.Token(methodRef);
+            }
+            else
+            {
+                this.EmitExpression(methodGroup.Receiver);
+
+                if (method.IsVirtual && !method.IsFinal)
+                {
+                    this.il.OpCode(ILOpCode.Dup);
+                    this.il.OpCode(ILOpCode.Ldvirtftn);
+                    this.il.Token(methodRef);
+                }
+                else
+                {
+                    this.il.OpCode(ILOpCode.Ldftn);
+                    this.il.Token(methodRef);
+                }
+            }
+
             this.il.OpCode(ILOpCode.Newobj);
             this.il.Token(this.outer.GetCtorReference(delegateCtor));
         }

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -490,6 +490,7 @@ public sealed class Evaluator
                 BoundNodeKind.TupleElementAccessExpression => EvaluateTupleElementAccessExpression((BoundTupleElementAccessExpression)node),
                 BoundNodeKind.FunctionLiteralExpression => EvaluateFunctionLiteralExpression((BoundFunctionLiteralExpression)node),
                 BoundNodeKind.MethodGroupExpression => EvaluateMethodGroupExpression((BoundMethodGroupExpression)node),
+                BoundNodeKind.ClrMethodGroupExpression => EvaluateClrMethodGroupExpression((BoundClrMethodGroupExpression)node),
                 BoundNodeKind.IndirectCallExpression => EvaluateIndirectCallExpression((BoundIndirectCallExpression)node),
                 BoundNodeKind.ClrConstructorCallExpression => EvaluateClrConstructorCallExpression((BoundClrConstructorCallExpression)node),
                 BoundNodeKind.ClrPropertyAccessExpression => EvaluateClrPropertyAccessExpression((BoundClrPropertyAccessExpression)node),
@@ -770,6 +771,24 @@ public sealed class Evaluator
         // the ClosureValue path.
         var body = program.Functions[node.Function];
         return new ClosureValue(node.Function, body, node.FunctionType, new Dictionary<VariableSymbol, object>());
+    }
+
+    private object EvaluateClrMethodGroupExpression(BoundClrMethodGroupExpression node)
+    {
+        // Issue #337: materialize the selected CLR overload as a real delegate
+        // of the target type. Static groups bind no receiver; instance groups
+        // capture the evaluated receiver as the delegate target.
+        var delegateType = node.DelegateType?.ClrType
+            ?? throw new InvalidOperationException(
+                $"CLR method group '{node.MethodName}' was not resolved to a target delegate type.");
+
+        if (node.ResolvedMethod.IsStatic)
+        {
+            return Delegate.CreateDelegate(delegateType, node.ResolvedMethod);
+        }
+
+        var receiver = EvaluateExpression(node.Receiver);
+        return Delegate.CreateDelegate(delegateType, receiver, node.ResolvedMethod);
     }
 
     private object EvaluateIndirectCallExpression(BoundIndirectCallExpression node)

--- a/test/Core.Tests/CodeAnalysis/Binding/ClrMethodGroupConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClrMethodGroupConversionTests.cs
@@ -1,0 +1,89 @@
+// <copyright file="ClrMethodGroupConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #337: converting a CLR member method group (static or instance) to a
+/// delegate value, with overload selection driven by the target delegate
+/// signature.
+/// </summary>
+public class ClrMethodGroupConversionTests
+{
+    [Fact]
+    public void StaticMethodGroup_ToFunc_SelectsOverloadAndInvokes()
+    {
+        // Int32.Parse(string) is selected by the Func[string, int32] target.
+        var result = Evaluate(@"
+import System
+
+var parse Func[string, int32] = Int32.Parse
+parse.Invoke(""41"")
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(41, result.Value);
+    }
+
+    [Fact]
+    public void StaticMethodGroup_ToAction_SelectsVoidOverload()
+    {
+        // Console.WriteLine has many overloads; the Action[string] target picks
+        // WriteLine(string). The resulting value is a real System.Action<string>.
+        var result = Evaluate(@"
+import System
+
+var write Action[string] = Console.WriteLine
+write
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.IsType<Action<string>>(result.Value);
+    }
+
+    [Fact]
+    public void InstanceMethodGroup_ToFunc_CapturesReceiver()
+    {
+        // sb.Append(string) is selected; the receiver `sb` is captured as the
+        // delegate target, so invoking the delegate mutates that instance.
+        var result = Evaluate(@"
+import System.Text
+
+var sb = StringBuilder()
+var append Func[string, StringBuilder] = sb.Append
+append.Invoke(""ab"")
+append.Invoke(""cd"")
+sb.ToString()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("abcd", result.Value);
+    }
+
+    [Fact]
+    public void MethodGroup_ToNonDelegateType_ReportsDiagnostic()
+    {
+        // A method group converted to a non-delegate target is rejected (GS0218).
+        var result = Evaluate(@"
+import System
+
+var x int32 = Console.WriteLine
+");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0218");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -231,6 +231,7 @@ ClrConversionCallExpression
 ClrEventSubscriptionExpression
 ClrIndexAssignmentExpression
 ClrIndexExpression
+ClrMethodGroupExpression
 ClrPropertyAccessExpression
 ClrPropertyAssignmentExpression
 ClrStaticCallExpression


### PR DESCRIPTION
Fixes #337.

Follow-up to #324/#332, which added method-group→delegate conversion for named G# functions. This adds the same for **CLR member method groups**.

## What works now
```gsharp
package App
import System
import System.Text

// static member group on an imported type (overload selection picks WriteLine(string))
var f Action[string] = Console.WriteLine
f.Invoke("hello")

// static member group with a return value
var h Func[string, int32] = Int32.Parse

// instance member group — receiver captured as the delegate target
var sb = StringBuilder()
var g Func[string, StringBuilder] = sb.Append
```

## Implementation
- **Binder**: `BindAccessorStep` now synthesizes a `BoundClrMethodGroupExpression` (carrying every name-matching overload) for a static member group on an imported type or an instance member group on a CLR receiver, instead of reporting `GS0158`. `BindConversion` resolves the group against the expected delegate signature, performing C#-style **overload selection** over the member's overloads — filtered by arity and return-type compatibility, then ranked by the delegate's `Invoke` parameter types. A non-delegate target or no matching overload reports the new **GS0218**.
- **Emit**: `ldnull/ldftn` for static groups; receiver capture with `ldftn` (or `dup; ldvirtftn` for virtual methods) for instance groups; then `newobj` of the resolved target delegate.
- **Evaluator**: materializes the selected overload via `Delegate.CreateDelegate`, capturing the receiver for instance groups.
- New `BoundNodeKind.ClrMethodGroupExpression` wired through printer/rewriter; `coverage-matrix.golden.txt` + `docs/coverage-matrix.md` updated.

## Tests
- Conformance sample `samples/ClrMethodGroupToDelegate.gs` (+ golden) covering static, instance, and overload-selection shapes (compiled via gsc, run under dotnet, stdout diffed).
- `ClrMethodGroupConversionTests` unit tests: static→Func, static→Action, instance→Func receiver capture, and the GS0218 negative case.

All solution tests pass (1818 passed, 0 failed).