### PR TITLE
Fix #418 (P1-7): ensure PropertyMap is created for orphaned static PropertyDefs

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -96,6 +96,12 @@ internal sealed class ReflectionMetadataEmitter
     // ADR-0051 Phase 6: property accessor method handles for PropertyDef + MethodSemantics emission.
     private readonly Dictionary<PropertySymbol, (MethodDefinitionHandle? Getter, MethodDefinitionHandle? Setter)> propertyAccessorHandles = new Dictionary<PropertySymbol, (MethodDefinitionHandle? Getter, MethodDefinitionHandle? Setter)>();
 
+    // Issue #418 (P1-7): tracks TypeDefs that already had a PropertyMap row emitted, so the
+    // static-property emission path can decide whether to add its own PropertyMap without
+    // relying on symbol-level heuristics (which fail when instance properties are declared
+    // but all skipped during emission, leaving the static PropertyDef rows orphaned).
+    private readonly HashSet<TypeDefinitionHandle> typesWithPropertyMap = new HashSet<TypeDefinitionHandle>();
+
     // ADR-0052: event accessor method handles for EventDef + MethodSemantics emission.
     // Issue #257: extended with optional Raise handle.
     private readonly Dictionary<EventSymbol, (MethodDefinitionHandle Add, MethodDefinitionHandle Remove, MethodDefinitionHandle? Raise)> eventAccessorHandles = new Dictionary<EventSymbol, (MethodDefinitionHandle Add, MethodDefinitionHandle Remove, MethodDefinitionHandle? Raise)>();
@@ -2116,6 +2122,7 @@ internal sealed class ReflectionMetadataEmitter
         if (!firstPropDef.IsNil)
         {
             this.metadata.AddPropertyMap(typeDefHandle, firstPropDef);
+            this.typesWithPropertyMap.Add(typeDefHandle);
         }
     }
 
@@ -2326,10 +2333,17 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         // PropertyMap row: links the TypeDef to its first PropertyDef.
-        // Only add if no instance properties already created a PropertyMap for this type.
-        if (!firstPropDef.IsNil && structSym.Properties.IsDefaultOrEmpty)
+        // Issue #418 (P1-7): only add a PropertyMap here if the instance-property
+        // emission path (EmitPropertyAccessors) didn't already add one. Using
+        // structSym.Properties.IsDefaultOrEmpty was incorrect — instance properties
+        // may be declared but all skipped during emission (e.g., computed property
+        // whose getter symbol has no entry in program.Functions), leaving no
+        // PropertyMap. Without this row the static PropertyDef rows would be
+        // orphaned and violate ECMA-335 §II.22.35.
+        if (!firstPropDef.IsNil && !this.typesWithPropertyMap.Contains(typeDefHandle))
         {
             this.metadata.AddPropertyMap(typeDefHandle, firstPropDef);
+            this.typesWithPropertyMap.Add(typeDefHandle);
         }
     }
 
@@ -4546,6 +4560,7 @@ internal sealed class ReflectionMetadataEmitter
         if (!firstPropDef.IsNil)
         {
             this.metadata.AddPropertyMap(typeDefHandle, firstPropDef);
+            this.typesWithPropertyMap.Add(typeDefHandle);
         }
     }
 

--- a/test/Core.Tests/CodeAnalysis/SharedBlockTests.cs
+++ b/test/Core.Tests/CodeAnalysis/SharedBlockTests.cs
@@ -7,6 +7,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
 using System.Runtime.Loader;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
@@ -664,5 +667,108 @@ Console.WriteLine(""subscribed"")
 ";
         var output = CompileLoadInvokeCaptureStdout(source, "SharedBlock-StaticEvent");
         Assert.Contains("subscribed", output);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 8. Issue #418 (P1-7): PropertyMap must not orphan static PropertyDef rows
+    // when instance properties are declared.  Even if every declared instance
+    // property is skipped during emission (so no instance PropertyDef row is
+    // produced), the static emission path must still add a PropertyMap row
+    // pointing at the first static PropertyDef. Without it, the static rows
+    // are unreachable from any TypeDef, violating ECMA-335 §II.22.35.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void StaticProperty_OnTypeWithInstanceProperty_IsReachableViaReflection()
+    {
+        // Sanity check for the mixed instance + static scenario.  Both the
+        // instance auto-property and the static auto-property must be
+        // reflectable, which requires a valid PropertyMap row for the type.
+        var source = @"package MixedProps
+import System
+
+type Mixed class {
+    prop Name string
+    shared {
+        prop Counter int32
+    }
+}
+
+Mixed.Counter = 7
+var m = Mixed{}
+m.Name = ""hello""
+Console.WriteLine(m.Name)
+Console.WriteLine(Mixed.Counter)
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "P1-7-MixedProps");
+        Assert.Contains("hello", output);
+        Assert.Contains("7", output);
+    }
+
+    [Fact]
+    public void StaticProperty_OnTypeWithoutInstanceProperty_EmitsExactlyOnePropertyMapRow()
+    {
+        // Verifies the static-only case keeps producing exactly one PropertyMap
+        // row pointing at the static PropertyDef.  Guards against regressions
+        // in the new typesWithPropertyMap tracking introduced for issue #418.
+        var source = @"package StaticOnlyProp
+import System
+
+type Config class {
+    shared {
+        prop Name string
+    }
+}
+
+Config.Name = ""world""
+Console.WriteLine(Config.Name)
+";
+        using var peStream = new MemoryStream();
+        var result = Compile(source, peStream);
+        Assert.True(result.Success);
+
+        peStream.Position = 0;
+        using var peReader = new PEReader(peStream);
+        var md = peReader.GetMetadataReader();
+
+        // Exactly one PropertyMap row for the static property on Config.
+        var pmRows = md.GetTableRowCount(TableIndex.PropertyMap);
+        Assert.Equal(1, pmRows);
+
+        // Exactly one PropertyDef row (the static one).
+        var pdRows = md.GetTableRowCount(TableIndex.Property);
+        Assert.Equal(1, pdRows);
+    }
+
+    [Fact]
+    public void StaticAndInstanceProperty_OnSameType_EmitsExactlyOnePropertyMapRow()
+    {
+        // When a type declares both instance and static properties, exactly
+        // one PropertyMap row must exist, pointing at the first (instance)
+        // PropertyDef.  Both PropertyDef rows belong to the same type via
+        // ECMA-335 §II.22.35 contiguity.
+        var source = @"package MixedPropsShape
+import System
+
+type Mixed class {
+    prop Name string
+    shared {
+        prop Counter int32
+    }
+}
+";
+        using var peStream = new MemoryStream();
+        var result = Compile(source, peStream);
+        Assert.True(result.Success);
+
+        peStream.Position = 0;
+        using var peReader = new PEReader(peStream);
+        var md = peReader.GetMetadataReader();
+
+        var pmRows = md.GetTableRowCount(TableIndex.PropertyMap);
+        Assert.Equal(1, pmRows);
+
+        var pdRows = md.GetTableRowCount(TableIndex.Property);
+        Assert.Equal(2, pdRows);
     }
 }


### PR DESCRIPTION
## Problem

In `ReflectionMetadataEmitter`, a TypeDef could end up with static `PropertyDef` rows but no `PropertyMap` row pointing at them, violating ECMA-335 §II.22.35.

- `EmitPropertyAccessors` adds a `PropertyMap` only when it actually produced at least one instance `PropertyDef` (`firstPropDef` populated).
- If every declared instance property was skipped (e.g., a computed property whose getter symbol has no body in `program.Functions`), no `PropertyMap` was added.
- `EmitStaticPropertyAccessors` then gated its own `PropertyMap` on `structSym.Properties.IsDefaultOrEmpty`. This is `false` whenever the symbol declared instance properties — *even if they were all skipped* — so the static path also omitted the `PropertyMap` while still emitting static `PropertyDef` rows. Those rows are orphans.

## Fix

Track which TypeDefs have had a `PropertyMap` row emitted in a new `typesWithPropertyMap` set, and use that as the predicate in the static path instead of the symbol-level heuristic. Robust against any future emission path that adds/skips property rows.

Touches: `src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs` (~lines 2116-2118, 2328-2332).

## Tests

Added in `test/Core.Tests/CodeAnalysis/SharedBlockTests.cs`:

- `StaticProperty_OnTypeWithInstanceProperty_IsReachableViaReflection` — mixed instance + static round-trip via reflection.
- `StaticProperty_OnTypeWithoutInstanceProperty_EmitsExactlyOnePropertyMapRow` — static-only PropertyMap row shape via MetadataReader.
- `StaticAndInstanceProperty_OnSameType_EmitsExactlyOnePropertyMapRow` — mixed PropertyMap row shape via MetadataReader.

Full suite passes: 2193 tests (1621 Core + 282 Compiler + 212 LanguageServer + 54 Interpreter + 24 Sdk).