### PR TITLE
docs(website): backfill GS0220–GS0225 interpolation diagnostics

### DIFF
--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -184,6 +184,21 @@ ADR-0047 introduces Kotlin-style attribute syntax (`@Foo(...)`) and the `@Attrib
 | GS0206 | Error | Annotations are only allowed on variable declarations, not on this statement. | `@Obsolete\nreturn` inside a function body — annotations may precede `var`/`let`/`const` but no other statement kind. |
 | GS0211 | Error | Attribute `[DllImport]` is recognised but not supported in v1.0; P/Invoke (extern function bodies) is a post-v1.0 feature. | `@DllImport("user32.dll") func MessageBox() {}` — emit support and the `extern` body marker arrive after v1.0. |
 
+### String interpolation diagnostics (GS0220–GS0225)
+
+ADR-0055 interpolation holes (`${expr,alignment:format}`) and the issue #368 interpolated-string-handler pattern report the following.
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0220 | Error | Interpolation alignment clause is not a constant integer. | `"${x,abc}"` — the value after the `,` in `${expr,alignment[:format]}` must be a constant integer (e.g. `${x,5}` or `${x,-8:X4}`). |
+| GS0221 | Error | An interpolated string passed to an `[InterpolatedStringHandler]` parameter could not satisfy `[InterpolatedStringHandlerArgument]` forwarding. | The forwarded argument names an unknown parameter, the receiver cannot be forwarded, or no handler constructor matches `(int, int, …forwarded[, out bool])`. |
+| GS0222 | Error | Unterminated interpolation hole; expected a closing `}`. | `"v=${a + b"` — the `${` opens a hole that the delimiter-aware scanner never closes before end of file. |
+| GS0223 | Error | Empty interpolation hole; expected an expression between `${` and `}`. | `"x=${}"` — a hole must contain an expression. |
+| GS0224 | Error | Empty format specifier; expected a format string after `:`. | `"${n:}"` — a `:` clause must be followed by a non-empty format string. |
+| GS0225 | Error | Newline in the literal portion of an interpolated string; only `${ … }` holes may span lines. | A raw newline appears outside a hole, e.g. a `"…` opened on one line with no closing `"` before the line break. (Multiline holes themselves are legal.) |
+
+> Note: ADR-0055 originally proposed GS0212–GS0216 for the malformed-hole diagnostics, but those codes were already taken; the implemented codes are **GS0222–GS0225**.
+
 ### By-ref-like (`ref struct`) diagnostics (GS0219)
 
 A by-ref-like type — a CLR `ref struct` carrying `System.Runtime.CompilerServices.IsByRefLikeAttribute`, such as `System.Span[T]`, `System.ReadOnlySpan[T]`, or `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler` — is stack-only (issue #367). G# permits declaring and using such a value as an ordinary local (including a user-declared `type X ref struct { … }`), but the CLR forbids any use that would let it reach the heap.


### PR DESCRIPTION
## Summary

Backfills the missing **GS0220–GS0225 string-interpolation diagnostics** in the website reference catalogue. The website `diagnostics.md` jumped from GS0211 (attributes) straight to the GS9001 pointer block, omitting the interpolation diagnostics that already exist in the canonical `docs/diagnostics.md`. This was flagged as out-of-scope doc debt in #385.

## Changes

- **`website/docs/ref/diagnostics.md`** — adds the **String interpolation diagnostics (GS0220–GS0225)** section, mirroring canonical `docs/diagnostics.md`:
  - GS0220 (non-constant alignment), GS0221 (handler-argument forwarding), GS0222 (unterminated hole), GS0223 (empty hole), GS0224 (empty format specifier), GS0225 (newline in literal portion).
  - Includes the ADR-0055 note that GS0212–GS0216 were originally proposed but the implemented codes are GS0222–GS0225.
- Placed in canonical order — interpolation block before the GS0219 `ref struct` section.

## Notes

- **Stacked on #385** (`DavidObando/website-span-byref-coverage`), which inserts the adjacent GS0219/GS0226 sections. Merge #385 first; this PR's base then collapses to just the interpolation block. (If you'd rather, it can be retargeted to `main` after #385 merges.)
- `versioned_docs/version-0.1/` left unchanged (frozen snapshot).

## Validation

Full `npm run build` (Docusaurus, `onBrokenLinks: 'throw'`) succeeds.

Refs ADR-0055, #368.
