### PR TITLE
Fix #420 (P3-12): use WriteUInt32 for PDB embedded source format marker

### DIFF
--- a/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
@@ -146,7 +146,7 @@ internal sealed class PortablePdbEmitter
         if (this.options.EmbedAllSources && sourceBytes.Length > 0)
         {
             var embedBlob = new BlobBuilder();
-            embedBlob.WriteInt32(0);
+            embedBlob.WriteUInt32(0);
             embedBlob.WriteBytes(sourceBytes);
             this.pdbMetadata.AddCustomDebugInformation(
                 parent: handle,

--- a/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
@@ -812,6 +812,41 @@ func main() {
     }
 
     [Fact]
+    public void EmbeddedSource_FormatMarker_Is_Unsigned_Zero_Bytes()
+    {
+        // Per ECMA Portable PDB spec § "EmbeddedSource", the format marker is
+        // an unsigned 4-byte little-endian integer prefix where 0 means the
+        // payload is the raw, uncompressed source. Regression guard for #420
+        // (P3-12): ensure the emitter writes the marker via WriteUInt32 so the
+        // four leading bytes are exactly 0x00,0x00,0x00,0x00 and the value
+        // round-trips as an unsigned integer.
+        var (_, pdb) = EmitWith(new DebugInformationOptions
+        {
+            Format = DebugInformationFormat.Portable,
+            EmbedAllSources = true,
+        });
+
+        var rows = FindCdi(pdb, PortablePdbEmitterTestHelpers.EmbeddedSourceKind);
+        Assert.NotEmpty(rows);
+
+        foreach (var (_, value) in rows)
+        {
+            var blob = pdb.GetBlobBytes(value);
+            Assert.True(blob.Length >= 4);
+            Assert.Equal(0x00, blob[0]);
+            Assert.Equal(0x00, blob[1]);
+            Assert.Equal(0x00, blob[2]);
+            Assert.Equal(0x00, blob[3]);
+
+            var unsignedMarker = (uint)blob[0]
+                | ((uint)blob[1] << 8)
+                | ((uint)blob[2] << 16)
+                | ((uint)blob[3] << 24);
+            Assert.Equal(0u, unsignedMarker);
+        }
+    }
+
+    [Fact]
     public void EmbeddedSource_Parent_Is_A_Document_Row()
     {
         var (_, pdb) = EmitWith(new DebugInformationOptions


### PR DESCRIPTION
Per the Portable PDB spec § "EmbeddedSource", the format marker preceding the source bytes is an **unsigned** 4-byte little-endian integer. `PortablePdbEmitter` was writing it via `BlobBuilder.WriteInt32`. For the current value (0 = uncompressed) the bit pattern is identical, but the code is fragile if the marker is ever extended or if a consumer becomes strict about signed vs unsigned.

## Change
- `src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs`: `embedBlob.WriteInt32(0)` → `embedBlob.WriteUInt32(0)`.
- Added a regression test `EmbeddedSource_FormatMarker_Is_Unsigned_Zero_Bytes` that asserts the first four bytes of every embedded-source blob are `0x00,0x00,0x00,0x00` and decode as the unsigned integer `0u`.

## Verification
- `dotnet build GSharp.sln -nologo -clp:NoSummary` → succeeds, 0 warnings, 0 errors.
- `dotnet test GSharp.sln --no-restore --nologo` → all tests pass (Sdk 24, Interpreter 54, LanguageServer 212, Core 1683, Compiler 311).

Closes #420 (P3-12).