### PR TITLE
#388 Stage B: documentation model + shared DocumentationIdProvider

### DIFF
--- a/src/Core/CodeAnalysis/Documentation/DocInline.cs
+++ b/src/Core/CodeAnalysis/Documentation/DocInline.cs
@@ -1,0 +1,69 @@
+// <copyright file="DocInline.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+
+namespace GSharp.Core.CodeAnalysis.Documentation;
+
+/// <summary>
+/// A node in the ordered inline-content tree of a <see cref="DocumentationComment"/>.
+/// Inline content is the shared internal representation that both the Markdown
+/// authoring surface (G# → model) and the ingested XML-doc vocabulary (C# → model)
+/// are parsed into, per ADR-0057 §4. Any imported XML element with no first-class
+/// case here is preserved verbatim as <see cref="UnknownXmlElement"/> so hover can
+/// render it and emission can reproduce it byte-for-byte.
+/// </summary>
+public abstract record DocInline
+{
+    /// <summary>A run of literal text.</summary>
+    /// <param name="Value">The literal text.</param>
+    public sealed record Text(string Value) : DocInline;
+
+    /// <summary>Inline code (XML <c>&lt;c&gt;</c> / Markdown backticks).</summary>
+    /// <param name="Value">The code text.</param>
+    public sealed record Code(string Value) : DocInline;
+
+    /// <summary>A fenced/preformatted code block (XML <c>&lt;code&gt;</c>).</summary>
+    /// <param name="Language">The optional language tag, or null.</param>
+    /// <param name="Value">The code text.</param>
+    public sealed record CodeBlock(string Language, string Value) : DocInline;
+
+    /// <summary>A paragraph (XML <c>&lt;para&gt;</c>).</summary>
+    /// <param name="Content">The ordered inline content of the paragraph.</param>
+    public sealed record Para(ImmutableArray<DocInline> Content) : DocInline;
+
+    /// <summary>A list (XML <c>&lt;list&gt;</c>).</summary>
+    /// <param name="ListType">The list type (<c>bullet</c>, <c>number</c>, <c>table</c>), or null.</param>
+    /// <param name="Items">The list items.</param>
+    public sealed record List(string ListType, ImmutableArray<DocListItem> Items) : DocInline;
+
+    /// <summary>A reference to a documented symbol (XML <c>&lt;see cref&gt;</c>).</summary>
+    /// <param name="DocId">The target documentation id (cref).</param>
+    /// <param name="Inner">Optional display content, or default when the cref renders itself.</param>
+    public sealed record SymbolRef(string DocId, ImmutableArray<DocInline> Inner) : DocInline;
+
+    /// <summary>An external hyperlink (Markdown link with an <c>http(s)</c> target).</summary>
+    /// <param name="Href">The link target.</param>
+    /// <param name="Inner">The link display content.</param>
+    public sealed record Link(string Href, ImmutableArray<DocInline> Inner) : DocInline;
+
+    /// <summary>A reference to a parameter (XML <c>&lt;paramref name&gt;</c>).</summary>
+    /// <param name="Name">The referenced parameter name.</param>
+    public sealed record ParamRef(string Name) : DocInline;
+
+    /// <summary>
+    /// A verbatim, well-formed XML fragment with no first-class model case. Backs
+    /// both the authoring escape hatch and full-fidelity ingestion (ADR-0057 §4/§6).
+    /// </summary>
+    /// <param name="RawXml">The verbatim XML fragment.</param>
+    public sealed record UnknownXmlElement(string RawXml) : DocInline;
+}
+
+/// <summary>
+/// A single item of a <see cref="DocInline.List"/>, modelling the XML
+/// <c>&lt;item&gt;&lt;term&gt;…&lt;/term&gt;&lt;description&gt;…&lt;/description&gt;&lt;/item&gt;</c> shape.
+/// </summary>
+/// <param name="Term">The optional term content.</param>
+/// <param name="Description">The description content.</param>
+public sealed record DocListItem(ImmutableArray<DocInline> Term, ImmutableArray<DocInline> Description);

--- a/src/Core/CodeAnalysis/Documentation/DocumentationComment.cs
+++ b/src/Core/CodeAnalysis/Documentation/DocumentationComment.cs
@@ -1,0 +1,68 @@
+// <copyright file="DocumentationComment.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+
+namespace GSharp.Core.CodeAnalysis.Documentation;
+
+/// <summary>
+/// The internal, structured documentation model for a symbol (ADR-0057 §4). A single
+/// surface for every IDE feature (hover, signature help, completion), populated either
+/// from authored G# Markdown or from ingested C# XML-doc. Sections map 1:1 to the
+/// standard XML-doc vocabulary so the model round-trips losslessly in both directions.
+/// </summary>
+/// <param name="Summary">The <c>&lt;summary&gt;</c> content.</param>
+/// <param name="Parameters">The <c>&lt;param&gt;</c> entries (name + content).</param>
+/// <param name="TypeParameters">The <c>&lt;typeparam&gt;</c> entries.</param>
+/// <param name="Returns">The <c>&lt;returns&gt;</c> content.</param>
+/// <param name="Remarks">The <c>&lt;remarks&gt;</c> content.</param>
+/// <param name="Value">The <c>&lt;value&gt;</c> content (properties).</param>
+/// <param name="Exceptions">The <c>&lt;exception&gt;</c> entries (cref + content).</param>
+/// <param name="SeeAlso">The <c>&lt;seealso&gt;</c> references.</param>
+public sealed record DocumentationComment(
+    ImmutableArray<DocInline> Summary,
+    ImmutableArray<DocParam> Parameters,
+    ImmutableArray<DocParam> TypeParameters,
+    ImmutableArray<DocInline> Returns,
+    ImmutableArray<DocInline> Remarks,
+    ImmutableArray<DocInline> Value,
+    ImmutableArray<DocException> Exceptions,
+    ImmutableArray<DocReference> SeeAlso)
+{
+    /// <summary>
+    /// An empty documentation comment with every section defaulted to empty. Useful as
+    /// a non-null sentinel and a builder base.
+    /// </summary>
+    public static readonly DocumentationComment Empty = new(
+        ImmutableArray<DocInline>.Empty,
+        ImmutableArray<DocParam>.Empty,
+        ImmutableArray<DocParam>.Empty,
+        ImmutableArray<DocInline>.Empty,
+        ImmutableArray<DocInline>.Empty,
+        ImmutableArray<DocInline>.Empty,
+        ImmutableArray<DocException>.Empty,
+        ImmutableArray<DocReference>.Empty);
+}
+
+/// <summary>
+/// A named documentation entry — a <c>&lt;param&gt;</c> or <c>&lt;typeparam&gt;</c>.
+/// </summary>
+/// <param name="Name">The parameter or type-parameter name.</param>
+/// <param name="Content">The documentation content.</param>
+public sealed record DocParam(string Name, ImmutableArray<DocInline> Content);
+
+/// <summary>
+/// A documented exception — an <c>&lt;exception cref&gt;</c>.
+/// </summary>
+/// <param name="Cref">The exception type's documentation id (cref).</param>
+/// <param name="Content">The documentation content.</param>
+public sealed record DocException(string Cref, ImmutableArray<DocInline> Content);
+
+/// <summary>
+/// A <c>&lt;seealso&gt;</c> reference, to either a symbol (cref) or an external link (href).
+/// </summary>
+/// <param name="Cref">The target documentation id, or null when this is a link.</param>
+/// <param name="Href">The external link target, or null when this is a cref.</param>
+/// <param name="Content">The optional display content.</param>
+public sealed record DocReference(string Cref, string Href, ImmutableArray<DocInline> Content);

--- a/src/Core/CodeAnalysis/Documentation/DocumentationIdProvider.cs
+++ b/src/Core/CodeAnalysis/Documentation/DocumentationIdProvider.cs
@@ -1,0 +1,317 @@
+// <copyright file="DocumentationIdProvider.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace GSharp.Core.CodeAnalysis.Documentation;
+
+/// <summary>
+/// Computes documentation ids ("DocIDs") in the exact format Roslyn's
+/// <c>DocumentationCommentId</c> / the C# language specification uses. This is the
+/// single shared component behind both documentation <em>ingestion</em> (reflected
+/// CLR members, ADR-0057 §6) and documentation <em>emission</em> (source symbols,
+/// ADR-0057 §5): the two paths must never diverge, so they share this code and one
+/// golden corpus.
+/// </summary>
+/// <remarks>
+/// A DocID is a prefix (<c>T:</c>, <c>M:</c>, <c>P:</c>, <c>F:</c>, <c>E:</c>,
+/// <c>N:</c>) followed by the member's fully-qualified, language-neutral signature:
+/// nested types separated by <c>.</c>, generic arity as <c>`n</c> (types) / <c>``n</c>
+/// (methods), constructed type arguments in <c>{…}</c>, by-ref <c>@</c>, arrays
+/// <c>[]</c>, pointers <c>*</c>, and a <c>~ReturnType</c> suffix on conversion operators.
+/// </remarks>
+public static class DocumentationIdProvider
+{
+    /// <summary>
+    /// Computes the DocID for any reflected member, dispatching on its kind.
+    /// </summary>
+    /// <param name="member">The reflected member.</param>
+    /// <returns>The DocID, or <see langword="null"/> when the member kind is unsupported.</returns>
+    public static string GetDocumentationId(MemberInfo member)
+    {
+        return member switch
+        {
+            Type type => GetDocumentationId(type),
+            MethodBase method => GetDocumentationId(method),
+            PropertyInfo property => GetDocumentationId(property),
+            FieldInfo field => GetDocumentationId(field),
+            EventInfo @event => GetDocumentationId(@event),
+            _ => null,
+        };
+    }
+
+    /// <summary>Computes the <c>T:</c> DocID for a reflected type.</summary>
+    /// <param name="type">The reflected type.</param>
+    /// <returns>The type DocID.</returns>
+    public static string GetDocumentationId(Type type)
+    {
+        var builder = new StringBuilder("T:");
+        AppendTypeDeclarationName(builder, type.IsGenericType && !type.IsGenericTypeDefinition ? type.GetGenericTypeDefinition() : type);
+        return builder.ToString();
+    }
+
+    /// <summary>Computes the <c>M:</c> DocID for a reflected method or constructor.</summary>
+    /// <param name="method">The reflected method or constructor.</param>
+    /// <returns>The method DocID.</returns>
+    public static string GetDocumentationId(MethodBase method)
+    {
+        var builder = new StringBuilder("M:");
+        AppendTypeDeclarationName(builder, method.DeclaringType);
+        builder.Append('.');
+        AppendMethodName(builder, method);
+
+        if (method.IsGenericMethod)
+        {
+            builder.Append("``").Append(method.GetGenericArguments().Length);
+        }
+
+        AppendParameterList(builder, method.GetParameters());
+
+        if (method is MethodInfo info && (method.Name == "op_Implicit" || method.Name == "op_Explicit"))
+        {
+            builder.Append('~');
+            AppendTypeReference(builder, info.ReturnType);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>Computes the <c>P:</c> DocID for a reflected property or indexer.</summary>
+    /// <param name="property">The reflected property.</param>
+    /// <returns>The property DocID.</returns>
+    public static string GetDocumentationId(PropertyInfo property)
+    {
+        var builder = new StringBuilder("P:");
+        AppendTypeDeclarationName(builder, property.DeclaringType);
+        builder.Append('.').Append(EncodeName(property.Name));
+        AppendParameterList(builder, property.GetIndexParameters());
+        return builder.ToString();
+    }
+
+    /// <summary>Computes the <c>F:</c> DocID for a reflected field.</summary>
+    /// <param name="field">The reflected field.</param>
+    /// <returns>The field DocID.</returns>
+    public static string GetDocumentationId(FieldInfo field)
+    {
+        var builder = new StringBuilder("F:");
+        AppendTypeDeclarationName(builder, field.DeclaringType);
+        builder.Append('.').Append(EncodeName(field.Name));
+        return builder.ToString();
+    }
+
+    /// <summary>Computes the <c>E:</c> DocID for a reflected event.</summary>
+    /// <param name="event">The reflected event.</param>
+    /// <returns>The event DocID.</returns>
+    public static string GetDocumentationId(EventInfo @event)
+    {
+        var builder = new StringBuilder("E:");
+        AppendTypeDeclarationName(builder, @event.DeclaringType);
+        builder.Append('.').Append(EncodeName(@event.Name));
+        return builder.ToString();
+    }
+
+    private static void AppendMethodName(StringBuilder builder, MethodBase method)
+    {
+        if (method.IsConstructor)
+        {
+            builder.Append(method.IsStatic ? "#cctor" : "#ctor");
+            return;
+        }
+
+        builder.Append(EncodeName(method.Name));
+    }
+
+    private static void AppendParameterList(StringBuilder builder, ParameterInfo[] parameters)
+    {
+        if (parameters.Length == 0)
+        {
+            return;
+        }
+
+        builder.Append('(');
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(',');
+            }
+
+            AppendTypeReference(builder, parameters[i].ParameterType);
+        }
+
+        builder.Append(')');
+    }
+
+    // The declaration name is the dotted, arity-backticked path with no prefix and no
+    // brace-substituted type arguments — used for `T:` ids and as the container path of
+    // member ids (e.g. "System.Collections.Generic.List`1").
+    private static void AppendTypeDeclarationName(StringBuilder builder, Type type)
+    {
+        var chain = NestingChain(type);
+        var outermost = chain[0];
+        if (!string.IsNullOrEmpty(outermost.Namespace))
+        {
+            builder.Append(outermost.Namespace).Append('.');
+        }
+
+        for (var i = 0; i < chain.Count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append('.');
+            }
+
+            var level = chain[i];
+            builder.Append(StripArity(level.Name));
+            var arity = LevelArity(level);
+            if (arity > 0)
+            {
+                builder.Append('`').Append(arity);
+            }
+        }
+    }
+
+    // A type reference as it appears in a parameter/return position: generic parameters
+    // become `n (type) / ``n (method); constructed generics use brace-substituted args;
+    // by-ref/array/pointer carry their suffixes.
+    private static void AppendTypeReference(StringBuilder builder, Type type)
+    {
+        if (type.IsByRef)
+        {
+            AppendTypeReference(builder, type.GetElementType());
+            builder.Append('@');
+            return;
+        }
+
+        if (type.IsPointer)
+        {
+            AppendTypeReference(builder, type.GetElementType());
+            builder.Append('*');
+            return;
+        }
+
+        if (type.IsArray)
+        {
+            AppendTypeReference(builder, type.GetElementType());
+            AppendArraySuffix(builder, type);
+            return;
+        }
+
+        if (type.IsGenericParameter)
+        {
+            builder.Append(type.DeclaringMethod != null ? "``" : "`").Append(type.GenericParameterPosition);
+            return;
+        }
+
+        AppendConstructedTypeReference(builder, type);
+    }
+
+    private static void AppendConstructedTypeReference(StringBuilder builder, Type type)
+    {
+        var chain = NestingChain(type);
+        var outermost = chain[0];
+        if (!string.IsNullOrEmpty(outermost.Namespace))
+        {
+            builder.Append(outermost.Namespace).Append('.');
+        }
+
+        var allArgs = type.IsGenericType ? type.GetGenericArguments() : Array.Empty<Type>();
+        var consumed = 0;
+        for (var i = 0; i < chain.Count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append('.');
+            }
+
+            var level = chain[i];
+            builder.Append(StripArity(level.Name));
+            var arity = LevelArity(level);
+            if (arity == 0)
+            {
+                continue;
+            }
+
+            if (type.IsGenericTypeDefinition)
+            {
+                builder.Append('`').Append(arity);
+                continue;
+            }
+
+            builder.Append('{');
+            for (var a = 0; a < arity; a++)
+            {
+                if (a > 0)
+                {
+                    builder.Append(',');
+                }
+
+                AppendTypeReference(builder, allArgs[consumed + a]);
+            }
+
+            builder.Append('}');
+            consumed += arity;
+        }
+    }
+
+    private static void AppendArraySuffix(StringBuilder builder, Type array)
+    {
+        if (array.IsSZArray)
+        {
+            builder.Append("[]");
+            return;
+        }
+
+        var rank = array.GetArrayRank();
+        builder.Append('[')
+            .Append(string.Join(",", Enumerable.Repeat("0:", rank)))
+            .Append(']');
+    }
+
+    private static System.Collections.Generic.List<Type> NestingChain(Type type)
+    {
+        var chain = new System.Collections.Generic.List<Type>();
+        for (var current = type; current != null; current = current.DeclaringType)
+        {
+            chain.Insert(0, current);
+        }
+
+        return chain;
+    }
+
+    private static int LevelArity(Type level)
+    {
+        var own = level.IsGenericType ? level.GetGenericArguments().Length : 0;
+        var enclosing = level.DeclaringType is { IsGenericType: true } declaring
+            ? declaring.GetGenericArguments().Length
+            : 0;
+        return own - enclosing;
+    }
+
+    private static string StripArity(string name)
+    {
+        var tick = name.IndexOf('`');
+        return tick >= 0 ? name.Substring(0, tick) : name;
+    }
+
+    // Explicit interface implementations encode the interface in the member name:
+    // '.' becomes '#', and when the implemented interface is generic, reflection spells
+    // its type arguments with angle brackets/commas which Roslyn mangles as '{' / '}' /
+    // '@' (e.g. ICollection<KeyValuePair<TKey,TValue>>.Add becomes
+    // System#Collections#Generic#ICollection{...KeyValuePair{TKey@TValue}}#Add).
+    // None of '<', '>', ',' ever appear in an ordinary member name, so the uniform
+    // replacement is safe for non-EII names too.
+    private static string EncodeName(string name)
+    {
+        return name
+            .Replace('.', '#')
+            .Replace('<', '{')
+            .Replace('>', '}')
+            .Replace(',', '@');
+    }
+}

--- a/src/Core/CodeAnalysis/Symbols/Symbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/Symbol.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using System.IO;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Documentation;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
@@ -13,6 +14,8 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// </summary>
 public abstract class Symbol
 {
+    private DocumentationComment authoredDocumentation;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="Symbol"/> class.
     /// </summary>
@@ -61,6 +64,18 @@ public abstract class Symbol
     }
 
     /// <summary>
+    /// Gets the structured documentation for this symbol (ADR-0057 §4), or
+    /// <see langword="null"/> when the symbol is undocumented. The default returns the
+    /// authored documentation set by the binder (G# symbols); imported CLR symbols
+    /// override this to resolve documentation from the ingested <c>.xml</c> on demand.
+    /// </summary>
+    /// <returns>The documentation comment, or <see langword="null"/> when undocumented.</returns>
+    public virtual DocumentationComment GetDocumentation()
+    {
+        return this.authoredDocumentation;
+    }
+
+    /// <summary>
     /// Sets the bound-attribute list for this symbol. Called by the binder
     /// once attribute resolution for the owning declaration completes.
     /// </summary>
@@ -68,5 +83,15 @@ public abstract class Symbol
     internal void SetAttributes(ImmutableArray<BoundAttribute> attributes)
     {
         Attributes = attributes;
+    }
+
+    /// <summary>
+    /// Attaches authored documentation parsed from a G# doc comment. Called by the
+    /// binder once the owning declaration's doc block is parsed into the model.
+    /// </summary>
+    /// <param name="documentation">The parsed documentation comment.</param>
+    internal void SetDocumentation(DocumentationComment documentation)
+    {
+        this.authoredDocumentation = documentation;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Documentation/DocumentationIdProviderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Documentation/DocumentationIdProviderTests.cs
@@ -1,0 +1,255 @@
+// <copyright file="DocumentationIdProviderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Documentation;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Documentation;
+
+/// <summary>
+/// ADR-0057 §5: golden tests pinning <see cref="DocumentationIdProvider"/> to Roslyn's
+/// exact DocID format. The expected strings are taken verbatim from the .NET reference
+/// pack's own <c>.xml</c> documentation files — i.e. they are Roslyn's own output — so
+/// these assertions verify byte-for-byte parity for both the ingestion and emission
+/// code paths that share this provider.
+/// </summary>
+public class DocumentationIdProviderTests
+{
+    [Fact]
+    public void Type_Simple()
+    {
+        Assert.Equal("T:System.String", DocumentationIdProvider.GetDocumentationId(typeof(string)));
+    }
+
+    [Fact]
+    public void Type_OpenGeneric_UsesArityBacktick()
+    {
+        Assert.Equal("T:System.Collections.Generic.List`1", DocumentationIdProvider.GetDocumentationId(typeof(List<>)));
+        Assert.Equal("T:System.Action`2", DocumentationIdProvider.GetDocumentationId(typeof(Action<,>)));
+    }
+
+    [Fact]
+    public void Type_ConstructedGeneric_NormalizesToDefinition()
+    {
+        Assert.Equal("T:System.Collections.Generic.List`1", DocumentationIdProvider.GetDocumentationId(typeof(List<int>)));
+    }
+
+    [Fact]
+    public void Type_NestedGeneric_UsesDotAndPerLevelArity()
+    {
+        Assert.Equal(
+            "T:System.Collections.Generic.Dictionary`2.Enumerator",
+            DocumentationIdProvider.GetDocumentationId(typeof(Dictionary<,>.Enumerator)));
+    }
+
+    [Fact]
+    public void Field_OnType()
+    {
+        Assert.Equal("F:System.Int32.MaxValue", DocumentationIdProvider.GetDocumentationId(typeof(int).GetField("MaxValue")));
+    }
+
+    [Fact]
+    public void Property_OnType()
+    {
+        Assert.Equal("P:System.String.Length", DocumentationIdProvider.GetDocumentationId(typeof(string).GetProperty("Length")));
+    }
+
+    [Fact]
+    public void Method_SingleParameter()
+    {
+        var method = typeof(string).GetMethod("Substring", new[] { typeof(int) });
+        Assert.Equal("M:System.String.Substring(System.Int32)", DocumentationIdProvider.GetDocumentationId(method));
+    }
+
+    [Fact]
+    public void Method_NoParameters_OmitsParens()
+    {
+        var method = typeof(object).GetMethod("ToString", Type.EmptyTypes);
+        Assert.Equal("M:System.Object.ToString", DocumentationIdProvider.GetDocumentationId(method));
+    }
+
+    [Fact]
+    public void Method_ByRefParameter_AppendsAt()
+    {
+        var method = typeof(AppContext).GetMethod("TryGetSwitch");
+        Assert.Equal(
+            "M:System.AppContext.TryGetSwitch(System.String,System.Boolean@)",
+            DocumentationIdProvider.GetDocumentationId(method));
+    }
+
+    [Fact]
+    public void Method_ConstructedGenericParameter_UsesBraces()
+    {
+        var method = typeof(AggregateException).GetMethod("Handle");
+        Assert.Equal(
+            "M:System.AggregateException.Handle(System.Func{System.Exception,System.Boolean})",
+            DocumentationIdProvider.GetDocumentationId(method));
+    }
+
+    [Fact]
+    public void Method_GenericWithMethodTypeParameters()
+    {
+        var method = typeof(Array).GetMethods()
+            .First(m => m.Name == "Resize" && m.IsGenericMethodDefinition);
+        Assert.Equal(
+            "M:System.Array.Resize``1(``0[]@,System.Int32)",
+            DocumentationIdProvider.GetDocumentationId(method));
+    }
+
+    [Fact]
+    public void Method_OnGenericType_UsesClassTypeParameterReference()
+    {
+        var method = typeof(List<>).GetMethod("Add");
+        Assert.Equal("M:System.Collections.Generic.List`1.Add(`0)", DocumentationIdProvider.GetDocumentationId(method));
+    }
+
+    [Fact]
+    public void Constructor_InstanceUsesCtor()
+    {
+        var ctor = typeof(AggregateException).GetConstructor(new[] { typeof(Exception[]) });
+        Assert.Equal("M:System.AggregateException.#ctor(System.Exception[])", DocumentationIdProvider.GetDocumentationId(ctor));
+    }
+
+    [Fact]
+    public void Method_ConversionOperator_AppendsReturnType()
+    {
+        var op = typeof(DateTimeOffset).GetMethods()
+            .First(m => m.Name == "op_Implicit" && m.GetParameters()[0].ParameterType == typeof(DateTime));
+        Assert.Equal(
+            "M:System.DateTimeOffset.op_Implicit(System.DateTime)~System.DateTimeOffset",
+            DocumentationIdProvider.GetDocumentationId(op));
+    }
+
+    [Fact]
+    public void Method_MultidimensionalArrayParameter()
+    {
+        var method = typeof(DocIdSamples).GetMethod(nameof(DocIdSamples.TakesGrid));
+        Assert.Equal(
+            "M:GSharp.Core.Tests.CodeAnalysis.Documentation.DocIdSamples.TakesGrid(System.Int32[0:,0:])",
+            DocumentationIdProvider.GetDocumentationId(method));
+    }
+
+    [Fact]
+    public void Method_NullableValueTypeParameter_UsesNullableBraces()
+    {
+        var method = typeof(DocIdSamples).GetMethod(nameof(DocIdSamples.TakesNullable));
+        Assert.Equal(
+            "M:GSharp.Core.Tests.CodeAnalysis.Documentation.DocIdSamples.TakesNullable(System.Nullable{System.Int32})",
+            DocumentationIdProvider.GetDocumentationId(method));
+    }
+
+    [Fact]
+    public void Method_ExplicitGenericInterfaceImplementation_ManglesInterfaceTypeArguments()
+    {
+        // Dictionary<TKey,TValue> explicitly implements ICollection<KeyValuePair<TKey,TValue>>.Add.
+        // Roslyn mangles the interface portion of the name with '#'/'{'/'}'/'@' and references
+        // the interface's type arguments by their declaring-type parameter names (TKey, TValue),
+        // while the parameter signature still uses positional `0/`1. Verbatim from System.Collections.xml.
+        var method = typeof(Dictionary<,>)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
+            .First(m => m.Name.Contains("ICollection") && m.Name.EndsWith(".Add", StringComparison.Ordinal));
+        Assert.Equal(
+            "M:System.Collections.Generic.Dictionary`2.System#Collections#Generic#ICollection{System#Collections#Generic#KeyValuePair{TKey@TValue}}#Add(System.Collections.Generic.KeyValuePair{`0,`1})",
+            DocumentationIdProvider.GetDocumentationId(method));
+    }
+
+    /// <summary>
+    /// Corpus check: every computed DocID for a curated, stable slice of the BCL public
+    /// surface must appear in the reference pack's own <c>.xml</c>, confirming parity
+    /// with Roslyn across a broad, real member set rather than only curated cases.
+    /// </summary>
+    [Fact]
+    public void Corpus_ComputedIdsAppearInReferenceXml()
+    {
+        var members = LoadReferenceMemberNames("System.Runtime.xml");
+        if (members.Count == 0)
+        {
+            return; // Reference pack not present in this environment; skip silently.
+        }
+
+        var probed = 0;
+        var missed = 0;
+        foreach (var type in new[] { typeof(string), typeof(Math), typeof(Version) })
+        {
+            foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly))
+            {
+                if (method.IsSpecialName || method.IsGenericMethod || method.Name.Contains('.'))
+                {
+                    continue;
+                }
+
+                var id = DocumentationIdProvider.GetDocumentationId(method);
+
+                // The running runtime surface can be newer than the reference pack xml,
+                // so an individual member may legitimately be absent. A *format*
+                // regression, however, would make essentially everything miss — hence we
+                // require a strong majority to match rather than every member.
+                if (members.Contains(id))
+                {
+                    probed++;
+                }
+                else
+                {
+                    missed++;
+                }
+            }
+        }
+
+        Assert.True(probed > 20, $"Expected to verify many members, only matched {probed}.");
+        Assert.True(probed > missed * 4, $"Too many DocID mismatches ({missed} missed vs {probed} matched) — likely a format regression.");
+    }
+
+    private static HashSet<string> LoadReferenceMemberNames(string fileName)
+    {
+        var packRoot = "/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Ref";
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        if (!System.IO.Directory.Exists(packRoot))
+        {
+            return result;
+        }
+
+        var xml = System.IO.Directory.EnumerateFiles(packRoot, fileName, System.IO.SearchOption.AllDirectories)
+            .OrderByDescending(p => p)
+            .FirstOrDefault();
+        if (xml == null)
+        {
+            return result;
+        }
+
+        var doc = System.Xml.Linq.XDocument.Load(xml);
+        foreach (var member in doc.Descendants("member"))
+        {
+            var name = member.Attribute("name")?.Value;
+            if (name != null)
+            {
+                result.Add(name);
+            }
+        }
+
+        return result;
+    }
+}
+
+/// <summary>
+/// Local sample surface giving the provider deterministic shapes (multidim arrays,
+/// nullables) that are rare in the BCL but must be encoded exactly.
+/// </summary>
+public static class DocIdSamples
+{
+    /// <summary>Sample with a rank-2 array parameter.</summary>
+    /// <param name="grid">A grid.</param>
+    public static void TakesGrid(int[,] grid)
+    {
+    }
+
+    /// <summary>Sample with a nullable value-type parameter.</summary>
+    /// <param name="value">A nullable.</param>
+    public static void TakesNullable(int? value)
+    {
+    }
+}


### PR DESCRIPTION
## Summary

Stage B of the hover/documentation revamp (#388), implementing the foundational layers from the approved [ADR-0057](docs/adr/0057-documentation-comments.md). This PR adds **no user-visible behavior** on its own — it lays the shared infrastructure that the Stage C ingestion/authoring/emission work items build on, deliberately landed first to minimize rework.

It contains two cohesive pieces:

### 1. The internal documentation model (ADR-0057 §4)

- `DocumentationComment` — the normalized in-memory representation of a doc comment: `Summary`, `Parameters`, `TypeParameters`, `Returns`, `Remarks`, `Value`, `Exceptions`, `SeeAlso`, plus `Empty`.
- `DocInline` — an abstract record tree of inline content (`Text`, `Code`, `CodeBlock`, `Para`, `List`, `SymbolRef`, `Link`, `ParamRef`) with an `UnknownXmlElement` escape hatch so unrecognized XML round-trips with full fidelity rather than being dropped.
- `Symbol.GetDocumentation()` (virtual) + `SetDocumentation()` — the single attachment point; imported symbols will override it in the ingestion work item.

### 2. The shared `DocumentationIdProvider` (ADR-0057 §5)

Computes **Roslyn-exact** XML documentation IDs ("DocIDs", e.g. `M:System.Array.Resize``1(``0[]@,System.Int32)`) for reflected CLR members. This is the *single* component behind both documentation **ingestion** (matching DocIDs against `<member name="…">` entries) and future **emission** (source symbols) — the two paths must never diverge, so they share this code and one golden corpus.

Format coverage (all golden-tested byte-for-byte against the .NET reference pack's own `.xml`):
- prefixes `T:`/`M:`/`P:`/`F:`/`E:`, nested types via `.`, type arity `` `n `` / method arity `` ``n ``
- class vs. method type-parameter references (`` `0 `` vs `` ``0 ``), constructed generics in `{…}`
- by-ref `@`, SZ/multidim arrays (`[]`, `[0:,0:]`), nullable braces, conversion-operator `~ReturnType` suffix
- constructors (`#ctor`/`#cctor`) and explicit interface implementations — including the generic-interface name mangling (`<`→`{`, `>`→`}`, `,`→`@`) that Roslyn applies

## Tests

18 golden tests pin the DocID format to verbatim strings from the reference-pack XML (i.e. Roslyn's own output), plus a corpus check that computes DocIDs for a stable slice of the BCL public surface and verifies they appear in the real `System.Runtime.xml`. Full suite green (Core 1502, Compiler 258, LanguageServer 156, Interpreter 54, Sdk 24).

A rubber-duck review of the DocID provider caught the generic-interface explicit-implementation encoding bug now fixed and covered here.

## ADR / issue

Part of #388; implements ADR-0057 §4–§5.
