### PR TITLE
docs: announce published SDK, templates, and VS Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A modern, simple, and accessible programming language for .NET.
 
 ## Getting started
 
-GSharp ships an MSBuild SDK (`Gsharp.NET.Sdk`) and a `dotnet new` template (`Gsharp.Templates`) so a `.gsproj` is just a regular .NET project that happens to compile `.gs` files. After installing the template package, you can scaffold and run a console app in three commands:
+GSharp ships an MSBuild SDK ([`Gsharp.NET.Sdk`](https://www.nuget.org/packages/Gsharp.NET.Sdk/)) and a `dotnet new` template package ([`Gsharp.Templates`](https://www.nuget.org/packages/Gsharp.Templates/)), both available on NuGet, so a `.gsproj` is just a regular .NET project that happens to compile `.gs` files. After installing the template package, you can scaffold and run a console app in three commands:
 
 ```sh
 dotnet new install Gsharp.Templates
@@ -31,7 +31,15 @@ A minimal `.gsproj` looks like any other modern .NET project:
 </Project>
 ```
 
-The SDK is validated against `net8.0` and `net10.0`; adding additional target frameworks is a one-line change in [`build/multitarget-e2e.sh`](build/multitarget-e2e.sh). See [`docs/sdk-usage.md`](docs/sdk-usage.md) for the full SDK + templates walkthrough (including how to side-load the SDK locally before it is published to a public NuGet feed) and [`docs/emit-pipeline.md`](docs/emit-pipeline.md) for the compiler architecture.
+The SDK is validated against `net8.0` and `net10.0`; adding additional target frameworks is a one-line change in [`build/multitarget-e2e.sh`](build/multitarget-e2e.sh). See [`docs/sdk-usage.md`](docs/sdk-usage.md) for the full SDK + templates walkthrough and [`docs/emit-pipeline.md`](docs/emit-pipeline.md) for the compiler architecture.
+
+## Editor support
+
+The **G# VS Code extension** is published on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=gsharplang.vscode-gsharp). It provides syntax highlighting, language-server features (completion, hover, diagnostics, formatting, and more), build/run commands, and debugger configuration for `.gs` and `.gsproj` files. Install it from within VS Code (search for "G#") or from the command line:
+
+```sh
+code --install-extension gsharplang.vscode-gsharp
+```
 
 ## Documentation
 

--- a/docs/sdk-usage.md
+++ b/docs/sdk-usage.md
@@ -2,7 +2,7 @@
 
 `Gsharp.NET.Sdk` is the MSBuild SDK that teaches `dotnet build` how to compile `.gs` source files into managed .NET assemblies. With it, a GSharp project is just a regular .NET project that happens to declare `Sdk="Gsharp.NET.Sdk"`.
 
-This document walks through the three supported authoring styles, the target frameworks the SDK supports, and how to side-load the SDK for local development before it is published to a public NuGet feed.
+This document walks through the three supported authoring styles, the target frameworks the SDK supports, and how to side-load a locally built SDK package for development of the SDK itself. The published [`Gsharp.NET.Sdk`](https://www.nuget.org/packages/Gsharp.NET.Sdk/) and [`Gsharp.Templates`](https://www.nuget.org/packages/Gsharp.Templates/) packages are available on NuGet, so most users do not need the side-loading workflow.
 
 ## Scaffolding with `dotnet new`
 
@@ -23,8 +23,8 @@ The template scaffolds a four-file project:
 | --- | --- |
 | `MyApp.gsproj` | Project file referencing `Gsharp.NET.Sdk/<version>` and declaring `OutputType=Exe` + `TargetFramework=net10.0`. |
 | `Program.gs` | A one-line GSharp Hello World. |
-| `NuGet.config` | Adds `./packages/` as a local NuGet source so the SDK can be side-loaded without modifying machine-wide config. |
-| `README.md` | Build/run instructions and notes on the side-load workflow. |
+| `NuGet.config` | Adds `./packages/` as a local NuGet source so a locally built SDK can be side-loaded without modifying machine-wide config. |
+| `README.md` | Build/run instructions and notes on the optional side-load workflow. |
 
 The template engine substitutes the project name everywhere `GsharpConsoleApp` appears, including the directory, project file name, and `RootNamespace`. The exact `Gsharp.NET.Sdk` version is pinned at template-pack time, so a scaffolded project always references the SDK version it was generated against.
 
@@ -60,9 +60,9 @@ The SDK supports any modern .NET target framework. The end-to-end test sweep in 
 
 The SDK's MSBuild task DLL is published as `netstandard2.0` so it loads in any MSBuild host (full-framework MSBuild, `dotnet build`, IDEs). The bundled `gsc.dll` compiler is `net10.0` and is invoked via `dotnet gsc.dll`, so it runs on any host that has the .NET 10 runtime installed.
 
-## Side-loading the SDK during local development
+## Side-loading a locally built SDK
 
-Until `Gsharp.NET.Sdk` is published to a public NuGet feed, projects must resolve it from a local `.nupkg`. The scaffolded `NuGet.config` adds `./packages/` to the project's source list, so the recommended workflow is:
+`Gsharp.NET.Sdk` and `Gsharp.Templates` are published on NuGet, so a normal `dotnet build` resolves the SDK from the public feed without any extra configuration. The side-loading workflow below is only needed when you are developing the SDK itself and want a project to resolve a locally built `.nupkg`. The scaffolded `NuGet.config` adds `./packages/` to the project's source list, so the workflow is:
 
 ```sh
 mkdir -p packages
@@ -70,7 +70,7 @@ cp /path/to/Gsharp.NET.Sdk.<version>.nupkg packages/
 dotnet build
 ```
 
-Once a public feed is available, delete the project's `NuGet.config` (or remove the `./packages/` entry) and the SDK will resolve normally.
+To resolve only published packages instead, delete the project's `NuGet.config` (or remove the `./packages/` entry) and the SDK will resolve from NuGet normally.
 
 ## Reference projects
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -25,7 +25,7 @@ G# targets the .NET CLR. The compiler can emit executables or libraries with man
 
 ## How do I install G#?
 
-Start with the [installation guide](/docs/getting-started/install). The current project flow uses `dotnet new install Gsharp.Templates`, a `gsharp-console` template, and `.gsproj` files that use the `Gsharp.NET.Sdk` MSBuild SDK.
+Start with the [installation guide](/docs/getting-started/install). The project flow uses `dotnet new install Gsharp.Templates`, a `gsharp-console` template, and `.gsproj` files that use the `Gsharp.NET.Sdk` MSBuild SDK. Both [`Gsharp.Templates`](https://www.nuget.org/packages/Gsharp.Templates/) and [`Gsharp.NET.Sdk`](https://www.nuget.org/packages/Gsharp.NET.Sdk/) are published on NuGet.
 
 ## Where is the language specification?
 
@@ -85,4 +85,4 @@ Yes. Fixed arrays use `[N]T`, slices use `[]T`, maps use `map[K]V`, and sequence
 
 ## What editor and debugging support exists?
 
-The repository includes a language server and a VS Code extension for `.gs` files, plus Portable PDB support for normal .NET/CoreCLR debugging of emitted assemblies. See [VS Code support](/docs/tooling/vscode), [LSP support](/docs/tooling/lsp), and [Debugging](/docs/tooling/debugging).
+A language server and a VS Code extension support `.gs` files, plus Portable PDB support enables normal .NET/CoreCLR debugging of emitted assemblies. The VS Code extension is published on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=gsharplang.vscode-gsharp). See [VS Code support](/docs/tooling/vscode), [LSP support](/docs/tooling/lsp), and [Debugging](/docs/tooling/debugging).

--- a/website/docs/getting-started/install.md
+++ b/website/docs/getting-started/install.md
@@ -6,7 +6,9 @@ draft: false
 
 # Install G#
 
-G# projects build with the normal .NET tools. The recommended path is to use the MSBuild SDK and project template; compiler developers can also build `gsc` from source.
+G# projects build with the normal .NET tools. The recommended path is to use the MSBuild SDK and project template, both published on NuGet; compiler developers can also build `gsc` from source.
+
+The published packages are [`Gsharp.NET.Sdk`](https://www.nuget.org/packages/Gsharp.NET.Sdk/) (the MSBuild SDK) and [`Gsharp.Templates`](https://www.nuget.org/packages/Gsharp.Templates/) (the `dotnet new` templates). They resolve from the public NuGet feed, so no extra feed configuration is required.
 
 ## Prerequisites
 
@@ -31,7 +33,7 @@ cd MyApp && dotnet build && dotnet run
 # -> Hello from GSharp!
 ```
 
-The generated project includes a `.gsproj`, a starter `Program.gs`, a `NuGet.config` for local SDK side-loading while packages are not yet on a public feed, and a README.
+The generated project includes a `.gsproj`, a starter `Program.gs`, a `NuGet.config` that enables optional local SDK side-loading, and a README.
 
 ## Author a project by hand
 
@@ -54,7 +56,7 @@ dotnet build
 dotnet run
 ```
 
-If you need to side-load a locally packed SDK, copy the package into the project's configured package source before building:
+If you are developing the SDK itself and want to side-load a locally packed build, copy the package into the project's configured package source before building:
 
 ```bash
 mkdir -p packages
@@ -63,6 +65,16 @@ dotnet build
 ```
 
 See [SDK projects](/docs/tooling/sdk-projects) for the full project-system walkthrough.
+
+## Install the VS Code extension
+
+The G# VS Code extension is published on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=gsharplang.vscode-gsharp). It adds syntax highlighting, language-server features, build/run commands, and debugger configuration for `.gs` and `.gsproj` files. Install it from within VS Code (search for "G#" in the Extensions view) or from the command line:
+
+```bash
+code --install-extension gsharplang.vscode-gsharp
+```
+
+See [the VS Code extension reference](/docs/tooling/vscode) for the full feature list and settings.
 
 ## Build the compiler from source
 

--- a/website/docs/tooling/sdk-projects.md
+++ b/website/docs/tooling/sdk-projects.md
@@ -26,7 +26,7 @@ Expected output from the template is:
 Hello from GSharp!
 ```
 
-The template pins the `Gsharp.NET.Sdk` version into the generated project, sets `OutputType` to `Exe`, targets `net10.0`, and includes local package-feed setup for side-loaded SDK packages before public NuGet publication.
+The template pins the `Gsharp.NET.Sdk` version into the generated project, sets `OutputType` to `Exe`, targets `net10.0`, and includes a `NuGet.config` that enables optional local SDK side-loading.
 
 ## Minimal project file
 
@@ -152,7 +152,7 @@ Top-level statements choose the entry-point package. The single-package case rem
 
 ## Local SDK side-loading
 
-Until the SDK and templates are available from a public feed, projects can resolve packed `.nupkg` files from a local feed. The template scaffolds a `NuGet.config` for this workflow.
+`Gsharp.NET.Sdk` and `Gsharp.Templates` are published on NuGet, so projects resolve the SDK from the public feed by default. When you are developing the SDK itself, projects can instead resolve packed `.nupkg` files from a local feed. The template scaffolds a `NuGet.config` for this workflow.
 
 ```bash
 mkdir -p packages

--- a/website/docs/tooling/vscode.md
+++ b/website/docs/tooling/vscode.md
@@ -8,6 +8,14 @@ draft: false
 
 The G# VS Code extension provides language registration, syntax highlighting, snippets, themes, language-server integration, build/run commands, task definitions, and debugger configuration for `.gs` and `.gsproj` files.
 
+## Install
+
+The extension is published on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=gsharplang.vscode-gsharp). Install it from the Extensions view in VS Code (search for "G#"), or from the command line:
+
+```bash
+code --install-extension gsharplang.vscode-gsharp
+```
+
 ## Activation and file types
 
 The extension activates when you open a G# file, when a workspace contains `.gs` or `.gsproj` files, when G# debug configuration is resolved, or when the restart-server command is invoked. It registers:

--- a/website/docs/tutorials/getting-started.md
+++ b/website/docs/tutorials/getting-started.md
@@ -12,7 +12,7 @@ In this tutorial, you will create a G# console project, replace the template bod
 
 - The .NET SDK that can target `net10.0`.
 - A terminal in a directory where you can create a project.
-- The `Gsharp.Templates` package. Until the SDK is published publicly, follow the side-loading notes in [SDK projects](/docs/tooling/sdk-projects) if your machine cannot resolve `Gsharp.NET.Sdk`.
+- The [`Gsharp.Templates`](https://www.nuget.org/packages/Gsharp.Templates/) package, available on NuGet. It installs the [`Gsharp.NET.Sdk`](https://www.nuget.org/packages/Gsharp.NET.Sdk/) used by the generated project, both resolved from the public NuGet feed.
 
 ## 1. Scaffold a console app
 

--- a/website/versioned_docs/version-0.1/faq.md
+++ b/website/versioned_docs/version-0.1/faq.md
@@ -25,7 +25,7 @@ G# targets the .NET CLR. The compiler can emit executables or libraries with man
 
 ## How do I install G#?
 
-Start with the [installation guide](/docs/getting-started/install). The current project flow uses `dotnet new install Gsharp.Templates`, a `gsharp-console` template, and `.gsproj` files that use the `Gsharp.NET.Sdk` MSBuild SDK.
+Start with the [installation guide](/docs/getting-started/install). The project flow uses `dotnet new install Gsharp.Templates`, a `gsharp-console` template, and `.gsproj` files that use the `Gsharp.NET.Sdk` MSBuild SDK. Both [`Gsharp.Templates`](https://www.nuget.org/packages/Gsharp.Templates/) and [`Gsharp.NET.Sdk`](https://www.nuget.org/packages/Gsharp.NET.Sdk/) are published on NuGet.
 
 ## Where is the language specification?
 
@@ -85,4 +85,4 @@ Yes. Fixed arrays use `[N]T`, slices use `[]T`, maps use `map[K]V`, and sequence
 
 ## What editor and debugging support exists?
 
-The repository includes a language server and a VS Code extension for `.gs` files, plus Portable PDB support for normal .NET/CoreCLR debugging of emitted assemblies. See [VS Code support](/docs/tooling/vscode), [LSP support](/docs/tooling/lsp), and [Debugging](/docs/tooling/debugging).
+A language server and a VS Code extension support `.gs` files, plus Portable PDB support enables normal .NET/CoreCLR debugging of emitted assemblies. The VS Code extension is published on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=gsharplang.vscode-gsharp). See [VS Code support](/docs/tooling/vscode), [LSP support](/docs/tooling/lsp), and [Debugging](/docs/tooling/debugging).

--- a/website/versioned_docs/version-0.1/getting-started/install.md
+++ b/website/versioned_docs/version-0.1/getting-started/install.md
@@ -6,7 +6,9 @@ draft: false
 
 # Install G#
 
-G# projects build with the normal .NET tools. The recommended path is to use the MSBuild SDK and project template; compiler developers can also build `gsc` from source.
+G# projects build with the normal .NET tools. The recommended path is to use the MSBuild SDK and project template, both published on NuGet; compiler developers can also build `gsc` from source.
+
+The published packages are [`Gsharp.NET.Sdk`](https://www.nuget.org/packages/Gsharp.NET.Sdk/) (the MSBuild SDK) and [`Gsharp.Templates`](https://www.nuget.org/packages/Gsharp.Templates/) (the `dotnet new` templates). They resolve from the public NuGet feed, so no extra feed configuration is required.
 
 ## Prerequisites
 
@@ -31,7 +33,7 @@ cd MyApp && dotnet build && dotnet run
 # -> Hello from GSharp!
 ```
 
-The generated project includes a `.gsproj`, a starter `Program.gs`, a `NuGet.config` for local SDK side-loading while packages are not yet on a public feed, and a README.
+The generated project includes a `.gsproj`, a starter `Program.gs`, a `NuGet.config` that enables optional local SDK side-loading, and a README.
 
 ## Author a project by hand
 
@@ -54,7 +56,7 @@ dotnet build
 dotnet run
 ```
 
-If you need to side-load a locally packed SDK, copy the package into the project's configured package source before building:
+If you are developing the SDK itself and want to side-load a locally packed build, copy the package into the project's configured package source before building:
 
 ```bash
 mkdir -p packages
@@ -63,6 +65,16 @@ dotnet build
 ```
 
 See [SDK projects](/docs/tooling/sdk-projects) for the full project-system walkthrough.
+
+## Install the VS Code extension
+
+The G# VS Code extension is published on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=gsharplang.vscode-gsharp). It adds syntax highlighting, language-server features, build/run commands, and debugger configuration for `.gs` and `.gsproj` files. Install it from within VS Code (search for "G#" in the Extensions view) or from the command line:
+
+```bash
+code --install-extension gsharplang.vscode-gsharp
+```
+
+See [the VS Code extension reference](/docs/tooling/vscode) for the full feature list and settings.
 
 ## Build the compiler from source
 

--- a/website/versioned_docs/version-0.1/tooling/sdk-projects.md
+++ b/website/versioned_docs/version-0.1/tooling/sdk-projects.md
@@ -26,7 +26,7 @@ Expected output from the template is:
 Hello from GSharp!
 ```
 
-The template pins the `Gsharp.NET.Sdk` version into the generated project, sets `OutputType` to `Exe`, targets `net10.0`, and includes local package-feed setup for side-loaded SDK packages before public NuGet publication.
+The template pins the `Gsharp.NET.Sdk` version into the generated project, sets `OutputType` to `Exe`, targets `net10.0`, and includes a `NuGet.config` that enables optional local SDK side-loading.
 
 ## Minimal project file
 
@@ -152,7 +152,7 @@ Top-level statements choose the entry-point package. The single-package case rem
 
 ## Local SDK side-loading
 
-Until the SDK and templates are available from a public feed, projects can resolve packed `.nupkg` files from a local feed. The template scaffolds a `NuGet.config` for this workflow.
+`Gsharp.NET.Sdk` and `Gsharp.Templates` are published on NuGet, so projects resolve the SDK from the public feed by default. When you are developing the SDK itself, projects can instead resolve packed `.nupkg` files from a local feed. The template scaffolds a `NuGet.config` for this workflow.
 
 ```bash
 mkdir -p packages

--- a/website/versioned_docs/version-0.1/tooling/vscode.md
+++ b/website/versioned_docs/version-0.1/tooling/vscode.md
@@ -8,6 +8,14 @@ draft: false
 
 The G# VS Code extension provides language registration, syntax highlighting, snippets, themes, language-server integration, build/run commands, task definitions, and debugger configuration for `.gs` and `.gsproj` files.
 
+## Install
+
+The extension is published on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=gsharplang.vscode-gsharp). Install it from the Extensions view in VS Code (search for "G#"), or from the command line:
+
+```bash
+code --install-extension gsharplang.vscode-gsharp
+```
+
 ## Activation and file types
 
 The extension activates when you open a G# file, when a workspace contains `.gs` or `.gsproj` files, when G# debug configuration is resolved, or when the restart-server command is invoked. It registers:

--- a/website/versioned_docs/version-0.1/tutorials/getting-started.md
+++ b/website/versioned_docs/version-0.1/tutorials/getting-started.md
@@ -12,7 +12,7 @@ In this tutorial, you will create a G# console project, replace the template bod
 
 - The .NET SDK that can target `net10.0`.
 - A terminal in a directory where you can create a project.
-- The `Gsharp.Templates` package. Until the SDK is published publicly, follow the side-loading notes in [SDK projects](/docs/tooling/sdk-projects) if your machine cannot resolve `Gsharp.NET.Sdk`.
+- The [`Gsharp.Templates`](https://www.nuget.org/packages/Gsharp.Templates/) package, available on NuGet. It installs the [`Gsharp.NET.Sdk`](https://www.nuget.org/packages/Gsharp.NET.Sdk/) used by the generated project, both resolved from the public NuGet feed.
 
 ## 1. Scaffold a console app
 


### PR DESCRIPTION
Closes #260

## Summary

G# is now publicly consumable: the SDK and templates are on NuGet and the VS Code extension is on the Visual Studio Marketplace. This updates the README and documentation to point at the published artifacts and to add install instructions.

- SDK: https://www.nuget.org/packages/Gsharp.NET.Sdk/
- Templates: https://www.nuget.org/packages/Gsharp.Templates/
- VS Code extension: https://marketplace.visualstudio.com/items?itemName=gsharplang.vscode-gsharp

## Changes

- README: link the SDK/templates to their NuGet pages, drop the "before it is published to a public NuGet feed" caveat, and add an "Editor support" section with the Marketplace link and `code --install-extension gsharplang.vscode-gsharp`.
- docs/sdk-usage.md: reframe the side-loading section as an SDK-development-only workflow (packages now resolve from the public feed by default).
- website (current + version-0.1 mirror, kept byte-identical):
  - getting-started/install.md: note the published packages, add an "Install the VS Code extension" section, soften side-load language.
  - tooling/vscode.md: add an "Install" section with the Marketplace link and CLI install command.
  - tooling/sdk-projects.md: reframe "Local SDK side-loading" now that packages are published.
  - tutorials/getting-started.md: link the NuGet packages in prerequisites; remove the "until published publicly" note.
  - faq.md: note packages are on NuGet and the extension is on the Marketplace.

## Validation

`npm run build` succeeds (onBrokenLinks: 'throw'). All website edits applied to both the current and version-0.1 docs.
