### PR TITLE
Fix #419 (P0-4): spill awaits in field/index assignments and unary expressions

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
@@ -294,6 +294,7 @@ public static class MoveNextBodyRewriter
         {
             private readonly RewriteContext ctx;
             private readonly TryDispatchPlan tryDispatch;
+            private int aliasOrdinal;
 
             public InnerRewriter(RewriteContext ctx, TryDispatchPlan tryDispatch)
             {
@@ -391,13 +392,107 @@ public static class MoveNextBodyRewriter
             {
                 var rewrittenValue = RewriteExpression(node.Value);
 
-                // If the receiver is the hoisted `this` (instance method on a closure),
-                // we cannot represent a nested field store with the current node shape.
-                // For read-only capture access this path won't be hit; defer full
-                // write-through support for captured vars in async lambdas.
+                // If the receiver is hoisted into a state-machine field, the
+                // BoundFieldAssignmentExpression node shape can't reference the
+                // field directly (Receiver is VariableSymbol).
+                if (node.Receiver != null
+                    && TryGetHoistedField(node.Receiver, out var recvField))
+                {
+                    if (node.StructType.IsClass)
+                    {
+                        // Class receiver — reference type. Alias the hoisted field
+                        // to a fresh local and store through it.
+                        var aliasLocal = new LocalVariableSymbol(
+                            "<>recv_alias_" + (aliasOrdinal++),
+                            isReadOnly: false,
+                            node.Receiver.Type);
+                        var decl = new BoundVariableDeclaration(null, aliasLocal, ctx.ReadField(recvField));
+                        var newAssign = new BoundFieldAssignmentExpression(
+                            null,
+                            aliasLocal,
+                            node.StructType,
+                            node.Field,
+                            rewrittenValue);
+                        return new BoundBlockExpression(
+                            null,
+                            ImmutableArray.Create<BoundStatement>(decl),
+                            newAssign);
+                    }
+                    else
+                    {
+                        // Value-type struct receiver. A read into a local would
+                        // capture a copy; we must write the mutated copy back into
+                        // the hoisted state-machine field for the change to persist.
+                        var copyLocal = new LocalVariableSymbol(
+                            "<>recv_copy_" + (aliasOrdinal++),
+                            isReadOnly: false,
+                            node.Receiver.Type);
+                        var copyDecl = new BoundVariableDeclaration(null, copyLocal, ctx.ReadField(recvField));
+                        var innerAssign = new BoundFieldAssignmentExpression(
+                            null,
+                            copyLocal,
+                            node.StructType,
+                            node.Field,
+                            rewrittenValue);
+                        var writeBack = new BoundExpressionStatement(
+                            null,
+                            ctx.WriteField(recvField, new BoundVariableExpression(null, copyLocal)));
+                        var resultRead = new BoundFieldAccessExpression(
+                            null,
+                            new BoundVariableExpression(null, copyLocal),
+                            node.StructType,
+                            node.Field);
+                        return new BoundBlockExpression(
+                            null,
+                            ImmutableArray.Create<BoundStatement>(
+                                copyDecl,
+                                new BoundExpressionStatement(null, innerAssign),
+                                writeBack),
+                            resultRead);
+                    }
+                }
+
                 if (rewrittenValue != node.Value)
                 {
                     return new BoundFieldAssignmentExpression(null, node.Receiver, node.StructType, node.Field, rewrittenValue);
+                }
+
+                return node;
+            }
+
+            protected override BoundExpression RewriteIndexAssignmentExpression(BoundIndexAssignmentExpression node)
+            {
+                var rewrittenIndex = RewriteExpression(node.Index);
+                var rewrittenValue = RewriteExpression(node.Value);
+
+                // If the target (array/slice/map) is hoisted into a state-machine
+                // field, the BoundIndexAssignmentExpression shape can't reference
+                // the field directly (Target is VariableSymbol). Arrays/slices/maps
+                // are reference types, so aliasing the hoisted field into a fresh
+                // local lets us perform the index store through that local; the
+                // mutation lands on the same underlying array.
+                if (TryGetHoistedField(node.Target, out var targetField))
+                {
+                    var aliasLocal = new LocalVariableSymbol(
+                        "<>arr_alias_" + (aliasOrdinal++),
+                        isReadOnly: false,
+                        node.Target.Type);
+                    var decl = new BoundVariableDeclaration(null, aliasLocal, ctx.ReadField(targetField));
+                    var newAssign = new BoundIndexAssignmentExpression(
+                        null,
+                        aliasLocal,
+                        rewrittenIndex,
+                        rewrittenValue,
+                        node.Type);
+                    return new BoundBlockExpression(
+                        null,
+                        ImmutableArray.Create<BoundStatement>(decl),
+                        newAssign);
+                }
+
+                if (rewrittenIndex != node.Index || rewrittenValue != node.Value)
+                {
+                    return new BoundIndexAssignmentExpression(null, node.Target, rewrittenIndex, rewrittenValue, node.Type);
                 }
 
                 return node;

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -247,6 +247,15 @@ public static class SpillSequenceSpiller
                 case BoundAssignmentExpression assign:
                     return SpillAssignment(assign);
 
+                case BoundFieldAssignmentExpression fieldAssign:
+                    return SpillFieldAssignment(fieldAssign);
+
+                case BoundIndexAssignmentExpression indexAssign:
+                    return SpillIndexAssignment(indexAssign);
+
+                case BoundUnaryExpression unary:
+                    return SpillUnary(unary);
+
                 case BoundUserInstanceCallExpression userInstance:
                     return SpillUserInstanceCall(userInstance);
 
@@ -653,6 +662,103 @@ public static class SpillSequenceSpiller
 
             var spilled = SpillExpression(assign.Expression);
             var value = new BoundAssignmentExpression(null, assign.Variable, spilled.Value);
+            return new BoundSpillSequenceExpression(
+                null,
+                spilled.Locals,
+                spilled.SideEffects,
+                value);
+        }
+
+        private BoundSpillSequenceExpression SpillFieldAssignment(BoundFieldAssignmentExpression assign)
+        {
+            // Receiver is a VariableSymbol — already a stable local read, no spilling needed.
+            // Only the RHS Value can contain an await.
+            if (!AsyncBoundTreeQueries.HasAwait(assign.Value))
+            {
+                return Trivial(assign);
+            }
+
+            var spilled = SpillExpression(assign.Value);
+            var value = new BoundFieldAssignmentExpression(
+                null,
+                assign.Receiver,
+                assign.StructType,
+                assign.Field,
+                spilled.Value);
+            return new BoundSpillSequenceExpression(
+                null,
+                spilled.Locals,
+                spilled.SideEffects,
+                value);
+        }
+
+        private BoundSpillSequenceExpression SpillIndexAssignment(BoundIndexAssignmentExpression assign)
+        {
+            // Target is a VariableSymbol — already a stable local read.
+            // Index and Value can each contain an await.
+            var indexHasAwait = AsyncBoundTreeQueries.HasAwait(assign.Index);
+            var valueHasAwait = AsyncBoundTreeQueries.HasAwait(assign.Value);
+
+            if (!indexHasAwait && !valueHasAwait)
+            {
+                return Trivial(assign);
+            }
+
+            var locals = ImmutableArray.CreateBuilder<LocalVariableSymbol>();
+            var sideEffects = ImmutableArray.CreateBuilder<BoundStatement>();
+
+            BoundExpression index;
+            if (indexHasAwait)
+            {
+                var spilledIndex = SpillExpression(assign.Index);
+                locals.AddRange(spilledIndex.Locals);
+                sideEffects.AddRange(spilledIndex.SideEffects);
+                index = spilledIndex.Value;
+            }
+            else
+            {
+                index = assign.Index;
+            }
+
+            // If the RHS has an await, the index must be stable across that suspension.
+            if (valueHasAwait && !IsPureOrConstant(index))
+            {
+                var indexTemp = MakeSpillTemp(index.Type);
+                locals.Add(indexTemp);
+                sideEffects.Add(new BoundVariableDeclaration(null, indexTemp, index));
+                index = new BoundVariableExpression(null, indexTemp);
+            }
+
+            BoundExpression rhs;
+            if (valueHasAwait)
+            {
+                var spilledValue = SpillExpression(assign.Value);
+                locals.AddRange(spilledValue.Locals);
+                sideEffects.AddRange(spilledValue.SideEffects);
+                rhs = spilledValue.Value;
+            }
+            else
+            {
+                rhs = assign.Value;
+            }
+
+            var value = new BoundIndexAssignmentExpression(null, assign.Target, index, rhs, assign.Type);
+            return new BoundSpillSequenceExpression(
+                null,
+                locals.ToImmutable(),
+                sideEffects.ToImmutable(),
+                value);
+        }
+
+        private BoundSpillSequenceExpression SpillUnary(BoundUnaryExpression unary)
+        {
+            if (!AsyncBoundTreeQueries.HasAwait(unary.Operand))
+            {
+                return Trivial(unary);
+            }
+
+            var spilled = SpillExpression(unary.Operand);
+            var value = new BoundUnaryExpression(null, unary.Op, spilled.Value);
             return new BoundSpillSequenceExpression(
                 null,
                 spilled.Locals,

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncSpillEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncSpillEmitTests.cs
@@ -166,6 +166,187 @@ Console.WriteLine(t.Result)
         Assert.Contains("42", output);
     }
 
+    [Fact]
+    public void Await_As_RHS_Of_Array_Index_Assignment_Stores_Correctly()
+    {
+        // Regression for issue #419 (P0-4): `arr[i] = await expr` used to
+        // crash emit with "Variable 'arr' has no local slot…" because the
+        // spiller had no case for BoundIndexAssignmentExpression and the
+        // hoisted-target receiver was never substituted into a state-machine
+        // field load.
+        const string Source = @"package SpillIndexAssignTest
+import System
+import System.Threading.Tasks
+
+async func compute() int32 { return await Task.FromResult(42) }
+
+async func test() int32 {
+    var arr = []int32{0, 0, 0}
+    arr[0] = await compute()
+    return arr[0]
+}
+
+var t = test()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        var output = CompileAndRun(Source, "SpillIndexAssignTest");
+        Assert.Contains("42", output);
+    }
+
+    [Fact]
+    public void Await_As_Index_Of_Array_Index_Assignment_Stores_At_Correct_Slot()
+    {
+        // The index expression itself can also be an await; the spiller must
+        // lift it out and the target alias logic must still kick in.
+        const string Source = @"package SpillIndexExprAwaitTest
+import System
+import System.Threading.Tasks
+
+async func idx() int32 { return await Task.FromResult(2) }
+
+async func test() int32 {
+    var arr = []int32{10, 20, 30}
+    arr[await idx()] = 99
+    return arr[0] + arr[1] + arr[2]
+}
+
+var t = test()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        var output = CompileAndRun(Source, "SpillIndexExprAwaitTest");
+        Assert.Contains("129", output);
+    }
+
+    [Fact]
+    public void Two_Awaits_In_Index_Assignment_Preserve_Evaluation_Order()
+    {
+        // Both index and RHS contain awaits. After spilling, the index
+        // must be evaluated and stabilized before the RHS await suspends.
+        const string Source = @"package SpillIndexAndRhsAwaitTest
+import System
+import System.Threading.Tasks
+
+async func idx() int32 { return await Task.FromResult(1) }
+async func val() int32 { return await Task.FromResult(77) }
+
+async func test() int32 {
+    var arr = []int32{0, 0, 0}
+    arr[await idx()] = await val()
+    return arr[1]
+}
+
+var t = test()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        var output = CompileAndRun(Source, "SpillIndexAndRhsAwaitTest");
+        Assert.Contains("77", output);
+    }
+
+    [Fact]
+    public void Await_As_RHS_Of_Field_Assignment_Stores_Correctly()
+    {
+        // Regression for issue #419 (P0-4): `obj.field = await expr` for a
+        // hoisted struct receiver must write the mutated copy back into the
+        // state-machine field for the change to persist.
+        const string Source = @"package SpillFieldAssignTest
+import System
+import System.Threading.Tasks
+
+type Box struct {
+    Value int32
+}
+
+async func compute() int32 { return await Task.FromResult(99) }
+
+async func test() int32 {
+    var b = Box{Value: 0}
+    b.Value = await compute()
+    return b.Value
+}
+
+var t = test()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        var output = CompileAndRun(Source, "SpillFieldAssignTest");
+        Assert.Contains("99", output);
+    }
+
+    [Fact]
+    public void Negate_Await_Computes_Correctly()
+    {
+        // Regression for issue #419 (P0-4): `-await expr` used to leak the
+        // un-spilled await through SpillExpression's default case.
+        const string Source = @"package SpillNegateAwaitTest
+import System
+import System.Threading.Tasks
+
+async func num() int32 { return await Task.FromResult(10) }
+
+async func test() int32 {
+    let r = -await num()
+    return r
+}
+
+var t = test()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        var output = CompileAndRun(Source, "SpillNegateAwaitTest");
+        Assert.Contains("-10", output);
+    }
+
+    [Fact]
+    public void LogicalNot_Await_Computes_Correctly()
+    {
+        const string Source = @"package SpillNotAwaitTest
+import System
+import System.Threading.Tasks
+
+async func ok() bool { return await Task.FromResult(false) }
+
+async func test() bool {
+    let r = !await ok()
+    return r
+}
+
+var t = test()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        var output = CompileAndRun(Source, "SpillNotAwaitTest");
+        Assert.Contains("True", output);
+    }
+
+    [Fact]
+    public void Multiple_Awaits_In_Index_Assignment_Chain_Run_Correctly()
+    {
+        const string Source = @"package SpillMultiAwaitChainTest
+import System
+import System.Threading.Tasks
+
+async func n(x int32) int32 { return await Task.FromResult(x) }
+
+async func test() int32 {
+    var arr = []int32{0, 0, 0}
+    arr[await n(0)] = await n(11)
+    arr[await n(1)] = await n(22) + await n(0)
+    arr[await n(2)] = -await n(7)
+    return arr[0] + arr[1] + arr[2]
+}
+
+var t = test()
+t.Wait()
+Console.WriteLine(t.Result)
+";
+        // 11 + 22 + (-7) = 26
+        var output = CompileAndRun(Source, "SpillMultiAwaitChainTest");
+        Assert.Contains("26", output);
+    }
+
     private static string CompileAndRun(string source, string contextName)
     {
         using var peStream = new MemoryStream();

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/SpillSequenceSpillerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/SpillSequenceSpillerTests.cs
@@ -274,6 +274,129 @@ public class SpillSequenceSpillerTests
         Assert.Same(body, result);
     }
 
+    [Fact]
+    public void Unary_Expression_With_Await_Operand_Spills_Operand()
+    {
+        // Arrange: -(await t)
+        var op = BoundUnaryOperator.Bind(SyntaxKind.MinusToken, TypeSymbol.Int32);
+        var awaitOperand = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int32);
+        var unary = new BoundUnaryExpression(null, op, awaitOperand);
+        var decl = new BoundVariableDeclaration(
+            null,
+            new LocalVariableSymbol("x", false, TypeSymbol.Int32),
+            unary);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(decl));
+
+        // Act
+        var result = SpillSequenceSpiller.Rewrite(body);
+
+        // Assert: the await is lifted to a spill temp before the final decl.
+        Assert.NotSame(body, result);
+        Assert.True(result.Statements.Length >= 2, "Expected spill statements before the final declaration.");
+
+        // The first spill temp's initializer should be the await.
+        var firstDecl = Assert.IsType<BoundVariableDeclaration>(result.Statements[0]);
+        Assert.StartsWith(GeneratedNames.SpillTempPrefix, firstDecl.Variable.Name);
+        Assert.IsType<BoundAwaitExpression>(firstDecl.Initializer);
+
+        // The final declaration's initializer is a unary expression whose operand
+        // is a variable read (the spill temp), not the original await.
+        var lastDecl = Assert.IsType<BoundVariableDeclaration>(result.Statements[^1]);
+        var unaryOut = Assert.IsType<BoundUnaryExpression>(lastDecl.Initializer);
+        Assert.IsType<BoundVariableExpression>(unaryOut.Operand);
+    }
+
+    [Fact]
+    public void Unary_Expression_Without_Await_Returns_Trivial()
+    {
+        // Arrange: -literal (no await).
+        var op = BoundUnaryOperator.Bind(SyntaxKind.MinusToken, TypeSymbol.Int32);
+        var unary = new BoundUnaryExpression(null, op, new BoundLiteralExpression(null, 5));
+        var decl = new BoundVariableDeclaration(
+            null,
+            new LocalVariableSymbol("x", false, TypeSymbol.Int32),
+            unary);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(decl));
+
+        // Act
+        var result = SpillSequenceSpiller.Rewrite(body);
+
+        // Assert: unchanged because there's no await anywhere.
+        Assert.Same(body, result);
+    }
+
+    [Fact]
+    public void Index_Assignment_With_Await_RHS_Spills_Value()
+    {
+        // Arrange: arr[0] = await t  (Target is a VariableSymbol)
+        var arr = new LocalVariableSymbol("arr", false, ArrayTypeSymbol.Get(TypeSymbol.Int32, 3));
+        var awaitVal = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int32);
+        var ixa = new BoundIndexAssignmentExpression(
+            null,
+            arr,
+            new BoundLiteralExpression(null, 0),
+            awaitVal,
+            TypeSymbol.Int32);
+        var stmt = new BoundExpressionStatement(null, ixa);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(stmt));
+
+        // Act
+        var result = SpillSequenceSpiller.Rewrite(body);
+
+        // Assert: a spill temp for the await result is introduced, then the
+        // final index assignment uses the temp as its value (no embedded await).
+        Assert.NotSame(body, result);
+        var spillCount = 0;
+        BoundIndexAssignmentExpression finalIxa = null;
+        foreach (var s in result.Statements)
+        {
+            if (s is BoundVariableDeclaration d
+                && d.Variable.Name.StartsWith(GeneratedNames.SpillTempPrefix))
+            {
+                spillCount++;
+            }
+
+            if (s is BoundExpressionStatement es && es.Expression is BoundIndexAssignmentExpression fix)
+            {
+                finalIxa = fix;
+            }
+        }
+
+        Assert.True(spillCount >= 1, "Expected at least one spill temp for the await.");
+        Assert.NotNull(finalIxa);
+        Assert.IsNotType<BoundAwaitExpression>(finalIxa!.Value);
+    }
+
+    [Fact]
+    public void Index_Assignment_With_Await_In_Index_And_Value_Spills_Both()
+    {
+        // Arrange: arr[await t1] = await t2  — index must be stabilized to a
+        // temp because the RHS await suspends after the index is computed.
+        var arr = new LocalVariableSymbol("arr", false, ArrayTypeSymbol.Get(TypeSymbol.Int32, 3));
+        var awaitIdx = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int32);
+        var awaitVal = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int32);
+        var ixa = new BoundIndexAssignmentExpression(null, arr, awaitIdx, awaitVal, TypeSymbol.Int32);
+        var stmt = new BoundExpressionStatement(null, ixa);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(stmt));
+
+        // Act
+        var result = SpillSequenceSpiller.Rewrite(body);
+
+        // Assert: at least two spill temps (index await + value await).
+        Assert.NotSame(body, result);
+        var spillCount = 0;
+        foreach (var s in result.Statements)
+        {
+            if (s is BoundVariableDeclaration d
+                && d.Variable.Name.StartsWith(GeneratedNames.SpillTempPrefix))
+            {
+                spillCount++;
+            }
+        }
+
+        Assert.True(spillCount >= 2, $"Expected at least 2 spill temps but got {spillCount}.");
+    }
+
     private static BoundCallExpression MakeCall(string name, TypeSymbol returnType)
     {
         var func = new FunctionSymbol(


### PR DESCRIPTION
Fixes one of the P0 items tracked in #419.

## Problem

`SpillSequenceSpiller.SpillExpression` had no case for `BoundFieldAssignmentExpression`, `BoundIndexAssignmentExpression`, or `BoundUnaryExpression`. An `await` embedded in any of these fell through to `Trivial()` un-spilled, leaving a stray `BoundAwaitExpression` in the lowered tree. Emit then crashed with:

```
(1,1,1,1): error GS9998: Variable 'arr' has no local slot or parameter index in the current method.
```

Investigation revealed a coupled gap in `MoveNextBodyRewriter`: even with the spiller fix, the rewriter had no handler for the hoisted-variable **receiver** of `BoundFieldAssignmentExpression` or **target** of `BoundIndexAssignmentExpression`. Both node shapes hold a bare `VariableSymbol` (not a `BoundExpression`), so the existing variable substitution that replaces `BoundVariableExpression` reads with state-machine field loads couldn't reach them. The hoisted variable's slot was therefore looked up at emit time and not found.

## Fix

**`SpillSequenceSpiller`** — adds the three missing cases, modeled on `SpillBinary` / `SpillImportedInstanceCall`:
- `SpillFieldAssignment` — receiver is a `VariableSymbol` (already a stable local read); spills the RHS value only.
- `SpillIndexAssignment` — spills both index and value; stabilizes the index to a temp when the RHS contains a later await.
- `SpillUnary` — spills the operand.

**`MoveNextBodyRewriter.InnerRewriter`** — handles hoisted receiver/target through synthesized `BoundBlockExpression` blocks with non-hoisted alias locals:
- `RewriteIndexAssignmentExpression` (new override): arrays/slices/maps are reference types, so aliasing the hoisted field into a fresh local lets the index store land on the same underlying object.
- `RewriteFieldAssignmentExpression` (extended): class receivers use the same alias trick; struct receivers use read-copy-mutate-writeback into the state-machine field so the change persists.

## Tests

All 2174 tests pass (was 2163; +11 new):

- `test/Core.Tests/CodeAnalysis/Emit/AsyncSpillEmitTests.cs` — 7 end-to-end emit + run tests covering `arr[i] = await`, `arr[await] = await`, `obj.field = await` (struct), `-await`, `!await`, two-await index assignment, and a compound multi-await chain.
- `test/Core.Tests/CodeAnalysis/Lowering/Async/SpillSequenceSpillerTests.cs` — 4 structural spill tests for the new `SpillExpression` cases.

Repro from the issue now compiles and runs:

```gsharp
async func compute() int32 { return await Task.FromResult(42) }
async func test() int32 {
  var arr = []int32{0, 0, 0}
  arr[0] = await compute()
  return arr[0]
}
// test().Result == 42
```
