### PR TITLE
Fix FieldAccessException for class auto-property access from outside the type

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -461,7 +461,7 @@ public sealed class Binder
             {
                 var binder = new Binder(parentScope, method);
                 var body = binder.BindStatement(method.Declaration.Body);
-                var loweredBody = Lowerer.Lower(body);
+                var loweredBody = Lowerer.Lower(body, structSym);
 
                 if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(loweredBody))
                 {
@@ -487,7 +487,7 @@ public sealed class Binder
 
             var ctorBinder = new Binder(parentScope, ctor.Function);
             var ctorBody = ctorBinder.BindStatement(ctor.Declaration.Body);
-            var ctorLoweredBody = Lowerer.Lower(ctorBody);
+            var ctorLoweredBody = Lowerer.Lower(ctorBody, structSym);
             functionBodies.Add(ctor.Function, ctorLoweredBody);
             diagnostics.AddRange(ctorBinder.Diagnostics);
         }
@@ -509,7 +509,7 @@ public sealed class Binder
                     {
                         var binder = new Binder(parentScope, prop.GetterSymbol);
                         var body = binder.BindStatement(prop.GetterBodySyntax);
-                        var loweredBody = Lowerer.Lower(body);
+                        var loweredBody = Lowerer.Lower(body, structSym);
 
                         if (!ControlFlowGraph.AllPathsReturn(loweredBody))
                         {
@@ -524,7 +524,7 @@ public sealed class Binder
                     {
                         var binder = new Binder(parentScope, prop.SetterSymbol);
                         var body = binder.BindStatement(prop.SetterBodySyntax);
-                        var loweredBody = Lowerer.Lower(body);
+                        var loweredBody = Lowerer.Lower(body, structSym);
                         functionBodies.Add(prop.SetterSymbol, loweredBody);
                         diagnostics.AddRange(binder.Diagnostics);
                     }
@@ -545,7 +545,7 @@ public sealed class Binder
                     {
                         var binder = new Binder(parentScope, ev.AddMethodSymbol);
                         var body = binder.BindStatement(ev.AddBodySyntax);
-                        var loweredBody = Lowerer.Lower(body);
+                        var loweredBody = Lowerer.Lower(body, structSym);
                         functionBodies.Add(ev.AddMethodSymbol, loweredBody);
                         diagnostics.AddRange(binder.Diagnostics);
                     }
@@ -554,7 +554,7 @@ public sealed class Binder
                     {
                         var binder = new Binder(parentScope, ev.RemoveMethodSymbol);
                         var body = binder.BindStatement(ev.RemoveBodySyntax);
-                        var loweredBody = Lowerer.Lower(body);
+                        var loweredBody = Lowerer.Lower(body, structSym);
                         functionBodies.Add(ev.RemoveMethodSymbol, loweredBody);
                         diagnostics.AddRange(binder.Diagnostics);
                     }
@@ -564,7 +564,7 @@ public sealed class Binder
                     {
                         var binder = new Binder(parentScope, ev.RaiseMethodSymbol);
                         var body = binder.BindStatement(ev.RaiseBodySyntax);
-                        var loweredBody = Lowerer.Lower(body);
+                        var loweredBody = Lowerer.Lower(body, structSym);
                         functionBodies.Add(ev.RaiseMethodSymbol, loweredBody);
                         diagnostics.AddRange(binder.Diagnostics);
                     }
@@ -591,7 +591,7 @@ public sealed class Binder
                 {
                     var binder = new Binder(parentScope, prop.GetterSymbol);
                     var body = binder.BindStatement(prop.GetterBodySyntax);
-                    var loweredBody = Lowerer.Lower(body);
+                    var loweredBody = Lowerer.Lower(body, structSym);
 
                     if (!ControlFlowGraph.AllPathsReturn(loweredBody))
                     {
@@ -606,7 +606,7 @@ public sealed class Binder
                 {
                     var binder = new Binder(parentScope, prop.SetterSymbol);
                     var body = binder.BindStatement(prop.SetterBodySyntax);
-                    var loweredBody = Lowerer.Lower(body);
+                    var loweredBody = Lowerer.Lower(body, structSym);
                     functionBodies.Add(prop.SetterSymbol, loweredBody);
                     diagnostics.AddRange(binder.Diagnostics);
                 }
@@ -632,7 +632,7 @@ public sealed class Binder
                 {
                     var binder = new Binder(parentScope, ev.AddMethodSymbol);
                     var body = binder.BindStatement(ev.AddBodySyntax);
-                    var loweredBody = Lowerer.Lower(body);
+                    var loweredBody = Lowerer.Lower(body, structSym);
                     functionBodies.Add(ev.AddMethodSymbol, loweredBody);
                     diagnostics.AddRange(binder.Diagnostics);
                 }
@@ -641,7 +641,7 @@ public sealed class Binder
                 {
                     var binder = new Binder(parentScope, ev.RemoveMethodSymbol);
                     var body = binder.BindStatement(ev.RemoveBodySyntax);
-                    var loweredBody = Lowerer.Lower(body);
+                    var loweredBody = Lowerer.Lower(body, structSym);
                     functionBodies.Add(ev.RemoveMethodSymbol, loweredBody);
                     diagnostics.AddRange(binder.Diagnostics);
                 }
@@ -651,7 +651,7 @@ public sealed class Binder
                 {
                     var binder = new Binder(parentScope, ev.RaiseMethodSymbol);
                     var body = binder.BindStatement(ev.RaiseBodySyntax);
-                    var loweredBody = Lowerer.Lower(body);
+                    var loweredBody = Lowerer.Lower(body, structSym);
                     functionBodies.Add(ev.RaiseMethodSymbol, loweredBody);
                     diagnostics.AddRange(binder.Diagnostics);
                 }
@@ -675,7 +675,7 @@ public sealed class Binder
 
                 var binder = new Binder(parentScope, method);
                 var body = binder.BindStatement(method.Declaration.Body);
-                var loweredBody = Lowerer.Lower(body);
+                var loweredBody = Lowerer.Lower(body, structSym);
 
                 if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(loweredBody))
                 {

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -16,10 +16,18 @@ namespace GSharp.Core.CodeAnalysis.Lowering;
 /// </summary>
 public sealed class Lowerer : BoundTreeRewriter
 {
+    // The type whose body is currently being lowered. When non-null, auto-property
+    // access on this type is lowered to direct backing-field access (the accessor
+    // is inside the type and has access to its private fields). When null (e.g.
+    // top-level statements), auto-property access remains as property access so
+    // the emitter generates callvirt get_/set_ — avoiding FieldAccessException.
+    private readonly StructSymbol declaringType;
+
     private int labelCount;
 
-    private Lowerer()
+    private Lowerer(StructSymbol declaringType = null)
     {
+        this.declaringType = declaringType;
     }
 
     /// <summary>
@@ -30,6 +38,22 @@ public sealed class Lowerer : BoundTreeRewriter
     public static BoundBlockStatement Lower(BoundStatement statement)
     {
         var lowerer = new Lowerer();
+        var result = lowerer.RewriteStatement(statement);
+        return Flatten(result);
+    }
+
+    /// <summary>
+    /// Produces a lowered version of the supplied bound statement within the
+    /// context of a declaring type. Auto-property access on the declaring type
+    /// is lowered to direct backing-field access; access from outside the type
+    /// is left as property access (emitted as callvirt get_/set_).
+    /// </summary>
+    /// <param name="statement">The bound statement.</param>
+    /// <param name="declaringType">The type whose member body is being lowered.</param>
+    /// <returns>A lowered version of the bound statement.</returns>
+    public static BoundBlockStatement Lower(BoundStatement statement, StructSymbol declaringType)
+    {
+        var lowerer = new Lowerer(declaringType);
         var result = lowerer.RewriteStatement(statement);
         return Flatten(result);
     }
@@ -300,13 +324,16 @@ public sealed class Lowerer : BoundTreeRewriter
     /// <inheritdoc/>
     protected override BoundExpression RewritePropertyAccessExpression(BoundPropertyAccessExpression node)
     {
-        // ADR-0051: auto-properties lower to backing field access.
-        if (node.Property.IsAutoProperty && node.Property.BackingField != null)
+        // ADR-0051: auto-properties lower to backing field access, but ONLY when
+        // we are inside the declaring type. From outside the type, the backing
+        // field is private so we must go through the accessor method (callvirt).
+        if (node.Property.IsAutoProperty && node.Property.BackingField != null
+            && this.declaringType != null && node.StructType == this.declaringType)
         {
             return new BoundFieldAccessExpression(null, node.Receiver, node.StructType, node.Property.BackingField);
         }
 
-        // Computed properties remain as BoundPropertyAccessExpression —
+        // Computed properties (or external access) remain as BoundPropertyAccessExpression —
         // the interpreter evaluates the getter body and the emitter emits a call to get_X.
         return base.RewritePropertyAccessExpression(node);
     }
@@ -314,8 +341,10 @@ public sealed class Lowerer : BoundTreeRewriter
     /// <inheritdoc/>
     protected override BoundExpression RewritePropertyAssignmentExpression(BoundPropertyAssignmentExpression node)
     {
-        // ADR-0051: auto-properties lower to backing field assignment.
-        if (node.Property.IsAutoProperty && node.Property.BackingField != null)
+        // ADR-0051: auto-properties lower to backing field assignment, but ONLY
+        // when we are inside the declaring type (same rationale as read access).
+        if (node.Property.IsAutoProperty && node.Property.BackingField != null
+            && this.declaringType != null && node.StructType == this.declaringType)
         {
             var value = RewriteExpression(node.Value);
 
@@ -331,7 +360,8 @@ public sealed class Lowerer : BoundTreeRewriter
             }
         }
 
-        // Computed properties (or non-variable receivers) remain as BoundPropertyAssignmentExpression.
+        // Computed properties (or non-variable receivers, or external access)
+        // remain as BoundPropertyAssignmentExpression.
         return base.RewritePropertyAssignmentExpression(node);
     }
 


### PR DESCRIPTION
## Problem

Accessing auto-properties on a class from outside the declaring type (e.g. `person.Name = "Alice"` in `Main()`) throws `System.FieldAccessException` at runtime:

```
Attempt by method 'Temp.<Program>.Main()' to access field 'Temp.Person.<Name>k__BackingField' failed.
```

## Root Cause

The Lowerer unconditionally lowered auto-property access to direct backing-field access (`stfld`/`ldfld`). Since backing fields are emitted as `FieldAttributes.Private`, any access from outside the declaring type violates CLR access rules.

## Fix

Added a `declaringType` context parameter to `Lowerer.Lower()`. Auto-property access is now only lowered to direct field access when the code being lowered belongs to the same type that owns the property (where the private backing field is accessible). External access remains as `BoundPropertyAccessExpression`/`BoundPropertyAssignmentExpression`, causing the emitter to generate `callvirt get_X`/`set_X` — matching C# semantics.

## Testing

- All 2,084 existing tests pass
- Verified the original repro case now runs successfully
- Cross-assembly C# interop (PropertyRef sample) continues to work as before