### PR TITLE
Fix #419: async catch with await preserves typed dispatch

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
@@ -24,13 +24,19 @@ namespace GSharp.Core.CodeAnalysis.Lowering.Async;
 /// <para><b>Pattern A — try/catch with await in catch:</b></para>
 /// <code>
 /// Exception pendingException = null;
+/// T? capture_i = null;                 // per-clause capture of original type
 /// try { body; }
-/// catch (Exception ex) { pendingException = ex; }
-/// if (pendingException != null) {
-///     T e = (T)pendingException;   // rebind original variable
-///     handlerBody;                 // await is now outside the handler
+/// catch (T e) { capture_i = e; pendingException = e; }   // KEEP ORIGINAL TYPE
+/// if (capture_i != null) {
+///     T e = capture_i;                 // rebind original variable
+///     handlerBody;                     // await is now outside the handler
 /// }
 /// </code>
+/// <para>Keeping the catch typed (instead of widening to <c>Exception</c>) is
+/// essential for correctness: it ensures the CLR catch dispatch only fires for
+/// the original handler's exception type, so subsequent catch arms — and the
+/// rethrow paths for unmatched exceptions — keep their original semantics
+/// (issue #419).</para>
 ///
 /// <para><b>Pattern B — try/finally with await in finally:</b></para>
 /// <code>
@@ -184,28 +190,51 @@ public static class AsyncExceptionHandlerRewriter
             TypeSymbol exceptionType)
         {
             // For each catch clause with await, replace the body with
-            // pendingException = ex; and emit the real body after the try.
+            //   capture_i = e; pendingException = e;
+            // and emit the real body after the try guarded by `if (capture_i != null)`.
+            // The catch clause KEEPS the original exception type so the CLR's
+            // catch dispatch matches only the intended type (issue #419 — without
+            // this, widening to System.Exception silently catches unrelated
+            // exceptions and shadows subsequent catch arms).
+            //
             // Catch clauses without await stay in-place.
             var newClauses = ImmutableArray.CreateBuilder<BoundCatchClause>();
-            var afterTryHandlers = ImmutableArray.CreateBuilder<(BoundCatchClause Original, BoundStatement Body)>();
+            var afterTryHandlers = new System.Collections.Generic.List<(BoundCatchClause Original, BoundStatement Body, LocalVariableSymbol Capture)>();
 
             foreach (var clause in catchClauses)
             {
                 if (AsyncBoundTreeQueries.HasAwait(clause.Body))
                 {
-                    // Replace body: pendingException = ex;
+                    // Per-clause capture local of nullable-of-original-type.
+                    // A reference-type nullable shares the CLR representation,
+                    // so this is a metadata-only annotation.
+                    var captureType = NullableTypeSymbol.Get(clause.ExceptionType);
+                    var captureLocal = new LocalVariableSymbol(
+                        $"<>catch_capture_{localOrdinal++}", isReadOnly: false, captureType);
+                    statements.Add(new BoundVariableDeclaration(
+                        null,
+                        captureLocal,
+                        new BoundLiteralExpression(null, null, TypeSymbol.Null)));
+
+                    // Replace body: capture_i = e; pendingException = e;
+                    var assignCapture = new BoundExpressionStatement(
+                        null,
+                        new BoundAssignmentExpression(
+                            null,
+                            captureLocal,
+                            new BoundVariableExpression(null, clause.Variable)));
                     var assignPending = new BoundExpressionStatement(
                         null,
                         new BoundAssignmentExpression(
                             null,
                             pendingExLocal,
                             new BoundVariableExpression(null, clause.Variable)));
-                    var catchAllClause = new BoundCatchClause(
-                        exceptionType,
+                    var typedCatchClause = new BoundCatchClause(
+                        clause.ExceptionType,
                         clause.Variable,
-                        new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(assignPending)));
-                    newClauses.Add(catchAllClause);
-                    afterTryHandlers.Add((clause, clause.Body));
+                        new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(assignCapture, assignPending)));
+                    newClauses.Add(typedCatchClause);
+                    afterTryHandlers.Add((clause, clause.Body, captureLocal));
                 }
                 else
                 {
@@ -216,30 +245,34 @@ public static class AsyncExceptionHandlerRewriter
             var tryStmt = new BoundTryStatement(null, tryBody, newClauses.ToImmutable(), finallyBlock);
             statements.Add(tryStmt);
 
-            // After the try: if (pendingException != null) { T e = (T)pendingException; handlerBody; }
-            foreach (var (original, body) in afterTryHandlers)
+            // After the try: for each lifted clause emit
+            //   if (capture_i == null) goto endLabel;
+            //   T e = capture_i;
+            //   handlerBody;
+            //   endLabel:
+            // The per-clause null check ensures the handler body only runs when
+            // its specific catch fired.
+            foreach (var (original, body, captureLocal) in afterTryHandlers)
             {
                 var endLabel = MakeLabel("catch_end");
-                var pendingExRef = new BoundVariableExpression(null, pendingExLocal);
+                var captureRef = new BoundVariableExpression(null, captureLocal);
                 var nullLit = new BoundLiteralExpression(null, null, TypeSymbol.Null);
                 var condition = new BoundBinaryExpression(
                     null,
-                    pendingExRef,
+                    captureRef,
                     BoundBinaryOperator.Bind(
                         CodeAnalysis.Syntax.SyntaxKind.EqualsEqualsToken,
-                        pendingExLocal.Type,
+                        captureLocal.Type,
                         TypeSymbol.Null),
                     nullLit);
 
-                // Jump past the handler if pendingException == null
                 statements.Add(new BoundConditionalGotoStatement(null, endLabel, condition, jumpIfTrue: true));
 
-                // Rebind the original catch variable: T e = (T)pendingException;
-                // Since GSharp's catch variable type may be same as Exception, just assign directly.
+                // Rebind the original catch variable: T e = capture_i;
                 var rebind = new BoundVariableDeclaration(
                     null,
                     original.Variable,
-                    new BoundVariableExpression(null, pendingExLocal));
+                    new BoundVariableExpression(null, captureLocal));
                 statements.Add(rebind);
 
                 // Emit the handler body
@@ -268,28 +301,48 @@ public static class AsyncExceptionHandlerRewriter
             TypeSymbol exceptionType,
             bool anyCatchHasAwait)
         {
-            // Build inner try: original try body + original catches (without await ones)
-            // + a catch-all that stores into pendingException.
+            // Build inner try: original try body + original catches.
+            // Typed catches with await KEEP their original type (issue #419)
+            // and capture into a per-clause local plus pendingException so the
+            // post-finally lifted body can dispatch only when the typed catch
+            // actually fired. A final catch-all (Exception) captures any
+            // remaining exceptions into pendingException so the finally can
+            // run regardless.
             var innerClauses = ImmutableArray.CreateBuilder<BoundCatchClause>();
-            var liftedCatchHandlers = ImmutableArray.CreateBuilder<(BoundCatchClause Original, BoundStatement Body)>();
+            var liftedCatchHandlers = new System.Collections.Generic.List<(BoundCatchClause Original, BoundStatement Body, LocalVariableSymbol Capture)>();
 
             foreach (var clause in catchClauses)
             {
                 if (AsyncBoundTreeQueries.HasAwait(clause.Body))
                 {
-                    // Capture into pending and lift body after finally
+                    // Per-clause capture local of nullable-of-original-type.
+                    var captureType = NullableTypeSymbol.Get(clause.ExceptionType);
+                    var captureLocal = new LocalVariableSymbol(
+                        $"<>catch_capture_{localOrdinal++}", isReadOnly: false, captureType);
+                    statements.Add(new BoundVariableDeclaration(
+                        null,
+                        captureLocal,
+                        new BoundLiteralExpression(null, null, TypeSymbol.Null)));
+
+                    // Capture into per-clause local and into pending; lift body after finally.
+                    var assignCapture = new BoundExpressionStatement(
+                        null,
+                        new BoundAssignmentExpression(
+                            null,
+                            captureLocal,
+                            new BoundVariableExpression(null, clause.Variable)));
                     var assignPending = new BoundExpressionStatement(
                         null,
                         new BoundAssignmentExpression(
                             null,
                             pendingExLocal,
                             new BoundVariableExpression(null, clause.Variable)));
-                    var captureClause = new BoundCatchClause(
-                        exceptionType,
+                    var typedCatchClause = new BoundCatchClause(
+                        clause.ExceptionType,
                         clause.Variable,
-                        new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(assignPending)));
-                    innerClauses.Add(captureClause);
-                    liftedCatchHandlers.Add((clause, clause.Body));
+                        new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(assignCapture, assignPending)));
+                    innerClauses.Add(typedCatchClause);
+                    liftedCatchHandlers.Add((clause, clause.Body, captureLocal));
                 }
                 else
                 {
@@ -314,18 +367,20 @@ public static class AsyncExceptionHandlerRewriter
             var innerTry = new BoundTryStatement(null, tryBody, innerClauses.ToImmutable(), finallyBlock: null);
             statements.Add(innerTry);
 
-            // Emit lifted catch handlers (for catch-with-await in try/catch/finally)
-            foreach (var (original, body) in liftedCatchHandlers)
+            // Emit lifted catch handlers (for catch-with-await in try/catch/finally).
+            // Each handler is guarded by its per-clause capture so it only runs
+            // when that specific typed catch actually fired.
+            foreach (var (original, body, captureLocal) in liftedCatchHandlers)
             {
                 var endLabel = MakeLabel("liftcatch_end");
-                var pendingExRef = new BoundVariableExpression(null, pendingExLocal);
+                var captureRef = new BoundVariableExpression(null, captureLocal);
                 var nullLit = new BoundLiteralExpression(null, null, TypeSymbol.Null);
                 var condition = new BoundBinaryExpression(
                     null,
-                    pendingExRef,
+                    captureRef,
                     BoundBinaryOperator.Bind(
                         CodeAnalysis.Syntax.SyntaxKind.EqualsEqualsToken,
-                        pendingExLocal.Type,
+                        captureLocal.Type,
                         TypeSymbol.Null),
                     nullLit);
 
@@ -334,7 +389,7 @@ public static class AsyncExceptionHandlerRewriter
                 var rebind = new BoundVariableDeclaration(
                     null,
                     original.Variable,
-                    new BoundVariableExpression(null, pendingExLocal));
+                    new BoundVariableExpression(null, captureLocal));
                 statements.Add(rebind);
 
                 if (body is BoundBlockStatement block)

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriterTests.cs
@@ -133,22 +133,31 @@ ImmutableArray.Create<BoundStatement>(
         var innerBlock = result.Statements[0] as BoundBlockStatement;
         Assert.NotNull(innerBlock);
 
-        // Pending exception declaration
+        // Pending exception declaration is first.
         Assert.IsType<BoundVariableDeclaration>(innerBlock.Statements[0]);
 
-        // Try statement with modified catch (just stores exception)
-        Assert.IsType<BoundTryStatement>(innerBlock.Statements[1]);
-        var rewrittenTry = (BoundTryStatement)innerBlock.Statements[1];
+        // Find the (single) rewritten try statement. Issue #419: the rewriter
+        // now also emits a per-clause capture local before the try, so the try
+        // is no longer at a fixed index — locate it instead.
+        var rewrittenTry = innerBlock.Statements.OfType<BoundTryStatement>().Single();
         Assert.Single(rewrittenTry.CatchClauses);
 
-        // The catch body should be a block containing an assignment (pendingEx = e)
+        // The rewritten catch keeps the ORIGINAL exception type (no widening
+        // to System.Exception) so the CLR catch dispatch only matches the
+        // intended type (issue #419).
+        Assert.Same(ExceptionType, rewrittenTry.CatchClauses[0].ExceptionType);
+
+        // The catch body should be a block of assignments
+        // (capture_i = e; pendingException = e;)
         var catchBodyRewritten = rewrittenTry.CatchClauses[0].Body;
         var catchBlock = Assert.IsType<BoundBlockStatement>(catchBodyRewritten);
-        Assert.Single(catchBlock.Statements);
+        Assert.Equal(2, catchBlock.Statements.Length);
         Assert.IsType<BoundExpressionStatement>(catchBlock.Statements[0]);
+        Assert.IsType<BoundExpressionStatement>(catchBlock.Statements[1]);
 
         // The await should be outside the try (in the lifted handler section)
-        var afterTry = innerBlock.Statements.Skip(2).ToArray();
+        var tryIndex = innerBlock.Statements.IndexOf(rewrittenTry);
+        var afterTry = innerBlock.Statements.Skip(tryIndex + 1).ToArray();
         Assert.True(afterTry.Any(s => AsyncBoundTreeQueries.HasAwait(s)),
             "Await should be lifted outside the try/catch region.");
     }
@@ -260,5 +269,207 @@ ImmutableArray.Create<BoundStatement>(
 
         // Assert: the finally body is lifted (pattern B applies)
         Assert.NotSame(body, result);
+    }
+
+    // ----------------------------------------------------------------------
+    // Issue #419: typed catch with await must keep its original exception type
+    // so the CLR catch dispatch only fires for matching exceptions.
+    // ----------------------------------------------------------------------
+
+    /// <summary>
+    /// A struct-class derived from <see cref="System.Exception"/> used to stand
+    /// in for a custom typed catch in the rewriter tests.
+    /// </summary>
+    private static TypeSymbol MakeDerivedExceptionType()
+    {
+        // ArgumentException is a real subtype of Exception in the host runtime,
+        // making it a convenient typed-catch target for structural assertions.
+        return TypeSymbol.FromClrType(typeof(System.ArgumentException));
+    }
+
+    [Fact]
+    public void TryCatch_TypedCatch_WithAwait_KeepsOriginalCatchType()
+    {
+        // Arrange: try { x = 1 } catch (e ArgumentException) { await ... }
+        // The rewriter must NOT widen this to catch (Exception); otherwise an
+        // InvalidOperationException would also be swallowed.
+        var argExType = MakeDerivedExceptionType();
+        var x = new LocalVariableSymbol("x", false, TypeSymbol.Int32);
+        var e = new LocalVariableSymbol("e", false, argExType);
+        var tryBlock = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 1)))));
+        var awaitExpr = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int32);
+        var catchBody = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(null, awaitExpr)));
+        var catchClause = new BoundCatchClause(argExType, e, catchBody);
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray.Create(catchClause), null);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
+
+        // Act
+        var result = AsyncExceptionHandlerRewriter.Rewrite(body);
+
+        // Assert
+        var innerBlock = Assert.IsType<BoundBlockStatement>(result.Statements[0]);
+        var rewrittenTry = innerBlock.Statements.OfType<BoundTryStatement>().Single();
+        Assert.Single(rewrittenTry.CatchClauses);
+        // The catch type must remain the ORIGINAL ArgumentException — never
+        // widened to System.Exception.
+        Assert.Same(argExType, rewrittenTry.CatchClauses[0].ExceptionType);
+        Assert.NotSame(ExceptionType, rewrittenTry.CatchClauses[0].ExceptionType);
+    }
+
+    [Fact]
+    public void TryCatch_MultipleTypedCatches_WithAwait_KeepEachOriginalType()
+    {
+        // Arrange: catch (a ArgumentException) { await } catch (g Exception) { await }
+        // Both clauses must remain typed: the CLR's in-order dispatch handles
+        // the discriminative routing, and each lifted handler runs only for
+        // its own exception type.
+        var argExType = MakeDerivedExceptionType();
+        var x = new LocalVariableSymbol("x", false, TypeSymbol.Int32);
+        var a = new LocalVariableSymbol("a", false, argExType);
+        var g = new LocalVariableSymbol("g", false, ExceptionType);
+        var tryBlock = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 1)))));
+        var awaitA = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int32);
+        var catchBodyA = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(new BoundExpressionStatement(null, awaitA)));
+        var catchA = new BoundCatchClause(argExType, a, catchBodyA);
+        var awaitG = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int32);
+        var catchBodyG = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(new BoundExpressionStatement(null, awaitG)));
+        var catchG = new BoundCatchClause(ExceptionType, g, catchBodyG);
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray.Create(catchA, catchG), null);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
+
+        // Act
+        var result = AsyncExceptionHandlerRewriter.Rewrite(body);
+
+        // Assert
+        var innerBlock = Assert.IsType<BoundBlockStatement>(result.Statements[0]);
+        var rewrittenTry = innerBlock.Statements.OfType<BoundTryStatement>().Single();
+        Assert.Equal(2, rewrittenTry.CatchClauses.Length);
+        Assert.Same(argExType, rewrittenTry.CatchClauses[0].ExceptionType);
+        Assert.Same(ExceptionType, rewrittenTry.CatchClauses[1].ExceptionType);
+    }
+
+    [Fact]
+    public void TryCatch_TypedCatchWithAwait_FollowedByGeneralCatch_PreservesFallthrough()
+    {
+        // Arrange: catch (a ArgumentException) { await }   <- with await
+        //          catch (g Exception) { x = 2 }           <- without await; stays in place
+        // The general catch must remain reachable: prior to the fix, the
+        // ArgumentException clause was widened to Exception and shadowed it.
+        var argExType = MakeDerivedExceptionType();
+        var x = new LocalVariableSymbol("x", false, TypeSymbol.Int32);
+        var a = new LocalVariableSymbol("a", false, argExType);
+        var g = new LocalVariableSymbol("g", false, ExceptionType);
+        var tryBlock = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 1)))));
+        var awaitA = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int32);
+        var catchBodyA = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(new BoundExpressionStatement(null, awaitA)));
+        var catchA = new BoundCatchClause(argExType, a, catchBodyA);
+        var catchBodyG = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 2)))));
+        var catchG = new BoundCatchClause(ExceptionType, g, catchBodyG);
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray.Create(catchA, catchG), null);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
+
+        // Act
+        var result = AsyncExceptionHandlerRewriter.Rewrite(body);
+
+        // Assert
+        var innerBlock = Assert.IsType<BoundBlockStatement>(result.Statements[0]);
+        var rewrittenTry = innerBlock.Statements.OfType<BoundTryStatement>().Single();
+        Assert.Equal(2, rewrittenTry.CatchClauses.Length);
+
+        // First clause: typed catch with await — keeps ArgumentException type
+        // and body is the capture/pending assignments (not the original body).
+        Assert.Same(argExType, rewrittenTry.CatchClauses[0].ExceptionType);
+        var typedBody = Assert.IsType<BoundBlockStatement>(rewrittenTry.CatchClauses[0].Body);
+        Assert.All(typedBody.Statements, s => Assert.IsType<BoundExpressionStatement>(s));
+
+        // Second clause: stays in place untouched (its body is the original).
+        Assert.Same(ExceptionType, rewrittenTry.CatchClauses[1].ExceptionType);
+        Assert.Same(catchBodyG, rewrittenTry.CatchClauses[1].Body);
+    }
+
+    [Fact]
+    public void TryCatch_TypedCatchWithAwait_DispatchUsesPerClauseCaptureNotPending()
+    {
+        // The post-try lifted handler must check a per-clause capture local
+        // (not the shared pendingException) so that when the catch-all (or
+        // another catch) sets pendingException to an unrelated exception, the
+        // handler does not erroneously run.
+        var argExType = MakeDerivedExceptionType();
+        var x = new LocalVariableSymbol("x", false, TypeSymbol.Int32);
+        var e = new LocalVariableSymbol("e", false, argExType);
+        var tryBlock = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 1)))));
+        var awaitExpr = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int32);
+        var catchBody = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(new BoundExpressionStatement(null, awaitExpr)));
+        var catchClause = new BoundCatchClause(argExType, e, catchBody);
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray.Create(catchClause), null);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
+
+        // Act
+        var result = AsyncExceptionHandlerRewriter.Rewrite(body);
+
+        // Assert
+        var innerBlock = Assert.IsType<BoundBlockStatement>(result.Statements[0]);
+
+        // Should have a per-clause capture local declared before the try.
+        var declsBeforeTry = innerBlock.Statements
+            .TakeWhile(s => s is not BoundTryStatement)
+            .OfType<BoundVariableDeclaration>()
+            .ToArray();
+        Assert.Contains(declsBeforeTry, d => d.Variable.Name.StartsWith("<>catch_capture_", System.StringComparison.Ordinal));
+        Assert.Contains(declsBeforeTry, d => d.Variable.Name.StartsWith("<>pending_ex_", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TryCatchFinally_TypedCatchWithAwait_KeepsTypedDispatch()
+    {
+        // Pattern B (finally has await) must still keep the typed catch's
+        // original exception type. The trailing catch-all (Exception) is the
+        // pattern-required capture for the finally; the typed catch retains
+        // its narrow type ahead of it.
+        var argExType = MakeDerivedExceptionType();
+        var x = new LocalVariableSymbol("x", false, TypeSymbol.Int32);
+        var e = new LocalVariableSymbol("e", false, argExType);
+        var tryBlock = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 1)))));
+        var awaitA = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int32);
+        var catchBody = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(new BoundExpressionStatement(null, awaitA)));
+        var catchClause = new BoundCatchClause(argExType, e, catchBody);
+        var awaitF = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int32);
+        var finallyBlock = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(new BoundExpressionStatement(null, awaitF)));
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray.Create(catchClause), finallyBlock);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
+
+        // Act
+        var result = AsyncExceptionHandlerRewriter.Rewrite(body);
+
+        // Assert
+        var innerBlock = Assert.IsType<BoundBlockStatement>(result.Statements[0]);
+        var rewrittenTry = innerBlock.Statements.OfType<BoundTryStatement>().Single();
+        Assert.Null(rewrittenTry.FinallyBlock);
+
+        // Two clauses: typed [ArgumentException] then catch-all [Exception]
+        // (the catch-all is the finally-pattern capture).
+        Assert.Equal(2, rewrittenTry.CatchClauses.Length);
+        Assert.Same(argExType, rewrittenTry.CatchClauses[0].ExceptionType);
+        Assert.Same(ExceptionType, rewrittenTry.CatchClauses[1].ExceptionType);
     }
 }


### PR DESCRIPTION
Fixes #419.

## Problem

`AsyncExceptionHandlerRewriter` rewrote every typed catch clause whose body contained an `await` into a catch-all `catch (Exception)` that unconditionally captured into a shared `pendingException` local. The lifted handler body then ran whenever `pendingException` was non-null, with no type check.

Two consequences:

1. The widened catch swallowed exceptions the original arm should have rethrown, shadowing any subsequent catch clauses.
2. The lifted handler body executed against an exception object that was not necessarily of the original catch type.

## Fix

Keep each await-catch typed with its **original exception type** so the CLR's catch dispatch only fires for matching exceptions. Capture the caught reference into a per-clause nullable local; gate the post-try lifted handler body on `if (capture_i != null)`. Pending-exception bookkeeping is still emitted for Pattern B (try/finally with await), but typed-catch dispatch no longer depends on it.

Both `RewriteCatchWithAwait` (Pattern A) and `RewriteFinallyWithAwait` (Pattern B) are updated.

## Tests

Added structural unit tests in `AsyncExceptionHandlerRewriterTests`:

- Typed catch with await keeps its original catch type (no widening).
- Multiple typed catches with await each retain their own type.
- Typed catch with await followed by a general catch preserves CLR-level fallthrough — the general catch is reachable.
- Post-try guard uses a per-clause capture local rather than shared `pendingException`.
- `try/catch/finally` (Pattern B) variant retains typed dispatch ahead of the catch-all required by the finally lift.

Updated one pre-existing assertion that hard-coded the rewritten try at `Statements[1]` — the rewriter now also emits per-clause capture locals before the try, so the test now locates the try by type.

## Verification

Full test suite passes locally: **1601 + 277 + 54 + 212 + 24 = 2168 tests passing, 0 failing**.