### PR TITLE
Fix #421 (P2-4): emit unsigned/unordered comparisons in relational patterns for uint/float types

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -12716,6 +12716,19 @@ internal sealed class ReflectionMetadataEmitter
         {
             loadValue();
             this.EmitExpression(rp.Value);
+
+            // For unsigned/char discriminants the signed opcodes mis-order
+            // values whose high bit is set (e.g. uint.MaxValue would compare
+            // as -1 under Clt). Always use the *_un variants.
+            //
+            // For float/double, match the IEEE-aware lowering Roslyn uses
+            // for C# relational operators: NaN must compare unordered with
+            // every value, so strict `<`/`>` keep the signed Clt/Cgt (which
+            // return 0 when an operand is NaN), but `<=`/`>=` — which we
+            // synthesize as `!(a > b)` / `!(a < b)` — must use the _un
+            // forms so the negation produces false for NaN instead of true.
+            bool isUnsigned = IsUnsignedOrChar(rp.Type);
+            bool isFloat = rp.Type == TypeSymbol.Float32 || rp.Type == TypeSymbol.Float64;
             switch (rp.Op.Kind)
             {
                 case BoundBinaryOperatorKind.Equals:
@@ -12727,18 +12740,18 @@ internal sealed class ReflectionMetadataEmitter
                     this.il.OpCode(ILOpCode.Ceq);
                     break;
                 case BoundBinaryOperatorKind.Less:
-                    this.il.OpCode(ILOpCode.Clt);
+                    this.il.OpCode(isUnsigned ? ILOpCode.Clt_un : ILOpCode.Clt);
                     break;
                 case BoundBinaryOperatorKind.LessOrEquals:
-                    this.il.OpCode(ILOpCode.Cgt);
+                    this.il.OpCode(isUnsigned || isFloat ? ILOpCode.Cgt_un : ILOpCode.Cgt);
                     this.il.LoadConstantI4(0);
                     this.il.OpCode(ILOpCode.Ceq);
                     break;
                 case BoundBinaryOperatorKind.Greater:
-                    this.il.OpCode(ILOpCode.Cgt);
+                    this.il.OpCode(isUnsigned ? ILOpCode.Cgt_un : ILOpCode.Cgt);
                     break;
                 case BoundBinaryOperatorKind.GreaterOrEquals:
-                    this.il.OpCode(ILOpCode.Clt);
+                    this.il.OpCode(isUnsigned || isFloat ? ILOpCode.Clt_un : ILOpCode.Clt);
                     this.il.LoadConstantI4(0);
                     this.il.OpCode(ILOpCode.Ceq);
                     break;

--- a/test/Core.Tests/CodeAnalysis/Emit/RelationalPatternEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/RelationalPatternEmitTests.cs
@@ -1,0 +1,201 @@
+// <copyright file="RelationalPatternEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Regression coverage for issue #421 (P2-4): relational patterns must
+/// emit unsigned/unordered comparison opcodes for unsigned-integer,
+/// char, and floating-point discriminants. Previously the emitter
+/// hard-coded <c>Clt</c>/<c>Cgt</c>, which yields wrong answers for
+/// <c>uint32</c>/<c>uint64</c>/<c>nuint</c>/<c>char</c> boundary values
+/// and disagrees with IEEE NaN semantics for <c>float32</c>/<c>float64</c>.
+/// </summary>
+public class RelationalPatternEmitTests
+{
+    [Fact]
+    public void RelationalPattern_UInt32_Boundary_UsesUnsignedComparison()
+    {
+        // 0xFFFFFFFFu is uint.MaxValue. Treated as signed it is -1 and
+        // would NOT satisfy `> 1u`; with unsigned Cgt_un it does.
+        const string Source = @"package P
+import System
+let v = 4294967295u
+let r = switch v { case > 1u -> ""hi"" default -> ""lo"" }
+Console.WriteLine(r)
+";
+        Assert.Contains("hi", CompileLoadInvokeCaptureStdout(Source, "RelPatUInt32"));
+    }
+
+    [Fact]
+    public void RelationalPattern_UInt32_GreaterOrEqual_UsesUnsignedComparison()
+    {
+        const string Source = @"package P
+import System
+let v = 4294967295u
+let r = switch v { case >= 2u -> ""ge"" default -> ""lt"" }
+Console.WriteLine(r)
+";
+        Assert.Contains("ge", CompileLoadInvokeCaptureStdout(Source, "RelPatUInt32Ge"));
+    }
+
+    [Fact]
+    public void RelationalPattern_UInt64_Boundary_UsesUnsignedComparison()
+    {
+        // 0xFFFFFFFFFFFFFFFF is ulong.MaxValue. Signed Clt would mis-order.
+        const string Source = @"package P
+import System
+let v = 18446744073709551615UL
+let r = switch v { case > 1UL -> ""hi"" default -> ""lo"" }
+Console.WriteLine(r)
+";
+        Assert.Contains("hi", CompileLoadInvokeCaptureStdout(Source, "RelPatUInt64"));
+    }
+
+    [Fact]
+    public void RelationalPattern_UInt64_LessOrEqual_UsesUnsignedComparison()
+    {
+        // 1UL <= ulong.MaxValue must hold. With signed Cgt this evaluates
+        // wrong because ulong.MaxValue is sign-interpreted as -1.
+        const string Source = @"package P
+import System
+let v = 1UL
+let r = switch v { case <= 18446744073709551615UL -> ""le"" default -> ""gt"" }
+Console.WriteLine(r)
+";
+        Assert.Contains("le", CompileLoadInvokeCaptureStdout(Source, "RelPatUInt64Le"));
+    }
+
+    [Fact]
+    public void RelationalPattern_Char_HighCodepoint_UsesUnsignedComparison()
+    {
+        // '\uFFFE' compared against 'A' (0x41). Signed Clt would view it
+        // as negative when widened — must compare as unsigned 16-bit.
+        const string Source = @"package P
+import System
+let c = '\uFFFE'
+let r = switch c { case > 'A' -> ""hi"" default -> ""lo"" }
+Console.WriteLine(r)
+";
+        Assert.Contains("hi", CompileLoadInvokeCaptureStdout(Source, "RelPatChar"));
+    }
+
+    [Fact]
+    public void RelationalPattern_Float64_NaN_UsesUnorderedComparison()
+    {
+        // IEEE-754: every ordered relation involving NaN must be false.
+        // For strict <, >: signed Clt/Cgt already return false on NaN.
+        // For <=, >=: must use Cgt_un/Clt_un so the negation flips to false.
+        const string Source = @"package P
+import System
+let v = 0.0 / 0.0
+let g  = switch v { case >  0.0 -> ""gt"" default -> ""nope"" }
+let l  = switch v { case <  0.0 -> ""lt"" default -> ""nope"" }
+let ge = switch v { case >= 0.0 -> ""ge"" default -> ""nope"" }
+let le = switch v { case <= 0.0 -> ""le"" default -> ""nope"" }
+Console.WriteLine(g)
+Console.WriteLine(l)
+Console.WriteLine(ge)
+Console.WriteLine(le)
+";
+        var output = CompileLoadInvokeCaptureStdout(Source, "RelPatFloat64NaN");
+        Assert.Equal("nope\nnope\nnope\nnope\n", output.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void RelationalPattern_Float32_NaN_UsesUnorderedComparison()
+    {
+        const string Source = @"package P
+import System
+let v = 0.0f / 0.0f
+let g  = switch v { case >  0.0f -> ""gt"" default -> ""nope"" }
+let ge = switch v { case >= 0.0f -> ""ge"" default -> ""nope"" }
+let le = switch v { case <= 0.0f -> ""le"" default -> ""nope"" }
+Console.WriteLine(g)
+Console.WriteLine(ge)
+Console.WriteLine(le)
+";
+        var output = CompileLoadInvokeCaptureStdout(Source, "RelPatFloat32NaN");
+        Assert.Equal("nope\nnope\nnope\n", output.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void RelationalPattern_Float64_NormalValues_StillWork()
+    {
+        const string Source = @"package P
+import System
+let v = 1.5
+let r = switch v { case > 1.0 -> ""hi"" default -> ""lo"" }
+Console.WriteLine(r)
+";
+        Assert.Contains("hi", CompileLoadInvokeCaptureStdout(Source, "RelPatFloat64Pos"));
+    }
+
+    [Fact]
+    public void RelationalPattern_Int32_Signed_StillUsesSignedComparison()
+    {
+        // Negative signed values must still satisfy `< 0`. Regression
+        // guard ensuring we did not accidentally flip *signed* discriminants
+        // to unsigned opcodes.
+        const string Source = @"package P
+import System
+let v = -5
+let r = switch v { case < 0 -> ""neg"" default -> ""nn"" }
+Console.WriteLine(r)
+";
+        Assert.Contains("neg", CompileLoadInvokeCaptureStdout(Source, "RelPatInt32Signed"));
+    }
+
+    private static string CompileLoadInvokeCaptureStdout(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, parameters: null);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
## Issue
Closes sub-issue P2-4 of #421.

`EmitRelationalPattern` in `ReflectionMetadataEmitter.cs` always emitted signed `Clt`/`Cgt` opcodes. That produces wrong answers when the discriminant is `uint32`/`uint64`/`nuint`/`char` (high-bit values sign-interpret as negative) and disagrees with IEEE-754 NaN semantics for `float32`/`float64` on `<=` / `>=`.

## Fix
Mirror Roslyn's lowering for C# relational operators, sharing the existing `IsUnsignedOrChar` helper:

| Discriminant | `<` | `<=` | `>` | `>=` |
|---|---|---|---|---|
| signed int (unchanged) | `Clt` | `Cgt`+ne | `Cgt` | `Clt`+ne |
| unsigned / char | `Clt_un` | `Cgt_un`+ne | `Cgt_un` | `Clt_un`+ne |
| float32 / float64 | `Clt` | `Cgt_un`+ne | `Cgt` | `Clt_un`+ne |

For floats, the strict `<` and `>` keep signed opcodes (which already return 0 on NaN), while the negated `<=` and `>=` switch to the `_un` forms so NaN correctly compares unordered (false on every relation) instead of true.

## Tests
New `RelationalPatternEmitTests.cs` (9 tests) covering:
- `uint32` boundary (`uint.MaxValue > 1u`, `>= 2u`)
- `uint64` boundary (`ulong.MaxValue > 1UL`, `1UL <= ulong.MaxValue`)
- `char` high codepoint (`'\uFFFE' > 'A'`)
- `float64` NaN against all four relational operators
- `float32` NaN against `>`, `>=`, `<=`
- `float64` normal value still works
- Signed `int32` regression guard

All 2 251 existing tests still pass.