### PR TITLE
Fix #421 (P2-7): use Nullable<T> for null-conditional on value-type results

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -9000,7 +9000,24 @@ public sealed class Binder
         scope = scope.Parent;
 
         var resultType = whenNotNull.Type is NullableTypeSymbol ? whenNotNull.Type : (TypeSymbol)NullableTypeSymbol.Get(whenNotNull.Type);
-        return new BoundNullConditionalAccessExpression(null, receiver, capture, whenNotNull, resultType);
+
+        // P2-7 / Issue #421: when the access result is a value type, the
+        // bound result type is `Nullable<T>` but the not-null branch pushes
+        // a raw `T` and the nil branch would push `null`. The emitter needs
+        // a typed temp slot to materialize `default(Nullable<T>)` for the
+        // nil branch (initobj) and to host the wrapped value for the
+        // not-null branch (newobj `Nullable<T>::.ctor(!0)`). We allocate
+        // that synthetic slot here so the emit pre-pass can give it a
+        // local index alongside the capture local.
+        LocalVariableSymbol resultSlot = null;
+        if (whenNotNull.Type is not NullableTypeSymbol
+            && whenNotNull.Type?.ClrType is { IsValueType: true })
+        {
+            var resultSlotName = "$nres_" + nullConditionalCaptureCounter.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            resultSlot = new LocalVariableSymbol(resultSlotName, isReadOnly: false, type: resultType);
+        }
+
+        return new BoundNullConditionalAccessExpression(null, receiver, capture, whenNotNull, resultType, resultSlot);
     }
 
     private bool TryBindImportAccessor(ImportSymbol import, ref ExpressionSyntax rightPart, out ImportedClassSymbol importedClass)

--- a/src/Core/CodeAnalysis/Binding/BoundNullConditionalAccessExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNullConditionalAccessExpression.cs
@@ -35,18 +35,23 @@ public sealed class BoundNullConditionalAccessExpression : BoundExpression
     /// <paramref name="capture"/> standing in for the receiver.</param>
     /// <param name="type">The result type — always a
     /// <see cref="NullableTypeSymbol"/>.</param>
+    /// <param name="resultSlot">Optional synthetic local that the emitter
+    /// uses to materialize <c>default(Nullable&lt;T&gt;)</c> when the access
+    /// result is a value type. Null for reference-typed results.</param>
     public BoundNullConditionalAccessExpression(
         SyntaxNode syntax,
         BoundExpression receiver,
         VariableSymbol capture,
         BoundExpression whenNotNull,
-        TypeSymbol type)
+        TypeSymbol type,
+        VariableSymbol resultSlot = null)
         : base(syntax)
     {
         Receiver = receiver;
         Capture = capture;
         WhenNotNull = whenNotNull;
         Type = type;
+        ResultSlot = resultSlot;
     }
 
     /// <inheritdoc/>
@@ -63,4 +68,11 @@ public sealed class BoundNullConditionalAccessExpression : BoundExpression
 
     /// <summary>Gets the access expression evaluated when the receiver is non-nil.</summary>
     public BoundExpression WhenNotNull { get; }
+
+    /// <summary>
+    /// Gets the synthetic temp slot used to materialize <c>default(Nullable&lt;T&gt;)</c>
+    /// in the nil branch when the access result is a value type. Null when the
+    /// result is a reference type (the nil branch then just pushes <c>ldnull</c>).
+    /// </summary>
+    public VariableSymbol ResultSlot { get; }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1574,7 +1574,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundNullConditionalAccessExpression(null, receiver, node.Capture, whenNotNull, node.Type);
+        return new BoundNullConditionalAccessExpression(null, receiver, node.Capture, whenNotNull, node.Type, node.ResultSlot);
     }
 
     /// <summary>Rewrites a tuple literal (Phase 4.5).</summary>

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -6553,6 +6553,16 @@ internal sealed class ReflectionMetadataEmitter
                 locals[nc.Capture] = localTypes.Count;
                 localTypes.Add(nc.Capture.Type);
             }
+
+            // P2-7 / Issue #421: value-type access results need a
+            // Nullable<T> result slot so the nil branch can emit
+            // `ldloca; initobj Nullable<T>; ldloc` and so the not-null
+            // branch can wrap the raw T via `newobj Nullable<T>::.ctor(!0)`.
+            if (nc.ResultSlot != null && !locals.ContainsKey(nc.ResultSlot))
+            {
+                locals[nc.ResultSlot] = localTypes.Count;
+                localTypes.Add(nc.ResultSlot.Type);
+            }
         }
 
         foreach (var append in CollectAppends(body))
@@ -8469,6 +8479,18 @@ internal sealed class ReflectionMetadataEmitter
 
     private EntityHandle GetElementTypeToken(TypeSymbol element)
     {
+        // P2-7 / Issue #421: nullable over a value type tokenises as
+        // System.Nullable<T>. NullableTypeSymbol over a reference type
+        // continues to share the underlying CLR type (handled below by
+        // the `element.ClrType != null` branch via the NullableTypeSymbol
+        // ctor that copies `underlying.ClrType`).
+        if (element is NullableTypeSymbol nullableElement
+            && nullableElement.UnderlyingType?.ClrType is { IsValueType: true } nullableInnerClr)
+        {
+            var nullableClr = typeof(System.Nullable<>).MakeGenericType(nullableInnerClr);
+            return this.GetTypeHandleForMember(nullableClr);
+        }
+
         if (element == TypeSymbol.Int32)
         {
             return this.GetTypeReference(this.coreInt32Type);
@@ -9145,16 +9167,27 @@ internal sealed class ReflectionMetadataEmitter
         if (type is NullableTypeSymbol nullable)
         {
             var inner = nullable.UnderlyingType;
+
+            // P2-7 / Issue #421: nullable over a value type encodes as
+            // System.Nullable<T> (generic instantiation). We support inner
+            // types backed by a CLR value type (primitives, BCL value types).
+            if (inner?.ClrType is { IsValueType: true } innerClrVt)
+            {
+                var nullableClr = typeof(System.Nullable<>).MakeGenericType(innerClrVt);
+                this.EncodeClrType(encoder, nullableClr);
+                return;
+            }
+
             if (inner is StructSymbol nestedStruct && !nestedStruct.IsClass)
             {
                 throw new NotSupportedException(
-                    $"Nullable value-type signatures for '{inner.Name}?' are not yet supported by the emitter.");
+                    $"Nullable user-defined struct '{inner.Name}?' is not yet supported by the emitter.");
             }
 
-            if (inner == TypeSymbol.Int32 || inner == TypeSymbol.Bool || (inner?.ClrType != null && inner.ClrType.IsValueType))
+            if (inner is EnumSymbol nestedEnum)
             {
                 throw new NotSupportedException(
-                    $"Nullable value-type signatures for '{inner?.Name}?' are not yet supported by the emitter.");
+                    $"Nullable user-defined enum '{nestedEnum.Name}?' is not yet supported by the emitter.");
             }
 
             EncodeTypeSymbol(encoder, inner);
@@ -12479,6 +12512,43 @@ internal sealed class ReflectionMetadataEmitter
             var end = this.il.DefineLabel();
             var nonNull = this.il.DefineLabel();
             this.il.Branch(ILOpCode.Brtrue, nonNull);
+
+            if (nc.ResultSlot != null)
+            {
+                // P2-7 / Issue #421: value-type access result. The bound type
+                // is Nullable<T> but the access sub-tree pushes a raw T. The
+                // nil branch must materialize `default(Nullable<T>)` and the
+                // not-null branch must wrap T via `Nullable<T>::.ctor(!0)`
+                // so both branches leave the same Nullable<T> stack shape.
+                var slot = this.locals[nc.ResultSlot];
+                var nullableType = (NullableTypeSymbol)nc.Type;
+                var innerClr = nullableType.UnderlyingType.ClrType
+                    ?? throw new InvalidOperationException(
+                        $"Null-conditional value-type result '{nullableType.UnderlyingType.Name}' has no CLR type.");
+                var nullableClr = typeof(System.Nullable<>).MakeGenericType(innerClr);
+
+                // nil branch: ldloca slot; initobj Nullable<T>; ldloc slot
+                this.il.LoadLocalAddress(slot);
+                this.il.OpCode(ILOpCode.Initobj);
+                this.il.Token(this.outer.GetTypeHandleForMember(nullableClr));
+                this.il.LoadLocal(slot);
+                this.il.Branch(ILOpCode.Br, end);
+
+                // not-null branch: produce T, then newobj Nullable<T>::.ctor(!0)
+                this.il.MarkLabel(nonNull);
+                this.EmitExpression(nc.WhenNotNull);
+                var ctor = nullableClr.GetConstructor(new[] { innerClr })
+                    ?? throw new InvalidOperationException(
+                        $"Nullable<{innerClr.FullName}> has no single-arg constructor.");
+                this.il.OpCode(ILOpCode.Newobj);
+                this.il.Token(this.outer.GetCtorReference(ctor));
+
+                this.il.MarkLabel(end);
+                return;
+            }
+
+            // Reference-typed access result: nullable<ref> shares the CLR
+            // representation of T, so ldnull is a valid Nullable<T> value.
             this.il.OpCode(ILOpCode.Ldnull);
             this.il.Branch(ILOpCode.Br, end);
             this.il.MarkLabel(nonNull);

--- a/test/Core.Tests/CodeAnalysis/Emit/NullConditionalValueTypeEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/NullConditionalValueTypeEmitTests.cs
@@ -1,0 +1,175 @@
+// <copyright file="NullConditionalValueTypeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #421 / P2-7: null-conditional <c>s?.M()</c> over a value-type
+/// member result must produce a <c>Nullable&lt;T&gt;</c> stack value on
+/// both branches. The nil branch materializes <c>default(Nullable&lt;T&gt;)</c>
+/// via <c>ldloca</c>/<c>initobj</c>; the not-null branch wraps the raw
+/// <c>T</c> via <c>newobj Nullable&lt;T&gt;::.ctor(!0)</c>. Without this
+/// fix, the nil branch pushes a ref-typed <c>ldnull</c> while the not-null
+/// branch pushes a raw <c>int32</c>, producing invalid IL.
+/// </summary>
+public class NullConditionalValueTypeEmitTests
+{
+    [Fact]
+    public void NullConditional_OnNonNullRef_ProducesNullableValueType()
+    {
+        // Reading the static field via reflection avoids brittleness around
+        // overload resolution for Console.WriteLine(Nullable<int>).
+        var source = @"
+package NullCondValueTypeNonNull
+import System
+
+var n int32? = ""hello""?.Length
+";
+        var n = CompileLoadInvokeReadField(source, nameof(NullConditional_OnNonNullRef_ProducesNullableValueType), "n");
+        Assert.Equal(5, (int)(int?)n);
+    }
+
+    [Fact]
+    public void NullConditional_OnNilRef_ProducesEmptyNullable()
+    {
+        var source = @"
+package NullCondValueTypeNil
+import System
+
+var s string? = nil
+var n int32? = s?.Length
+";
+        var n = CompileLoadInvokeReadField(source, nameof(NullConditional_OnNilRef_ProducesEmptyNullable), "n");
+        Assert.Null(n);
+    }
+
+    [Fact]
+    public void NullConditional_OnNonNullRef_NullableField_HasValueAndValue()
+    {
+        // Verify the emitted Nullable<int> is a real value-type Nullable —
+        // its field signature must be Nullable<int> and runtime Value is 2.
+        var source = @"
+package NullCondValueTypeShape
+import System
+
+var s string? = ""hi""
+var n int32? = s?.Length
+";
+        using var peStream = new MemoryStream();
+        var result = Compile(source, peStream);
+        Assert.True(result.Success);
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(nameof(NullConditional_OnNonNullRef_NullableField_HasValueAndValue), isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var field = programType!.GetField("n", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            Assert.Equal(typeof(int?), field!.FieldType);
+
+            var entry = programType.GetMethod("<Main>$", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            entry!.Invoke(null, parameters: null);
+
+            // GetValue on a Nullable<T> field unboxes to T or returns null.
+            var boxed = field.GetValue(null);
+            Assert.NotNull(boxed);
+            Assert.Equal(2, (int)boxed!);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    [Fact]
+    public void NullConditional_OnNilRef_FieldType_IsNullableInt()
+    {
+        // The static backing field for `var n int32? = ...` must be
+        // emitted with signature `Nullable<int32>`, not raw `int32`.
+        var source = @"
+package NullCondValueTypeFieldType
+import System
+
+var s string? = nil
+var n int32? = s?.Length
+";
+        var fieldType = CompileLoadGetFieldType(source, nameof(NullConditional_OnNilRef_FieldType_IsNullableInt), "n");
+        Assert.Equal(typeof(int?), fieldType);
+    }
+
+    private static EmitResult Compile(string source, Stream peStream)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Emit(peStream);
+    }
+
+    private static object CompileLoadInvokeReadField(string source, string contextName, string fieldName)
+    {
+        using var peStream = new MemoryStream();
+        var result = Compile(source, peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+            entry!.Invoke(null, parameters: null);
+
+            var field = programType.GetField(fieldName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            return field!.GetValue(null);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static Type CompileLoadGetFieldType(string source, string contextName, string fieldName)
+    {
+        using var peStream = new MemoryStream();
+        var result = Compile(source, peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var field = programType!.GetField(fieldName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            return field!.FieldType;
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
Fixes sub-issue P2-7 of #421.

## Problem

For `s?.M()` where `M` returns a value type (e.g. `s?.Length` where `Length` is `int`), the bound result type is `Nullable<T>` but the emitter pushed incompatible stack shapes on the two branches:

- nil branch: `ldnull` (ref-typed)
- not-null branch: raw `T` value

Nullable value-type signatures were also explicitly rejected by the encoder (`NotSupportedException`). This was latent until value-type nullables were exercised; the moment they were, it produced invalid IL.

## Fix

* **Binder** (`Binder.cs`): when the access result is a value type, allocate a synthetic `Nullable<T>` result-slot local so the emit pre-pass can give it a stable index. Stored on a new optional `ResultSlot` property of `BoundNullConditionalAccessExpression`.
* **Emitter** (`ReflectionMetadataEmitter.cs`):
  - nil branch materializes `default(Nullable<T>)` via `ldloca slot; initobj Nullable<T>; ldloc slot`.
  - not-null branch wraps the raw `T` via `newobj Nullable<T>::.ctor(!0)`.
  - Both branches now leave the same `Nullable<T>` value on the stack.
* **Encoder** (`EncodeTypeSymbol` / `GetElementTypeToken`): `NullableTypeSymbol` over a CLR value type now encodes as `System.Nullable<T>` (generic instantiation) instead of throwing — required for the result-slot's local signature and for any `Nullable<T> -> object` box token.

## Tests

`test/Core.Tests/CodeAnalysis/Emit/NullConditionalValueTypeEmitTests.cs` — four new emit-and-execute tests:

1. Non-null receiver: `"\"hello\"\"?.Length` → boxed value 5.
2. Nil receiver: `s?.Length` with `s = nil` → null (empty `Nullable<int>`).
3. Field type for the result is `typeof(int?)`, not raw `int`.
4. Combined shape + value check (FieldType is `Nullable<int>`, runtime value is 2).

Full `dotnet test GSharp.sln` passes: Sdk 24 ✓ · Interpreter 54 ✓ · LanguageServer 212 ✓ · Core 1665 ✓ · Compiler 291 ✓.

## Out of scope

Elvis (`?:`) on a `Nullable<value>` left operand still uses `brtrue` which is not valid for value-typed structs — that's a separate bug worth its own issue. The receiver-side mirror (`int?` value-type receivers on `?.`) is also not addressed here; the common scenario this issue cites is value-type *result* with a reference-type receiver.