### PR TITLE
Fix #418 (P1-9): defer hole evaluation until after shouldAppend gate

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
@@ -253,6 +253,31 @@ internal sealed class InterpolatedStringHandlerLowerer : BoundTreeRewriter
     }
 
     /// <summary>
+    /// Issue #418 (P1-9): for user handlers that require a per-append gate
+    /// (<c>out bool shouldAppend</c> or bool-returning append methods), each
+    /// hole expression must be evaluated lazily inside the gated block. This
+    /// helper recursively lowers each hole value <em>without</em> pre-spilling
+    /// to leading temps; awaiting holes are spilled into temps inside the gated
+    /// block by <see cref="MakeAppendStatement"/>.
+    /// </summary>
+    private ImmutableArray<BoundInterpolatedStringPart> LowerHoleValuesInPlace(BoundInterpolatedStringExpression node)
+    {
+        var lowered = ImmutableArray.CreateBuilder<BoundInterpolatedStringPart>(node.Parts.Length);
+        foreach (var part in node.Parts)
+        {
+            if (part.IsLiteral)
+            {
+                lowered.Add(part);
+                continue;
+            }
+
+            lowered.Add(part.WithValue(this.RewriteExpression(part.Value)));
+        }
+
+        return lowered.ToImmutable();
+    }
+
+    /// <summary>
     /// Issue #368: lowers an interpolated string targeting a user-defined
     /// <c>[InterpolatedStringHandler]</c> parameter. Constructs the handler with
     /// <c>(literalLength, formattedCount, ...forwarded args [, out bool shouldAppend])</c>,
@@ -268,10 +293,34 @@ internal sealed class InterpolatedStringHandlerLowerer : BoundTreeRewriter
         var handlerLocal = new LocalVariableSymbol($"<>interp{this.counter++}", isReadOnly: false, handlerSymbol);
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
 
-        // Issue #368: pre-evaluate any await-containing hole values into leading
-        // temporaries before the handler is constructed (see PrepareParts).
-        var (parts, leading) = this.PrepareParts(node);
-        statements.AddRange(leading);
+        var appendLiteral = FindAppendLiteral(handlerClrType);
+
+        // Issue #418 (P1-9): when the handler ctor produces an `out bool shouldAppend`
+        // or some append method returns `bool`, every per-append call (including
+        // evaluation of the hole expression) must be gated behind that running
+        // condition. The spec requires lazy evaluation of holes — setting
+        // shouldAppend = false in the ctor must skip both the AppendFormatted call
+        // and the side effects of the hole expression itself (e.g. an `await`).
+        var appendsReturnBool = AppendsReturnBool(handlerClrType, appendLiteral);
+        var needsGate = info.HasTrailingOutBool || appendsReturnBool;
+
+        // When gating is needed we cannot pre-spill holes into leading temps
+        // because that evaluates them before the ctor decides shouldAppend.
+        // Instead, recursively lower the hole values in place and defer any
+        // await-spill into the gated block (see MakeAppendStatement). Without
+        // gating, the existing PrepareParts pre-spill preserves ref-struct
+        // safety across awaits.
+        ImmutableArray<BoundInterpolatedStringPart> parts;
+        if (needsGate)
+        {
+            parts = this.LowerHoleValuesInPlace(node);
+        }
+        else
+        {
+            ImmutableArray<BoundStatement> leading;
+            (parts, leading) = this.PrepareParts(node);
+            statements.AddRange(leading);
+        }
 
         // Build the constructor argument list: (literalLength, formattedCount,
         // ...forwarded args [, &shouldAppend]).
@@ -310,14 +359,6 @@ internal sealed class InterpolatedStringHandlerLowerer : BoundTreeRewriter
             ctorRefKinds);
         statements.Add(new BoundVariableDeclaration(node.Syntax, handlerLocal, construct));
 
-        var appendLiteral = FindAppendLiteral(handlerClrType);
-
-        // Determine whether append calls must be gated by a running condition:
-        // either the constructor produced an `out bool shouldAppend`, or some
-        // append method returns `bool` (the short-circuit handler shape).
-        var appendsReturnBool = AppendsReturnBool(handlerClrType, appendLiteral);
-        var needsGate = info.HasTrailingOutBool || appendsReturnBool;
-
         LocalVariableSymbol continueLocal = null;
         if (needsGate)
         {
@@ -348,6 +389,19 @@ internal sealed class InterpolatedStringHandlerLowerer : BoundTreeRewriter
             else
             {
                 var value = part.Value;
+
+                // Issue #418: when gating, an await inside the hole must not run
+                // before the gate is checked. Defer the spill into the gated block
+                // so the temp is initialized only when the gate allows the append.
+                ImmutableArray<BoundStatement> holeLeading = ImmutableArray<BoundStatement>.Empty;
+                if (needsGate && Async.AsyncBoundTreeQueries.HasAwait(value))
+                {
+                    var holeTmp = new LocalVariableSymbol($"<>hole{this.counter++}", isReadOnly: false, value.Type);
+                    holeLeading = ImmutableArray.Create<BoundStatement>(
+                        new BoundVariableDeclaration(null, holeTmp, value));
+                    value = new BoundVariableExpression(null, holeTmp);
+                }
+
                 var (method, typeArguments) = this.ResolveUserAppendFormatted(handlerClrType, part, value.Type);
 
                 var arguments = ImmutableArray.CreateBuilder<BoundExpression>();
@@ -370,6 +424,9 @@ internal sealed class InterpolatedStringHandlerLowerer : BoundTreeRewriter
                     arguments.ToImmutable(),
                     argumentRefKinds: default,
                     typeArgumentSymbols: typeArguments);
+
+                statements.Add(this.MakeAppendStatement(node.Syntax, appendCall, continueLocal, holeLeading));
+                continue;
             }
 
             statements.Add(this.MakeAppendStatement(node.Syntax, appendCall, continueLocal));
@@ -384,14 +441,33 @@ internal sealed class InterpolatedStringHandlerLowerer : BoundTreeRewriter
     /// condition (<paramref name="continueLocal"/>) is still <c>true</c>. When
     /// the append returns <c>bool</c> its result updates the condition. When no
     /// gating is required the call is emitted unconditionally.
+    /// <para>
+    /// Issue #418 (P1-9): any <paramref name="holeLeading"/> statements
+    /// (hole-evaluation spills produced for awaiting holes when gating is in
+    /// effect) are emitted <em>inside</em> the gated block so the hole
+    /// expression is evaluated only when the gate allows the append.
+    /// </para>
     /// </summary>
-    private BoundStatement MakeAppendStatement(SyntaxNode syntax, BoundExpression appendCall, LocalVariableSymbol continueLocal)
+    private BoundStatement MakeAppendStatement(
+        SyntaxNode syntax,
+        BoundExpression appendCall,
+        LocalVariableSymbol continueLocal,
+        ImmutableArray<BoundStatement> holeLeading = default)
     {
         var returnsBool = appendCall.Type?.ClrType == typeof(bool);
+        var leading = holeLeading.IsDefault ? ImmutableArray<BoundStatement>.Empty : holeLeading;
 
         if (continueLocal == null)
         {
-            return new BoundExpressionStatement(syntax, appendCall);
+            if (leading.IsEmpty)
+            {
+                return new BoundExpressionStatement(syntax, appendCall);
+            }
+
+            var unguarded = ImmutableArray.CreateBuilder<BoundStatement>(leading.Length + 1);
+            unguarded.AddRange(leading);
+            unguarded.Add(new BoundExpressionStatement(syntax, appendCall));
+            return new BoundBlockStatement(syntax, unguarded.ToImmutable());
         }
 
         BoundStatement inner = returnsBool
@@ -403,6 +479,7 @@ internal sealed class InterpolatedStringHandlerLowerer : BoundTreeRewriter
         // BoundIfStatement introduced here would never be lowered for emit:
         //
         //   gotoFalse <>cont end
+        //   [hole-leading spills (issue #418)]
         //   <append (maybe assigns <>cont)>
         //   end:
         var endLabel = new BoundLabel($"<>appendEnd{this.counter++}");
@@ -412,9 +489,13 @@ internal sealed class InterpolatedStringHandlerLowerer : BoundTreeRewriter
             new BoundVariableExpression(null, continueLocal),
             jumpIfTrue: false);
         var endLabelStatement = new BoundLabelStatement(null, endLabel);
-        return new BoundBlockStatement(
-            syntax,
-            ImmutableArray.Create<BoundStatement>(gotoFalse, inner, endLabelStatement));
+
+        var block = ImmutableArray.CreateBuilder<BoundStatement>(2 + leading.Length + 1);
+        block.Add(gotoFalse);
+        block.AddRange(leading);
+        block.Add(inner);
+        block.Add(endLabelStatement);
+        return new BoundBlockStatement(syntax, block.ToImmutable());
     }
 
     private (MethodInfo Method, ImmutableArray<TypeSymbol> TypeArguments) ResolveUserAppendFormatted(

--- a/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringHandlerArgumentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringHandlerArgumentTests.cs
@@ -162,6 +162,74 @@ Console.WriteLine(msg)
         Assert.DoesNotContain("[str:", output);
     }
 
+    /// <summary>
+    /// Issue #418 (P1-9): when the handler ctor sets <c>shouldAppend = false</c>,
+    /// hole expressions must NOT be evaluated. Prior to the fix the lowering
+    /// pre-spilled every hole containing an <c>await</c> into a temp before
+    /// the ctor ran, so the awaiting side effect (here, incrementing
+    /// <c>HoleEvaluations</c>) fired even when the gate disabled appends.
+    /// </summary>
+    [Fact]
+    public void OutBool_Gated_Handler_Disabled_Does_Not_Evaluate_Awaiting_Holes()
+    {
+        const string Source = @"package HandlerGatedOffNoEval
+import System.Threading.Tasks
+import GSharp.Core.Tests.Fixtures
+
+InterpolationHarness.ResetHoleEvaluations()
+
+async func runDisabled() string {
+    return InterpolationHarness.Gated(false, ""y=${await InterpolationHarness.BumpAndReturnAsync(9)}"")
+}
+
+var t = runDisabled()
+t.Wait()
+";
+        var evaluations = CompileAndReadHoleEvaluations(Source, "HandlerGatedOffNoEvalTest");
+        Assert.Equal(0, evaluations);
+    }
+
+    /// <summary>
+    /// Issue #418 (P1-9) sanity check: when the gate is enabled, awaiting holes
+    /// must still be evaluated exactly once per append.
+    /// </summary>
+    [Fact]
+    public void OutBool_Gated_Handler_Enabled_Evaluates_Awaiting_Holes_Once()
+    {
+        const string Source = @"package HandlerGatedOnEvalOnce
+import System.Threading.Tasks
+import GSharp.Core.Tests.Fixtures
+
+InterpolationHarness.ResetHoleEvaluations()
+
+async func runEnabled() string {
+    return InterpolationHarness.Gated(true, ""a=${await InterpolationHarness.BumpAndReturnAsync(1)} b=${await InterpolationHarness.BumpAndReturnAsync(2)}"")
+}
+
+var t = runEnabled()
+t.Wait()
+";
+        var evaluations = CompileAndReadHoleEvaluations(Source, "HandlerGatedOnEvalOnceTest");
+        Assert.Equal(2, evaluations);
+    }
+
+    /// <summary>
+    /// Issue #418 (P1-9): non-await holes already evaluated lazily inside the
+    /// gated block; verify that behavior remains correct after the refactor.
+    /// </summary>
+    [Fact]
+    public void OutBool_Gated_Handler_Disabled_Does_Not_Evaluate_Plain_Holes()
+    {
+        const string Source = @"package HandlerGatedOffPlainNoEval
+import GSharp.Core.Tests.Fixtures
+
+InterpolationHarness.ResetHoleEvaluations()
+let msg = InterpolationHarness.Gated(false, ""y=${InterpolationHarness.BumpAndReturn(9)}"")
+";
+        var evaluations = CompileAndReadHoleEvaluations(Source, "HandlerGatedOffPlainNoEvalTest");
+        Assert.Equal(0, evaluations);
+    }
+
     private static (ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Diagnostics, object? Value) EvaluateNamed(string source, string variableName)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));
@@ -213,5 +281,19 @@ Console.WriteLine(msg)
         {
             loadContext.Unload();
         }
+    }
+
+    /// <summary>
+    /// Issue #418 (P1-9): compiles and runs the G# source, then reads the
+    /// host-process value of <see cref="GSharp.Core.Tests.Fixtures.InterpolationHarness.HoleEvaluations"/>
+    /// to assert how many hole expressions actually executed. The collectible
+    /// ALC resolves the fixture assembly through the default ALC, so the
+    /// counter is shared between the generated assembly and the host test.
+    /// </summary>
+    private static int CompileAndReadHoleEvaluations(string source, string contextName)
+    {
+        GSharp.Core.Tests.Fixtures.InterpolationHarness.ResetHoleEvaluations();
+        CompileAndRun(source, contextName);
+        return GSharp.Core.Tests.Fixtures.InterpolationHarness.HoleEvaluations;
     }
 }

--- a/test/Core.Tests/Fixtures/InterpolatedStringHandlerFixtures.cs
+++ b/test/Core.Tests/Fixtures/InterpolatedStringHandlerFixtures.cs
@@ -97,6 +97,28 @@ public sealed class InterpolationLog
 /// <summary>Static consuming APIs for the issue #368 handler fixtures.</summary>
 public static class InterpolationHarness
 {
+    /// <summary>
+    /// Issue #418 (P1-9): observes side effects of interpolated-string hole
+    /// expressions. Tests increment this counter inside a hole and then verify
+    /// it stays at zero when the handler gate (shouldAppend = false) skips
+    /// the appends — proving holes are evaluated lazily, after the ctor.
+    /// </summary>
+    public static int HoleEvaluations;
+
+    public static int BumpAndReturn(int value)
+    {
+        System.Threading.Interlocked.Increment(ref HoleEvaluations);
+        return value;
+    }
+
+    public static System.Threading.Tasks.Task<int> BumpAndReturnAsync(int value)
+    {
+        System.Threading.Interlocked.Increment(ref HoleEvaluations);
+        return System.Threading.Tasks.Task.FromResult(value);
+    }
+
+    public static void ResetHoleEvaluations() => HoleEvaluations = 0;
+
     public static string Format(string prefix, [InterpolatedStringHandlerArgument("prefix")] PrefixedInterpolatedStringHandler handler)
         => handler.ToString();
 


### PR DESCRIPTION
## Problem (issue #418, P1-9)

A user `[InterpolatedStringHandler]` type may set its `out bool shouldAppend` parameter to `false` in the constructor to short-circuit further appends. The previous lowering pre-spilled every hole expression containing an `await` into a leading temp **before** the handler ctor ran, so the awaiting side effect fired even when the ctor disabled the gate.

## Fix

In `InterpolatedStringHandlerLowerer.RewriteUserHandler`:

* Compute `needsGate` (out-bool ctor or bool-returning appends) **before** preparing the parts.
* When gating is required, lower hole values **in place** via the new `LowerHoleValuesInPlace` helper instead of running `PrepareParts`' pre-ctor spill.
* For each awaiting hole, emit a single `var <>hole = <expr>` spill **inside** the per-append gated block (via a new `holeLeading` parameter to `MakeAppendStatement`), so the temp initialization — and therefore the await side effect — runs only when the gate allows the append.

Non-gated handlers keep the existing ref-struct-across-await safety spill via `PrepareParts`.

## Tests

Added three new tests to `InterpolatedStringHandlerArgumentTests`, backed by a small `BumpAndReturn` / `BumpAndReturnAsync` instrumentation on `InterpolationHarness`:

* `OutBool_Gated_Handler_Disabled_Does_Not_Evaluate_Awaiting_Holes` — the bug reproducer; fails on `main` (HoleEvaluations=1), passes after the fix (HoleEvaluations=0).
* `OutBool_Gated_Handler_Enabled_Evaluates_Awaiting_Holes_Once` — sanity check that gating doesn't double- or under-count.
* `OutBool_Gated_Handler_Disabled_Does_Not_Evaluate_Plain_Holes` — regression for the non-await branch.

Full suite: `Core.Tests 1621 / Compiler.Tests 282 / LanguageServer.Tests 212 / Interpreter.Tests 54 / Sdk.Tests 24` — all green.

Fixes #418.