### PR TITLE
Fix #420 (P3-11): cache MemberRef for IsReadOnly/IsByRefLike attribute emit

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -117,6 +117,12 @@ internal sealed class ReflectionMetadataEmitter
     // Issue #256: cached open MemberRef for Interlocked.CompareExchange<T>(ref T, T, T).
     private MemberReferenceHandle? interlockedCompareExchangeOpenRef;
 
+    // Issue #420 (P3-11): cached MemberRefs for IsReadOnlyAttribute/IsByRefLikeAttribute/ObsoleteAttribute ctors,
+    // so repeated emission of these markers doesn't create duplicate MemberRef rows.
+    private MemberReferenceHandle? isReadOnlyAttributeCtorRef;
+    private MemberReferenceHandle? isByRefLikeAttributeCtorRef;
+    private MemberReferenceHandle? obsoleteAttributeStringBoolCtorRef;
+
     // Phase 4 emit parity (E1): synthesized lambda bodies (no captures).
     // Populated by a pre-pass walker over every user function/entry body.
     // Each lambda's synthetic FunctionSymbol is registered alongside user
@@ -3726,19 +3732,7 @@ internal sealed class ReflectionMetadataEmitter
     /// <param name="typeHandle">The inline struct TypeDef handle.</param>
     private void EmitIsReadOnlyAttribute(TypeDefinitionHandle typeHandle)
     {
-        var attrType = this.references.TryResolveType("System.Runtime.CompilerServices.IsReadOnlyAttribute", out var resolved)
-            ? resolved
-            : typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute);
-        var attrTypeRef = this.GetTypeReference(attrType);
-
-        var ctorSig = new BlobBuilder();
-        new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
-            .Parameters(0, r => r.Void(), _ => { });
-
-        var ctorRef = this.metadata.AddMemberReference(
-            attrTypeRef,
-            this.metadata.GetOrAddString(".ctor"),
-            this.metadata.GetOrAddBlob(ctorSig));
+        var ctorRef = this.GetIsReadOnlyAttributeCtorRef();
 
         var valueBlob = new BlobBuilder();
         valueBlob.WriteUInt16(0x0001);
@@ -3748,6 +3742,29 @@ internal sealed class ReflectionMetadataEmitter
             parent: typeHandle,
             constructor: ctorRef,
             value: this.metadata.GetOrAddBlob(valueBlob));
+    }
+
+    private MemberReferenceHandle GetIsReadOnlyAttributeCtorRef()
+    {
+        if (this.isReadOnlyAttributeCtorRef.HasValue)
+        {
+            return this.isReadOnlyAttributeCtorRef.Value;
+        }
+
+        var attrType = this.references.TryResolveType("System.Runtime.CompilerServices.IsReadOnlyAttribute", out var resolved)
+            ? resolved
+            : typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute);
+        var attrTypeRef = this.GetTypeReference(attrType);
+
+        var ctorSig = new BlobBuilder();
+        new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => r.Void(), _ => { });
+
+        this.isReadOnlyAttributeCtorRef = this.metadata.AddMemberReference(
+            attrTypeRef,
+            this.metadata.GetOrAddString(".ctor"),
+            this.metadata.GetOrAddBlob(ctorSig));
+        return this.isReadOnlyAttributeCtorRef.Value;
     }
 
     /// <summary>
@@ -3766,20 +3783,7 @@ internal sealed class ReflectionMetadataEmitter
     /// <param name="typeHandle">The ref-struct TypeDef handle.</param>
     private void EmitIsByRefLikeAttribute(TypeDefinitionHandle typeHandle)
     {
-        // IsByRefLikeAttribute() — parameterless ctor, no fixed/named args.
-        var attrType = this.references.TryResolveType("System.Runtime.CompilerServices.IsByRefLikeAttribute", out var resolved)
-            ? resolved
-            : typeof(System.Runtime.CompilerServices.IsByRefLikeAttribute);
-        var attrTypeRef = this.GetTypeReference(attrType);
-
-        var ctorSig = new BlobBuilder();
-        new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
-            .Parameters(0, r => r.Void(), _ => { });
-
-        var ctorRef = this.metadata.AddMemberReference(
-            attrTypeRef,
-            this.metadata.GetOrAddString(".ctor"),
-            this.metadata.GetOrAddBlob(ctorSig));
+        var ctorRef = this.GetIsByRefLikeAttributeCtorRef();
 
         var valueBlob = new BlobBuilder();
         valueBlob.WriteUInt16(0x0001);
@@ -3790,8 +3794,50 @@ internal sealed class ReflectionMetadataEmitter
             constructor: ctorRef,
             value: this.metadata.GetOrAddBlob(valueBlob));
 
-        // Obsolete("Types with embedded references are not supported in this
-        // version of your compiler.", true) — the C# compiler's guard marker.
+        var obsoleteCtorRef = this.GetObsoleteAttributeStringBoolCtorRef();
+
+        var obsoleteBlob = new BlobBuilder();
+        obsoleteBlob.WriteUInt16(0x0001);
+        obsoleteBlob.WriteSerializedString("Types with embedded references are not supported in this version of your compiler.");
+        obsoleteBlob.WriteByte(1);
+        obsoleteBlob.WriteUInt16(0);
+
+        this.metadata.AddCustomAttribute(
+            parent: typeHandle,
+            constructor: obsoleteCtorRef,
+            value: this.metadata.GetOrAddBlob(obsoleteBlob));
+    }
+
+    private MemberReferenceHandle GetIsByRefLikeAttributeCtorRef()
+    {
+        if (this.isByRefLikeAttributeCtorRef.HasValue)
+        {
+            return this.isByRefLikeAttributeCtorRef.Value;
+        }
+
+        var attrType = this.references.TryResolveType("System.Runtime.CompilerServices.IsByRefLikeAttribute", out var resolved)
+            ? resolved
+            : typeof(System.Runtime.CompilerServices.IsByRefLikeAttribute);
+        var attrTypeRef = this.GetTypeReference(attrType);
+
+        var ctorSig = new BlobBuilder();
+        new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => r.Void(), _ => { });
+
+        this.isByRefLikeAttributeCtorRef = this.metadata.AddMemberReference(
+            attrTypeRef,
+            this.metadata.GetOrAddString(".ctor"),
+            this.metadata.GetOrAddBlob(ctorSig));
+        return this.isByRefLikeAttributeCtorRef.Value;
+    }
+
+    private MemberReferenceHandle GetObsoleteAttributeStringBoolCtorRef()
+    {
+        if (this.obsoleteAttributeStringBoolCtorRef.HasValue)
+        {
+            return this.obsoleteAttributeStringBoolCtorRef.Value;
+        }
+
         var obsoleteType = this.references.TryResolveType("System.ObsoleteAttribute", out var obsoleteResolved)
             ? obsoleteResolved
             : typeof(System.ObsoleteAttribute);
@@ -3805,21 +3851,11 @@ internal sealed class ReflectionMetadataEmitter
                 p.AddParameter().Type().Boolean();
             });
 
-        var obsoleteCtorRef = this.metadata.AddMemberReference(
+        this.obsoleteAttributeStringBoolCtorRef = this.metadata.AddMemberReference(
             obsoleteTypeRef,
             this.metadata.GetOrAddString(".ctor"),
             this.metadata.GetOrAddBlob(obsoleteCtorSig));
-
-        var obsoleteBlob = new BlobBuilder();
-        obsoleteBlob.WriteUInt16(0x0001);
-        obsoleteBlob.WriteSerializedString("Types with embedded references are not supported in this version of your compiler.");
-        obsoleteBlob.WriteByte(1);
-        obsoleteBlob.WriteUInt16(0);
-
-        this.metadata.AddCustomAttribute(
-            parent: typeHandle,
-            constructor: obsoleteCtorRef,
-            value: this.metadata.GetOrAddBlob(obsoleteBlob));
+        return this.obsoleteAttributeStringBoolCtorRef.Value;
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Emit/AttributeMemberRefCacheTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AttributeMemberRefCacheTests.cs
@@ -1,0 +1,117 @@
+// <copyright file="AttributeMemberRefCacheTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #420 (P3-11): <c>EmitIsReadOnlyAttribute</c> and
+/// <c>EmitIsByRefLikeAttribute</c> previously allocated a fresh
+/// <c>MemberRef</c> for the attribute constructor on every call, producing
+/// duplicate rows when multiple inline structs / ref structs were emitted.
+/// These tests verify that exactly one MemberRef row exists per attribute
+/// ctor regardless of how many type defs are decorated.
+/// </summary>
+public class AttributeMemberRefCacheTests
+{
+    [Fact]
+    public void MultipleInlineStructs_ProduceSingleIsReadOnlyAttributeCtorMemberRef()
+    {
+        const string source = @"package InlineStructCache
+type AId inline struct(value string) {}
+type BId inline struct(value string) {}
+type CId inline struct(value string) {}
+func Main() {}
+";
+        using var pe = Compile(source);
+        var counts = CountAttributeCtorMemberRefs(pe);
+
+        // Expect exactly one MemberRef for IsReadOnlyAttribute..ctor() across all
+        // three inline structs (each gets the attribute, but the MemberRef is cached).
+        Assert.Equal(1, counts.IsReadOnly);
+    }
+
+    [Fact]
+    public void MultipleRefStructs_ProduceSingleIsByRefLikeAndObsoleteAttributeCtorMemberRef()
+    {
+        const string source = @"package RefStructCache
+type A ref struct { x int32 }
+type B ref struct { y int32 }
+type C ref struct { z int32 }
+func Main() {}
+";
+        using var pe = Compile(source);
+        var counts = CountAttributeCtorMemberRefs(pe);
+
+        // Each ref struct gets IsByRefLikeAttribute + ObsoleteAttribute(string,bool).
+        // With caching, only one MemberRef per ctor should be emitted.
+        Assert.Equal(1, counts.IsByRefLike);
+        Assert.Equal(1, counts.ObsoleteStringBool);
+    }
+
+    private static MemoryStream Compile(string source)
+    {
+        var pe = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(pe);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        pe.Position = 0;
+        return pe;
+    }
+
+    private static (int IsReadOnly, int IsByRefLike, int ObsoleteStringBool) CountAttributeCtorMemberRefs(MemoryStream pe)
+    {
+        using var peReader = new PEReader(pe, PEStreamOptions.LeaveOpen);
+        var md = peReader.GetMetadataReader();
+
+        int isReadOnly = 0;
+        int isByRefLike = 0;
+        int obsolete = 0;
+
+        foreach (var mrHandle in md.MemberReferences)
+        {
+            var mr = md.GetMemberReference(mrHandle);
+            var name = md.GetString(mr.Name);
+            if (name != ".ctor")
+            {
+                continue;
+            }
+
+            if (mr.Parent.Kind != HandleKind.TypeReference)
+            {
+                continue;
+            }
+
+            var tr = md.GetTypeReference((TypeReferenceHandle)mr.Parent);
+            var typeName = md.GetString(tr.Name);
+            var ns = md.GetString(tr.Namespace);
+
+            if (ns == "System.Runtime.CompilerServices" && typeName == "IsReadOnlyAttribute")
+            {
+                isReadOnly++;
+            }
+            else if (ns == "System.Runtime.CompilerServices" && typeName == "IsByRefLikeAttribute")
+            {
+                isByRefLike++;
+            }
+            else if (ns == "System" && typeName == "ObsoleteAttribute")
+            {
+                obsolete++;
+            }
+        }
+
+        return (isReadOnly, isByRefLike, obsolete);
+    }
+}


### PR DESCRIPTION
Resolves P3-11 from #420.

## Problem

`EmitIsReadOnlyAttribute` and `EmitIsByRefLikeAttribute` allocated a fresh `MemberRef` per call. Each invocation produced duplicate MemberRef rows in the emitted metadata — wasteful and easily fixed with caching, matching the existing patterns already used for `NotImplementedException..ctor`, `Delegate.Combine`, etc.

## Fix

Added three cached `MemberReferenceHandle?` fields:
- `isReadOnlyAttributeCtorRef` — for `IsReadOnlyAttribute..ctor()` (inline structs)
- `isByRefLikeAttributeCtorRef` — for `IsByRefLikeAttribute..ctor()` (ref structs)
- `obsoleteAttributeStringBoolCtorRef` — for `ObsoleteAttribute..ctor(string, bool)` (emitted alongside `IsByRefLikeAttribute` as the C# guard marker)

Extracted lazy getters following the existing `GetNotImplementedExceptionCtor` pattern, and rewired the two emit methods to use them.

## Tests

New `AttributeMemberRefCacheTests`:
- `MultipleInlineStructs_ProduceSingleIsReadOnlyAttributeCtorMemberRef` — three inline structs → exactly 1 `IsReadOnlyAttribute..ctor` MemberRef row.
- `MultipleRefStructs_ProduceSingleIsByRefLikeAndObsoleteAttributeCtorMemberRef` — three ref structs → exactly 1 `IsByRefLikeAttribute..ctor` and 1 `ObsoleteAttribute(string,bool)..ctor` MemberRef row.

Both inspect the emitted PE via `System.Reflection.Metadata` and would fail under the old behavior (3 rows each).

## Validation
- `dotnet build GSharp.sln -nologo -clp:NoSummary` — succeeded, 0 warnings.
- `dotnet test GSharp.sln --no-restore --nologo` — all 2285 tests pass.