### PR TITLE
Produce clean version on tag builds and surface nbgv version in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,22 @@ jobs:
       - name: Restore
         run: dotnet restore GSharp.sln
 
+      - name: Show Nerdbank.GitVersioning version
+        # Surface the version nbgv will stamp on assemblies / NuGet packages so
+        # that, when a build from `main` is green, the printed NuGetPackageVersion
+        # can be used directly as the `vX.Y.Z` release tag.
+        run: |
+          dotnet tool install --global nbgv || dotnet tool update --global nbgv
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          nbgv get-version
+          {
+            echo "### Nerdbank.GitVersioning"
+            echo ''
+            echo '```'
+            nbgv get-version
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Build
         # Build the solution explicitly with the static project graph so each
         # project (notably Compiler, which is referenced by Compiler.Tests) is

--- a/version.json
+++ b/version.json
@@ -8,6 +8,7 @@
   
     "publicReleaseRefSpec": [
       "^refs/heads/main$", // we release out of main
+      "^refs/tags/v\\d+(?:\\.\\d+)*$" // tagged releases (e.g. refs/tags/v1.2.3)
     ],
     "cloudBuild": {
       "buildNumber": {


### PR DESCRIPTION
## Summary

When release builds are triggered by pushing a `vX.Y.Z` tag, Nerdbank.GitVersioning was producing versions of the shape `X.Y.Z-gSHORTSHA` because `publicReleaseRefSpec` in `version.json` only matched `refs/heads/main`. Tag refs fell outside the public-release list and got the git-hash prerelease suffix on assemblies and NuGet packages.

## Changes

- **`version.json`**: add `^refs/tags/v\d+(?:\.\d+)*$` to `publicReleaseRefSpec` so builds from `vX[.Y[.Z]]` tags are treated as public releases and emit clean `X.Y.Z` versions.
- **`.github/workflows/build.yml`**: add a *Show Nerdbank.GitVersioning version* step early in the `build` job. It installs the `nbgv` global tool (same pattern as the existing `vsix` job), runs `nbgv get-version` to print the full version table to the log, and mirrors it into `$GITHUB_STEP_SUMMARY`. This makes the `NuGetPackageVersion` from a green `main` build easy to spot so it can be used directly as the next `vX.Y.Z` release tag.

## Notes

- The tag regex matches `vMAJOR`, `vMAJOR.MINOR`, and `vMAJOR.MINOR.PATCH`. Tweak later if we ever ship tags with prerelease suffixes (e.g. `v1.2.3-rc1`).
- Remember to bump `version` in `version.json` to match the tag before releasing, so the computed version at the tag commit equals the tag.