### PR TITLE
Fix #421 (P2-3): route decimal constant patterns through op_Equality instead of Ceq

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -12630,6 +12630,18 @@ internal sealed class ReflectionMetadataEmitter
                 return;
             }
 
+            // Issue #421 (P2-3): `decimal` is a struct; per ECMA-335 §III.4
+            // `ceq` is undefined on struct operands. Route through
+            // `decimal.op_Equality` to produce verifiable IL.
+            if (valueType == TypeSymbol.Decimal)
+            {
+                loadValue();
+                this.EmitExpression(cp.Value);
+                this.TryEmitDecimalBinary(BoundBinaryOperatorKind.Equals);
+                this.il.Branch(ILOpCode.Brfalse, failLabel);
+                return;
+            }
+
             // int / bool / other primitives lowered to ceq + brfalse.
             loadValue();
             this.EmitExpression(cp.Value);

--- a/test/Core.Tests/CodeAnalysis/Emit/DecimalPatternEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/DecimalPatternEmitTests.cs
@@ -1,0 +1,111 @@
+// <copyright file="DecimalPatternEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Regression coverage for issue #421 (P2-3): constant patterns over the
+/// <c>decimal</c> struct type must not emit <c>Ceq</c> (undefined on struct
+/// operands per ECMA-335 §III.4). The emitter must route through
+/// <c>decimal.op_Equality</c> so the produced IL is verifiable and the
+/// runtime actually executes the comparison.
+/// </summary>
+public class DecimalPatternEmitTests
+{
+    [Fact]
+    public void Switch_DecimalConstantPattern_Matches()
+    {
+        const string Source = @"package DecPatMatch
+import System
+let v = 1.5m
+let x = switch v { case 1.5m -> ""hit"" default -> ""miss"" }
+Console.WriteLine(x)
+";
+        var output = CompileLoadInvokeCaptureStdout(Source, nameof(Switch_DecimalConstantPattern_Matches));
+        Assert.Contains("hit", output);
+    }
+
+    [Fact]
+    public void Switch_DecimalConstantPattern_DoesNotMatch_FallsThroughToDefault()
+    {
+        const string Source = @"package DecPatMiss
+import System
+let v = 2.5m
+let x = switch v { case 1.5m -> ""hit"" default -> ""miss"" }
+Console.WriteLine(x)
+";
+        var output = CompileLoadInvokeCaptureStdout(Source, nameof(Switch_DecimalConstantPattern_DoesNotMatch_FallsThroughToDefault));
+        Assert.Contains("miss", output);
+    }
+
+    [Fact]
+    public void Switch_DecimalConstantPattern_PicksCorrectArmAmongMany()
+    {
+        const string Source = @"package DecPatMulti
+import System
+let v = 3.25m
+let x = switch v {
+    case 1.0m -> ""one""
+    case 2.0m -> ""two""
+    case 3.25m -> ""three-quarter""
+    default -> ""other""
+}
+Console.WriteLine(x)
+";
+        var output = CompileLoadInvokeCaptureStdout(Source, nameof(Switch_DecimalConstantPattern_PicksCorrectArmAmongMany));
+        Assert.Contains("three-quarter", output);
+    }
+
+    private static string CompileLoadInvokeCaptureStdout(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, parameters: null);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the P2-3 sub-issue of #421. Constant patterns over the `decimal` struct type were emitting `Ceq` directly on the struct operands. Per ECMA-335 §III.4, `Ceq` is undefined for struct stack types, which produced unverifiable IL and incorrect runtime behavior — a `case 1.5m` arm would never match.

## Fix

`ReflectionMetadataEmitter.EmitConstantPattern` now special-cases `TypeSymbol.Decimal` and routes through `decimal.op_Equality` (via the pre-existing `TryEmitDecimalBinary` helper) before branching on the boolean result. This mirrors how binary equality on `decimal` is already emitted. The `String` path is unchanged; `int`/`bool` and other primitives continue to use the `Ceq` fast path.

## Tests

Adds `DecimalPatternEmitTests` with three end-to-end (compile → load → invoke) cases:

- `Switch_DecimalConstantPattern_Matches` — a matching `case` arm fires.
- `Switch_DecimalConstantPattern_DoesNotMatch_FallsThroughToDefault` — a non-matching pattern falls through to `default`.
- `Switch_DecimalConstantPattern_PicksCorrectArmAmongMany` — the correct arm is selected when several decimal `case`s coexist.

Verified that 2 of these 3 tests fail on `main` and all 3 pass with the fix. Full suite (2245 tests) green.

Closes part of #421 (P2-3).