### PR TITLE
Fix #418 (P1-5): route struct property receivers through EmitInstanceReceiver

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -10206,6 +10206,29 @@ internal sealed class ReflectionMetadataEmitter
             return base.RewriteClrPropertyAssignmentExpression(node);
         }
 
+        // Issue #418 (P1-5): G# computed/auto properties also need the spill
+        // infrastructure when the receiver is a non-addressable struct rvalue
+        // (e.g. `makePoint(5, 6).Sum`, `getOuter().Inner.Length`).
+        protected override BoundExpression RewritePropertyAccessExpression(BoundPropertyAccessExpression node)
+        {
+            if (node.Receiver != null)
+            {
+                this.AddIfNeeded(node.Receiver);
+            }
+
+            return base.RewritePropertyAccessExpression(node);
+        }
+
+        protected override BoundExpression RewritePropertyAssignmentExpression(BoundPropertyAssignmentExpression node)
+        {
+            if (node.Receiver != null)
+            {
+                this.AddIfNeeded(node.Receiver);
+            }
+
+            return base.RewritePropertyAssignmentExpression(node);
+        }
+
         protected override BoundExpression RewriteClrEventSubscriptionExpression(BoundClrEventSubscriptionExpression node)
         {
             if (node.Receiver != null)
@@ -12973,16 +12996,13 @@ internal sealed class ReflectionMetadataEmitter
                 return;
             }
 
-            // Load receiver.
+            // Load receiver. Issue #418 (P1-5): route through
+            // EmitInstanceReceiver so non-variable struct receivers
+            // (method-call results, indexer reads, tuple elements, etc.) are
+            // spilled to a temp and addressed via `ldloca` rather than left as
+            // a value on the stack (unverifiable / SIGSEGV).
             var receiverIsClass = access.Receiver.Type is StructSymbol rs && rs.IsClass;
-            if (!receiverIsClass && access.Receiver is BoundVariableExpression bv && this.TryLoadVariableAddress(bv.Variable))
-            {
-                // address loaded
-            }
-            else
-            {
-                this.EmitExpression(access.Receiver);
-            }
+            this.EmitInstanceReceiver(access.Receiver);
 
             this.il.OpCode(receiverIsClass ? ILOpCode.Callvirt : ILOpCode.Call);
             this.il.Token(handles.Getter.Value);
@@ -13010,30 +13030,19 @@ internal sealed class ReflectionMetadataEmitter
                 return;
             }
 
-            // Load receiver, emit value, call setter.
+            // Load receiver, emit value, call setter. Issue #418 (P1-5):
+            // route through EmitInstanceReceiver so non-variable struct
+            // receivers spill to a temp and pass `ldloca` as `this` instead
+            // of leaving a value on the stack.
             var receiverIsClass = assn.Receiver.Type is StructSymbol rs && rs.IsClass;
-            if (!receiverIsClass && assn.Receiver is BoundVariableExpression bv && this.TryLoadVariableAddress(bv.Variable))
-            {
-                // address loaded
-            }
-            else
-            {
-                this.EmitExpression(assn.Receiver);
-            }
+            this.EmitInstanceReceiver(assn.Receiver);
 
             this.EmitExpression(assn.Value);
             this.il.OpCode(receiverIsClass ? ILOpCode.Callvirt : ILOpCode.Call);
             this.il.Token(handles.Setter.Value);
 
             // Re-load the assigned value as the expression result via the getter.
-            if (!receiverIsClass && assn.Receiver is BoundVariableExpression bv2 && this.TryLoadVariableAddress(bv2.Variable))
-            {
-                // address loaded
-            }
-            else
-            {
-                this.EmitExpression(assn.Receiver);
-            }
+            this.EmitInstanceReceiver(assn.Receiver);
 
             this.il.OpCode(receiverIsClass ? ILOpCode.Callvirt : ILOpCode.Call);
             this.il.Token(handles.Getter.Value);
@@ -13352,17 +13361,24 @@ internal sealed class ReflectionMetadataEmitter
             // Phase 4 emit parity: indexer write. `d[k] = v` -> `callvirt set_Item(k, v)`.
             // Like the array-index assignment path, the expression result is the
             // assigned value, so re-read via `get_Item` after the store.
-            this.EmitLoadVariable(ixa.Target);
+            // Issue #418 (P1-5): route through EmitInstanceReceiver so a
+            // value-type target (`ldloca`) and reference-type target (`ldloc`)
+            // are both addressed correctly. For value-type indexers we also
+            // need `call` instead of `callvirt`.
+            var writeReceiver = new BoundVariableExpression(null, ixa.Target);
+            var targetIsValueType = IsValueTypeSymbol(ixa.Target.Type);
+
+            this.EmitInstanceReceiver(writeReceiver);
             foreach (var arg in ixa.Arguments)
             {
                 this.EmitExpression(arg);
             }
 
             this.EmitExpression(ixa.Value);
-            this.il.OpCode(ILOpCode.Callvirt);
+            this.il.OpCode(targetIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
             this.il.Token(this.outer.GetMethodReference(setter));
 
-            this.EmitLoadVariable(ixa.Target);
+            this.EmitInstanceReceiver(writeReceiver);
             foreach (var arg in ixa.Arguments)
             {
                 this.EmitExpression(arg);
@@ -13371,7 +13387,7 @@ internal sealed class ReflectionMetadataEmitter
             var getter = ixa.Indexer.GetGetMethod(nonPublic: false)
                 ?? throw new InvalidOperationException(
                     $"Indexer on '{ixa.Indexer.DeclaringType?.FullName}' has no public getter.");
-            this.il.OpCode(ILOpCode.Callvirt);
+            this.il.OpCode(targetIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
             this.il.Token(this.outer.GetMethodReference(getter));
         }
 

--- a/test/Compiler.Tests/Emit/UserStructPropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/UserStructPropertyEmitTests.cs
@@ -1,0 +1,268 @@
+// <copyright file="UserStructPropertyEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #418 (P1-5) regression tests. Reading or writing a G# property on
+/// a value-type (struct) receiver must pass a managed pointer as <c>this</c>
+/// for every receiver shape — including method-call results, indexer reads,
+/// tuple elements, and nested-field chains — not just a plain
+/// <c>BoundVariableExpression</c>. Pushing the struct value as <c>this</c>
+/// reinterprets the bits as the pointer and crashes the JIT (SIGSEGV /
+/// <see cref="InvalidProgramException"/>).
+///
+/// Each test compiles a small program, invokes <c>&lt;Main&gt;$</c>, and
+/// reads a top-level <c>result</c> field via reflection.
+/// </summary>
+public class UserStructPropertyEmitTests
+{
+    [Fact]
+    public void PropertyAccess_On_Variable_Struct_Receiver_RoundTrips()
+    {
+        var source = """
+            package P
+            import System
+
+            type Point struct {
+                X int32
+                Y int32
+                prop Sum int32 {
+                    get { return this.X + this.Y }
+                }
+            }
+
+            let p = Point{X: 5, Y: 6}
+            public var result = p.Sum
+            """;
+
+        Assert.Equal(11, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void PropertyAccess_On_Method_Call_Struct_Receiver_RoundTrips()
+    {
+        // Receiver is `makePoint(5, 6)` — a struct rvalue with no
+        // addressable storage. Before #418 the getter call received the
+        // struct value as `this` and the JIT crashed with SIGSEGV.
+        var source = """
+            package P
+            import System
+
+            type Point struct {
+                X int32
+                Y int32
+                prop Sum int32 {
+                    get { return this.X + this.Y }
+                }
+            }
+
+            func makePoint(x int32, y int32) Point {
+                return Point{X: x, Y: y}
+            }
+
+            public var result = makePoint(5, 6).Sum
+            """;
+
+        Assert.Equal(11, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void PropertyAccess_On_Nested_Field_Of_Rvalue_RoundTrips()
+    {
+        // Receiver is `makeOuter().Inner` — a field-chain whose head is an
+        // rvalue. Same spill path as method-call receivers.
+        var source = """
+            package P
+            import System
+
+            type Inner struct {
+                V int32
+                prop Triple int32 {
+                    get { return this.V * 3 }
+                }
+            }
+
+            type Outer struct {
+                Inner Inner
+            }
+
+            func makeOuter(v int32) Outer {
+                return Outer{Inner: Inner{V: v}}
+            }
+
+            public var result = makeOuter(7).Inner.Triple
+            """;
+
+        Assert.Equal(21, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void PropertyAccess_On_Indexer_Result_Struct_Receiver_RoundTrips()
+    {
+        // Receiver is `arr[0]` — an indexer read returning a struct rvalue.
+        var source = """
+            package P
+            import System
+
+            type Point struct {
+                X int32
+                Y int32
+                prop Sum int32 {
+                    get { return this.X + this.Y }
+                }
+            }
+
+            let arr = [3]Point{ Point{X: 5, Y: 6}, Point{X: 1, Y: 2}, Point{X: 10, Y: 20} }
+            public var result = arr[0].Sum
+            """;
+
+        Assert.Equal(11, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void PropertyAccess_On_Cast_Struct_Receiver_RoundTrips()
+    {
+        // Receiver is a cast expression `Point(other)` — synthesised rvalue.
+        // The existing code path's `BoundVariableExpression` check skipped
+        // this shape and emitted `call get_Sum` against a value on the stack.
+        var source = """
+            package P
+            import System
+
+            type Point struct {
+                X int32
+                Y int32
+                prop Sum int32 {
+                    get { return this.X + this.Y }
+                }
+            }
+
+            type Pair struct {
+                A int32
+                B int32
+            }
+
+            func makePoint(x int32, y int32) Point {
+                return Point{X: x, Y: y}
+            }
+
+            // Read property off the result of a sequence of method calls.
+            public var result = makePoint(makePoint(2, 3).Sum, makePoint(1, 5).Sum).Sum
+            """;
+
+        // (2+3) + (1+5) = 11
+        Assert.Equal(11, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void PropertyAccess_On_Class_Receiver_Still_Uses_Callvirt()
+    {
+        // Class receivers must still use callvirt; verify class properties
+        // continue to round-trip unchanged.
+        var source = """
+            package P
+            import System
+
+            type Box class {
+                prop V int32
+                prop Doubled int32 {
+                    get { return this.V * 2 }
+                }
+            }
+
+            func makeBox(v int32) Box {
+                let b = Box{}
+                b.V = v
+                return b
+            }
+
+            public var result = makeBox(13).Doubled
+            """;
+
+        Assert.Equal(26, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void PropertyAssignment_On_Variable_Struct_Receiver_RoundTrips()
+    {
+        var source = """
+            package P
+            import System
+
+            type Holder struct {
+                prop raw int32
+                prop V int32 {
+                    get { return this.raw }
+                    set(v) { this.raw = v * 2 }
+                }
+            }
+
+            var h = Holder{}
+            public var result = h.V = 21
+            """;
+
+        // assignment expression yields the value re-read via getter -> 42
+        Assert.Equal(42, RunAndGetIntResult(source));
+    }
+
+    private static int RunAndGetIntResult(string source)
+    {
+        var assembly = CompileToAssembly(source, target: "exe");
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod(
+            "<Main>$",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField(
+            "result",
+            BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, null);
+        return (int)resultField!.GetValue(null)!;
+    }
+
+    private static Assembly CompileToAssembly(string source, string target)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_user_prop_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}


### PR DESCRIPTION
## Problem (P1-5 from #418)

The G# property access/assignment emit paths in `ReflectionMetadataEmitter` (`EmitPropertyAccess` ~L12960, `EmitPropertyAssignment` ~L12992) only address-loaded the struct receiver when it was a plain `BoundVariableExpression` with an address-loadable variable. Any other shape — method-call result, indexer read, tuple element, nested field of an rvalue, cast — fell back to `EmitExpression(receiver); call get_X` with the struct value on the stack as `this`.

The CLR reinterprets those bits as the `this` managed pointer, producing a SIGSEGV at runtime. This is the same class of bug fixed by #417 for `EmitInstanceReceiver`; the property-access paths were never updated to route through the new spill-slot infrastructure.

Repro before the fix (exit 139 / SIGSEGV):

```gs
type Point struct {
    X int32
    Y int32
    prop Sum int32 { get { return this.X + this.Y } }
}

func makePoint(x int32, y int32) Point { return Point{X: x, Y: y} }

public var result = makePoint(5, 6).Sum  // crashes the JIT
```

## Fix

* `EmitPropertyAccess` / `EmitPropertyAssignment` now route through `EmitInstanceReceiver`, which spills rvalue value-type receivers to a temp and passes `ldloca` as `this`.
* `CollectReceiverSpills` (via `ReceiverSpillCollector`) now discovers `BoundPropertyAccessExpression` and `BoundPropertyAssignmentExpression` receivers so a spill slot is preallocated.
* `EmitClrIndexAssignment` now routes the target through `EmitInstanceReceiver` (via a synthesised `BoundVariableExpression`) and uses `call` instead of `callvirt` for value-type targets, matching the existing read path (`EmitClrIndex`) and the span-element write path above it.

CLR property access/assignment (`EmitClrPropertyAccess`/`EmitClrPropertyAssignment`), CLR event subscription, and user-defined event subscription already used `EmitInstanceReceiver` and need no change.

## Tests

Adds 7 emit regression tests in `UserStructPropertyEmitTests` covering:

* variable struct receiver (baseline)
* method-call result receiver (`makePoint(5,6).Sum`)
* nested field of an rvalue (`makeOuter(7).Inner.Triple`)
* indexer-result receiver (`arr[0].Sum`)
* nested method-call composition (`makePoint(makePoint(2,3).Sum, makePoint(1,5).Sum).Sum`)
* class receiver — verifies `callvirt` is still emitted
* property assignment with custom setter on a variable struct receiver

## Validation

```
Passed!  - Failed: 0, Passed: 1618 - GSharp.Core.Tests.dll
Passed!  - Failed: 0, Passed:  289 - GSharp.Compiler.Tests.dll (+7 new)
Passed!  - Failed: 0, Passed:  212 - GSharp.LanguageServer.Tests.dll
Passed!  - Failed: 0, Passed:   54 - GSharp.Interpreter.Tests.dll
Passed!  - Failed: 0, Passed:   24 - GSharp.Sdk.Tests.dll
Total: 2197 passed, 0 failed
```

Fixes P1-5 from #418.