### PR TITLE
Fix yield inside try/finally producing InvalidProgramException (#419)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -7393,10 +7393,7 @@ internal sealed class ReflectionMetadataEmitter
                     null,
                     TypeSymbol.FromClrType(typeof(object)),
                     new BoundFieldAccessExpression(null, new BoundVariableExpression(null, getCurrentObject.ThisParameter), smClass, currentField))))));
-            this.lambdaBodies[dispose] = Lowerer.Lower(new BoundBlockStatement(null,
-                ImmutableArray.Create<BoundStatement>(
-                new BoundExpressionStatement(null, new BoundFieldAssignmentExpression(null, dispose.ThisParameter, smClass, stateField, new BoundLiteralExpression(null, -1))),
-                new BoundReturnStatement(null, null))));
+            this.lambdaBodies[dispose] = IteratorMoveNextBodyBuilder.BuildDisposeBody(plan, stateField, dispose.ThisParameter, smClass, fieldMap);
             this.lambdaBodies[reset] = Lowerer.Lower(new BoundBlockStatement(null,
                 ImmutableArray.Create<BoundStatement>(
                 new BoundExpressionStatement(null, new BoundFieldAssignmentExpression(null, reset.ThisParameter, smClass, stateField, new BoundLiteralExpression(null, -1))),

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorMoveNextBodyBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorMoveNextBodyBuilder.cs
@@ -9,6 +9,8 @@
 #pragma warning disable CS1572 // XML comment has a param tag
 #pragma warning disable CS1573 // Parameter has no matching param tag
 #pragma warning disable SA1512 // Single-line comments should not be followed by blank line
+#pragma warning disable SA1201 // Elements should appear in the correct order
+#pragma warning disable SA1615 // Element return value should be documented
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -49,10 +51,23 @@ public static class IteratorMoveNextBodyBuilder
 
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
 
+        // Pre-pass: locate each yield within the user's try-statement nesting.
+        // For iterators we cannot keep user try-finally regions in MoveNext
+        // because:
+        //   * `ret` is illegal inside a CLR protected region, so the yield's
+        //     `return true` cannot stay there, and
+        //   * `leave` from the try would trigger the finally on every yield.
+        // Instead, the user try-finally is removed in MoveNext: the try body
+        // is inlined followed by the finally body so that normal completion
+        // still runs cleanup. Dispose handles premature termination by
+        // running the pending finallies based on the current suspension state.
+        var tryDispatch = IteratorTryDispatchPlanner.Plan(plan.Body, plan.YieldStates);
+
         var yieldLabels = new Dictionary<int, BoundLabel>();
         foreach (var kvp in plan.YieldStates)
         {
-            var label = new BoundLabel($"$iterResume_{kvp.Value}");
+            var label = tryDispatch.GetResumeLabel(kvp.Value)
+                        ?? new BoundLabel($"$iterResume_{kvp.Value}");
             yieldLabels[kvp.Value] = label;
         }
 
@@ -71,6 +86,9 @@ public static class IteratorMoveNextBodyBuilder
 
         foreach (var kvp in plan.YieldStates)
         {
+            // Because we remove the user's try wrappers in MoveNext (see
+            // above), the outer dispatch can jump directly to the resume
+            // label — there is no protected region to route around.
             statements.Add(new BoundConditionalGotoStatement(
                 null,
                 yieldLabels[kvp.Value],
@@ -85,7 +103,7 @@ public static class IteratorMoveNextBodyBuilder
         statements.Add(new BoundGotoStatement(null, endLabel));
         statements.Add(new BoundLabelStatement(null, startLabel));
 
-        var rewriter = new FieldAccessYieldRewriter(smClass, thisParameter, stateField, currentField, hoistedFieldMap, yieldLabels, endLabel);
+        var rewriter = new FieldAccessYieldRewriter(smClass, thisParameter, stateField, currentField, hoistedFieldMap, yieldLabels, endLabel, tryDispatch, plan.YieldStates);
         var rewrittenBody = rewriter.RewriteStatement(plan.Body);
         if (rewrittenBody is BoundBlockStatement block)
         {
@@ -101,6 +119,182 @@ public static class IteratorMoveNextBodyBuilder
         statements.Add(new BoundReturnStatement(null, new BoundLiteralExpression(null, false)));
 
         return new IteratorMoveNextBody(Lowerer.Lower(new BoundBlockStatement(null, statements.ToImmutable())), thisParameter);
+    }
+
+    /// <summary>
+    /// Builds the <c>Dispose()</c> body for an iterator state machine.
+    /// </summary>
+    /// <remarks>
+    /// <para>For each user <c>try { … } finally { … }</c> that contains
+    /// <c>yield</c> statements, Dispose must run the <c>finally</c> block
+    /// when invoked while the enumerator is suspended inside that try. The
+    /// suspension is identified by the current state field value, which
+    /// equals one of the yield states inside the try.</para>
+    /// <para>Nested try-finally with yields produces innermost-first walking
+    /// so that inner finallies run before their enclosers, matching the
+    /// normal stack-unwinding semantics on <c>foreach</c> early break.</para>
+    /// <para>If the iterator body contains no yields inside any try-finally
+    /// the body is the trivial <c>state = -1; return;</c> as before.</para>
+    /// </remarks>
+    public static BoundBlockStatement BuildDisposeBody(
+        IteratorStateMachinePlan plan,
+        FieldSymbol stateField,
+        ParameterSymbol thisParameter,
+        StructSymbol smClass,
+        Dictionary<VariableSymbol, FieldSymbol> hoistedFieldMap)
+    {
+        BoundExpression FieldRead(FieldSymbol field) =>
+            new BoundFieldAccessExpression(null, new BoundVariableExpression(null, thisParameter), smClass, field);
+
+        BoundExpression FieldWrite(FieldSymbol field, BoundExpression value) =>
+            new BoundFieldAssignmentExpression(null, thisParameter, smClass, field, value);
+
+        var tryDispatch = IteratorTryDispatchPlanner.Plan(plan.Body, plan.YieldStates);
+
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+
+        // Walk pending try-finallies in innermost-first order. For each:
+        //   if (<state matches a yield state inside this try>) {
+        //     try { /* empty: leave triggers finally */ } finally { <user finally> }
+        //   }
+        // We always set state = -1 BEFORE the chain so the iterator is left
+        // in the finished state even if a finally throws.
+        statements.Add(new BoundExpressionStatement(null, FieldWrite(stateField, new BoundLiteralExpression(null, -1))));
+
+        if (!tryDispatch.FinallyTrysInnermostFirst.IsDefaultOrEmpty)
+        {
+            // We need to compute the per-try yield-state membership using
+            // the ORIGINAL (pre-Dispose-rewrite) state field. Capture it
+            // into a local once so the chain of if/try-finally blocks all
+            // observe the suspension state.
+            var savedStateLocal = new LocalVariableSymbol("<>savedState", isReadOnly: true, TypeSymbol.Int32);
+
+            // Restore: state = -1 was already written above; we keep it.
+            // Replace the unconditional `state = -1` write with a local-init
+            // that snapshots the current state, then writes -1.
+            statements.Clear();
+            statements.Add(new BoundVariableDeclaration(null, savedStateLocal, FieldRead(stateField)));
+            statements.Add(new BoundExpressionStatement(null, FieldWrite(stateField, new BoundLiteralExpression(null, -1))));
+
+            // For each try-finally that contains yields (innermost first):
+            //   if (savedState == s1 || savedState == s2 || ...) {
+            //     try {} finally { <rewritten user finally> }
+            //   }
+            foreach (var tryStmt in tryDispatch.FinallyTrysInnermostFirst)
+            {
+                var insideStates = tryDispatch.GetYieldStatesInTry(tryStmt);
+                if (insideStates.IsDefaultOrEmpty)
+                {
+                    continue;
+                }
+
+                // Build OR-chain: savedState == s1 || savedState == s2 || ...
+                BoundExpression condition = null;
+                foreach (var s in insideStates)
+                {
+                    var eq = new BoundBinaryExpression(
+                        null,
+                        new BoundVariableExpression(null, savedStateLocal),
+                        BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, TypeSymbol.Int32, TypeSymbol.Int32),
+                        new BoundLiteralExpression(null, s));
+                    condition = condition == null
+                        ? eq
+                        : new BoundBinaryExpression(
+                            null,
+                            condition,
+                            BoundBinaryOperator.Bind(SyntaxKind.PipePipeToken, TypeSymbol.Bool, TypeSymbol.Bool),
+                            eq);
+                }
+
+                // Rewrite the user's finally body so any references to
+                // hoisted locals resolve to fields on the state machine
+                // (Dispose has its own `this`, distinct from MoveNext's).
+                var disposeRewriter = new FieldAccessRewriter(smClass, thisParameter, hoistedFieldMap);
+                var rewrittenFinally = disposeRewriter.RewriteStatement(tryStmt.FinallyBlock);
+
+                // try {} finally { … }
+                var emptyTryBody = new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
+                var tryFinally = new BoundTryStatement(
+                    null,
+                    emptyTryBody,
+                    ImmutableArray<BoundCatchClause>.Empty,
+                    rewrittenFinally);
+
+                statements.Add(new BoundIfStatement(null, condition, tryFinally, elseStatement: null));
+            }
+        }
+
+        statements.Add(new BoundReturnStatement(null, null));
+
+        return Lowerer.Lower(new BoundBlockStatement(null, statements.ToImmutable()));
+    }
+
+    /// <summary>
+    /// Lightweight rewriter that maps hoisted local reads/writes to field
+    /// accesses on the synthesized state machine, using the supplied
+    /// <c>this</c> parameter (different per state-machine method).
+    /// </summary>
+    private sealed class FieldAccessRewriter : BoundTreeRewriter
+    {
+        private readonly StructSymbol smClass;
+        private readonly ParameterSymbol thisParameter;
+        private readonly Dictionary<VariableSymbol, FieldSymbol> fieldMap;
+
+        public FieldAccessRewriter(
+            StructSymbol smClass,
+            ParameterSymbol thisParameter,
+            Dictionary<VariableSymbol, FieldSymbol> fieldMap)
+        {
+            this.smClass = smClass;
+            this.thisParameter = thisParameter;
+            this.fieldMap = fieldMap;
+        }
+
+        protected override BoundExpression RewriteVariableExpression(BoundVariableExpression node)
+        {
+            if (this.fieldMap.TryGetValue(node.Variable, out var field))
+            {
+                return new BoundFieldAccessExpression(
+                    null,
+                    new BoundVariableExpression(null, this.thisParameter),
+                    this.smClass,
+                    field);
+            }
+
+            return node;
+        }
+
+        protected override BoundExpression RewriteAssignmentExpression(BoundAssignmentExpression node)
+        {
+            if (this.fieldMap.TryGetValue(node.Variable, out var field))
+            {
+                return new BoundFieldAssignmentExpression(
+                    null,
+                    this.thisParameter,
+                    this.smClass,
+                    field,
+                    this.RewriteExpression(node.Expression));
+            }
+
+            return base.RewriteAssignmentExpression(node);
+        }
+
+        protected override BoundStatement RewriteVariableDeclaration(BoundVariableDeclaration node)
+        {
+            if (this.fieldMap.TryGetValue(node.Variable, out var field))
+            {
+                return new BoundExpressionStatement(
+                    null,
+                    new BoundFieldAssignmentExpression(
+                        null,
+                        this.thisParameter,
+                        this.smClass,
+                        field,
+                        this.RewriteExpression(node.Initializer)));
+            }
+
+            return base.RewriteVariableDeclaration(node);
+        }
     }
 
     public static IteratorMoveNextBody Build(
@@ -191,7 +385,15 @@ public static class IteratorMoveNextBodyBuilder
         private readonly Dictionary<VariableSymbol, FieldSymbol> fieldMap;
         private readonly Dictionary<int, BoundLabel> yieldLabels;
         private readonly BoundLabel endLabel;
-        private int yieldIndex;
+        private readonly IteratorTryDispatchPlan tryDispatch;
+        private readonly IReadOnlyDictionary<BoundYieldStatement, int> yieldStateMap;
+
+        // Stack of pending user-finally blocks during walk (innermost first).
+        // A `return` lexically inside these trys must run each finally body
+        // before jumping to endLabel, mirroring the CLR's normal stack
+        // unwinding on `leave`. Yields do NOT consume this stack — the
+        // finally is run lazily by Dispose on premature termination.
+        private readonly Stack<BoundStatement> pendingFinallies = new Stack<BoundStatement>();
 
         public FieldAccessYieldRewriter(
             StructSymbol smClass,
@@ -200,7 +402,9 @@ public static class IteratorMoveNextBodyBuilder
             FieldSymbol currentField,
             Dictionary<VariableSymbol, FieldSymbol> fieldMap,
             Dictionary<int, BoundLabel> yieldLabels,
-            BoundLabel endLabel)
+            BoundLabel endLabel,
+            IteratorTryDispatchPlan tryDispatch,
+            IReadOnlyDictionary<BoundYieldStatement, int> yieldStateMap)
         {
             this.smClass = smClass;
             this.thisParameter = thisParameter;
@@ -209,6 +413,8 @@ public static class IteratorMoveNextBodyBuilder
             this.fieldMap = fieldMap;
             this.yieldLabels = yieldLabels;
             this.endLabel = endLabel;
+            this.tryDispatch = tryDispatch;
+            this.yieldStateMap = yieldStateMap;
         }
 
         protected override BoundExpression RewriteVariableExpression(BoundVariableExpression node)
@@ -243,20 +449,115 @@ public static class IteratorMoveNextBodyBuilder
 
         protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
         {
-            this.yieldIndex++;
-            var label = this.yieldLabels[this.yieldIndex];
+            var state = this.yieldStateMap[node];
+            var label = this.yieldLabels[state];
             var statements = ImmutableArray.CreateBuilder<BoundStatement>();
             statements.Add(new BoundExpressionStatement(null, this.FieldWrite(this.currentField, this.RewriteExpression(node.Expression))));
-            statements.Add(new BoundExpressionStatement(null, this.FieldWrite(this.stateField, new BoundLiteralExpression(null, this.yieldIndex))));
+            statements.Add(new BoundExpressionStatement(null, this.FieldWrite(this.stateField, new BoundLiteralExpression(null, state))));
             statements.Add(new BoundReturnStatement(null, new BoundLiteralExpression(null, true)));
             statements.Add(new BoundLabelStatement(null, label));
             statements.Add(new BoundExpressionStatement(null, this.FieldWrite(this.stateField, new BoundLiteralExpression(null, 0))));
             return new BoundBlockStatement(null, statements.ToImmutable());
         }
 
+        protected override BoundStatement RewriteTryStatement(BoundTryStatement node)
+        {
+            // Inspect whether this try contains any yields. If not, leave
+            // it intact (a normal protected region with no resume needs).
+            var statesInside = this.tryDispatch.GetYieldStatesInTry(node);
+            if (statesInside.IsDefaultOrEmpty)
+            {
+                return base.RewriteTryStatement(node);
+            }
+
+            // The user try contains yields. We cannot keep it as a CLR
+            // protected region in MoveNext because the yield's `return true`
+            // would be illegal inside the try, and a `leave` would run the
+            // finally on every yield. Instead, we remove the try wrapper:
+            //   * Inline the rewritten try body.
+            //   * If a finally is present, inline it after the body so that
+            //     normal completion still runs cleanup.
+            //   * Premature termination (early break / Dispose) is handled
+            //     by the synthesized Dispose body, which runs the same
+            //     finally based on the current state.
+            //
+            // Catch clauses are not supported when the try contains yields
+            // (the language disallows this). If present we drop them; this
+            // is conservative and matches the C# iterator restriction.
+            if (node.FinallyBlock != null)
+            {
+                this.pendingFinallies.Push(node.FinallyBlock);
+            }
+
+            BoundStatement rewrittenTryBody;
+            try
+            {
+                rewrittenTryBody = this.RewriteStatement(node.TryBlock);
+            }
+            finally
+            {
+                if (node.FinallyBlock != null)
+                {
+                    this.pendingFinallies.Pop();
+                }
+            }
+
+            var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+            if (rewrittenTryBody is BoundBlockStatement b)
+            {
+                statements.AddRange(b.Statements);
+            }
+            else
+            {
+                statements.Add(rewrittenTryBody);
+            }
+
+            if (node.FinallyBlock != null)
+            {
+                // Finally body is rewritten with the same field-access /
+                // local-hoisting transforms (but the finally itself does
+                // not contain yields by language rule, so the yield
+                // rewriter is a safe pass-through here).
+                var rewrittenFinally = this.RewriteStatement(node.FinallyBlock);
+                if (rewrittenFinally is BoundBlockStatement fb)
+                {
+                    statements.AddRange(fb.Statements);
+                }
+                else
+                {
+                    statements.Add(rewrittenFinally);
+                }
+            }
+
+            return new BoundBlockStatement(null, statements.ToImmutable());
+        }
+
         protected override BoundStatement RewriteReturnStatement(BoundReturnStatement node)
         {
-            return new BoundGotoStatement(null, this.endLabel);
+            // `return` inside an iterator terminates enumeration. Run any
+            // pending user-finally blocks (innermost first) before jumping
+            // to the end label, mirroring CLR `leave` unwinding semantics.
+            if (this.pendingFinallies.Count == 0)
+            {
+                return new BoundGotoStatement(null, this.endLabel);
+            }
+
+            var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+            foreach (var finallyBlock in this.pendingFinallies)
+            {
+                var rewrittenFinally = this.RewriteStatement(finallyBlock);
+                if (rewrittenFinally is BoundBlockStatement fb)
+                {
+                    statements.AddRange(fb.Statements);
+                }
+                else
+                {
+                    statements.Add(rewrittenFinally);
+                }
+            }
+
+            statements.Add(new BoundGotoStatement(null, this.endLabel));
+            return new BoundBlockStatement(null, statements.ToImmutable());
         }
 
         private BoundExpression FieldRead(FieldSymbol field) =>

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorTryDispatchPlanner.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorTryDispatchPlanner.cs
@@ -1,0 +1,316 @@
+// <copyright file="IteratorTryDispatchPlanner.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#pragma warning disable SA1201 // Elements should appear in the correct order
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Iterators;
+
+/// <summary>
+/// Pre-pass walker that builds a <see cref="IteratorTryDispatchPlan"/> from
+/// the user iterator body by locating each <c>yield</c> within the lexical
+/// nesting of user <c>try</c> statements.
+/// </summary>
+/// <remarks>
+/// <para>The CLR forbids branching <c>br</c>/<c>brtrue</c>/<c>brfalse</c>
+/// into a protected (try) region from outside. The outer <c>MoveNext</c>
+/// state dispatch therefore cannot jump directly to a resume label that lies
+/// inside a user try. Instead, a synthesized <i>entry label</i> is placed
+/// immediately before each user try with yields, and the outer dispatch
+/// routes there. Inside that try a second dispatch then either routes
+/// further (to a nested try's entry label) or to a resume label for a
+/// yield directly in that try.</para>
+///
+/// <para>The plan also captures, for each user <c>try</c> that has a
+/// <c>finally</c> block and contains yields, the set of yield states inside
+/// it (innermost-first). The Dispose synthesizer uses the per-try yield-state
+/// sets to emit a finally walk that runs each pending <c>finally</c> when an
+/// in-progress enumerator is disposed.</para>
+/// </remarks>
+internal static class IteratorTryDispatchPlanner
+{
+    /// <summary>
+    /// Builds a dispatch plan for the given iterator body.
+    /// </summary>
+    /// <param name="body">The user iterator body to scan.</param>
+    /// <param name="yieldStates">The yield-statement to state map produced by <see cref="IteratorRewriter"/>.</param>
+    /// <returns>A plan describing how to route the outer and per-try dispatches and what finallies Dispose must run.</returns>
+    public static IteratorTryDispatchPlan Plan(
+        BoundStatement body,
+        IReadOnlyDictionary<BoundYieldStatement, int> yieldStates)
+    {
+        var walker = new Walker(yieldStates);
+        walker.RewriteStatement(body);
+        return walker.Build();
+    }
+
+    private sealed class Walker : BoundTreeRewriter
+    {
+        private readonly IReadOnlyDictionary<BoundYieldStatement, int> yieldStates;
+        private readonly Stack<BoundTryStatement> tryStack = new Stack<BoundTryStatement>();
+        private readonly Dictionary<BoundTryStatement, BoundLabel> entryLabels = new Dictionary<BoundTryStatement, BoundLabel>();
+        private readonly Dictionary<int, BoundLabel> outerDispatch = new Dictionary<int, BoundLabel>();
+        private readonly Dictionary<BoundTryStatement, List<IteratorTryDispatchEntry>> internalDispatch = new Dictionary<BoundTryStatement, List<IteratorTryDispatchEntry>>();
+        private readonly Dictionary<BoundTryStatement, List<int>> tryYieldStates = new Dictionary<BoundTryStatement, List<int>>();
+        private readonly List<BoundTryStatement> finallyTrysInnermostFirst = new List<BoundTryStatement>();
+        private readonly Dictionary<int, BoundLabel> resumeLabels = new Dictionary<int, BoundLabel>();
+        private int entryOrdinal;
+
+        public Walker(IReadOnlyDictionary<BoundYieldStatement, int> yieldStates)
+        {
+            this.yieldStates = yieldStates;
+        }
+
+        public IteratorTryDispatchPlan Build()
+        {
+            return new IteratorTryDispatchPlan(
+                outerDispatch.ToImmutableDictionary(),
+                entryLabels.ToImmutableDictionary(),
+                resumeLabels.ToImmutableDictionary(),
+                internalDispatch.ToImmutableDictionary(
+                    kv => kv.Key,
+                    kv => kv.Value.ToImmutableArray()),
+                tryYieldStates.ToImmutableDictionary(
+                    kv => kv.Key,
+                    kv => kv.Value.ToImmutableArray()),
+                finallyTrysInnermostFirst.ToImmutableArray());
+        }
+
+        protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
+        {
+            if (yieldStates.TryGetValue(node, out var state))
+            {
+                RecordYield(state);
+            }
+
+            return node;
+        }
+
+        protected override BoundStatement RewriteTryStatement(BoundTryStatement node)
+        {
+            tryStack.Push(node);
+            try
+            {
+                RewriteStatement(node.TryBlock);
+
+                // Catches and finallies should not themselves contain yields
+                // for the purpose of state routing (binder rejects yield in
+                // catch/finally). Still walk for completeness — yields found
+                // here are simply ignored by RecordYield (state will route
+                // them via the outer dispatch as if outside the try, which
+                // is incorrect but cannot occur in well-formed programs).
+                foreach (var c in node.CatchClauses)
+                {
+                    RewriteStatement(c.Body);
+                }
+
+                if (node.FinallyBlock != null)
+                {
+                    RewriteStatement(node.FinallyBlock);
+                }
+            }
+            finally
+            {
+                tryStack.Pop();
+            }
+
+            // If this try had a finally and any yields, remember it so
+            // Dispose can run the finally on premature disposal.
+            if (node.FinallyBlock != null
+                && tryYieldStates.TryGetValue(node, out var inside)
+                && inside.Count > 0)
+            {
+                finallyTrysInnermostFirst.Add(node);
+            }
+
+            return node;
+        }
+
+        private void RecordYield(int state)
+        {
+            // Always create a resume label for this state.
+            var resumeLabel = GetOrCreateResumeLabel(state);
+
+            if (tryStack.Count == 0)
+            {
+                return;
+            }
+
+            // The outer dispatch routes to the OUTERMOST containing try's entry.
+            var stackArr = tryStack.ToArray(); // top-of-stack first → innermost first
+            var outermost = stackArr[stackArr.Length - 1];
+            outerDispatch[state] = GetOrCreateEntryLabel(outermost);
+
+            // Each enclosing try (from outermost inward) gets an internal
+            // dispatch entry. For the try at index idx, the target is either
+            // the entry label of the next-deeper try (idx-1), or the resume
+            // label itself when this try is the innermost containing one.
+            for (int idx = stackArr.Length - 1; idx >= 0; idx--)
+            {
+                var tryAtLevel = stackArr[idx];
+                BoundLabel target = idx == 0 ? resumeLabel : GetOrCreateEntryLabel(stackArr[idx - 1]);
+
+                if (!internalDispatch.TryGetValue(tryAtLevel, out var list))
+                {
+                    list = new List<IteratorTryDispatchEntry>();
+                    internalDispatch[tryAtLevel] = list;
+                }
+
+                list.Add(new IteratorTryDispatchEntry(state, target));
+
+                if (!tryYieldStates.TryGetValue(tryAtLevel, out var yieldList))
+                {
+                    yieldList = new List<int>();
+                    tryYieldStates[tryAtLevel] = yieldList;
+                }
+
+                yieldList.Add(state);
+            }
+        }
+
+        private BoundLabel GetOrCreateEntryLabel(BoundTryStatement tryStmt)
+        {
+            if (!entryLabels.TryGetValue(tryStmt, out var lbl))
+            {
+                lbl = new BoundLabel("$iter_try_entry_" + entryOrdinal++);
+                entryLabels[tryStmt] = lbl;
+            }
+
+            return lbl;
+        }
+
+        private BoundLabel GetOrCreateResumeLabel(int state)
+        {
+            if (!resumeLabels.TryGetValue(state, out var lbl))
+            {
+                lbl = new BoundLabel("$iterResume_" + state);
+                resumeLabels[state] = lbl;
+            }
+
+            return lbl;
+        }
+    }
+}
+
+/// <summary>One entry in a user try's internal state dispatch (iterator).</summary>
+internal readonly struct IteratorTryDispatchEntry
+{
+    /// <summary>Initializes a new instance of the <see cref="IteratorTryDispatchEntry"/> struct.</summary>
+    /// <param name="state">The yield state number.</param>
+    /// <param name="target">The dispatch target label.</param>
+    public IteratorTryDispatchEntry(int state, BoundLabel target)
+    {
+        State = state;
+        Target = target;
+    }
+
+    /// <summary>Gets the yield state number.</summary>
+    public int State { get; }
+
+    /// <summary>Gets the dispatch target label.</summary>
+    public BoundLabel Target { get; }
+}
+
+/// <summary>
+/// Result of <see cref="IteratorTryDispatchPlanner.Plan"/>: per-state outer
+/// dispatch routing, per-try entry labels, per-try internal dispatch entries,
+/// per-try yield state sets, and the innermost-first list of try-finallies
+/// that contain yields (which Dispose must walk).
+/// </summary>
+internal sealed class IteratorTryDispatchPlan
+{
+    private readonly ImmutableDictionary<int, BoundLabel> outerDispatchTargets;
+    private readonly ImmutableDictionary<BoundTryStatement, BoundLabel> entryLabels;
+    private readonly ImmutableDictionary<int, BoundLabel> resumeLabels;
+    private readonly ImmutableDictionary<BoundTryStatement, ImmutableArray<IteratorTryDispatchEntry>> internalDispatch;
+    private readonly ImmutableDictionary<BoundTryStatement, ImmutableArray<int>> tryYieldStates;
+    private readonly ImmutableArray<BoundTryStatement> finallyTrysInnermostFirst;
+
+    /// <summary>Initializes a new instance of the <see cref="IteratorTryDispatchPlan"/> class.</summary>
+    /// <param name="outerDispatchTargets">Map from yield state to outer-dispatch target label.</param>
+    /// <param name="entryLabels">Map from user try statement to its synthesized entry label.</param>
+    /// <param name="resumeLabels">Map from yield state to its canonical resume label.</param>
+    /// <param name="internalDispatch">Map from user try statement to its internal dispatch entries.</param>
+    /// <param name="tryYieldStates">Map from user try statement to the yield states it transitively contains.</param>
+    /// <param name="finallyTrysInnermostFirst">Innermost-first list of user try-finally statements that contain yields.</param>
+    public IteratorTryDispatchPlan(
+        ImmutableDictionary<int, BoundLabel> outerDispatchTargets,
+        ImmutableDictionary<BoundTryStatement, BoundLabel> entryLabels,
+        ImmutableDictionary<int, BoundLabel> resumeLabels,
+        ImmutableDictionary<BoundTryStatement, ImmutableArray<IteratorTryDispatchEntry>> internalDispatch,
+        ImmutableDictionary<BoundTryStatement, ImmutableArray<int>> tryYieldStates,
+        ImmutableArray<BoundTryStatement> finallyTrysInnermostFirst)
+    {
+        this.outerDispatchTargets = outerDispatchTargets;
+        this.entryLabels = entryLabels;
+        this.resumeLabels = resumeLabels;
+        this.internalDispatch = internalDispatch;
+        this.tryYieldStates = tryYieldStates;
+        this.finallyTrysInnermostFirst = finallyTrysInnermostFirst;
+    }
+
+    /// <summary>
+    /// Gets the label the outer dispatch should branch to for the given
+    /// yield state, or <see langword="null"/> if the yield is not inside
+    /// any user try (in which case the caller should jump directly to the
+    /// resume label).
+    /// </summary>
+    /// <param name="state">The yield suspension state number.</param>
+    /// <returns>The entry-label target, or null.</returns>
+    public BoundLabel GetOuterDispatchTarget(int state)
+    {
+        return outerDispatchTargets.TryGetValue(state, out var lbl) ? lbl : null;
+    }
+
+    /// <summary>
+    /// Gets the entry label placed immediately before the given user try,
+    /// or <see langword="null"/> if the try contains no yields and needs
+    /// no entry routing.
+    /// </summary>
+    /// <param name="tryStmt">The user try statement (pre-rewrite identity).</param>
+    /// <returns>The synthesized entry label, or null.</returns>
+    public BoundLabel GetEntryLabel(BoundTryStatement tryStmt)
+    {
+        return entryLabels.TryGetValue(tryStmt, out var lbl) ? lbl : null;
+    }
+
+    /// <summary>
+    /// Gets the internal dispatch entries to prepend to the given user
+    /// try's body. Each entry pairs a yield state with the label control
+    /// should jump to (either a resume label or a nested try's entry).
+    /// </summary>
+    /// <param name="tryStmt">The user try statement (pre-rewrite identity).</param>
+    /// <returns>The dispatch entries; empty if this try has no yields inside.</returns>
+    public ImmutableArray<IteratorTryDispatchEntry> GetInternalDispatchEntries(BoundTryStatement tryStmt)
+    {
+        return internalDispatch.TryGetValue(tryStmt, out var entries) ? entries : default;
+    }
+
+    /// <summary>Gets the yield states transitively inside the given user try.</summary>
+    /// <param name="tryStmt">The user try statement.</param>
+    /// <returns>The yield states inside the try, or default if none.</returns>
+    public ImmutableArray<int> GetYieldStatesInTry(BoundTryStatement tryStmt)
+    {
+        return tryYieldStates.TryGetValue(tryStmt, out var entries) ? entries : default;
+    }
+
+    /// <summary>Gets the canonical resume label for the given yield state.</summary>
+    /// <param name="state">The yield state.</param>
+    /// <returns>The resume label, or null if no yield with that state was recorded.</returns>
+    public BoundLabel GetResumeLabel(int state)
+    {
+        return resumeLabels.TryGetValue(state, out var lbl) ? lbl : null;
+    }
+
+    /// <summary>
+    /// Gets the user try-finally statements that contain yields, in
+    /// innermost-first order. Dispose must walk these in this order so
+    /// nested finallies run before their enclosers, mirroring normal
+    /// stack unwinding.
+    /// </summary>
+    public ImmutableArray<BoundTryStatement> FinallyTrysInnermostFirst => finallyTrysInnermostFirst;
+}

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -740,7 +740,84 @@ public sealed class Lowerer : BoundTreeRewriter
         statements.Add(new BoundLabelStatement(node.Syntax, startLabel));
         statements.Add(new BoundConditionalGotoStatement(node.Syntax, bodyLabel, moveNextCallFactory(enumeratorExpr), jumpIfTrue: true));
         statements.Add(new BoundLabelStatement(node.Syntax, node.BreakLabel));
+
+        // Wrap the iteration in try-finally so the enumerator is disposed
+        // on early break, return, or exception — matching C# foreach. We
+        // only emit the disposer when the enumerator implements IDisposable
+        // (e.g. all synthesized iterator state machines do). The enumerator
+        // variable declaration is moved into an outer scope so its handle
+        // is still in scope in the finally.
+        //
+        // We skip the wrap when the loop body itself contains a yield or
+        // await: in those cases the enclosing function is rewritten as an
+        // iterator or async state machine, and that pipeline does not yet
+        // generally handle protected regions around its suspension points.
+        // Avoiding the wrap here preserves the pre-existing behavior for
+        // those callers while still adding Dispose coverage for the common
+        // case (plain foreach over an enumerable).
+        var disposeCall = TryBuildEnumeratorDisposeCall(enumeratorSymbol);
+        if (disposeCall != null && !BodyContainsYieldOrAwait(node.Body))
+        {
+            // Outer block:
+            //   var $enum = coll.GetEnumerator();
+            //   try { ... loop body ... } finally { $enum.Dispose(); }
+            var loopStatements = statements.ToImmutable();
+
+            // Drop the enumeratorDecl from the loop body — it lives outside the try.
+            // (It was added at index 0.)
+            var withoutEnumDecl = ImmutableArray.CreateRange(System.Linq.Enumerable.Skip(loopStatements, 1));
+
+            var tryBlock = new BoundBlockStatement(node.Syntax, withoutEnumDecl);
+            var finallyBlock = new BoundBlockStatement(
+                node.Syntax,
+                ImmutableArray.Create<BoundStatement>(new BoundExpressionStatement(node.Syntax, disposeCall)));
+            var tryFinally = new BoundTryStatement(
+                node.Syntax,
+                tryBlock,
+                ImmutableArray<BoundCatchClause>.Empty,
+                finallyBlock);
+
+            return new BoundBlockStatement(
+                node.Syntax,
+                ImmutableArray.Create<BoundStatement>(enumeratorDecl, tryFinally));
+        }
+
         return new BoundBlockStatement(node.Syntax, statements.ToImmutable());
+    }
+
+    private static BoundExpression TryBuildEnumeratorDisposeCall(LocalVariableSymbol enumeratorSymbol)
+    {
+        var clrType = enumeratorSymbol.Type?.ClrType;
+        if (clrType == null)
+        {
+            return null;
+        }
+
+        if (!typeof(System.IDisposable).IsAssignableFrom(clrType))
+        {
+            return null;
+        }
+
+        var disposeMethod = typeof(System.IDisposable).GetMethod("Dispose", System.Type.EmptyTypes);
+        if (disposeMethod == null)
+        {
+            return null;
+        }
+
+        var receiver = new BoundVariableExpression(null, enumeratorSymbol);
+        return new BoundImportedInstanceCallExpression(
+            null,
+            receiver,
+            disposeMethod,
+            TypeSymbol.Void,
+            ImmutableArray<BoundExpression>.Empty);
+    }
+
+    private static bool BodyContainsYieldOrAwait(BoundStatement body)
+    {
+        var walker = new YieldOrAwaitDetector();
+        walker.RewriteStatement(body);
+        return walker.Found;
     }
 
     private static bool TryBuildGetEnumeratorCall(
@@ -963,5 +1040,22 @@ public sealed class Lowerer : BoundTreeRewriter
         stmts.Add(new BoundReturnStatement(null, retExpr));
 
         return new BoundBlockStatement(null, stmts.ToImmutable());
+    }
+
+    private sealed class YieldOrAwaitDetector : BoundTreeRewriter
+    {
+        public bool Found { get; private set; }
+
+        protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
+        {
+            this.Found = true;
+            return node;
+        }
+
+        protected override BoundExpression RewriteAwaitExpression(BoundAwaitExpression node)
+        {
+            this.Found = true;
+            return node;
+        }
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Emit/IteratorTryFinallyEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/IteratorTryFinallyEmitTests.cs
@@ -1,0 +1,276 @@
+// <copyright file="IteratorTryFinallyEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// End-to-end emit tests for iterator functions that contain
+/// <c>yield</c> statements inside <c>try</c>/<c>finally</c> blocks
+/// (issue #419 — P0-3).
+/// </summary>
+public class IteratorTryFinallyEmitTests
+{
+    [Fact]
+    public void Iterator_YieldInsideTryFinally_RunsFinallyAfterFullEnumeration()
+    {
+        var source = @"
+package IterTest
+import System
+import System.Collections.Generic
+
+func gen() IEnumerable[int32] {
+    try {
+        yield 1
+        yield 2
+    } finally {
+        Console.WriteLine(""dispose"")
+    }
+}
+
+for v in gen() {
+    Console.WriteLine(v)
+}
+";
+        var output = CompileLoadInvokeCaptureStdout(source, nameof(Iterator_YieldInsideTryFinally_RunsFinallyAfterFullEnumeration));
+        Assert.Contains("1", output);
+        Assert.Contains("2", output);
+        Assert.Contains("dispose", output);
+        // Finally must run AFTER the last yielded value.
+        var idx1 = output.IndexOf("1", StringComparison.Ordinal);
+        var idx2 = output.IndexOf("2", StringComparison.Ordinal);
+        var idxFinally = output.IndexOf("dispose", StringComparison.Ordinal);
+        Assert.True(idx1 < idx2);
+        Assert.True(idx2 < idxFinally);
+    }
+
+    [Fact]
+    public void Iterator_YieldInsideTryCatchFinally_RunsFinally()
+    {
+        var source = @"
+package IterTest
+import System
+import System.Collections.Generic
+
+func gen() IEnumerable[int32] {
+    try {
+        yield 10
+        yield 20
+    } catch (e Exception) {
+        Console.WriteLine(""caught"")
+    } finally {
+        Console.WriteLine(""done"")
+    }
+}
+
+for v in gen() {
+    Console.WriteLine(v)
+}
+";
+        var output = CompileLoadInvokeCaptureStdout(source, nameof(Iterator_YieldInsideTryCatchFinally_RunsFinally));
+        Assert.Contains("10", output);
+        Assert.Contains("20", output);
+        Assert.Contains("done", output);
+        Assert.DoesNotContain("caught", output);
+    }
+
+    [Fact]
+    public void Iterator_NestedTryFinally_RunsBothFinallies_InCorrectOrder()
+    {
+        var source = @"
+package IterTest
+import System
+import System.Collections.Generic
+
+func gen() IEnumerable[int32] {
+    try {
+        try {
+            yield 1
+            yield 2
+        } finally {
+            Console.WriteLine(""inner"")
+        }
+    } finally {
+        Console.WriteLine(""outer"")
+    }
+}
+
+for v in gen() {
+    Console.WriteLine(v)
+}
+";
+        var output = CompileLoadInvokeCaptureStdout(source, nameof(Iterator_NestedTryFinally_RunsBothFinallies_InCorrectOrder));
+        Assert.Contains("1", output);
+        Assert.Contains("2", output);
+        var idxInner = output.IndexOf("inner", StringComparison.Ordinal);
+        var idxOuter = output.IndexOf("outer", StringComparison.Ordinal);
+        Assert.True(idxInner > 0, "inner finally must run");
+        Assert.True(idxOuter > 0, "outer finally must run");
+        Assert.True(idxInner < idxOuter, "inner finally runs before outer finally");
+    }
+
+    [Fact]
+    public void Iterator_EarlyBreak_TriggersDispose_WhichRunsFinally()
+    {
+        // foreach in G# desugars to a for-range loop that disposes the
+        // enumerator on early exit. Break out after the first yield and
+        // verify the finally still runs.
+        var source = @"
+package IterTest
+import System
+import System.Collections.Generic
+
+func gen() IEnumerable[int32] {
+    try {
+        yield 1
+        yield 2
+        yield 3
+    } finally {
+        Console.WriteLine(""dispose"")
+    }
+}
+
+for v in gen() {
+    Console.WriteLine(v)
+    if v == 1 {
+        break
+    }
+}
+";
+        var output = CompileLoadInvokeCaptureStdout(source, nameof(Iterator_EarlyBreak_TriggersDispose_WhichRunsFinally));
+        Assert.Contains("1", output);
+        Assert.DoesNotContain("2", output);
+        Assert.Contains("dispose", output);
+    }
+
+    [Fact]
+    public void Iterator_NestedEarlyBreak_RunsInnerThenOuterFinally()
+    {
+        var source = @"
+package IterTest
+import System
+import System.Collections.Generic
+
+func gen() IEnumerable[int32] {
+    try {
+        try {
+            yield 1
+            yield 2
+        } finally {
+            Console.WriteLine(""inner"")
+        }
+    } finally {
+        Console.WriteLine(""outer"")
+    }
+}
+
+for v in gen() {
+    Console.WriteLine(v)
+    if v == 1 {
+        break
+    }
+}
+";
+        var output = CompileLoadInvokeCaptureStdout(source, nameof(Iterator_NestedEarlyBreak_RunsInnerThenOuterFinally));
+        var idx1 = output.IndexOf("1", StringComparison.Ordinal);
+        var idxInner = output.IndexOf("inner", StringComparison.Ordinal);
+        var idxOuter = output.IndexOf("outer", StringComparison.Ordinal);
+        Assert.True(idx1 >= 0);
+        Assert.True(idxInner > idx1);
+        Assert.True(idxOuter > idxInner);
+        Assert.DoesNotContain("2", output);
+    }
+
+    [Fact]
+    public void Iterator_YieldInTryFinally_ResumesAcrossYields()
+    {
+        // Verifies the resume path: each MoveNext must correctly re-enter
+        // the protected region via the synthesized entry label and pick
+        // up after the prior yield without the CLR rejecting the IL.
+        var source = @"
+package IterTest
+import System
+import System.Collections.Generic
+
+func gen() IEnumerable[int32] {
+    try {
+        yield 100
+        Console.WriteLine(""mid"")
+        yield 200
+    } finally {
+        Console.WriteLine(""fin"")
+    }
+}
+
+for v in gen() {
+    Console.WriteLine(v)
+}
+";
+        var output = CompileLoadInvokeCaptureStdout(source, nameof(Iterator_YieldInTryFinally_ResumesAcrossYields));
+        var idx1 = output.IndexOf("100", StringComparison.Ordinal);
+        var idxMid = output.IndexOf("mid", StringComparison.Ordinal);
+        var idx2 = output.IndexOf("200", StringComparison.Ordinal);
+        var idxFin = output.IndexOf("fin", StringComparison.Ordinal);
+        Assert.True(idx1 >= 0);
+        Assert.True(idxMid > idx1, "user code between yields must execute");
+        Assert.True(idx2 > idxMid);
+        Assert.True(idxFin > idx2);
+    }
+
+    private static EmitResult Compile(string source, Stream peStream)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Emit(peStream);
+    }
+
+    private static string CompileLoadInvokeCaptureStdout(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var result = Compile(source, peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, parameters: null);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #419.

## Problem

The iterator state-machine rewriter had no analogue of the async `TryDispatchPlanner`. It left the user's `try` block in place inside `MoveNext`, with branches from the dispatcher switch table jumping directly into a CLR protected region. The JIT rejected this with `InvalidProgramException`.

Repro:
```gsharp
func gen() IEnumerable[int32] {
  try { yield 1; yield 2 }
  finally { Console.WriteLine("dispose") }
}
```

## Fix

Iterators cannot reuse the async `TryDispatchPlanner` shape verbatim because (a) `ret` inside a CLR protected region is illegal, and (b) `leave` would run the finally on every yield. Instead this PR uses an iterator-specific lowering:

- **MoveNext**: try-finally regions containing yields are inlined as `{ tryBody; finallyBody; }` so the finally still runs on normal completion without a protected region. Returns inside such trys inline pending finallies before `goto endLabel`.
- **Dispose**: a generated body snapshots the suspended state, sets state=-1, then walks pending try-finallies innermost-first, running each user finally whose try contained the suspending yield.
- **for-range**: when the enumerator implements `IDisposable`, iteration is wrapped in `try { loop } finally { enum.Dispose() }` so early `break` triggers `Dispose` (which runs pending iterator finallies). Skipped when the loop body itself contains yield/await so async-iterator lowering is unaffected.

New `IteratorTryDispatchPlanner` walks the body to discover per-try yield-state membership and the innermost-first list of try-finallies containing yields.

## Tests

6 new end-to-end emit/runtime tests in `IteratorTryFinallyEmitTests`:
- yield inside try/finally — values yielded and finally runs on dispose
- yield inside try/catch/finally
- nested try/finally with yields at multiple levels
- early break from foreach triggers Dispose → finally
- nested early break
- resume across yields

Full suite: **2145 tests pass, 0 fail**.