### PR TITLE
Fix #421 (P2-9): tokenize response-file lines respecting quotes and spaces

### DIFF
--- a/src/Compiler/Compiler.csproj
+++ b/src/Compiler/Compiler.csproj
@@ -13,4 +13,8 @@
     <ProjectReference Include="@(GsharpCore)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="GSharp.Compiler.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -106,6 +106,67 @@ public class Program
         return Emit(compilation, parsed);
     }
 
+    // Tokenizes a single response-file line, splitting on whitespace while
+    // respecting double-quote delimiters. Quotes are stripped from the
+    // resulting tokens but the content between them (including spaces) is
+    // preserved as a single token. A doubled quote ("") inside a quoted
+    // section emits a literal quote character. Behavior matches what csc /
+    // dotnet build accept for response files.
+    internal static List<string> TokenizeResponseFileLine(string line)
+    {
+        var tokens = new List<string>();
+        if (string.IsNullOrEmpty(line))
+        {
+            return tokens;
+        }
+
+        var sb = new StringBuilder();
+        bool inQuotes = false;
+        bool hasToken = false;
+
+        for (int i = 0; i < line.Length; i++)
+        {
+            char c = line[i];
+
+            if (c == '"')
+            {
+                if (inQuotes && i + 1 < line.Length && line[i + 1] == '"')
+                {
+                    // Escaped quote inside a quoted section.
+                    sb.Append('"');
+                    hasToken = true;
+                    i++;
+                }
+                else
+                {
+                    inQuotes = !inQuotes;
+                    hasToken = true;
+                }
+            }
+            else if (!inQuotes && char.IsWhiteSpace(c))
+            {
+                if (hasToken)
+                {
+                    tokens.Add(sb.ToString());
+                    sb.Clear();
+                    hasToken = false;
+                }
+            }
+            else
+            {
+                sb.Append(c);
+                hasToken = true;
+            }
+        }
+
+        if (hasToken)
+        {
+            tokens.Add(sb.ToString());
+        }
+
+        return tokens;
+    }
+
     private static void ReportMissingTransitiveReferences(ReferenceResolver references, CommandLineArgs args)
     {
         if (references is null || references.MissingTransitiveReferences.IsDefaultOrEmpty)
@@ -608,7 +669,10 @@ public class Program
                         continue;
                     }
 
-                    result.Add(trimmed);
+                    foreach (var token in TokenizeResponseFileLine(trimmed))
+                    {
+                        result.Add(token);
+                    }
                 }
             }
             else

--- a/test/Compiler.Tests/ProgramTests.cs
+++ b/test/Compiler.Tests/ProgramTests.cs
@@ -154,6 +154,94 @@ public class ProgramTests
     }
 
     [Fact]
+    public void TokenizeResponseFileLine_SplitsOnWhitespace()
+    {
+        var tokens = GSharp.Compiler.Program.TokenizeResponseFileLine("/out:foo.dll /target:library a.gs");
+        Assert.Equal(new[] { "/out:foo.dll", "/target:library", "a.gs" }, tokens);
+    }
+
+    [Fact]
+    public void TokenizeResponseFileLine_RespectsDoubleQuotes()
+    {
+        var tokens = GSharp.Compiler.Program.TokenizeResponseFileLine("/out:\"bin/my app.dll\" a.gs");
+        Assert.Equal(new[] { "/out:bin/my app.dll", "a.gs" }, tokens);
+    }
+
+    [Fact]
+    public void TokenizeResponseFileLine_QuotedTokenContainingSpaces()
+    {
+        var tokens = GSharp.Compiler.Program.TokenizeResponseFileLine("\"path with spaces/foo.gs\"");
+        Assert.Equal(new[] { "path with spaces/foo.gs" }, tokens);
+    }
+
+    [Fact]
+    public void TokenizeResponseFileLine_EmptyAndWhitespaceLines()
+    {
+        Assert.Empty(GSharp.Compiler.Program.TokenizeResponseFileLine(string.Empty));
+        Assert.Empty(GSharp.Compiler.Program.TokenizeResponseFileLine("   \t  "));
+    }
+
+    [Fact]
+    public void TokenizeResponseFileLine_EscapedDoubleQuoteInsideQuotes()
+    {
+        // Inside a quoted segment, "" represents a literal quote.
+        var tokens = GSharp.Compiler.Program.TokenizeResponseFileLine("\"a\"\"b\" c");
+        Assert.Equal(new[] { "a\"b", "c" }, tokens);
+    }
+
+    [Fact]
+    public void TokenizeResponseFileLine_AdjacentQuotedAndUnquoted()
+    {
+        // /out:"my app.dll" should yield a single token /out:my app.dll.
+        var tokens = GSharp.Compiler.Program.TokenizeResponseFileLine("/out:\"my app.dll\"");
+        Assert.Single(tokens);
+        Assert.Equal("/out:my app.dll", tokens[0]);
+    }
+
+    [Fact]
+    public void TokenizeResponseFileLine_MultipleSpacesAndTabs()
+    {
+        var tokens = GSharp.Compiler.Program.TokenizeResponseFileLine("  a\tb   c  ");
+        Assert.Equal(new[] { "a", "b", "c" }, tokens);
+    }
+
+    [Fact]
+    public void TokenizeResponseFileLine_EmptyQuotedStringYieldsEmptyToken()
+    {
+        // "" on its own is a deliberate empty argument.
+        var tokens = GSharp.Compiler.Program.TokenizeResponseFileLine("a \"\" b");
+        Assert.Equal(new[] { "a", string.Empty, "b" }, tokens);
+    }
+
+    [Fact]
+    public void Main_WithResponseFile_HandlesQuotedPathWithSpaces()
+    {
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package P\n");
+        var tempDir = Directory.CreateTempSubdirectory("gsc_rsp_quoted_").FullName;
+        var spaceDir = Path.Combine(tempDir, "out put");
+        Directory.CreateDirectory(spaceDir);
+        var outPath = Path.Combine(spaceDir, "P.dll");
+        var rspPath = Path.Combine(tempDir, "args.rsp");
+        File.WriteAllLines(rspPath, new[]
+        {
+            $"/out:\"{outPath}\" /target:library",
+            $"\"{sample}\"",
+        });
+        try
+        {
+            var exit = GSharp.Compiler.Program.Main(new[] { "@" + rspPath });
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(outPath), $"expected output at '{outPath}'");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
+
+    [Fact]
     public void Main_WithSyntaxError_ReturnsErrorExitCode()
     {
         var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");


### PR DESCRIPTION
Fixes sub-issue P2-9 of #421.

## Problem
`ExpandResponseFiles` in `src/Compiler/Program.cs` previously added each non-empty, non-comment line of an `@response.rsp` file as a **single** raw argument. A common pattern such as:

```
/out:"bin/my app.dll" /target:library
src/main.gs
```

reached `ParseCommandLine` as the literal string `/out:"bin/my app.dll" /target:library` (quotes included, multiple flags fused together) — so quoted paths with spaces and multiple switches on one line never worked.

## Fix
Add a small character-by-character tokenizer `TokenizeResponseFileLine` and use it from `ExpandResponseFiles`. It matches what `csc` / `dotnet build` accept for response files:

- Splits on whitespace (spaces and tabs).
- Treats matching double-quotes (`"…"`) as delimiters: quotes are stripped, embedded whitespace is preserved as part of one token.
- A doubled quote (`""`) inside a quoted segment emits a literal `"`.
- An empty quoted string (`""`) still produces an empty argument so it can be passed through deliberately.
- Empty / whitespace-only / comment (`#`) lines continue to be skipped.

## Tests
Eight new tests in `test/Compiler.Tests/ProgramTests.cs`:

- `TokenizeResponseFileLine_SplitsOnWhitespace`
- `TokenizeResponseFileLine_RespectsDoubleQuotes`
- `TokenizeResponseFileLine_QuotedTokenContainingSpaces`
- `TokenizeResponseFileLine_EmptyAndWhitespaceLines`
- `TokenizeResponseFileLine_EscapedDoubleQuoteInsideQuotes`
- `TokenizeResponseFileLine_AdjacentQuotedAndUnquoted`
- `TokenizeResponseFileLine_MultipleSpacesAndTabs`
- `TokenizeResponseFileLine_EmptyQuotedStringYieldsEmptyToken`
- `Main_WithResponseFile_HandlesQuotedPathWithSpaces` (end-to-end: builds an assembly written to a path containing a space, passed via a quoted `/out:` switch in a `.rsp`).

`InternalsVisibleTo("GSharp.Compiler.Tests")` was added to `Compiler.csproj` so the new `internal` helper can be unit-tested directly.

## Verification
- `dotnet build GSharp.sln -nologo -clp:NoSummary` — succeeds, 0 warnings.
- `dotnet test GSharp.sln --no-restore --nologo` — all suites pass; `GSharp.Compiler.Tests`: **300 passed**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>