### PR TITLE
Fix #421 (P2-12): ensure first sequence point is non-hidden for debugger compatibility

### DIFF
--- a/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
@@ -245,10 +245,29 @@ internal sealed class PortablePdbEmitter
             if (this.recordedMethods.TryGetValue(rid, out var rec) && rec.Points.Count > 0)
             {
                 var primaryDoc = FindPrimaryDocument(rec.Points);
-                var blobBuilder = new BlobBuilder();
-                EncodeSequencePoints(blobBuilder, rec.Points, primaryDoc, rec.LocalSignatureToken);
-                var blobHandle = this.pdbMetadata.GetOrAddBlob(blobBuilder);
-                this.pdbMetadata.AddMethodDebugInformation(primaryDoc, blobHandle);
+
+                // P2-12 (issue #421): When no point carries a usable document
+                // (every record is the synthesised 0xfeefee hidden marker), we
+                // cannot legally emit a sequence-points blob: the spec
+                // requires either MethodDebugInformation.Document or an
+                // InitialDocument prefix in the blob, and we have neither. A
+                // blob without InitialDocument plus a nil Document column
+                // causes Portable PDB readers to mis-parse the very first
+                // record as a document-record (δIL=0 marker) and throw
+                // "Invalid handle". Drop the blob — the method's LocalScope /
+                // LocalVariable / LocalConstant rows still flow through Step 3
+                // below so the debugger's locals window keeps working.
+                if (primaryDoc.IsNil)
+                {
+                    this.pdbMetadata.AddMethodDebugInformation(default, default);
+                }
+                else
+                {
+                    var blobBuilder = new BlobBuilder();
+                    EncodeSequencePoints(blobBuilder, rec.Points, primaryDoc, rec.LocalSignatureToken);
+                    var blobHandle = this.pdbMetadata.GetOrAddBlob(blobBuilder);
+                    this.pdbMetadata.AddMethodDebugInformation(primaryDoc, blobHandle);
+                }
             }
             else
             {
@@ -519,8 +538,34 @@ internal sealed class PortablePdbEmitter
         var prevStartColumn = 0;
         var firstRecord = true;
 
-        foreach (var p in points)
+        // P2-12 (issue #421): Debuggers (Visual Studio, Rider) reportedly bind
+        // F5 breakpoints flakily when the first sequence-point record of a
+        // method is hidden (the 0xfeefee marker). Skip any leading hidden
+        // points so the first emitted record always carries a real
+        // line/column. Methods that are entirely hidden still emit their full
+        // (hidden-only) sequence, preserving prior behaviour where there is
+        // nothing user-visible to anchor on.
+        var startIndex = 0;
+        var hasVisible = false;
+        for (var i = 0; i < points.Count; i++)
         {
+            if (!points[i].IsHidden)
+            {
+                hasVisible = true;
+                startIndex = i;
+                break;
+            }
+        }
+
+        if (!hasVisible)
+        {
+            startIndex = 0;
+        }
+
+        for (var idx = startIndex; idx < points.Count; idx++)
+        {
+            var p = points[idx];
+
             // δIL — first record encodes the absolute IL offset, the rest the
             // delta from the previous record. The spec forbids two records
             // sharing the same IL offset; the BodyEmitter is responsible for

--- a/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
@@ -240,6 +240,163 @@ func main() {
 
         Assert.True(foundLine4, "Expected a visible sequence point on source line 4.");
     }
+
+    /// <summary>
+    /// Issue #421 P2-12: Visual Studio and Rider have been reported to bind F5
+    /// breakpoints flakily when the first sequence-point record of a method is
+    /// the hidden 0xfeefee marker. Every method that emits any visible
+    /// sequence point must therefore have a non-hidden first record.
+    /// </summary>
+    [Fact]
+    public void EveryMethod_FirstSequencePoint_IsNonHidden_WhenAnyVisible()
+    {
+        const string source = @"package main
+
+func add(a int32, b int32) int32 {
+    return a + b
+}
+
+func main() {
+    let x = 1
+    let y = 2
+    let z = add(x, y)
+}
+";
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source, "prog.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream, pdbStream, null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var reader = provider.GetMetadataReader();
+
+        foreach (var handle in reader.MethodDebugInformation)
+        {
+            var info = reader.GetMethodDebugInformation(handle);
+            if (info.SequencePointsBlob.IsNil)
+            {
+                continue;
+            }
+
+            System.Reflection.Metadata.SequencePoint? first = null;
+            var anyVisible = false;
+            foreach (var p in info.GetSequencePoints())
+            {
+                if (first is null)
+                {
+                    first = p;
+                }
+
+                if (!p.IsHidden)
+                {
+                    anyVisible = true;
+                }
+            }
+
+            if (anyVisible)
+            {
+                Assert.NotNull(first);
+                Assert.False(first.Value.IsHidden, "First sequence point of a method with visible points must not be hidden (issue #421 P2-12).");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Issue #421 P2-12: Compiling an async function used to produce a
+    /// MoveNext sequence-points blob whose first record was the synthesised
+    /// hidden state-dispatch prologue. With <c>MethodDebugInformation.Document</c>
+    /// also nil (no point carries a usable document) the encoded blob was
+    /// outright invalid — Portable PDB readers mis-parsed the first record as
+    /// a document-record marker and threw <see cref="System.BadImageFormatException"/>
+    /// (&quot;Invalid handle&quot;). Verify the PDB is now iterable for every method
+    /// and any visible first record is non-hidden.
+    /// </summary>
+    [Fact]
+    public void AsyncMoveNext_PdbBlob_IsIterable_AndFirstVisibleIsNonHidden()
+    {
+        const string source = @"package main
+import System
+import System.Threading.Tasks
+
+async func compute() int32 {
+    let a = await Task.FromResult(10)
+    let b = await Task.FromResult(32)
+    return a + b
+}
+
+func main() {
+}
+";
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source, "async.gs")))
+        {
+            DebugInformation = new DebugInformationOptions { Format = DebugInformationFormat.Portable },
+        };
+        var result = compilation.Emit(peStream, pdbStream, null);
+        Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        pdbStream.Position = 0;
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var reader = provider.GetMetadataReader();
+
+        peStream.Position = 0;
+        using var peReader = new System.Reflection.PortableExecutable.PEReader(peStream);
+        var peMeta = peReader.GetMetadataReader();
+
+        var sawMoveNext = false;
+        foreach (var methodHandle in reader.MethodDebugInformation)
+        {
+            var row = MetadataTokens.GetRowNumber(methodHandle);
+            var methodDef = MetadataTokens.MethodDefinitionHandle(row);
+            var method = peMeta.GetMethodDefinition(methodDef);
+            var name = peMeta.GetString(method.Name);
+            if (name == "MoveNext")
+            {
+                sawMoveNext = true;
+            }
+
+            var info = reader.GetMethodDebugInformation(methodHandle);
+            if (info.SequencePointsBlob.IsNil)
+            {
+                continue;
+            }
+
+            System.Reflection.Metadata.SequencePoint? first = null;
+            var anyVisible = false;
+
+            // The mere act of iterating must not throw — readers used to fault
+            // on the all-hidden / nil-document blob the emitter previously
+            // produced for MoveNext.
+            foreach (var p in info.GetSequencePoints())
+            {
+                if (first is null)
+                {
+                    first = p;
+                }
+
+                if (!p.IsHidden)
+                {
+                    anyVisible = true;
+                }
+            }
+
+            if (anyVisible)
+            {
+                Assert.NotNull(first);
+                Assert.False(first.Value.IsHidden, $"First sequence point of '{name}' must not be hidden when any visible record is present (issue #421 P2-12).");
+            }
+        }
+
+        Assert.True(sawMoveNext, "Expected at least one MoveNext method in the emitted PE.");
+    }
 }
 
 public class PortablePdbPhase5Tests


### PR DESCRIPTION
## Summary

Sub-issue **P2-12** of #421: PDB first sequence point hidden may confuse Visual Studio / Rider.

### Fix in `PortablePdbEmitter.EncodeSequencePoints`
Skip any leading hidden (0xfeefee) sequence points so the first emitted record always carries a real line/column when at least one visible point exists. Visual Studio and Rider are reported to bind F5 breakpoints flakily when a method's first sequence-point record is the hidden marker. Methods that consist of only hidden points still emit their full (hidden-only) sequence — there is nothing user-visible to anchor on.

### Adjacent fix in `PortablePdbEmitter.Serialize`
While validating the async kickoff path I found that when every captured sequence point is hidden (e.g. async `MoveNext` whose synthesised state-dispatch prologue and lowered statements all lack source syntax), no point has a usable document → `MethodDebugInformation.Document` is nil. Writing a sequence-points blob in that state produces a structurally invalid PDB: the spec requires either `Document` or an `InitialDocument` blob prefix, and we had neither. Portable PDB readers mis-parse the first record as a document-record marker and throw `BadImageFormatException: Invalid handle`. `Serialize` now drops the blob entirely when `primaryDoc` is nil; `LocalScope` / `LocalVariable` / `LocalConstant` rows still flow so the debugger's locals window keeps working.

> Note: the deeper issue that an async `MoveNext` ends up with all-hidden points (user statements losing syntax through the async lowering pipeline) is a separate bug and not in scope for P2-12. The Serialize defense above keeps the PDB valid until that is fixed.

### Tests
`PortablePdbEmitTests` gains two cases:
- `EveryMethod_FirstSequencePoint_IsNonHidden_WhenAnyVisible` — synchronous source, asserts every method with any visible sequence point has a non-hidden first record.
- `AsyncMoveNext_PdbBlob_IsIterable_AndFirstVisibleIsNonHidden` — async source, iterates the blob end-to-end to prove it is structurally valid (regression guard for the Invalid-handle failure) and that any visible first record is non-hidden.

### Verification
```
dotnet build GSharp.sln  ✓
dotnet test  GSharp.sln  ✓  (2,244 tests pass — 1663 Core, 291 Compiler, 212 LSP, 54 Interp, 24 Sdk)
```

Closes the P2-12 sub-task of #421.