### PR TITLE
Apply []T -> Span/ReadOnlySpan conversion in argument position

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -7255,6 +7255,12 @@ public sealed class Binder
             if (argument.Type != parameter.Type
                 && !Conversion.Classify(argument.Type, parameter.Type).IsImplicit)
             {
+                if (TryApplyUserDefinedImplicitArgumentConversion(argument, parameter.Type, out var convertedArg))
+                {
+                    boundArguments[i] = convertedArg;
+                    continue;
+                }
+
                 if (argument.Type != TypeSymbol.Error)
                 {
                     Diagnostics.ReportWrongArgumentType(syntax.Arguments[i].Location, parameter.Name, parameter.Type, argument.Type);
@@ -7331,6 +7337,12 @@ public sealed class Binder
             if (argument.Type != parameter.Type
                 && !Conversion.Classify(argument.Type, parameter.Type).IsImplicit)
             {
+                if (TryApplyUserDefinedImplicitArgumentConversion(argument, parameter.Type, out var convertedArg))
+                {
+                    convertedArguments.Add(convertedArg);
+                    continue;
+                }
+
                 if (argument.Type != TypeSymbol.Error)
                 {
                     Diagnostics.ReportWrongArgumentType(syntax.Arguments[i].Location, parameter.Name, parameter.Type, argument.Type);
@@ -7590,6 +7602,12 @@ public sealed class Binder
                 && !(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type))
                 && !Conversion.Classify(argument.Type, expectedType).IsImplicit)
             {
+                if (TryApplyUserDefinedImplicitArgumentConversion(argument, expectedType, out var convertedArg))
+                {
+                    boundArguments[i] = convertedArg;
+                    continue;
+                }
+
                 if (argument.Type != TypeSymbol.Error)
                 {
                     Diagnostics.ReportWrongArgumentType(syntax.Arguments[i].Location, parameter.Name, expectedType, argument.Type);
@@ -10266,6 +10284,29 @@ public sealed class Binder
         }
 
         return new BoundConversionExpression(null, type, expression);
+    }
+
+    // ADR-0056 (#344), low-hanging-fruit item #3: a call argument whose declared
+    // parameter type is reachable only through a user-defined CLR `op_Implicit`
+    // (e.g. `[]T -> System.ReadOnlySpan[T]` / `Span[T]`) is converted here, the
+    // same way local-init/explicit-target conversions go through `BindConversion`.
+    // Built-in conversions (identity, numeric widening, ...) classify earlier and
+    // never reach this fallback, so existing overloads keep selecting unchanged.
+    // Returns true and emits a `BoundClrConversionCallExpression` when a
+    // user-defined implicit conversion applies; false leaves the argument as-is.
+    private bool TryApplyUserDefinedImplicitArgumentConversion(BoundExpression argument, TypeSymbol expectedType, out BoundExpression converted)
+    {
+        if (argument?.Type?.ClrType != null
+            && expectedType?.ClrType != null
+            && argument.Type != TypeSymbol.Error
+            && ClrOperatorResolution.TryResolveConversion(argument.Type.ClrType, expectedType.ClrType, allowExplicit: false, out var convMethod, out _))
+        {
+            converted = new BoundClrConversionCallExpression(null, argument, convMethod, expectedType);
+            return true;
+        }
+
+        converted = argument;
+        return false;
     }
 
     private VariableSymbol BindVariableDeclaration(SyntaxToken identifier, bool isReadOnly, TypeSymbol type)

--- a/test/Core.Tests/CodeAnalysis/Binding/RefStructTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefStructTests.cs
@@ -55,6 +55,42 @@ func length(arr []int32) int32 {
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
     }
 
+    // ADR-0056 (#344) low-hanging-fruit #3: the `[]T -> ReadOnlySpan[T]`
+    // user-defined `op_Implicit` that already works at local-init position must
+    // also apply when the slice is passed as a call argument, with no GS0154.
+    [Fact]
+    public void SliceArgument_ToReadOnlySpanParameter_IsPermitted()
+    {
+        var source = @"
+import System
+func sum(s ReadOnlySpan[int32]) int32 { return s.Length }
+func Main() {
+    var nums []int32 = []int32{10, 20, 30}
+    Console.WriteLine(sum(nums))
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0154");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    // ADR-0056 (#344): the same implicit conversion applies for `Span[T]`.
+    [Fact]
+    public void SliceArgument_ToSpanParameter_IsPermitted()
+    {
+        var source = @"
+import System
+func len(s Span[int32]) int32 { return s.Length }
+func Main() {
+    var nums []int32 = []int32{1, 2, 3, 4}
+    Console.WriteLine(len(nums))
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0154");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
     [Fact]
     public void Boxing_RefStruct_ToObject_Reports_GS0219()
     {

--- a/test/Core.Tests/CodeAnalysis/Emit/ByRefEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/ByRefEmitTests.cs
@@ -75,6 +75,26 @@ Console.WriteLine(counter)
         Assert.Contains("1", output);
     }
 
+    // ADR-0056 (#344) low-hanging-fruit #3: a `[]int32` argument flowing into a
+    // `ReadOnlySpan[int32]` parameter goes through the `op_Implicit` conversion at
+    // the call site, end-to-end, just like it already does at local-init position.
+    [Fact]
+    public void SliceArgument_ToReadOnlySpanParameter_Emits_And_Runs()
+    {
+        const string Source = @"package SliceToSpanArg
+import System
+
+func sum(s ReadOnlySpan[int32]) int32 {
+    return s.Length
+}
+
+var nums []int32 = []int32{10, 20, 30}
+Console.WriteLine(sum(nums))
+";
+        var output = CompileAndRun(Source, "SliceToSpanArg");
+        Assert.Contains("3", output);
+    }
+
     private static string CompileAndRun(string source, string contextName)
     {
         using var peStream = new MemoryStream();


### PR DESCRIPTION
## Summary

Implements **low-hanging-fruit item #3** from the ADR-0056 (Span consumption v1) gap analysis: applying the implicit `[]T → System.Span[T]` / `[]T → System.ReadOnlySpan[T]` conversion in **argument position**.

The slice→span conversion is a user-defined CLR `op_Implicit` (`ReadOnlySpan<T>`/`Span<T>` define an implicit operator from `T[]`). It already worked at **local-init** position because `Binder.BindConversion` falls back to `ClrOperatorResolution.TryResolveConversion` and emits a `BoundClrConversionCallExpression` when built-in `Conversion.Classify` returns `None`. Call/overload binding, however, validated arguments with `Conversion.Classify` only and never reached that fallback, so passing a `[]int32` where a `ReadOnlySpan[int32]` parameter was expected failed:

```
func sum(s ReadOnlySpan[int32]) int32 { return s.Length }
sum(nums)   // GS0154: parameter 's' requires ReadOnlySpan[int32] but was given []int32
```

## Fix

`src/Core/CodeAnalysis/Binding/Binder.cs`:

- Added a small helper `TryApplyUserDefinedImplicitArgumentConversion(argument, expectedType, out converted)` that, when no built-in conversion applies, looks up a user-defined `op_Implicit` via `ClrOperatorResolution.TryResolveConversion(..., allowExplicit: false, ...)` and produces a `BoundClrConversionCallExpression` — the exact node `BindConversion` already uses.
- Routed the argument-validation loops through this helper **before** reporting GS0154, in the user-function call path, the primary-constructor path, and the explicit-constructor path.

The fallback is only reached after `Conversion.Classify` reports the argument is not identity/implicit, so identity and exact-typed arguments still win and existing overload selection is unchanged. It is implicit-only (`allowExplicit: false`). The by-ref-like escape rules (GS0219) are untouched — passing a span by value remains fine.

## Tests added

- `test/Core.Tests/CodeAnalysis/Binding/RefStructTests.cs`
  - `SliceArgument_ToReadOnlySpanParameter_IsPermitted` — `[]int32` arg binds to a `ReadOnlySpan[int32]` parameter with no GS0154/GS0219.
  - `SliceArgument_ToSpanParameter_IsPermitted` — same for `Span[int32]`.
- `test/Core.Tests/CodeAnalysis/Emit/ByRefEmitTests.cs`
  - `SliceArgument_ToReadOnlySpanParameter_Emits_And_Runs` — end-to-end emit+run of `sum(nums)`.

## Test results

Full `dotnet test GSharp.sln` passes: Core 1474, Compiler 256, LanguageServer 143, Interpreter 54, Sdk 24 — **0 failed, 0 skipped**.

Refs ADR-0056, #344.
