### PR TITLE
Improve hover experience and add GS0231 unknown doc tag warning

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -243,7 +243,7 @@ These diagnostics indicate an internal compiler problem. If you encounter them, 
 | GS9998 | Error | An unexpected `NotSupportedException` or `InvalidOperationException` was raised during IL emission. The message text contains the original exception message. |
 | GS9999 | Error | An unexpected exception was caught by the evaluator. The message text contains the original exception message. |
 
-## Documentation diagnostics (GS0227–GS0230)
+## Documentation diagnostics (GS0227–GS0231)
 
 | Code | Severity | Message |
 |------|----------|---------|
@@ -251,3 +251,4 @@ These diagnostics indicate an internal compiler problem. If you encounter them, 
 | GS0228 | Warning | Missing documentation comment on public member '{name}'. (opt-in) |
 | GS0229 | Warning | Documentation @param '{name}' does not match any parameter of '{symbol}'. |
 | GS0230 | Warning | Unsupported documentation Markdown: {detail}. |
+| GS0231 | Warning | Unknown documentation tag '{tag}'. Valid tags are: @param, @typeparam, @returns, @remarks, @value, @exception, @seealso. |

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1583,6 +1583,17 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0230", $"Unsupported documentation Markdown: {detail}. Use ```xmldoc for complex XML-doc constructs.", DiagnosticSeverity.Warning);
     }
 
+    /// <summary>
+    /// Reports GS0231 when a documentation comment contains an unknown block tag
+    /// (e.g. <c>@return</c> instead of <c>@returns</c>).
+    /// </summary>
+    /// <param name="location">The location of the documentation comment.</param>
+    /// <param name="tagName">The unrecognised tag text.</param>
+    public void ReportUnknownDocumentationTag(TextLocation location, string tagName)
+    {
+        Report(location, "GS0231", $"Unknown documentation tag '{tagName}'. Valid tags are: @param, @typeparam, @returns, @remarks, @value, @exception, @seealso.", DiagnosticSeverity.Warning);
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Documentation/DocumentationValidator.cs
+++ b/src/Core/CodeAnalysis/Documentation/DocumentationValidator.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -12,6 +13,17 @@ namespace GSharp.Core.CodeAnalysis.Documentation;
 
 internal static class DocumentationValidator
 {
+    private static readonly HashSet<string> KnownTags = new(StringComparer.Ordinal)
+    {
+        "@param",
+        "@typeparam",
+        "@returns",
+        "@remarks",
+        "@value",
+        "@exception",
+        "@seealso",
+    };
+
     /// <summary>
     /// Validates documentation across a single syntax tree, emitting diagnostics.
     /// Called after binding is complete.
@@ -50,6 +62,7 @@ internal static class DocumentationValidator
         foreach (var tree in trees)
         {
             ValidateFloatingDocComments(tree, diagnostics);
+            ValidateUnknownTags(tree, diagnostics);
         }
 
         ValidateParamMatches(functions, diagnostics);
@@ -106,6 +119,36 @@ internal static class DocumentationValidator
             if (!attached[i])
             {
                 diagnostics.ReportFloatingDocumentationComment(blocks[i].Location);
+            }
+        }
+    }
+
+    private static void ValidateUnknownTags(SyntaxTree tree, DiagnosticBag diagnostics)
+    {
+        var blocks = DocumentationAttacher.GetBlocks(tree);
+        if (blocks.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        foreach (var block in blocks)
+        {
+            foreach (var line in block.Text.Split('\n'))
+            {
+                var trimmed = line.TrimStart();
+                if (trimmed.Length < 2 || trimmed[0] != '@')
+                {
+                    continue;
+                }
+
+                // Extract the tag name: everything from '@' up to the first space or end of line.
+                var spaceIdx = trimmed.IndexOf(' ');
+                var tag = spaceIdx < 0 ? trimmed : trimmed.Substring(0, spaceIdx);
+
+                if (!KnownTags.Contains(tag))
+                {
+                    diagnostics.ReportUnknownDocumentationTag(block.Location, tag);
+                }
             }
         }
     }

--- a/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
+++ b/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
@@ -142,13 +142,34 @@ public static class SymbolDisplay
             return builder.ToImmutable();
         }
 
-        var keyword = clrType.IsInterface ? "interface"
-            : clrType.IsEnum ? "enum"
-            : clrType.IsValueType ? "struct"
-            : "class";
-        builder.Keyword(keyword);
+        builder.Keyword("type");
         builder.Space();
         builder.Type(FormatClrTypeName(clrType, format.QualifyNames));
+        builder.Space();
+
+        if (clrType.IsInterface)
+        {
+            builder.Keyword("interface");
+        }
+        else if (clrType.IsEnum)
+        {
+            builder.Keyword("enum");
+        }
+        else if (clrType.IsValueType)
+        {
+            if (IsByRefLikeType(clrType))
+            {
+                builder.Keyword("ref");
+                builder.Space();
+            }
+
+            builder.Keyword("struct");
+        }
+        else
+        {
+            builder.Keyword("class");
+        }
+
         return builder.ToImmutable();
     }
 
@@ -275,28 +296,53 @@ public static class SymbolDisplay
 
     private static void AppendAggregate(PartBuilder builder, SymbolDisplayFormat format, StructSymbol aggregate)
     {
-        builder.Keyword(aggregate.IsClass ? "class" : "struct");
+        builder.Keyword("type");
         builder.Space();
         builder.Type(QualifiedName(format, aggregate.PackageName, aggregate.Name));
         AppendTypeParameters(builder, aggregate.TypeParameters);
         builder.Space();
-        builder.Punctuation("{");
-        builder.Space();
-        for (var i = 0; i < aggregate.Fields.Length; i++)
-        {
-            if (i > 0)
-            {
-                builder.Punctuation(";");
-                builder.Space();
-            }
 
-            builder.Add(SymbolDisplayPartKind.FieldName, aggregate.Fields[i].Name);
+        if (aggregate.IsRefStruct)
+        {
+            builder.Keyword("ref");
             builder.Space();
-            builder.Type(FormatType(aggregate.Fields[i].Type));
         }
 
-        builder.Space();
-        builder.Punctuation("}");
+        if (aggregate.IsData)
+        {
+            builder.Keyword("data");
+            builder.Space();
+        }
+
+        if (aggregate.IsInline)
+        {
+            builder.Keyword("inline");
+            builder.Space();
+        }
+
+        builder.Keyword(aggregate.IsClass ? "class" : "struct");
+
+        if (!aggregate.Fields.IsEmpty)
+        {
+            builder.Space();
+            builder.Punctuation("{");
+            builder.Space();
+            for (var i = 0; i < aggregate.Fields.Length; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Punctuation(";");
+                    builder.Space();
+                }
+
+                builder.Add(SymbolDisplayPartKind.FieldName, aggregate.Fields[i].Name);
+                builder.Space();
+                builder.Type(FormatType(aggregate.Fields[i].Type));
+            }
+
+            builder.Space();
+            builder.Punctuation("}");
+        }
     }
 
     private static void AppendEnum(PartBuilder builder, SymbolDisplayFormat format, EnumSymbol enumSymbol)
@@ -432,9 +478,9 @@ public static class SymbolDisplay
 
     private static void AppendClrProperty(PartBuilder builder, SymbolDisplayFormat format, PropertyInfo property)
     {
-        builder.Type(FormatClrTypeName(property.PropertyType, format.QualifyNames));
-        builder.Space();
         builder.Add(SymbolDisplayPartKind.PropertyName, FormatClrMemberName(property.DeclaringType, property.Name, format));
+        builder.Space();
+        builder.Type(FormatClrTypeName(property.PropertyType, format.QualifyNames));
         if (format.IncludePropertyAccessors)
         {
             builder.Space();
@@ -460,25 +506,34 @@ public static class SymbolDisplay
 
     private static void AppendClrField(PartBuilder builder, SymbolDisplayFormat format, FieldInfo field)
     {
-        builder.Type(FormatClrTypeName(field.FieldType, format.QualifyNames));
-        builder.Space();
         builder.Add(SymbolDisplayPartKind.FieldName, FormatClrMemberName(field.DeclaringType, field.Name, format));
+        builder.Space();
+        builder.Type(FormatClrTypeName(field.FieldType, format.QualifyNames));
     }
 
     private static void AppendClrEvent(PartBuilder builder, SymbolDisplayFormat format, EventInfo @event)
     {
         builder.Keyword("event");
         builder.Space();
-        builder.Type(FormatClrTypeName(@event.EventHandlerType, format.QualifyNames));
-        builder.Space();
         builder.Add(SymbolDisplayPartKind.Identifier, FormatClrMemberName(@event.DeclaringType, @event.Name, format));
+        builder.Space();
+        builder.Type(FormatClrTypeName(@event.EventHandlerType, format.QualifyNames));
     }
 
     private static void AppendClrMethod(PartBuilder builder, SymbolDisplayFormat format, MethodInfo method)
     {
-        builder.Type(FormatClrTypeName(method.ReturnType, format.QualifyNames));
+        builder.Keyword("func");
         builder.Space();
-        builder.Add(SymbolDisplayPartKind.MethodName, FormatClrMemberName(method.DeclaringType, method.Name, format));
+
+        if (format.QualifyNames && method.DeclaringType != null)
+        {
+            builder.Punctuation("(");
+            builder.Type(FormatClrTypeName(method.DeclaringType, qualifyNames: true));
+            builder.Punctuation(")");
+            builder.Space();
+        }
+
+        builder.Add(SymbolDisplayPartKind.MethodName, method.Name);
         builder.Punctuation("(");
         var parameters = method.GetParameters();
         for (var i = 0; i < parameters.Length; i++)
@@ -495,6 +550,12 @@ public static class SymbolDisplay
         }
 
         builder.Punctuation(")");
+
+        if (method.ReturnType != typeof(void))
+        {
+            builder.Space();
+            builder.Type(FormatClrTypeName(method.ReturnType, format.QualifyNames));
+        }
     }
 
     private static string QualifiedName(SymbolDisplayFormat format, string packageName, string name)
@@ -523,6 +584,17 @@ public static class SymbolDisplay
         if (clrType == null)
         {
             return "void";
+        }
+
+        if (clrType == typeof(void))
+        {
+            return "void";
+        }
+
+        // Map CLR primitives to G# type names.
+        if (TryGetGSharpPrimitiveName(clrType, out var primitiveName))
+        {
+            return primitiveName;
         }
 
         if (clrType.IsByRef)
@@ -560,6 +632,122 @@ public static class SymbolDisplay
         typeName = typeName.Replace('+', '.');
         var args = clrType.GetGenericArguments();
         return $"{typeName}[{string.Join(", ", args.Select(a => FormatClrTypeName(a, qualifyNames)))}]";
+    }
+
+    private static bool TryGetGSharpPrimitiveName(Type clrType, out string name)
+    {
+        if (clrType == typeof(bool))
+        {
+            name = "bool";
+            return true;
+        }
+
+        if (clrType == typeof(byte))
+        {
+            name = "uint8";
+            return true;
+        }
+
+        if (clrType == typeof(sbyte))
+        {
+            name = "int8";
+            return true;
+        }
+
+        if (clrType == typeof(short))
+        {
+            name = "int16";
+            return true;
+        }
+
+        if (clrType == typeof(ushort))
+        {
+            name = "uint16";
+            return true;
+        }
+
+        if (clrType == typeof(int))
+        {
+            name = "int32";
+            return true;
+        }
+
+        if (clrType == typeof(uint))
+        {
+            name = "uint32";
+            return true;
+        }
+
+        if (clrType == typeof(long))
+        {
+            name = "int64";
+            return true;
+        }
+
+        if (clrType == typeof(ulong))
+        {
+            name = "uint64";
+            return true;
+        }
+
+        if (clrType == typeof(nint))
+        {
+            name = "nint";
+            return true;
+        }
+
+        if (clrType == typeof(nuint))
+        {
+            name = "nuint";
+            return true;
+        }
+
+        if (clrType == typeof(float))
+        {
+            name = "float32";
+            return true;
+        }
+
+        if (clrType == typeof(double))
+        {
+            name = "float64";
+            return true;
+        }
+
+        if (clrType == typeof(decimal))
+        {
+            name = "decimal";
+            return true;
+        }
+
+        if (clrType == typeof(char))
+        {
+            name = "char";
+            return true;
+        }
+
+        if (clrType == typeof(string))
+        {
+            name = "string";
+            return true;
+        }
+
+        if (clrType == typeof(object))
+        {
+            name = "object";
+            return true;
+        }
+
+        name = null;
+        return false;
+    }
+
+    private static bool IsByRefLikeType(Type type)
+    {
+        // System.Runtime.CompilerServices.IsByRefLikeAttribute is present on ref structs.
+        return type.IsValueType
+            && type.GetCustomAttributes(inherit: false)
+                .Any(a => a.GetType().FullName == "System.Runtime.CompilerServices.IsByRefLikeAttribute");
     }
 
     private static bool IsVoid(TypeSymbol type)

--- a/src/LanguageServer/DocumentSyncHandler.cs
+++ b/src/LanguageServer/DocumentSyncHandler.cs
@@ -4,9 +4,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Documentation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.LanguageServer.Protocol;
 using Range = GSharp.LanguageServer.Protocol.Range;
@@ -87,6 +89,25 @@ public static class DocumentSyncHandler
 
                 diagnostics.Add(BuildDiagnostic("Binding", d.Message, d.Location.Span.Start, d.Location.Span.End, syntaxTree.Text));
             }
+
+            // Documentation validation (warnings only — these don't block compilation).
+            var docDiagnostics = new Core.CodeAnalysis.DiagnosticBag();
+            DocumentationValidator.Validate(
+                useProject ? compilation.SyntaxTrees : ImmutableArray.Create(syntaxTree),
+                program.Functions.Keys.ToImmutableArray(),
+                program.Structs,
+                docDiagnostics,
+                warnOnMissingDocs: false);
+
+            foreach (var d in docDiagnostics)
+            {
+                if (useProject && d.Location.Text != syntaxTree.Text)
+                {
+                    continue;
+                }
+
+                diagnostics.Add(BuildDiagnostic(d.Id, d.Message, d.Location.Span.Start, d.Location.Span.End, syntaxTree.Text, ToLspSeverity(d.Severity)));
+            }
         }
 
         return new DiagnosticComputationResult(new DocumentContent(syntaxTree, newLines, project), diagnostics);
@@ -94,13 +115,28 @@ public static class DocumentSyncHandler
 
     private static Diagnostic BuildDiagnostic(string code, string message, int start, int end, GSharp.Core.CodeAnalysis.Text.SourceText sourceText)
     {
+        return BuildDiagnostic(code, message, start, end, sourceText, DiagnosticSeverity.Error);
+    }
+
+    private static Diagnostic BuildDiagnostic(string code, string message, int start, int end, GSharp.Core.CodeAnalysis.Text.SourceText sourceText, DiagnosticSeverity severity)
+    {
         return new Diagnostic
         {
             Code = new DiagnosticCode(code),
             Message = message,
             Range = new Range(ToPosition(start, sourceText), ToPosition(end, sourceText)),
-            Severity = DiagnosticSeverity.Error,
+            Severity = severity,
             Source = Constants.LanguageIdentifier,
+        };
+    }
+
+    private static DiagnosticSeverity ToLspSeverity(Core.CodeAnalysis.DiagnosticSeverity severity)
+    {
+        return severity switch
+        {
+            Core.CodeAnalysis.DiagnosticSeverity.Error => DiagnosticSeverity.Error,
+            Core.CodeAnalysis.DiagnosticSeverity.Warning => DiagnosticSeverity.Warning,
+            _ => DiagnosticSeverity.Information,
         };
     }
 

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -28,9 +28,23 @@ public static class HoverComputer
         var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
         var symbol = SemanticLookup.ResolveSymbol(compilation, token);
 
+        // When the token isn't directly in the semantic model (e.g. member access
+        // on a user-defined type like person.Name), try resolving through the
+        // accessor expression's receiver type.
+        if (symbol == null)
+        {
+            symbol = TryResolveGSharpMember(content.SyntaxTree, compilation, token);
+        }
+
         var model = symbol != null
             ? BuildHoverModel(symbol, compilation)
             : BuildImportedClrModel(content.SyntaxTree, compilation, token);
+
+        // Literal tokens (numbers, strings, booleans) show their inferred type.
+        if (model == null)
+        {
+            model = BuildLiteralModel(token);
+        }
 
         if (model == null)
         {
@@ -122,6 +136,47 @@ public static class HoverComputer
         };
     }
 
+    private static HoverModel BuildLiteralModel(SyntaxToken token)
+    {
+        if (token == null)
+        {
+            return null;
+        }
+
+        var typeName = token.Kind switch
+        {
+            SyntaxKind.NumberToken => GetNumericTypeName(token.Value),
+            SyntaxKind.StringToken => "string",
+            SyntaxKind.InterpolatedStringToken => "string",
+            SyntaxKind.TrueKeyword => "bool",
+            SyntaxKind.FalseKeyword => "bool",
+            _ => null,
+        };
+
+        if (typeName == null)
+        {
+            return null;
+        }
+
+        var signature = $"({typeName}) {token.Text}";
+        return new HoverModel(signature, Array.Empty<HoverDocSection>(), OverloadCount: 1);
+    }
+
+    private static string GetNumericTypeName(object value)
+    {
+        return value switch
+        {
+            int => "int32",
+            uint => "uint32",
+            long => "int64",
+            ulong => "uint64",
+            float => "float32",
+            double => "float64",
+            decimal => "decimal",
+            _ => "int32",
+        };
+    }
+
     private static bool TryResolveClrMember(SyntaxTree tree, Compilation compilation, SyntaxToken token, out MemberInfo member, out int overloadCount)
     {
         member = null;
@@ -171,6 +226,154 @@ public static class HoverComputer
         member = methods[0];
         overloadCount = methods.Length;
         return true;
+    }
+
+    /// <summary>
+    /// Resolves a member access on a user-defined G# type (struct/class).
+    /// For example, hovering over <c>Name</c> in <c>person.Name</c> where
+    /// <c>person</c> is a G#-defined class resolves to the <see cref="PropertySymbol"/>,
+    /// <see cref="FieldSymbol"/>, <see cref="EventSymbol"/>, or <see cref="FunctionSymbol"/>
+    /// declared on that type.
+    /// </summary>
+    private static Symbol TryResolveGSharpMember(SyntaxTree tree, Compilation compilation, SyntaxToken token)
+    {
+        if (token == null || token.Kind != SyntaxKind.IdentifierToken)
+        {
+            return null;
+        }
+
+        // Case 1: member access expression (e.g. var x = person.Name)
+        var accessor = FindAccessorWithHoveredRightPart(tree.Root, token);
+        if (accessor != null && TryGetAccessorMemberName(accessor.RightPart, token, out var memberName))
+        {
+            var structSymbol = ResolveReceiverStructSymbol(tree, compilation, accessor.LeftPart);
+            if (structSymbol != null)
+            {
+                return LookupMemberOnStruct(structSymbol, memberName);
+            }
+        }
+
+        // Case 2: field assignment expression (e.g. person.Age = 30)
+        var fieldAssignment = FindFieldAssignmentWithHoveredField(tree.Root, token);
+        if (fieldAssignment != null)
+        {
+            var receiverSymbol = SemanticLookup.ResolveSymbol(compilation, fieldAssignment.Receiver);
+            var receiverStruct = receiverSymbol switch
+            {
+                VariableSymbol variable => variable.Type as StructSymbol,
+                StructSymbol structSym => structSym,
+                _ => null,
+            };
+
+            if (receiverStruct != null)
+            {
+                return LookupMemberOnStruct(receiverStruct, fieldAssignment.FieldIdentifier.Text);
+            }
+        }
+
+        return null;
+    }
+
+    private static FieldAssignmentExpressionSyntax FindFieldAssignmentWithHoveredField(SyntaxNode root, SyntaxToken token)
+    {
+        return FindNodes<FieldAssignmentExpressionSyntax>(root)
+            .Where(f => MatchesToken(f.FieldIdentifier, token))
+            .FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Resolves the receiver expression of an accessor to its <see cref="StructSymbol"/>
+    /// type (user-defined G# struct or class).
+    /// </summary>
+    private static StructSymbol ResolveReceiverStructSymbol(SyntaxTree tree, Compilation compilation, ExpressionSyntax expression)
+    {
+        switch (expression)
+        {
+            case NameExpressionSyntax name:
+                var symbol = SemanticLookup.ResolveSymbol(compilation, name.IdentifierToken);
+                return symbol switch
+                {
+                    VariableSymbol variable => variable.Type as StructSymbol,
+                    StructSymbol structSym => structSym,
+                    _ => null,
+                };
+            case CallExpressionSyntax call:
+                var callSymbol = SemanticLookup.ResolveSymbol(compilation, call.Identifier);
+                return callSymbol switch
+                {
+                    FunctionSymbol function => function.Type as StructSymbol,
+                    StructSymbol structSym => structSym,
+                    _ => null,
+                };
+            case AccessorExpressionSyntax nestedAccessor:
+                // Chained access: resolve the intermediate member's type.
+                if (!TryGetAccessorMemberName(nestedAccessor.RightPart, token: null, out var intermediateName))
+                {
+                    return null;
+                }
+
+                var outerStruct = ResolveReceiverStructSymbol(tree, compilation, nestedAccessor.LeftPart);
+                if (outerStruct == null)
+                {
+                    return null;
+                }
+
+                var member = LookupMemberOnStruct(outerStruct, intermediateName);
+                return member switch
+                {
+                    PropertySymbol property => property.Type as StructSymbol,
+                    FieldSymbol field => field.Type as StructSymbol,
+                    FunctionSymbol function => function.Type as StructSymbol,
+                    _ => null,
+                };
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// Looks up a member (property, field, event, or method) by name on a G# struct/class symbol,
+    /// including inherited members from base classes.
+    /// </summary>
+    private static Symbol LookupMemberOnStruct(StructSymbol structSymbol, string memberName)
+    {
+        // Walk the type hierarchy (including base classes).
+        for (var current = structSymbol; current != null; current = current.BaseClass)
+        {
+            // Properties (instance + static)
+            var property = current.Properties.Concat(current.StaticProperties)
+                .FirstOrDefault(p => p.Name == memberName);
+            if (property != null)
+            {
+                return property;
+            }
+
+            // Fields (instance + static)
+            var field = current.Fields.Concat(current.StaticFields)
+                .FirstOrDefault(f => f.Name == memberName);
+            if (field != null)
+            {
+                return field;
+            }
+
+            // Events (instance + static)
+            var @event = current.Events.Concat(current.StaticEvents)
+                .FirstOrDefault(e => e.Name == memberName);
+            if (@event != null)
+            {
+                return @event;
+            }
+
+            // Methods (instance + static)
+            var method = current.Methods.Concat(current.StaticMethods)
+                .FirstOrDefault(m => m.Name == memberName);
+            if (method != null)
+            {
+                return method;
+            }
+        }
+
+        return null;
     }
 
     private static AccessorExpressionSyntax FindAccessorWithHoveredRightPart(SyntaxNode root, SyntaxToken token)

--- a/test/Core.Tests/CodeAnalysis/Documentation/DocumentationValidatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Documentation/DocumentationValidatorTests.cs
@@ -77,6 +77,40 @@ public class DocumentationValidatorTests
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0228" && d.Message.Contains("'Foo'"));
     }
 
+    [Fact]
+    public void UnknownDocTag_ProducesGS0231()
+    {
+        var result = Compile(
+            """
+            package Lib
+
+            /// Gets a value.
+            /// @return the value
+            func Get() int32 {
+                return 0
+            }
+            """);
+
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0231" && d.Message.Contains("'@return'"));
+    }
+
+    [Fact]
+    public void KnownDocTag_DoesNotProduceGS0231()
+    {
+        var result = Compile(
+            """
+            package Lib
+
+            /// Gets a value.
+            /// @returns the value
+            func Get() int32 {
+                return 0
+            }
+            """);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0231");
+    }
+
     private static EmitResult Compile(string source, bool warnOnMissingDocs = false)
     {
         var tree = SyntaxTree.Parse(source);

--- a/test/LanguageServer.Tests/DocumentDiagnosticHandlerTests.cs
+++ b/test/LanguageServer.Tests/DocumentDiagnosticHandlerTests.cs
@@ -160,4 +160,28 @@ public class DocumentDiagnosticHandlerTests
         });
         return (server, uri);
     }
+
+    [Fact]
+    public async Task DocumentDiagnostic_UnknownDocTag_ReportsGS0231Warning()
+    {
+        const string source = """
+            package Lib
+
+            /// Gets a value.
+            /// @return the value
+            func Get() int32 {
+                return 0
+            }
+            """;
+        var (server, uri) = await CreateServerWithDocumentAsync(source);
+
+        var report = await server.DocumentDiagnosticAsync(
+            new DocumentDiagnosticParams { TextDocument = new TextDocumentIdentifier { Uri = uri } },
+            CancellationToken.None);
+
+        var full = Assert.IsType<FullDocumentDiagnosticReport>(report);
+        var diag = Assert.Single(full.Items, d => d.Code.Value == "GS0231");
+        Assert.Equal(DiagnosticSeverity.Warning, diag.Severity);
+        Assert.Contains("@return", diag.Message, StringComparison.Ordinal);
+    }
 }

--- a/test/LanguageServer.Tests/HoverHandlerTests.cs
+++ b/test/LanguageServer.Tests/HoverHandlerTests.cs
@@ -18,9 +18,9 @@ public class HoverHandlerTests
     [InlineData("var count = 0\n", "count", "var count int32")]
     [InlineData("func add(a int32, b int32) int32 { return a + b }\n", "add", "func add(a int32, b int32) int32")]
     [InlineData("func greet(name string) { }\n", "name", "name string")]
-    [InlineData("type Point struct {\nX int32\nY int32\n}\n", "Point", "struct Point { X int32; Y int32 }")]
+    [InlineData("type Point struct {\nX int32\nY int32\n}\n", "Point", "type Point struct { X int32; Y int32 }")]
     [InlineData("type Color enum { Red, Green }\n", "Color", "enum Color { Red, Green }")]
-    [InlineData("import System\nfunc main() {\nConsole.WriteLine(\"hi\")\n}\n", "Console", "class System.Console")]
+    [InlineData("import System\nfunc main() {\nConsole.WriteLine(\"hi\")\n}\n", "Console", "type System.Console class")]
     public void ComputeHover_ReturnsMarkdownSignature(string source, string token, string expected)
     {
         var content = LanguageServerTestHelpers.Content(source);
@@ -75,6 +75,75 @@ public class HoverHandlerTests
     }
 
     [Fact]
+    public void ComputeHover_ResolvesPropertyOnUserDefinedClass()
+    {
+        const string source = "package P\ntype Person class {\n    /// The name\n    prop Name string\n}\nfunc Main() {\n    var person = Person{}\n    var n = person.Name\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "Name", 1));
+
+        Assert.NotNull(hover);
+        var value = hover.Contents.ToString();
+        Assert.Contains("Name string", value, System.StringComparison.Ordinal);
+        Assert.Contains("The name", value, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ComputeHover_ResolvesFieldOnUserDefinedStruct()
+    {
+        const string source = "package P\ntype Point struct {\n    /// X coordinate\n    X int32\n    Y int32\n}\nfunc Main() {\n    var p = Point{}\n    var x = p.X\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "X", 1));
+
+        Assert.NotNull(hover);
+        var value = hover.Contents.ToString();
+        Assert.Contains("X int32", value, System.StringComparison.Ordinal);
+        Assert.Contains("X coordinate", value, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ComputeHover_ResolvesMethodOnUserDefinedClass()
+    {
+        const string source = "package P\ntype Person class {\n    prop Name string\n    /// Says hello\n    func Greet() string { return \"hi\" }\n}\nfunc Main() {\n    var person = Person{}\n    person.Greet()\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "Greet", 1));
+
+        Assert.NotNull(hover);
+        var value = hover.Contents.ToString();
+        Assert.Contains("Greet", value, System.StringComparison.Ordinal);
+        Assert.Contains("Says hello", value, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ComputeHover_ResolvesFieldAssignmentOnUserDefinedClass()
+    {
+        const string source = "package P\ntype Person class {\n    /// The age of the person\n    prop Age int32\n}\nfunc Main() {\n    var person = Person{}\n    person.Age = 30\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "Age", 1));
+
+        Assert.NotNull(hover);
+        var value = hover.Contents.ToString();
+        Assert.Contains("Age int32", value, System.StringComparison.Ordinal);
+        Assert.Contains("The age of the person", value, System.StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("func main() {\n    let x = 42\n}\n", "42", "int32")]
+    [InlineData("func main() {\n    let x = 3.14\n}\n", "3.14", "float64")]
+    [InlineData("func main() {\n    let x = \"hello\"\n}\n", "\"hello\"", "string")]
+    [InlineData("func main() {\n    let x = true\n}\n", "true", "bool")]
+    [InlineData("func main() {\n    let x = false\n}\n", "false", "bool")]
+    public void ComputeHover_ShowsLiteralType(string source, string token, string expectedType)
+    {
+        var content = LanguageServerTestHelpers.Content(source);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, token));
+
+        Assert.NotNull(hover);
+        var value = hover.Contents.ToString();
+        Assert.Contains(expectedType, value, System.StringComparison.Ordinal);
+        Assert.Contains(token, value, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ComputeHover_RendersImportedClrInstancePropertyDocumentation()
     {
         const string source = "import System.Text\nfunc main() {\n    var sb = StringBuilder()\n    var length = sb.Length\n}\n";
@@ -84,7 +153,7 @@ public class HoverHandlerTests
         Assert.NotNull(hover);
         var value = hover.Contents.ToString();
         Assert.Contains("System.Text.StringBuilder.Length", value, System.StringComparison.Ordinal);
-        Assert.Contains("System.Int32", value, System.StringComparison.Ordinal);
+        Assert.Contains("int32", value, System.StringComparison.Ordinal);
     }
 
     [Fact]
@@ -97,7 +166,7 @@ public class HoverHandlerTests
         Assert.NotNull(hover);
         var value = hover.Contents.ToString();
         Assert.Contains("System.Math.PI", value, System.StringComparison.Ordinal);
-        Assert.Contains("System.Double", value, System.StringComparison.Ordinal);
+        Assert.Contains("float64", value, System.StringComparison.Ordinal);
     }
 
     [Fact]
@@ -123,8 +192,9 @@ public class HoverHandlerTests
 
         Assert.NotNull(hover);
         var value = hover.Contents.ToString();
-        Assert.Contains("System.Console.WriteLine", value, System.StringComparison.Ordinal);
-        Assert.Contains("System.Void", value, System.StringComparison.Ordinal);
+        Assert.Contains("func", value, System.StringComparison.Ordinal);
+        Assert.Contains("System.Console", value, System.StringComparison.Ordinal);
+        Assert.Contains("WriteLine", value, System.StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Enhances the VS Code extension hover experience and adds a new documentation diagnostic.

### Hover improvements
- **User-defined G# type members**: Hover now works on property/field/method access expressions (e.g. `person.Name`, `person.Age`, `person.ToString()`)
- **Field assignments**: Hover works on the left-hand side of assignments like `person.Age = 30`
- **Literals**: Hovering over literals shows their type — e.g. `(int32) 42`, `(string) "hello"`, `(bool) true`

### G#-flavored symbol display
- Types render as `type System.Console class` (not `class System.Console`)
- Methods render as `func (System.Console) WriteLine(...)` (not `System.Void System.Console.WriteLine(...)`)
- Properties/fields show name before type: `System.Text.StringBuilder.Length int32 { get; set; }`
- CLR primitives map to G# names: `System.Int32` → `int32`, `System.String` → `string`, etc.
- Supports `ref struct`, `data`, `inline` modifiers

### GS0231 — Unknown documentation tag
- Emits a warning when an unrecognized `@tag` is used in a doc comment (e.g. `@return` instead of `@returns`)
- Lists the valid tags in the diagnostic message
- Wired into the LSP pipeline so the warning appears as a squiggle in VS Code

### Tests
- 11 new tests across Core.Tests and LanguageServer.Tests
- All 2,084 tests pass