### PR TITLE
Fix #418 (P1-8): use MetadataLoadContext-safe enum underlying type lookup

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -4093,7 +4093,7 @@ internal sealed class ReflectionMetadataEmitter
 
         if (to.IsEnum)
         {
-            return from == Enum.GetUnderlyingType(to);
+            return from == GetEnumUnderlyingTypeSafe(to);
         }
 
         if (from.IsArray && to.IsArray && from.GetArrayRank() == 1 && to.GetArrayRank() == 1)
@@ -4164,7 +4164,7 @@ internal sealed class ReflectionMetadataEmitter
         }
         else if (t.IsEnum)
         {
-            EncodeClrTypeForCtorSig(enc, Enum.GetUnderlyingType(t));
+            EncodeClrTypeForCtorSig(enc, GetEnumUnderlyingTypeSafe(t));
         }
         else if (t.IsArray && t.GetArrayRank() == 1)
         {
@@ -4187,7 +4187,7 @@ internal sealed class ReflectionMetadataEmitter
     {
         if (paramType.IsEnum)
         {
-            WriteCustomAttributeFixedArg(bb, Enum.GetUnderlyingType(paramType), value);
+            WriteCustomAttributeFixedArg(bb, GetEnumUnderlyingTypeSafe(paramType), value);
             return;
         }
 
@@ -4304,6 +4304,38 @@ internal sealed class ReflectionMetadataEmitter
         // may omit the assembly portion. We always emit the assembly-qualified
         // form so the consumer can unambiguously rebind the type.
         return t.AssemblyQualifiedName ?? t.FullName ?? t.Name;
+    }
+
+    /// <summary>
+    /// Returns the underlying primitive type of an enum in a way that works for
+    /// types loaded through a <see cref="MetadataLoadContext"/>. The BCL helper
+    /// <see cref="Enum.GetUnderlyingType(Type)"/> requires a runtime
+    /// <see cref="Type"/> and throws <see cref="NotSupportedException"/> for
+    /// metadata-loaded types (issue #418 / P1-8), which surfaces as an emit-time
+    /// crash in the custom-attribute blob writer whenever an attribute argument
+    /// is an enum defined in a referenced (non-BCL) package.
+    /// </summary>
+    /// <remarks>
+    /// Per ECMA-335 II.14.3 every enum is laid out as a class containing a
+    /// single instance field named <c>value__</c> whose type is the underlying
+    /// primitive (e.g. <see cref="int"/>). Reading that field's type works
+    /// uniformly for runtime and metadata-loaded types. The result is then
+    /// normalized to the executing runtime's <see cref="Type"/> so that the
+    /// reference-equality dispatch in the blob writers matches.
+    /// </remarks>
+    private static Type GetEnumUnderlyingTypeSafe(Type enumType)
+    {
+        var valueField = enumType.GetField("value__", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        var fieldType = valueField?.FieldType;
+        if (fieldType == null)
+        {
+            // Defensive fallback: a malformed enum without value__ would be
+            // invalid metadata, but treating it as int32 keeps the writer
+            // robust rather than crashing during emit.
+            return typeof(int);
+        }
+
+        return NormalizeWellKnownType(fieldType);
     }
 
     private static void WriteCustomAttributeNamedArg(BlobBuilder bb, Type attributeType, BoundAttributeArgument arg)

--- a/test/Core.Tests/CodeAnalysis/Emit/ImportedEnumAttributeEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/ImportedEnumAttributeEmitTests.cs
@@ -1,0 +1,151 @@
+// <copyright file="ImportedEnumAttributeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Core.Tests.Fixtures;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Regression tests for issue #418 (P1-8): emitting a custom attribute whose
+/// named-arg member is an enum defined in a referenced (non-BCL) assembly
+/// must not lose the attribute. Such enum <see cref="System.Type"/> instances
+/// are reified through a <see cref="System.Reflection.MetadataLoadContext"/>,
+/// so the attribute-blob writer cannot call <see cref="System.Enum.GetUnderlyingType"/>
+/// (which is runtime-Type only and throws <see cref="System.NotSupportedException"/>) —
+/// it must instead read the <c>value__</c> instance field's type per
+/// ECMA-335 II.14.3.
+/// </summary>
+public class ImportedEnumAttributeEmitTests
+{
+    private static ReferenceResolver FixtureResolver()
+    {
+        // Adding the test-assembly path forces every type from it to be
+        // reified through a MetadataLoadContext when resolved by the compiler.
+        var fixturePath = typeof(ImportedEnumArgAttribute).Assembly.Location;
+        return ReferenceResolver.WithReferences(new[] { fixturePath });
+    }
+
+    private static Compilation CompileWithFixtures(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(FixtureResolver(), tree);
+    }
+
+    [Fact]
+    public void Emit_Imported_Enum_NamedArg_Is_Written_To_Blob()
+    {
+        // Before the fix, ReflectionMetadataEmitter.WriteCustomAttributeFixedArg
+        // called Enum.GetUnderlyingType on the MetadataLoadContext-resolved
+        // enum and threw NotSupportedException; the surrounding try/catch
+        // would drop the attribute, so the emitted Tagged type carried zero
+        // custom attributes. After the fix the attribute (and its enum
+        // named-arg value) must round-trip through the blob.
+        var source = """
+            package Demo
+            import GSharp.Core.Tests.Fixtures
+
+            @ImportedEnumArg(Mode = ImportedAttributeMode.Warning)
+            type Tagged class {
+            }
+            """;
+
+        var compilation = CompileWithFixtures(source);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        using var peReader = new PEReader(peStream, PEStreamOptions.LeaveOpen);
+        var md = peReader.GetMetadataReader();
+        var taggedDef = md.TypeDefinitions
+            .Select(md.GetTypeDefinition)
+            .Single(td => md.GetString(td.Name) == "Tagged");
+
+        // The Tagged type must carry exactly one custom attribute: our fixture.
+        var attrHandle = Assert.Single(taggedDef.GetCustomAttributes());
+        var attr = md.GetCustomAttribute(attrHandle);
+
+        // The constructor reference must point at ImportedEnumArgAttribute..ctor.
+        var ctorRef = md.GetMemberReference((MemberReferenceHandle)attr.Constructor);
+        var attrTypeName = md.GetString(md.GetTypeReference((TypeReferenceHandle)ctorRef.Parent).Name);
+        Assert.Equal("ImportedEnumArgAttribute", attrTypeName);
+
+        // Sanity: the blob is non-empty (prolog + zero positional args +
+        // one named arg payload).
+        var blob = md.GetBlobBytes(attr.Value);
+        Assert.NotEmpty(blob);
+    }
+
+    [Fact]
+    public void Emit_Imported_Enum_NamedArg_Roundtrips_Through_Reflection()
+    {
+        // Stronger check: load the emitted PE and read the attribute via
+        // System.Reflection.CustomAttributeData. The named-arg enum value
+        // must round-trip with its correct underlying int value.
+        var source = """
+            package Demo
+            import GSharp.Core.Tests.Fixtures
+
+            @ImportedEnumArg(Mode = ImportedAttributeMode.Warning)
+            type Tagged class {
+            }
+            """;
+
+        var compilation = CompileWithFixtures(source);
+
+        using var peStream = new MemoryStream();
+        var emit = compilation.Emit(peStream);
+        Assert.True(emit.Success, string.Join("; ", emit.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+
+        var loadContext = new AssemblyLoadContext(nameof(Emit_Imported_Enum_NamedArg_Roundtrips_Through_Reflection), isCollectible: true);
+        try
+        {
+            // The emitted assembly references the fixture (test) assembly; the
+            // loader needs to be told to reuse the test runtime's instance.
+            loadContext.Resolving += (ctx, name) =>
+            {
+                if (name.Name == typeof(ImportedEnumArgAttribute).Assembly.GetName().Name)
+                {
+                    return typeof(ImportedEnumArgAttribute).Assembly;
+                }
+
+                return null;
+            };
+
+            var asm = loadContext.LoadFromStream(peStream);
+            var tagged = asm.GetTypes().Single(t => t.Name == "Tagged");
+
+            var cad = CustomAttributeData.GetCustomAttributes(tagged)
+                .Single(c => c.AttributeType == typeof(ImportedEnumArgAttribute));
+
+            Assert.Empty(cad.ConstructorArguments);
+
+            var named = Assert.Single(cad.NamedArguments);
+            Assert.Equal("Mode", named.MemberName);
+            Assert.Equal(typeof(ImportedAttributeMode), named.TypedValue.ArgumentType);
+            Assert.Equal(ImportedAttributeMode.Warning, (ImportedAttributeMode)named.TypedValue.Value!);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Core.Tests/Fixtures/ImportedAttributeFixtures.cs
+++ b/test/Core.Tests/Fixtures/ImportedAttributeFixtures.cs
@@ -29,6 +29,40 @@ public sealed class ImportedDefaultAttribute : Attribute
 }
 
 /// <summary>
+/// A user-defined enum used as the type of a custom-attribute named/positional
+/// argument by <see cref="ImportedEnumArgAttribute"/>. Defined in a referenced
+/// fixture assembly, so when consumed via the G# compiler's reference resolver
+/// the enum type is reified through a <see cref="System.Reflection.MetadataLoadContext"/>.
+/// </summary>
+public enum ImportedAttributeMode
+{
+    /// <summary>The default mode.</summary>
+    None = 0,
+
+    /// <summary>An "info" mode.</summary>
+    Info = 1,
+
+    /// <summary>A "warning" mode.</summary>
+    Warning = 2,
+}
+
+/// <summary>
+/// Regression fixture for issue #418 (P1-8): an attribute whose named-arg
+/// property is enum-typed. When applied to a G# declaration the emitter
+/// writes the named enum argument into the custom-attribute blob, exercising
+/// <c>WriteCustomAttributeFixedArg</c> with an enum <see cref="System.Type"/>
+/// resolved through a <see cref="System.Reflection.MetadataLoadContext"/>.
+/// The ctor is parameterless so the regression is scoped to the named-arg
+/// path called out in the bug report.
+/// </summary>
+[AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = true)]
+public sealed class ImportedEnumArgAttribute : Attribute
+{
+    /// <summary>Gets or sets a mode as a named argument.</summary>
+    public ImportedAttributeMode Mode { get; set; }
+}
+
+/// <summary>
 /// A plain reference-assembly class used to verify that imports of non-System
 /// namespaces resolve inside function and method bodies — not just in top-level
 /// statements. Constructing this type or calling its members from within a


### PR DESCRIPTION
## Summary

Fixes issue #418 (P1-8): `Enum.GetUnderlyingType` works only on runtime types and throws `NotSupportedException` for enums reified through a `MetadataLoadContext` — which is how the compiler loads every type from a referenced (non-BCL) package. Whenever a custom-attribute argument referred to a user-defined enum, the emitter either dropped the attribute or wrote a corrupted blob.

## Fix

Replace all three call sites in `ReflectionMetadataEmitter` (named-arg blob writer, ctor-sig encoder, trivial-conversion check) with a new `GetEnumUnderlyingTypeSafe` helper that reads the enum's mandatory `value__` instance field (ECMA-335 II.14.3) using `BindingFlags.Instance | Public | NonPublic` and normalizes the result back to the executing runtime's primitive `Type`.

## Tests

Adds an `ImportedEnumArgAttribute` / `ImportedAttributeMode` fixture and two regression tests under `test/Core.Tests/CodeAnalysis/Emit/ImportedEnumAttributeEmitTests.cs`:

1. **Blob round-trip via metadata reader** — emits a G# type carrying `@ImportedEnumArg(Mode = ImportedAttributeMode.Warning)`, then asserts the `Tagged` type carries exactly one custom attribute whose constructor references the fixture attribute type.
2. **Round-trip via `System.Reflection.CustomAttributeData`** — loads the emitted PE in a collectible `AssemblyLoadContext` and verifies the named-arg enum value (`Warning`) round-trips with the correct type and underlying value.

Without the fix the second test fails with `CustomAttributeFormatException: Specified argument was out of the range of valid values`; with the fix both pass.

## Full test suite

All 2192 existing tests continue to pass:
- Core.Tests: 1620 passed (+2 new)
- Compiler.Tests: 282 passed
- LanguageServer.Tests: 212 passed
- Interpreter.Tests: 54 passed
- Sdk.Tests: 24 passed