### PR TITLE
Fix P0-2: rewrite return-in-try/catch/finally to leave + ret epilogue (#419)

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -25,6 +25,20 @@ public sealed class Lowerer : BoundTreeRewriter
 
     private int labelCount;
 
+    // Issue #419 (P0-2): nesting depth of the try / catch / finally regions
+    // currently being lowered. ECMA-335 forbids `ret` from inside a protected
+    // region; the only legal exit is `leave`. When the depth is positive, any
+    // BoundReturnStatement encountered is rewritten to store its value into a
+    // synthetic temp local (if non-void) and `goto` a synthetic method-exit
+    // label placed lexically OUTSIDE every protected region. The emitter
+    // already translates a goto crossing a protected-region boundary into the
+    // CIL `leave` opcode, so this rewrite is enough to keep the generated IL
+    // verifiable.
+    private int tryNestingDepth;
+    private LocalVariableSymbol returnValueLocal;
+    private BoundLabel methodExitLabel;
+    private bool hasRewrittenReturnsInProtectedRegions;
+
     private Lowerer(StructSymbol declaringType = null)
     {
         this.declaringType = declaringType;
@@ -39,6 +53,7 @@ public sealed class Lowerer : BoundTreeRewriter
     {
         var lowerer = new Lowerer();
         var result = lowerer.RewriteStatement(statement);
+        result = lowerer.WrapWithMethodExitEpilogue(result);
         return Flatten(result);
     }
 
@@ -55,7 +70,82 @@ public sealed class Lowerer : BoundTreeRewriter
     {
         var lowerer = new Lowerer(declaringType);
         var result = lowerer.RewriteStatement(statement);
+        result = lowerer.WrapWithMethodExitEpilogue(result);
         return Flatten(result);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Issue #419 (P0-2): tracks try / catch / finally nesting depth so
+    /// <see cref="RewriteReturnStatement(BoundReturnStatement)"/> can detect a
+    /// return that crosses a protected-region boundary and rewrite it into a
+    /// store-to-temp + goto-exit pair. ECMA-335 forbids emitting <c>ret</c>
+    /// from inside a protected region; the only legal exit is <c>leave</c>,
+    /// which the emitter produces automatically for a goto whose target lies
+    /// outside the innermost protected region.
+    /// </remarks>
+    protected override BoundStatement RewriteTryStatement(BoundTryStatement node)
+    {
+        this.tryNestingDepth++;
+        try
+        {
+            return base.RewriteTryStatement(node);
+        }
+        finally
+        {
+            this.tryNestingDepth--;
+        }
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Issue #419 (P0-2): rewrites <c>return</c> statements that appear
+    /// lexically inside a try / catch / finally region. The original
+    /// <c>BoundReturnStatement</c> is replaced with a store to a synthetic
+    /// temp local (omitted when the return is value-less) followed by a goto
+    /// to the synthesized method-exit label. The emitter's protected-region
+    /// goto handling then translates the goto into the CIL <c>leave</c> the
+    /// runtime requires. The matching label + final <c>return $tmp;</c>
+    /// epilogue is appended by <c>WrapWithMethodExitEpilogue</c>.
+    /// </remarks>
+    protected override BoundStatement RewriteReturnStatement(BoundReturnStatement node)
+    {
+        var rewritten = (BoundReturnStatement)base.RewriteReturnStatement(node);
+        if (this.tryNestingDepth == 0)
+        {
+            return rewritten;
+        }
+
+        this.hasRewrittenReturnsInProtectedRegions = true;
+        if (this.methodExitLabel == null)
+        {
+            this.methodExitLabel = GenerateLabel();
+        }
+
+        var stmts = ImmutableArray.CreateBuilder<BoundStatement>();
+        if (rewritten.Expression != null)
+        {
+            // First non-void return seen — bind the temp's type. Subsequent
+            // value-returning rewrites reuse the same local; the binder has
+            // already enforced a single return type for the enclosing
+            // function, so all expressions are assignment-compatible with it.
+            if (this.returnValueLocal == null)
+            {
+                this.returnValueLocal = new LocalVariableSymbol(
+                    "$returnTemp",
+                    isReadOnly: false,
+                    type: rewritten.Expression.Type);
+            }
+
+            var assignment = new BoundAssignmentExpression(
+                null,
+                this.returnValueLocal,
+                rewritten.Expression);
+            stmts.Add(new BoundExpressionStatement(null, assignment));
+        }
+
+        stmts.Add(new BoundGotoStatement(null, this.methodExitLabel));
+        return new BoundBlockStatement(null, stmts.ToImmutable());
     }
 
     /// <inheritdoc/>
@@ -836,5 +926,42 @@ public sealed class Lowerer : BoundTreeRewriter
     {
         var name = $"Label{++labelCount}";
         return new BoundLabel(name);
+    }
+
+    /// <summary>
+    /// Issue #419 (P0-2): when at least one return was rewritten as a goto by
+    /// <see cref="RewriteReturnStatement(BoundReturnStatement)"/>, append the
+    /// synthetic method-exit label and a terminating <c>return</c> that
+    /// reloads the temp (or has no expression for void-returning functions).
+    /// The temp is declared at the very top of the method so the emitter's
+    /// locals collector allocates a slot for it; the <c>default(T)</c>
+    /// initializer makes the slot definitely-assigned and avoids verifier
+    /// complaints on unreachable fall-through paths.
+    /// </summary>
+    private BoundStatement WrapWithMethodExitEpilogue(BoundStatement body)
+    {
+        if (!this.hasRewrittenReturnsInProtectedRegions)
+        {
+            return body;
+        }
+
+        var stmts = ImmutableArray.CreateBuilder<BoundStatement>();
+        if (this.returnValueLocal != null)
+        {
+            stmts.Add(new BoundVariableDeclaration(
+                null,
+                this.returnValueLocal,
+                new BoundDefaultExpression(null, this.returnValueLocal.Type)));
+        }
+
+        stmts.Add(body);
+        stmts.Add(new BoundLabelStatement(null, this.methodExitLabel));
+
+        BoundExpression retExpr = this.returnValueLocal == null
+            ? null
+            : new BoundVariableExpression(null, this.returnValueLocal);
+        stmts.Add(new BoundReturnStatement(null, retExpr));
+
+        return new BoundBlockStatement(null, stmts.ToImmutable());
     }
 }

--- a/test/Compiler.Tests/Emit/ReturnInTryFinallyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/ReturnInTryFinallyEmitTests.cs
@@ -1,0 +1,230 @@
+// <copyright file="ReturnInTryFinallyEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #419 (P0-2): a <c>return</c> statement lexically inside a
+/// <c>try</c> / <c>catch</c> / <c>finally</c> region used to be emitted as a
+/// plain CIL <c>ret</c>, which is rejected by the runtime with
+/// <c>InvalidProgramException</c> (ECMA-335 forbids <c>ret</c> from inside a
+/// protected region — the only legal exit is <c>leave</c>). The Lowerer now
+/// rewrites such returns into a store-to-temp + goto-exit pair so the emitter
+/// produces a <c>leave</c>, runs the enclosing finally handlers, then reloads
+/// the temp and emits the single <c>ret</c> at the synthesized method-exit.
+/// These tests compile and execute small G# programs end-to-end and assert the
+/// final stdout to verify both the returned value AND the finally side-effect.
+/// </summary>
+public class ReturnInTryFinallyEmitTests
+{
+    [Fact]
+    public void Return_From_Try_With_Finally_Returns_Value_And_Runs_Finally()
+    {
+        var src = """
+            package main
+            import System
+
+            func compute() int32 {
+                try {
+                    return 7
+                } finally {
+                    Console.WriteLine("finally ran")
+                }
+                return 0
+            }
+
+            func Main() int32 {
+                let v = compute()
+                Console.WriteLine(v)
+                return 0
+            }
+            """;
+
+        Assert.Equal("finally ran\n7\n", CompileAndRun(src));
+    }
+
+    [Fact]
+    public void Return_From_Catch_Block_Returns_Value_And_Runs_Finally()
+    {
+        var src = """
+            package main
+            import System
+
+            func compute() int32 {
+                try {
+                    throw Exception("boom")
+                } catch (e Exception) {
+                    return 42
+                } finally {
+                    Console.WriteLine("finally ran")
+                }
+                return 0
+            }
+
+            func Main() int32 {
+                let v = compute()
+                Console.WriteLine(v)
+                return 0
+            }
+            """;
+
+        Assert.Equal("finally ran\n42\n", CompileAndRun(src));
+    }
+
+    [Fact]
+    public void Return_From_Nested_Try_Finally_Runs_All_Finallies_In_Order()
+    {
+        var src = """
+            package main
+            import System
+
+            func compute() int32 {
+                try {
+                    try {
+                        return 100
+                    } finally {
+                        Console.WriteLine("inner finally")
+                    }
+                } finally {
+                    Console.WriteLine("outer finally")
+                }
+                return 0
+            }
+
+            func Main() int32 {
+                let v = compute()
+                Console.WriteLine(v)
+                return 0
+            }
+            """;
+
+        Assert.Equal("inner finally\nouter finally\n100\n", CompileAndRun(src));
+    }
+
+    [Fact]
+    public void Void_Returning_Function_With_Return_Inside_Try_Finally_Runs_Finally()
+    {
+        var src = """
+            package main
+            import System
+
+            func work() {
+                try {
+                    Console.WriteLine("before return")
+                    return
+                } finally {
+                    Console.WriteLine("finally ran")
+                }
+                Console.WriteLine("unreachable")
+            }
+
+            func Main() int32 {
+                work()
+                Console.WriteLine("done")
+                return 0
+            }
+            """;
+
+        Assert.Equal("before return\nfinally ran\ndone\n", CompileAndRun(src));
+    }
+
+    [Fact]
+    public void Multiple_Returns_Inside_Try_Finally_All_Route_Through_Exit()
+    {
+        var src = """
+            package main
+            import System
+
+            func pick(b bool) int32 {
+                try {
+                    if b {
+                        return 1
+                    }
+                    return 2
+                } finally {
+                    Console.WriteLine("finally ran")
+                }
+                return 0
+            }
+
+            func Main() int32 {
+                Console.WriteLine(pick(true))
+                Console.WriteLine(pick(false))
+                return 0
+            }
+            """;
+
+        Assert.Equal("finally ran\n1\nfinally ran\n2\n", CompileAndRun(src));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_p0_2_ret_try_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); }
+            catch { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #419.

## Problem

ECMA-335 forbids emitting a CIL `ret` from inside a try / catch / finally region — the only legal exit is `leave`. The emitter previously always emitted `ret` for a `BoundReturnStatement`, so the following program produced an assembly that failed at runtime with `System.InvalidProgramException`:

```gsharp
package main
import System
func compute() int32 {
  try { return 7 } finally { Console.WriteLine("finally ran") }
  return 0
}
func Main() int32 { return compute() }
```

## Fix

Done in the Lowerer (`src/Core/CodeAnalysis/Lowering/Lowerer.cs`) since the bound tree is already in front of locals collection, so the synthetic temp's slot gets allocated automatically:

1. `RewriteTryStatement` increments a `tryNestingDepth` counter around the base recursion so every `BoundReturnStatement` lexically inside `try` / `catch` / `finally` is observed with depth > 0.
2. `RewriteReturnStatement` rewrites such returns into:
   ```
   $returnTemp = expr;   // only when the return has a value
   goto $methodExit;
   ```
   The temp local is lazily allocated against the first non-void return's type (binder already enforced a single return type for the function, so subsequent rewrites reuse the same slot).
3. A single synthetic epilogue is appended at top level of the method body, lexically outside every protected region:
   ```
   $returnTemp = default(T);   // top-of-method decl so the locals collector allocates a slot
   ... user body ...
   $methodExit:
   return $returnTemp;          // or 'return;' for void-returning functions
   ```

The emitter's existing protected-region goto handling (`EmitBranch` in `ReflectionMetadataEmitter.cs`) translates a goto whose target lies outside the innermost protected region into the CIL `leave` opcode, which correctly walks the enclosing finally handlers on the way out. No emitter change was needed.

## Tests

Added `test/Compiler.Tests/Emit/ReturnInTryFinallyEmitTests.cs` with five end-to-end emit-and-execute tests that assert both the returned value AND the finally side-effect:

- `Return_From_Try_With_Finally_Returns_Value_And_Runs_Finally` — the reproducer from the issue.
- `Return_From_Catch_Block_Returns_Value_And_Runs_Finally` — return inside a catch with a finally.
- `Return_From_Nested_Try_Finally_Runs_All_Finallies_In_Order` — both inner and outer finally run before the value is returned.
- `Void_Returning_Function_With_Return_Inside_Try_Finally_Runs_Finally` — bare `return` in a void func.
- `Multiple_Returns_Inside_Try_Finally_All_Route_Through_Exit` — two returns in the same try, both go through the synthetic exit.

## Validation

- `dotnet build GSharp.sln` — clean (0 warnings, 0 errors).
- `dotnet test GSharp.sln` — **2168 passed** (24 Sdk + 1596 Core + 212 LSP + 54 Interpreter + 282 Compiler), up from the 2163 baseline by the 5 new tests. Zero regressions.