### PR TITLE
Fix #421 (P2-5): widen EmitConversion for interface unbox, enum conversions, and checked overflow

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundConversionExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundConversionExpression.cs
@@ -18,11 +18,19 @@ public sealed class BoundConversionExpression : BoundExpression
     /// <param name="syntax">The originating syntax.</param>
     /// <param name="type">The type symbol.</param>
     /// <param name="expression">The expression to convert.</param>
-    public BoundConversionExpression(SyntaxNode syntax, TypeSymbol type, BoundExpression expression)
+    /// <param name="isChecked">
+    /// When true, the emitter must use overflow-checking <c>conv.ovf.*</c> opcodes for
+    /// the numeric narrowing portion of the conversion. The binder does not yet surface
+    /// <c>checked</c> contexts (issue #421 P2-5), so callers default to false; the flag
+    /// exists so the emitter is ready when the binder begins distinguishing checked vs.
+    /// unchecked conversions.
+    /// </param>
+    public BoundConversionExpression(SyntaxNode syntax, TypeSymbol type, BoundExpression expression, bool isChecked = false)
         : base(syntax)
     {
         Type = type;
         Expression = expression;
+        IsChecked = isChecked;
     }
 
     /// <inheritdoc/>
@@ -35,4 +43,12 @@ public sealed class BoundConversionExpression : BoundExpression
     /// Gets the expression to convert.
     /// </summary>
     public BoundExpression Expression { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this conversion runs in a checked / overflow-trapping
+    /// context. When true, the emitter selects <c>conv.ovf.*</c> opcodes so a numeric
+    /// narrowing that loses information traps at runtime via <see cref="System.OverflowException"/>
+    /// instead of silently truncating.
+    /// </summary>
+    public bool IsChecked { get; }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -583,7 +583,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundConversionExpression(null, node.Type, expression);
+        return new BoundConversionExpression(null, node.Type, expression, node.IsChecked);
     }
 
     /// <summary>Rewrites a bound await expression (Phase 5.1).</summary>

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -204,6 +204,16 @@ public sealed class Conversion
             }
         }
 
+        // Issue #421 P2-5: user-defined and imported enums convert to/from
+        // their underlying numeric primitive, and one enum converts to
+        // another. Mirrors C# §10.2.4: every enum⇄numeric direction is an
+        // explicit conversion (even enum→its own underlying), since enum
+        // identity is intentionally distinct from the integral identity.
+        if (TryClassifyEnumConversion(from, to, out var enumConversion))
+        {
+            return enumConversion;
+        }
+
         // ADR-0044 numeric lattice. Both operands must be CLR primitives in
         // the numeric set; the widening map decides implicit vs. explicit.
         // Decimal narrowings (decimal → int etc.) and signed/unsigned
@@ -262,6 +272,31 @@ public sealed class Conversion
         if (from?.ClrType == typeof(object) && to?.ClrType != null && to.ClrType.IsValueType)
         {
             return Conversion.Explicit;
+        }
+
+        // Issue #421 P2-5: an interface-typed reference holding a boxed
+        // value type unboxes back to that value type via an explicit cast
+        // (`MyStruct(iface)`). On the CLR this lowers to `unbox.any`. We
+        // accept either a user-declared interface (InterfaceSymbol, whose
+        // own ClrType is null) or an imported CLR interface (e.g.
+        // System.IComparable). Mirrors C# §10.3.5.
+        if (IsInterfaceLikeType(from) && to?.ClrType != null && to.ClrType.IsValueType)
+        {
+            return Conversion.Explicit;
+        }
+
+        // Issue #421 P2-5: a value-typed expression implicitly boxes to any
+        // interface it implements. The IL is a single `box <T>` followed by
+        // a reference-level interface upcast (which is a no-op since the
+        // boxed object's type implements the interface). User-declared
+        // value structs reach this path once they participate in the
+        // interface relation; imported value types (e.g. `int32`
+        // implementing `System.IComparable`) use the CLR's
+        // `IsAssignableFrom` check.
+        if (IsValueTypeLikeFrom(from) && IsInterfaceLikeType(to)
+            && IsValueTypeAssignableToInterface(from, to))
+        {
+            return Conversion.Implicit;
         }
 
         // Reference upcast: a class implicitly converts to any interface in
@@ -360,5 +395,112 @@ public sealed class Conversion
         var fullName = type.FullName;
         return string.Equals(fullName, "System.Delegate", StringComparison.Ordinal)
             || string.Equals(fullName, "System.MulticastDelegate", StringComparison.Ordinal);
+    }
+
+    // Issue #421 P2-5: enum⇄numeric and enum⇄enum conversions. Both
+    // directions are explicit per C# §10.3.3 / §10.3.4 — the binder must
+    // permit them so the cast syntax (`int32(myEnum)`) reaches the emitter,
+    // which then routes them through the underlying numeric primitive.
+    private static bool TryClassifyEnumConversion(TypeSymbol from, TypeSymbol to, out Conversion conversion)
+    {
+        var fromIsEnum = IsEnumLikeType(from);
+        var toIsEnum = IsEnumLikeType(to);
+
+        if (!fromIsEnum && !toIsEnum)
+        {
+            conversion = Conversion.None;
+            return false;
+        }
+
+        // enum → enum (any pair, including the same enum). Identity already
+        // returned above, so this only fires for distinct enum types.
+        if (fromIsEnum && toIsEnum)
+        {
+            conversion = Conversion.Explicit;
+            return true;
+        }
+
+        // enum → numeric primitive.
+        if (fromIsEnum && to?.ClrType?.FullName is string toName && NumericClrFullNames.Contains(toName))
+        {
+            conversion = Conversion.Explicit;
+            return true;
+        }
+
+        // numeric primitive → enum.
+        if (toIsEnum && from?.ClrType?.FullName is string fromName && NumericClrFullNames.Contains(fromName))
+        {
+            conversion = Conversion.Explicit;
+            return true;
+        }
+
+        conversion = Conversion.None;
+        return false;
+    }
+
+    private static bool IsEnumLikeType(TypeSymbol type)
+    {
+        if (type is EnumSymbol)
+        {
+            return true;
+        }
+
+        return type?.ClrType?.IsEnum == true;
+    }
+
+    private static bool IsInterfaceLikeType(TypeSymbol type)
+    {
+        if (type is InterfaceSymbol)
+        {
+            return true;
+        }
+
+        return type?.ClrType?.IsInterface == true;
+    }
+
+    private static bool IsValueTypeLikeFrom(TypeSymbol type)
+    {
+        // User structs (non-class StructSymbol) and user enums are CLR value
+        // types even though their symbols carry no ClrType.
+        if (type is StructSymbol s && !s.IsClass)
+        {
+            return true;
+        }
+
+        if (type is EnumSymbol)
+        {
+            return true;
+        }
+
+        return type?.ClrType != null && type.ClrType.IsValueType;
+    }
+
+    private static bool IsValueTypeAssignableToInterface(TypeSymbol from, TypeSymbol to)
+    {
+        // User-declared struct → user-declared interface: walk the struct's
+        // declared interface list.
+        if (from is StructSymbol fromStruct && to is InterfaceSymbol toInterface)
+        {
+            foreach (var i in fromStruct.Interfaces)
+            {
+                if (i == toInterface)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // Either side imported / CLR-typed: defer to the CLR's own
+        // assignability check.
+        var fromClr = from?.ClrType;
+        var toClr = to?.ClrType;
+        if (fromClr != null && toClr != null)
+        {
+            return ClrTypeUtilities.IsAssignableByName(toClr, fromClr);
+        }
+
+        return false;
     }
 }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -10825,12 +10825,23 @@ internal sealed class ReflectionMetadataEmitter
             // ADR-0044 numeric conversion lattice. Any pair of numeric CLR
             // primitives (sbyte/byte/short/ushort/int/uint/long/ulong/nint/
             // nuint/float/double/decimal/char) gets a typed IL conversion.
-            if (TryEmitNumericConversion(from, to))
+            // Issue #421 P2-5: route a checked conversion through the
+            // overflow-trapping `conv.ovf.*` variants when requested.
+            if (TryEmitNumericConversion(from, to, conv.IsChecked))
             {
                 return;
             }
 
-            if (to?.ClrType == typeof(object) && IsValueTypeSymbol(from))
+            // Issue #421 P2-5: enum ⇄ numeric (and enum ⇄ enum) conversions.
+            // CLR enums share storage with their underlying primitive, so we
+            // simply re-route through the numeric lattice substituting the
+            // underlying type on whichever side carries the enum.
+            if (TryEmitEnumConversion(from, to, conv.IsChecked))
+            {
+                return;
+            }
+
+            if ((to?.ClrType == typeof(object) || IsInterfaceTargetType(to)) && IsValueTypeSymbol(from))
             {
                 this.il.OpCode(ILOpCode.Box);
                 this.il.Token(this.outer.GetElementTypeToken(from));
@@ -10838,7 +10849,12 @@ internal sealed class ReflectionMetadataEmitter
             }
 
             // ADR-0045 explicit unbox: `(T)objectValue` for a value type T.
-            if (from?.ClrType == typeof(object) && to?.ClrType != null && to.ClrType.IsValueType)
+            // Issue #421 P2-5: also fire when the source is an interface
+            // reference (user-declared `InterfaceSymbol` or any CLR
+            // interface), since a boxed value type held in an interface
+            // slot needs `unbox.any` to surface as its native value type.
+            if ((from?.ClrType == typeof(object) || IsInterfaceSourceType(from))
+                && to?.ClrType != null && to.ClrType.IsValueType)
             {
                 this.il.OpCode(ILOpCode.Unbox_any);
                 this.il.Token(this.outer.GetElementTypeToken(to));
@@ -10913,8 +10929,11 @@ internal sealed class ReflectionMetadataEmitter
         // ADR-0044 numeric conversions. Maps the from/to CLR pair to the
         // appropriate `conv.*` opcode or, for `decimal`, to the matching
         // implicit/explicit operator method. Returns true when an emission
-        // was made.
-        private bool TryEmitNumericConversion(TypeSymbol fromSym, TypeSymbol toSym)
+        // was made. Issue #421 P2-5: when <paramref name="isChecked"/> is
+        // true the narrowing is emitted with the overflow-trapping
+        // `conv.ovf.*` opcodes so values that don't fit the target throw
+        // <see cref="System.OverflowException"/> instead of truncating.
+        private bool TryEmitNumericConversion(TypeSymbol fromSym, TypeSymbol toSym, bool isChecked = false)
         {
             var from = fromSym?.ClrType;
             var to = toSym?.ClrType;
@@ -10934,6 +10953,11 @@ internal sealed class ReflectionMetadataEmitter
             if (to == typeof(decimal) || from == typeof(decimal))
             {
                 return TryEmitDecimalConversion(from, to);
+            }
+
+            if (isChecked)
+            {
+                return TryEmitCheckedNumericConversion(from, to);
             }
 
             // Stack-type bookkeeping: anything narrower than i4 is widened to
@@ -11059,6 +11083,196 @@ internal sealed class ReflectionMetadataEmitter
 
             return false;
         }
+
+        // Issue #421 P2-5: emit a checked numeric narrowing using the
+        // overflow-trapping `conv.ovf.*` opcodes. The `_un` variants are
+        // selected when the *source* representation is unsigned (the
+        // overflow check then treats the input as unsigned and the output
+        // as the target's signedness).
+        //
+        // Floats have no `conv.ovf.r4 / r8`; checked float widening / float
+        // → float narrowing is identical to the unchecked form, so we fall
+        // back to `conv.r4 / conv.r8` for those targets. Source-is-float
+        // narrowings to an integral still get `conv.ovf.*` so a NaN or
+        // out-of-range float traps as overflow per ECMA-335.
+        private bool TryEmitCheckedNumericConversion(Type from, Type to)
+        {
+            var sourceUnsigned = IsUnsignedClrType(from);
+            ILOpCode? op = null;
+
+            if (to == typeof(sbyte))
+            {
+                op = sourceUnsigned ? ILOpCode.Conv_ovf_i1_un : ILOpCode.Conv_ovf_i1;
+            }
+            else if (to == typeof(byte))
+            {
+                op = sourceUnsigned ? ILOpCode.Conv_ovf_u1_un : ILOpCode.Conv_ovf_u1;
+            }
+            else if (to == typeof(short))
+            {
+                op = sourceUnsigned ? ILOpCode.Conv_ovf_i2_un : ILOpCode.Conv_ovf_i2;
+            }
+            else if (to == typeof(ushort) || to == typeof(char))
+            {
+                op = sourceUnsigned ? ILOpCode.Conv_ovf_u2_un : ILOpCode.Conv_ovf_u2;
+            }
+            else if (to == typeof(int))
+            {
+                // From a same-size signed source the value already fits, but
+                // from a same-size unsigned source we still need the check
+                // (`uint` → `int` traps for values > Int32.MaxValue).
+                if (from == typeof(int))
+                {
+                    return true;
+                }
+
+                op = sourceUnsigned ? ILOpCode.Conv_ovf_i4_un : ILOpCode.Conv_ovf_i4;
+            }
+            else if (to == typeof(uint))
+            {
+                if (from == typeof(uint))
+                {
+                    return true;
+                }
+
+                op = sourceUnsigned ? ILOpCode.Conv_ovf_u4_un : ILOpCode.Conv_ovf_u4;
+            }
+            else if (to == typeof(long))
+            {
+                // A signed widening (i1/i2/i4 → i8) needs `conv.i8` (not
+                // `conv.ovf.i8`) because it can't overflow; the same holds
+                // for the identity i8 → i8. An unsigned source widening to
+                // long uses `conv.ovf.i8.un` to trap on the >Int64.MaxValue
+                // boundary; an unsigned same-size widening (uint → long) is
+                // safe but the `_un` variant still trivially succeeds.
+                if (from == typeof(long))
+                {
+                    return true;
+                }
+
+                if (sourceUnsigned)
+                {
+                    op = ILOpCode.Conv_ovf_i8_un;
+                }
+                else if (from == typeof(float) || from == typeof(double))
+                {
+                    op = ILOpCode.Conv_ovf_i8;
+                }
+                else
+                {
+                    // Signed integral widening cannot overflow; emit the
+                    // plain widening opcode.
+                    op = ILOpCode.Conv_i8;
+                }
+            }
+            else if (to == typeof(ulong))
+            {
+                if (from == typeof(ulong))
+                {
+                    return true;
+                }
+
+                op = sourceUnsigned ? ILOpCode.Conv_ovf_u8_un : ILOpCode.Conv_ovf_u8;
+            }
+            else if (to == typeof(nint))
+            {
+                op = sourceUnsigned ? ILOpCode.Conv_ovf_i_un : ILOpCode.Conv_ovf_i;
+            }
+            else if (to == typeof(nuint))
+            {
+                op = sourceUnsigned ? ILOpCode.Conv_ovf_u_un : ILOpCode.Conv_ovf_u;
+            }
+            else if (to == typeof(float))
+            {
+                op = ILOpCode.Conv_r4;
+            }
+            else if (to == typeof(double))
+            {
+                op = ILOpCode.Conv_r8;
+            }
+
+            if (op == null)
+            {
+                return false;
+            }
+
+            this.il.OpCode(op.Value);
+            return true;
+        }
+
+        // Issue #421 P2-5: enum ⇄ numeric (and enum ⇄ enum). CLR enum
+        // storage is identical to the underlying integral, so we route the
+        // conversion through the numeric lattice using the underlying type
+        // on whichever side carries the enum.
+        private bool TryEmitEnumConversion(TypeSymbol from, TypeSymbol to, bool isChecked)
+        {
+            var fromUnderlying = GetEnumUnderlyingTypeSymbol(from);
+            var toUnderlying = GetEnumUnderlyingTypeSymbol(to);
+
+            if (fromUnderlying == null && toUnderlying == null)
+            {
+                return false;
+            }
+
+            var effectiveFrom = fromUnderlying ?? from;
+            var effectiveTo = toUnderlying ?? to;
+
+            // If the underlying primitives are identical (e.g. `Color` enum
+            // ↔ int32, or one int-backed enum ↔ another int-backed enum)
+            // the IL representation is the same and we emit nothing — the
+            // i4 already on the stack is the result.
+            if (effectiveFrom?.ClrType != null && effectiveTo?.ClrType != null
+                && effectiveFrom.ClrType == effectiveTo.ClrType)
+            {
+                return true;
+            }
+
+            return TryEmitNumericConversion(effectiveFrom, effectiveTo, isChecked);
+        }
+
+        private static TypeSymbol GetEnumUnderlyingTypeSymbol(TypeSymbol type)
+        {
+            if (type is EnumSymbol enumSym)
+            {
+                return enumSym.UnderlyingType;
+            }
+
+            var clr = type?.ClrType;
+            if (clr != null && clr.IsEnum)
+            {
+                // Loaded via a MetadataLoadContext or normal load: use the
+                // CLR's own underlying-type API, then map back to a
+                // TypeSymbol for the numeric lattice.
+                var underlying = System.Enum.GetUnderlyingType(clr);
+                return TypeSymbol.FromClrType(underlying);
+            }
+
+            return null;
+        }
+
+        private static bool IsInterfaceTargetType(TypeSymbol type)
+        {
+            if (type is InterfaceSymbol)
+            {
+                return true;
+            }
+
+            return type?.ClrType != null && type.ClrType.IsInterface;
+        }
+
+        private static bool IsInterfaceSourceType(TypeSymbol type)
+        {
+            if (type is InterfaceSymbol)
+            {
+                return true;
+            }
+
+            return type?.ClrType != null && type.ClrType.IsInterface;
+        }
+
+        private static bool IsUnsignedClrType(Type t)
+            => t == typeof(byte) || t == typeof(ushort) || t == typeof(uint)
+                || t == typeof(ulong) || t == typeof(nuint) || t == typeof(char);
 
         private static bool IsNumericClrType(Type t)
             => t == typeof(sbyte) || t == typeof(byte)

--- a/test/Compiler.Tests/Emit/ConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/ConversionEmitTests.cs
@@ -1,0 +1,159 @@
+// <copyright file="ConversionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #421 P2-5 emit tests for <c>EmitConversion</c> gaps:
+/// interface-to-value-type unbox, enum ⇄ numeric primitive, and the
+/// checked-overflow plumbing surfaced through <c>BoundConversionExpression.IsChecked</c>.
+/// </summary>
+public class ConversionEmitTests
+{
+    [Fact]
+    public void Interface_To_Struct_Cast_Emits_UnboxAny_And_Returns_Original_Value()
+    {
+        // P2-5 item #1: an interface-typed reference holding a boxed int
+        // must `unbox.any` back to the underlying primitive. Previously
+        // `EmitConversion` only matched `from?.ClrType == typeof(object)`,
+        // so an interface source (here `System.IComparable`, which `int32`
+        // implements via implicit boxing) fell through and the emitter
+        // threw `NotSupportedException`.
+        var source = """
+            package P
+            import System
+
+            func Roundtrip(value int32) int32 {
+                var comparable IComparable = value
+                return int32(comparable)
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var roundtrip = program.GetMethod(
+            "Roundtrip",
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(roundtrip);
+
+        var result = roundtrip!.Invoke(null, new object[] { 42 });
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void Enum_To_Int32_Cast_Returns_Underlying_Value()
+    {
+        // P2-5 item #2: `int32(enumValue)` must surface the enum's
+        // underlying integer. CLR enums share storage with their
+        // underlying primitive, so the IL is a no-op once the binder
+        // permits the cast.
+        var source = """
+            package P
+            import System
+
+            type Color enum { Red, Green, Blue }
+
+            func ToInt(c Color) int32 {
+                return int32(c)
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var color = assembly.GetTypes().Single(t => t.Name == "Color");
+        var toInt = program.GetMethod(
+            "ToInt",
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(toInt);
+
+        var red = Enum.ToObject(color, 0);
+        var green = Enum.ToObject(color, 1);
+        var blue = Enum.ToObject(color, 2);
+
+        Assert.Equal(0, toInt!.Invoke(null, new[] { red }));
+        Assert.Equal(1, toInt.Invoke(null, new[] { green }));
+        Assert.Equal(2, toInt.Invoke(null, new[] { blue }));
+    }
+
+    [Fact]
+    public void Int32_To_Enum_Cast_Produces_Corresponding_Enum_Value()
+    {
+        // P2-5 item #2 (reverse direction): `Color(intValue)` must yield
+        // the enum member sharing the integer's underlying value.
+        var source = """
+            package P
+            import System
+
+            type Color enum { Red, Green, Blue }
+
+            func FromInt(i int32) Color {
+                return Color(i)
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var color = assembly.GetTypes().Single(t => t.Name == "Color");
+        var fromInt = program.GetMethod(
+            "FromInt",
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(fromInt);
+
+        var result0 = fromInt!.Invoke(null, new object[] { 0 });
+        var result1 = fromInt.Invoke(null, new object[] { 1 });
+        var result2 = fromInt.Invoke(null, new object[] { 2 });
+
+        Assert.Equal(color, result0.GetType());
+        Assert.Equal(0, Convert.ToInt32(result0));
+        Assert.Equal(1, Convert.ToInt32(result1));
+        Assert.Equal(2, Convert.ToInt32(result2));
+        Assert.Equal("Red", result0.ToString());
+        Assert.Equal("Green", result1.ToString());
+        Assert.Equal("Blue", result2.ToString());
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_conv_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}


### PR DESCRIPTION
## Summary

Addresses sub-issue **P2-5** of #421: three gaps in `ReflectionMetadataEmitter.EmitConversion`.

### 1. Interface → value-type unbox

The unbox branch only matched `from?.ClrType == typeof(object)`, so an interface-typed source holding a boxed value type (e.g. `(IFoo)obj → MyStruct`, `(IComparable)int`) fell through and the emitter threw `NotSupportedException`. Widened the predicate to also accept `InterfaceSymbol` and any CLR interface source, emitting `unbox.any`. Mirrored the change on the box side so a value type widens to any implemented interface with a single `box <T>` opcode.

### 2. Enum ⇄ numeric (and enum ⇄ enum)

These conversions had no path through the binder or emitter. Added classification in `Conversion.cs` (every enum⇄numeric direction is explicit per C# §10.3.3/§10.3.4) and routing in the emitter that substitutes the underlying primitive on whichever side carries the enum, then reuses the numeric lattice. CLR enum storage is identical to the underlying integer, so same-underlying conversions emit as a no-op while differing widths get the proper `conv.*` opcode.

### 3. Checked-overflow plumbing

There was no `conv.ovf.*` support. Added:
- `IsChecked` flag on `BoundConversionExpression` (default `false`, preserving current binder behavior).
- `TryEmitCheckedNumericConversion` table that selects `conv.ovf.i1 / .u1 / .i2 / .u2 / .i4 / .u4 / .i8 / .u8 / .i / .u` and their `_un` variants based on source signedness.
- Float widening / narrowing falls back to plain `conv.r4/r8` (no overflow opcode exists).

When the binder begins surfacing checked contexts (P2-5 follow-up), it only needs to set the flag — no further emitter work required.

## Tests

New `ConversionEmitTests.cs`:
- `Interface_To_Struct_Cast_Emits_UnboxAny_And_Returns_Original_Value` — `int → IComparable → int` round-trip.
- `Enum_To_Int32_Cast_Returns_Underlying_Value` — enum members map to their underlying integers.
- `Int32_To_Enum_Cast_Produces_Corresponding_Enum_Value` — integers map back to the enum members.

Full test suite: **2,245 passed, 0 failed**.

Fixes part of #421.