### PR TITLE
#388 Stage C (P2): doc-authoring — lex, attach, parse authored docs

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -52,6 +52,7 @@ DefaultKeyword
 DeferKeyword
 DeferStatement
 DiscardPattern
+DocumentationCommentToken
 DotToken
 EllipsisToken
 ElseClause

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using GSharp.Core.CodeAnalysis.Documentation;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Lowering.Async;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -289,6 +290,7 @@ public sealed class Binder
                 packageSymbol = new PackageSymbol(packageName, packageSyntax);
                 packagesByName[packageName] = packageSymbol;
                 packagesInOrder.Add(packageSymbol);
+                AttachDocumentation(packageSymbol, packageSyntax);
             }
 
             packageByTree[tree] = packageSymbol;
@@ -836,6 +838,7 @@ public sealed class Binder
         var targetPath = sb.ToString();
         var localName = import.AliasIdentifier?.Text ?? targetPath;
         var importSymbol = new ImportSymbol(localName, targetPath, import);
+        AttachDocumentation(importSymbol, import);
         scope.TryImport(importSymbol);
     }
 
@@ -885,6 +888,7 @@ public sealed class Binder
 
         var accessibility = ResolveAccessibility(syntax.AccessibilityModifier);
         var enumSymbol = new EnumSymbol(name, accessibility, package.Name, syntax);
+        AttachDocumentation(enumSymbol, syntax);
         enumSymbol.SetAttributes(BindAttributes(
             syntax.Annotations,
             AttributeTargetKind.Type,
@@ -904,6 +908,7 @@ public sealed class Binder
             }
 
             var memberSymbol = new EnumMemberSymbol(memberName, enumSymbol, members.Count);
+            AttachDocumentation(memberSymbol, memberSyntax);
 
             // Issue #188 / ADR-0047 §3: bind any `@Foo` annotations attached
             // to the enum-member entry with default target `field` (enum
@@ -1050,6 +1055,7 @@ public sealed class Binder
 
             var fieldAccessibility = ResolveAccessibility(fieldSyntax.AccessibilityModifier);
             var fieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: syntax.IsInline);
+            AttachDocumentation(fieldSymbol, fieldSyntax);
 
             // Issue #186 / ADR-0047 §3: bind any `@Foo` annotations attached
             // to the field declaration with default target `field` so #175
@@ -1204,6 +1210,7 @@ public sealed class Binder
             primaryCtorParameters,
             isOpen: syntax.IsOpen && syntax.IsClass,
             baseClass: baseClassSymbol);
+        AttachDocumentation(structSymbol, syntax);
 
         if (!typeParameters.IsDefaultOrEmpty)
         {
@@ -1357,6 +1364,7 @@ public sealed class Binder
                         isOverride: methodSyntax.IsOverride);
                     methodSymbol.OverriddenMethod = overriddenMethod;
                     methodSymbol.TypeParameters = methodTypeParameters;
+                    AttachDocumentation(methodSymbol, methodSyntax);
 
                     if (!methodSyntax.Annotations.IsDefaultOrEmpty)
                     {
@@ -1477,6 +1485,7 @@ public sealed class Binder
                     isVirtual,
                     isOverride,
                     setterParamName);
+                AttachDocumentation(propertySymbol, propSyntax);
 
                 // Create backing field for auto-properties
                 if (isAutoProperty && !syntax.IsData)
@@ -1585,6 +1594,7 @@ public sealed class Binder
                     isFieldLike,
                     isVirtual,
                     isOverride);
+                AttachDocumentation(eventSymbol, eventSyntax);
 
                 // Create backing field for field-like events
                 if (isFieldLike)
@@ -1729,6 +1739,8 @@ public sealed class Binder
                         System.AttributeTargets.Field));
                 }
 
+                AttachDocumentation(fieldSymbol, fieldSyntax);
+
                 // Issue #262: bind the initializer expression if present.
                 if (fieldSyntax.Initializer != null)
                 {
@@ -1819,6 +1831,8 @@ public sealed class Binder
                             System.AttributeTargets.Method);
                         methodSymbol.SetAttributes(methodAttributes);
                     }
+
+                    AttachDocumentation(methodSymbol, methodSyntax);
 
                     staticMethodsBuilder.Add(methodSymbol);
                 }
@@ -1948,6 +1962,8 @@ public sealed class Binder
                         System.AttributeTargets.Property));
                 }
 
+                AttachDocumentation(propertySymbol, propSyntax);
+
                 staticPropertiesBuilder.Add(propertySymbol);
             }
 
@@ -2070,6 +2086,8 @@ public sealed class Binder
                         "an event declaration",
                         System.AttributeTargets.Event));
                 }
+
+                AttachDocumentation(eventSymbol, eventSyntax);
 
                 staticEventsBuilder.Add(eventSymbol);
             }
@@ -2196,6 +2214,7 @@ public sealed class Binder
         var name = syntax.Identifier.Text;
         var accessibility = ResolveAccessibility(syntax.AccessibilityModifier);
         var interfaceSymbol = new InterfaceSymbol(name, accessibility, syntax, package.Name);
+        AttachDocumentation(interfaceSymbol, syntax);
         interfaceSymbol.SetAttributes(BindAttributes(
             syntax.Annotations,
             AttributeTargetKind.Type,
@@ -2296,6 +2315,7 @@ public sealed class Binder
                 package,
                 Accessibility.Public,
                 receiverType: null);
+            AttachDocumentation(methodSymbol, methodSyntax);
             methodsBuilder.Add(methodSymbol);
         }
 
@@ -2349,6 +2369,7 @@ public sealed class Binder
                     isVirtual: false,
                     isOverride: false);
 
+                AttachDocumentation(propSymbol, propSyntax);
                 propertiesBuilder.Add(propSymbol);
             }
 
@@ -2382,6 +2403,7 @@ public sealed class Binder
                     isVirtual: false,
                     isOverride: false);
 
+                AttachDocumentation(eventSymbol, eventSyntax);
                 eventsBuilder.Add(eventSymbol);
             }
 
@@ -2637,6 +2659,7 @@ public sealed class Binder
                     explicitReceiverParameter);
                 function.TypeParameters = typeParameters;
                 function.IsAsync = syntax.IsAsync || IsAsyncIteratorReturnType(type);
+                AttachDocumentation(function, syntax);
                 function.SetAttributes(functionAttributes);
                 methodReceiverStruct.AddMethods(ImmutableArray.Create(function));
                 return;
@@ -2645,6 +2668,7 @@ public sealed class Binder
             function = new FunctionSymbol(syntax.Identifier.Text, parameters.ToImmutable(), type, syntax, package, accessibility);
             function.TypeParameters = typeParameters;
             function.IsAsync = syntax.IsAsync || IsAsyncIteratorReturnType(type);
+            AttachDocumentation(function, syntax);
             function.SetAttributes(functionAttributes);
 
             if (syntax.IsExtension)
@@ -10994,6 +11018,7 @@ public sealed class Binder
         };
 
         var constructorSymbol = new ConstructorSymbol(ctorFunction, ctorSyntax);
+        AttachDocumentation(ctorFunction, ctorSyntax);
 
         // Resolve the optional `: base(args)` initializer, with the constructor
         // parameters in scope so they can be forwarded to the base.
@@ -11184,6 +11209,25 @@ public sealed class Binder
         }
 
         return annotation.NameSegments[0].Text == "Attribute";
+    }
+
+    /// <summary>
+    /// Attaches authored documentation from a G# doc comment to a symbol (ADR-0057 §7/§8).
+    /// Parses the block text from the syntax tree side-table and calls <see cref="Symbol.SetDocumentation"/>.
+    /// </summary>
+    private static void AttachDocumentation(Symbol symbol, SyntaxNode syntax)
+    {
+        var docText = syntax?.SyntaxTree?.GetDocumentation(syntax);
+        if (docText == null)
+        {
+            return;
+        }
+
+        var doc = GSharpDocumentationParser.Parse(docText);
+        if (doc != null)
+        {
+            symbol.SetDocumentation(doc);
+        }
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Documentation/GSharpDocumentationParser.cs
+++ b/src/Core/CodeAnalysis/Documentation/GSharpDocumentationParser.cs
@@ -1,0 +1,509 @@
+// <copyright file="GSharpDocumentationParser.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using System.Xml.Linq;
+
+namespace GSharp.Core.CodeAnalysis.Documentation;
+
+/// <summary>
+/// Parses a G# documentation block (Markdown + KDoc-style block tags + xmldoc escape hatch)
+/// into the internal <see cref="DocumentationComment"/> model (ADR-0057 §3).
+/// </summary>
+internal static class GSharpDocumentationParser
+{
+    /// <summary>
+    /// Parses the raw joined documentation block text into a <see cref="DocumentationComment"/>.
+    /// Returns <see langword="null"/> when the input is null or whitespace-only.
+    /// </summary>
+    /// <param name="blockText">The joined lines from the doc block (newline-separated).</param>
+    /// <returns>The parsed documentation model, or <see langword="null"/>.</returns>
+    internal static DocumentationComment Parse(string blockText)
+    {
+        if (string.IsNullOrWhiteSpace(blockText))
+        {
+            return null;
+        }
+
+        var lines = blockText.Split('\n');
+        var sections = SplitIntoSections(lines);
+
+        var summary = ImmutableArray<DocInline>.Empty;
+        var parameters = ImmutableArray.CreateBuilder<DocParam>();
+        var typeParameters = ImmutableArray.CreateBuilder<DocParam>();
+        var returns = ImmutableArray<DocInline>.Empty;
+        var remarks = ImmutableArray<DocInline>.Empty;
+        var value = ImmutableArray<DocInline>.Empty;
+        var exceptions = ImmutableArray.CreateBuilder<DocException>();
+        var seeAlso = ImmutableArray.CreateBuilder<DocReference>();
+
+        foreach (var section in sections)
+        {
+            switch (section.Tag)
+            {
+                case null:
+                    // Leading prose = summary.
+                    summary = ParseInlineContent(section.Body);
+                    break;
+                case "@param":
+                    if (TryExtractName(section.Body, out var paramName, out var paramContent))
+                    {
+                        parameters.Add(new DocParam(paramName, ParseInlineContent(paramContent)));
+                    }
+
+                    break;
+                case "@typeparam":
+                    if (TryExtractName(section.Body, out var typeParamName, out var typeParamContent))
+                    {
+                        typeParameters.Add(new DocParam(typeParamName, ParseInlineContent(typeParamContent)));
+                    }
+
+                    break;
+                case "@returns":
+                    returns = ParseInlineContent(section.Body);
+                    break;
+                case "@remarks":
+                    remarks = ParseInlineContent(section.Body);
+                    break;
+                case "@value":
+                    value = ParseInlineContent(section.Body);
+                    break;
+                case "@exception":
+                    if (TryExtractName(section.Body, out var exCref, out var exContent))
+                    {
+                        exceptions.Add(new DocException(exCref, ParseInlineContent(exContent)));
+                    }
+
+                    break;
+                case "@seealso":
+                    if (TryExtractName(section.Body, out var saCref, out var saContent))
+                    {
+                        var inlines = ParseInlineContent(saContent);
+                        if (saCref.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+                            saCref.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                        {
+                            seeAlso.Add(new DocReference(null, saCref, inlines));
+                        }
+                        else
+                        {
+                            seeAlso.Add(new DocReference(saCref, null, inlines));
+                        }
+                    }
+
+                    break;
+            }
+        }
+
+        return new DocumentationComment(
+            summary,
+            parameters.ToImmutable(),
+            typeParameters.ToImmutable(),
+            returns,
+            remarks,
+            value,
+            exceptions.ToImmutable(),
+            seeAlso.ToImmutable());
+    }
+
+    private static List<Section> SplitIntoSections(string[] lines)
+    {
+        var sections = new List<Section>();
+        string currentTag = null;
+        var currentBody = new StringBuilder();
+
+        foreach (var line in lines)
+        {
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith("@param ", StringComparison.Ordinal) ||
+                trimmed.StartsWith("@typeparam ", StringComparison.Ordinal) ||
+                trimmed.StartsWith("@returns", StringComparison.Ordinal) ||
+                trimmed.StartsWith("@remarks", StringComparison.Ordinal) ||
+                trimmed.StartsWith("@value", StringComparison.Ordinal) ||
+                trimmed.StartsWith("@exception ", StringComparison.Ordinal) ||
+                trimmed.StartsWith("@seealso ", StringComparison.Ordinal))
+            {
+                // Flush previous section.
+                if (currentBody.Length > 0 || currentTag != null)
+                {
+                    sections.Add(new Section(currentTag, currentBody.ToString()));
+                    currentBody.Clear();
+                }
+
+                // Extract tag and the rest of the line.
+                var spaceIdx = trimmed.IndexOf(' ');
+                if (spaceIdx < 0)
+                {
+                    currentTag = trimmed;
+                }
+                else
+                {
+                    currentTag = trimmed.Substring(0, spaceIdx);
+                    currentBody.Append(trimmed.Substring(spaceIdx + 1));
+                }
+            }
+            else
+            {
+                if (currentBody.Length > 0)
+                {
+                    currentBody.Append('\n');
+                }
+
+                currentBody.Append(line);
+            }
+        }
+
+        if (currentBody.Length > 0 || currentTag != null)
+        {
+            sections.Add(new Section(currentTag, currentBody.ToString()));
+        }
+
+        return sections;
+    }
+
+    private static bool TryExtractName(string body, out string name, out string remainder)
+    {
+        name = null;
+        remainder = string.Empty;
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return false;
+        }
+
+        var trimmed = body.TrimStart();
+        var spaceIdx = trimmed.IndexOf(' ');
+        if (spaceIdx < 0)
+        {
+            name = trimmed;
+            remainder = string.Empty;
+        }
+        else
+        {
+            name = trimmed.Substring(0, spaceIdx);
+            remainder = trimmed.Substring(spaceIdx + 1);
+        }
+
+        return !string.IsNullOrEmpty(name);
+    }
+
+    private static ImmutableArray<DocInline> ParseInlineContent(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return ImmutableArray<DocInline>.Empty;
+        }
+
+        var result = ImmutableArray.CreateBuilder<DocInline>();
+        var lines = text.Split('\n');
+        var i = 0;
+
+        while (i < lines.Length)
+        {
+            // Fenced code block detection.
+            if (lines[i].TrimStart().StartsWith("```", StringComparison.Ordinal))
+            {
+                var fenceLine = lines[i].TrimStart();
+                var lang = fenceLine.Length > 3 ? fenceLine.Substring(3).Trim() : string.Empty;
+
+                if (string.Equals(lang, "xmldoc", StringComparison.OrdinalIgnoreCase))
+                {
+                    // XML escape hatch: collect raw XML until closing ```.
+                    i++;
+                    var xmlBuilder = new StringBuilder();
+                    while (i < lines.Length && !lines[i].TrimStart().StartsWith("```", StringComparison.Ordinal))
+                    {
+                        if (xmlBuilder.Length > 0)
+                        {
+                            xmlBuilder.Append('\n');
+                        }
+
+                        xmlBuilder.Append(lines[i]);
+                        i++;
+                    }
+
+                    if (i < lines.Length)
+                    {
+                        i++; // skip closing ```
+                    }
+
+                    var rawXml = xmlBuilder.ToString().Trim();
+                    if (!string.IsNullOrEmpty(rawXml))
+                    {
+                        result.Add(new DocInline.UnknownXmlElement(rawXml));
+                    }
+                }
+                else
+                {
+                    // Regular fenced code block.
+                    i++;
+                    var codeBuilder = new StringBuilder();
+                    while (i < lines.Length && !lines[i].TrimStart().StartsWith("```", StringComparison.Ordinal))
+                    {
+                        if (codeBuilder.Length > 0)
+                        {
+                            codeBuilder.Append('\n');
+                        }
+
+                        codeBuilder.Append(lines[i]);
+                        i++;
+                    }
+
+                    if (i < lines.Length)
+                    {
+                        i++; // skip closing ```
+                    }
+
+                    result.Add(new DocInline.CodeBlock(lang, codeBuilder.ToString()));
+                }
+
+                continue;
+            }
+
+            // Check for list items (bullet or ordered).
+            if (IsListItem(lines[i]))
+            {
+                var (listType, items) = ParseList(lines, ref i);
+                result.Add(new DocInline.List(listType, items));
+                continue;
+            }
+
+            // Paragraph: collect lines until blank line or special structure.
+            var paraBuilder = new StringBuilder();
+            while (i < lines.Length &&
+                   !string.IsNullOrWhiteSpace(lines[i]) &&
+                   !lines[i].TrimStart().StartsWith("```", StringComparison.Ordinal) &&
+                   !IsListItem(lines[i]))
+            {
+                if (paraBuilder.Length > 0)
+                {
+                    paraBuilder.Append(' ');
+                }
+
+                paraBuilder.Append(lines[i].TrimEnd());
+                i++;
+            }
+
+            if (paraBuilder.Length > 0)
+            {
+                var paraInlines = ParseInlineRuns(paraBuilder.ToString());
+                if (result.Count > 0)
+                {
+                    // Wrap in Para if it's not the first block.
+                    result.Add(new DocInline.Para(paraInlines));
+                }
+                else
+                {
+                    result.AddRange(paraInlines);
+                }
+            }
+
+            // Skip blank lines between paragraphs.
+            while (i < lines.Length && string.IsNullOrWhiteSpace(lines[i]))
+            {
+                i++;
+            }
+        }
+
+        return result.ToImmutable();
+    }
+
+    private static bool IsListItem(string line)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.StartsWith("- ", StringComparison.Ordinal) ||
+            trimmed.StartsWith("* ", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // Ordered list: digit(s) followed by '. '
+        for (var j = 0; j < trimmed.Length; j++)
+        {
+            if (char.IsDigit(trimmed[j]))
+            {
+                continue;
+            }
+
+            if (trimmed[j] == '.' && j > 0 && j + 1 < trimmed.Length && trimmed[j + 1] == ' ')
+            {
+                return true;
+            }
+
+            break;
+        }
+
+        return false;
+    }
+
+    private static (string ListType, ImmutableArray<DocListItem> Items) ParseList(string[] lines, ref int i)
+    {
+        var items = ImmutableArray.CreateBuilder<DocListItem>();
+        var first = lines[i].TrimStart();
+        var isOrdered = char.IsDigit(first[0]);
+        var listType = isOrdered ? "number" : "bullet";
+
+        while (i < lines.Length && IsListItem(lines[i]))
+        {
+            var trimmed = lines[i].TrimStart();
+            string itemText;
+            if (isOrdered)
+            {
+                var dotIdx = trimmed.IndexOf(". ", StringComparison.Ordinal);
+                itemText = dotIdx >= 0 ? trimmed.Substring(dotIdx + 2) : trimmed;
+            }
+            else
+            {
+                itemText = trimmed.Substring(2); // skip "- " or "* "
+            }
+
+            var inlines = ParseInlineRuns(itemText);
+            items.Add(new DocListItem(ImmutableArray<DocInline>.Empty, inlines));
+            i++;
+        }
+
+        return (listType, items.ToImmutable());
+    }
+
+    private static ImmutableArray<DocInline> ParseInlineRuns(string text)
+    {
+        var result = ImmutableArray.CreateBuilder<DocInline>();
+        var pos = 0;
+        var textBuilder = new StringBuilder();
+
+        while (pos < text.Length)
+        {
+            // Inline code: `code`
+            if (text[pos] == '`')
+            {
+                FlushText(result, textBuilder);
+                pos++;
+                var codeEnd = text.IndexOf('`', pos);
+                if (codeEnd < 0)
+                {
+                    codeEnd = text.Length;
+                }
+
+                result.Add(new DocInline.Code(text.Substring(pos, codeEnd - pos)));
+                pos = codeEnd < text.Length ? codeEnd + 1 : codeEnd;
+                continue;
+            }
+
+            // Link/ref forms: [text](target) or [`name`](paramref)
+            if (text[pos] == '[')
+            {
+                var closeBracket = FindClosingBracket(text, pos);
+                if (closeBracket > pos && closeBracket + 1 < text.Length && text[closeBracket + 1] == '(')
+                {
+                    var closeParen = text.IndexOf(')', closeBracket + 2);
+                    if (closeParen > closeBracket + 1)
+                    {
+                        var linkText = text.Substring(pos + 1, closeBracket - pos - 1);
+                        var target = text.Substring(closeBracket + 2, closeParen - closeBracket - 2);
+
+                        FlushText(result, textBuilder);
+                        if (string.Equals(target, "paramref", StringComparison.Ordinal))
+                        {
+                            // [`name`](paramref) → ParamRef
+                            var name = linkText.Trim('`');
+                            result.Add(new DocInline.ParamRef(name));
+                        }
+                        else if (target.StartsWith("cref:", StringComparison.Ordinal))
+                        {
+                            // [text](cref:Target) → SymbolRef
+                            var crefTarget = target.Substring(5);
+                            var inner = string.IsNullOrEmpty(linkText)
+                                ? ImmutableArray<DocInline>.Empty
+                                : ImmutableArray.Create<DocInline>(new DocInline.Text(linkText));
+                            result.Add(new DocInline.SymbolRef(crefTarget, inner));
+                        }
+                        else if (target.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+                                 target.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                        {
+                            // [text](https://…) → Link
+                            var inner = string.IsNullOrEmpty(linkText)
+                                ? ImmutableArray<DocInline>.Empty
+                                : ImmutableArray.Create<DocInline>(new DocInline.Text(linkText));
+                            result.Add(new DocInline.Link(target, inner));
+                        }
+                        else
+                        {
+                            // Unknown link form — treat as text.
+                            textBuilder.Append(text, pos, closeParen - pos + 1);
+                        }
+
+                        pos = closeParen + 1;
+                        continue;
+                    }
+                }
+            }
+
+            // Bare (cref:Target) form.
+            if (text[pos] == '(' && pos + 5 < text.Length &&
+                text.Substring(pos + 1, 5) == "cref:")
+            {
+                var closeParen = text.IndexOf(')', pos + 6);
+                if (closeParen > pos + 6)
+                {
+                    FlushText(result, textBuilder);
+                    var target = text.Substring(pos + 6, closeParen - pos - 6);
+                    result.Add(new DocInline.SymbolRef(target, ImmutableArray<DocInline>.Empty));
+                    pos = closeParen + 1;
+                    continue;
+                }
+            }
+
+            textBuilder.Append(text[pos]);
+            pos++;
+        }
+
+        FlushText(result, textBuilder);
+        return result.ToImmutable();
+    }
+
+    private static int FindClosingBracket(string text, int openPos)
+    {
+        var depth = 0;
+        for (var i = openPos; i < text.Length; i++)
+        {
+            if (text[i] == '[')
+            {
+                depth++;
+            }
+            else if (text[i] == ']')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    private static void FlushText(ImmutableArray<DocInline>.Builder result, StringBuilder textBuilder)
+    {
+        if (textBuilder.Length > 0)
+        {
+            result.Add(new DocInline.Text(textBuilder.ToString()));
+            textBuilder.Clear();
+        }
+    }
+
+    private readonly struct Section
+    {
+        public Section(string tag, string body)
+        {
+            Tag = tag;
+            Body = body;
+        }
+
+        public string Tag { get; }
+
+        public string Body { get; }
+    }
+}

--- a/src/Core/CodeAnalysis/Syntax/DocumentationAttacher.cs
+++ b/src/Core/CodeAnalysis/Syntax/DocumentationAttacher.cs
@@ -1,0 +1,252 @@
+// <copyright file="DocumentationAttacher.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Text;
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Implements the position-based documentation attachment pass (ADR-0057 §7).
+/// Groups consecutive <see cref="SyntaxKind.DocumentationCommentToken"/>s into blocks
+/// by line-adjacency, then attaches each block to the nearest documentable declaration
+/// whose start follows immediately after.
+/// </summary>
+internal static class DocumentationAttacher
+{
+    /// <summary>
+    /// Runs the attachment algorithm over a parsed syntax tree, returning a table
+    /// that maps declaration nodes to their joined documentation block text.
+    /// </summary>
+    /// <param name="tree">The fully-parsed syntax tree.</param>
+    /// <returns>A dictionary from declaration node to documentation text.</returns>
+    internal static Dictionary<SyntaxNode, string> Attach(SyntaxTree tree)
+    {
+        var result = new Dictionary<SyntaxNode, string>();
+        var docTokens = tree.DocumentationTokens;
+        if (docTokens.IsDefaultOrEmpty)
+        {
+            return result;
+        }
+
+        var sourceText = tree.Text;
+        var blocks = GroupIntoBlocks(docTokens, sourceText);
+        if (blocks.Count == 0)
+        {
+            return result;
+        }
+
+        // Collect all documentable declarations sorted by source position.
+        var declarations = CollectDocumentableDeclarations(tree.Root);
+        declarations.Sort((a, b) => a.Span.Start.CompareTo(b.Span.Start));
+
+        var declIndex = 0;
+        foreach (var block in blocks)
+        {
+            // Advance past declarations that start before the block end.
+            while (declIndex < declarations.Count &&
+                   declarations[declIndex].Span.Start < block.EndPosition)
+            {
+                declIndex++;
+            }
+
+            if (declIndex >= declarations.Count)
+            {
+                break;
+            }
+
+            var candidate = declarations[declIndex];
+
+            // The declaration must start on the line immediately following the block's last line.
+            var candidateLine = sourceText.GetLineIndex(candidate.Span.Start);
+            if (candidateLine == block.LastLine + 1)
+            {
+                result[candidate] = block.Text;
+            }
+        }
+
+        return result;
+    }
+
+    private static List<DocBlock> GroupIntoBlocks(ImmutableArray<SyntaxToken> docTokens, SourceText sourceText)
+    {
+        var blocks = new List<DocBlock>();
+        var currentLines = new List<string>();
+        var currentFirstLine = -1;
+        var currentLastLine = -1;
+        var currentEndPosition = 0;
+
+        foreach (var token in docTokens)
+        {
+            var tokenLine = sourceText.GetLineIndex(token.Span.Start);
+
+            if (currentLines.Count > 0 && tokenLine != currentLastLine + 1)
+            {
+                // Gap: finalize current block.
+                blocks.Add(new DocBlock(currentFirstLine, currentLastLine, currentEndPosition, JoinBlock(currentLines)));
+                currentLines.Clear();
+            }
+
+            if (currentLines.Count == 0)
+            {
+                currentFirstLine = tokenLine;
+            }
+
+            currentLastLine = tokenLine;
+            currentEndPosition = token.Span.End;
+            currentLines.Add((string)token.Value ?? string.Empty);
+        }
+
+        if (currentLines.Count > 0)
+        {
+            blocks.Add(new DocBlock(currentFirstLine, currentLastLine, currentEndPosition, JoinBlock(currentLines)));
+        }
+
+        return blocks;
+    }
+
+    private static string JoinBlock(List<string> lines)
+    {
+        return string.Join("\n", lines);
+    }
+
+    private static List<SyntaxNode> CollectDocumentableDeclarations(CompilationUnitSyntax root)
+    {
+        var result = new List<SyntaxNode>();
+
+        foreach (var member in root.Members)
+        {
+            CollectFromMember(member, result);
+        }
+
+        return result;
+    }
+
+    private static void CollectFromMember(SyntaxNode node, List<SyntaxNode> result)
+    {
+        switch (node)
+        {
+            case PackageSyntax pkg:
+                result.Add(pkg);
+                break;
+
+            case ImportSyntax imp:
+                result.Add(imp);
+                break;
+
+            case FunctionDeclarationSyntax func:
+                result.Add(func);
+                break;
+
+            case ConstructorDeclarationSyntax ctor:
+                result.Add(ctor);
+                break;
+
+            case TypeAliasDeclarationSyntax alias:
+                result.Add(alias);
+                break;
+
+            case StructDeclarationSyntax structDecl:
+                result.Add(structDecl);
+                CollectFromStructBody(structDecl, result);
+                break;
+
+            case EnumDeclarationSyntax enumDecl:
+                result.Add(enumDecl);
+                CollectFromEnumBody(enumDecl, result);
+                break;
+
+            case InterfaceDeclarationSyntax ifaceDecl:
+                result.Add(ifaceDecl);
+                CollectFromInterfaceBody(ifaceDecl, result);
+                break;
+
+            case GlobalStatementSyntax global:
+                // Top-level variable declarations are documentable.
+                if (global.Statement is VariableDeclarationSyntax)
+                {
+                    result.Add(global);
+                }
+
+                break;
+        }
+    }
+
+    private static void CollectFromStructBody(StructDeclarationSyntax structDecl, List<SyntaxNode> result)
+    {
+        foreach (var field in structDecl.Fields)
+        {
+            result.Add(field);
+        }
+
+        foreach (var prop in structDecl.Properties)
+        {
+            result.Add(prop);
+        }
+
+        foreach (var evt in structDecl.Events)
+        {
+            result.Add(evt);
+        }
+
+        foreach (var method in structDecl.Methods)
+        {
+            result.Add(method);
+        }
+
+        if (structDecl.Constructors != null)
+        {
+            foreach (var ctor in structDecl.Constructors)
+            {
+                result.Add(ctor);
+            }
+        }
+    }
+
+    private static void CollectFromEnumBody(EnumDeclarationSyntax enumDecl, List<SyntaxNode> result)
+    {
+        foreach (var member in enumDecl.Members)
+        {
+            result.Add(member);
+        }
+    }
+
+    private static void CollectFromInterfaceBody(InterfaceDeclarationSyntax interfaceDecl, List<SyntaxNode> result)
+    {
+        foreach (var prop in interfaceDecl.Properties)
+        {
+            result.Add(prop);
+        }
+
+        foreach (var evt in interfaceDecl.Events)
+        {
+            result.Add(evt);
+        }
+
+        foreach (var method in interfaceDecl.Methods)
+        {
+            result.Add(method);
+        }
+    }
+
+    private readonly struct DocBlock
+    {
+        public DocBlock(int firstLine, int lastLine, int endPosition, string text)
+        {
+            FirstLine = firstLine;
+            LastLine = lastLine;
+            EndPosition = endPosition;
+            Text = text;
+        }
+
+        public int FirstLine { get; }
+
+        public int LastLine { get; }
+
+        public int EndPosition { get; }
+
+        public string Text { get; }
+    }
+}

--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -114,7 +114,11 @@ public sealed class Lexer
                 break;
             case '/':
                 position++;
-                if (Current == '/')
+                if (Current == '/' && Peek(1) == '/')
+                {
+                    ReadDocumentationComment();
+                }
+                else if (Current == '/')
                 {
                     ReadSingleLineComment();
                 }
@@ -479,6 +483,55 @@ public sealed class Lexer
         }
 
         kind = SyntaxKind.CommentToken;
+        value = sb.ToString();
+    }
+
+    // ADR-0057 §2: exactly three slashes start a doc comment. The first slash was
+    // consumed by the Lex() dispatcher; we enter here with Current=='/' and
+    // Peek(1)=='/'. We consume the second and third slashes, then strip one optional
+    // following space. Everything after (including a 4th slash) is content.
+    private void ReadDocumentationComment()
+    {
+        // Consume the second and third slashes (first was consumed by Lex dispatcher).
+        position += 2;
+
+        // Strip one optional leading space (ADR §2).
+        if (Current == ' ')
+        {
+            position++;
+        }
+
+        var sb = new StringBuilder();
+        var done = false;
+
+        while (!done)
+        {
+            switch (Current)
+            {
+                case '\0':
+                    done = true;
+                    break;
+                case '\r':
+                    if (Lookahead == '\n')
+                    {
+                        position++;
+                    }
+
+                    position++;
+                    done = true;
+                    break;
+                case '\n':
+                    position++;
+                    done = true;
+                    break;
+                default:
+                    sb.Append(Current);
+                    position++;
+                    break;
+            }
+        }
+
+        kind = SyntaxKind.DocumentationCommentToken;
         value = sb.ToString();
     }
 

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -25,6 +25,7 @@ public class Parser
     public Parser(SyntaxTree syntaxTree)
     {
         var tokens = new List<SyntaxToken>();
+        var docTokens = ImmutableArray.CreateBuilder<SyntaxToken>();
 
         var lexer = new Lexer(syntaxTree);
         SyntaxToken token;
@@ -32,7 +33,11 @@ public class Parser
         {
             token = lexer.Lex();
 
-            if (token.Kind != SyntaxKind.WhitespaceToken &&
+            if (token.Kind == SyntaxKind.DocumentationCommentToken)
+            {
+                docTokens.Add(token);
+            }
+            else if (token.Kind != SyntaxKind.WhitespaceToken &&
                 token.Kind != SyntaxKind.CommentToken &&
                 token.Kind != SyntaxKind.BadToken)
             {
@@ -43,6 +48,7 @@ public class Parser
 
         this.syntaxTree = syntaxTree;
         this.tokens = tokens.ToImmutableArray();
+        DocumentationTokens = docTokens.ToImmutable();
         Diagnostics.AddRange(lexer.Diagnostics);
     }
 
@@ -50,6 +56,13 @@ public class Parser
     /// Gets tiagnostic bag associated to this parser.
     /// </summary>
     public DiagnosticBag Diagnostics { get; } = new DiagnosticBag();
+
+    /// <summary>
+    /// Gets the documentation comment tokens collected during lexing (ADR-0057 §7).
+    /// These are retained in a side-channel so the parser ignores them during
+    /// parsing but can provide them for the post-parse attachment pass.
+    /// </summary>
+    internal ImmutableArray<SyntaxToken> DocumentationTokens { get; }
 
     private SyntaxToken Current => Peek(0);
 

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -17,6 +17,7 @@ public enum SyntaxKind
     BadToken,
     WhitespaceToken,
     CommentToken,
+    DocumentationCommentToken,
     EndOfFileToken,
 
     // Language tokens

--- a/src/Core/CodeAnalysis/Syntax/SyntaxTree.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxTree.cs
@@ -14,18 +14,22 @@ namespace GSharp.Core.CodeAnalysis.Syntax;
 /// </summary>
 public class SyntaxTree
 {
-    private SyntaxTree(SourceText text,  ParseHandler handler)
+    private Dictionary<SyntaxNode, string> documentationTable;
+
+    private SyntaxTree(SourceText text, ParseHandler handler)
     {
         Text = text;
-        handler(this, out var root, out var diagnostics);
+        handler(this, out var root, out var diagnostics, out var docTokens);
         Root = root;
         Diagnostics = diagnostics;
+        DocumentationTokens = docTokens;
     }
 
     private delegate void ParseHandler(
         SyntaxTree syntaxTree,
         out CompilationUnitSyntax root,
-        out ImmutableArray<Diagnostic> diagnostics);
+        out ImmutableArray<Diagnostic> diagnostics,
+        out ImmutableArray<SyntaxToken> documentationTokens);
 
     /// <summary>
     /// Gets the source text.
@@ -41,6 +45,11 @@ public class SyntaxTree
     /// Gets the compilation unit root.
     /// </summary>
     public CompilationUnitSyntax Root { get; }
+
+    /// <summary>
+    /// Gets the documentation comment tokens collected during lexing (ADR-0057 §7).
+    /// </summary>
+    internal ImmutableArray<SyntaxToken> DocumentationTokens { get; }
 
     /// <summary>
     /// Parses the source text from the provided file path into a syntax tree.
@@ -73,11 +82,12 @@ public class SyntaxTree
     /// <returns>A parsed syntax tree.</returns>
     public static SyntaxTree Parse(SourceText text)
     {
-        static void Parse(SyntaxTree syntaxTree, out CompilationUnitSyntax root, out ImmutableArray<Diagnostic> diagnostics)
+        static void Parse(SyntaxTree syntaxTree, out CompilationUnitSyntax root, out ImmutableArray<Diagnostic> diagnostics, out ImmutableArray<SyntaxToken> docTokens)
         {
             var parser = new Parser(syntaxTree);
             root = parser.ParseCompilationUnit();
             diagnostics = parser.Diagnostics.ToImmutableArray();
+            docTokens = parser.DocumentationTokens;
         }
 
         return new SyntaxTree(text, Parse);
@@ -126,9 +136,10 @@ public class SyntaxTree
     {
         var tokens = new List<SyntaxToken>();
 
-        void ParseTokens(SyntaxTree st, out CompilationUnitSyntax root, out ImmutableArray<Diagnostic> d)
+        void ParseTokens(SyntaxTree st, out CompilationUnitSyntax root, out ImmutableArray<Diagnostic> d, out ImmutableArray<SyntaxToken> docTokens)
         {
             root = null;
+            docTokens = ImmutableArray<SyntaxToken>.Empty;
             var l = new Lexer(st);
             while (true)
             {
@@ -148,5 +159,21 @@ public class SyntaxTree
         var syntaxTree = new SyntaxTree(text, ParseTokens);
         diagnostics = syntaxTree.Diagnostics;
         return tokens.ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Gets the attached documentation text for a declaration node, or <see langword="null"/>
+    /// when no documentation block is associated (ADR-0057 §7).
+    /// </summary>
+    /// <param name="node">The declaration syntax node.</param>
+    /// <returns>The joined documentation block text, or <see langword="null"/>.</returns>
+    internal string GetDocumentation(SyntaxNode node)
+    {
+        if (documentationTable == null)
+        {
+            documentationTable = DocumentationAttacher.Attach(this);
+        }
+
+        return documentationTable.TryGetValue(node, out var doc) ? doc : null;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Documentation/GSharpDocumentationParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Documentation/GSharpDocumentationParserTests.cs
@@ -1,0 +1,176 @@
+// <copyright file="GSharpDocumentationParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Documentation;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Documentation;
+
+/// <summary>
+/// ADR-0057 §3: tests that the G# Markdown+KDoc authoring surface is parsed
+/// into the internal <see cref="DocumentationComment"/> model.
+/// </summary>
+public class GSharpDocumentationParserTests
+{
+    [Fact]
+    public void Null_ReturnsNull()
+    {
+        Assert.Null(GSharpDocumentationParser.Parse(null));
+    }
+
+    [Fact]
+    public void WhitespaceOnly_ReturnsNull()
+    {
+        Assert.Null(GSharpDocumentationParser.Parse("   \n  "));
+    }
+
+    [Fact]
+    public void LeadingProse_BecomesSummary()
+    {
+        var doc = GSharpDocumentationParser.Parse("Computes the area of a rectangle.");
+        Assert.NotNull(doc);
+        Assert.Equal("Computes the area of a rectangle.", PlainText(doc.Summary));
+    }
+
+    [Fact]
+    public void ParamTag_CapturesNameAndContent()
+    {
+        var doc = GSharpDocumentationParser.Parse("Summary.\n@param x the horizontal offset");
+        Assert.NotNull(doc);
+        Assert.Equal("Summary.", PlainText(doc.Summary));
+        var p = Assert.Single(doc.Parameters);
+        Assert.Equal("x", p.Name);
+        Assert.Equal("the horizontal offset", PlainText(p.Content));
+    }
+
+    [Fact]
+    public void TypeparamTag_CapturesNameAndContent()
+    {
+        var doc = GSharpDocumentationParser.Parse("Summary.\n@typeparam T the element type");
+        var tp = Assert.Single(doc.TypeParameters);
+        Assert.Equal("T", tp.Name);
+        Assert.Equal("the element type", PlainText(tp.Content));
+    }
+
+    [Fact]
+    public void ReturnsTag_CapturesContent()
+    {
+        var doc = GSharpDocumentationParser.Parse("Summary.\n@returns the computed area");
+        Assert.Equal("the computed area", PlainText(doc.Returns));
+    }
+
+    [Fact]
+    public void ExceptionTag_CapturesCrefAndContent()
+    {
+        var doc = GSharpDocumentationParser.Parse("Summary.\n@exception OverflowException when too large");
+        var ex = Assert.Single(doc.Exceptions);
+        Assert.Equal("OverflowException", ex.Cref);
+        Assert.Equal("when too large", PlainText(ex.Content));
+    }
+
+    [Fact]
+    public void InlineCode_ProducesCodeInline()
+    {
+        var doc = GSharpDocumentationParser.Parse("Returns `Width * Height`.");
+        var code = doc.Summary.OfType<DocInline.Code>().Single();
+        Assert.Equal("Width * Height", code.Value);
+    }
+
+    [Fact]
+    public void CrefLink_ProducesSymbolRef()
+    {
+        var doc = GSharpDocumentationParser.Parse("See [Rect](cref:MyNs.Rect) for details.");
+        var sref = doc.Summary.OfType<DocInline.SymbolRef>().Single();
+        Assert.Equal("MyNs.Rect", sref.DocId);
+        Assert.Equal("Rect", PlainText(sref.Inner));
+    }
+
+    [Fact]
+    public void BareCref_ProducesSymbolRefWithNoInner()
+    {
+        var doc = GSharpDocumentationParser.Parse("See (cref:System.String) for details.");
+        var sref = doc.Summary.OfType<DocInline.SymbolRef>().Single();
+        Assert.Equal("System.String", sref.DocId);
+        Assert.True(sref.Inner.IsEmpty);
+    }
+
+    [Fact]
+    public void HttpLink_ProducesLinkInline()
+    {
+        var doc = GSharpDocumentationParser.Parse("Visit [docs](https://example.com).");
+        var link = doc.Summary.OfType<DocInline.Link>().Single();
+        Assert.Equal("https://example.com", link.Href);
+        Assert.Equal("docs", PlainText(link.Inner));
+    }
+
+    [Fact]
+    public void ParamRef_ProducesParamRefInline()
+    {
+        var doc = GSharpDocumentationParser.Parse("Returns [`x`](paramref) squared.");
+        var pref = doc.Summary.OfType<DocInline.ParamRef>().Single();
+        Assert.Equal("x", pref.Name);
+    }
+
+    [Fact]
+    public void FencedCodeBlock_ProducesCodeBlockInline()
+    {
+        var doc = GSharpDocumentationParser.Parse("Example:\n```gs\nlet x = 1\n```");
+        var cb = doc.Summary.OfType<DocInline.CodeBlock>().FirstOrDefault()
+              ?? doc.Summary.OfType<DocInline.Para>().SelectMany(p => p.Content).OfType<DocInline.CodeBlock>().First();
+        Assert.Equal("gs", cb.Language);
+        Assert.Contains("let x = 1", cb.Value);
+    }
+
+    [Fact]
+    public void XmldocEscapeHatch_ProducesUnknownXmlElement()
+    {
+        var doc = GSharpDocumentationParser.Parse("Summary.\n```xmldoc\n<note>Important</note>\n```");
+        var unknown = doc.Summary.OfType<DocInline.UnknownXmlElement>().FirstOrDefault()
+                  ?? doc.Summary.OfType<DocInline.Para>().SelectMany(p => p.Content).OfType<DocInline.UnknownXmlElement>().First();
+        Assert.Contains("<note>Important</note>", unknown.RawXml);
+    }
+
+    [Fact]
+    public void BulletList_ProducesListInline()
+    {
+        var doc = GSharpDocumentationParser.Parse("Options:\n- First\n- Second");
+        var list = doc.Summary.OfType<DocInline.List>().FirstOrDefault()
+                ?? doc.Summary.OfType<DocInline.Para>().SelectMany(p => p.Content).OfType<DocInline.List>().First();
+        Assert.Equal("bullet", list.ListType);
+        Assert.Equal(2, list.Items.Length);
+    }
+
+    [Fact]
+    public void OrderedList_ProducesNumberList()
+    {
+        var doc = GSharpDocumentationParser.Parse("Steps:\n1. Alpha\n2. Beta");
+        var list = doc.Summary.OfType<DocInline.List>().FirstOrDefault()
+                ?? doc.Summary.OfType<DocInline.Para>().SelectMany(p => p.Content).OfType<DocInline.List>().First();
+        Assert.Equal("number", list.ListType);
+        Assert.Equal(2, list.Items.Length);
+    }
+
+    [Fact]
+    public void RemarksTag_CapturesContent()
+    {
+        var doc = GSharpDocumentationParser.Parse("Summary.\n@remarks This is a remark.");
+        Assert.Equal("This is a remark.", PlainText(doc.Remarks));
+    }
+
+    [Fact]
+    public void MultipleParams_AllCaptured()
+    {
+        var doc = GSharpDocumentationParser.Parse("Summary.\n@param x the x\n@param y the y");
+        Assert.Equal(2, doc.Parameters.Length);
+        Assert.Equal("x", doc.Parameters[0].Name);
+        Assert.Equal("y", doc.Parameters[1].Name);
+    }
+
+    private static string PlainText(ImmutableArray<DocInline> content)
+    {
+        return string.Concat(content.OfType<DocInline.Text>().Select(t => t.Value)).Trim();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/DocumentationAttacherTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/DocumentationAttacherTests.cs
@@ -1,0 +1,87 @@
+// <copyright file="DocumentationAttacherTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// ADR-0057 §7: Tests the position-based attachment of doc blocks to declarations.
+/// </summary>
+public class DocumentationAttacherTests
+{
+    [Fact]
+    public void DocAttaches_ToImmediatelyFollowingFunction()
+    {
+        var source = "/// Adds two numbers.\nfunc Add(a int32, b int32) int32 { return a + b }";
+        var tree = SyntaxTree.Parse(source);
+        var funcDecl = tree.Root.Members[0];
+        var doc = tree.GetDocumentation(funcDecl);
+        Assert.Equal("Adds two numbers.", doc);
+    }
+
+    [Fact]
+    public void MultiLineDoc_ConcatenatesLines()
+    {
+        var source = "/// Line one.\n/// Line two.\nfunc Foo() {}";
+        var tree = SyntaxTree.Parse(source);
+        var funcDecl = tree.Root.Members[0];
+        var doc = tree.GetDocumentation(funcDecl);
+        Assert.Contains("Line one.", doc);
+        Assert.Contains("Line two.", doc);
+    }
+
+    [Fact]
+    public void GapBetweenDocAndDeclaration_NoAttachment()
+    {
+        // A blank line between doc and declaration breaks attachment
+        var source = "/// Orphan doc.\n\nfunc Foo() {}";
+        var tree = SyntaxTree.Parse(source);
+        var funcDecl = tree.Root.Members[0];
+        var doc = tree.GetDocumentation(funcDecl);
+        Assert.Null(doc);
+    }
+
+    [Fact]
+    public void NoDocComment_ReturnsNull()
+    {
+        var source = "func Bar() {}";
+        var tree = SyntaxTree.Parse(source);
+        var funcDecl = tree.Root.Members[0];
+        var doc = tree.GetDocumentation(funcDecl);
+        Assert.Null(doc);
+    }
+
+    [Fact]
+    public void RegularComment_DoesNotAttach()
+    {
+        var source = "// Not a doc comment\nfunc Baz() {}";
+        var tree = SyntaxTree.Parse(source);
+        var funcDecl = tree.Root.Members[0];
+        var doc = tree.GetDocumentation(funcDecl);
+        Assert.Null(doc);
+    }
+
+    [Fact]
+    public void MultipleFunctions_EachGetsOwnDoc()
+    {
+        var source = "/// Doc for A.\nfunc A() {}\n/// Doc for B.\nfunc B() {}";
+        var tree = SyntaxTree.Parse(source);
+        var a = tree.Root.Members[0];
+        var b = tree.Root.Members[1];
+        Assert.Equal("Doc for A.", tree.GetDocumentation(a));
+        Assert.Equal("Doc for B.", tree.GetDocumentation(b));
+    }
+
+    [Fact]
+    public void DocOnEnum_Attaches()
+    {
+        var source = "/// My enum.\ntype Color enum { Red, Green, Blue }";
+        var tree = SyntaxTree.Parse(source);
+        var enumDecl = tree.Root.Members[0];
+        var doc = tree.GetDocumentation(enumDecl);
+        Assert.Equal("My enum.", doc);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/DocumentationCommentLexerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/DocumentationCommentLexerTests.cs
@@ -1,0 +1,87 @@
+// <copyright file="DocumentationCommentLexerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// ADR-0057 §2: Tests that the lexer emits <see cref="SyntaxKind.DocumentationCommentToken"/>
+/// with correct content and positional rules.
+/// </summary>
+public class DocumentationCommentLexerTests
+{
+    [Fact]
+    public void TripleSlash_EmitsDocToken()
+    {
+        var tokens = SyntaxTree.ParseTokens("/// Hello");
+        var doc = tokens.Single(t => t.Kind == SyntaxKind.DocumentationCommentToken);
+        Assert.Equal("Hello", (string)doc.Value);
+    }
+
+    [Fact]
+    public void TripleSlash_NoSpace_ContentStartsAtFourthChar()
+    {
+        var tokens = SyntaxTree.ParseTokens("///NoSpace");
+        var doc = tokens.Single(t => t.Kind == SyntaxKind.DocumentationCommentToken);
+        Assert.Equal("NoSpace", (string)doc.Value);
+    }
+
+    [Fact]
+    public void FourSlashes_ContentIncludesExtraSlash()
+    {
+        // //// x → doc content is "/ x" (ADR §2: 4th slash is part of content)
+        var tokens = SyntaxTree.ParseTokens("//// extra");
+        var doc = tokens.Single(t => t.Kind == SyntaxKind.DocumentationCommentToken);
+        Assert.Equal("/ extra", (string)doc.Value);
+    }
+
+    [Fact]
+    public void TripleSlashEquals_ContentIsEquals()
+    {
+        // ///= x → content is "= x"
+        var tokens = SyntaxTree.ParseTokens("///= x");
+        var doc = tokens.Single(t => t.Kind == SyntaxKind.DocumentationCommentToken);
+        Assert.Equal("= x", (string)doc.Value);
+    }
+
+    [Fact]
+    public void BlankDocComment_EmptyContent()
+    {
+        // /// with nothing after it
+        var tokens = SyntaxTree.ParseTokens("///");
+        var doc = tokens.Single(t => t.Kind == SyntaxKind.DocumentationCommentToken);
+        Assert.Equal(string.Empty, (string)doc.Value);
+    }
+
+    [Fact]
+    public void DoubleSlash_StaysAsRegularComment()
+    {
+        var tokens = SyntaxTree.ParseTokens("// regular comment");
+        Assert.DoesNotContain(tokens, t => t.Kind == SyntaxKind.DocumentationCommentToken);
+        Assert.Contains(tokens, t => t.Kind == SyntaxKind.CommentToken);
+    }
+
+    [Fact]
+    public void MultipleDocComments_OnSeparateLines()
+    {
+        var source = "/// Line one\n/// Line two";
+        var tokens = SyntaxTree.ParseTokens(source);
+        var docs = tokens.Where(t => t.Kind == SyntaxKind.DocumentationCommentToken).ToArray();
+        Assert.Equal(2, docs.Length);
+        Assert.Equal("Line one", (string)docs[0].Value);
+        Assert.Equal("Line two", (string)docs[1].Value);
+    }
+
+    [Fact]
+    public void DocCommentBeforeCode_DoesNotConsumeCode()
+    {
+        var source = "/// doc\nlet x = 1";
+        var tokens = SyntaxTree.ParseTokens(source);
+        Assert.Contains(tokens, t => t.Kind == SyntaxKind.DocumentationCommentToken);
+        Assert.Contains(tokens, t => t.Kind == SyntaxKind.LetKeyword);
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -52,6 +52,7 @@ DefaultKeyword
 DeferKeyword
 DeferStatement
 DiscardPattern
+DocumentationCommentToken
 DotToken
 EllipsisToken
 ElseClause


### PR DESCRIPTION
## Summary

Implements ADR-0057 §2/§3/§7: the full doc-authoring pipeline for G# source documentation comments.

### Changes

**Lexer** — `///` emits `DocumentationCommentToken` with exactly 3 slashes consumed; 4th+ is content; one optional leading space stripped.

**Parser** — Side-channel collection of doc tokens (`DocumentationTokens` property).

**SyntaxTree** — Carries doc tokens; lazy `GetDocumentation(SyntaxNode)` triggers attachment on first call.

**DocumentationAttacher** (ADR §7) — Position-based attachment: groups consecutive doc tokens into blocks by line-adjacency, collects all documentable declarations sorted by span, attaches to nearest following declaration.

**GSharpDocumentationParser** (ADR §3) — Parses Markdown+KDoc authoring surface into `DocumentationComment` model:
- Leading prose → summary
- `@param`/`@typeparam`/`@returns`/`@remarks`/`@exception`/`@seealso` block tags
- Inline: backtick code, `[text](cref:X)`, `(cref:X)`, `[\`n\`](paramref)`, `[text](https://...)`
- Fenced code blocks, \`\`\`xmldoc escape hatch → UnknownXmlElement
- Bullet/ordered lists

**Binder** — `AttachDocumentation(Symbol, SyntaxNode)` helper wired at all symbol creation sites (package, import, enum+members, struct, interface, fields, properties, events, methods instance+static, constructors).

**Coverage matrix** — Updated for `DocumentationCommentToken`.

### Tests added
- `DocumentationCommentLexerTests` (8 tests) — token emission, content stripping, edge cases
- `DocumentationAttacherTests` (7 tests) — attachment, gap detection, multi-function
- `GSharpDocumentationParserTests` (18 tests) — full parser coverage

### All 2050 existing tests pass ✅

Closes part of #388 (work item 6).