### PR TITLE
docs: remove stale source/docs discrepancy notes

### DIFF
--- a/website/docs/ref/feature-matrix.md
+++ b/website/docs/ref/feature-matrix.md
@@ -128,8 +128,4 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Reference assemblies | Supported | N/A | SDK can produce reference assemblies. |
 | SDK `.gsproj` build/run/pack | Supported | N/A | `Gsharp.NET.Sdk` integrates with MSBuild and `dotnet`. |
 | REPL | N/A | Supported | Interpreter executable starts a REPL with no file argument. |
-| Language server and VS Code extension | N/A | N/A | Tooling uses parser/binder services and has richer capabilities than older docs may list. |
-
-## Known documentation/source consistency notes
-
-The generated `docs/coverage-matrix.md` is a symbol snapshot, not a prose support matrix. It lists nodes such as `MapDeleteExpression`, `ClrEventSubscriptionExpression`, `StateMachineAwaitOnCompleted`, and `AddressOfExpression`; those confirm syntax/bound-node coverage but do not by themselves prove complete runtime parity. Current source also supports block comments while an older VS Code grammar note says it does not, and source advertises more LSP capabilities than older `docs/lsp.md` text. The primary feature matrix above follows the implementation snapshot and uses `docs/coverage-matrix.md` as corroboration where the snapshot exposes bound-node differences.
+| Language server and VS Code extension | N/A | N/A | Tooling uses parser/binder services and provides rich editor capabilities. |

--- a/website/docs/tooling/lsp.md
+++ b/website/docs/tooling/lsp.md
@@ -34,7 +34,7 @@ VS Code exposes logging through `gsharp.server.log` and `gsharp.server.logPath`.
 
 ## Advertised capabilities
 
-Current source advertises more than the older `docs/lsp.md` table. The server capability factory currently enables:
+The server capability factory enables the following:
 
 | Capability | LSP surface |
 | --- | --- |

--- a/website/versioned_docs/version-0.1/ref/feature-matrix.md
+++ b/website/versioned_docs/version-0.1/ref/feature-matrix.md
@@ -128,8 +128,4 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Reference assemblies | Supported | N/A | SDK can produce reference assemblies. |
 | SDK `.gsproj` build/run/pack | Supported | N/A | `Gsharp.NET.Sdk` integrates with MSBuild and `dotnet`. |
 | REPL | N/A | Supported | Interpreter executable starts a REPL with no file argument. |
-| Language server and VS Code extension | N/A | N/A | Tooling uses parser/binder services and has richer capabilities than older docs may list. |
-
-## Known documentation/source consistency notes
-
-The generated `docs/coverage-matrix.md` is a symbol snapshot, not a prose support matrix. It lists nodes such as `MapDeleteExpression`, `ClrEventSubscriptionExpression`, `StateMachineAwaitOnCompleted`, and `AddressOfExpression`; those confirm syntax/bound-node coverage but do not by themselves prove complete runtime parity. Current source also supports block comments while an older VS Code grammar note says it does not, and source advertises more LSP capabilities than older `docs/lsp.md` text. The primary feature matrix above follows the implementation snapshot and uses `docs/coverage-matrix.md` as corroboration where the snapshot exposes bound-node differences.
+| Language server and VS Code extension | N/A | N/A | Tooling uses parser/binder services and provides rich editor capabilities. |

--- a/website/versioned_docs/version-0.1/tooling/lsp.md
+++ b/website/versioned_docs/version-0.1/tooling/lsp.md
@@ -34,7 +34,7 @@ VS Code exposes logging through `gsharp.server.log` and `gsharp.server.logPath`.
 
 ## Advertised capabilities
 
-Current source advertises more than the older `docs/lsp.md` table. The server capability factory currently enables:
+The server capability factory enables the following:
 
 | Capability | LSP surface |
 | --- | --- |


### PR DESCRIPTION
## Summary

Removes now-stale documentation/source discrepancy clarifications from the website, following the recent grammar and LSP corrections.

- **`ref/feature-matrix.md`**: drop the "Known documentation/source consistency notes" section, and reword the Language server / VS Code extension row to stop referencing "older docs may list".
- **`tooling/lsp.md`**: remove the "Current source advertises more than the older `docs/lsp.md` table" sentence, leaving a clean lead-in to the capabilities table.

Applied to both the current docs and the `version-0.1` snapshot.

Legitimate "authoritative source" pointers (in `ref/diagnostics.md` and `contributing/docs-authoring.md`) are left intact since they reference source-of-truth files rather than describing stale discrepancies.

## Testing

Docs-only change; no build/test impact.