### PR TITLE
docs(website): refresh version-0.1 snapshot from current docs

### DIFF
--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -184,6 +184,21 @@ ADR-0047 introduces Kotlin-style attribute syntax (`@Foo(...)`) and the `@Attrib
 | GS0206 | Error | Annotations are only allowed on variable declarations, not on this statement. | `@Obsolete\nreturn` inside a function body — annotations may precede `var`/`let`/`const` but no other statement kind. |
 | GS0211 | Error | Attribute `[DllImport]` is recognised but not supported in v1.0; P/Invoke (extern function bodies) is a post-v1.0 feature. | `@DllImport("user32.dll") func MessageBox() {}` — emit support and the `extern` body marker arrive after v1.0. |
 
+### String interpolation diagnostics (GS0220–GS0225)
+
+ADR-0055 interpolation holes (`${expr,alignment:format}`) and the issue #368 interpolated-string-handler pattern report the following.
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0220 | Error | Interpolation alignment clause is not a constant integer. | `"${x,abc}"` — the value after the `,` in `${expr,alignment[:format]}` must be a constant integer (e.g. `${x,5}` or `${x,-8:X4}`). |
+| GS0221 | Error | An interpolated string passed to an `[InterpolatedStringHandler]` parameter could not satisfy `[InterpolatedStringHandlerArgument]` forwarding. | The forwarded argument names an unknown parameter, the receiver cannot be forwarded, or no handler constructor matches `(int, int, …forwarded[, out bool])`. |
+| GS0222 | Error | Unterminated interpolation hole; expected a closing `}`. | `"v=${a + b"` — the `${` opens a hole that the delimiter-aware scanner never closes before end of file. |
+| GS0223 | Error | Empty interpolation hole; expected an expression between `${` and `}`. | `"x=${}"` — a hole must contain an expression. |
+| GS0224 | Error | Empty format specifier; expected a format string after `:`. | `"${n:}"` — a `:` clause must be followed by a non-empty format string. |
+| GS0225 | Error | Newline in the literal portion of an interpolated string; only `${ … }` holes may span lines. | A raw newline appears outside a hole, e.g. a `"…` opened on one line with no closing `"` before the line break. (Multiline holes themselves are legal.) |
+
+> Note: ADR-0055 originally proposed GS0212–GS0216 for the malformed-hole diagnostics, but those codes were already taken; the implemented codes are **GS0222–GS0225**.
+
 ### By-ref-like (`ref struct`) diagnostics (GS0219)
 
 A by-ref-like type — a CLR `ref struct` carrying `System.Runtime.CompilerServices.IsByRefLikeAttribute`, such as `System.Span[T]`, `System.ReadOnlySpan[T]`, or `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler` — is stack-only (issue #367). G# permits declaring and using such a value as an ordinary local (including a user-declared `type X ref struct { … }`), but the CLR forbids any use that would let it reach the heap.

--- a/website/versioned_docs/version-0.1/design-decisions.md
+++ b/website/versioned_docs/version-0.1/design-decisions.md
@@ -78,6 +78,8 @@ This is a curated reference index of the Architecture Decision Records in the re
 | [0011](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0011-string-interpolation-grammar.md) | String interpolation grammar and lowering | Specifies interpolation parsing and lowering details. |
 | [0012](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0012-raw-string-delimiter.md) | Raw string delimiter — backtick | Chooses backtick-delimited raw strings. |
 | [0014](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0014-visibility-default.md) | Visibility defaults — `public` for top-level declarations | Makes unmodified top-level declarations public by default. |
+| [0054](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0054-postfix-member-access-on-primary-expressions.md) | Postfix member/index access on primary expressions | Chains `.`/`?.`/`[]` after any primary except a bare numeric literal (`(42).Member`). |
+| [0055](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0055-string-interpolation-revamp.md) | String interpolation revamp | Delimiter-aware multiline holes, alignment/format clauses, late context-driven lowering (`DefaultInterpolatedStringHandler`/`FormattableString`), and full IDE support inside holes. |
 
 ## CLR interop
 
@@ -91,6 +93,7 @@ This is a curated reference index of the Architecture Decision Records in the re
 | [0037](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0037-numeric-tiebreaking.md) | Numeric better-conversion target tie-breaking in overload resolution | Defines numeric conversion ranking for overload resolution. |
 | [0039](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0039-byref-pointers-and-clr-interop.md) | By-ref pointers and CLR interop for `ref` / `out` / `in` parameters | Introduces `*T`, `&`, dereference, `ref` arguments, and related diagnostics. |
 | [0047](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0047-attribute-syntax-and-declaration.md) | Attribute consumption and declaration (Kotlin-style annotations) | Defines `@` annotation syntax, use-site targets, attribute arguments, and `@Attribute` sugar. |
+| [0056](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0056-span-consumption-v1.md) | Span consumption v1 — ref-returning members, span element access, closed generic value-type fields | Auto-dereferences ref-returning members in rvalue position, makes spans indexable (read/write), applies `[]T → Span[T]` conversion in argument position, and gives closed generic value-type fields real layout. |
 
 ## Emit and tooling
 

--- a/website/versioned_docs/version-0.1/guide/expressions-and-statements.md
+++ b/website/versioned_docs/version-0.1/guide/expressions-and-statements.md
@@ -14,19 +14,27 @@ Unary operators include numeric identity and negation, logical not, bitwise comp
 
 ## Calls, access, and literals
 
-Calls use parentheses. Generic calls use bracketed type arguments. Member access uses `.`, null-conditional access uses `?.`, and indexing uses brackets. Struct literals use field labels; data structs can be copied with `with` updates.
+Calls use parentheses. Generic calls use bracketed type arguments. Member access uses `.`, null-conditional access uses `?.`, and indexing uses brackets. These postfix operators chain after any primary expression, including a parenthesized one — `(a + b).GetType()`, `(nums)[0]`, and `("s").Length` are all valid. The one exception is a bare numeric literal: write `(42).ToString()` rather than `42.ToString()`, which is ambiguous with float-literal lexing (see [ADR-0054](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0054-postfix-member-access-on-primary-expressions.md)). Struct literals use field labels; data structs can be copied with `with` updates.
 
 ```gsharp
 let p = Point{X: 3, Y: 4}
 let q = p with { X = 10 }
 let value = maybePoint?.X ?: 0
+let kind = (p.X + p.Y).GetType()
 ```
 
 Function literals are written with `func` or `async func`. A trailing lambda may follow a call as the final argument. There is no arrow-lambda expression today; `->` is used for switch expression arms. See [ADR-0050](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0050-trailing-arrow-lambda.md) for the design discussion behind trailing lambda syntax and the current parser behavior.
 
 ## Interpolation
 
-Interpolated strings evaluate `$name` and braced expression fragments inside normal double-quoted strings. Use `$$` for a literal dollar sign. Keep complex interpolation expressions readable by computing intermediate `let` values.
+Interpolated strings evaluate `$name` and braced `${expression}` fragments inside normal double-quoted strings — there is no `$"…"` prefix. A braced hole may add an alignment and format clause, `${expr,alignment:format}`, and the delimiter-aware scanner lets a hole contain nested strings, indexers, ternaries, and even newlines. Use `$$` for a literal dollar sign. By default an interpolation lowers to `DefaultInterpolatedStringHandler`; targeting `IFormattable`/`FormattableString` defers formatting via `FormattableStringFactory.Create`. Keep complex interpolation expressions readable by computing intermediate `let` values.
+
+```gsharp
+let value = 255
+let label = "hi"
+Console.WriteLine("hex=${value:X4}")
+Console.WriteLine("padded=[${label,5}]")
+```
 
 ## Declarations, assignment, and deconstruction
 

--- a/website/versioned_docs/version-0.1/guide/lexical-structure.md
+++ b/website/versioned_docs/version-0.1/guide/lexical-structure.md
@@ -36,7 +36,7 @@ A character literal is one UTF-16 code unit or escape in single quotes. Supporte
 
 Normal strings are double-quoted. In the implementation snapshot, doubled quotes produce a literal quote; backslash escapes are not interpreted by the normal string lexer. Raw strings are backtick-delimited, can span lines, normalize CR and CRLF to LF, and do not process escapes or interpolation. See [ADR-0012](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0012-raw-string-delimiter.md).
 
-Interpolated strings use `$name` and braced expression interpolation. Use `$$` for a literal dollar sign.
+Interpolated strings are sigil-free: holes live inside ordinary double-quoted strings rather than behind a C#-style `$"…"` prefix. A hole is `$name` (a single identifier) or a braced `${expression}`, optionally with an alignment and format clause, `${expr,alignment:format}`. Use `$$` for a literal dollar sign; there is no `{{`/`}}` brace escaping. The braced-hole scanner is delimiter-aware — it balances brackets, skips nested string and char literals and comments, and allows the expression to span lines — so `${dict["k"]}`, `${cond ? "a" : "b"}`, and multiline holes all work. Holes are real code: hover, go-to-definition, find-references, completion, and signature help all work inside `${…}`.
 
 ```gsharp title="samples/InterpolatedString.gs"
 package InterpolatedString
@@ -48,7 +48,7 @@ Console.WriteLine("answer = ${n * 7}")
 Console.WriteLine("$$ stays literal")
 ```
 
-Interpolation rationale: [ADR-0007](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0007-string-interpolation.md) and [ADR-0011](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0011-string-interpolation-grammar.md).
+Interpolation rationale: [ADR-0007](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0007-string-interpolation.md), [ADR-0011](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0011-string-interpolation-grammar.md), and [ADR-0055](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0055-string-interpolation-revamp.md) (delimiter-aware grammar, alignment/format clauses, late lowering, and IDE support).
 
 ## Operators and punctuation
 

--- a/website/versioned_docs/version-0.1/ref/clr-interop.md
+++ b/website/versioned_docs/version-0.1/ref/clr-interop.md
@@ -144,18 +144,117 @@ Annotation names resolve either to the exact type name or to the conventional `A
 
 Compiler-synthesized attributes such as `CompilerGenerated`, `Extension`, `AsyncStateMachine`, `Nullable`, and `NullableContext` are reserved. `[DllImport]` is recognized but unsupported for v1.0; using it reports `GS0211`.
 
-## By-ref and pointer surface
+## By-ref pointers (`&` / `*` / `*T`)
 
-The by-ref/pointer interop surface is intentionally narrow today:
+G# has a managed by-ref surface that lets you call CLR methods with `ref`, `out`, and `in` parameters. It is implemented end-to-end in binding and emit (per [ADR-0039](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0039-byref-pointers-and-clr-interop.md)): taking the address of a local and passing it to a `ref`/`out` parameter compiles to `ldloca` and runs.
 
 | Surface | Meaning |
 | --- | --- |
-| `*T` | By-ref/pointer type clause syntax. |
-| `&expr` | Address-of expression. |
-| `*expr` | Dereference expression. |
-| `ref` arguments | Required for CLR `ref`, `out`, or `in` parameter calls when the binder demands it. |
+| `&x` | Address-of: produces a managed pointer to the lvalue `x`, used to pass `ref` / `out` / `in` arguments. |
+| `*p` | Dereference: reads or writes through a managed pointer `p`. |
+| `*T` | The managed-pointer (by-ref) type, equivalent to C#'s `ref T` at a parameter or local level. |
 
-Diagnostics `GS9001` through `GS9006` cover non-lvalue address-of, missing `ref`, definite assignment before `ref`, ref escape, constants, and pointer fields. The evaluator does not implement generic address-of/dereference execution, so this surface is primarily for emit and CLR interop.
+Taking an address with `&` requires an lvalue — a local, parameter, field, or array element. The address-of operand is what makes the argument flow by reference at the call site, so `&` is written explicitly at CLR `ref`/`out`/`in` call sites:
+
+```gsharp
+import System
+
+var result = 0
+var ok = Int32.TryParse("42", &result)
+if ok {
+    Console.WriteLine(result)
+}
+```
+
+The same `&` form drives any `ref`/`out` BCL API, for example `Interlocked.CompareExchange`:
+
+```gsharp
+import System
+import System.Threading
+
+var counter = 0
+Interlocked.CompareExchange(&counter, 1, 0)
+Console.WriteLine(counter)
+```
+
+`out` variables need not be definitely assigned before the call: passing `&result` at an `out` position is allowed even when `result` was never written, and after the call the variable is considered definitely assigned. Variables passed at a `ref` (not `out`) position must already be definitely assigned.
+
+At the CLR metadata level, `*T` maps to `ELEMENT_TYPE_BYREF` — a managed reference, the same encoding as C#'s `ref T` — and not to `ELEMENT_TYPE_PTR` (an unmanaged pointer). No unmanaged-pointer semantics (arithmetic, pinning, `fixed`) are implied.
+
+### Limitations
+
+The by-ref surface is deliberately scoped to managed references for CLR interop. Per ADR-0039 the following are out of scope today: unmanaged pointers, pointer arithmetic, and `unsafe` blocks; by-ref returns from G# functions (`func foo() *int { return &x }`); and the full Roslyn-style `ref-safe-to-escape` / `safe-to-escape` two-level escape analysis, which is deferred to [issue #376](https://github.com/DavidObando/gsharp/issues/376). V1 uses a simpler rule: by-ref values cannot escape their declaring scope.
+
+### Diagnostics
+
+| Diagnostic | Reported when |
+| --- | --- |
+| `GS9001` | `&` is applied to a non-lvalue expression. |
+| `GS9002` | A `ref`/`out`/`in` argument is missing the required `&` at the call site. |
+| `GS9003` | A variable is passed at a `ref` (not `out`) position before being definitely assigned. |
+| `GS9004` | A by-ref value would escape its declaring scope (captured in a lambda, returned, or stored in a field). |
+| `GS9005` | `&` is applied to a constant. |
+| `GS9006` | A pointer (`*T`) type is used as a field type. |
+
+## Spans and `ref struct` types
+
+G# can consume CLR `ref struct` types — most importantly `System.Span[T]` and `System.ReadOnlySpan[T]` — as ordinary stack-only locals, parameters, and fields. The consumption surface is defined by [ADR-0056](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0056-span-consumption-v1.md) and builds on the by-ref machinery above.
+
+A by-ref-like (`ref struct`) value carries `System.Runtime.CompilerServices.IsByRefLikeAttribute` and is stack-only: the CLR forbids any use that would let it reach the heap. G# enforces this with **`GS0219`** — boxing or converting it to a reference type, storing it in a non-`ref struct` field, capturing it in a closure, hoisting it into an `async`/iterator state machine, using it as a generic type argument, or declaring it as a top-level global are all rejected. Because of the last rule, span locals live inside functions.
+
+### Span element access
+
+A `Span[T]` / `ReadOnlySpan[T]` indexer returns a managed pointer (`ref T` / `ref readonly T`). Reading an element in rvalue position **auto-dereferences** the ref return to the pointee `T` (you do not write `*`), and a `Span[T]` element write `s[i] = v` stores through the returned `ref T`:
+
+```gsharp
+import System
+
+func sumSpan(values []int32) int32 {
+    var s ReadOnlySpan[int32] = values   // []T -> ReadOnlySpan[T] implicit conversion
+    var total = 0
+    var i = 0
+    for i < s.Length {
+        total = total + s[i]             // read auto-dereferences ref readonly int32 -> int32
+        i = i + 1
+    }
+    return total
+}
+
+func writeBack(values []int32) int32 {
+    var s Span[int32] = values
+    s[0] = 100                           // store through the ref int32 from get_Item
+    s[2] = 300
+    return s[0] + s[1] + s[2]
+}
+```
+
+A `ReadOnlySpan[T]` element is `ref readonly T`, so writing through it is a hard error — **`GS0226`** (`s[0] = 1` on a `ReadOnlySpan[T]`); reading it is always allowed. Auto-dereference is the same general rule for every ref-returning CLR member (indexers, `ref` property getters, ref-returning methods): **ref returns auto-dereference in rvalue position; taking an address still requires `&`.**
+
+### Slice-to-span conversion
+
+A `[]T` slice converts implicitly to `Span[T]` / `ReadOnlySpan[T]` (via the BCL's `op_Implicit`) at local initialization **and** in argument position, so a slice flows straight into a span-typed BCL or user API without an explicit cast.
+
+### Closed generic value-type fields
+
+A user `ref struct` may embed a **closed** constructed generic value-type field, such as a span:
+
+```gsharp
+import System
+
+type Window ref struct {
+    data ReadOnlySpan[int32]
+}
+
+func firstLen(w Window) int32 {
+    return w.data.Length
+}
+```
+
+Such a field is emitted with its real layout (`valuetype ReadOnlySpan<int32>`, never erased to `System.Object`), and instance-member calls on the field receiver take its address correctly. Type erasure (see [Generics interop](#generics-interop)) applies only to *open*, type-parameter-bearing shapes; closed value-type generics in field position carry real layout.
+
+### Limitations
+
+Per ADR-0056, the following remain out of scope: by-ref returns from G# functions and the full two-level `ref-safe-to-escape` analysis (`scoped`, `[UnscopedRef]`), deferred to [issue #376](https://github.com/DavidObando/gsharp/issues/376); open generic value-type `ref struct` fields (`type Buffer[T] ref struct { data ReadOnlySpan[T] }`); `stackalloc` and other span-*creation* primitives; and a lowercase `span[T]` alias (spans are imported CLR types `Span[T]` / `ReadOnlySpan[T]`, requiring `import System`).
 
 ## Generics interop
 
@@ -167,7 +266,33 @@ import System.Collections.Generic
 var xs = List[int32]()
 ```
 
-G# emits metadata specs for constructed generic types and methods, supports type-argument inference for imported open generic methods, and supports variance markers and constraints in its own type parameter model. The current implementation also has a type-erased generic model for some open or partially constructed shapes that contain type parameters; those shapes may be represented as `object` in emit paths. Treat this as an implementation constraint rather than a source-level API.
+G# emits metadata specs for constructed generic types and methods, supports type-argument inference for imported open generic methods, and supports variance markers and constraints in its own type parameter model. The current implementation also has a type-erased generic model for some open or partially constructed shapes that contain type parameters; those shapes may be represented as `object` in emit paths. Closed constructed generic *value* types (e.g. `ReadOnlySpan[int32]`, `Nullable[int32]`) are an exception: in field position they carry their real layout and are never erased (see [Spans and `ref struct` types](#spans-and-ref-struct-types)). Treat the open-shape erasure as an implementation constraint rather than a source-level API.
+
+## Interpolated strings and formatting
+
+Interpolated string literals are sigil-free in G# — holes (`$name`, `${expr}`, `${expr,alignment:format}`) live inside ordinary `"…"` strings — but their lowering is CLR formatting interop. The target type drives which formatting type is used:
+
+- By default an interpolated string lowers to `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler`. The handler is a `ref struct`, so value-typed holes are appended without boxing, and the result is materialized with `ToStringAndClear()`.
+- When the contextual target type is `System.IFormattable` or `System.FormattableString`, the string lowers to `FormattableStringFactory.Create(format, args)` instead of an eager `string`. Formatting is deferred, so the caller chooses the culture via `ToString(IFormatProvider)`. This applies in `let`/`return`/cast contexts and when the interpolation is passed directly as an argument to a `FormattableString` parameter.
+- A parameter annotated with `[InterpolatedStringHandler]` receives the handler value directly, and `[InterpolatedStringHandlerArgument]` forwarding is honored when the handler constructor requests additional arguments.
+
+```gsharp title="samples/InterpolatedStringFormattable.gs"
+import System
+import System.Globalization
+
+func renderInvariant(fs FormattableString) string {
+    return fs.ToString(CultureInfo.InvariantCulture)
+}
+
+let total = 1234.5
+let qty = 7
+let fs FormattableString = "amount: ${total:N2} (x${qty,4})"
+
+Console.WriteLine(fs.ToString(CultureInfo.InvariantCulture))
+Console.WriteLine(fs.ToString(CultureInfo.GetCultureInfo("de-DE")))
+```
+
+Alignment (`,4`) and format (`:N2`) clauses are preserved in the synthesized composite format string, so the same `FormattableString` renders differently under different cultures. The grammar and diagnostics for holes are documented in the [language specification](./spec.md#string-literals).
 
 ## Unsupported interop surface
 

--- a/website/versioned_docs/version-0.1/ref/diagnostics.md
+++ b/website/versioned_docs/version-0.1/ref/diagnostics.md
@@ -74,7 +74,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0113 | Error | Undefined type. | A type name referenced in code does not exist. |
 | GS0114 | Error | Invalid array length. | Array length must be a non-negative integer literal. |
 | GS0115 | Error | Array literal length mismatch. | `[3]int{1, 2}` — literal has 2 elements but length is 3. |
-| GS0116 | Error | Type is not indexable. | `x[0]` where `x` is `bool` or another non-array/slice type. |
+| GS0116 | Error | Type is not indexable. | `x[0]` where `x` is `bool` or another type with no array/slice/map element access and no CLR indexer. Arrays, slices, maps, CLR indexers, and `Span[T]` / `ReadOnlySpan[T]` (ADR-0056 §2) are all indexable. |
 | GS0117 | Error | Invalid argument type for a built-in function. | `len(42)` — `len` cannot be applied to an `int`. |
 | GS0118 | Error | A `try` statement requires at least one `catch` or `finally` clause. | `try { f() }` with no `catch` or `finally`. |
 | GS0119 | Error | Type is not disposable. | `using x = Foo()` where `Foo` provides no public `Dispose()` method. |
@@ -183,6 +183,37 @@ ADR-0047 introduces Kotlin-style attribute syntax (`@Foo(...)`) and the `@Attrib
 | GS0205 | Error | Attribute is reserved for compiler synthesis. | `@CompilerGenerated`, `@Extension`, `@AsyncStateMachine`, `@Nullable`, or `@NullableContext` written in user source. |
 | GS0206 | Error | Annotations are only allowed on variable declarations, not on this statement. | `@Obsolete\nreturn` inside a function body — annotations may precede `var`/`let`/`const` but no other statement kind. |
 | GS0211 | Error | Attribute `[DllImport]` is recognised but not supported in v1.0; P/Invoke (extern function bodies) is a post-v1.0 feature. | `@DllImport("user32.dll") func MessageBox() {}` — emit support and the `extern` body marker arrive after v1.0. |
+
+### String interpolation diagnostics (GS0220–GS0225)
+
+ADR-0055 interpolation holes (`${expr,alignment:format}`) and the issue #368 interpolated-string-handler pattern report the following.
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0220 | Error | Interpolation alignment clause is not a constant integer. | `"${x,abc}"` — the value after the `,` in `${expr,alignment[:format]}` must be a constant integer (e.g. `${x,5}` or `${x,-8:X4}`). |
+| GS0221 | Error | An interpolated string passed to an `[InterpolatedStringHandler]` parameter could not satisfy `[InterpolatedStringHandlerArgument]` forwarding. | The forwarded argument names an unknown parameter, the receiver cannot be forwarded, or no handler constructor matches `(int, int, …forwarded[, out bool])`. |
+| GS0222 | Error | Unterminated interpolation hole; expected a closing `}`. | `"v=${a + b"` — the `${` opens a hole that the delimiter-aware scanner never closes before end of file. |
+| GS0223 | Error | Empty interpolation hole; expected an expression between `${` and `}`. | `"x=${}"` — a hole must contain an expression. |
+| GS0224 | Error | Empty format specifier; expected a format string after `:`. | `"${n:}"` — a `:` clause must be followed by a non-empty format string. |
+| GS0225 | Error | Newline in the literal portion of an interpolated string; only `${ … }` holes may span lines. | A raw newline appears outside a hole, e.g. a `"…` opened on one line with no closing `"` before the line break. (Multiline holes themselves are legal.) |
+
+> Note: ADR-0055 originally proposed GS0212–GS0216 for the malformed-hole diagnostics, but those codes were already taken; the implemented codes are **GS0222–GS0225**.
+
+### By-ref-like (`ref struct`) diagnostics (GS0219)
+
+A by-ref-like type — a CLR `ref struct` carrying `System.Runtime.CompilerServices.IsByRefLikeAttribute`, such as `System.Span[T]`, `System.ReadOnlySpan[T]`, or `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler` — is stack-only (issue #367). G# permits declaring and using such a value as an ordinary local (including a user-declared `type X ref struct { … }`), but the CLR forbids any use that would let it reach the heap.
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0219 | Error | A by-ref-like (`ref struct`) value is used in a position that would let it escape the stack: boxing / converting it to a reference type, storing it in a field of a non-`ref struct` (instance, primary-constructor, or static), capturing it in a closure, declaring it as a local in an `async` function or iterator (where it would be hoisted into the heap-allocated state machine), using it as a generic type argument, or declaring it as a top-level global. | `var o object = span` (box); a `class` field typed `Span[int32]`; capturing a `ReadOnlySpan[char]` local inside `func() { … }`; a `Span[int32]` local in an `async` function; `List[ReadOnlySpan[int32]]`. |
+
+### Span element access diagnostics (GS0226)
+
+ADR-0056 §1/§2 makes spans indexable: a `Span[T]` / `ReadOnlySpan[T]` indexer returns a managed pointer (`ref T` / `ref readonly T`), and a read in rvalue position auto-dereferences to the pointee `T`. A `Span[T]` element write `s[i] = v` stores through the `ref T`; a `ReadOnlySpan[T]` element is `ref readonly T`, so writing through it is rejected.
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0226 | Error | Cannot assign through a read-only span element (`ReadOnlySpan[T]` is read-only). | `var s ReadOnlySpan[int32] = arr` then `s[0] = 1` — a `ReadOnlySpan[T]` indexer is `ref readonly T`; use `Span[T]` to write. |
 
 ### Pointer / by-ref diagnostics (GS9001–GS9006)
 

--- a/website/versioned_docs/version-0.1/ref/feature-matrix.md
+++ b/website/versioned_docs/version-0.1/ref/feature-matrix.md
@@ -17,7 +17,7 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Implicit `System` import | Supported | Supported | Enabled by default; disabled with `/noimplicitimports` or `/no-implicit-imports`. |
 | Top-level statements and `func Main` | Supported | Supported | Mixing top-level statements and explicit `Main` is diagnosed by `GS0165`/`GS0166`. |
 | Comments | Supported | Supported | Line and block comments are accepted by the compiler lexer; editor grammar may lag. |
-| String, raw string, and interpolated string literals | Supported | Supported | Interpolation is parsed into expression segments. |
+| String, raw string, and interpolated string literals | Supported | Supported | Sigil-free interpolation with `$name`/`${expr,alignment:format}`, delimiter-aware multiline holes, and `DefaultInterpolatedStringHandler`/`FormattableString` lowering (ADR-0055). |
 | Character literals | Supported | Supported | Character diagnostics are `GS0191` through `GS0195`. |
 
 ## Types and values
@@ -44,7 +44,8 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Function types, literals, closures | Supported | Supported | Delegate conversions are strongest on the emit path. |
 | Generics and method inference | Supported | Supported for binding/evaluation | Metadata specs plus type-erased handling for open type-parameter-containing shapes. |
 | Variance and constraints | Supported semantically | Supported semantically | Diagnostics include `GS0150` through `GS0153`. |
-| By-ref and pointers | Partial | Limited/not supported | Syntax and diagnostics exist; evaluator rejects generic address/deref execution. |
+| By-ref and pointers | Partial | Limited/not supported | `&` / `*` / `*T` for CLR `ref`/`out`/`in` interop (ADR-0039); ref returns auto-dereference in rvalue position (ADR-0056 §1). Evaluator rejects generic address/deref execution. |
+| Spans and `ref struct` types | Mostly supported | Limited | Stack-only consumption of `Span[T]` / `ReadOnlySpan[T]` and user `type X ref struct`: element read/write, `[]T`→span conversion, closed generic value-type fields (ADR-0056). Escape rules are `GS0219`; `ReadOnlySpan[T]` writes are `GS0226`. Full ref-safe-to-escape analysis is deferred (#376). |
 
 ## Declarations and members
 

--- a/website/versioned_docs/version-0.1/ref/spec.md
+++ b/website/versioned_docs/version-0.1/ref/spec.md
@@ -82,7 +82,9 @@ Character literals are single-quoted and represent exactly one UTF-16 code unit 
 
 Normal string literals are delimited by double quotes. In the current compiler lexer, the escape-like form for a literal quote inside a normal string is doubled quotes, as in `"a ""quoted"" word"`; backslash escapes are not interpreted by the normal string lexer. Raw strings are delimited by backticks, may span lines, do not process escapes or interpolation, normalize CR and CRLF to LF in their value, and cannot contain a backtick.
 
-Interpolated strings are normal double-quoted strings containing `$name` or braced interpolation fragments. Use `$$` for a literal dollar sign. Braced interpolation parses the captured expression text as a fresh expression syntax tree.
+Interpolation is sigil-free: holes live inside ordinary double-quoted strings, not behind a C#-style `$"…"` prefix. A hole is either `$name`, which captures a single identifier, or a braced `${expression}`. Use `$$` for a literal dollar sign. There is no `{{`/`}}` brace escaping; a literal brace is just a brace. Braced interpolation parses the captured expression text as a fresh expression syntax tree whose tokens carry absolute source spans, so IDE features (hover, go-to-definition, find-references, completion, signature help) work inside a hole.
+
+A braced hole may carry an optional alignment and format clause: `${expr,alignment}`, `${expr:format}`, or `${expr,alignment:format}`. The alignment is a constant integer (negative for left-justify), and the format is a standard .NET format string. The `,` and `:` separators are recognized only at the top level of the hole.
 
 ```gsharp title="samples/InterpolatedString.gs"
 package InterpolatedString
@@ -93,6 +95,18 @@ Console.WriteLine("Hello, $name!")
 Console.WriteLine("answer = ${n * 7}")
 Console.WriteLine("$$ stays literal")
 ```
+
+The `${…}` scanner is delimiter-aware. It tracks `()`, `[]`, and `{}` nesting, skips over nested `"…"` and `'…'` literals and `//` and `/* */` comments, and allows the hole expression to span multiple lines. Consequently `${dict["k"]}`, `${cond ? "a" : "b"}`, and a hole whose expression wraps onto a second line all lex correctly, and a `,` or `:` inside a nested string is never mistaken for an alignment or format clause.
+
+```gsharp title="samples/InterpolatedStringRichHoles.gs"
+let n = 6
+Console.WriteLine("greeting=${"hello"}")
+Console.WriteLine("len=${"a,b:c".Length}")
+Console.WriteLine("answer=${n *
+7}")
+```
+
+Malformed interpolation is reported by dedicated diagnostics: `GS0220` (non-constant alignment), `GS0221` (handler forwarding), `GS0222` (unterminated hole), `GS0223` (empty hole), `GS0224` (empty format specifier), and `GS0225` (newline in the literal portion of the string). By default an interpolated string lowers to `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler` (composite formatting in the interpreter); when its contextual target type is `IFormattable` or `FormattableString` it instead lowers to `FormattableStringFactory.Create`, deferring formatting so the caller selects the culture. See the [CLR interop reference](./clr-interop.md#interpolated-strings-and-formatting).
 
 ### Boolean and nil literals
 
@@ -259,6 +273,8 @@ TypeArgList = "[" TypeClause { "," TypeClause } "]" .
 
 Byref/pointer syntax exists as `*T`, unary `&`, and unary `*`. It is primarily an emit/interop feature today; the evaluator rejects the generic address-of and dereference path.
 
+CLR `ref struct` types such as `Span[T]` and `ReadOnlySpan[T]` are consumable as stack-only values (ADR-0056): they are indexable (`s[i]`), ref-returning members auto-dereference in rvalue position, a `[]T` slice converts implicitly to a span, and a user `type X ref struct { … }` may embed a closed generic value-type field. Stack-escape violations are reported as `GS0219`; writing through a `ReadOnlySpan[T]` element is `GS0226`. The full ref-safe-to-escape analysis is deferred (issue #376).
+
 ## Declarations and scope
 
 ### Packages and imports
@@ -342,7 +358,7 @@ Unary operators bind tighter than binary operators. Binary operators are left-as
 | 2 | `&&` | logical and |
 | 1 | `\|\|`, `?:` | logical or and null coalescing |
 
-Postfix `!!`, member access `.`, null-conditional access `?.`, indexing, calls, and generic instantiation are parsed greedily on primary expressions.
+Postfix `!!`, member access `.`, null-conditional access `?.`, indexing, calls, and generic instantiation are parsed greedily on primary expressions. This applies to **any** primary, including a parenthesized expression — for example `(a + b).GetType()`, `(nums)[0]`, and `("s").Length` are all valid. The sole exception is a bare numeric literal: `42.Member` is not accepted because it is ambiguous with float-literal lexing; wrap it as `(42).Member` instead (see ADR-0054).
 
 ### Primary expressions and calls
 
@@ -360,7 +376,7 @@ TrailingLambda  = FunctionLiteral .
 
 ### Accessor chains
 
-Member access and indexing chain after primaries. `a.b`, `a?.b`, `a[i]`, `a.b(c)`, and generic call access forms are valid where the binder can resolve the target. Assignment permits identifiers, indexed targets, field/property targets, and event `+=` or `-=` on accessors.
+Member access and indexing chain after primaries. `a.b`, `a?.b`, `a[i]`, `a.b(c)`, and generic call access forms are valid where the binder can resolve the target. Chains also apply to parenthesized and literal receivers — `(a + b).GetType()`, `(nums)[0]`, `("s").Length`, and `switch v { … }.ToString()` — with one exception: a bare numeric literal does not chain (`42.Member` is unsupported; write `(42).Member`). Assignment permits identifiers, indexed targets, field/property targets, and event `+=` or `-=` on accessors.
 
 ### Composite literals
 
@@ -394,6 +410,11 @@ BinaryExpression  = PrefixExpression { BinaryOperator PrefixExpression } .
 PrefixExpression  = ( "+" | "-" | "!" | "^" | "*" | "&" | "<-" | "await" ) PrefixExpression | PostfixExpression .
 PostfixExpression = PrimaryExpression { "!!" } { ( "." | "?." ) NameOrCall | "[" Expression "]" } ( "with" "{" FieldEqualsList? "}" )? .
 PrimaryExpression = Literal | identifier | Call | GenericCall | StructLiteral | ArrayLiteral | MapLiteral | FunctionLiteral | SwitchExpr | "(" Expression ")" | TupleLiteral | MakeChannel | TypeOf | NameOf .
+(* Postfix chains apply to every PrimaryExpression except a bare numeric Literal: `42.Member` is not accepted; use `(42).Member`. See ADR-0054. *)
+Literal           = Number | String | InterpolatedString | "true" | "false" | "nil" | char .
+InterpolatedString = '"' { InterpolationText | "$$" | "$" identifier | InterpolationHole } '"' .
+InterpolationHole = "${" Expression ( "," Expression )? ( ":" FormatText )? "}" .
+(* The hole scanner is delimiter-aware: it balances ()[]{}, skips nested string/char literals and comments, and permits newlines, so the "," and ":" clause separators are only recognized at the top level of the hole. See ADR-0055. *)
 ```
 
 ## Statements
@@ -503,6 +524,8 @@ Iterator functions return `sequence[T]` and contain `yield`. Async sequences use
 G# imports can resolve CLR namespaces and metadata references. CLR primitive types map to G# built-ins when possible; other CLR types are represented as imported types. The binder and evaluator support imported constructors, static and instance methods, fields, properties, indexers, events, delegates, method groups, operator overloads, and conversion operators. G# function values can convert to compatible CLR delegates such as `Action`, `Func`, named delegates, and `Predicate`, and can widen to `System.Delegate` or `System.MulticastDelegate`.
 
 Attributes use `@Name(...)` and optional use-site targets such as `@field:`, `@param:`, and `@return:`. The current implementation recognizes attributes, but user P/Invoke or extern declarations are not supported.
+
+Interpolated strings interoperate with the CLR formatting types. By default they lower to `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler` (value-type holes are not boxed); a string targeted at `IFormattable` or `FormattableString` lowers to `FormattableStringFactory.Create` for deferred, culture-aware formatting; and a parameter annotated with `[InterpolatedStringHandler]` receives the handler directly, including `[InterpolatedStringHandlerArgument]` forwarding.
 
 ## Appendix: full parser grammar
 
@@ -635,6 +658,9 @@ BinaryExpression  ::= PrefixExpression (BinaryOperator PrefixExpression)*
 PrefixExpression  ::= ('+' | '-' | '!' | '^' | '*' | '&' | '<-' | 'await') PrefixExpression | PostfixExpression
 PostfixExpression ::= PrimaryExpression '!!'* (('.' | '?.') NameOrCall | '[' Expression ']')* ('with' '{' FieldEqualsList? '}')?
 PrimaryExpression ::= Literal | identifier | Call | GenericCall | StructLiteral | ArrayLiteral | MapLiteral | FunctionLiteral | SwitchExpr | '(' Expression ')' | TupleLiteral | MakeChannel | TypeOf | NameOf
+Literal           ::= Number | String | InterpolatedString | 'true' | 'false' | 'nil' | char
+InterpolatedString ::= '"' ( InterpolationText | '$$' | '$' identifier | InterpolationHole )* '"'
+InterpolationHole ::= '${' Expression ( ',' Expression )? ( ':' FormatText )? '}'
 Call              ::= identifier '(' Arguments? ')' TrailingLambda?
 GenericCall       ::= identifier TypeArgList ('(' Arguments? ')' TrailingLambda? | StructLiteralBody)
 StructLiteral     ::= identifier '{' FieldInitList? '}'

--- a/website/versioned_docs/version-0.1/tooling/lsp.md
+++ b/website/versioned_docs/version-0.1/tooling/lsp.md
@@ -39,7 +39,7 @@ The server capability factory enables the following:
 | Capability | LSP surface |
 | --- | --- |
 | Text synchronization | Open/close, full-document changes, save with text. |
-| Diagnostics | `textDocument/publishDiagnostics` notifications after open/change/save. |
+| Diagnostics | `textDocument/diagnostic` pull requests (live as-you-type), with `workspace/diagnostic/refresh` for cross-file edits; falls back to `textDocument/publishDiagnostics` for push-only clients. |
 | Hover | `textDocument/hover`. |
 | Definition | `textDocument/definition`. |
 | Type definition | `textDocument/typeDefinition`. |
@@ -62,7 +62,7 @@ The server capability factory enables the following:
 
 ## Diagnostics lifecycle
 
-On open and change, the server parses the active document and publishes responsive syntax/global-scope diagnostics while skipping the full binding pass. On save, it runs the fuller binding pipeline and republishes diagnostics. The active document is stored in memory, and if it belongs to a discovered `.gsproj`, the project state is updated before diagnostics are computed.
+The server keeps the active document parsed in memory and, when it belongs to a discovered `.gsproj`, updates the project state on open/change/save. Diagnostics are served through the LSP **pull model**: the editor requests `textDocument/diagnostic` as the user types and on save, and the server runs the full pipeline — syntax, global-scope semantic analysis, and the binding pass — on every pull, so binding errors appear live rather than only on save. Each report carries a `resultId`; unchanged results return an `unchanged` report so the client reuses existing squiggles. The binding pass runs off the handler gate and supports cancellation, keeping interactive requests responsive, and cross-file edits in multi-file projects trigger a debounced `workspace/diagnostic/refresh`. Push-only clients (no pull-diagnostic capability) fall back to `textDocument/publishDiagnostics` on open/change/save.
 
 ## Workspace and project awareness
 

--- a/website/versioned_docs/version-0.1/tour/basics.md
+++ b/website/versioned_docs/version-0.1/tour/basics.md
@@ -97,7 +97,7 @@ Console.WriteLine(sum)
 
 The primitive names are explicit about width: `bool`, `int32`, `uint32`, `int64`, `uint64`, `float32`, `float64`, `decimal`, `char`, `string`, and `object` are common examples. Older aliases such as `int`, `uint`, `long`, and `byte` are not G# built-in primitive names.
 
-Strings support interpolation with `$name` and braced expressions inside string literals:
+Strings support sigil-free interpolation with `$name` and braced `${expr}` holes inside ordinary string literals. Holes may add an alignment and format clause, `${expr,alignment:format}`:
 
 ```gsharp title="InterpolatedString.gs"
 package InterpolatedString


### PR DESCRIPTION
## Summary

Refreshes the **version-0.1** versioned-docs snapshot so it matches the current `docs/`, per the Option A in-place refresh. Two commits:

1. **Re-land the GS0220–GS0225 interpolation block on current docs.** PR #386 was merged into the #385 branch ~9s *after* #385 had already merged to `main`, so its interpolation content was stranded on the feature branch and never reached `main`. This commit cherry-picks it back onto `main`'s `website/docs/ref/diagnostics.md`.
2. **Refresh `versioned_docs/version-0.1/` from current docs.** Bulk `cp` of `docs/` → `versioned_docs/version-0.1/`, syncing the 9 drifted pages.

## What changed in the snapshot

`diff -rq` showed **9 files drifted, no pages added or removed**, so `versioned_sidebars/version-0.1-sidebars.json` and `versions.json` are unchanged. The refreshed pages:

- `ref/clr-interop.md`, `ref/diagnostics.md`, `ref/feature-matrix.md`, `ref/spec.md` — ADR-0056 span consumption + by-ref semantics, GS0219/GS0226, and the GS0220–GS0225 interpolation block.
- `design-decisions.md`, `guide/expressions-and-statements.md`, `guide/lexical-structure.md`, `tooling/lsp.md`, `tour/basics.md` — accumulated edits that had landed in current docs since the 0.1 cut.

## Note on intent

A versioned snapshot normally records *what shipped* in that release; this PR deliberately re-points 0.1 at the latest docs at the maintainer's request (0.1 is still the in-flight release line). The frozen-snapshot caveat was discussed — proceeding with the explicit refresh.

## Validation

Full `npm run build` (Docusaurus, `onBrokenLinks: 'throw'`) succeeds for both the current and version-0.1 doc sets.
