### PR TITLE
Fix #418 (P1-11): use ExceptionDispatchInfo.Capture().Throw() for async rethrow

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
@@ -44,7 +44,10 @@ namespace GSharp.Core.CodeAnalysis.Lowering.Async;
 /// try { body; }
 /// catch (Exception ex) { pendingException = ex; }
 /// finallyBody;   // await is now outside the finally region
-/// if (pendingException != null) { throw pendingException; }
+/// if (pendingException != null) {
+///     System.Runtime.ExceptionServices.ExceptionDispatchInfo
+///         .Capture(pendingException).Throw();   // preserve original stack trace (#418)
+/// }
 /// </code>
 ///
 /// <para><b>Deferred:</b> Pending-branch dispatch for <c>return</c>/<c>goto</c>/
@@ -441,8 +444,52 @@ public static class AsyncExceptionHandlerRewriter
                 nullLitFinal);
 
             statements.Add(new BoundConditionalGotoStatement(null, rethrowEndLabel, rethrowCondition, jumpIfTrue: true));
-            statements.Add(new BoundThrowStatement(null, new BoundVariableExpression(null, pendingExLocal)));
+
+            // Rethrow via ExceptionDispatchInfo.Capture(pendingException).Throw() so the
+            // original throw site (stack trace, watson bucketing) is preserved across the
+            // async lift. Using a bare `throw pendingException` would reset the stack
+            // trace and defeat production diagnostics (issue #418 P1-11).
+            statements.Add(BuildEdiCaptureThrow(new BoundVariableExpression(null, pendingExLocal), exceptionType));
             statements.Add(new BoundLabelStatement(null, rethrowEndLabel));
+        }
+
+        /// <summary>
+        /// Builds the lowered statement
+        /// <c>ExceptionDispatchInfo.Capture(<paramref name="exceptionExpr"/>).Throw();</c>.
+        /// Used by the async-rethrow path so that an exception captured into a
+        /// pending-exception local is re-raised with its original stack trace,
+        /// matching the semantics of an unrewritten <c>throw;</c> inside a CLR
+        /// finally handler.
+        /// </summary>
+        /// <param name="exceptionExpr">Expression producing the exception to rethrow.</param>
+        /// <param name="exceptionType">The bound <see cref="System.Exception"/> type symbol.</param>
+        /// <returns>A bound expression statement invoking <c>Capture(...).Throw()</c>.</returns>
+        private static BoundStatement BuildEdiCaptureThrow(BoundExpression exceptionExpr, TypeSymbol exceptionType)
+        {
+            var ediType = typeof(System.Runtime.ExceptionServices.ExceptionDispatchInfo);
+            var captureMethod = ediType.GetMethod(
+                nameof(System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture),
+                new[] { typeof(Exception) });
+            var throwMethod = ediType.GetMethod(
+                nameof(System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw),
+                Type.EmptyTypes);
+
+            var ediClass = new ImportedClassSymbol(ediType, declaration: null);
+            var captureFn = new ImportedFunctionSymbol(captureMethod.Name, ediClass, captureMethod, declaration: null);
+
+            var captureCall = new BoundImportedCallExpression(
+                null,
+                captureFn,
+                ImmutableArray.Create(exceptionExpr));
+
+            var throwCall = new BoundImportedInstanceCallExpression(
+                null,
+                captureCall,
+                throwMethod,
+                TypeSymbol.Void,
+                ImmutableArray<BoundExpression>.Empty);
+
+            return new BoundExpressionStatement(null, throwCall);
         }
 
         private static bool CatchesChanged(

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriterTests.cs
@@ -472,4 +472,114 @@ ImmutableArray.Create<BoundStatement>(
         Assert.Same(argExType, rewrittenTry.CatchClauses[0].ExceptionType);
         Assert.Same(ExceptionType, rewrittenTry.CatchClauses[1].ExceptionType);
     }
+
+    // ----------------------------------------------------------------------
+    // Issue #418 P1-11: the auto-rethrow at the tail of a try/finally-with-await
+    // rewrite must preserve the original stack trace by going through
+    // ExceptionDispatchInfo.Capture(...).Throw() instead of `throw ex;`.
+    // ----------------------------------------------------------------------
+
+    [Fact]
+    public void TryFinally_WithAwaitInFinally_RethrowsViaExceptionDispatchInfo_NotBareThrow()
+    {
+        // Arrange: try { x = 1 } finally { await ... }
+        var x = new LocalVariableSymbol("x", false, TypeSymbol.Int32);
+        var tryBlock = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 1)))));
+        var awaitExpr = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int32);
+        var finallyBlock = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(null, awaitExpr)));
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray<BoundCatchClause>.Empty, finallyBlock);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
+
+        // Act
+        var result = AsyncExceptionHandlerRewriter.Rewrite(body);
+
+        // Assert: the auto-rethrow at the tail must NOT be a BoundThrowStatement
+        // (which would lower to `throw ex` and reset the stack trace). It must
+        // call ExceptionDispatchInfo.Capture(pendingException).Throw().
+        var innerBlock = Assert.IsType<BoundBlockStatement>(result.Statements[0]);
+        var allStmts = FlattenStatements(innerBlock).ToArray();
+
+        // No BoundThrowStatement should be present anywhere in the rewritten body —
+        // the only throw-shaped operation should be the EDI Throw() instance call.
+        Assert.DoesNotContain(allStmts, s => s is BoundThrowStatement);
+
+        // Locate the EDI Throw() call.
+        var ediThrowCalls = allStmts
+            .OfType<BoundExpressionStatement>()
+            .Select(es => es.Expression)
+            .OfType<BoundImportedInstanceCallExpression>()
+            .Where(ic => ic.Method.DeclaringType == typeof(System.Runtime.ExceptionServices.ExceptionDispatchInfo)
+                         && ic.Method.Name == nameof(System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw))
+            .ToArray();
+        Assert.Single(ediThrowCalls);
+
+        // The receiver must be ExceptionDispatchInfo.Capture(pendingException).
+        var receiverCall = Assert.IsType<BoundImportedCallExpression>(ediThrowCalls[0].Receiver);
+        Assert.Equal(nameof(System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture), receiverCall.Function.Method.Name);
+        Assert.Equal(typeof(System.Runtime.ExceptionServices.ExceptionDispatchInfo), receiverCall.Function.Method.DeclaringType);
+
+        // Capture must take a single Exception-typed argument: the pendingException local.
+        var arg = Assert.Single(receiverCall.Arguments);
+        var pendingRef = Assert.IsType<BoundVariableExpression>(arg);
+        Assert.Contains("<>pending_ex_", pendingRef.Variable.Name);
+    }
+
+    [Fact]
+    public void TryCatchFinally_WithAwait_RethrowUsesExceptionDispatchInfo()
+    {
+        // Arrange: try { x = 1 } catch (e) { x = 2 } finally { await b }
+        // The rewriter must lift the finally and emit an EDI-based rethrow at the
+        // tail, NOT a bare `throw pendingException`.
+        var x = new LocalVariableSymbol("x", false, TypeSymbol.Int32);
+        var e = new LocalVariableSymbol("e", false, ExceptionType);
+        var tryBlock = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 1)))));
+        var catchBody = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(null, new BoundAssignmentExpression(null, x, new BoundLiteralExpression(null, 2)))));
+        var catchClause = new BoundCatchClause(ExceptionType, e, catchBody);
+        var awaitB = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int32);
+        var finallyBlock = new BoundBlockStatement(null,
+            ImmutableArray.Create<BoundStatement>(new BoundExpressionStatement(null, awaitB)));
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray.Create(catchClause), finallyBlock);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
+
+        // Act
+        var result = AsyncExceptionHandlerRewriter.Rewrite(body);
+
+        // Assert: no bare BoundThrowStatement in the rewritten body; EDI Throw() exists.
+        var innerBlock = Assert.IsType<BoundBlockStatement>(result.Statements[0]);
+        var allStmts = FlattenStatements(innerBlock).ToArray();
+        Assert.DoesNotContain(allStmts, s => s is BoundThrowStatement);
+        Assert.Contains(
+            allStmts.OfType<BoundExpressionStatement>().Select(s => s.Expression).OfType<BoundImportedInstanceCallExpression>(),
+            ic => ic.Method.DeclaringType == typeof(System.Runtime.ExceptionServices.ExceptionDispatchInfo)
+                  && ic.Method.Name == nameof(System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw));
+    }
+
+    /// <summary>
+    /// Recursively yields all <see cref="BoundStatement"/> nodes in a block,
+    /// descending into nested <see cref="BoundBlockStatement"/>s. Used so tests
+    /// can assert on the absence of specific statement kinds anywhere in the
+    /// rewritten body regardless of nesting introduced by the rewriter.
+    /// </summary>
+    private static System.Collections.Generic.IEnumerable<BoundStatement> FlattenStatements(BoundBlockStatement block)
+    {
+        foreach (var stmt in block.Statements)
+        {
+            yield return stmt;
+            if (stmt is BoundBlockStatement nested)
+            {
+                foreach (var inner in FlattenStatements(nested))
+                {
+                    yield return inner;
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## P1-11: Async rethrow loses stack trace

Fixes part of #418.

### Problem
`AsyncExceptionHandlerRewriter` lifts try/finally-with-await out of the protected region and emits an auto-rethrow at the tail to propagate any exception captured into `pendingException`. That rethrow was lowered as a fresh `throw pendingException;` (`BoundThrowStatement`) which resets the exception's stack trace — destroying the original throw site, defeating production diagnostics, and breaking watson bucketing.

### Fix
Replace the `throw` lowering with the standard CLR pattern:

```csharp
System.Runtime.ExceptionServices.ExceptionDispatchInfo
    .Capture(pendingException).Throw();
```

The bound tree is built as:
- `BoundImportedCallExpression` → static `ExceptionDispatchInfo.Capture(Exception)`
- `BoundImportedInstanceCallExpression` → instance `.Throw()` on the captured value

Both node kinds are already handled by `SpillSequenceSpiller`, `MoveNextBodyRewriter`, and `TryDispatchPlanner`, so the rewritten tree flows through the rest of the async pipeline unchanged. (`MoveNextBodyRewriter` already uses the same shape for `SetException`.)

The XML doc comment showing pattern B was updated accordingly.

### Tests
Added two structural tests to `AsyncExceptionHandlerRewriterTests`:
- `TryFinally_WithAwaitInFinally_RethrowsViaExceptionDispatchInfo_NotBareThrow` — asserts the rewritten body contains no `BoundThrowStatement` and that the EDI `Throw()` call's receiver is `Capture(pendingException)`.
- `TryCatchFinally_WithAwait_RethrowUsesExceptionDispatchInfo` — same invariants for the try/catch/finally variant.

### Verification
All existing tests pass:
- Core.Tests: 1620 / Compiler.Tests: 282 / LanguageServer.Tests: 212 / Interpreter.Tests: 54 / Sdk.Tests: 24 — all green.