### PR TITLE
docs: G# syntax accuracy sweep across docs website (#276)

### DIFF
--- a/website/docs/bridges/gsharp-for-go-developers.md
+++ b/website/docs/bridges/gsharp-for-go-developers.md
@@ -14,7 +14,7 @@ G# is a Go-inspired language for .NET. You will recognize packages, `func`, `def
 | --- | --- | --- |
 | `package main` | `package MyApp.Cli` | Packages map to CLR namespaces rather than import paths. |
 | `import "fmt"` | `import System` | Imports bind CLR namespaces, G# packages, and aliases. |
-| `func main()` | top-level statements or `func main()` | SDK projects synthesize an entry point from top-level statements. |
+| `func main()` | top-level statements or `func Main()` | SDK projects synthesize an entry point from top-level statements. |
 | `fmt.Println(x)` | `Console.WriteLine(x)` | Use .NET library types directly. |
 | `var x int` | `var x int32` or `var x int64` | G# uses width-bearing numeric names. |
 | `:=` | `:=` | Short declarations are available where inference is possible. |
@@ -56,7 +56,7 @@ Go exports identifiers by capitalization. G# uses explicit modifiers:
 
 ```gsharp
 public class Customer {
-    private var id string
+    private id string
     internal func DebugId() string { return id }
 }
 ```

--- a/website/docs/ref/clr-interop.md
+++ b/website/docs/ref/clr-interop.md
@@ -114,13 +114,13 @@ Event accessors on user types are declared with the G# `event` member form; impo
 Imported CLR operator overloads and conversion operators participate in binding. User-defined G# operator declarations use receiver syntax and map to CLR `op_*` names for emit and interop.
 
 ```gsharp
-type Vec struct {
+type Vec class {
     X int32
     Y int32
+}
 
-    func (v Vec) operator +(other Vec) Vec {
-        return Vec{X: v.X + other.X, Y: v.Y + other.Y}
-    }
+func (v Vec) operator +(other Vec) Vec {
+    return Vec{X: v.X + other.X, Y: v.Y + other.Y}
 }
 ```
 

--- a/website/docs/tooling/lsp.md
+++ b/website/docs/tooling/lsp.md
@@ -19,7 +19,7 @@ dotnet build src/LanguageServer
 By default, the server reads LSP messages from standard input and writes responses and notifications to standard output.
 
 ```bash
-dotnet src/LanguageServer/bin/Debug/net10.0/GSharp.LanguageServer.dll
+dotnet out/bin/Debug/LanguageServer/GSharp.LanguageServer.dll
 ```
 
 Recognized command-line arguments are:

--- a/website/docs/tutorials/dotnet-interop.md
+++ b/website/docs/tutorials/dotnet-interop.md
@@ -120,7 +120,7 @@ GSharp.Example.ImportedBaseClass.Args
 
 ## 3. Add extension functions
 
-An `extension` function lowers to a CLR extension method. Static extension containers are generated so C# and LINQ-style consumers can see the method:
+An extension function lowers to a CLR extension method. Static extension containers are generated so C# and LINQ-style consumers can see the method:
 
 ```gsharp title="ExtensionFunctions.gs"
 // file: ExtensionFunctions.gs

--- a/website/versioned_docs/version-0.1/bridges/gsharp-for-go-developers.md
+++ b/website/versioned_docs/version-0.1/bridges/gsharp-for-go-developers.md
@@ -14,7 +14,7 @@ G# is a Go-inspired language for .NET. You will recognize packages, `func`, `def
 | --- | --- | --- |
 | `package main` | `package MyApp.Cli` | Packages map to CLR namespaces rather than import paths. |
 | `import "fmt"` | `import System` | Imports bind CLR namespaces, G# packages, and aliases. |
-| `func main()` | top-level statements or `func main()` | SDK projects synthesize an entry point from top-level statements. |
+| `func main()` | top-level statements or `func Main()` | SDK projects synthesize an entry point from top-level statements. |
 | `fmt.Println(x)` | `Console.WriteLine(x)` | Use .NET library types directly. |
 | `var x int` | `var x int32` or `var x int64` | G# uses width-bearing numeric names. |
 | `:=` | `:=` | Short declarations are available where inference is possible. |
@@ -56,7 +56,7 @@ Go exports identifiers by capitalization. G# uses explicit modifiers:
 
 ```gsharp
 public class Customer {
-    private var id string
+    private id string
     internal func DebugId() string { return id }
 }
 ```

--- a/website/versioned_docs/version-0.1/ref/clr-interop.md
+++ b/website/versioned_docs/version-0.1/ref/clr-interop.md
@@ -114,13 +114,13 @@ Event accessors on user types are declared with the G# `event` member form; impo
 Imported CLR operator overloads and conversion operators participate in binding. User-defined G# operator declarations use receiver syntax and map to CLR `op_*` names for emit and interop.
 
 ```gsharp
-type Vec struct {
+type Vec class {
     X int32
     Y int32
+}
 
-    func (v Vec) operator +(other Vec) Vec {
-        return Vec{X: v.X + other.X, Y: v.Y + other.Y}
-    }
+func (v Vec) operator +(other Vec) Vec {
+    return Vec{X: v.X + other.X, Y: v.Y + other.Y}
 }
 ```
 

--- a/website/versioned_docs/version-0.1/tooling/lsp.md
+++ b/website/versioned_docs/version-0.1/tooling/lsp.md
@@ -19,7 +19,7 @@ dotnet build src/LanguageServer
 By default, the server reads LSP messages from standard input and writes responses and notifications to standard output.
 
 ```bash
-dotnet src/LanguageServer/bin/Debug/net10.0/GSharp.LanguageServer.dll
+dotnet out/bin/Debug/LanguageServer/GSharp.LanguageServer.dll
 ```
 
 Recognized command-line arguments are:

--- a/website/versioned_docs/version-0.1/tutorials/dotnet-interop.md
+++ b/website/versioned_docs/version-0.1/tutorials/dotnet-interop.md
@@ -120,7 +120,7 @@ GSharp.Example.ImportedBaseClass.Args
 
 ## 3. Add extension functions
 
-An `extension` function lowers to a CLR extension method. Static extension containers are generated so C# and LINQ-style consumers can see the method:
+An extension function lowers to a CLR extension method. Static extension containers are generated so C# and LINQ-style consumers can see the method:
 
 ```gsharp title="ExtensionFunctions.gs"
 // file: ExtensionFunctions.gs


### PR DESCRIPTION
## Summary

Fleet-mode accuracy audit of the entire G# documentation website (issue #276). Seven parallel reviewers cross-checked every code snippet and syntax/tooling description across all 40 remaining doc pages (the C# bridge was already corrected in #352) against the implementation-grounded language truth, the guaranteed-compiling samples, and the compiler/tooling source under src/.

Each fix is applied to both the current page and its version-0.1 mirror (the snapshot served at /docs/), keeping them byte-identical.

## Inaccuracies fixed (4 pages)

- bridges/gsharp-for-go-developers.md: entry point func main() to func Main() (binder matches Name == "Main"); class field "private var id string" to "private id string" (field decls take no var).
- ref/clr-interop.md: operator-overload example declared a receiver method inside a struct body (invalid: only class bodies take methods, and body methods carry no receiver clause). Rewritten as a top-level receiver function on a class, matching samples/Operators.gs.
- tutorials/dotnet-interop.md: removed backticks around "extension" that falsely implied a language keyword (G# has no extension keyword; extension methods use a receiver clause).
- tooling/lsp.md: corrected the language-server DLL path to the real build output layout (out/bin/Debug/LanguageServer/GSharp.LanguageServer.dll).

## Clean pages (no changes needed)

tour, guide, most of tutorials/ref/onboarding/tooling, and misc pages were verified accurate, including correct handling of arrow (switch arms only, not lambdas), square-bracket generics, width-bearing primitives, brace-init construction, with-copy syntax, and ADR-0050 arrow lambdas correctly marked Proposed/unimplemented.

## Validation

npm ci && npm run build succeeds (onBrokenLinks: throw).

Relates to #276. Follows #351 (palette) and #352 (C# bridge).
