### PR TITLE
#388 Stage C (P1): ingest C#/.NET library docs into hover

### DIFF
--- a/src/Core/CodeAnalysis/Documentation/AssemblyDocumentationProvider.cs
+++ b/src/Core/CodeAnalysis/Documentation/AssemblyDocumentationProvider.cs
@@ -1,0 +1,226 @@
+// <copyright file="AssemblyDocumentationProvider.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace GSharp.Core.CodeAnalysis.Documentation;
+
+/// <summary>
+/// Loads and indexes the companion <c>.xml</c> documentation file for a single resolved
+/// assembly, exposing a DocID → <see cref="DocumentationComment"/> lookup (ADR-0057 §6).
+/// </summary>
+/// <remarks>
+/// Instances are obtained through <see cref="ForAssembly"/>, which caches one provider per
+/// <see cref="Assembly"/> so a given assembly's (potentially large) xml is discovered and
+/// parsed at most once per process. Parsing is <em>lazy</em> — the file is read on the
+/// first lookup, not at construction — and <em>XXE-safe</em> (DTD processing prohibited,
+/// no external resolver, bounded size). Any failure (missing file, malformed xml, oversize)
+/// degrades silently to "docs unavailable": ingestion never fails a hover or a build.
+/// </remarks>
+public sealed class AssemblyDocumentationProvider
+{
+    /// <summary>The largest documentation xml we will read; larger files are treated as unavailable.</summary>
+    private const long MaxXmlBytes = 96L * 1024 * 1024;
+
+    private static readonly ConditionalWeakTable<Assembly, AssemblyDocumentationProvider> Cache = new();
+
+    private readonly Lazy<Dictionary<string, DocumentationComment>> index;
+
+    private AssemblyDocumentationProvider(string xmlPath)
+    {
+        this.index = new Lazy<Dictionary<string, DocumentationComment>>(
+            () => LoadIndex(xmlPath),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    /// <summary>
+    /// Gets the cached documentation provider for an assembly, discovering its companion
+    /// xml on first request. Returns <see langword="null"/> when the assembly has no
+    /// readable location (in-memory/dynamic assemblies).
+    /// </summary>
+    /// <param name="assembly">The assembly whose documentation to provide.</param>
+    /// <returns>The provider, or <see langword="null"/> when none can be associated.</returns>
+    public static AssemblyDocumentationProvider ForAssembly(Assembly assembly)
+    {
+        if (assembly is null)
+        {
+            return null;
+        }
+
+        return Cache.GetValue(assembly, Create);
+    }
+
+    /// <summary>
+    /// Resolves the ingested documentation for a reflected type from its assembly's
+    /// companion xml, or <see langword="null"/> when unavailable.
+    /// </summary>
+    /// <param name="type">The reflected type.</param>
+    /// <returns>The documentation, or <see langword="null"/>.</returns>
+    public static DocumentationComment Resolve(Type type)
+    {
+        if (type is null)
+        {
+            return null;
+        }
+
+        var provider = ForAssembly(SafeAssembly(type));
+        if (provider == null)
+        {
+            return null;
+        }
+
+        var id = DocumentationIdProvider.GetDocumentationId(type);
+        return provider.TryGetDocumentation(id, out var documentation) ? documentation : null;
+    }
+
+    /// <summary>
+    /// Resolves the ingested documentation for a reflected method from its assembly's
+    /// companion xml, or <see langword="null"/> when unavailable. A constructed generic
+    /// method is normalized to its generic definition so its DocID matches the xml.
+    /// </summary>
+    /// <param name="method">The reflected method.</param>
+    /// <returns>The documentation, or <see langword="null"/>.</returns>
+    public static DocumentationComment Resolve(MethodInfo method)
+    {
+        if (method is null)
+        {
+            return null;
+        }
+
+        if (method.IsGenericMethod && !method.IsGenericMethodDefinition)
+        {
+            method = method.GetGenericMethodDefinition();
+        }
+
+        var provider = ForAssembly(SafeAssembly(method.DeclaringType));
+        if (provider == null)
+        {
+            return null;
+        }
+
+        var id = DocumentationIdProvider.GetDocumentationId(method);
+        return provider.TryGetDocumentation(id, out var documentation) ? documentation : null;
+    }
+
+    /// <summary>
+    /// Looks up the documentation for a member by its DocID.
+    /// </summary>
+    /// <param name="documentationId">The member's DocID (e.g. <c>T:System.Console</c>).</param>
+    /// <param name="documentation">The parsed documentation, when found.</param>
+    /// <returns><see langword="true"/> when documentation was found; otherwise <see langword="false"/>.</returns>
+    public bool TryGetDocumentation(string documentationId, out DocumentationComment documentation)
+    {
+        documentation = null;
+        if (string.IsNullOrEmpty(documentationId))
+        {
+            return false;
+        }
+
+        var map = this.index.Value;
+        return map.TryGetValue(documentationId, out documentation);
+    }
+
+    private static AssemblyDocumentationProvider Create(Assembly assembly)
+    {
+        return new AssemblyDocumentationProvider(DiscoverXmlPath(assembly));
+    }
+
+    private static Assembly SafeAssembly(Type type)
+    {
+        try
+        {
+            return type?.Assembly;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    // Discovery (ADR-0057 §6): the companion xml sits next to the resolved assembly for
+    // both reference packs and NuGet lib/ref assets, so the sibling .xml is the primary
+    // (and, in this environment, sufficient) location. A culture-invariant sibling is the
+    // only fallback needed today; richer NuGet/targeting-pack probing is a follow-up.
+    private static string DiscoverXmlPath(Assembly assembly)
+    {
+        string location;
+        try
+        {
+            location = assembly.Location;
+        }
+        catch (NotSupportedException)
+        {
+            return null;
+        }
+
+        if (string.IsNullOrEmpty(location))
+        {
+            return null;
+        }
+
+        var sibling = Path.ChangeExtension(location, ".xml");
+        return File.Exists(sibling) ? sibling : null;
+    }
+
+    private static Dictionary<string, DocumentationComment> LoadIndex(string path)
+    {
+        var result = new Dictionary<string, DocumentationComment>(StringComparer.Ordinal);
+        if (string.IsNullOrEmpty(path))
+        {
+            return result;
+        }
+
+        try
+        {
+            if (new FileInfo(path).Length > MaxXmlBytes)
+            {
+                return result;
+            }
+
+            var settings = new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Prohibit,
+                XmlResolver = null,
+                IgnoreComments = true,
+                IgnoreProcessingInstructions = true,
+                MaxCharactersFromEntities = 0,
+            };
+
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var reader = XmlReader.Create(stream, settings);
+            var doc = XDocument.Load(reader);
+
+            var membersElement = doc.Root?.Element("members");
+            if (membersElement == null)
+            {
+                return result;
+            }
+
+            foreach (var member in membersElement.Elements("member"))
+            {
+                var name = (string)member.Attribute("name");
+                if (string.IsNullOrEmpty(name) || result.ContainsKey(name))
+                {
+                    continue;
+                }
+
+                result[name] = XmlDocumentationParser.ParseMember(member);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or XmlException or InvalidOperationException)
+        {
+            // Malformed/unreadable xml ⇒ docs unavailable for this assembly, never a failure.
+            return new Dictionary<string, DocumentationComment>(StringComparer.Ordinal);
+        }
+
+        return result;
+    }
+}

--- a/src/Core/CodeAnalysis/Documentation/XmlDocumentationParser.cs
+++ b/src/Core/CodeAnalysis/Documentation/XmlDocumentationParser.cs
@@ -1,0 +1,291 @@
+// <copyright file="XmlDocumentationParser.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace GSharp.Core.CodeAnalysis.Documentation;
+
+/// <summary>
+/// Parses a standard XML-doc <c>&lt;member&gt;</c> fragment (as found in a companion
+/// <c>.xml</c> documentation file) into the internal <see cref="DocumentationComment"/>
+/// model (ADR-0057 §6 ingestion). The full XML-doc vocabulary is rendered; any element
+/// with no first-class model case is preserved verbatim as
+/// <see cref="DocInline.UnknownXmlElement"/> rather than dropped, so ingested docs keep
+/// full fidelity.
+/// </summary>
+public static class XmlDocumentationParser
+{
+    /// <summary>
+    /// Parses the children of a <c>&lt;member&gt;</c> element into a documentation comment.
+    /// </summary>
+    /// <param name="member">The <c>&lt;member&gt;</c> element, or any element whose children are doc sections.</param>
+    /// <returns>The parsed documentation comment, or <see cref="DocumentationComment.Empty"/> when <paramref name="member"/> is null.</returns>
+    public static DocumentationComment ParseMember(XElement member)
+    {
+        if (member is null)
+        {
+            return DocumentationComment.Empty;
+        }
+
+        var summary = ImmutableArray<DocInline>.Empty;
+        var returns = ImmutableArray<DocInline>.Empty;
+        var value = ImmutableArray<DocInline>.Empty;
+        var parameters = ImmutableArray.CreateBuilder<DocParam>();
+        var typeParameters = ImmutableArray.CreateBuilder<DocParam>();
+        var exceptions = ImmutableArray.CreateBuilder<DocException>();
+        var seeAlso = ImmutableArray.CreateBuilder<DocReference>();
+        var remarks = ImmutableArray.CreateBuilder<DocInline>();
+
+        foreach (var element in member.Elements())
+        {
+            switch (element.Name.LocalName)
+            {
+                case "summary":
+                    summary = ParseInline(element);
+                    break;
+                case "returns":
+                    returns = ParseInline(element);
+                    break;
+                case "value":
+                    value = ParseInline(element);
+                    break;
+                case "remarks":
+                    AppendInto(remarks, ParseInline(element));
+                    break;
+                case "param":
+                    parameters.Add(new DocParam(NameAttribute(element), ParseInline(element)));
+                    break;
+                case "typeparam":
+                    typeParameters.Add(new DocParam(NameAttribute(element), ParseInline(element)));
+                    break;
+                case "exception":
+                    exceptions.Add(new DocException(CrefAttribute(element), ParseInline(element)));
+                    break;
+                case "seealso":
+                    seeAlso.Add(ParseReference(element));
+                    break;
+
+                // Elements with no first-class section (e.g. <example>) are preserved
+                // verbatim under remarks so they still render and are never dropped.
+                default:
+                    remarks.Add(new DocInline.UnknownXmlElement(element.ToString(SaveOptions.DisableFormatting)));
+                    break;
+            }
+        }
+
+        return new DocumentationComment(
+            summary,
+            parameters.ToImmutable(),
+            typeParameters.ToImmutable(),
+            returns,
+            remarks.ToImmutable(),
+            value,
+            exceptions.ToImmutable(),
+            seeAlso.ToImmutable());
+    }
+
+    /// <summary>
+    /// Parses the mixed content of an element into ordered inline nodes, trimming the
+    /// surrounding whitespace introduced by the source file's <c>///</c> indentation.
+    /// </summary>
+    /// <param name="container">The element whose content to parse.</param>
+    /// <returns>The ordered inline content.</returns>
+    public static ImmutableArray<DocInline> ParseInline(XElement container)
+    {
+        if (container is null)
+        {
+            return ImmutableArray<DocInline>.Empty;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<DocInline>();
+        foreach (var node in container.Nodes())
+        {
+            switch (node)
+            {
+                case XText text:
+                    var normalized = NormalizeWhitespace(text.Value);
+                    if (normalized.Length > 0)
+                    {
+                        builder.Add(new DocInline.Text(normalized));
+                    }
+
+                    break;
+                case XElement element:
+                    builder.Add(ParseInlineElement(element));
+                    break;
+            }
+        }
+
+        return TrimEdges(builder);
+    }
+
+    private static DocInline ParseInlineElement(XElement element)
+    {
+        switch (element.Name.LocalName)
+        {
+            case "c":
+                return new DocInline.Code(element.Value);
+            case "code":
+                return new DocInline.CodeBlock(
+                    (string)element.Attribute("language"),
+                    element.Value);
+            case "para":
+                return new DocInline.Para(ParseInline(element));
+            case "list":
+                return ParseList(element);
+            case "paramref":
+            case "typeparamref":
+                return new DocInline.ParamRef(NameAttribute(element));
+            case "see":
+                return ParseSee(element);
+            default:
+                return new DocInline.UnknownXmlElement(element.ToString(SaveOptions.DisableFormatting));
+        }
+    }
+
+    private static DocInline ParseSee(XElement element)
+    {
+        var cref = CrefAttribute(element);
+        if (cref != null)
+        {
+            return new DocInline.SymbolRef(cref, ParseInline(element));
+        }
+
+        var href = (string)element.Attribute("href");
+        if (href != null)
+        {
+            return new DocInline.Link(href, ParseInline(element));
+        }
+
+        // <see langword="null"/> renders as inline code, like its IDE presentation.
+        var langword = (string)element.Attribute("langword");
+        if (langword != null)
+        {
+            return new DocInline.Code(langword);
+        }
+
+        return new DocInline.UnknownXmlElement(element.ToString(SaveOptions.DisableFormatting));
+    }
+
+    private static DocInline ParseList(XElement element)
+    {
+        var listType = (string)element.Attribute("type");
+        var items = ImmutableArray.CreateBuilder<DocListItem>();
+
+        // <listheader> describes the columns; model it as the first item's term/description.
+        foreach (var item in element.Elements().Where(e => e.Name.LocalName is "item" or "listheader"))
+        {
+            var term = item.Elements().FirstOrDefault(e => e.Name.LocalName == "term");
+            var description = item.Elements().FirstOrDefault(e => e.Name.LocalName == "description");
+
+            if (term == null && description == null)
+            {
+                // <item>text</item> shorthand: the whole item is the description.
+                items.Add(new DocListItem(ImmutableArray<DocInline>.Empty, ParseInline(item)));
+                continue;
+            }
+
+            items.Add(new DocListItem(
+                term == null ? ImmutableArray<DocInline>.Empty : ParseInline(term),
+                description == null ? ImmutableArray<DocInline>.Empty : ParseInline(description)));
+        }
+
+        return new DocInline.List(listType, items.ToImmutable());
+    }
+
+    private static DocReference ParseReference(XElement element)
+    {
+        return new DocReference(
+            CrefAttribute(element),
+            (string)element.Attribute("href"),
+            ParseInline(element));
+    }
+
+    private static void AppendInto(ImmutableArray<DocInline>.Builder builder, ImmutableArray<DocInline> items)
+    {
+        foreach (var item in items)
+        {
+            builder.Add(item);
+        }
+    }
+
+    private static string NameAttribute(XElement element)
+    {
+        return (string)element.Attribute("name") ?? string.Empty;
+    }
+
+    private static string CrefAttribute(XElement element)
+    {
+        return (string)element.Attribute("cref");
+    }
+
+    // Collapse the runs of whitespace (including the newlines and leading indentation
+    // that the `///` prefix leaves in the xml) into single spaces. A leading/trailing
+    // space is preserved (collapsed to one) so the spacing between adjacent text and
+    // inline elements survives; TrimEdges removes the spaces at the true block edges.
+    // Code blocks bypass this and keep their original text via element.Value.
+    private static string NormalizeWhitespace(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        var builder = new System.Text.StringBuilder(value.Length);
+        var inWhitespace = false;
+        var leadingWhitespace = char.IsWhiteSpace(value[0]);
+        foreach (var ch in value)
+        {
+            if (char.IsWhiteSpace(ch))
+            {
+                inWhitespace = true;
+                continue;
+            }
+
+            if (inWhitespace && (builder.Length > 0 || leadingWhitespace))
+            {
+                builder.Append(' ');
+            }
+
+            inWhitespace = false;
+            builder.Append(ch);
+        }
+
+        if (inWhitespace)
+        {
+            builder.Append(' ');
+        }
+
+        return builder.ToString();
+    }
+
+    private static ImmutableArray<DocInline> TrimEdges(ImmutableArray<DocInline>.Builder builder)
+    {
+        while (builder.Count > 0 && builder[0] is DocInline.Text { Value: " " })
+        {
+            builder.RemoveAt(0);
+        }
+
+        while (builder.Count > 0 && builder[builder.Count - 1] is DocInline.Text { Value: " " })
+        {
+            builder.RemoveAt(builder.Count - 1);
+        }
+
+        if (builder.Count > 0 && builder[0] is DocInline.Text first)
+        {
+            builder[0] = new DocInline.Text(first.Value.TrimStart());
+        }
+
+        if (builder.Count > 0 && builder[builder.Count - 1] is DocInline.Text last)
+        {
+            builder[builder.Count - 1] = new DocInline.Text(last.Value.TrimEnd());
+        }
+
+        return builder.ToImmutable();
+    }
+}

--- a/src/Core/CodeAnalysis/Symbols/ImportedFunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedFunctionSymbol.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Reflection;
+using GSharp.Core.CodeAnalysis.Documentation;
 using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
@@ -63,6 +64,12 @@ public sealed class ImportedFunctionSymbol : Symbol
     /// Gets the imported function type.
     /// </summary>
     public TypeSymbol Type { get; }
+
+    /// <inheritdoc/>
+    public override DocumentationComment GetDocumentation()
+    {
+        return AssemblyDocumentationProvider.Resolve(Method) ?? base.GetDocumentation();
+    }
 
     private TypeSymbol GetMethodType(MethodInfo method)
     {

--- a/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Linq;
+using GSharp.Core.CodeAnalysis.Documentation;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
@@ -100,5 +101,11 @@ public sealed class ImportedTypeSymbol : TypeSymbol
         var baseName = openDefinition?.FullName ?? openDefinition?.Name ?? erasedClosedType.FullName ?? erasedClosedType.Name;
         var name = $"{baseName}[{argNames}]";
         return new ImportedTypeSymbol(name, erasedClosedType, openDefinition, typeArguments);
+    }
+
+    /// <inheritdoc/>
+    public override DocumentationComment GetDocumentation()
+    {
+        return AssemblyDocumentationProvider.Resolve(OpenDefinition ?? Type) ?? base.GetDocumentation();
     }
 }

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -93,7 +93,9 @@ public static class HoverComputer
         }
 
         var signature = SymbolDisplay.ToDisplayString(clrType, SymbolDisplayFormat.Hover);
-        return new HoverModel(signature, Array.Empty<HoverDocSection>(), OverloadCount: 1);
+        var documentation = HoverDocumentationRenderer.Render(
+            GSharp.Core.CodeAnalysis.Documentation.AssemblyDocumentationProvider.Resolve(clrType));
+        return new HoverModel(signature, documentation, OverloadCount: 1);
     }
 
     private static string RenderHover(HoverModel model)
@@ -136,11 +138,12 @@ public static class HoverComputer
         return compilation.GlobalScope.Functions.Count(f => f.Name == function.Name);
     }
 
-    // Documentation sections are an empty shell until ADR-0057 ingestion/authoring
-    // (Stage C) populate the model. The renderer above already lays them out.
+    // Surfaces ingested CLR documentation (ADR-0057 §6): imported symbols resolve their
+    // companion .xml on demand via GetDocumentation(); authored G# docs (P2) flow through
+    // the same path once attached. Symbols with no documentation render just the signature.
     private static IReadOnlyList<HoverDocSection> BuildDocumentation(Symbol symbol)
     {
-        return Array.Empty<HoverDocSection>();
+        return HoverDocumentationRenderer.Render(symbol.GetDocumentation());
     }
 
     private static string FormatType(TypeSymbol type)
@@ -149,9 +152,12 @@ public static class HoverComputer
     }
 
     private sealed record HoverModel(string Signature, IReadOnlyList<HoverDocSection> Documentation, int OverloadCount);
-
-    private sealed record HoverDocSection(string Heading, string Body);
 }
+
+/// <summary>A rendered hover documentation section: an optional bold heading and a Markdown body.</summary>
+/// <param name="Heading">The section heading, or null for the lead (summary) section.</param>
+/// <param name="Body">The Markdown body.</param>
+internal sealed record HoverDocSection(string Heading, string Body);
 
 public static class ReferencesComputer
 {

--- a/src/LanguageServer/HoverDocumentationRenderer.cs
+++ b/src/LanguageServer/HoverDocumentationRenderer.cs
@@ -1,0 +1,233 @@
+// <copyright file="HoverDocumentationRenderer.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using GSharp.Core.CodeAnalysis.Documentation;
+
+namespace GSharp.LanguageServer;
+
+/// <summary>
+/// Renders the structured <see cref="DocumentationComment"/> model (ADR-0057 §4) into the
+/// Markdown sections a hover card displays. Shared by ingested (C# → G#) and, later,
+/// authored (G#) documentation so both surfaces render identically.
+/// </summary>
+internal static class HoverDocumentationRenderer
+{
+    /// <summary>
+    /// Renders a documentation comment into ordered hover sections, or an empty list when
+    /// the comment is null/empty.
+    /// </summary>
+    /// <param name="documentation">The documentation to render.</param>
+    /// <returns>The ordered sections (heading + Markdown body).</returns>
+    public static IReadOnlyList<HoverDocSection> Render(DocumentationComment documentation)
+    {
+        if (documentation is null)
+        {
+            return System.Array.Empty<HoverDocSection>();
+        }
+
+        var sections = new List<HoverDocSection>();
+
+        AddProse(sections, heading: null, documentation.Summary);
+        AddNamed(sections, "Type parameters", documentation.TypeParameters);
+        AddNamed(sections, "Parameters", documentation.Parameters);
+        AddProse(sections, "Returns", documentation.Returns);
+        AddProse(sections, "Value", documentation.Value);
+        AddExceptions(sections, documentation.Exceptions);
+        AddProse(sections, "Remarks", documentation.Remarks);
+
+        return sections;
+    }
+
+    private static void AddProse(List<HoverDocSection> sections, string heading, ImmutableArray<DocInline> content)
+    {
+        var body = RenderInline(content).Trim();
+        if (body.Length > 0)
+        {
+            sections.Add(new HoverDocSection(heading, body));
+        }
+    }
+
+    private static void AddNamed(List<HoverDocSection> sections, string heading, ImmutableArray<DocParam> entries)
+    {
+        if (entries.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var builder = new StringBuilder();
+        foreach (var entry in entries)
+        {
+            var description = RenderInline(entry.Content).Trim();
+            builder.Append("- `").Append(entry.Name).Append('`');
+            if (description.Length > 0)
+            {
+                builder.Append(" — ").Append(description);
+            }
+
+            builder.Append('\n');
+        }
+
+        sections.Add(new HoverDocSection(heading, builder.ToString().TrimEnd()));
+    }
+
+    private static void AddExceptions(List<HoverDocSection> sections, ImmutableArray<DocException> exceptions)
+    {
+        if (exceptions.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var builder = new StringBuilder();
+        foreach (var exception in exceptions)
+        {
+            var description = RenderInline(exception.Content).Trim();
+            builder.Append("- `").Append(SimpleCrefName(exception.Cref)).Append('`');
+            if (description.Length > 0)
+            {
+                builder.Append(" — ").Append(description);
+            }
+
+            builder.Append('\n');
+        }
+
+        sections.Add(new HoverDocSection("Exceptions", builder.ToString().TrimEnd()));
+    }
+
+    private static string RenderInline(ImmutableArray<DocInline> content)
+    {
+        if (content.IsDefaultOrEmpty)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+        foreach (var node in content)
+        {
+            RenderNode(builder, node);
+        }
+
+        return builder.ToString();
+    }
+
+    private static void RenderNode(StringBuilder builder, DocInline node)
+    {
+        switch (node)
+        {
+            case DocInline.Text text:
+                builder.Append(Escape(text.Value));
+                break;
+            case DocInline.Code code:
+                builder.Append('`').Append(code.Value).Append('`');
+                break;
+            case DocInline.CodeBlock codeBlock:
+                builder.Append("\n\n```").Append(codeBlock.Language ?? string.Empty).Append('\n')
+                    .Append(codeBlock.Value.Trim('\n')).Append("\n```\n\n");
+                break;
+            case DocInline.Para para:
+                builder.Append("\n\n").Append(RenderInline(para.Content).Trim()).Append("\n\n");
+                break;
+            case DocInline.List list:
+                RenderList(builder, list);
+                break;
+            case DocInline.SymbolRef symbolRef:
+                var refText = RenderInline(symbolRef.Inner).Trim();
+                builder.Append('`').Append(refText.Length > 0 ? refText : SimpleCrefName(symbolRef.DocId)).Append('`');
+                break;
+            case DocInline.Link link:
+                var linkText = RenderInline(link.Inner).Trim();
+                builder.Append('[').Append(linkText.Length > 0 ? linkText : link.Href).Append("](").Append(link.Href).Append(')');
+                break;
+            case DocInline.ParamRef paramRef:
+                builder.Append('`').Append(paramRef.Name).Append('`');
+                break;
+            case DocInline.UnknownXmlElement unknown:
+                builder.Append(Escape(StripTags(unknown.RawXml)));
+                break;
+        }
+    }
+
+    private static void RenderList(StringBuilder builder, DocInline.List list)
+    {
+        builder.Append('\n');
+        var ordered = list.ListType == "number";
+        var i = 1;
+        foreach (var item in list.Items)
+        {
+            var term = RenderInline(item.Term).Trim();
+            var description = RenderInline(item.Description).Trim();
+            builder.Append('\n').Append(ordered ? $"{i}. " : "- ");
+            if (term.Length > 0)
+            {
+                builder.Append("**").Append(term).Append("**");
+                if (description.Length > 0)
+                {
+                    builder.Append(" — ");
+                }
+            }
+
+            builder.Append(description);
+            i++;
+        }
+
+        builder.Append('\n');
+    }
+
+    // The cref carries a "T:"/"M:"/... prefix and a fully-qualified name; hover shows the
+    // trailing simple name (and method/parameter tail) for readability.
+    private static string SimpleCrefName(string cref)
+    {
+        if (string.IsNullOrEmpty(cref))
+        {
+            return string.Empty;
+        }
+
+        var name = cref.Length > 2 && cref[1] == ':' ? cref.Substring(2) : cref;
+        var parenIndex = name.IndexOf('(');
+        var head = parenIndex >= 0 ? name.Substring(0, parenIndex) : name;
+        var lastDot = head.LastIndexOf('.');
+        return lastDot >= 0 ? name.Substring(lastDot + 1) : name;
+    }
+
+    private static string StripTags(string rawXml)
+    {
+        var builder = new StringBuilder(rawXml.Length);
+        var inside = false;
+        foreach (var ch in rawXml)
+        {
+            if (ch == '<')
+            {
+                inside = true;
+            }
+            else if (ch == '>')
+            {
+                inside = false;
+            }
+            else if (!inside)
+            {
+                builder.Append(ch);
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static string Escape(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            if (ch is '\\' or '`' or '*' or '_' or '[' or ']' or '<')
+            {
+                builder.Append('\\');
+            }
+
+            builder.Append(ch);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Documentation/AssemblyDocumentationProviderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Documentation/AssemblyDocumentationProviderTests.cs
@@ -1,0 +1,90 @@
+// <copyright file="AssemblyDocumentationProviderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Documentation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Documentation;
+
+/// <summary>
+/// ADR-0057 §6 ingestion: end-to-end tests that real companion <c>.xml</c> documentation
+/// is discovered beside a resolved reference assembly, parsed XXE-safely, indexed by DocID,
+/// and rendered through the shared <see cref="DocumentationIdProvider"/>.
+/// </summary>
+public class AssemblyDocumentationProviderTests
+{
+    [Fact]
+    public void Resolve_KnownBclType_ReturnsSummaryFromReferencePackXml()
+    {
+        var resolver = ReferenceResolverForBcl();
+        if (resolver == null)
+        {
+            return; // Reference pack not present in this environment; skip silently.
+        }
+
+        Assert.True(resolver.TryResolveType("System.String", out var stringType));
+
+        var documentation = AssemblyDocumentationProvider.Resolve(stringType);
+        Assert.NotNull(documentation);
+        Assert.NotEmpty(documentation.Summary);
+    }
+
+    [Fact]
+    public void Resolve_KnownBclMethod_ReturnsDocumentation()
+    {
+        var resolver = ReferenceResolverForBcl();
+        if (resolver == null)
+        {
+            return;
+        }
+
+        Assert.True(resolver.TryResolveType("System.String", out var stringType));
+        var method = stringType.GetMethods()
+            .First(m => m.Name == "Substring" && m.GetParameters().Length == 1);
+
+        var documentation = AssemblyDocumentationProvider.Resolve(method);
+        Assert.NotNull(documentation);
+        Assert.NotEmpty(documentation.Summary);
+        Assert.Single(documentation.Parameters);
+    }
+
+    [Fact]
+    public void Resolve_NullInputs_ReturnNull()
+    {
+        Assert.Null(AssemblyDocumentationProvider.Resolve((Type)null));
+        Assert.Null(AssemblyDocumentationProvider.Resolve((System.Reflection.MethodInfo)null));
+    }
+
+    [Fact]
+    public void ForAssembly_WithoutSiblingXml_ReturnsProviderThatFindsNothing()
+    {
+        // The host runtime's shared-framework assemblies ship no sibling xml, so the
+        // provider must degrade to "docs unavailable" rather than throw.
+        var provider = AssemblyDocumentationProvider.ForAssembly(typeof(object).Assembly);
+        Assert.NotNull(provider);
+        Assert.False(provider.TryGetDocumentation("T:System.Object", out _));
+    }
+
+    private static ReferenceResolver ReferenceResolverForBcl()
+    {
+        var packRoot = "/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Ref";
+        if (!Directory.Exists(packRoot))
+        {
+            return null;
+        }
+
+        // Pick the System.Runtime.dll whose sibling System.Runtime.xml exists, preferring
+        // the highest version directory.
+        var runtimeDll = Directory.EnumerateFiles(packRoot, "System.Runtime.dll", SearchOption.AllDirectories)
+            .Where(p => File.Exists(Path.ChangeExtension(p, ".xml")))
+            .OrderByDescending(p => p)
+            .FirstOrDefault();
+
+        return runtimeDll == null ? null : ReferenceResolver.WithReferences(new[] { runtimeDll });
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Documentation/XmlDocumentationParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Documentation/XmlDocumentationParserTests.cs
@@ -1,0 +1,163 @@
+// <copyright file="XmlDocumentationParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Xml.Linq;
+using GSharp.Core.CodeAnalysis.Documentation;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Documentation;
+
+/// <summary>
+/// ADR-0057 §6: tests that the XML-doc vocabulary is parsed into the internal
+/// <see cref="DocumentationComment"/> model with full fidelity.
+/// </summary>
+public class XmlDocumentationParserTests
+{
+    [Fact]
+    public void NullMember_ReturnsEmpty()
+    {
+        Assert.Same(DocumentationComment.Empty, XmlDocumentationParser.ParseMember(null));
+    }
+
+    [Fact]
+    public void Summary_TextIsNormalizedAndTrimmed()
+    {
+        var member = Member("<summary>\n            Gets the length.\n        </summary>");
+        var doc = XmlDocumentationParser.ParseMember(member);
+        Assert.Equal("Gets the length.", PlainText(doc.Summary));
+    }
+
+    [Fact]
+    public void Params_TypeParams_Returns_AreCaptured()
+    {
+        var member = Member(
+            "<summary>Creates a list.</summary>" +
+            "<typeparam name=\"T\">The element type.</typeparam>" +
+            "<param name=\"capacity\">The initial capacity.</param>" +
+            "<returns>A new list.</returns>");
+        var doc = XmlDocumentationParser.ParseMember(member);
+
+        Assert.Equal("Creates a list.", PlainText(doc.Summary));
+        Assert.Equal("T", doc.TypeParameters.Single().Name);
+        Assert.Equal("The element type.", PlainText(doc.TypeParameters.Single().Content));
+        Assert.Equal("capacity", doc.Parameters.Single().Name);
+        Assert.Equal("The initial capacity.", PlainText(doc.Parameters.Single().Content));
+        Assert.Equal("A new list.", PlainText(doc.Returns));
+    }
+
+    [Fact]
+    public void Exception_CapturesCrefAndContent()
+    {
+        var member = Member("<exception cref=\"T:System.ArgumentNullException\">When null.</exception>");
+        var doc = XmlDocumentationParser.ParseMember(member);
+        var exception = Assert.Single(doc.Exceptions);
+        Assert.Equal("T:System.ArgumentNullException", exception.Cref);
+        Assert.Equal("When null.", PlainText(exception.Content));
+    }
+
+    [Fact]
+    public void InlineCode_And_SeeCref_AreModelled()
+    {
+        var member = Member("<summary>Use <c>Add</c> then <see cref=\"M:N.C.Clear\"/>.</summary>");
+        var doc = XmlDocumentationParser.ParseMember(member);
+
+        var code = doc.Summary.OfType<DocInline.Code>().Single();
+        Assert.Equal("Add", code.Value);
+
+        var reference = doc.Summary.OfType<DocInline.SymbolRef>().Single();
+        Assert.Equal("M:N.C.Clear", reference.DocId);
+    }
+
+    [Fact]
+    public void ParamRef_And_Langword_AreModelled()
+    {
+        var member = Member("<summary>Returns <paramref name=\"x\"/> or <see langword=\"null\"/>.</summary>");
+        var doc = XmlDocumentationParser.ParseMember(member);
+
+        Assert.Equal("x", doc.Summary.OfType<DocInline.ParamRef>().Single().Name);
+        Assert.Contains(doc.Summary.OfType<DocInline.Code>(), c => c.Value == "null");
+    }
+
+    [Fact]
+    public void List_ItemsBecomeListModel()
+    {
+        var member = Member(
+            "<summary><list type=\"bullet\">" +
+            "<item><term>One</term><description>First.</description></item>" +
+            "<item><description>Second.</description></item>" +
+            "</list></summary>");
+        var doc = XmlDocumentationParser.ParseMember(member);
+
+        var list = doc.Summary.OfType<DocInline.List>().Single();
+        Assert.Equal("bullet", list.ListType);
+        Assert.Equal(2, list.Items.Length);
+        Assert.Equal("One", PlainText(list.Items[0].Term));
+        Assert.Equal("First.", PlainText(list.Items[0].Description));
+        Assert.Equal("Second.", PlainText(list.Items[1].Description));
+    }
+
+    [Fact]
+    public void UnknownInlineElement_IsPreservedVerbatim()
+    {
+        var member = Member("<summary>See <bogus a=\"1\">x</bogus>.</summary>");
+        var doc = XmlDocumentationParser.ParseMember(member);
+        var unknown = doc.Summary.OfType<DocInline.UnknownXmlElement>().Single();
+        Assert.Contains("<bogus", unknown.RawXml);
+        Assert.Contains("x</bogus>", unknown.RawXml);
+    }
+
+    [Fact]
+    public void UnknownTopLevelElement_IsPreservedUnderRemarks()
+    {
+        var member = Member("<summary>S.</summary><example>Sample.</example>");
+        var doc = XmlDocumentationParser.ParseMember(member);
+        var unknown = doc.Remarks.OfType<DocInline.UnknownXmlElement>().Single();
+        Assert.Contains("<example>", unknown.RawXml);
+    }
+
+    [Fact]
+    public void CodeBlock_PreservesLanguageAndText()
+    {
+        var member = Member("<summary><code language=\"csharp\">var x = 1;</code></summary>");
+        var doc = XmlDocumentationParser.ParseMember(member);
+        var codeBlock = doc.Summary.OfType<DocInline.CodeBlock>().Single();
+        Assert.Equal("csharp", codeBlock.Language);
+        Assert.Contains("var x = 1;", codeBlock.Value);
+    }
+
+    [Fact]
+    public void InterElementSpacing_IsPreservedAroundInlineElements()
+    {
+        var member = Member("<summary>Returns the <see cref=\"T:System.String\"/> value of <c>x</c> now.</summary>");
+        var doc = XmlDocumentationParser.ParseMember(member);
+        var texts = doc.Summary.OfType<DocInline.Text>().Select(t => t.Value).ToArray();
+
+        Assert.Equal("Returns the ", texts[0]);
+        Assert.Equal(" value of ", texts[1]);
+        Assert.Equal(" now.", texts[2]);
+    }
+
+    [Fact]
+    public void Langword_KeepsSurroundingSpaces()
+    {
+        var member = Member("<summary>Returns <see langword=\"true\"/> if equal.</summary>");
+        var doc = XmlDocumentationParser.ParseMember(member);
+        var texts = doc.Summary.OfType<DocInline.Text>().Select(t => t.Value).ToArray();
+
+        Assert.Equal("Returns ", texts[0]);
+        Assert.Equal(" if equal.", texts[1]);
+    }
+
+    private static XElement Member(string innerXml)
+    {
+        return XElement.Parse($"<member name=\"T:Test\">{innerXml}</member>");
+    }
+
+    private static string PlainText(ImmutableArray<DocInline> content)
+    {
+        return string.Concat(content.OfType<DocInline.Text>().Select(t => t.Value)).Trim();
+    }
+}

--- a/test/LanguageServer.Tests/HoverDocumentationRendererTests.cs
+++ b/test/LanguageServer.Tests/HoverDocumentationRendererTests.cs
@@ -1,0 +1,102 @@
+// <copyright file="HoverDocumentationRendererTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Documentation;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// Tests that the shared hover renderer turns the <see cref="DocumentationComment"/> model
+/// (ADR-0057 §4) into the Markdown sections a hover card displays.
+/// </summary>
+public class HoverDocumentationRendererTests
+{
+    [Fact]
+    public void Null_RendersNoSections()
+    {
+        Assert.Empty(HoverDocumentationRenderer.Render(null));
+    }
+
+    [Fact]
+    public void Empty_RendersNoSections()
+    {
+        Assert.Empty(HoverDocumentationRenderer.Render(DocumentationComment.Empty));
+    }
+
+    [Fact]
+    public void Summary_RendersAsLeadSectionWithoutHeading()
+    {
+        var doc = DocumentationComment.Empty with { Summary = Inline("Gets the length.") };
+        var section = Assert.Single(HoverDocumentationRenderer.Render(doc));
+        Assert.Null(section.Heading);
+        Assert.Equal("Gets the length.", section.Body);
+    }
+
+    [Fact]
+    public void Parameters_RenderAsBulletedList()
+    {
+        var doc = DocumentationComment.Empty with
+        {
+            Summary = Inline("Does a thing."),
+            Parameters = ImmutableArray.Create(
+                new DocParam("count", Inline("How many.")),
+                new DocParam("name", Inline("The name."))),
+        };
+
+        var sections = HoverDocumentationRenderer.Render(doc);
+        var parameters = sections.Single(s => s.Heading == "Parameters");
+        Assert.Contains("- `count` — How many.", parameters.Body);
+        Assert.Contains("- `name` — The name.", parameters.Body);
+    }
+
+    [Fact]
+    public void ReturnsAndExceptions_RenderAsSections()
+    {
+        var doc = DocumentationComment.Empty with
+        {
+            Returns = Inline("The result."),
+            Exceptions = ImmutableArray.Create(
+                new DocException("T:System.ArgumentNullException", Inline("When null."))),
+        };
+
+        var sections = HoverDocumentationRenderer.Render(doc);
+        Assert.Equal("The result.", sections.Single(s => s.Heading == "Returns").Body);
+        var exceptions = sections.Single(s => s.Heading == "Exceptions").Body;
+        Assert.Contains("- `ArgumentNullException` — When null.", exceptions);
+    }
+
+    [Fact]
+    public void InlineCodeAndSymbolRef_RenderAsBackticks()
+    {
+        var summary = ImmutableArray.Create<DocInline>(
+            new DocInline.Text("Use "),
+            new DocInline.Code("Add"),
+            new DocInline.Text(" or "),
+            new DocInline.SymbolRef("M:System.Collections.Generic.List`1.Clear", ImmutableArray<DocInline>.Empty),
+            new DocInline.Text("."));
+        var doc = DocumentationComment.Empty with { Summary = summary };
+
+        var body = Assert.Single(HoverDocumentationRenderer.Render(doc)).Body;
+        Assert.Contains("`Add`", body);
+        Assert.Contains("`Clear`", body);
+    }
+
+    [Fact]
+    public void MarkdownSpecialCharactersInText_AreEscaped()
+    {
+        var doc = DocumentationComment.Empty with { Summary = Inline("a * b _ c [d]") };
+        var body = Assert.Single(HoverDocumentationRenderer.Render(doc)).Body;
+        Assert.Contains("\\*", body);
+        Assert.Contains("\\_", body);
+        Assert.Contains("\\[d\\]", body);
+    }
+
+    private static ImmutableArray<DocInline> Inline(string text)
+    {
+        return ImmutableArray.Create<DocInline>(new DocInline.Text(text));
+    }
+}


### PR DESCRIPTION
## Stage C, work item 5 (ADR-0057 P1): ingest C#/.NET library docs into hover

Part of #388. Builds on the merged doc-model + shared `DocumentationIdProvider` (#391). This makes G# hover surface the XML documentation that ships alongside referenced C#/.NET libraries (BCL ref packs, NuGet `lib`/`ref`), keyed by the same Roslyn-exact DocIDs.

### What's added
- **`XmlDocumentationParser`** — parses a `<member>` XML fragment into the internal `DocumentationComment` model. Full vocabulary (`summary`/`param`/`typeparam`/`returns`/`remarks`/`value`/`exception`/`seealso`, inline `c`/`code`/`para`/`list`/`paramref`/`typeparamref`/`see`); unknown elements are preserved verbatim as `UnknownXmlElement` (top-level unknowns fold into Remarks) so nothing is silently dropped.
- **`AssemblyDocumentationProvider`** — discovers the companion `.xml` next to a resolved assembly, parses it **XXE-safely** (DTD prohibited, no external resolver, 96 MB cap), and exposes a lazy DocID → `DocumentationComment` index. One provider is cached per `Assembly` via a static `ConditionalWeakTable`, so each assembly's xml is read at most once per process. Any failure (missing/malformed/oversize) degrades silently to "docs unavailable" — ingestion never fails a hover or a build.
- **`HoverDocumentationRenderer`** (LanguageServer) — renders a `DocumentationComment` into Markdown hover sections, with escaping and `cref` simple-name display.
- `ImportedTypeSymbol`/`ImportedFunctionSymbol` implement `GetDocumentation()` via the shared provider; `HoverComputer` resolves type docs on the reachable imported-type-name hover path.

### Discovery & DocID sharing
Per ADR §6, the companion `.xml` sits beside the resolved `.dll` for both reference packs and NuGet assets, so the sibling `.xml` is the primary (and, in this environment, sufficient) location; a culture-invariant sibling is the only fallback. Lookups reuse the **same** `DocumentationIdProvider` used by emission, so ingested and (future) emitted docs agree byte-for-byte on keys.

### Reviewed
Rubber-duck critique caught and fixed before this PR:
- **Whitespace bug (blocking):** `NormalizeWhitespace` was dropping the leading space of every text node, so `the <see/> class` rendered as "Stringclass". Now interior spacing around inline elements is preserved and only true block-edge whitespace is trimmed. Added regression tests (`InterElementSpacing_IsPreservedAroundInlineElements`, `Langword_KeepsSurroundingSpaces`).
- **Thread-safety:** replaced hand-rolled double-checked locking (unsafe without a barrier on ARM64) with `Lazy<T>(ExecutionAndPublication)`.

XXE hardening and the per-`Assembly` weak cache were reviewed and confirmed sound.

### Tests
- Core: parser fidelity (incl. spacing regressions) + provider integration against the real BCL ref-pack xml.
- LanguageServer: renderer Markdown output.
- Full suite green: Core 1518, LanguageServer 163, Compiler 258, Interpreter 54, Sdk 24.

No language change.
