### PR TITLE
Fix #420 (P3-4): document and assert receiver-reload safety in EmitFieldAssignment

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -13121,6 +13122,26 @@ internal sealed class ReflectionMetadataEmitter
                 return;
             }
 
+            // Issue #420 (P3-4): the non-static paths below emit the receiver
+            // twice — once for the `stfld`, and once again after the store to
+            // reload the field for the expression result. This is only safe
+            // when evaluating `fas.Value` cannot mutate `fas.Receiver`. For
+            // class receivers a re-assignment of the receiver variable in the
+            // value expression would make the post-store reload observe the
+            // mutated reference and read the field off the wrong object; for
+            // struct receivers the address would still be stable, but a
+            // self-write inside `fas.Value` would race with `stfld`. Today the
+            // binder (Binder.BindFieldAssignmentExpression) does not produce
+            // such shapes: nested `BoundAssignmentExpression` writing back to
+            // the same receiver variable is not a pattern the front end emits
+            // for field-assignment values. The assertion below makes that
+            // invariant explicit so any future binder change that introduces
+            // self-mutating value expressions trips loudly in Debug instead of
+            // silently miscompiling.
+            Debug.Assert(
+                !ValueExpressionMutatesReceiver(fas.Value, fas.Receiver),
+                $"EmitFieldAssignment: value expression for field '{fas.Field.Name}' must not reassign the receiver variable '{fas.Receiver.Name}'.");
+
             // Class field assignment: load the reference, evaluate the value,
             // stfld through the reference. Re-load the receiver + ldfld to
             // leave the new value on the stack as the expression result.
@@ -13187,6 +13208,46 @@ internal sealed class ReflectionMetadataEmitter
 
             this.il.OpCode(ILOpCode.Ldfld);
             this.il.Token(fieldHandle);
+        }
+
+        // Issue #420 (P3-4): debug-only check used by EmitFieldAssignment to
+        // assert the binder never feeds a value expression that reassigns the
+        // field-assignment receiver variable. Looks for any
+        // BoundAssignmentExpression whose target is the same VariableSymbol as
+        // the receiver. Conservative — false positives are fine because this
+        // is a debug-only assertion guarding a code-gen invariant.
+        private static bool ValueExpressionMutatesReceiver(BoundExpression value, VariableSymbol receiver)
+        {
+            if (value == null || receiver == null)
+            {
+                return false;
+            }
+
+            var detector = new ReceiverMutationDetector(receiver);
+            detector.Visit(value);
+            return detector.Found;
+        }
+
+        private sealed class ReceiverMutationDetector : BoundTreeWalker
+        {
+            private readonly VariableSymbol receiver;
+
+            public ReceiverMutationDetector(VariableSymbol receiver)
+            {
+                this.receiver = receiver;
+            }
+
+            public bool Found { get; private set; }
+
+            protected override void VisitAssignmentExpression(BoundAssignmentExpression node)
+            {
+                if (ReferenceEquals(node.Variable, this.receiver))
+                {
+                    this.Found = true;
+                }
+
+                base.VisitAssignmentExpression(node);
+            }
         }
 
         // ADR-0051 Phase 6: emit IL for BoundPropertyAccessExpression (computed properties).

--- a/test/Compiler.Tests/Emit/FieldAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/FieldAssignmentEmitTests.cs
@@ -1,0 +1,184 @@
+// <copyright file="FieldAssignmentEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #420 (P3-4) regression tests. <c>EmitFieldAssignment</c> emits the
+/// receiver twice — once for the <c>stfld</c>, once again after the store to
+/// reload the field for the expression result. The reload only matches the
+/// freshly-stored value as long as evaluating the value expression cannot
+/// reassign the receiver variable. These tests pin down the normal-case
+/// behavior (post-store reload returns the just-written value for struct and
+/// class receivers) so any regression in the receiver-reload sequence is
+/// caught immediately.
+/// </summary>
+public class FieldAssignmentEmitTests
+{
+    [Fact]
+    public void StructFieldAssignment_ResultIs_AssignedValue()
+    {
+        // The assignment expression is used as the initializer for `result`,
+        // so its value must equal the freshly-stored 42 — which is what the
+        // post-store ldfld in EmitFieldAssignment guarantees.
+        var source = """
+            package P
+            import System
+
+            type Point struct {
+                X int32
+                Y int32
+            }
+
+            var p = Point{X: 1, Y: 2}
+            public var result = (p.X = 42)
+            """;
+
+        Assert.Equal(42, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void StructFieldAssignment_LeavesReceiverFieldUpdated()
+    {
+        // Verifies the stfld actually writes through the receiver address —
+        // reading p.X after the assignment must yield the stored value.
+        var source = """
+            package P
+            import System
+
+            type Point struct {
+                X int32
+                Y int32
+            }
+
+            var p = Point{X: 1, Y: 2}
+            p.X = 99
+            public var result = p.X
+            """;
+
+        Assert.Equal(99, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void ClassFieldAssignment_ResultIs_AssignedValue()
+    {
+        // Class receiver path: receiver reference is loaded twice. The
+        // post-store ldfld must observe the just-written value.
+        var source = """
+            package P
+            import System
+
+            type Box class {
+                Value int32
+            }
+
+            var b = Box{Value: 1}
+            public var result = (b.Value = 7)
+            """;
+
+        Assert.Equal(7, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void ClassFieldAssignment_LeavesReceiverFieldUpdated()
+    {
+        var source = """
+            package P
+            import System
+
+            type Box class {
+                Value int32
+            }
+
+            var b = Box{Value: 1}
+            b.Value = 123
+            public var result = b.Value
+            """;
+
+        Assert.Equal(123, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void StructFieldAssignment_ValueExpressionReadsReceiver()
+    {
+        // Reading the receiver inside the value expression is fine and must
+        // be supported — only *mutating* the receiver in the value side is
+        // the unsafe shape the binder doesn't produce. This guards the
+        // assertion in EmitFieldAssignment from being overly aggressive.
+        var source = """
+            package P
+            import System
+
+            type Point struct {
+                X int32
+                Y int32
+            }
+
+            var p = Point{X: 10, Y: 0}
+            p.X = p.X + 5
+            public var result = p.X
+            """;
+
+        Assert.Equal(15, RunAndGetIntResult(source));
+    }
+
+    private static int RunAndGetIntResult(string source)
+    {
+        var assembly = CompileToAssembly(source, target: "exe");
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod(
+            "<Main>$",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField(
+            "result",
+            BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, null);
+        return (int)resultField!.GetValue(null)!;
+    }
+
+    private static Assembly CompileToAssembly(string source, string target)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_field_assign_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}


### PR DESCRIPTION
Resolves the P3-4 item of #420.

## Problem

`EmitFieldAssignment` emits the receiver twice on the non-static paths — once for the `stfld` and again after the store to reload the field for the expression result. That sequence is only correct as long as the value expression cannot reassign the receiver variable; for class receivers a self-write inside the value would make the post-store reload observe the mutated reference and read the field off the wrong object.

## Verification

Today the binder (`Binder.BindFieldAssignmentExpression`) does not produce such shapes for field-assignment values: the value position is bound as a plain `BoundExpression` and there is no surface syntax that lowers to a nested assignment writing back to the receiver variable during a field assignment.

## Fix

- Document the invariant inline in `EmitFieldAssignment`.
- Add a `Debug.Assert` backed by a small `BoundTreeWalker` (`ReceiverMutationDetector`) that scans the value expression for a `BoundAssignmentExpression` writing back to the same `VariableSymbol`. Future binder changes that introduce a self-mutating value expression will trip the assertion in Debug instead of silently miscompiling.
- Add `FieldAssignmentEmitTests` regression coverage pinning the normal-case behavior on struct and class receivers (post-store reload returns the just-written value; reading the receiver in the value expression remains supported).

## Build & test

- `dotnet build GSharp.sln -nologo -clp:NoSummary` ✅
- `dotnet test GSharp.sln --no-restore --nologo` ✅ (all 2288 tests pass)
