### PR TITLE
Fix #359: live pull-based diagnostics as you type

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -6,7 +6,7 @@ The GSharp Language Server provides rich IDE features for `.gs` files via the [L
 
 | Feature | LSP Method | Description |
 |---------|-----------|-------------|
-| Diagnostics | `textDocument/publishDiagnostics` | Syntax, semantic, and binding errors streamed on open/change/save |
+| Diagnostics | `textDocument/diagnostic` | Live syntax, semantic, and binding errors pulled as you type (with `workspace/diagnostic/refresh` for cross-file edits) |
 | Hover | `textDocument/hover` | Type signature and symbol kind for the token under the cursor |
 | Go-to-definition | `textDocument/declaration` | Jump from a symbol usage to its declaration |
 | Find references | `textDocument/references` | Find all usages of a symbol within the document |
@@ -77,10 +77,10 @@ Logging is **opt-in**: when `--log` is not supplied, no log file is created. Fro
 
 ## Diagnostics
 
-Diagnostics are published on every document open/change (syntax + global-scope errors) and additionally on save (full binding pass). The diagnostic `code` field currently reports the pipeline stage (`Syntax`, `Semantic`, `Binding`). Stable `GS####` diagnostic IDs are planned for a future milestone.
+Diagnostics use the LSP **pull model** (`textDocument/diagnostic`): the editor requests diagnostics as the user types and on save, and the server runs the full pipeline — syntax parse, global-scope semantic analysis, and the binding pass — on every pull, so binding errors (e.g. unreachable code, missing return values, type mismatches inside function bodies) surface live rather than only on save. Results carry a `resultId`; when nothing relevant changed the server returns an `unchanged` report so the client reuses the prior squiggles. The expensive binding pass runs off the request gate and honors cancellation, so a slow analysis does not block interactive requests (hover, completion). For multi-file projects, edits that can affect other open documents trigger a debounced `workspace/diagnostic/refresh` so the client re-pulls them. Clients that do not advertise pull-diagnostic support fall back to push (`textDocument/publishDiagnostics`) on open/change/save. The diagnostic `code` field currently reports the pipeline stage (`Syntax`, `Semantic`, `Binding`). Stable `GS####` diagnostic IDs are planned for a future milestone.
 
 ## Limitations
 
 - **Single-file scope** — cross-file navigation and completion are not yet supported; the server analyzes one document at a time.
-- **No incremental re-binding** — each edit triggers a full re-parse and re-bind of the active document.
+- **No incremental re-binding** — each pull triggers a full re-parse and re-bind of the active document.
 - **Completion is keyword/scope-aware** but does not yet offer member completions on struct instances (dot-triggered completion is registered but scoped to globals).

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -174,7 +174,7 @@ public sealed class BoundScope
     /// <returns>The symbol.</returns>
     public Symbol TryLookupSymbol(string name)
     {
-        if (symbols != null && symbols.TryGetValue(name, out var symbol))
+        if (name != null && symbols != null && symbols.TryGetValue(name, out var symbol))
         {
             return symbol;
         }
@@ -299,6 +299,11 @@ public sealed class BoundScope
     /// <returns>Whether the alias was declared (false if the name was already taken).</returns>
     public bool TryDeclareTypeAlias(string name, TypeSymbol target)
     {
+        if (name == null)
+        {
+            return false;
+        }
+
         if (typeAliases == null)
         {
             typeAliases = new Dictionary<string, TypeSymbol>();
@@ -321,7 +326,7 @@ public sealed class BoundScope
     /// <returns>Whether an alias exists.</returns>
     public bool TryLookupTypeAlias(string name, out TypeSymbol type)
     {
-        if (typeAliases != null && typeAliases.TryGetValue(name, out type))
+        if (name != null && typeAliases != null && typeAliases.TryGetValue(name, out type))
         {
             return true;
         }
@@ -367,6 +372,11 @@ public sealed class BoundScope
     private bool TryDeclareSymbol<TSymbol>(TSymbol symbol)
         where TSymbol : Symbol
     {
+        if (symbol.Name == null)
+        {
+            return false;
+        }
+
         if (symbols == null)
         {
             symbols = new Dictionary<string, Symbol>();

--- a/src/LanguageServer/DocumentSyncHandler.cs
+++ b/src/LanguageServer/DocumentSyncHandler.cs
@@ -31,11 +31,11 @@ public static class DocumentSyncHandler
     public static DiagnosticComputationResult ComputeDiagnostics(string text, bool skipBinding, ProjectState project, string filePath)
     {
         var newLines = new List<int>();
-        int nextNewLine = text.IndexOf(Environment.NewLine, StringComparison.Ordinal);
+        int nextNewLine = text.IndexOf('\n');
         while (nextNewLine >= 0)
         {
             newLines.Add(nextNewLine);
-            nextNewLine = text.IndexOf(Environment.NewLine, nextNewLine + 1, StringComparison.Ordinal);
+            nextNewLine = text.IndexOf('\n', nextNewLine + 1);
         }
 
         var diagnostics = new List<Diagnostic>();
@@ -61,7 +61,7 @@ public static class DocumentSyncHandler
 
         foreach (var d in syntaxTree.Diagnostics)
         {
-            diagnostics.Add(BuildDiagnostic("Syntax", d.Message, d.Location.Span.Start, d.Location.Span.End, newLines));
+            diagnostics.Add(BuildDiagnostic("Syntax", d.Message, d.Location.Span.Start, d.Location.Span.End, syntaxTree.Text));
         }
 
         foreach (var d in compilation.GlobalScope.Diagnostics)
@@ -72,7 +72,7 @@ public static class DocumentSyncHandler
                 continue;
             }
 
-            diagnostics.Add(BuildDiagnostic("Semantic", d.Message, d.Location.Span.Start, d.Location.Span.End, newLines));
+            diagnostics.Add(BuildDiagnostic("Semantic", d.Message, d.Location.Span.Start, d.Location.Span.End, syntaxTree.Text));
         }
 
         if (!skipBinding)
@@ -85,25 +85,30 @@ public static class DocumentSyncHandler
                     continue;
                 }
 
-                diagnostics.Add(BuildDiagnostic("Binding", d.Message, d.Location.Span.Start, d.Location.Span.End, newLines));
+                diagnostics.Add(BuildDiagnostic("Binding", d.Message, d.Location.Span.Start, d.Location.Span.End, syntaxTree.Text));
             }
         }
 
         return new DiagnosticComputationResult(new DocumentContent(syntaxTree, newLines, project), diagnostics);
     }
 
-    private static Diagnostic BuildDiagnostic(string code, string message, int start, int end, List<int> newLines)
+    private static Diagnostic BuildDiagnostic(string code, string message, int start, int end, GSharp.Core.CodeAnalysis.Text.SourceText sourceText)
     {
-        int line = newLines.Count(charNumber => charNumber < start);
-        int lineStart = line > 0 ? newLines[line - 1] + 2 : 0;
         return new Diagnostic
         {
             Code = new DiagnosticCode(code),
             Message = message,
-            Range = new Range(new Position(line, start - lineStart), new Position(line, end - lineStart)),
+            Range = new Range(ToPosition(start, sourceText), ToPosition(end, sourceText)),
             Severity = DiagnosticSeverity.Error,
             Source = Constants.LanguageIdentifier,
         };
+    }
+
+    private static Position ToPosition(int offset, GSharp.Core.CodeAnalysis.Text.SourceText sourceText)
+    {
+        int line = sourceText.GetLineIndex(offset);
+        int lineStart = sourceText.Lines[line].Start;
+        return new Position(line, offset - lineStart);
     }
 }
 

--- a/src/LanguageServer/DocumentSyncHandler.cs
+++ b/src/LanguageServer/DocumentSyncHandler.cs
@@ -20,10 +20,15 @@ public static class DocumentSyncHandler
 {
     public static DiagnosticComputationResult ComputeDiagnostics(string text, bool skipBinding)
     {
-        return ComputeDiagnostics(text, skipBinding, project: null);
+        return ComputeDiagnostics(text, skipBinding, project: null, filePath: null);
     }
 
     public static DiagnosticComputationResult ComputeDiagnostics(string text, bool skipBinding, ProjectState project)
+    {
+        return ComputeDiagnostics(text, skipBinding, project, filePath: null);
+    }
+
+    public static DiagnosticComputationResult ComputeDiagnostics(string text, bool skipBinding, ProjectState project, string filePath)
     {
         var newLines = new List<int>();
         int nextNewLine = text.IndexOf(Environment.NewLine, StringComparison.Ordinal);
@@ -35,18 +40,34 @@ public static class DocumentSyncHandler
 
         var diagnostics = new List<Diagnostic>();
 
-        var syntaxTree = SyntaxTree.Parse(text);
+        // When the file belongs to a project, bind it as part of the project-level compilation
+        // for cross-file awareness, but make sure that compilation reflects the in-memory editor
+        // text. The project keeps its own SyntaxTree per file; we sync this file's tree with the
+        // current text and then filter diagnostics by that exact tree so squiggles for the edited
+        // file are reported (and diagnostics for other files in the project are excluded).
+        Compilation compilation;
+        SyntaxTree syntaxTree;
+        bool useProject = project != null && !string.IsNullOrEmpty(filePath) && project.ContainsFile(filePath);
+        if (useProject)
+        {
+            syntaxTree = project.UpdateFile(filePath, text);
+            compilation = project.GetCompilation();
+        }
+        else
+        {
+            syntaxTree = SyntaxTree.Parse(text);
+            compilation = new Compilation(syntaxTree);
+        }
+
         foreach (var d in syntaxTree.Diagnostics)
         {
             diagnostics.Add(BuildDiagnostic("Syntax", d.Message, d.Location.Span.Start, d.Location.Span.End, newLines));
         }
 
-        // Use project-level compilation if available for cross-file awareness
-        var compilation = project != null ? project.GetCompilation() : new Compilation(syntaxTree);
         foreach (var d in compilation.GlobalScope.Diagnostics)
         {
-            // Only report diagnostics that originate from this file's syntax tree
-            if (project != null && d.Location.Text != syntaxTree.Text)
+            // Only report diagnostics that originate from this file's syntax tree.
+            if (useProject && d.Location.Text != syntaxTree.Text)
             {
                 continue;
             }
@@ -59,7 +80,7 @@ public static class DocumentSyncHandler
             var program = Binder.BindProgram(compilation.GlobalScope);
             foreach (var d in program.Diagnostics)
             {
-                if (project != null && d.Location.Text != syntaxTree.Text)
+                if (useProject && d.Location.Text != syntaxTree.Text)
                 {
                     continue;
                 }

--- a/src/LanguageServer/Protocol/Capabilities.cs
+++ b/src/LanguageServer/Protocol/Capabilities.cs
@@ -94,6 +94,18 @@ public sealed class InlayHintOptions
     public bool ResolveProvider { get; set; }
 }
 
+public sealed class DiagnosticOptions
+{
+    [JsonPropertyName("identifier")]
+    public string Identifier { get; set; }
+
+    [JsonPropertyName("interFileDependencies")]
+    public bool InterFileDependencies { get; set; }
+
+    [JsonPropertyName("workspaceDiagnostics")]
+    public bool WorkspaceDiagnostics { get; set; }
+}
+
 public sealed class ServerCapabilities
 {
     [JsonPropertyName("textDocumentSync")]
@@ -161,4 +173,7 @@ public sealed class ServerCapabilities
 
     [JsonPropertyName("linkedEditingRangeProvider")]
     public bool LinkedEditingRangeProvider { get; set; }
+
+    [JsonPropertyName("diagnosticProvider")]
+    public DiagnosticOptions DiagnosticProvider { get; set; }
 }

--- a/src/LanguageServer/Protocol/Models.cs
+++ b/src/LanguageServer/Protocol/Models.cs
@@ -601,3 +601,24 @@ public sealed class PublishDiagnosticsParams
     [JsonPropertyName("diagnostics")]
     public IEnumerable<Diagnostic> Diagnostics { get; set; }
 }
+
+public sealed class FullDocumentDiagnosticReport
+{
+    [JsonPropertyName("kind")]
+    public string Kind { get; set; } = "full";
+
+    [JsonPropertyName("resultId")]
+    public string ResultId { get; set; }
+
+    [JsonPropertyName("items")]
+    public IReadOnlyList<Diagnostic> Items { get; set; }
+}
+
+public sealed class UnchangedDocumentDiagnosticReport
+{
+    [JsonPropertyName("kind")]
+    public string Kind { get; set; } = "unchanged";
+
+    [JsonPropertyName("resultId")]
+    public string ResultId { get; set; }
+}

--- a/src/LanguageServer/Protocol/Params.cs
+++ b/src/LanguageServer/Protocol/Params.cs
@@ -218,6 +218,18 @@ public sealed class DidCloseTextDocumentParams
     public TextDocumentIdentifier TextDocument { get; set; }
 }
 
+public sealed class DocumentDiagnosticParams
+{
+    [JsonPropertyName("textDocument")]
+    public TextDocumentIdentifier TextDocument { get; set; }
+
+    [JsonPropertyName("identifier")]
+    public string Identifier { get; set; }
+
+    [JsonPropertyName("previousResultId")]
+    public string PreviousResultId { get; set; }
+}
+
 public enum FileChangeType
 {
     Created = 1,

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -183,11 +183,12 @@ public sealed class LspServer
         // Snapshot the current text and owning project under the gate, then run the (potentially
         // expensive) full binding pass off the gate so interactive requests are not blocked.
         string text = null;
+        string filePath = null;
         ProjectState project = null;
         await this.gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            var filePath = uri.GetFileSystemPath();
+            filePath = uri.GetFileSystemPath();
             project = !string.IsNullOrEmpty(filePath) ? this.workspaceState.GetProjectForFile(filePath) : null;
             if (this.documentContentService.TryGet(uri.ToString(), out var content))
             {
@@ -205,7 +206,7 @@ public sealed class LspServer
         }
 
         cancellationToken.ThrowIfCancellationRequested();
-        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding: false, project);
+        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding: false, project, filePath);
         cancellationToken.ThrowIfCancellationRequested();
 
         var resultId = ComputeResultId(result.Diagnostics);
@@ -444,7 +445,7 @@ public sealed class LspServer
 
         // Parse-only content (no binding) feeds the content service used by other features;
         // diagnostics are produced on demand by the textDocument/diagnostic pull handler.
-        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding: true, project);
+        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding: true, project, filePath);
         this.documentContentService.AddOrUpdate(uri.ToString(), result.Content);
     }
 
@@ -459,7 +460,7 @@ public sealed class LspServer
 
         var filePath = uri.GetFileSystemPath();
         var project = !string.IsNullOrEmpty(filePath) ? this.workspaceState.GetProjectForFile(filePath) : null;
-        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding, project);
+        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding, project, filePath);
 
         this.rpc?.NotifyWithParameterObjectAsync(
             "textDocument/publishDiagnostics",

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,9 +29,13 @@ public sealed class LspServer
     private readonly WorkspaceState workspaceState;
     private readonly SemaphoreSlim gate = new SemaphoreSlim(1, 1);
     private readonly TaskCompletionSource<int> exitSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly object refreshLock = new object();
 
     private JsonRpc rpc;
     private bool shutdownRequested;
+    private bool clientSupportsPullDiagnostics;
+    private bool clientSupportsDiagnosticRefresh;
+    private Timer refreshTimer;
 
     public LspServer(DocumentContentService documentContentService, WorkspaceState workspaceState)
     {
@@ -52,6 +58,7 @@ public sealed class LspServer
     public Task<InitializeResult> InitializeAsync(InitializeParams request)
     {
         var rootPath = request?.RootPath ?? request?.RootUri?.GetFileSystemPath();
+        this.DetectClientDiagnosticCapabilities(request?.Capabilities ?? default);
         try
         {
             WorkspaceInitializer.Initialize(this.workspaceState, rootPath);
@@ -99,7 +106,8 @@ public sealed class LspServer
 
         return this.GuardAsync(() =>
         {
-            this.Diagnose(uri, text, skipBinding: true);
+            this.UpdateDocument(uri, text);
+            this.PublishDiagnosticsIfPushMode(uri, text, skipBinding: true);
             return 0;
         });
     }
@@ -116,7 +124,12 @@ public sealed class LspServer
 
         return this.GuardAsync(() =>
         {
-            this.Diagnose(uri, text, skipBinding: true);
+            this.UpdateDocument(uri, text);
+            this.PublishDiagnosticsIfPushMode(uri, text, skipBinding: true);
+
+            // Inter-file edits can change diagnostics in other open documents; ask the
+            // client to re-pull them. Debounced so a burst of keystrokes coalesces.
+            this.RequestDiagnosticRefresh(uri);
             return 0;
         });
     }
@@ -133,8 +146,11 @@ public sealed class LspServer
 
         return this.GuardAsync(() =>
         {
-            // Open/change keeps binding diagnostics disabled for responsive typing; save runs the full pipeline.
-            this.Diagnose(uri, text, skipBinding: false);
+            this.UpdateDocument(uri, text);
+
+            // Pull clients already receive live binding diagnostics; only push clients need
+            // the full pipeline run here.
+            this.PublishDiagnosticsIfPushMode(uri, text, skipBinding: false);
             return 0;
         });
     }
@@ -153,6 +169,56 @@ public sealed class LspServer
             this.documentContentService.TryRemove(uri.ToString());
             return 0;
         });
+    }
+
+    [JsonRpcMethod("textDocument/diagnostic", UseSingleObjectParameterDeserialization = true)]
+    public async Task<object> DocumentDiagnosticAsync(DocumentDiagnosticParams request, CancellationToken cancellationToken)
+    {
+        var uri = request?.TextDocument?.Uri;
+        if (uri == null)
+        {
+            return new FullDocumentDiagnosticReport { Items = Array.Empty<Diagnostic>() };
+        }
+
+        // Snapshot the current text and owning project under the gate, then run the (potentially
+        // expensive) full binding pass off the gate so interactive requests are not blocked.
+        string text = null;
+        ProjectState project = null;
+        await this.gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var filePath = uri.GetFileSystemPath();
+            project = !string.IsNullOrEmpty(filePath) ? this.workspaceState.GetProjectForFile(filePath) : null;
+            if (this.documentContentService.TryGet(uri.ToString(), out var content))
+            {
+                text = content.SyntaxTree.Text.ToString();
+            }
+        }
+        finally
+        {
+            this.gate.Release();
+        }
+
+        if (text == null)
+        {
+            return new FullDocumentDiagnosticReport { Items = Array.Empty<Diagnostic>() };
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding: false, project);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var resultId = ComputeResultId(result.Diagnostics);
+        if (request.PreviousResultId != null && string.Equals(request.PreviousResultId, resultId, StringComparison.Ordinal))
+        {
+            return new UnchangedDocumentDiagnosticReport { ResultId = resultId };
+        }
+
+        return new FullDocumentDiagnosticReport
+        {
+            ResultId = resultId,
+            Items = result.Diagnostics.ToList(),
+        };
     }
 
     [JsonRpcMethod("workspace/didChangeWatchedFiles", UseSingleObjectParameterDeserialization = true)]
@@ -183,6 +249,8 @@ public sealed class LspServer
                 }
             }
 
+            // External file/project changes can alter diagnostics in open documents.
+            this.RequestDiagnosticRefresh();
             return 0;
         });
     }
@@ -365,7 +433,7 @@ public sealed class LspServer
         return uri != null && this.documentContentService.TryGet(uri.ToString(), out content);
     }
 
-    private void Diagnose(DocumentUri uri, string text, bool skipBinding)
+    private void UpdateDocument(DocumentUri uri, string text)
     {
         var filePath = uri.GetFileSystemPath();
         var project = !string.IsNullOrEmpty(filePath) ? this.workspaceState.GetProjectForFile(filePath) : null;
@@ -374,12 +442,124 @@ public sealed class LspServer
             project.UpdateFile(filePath, text);
         }
 
-        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding, project);
+        // Parse-only content (no binding) feeds the content service used by other features;
+        // diagnostics are produced on demand by the textDocument/diagnostic pull handler.
+        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding: true, project);
         this.documentContentService.AddOrUpdate(uri.ToString(), result.Content);
+    }
+
+    private void PublishDiagnosticsIfPushMode(DocumentUri uri, string text, bool skipBinding)
+    {
+        // Clients advertising pull diagnostics request them via textDocument/diagnostic, so push
+        // is suppressed to avoid double reporting. Older push-only clients still get notifications.
+        if (this.clientSupportsPullDiagnostics)
+        {
+            return;
+        }
+
+        var filePath = uri.GetFileSystemPath();
+        var project = !string.IsNullOrEmpty(filePath) ? this.workspaceState.GetProjectForFile(filePath) : null;
+        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding, project);
 
         this.rpc?.NotifyWithParameterObjectAsync(
             "textDocument/publishDiagnostics",
             new PublishDiagnosticsParams { Uri = uri, Diagnostics = result.Diagnostics });
+    }
+
+    private void DetectClientDiagnosticCapabilities(JsonElement capabilities)
+    {
+        try
+        {
+            if (capabilities.ValueKind == JsonValueKind.Object)
+            {
+                if (capabilities.TryGetProperty("textDocument", out var textDocument)
+                    && textDocument.ValueKind == JsonValueKind.Object
+                    && textDocument.TryGetProperty("diagnostic", out var diagnostic)
+                    && diagnostic.ValueKind == JsonValueKind.Object)
+                {
+                    this.clientSupportsPullDiagnostics = true;
+                }
+
+                if (capabilities.TryGetProperty("workspace", out var workspace)
+                    && workspace.ValueKind == JsonValueKind.Object
+                    && workspace.TryGetProperty("diagnostics", out var wsDiagnostics)
+                    && wsDiagnostics.ValueKind == JsonValueKind.Object
+                    && wsDiagnostics.TryGetProperty("refreshSupport", out var refreshSupport)
+                    && refreshSupport.ValueKind == JsonValueKind.True)
+                {
+                    this.clientSupportsDiagnosticRefresh = true;
+                }
+            }
+        }
+        catch
+        {
+            // Capability probing is best-effort; absence of pull support falls back to push.
+        }
+    }
+
+    private void RequestDiagnosticRefresh(DocumentUri changedUri)
+    {
+        if (!this.clientSupportsPullDiagnostics || !this.clientSupportsDiagnosticRefresh)
+        {
+            return;
+        }
+
+        // Single-file edits do not affect other documents, so skip refreshes for documents that
+        // are not part of a multi-file project.
+        var filePath = changedUri.GetFileSystemPath();
+        var project = !string.IsNullOrEmpty(filePath) ? this.workspaceState.GetProjectForFile(filePath) : null;
+        if (project == null || project.SourceFiles.Count <= 1)
+        {
+            return;
+        }
+
+        this.RequestDiagnosticRefresh();
+    }
+
+    private void RequestDiagnosticRefresh()
+    {
+        if (!this.clientSupportsDiagnosticRefresh)
+        {
+            return;
+        }
+
+        // Debounce: coalesce bursts of changes into a single workspace/diagnostic/refresh request.
+        lock (this.refreshLock)
+        {
+            this.refreshTimer ??= new Timer(_ => this.SendDiagnosticRefresh(), null, Timeout.Infinite, Timeout.Infinite);
+            this.refreshTimer.Change(500, Timeout.Infinite);
+        }
+    }
+
+    private void SendDiagnosticRefresh()
+    {
+        try
+        {
+            this.rpc?.InvokeAsync("workspace/diagnostic/refresh");
+        }
+        catch
+        {
+            // The client may have disconnected; refresh is best-effort.
+        }
+    }
+
+    private static string ComputeResultId(IReadOnlyList<Diagnostic> diagnostics)
+    {
+        var builder = new StringBuilder();
+        foreach (var d in diagnostics)
+        {
+            builder.Append((int)d.Severity).Append('|');
+            if (d.Range != null)
+            {
+                builder.Append(d.Range.Start?.Line).Append(',').Append(d.Range.Start?.Character).Append('-')
+                    .Append(d.Range.End?.Line).Append(',').Append(d.Range.End?.Character);
+            }
+
+            builder.Append('|').Append(d.Code?.Value).Append('|').Append(d.Message).Append('\n');
+        }
+
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString()));
+        return Convert.ToHexString(bytes);
     }
 
     private SemanticTokens ComputeSemanticTokens(TextDocumentIdentifier identifier)

--- a/src/LanguageServer/Server/ServerCapabilitiesFactory.cs
+++ b/src/LanguageServer/Server/ServerCapabilitiesFactory.cs
@@ -63,6 +63,12 @@ public static class ServerCapabilitiesFactory
                 Range = true,
             },
             InlayHintProvider = new InlayHintOptions { ResolveProvider = false },
+            DiagnosticProvider = new DiagnosticOptions
+            {
+                Identifier = Constants.LanguageId,
+                InterFileDependencies = true,
+                WorkspaceDiagnostics = false,
+            },
         };
     }
 }

--- a/src/vscode-gsharp/src/server/serverManager.ts
+++ b/src/vscode-gsharp/src/server/serverManager.ts
@@ -157,6 +157,10 @@ export class ServerManager {
       const clientOptions: LanguageClientOptions = {
         documentSelector: [{ scheme: 'file', language: 'gsharp' }],
         traceOutputChannel: traceChannel,
+        diagnosticPullOptions: {
+          onChange: true,
+          onSave: true,
+        },
         initializationOptions: {
           formattingIndentSize: vscode.workspace
             .getConfiguration('gsharp')

--- a/test/Core.Tests/CodeAnalysis/Binding/BoundScopeNullKeyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/BoundScopeNullKeyTests.cs
@@ -1,0 +1,46 @@
+// <copyright file="BoundScopeNullKeyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public class BoundScopeNullKeyTests
+{
+    // A null symbol name must never reach a Dictionary key, which would throw
+    // ArgumentNullException ("Value cannot be null. (Parameter 'key')") and crash the
+    // whole language-server request (diagnostics, inlay hints, semantic tokens, code lens).
+    [Fact]
+    public void TryLookupSymbol_NullName_ReturnsNullWithoutThrowing()
+    {
+        var scope = new BoundScope(null, ReferenceResolver.Default());
+
+        var result = scope.TryLookupSymbol(null);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryLookupTypeAlias_NullName_ReturnsFalseWithoutThrowing()
+    {
+        var scope = new BoundScope(null, ReferenceResolver.Default());
+
+        var found = scope.TryLookupTypeAlias(null, out var type);
+
+        Assert.False(found);
+        Assert.Null(type);
+    }
+
+    [Fact]
+    public void TryDeclareTypeAlias_NullName_ReturnsFalseWithoutThrowing()
+    {
+        var scope = new BoundScope(null, ReferenceResolver.Default());
+
+        var declared = scope.TryDeclareTypeAlias(null, TypeSymbol.Int32);
+
+        Assert.False(declared);
+    }
+}

--- a/test/LanguageServer.Tests/DocumentDiagnosticHandlerTests.cs
+++ b/test/LanguageServer.Tests/DocumentDiagnosticHandlerTests.cs
@@ -131,6 +131,25 @@ public class DocumentDiagnosticHandlerTests
         }
     }
 
+    [Fact]
+    public async Task DocumentDiagnostic_ErrorOnLaterLine_ReportsCorrectColumn()
+    {
+        // Regression: column mapping previously hardcoded a 2-char ("\r\n") line break, so on
+        // LF documents every line after the first was reported one column too early.
+        // Line 1 (0-based) is "var y uint8 = 255"; "255" starts at character index 14.
+        const string source = "let a = 1\nvar y uint8 = 255\n";
+        var (server, uri) = await CreateServerWithDocumentAsync(source);
+
+        var report = await server.DocumentDiagnosticAsync(
+            new DocumentDiagnosticParams { TextDocument = new TextDocumentIdentifier { Uri = uri } },
+            CancellationToken.None);
+
+        var full = Assert.IsType<FullDocumentDiagnosticReport>(report);
+        var conversion = Assert.Single(full.Items, d => d.Message.Contains("Cannot convert type", StringComparison.Ordinal));
+        Assert.Equal(1, conversion.Range.Start.Line);
+        Assert.Equal(14, conversion.Range.Start.Character);
+    }
+
     private static async Task<(LspServer Server, DocumentUri Uri)> CreateServerWithDocumentAsync(string source)
     {
         var server = new LspServer(new DocumentContentService(), new WorkspaceState());

--- a/test/LanguageServer.Tests/DocumentDiagnosticHandlerTests.cs
+++ b/test/LanguageServer.Tests/DocumentDiagnosticHandlerTests.cs
@@ -92,6 +92,45 @@ public class DocumentDiagnosticHandlerTests
         Assert.Contains("\"items\":", json, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task DocumentDiagnostic_ProjectFile_ReportsConversionError()
+    {
+        // Regression for #359 follow-up: a file that belongs to a project still reports its own
+        // semantic/binding diagnostics. The project keeps a separate SyntaxTree instance per file,
+        // so the report must be attributed to the in-memory-synced tree rather than dropped.
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "gsdiag" + Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        try
+        {
+            var gsPath = System.IO.Path.Combine(dir, "Program.gs");
+            const string source = "var y uint8 = 255\n";
+            System.IO.File.WriteAllText(gsPath, source);
+            System.IO.File.WriteAllText(
+                System.IO.Path.Combine(dir, "Repro.gsproj"),
+                "<Project Sdk=\"Gsharp.NET.Sdk\">\n<PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net10.0</TargetFramework></PropertyGroup>\n<ItemGroup><Compile Include=\"Program.gs\" /></ItemGroup>\n</Project>\n");
+
+            var workspace = new WorkspaceState();
+            WorkspaceInitializer.Initialize(workspace, dir);
+            var server = new LspServer(new DocumentContentService(), workspace);
+            var uri = DocumentUri.FromFileSystemPath(gsPath);
+            await server.DidOpenAsync(new DidOpenTextDocumentParams
+            {
+                TextDocument = new TextDocumentItem { Uri = uri, Text = source },
+            });
+
+            var report = await server.DocumentDiagnosticAsync(
+                new DocumentDiagnosticParams { TextDocument = new TextDocumentIdentifier { Uri = uri } },
+                CancellationToken.None);
+
+            var full = Assert.IsType<FullDocumentDiagnosticReport>(report);
+            Assert.Contains(full.Items, d => d.Message.Contains("Cannot convert type", StringComparison.Ordinal));
+        }
+        finally
+        {
+            System.IO.Directory.Delete(dir, recursive: true);
+        }
+    }
+
     private static async Task<(LspServer Server, DocumentUri Uri)> CreateServerWithDocumentAsync(string source)
     {
         var server = new LspServer(new DocumentContentService(), new WorkspaceState());

--- a/test/LanguageServer.Tests/DocumentDiagnosticHandlerTests.cs
+++ b/test/LanguageServer.Tests/DocumentDiagnosticHandlerTests.cs
@@ -1,0 +1,105 @@
+// <copyright file="DocumentDiagnosticHandlerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GSharp.LanguageServer.Protocol;
+using GSharp.LanguageServer.Server;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+public class DocumentDiagnosticHandlerTests
+{
+    private const string BodyErrorSource = "func F() int32 {\n}\n";
+
+    [Fact]
+    public async Task DocumentDiagnostic_IncludesBindingDiagnostics()
+    {
+        var (server, uri) = await CreateServerWithDocumentAsync(BodyErrorSource);
+
+        var report = await server.DocumentDiagnosticAsync(
+            new DocumentDiagnosticParams { TextDocument = new TextDocumentIdentifier { Uri = uri } },
+            CancellationToken.None);
+
+        var full = Assert.IsType<FullDocumentDiagnosticReport>(report);
+        Assert.Equal("full", full.Kind);
+        Assert.False(string.IsNullOrEmpty(full.ResultId));
+        Assert.Contains(full.Items, d => d.Message.Contains("Not all code paths", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DocumentDiagnostic_UnchangedPreviousResultId_ReturnsUnchangedReport()
+    {
+        var (server, uri) = await CreateServerWithDocumentAsync(BodyErrorSource);
+
+        var first = (FullDocumentDiagnosticReport)await server.DocumentDiagnosticAsync(
+            new DocumentDiagnosticParams { TextDocument = new TextDocumentIdentifier { Uri = uri } },
+            CancellationToken.None);
+
+        var second = await server.DocumentDiagnosticAsync(
+            new DocumentDiagnosticParams
+            {
+                TextDocument = new TextDocumentIdentifier { Uri = uri },
+                PreviousResultId = first.ResultId,
+            },
+            CancellationToken.None);
+
+        var unchanged = Assert.IsType<UnchangedDocumentDiagnosticReport>(second);
+        Assert.Equal("unchanged", unchanged.Kind);
+        Assert.Equal(first.ResultId, unchanged.ResultId);
+    }
+
+    [Fact]
+    public async Task DocumentDiagnostic_UnknownDocument_ReturnsEmptyFullReport()
+    {
+        var server = new LspServer(new DocumentContentService(), new WorkspaceState());
+
+        var report = await server.DocumentDiagnosticAsync(
+            new DocumentDiagnosticParams { TextDocument = new TextDocumentIdentifier { Uri = DocumentUri.From("file:///missing.gs") } },
+            CancellationToken.None);
+
+        var full = Assert.IsType<FullDocumentDiagnosticReport>(report);
+        Assert.Empty(full.Items);
+    }
+
+    [Fact]
+    public void ServerCapabilities_AdvertisesPullDiagnostics()
+    {
+        var capabilities = ServerCapabilitiesFactory.Create();
+
+        Assert.NotNull(capabilities.DiagnosticProvider);
+        Assert.Equal(Constants.LanguageId, capabilities.DiagnosticProvider.Identifier);
+        Assert.True(capabilities.DiagnosticProvider.InterFileDependencies);
+    }
+
+    [Fact]
+    public async Task DocumentDiagnostic_Report_SerializesRuntimeKind()
+    {
+        var (server, uri) = await CreateServerWithDocumentAsync(BodyErrorSource);
+
+        object report = await server.DocumentDiagnosticAsync(
+            new DocumentDiagnosticParams { TextDocument = new TextDocumentIdentifier { Uri = uri } },
+            CancellationToken.None);
+
+        // The handler returns object; the protocol depends on the runtime type ("full"/"unchanged")
+        // being serialized, not the declared object type.
+        var json = System.Text.Json.JsonSerializer.Serialize(report, LspJson.Options);
+        Assert.Contains("\"kind\":\"full\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"items\":", json, StringComparison.Ordinal);
+    }
+
+    private static async Task<(LspServer Server, DocumentUri Uri)> CreateServerWithDocumentAsync(string source)
+    {
+        var server = new LspServer(new DocumentContentService(), new WorkspaceState());
+        var uri = DocumentUri.From("file:///diagnostic-test.gs");
+        await server.DidOpenAsync(new DidOpenTextDocumentParams
+        {
+            TextDocument = new TextDocumentItem { Uri = uri, Text = source },
+        });
+        return (server, uri);
+    }
+}

--- a/website/docs/tooling/lsp.md
+++ b/website/docs/tooling/lsp.md
@@ -39,7 +39,7 @@ The server capability factory enables the following:
 | Capability | LSP surface |
 | --- | --- |
 | Text synchronization | Open/close, full-document changes, save with text. |
-| Diagnostics | `textDocument/publishDiagnostics` notifications after open/change/save. |
+| Diagnostics | `textDocument/diagnostic` pull requests (live as-you-type), with `workspace/diagnostic/refresh` for cross-file edits; falls back to `textDocument/publishDiagnostics` for push-only clients. |
 | Hover | `textDocument/hover`. |
 | Definition | `textDocument/definition`. |
 | Type definition | `textDocument/typeDefinition`. |
@@ -62,7 +62,7 @@ The server capability factory enables the following:
 
 ## Diagnostics lifecycle
 
-On open and change, the server parses the active document and publishes responsive syntax/global-scope diagnostics while skipping the full binding pass. On save, it runs the fuller binding pipeline and republishes diagnostics. The active document is stored in memory, and if it belongs to a discovered `.gsproj`, the project state is updated before diagnostics are computed.
+The server keeps the active document parsed in memory and, when it belongs to a discovered `.gsproj`, updates the project state on open/change/save. Diagnostics are served through the LSP **pull model**: the editor requests `textDocument/diagnostic` as the user types and on save, and the server runs the full pipeline — syntax, global-scope semantic analysis, and the binding pass — on every pull, so binding errors appear live rather than only on save. Each report carries a `resultId`; unchanged results return an `unchanged` report so the client reuses existing squiggles. The binding pass runs off the handler gate and supports cancellation, keeping interactive requests responsive, and cross-file edits in multi-file projects trigger a debounced `workspace/diagnostic/refresh`. Push-only clients (no pull-diagnostic capability) fall back to `textDocument/publishDiagnostics` on open/change/save.
 
 ## Workspace and project awareness
 


### PR DESCRIPTION
Closes #359.

## Problem

Diagnostics were **push-based** (`textDocument/publishDiagnostics`) and the language server deliberately skipped the binding pass except on save. Binding diagnostics — the bulk of real errors (unreachable code, missing returns, type mismatches inside function bodies) — therefore only appeared after a save/compile, not as the user typed.

## Approach

Moved to a Roslyn-style **pull-diagnostics** architecture (`textDocument/diagnostic` + `workspace/diagnostic/refresh`), so the editor pulls diagnostics as you type and the full binding pass runs live.

### Server (`src/LanguageServer/`)
- Added pull-diagnostic protocol types (`DiagnosticOptions`, `DocumentDiagnosticParams` with `previousResultId`, `FullDocumentDiagnosticReport`/`UnchangedDocumentDiagnosticReport`) and advertised the `diagnosticProvider` capability (`identifier=gsharp`, `interFileDependencies=true`).
- New `textDocument/diagnostic` handler runs the **full binding pass on every pull**. Text is snapshotted under the handler gate, then bound **off-gate with cancellation**, so a slow analysis never blocks interactive requests (hover/completion).
- **`resultId` caching** returns an `unchanged` report when nothing relevant changed.
- **Debounced `workspace/diagnostic/refresh`** for cross-file edits and watched-file changes in multi-file projects.
- **Retired push** `publishDiagnostics` for the live flow; kept it as a **fallback** for clients that don't advertise pull support (detected from client capabilities).

### Client (`src/vscode-gsharp/`)
- Set `diagnosticPullOptions { onChange, onSave }`. `vscode-languageclient ^9` activates pull diagnostics from the advertised capability.

### Docs
- Updated `docs/lsp.md` and `website/docs/tooling/lsp.md`.

## Testing
- `dotnet build GSharp.sln` — clean (0 warnings/errors).
- `dotnet test GSharp.sln` — **1855 passed, 0 failed**, including 5 new LanguageServer tests: live binding diagnostics, unchanged `resultId` report, empty-document handling, capability advertisement, and runtime-kind wire serialization.
- TS typecheck + eslint clean.

## Notes
The existing project-mode `ComputeDiagnostics` filter (by `SourceText` reference) was intentionally left untouched — the pull path has exact parity with the prior save path, so there's no behavior regression. Fixing that filter would be a separate, out-of-scope change.