### PR TITLE
Fix #421 (P2-2): normalize shift count to zero result when count >= width (Go semantics)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -11383,10 +11383,12 @@ internal sealed class ReflectionMetadataEmitter
                     this.il.OpCode(isUnsigned ? ILOpCode.Rem_un : ILOpCode.Rem);
                     break;
                 case BoundBinaryOperatorKind.ShiftLeft:
-                    this.il.OpCode(ILOpCode.Shl);
+                    this.EmitShiftWithGoSemanticsGuard(ILOpCode.Shl, b.Left.Type);
                     break;
                 case BoundBinaryOperatorKind.ShiftRight:
-                    this.il.OpCode(isUnsigned ? ILOpCode.Shr_un : ILOpCode.Shr);
+                    this.EmitShiftWithGoSemanticsGuard(
+                        isUnsigned ? ILOpCode.Shr_un : ILOpCode.Shr,
+                        b.Left.Type);
                     break;
                 case BoundBinaryOperatorKind.BitwiseAnd:
                     this.il.OpCode(ILOpCode.And);
@@ -11482,6 +11484,89 @@ internal sealed class ReflectionMetadataEmitter
                 || t == TypeSymbol.UInt64
                 || t == TypeSymbol.NUInt
                 || t == TypeSymbol.Char;
+        }
+
+        // Issue #421 (P2-2): IL `shl`/`shr`/`shr_un` mask the shift count to
+        // the low log2(stack-width) bits (5 for i4, 6 for i8). G# follows Go
+        // semantics, where a shift count >= the operand's natural width
+        // yields zero. Without this guard, `int32(1) << 33` would produce 2
+        // under the CLR mask but should produce 0 in Go. Emit a runtime
+        // check `count >= width` and substitute zero when the count is
+        // out-of-range; otherwise emit the normal shift opcode.
+        //
+        // Stack on entry: [value, count(i4)]; stack on exit: [result].
+        // For signed right shift this simplification (zero instead of
+        // sign-extension to all-ones for negative values) matches the
+        // documented G# behavior — interpreter and emitter agree on it.
+        private void EmitShiftWithGoSemanticsGuard(ILOpCode shiftOp, TypeSymbol leftType)
+        {
+            var zeroLabel = this.il.DefineLabel();
+            var endLabel = this.il.DefineLabel();
+
+            this.il.OpCode(ILOpCode.Dup);
+            this.EmitTypeBitWidth(leftType);
+            this.il.Branch(ILOpCode.Bge_un, zeroLabel);
+            this.il.OpCode(shiftOp);
+            this.il.Branch(ILOpCode.Br, endLabel);
+
+            this.il.MarkLabel(zeroLabel);
+            this.il.OpCode(ILOpCode.Pop);
+            this.il.OpCode(ILOpCode.Pop);
+            this.EmitZeroForShiftResult(leftType);
+
+            this.il.MarkLabel(endLabel);
+        }
+
+        private void EmitTypeBitWidth(TypeSymbol t)
+        {
+            if (t == TypeSymbol.Int8 || t == TypeSymbol.UInt8)
+            {
+                this.il.LoadConstantI4(8);
+            }
+            else if (t == TypeSymbol.Int16 || t == TypeSymbol.UInt16 || t == TypeSymbol.Char)
+            {
+                this.il.LoadConstantI4(16);
+            }
+            else if (t == TypeSymbol.Int32 || t == TypeSymbol.UInt32)
+            {
+                this.il.LoadConstantI4(32);
+            }
+            else if (t == TypeSymbol.Int64 || t == TypeSymbol.UInt64)
+            {
+                this.il.LoadConstantI4(64);
+            }
+            else if (t == TypeSymbol.NInt || t == TypeSymbol.NUInt)
+            {
+                // Width is sizeof(IntPtr) * 8, determined at IL runtime so
+                // 32-bit and 64-bit hosts both produce Go-correct results.
+                this.il.OpCode(ILOpCode.Sizeof);
+                this.il.Token(this.outer.GetTypeReference(typeof(IntPtr)));
+                this.il.LoadConstantI4(8);
+                this.il.OpCode(ILOpCode.Mul);
+            }
+            else
+            {
+                // Fallback (shouldn't reach here for non-integer types since
+                // shifts are only bound on integer operands).
+                this.il.LoadConstantI4(32);
+            }
+        }
+
+        private void EmitZeroForShiftResult(TypeSymbol t)
+        {
+            if (t == TypeSymbol.Int64 || t == TypeSymbol.UInt64)
+            {
+                this.il.LoadConstantI8(0);
+            }
+            else if (t == TypeSymbol.NInt || t == TypeSymbol.NUInt)
+            {
+                this.il.LoadConstantI4(0);
+                this.il.OpCode(ILOpCode.Conv_i);
+            }
+            else
+            {
+                this.il.LoadConstantI4(0);
+            }
         }
 
         private bool TryEmitDecimalBinary(BoundBinaryOperatorKind kind)

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -1800,7 +1800,42 @@ public sealed class Evaluator
         _ => throw new InvalidOperationException($"Unsupported ^ on {l?.GetType()} and {r?.GetType()}"),
     };
 
-    private static object NumericShl(object l, int r) => l switch
+    // Issue #421 (P2-2): Go semantics for shift operations. The C# `<<` and
+    // `>>` operators mask the shift count to log2(width) low bits, matching
+    // ECMA-335 `shl`/`shr`. G# follows Go, where a shift count >= the
+    // operand's natural width yields zero. Match the emitter's behavior so
+    // interpreter results agree with compiled output.
+    private static int BitWidthOf(object l) => l switch
+    {
+        sbyte _ => 8,
+        byte _ => 8,
+        short _ => 16,
+        ushort _ => 16,
+        int _ => 32,
+        uint _ => 32,
+        long _ => 64,
+        ulong _ => 64,
+        nint _ => IntPtr.Size * 8,
+        nuint _ => IntPtr.Size * 8,
+        _ => 32,
+    };
+
+    private static object ZeroOfShape(object l) => l switch
+    {
+        sbyte _ => (sbyte)0,
+        byte _ => (byte)0,
+        short _ => (short)0,
+        ushort _ => (ushort)0,
+        int _ => 0,
+        uint _ => 0u,
+        long _ => 0L,
+        ulong _ => 0UL,
+        nint _ => (nint)0,
+        nuint _ => (nuint)0,
+        _ => 0,
+    };
+
+    private static object NumericShl(object l, int r) => (r < 0 || r >= BitWidthOf(l)) ? ZeroOfShape(l) : l switch
     {
         int li => li << r,
         long li => li << r,
@@ -1815,7 +1850,7 @@ public sealed class Evaluator
         _ => throw new InvalidOperationException($"Unsupported << on {l?.GetType()}"),
     };
 
-    private static object NumericShr(object l, int r) => l switch
+    private static object NumericShr(object l, int r) => (r < 0 || r >= BitWidthOf(l)) ? ZeroOfShape(l) : l switch
     {
         int li => li >> r,
         long li => li >> r,

--- a/test/Compiler.Tests/Emit/PrimitiveOperatorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/PrimitiveOperatorEmitTests.cs
@@ -32,6 +32,28 @@ public class PrimitiveOperatorEmitTests
     [InlineData("int64", "100L ^ 6L", "98")]
     [InlineData("int64", "1L << 10", "1024")]
     [InlineData("int64", "1024L >> 2", "256")]
+
+    // Issue #421 (P2-2): Go semantics — count >= width yields 0 (not CLR's masked shift).
+    [InlineData("int32", "1 << 33", "0")]
+    [InlineData("int32", "1 << 32", "0")]
+    [InlineData("int32", "100 >> 32", "0")]
+    [InlineData("uint32", "uint32(1) << 32", "0")]
+    [InlineData("uint32", "uint32(100) >> 64", "0")]
+    [InlineData("int64", "1L << 64", "0")]
+    [InlineData("int64", "1L << 100", "0")]
+    [InlineData("int64", "1024L >> 64", "0")]
+    [InlineData("uint64", "uint64(1) << 64", "0")]
+    [InlineData("uint64", "uint64(1024) >> 64", "0")]
+
+    // Boundary: shift by exactly width-1 still works normally.
+    [InlineData("int32", "1 << 31", "-2147483648")]
+    [InlineData("int64", "1L << 63", "-9223372036854775808")]
+    [InlineData("uint32", "uint32(1) << 31", "2147483648")]
+    [InlineData("uint64", "uint64(1) << 63", "9223372036854775808")]
+
+    // Shift by 0 is identity.
+    [InlineData("int32", "42 << 0", "42")]
+    [InlineData("int64", "42L >> 0", "42")]
     public void Long_Operators_ProduceExpectedValue(string _, string expr, string expected)
     {
         Assert.Equal(expected + "\n", CompileAndRun(BuildSource(expr)));

--- a/test/Interpreter.Tests/PrimitiveInterpreterTests.cs
+++ b/test/Interpreter.Tests/PrimitiveInterpreterTests.cs
@@ -29,6 +29,20 @@ public class PrimitiveInterpreterTests
     [InlineData("10M * 7M", "70")]
     [InlineData("1L << 10", "1024")]
     [InlineData("1024L >> 2", "256")]
+
+    // Issue #421 (P2-2): Go semantics — count >= width yields 0.
+    [InlineData("1 << 33", "0")]
+    [InlineData("1 << 32", "0")]
+    [InlineData("100 >> 32", "0")]
+    [InlineData("1L << 64", "0")]
+    [InlineData("1L << 100", "0")]
+    [InlineData("1024L >> 64", "0")]
+    [InlineData("uint32(1) << 32", "0")]
+    [InlineData("uint64(1) << 64", "0")]
+
+    // Boundary: shift by exactly width-1 still works normally.
+    [InlineData("1 << 31", "-2147483648")]
+    [InlineData("uint32(1) << 31", "2147483648")]
     [InlineData("100L < 200L", "True")]
     [InlineData("100L == 100L", "True")]
     [InlineData("-42L", "-42")]


### PR DESCRIPTION
## Summary

Fixes sub-issue **P2-2** of #421: Integer shift count not normalized; G#/Go semantics ≠ CLR semantics.

ECMA-335 `shl`/`shr`/`shr_un` mask the shift count to the low log2(stack-width) bits (5 for i4, 6 for i8), so `int32(1) << 33` produced 2 under the CLR mask. G# follows Go semantics where a shift count `>= width` yields zero. The emitter and interpreter now agree on the Go-correct result.

## Changes

### Emitter — `src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs`
- New helper `EmitShiftWithGoSemanticsGuard` wraps each shift in a runtime `count >= width` check (`dup; ldc width; bge.un zeroLabel; shift; br end; zero: pop; pop; ldc.0; end:`).
- Width is the natural type width: 8/16/32/64 for fixed-size integers; `sizeof(IntPtr)*8` for `nint`/`nuint` so the same emitted IL behaves correctly on 32-bit and 64-bit hosts.
- Type-shaped zero is pushed on the zero branch (`ldc.i4.0` / `ldc.i8 0` / `ldc.i4.0; conv.i`).

### Interpreter — `src/Core/CodeAnalysis/Evaluator.cs`
- `NumericShl` / `NumericShr` short-circuit to a typed zero (matching the operand's CLR shape) when the count is negative or `>= BitWidthOf(left)`, so REPL/evaluation results now agree with compiled output.

### Tests
- `Test/Compiler.Tests/Emit/PrimitiveOperatorEmitTests.cs`: over-width, exact-width, width-1 boundary, and zero-count shifts for int32, int64, uint32, uint64.
- `Test/Interpreter.Tests/PrimitiveInterpreterTests.cs`: matching parity cases.

## Verification

- `dotnet build GSharp.sln` — succeeds with 0 warnings/0 errors.
- `dotnet test GSharp.sln` — **all 2268 tests pass** (Core 1661, Compiler 307, Interpreter 64, LanguageServer 212, Sdk 24).

## Notes

For signed right shift, this implementation returns 0 when `count >= width` (the simplification called out in the task) rather than Go's sign-extension to all-ones for negative operands. This keeps interpreter and emitter trivially in sync; the choice is documented in the helper's comment so a future tightening to full Go semantics can be made consistently in both places.

Refs #421