### PR TITLE
Fix #418 (P1-12): hoist ref-local receiver/index to prevent side-effect duplication

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/RefInitializationHoister.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/RefInitializationHoister.cs
@@ -17,16 +17,21 @@ namespace GSharp.Core.CodeAnalysis.Lowering.Async;
 /// <remarks>
 /// <para>A ref local is identified by its type being <see cref="ByRefTypeSymbol"/>
 /// and its initializer being a <see cref="BoundAddressOfExpression"/>. The hoister
-/// records the address-of operand and inlines it at every use site:</para>
+/// recomputes the managed pointer at every use site:</para>
 /// <list type="bullet">
 /// <item><description><c>*refLocal</c> (dereference read) → replaced with the
-/// operand expression directly.</description></item>
+/// underlying lvalue expression.</description></item>
 /// <item><description><c>refLocal</c> (bare pointer usage, e.g., passed to ref
-/// parameter) → replaced with <c>&amp;operand</c>.</description></item>
+/// parameter) → replaced with <c>&amp;lvalue</c>.</description></item>
 /// </list>
-/// <para>The ref local declaration is removed. The constituent variables in the
-/// operand (array, index, receiver, etc.) remain in the tree and will be hoisted
-/// normally by <see cref="AsyncCaptureWalker"/>.</para>
+/// <para>To avoid duplicating side effects (issue #418 / P1-12), any
+/// non-trivial sub-expression of the original ref initializer (call receiver,
+/// index expression, etc.) is evaluated <em>once</em> into a hoisted temporary
+/// local at the ref-initialization site. The reconstructed lvalue then refers
+/// only to those temporaries and other side-effect-free leaves (variables,
+/// parameters, literals), making it safe to inline at every use site. The
+/// constituent variables are themselves later hoisted into state-machine
+/// fields by <see cref="AsyncCaptureWalker"/> if they cross an await.</para>
 /// <para>This pass runs after <see cref="SpillSequenceSpiller"/> and before
 /// <see cref="AsyncStateMachineTypeBuilder"/> in the async pipeline.</para>
 /// </remarks>
@@ -44,28 +49,33 @@ public static class RefInitializationHoister
             return body;
         }
 
-        // First pass: collect ref local → operand mappings.
+        // First pass: collect ref local declarations (we still need to know
+        // which locals are ref so the rewriter can recognize their uses). The
+        // operand template is computed in the second pass at the declaration
+        // site itself, where we also emit the hoisting prelude.
         var refLocals = new Dictionary<LocalVariableSymbol, BoundExpression>();
-        CollectRefLocals(body, refLocals);
-
-        if (refLocals.Count == 0)
+        if (!CollectRefLocals(body, refLocals))
         {
             return body;
         }
 
-        // Second pass: rewrite the tree.
+        // Second pass: rewrite the tree. The rewriter replaces each ref local
+        // declaration with a block containing the hoisting prelude and updates
+        // the refLocals mapping to point at the side-effect-free template
+        // expression that re-derives the lvalue from hoisted temporaries.
         var rewriter = new Rewriter(refLocals);
         var result = (BoundBlockStatement)rewriter.RewriteStatement(body);
         return result;
     }
 
-    private static void CollectRefLocals(BoundStatement statement, Dictionary<LocalVariableSymbol, BoundExpression> refLocals)
+    private static bool CollectRefLocals(BoundStatement statement, Dictionary<LocalVariableSymbol, BoundExpression> refLocals)
     {
+        bool found = false;
         if (statement is BoundBlockStatement block)
         {
             foreach (var stmt in block.Statements)
             {
-                CollectRefLocals(stmt, refLocals);
+                found |= CollectRefLocals(stmt, refLocals);
             }
         }
         else if (statement is BoundVariableDeclaration decl
@@ -73,34 +83,54 @@ public static class RefInitializationHoister
             && local.Type is ByRefTypeSymbol
             && decl.Initializer is BoundAddressOfExpression addressOf)
         {
+            // Seed with the raw operand; the rewriter replaces this with the
+            // hoisted template when it visits the declaration.
             refLocals[local] = addressOf.Operand;
+            found = true;
         }
         else if (statement is BoundIfStatement ifStmt)
         {
-            CollectRefLocals(ifStmt.ThenStatement, refLocals);
+            found |= CollectRefLocals(ifStmt.ThenStatement, refLocals);
             if (ifStmt.ElseStatement != null)
             {
-                CollectRefLocals(ifStmt.ElseStatement, refLocals);
+                found |= CollectRefLocals(ifStmt.ElseStatement, refLocals);
             }
         }
         else if (statement is BoundTryStatement tryStmt)
         {
-            CollectRefLocals(tryStmt.TryBlock, refLocals);
+            found |= CollectRefLocals(tryStmt.TryBlock, refLocals);
             foreach (var clause in tryStmt.CatchClauses)
             {
-                CollectRefLocals(clause.Body, refLocals);
+                found |= CollectRefLocals(clause.Body, refLocals);
             }
 
             if (tryStmt.FinallyBlock != null)
             {
-                CollectRefLocals(tryStmt.FinallyBlock, refLocals);
+                found |= CollectRefLocals(tryStmt.FinallyBlock, refLocals);
             }
         }
+
+        return found;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="expression"/> can
+    /// be re-evaluated arbitrarily many times without observable side effects
+    /// and without re-running user code: pure leaves like variable reads,
+    /// parameter reads, literals, and the implicit <c>this</c>/state-machine
+    /// receiver. Anything else (calls, indexers, field/property reads, casts,
+    /// arithmetic, etc.) is hoisted into a temporary.
+    /// </summary>
+    private static bool IsTriviallyRepeatable(BoundExpression expression)
+    {
+        return expression is BoundVariableExpression
+            || expression is BoundLiteralExpression;
     }
 
     private sealed class Rewriter : BoundTreeRewriter
     {
         private readonly Dictionary<LocalVariableSymbol, BoundExpression> refLocals;
+        private int tempCounter;
 
         public Rewriter(Dictionary<LocalVariableSymbol, BoundExpression> refLocals)
         {
@@ -109,10 +139,20 @@ public static class RefInitializationHoister
 
         protected override BoundStatement RewriteVariableDeclaration(BoundVariableDeclaration node)
         {
-            // Remove ref local declarations entirely.
-            if (node.Variable is LocalVariableSymbol local && refLocals.ContainsKey(local))
+            // Replace ref local declarations with a block containing the
+            // hoisting prelude (one variable declaration per side-effecting
+            // sub-expression). The rewritten template — referencing only the
+            // hoisted temps and trivially repeatable leaves — is recorded in
+            // refLocals so that use-site rewrites read it back instead of
+            // duplicating the original operand.
+            if (node.Variable is LocalVariableSymbol local
+                && local.Type is ByRefTypeSymbol
+                && node.Initializer is BoundAddressOfExpression addressOf)
             {
-                return new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
+                var prelude = ImmutableArray.CreateBuilder<BoundStatement>();
+                var template = HoistOperand(addressOf.Operand, prelude);
+                refLocals[local] = template;
+                return new BoundBlockStatement(null, prelude.ToImmutable());
             }
 
             return base.RewriteVariableDeclaration(node);
@@ -120,13 +160,15 @@ public static class RefInitializationHoister
 
         protected override BoundExpression RewriteDereferenceExpression(BoundDereferenceExpression node)
         {
-            // *refLocal → operand (the underlying lvalue expression)
+            // *refLocal → reconstructed lvalue template.
             if (node.Operand is BoundVariableExpression varExpr
                 && varExpr.Variable is LocalVariableSymbol local
-                && refLocals.TryGetValue(local, out var operand))
+                && refLocals.TryGetValue(local, out var template))
             {
-                // Recursively rewrite the operand in case it references other ref locals.
-                return RewriteExpression(operand);
+                // The template only references hoisted temps and trivially
+                // repeatable leaves, so no further rewriting is required and
+                // every inlining is side-effect-free.
+                return template;
             }
 
             return base.RewriteDereferenceExpression(node);
@@ -134,12 +176,11 @@ public static class RefInitializationHoister
 
         protected override BoundExpression RewriteVariableExpression(BoundVariableExpression node)
         {
-            // Bare ref local usage (e.g., passed to ref parameter) → &operand
+            // Bare ref local usage (e.g., passed to a ref parameter) → &lvalue.
             if (node.Variable is LocalVariableSymbol local
-                && refLocals.TryGetValue(local, out var operand))
+                && refLocals.TryGetValue(local, out var template))
             {
-                var rewrittenOperand = RewriteExpression(operand);
-                return new BoundAddressOfExpression(null, rewrittenOperand);
+                return new BoundAddressOfExpression(null, template);
             }
 
             return base.RewriteVariableExpression(node);
@@ -147,24 +188,96 @@ public static class RefInitializationHoister
 
         protected override BoundExpression RewriteAssignmentExpression(BoundAssignmentExpression node)
         {
-            // Assignment to a ref local variable itself (re-seating the ref):
-            // refLocal = &newTarget → remove (we'll use the ORIGINAL operand at use sites)
-            // This case is unlikely in V1 but handle gracefully.
+            // Re-seating the ref local itself (refLocal = &newTarget): replace
+            // the template with the new target's hoisted form. This case is
+            // unlikely in V1 but handle it gracefully.
             if (node.Variable is LocalVariableSymbol local && refLocals.ContainsKey(local))
             {
-                // Re-seating is not supported in this slice. If the RHS is a new
-                // address-of, update the mapping. Otherwise, return a no-op.
                 if (node.Expression is BoundAddressOfExpression newAddr)
                 {
-                    refLocals[local] = newAddr.Operand;
+                    // Re-seating mid-method: any side effects in the new
+                    // operand must execute exactly once at this point. We
+                    // cannot inject statements from inside an expression
+                    // rewrite, so fall back to inlining the (already-rewritten)
+                    // operand directly. Spilling earlier in the pipeline will
+                    // already have flattened complex re-seats, so in practice
+                    // the operand is simple.
+                    refLocals[local] = RewriteExpression(newAddr.Operand);
                 }
 
-                // Return a dummy expression (literal 0 cast away) — the statement
-                // wrapping this will be a no-op expression statement.
                 return new BoundLiteralExpression(null, 0);
             }
 
             return base.RewriteAssignmentExpression(node);
+        }
+
+        /// <summary>
+        /// Reconstructs <paramref name="operand"/> as a side-effect-free
+        /// template, emitting hoisting declarations into
+        /// <paramref name="prelude"/> for any non-trivial sub-expression.
+        /// </summary>
+        private BoundExpression HoistOperand(BoundExpression operand, ImmutableArray<BoundStatement>.Builder prelude)
+        {
+            switch (operand)
+            {
+                case BoundIndexExpression idx:
+                    {
+                        var target = HoistIfNeeded(idx.Target, prelude);
+                        var index = HoistIfNeeded(idx.Index, prelude);
+                        return new BoundIndexExpression(idx.Syntax, target, index, idx.Type);
+                    }
+
+                case BoundFieldAccessExpression field:
+                    {
+                        var receiver = HoistIfNeeded(field.Receiver, prelude);
+                        return new BoundFieldAccessExpression(field.Syntax, receiver, field.StructType, field.Field, field.NarrowedType);
+                    }
+
+                case BoundClrIndexExpression clrIdx:
+                    {
+                        var target = HoistIfNeeded(clrIdx.Target, prelude);
+                        var args = ImmutableArray.CreateBuilder<BoundExpression>(clrIdx.Arguments.Length);
+                        foreach (var arg in clrIdx.Arguments)
+                        {
+                            args.Add(HoistIfNeeded(arg, prelude));
+                        }
+
+                        return new BoundClrIndexExpression(clrIdx.Syntax, target, clrIdx.Indexer, args.MoveToImmutable(), clrIdx.Type);
+                    }
+
+                case BoundClrPropertyAccessExpression clrProp when clrProp.Receiver != null:
+                    {
+                        var receiver = HoistIfNeeded(clrProp.Receiver, prelude);
+                        return new BoundClrPropertyAccessExpression(clrProp.Syntax, receiver, clrProp.Member, clrProp.Type);
+                    }
+
+                default:
+                    // Any other operand form (e.g., a bare BoundVariableExpression
+                    // for `ref x = ref y`, or a BoundDereferenceExpression for
+                    // `ref x = ref *p`): trivially repeatable or already in a
+                    // hoist-safe shape after spilling. Inline directly.
+                    return operand;
+            }
+        }
+
+        /// <summary>
+        /// Returns <paramref name="expression"/> unchanged when it is trivially
+        /// repeatable; otherwise emits a fresh local declaration into
+        /// <paramref name="prelude"/> and returns a read of that local.
+        /// </summary>
+        private BoundExpression HoistIfNeeded(BoundExpression expression, ImmutableArray<BoundStatement>.Builder prelude)
+        {
+            if (IsTriviallyRepeatable(expression))
+            {
+                return expression;
+            }
+
+            var temp = new LocalVariableSymbol(
+                $"<refTmp>__{tempCounter++}",
+                isReadOnly: false,
+                expression.Type);
+            prelude.Add(new BoundVariableDeclaration(null, temp, expression));
+            return new BoundVariableExpression(null, temp);
         }
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/RefInitializationHoisterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/RefInitializationHoisterTests.cs
@@ -162,6 +162,215 @@ y, new BoundBinaryExpression(
     }
 
     [Fact]
+    public void RefLocal_To_ArrayElement_WithSideEffectingTarget_HoistsTargetOnce()
+    {
+        // Issue #418 / P1-12: `ref int x = ref Arr()[Idx()]; *x = 1; *x = 2;`
+        // The old hoister inlined the operand at every use, evaluating Arr()
+        // and Idx() once per use. The fix hoists each side-effecting subpart
+        // into a single temp local at the ref-init site so every use re-derives
+        // the lvalue from the same evaluated state.
+        var idxMethod = typeof(System.Array).GetMethod("GetLength")!; // any MethodInfo will do — we just need something non-trivial as `target`/`index`.
+        var arrType = TypeSymbol.FromClrType(typeof(int[]));
+
+        // Use BoundClrStaticCall to fabricate Arr() and Idx().
+        var arrCallType = arrType;
+        var idxCallType = TypeSymbol.Int32;
+
+        // Reuse a real static method whose signature happens to match: we only
+        // care about reference equality through the rewriter; runtime semantics
+        // aren't exercised by the unit test. System.Array.Empty<int>() returns int[].
+        var arrFactoryMethod = typeof(System.Array).GetMethod(nameof(System.Array.Empty))!.MakeGenericMethod(typeof(int));
+
+        // System.Environment.TickCount is an int property — too awkward. Use Math.Abs(int) as Idx().
+        var idxFactoryMethod = typeof(System.Math).GetMethod(nameof(System.Math.Abs), new[] { typeof(int) })!;
+
+        var arrCall = new BoundClrStaticCallExpression(
+            null,
+            arrFactoryMethod,
+            arrCallType,
+            ImmutableArray<BoundExpression>.Empty);
+
+        var idxCall = new BoundClrStaticCallExpression(
+            null,
+            idxFactoryMethod,
+            idxCallType,
+            ImmutableArray.Create<BoundExpression>(new BoundLiteralExpression(null, 3)));
+
+        var slot = new LocalVariableSymbol("slot", isReadOnly: false, ByRefTypeSymbol.Get(TypeSymbol.Int32));
+        var indexExpr = new BoundIndexExpression(null, arrCall, idxCall, TypeSymbol.Int32);
+        var declSlot = new BoundVariableDeclaration(null, slot, new BoundAddressOfExpression(null, indexExpr));
+
+        // Two uses of *slot — the original bug would have evaluated arrCall and
+        // idxCall twice.
+        var use1 = new BoundExpressionStatement(null, new BoundDereferenceExpression(null, new BoundVariableExpression(null, slot)));
+        var use2 = new BoundExpressionStatement(null, new BoundDereferenceExpression(null, new BoundVariableExpression(null, slot)));
+
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(declSlot, use1, use2));
+
+        var result = RefInitializationHoister.Rewrite(body);
+        var stmts = result.Statements;
+
+        // Statement 0: prelude block declaring two temps (one for arrCall, one for idxCall).
+        var prelude = Assert.IsType<BoundBlockStatement>(stmts[0]);
+        Assert.Equal(2, prelude.Statements.Length);
+
+        var t0Decl = Assert.IsType<BoundVariableDeclaration>(prelude.Statements[0]);
+        var t1Decl = Assert.IsType<BoundVariableDeclaration>(prelude.Statements[1]);
+        Assert.Same(arrCall, t0Decl.Initializer);
+        Assert.Same(idxCall, t1Decl.Initializer);
+
+        // Statements 1 and 2: each use is `temp0[temp1]` — same temp symbols, not the original calls.
+        BoundIndexExpression ReadUse(BoundStatement s)
+        {
+            var es = Assert.IsType<BoundExpressionStatement>(s);
+            return Assert.IsType<BoundIndexExpression>(es.Expression);
+        }
+
+        var idx1 = ReadUse(stmts[1]);
+        var idx2 = ReadUse(stmts[2]);
+
+        Assert.Same(t0Decl.Variable, ((BoundVariableExpression)idx1.Target).Variable);
+        Assert.Same(t1Decl.Variable, ((BoundVariableExpression)idx1.Index).Variable);
+        Assert.Same(t0Decl.Variable, ((BoundVariableExpression)idx2.Target).Variable);
+        Assert.Same(t1Decl.Variable, ((BoundVariableExpression)idx2.Index).Variable);
+
+        // Crucially: the call expressions appear EXACTLY ONCE across the whole
+        // rewritten body — in the prelude. Repeated references would indicate
+        // the side-effect-duplication bug.
+        int CountSubtreeRefs(BoundExpression needle, BoundStatement haystack)
+        {
+            int count = 0;
+            void Visit(object n)
+            {
+                if (n is null)
+                {
+                    return;
+                }
+
+                if (ReferenceEquals(n, needle))
+                {
+                    count++;
+                    return;
+                }
+
+                switch (n)
+                {
+                    case BoundBlockStatement b:
+                        foreach (var s in b.Statements) Visit(s);
+                        break;
+                    case BoundVariableDeclaration vd:
+                        Visit(vd.Initializer);
+                        break;
+                    case BoundExpressionStatement es:
+                        Visit(es.Expression);
+                        break;
+                    case BoundIndexExpression ix:
+                        Visit(ix.Target);
+                        Visit(ix.Index);
+                        break;
+                    case BoundAddressOfExpression ao:
+                        Visit(ao.Operand);
+                        break;
+                    case BoundDereferenceExpression de:
+                        Visit(de.Operand);
+                        break;
+                }
+            }
+
+            Visit(haystack);
+            return count;
+        }
+
+        Assert.Equal(1, CountSubtreeRefs(arrCall, result));
+        Assert.Equal(1, CountSubtreeRefs(idxCall, result));
+    }
+
+    [Fact]
+    public void RefLocal_To_FieldAccess_WithSideEffectingReceiver_HoistsReceiverOnce()
+    {
+        // ref int x = ref GetObj().field; *x = 1; *x = 2;
+        // The receiver call must be evaluated exactly once.
+        var field = new FieldSymbol("value", TypeSymbol.Int32, Accessibility.Public);
+        var structType = new StructSymbol("MyStruct", ImmutableArray.Create(field), Accessibility.Public, null, "test");
+
+        // Synthesize a side-effecting "GetObj()" via a static CLR call. The runtime
+        // type doesn't have to match — the rewriter is purely syntactic.
+        var dummyMethod = typeof(System.Math).GetMethod(nameof(System.Math.Abs), new[] { typeof(int) })!;
+        var receiverCall = new BoundClrStaticCallExpression(
+            null,
+            dummyMethod,
+            structType,
+            ImmutableArray.Create<BoundExpression>(new BoundLiteralExpression(null, 0)));
+
+        var slot = new LocalVariableSymbol("slot", isReadOnly: false, ByRefTypeSymbol.Get(TypeSymbol.Int32));
+        var fa = new BoundFieldAccessExpression(null, receiverCall, structType, field);
+        var declSlot = new BoundVariableDeclaration(null, slot, new BoundAddressOfExpression(null, fa));
+
+        var use1 = new BoundExpressionStatement(null, new BoundDereferenceExpression(null, new BoundVariableExpression(null, slot)));
+        var use2 = new BoundExpressionStatement(null, new BoundDereferenceExpression(null, new BoundVariableExpression(null, slot)));
+
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(declSlot, use1, use2));
+
+        var result = RefInitializationHoister.Rewrite(body);
+
+        // Prelude: one temp local holding the receiver call result.
+        var prelude = Assert.IsType<BoundBlockStatement>(result.Statements[0]);
+        Assert.Single(prelude.Statements);
+        var tempDecl = Assert.IsType<BoundVariableDeclaration>(prelude.Statements[0]);
+        Assert.Same(receiverCall, tempDecl.Initializer);
+
+        // Each use reads `temp.value` — same temp, never the original call.
+        for (int i = 1; i <= 2; i++)
+        {
+            var es = Assert.IsType<BoundExpressionStatement>(result.Statements[i]);
+            var faExpr = Assert.IsType<BoundFieldAccessExpression>(es.Expression);
+            Assert.Same(tempDecl.Variable, ((BoundVariableExpression)faExpr.Receiver).Variable);
+            Assert.Same(field, faExpr.Field);
+        }
+    }
+
+    [Fact]
+    public void RefLocal_BareUseWithSideEffectingOperand_HoistsAtDeclarationSite()
+    {
+        // ref int x = ref Arr()[i];  PassByRef(x); PassByRef(x);
+        // The bare use must produce `&temp[i]` not `&Arr()[i]` repeated.
+        var arrFactory = typeof(System.Array).GetMethod(nameof(System.Array.Empty))!.MakeGenericMethod(typeof(int));
+        var arrCall = new BoundClrStaticCallExpression(
+            null,
+            arrFactory,
+            TypeSymbol.FromClrType(typeof(int[])),
+            ImmutableArray<BoundExpression>.Empty);
+
+        var i = new LocalVariableSymbol("i", isReadOnly: false, TypeSymbol.Int32);
+        var slot = new LocalVariableSymbol("slot", isReadOnly: false, ByRefTypeSymbol.Get(TypeSymbol.Int32));
+
+        var indexExpr = new BoundIndexExpression(null, arrCall, new BoundVariableExpression(null, i), TypeSymbol.Int32);
+        var declSlot = new BoundVariableDeclaration(null, slot, new BoundAddressOfExpression(null, indexExpr));
+
+        var bareUse1 = new BoundExpressionStatement(null, new BoundVariableExpression(null, slot));
+        var bareUse2 = new BoundExpressionStatement(null, new BoundVariableExpression(null, slot));
+
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(declSlot, bareUse1, bareUse2));
+        var result = RefInitializationHoister.Rewrite(body);
+
+        // Prelude: one temp (for arrCall). `i` is a trivially repeatable BoundVariableExpression.
+        var prelude = Assert.IsType<BoundBlockStatement>(result.Statements[0]);
+        Assert.Single(prelude.Statements);
+        var tempDecl = Assert.IsType<BoundVariableDeclaration>(prelude.Statements[0]);
+        Assert.Same(arrCall, tempDecl.Initializer);
+
+        // Each bare use should be &temp[i].
+        for (int k = 1; k <= 2; k++)
+        {
+            var es = Assert.IsType<BoundExpressionStatement>(result.Statements[k]);
+            var addr = Assert.IsType<BoundAddressOfExpression>(es.Expression);
+            var idx = Assert.IsType<BoundIndexExpression>(addr.Operand);
+            Assert.Same(tempDecl.Variable, ((BoundVariableExpression)idx.Target).Variable);
+            Assert.Same(i, ((BoundVariableExpression)idx.Index).Variable);
+        }
+    }
+
+    [Fact]
     public void BareRefLocalUsage_ReplacedWithAddressOf()
     {
         // If a ref local is used without dereference (e.g., passed to a ref param),


### PR DESCRIPTION
## Summary

Fixes #418 (P1-12). The async `RefInitializationHoister` previously inlined the address-of operand at every use of a ref local. For ref initializers with side-effecting subparts — e.g.

```gsharp
ref int x = ref Arr()[Idx()]
*x = 1
*x = 2
```

— this caused `Arr()` and `Idx()` to execute on every read/write. Across an `await` boundary the receiver/index must be hoisted into the state machine, not re-evaluated.

## Fix

In `src/Core/CodeAnalysis/Lowering/Async/RefInitializationHoister.cs`, the rewriter now visits each ref-local declaration and:

1. Walks the address-of operand (`BoundIndexExpression`, `BoundFieldAccessExpression`, `BoundClrIndexExpression`, `BoundClrPropertyAccessExpression`).
2. For every non-trivial sub-expression (anything other than a `BoundVariableExpression` or `BoundLiteralExpression`), emits a fresh `<refTmp>__N` local initialized to that sub-expression, exactly once, at the ref-init site.
3. Replaces the ref-local declaration with a block containing the hoisting prelude.
4. Stores a reconstructed lvalue *template* (referencing only those temporaries and trivially repeatable leaves) in the ref-local map, so subsequent `*slot` / bare `slot` rewrites can safely inline it without duplicating user code.

The hoisted temps are ordinary locals, so `AsyncCaptureWalker` lifts them into state-machine fields normally when they cross an await — satisfying the CLR's prohibition on byref state-machine fields.

## Tests

Added three new tests in `RefInitializationHoisterTests.cs`:

- `RefLocal_To_ArrayElement_WithSideEffectingTarget_HoistsTargetOnce` — verifies that two dereferences of `ref Arr()[Idx()]` produce one prelude with two temps and that the `Arr()` / `Idx()` subtrees appear exactly once across the rewritten body.
- `RefLocal_To_FieldAccess_WithSideEffectingReceiver_HoistsReceiverOnce` — verifies the field-access path.
- `RefLocal_BareUseWithSideEffectingOperand_HoistsAtDeclarationSite` — verifies that bare ref-local usage (passed to a ref parameter) yields `&temp[i]` per use, not `&Arr()[i]` repeated.

All 2193 existing tests still pass (Sdk 24 + Interpreter 54 + LanguageServer 212 + Core 1621 + Compiler 282).