### PR TITLE
Fix hover for 'this' and implicit this member access in class methods

### DIFF
--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -276,6 +276,18 @@ public static class HoverComputer
             }
         }
 
+        // Case 3: implicit this — bare identifier inside a struct/class method body
+        // that matches a member of the enclosing type (e.g. `Name` instead of `this.Name`).
+        var enclosingStruct = FindEnclosingStructSymbol(tree, compilation, token);
+        if (enclosingStruct != null)
+        {
+            var member = LookupMemberOnStruct(enclosingStruct, token.Text);
+            if (member != null)
+            {
+                return member;
+            }
+        }
+
         return null;
     }
 
@@ -284,6 +296,36 @@ public static class HoverComputer
         return FindNodes<FieldAssignmentExpressionSyntax>(root)
             .Where(f => MatchesToken(f.FieldIdentifier, token))
             .FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Finds the <see cref="StructSymbol"/> for the struct/class whose method body
+    /// encloses <paramref name="token"/>, if any. Used for implicit-this resolution.
+    /// </summary>
+    private static StructSymbol FindEnclosingStructSymbol(SyntaxTree tree, Compilation compilation, SyntaxToken token)
+    {
+        // Find the innermost StructDeclarationSyntax whose span contains the token.
+        var enclosingDecl = FindNodes<StructDeclarationSyntax>(tree.Root)
+            .Where(s => s.Span.Start <= token.Span.Start && token.Span.End <= s.Span.End)
+            .OrderBy(s => s.Span.Length)
+            .FirstOrDefault();
+
+        if (enclosingDecl == null)
+        {
+            return null;
+        }
+
+        // Ensure the token is inside a method body, not in the struct's own declarations.
+        var insideMethod = enclosingDecl.Methods
+            .Any(m => m.Body != null && m.Body.Span.Start <= token.Span.Start && token.Span.End <= m.Body.Span.End);
+        if (!insideMethod)
+        {
+            return null;
+        }
+
+        // Resolve the struct declaration to its symbol.
+        var structSymbol = SemanticLookup.ResolveSymbol(compilation, enclosingDecl.Identifier) as StructSymbol;
+        return structSymbol;
     }
 
     /// <summary>

--- a/src/LanguageServer/SemanticLookup.cs
+++ b/src/LanguageServer/SemanticLookup.cs
@@ -344,6 +344,20 @@ public static class SemanticLookup
                     declarations,
                     aggregate.Declaration.Methods.Select(m => m.Identifier),
                     aggregate.Methods.Concat(aggregate.StaticMethods));
+
+                // Register parameters and implicit 'this' for struct/class methods
+                // so that hover, go-to-definition, etc. work inside method bodies.
+                foreach (var method in aggregate.Methods.Concat(aggregate.StaticMethods))
+                {
+                    if (method.Declaration != null)
+                    {
+                        MapParameters(method.Declaration, method.Parameters, declarations, localDeclarations);
+                        if (method.ThisParameter != null)
+                        {
+                            GetLocals(localDeclarations, method.Declaration)[method.ThisParameter.Name] = method.ThisParameter;
+                        }
+                    }
+                }
             }
         }
 

--- a/test/LanguageServer.Tests/HoverHandlerTests.cs
+++ b/test/LanguageServer.Tests/HoverHandlerTests.cs
@@ -252,6 +252,44 @@ public class HoverHandlerTests
         Assert.DoesNotContain("overload", hover.Contents.ToString(), System.StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ComputeHover_ThisKeyword_InsideClassMethod_ResolvesToReceiver()
+    {
+        const string source = "package P\ntype Person class {\n    prop Name string\n    func ToString() string {\n        return \"${this.Name}\"\n    }\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        // Hover on 'this' should resolve to the implicit receiver parameter.
+        var hoverThis = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "this"));
+        Assert.NotNull(hoverThis);
+        Assert.Contains("Person", hoverThis.Contents.ToString(), System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ComputeHover_MemberAccess_ViaThis_InsideClassMethod()
+    {
+        const string source = "package P\ntype Person class {\n    prop Name string\n    func ToString() string {\n        return \"${this.Name}\"\n    }\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        // Hover on 'Name' in 'this.Name' should resolve to the property.
+        var hoverName = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "Name", 1));
+        Assert.NotNull(hoverName);
+        Assert.Contains("Name", hoverName.Contents.ToString(), System.StringComparison.Ordinal);
+        Assert.Contains("string", hoverName.Contents.ToString(), System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ComputeHover_ImplicitThis_BarePropertyName_InsideClassMethod()
+    {
+        const string source = "package P\ntype Person class {\n    prop Name string\n    prop Age int32\n    func Greet() string {\n        return Name\n    }\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        // Hover on bare 'Name' inside method body should resolve to the property via implicit this.
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "Name", 1));
+        Assert.NotNull(hover);
+        Assert.Contains("Name", hover.Contents.ToString(), System.StringComparison.Ordinal);
+        Assert.Contains("string", hover.Contents.ToString(), System.StringComparison.Ordinal);
+    }
+
     private static ReferenceResolver CreateReferencePackResolver()
     {
         var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);


### PR DESCRIPTION
## Problem

Hovering over `this`, `this.Name`, or bare `Name` inside a struct/class method body produced no doc card. This affected both regular statements and interpolated string holes.

## Root Cause

The language server's semantic model never registered the implicit `this` parameter for struct/class instance methods as a local, so:
- `this` couldn't be resolved to the receiver `ParameterSymbol`
- `this.Member` couldn't resolve the receiver type to look up the member
- Bare member names (implicit this) had no fallback resolution path

## Fix

1. **`SemanticLookup.BuildModel`**: After mapping struct method identifiers, also register each method's parameters and `ThisParameter` as locals — mirroring what was already done for top-level functions with explicit receivers.

2. **`HoverComputer.TryResolveGSharpMember`**: Added Case 3 (implicit this) with a `FindEnclosingStructSymbol` helper that detects when a bare identifier is inside a method body and resolves it against the enclosing type's members.

## Tests

Added three new tests:
- Hover on `this` keyword → shows receiver type
- Hover on `Name` in `this.Name` → shows property info
- Hover on bare `Name` (implicit this) → shows property info

All 2124 tests pass.