### PR TITLE
Fix #421 (P2-8): make PDB path absolute when --out is relative

### DIFF
--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -192,8 +192,16 @@ public class Program
             if (string.IsNullOrEmpty(pdbOutputPath))
             {
                 pdbOutputPath = Path.ChangeExtension(outputPath, ".pdb");
-                compilation.DebugInformation.PdbFilePath = pdbOutputPath;
             }
+
+            // Resolve to an absolute path so the CodeView entry recorded in
+            // the PE points at a rooted sidecar location. Debuggers (vsdbg/
+            // coreclr) require an absolute PDB path to bind breakpoints; a
+            // relative /out:<path> would otherwise leave the sidecar
+            // reference unresolvable from the debugger's working directory.
+            // Mirrors the source-path fix in commit 34002ff.
+            pdbOutputPath = Path.GetFullPath(pdbOutputPath);
+            compilation.DebugInformation.PdbFilePath = pdbOutputPath;
 
             var pdbDir = Path.GetDirectoryName(pdbOutputPath);
             if (!string.IsNullOrEmpty(pdbDir))

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1460,11 +1460,22 @@ internal sealed class ReflectionMetadataEmitter
             // CodeView: identifies the PDB the runtime/debugger should fetch.
             // For embedded format the path is conventionally just the bare
             // pdb file name (no directory) because the consumer reads it out
-            // of the PE itself; for sidecar it can be a full path supplied
-            // via /pdb:<path>, else the bare ".pdb" suffix of the PE name.
-            var codeViewPath = !string.IsNullOrEmpty(this.debugInformation.PdbFilePath)
-                ? this.debugInformation.PdbFilePath
-                : (this.assemblyNameOverride ?? this.program.PackageName ?? "module") + ".pdb";
+            // of the PE itself; for sidecar it must be an absolute path so
+            // vsdbg/coreclr can locate the sidecar regardless of the
+            // debugger's working directory. A relative path here would leave
+            // breakpoints unbound. Mirrors the source-path fix in 34002ff.
+            string codeViewPath;
+            if (!string.IsNullOrEmpty(this.debugInformation.PdbFilePath))
+            {
+                codeViewPath = isEmbedded
+                    ? Path.GetFileName(this.debugInformation.PdbFilePath)
+                    : Path.GetFullPath(this.debugInformation.PdbFilePath);
+            }
+            else
+            {
+                codeViewPath = (this.assemblyNameOverride ?? this.program.PackageName ?? "module") + ".pdb";
+            }
+
             debugDirectory.AddCodeViewEntry(
                 pdbPath: codeViewPath,
                 pdbContentId: pdbContentId,

--- a/test/Compiler.Tests/ProgramTests.cs
+++ b/test/Compiler.Tests/ProgramTests.cs
@@ -511,4 +511,53 @@ public class ProgramTests
         // so the closure handed to gsc is incomplete.
         return libPath;
     }
+
+    [Fact]
+    public void Main_WithRelativeOut_And_Debug_EmitsAbsolutePdbPathInCodeView()
+    {
+        // Regression for #421 (P2-8): a relative /out:<path> used to default
+        // the PDB sidecar to a relative path too, which then flowed into the
+        // CodeView debug directory entry verbatim. vsdbg/coreclr require an
+        // absolute PDB path to bind breakpoints — a relative one leaves the
+        // sidecar unresolvable from the debugger's working directory.
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package RelOut\n\nfunc Main() {\n}\n");
+        var originalCwd = Directory.GetCurrentDirectory();
+        var tempCwd = Directory.CreateTempSubdirectory("gsc_relout_").FullName;
+        Directory.SetCurrentDirectory(tempCwd);
+        try
+        {
+            const string relativeOut = "RelOut.dll";
+            var exit = Program.Main(new[]
+            {
+                "/out:" + relativeOut,
+                "/target:library",
+                "/debug:portable",
+                sample,
+            });
+            Assert.Equal(0, exit);
+
+            var absoluteOut = Path.Combine(tempCwd, relativeOut);
+            var absolutePdb = Path.ChangeExtension(absoluteOut, ".pdb");
+            Assert.True(File.Exists(absoluteOut), "expected output assembly to exist");
+            Assert.True(File.Exists(absolutePdb), "expected sidecar PDB to exist");
+
+            using var peReader = new System.Reflection.PortableExecutable.PEReader(
+                new MemoryStream(File.ReadAllBytes(absoluteOut)));
+            var cv = peReader.ReadDebugDirectory()
+                .Single(e => e.Type == System.Reflection.PortableExecutable.DebugDirectoryEntryType.CodeView);
+            var data = peReader.ReadCodeViewDebugDirectoryData(cv);
+
+            Assert.True(
+                Path.IsPathRooted(data.Path),
+                $"expected absolute CodeView PDB path, got: {data.Path}");
+            Assert.EndsWith("RelOut.pdb", data.Path, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCwd);
+            try { Directory.Delete(tempCwd, recursive: true); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
 }

--- a/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
@@ -784,6 +784,63 @@ func main() {
     }
 
     [Fact]
+    public void CodeView_PdbPath_Is_Absolute_For_Sidecar_When_PdbFilePath_Is_Relative()
+    {
+        // Regression for #421 (P2-8): a relative /pdb:<path> (or a relative
+        // /out:<path> that defaults the PDB beside it) used to flow into the
+        // CodeView entry verbatim, leaving vsdbg unable to locate the sidecar
+        // from its working directory. The emitter must root the path.
+        var peStream = new MemoryStream();
+        var pdbStream = new MemoryStream();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(SimpleProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions
+            {
+                Format = DebugInformationFormat.Portable,
+                PdbFilePath = Path.Combine("relative", "sub", "out.pdb"),
+            },
+        };
+        var result = compilation.Emit(peStream, pdbStream, null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        using var peReader = new PEReader(new MemoryStream(peStream.ToArray()));
+        var cv = peReader.ReadDebugDirectory()
+            .Single(e => e.Type == DebugDirectoryEntryType.CodeView);
+        var data = peReader.ReadCodeViewDebugDirectoryData(cv);
+
+        Assert.True(Path.IsPathRooted(data.Path), $"expected rooted CodeView path, got: {data.Path}");
+        Assert.EndsWith("out.pdb", data.Path, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CodeView_PdbPath_Is_Bare_Filename_For_Embedded_When_PdbFilePath_Has_Directory()
+    {
+        // For embedded format the CodeView path is conventionally just the
+        // bare ".pdb" file name (no directory) because the consumer reads the
+        // PDB blob out of the PE itself. A directory portion would be
+        // misleading and inconsistent with csc.
+        var peStream = new MemoryStream();
+        var pdbStream = new MemoryStream();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(SimpleProgram, "main.gs")))
+        {
+            DebugInformation = new DebugInformationOptions
+            {
+                Format = DebugInformationFormat.Embedded,
+                PdbFilePath = Path.Combine(Path.GetTempPath(), "some", "dir", "embedded.pdb"),
+            },
+        };
+        var result = compilation.Emit(peStream, pdbStream, null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        using var peReader = new PEReader(new MemoryStream(peStream.ToArray()));
+        var cv = peReader.ReadDebugDirectory()
+            .Single(e => e.Type == DebugDirectoryEntryType.CodeView);
+        var data = peReader.ReadCodeViewDebugDirectoryData(cv);
+
+        Assert.Equal("embedded.pdb", data.Path);
+    }
+
+    [Fact]
     public void CodeView_Pdb_ContentId_Matches_Sidecar_PdbId()
     {
         var (pe, pdbBytes) = EmitWith(new DebugInformationOptions { Format = DebugInformationFormat.Portable });


### PR DESCRIPTION
## Summary
Sub-issue **P2-8** of #421. vsdbg/coreclr require an absolute PDB path in the CodeView debug directory entry to bind breakpoints. Before this change a relative `/out:<path>` (or `/pdb:<path>`) flowed verbatim into CodeView, leaving the sidecar unresolvable from the debugger's working directory and breakpoints unbound.

Mirrors the source-path fix in 34002ff (which solved the analogous problem for PDB Document names).

## Changes
- **`src/Compiler/Program.cs`** — `Path.GetFullPath` the resolved PDB sidecar path (whether user-supplied via `/pdb:<path>` or defaulted from `/out:<path>`) before writing it back to `compilation.DebugInformation.PdbFilePath` and opening the sidecar stream.
- **`src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs`** — defense in depth at the CodeView entry: `Path.GetFullPath` for sidecar emit; for embedded emit, use only `Path.GetFileName` since the consumer reads the PDB blob out of the PE itself (a directory portion would be misleading and inconsistent with csc).

## Tests
- **`test/Core.Tests/.../PortablePdbEmitTests.cs`**
  - `CodeView_PdbPath_Is_Absolute_For_Sidecar_When_PdbFilePath_Is_Relative` — emits with a relative `PdbFilePath` and asserts the CodeView path is rooted.
  - `CodeView_PdbPath_Is_Bare_Filename_For_Embedded_When_PdbFilePath_Has_Directory` — emits embedded with a rooted `PdbFilePath` and asserts CodeView records just the bare filename.
- **`test/Compiler.Tests/ProgramTests.cs`**
  - `Main_WithRelativeOut_And_Debug_EmitsAbsolutePdbPathInCodeView` — end-to-end: runs `Program.Main` with a relative `/out:RelOut.dll /debug:portable` and verifies the emitted PE's CodeView entry contains an absolute path.

Full suite passes (Core 1663, Compiler 292, Interpreter 54, LanguageServer 212, Sdk 24).

Refs #421.