### PR TITLE
Fix #421 (P2-10): catch IOException/UnauthorizedAccessException in compiler Main

### DIFF
--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -129,15 +129,6 @@ public class Program
         }
     }
 
-    private static int ReportFatalIOError(Exception ex)
-    {
-        // Emit in the csc-compatible "gsc: error GS9999: <message>" form so
-        // the SDK BuildTask's diagnostic regex surfaces it as a structured
-        // MSBuild error rather than an opaque process crash.
-        Console.Error.WriteLine($"gsc: error GS9999: {ex.Message}");
-        return Error;
-    }
-
     // Tokenizes a single response-file line, splitting on whitespace while
     // respecting double-quote delimiters. Quotes are stripped from the
     // resulting tokens but the content between them (including spaces) is
@@ -197,6 +188,15 @@ public class Program
         }
 
         return tokens;
+    }
+
+    private static int ReportFatalIOError(Exception ex)
+    {
+        // Emit in the csc-compatible "gsc: error GS9999: <message>" form so
+        // the SDK BuildTask's diagnostic regex surfaces it as a structured
+        // MSBuild error rather than an opaque process crash.
+        Console.Error.WriteLine($"gsc: error GS9999: {ex.Message}");
+        return Error;
     }
 
     private static void ReportMissingTransitiveReferences(ReferenceResolver references, CommandLineArgs args)

--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -53,6 +53,14 @@ public class Program
             Console.Error.WriteLine(ex.Message);
             return Error;
         }
+        catch (IOException ex)
+        {
+            return ReportFatalIOError(ex);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ReportFatalIOError(ex);
+        }
 
         if (parsed.SourceFiles.Count == 0)
         {
@@ -60,50 +68,74 @@ public class Program
             return Error;
         }
 
-        var syntaxTrees = new List<SyntaxTree>(parsed.SourceFiles.Count);
-        foreach (var path in parsed.SourceFiles)
+        try
         {
-            if (!File.Exists(path))
+            var syntaxTrees = new List<SyntaxTree>(parsed.SourceFiles.Count);
+            foreach (var path in parsed.SourceFiles)
             {
-                Console.Error.WriteLine($"Unable to find specified file {path}");
-                return Error;
+                if (!File.Exists(path))
+                {
+                    Console.Error.WriteLine($"Unable to find specified file {path}");
+                    return Error;
+                }
+
+                // Resolve to an absolute path so the document name recorded in the
+                // PDB is rooted. Debuggers (vsdbg/coreclr) match on-disk breakpoints
+                // against the PDB document name; a relative name leaves source
+                // unresolvable, which surfaces as a phantom tab with
+                // "Could not load source ...: Incorrect format of 'source' message."
+                var fullPath = Path.GetFullPath(path);
+                syntaxTrees.Add(SyntaxTree.Load(fullPath));
             }
 
-            // Resolve to an absolute path so the document name recorded in the
-            // PDB is rooted. Debuggers (vsdbg/coreclr) match on-disk breakpoints
-            // against the PDB document name; a relative name leaves source
-            // unresolvable, which surfaces as a phantom tab with
-            // "Could not load source ...: Incorrect format of 'source' message."
-            var fullPath = Path.GetFullPath(path);
-            syntaxTrees.Add(SyntaxTree.Load(fullPath));
-        }
+            var references = parsed.References.Count > 0
+                ? ReferenceResolver.WithReferences(parsed.References)
+                : null;
 
-        var references = parsed.References.Count > 0
-            ? ReferenceResolver.WithReferences(parsed.References)
-            : null;
+            ReportMissingTransitiveReferences(references, parsed);
 
-        ReportMissingTransitiveReferences(references, parsed);
-
-        var compilation = new Compilation(references, syntaxTrees.ToArray())
-        {
-            ImplicitSystemImport = parsed.ImplicitSystemImport,
-            DebugInformation =
+            var compilation = new Compilation(references, syntaxTrees.ToArray())
             {
-                Format = parsed.DebugFormat,
-                PdbFilePath = parsed.PdbPath,
-                SourceLinkFilePath = parsed.SourceLinkPath,
-                Deterministic = parsed.Deterministic,
-                EmbedAllSources = parsed.EmbedAllSources,
-            },
-        };
+                ImplicitSystemImport = parsed.ImplicitSystemImport,
+                DebugInformation =
+                {
+                    Format = parsed.DebugFormat,
+                    PdbFilePath = parsed.PdbPath,
+                    SourceLinkFilePath = parsed.SourceLinkPath,
+                    Deterministic = parsed.Deterministic,
+                    EmbedAllSources = parsed.EmbedAllSources,
+                },
+            };
 
-        if (parsed.OutputPath is null)
-        {
-            // Legacy / no-output mode: interpret the program (back-compat).
-            return Interpret(compilation, parsed);
+            if (parsed.OutputPath is null)
+            {
+                // Legacy / no-output mode: interpret the program (back-compat).
+                return Interpret(compilation, parsed);
+            }
+
+            return Emit(compilation, parsed);
         }
+        catch (IOException ex)
+        {
+            // I/O failures during source loading, directory creation, output
+            // file creation, or assembly emit must surface as a structured
+            // diagnostic with a non-zero exit code rather than crashing gsc.
+            return ReportFatalIOError(ex);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            // Permission-denied while reading sources or writing outputs.
+            return ReportFatalIOError(ex);
+        }
+    }
 
-        return Emit(compilation, parsed);
+    private static int ReportFatalIOError(Exception ex)
+    {
+        // Emit in the csc-compatible "gsc: error GS9999: <message>" form so
+        // the SDK BuildTask's diagnostic regex surfaces it as a structured
+        // MSBuild error rather than an opaque process crash.
+        Console.Error.WriteLine($"gsc: error GS9999: {ex.Message}");
+        return Error;
     }
 
     // Tokenizes a single response-file line, splitting on whitespace while

--- a/test/Compiler.Tests/ProgramTests.cs
+++ b/test/Compiler.Tests/ProgramTests.cs
@@ -648,4 +648,81 @@ public class ProgramTests
             try { File.Delete(sample); } catch { }
         }
     }
+
+    [Fact]
+    public void Main_OutputPathInUnwritableLocation_ReportsErrorAndExitsNonZero()
+    {
+        // Direct /out at a path whose containing directory cannot be created
+        // (an existing FILE acts as a non-directory parent). On every OS this
+        // makes Directory.CreateDirectory throw IOException, which previously
+        // propagated out of Main and crashed gsc. The fix wraps Main with a
+        // catch that reports GS9999 and returns Error.
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package P\n");
+        var blocker = Path.Combine(Path.GetTempPath(), $"gs_blocker_{System.Guid.NewGuid():N}");
+        File.WriteAllText(blocker, "not a directory");
+        var outPath = Path.Combine(blocker, "sub", "P.dll");
+        using var outWriter = new StringWriter();
+        using var errWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(outWriter);
+        Console.SetError(errWriter);
+        try
+        {
+            int exit = -42;
+            var ex = Record.Exception(() =>
+            {
+                exit = Program.Main(new[] { "/out:" + outPath, "/target:library", sample });
+            });
+            Assert.Null(ex);
+            Assert.NotEqual(0, exit);
+            var stderr = errWriter.ToString();
+            Assert.Contains("GS9999", stderr);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+            try { File.Delete(blocker); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Main_OutputPathIsExistingDirectory_ReportsErrorAndExitsNonZero()
+    {
+        // Pointing /out at an existing directory makes File.Create throw
+        // UnauthorizedAccessException (Windows) or IOException (Unix). Both
+        // must be caught and surfaced as a structured GS9999 error.
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package P\n");
+        var tempDir = Directory.CreateTempSubdirectory("gsc_io_err_").FullName;
+        using var outWriter = new StringWriter();
+        using var errWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(outWriter);
+        Console.SetError(errWriter);
+        try
+        {
+            int exit = -42;
+            var ex = Record.Exception(() =>
+            {
+                // /out: points at the directory itself (not a file inside it).
+                exit = Program.Main(new[] { "/out:" + tempDir, "/target:library", sample });
+            });
+            Assert.Null(ex);
+            Assert.NotEqual(0, exit);
+            var stderr = errWriter.ToString();
+            Assert.Contains("GS9999", stderr);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
 }


### PR DESCRIPTION
## Issue
Resolves sub-issue **P2-10** of #421.

`Compiler.Program.Main` only caught `CommandLineException`. I/O failures from `Directory.CreateDirectory`, `File.Create`, or `compilation.Emit` (Program.cs:47-55, 161, 206-209, 211) propagated uncaught and crashed gsc with a raw .NET stack trace instead of returning the documented non-zero exit code with a meaningful diagnostic.

## Fix
- Wrap `ParseCommandLine` and the main compilation/emit flow in `Program.Main` with `catch (IOException)` and `catch (UnauthorizedAccessException)` handlers.
- New helper `ReportFatalIOError` writes a structured diagnostic in the csc/MSBuild-compatible form `gsc: error GS9999: <message>` to stderr and returns the existing `Error` (1) exit code, matching the convention already used by `Compilation.Evaluate` for fatal interpreter errors.
- Covers all the cited call sites: response-file reads in command-line parsing, `SyntaxTree.Load`, output / ref / docs / pdb directory creation, sidecar file creation, and the emit call itself.

## Tests
Two new regression tests in `test/Compiler.Tests/ProgramTests.cs`:
- `Main_OutputPathInUnwritableLocation_ReportsErrorAndExitsNonZero` — `/out:` under a path whose parent is an existing **file** forces `Directory.CreateDirectory` to throw `IOException`.
- `Main_OutputPathIsExistingDirectory_ReportsErrorAndExitsNonZero` — `/out:` pointing at an existing **directory** forces `File.Create` to throw `IOException`/`UnauthorizedAccessException`.

Both assert: no exception escapes `Main`, exit code ≠ 0, and stderr contains `GS9999`.

## Validation
- `dotnet build GSharp.sln` — clean, 0 warnings, 0 errors.
- `dotnet test GSharp.sln` — all suites green:
  - Sdk.Tests: 24/24
  - Interpreter.Tests: 54/54
  - LanguageServer.Tests: 212/212
  - Core.Tests: 1661/1661
  - Compiler.Tests: 293/293 (includes the 2 new tests)