### PR TITLE
Hover foundations: symbol resolution + SymbolDisplay service (#388 Stage A)

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
+++ b/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
@@ -1,0 +1,479 @@
+// <copyright file="SymbolDisplay.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Symbols.Display;
+
+/// <summary>
+/// Produces a classified, declaratively-formatted display of a <see cref="Symbol"/>
+/// for IDE features (LSP hover, signature help, completion detail). This is the
+/// single source of truth for IDE symbol rendering — the analog of Roslyn's
+/// <c>ISymbolDisplayService</c> — so the language server never maintains divergent
+/// ad-hoc formatters.
+/// </summary>
+/// <remarks>
+/// This service intentionally renders a richer, IDE-oriented view than
+/// <see cref="SymbolPrinter"/>, which produces the terse, classified output used by
+/// diagnostics and <see cref="Symbol.ToString"/>. The two serve different audiences
+/// and are not duplicate logic.
+/// </remarks>
+public static class SymbolDisplay
+{
+    /// <summary>
+    /// Renders <paramref name="symbol"/> to a flat string under <paramref name="format"/>.
+    /// </summary>
+    /// <param name="symbol">The symbol to render.</param>
+    /// <param name="format">The display options.</param>
+    /// <param name="compilation">An optional compilation used to recover a variable's exact declaring keyword.</param>
+    /// <returns>The rendered display string.</returns>
+    public static string ToDisplayString(Symbol symbol, SymbolDisplayFormat format, Compilation.Compilation compilation = null)
+    {
+        return PartsToString(ToDisplayParts(symbol, format, compilation));
+    }
+
+    /// <summary>
+    /// Renders an imported CLR <paramref name="clrType"/> to a flat string.
+    /// </summary>
+    /// <param name="clrType">The reflected CLR type.</param>
+    /// <param name="format">The display options.</param>
+    /// <returns>The rendered display string.</returns>
+    public static string ToDisplayString(Type clrType, SymbolDisplayFormat format)
+    {
+        return PartsToString(ToDisplayParts(clrType, format));
+    }
+
+    /// <summary>
+    /// Renders <paramref name="symbol"/> to classified display parts under <paramref name="format"/>.
+    /// </summary>
+    /// <param name="symbol">The symbol to render.</param>
+    /// <param name="format">The display options.</param>
+    /// <param name="compilation">An optional compilation used to recover a variable's exact declaring keyword.</param>
+    /// <returns>The classified display parts.</returns>
+    public static ImmutableArray<SymbolDisplayPart> ToDisplayParts(Symbol symbol, SymbolDisplayFormat format, Compilation.Compilation compilation = null)
+    {
+        if (symbol == null)
+        {
+            return ImmutableArray<SymbolDisplayPart>.Empty;
+        }
+
+        var builder = new PartBuilder();
+        switch (symbol)
+        {
+            case ParameterSymbol parameter:
+                AppendVariableLike(builder, format, SymbolDisplayPartKind.ParameterName, "parameter", parameter.Name, parameter.Type);
+                break;
+            case LocalVariableSymbol local:
+                AppendVariableLike(builder, format, SymbolDisplayPartKind.Identifier, "local variable", local.Name, local.Type);
+                break;
+            case VariableSymbol variable:
+                AppendGlobalVariable(builder, format, variable, compilation);
+                break;
+            case FunctionSymbol function:
+                AppendFunction(builder, format, function);
+                break;
+            case StructSymbol aggregate:
+                AppendAggregate(builder, format, aggregate);
+                break;
+            case EnumSymbol enumSymbol:
+                AppendEnum(builder, format, enumSymbol);
+                break;
+            case EnumMemberSymbol member:
+                AppendEnumMember(builder, format, member);
+                break;
+            case PropertySymbol property:
+                AppendProperty(builder, format, property);
+                break;
+            case EventSymbol @event:
+                AppendEvent(builder, @event);
+                break;
+            case FieldSymbol field:
+                AppendField(builder, format, field);
+                break;
+            case ImportSymbol import:
+                AppendImport(builder, import);
+                break;
+            case PackageSymbol package:
+                AppendPackage(builder, package);
+                break;
+            case TypeSymbol type:
+                builder.Keyword("type");
+                builder.Space();
+                builder.Type(FormatType(type));
+                break;
+            default:
+                builder.Identifier(symbol.Name);
+                break;
+        }
+
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Renders an imported CLR <paramref name="clrType"/> to classified display parts.
+    /// </summary>
+    /// <param name="clrType">The reflected CLR type.</param>
+    /// <param name="format">The display options.</param>
+    /// <returns>The classified display parts.</returns>
+    public static ImmutableArray<SymbolDisplayPart> ToDisplayParts(Type clrType, SymbolDisplayFormat format)
+    {
+        var builder = new PartBuilder();
+        if (clrType == null)
+        {
+            return builder.ToImmutable();
+        }
+
+        var keyword = clrType.IsInterface ? "interface"
+            : clrType.IsEnum ? "enum"
+            : clrType.IsValueType ? "struct"
+            : "class";
+        builder.Keyword(keyword);
+        builder.Space();
+        builder.Type(format.QualifyNames ? clrType.FullName ?? clrType.Name : clrType.Name);
+        return builder.ToImmutable();
+    }
+
+    private static void AppendVariableLike(PartBuilder builder, SymbolDisplayFormat format, SymbolDisplayPartKind nameKind, string descriptor, string name, TypeSymbol type)
+    {
+        if (format.IncludeDescriptorPrefix)
+        {
+            builder.Descriptor($"({descriptor})");
+            builder.Space();
+        }
+
+        builder.Add(nameKind, name);
+        builder.Space();
+        builder.Type(FormatType(type));
+    }
+
+    private static void AppendGlobalVariable(PartBuilder builder, SymbolDisplayFormat format, VariableSymbol variable, Compilation.Compilation compilation)
+    {
+        builder.Keyword(ResolveVariableKeyword(variable, compilation));
+        builder.Space();
+        builder.Identifier(variable.Name);
+        builder.Space();
+        builder.Type(FormatType(variable.Type));
+    }
+
+    private static void AppendFunction(PartBuilder builder, SymbolDisplayFormat format, FunctionSymbol function)
+    {
+        if (format.IncludeModifiers)
+        {
+            foreach (var modifier in FunctionModifiers(function))
+            {
+                builder.Keyword(modifier);
+                builder.Space();
+            }
+        }
+
+        builder.Keyword("func");
+        builder.Space();
+
+        if (format.IncludeModifiers && function.ReceiverType != null)
+        {
+            builder.Punctuation("(");
+            builder.Type(FormatType(function.ReceiverType));
+            builder.Punctuation(")");
+            builder.Space();
+        }
+
+        builder.Add(SymbolDisplayPartKind.MethodName, function.Name, function);
+        AppendTypeParameters(builder, function.TypeParameters);
+
+        builder.Punctuation("(");
+        for (var i = 0; i < function.Parameters.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Punctuation(",");
+                builder.Space();
+            }
+
+            builder.Add(SymbolDisplayPartKind.ParameterName, function.Parameters[i].Name);
+            builder.Space();
+            builder.Type(FormatType(function.Parameters[i].Type));
+        }
+
+        builder.Punctuation(")");
+
+        if (!IsVoid(function.Type))
+        {
+            builder.Space();
+            builder.Type(FormatType(function.Type));
+        }
+    }
+
+    private static IEnumerable<string> FunctionModifiers(FunctionSymbol function)
+    {
+        if (function.IsStatic)
+        {
+            yield return "static";
+        }
+
+        if (function.IsOpen)
+        {
+            yield return "open";
+        }
+
+        if (function.IsOverride)
+        {
+            yield return "override";
+        }
+
+        if (function.IsAsync)
+        {
+            yield return "async";
+        }
+    }
+
+    private static void AppendAggregate(PartBuilder builder, SymbolDisplayFormat format, StructSymbol aggregate)
+    {
+        builder.Keyword(aggregate.IsClass ? "class" : "struct");
+        builder.Space();
+        builder.Type(QualifiedName(format, aggregate.PackageName, aggregate.Name));
+        AppendTypeParameters(builder, aggregate.TypeParameters);
+        builder.Space();
+        builder.Punctuation("{");
+        builder.Space();
+        for (var i = 0; i < aggregate.Fields.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Punctuation(";");
+                builder.Space();
+            }
+
+            builder.Add(SymbolDisplayPartKind.FieldName, aggregate.Fields[i].Name);
+            builder.Space();
+            builder.Type(FormatType(aggregate.Fields[i].Type));
+        }
+
+        builder.Space();
+        builder.Punctuation("}");
+    }
+
+    private static void AppendEnum(PartBuilder builder, SymbolDisplayFormat format, EnumSymbol enumSymbol)
+    {
+        builder.Keyword("enum");
+        builder.Space();
+        builder.Type(QualifiedName(format, enumSymbol.PackageName, enumSymbol.Name));
+        builder.Space();
+        builder.Punctuation("{");
+        builder.Space();
+        for (var i = 0; i < enumSymbol.Members.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Punctuation(",");
+                builder.Space();
+            }
+
+            builder.Add(SymbolDisplayPartKind.EnumMemberName, enumSymbol.Members[i].Name);
+        }
+
+        builder.Space();
+        builder.Punctuation("}");
+    }
+
+    private static void AppendEnumMember(PartBuilder builder, SymbolDisplayFormat format, EnumMemberSymbol member)
+    {
+        builder.Type(member.EnumType.Name);
+        builder.Punctuation(".");
+        builder.Add(SymbolDisplayPartKind.EnumMemberName, member.Name);
+        if (format.IncludeConstantValue)
+        {
+            builder.Space();
+            builder.Punctuation("=");
+            builder.Space();
+            builder.Add(SymbolDisplayPartKind.NumericLiteral, member.Value.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    private static void AppendProperty(PartBuilder builder, SymbolDisplayFormat format, PropertySymbol property)
+    {
+        builder.Add(SymbolDisplayPartKind.PropertyName, property.Name);
+        builder.Space();
+        builder.Type(FormatType(property.Type));
+        if (format.IncludePropertyAccessors)
+        {
+            builder.Space();
+            builder.Punctuation("{");
+            if (property.HasGetter)
+            {
+                builder.Space();
+                builder.Keyword("get");
+                builder.Punctuation(";");
+            }
+
+            if (property.HasSetter)
+            {
+                builder.Space();
+                builder.Keyword("set");
+                builder.Punctuation(";");
+            }
+
+            builder.Space();
+            builder.Punctuation("}");
+        }
+    }
+
+    private static void AppendEvent(PartBuilder builder, EventSymbol @event)
+    {
+        builder.Keyword("event");
+        builder.Space();
+        builder.Identifier(@event.Name);
+        builder.Space();
+        builder.Type(FormatType(@event.Type));
+    }
+
+    private static void AppendField(PartBuilder builder, SymbolDisplayFormat format, FieldSymbol field)
+    {
+        if (format.IncludeDescriptorPrefix)
+        {
+            builder.Descriptor("(field)");
+            builder.Space();
+        }
+
+        builder.Add(SymbolDisplayPartKind.FieldName, field.Name);
+        builder.Space();
+        builder.Type(FormatType(field.Type));
+    }
+
+    private static void AppendImport(PartBuilder builder, ImportSymbol import)
+    {
+        builder.Keyword("import");
+        builder.Space();
+        if (import.IsAlias)
+        {
+            builder.Add(SymbolDisplayPartKind.AliasName, import.Name);
+            builder.Space();
+            builder.Punctuation("=");
+            builder.Space();
+        }
+
+        builder.Add(SymbolDisplayPartKind.NamespaceName, import.Target);
+    }
+
+    private static void AppendPackage(PartBuilder builder, PackageSymbol package)
+    {
+        builder.Keyword("package");
+        builder.Space();
+        builder.Add(SymbolDisplayPartKind.NamespaceName, package.Name);
+    }
+
+    private static void AppendTypeParameters(PartBuilder builder, ImmutableArray<TypeParameterSymbol> typeParameters)
+    {
+        if (typeParameters.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        builder.Punctuation("<");
+        for (var i = 0; i < typeParameters.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Punctuation(",");
+                builder.Space();
+            }
+
+            builder.Type(typeParameters[i].Name);
+        }
+
+        builder.Punctuation(">");
+    }
+
+    private static string QualifiedName(SymbolDisplayFormat format, string packageName, string name)
+    {
+        // "Default" is G#'s implicit package (the analog of C#'s global namespace);
+        // qualifying with it is noise, so it is treated as unqualified.
+        return format.QualifyNames && !string.IsNullOrEmpty(packageName) && packageName != "Default"
+            ? $"{packageName}.{name}"
+            : name;
+    }
+
+    private static string FormatType(TypeSymbol type)
+    {
+        return type == null || IsVoid(type) ? "void" : type.Name;
+    }
+
+    private static bool IsVoid(TypeSymbol type)
+    {
+        return type == null || ReferenceEquals(type, TypeSymbol.Void);
+    }
+
+    private static string ResolveVariableKeyword(VariableSymbol variable, Compilation.Compilation compilation)
+    {
+        if (compilation != null && variable.DeclaringSyntax is SyntaxToken identifier)
+        {
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                foreach (var declaration in FindVariableDeclarations(tree.Root))
+                {
+                    if (ReferenceEquals(declaration.Identifier, identifier)
+                        || (declaration.Identifier.Span.Start == identifier.Span.Start
+                            && declaration.Identifier.Span.Length == identifier.Span.Length
+                            && declaration.Identifier.Text == identifier.Text))
+                    {
+                        var keyword = declaration.Keyword?.Text;
+                        if (!string.IsNullOrEmpty(keyword))
+                        {
+                            return keyword;
+                        }
+                    }
+                }
+            }
+        }
+
+        return variable.IsReadOnly ? "let" : "var";
+    }
+
+    private static IEnumerable<VariableDeclarationSyntax> FindVariableDeclarations(SyntaxNode node)
+    {
+        if (node is VariableDeclarationSyntax declaration)
+        {
+            yield return declaration;
+        }
+
+        foreach (var child in node.GetChildren())
+        {
+            foreach (var descendant in FindVariableDeclarations(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+
+    private static string PartsToString(ImmutableArray<SymbolDisplayPart> parts)
+    {
+        return string.Concat(parts.Select(p => p.Text));
+    }
+
+    private sealed class PartBuilder
+    {
+        private readonly ImmutableArray<SymbolDisplayPart>.Builder parts = ImmutableArray.CreateBuilder<SymbolDisplayPart>();
+
+        public void Add(SymbolDisplayPartKind kind, string text, Symbol symbol = null) => this.parts.Add(new SymbolDisplayPart(kind, text, symbol));
+
+        public void Keyword(string text) => this.Add(SymbolDisplayPartKind.Keyword, text);
+
+        public void Identifier(string text) => this.Add(SymbolDisplayPartKind.Identifier, text);
+
+        public void Type(string text) => this.Add(SymbolDisplayPartKind.TypeName, text);
+
+        public void Punctuation(string text) => this.Add(SymbolDisplayPartKind.Punctuation, text);
+
+        public void Descriptor(string text) => this.Add(SymbolDisplayPartKind.Descriptor, text);
+
+        public void Space() => this.Add(SymbolDisplayPartKind.Space, " ");
+
+        public ImmutableArray<SymbolDisplayPart> ToImmutable() => this.parts.ToImmutable();
+    }
+}

--- a/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplayFormat.cs
+++ b/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplayFormat.cs
@@ -1,0 +1,59 @@
+// <copyright file="SymbolDisplayFormat.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Symbols.Display;
+
+/// <summary>
+/// Declarative options controlling how <see cref="SymbolDisplay.ToDisplayParts(GSharp.Core.CodeAnalysis.Symbols.Symbol, SymbolDisplayFormat, GSharp.Core.CodeAnalysis.Compilation.Compilation)"/>
+/// renders a symbol. The analog of Roslyn's <c>SymbolDisplayFormat</c>: a single
+/// service produces every IDE view by varying this format rather than maintaining
+/// divergent ad-hoc formatters.
+/// </summary>
+/// <param name="IncludeDescriptorPrefix">
+/// Emit a leading descriptor such as <c>(local variable)</c>, <c>(parameter)</c>,
+/// or <c>(field)</c> (the Roslyn <c>Description(...)</c> convention).
+/// </param>
+/// <param name="QualifyNames">
+/// Qualify type, enum, and package names with their containing package
+/// (fully-qualified names) when a package is known.
+/// </param>
+/// <param name="IncludeConstantValue">
+/// Append an enum member's numeric value (e.g. <c>Color.Red = 1</c>).
+/// </param>
+/// <param name="IncludePropertyAccessors">
+/// Append a property's accessor descriptor (e.g. <c>{ get; set; }</c>).
+/// </param>
+/// <param name="IncludeModifiers">
+/// Include declaration modifiers (e.g. <c>static</c>, <c>async</c>, <c>open</c>,
+/// <c>override</c>) and the extension/receiver clause on functions.
+/// </param>
+public sealed record SymbolDisplayFormat(
+    bool IncludeDescriptorPrefix,
+    bool QualifyNames,
+    bool IncludeConstantValue,
+    bool IncludePropertyAccessors,
+    bool IncludeModifiers)
+{
+    /// <summary>
+    /// The rich format used for LSP hover: descriptors, fully-qualified names,
+    /// enum values, property accessors, and modifiers.
+    /// </summary>
+    public static readonly SymbolDisplayFormat Hover = new(
+        IncludeDescriptorPrefix: true,
+        QualifyNames: true,
+        IncludeConstantValue: true,
+        IncludePropertyAccessors: true,
+        IncludeModifiers: true);
+
+    /// <summary>
+    /// The compact format used for signature labels (signature help, completion
+    /// detail): modifiers and accessors but no descriptor prefix.
+    /// </summary>
+    public static readonly SymbolDisplayFormat Signature = new(
+        IncludeDescriptorPrefix: false,
+        QualifyNames: false,
+        IncludeConstantValue: true,
+        IncludePropertyAccessors: true,
+        IncludeModifiers: true);
+}

--- a/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplayPart.cs
+++ b/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplayPart.cs
@@ -1,0 +1,18 @@
+// <copyright file="SymbolDisplayPart.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Symbols.Display;
+
+/// <summary>
+/// A single classified run of text in a symbol's display, optionally carrying the
+/// <see cref="Symbol"/> it refers to (for navigation). The analog of Roslyn's
+/// <c>SymbolDisplayPart</c>.
+/// </summary>
+/// <param name="Kind">The classification of this part.</param>
+/// <param name="Text">The literal text of this part.</param>
+/// <param name="Symbol">The symbol this part refers to, when applicable.</param>
+public readonly record struct SymbolDisplayPart(
+    SymbolDisplayPartKind Kind,
+    string Text,
+    Symbol Symbol = null);

--- a/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplayPartKind.cs
+++ b/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplayPartKind.cs
@@ -1,0 +1,58 @@
+// <copyright file="SymbolDisplayPartKind.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Symbols.Display;
+
+/// <summary>
+/// Classifies a single <see cref="SymbolDisplayPart"/> so renderers (LSP hover,
+/// signature help, completion) can colorize or place parts independently. Mirrors
+/// a trimmed subset of Roslyn's <c>SymbolDisplayPartKind</c>.
+/// </summary>
+public enum SymbolDisplayPartKind
+{
+    /// <summary>A language keyword (e.g. <c>func</c>, <c>struct</c>, <c>let</c>).</summary>
+    Keyword,
+
+    /// <summary>Punctuation (e.g. <c>(</c>, <c>,</c>, <c>{</c>).</summary>
+    Punctuation,
+
+    /// <summary>Whitespace between parts.</summary>
+    Space,
+
+    /// <summary>A generic identifier with no more specific classification.</summary>
+    Identifier,
+
+    /// <summary>A type name (class/struct/interface/enum/primitive).</summary>
+    TypeName,
+
+    /// <summary>A parameter name.</summary>
+    ParameterName,
+
+    /// <summary>A property name.</summary>
+    PropertyName,
+
+    /// <summary>A field name.</summary>
+    FieldName,
+
+    /// <summary>A method or function name.</summary>
+    MethodName,
+
+    /// <summary>An enum member name.</summary>
+    EnumMemberName,
+
+    /// <summary>A namespace or package name.</summary>
+    NamespaceName,
+
+    /// <summary>An import alias name.</summary>
+    AliasName,
+
+    /// <summary>A numeric literal (e.g. an enum member's constant value).</summary>
+    NumericLiteral,
+
+    /// <summary>A descriptor such as <c>(local variable)</c> or <c>(+ 2 overloads)</c>.</summary>
+    Descriptor,
+
+    /// <summary>Free text with no other classification.</summary>
+    Text,
+}

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Text;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Symbols.Display;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using GSharp.LanguageServer.Protocol;
@@ -27,11 +28,11 @@ public static class HoverComputer
         var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
         var symbol = SemanticLookup.ResolveSymbol(compilation, token);
 
-        var signature = symbol != null
-            ? FormatSymbol(symbol, compilation)
-            : FormatImportedClrType(content.SyntaxTree, compilation, token);
+        var model = symbol != null
+            ? BuildHoverModel(symbol, compilation)
+            : BuildImportedClrModel(content.SyntaxTree, compilation, token);
 
-        if (signature == null)
+        if (model == null)
         {
             return null;
         }
@@ -41,78 +42,44 @@ public static class HoverComputer
             Contents = new MarkedStringsOrMarkupContent(new MarkupContent
             {
                 Kind = MarkupKind.Markdown,
-                Value = $"```gsharp\n{signature}\n```",
+                Value = RenderHover(model),
             }),
             Range = SemanticLookup.ToRange(token),
         };
     }
 
+    /// <summary>
+    /// Renders a symbol's compact signature label for signature help and completion
+    /// detail. Hover uses the richer <see cref="SymbolDisplayFormat.Hover"/> form via
+    /// <see cref="ComputeHover"/>.
+    /// </summary>
+    /// <param name="symbol">The symbol to render.</param>
+    /// <returns>The compact signature label.</returns>
     public static string FormatSymbol(Symbol symbol)
     {
-        return FormatSymbol(symbol, compilation: null);
+        return SymbolDisplay.ToDisplayString(symbol, SymbolDisplayFormat.Signature);
     }
 
+    /// <summary>
+    /// Renders a symbol's compact signature label, using <paramref name="compilation"/>
+    /// to recover a variable's exact declaring keyword.
+    /// </summary>
+    /// <param name="symbol">The symbol to render.</param>
+    /// <param name="compilation">The compilation providing declaration syntax.</param>
+    /// <returns>The compact signature label.</returns>
     public static string FormatSymbol(Symbol symbol, Compilation compilation)
     {
-        return symbol switch
-        {
-            ParameterSymbol parameter => $"{parameter.Name} {FormatType(parameter.Type)}",
-            VariableSymbol variable => $"{ResolveVariableKeyword(variable, compilation)} {variable.Name} {FormatType(variable.Type)}",
-            FunctionSymbol function => FormatFunction(function),
-            StructSymbol aggregate => FormatAggregate(aggregate),
-            EnumSymbol enumSymbol => FormatEnum(enumSymbol),
-            EnumMemberSymbol member => $"enum member {member.EnumType.Name}.{member.Name}: {FormatType(member.EnumType)}",
-            FieldSymbol field => $"field {field.Name}: {FormatType(field.Type)}",
-            TypeSymbol type => $"type {FormatType(type)}",
-            _ => $"{symbol.Kind.ToString().ToLowerInvariant()} {symbol.Name}",
-        };
+        return SymbolDisplay.ToDisplayString(symbol, SymbolDisplayFormat.Signature, compilation);
     }
 
-    private static string ResolveVariableKeyword(VariableSymbol variable, Compilation compilation)
+    private static HoverModel BuildHoverModel(Symbol symbol, Compilation compilation)
     {
-        if (compilation != null && variable.DeclaringSyntax is SyntaxToken identifier)
-        {
-            foreach (var tree in compilation.SyntaxTrees)
-            {
-                foreach (var declaration in FindVariableDeclarations(tree.Root))
-                {
-                    if (ReferenceEquals(declaration.Identifier, identifier)
-                        || (declaration.Identifier.Span.Start == identifier.Span.Start
-                            && declaration.Identifier.Span.Length == identifier.Span.Length
-                            && declaration.Identifier.Text == identifier.Text))
-                    {
-                        var keyword = declaration.Keyword?.Text;
-                        if (!string.IsNullOrEmpty(keyword))
-                        {
-                            return keyword;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Fallback when the declaration cannot be located: `let` is read-only,
-        // `var` is mutable (ADR keeps `const` read-only as well).
-        return variable.IsReadOnly ? "let" : "var";
+        var signature = SymbolDisplay.ToDisplayString(symbol, SymbolDisplayFormat.Hover, compilation);
+        var overloadCount = symbol is FunctionSymbol function ? CountOverloads(compilation, function) : 1;
+        return new HoverModel(signature, BuildDocumentation(symbol), overloadCount);
     }
 
-    private static IEnumerable<VariableDeclarationSyntax> FindVariableDeclarations(SyntaxNode node)
-    {
-        if (node is VariableDeclarationSyntax declaration)
-        {
-            yield return declaration;
-        }
-
-        foreach (var child in node.GetChildren())
-        {
-            foreach (var descendant in FindVariableDeclarations(child))
-            {
-                yield return descendant;
-            }
-        }
-    }
-
-    private static string FormatImportedClrType(SyntaxTree tree, Compilation compilation, SyntaxToken token)
+    private static HoverModel BuildImportedClrModel(SyntaxTree tree, Compilation compilation, SyntaxToken token)
     {
         if (token == null || token.Kind != SyntaxKind.IdentifierToken)
         {
@@ -125,38 +92,65 @@ public static class HoverComputer
             return null;
         }
 
-        var keyword = clrType.IsInterface ? "interface"
-            : clrType.IsEnum ? "enum"
-            : clrType.IsValueType ? "struct"
-            : "class";
-
-        return $"{keyword} {clrType.FullName ?? clrType.Name}";
+        var signature = SymbolDisplay.ToDisplayString(clrType, SymbolDisplayFormat.Hover);
+        return new HoverModel(signature, Array.Empty<HoverDocSection>(), OverloadCount: 1);
     }
 
-    private static string FormatFunction(FunctionSymbol function)
+    private static string RenderHover(HoverModel model)
     {
-        var parameters = string.Join(", ", function.Parameters.Select(p => $"{p.Name} {FormatType(p.Type)}"));
-        var returnType = ReferenceEquals(function.Type, TypeSymbol.Void) ? string.Empty : $" {FormatType(function.Type)}";
-        return $"func {function.Name}({parameters}){returnType}";
+        var sb = new StringBuilder();
+        sb.Append("```gsharp\n").Append(model.Signature).Append("\n```");
+
+        if (model.OverloadCount > 1)
+        {
+            var others = model.OverloadCount - 1;
+            sb.Append("\n\n*(+ ").Append(others).Append(others == 1 ? " overload)*" : " overloads)*");
+        }
+
+        foreach (var section in model.Documentation)
+        {
+            sb.Append("\n\n");
+            if (!string.IsNullOrEmpty(section.Heading))
+            {
+                sb.Append("**").Append(section.Heading).Append("**\n\n");
+            }
+
+            sb.Append(section.Body);
+        }
+
+        return sb.ToString();
     }
 
-    private static string FormatAggregate(StructSymbol aggregate)
+    private static int CountOverloads(Compilation compilation, FunctionSymbol function)
     {
-        var keyword = aggregate.IsClass ? "class" : "struct";
-        var fields = string.Join("; ", aggregate.Fields.Select(f => $"{f.Name} {FormatType(f.Type)}"));
-        return $"{keyword} {aggregate.Name} {{ {fields} }}";
+        if (function.StaticOwnerType is StructSymbol staticOwner)
+        {
+            return staticOwner.StaticMethods.Count(m => m.Name == function.Name);
+        }
+
+        if (function.ReceiverType is StructSymbol owner)
+        {
+            return owner.Methods.Count(m => m.Name == function.Name);
+        }
+
+        return compilation.GlobalScope.Functions.Count(f => f.Name == function.Name);
     }
 
-    private static string FormatEnum(EnumSymbol enumSymbol)
+    // Documentation sections are an empty shell until ADR-0057 ingestion/authoring
+    // (Stage C) populate the model. The renderer above already lays them out.
+    private static IReadOnlyList<HoverDocSection> BuildDocumentation(Symbol symbol)
     {
-        var members = string.Join(", ", enumSymbol.Members.Select(m => m.Name));
-        return $"enum {enumSymbol.Name} {{ {members} }}";
+        return Array.Empty<HoverDocSection>();
     }
 
     private static string FormatType(TypeSymbol type)
     {
         return type?.Name ?? "void";
     }
+
+    private sealed record HoverModel(string Signature, IReadOnlyList<HoverDocSection> Documentation, int OverloadCount);
+
+    private sealed record HoverDocSection(string Heading, string Body);
 }
 
 public static class ReferencesComputer

--- a/src/LanguageServer/SemanticLookup.cs
+++ b/src/LanguageServer/SemanticLookup.cs
@@ -324,6 +324,37 @@ public static class SemanticLookup
                 {
                     declarations[aggregate.Declaration.Fields[i].Identifier] = aggregate.Fields[i];
                 }
+
+                MapMembersByName(
+                    declarations,
+                    aggregate.Declaration.Properties.Select(p => p.Identifier),
+                    aggregate.Properties.Concat(aggregate.StaticProperties));
+
+                MapMembersByName(
+                    declarations,
+                    aggregate.Declaration.Events.Select(e => e.Identifier),
+                    aggregate.Events.Concat(aggregate.StaticEvents));
+            }
+        }
+
+        foreach (var import in compilation.GlobalScope.Imports)
+        {
+            if (import.Declaration?.AliasIdentifier is { } aliasIdentifier)
+            {
+                declarations[aliasIdentifier] = import;
+            }
+        }
+
+        foreach (var package in compilation.GlobalScope.Packages)
+        {
+            if (package.Declaration == null)
+            {
+                continue;
+            }
+
+            foreach (var identifier in package.Declaration.Identifiers)
+            {
+                declarations[identifier] = package;
             }
         }
 
@@ -344,6 +375,26 @@ public static class SemanticLookup
 
         MapLocalVariables(compilation, declarations, localDeclarations);
         return new SemanticModel(compilation, declarations, globals, localDeclarations);
+    }
+
+    private static void MapMembersByName(
+        Dictionary<SyntaxToken, Symbol> declarations,
+        IEnumerable<SyntaxToken> identifiers,
+        IEnumerable<Symbol> symbols)
+    {
+        var byName = new Dictionary<string, Symbol>(StringComparer.Ordinal);
+        foreach (var symbol in symbols)
+        {
+            byName[symbol.Name] = symbol;
+        }
+
+        foreach (var identifier in identifiers)
+        {
+            if (identifier != null && byName.TryGetValue(identifier.Text, out var symbol))
+            {
+                declarations[identifier] = symbol;
+            }
+        }
     }
 
     private static void MapParameters(

--- a/test/LanguageServer.Tests/HoverHandlerTests.cs
+++ b/test/LanguageServer.Tests/HoverHandlerTests.cs
@@ -39,4 +39,44 @@ public class HoverHandlerTests
         Assert.NotNull(hover);
         Assert.Contains(token, hover.Contents.ToString(), System.StringComparison.Ordinal);
     }
+
+    [Theory]
+    [InlineData("func greet(name string) { }\n", "name", "(parameter) name string")]
+    [InlineData("func f() {\nvar x = 5\nx = x + 1\n}\n", "x", "(local variable) x int32")]
+    [InlineData("type Color enum { Red, Green }\n", "Red", "Color.Red = 0")]
+    [InlineData("type Color enum { Red, Green }\n", "Green", "Color.Green = 1")]
+    [InlineData("package P\nimport sys = System\n", "sys", "import sys = System")]
+    [InlineData("package Outer.Inner\n", "Inner", "package Outer.Inner")]
+    public void ComputeHover_RendersEnrichedDescriptors(string source, string token, string expected)
+    {
+        var content = LanguageServerTestHelpers.Content(source);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, token));
+
+        Assert.NotNull(hover);
+        Assert.Contains(expected, hover.Contents.ToString(), System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ComputeHover_RendersPropertyAccessors()
+    {
+        const string source = "package P\ntype Person class {\n    prop Name string\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "Name"));
+
+        Assert.NotNull(hover);
+        var value = hover.Contents.ToString();
+        Assert.Contains("Name string {", value, System.StringComparison.Ordinal);
+        Assert.Contains("get;", value, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ComputeHover_DoesNotAnnotateOverloadsForSingleFunction()
+    {
+        const string source = "func add(a int32, b int32) int32 { return a + b }\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "add"));
+
+        Assert.NotNull(hover);
+        Assert.DoesNotContain("overload", hover.Contents.ToString(), System.StringComparison.Ordinal);
+    }
 }

--- a/test/LanguageServer.Tests/HoverHandlerTests.cs
+++ b/test/LanguageServer.Tests/HoverHandlerTests.cs
@@ -24,4 +24,19 @@ public class HoverHandlerTests
         Assert.NotNull(hover);
         Assert.Contains(expected, hover.Contents.ToString(), System.StringComparison.Ordinal);
     }
+
+    [Theory]
+    [InlineData("package P\ntype Person class {\n    prop Name string\n}\n", "Name")]
+    [InlineData("package P\nimport sys = System\n", "sys")]
+    [InlineData("package Outer.Inner\n", "Outer")]
+    [InlineData("package Outer.Inner\n", "Inner")]
+    [InlineData("package P\nimport System\ntype Foo class {\n  event Click func(Object, EventArgs)\n}\n", "Click")]
+    public void ComputeHover_ResolvesPropertyImportPackageAndEventSymbols(string source, string token)
+    {
+        var content = LanguageServerTestHelpers.Content(source);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, token));
+
+        Assert.NotNull(hover);
+        Assert.Contains(token, hover.Contents.ToString(), System.StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
## Summary

Stage A of the hover-revamp plan (issue #388, building on the merged ADR-0057 #389). This delivers the **hover foundations**: complete symbol resolution at hover sites, a single classified `SymbolDisplay` service that becomes the IDE source of truth, and a multi-section hover renderer. No language change.

These three work items are the anti-rework spine: per-kind display richness is written **once** into the shared service rather than into ad-hoc formatters that later get redone, and the multi-section `HoverModel` is the renderer every later documentation step (ADR-0057 Stage B/C) plugs into.

## What's included

**1. Resolution wiring** (`SemanticLookup.BuildModel`)
- Hover now resolves property, event, import-alias, and package declaration tokens (previously unreachable), via a new `MapMembersByName` helper.

**2. SymbolDisplay service** (`src/Core/CodeAnalysis/Symbols/Display/`)
- New `SymbolDisplay`, `SymbolDisplayPart`, `SymbolDisplayPartKind`, `SymbolDisplayFormat` — the analog of Roslyn's symbol-display service. Single source of truth for hover, signature help and completion detail.
- `SymbolPrinter` is intentionally **left untouched** (it is the terse diagnostic view behind `Symbol.ToString()`; a different audience, not duplicate logic).
- Enriched per-kind rendering: `(parameter)` / `(local variable)` / `(field)` descriptors, enum member values (`Color.Red = 1`), property `{ get; set; }` accessors, fully-qualified names (the implicit `Default` package is elided like C#'s global namespace), `import Alias = Target`, `package Fully.Qualified`, function modifiers, and a `System.Type` overload that folds imported-CLR-type rendering into the service.

**3. Multi-section hover** (`HoverComputer`)
- `ComputeHover` now builds a `HoverModel { Signature; Documentation; OverloadCount }`: a `gsharp` fenced signature, an `(+ N overloads)` annotation, and an (empty for now) documentation section shell that ADR-0057 Stage C will fill.
- The legacy `FormatSymbol*` / `FormatType` formatters are removed; signature help and completion route through the service.

## Tests

- `HoverHandlerTests`: existing behavior-preservation goldens kept; added enriched-descriptor, property-accessor, and overload-annotation tests.
- Full suite green: Core 1484, Compiler 258, LanguageServer 156, Interpreter 54, Sdk — 0 failures.

## Notes

- G# rejects user-defined function overloads (GS0102), so the overload annotation is dormant infrastructure for user code today; it stays correct (count is 1) and is ready for imported-CLR-method hover.

Refs #388. Builds on #389 (ADR-0057).
