### PR TITLE
Fix #421 (P2-11): encode null string constants in PDB instead of dropping them

### DIFF
--- a/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
@@ -640,15 +640,20 @@ internal sealed class PortablePdbEmitter
                 break;
             case string str:
                 blob.WriteByte(0x0E); // ELEMENT_TYPE_STRING
-                if (str is null)
-                {
-                    blob.WriteByte(0xFF);
-                }
-                else
-                {
-                    blob.WriteBytes(Encoding.Unicode.GetBytes(str));
-                }
-
+                blob.WriteBytes(Encoding.Unicode.GetBytes(str));
+                break;
+            case null:
+                // Portable PDB spec §II.23.2: a null string constant is encoded
+                // as ELEMENT_TYPE_STRING followed by the single-byte sentinel
+                // 0xFF (a real empty string has zero trailing bytes; the 0xFF
+                // sentinel can never appear at the start of a valid UTF-16
+                // payload because it would imply a half code unit). Without a
+                // tracked declared type we treat any null constant as a null
+                // string reference — matching what debuggers expect for the
+                // common `const s = nil` case and avoiding the silent dropping
+                // of the LocalConstant row.
+                blob.WriteByte(0x0E); // ELEMENT_TYPE_STRING
+                blob.WriteByte(0xFF);
                 break;
             default:
                 return default;

--- a/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
@@ -558,6 +558,47 @@ func main() {
         Assert.Contains("B", names);
         Assert.Contains("C", names);
     }
+
+    /// <summary>
+    /// Issue #421 (P2-11): a <c>null</c> string constant must produce a
+    /// well-formed <c>LocalConstant</c> blob (<c>ELEMENT_TYPE_STRING</c>
+    /// followed by the <c>0xFF</c> sentinel per Portable PDB spec §II.23.2)
+    /// rather than being silently dropped. Drives the private
+    /// <c>EncodeLocalConstantSignature</c> encoder directly via reflection
+    /// because the source language has no surface syntax for a typed
+    /// <c>const</c> initialised to <c>nil</c>.
+    /// </summary>
+    [Fact]
+    public void Null_String_Constant_Is_Encoded_As_NullString_Sentinel()
+    {
+        var emitter = new PortablePdbEmitter(new DebugInformationOptions { Format = DebugInformationFormat.Portable });
+        var method = typeof(PortablePdbEmitter).GetMethod(
+            "EncodeLocalConstantSignature",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var nullHandle = (BlobHandle)method.Invoke(emitter, new object[] { null });
+
+        // The pre-fix code matched `case string str:` (which never matches
+        // null) and fell through to `default: return default`, producing a
+        // nil BlobHandle that the caller then dropped — so the LocalConstant
+        // row never reached the PDB. A non-nil handle here proves the
+        // regression is fixed.
+        Assert.False(nullHandle.IsNil, "null constant must produce a non-nil signature blob (regression: previously fell through to default and was dropped)");
+
+        // A sibling non-null string still produces its own distinct blob —
+        // confirms the null path didn't accidentally collapse onto the
+        // empty-string encoding.
+        var emptyHandle = (BlobHandle)method.Invoke(emitter, new object[] { string.Empty });
+        Assert.False(emptyHandle.IsNil);
+        Assert.NotEqual(nullHandle, emptyHandle);
+
+        // Equal blobs deduplicate through GetOrAddBlob, so two null encodings
+        // must round-trip to the same handle — i.e. the encoder is
+        // deterministic, not accidentally emitting per-call garbage.
+        var secondNullHandle = (BlobHandle)method.Invoke(emitter, new object[] { null });
+        Assert.Equal(nullHandle, secondNullHandle);
+    }
 }
 
 internal static class PortablePdbEmitterTestHelpers


### PR DESCRIPTION
## Summary
Sub-issue **P2-11** of #421.

`PortablePdbEmitter.EncodeLocalConstantSignature` used `case string str:` to handle string constants. In C# pattern matching, that arm does **not** match a `null` reference, so null constants fell through to `default: return default` and the caller skipped `AddLocalConstant` entirely. The PDB therefore had no `LocalConstant` row for the binding and debuggers showed *"value not available"* instead of `null`.

## Fix
Add an explicit `case null:` arm that emits the Portable PDB §II.23.2 null-string encoding — `ELEMENT_TYPE_STRING` (`0x0E`) followed by the `0xFF` sentinel byte. The existing (dead) `if (str is null)` branch inside the string arm is removed now that null can never reach it.

## Tests
`PortablePdbLocalConstantTests.Null_String_Constant_Is_Encoded_As_NullString_Sentinel` drives the private encoder via reflection and asserts:
- the returned `BlobHandle` is non-nil for `null` input (the actual regression),
- a null encoding is distinct from the empty-string encoding,
- two null encodings deduplicate to the same handle (deterministic).

All existing tests still pass (`dotnet test GSharp.sln` — Compiler 291✅, Core 1662✅, LanguageServer 212✅, Interpreter 54✅, Sdk 24✅).

Closes P2-11 of #421.