### PR TITLE
Fix #418 (P1-4): extend CollectLabels to descend into BoundBlockExpression

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -10048,6 +10048,33 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
+    // Walks an arbitrary bound sub-tree and records every BoundLabelStatement
+    // label it discovers. Implemented as a BoundTreeRewriter subclass so it
+    // automatically descends through every statement and expression kind
+    // (including BoundBlockExpression, BoundSpillSequenceExpression, etc.)
+    // without having to enumerate them by hand. The rewriter is used purely
+    // as a visitor — its returned nodes are discarded.
+    private sealed class ExpressionBlockLabelCollector : BoundTreeRewriter
+    {
+        private readonly HashSet<BoundLabel> sink;
+
+        public ExpressionBlockLabelCollector(HashSet<BoundLabel> sink)
+        {
+            this.sink = sink;
+        }
+
+        public void Visit(BoundExpression expression)
+        {
+            this.RewriteExpression(expression);
+        }
+
+        protected override BoundStatement RewriteLabelStatement(BoundLabelStatement node)
+        {
+            this.sink.Add(node.Label);
+            return node;
+        }
+    }
+
     private sealed class LambdaCollector : BoundTreeRewriter
     {
         private readonly List<BoundFunctionLiteralExpression> sink;
@@ -12081,13 +12108,47 @@ internal sealed class ReflectionMetadataEmitter
                 case BoundScopeStatement sc:
                     CollectLabels(sc.Body, sink);
                     return;
+                case BoundExpressionStatement es:
+                    CollectLabelsInExpression(es.Expression, sink);
+                    return;
+                case BoundConditionalGotoStatement cg:
+                    CollectLabelsInExpression(cg.Condition, sink);
+                    return;
+                case BoundReturnStatement rs:
+                    CollectLabelsInExpression(rs.Expression, sink);
+                    return;
                 default:
                     // All other structured statements (if/for/while/...) are
                     // flattened to BoundGotoStatement/BoundConditionalGotoStatement
-                    // by Lowerer before reaching the emitter, so there are no
-                    // hidden BoundLabelStatements to discover.
+                    // by Lowerer before reaching the emitter. However, any
+                    // statement that carries a BoundExpression may transitively
+                    // contain a BoundBlockExpression (interpolated-string handler
+                    // gate, null-conditional capture, switch-expression spill,
+                    // ...) whose statement list introduces BoundLabelStatements.
+                    // Those labels are registered in this.labels by
+                    // EmitBlockExpression, but if they are not added here the
+                    // EmitBranch crossesRegion heuristic emits an illegal Leave
+                    // for a same-region goto (issue #418 / P1-4). Use a generic
+                    // walker as a safety net for any statement kind that might
+                    // carry an expression-position block.
+                    var stmtWalker = new ExpressionBlockLabelCollector(sink);
+                    stmtWalker.RewriteStatement(statement);
                     return;
             }
+        }
+
+        // Recursively collects BoundLabelStatement labels that live inside a
+        // BoundExpression sub-tree. This is the inverse-side of CollectLabels
+        // for expression-position blocks (BoundBlockExpression et al.).
+        private static void CollectLabelsInExpression(BoundExpression expression, HashSet<BoundLabel> sink)
+        {
+            if (expression == null)
+            {
+                return;
+            }
+
+            var walker = new ExpressionBlockLabelCollector(sink);
+            walker.Visit(expression);
         }
 
         private void EmitBranch(BoundLabel target, BoundExpression conditional, bool jumpIfTrue)

--- a/test/Core.Tests/CodeAnalysis/Emit/CollectLabelsInsideBlockExpressionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/CollectLabelsInsideBlockExpressionTests.cs
@@ -1,0 +1,164 @@
+// <copyright file="CollectLabelsInsideBlockExpressionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#nullable enable
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #418 (P1-4): <c>CollectLabels</c> used to ignore labels living
+/// inside a <c>BoundBlockExpression</c> (interpolated-string handler gate,
+/// null-conditional capture, switch-expression spill, ...). Those labels
+/// are registered in <c>this.labels</c> by <c>EmitBlockExpression</c>, but
+/// the lexical label set for the enclosing <c>try</c> never saw them. A
+/// <c>goto</c> whose source and target both lived inside the same protected
+/// region therefore tripped <c>EmitBranch</c>'s <c>crossesRegion</c>
+/// heuristic and emitted a CIL <c>leave</c> — illegal when the target is
+/// inside the same region; the JIT rejects the method with
+/// <see cref="System.InvalidProgramException"/>.
+///
+/// These tests reproduce the bug end-to-end by placing an interpolated
+/// string that binds to the <c>GatedInterpolatedStringHandler</c> fixture
+/// (an <c>[InterpolatedStringHandler]</c> whose constructor takes
+/// <c>out bool shouldAppend</c>) inside a <c>try</c>. The lowering pass
+/// emits a <c>BoundBlockExpression</c> whose statement list contains
+/// per-append short-circuit <c>BoundConditionalGotoStatement</c> /
+/// <c>BoundLabelStatement</c> pairs; pre-fix, the <c>goto</c>s were
+/// translated to <c>leave</c> and the resulting method failed to JIT.
+/// </summary>
+public class CollectLabelsInsideBlockExpressionTests
+{
+    [Fact]
+    public void Gated_Interpolated_String_Inside_Try_Catch_Is_Valid_IL()
+    {
+        const string Source = @"package CollectLabelsTryCatch
+import System
+import GSharp.Core.Tests.Fixtures
+
+try {
+    let msg = InterpolationHarness.Gated(true, ""y=${9}"")
+    Console.WriteLine(msg)
+} catch (e Exception) {
+    Console.WriteLine(""caught"")
+}
+";
+        var output = CompileAndRun(Source, "P1_4_TryCatch");
+        Assert.Contains("y=9", output);
+    }
+
+    [Fact]
+    public void Gated_Interpolated_String_Inside_Try_Finally_Is_Valid_IL()
+    {
+        const string Source = @"package CollectLabelsTryFinally
+import System
+import GSharp.Core.Tests.Fixtures
+
+try {
+    let msg = InterpolationHarness.Gated(true, ""z=${42}"")
+    Console.WriteLine(msg)
+} finally {
+    Console.WriteLine(""done"")
+}
+";
+        var output = CompileAndRun(Source, "P1_4_TryFinally");
+        Assert.Contains("z=42", output);
+        Assert.Contains("done", output);
+    }
+
+    [Fact]
+    public void Gated_Interpolated_String_With_Many_Holes_Inside_Try_Is_Valid_IL()
+    {
+        // Multiple holes => multiple per-append BoundConditionalGoto/BoundLabel
+        // pairs inside the same BoundBlockExpression. All of them must be
+        // collected into the enclosing try's lexical label set so that the
+        // emitter does not translate them to `leave`.
+        const string Source = @"package CollectLabelsTryMultiHole
+import System
+import GSharp.Core.Tests.Fixtures
+
+try {
+    let msg = InterpolationHarness.Gated(true, ""a=${1} b=${2} c=${3}"")
+    Console.WriteLine(msg)
+} catch (e Exception) {
+    Console.WriteLine(""caught"")
+}
+";
+        var output = CompileAndRun(Source, "P1_4_MultiHole");
+        Assert.Contains("a=1 b=2 c=3", output);
+    }
+
+    [Fact]
+    public void Gated_Interpolated_String_Disabled_Inside_Try_Is_Valid_IL()
+    {
+        // shouldAppend = false: the gate short-circuits past every append.
+        // Pre-fix, the conditional gotos inside the BoundBlockExpression
+        // were emitted as `leave`, so the IL would fail to JIT even when
+        // taking the disabled branch.
+        const string Source = @"package CollectLabelsTryDisabled
+import System
+import GSharp.Core.Tests.Fixtures
+
+try {
+    let msg = InterpolationHarness.Gated(false, ""y=${9}"")
+    Console.WriteLine(""len="" + msg.Length.ToString())
+} catch (e Exception) {
+    Console.WriteLine(""caught"")
+}
+";
+        var output = CompileAndRun(Source, "P1_4_Disabled");
+        Assert.Contains("len=0", output);
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = System.Console.Out;
+            var captured = new StringWriter();
+            System.Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, parameters: null);
+            }
+            finally
+            {
+                System.Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
Fixes issue #418 / P1-4.

## Problem
`CollectLabels` in `ReflectionMetadataEmitter` only recursed into
`BoundBlockStatement`, `BoundTryStatement`, and `BoundScopeStatement`.
Statements that carry an expression (`BoundExpressionStatement`,
`BoundConditionalGotoStatement`, `BoundReturnStatement`, ...) can
transitively contain a `BoundBlockExpression` whose statement list
introduces `BoundLabelStatement`s — for example the interpolated-string
handler short-circuit gate, null-conditional capture, or switch-expression
spill. Those labels are registered in the emitter's label map by
`EmitBlockExpression`, but they were never added to the enclosing try's
protected-region label set.

A `goto` whose source and target both live inside the same protected
region therefore tripped `EmitBranch`'s `crossesRegion` heuristic and was
emitted as a CIL `leave` — illegal when the target is inside the same
region — and the JIT rejected the resulting method with
`InvalidProgramException`.

## Fix
Extend `CollectLabels` to handle `BoundExpressionStatement`,
`BoundConditionalGotoStatement`, and `BoundReturnStatement` directly, and
add a `BoundTreeRewriter`-based safety-net walker
(`ExpressionBlockLabelCollector`) for any other statement kind that may
carry an expression-position block. The walker reuses the existing
rewriter dispatch so it transparently descends through every expression
shape (`BoundBlockExpression`, `BoundSpillSequenceExpression`,
`BoundSwitchExpression`, ...) without per-kind enumeration.

## Tests
Four new end-to-end emit tests in
`test/Core.Tests/CodeAnalysis/Emit/CollectLabelsInsideBlockExpressionTests.cs`
bind an interpolated string to `GatedInterpolatedStringHandler` (an
`[InterpolatedStringHandler]` fixture whose constructor takes
`out bool shouldAppend`) inside a `try`/`catch` and `try`/`finally`.

* Pre-fix: all four fail to JIT with `InvalidProgramException`.
* Post-fix: they produce the expected output.

Full suite: 1622 + 282 + 54 + 212 + 24 = 2194 tests, 0 failures.