### PR TITLE
Fix #418 (P1-6): pop DynamicInvoke result for void delegate calls

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -13719,6 +13719,17 @@ internal sealed class ReflectionMetadataEmitter
 
             this.il.OpCode(ILOpCode.Callvirt);
             this.il.Token(this.outer.GetMethodReference(dynamicInvoke));
+
+            // Issue #418 (P1-6): Delegate.DynamicInvoke always returns object.
+            // For an erased void-returning delegate (`func(T)` with no return),
+            // the BoundIndirectCallExpression.Type is Void, so the surrounding
+            // BoundExpressionStatement skips its usual Pop and the boxed result
+            // would linger on the stack, producing invalid IL at the next
+            // ret/leave. Absorb the unused object here.
+            if (call.FunctionType.ReturnType == TypeSymbol.Void)
+            {
+                this.il.OpCode(ILOpCode.Pop);
+            }
         }
 
         private void EmitInstanceReceiver(BoundExpression receiver)

--- a/test/Compiler.Tests/Emit/GenericFunctionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/GenericFunctionEmitTests.cs
@@ -119,6 +119,48 @@ public class GenericFunctionEmitTests
         Assert.Equal("42\n", output);
     }
 
+    [Fact]
+    public void GenericVoidDelegate_DynamicInvoke_PopsResult_Issue418()
+    {
+        // Issue #418 (P1-6): an erased void-returning delegate (func(T) with
+        // no return) is invoked via System.Delegate.DynamicInvoke which always
+        // returns object. Without an explicit Pop the boxed result lingers on
+        // the stack until the next ret/leave, producing invalid IL that
+        // refuses to load.
+        var source = """
+            package P
+            import System
+
+            func Run[T any](x T, f func(T)) { f(x) }
+            Run(7, func(n int32) { Console.WriteLine(n) })
+            Run("hi", func(s string) { Console.WriteLine(s) })
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\nhi\n", output);
+    }
+
+    [Fact]
+    public void GenericVoidDelegate_DynamicInvoke_CalledInLoop_Issue418()
+    {
+        // Repeated invocation makes the stack-leak bug deterministic: each
+        // iteration would push an object that survives across the back-edge.
+        var source = """
+            package P
+            import System
+
+            func Repeat[T any](x T, n int32, f func(T)) {
+                for i := 0; i < n; i = i + 1 {
+                    f(x)
+                }
+            }
+            Repeat(42, 3, func(v int32) { Console.WriteLine(v) })
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n42\n42\n", output);
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_generic_emit_").FullName;


### PR DESCRIPTION
## Problem (P1-6 of #418)

`EmitIndirectCall` routes type-erased open-delegate calls (`call.FunctionType.ClrType == null`) through `System.Delegate.DynamicInvoke`, which always returns `object`. For an erased `func(T)` with no return, `BoundIndirectCallExpression.Type` is `Void`, so the surrounding `BoundExpressionStatement` skips its usual `Pop`. The boxed result lingered on the evaluation stack until the next `ret` / `leave`, producing IL that the JIT rejects with `InvalidProgramException`.

## Fix

In `EmitOpenDelegateDynamicInvoke` (`src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs`), after the `callvirt` to `Delegate.DynamicInvoke`, emit `pop` when `call.FunctionType.ReturnType == TypeSymbol.Void` to absorb the always-returned `object`.

## Tests

Added to `test/Compiler.Tests/Emit/GenericFunctionEmitTests.cs`:

- `GenericVoidDelegate_DynamicInvoke_PopsResult_Issue418` — calls an erased `func(T)` with no return for both an `int32` and a `string` substitution.
- `GenericVoidDelegate_DynamicInvoke_CalledInLoop_Issue418` — repeated invocation in a loop, which makes the stack-leak deterministic and threw `InvalidProgramException` without the fix.

Verified both tests fail (with `InvalidProgramException`) without the emitter change and pass with it. Full suite: **2192 passed, 0 failed**.

Closes part P1-6 of #418.