### PR TITLE
docs(website): cover ADR-0056 span consumption and by-ref semantics

### DIFF
--- a/website/docs/ref/clr-interop.md
+++ b/website/docs/ref/clr-interop.md
@@ -196,6 +196,66 @@ The by-ref surface is deliberately scoped to managed references for CLR interop.
 | `GS9005` | `&` is applied to a constant. |
 | `GS9006` | A pointer (`*T`) type is used as a field type. |
 
+## Spans and `ref struct` types
+
+G# can consume CLR `ref struct` types — most importantly `System.Span[T]` and `System.ReadOnlySpan[T]` — as ordinary stack-only locals, parameters, and fields. The consumption surface is defined by [ADR-0056](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0056-span-consumption-v1.md) and builds on the by-ref machinery above.
+
+A by-ref-like (`ref struct`) value carries `System.Runtime.CompilerServices.IsByRefLikeAttribute` and is stack-only: the CLR forbids any use that would let it reach the heap. G# enforces this with **`GS0219`** — boxing or converting it to a reference type, storing it in a non-`ref struct` field, capturing it in a closure, hoisting it into an `async`/iterator state machine, using it as a generic type argument, or declaring it as a top-level global are all rejected. Because of the last rule, span locals live inside functions.
+
+### Span element access
+
+A `Span[T]` / `ReadOnlySpan[T]` indexer returns a managed pointer (`ref T` / `ref readonly T`). Reading an element in rvalue position **auto-dereferences** the ref return to the pointee `T` (you do not write `*`), and a `Span[T]` element write `s[i] = v` stores through the returned `ref T`:
+
+```gsharp
+import System
+
+func sumSpan(values []int32) int32 {
+    var s ReadOnlySpan[int32] = values   // []T -> ReadOnlySpan[T] implicit conversion
+    var total = 0
+    var i = 0
+    for i < s.Length {
+        total = total + s[i]             // read auto-dereferences ref readonly int32 -> int32
+        i = i + 1
+    }
+    return total
+}
+
+func writeBack(values []int32) int32 {
+    var s Span[int32] = values
+    s[0] = 100                           // store through the ref int32 from get_Item
+    s[2] = 300
+    return s[0] + s[1] + s[2]
+}
+```
+
+A `ReadOnlySpan[T]` element is `ref readonly T`, so writing through it is a hard error — **`GS0226`** (`s[0] = 1` on a `ReadOnlySpan[T]`); reading it is always allowed. Auto-dereference is the same general rule for every ref-returning CLR member (indexers, `ref` property getters, ref-returning methods): **ref returns auto-dereference in rvalue position; taking an address still requires `&`.**
+
+### Slice-to-span conversion
+
+A `[]T` slice converts implicitly to `Span[T]` / `ReadOnlySpan[T]` (via the BCL's `op_Implicit`) at local initialization **and** in argument position, so a slice flows straight into a span-typed BCL or user API without an explicit cast.
+
+### Closed generic value-type fields
+
+A user `ref struct` may embed a **closed** constructed generic value-type field, such as a span:
+
+```gsharp
+import System
+
+type Window ref struct {
+    data ReadOnlySpan[int32]
+}
+
+func firstLen(w Window) int32 {
+    return w.data.Length
+}
+```
+
+Such a field is emitted with its real layout (`valuetype ReadOnlySpan<int32>`, never erased to `System.Object`), and instance-member calls on the field receiver take its address correctly. Type erasure (see [Generics interop](#generics-interop)) applies only to *open*, type-parameter-bearing shapes; closed value-type generics in field position carry real layout.
+
+### Limitations
+
+Per ADR-0056, the following remain out of scope: by-ref returns from G# functions and the full two-level `ref-safe-to-escape` analysis (`scoped`, `[UnscopedRef]`), deferred to [issue #376](https://github.com/DavidObando/gsharp/issues/376); open generic value-type `ref struct` fields (`type Buffer[T] ref struct { data ReadOnlySpan[T] }`); `stackalloc` and other span-*creation* primitives; and a lowercase `span[T]` alias (spans are imported CLR types `Span[T]` / `ReadOnlySpan[T]`, requiring `import System`).
+
 ## Generics interop
 
 Imported generic types and methods use G# bracket syntax:
@@ -206,7 +266,7 @@ import System.Collections.Generic
 var xs = List[int32]()
 ```
 
-G# emits metadata specs for constructed generic types and methods, supports type-argument inference for imported open generic methods, and supports variance markers and constraints in its own type parameter model. The current implementation also has a type-erased generic model for some open or partially constructed shapes that contain type parameters; those shapes may be represented as `object` in emit paths. Treat this as an implementation constraint rather than a source-level API.
+G# emits metadata specs for constructed generic types and methods, supports type-argument inference for imported open generic methods, and supports variance markers and constraints in its own type parameter model. The current implementation also has a type-erased generic model for some open or partially constructed shapes that contain type parameters; those shapes may be represented as `object` in emit paths. Closed constructed generic *value* types (e.g. `ReadOnlySpan[int32]`, `Nullable[int32]`) are an exception: in field position they carry their real layout and are never erased (see [Spans and `ref struct` types](#spans-and-ref-struct-types)). Treat the open-shape erasure as an implementation constraint rather than a source-level API.
 
 ## Interpolated strings and formatting
 

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -74,7 +74,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0113 | Error | Undefined type. | A type name referenced in code does not exist. |
 | GS0114 | Error | Invalid array length. | Array length must be a non-negative integer literal. |
 | GS0115 | Error | Array literal length mismatch. | `[3]int{1, 2}` — literal has 2 elements but length is 3. |
-| GS0116 | Error | Type is not indexable. | `x[0]` where `x` is `bool` or another non-array/slice type. |
+| GS0116 | Error | Type is not indexable. | `x[0]` where `x` is `bool` or another type with no array/slice/map element access and no CLR indexer. Arrays, slices, maps, CLR indexers, and `Span[T]` / `ReadOnlySpan[T]` (ADR-0056 §2) are all indexable. |
 | GS0117 | Error | Invalid argument type for a built-in function. | `len(42)` — `len` cannot be applied to an `int`. |
 | GS0118 | Error | A `try` statement requires at least one `catch` or `finally` clause. | `try { f() }` with no `catch` or `finally`. |
 | GS0119 | Error | Type is not disposable. | `using x = Foo()` where `Foo` provides no public `Dispose()` method. |
@@ -183,6 +183,22 @@ ADR-0047 introduces Kotlin-style attribute syntax (`@Foo(...)`) and the `@Attrib
 | GS0205 | Error | Attribute is reserved for compiler synthesis. | `@CompilerGenerated`, `@Extension`, `@AsyncStateMachine`, `@Nullable`, or `@NullableContext` written in user source. |
 | GS0206 | Error | Annotations are only allowed on variable declarations, not on this statement. | `@Obsolete\nreturn` inside a function body — annotations may precede `var`/`let`/`const` but no other statement kind. |
 | GS0211 | Error | Attribute `[DllImport]` is recognised but not supported in v1.0; P/Invoke (extern function bodies) is a post-v1.0 feature. | `@DllImport("user32.dll") func MessageBox() {}` — emit support and the `extern` body marker arrive after v1.0. |
+
+### By-ref-like (`ref struct`) diagnostics (GS0219)
+
+A by-ref-like type — a CLR `ref struct` carrying `System.Runtime.CompilerServices.IsByRefLikeAttribute`, such as `System.Span[T]`, `System.ReadOnlySpan[T]`, or `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler` — is stack-only (issue #367). G# permits declaring and using such a value as an ordinary local (including a user-declared `type X ref struct { … }`), but the CLR forbids any use that would let it reach the heap.
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0219 | Error | A by-ref-like (`ref struct`) value is used in a position that would let it escape the stack: boxing / converting it to a reference type, storing it in a field of a non-`ref struct` (instance, primary-constructor, or static), capturing it in a closure, declaring it as a local in an `async` function or iterator (where it would be hoisted into the heap-allocated state machine), using it as a generic type argument, or declaring it as a top-level global. | `var o object = span` (box); a `class` field typed `Span[int32]`; capturing a `ReadOnlySpan[char]` local inside `func() { … }`; a `Span[int32]` local in an `async` function; `List[ReadOnlySpan[int32]]`. |
+
+### Span element access diagnostics (GS0226)
+
+ADR-0056 §1/§2 makes spans indexable: a `Span[T]` / `ReadOnlySpan[T]` indexer returns a managed pointer (`ref T` / `ref readonly T`), and a read in rvalue position auto-dereferences to the pointee `T`. A `Span[T]` element write `s[i] = v` stores through the `ref T`; a `ReadOnlySpan[T]` element is `ref readonly T`, so writing through it is rejected.
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0226 | Error | Cannot assign through a read-only span element (`ReadOnlySpan[T]` is read-only). | `var s ReadOnlySpan[int32] = arr` then `s[0] = 1` — a `ReadOnlySpan[T]` indexer is `ref readonly T`; use `Span[T]` to write. |
 
 ### Pointer / by-ref diagnostics (GS9001–GS9006)
 

--- a/website/docs/ref/feature-matrix.md
+++ b/website/docs/ref/feature-matrix.md
@@ -44,7 +44,8 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Function types, literals, closures | Supported | Supported | Delegate conversions are strongest on the emit path. |
 | Generics and method inference | Supported | Supported for binding/evaluation | Metadata specs plus type-erased handling for open type-parameter-containing shapes. |
 | Variance and constraints | Supported semantically | Supported semantically | Diagnostics include `GS0150` through `GS0153`. |
-| By-ref and pointers | Partial | Limited/not supported | Syntax and diagnostics exist; evaluator rejects generic address/deref execution. |
+| By-ref and pointers | Partial | Limited/not supported | `&` / `*` / `*T` for CLR `ref`/`out`/`in` interop (ADR-0039); ref returns auto-dereference in rvalue position (ADR-0056 §1). Evaluator rejects generic address/deref execution. |
+| Spans and `ref struct` types | Mostly supported | Limited | Stack-only consumption of `Span[T]` / `ReadOnlySpan[T]` and user `type X ref struct`: element read/write, `[]T`→span conversion, closed generic value-type fields (ADR-0056). Escape rules are `GS0219`; `ReadOnlySpan[T]` writes are `GS0226`. Full ref-safe-to-escape analysis is deferred (#376). |
 
 ## Declarations and members
 

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -273,6 +273,8 @@ TypeArgList = "[" TypeClause { "," TypeClause } "]" .
 
 Byref/pointer syntax exists as `*T`, unary `&`, and unary `*`. It is primarily an emit/interop feature today; the evaluator rejects the generic address-of and dereference path.
 
+CLR `ref struct` types such as `Span[T]` and `ReadOnlySpan[T]` are consumable as stack-only values (ADR-0056): they are indexable (`s[i]`), ref-returning members auto-dereference in rvalue position, a `[]T` slice converts implicitly to a span, and a user `type X ref struct { … }` may embed a closed generic value-type field. Stack-escape violations are reported as `GS0219`; writing through a `ReadOnlySpan[T]` element is `GS0226`. The full ref-safe-to-escape analysis is deferred (issue #376).
+
 ## Declarations and scope
 
 ### Packages and imports


### PR DESCRIPTION
## Summary

The website reference docs lagged the recently-merged ADR-0056 span-consumption work (#382, #383, #384) and the by-ref-like (`ref struct`) escape rules. This brings the **current** docs (`website/docs/ref/`) up to date so spans and the by-ref surface are properly represented.

## Changes

- **`clr-interop.md`** — new **"Spans and `ref struct` types"** section covering ADR-0056 §1–§4: stack-only consumption + `GS0219`, span element read/write with ref-return auto-deref, `ReadOnlySpan[T]` write rejection (`GS0226`), `[]T`→span conversion, and closed generic value-type fields. Also notes in *Generics interop* that closed value-type generics carry real layout (open shapes still erase).
- **`diagnostics.md`** — the catalogue was missing the entire `GS0219`/`GS0226` block. Added **GS0219** (by-ref-like / `ref struct` escape) and **GS0226** (read-only span element write) sections, and refreshed the **GS0116** example to note spans are now indexable.
- **`feature-matrix.md`** — refreshed the *By-ref and pointers* row (ADR-0039 + §1 auto-deref) and added a *Spans and `ref struct` types* row.
- **`spec.md`** — added a span-consumption note to the byref/pointer paragraph.

## Scope notes

- `versioned_docs/version-0.1/` is a **frozen** pre-ADR-0056 snapshot (last touched May 31, no Span/0056 content) and is intentionally left unchanged — new features belong in the current docs.
- The `design-decisions.md` index row for ADR-0056 already landed in #379; this PR is purely the reference-doc coverage.
- Out of scope of these docs (noted as deferred): the unrelated `GS0220–GS0225` interpolation block is also absent from the website catalogue — flagged separately, not addressed here.

## Validation

Full `npm run build` (Docusaurus production build, `onBrokenLinks: 'throw'`) succeeds with no broken links or anchors.

Refs ADR-0056, #382, #383, #384.
