### PR TITLE
#388 Stage C (P3): doc-emission — XML documentation file generation

### DIFF
--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -171,6 +171,16 @@ public class Program
             }
         }
 
+        var documentationOutputPath = args.DocumentationFile;
+        if (!string.IsNullOrEmpty(documentationOutputPath))
+        {
+            var documentationDir = Path.GetDirectoryName(documentationOutputPath);
+            if (!string.IsNullOrEmpty(documentationDir))
+            {
+                Directory.CreateDirectory(documentationDir);
+            }
+        }
+
         // Phase 3 / ADR-0027 §7.7a: when Portable PDB is requested, open the
         // sidecar stream alongside the PE. If the caller did not supply an
         // explicit /pdb:<path>, default to "<PE>.pdb" (csc.exe convention).
@@ -196,8 +206,9 @@ public class Program
         using (var peStream = File.Create(outputPath))
         using (var refStream = string.IsNullOrEmpty(refOutputPath) ? null : File.Create(refOutputPath))
         using (var pdbStream = pdbOutputPath is null ? null : File.Create(pdbOutputPath))
+        using (var docStream = string.IsNullOrEmpty(documentationOutputPath) ? null : File.Create(documentationOutputPath))
         {
-            result = compilation.Emit(peStream, pdbStream, refStream, args.AssemblyName, args.Version);
+            result = compilation.Emit(peStream, pdbStream, refStream, docStream, args.AssemblyName, args.Version);
         }
 
         // Apply /nowarn, /warnaserror filtering.
@@ -222,6 +233,11 @@ public class Program
             if (!string.IsNullOrEmpty(pdbOutputPath))
             {
                 TryDelete(pdbOutputPath);
+            }
+
+            if (!string.IsNullOrEmpty(documentationOutputPath))
+            {
+                TryDelete(documentationOutputPath);
             }
 
             Console.Error.WriteLine("Failed.");
@@ -478,6 +494,15 @@ public class Program
 
                         break;
 
+                    case "doc":
+                        if (string.IsNullOrEmpty(value))
+                        {
+                            throw new CommandLineException("/doc requires a path: /doc:<file>.");
+                        }
+
+                        result.DocumentationFile = value;
+                        break;
+
                     case "sourcelink":
                         if (string.IsNullOrEmpty(value))
                         {
@@ -709,6 +734,9 @@ public class Program
 
         /// <summary>Gets or sets the explicit sidecar PDB path (from /pdb:&lt;path&gt;). Null means "default to {OutputPath}.pdb".</summary>
         public string PdbPath { get; set; }
+
+        /// <summary>Gets or sets the XML documentation output path (from /doc:&lt;path&gt;).</summary>
+        public string DocumentationFile { get; set; }
 
         /// <summary>Gets or sets the path to a Source Link JSON file (from /sourcelink:&lt;path&gt;).</summary>
         public string SourceLinkPath { get; set; }

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Compilation.cs" company="GSharp">
+// <copyright file="Compilation.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Documentation;
 using GSharp.Core.CodeAnalysis.Emit;
 using GSharp.Core.CodeAnalysis.Lowering.Iterators;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -290,7 +291,7 @@ public class Compilation
     /// </summary>
     /// <param name="peStream">Destination stream for the PE bytes.</param>
     /// <returns>An emit result.</returns>
-    public EmitResult Emit(Stream peStream) => Emit(peStream, pdbStream: null, refStream: null, assemblyName: null);
+    public EmitResult Emit(Stream peStream) => Emit(peStream, pdbStream: null, refStream: null, docStream: null, assemblyName: null);
 
     /// <summary>
     /// Compiles the current syntax tree and writes the resulting assembly to
@@ -306,6 +307,23 @@ public class Compilation
     /// <param name="assemblyVersion">Optional informational version string stamped as <c>AssemblyInformationalVersionAttribute</c>.</param>
     /// <returns>An emit result.</returns>
     public EmitResult Emit(Stream peStream, Stream pdbStream, Stream refStream, string assemblyName = null, string assemblyVersion = null)
+        => Emit(peStream, pdbStream, refStream, docStream: null, assemblyName, assemblyVersion);
+
+    /// <summary>
+    /// Compiles the current syntax tree and writes the resulting assembly to
+    /// <paramref name="peStream"/>, optionally writing a Portable PDB stream
+    /// to <paramref name="pdbStream"/>, a metadata-only sibling assembly to
+    /// <paramref name="refStream"/>, and an XML documentation file to
+    /// <paramref name="docStream"/>.
+    /// </summary>
+    /// <param name="peStream">Destination stream for the PE bytes. May be <c>null</c> when only non-PE sidecars are desired.</param>
+    /// <param name="pdbStream">Destination stream for the Portable PDB sidecar. Only consumed when <see cref="DebugInformation"/>'s <see cref="DebugInformationOptions.Format"/> is <see cref="DebugInformationFormat.Portable"/>.</param>
+    /// <param name="refStream">Optional destination stream for the metadata-only reference assembly.</param>
+    /// <param name="docStream">Optional destination stream for the XML documentation file.</param>
+    /// <param name="assemblyName">Optional override for the assembly identity. When null, the entry-point package name is used.</param>
+    /// <param name="assemblyVersion">Optional informational version string stamped as <c>AssemblyInformationalVersionAttribute</c>.</param>
+    /// <returns>An emit result.</returns>
+    public EmitResult Emit(Stream peStream, Stream pdbStream, Stream refStream, Stream docStream, string assemblyName = null, string assemblyVersion = null)
     {
         var parseDiagnostics = SyntaxTrees.SelectMany(st => st.Diagnostics);
         var syntaxDiagnostics = parseDiagnostics.Concat(GlobalScope.Diagnostics).ToImmutableArray();
@@ -352,6 +370,11 @@ public class Compilation
                 // pointing at a sidecar that doesn't describe this PE.
                 EmitAssembly(program, refStream, References, assemblyName, assemblyVersion, metadataOnly: true, asyncRewriteResult: lowered.AsyncRewriteResult, iteratorRewriteResult: lowered.IteratorRewriteResult, asyncIteratorRewriteResult: lowered.AsyncIteratorRewriteResult, debugInformation: null, pdbStream: null);
             }
+
+            if (docStream is not null)
+            {
+                DocumentationFileEmitter.Emit(docStream, assemblyName ?? program.PackageName, program.Structs, program.Functions.Keys);
+            }
         }
         catch (Exception ex) when (ex is NotSupportedException || ex is InvalidOperationException)
         {
@@ -373,7 +396,7 @@ public class Compilation
     /// <param name="refStream">Optional destination stream for the metadata-only reference assembly.</param>
     /// <returns>An emit result.</returns>
     public EmitResult Emit(Stream peStream, Stream refStream) =>
-        Emit(peStream, pdbStream: null, refStream, assemblyName: null);
+        Emit(peStream, pdbStream: null, refStream, docStream: null, assemblyName: null);
 
     /// <summary>
     /// The canonical async/iterator lowering pipeline. Runs all rewriter

--- a/src/Core/CodeAnalysis/Documentation/DocumentationFileEmitter.cs
+++ b/src/Core/CodeAnalysis/Documentation/DocumentationFileEmitter.cs
@@ -1,0 +1,192 @@
+// <copyright file="DocumentationFileEmitter.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Documentation;
+
+internal static class DocumentationFileEmitter
+{
+    public static void Emit(Stream xmlStream, string assemblyName, IEnumerable<StructSymbol> types, IEnumerable<FunctionSymbol> topLevelFunctions)
+    {
+        ArgumentNullException.ThrowIfNull(xmlStream);
+
+        var members = CollectMembers(types ?? Enumerable.Empty<StructSymbol>(), topLevelFunctions ?? Enumerable.Empty<FunctionSymbol>())
+            .OrderBy(entry => entry.DocId, StringComparer.Ordinal)
+            .ToArray();
+
+        using var streamWriter = new StreamWriter(xmlStream, new UTF8Encoding(false), 1024, leaveOpen: true)
+        {
+            NewLine = "\n",
+        };
+
+        streamWriter.WriteLine("<?xml version=\"1.0\"?>");
+
+        var settings = new XmlWriterSettings
+        {
+            CloseOutput = false,
+            Indent = true,
+            IndentChars = "    ",
+            NewLineChars = "\n",
+            OmitXmlDeclaration = true,
+        };
+
+        using var writer = XmlWriter.Create(streamWriter, settings);
+        writer.WriteStartElement("doc");
+
+        writer.WriteStartElement("assembly");
+        writer.WriteElementString("name", assemblyName ?? string.Empty);
+        writer.WriteEndElement();
+
+        writer.WriteStartElement("members");
+        foreach (var member in members)
+        {
+            writer.WriteStartElement("member");
+            writer.WriteAttributeString("name", member.DocId);
+            if (!string.IsNullOrEmpty(member.XmlFragment))
+            {
+                writer.WriteRaw("\n");
+                writer.WriteRaw(IndentFragment(member.XmlFragment, "            "));
+                writer.WriteRaw("\n        ");
+            }
+
+            writer.WriteEndElement();
+        }
+
+        writer.WriteEndElement();
+        writer.WriteEndElement();
+        writer.Flush();
+        streamWriter.Flush();
+    }
+
+    private static IEnumerable<MemberDocumentation> CollectMembers(IEnumerable<StructSymbol> types, IEnumerable<FunctionSymbol> topLevelFunctions)
+    {
+        var members = new List<MemberDocumentation>();
+
+        foreach (var type in types)
+        {
+            AddIfDocumented(members, type);
+
+            foreach (var field in type.Fields)
+            {
+                AddIfDocumented(members, field, type);
+            }
+
+            foreach (var property in type.Properties)
+            {
+                AddIfDocumented(members, property, type);
+            }
+
+            foreach (var @event in type.Events)
+            {
+                AddIfDocumented(members, @event, type);
+            }
+
+            foreach (var method in type.Methods)
+            {
+                AddIfDocumented(members, method);
+            }
+
+            foreach (var field in type.StaticFields)
+            {
+                AddIfDocumented(members, field, type);
+            }
+
+            foreach (var property in type.StaticProperties)
+            {
+                AddIfDocumented(members, property, type);
+            }
+
+            foreach (var @event in type.StaticEvents)
+            {
+                AddIfDocumented(members, @event, type);
+            }
+
+            foreach (var method in type.StaticMethods)
+            {
+                AddIfDocumented(members, method);
+            }
+
+            if (type.ExplicitConstructor is { } constructor)
+            {
+                AddIfDocumented(members, constructor.Function);
+            }
+        }
+
+        foreach (var function in topLevelFunctions)
+        {
+            if (function.ReceiverType is null && function.StaticOwnerType is null)
+            {
+                AddIfDocumented(members, function);
+            }
+        }
+
+        return members;
+    }
+
+    private static void AddIfDocumented(List<MemberDocumentation> members, Symbol symbol)
+    {
+        var documentation = symbol.GetDocumentation();
+        if (documentation is null)
+        {
+            return;
+        }
+
+        var docId = SymbolDocumentationIdProvider.GetDocumentationId(symbol);
+        if (docId is null)
+        {
+            return;
+        }
+
+        members.Add(new MemberDocumentation(docId, DocumentationXmlWriter.WriteXmlFragment(documentation)));
+    }
+
+    private static void AddIfDocumented(List<MemberDocumentation> members, Symbol symbol, StructSymbol ownerType)
+    {
+        var documentation = symbol.GetDocumentation();
+        if (documentation is null)
+        {
+            return;
+        }
+
+        var docId = SymbolDocumentationIdProvider.GetDocumentationId(symbol, ownerType);
+        if (docId is null)
+        {
+            return;
+        }
+
+        members.Add(new MemberDocumentation(docId, DocumentationXmlWriter.WriteXmlFragment(documentation)));
+    }
+
+    private static string IndentFragment(string fragment, string indentation)
+    {
+        var normalized = fragment.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var lines = normalized.Split('\n');
+        var builder = new StringBuilder();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append('\n');
+            }
+
+            if (lines[i].Length > 0)
+            {
+                builder.Append(indentation);
+            }
+
+            builder.Append(lines[i]);
+        }
+
+        return builder.ToString();
+    }
+
+    private sealed record MemberDocumentation(string DocId, string XmlFragment);
+}

--- a/src/Core/CodeAnalysis/Documentation/DocumentationXmlWriter.cs
+++ b/src/Core/CodeAnalysis/Documentation/DocumentationXmlWriter.cs
@@ -1,0 +1,172 @@
+// <copyright file="DocumentationXmlWriter.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Text;
+using System.Xml;
+
+namespace GSharp.Core.CodeAnalysis.Documentation;
+
+internal static class DocumentationXmlWriter
+{
+    public static string WriteXmlFragment(DocumentationComment doc)
+    {
+        if (doc is null)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+        var settings = new XmlWriterSettings
+        {
+            ConformanceLevel = ConformanceLevel.Fragment,
+            Indent = true,
+            IndentChars = "    ",
+            NewLineChars = "\n",
+            OmitXmlDeclaration = true,
+        };
+
+        using var writer = XmlWriter.Create(builder, settings);
+        WriteSection(writer, "summary", doc.Summary);
+        WriteParameters(writer, "param", doc.Parameters);
+        WriteParameters(writer, "typeparam", doc.TypeParameters);
+        WriteSection(writer, "returns", doc.Returns);
+        WriteSection(writer, "remarks", doc.Remarks);
+        WriteSection(writer, "value", doc.Value);
+
+        foreach (var exception in doc.Exceptions)
+        {
+            writer.WriteStartElement("exception");
+            if (!string.IsNullOrEmpty(exception.Cref))
+            {
+                writer.WriteAttributeString("cref", exception.Cref);
+            }
+
+            WriteInlines(writer, exception.Content);
+            writer.WriteEndElement();
+        }
+
+        foreach (var reference in doc.SeeAlso)
+        {
+            writer.WriteStartElement("seealso");
+            if (!string.IsNullOrEmpty(reference.Cref))
+            {
+                writer.WriteAttributeString("cref", reference.Cref);
+            }
+
+            if (!string.IsNullOrEmpty(reference.Href))
+            {
+                writer.WriteAttributeString("href", reference.Href);
+            }
+
+            WriteInlines(writer, reference.Content);
+            writer.WriteEndElement();
+        }
+
+        writer.Flush();
+        return builder.ToString();
+    }
+
+    private static void WriteParameters(XmlWriter writer, string elementName, ImmutableArray<DocParam> parameters)
+    {
+        foreach (var parameter in parameters)
+        {
+            writer.WriteStartElement(elementName);
+            writer.WriteAttributeString("name", parameter.Name);
+            WriteInlines(writer, parameter.Content);
+            writer.WriteEndElement();
+        }
+    }
+
+    private static void WriteSection(XmlWriter writer, string elementName, ImmutableArray<DocInline> content)
+    {
+        if (content.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        writer.WriteStartElement(elementName);
+        WriteInlines(writer, content);
+        writer.WriteEndElement();
+    }
+
+    private static void WriteInlines(XmlWriter writer, ImmutableArray<DocInline> content)
+    {
+        foreach (var inline in content)
+        {
+            WriteInline(writer, inline);
+        }
+    }
+
+    private static void WriteInline(XmlWriter writer, DocInline inline)
+    {
+        switch (inline)
+        {
+            case DocInline.Text text:
+                writer.WriteString(text.Value);
+                break;
+            case DocInline.Code code:
+                writer.WriteStartElement("c");
+                writer.WriteString(code.Value);
+                writer.WriteEndElement();
+                break;
+            case DocInline.CodeBlock codeBlock:
+                writer.WriteStartElement("code");
+                if (!string.IsNullOrEmpty(codeBlock.Language))
+                {
+                    writer.WriteAttributeString("language", codeBlock.Language);
+                }
+
+                writer.WriteString(codeBlock.Value);
+                writer.WriteEndElement();
+                break;
+            case DocInline.Para para:
+                writer.WriteStartElement("para");
+                WriteInlines(writer, para.Content);
+                writer.WriteEndElement();
+                break;
+            case DocInline.List list:
+                writer.WriteStartElement("list");
+                writer.WriteAttributeString("type", string.IsNullOrEmpty(list.ListType) ? "bullet" : list.ListType);
+                foreach (var item in list.Items)
+                {
+                    writer.WriteStartElement("item");
+                    if (!item.Term.IsDefaultOrEmpty)
+                    {
+                        writer.WriteStartElement("term");
+                        WriteInlines(writer, item.Term);
+                        writer.WriteEndElement();
+                    }
+
+                    writer.WriteStartElement("description");
+                    WriteInlines(writer, item.Description);
+                    writer.WriteEndElement();
+                    writer.WriteEndElement();
+                }
+
+                writer.WriteEndElement();
+                break;
+            case DocInline.SymbolRef symbolRef:
+                writer.WriteStartElement("see");
+                writer.WriteAttributeString("cref", symbolRef.DocId);
+                WriteInlines(writer, symbolRef.Inner);
+                writer.WriteEndElement();
+                break;
+            case DocInline.Link link:
+                writer.WriteStartElement("see");
+                writer.WriteAttributeString("href", link.Href);
+                WriteInlines(writer, link.Inner);
+                writer.WriteEndElement();
+                break;
+            case DocInline.ParamRef paramRef:
+                writer.WriteStartElement("paramref");
+                writer.WriteAttributeString("name", paramRef.Name);
+                writer.WriteEndElement();
+                break;
+            case DocInline.UnknownXmlElement unknownXml:
+                writer.WriteRaw(unknownXml.RawXml);
+                break;
+        }
+    }
+}

--- a/src/Core/CodeAnalysis/Documentation/SymbolDocumentationIdProvider.cs
+++ b/src/Core/CodeAnalysis/Documentation/SymbolDocumentationIdProvider.cs
@@ -1,0 +1,493 @@
+// <copyright file="SymbolDocumentationIdProvider.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Documentation;
+
+internal static class SymbolDocumentationIdProvider
+{
+    public static string GetDocumentationId(Symbol symbol)
+    {
+        return symbol switch
+        {
+            PackageSymbol package => GetDocumentationId(package),
+            StructSymbol type => GetDocumentationId(type),
+            FunctionSymbol function => GetDocumentationId(function),
+            _ => null,
+        };
+    }
+
+    public static string GetDocumentationId(Symbol member, StructSymbol ownerType)
+    {
+        return member switch
+        {
+            FieldSymbol field => GetDocumentationId(field, ownerType),
+            PropertySymbol property => GetDocumentationId(property, ownerType),
+            EventSymbol @event => GetDocumentationId(@event, ownerType),
+            FunctionSymbol function => GetDocumentationId(function),
+            _ => null,
+        };
+    }
+
+    internal static string GetDocumentationId(PackageSymbol package)
+    {
+        return package is null ? null : $"N:{package.Name}";
+    }
+
+    internal static string GetDocumentationId(StructSymbol type)
+    {
+        if (type is null)
+        {
+            return null;
+        }
+
+        var builder = new StringBuilder("T:");
+        AppendTypeDeclarationName(builder, type);
+        return builder.ToString();
+    }
+
+    internal static string GetDocumentationId(FunctionSymbol function)
+    {
+        if (function is null)
+        {
+            return null;
+        }
+
+        var builder = new StringBuilder("M:");
+        var ownerType = function.ReceiverType as StructSymbol ?? function.StaticOwnerType;
+        if (ownerType is not null)
+        {
+            AppendTypeDeclarationName(builder, ownerType);
+        }
+        else if (!string.IsNullOrEmpty(function.Package?.Name))
+        {
+            builder.Append(function.Package.Name);
+        }
+        else
+        {
+            return null;
+        }
+
+        builder.Append('.');
+        AppendMethodName(builder, function);
+
+        if (!IsConstructor(function) && function.TypeParameters.Length > 0)
+        {
+            builder.Append("``").Append(function.TypeParameters.Length);
+        }
+
+        AppendParameterList(builder, function, ownerType);
+        return builder.ToString();
+    }
+
+    private static string GetDocumentationId(FieldSymbol field, StructSymbol ownerType)
+    {
+        if (field is null || ownerType is null)
+        {
+            return null;
+        }
+
+        var builder = new StringBuilder("F:");
+        AppendTypeDeclarationName(builder, ownerType);
+        builder.Append('.').Append(EncodeName(field.Name));
+        return builder.ToString();
+    }
+
+    private static string GetDocumentationId(PropertySymbol property, StructSymbol ownerType)
+    {
+        if (property is null || ownerType is null)
+        {
+            return null;
+        }
+
+        var builder = new StringBuilder("P:");
+        AppendTypeDeclarationName(builder, ownerType);
+        builder.Append('.').Append(EncodeName(property.Name));
+        return builder.ToString();
+    }
+
+    private static string GetDocumentationId(EventSymbol @event, StructSymbol ownerType)
+    {
+        if (@event is null || ownerType is null)
+        {
+            return null;
+        }
+
+        var builder = new StringBuilder("E:");
+        AppendTypeDeclarationName(builder, ownerType);
+        builder.Append('.').Append(EncodeName(@event.Name));
+        return builder.ToString();
+    }
+
+    private static void AppendMethodName(StringBuilder builder, FunctionSymbol function)
+    {
+        if (IsConstructor(function))
+        {
+            builder.Append(IsStaticConstructor(function) ? "#cctor" : "#ctor");
+            return;
+        }
+
+        builder.Append(EncodeName(function.Name));
+    }
+
+    private static void AppendParameterList(StringBuilder builder, FunctionSymbol function, StructSymbol ownerType)
+    {
+        var start = function.ReceiverType != null && function.ExplicitReceiverParameter != null ? 1 : 0;
+        if (function.Parameters.Length <= start)
+        {
+            return;
+        }
+
+        builder.Append('(');
+        for (var i = start; i < function.Parameters.Length; i++)
+        {
+            if (i > start)
+            {
+                builder.Append(',');
+            }
+
+            AppendTypeReference(builder, function.Parameters[i].Type, ownerType, function);
+        }
+
+        builder.Append(')');
+    }
+
+    private static void AppendTypeDeclarationName(StringBuilder builder, StructSymbol type)
+    {
+        var definition = type.Definition ?? type;
+        AppendSourceTypeDeclarationName(builder, definition.PackageName, definition.Name, definition.TypeParameters.Length);
+    }
+
+    private static void AppendTypeReference(StringBuilder builder, TypeSymbol type, StructSymbol ownerType, FunctionSymbol function)
+    {
+        switch (type)
+        {
+            case null:
+                builder.Append("System.Void");
+                return;
+            case TypeParameterSymbol typeParameter:
+                builder.Append(IsMethodTypeParameter(typeParameter, function) ? "``" : "`").Append(typeParameter.Ordinal);
+                return;
+            case ArrayTypeSymbol arrayType:
+                AppendTypeReference(builder, arrayType.ElementType, ownerType, function);
+                builder.Append("[]");
+                return;
+            case ByRefTypeSymbol byRefType:
+                AppendTypeReference(builder, byRefType.PointeeType, ownerType, function);
+                builder.Append('@');
+                return;
+            case NullableTypeSymbol nullableType:
+                builder.Append("System.Nullable`1{");
+                AppendTypeReference(builder, nullableType.UnderlyingType, ownerType, function);
+                builder.Append('}');
+                return;
+            case StructSymbol structType:
+                AppendSourceTypeReference(builder, structType, ownerType, function);
+                return;
+            case InterfaceSymbol interfaceType:
+                AppendSourceTypeReference(builder, interfaceType, ownerType, function);
+                return;
+            case ImportedTypeSymbol importedType when importedType.OpenDefinition is not null && !importedType.TypeArguments.IsDefaultOrEmpty:
+                AppendClrConstructedTypeReference(builder, importedType.OpenDefinition, importedType.TypeArguments, ownerType, function);
+                return;
+            case ImportedTypeSymbol importedType when importedType.Type is not null:
+                AppendClrTypeReference(builder, importedType.Type);
+                return;
+            default:
+                if (type.ClrType is not null)
+                {
+                    AppendClrTypeReference(builder, type.ClrType);
+                }
+                else
+                {
+                    builder.Append(EncodeName(type.Name));
+                }
+
+                return;
+        }
+    }
+
+    private static void AppendSourceTypeReference(StringBuilder builder, StructSymbol type, StructSymbol ownerType, FunctionSymbol function)
+    {
+        var definition = type.Definition ?? type;
+        AppendSourceNamedTypeReference(builder, definition.PackageName, definition.Name, definition.TypeParameters.Length, type.TypeArguments, ownerType, function);
+    }
+
+    private static void AppendSourceTypeReference(StringBuilder builder, InterfaceSymbol type, StructSymbol ownerType, FunctionSymbol function)
+    {
+        var definition = type.Definition ?? type;
+        AppendSourceNamedTypeReference(builder, definition.PackageName, definition.Name, definition.TypeParameters.Length, type.TypeArguments, ownerType, function);
+    }
+
+    private static void AppendSourceNamedTypeReference(
+        StringBuilder builder,
+        string packageName,
+        string name,
+        int arity,
+        ImmutableArray<TypeSymbol> typeArguments,
+        StructSymbol ownerType,
+        FunctionSymbol function)
+    {
+        if (!string.IsNullOrEmpty(packageName))
+        {
+            builder.Append(packageName).Append('.');
+        }
+
+        builder.Append(EncodeName(name));
+        if (!typeArguments.IsDefaultOrEmpty && typeArguments.Length > 0)
+        {
+            builder.Append('{');
+            for (var i = 0; i < typeArguments.Length; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append(',');
+                }
+
+                AppendTypeReference(builder, typeArguments[i], ownerType, function);
+            }
+
+            builder.Append('}');
+            return;
+        }
+
+        if (arity > 0)
+        {
+            builder.Append('`').Append(arity);
+        }
+    }
+
+    private static void AppendSourceTypeDeclarationName(StringBuilder builder, string packageName, string name, int arity)
+    {
+        if (!string.IsNullOrEmpty(packageName))
+        {
+            builder.Append(packageName).Append('.');
+        }
+
+        builder.Append(EncodeName(name));
+        if (arity > 0)
+        {
+            builder.Append('`').Append(arity);
+        }
+    }
+
+    private static void AppendClrTypeReference(StringBuilder builder, Type type)
+    {
+        if (type.IsByRef)
+        {
+            AppendClrTypeReference(builder, type.GetElementType());
+            builder.Append('@');
+            return;
+        }
+
+        if (type.IsPointer)
+        {
+            AppendClrTypeReference(builder, type.GetElementType());
+            builder.Append('*');
+            return;
+        }
+
+        if (type.IsArray)
+        {
+            AppendClrTypeReference(builder, type.GetElementType());
+            AppendArraySuffix(builder, type);
+            return;
+        }
+
+        if (type.IsGenericParameter)
+        {
+            builder.Append(type.DeclaringMethod != null ? "``" : "`").Append(type.GenericParameterPosition);
+            return;
+        }
+
+        AppendClrConstructedTypeReference(builder, type);
+    }
+
+    private static void AppendClrConstructedTypeReference(StringBuilder builder, Type type)
+    {
+        var chain = NestingChain(type);
+        var outermost = chain[0];
+        if (!string.IsNullOrEmpty(outermost.Namespace))
+        {
+            builder.Append(outermost.Namespace).Append('.');
+        }
+
+        var allArgs = type.IsGenericType ? type.GetGenericArguments() : Type.EmptyTypes;
+        var consumed = 0;
+        for (var i = 0; i < chain.Count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append('.');
+            }
+
+            var level = chain[i];
+            builder.Append(StripArity(level.Name));
+            var arity = LevelArity(level);
+            if (arity == 0)
+            {
+                continue;
+            }
+
+            if (type.IsGenericTypeDefinition)
+            {
+                builder.Append('`').Append(arity);
+                continue;
+            }
+
+            builder.Append('{');
+            for (var a = 0; a < arity; a++)
+            {
+                if (a > 0)
+                {
+                    builder.Append(',');
+                }
+
+                AppendClrTypeReference(builder, allArgs[consumed + a]);
+            }
+
+            builder.Append('}');
+            consumed += arity;
+        }
+    }
+
+    private static void AppendClrConstructedTypeReference(
+        StringBuilder builder,
+        Type openDefinition,
+        ImmutableArray<TypeSymbol> typeArguments,
+        StructSymbol ownerType,
+        FunctionSymbol function)
+    {
+        var chain = NestingChain(openDefinition);
+        var outermost = chain[0];
+        if (!string.IsNullOrEmpty(outermost.Namespace))
+        {
+            builder.Append(outermost.Namespace).Append('.');
+        }
+
+        var consumed = 0;
+        for (var i = 0; i < chain.Count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append('.');
+            }
+
+            var level = chain[i];
+            builder.Append(StripArity(level.Name));
+            var arity = LevelArity(level);
+            if (arity == 0)
+            {
+                continue;
+            }
+
+            builder.Append('{');
+            for (var a = 0; a < arity; a++)
+            {
+                if (a > 0)
+                {
+                    builder.Append(',');
+                }
+
+                AppendTypeReference(builder, typeArguments[consumed + a], ownerType, function);
+            }
+
+            builder.Append('}');
+            consumed += arity;
+        }
+    }
+
+    private static void AppendArraySuffix(StringBuilder builder, Type array)
+    {
+        if (array.IsSZArray)
+        {
+            builder.Append("[]");
+            return;
+        }
+
+        var rank = array.GetArrayRank();
+        builder.Append('[');
+        for (var i = 0; i < rank; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(',');
+            }
+
+            builder.Append("0:");
+        }
+
+        builder.Append(']');
+    }
+
+    private static List<Type> NestingChain(Type type)
+    {
+        var chain = new List<Type>();
+        for (var current = type; current != null; current = current.DeclaringType)
+        {
+            chain.Insert(0, current);
+        }
+
+        return chain;
+    }
+
+    private static int LevelArity(Type level)
+    {
+        var own = level.IsGenericType ? level.GetGenericArguments().Length : 0;
+        var enclosing = level.DeclaringType is { IsGenericType: true } declaring
+            ? declaring.GetGenericArguments().Length
+            : 0;
+        return own - enclosing;
+    }
+
+    private static string StripArity(string name)
+    {
+        var tick = name.IndexOf('`');
+        return tick >= 0 ? name.Substring(0, tick) : name;
+    }
+
+    private static bool IsMethodTypeParameter(TypeParameterSymbol typeParameter, FunctionSymbol function)
+    {
+        if (function is null || function.TypeParameters.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < function.TypeParameters.Length; i++)
+        {
+            if (ReferenceEquals(function.TypeParameters[i], typeParameter))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsConstructor(FunctionSymbol function)
+    {
+        return string.Equals(function.Name, ".ctor", StringComparison.Ordinal) ||
+               string.Equals(function.Name, "#ctor", StringComparison.Ordinal);
+    }
+
+    private static bool IsStaticConstructor(FunctionSymbol function)
+    {
+        return string.Equals(function.Name, ".cctor", StringComparison.Ordinal) ||
+               string.Equals(function.Name, "#cctor", StringComparison.Ordinal);
+    }
+
+    private static string EncodeName(string name)
+    {
+        return name
+            .Replace('.', '#')
+            .Replace('<', '{')
+            .Replace('>', '}')
+            .Replace(',', '@');
+    }
+}

--- a/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
+++ b/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
@@ -94,6 +94,9 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
     /// <summary>Gets or sets the path of the metadata-only reference assembly to write (refint).</summary>
     public string RefAssembly { get; set; }
 
+    /// <summary>Gets or sets the path of the XML documentation file to write.</summary>
+    public string DocumentationFile { get; set; }
+
     /// <summary>Gets or sets the comma-separated list of diagnostic IDs to suppress (NoWarn MSBuild property).</summary>
     public string NoWarn { get; set; }
 
@@ -174,6 +177,11 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
         if (!string.IsNullOrEmpty(this.RefAssembly))
         {
             args.Add($"/refout:{this.RefAssembly}");
+        }
+
+        if (!string.IsNullOrEmpty(this.DocumentationFile))
+        {
+            args.Add($"/doc:{this.DocumentationFile}");
         }
 
         if (!string.IsNullOrEmpty(this.NoWarn))

--- a/src/Sdk/Gsharp.NET.Sdk/Sdk/Sdk.props
+++ b/src/Sdk/Gsharp.NET.Sdk/Sdk/Sdk.props
@@ -17,6 +17,7 @@
     <!-- Phase 7.7b: enable XML documentation file generation for library
          projects so consumers get IntelliSense / XML doc hover. -->
     <GenerateDocumentationFile Condition=" '$(GenerateDocumentationFile)' == '' and '$(OutputType)' != 'Exe' ">true</GenerateDocumentationFile>
+    <DocumentationFile Condition=" '$(GenerateDocumentationFile)' == 'true' and '$(DocumentationFile)' == '' ">$(IntermediateOutputPath)$(TargetName).xml</DocumentationFile>
 
     <!-- Phase 7.7b: ensure dotnet pack produces a .snupkg symbol package
          carrying the Portable PDB alongside the main .nupkg. -->

--- a/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
+++ b/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
@@ -49,6 +49,7 @@
         Optimization="$(Optimize)"
         DebugType="$(DebugType)"
         PdbFile="@(_DebugSymbolsIntermediatePath)"
+        DocumentationFile="$(DocumentationFile)"
         SourceLink="$(SourceLink)"
         EmbedAllSources="$(EmbedAllSources)"
         Deterministic="$(Deterministic)"
@@ -65,6 +66,7 @@
     <ItemGroup>
       <FileWrites Include="$(IntermediateOutputPath)$(TargetName)$(TargetExt)" />
       <FileWrites Include="$(_GsharpRefAssemblyPath)" Condition=" '$(_GsharpRefAssemblyPath)' != '' " />
+      <FileWrites Include="$(DocumentationFile)" Condition=" '$(DocumentationFile)' != '' " />
 
       <!-- Phase 8: declare the sidecar PDB to MSBuild so incremental build,
            Clean, dotnet publish, and dotnet pack (when GeneratePackageOnBuild

--- a/test/Core.Tests/CodeAnalysis/Documentation/DocumentationFileEmitterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Documentation/DocumentationFileEmitterTests.cs
@@ -1,0 +1,118 @@
+// <copyright file="DocumentationFileEmitterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Text;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Documentation;
+
+/// <summary>
+/// ADR-0057 §5: Tests that the G# doc-emission pipeline produces correct .xml files
+/// that C# consumers can parse.
+/// </summary>
+public class DocumentationFileEmitterTests
+{
+    [Fact]
+    public void EmitsXmlForDocumentedFunction()
+    {
+        var source = @"package MyLib
+
+/// Adds two numbers.
+/// @param a first operand
+/// @param b second operand
+/// @returns the sum
+func Add(a int32, b int32) int32 {
+    return a + b
+}
+";
+        var xml = EmitDocXml(source, "MyLib");
+
+        Assert.Contains("<member name=\"M:MyLib.Add(System.Int32,System.Int32)\">", xml);
+        Assert.Contains("<summary>", xml);
+        Assert.Contains("Adds two numbers.", xml);
+        Assert.Contains("<param name=\"a\">", xml);
+        Assert.Contains("<param name=\"b\">", xml);
+        Assert.Contains("<returns>", xml);
+    }
+
+    [Fact]
+    public void EmitsXmlForDocumentedStruct()
+    {
+        var source = @"package Shapes
+
+/// Represents a 2D point.
+type Point data struct {
+    /// The X coordinate.
+    X float64
+    /// The Y coordinate.
+    Y float64
+}
+";
+        var xml = EmitDocXml(source, "Shapes");
+
+        Assert.Contains("<member name=\"T:Shapes.Point\">", xml);
+        Assert.Contains("Represents a 2D point.", xml);
+        Assert.Contains("<member name=\"F:Shapes.Point.X\">", xml);
+        Assert.Contains("The X coordinate.", xml);
+        Assert.Contains("<member name=\"F:Shapes.Point.Y\">", xml);
+        Assert.Contains("The Y coordinate.", xml);
+    }
+
+    [Fact]
+    public void EmitsAssemblyName()
+    {
+        var source = @"package Lib
+
+/// A function.
+func Foo() {}
+";
+        var xml = EmitDocXml(source, "Lib");
+        Assert.Contains("<name>Lib</name>", xml);
+    }
+
+    [Fact]
+    public void UndocumentedSymbols_NotEmitted()
+    {
+        var source = @"package Lib
+
+func NoDoc() {}
+
+/// Has docs.
+func WithDoc() {}
+";
+        var xml = EmitDocXml(source, "Lib");
+        Assert.DoesNotContain("M:Lib.NoDoc", xml);
+        Assert.Contains("M:Lib.WithDoc", xml);
+    }
+
+    [Fact]
+    public void MembersAreSortedByDocId()
+    {
+        var source = @"package Lib
+
+/// Z function.
+func Zulu() {}
+
+/// A function.
+func Alpha() {}
+";
+        var xml = EmitDocXml(source, "Lib");
+        var alphaPos = xml.IndexOf("M:Lib.Alpha");
+        var zuluPos = xml.IndexOf("M:Lib.Zulu");
+        Assert.True(alphaPos < zuluPos, "Members should be sorted by DocID");
+    }
+
+    private static string EmitDocXml(string source, string assemblyName)
+    {
+        var tree = SyntaxTree.Parse(source);
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        using var docStream = new MemoryStream();
+        compilation.Emit(peStream, pdbStream: null, refStream: null, docStream, assemblyName);
+        return Encoding.UTF8.GetString(docStream.ToArray());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Documentation/SymbolDocumentationIdProviderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Documentation/SymbolDocumentationIdProviderTests.cs
@@ -1,0 +1,69 @@
+// <copyright file="SymbolDocumentationIdProviderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Documentation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Documentation;
+
+/// <summary>
+/// ADR-0057 §5: Tests that <see cref="SymbolDocumentationIdProvider"/> generates
+/// correct DocIDs for G# source symbols.
+/// </summary>
+public class SymbolDocumentationIdProviderTests
+{
+    [Fact]
+    public void Package_GeneratesNPrefix()
+    {
+        var package = new PackageSymbol("MyNamespace", null);
+        var id = SymbolDocumentationIdProvider.GetDocumentationId(package);
+        Assert.Equal("N:MyNamespace", id);
+    }
+
+    [Fact]
+    public void SimpleFunction_GeneratesMPrefix()
+    {
+        var tree = SyntaxTree.Parse("package Lib\nfunc Greet() {}");
+        var compilation = new Compilation(tree);
+        var func = compilation.GlobalScope.Functions.First(f => f.Name == "Greet");
+        var id = SymbolDocumentationIdProvider.GetDocumentationId(func);
+        Assert.Equal("M:Lib.Greet", id);
+    }
+
+    [Fact]
+    public void FunctionWithParams_IncludesParameterTypes()
+    {
+        var tree = SyntaxTree.Parse("package Lib\nfunc Add(a int32, b int32) int32 { return a + b }");
+        var compilation = new Compilation(tree);
+        var func = compilation.GlobalScope.Functions.First(f => f.Name == "Add");
+        var id = SymbolDocumentationIdProvider.GetDocumentationId(func);
+        Assert.Equal("M:Lib.Add(System.Int32,System.Int32)", id);
+    }
+
+    [Fact]
+    public void StructType_GeneratesTPrefix()
+    {
+        var tree = SyntaxTree.Parse("package Lib\ntype Point data struct { X int32, Y int32 }");
+        var compilation = new Compilation(tree);
+        var type = compilation.GlobalScope.Structs.First(s => s.Name == "Point");
+        var id = SymbolDocumentationIdProvider.GetDocumentationId(type);
+        Assert.Equal("T:Lib.Point", id);
+    }
+
+    [Fact]
+    public void StructField_GeneratesFPrefix()
+    {
+        var tree = SyntaxTree.Parse("package Lib\ntype Point data struct { X int32, Y int32 }");
+        var compilation = new Compilation(tree);
+        var type = compilation.GlobalScope.Structs.First(s => s.Name == "Point");
+        var field = type.Fields[0];
+        var id = SymbolDocumentationIdProvider.GetDocumentationId(field, type);
+        Assert.Equal("F:Lib.Point.X", id);
+    }
+}


### PR DESCRIPTION
## Summary

Implements ADR-0057 §5: the full documentation emission pipeline that closes the G#↔C# round-trip. After this PR, G# libraries produce standard `.xml` documentation files that C# consumers can parse for IntelliSense/hover.

### Changes

**SymbolDocumentationIdProvider** — Computes Roslyn-exact DocIDs from G# source symbols. Handles all member kinds (N:/T:/M:/F:/P:/E:), generics (`n/``n), parameter types, constructed generics, imported CLR types.

**DocumentationXmlWriter** — Serializes `DocumentationComment` model → XML fragments. Handles all `DocInline` variants with deterministic output.

**DocumentationFileEmitter** — Orchestrates `.xml` file generation: collects documented symbols, generates DocIDs, writes standard `<doc>`/`<assembly>`/`<members>` structure with alphabetical ordering.

**CLI** — `/doc:<path>` flag in gsc. Creates doc file alongside PE/PDB/ref. Cleans up on failure.

**Compilation** — New `Emit` overload with `docStream` parameter. Existing overloads chain through (backward-compatible).

**SDK** — `DocumentationFile` on BuildTask, default path wiring when `GenerateDocumentationFile=true`, `FileWrites` for incremental build.

### Tests added
- `SymbolDocumentationIdProviderTests` (5 tests) — DocID generation correctness
- `DocumentationFileEmitterTests` (5 tests) — end-to-end XML emission

### All 2060 tests pass ✅

This **closes the round-trip**: G# author → `.xml` → DocID matches what a C# consumer expects.

Closes part of #388 (work item 7).