### PR TITLE
Fix #419: short-circuit evaluation for && and ||

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -11464,6 +11464,25 @@ internal sealed class ReflectionMetadataEmitter
                 return;
             }
 
+            // Short-circuit evaluation for logical `&&` and `||`: the right
+            // operand must not be evaluated when the left operand already
+            // determines the result. Emit a dup + conditional branch so the
+            // LHS value is reused as the result without evaluating the RHS.
+            if (b.Op.Kind == BoundBinaryOperatorKind.LogicalAnd ||
+                b.Op.Kind == BoundBinaryOperatorKind.LogicalOr)
+            {
+                var endLabel = this.il.DefineLabel();
+                this.EmitExpression(b.Left);
+                this.il.OpCode(ILOpCode.Dup);
+                this.il.Branch(
+                    b.Op.Kind == BoundBinaryOperatorKind.LogicalAnd ? ILOpCode.Brfalse : ILOpCode.Brtrue,
+                    endLabel);
+                this.il.OpCode(ILOpCode.Pop);
+                this.EmitExpression(b.Right);
+                this.il.MarkLabel(endLabel);
+                return;
+            }
+
             this.EmitExpression(b.Left);
             this.EmitExpression(b.Right);
             if (b.Left.Type == TypeSymbol.Decimal && b.Right.Type == TypeSymbol.Decimal)
@@ -11499,11 +11518,9 @@ internal sealed class ReflectionMetadataEmitter
                     this.il.OpCode(isUnsigned ? ILOpCode.Shr_un : ILOpCode.Shr);
                     break;
                 case BoundBinaryOperatorKind.BitwiseAnd:
-                case BoundBinaryOperatorKind.LogicalAnd:
                     this.il.OpCode(ILOpCode.And);
                     break;
                 case BoundBinaryOperatorKind.BitwiseOr:
-                case BoundBinaryOperatorKind.LogicalOr:
                     this.il.OpCode(ILOpCode.Or);
                     break;
                 case BoundBinaryOperatorKind.BitwiseXor:

--- a/test/Core.Tests/CodeAnalysis/Emit/ShortCircuitEvalEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/ShortCircuitEvalEmitTests.cs
@@ -1,0 +1,210 @@
+// <copyright file="ShortCircuitEvalEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Regression tests for issue #419 (P0-1): the logical operators `&amp;&amp;`
+/// and `||` must short-circuit — the right operand must NOT be evaluated when
+/// the left operand already determines the result.
+/// </summary>
+public class ShortCircuitEvalEmitTests
+{
+    [Fact]
+    public void LogicalAnd_DoesNotEvaluateRight_WhenLeftIsFalse()
+    {
+        const string Source = @"package ShortAndFalse
+import System
+var counter = 0
+func sideEffect() bool {
+    counter = counter + 1
+    return true
+}
+var r = false && sideEffect()
+Console.WriteLine(counter)
+Console.WriteLine(r)
+";
+        var lines = SplitLines(CompileLoadInvokeCaptureStdout(Source, "ShortCircuit-AndFalse"));
+        Assert.Equal("0", lines[0]);
+        Assert.Equal("False", lines[1]);
+    }
+
+    [Fact]
+    public void LogicalOr_DoesNotEvaluateRight_WhenLeftIsTrue()
+    {
+        const string Source = @"package ShortOrTrue
+import System
+var counter = 0
+func sideEffect() bool {
+    counter = counter + 1
+    return false
+}
+var r = true || sideEffect()
+Console.WriteLine(counter)
+Console.WriteLine(r)
+";
+        var lines = SplitLines(CompileLoadInvokeCaptureStdout(Source, "ShortCircuit-OrTrue"));
+        Assert.Equal("0", lines[0]);
+        Assert.Equal("True", lines[1]);
+    }
+
+    [Fact]
+    public void LogicalAnd_EvaluatesRight_WhenLeftIsTrue()
+    {
+        const string Source = @"package ShortAndTrue
+import System
+var counter = 0
+func sideEffect() bool {
+    counter = counter + 1
+    return true
+}
+var r = true && sideEffect()
+Console.WriteLine(counter)
+Console.WriteLine(r)
+";
+        var lines = SplitLines(CompileLoadInvokeCaptureStdout(Source, "ShortCircuit-AndTrue"));
+        Assert.Equal("1", lines[0]);
+        Assert.Equal("True", lines[1]);
+    }
+
+    [Fact]
+    public void LogicalOr_EvaluatesRight_WhenLeftIsFalse()
+    {
+        const string Source = @"package ShortOrFalse
+import System
+var counter = 0
+func sideEffect() bool {
+    counter = counter + 1
+    return true
+}
+var r = false || sideEffect()
+Console.WriteLine(counter)
+Console.WriteLine(r)
+";
+        var lines = SplitLines(CompileLoadInvokeCaptureStdout(Source, "ShortCircuit-OrFalse"));
+        Assert.Equal("1", lines[0]);
+        Assert.Equal("True", lines[1]);
+    }
+
+    [Fact]
+    public void LogicalAnd_ChainsShortCircuit_StopsAtFirstFalse()
+    {
+        const string Source = @"package ShortAndChain
+import System
+var aCount = 0
+var bCount = 0
+var cCount = 0
+func a() bool {
+    aCount = aCount + 1
+    return true
+}
+func b() bool {
+    bCount = bCount + 1
+    return false
+}
+func c() bool {
+    cCount = cCount + 1
+    return true
+}
+var r = a() && b() && c()
+Console.WriteLine(aCount)
+Console.WriteLine(bCount)
+Console.WriteLine(cCount)
+Console.WriteLine(r)
+";
+        var lines = SplitLines(CompileLoadInvokeCaptureStdout(Source, "ShortCircuit-AndChain"));
+        Assert.Equal("1", lines[0]);
+        Assert.Equal("1", lines[1]);
+        Assert.Equal("0", lines[2]);
+        Assert.Equal("False", lines[3]);
+    }
+
+    [Fact]
+    public void LogicalOr_ChainsShortCircuit_StopsAtFirstTrue()
+    {
+        const string Source = @"package ShortOrChain
+import System
+var aCount = 0
+var bCount = 0
+var cCount = 0
+func a() bool {
+    aCount = aCount + 1
+    return false
+}
+func b() bool {
+    bCount = bCount + 1
+    return true
+}
+func c() bool {
+    cCount = cCount + 1
+    return false
+}
+var r = a() || b() || c()
+Console.WriteLine(aCount)
+Console.WriteLine(bCount)
+Console.WriteLine(cCount)
+Console.WriteLine(r)
+";
+        var lines = SplitLines(CompileLoadInvokeCaptureStdout(Source, "ShortCircuit-OrChain"));
+        Assert.Equal("1", lines[0]);
+        Assert.Equal("1", lines[1]);
+        Assert.Equal("0", lines[2]);
+        Assert.Equal("True", lines[3]);
+    }
+
+    private static string[] SplitLines(string output) =>
+        output.Replace("\r\n", "\n").TrimEnd('\n').Split('\n');
+
+    private static string CompileLoadInvokeCaptureStdout(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, parameters: null);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #419 (P0-1).

## Problem

In `ReflectionMetadataEmitter.EmitBinary`, both operands of a binary expression were evaluated unconditionally **before** dispatching on the operator kind, and `LogicalAnd`/`LogicalOr` were emitted as the bitwise IL `and`/`or` opcodes. As a result, `&&` and `||` did not short-circuit — the right operand was always evaluated, breaking side-effect ordering and null-guard idioms such as `s != nil && s.Length > 0`.

### Reproducer (before this PR)

```gsharp
package main
import System
var counter = 0
func sideEffect() bool {
    counter = counter + 1
    return true
}
var r = false && sideEffect()
Console.WriteLine(counter)  // printed 1; should print 0
```

## Fix

Detect `LogicalAnd`/`LogicalOr` in `EmitBinary` **before** evaluating both operands and emit the standard CIL short-circuit pattern:

- **`&&`**: emit LHS, `dup`, `brfalse` end, `pop`, emit RHS, end:
- **`||`**: emit LHS, `dup`, `brtrue` end, `pop`, emit RHS, end:

The LHS value is reused (via `dup`) as the result of the short-circuit path, so exactly one `bool` is on the stack at the end label on both paths. The now-unreachable `LogicalAnd`/`LogicalOr` fall-through arms are removed from the bitwise switch.

## Tests

New `ShortCircuitEvalEmitTests` with six end-to-end emit tests that compile, load, and invoke real programs to assert:

- `false && f()` ⇒ counter stays `0`, result `false`
- `true || f()`  ⇒ counter stays `0`, result `true`
- `true && f()`  ⇒ counter becomes `1`, result `true`
- `false || f()` ⇒ counter becomes `1`, result `true`
- 3-operand `&&` chain stops at the first `false`
- 3-operand `||` chain stops at the first `true`

## Verification

```
dotnet build GSharp.sln -nologo -clp:NoSummary    # succeeds
dotnet test  GSharp.sln --no-restore --nologo     # 2169 passed, 0 failed
```
