### PR TITLE
Fix #420 (P3-9): use structural equality for TypeRef cache to prevent duplicate rows

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -52,8 +52,11 @@ internal sealed class ReflectionMetadataEmitter
     private readonly MetadataBuilder metadata = new MetadataBuilder();
     private readonly Dictionary<Assembly, AssemblyReferenceHandle> assemblyRefs = new Dictionary<Assembly, AssemblyReferenceHandle>();
     private AssemblyReferenceHandle systemRuntimeAssemblyRef;
-    private readonly Dictionary<Type, TypeReferenceHandle> typeRefs = new Dictionary<Type, TypeReferenceHandle>();
-    private readonly Dictionary<Type, TypeSpecificationHandle> typeSpecs = new Dictionary<Type, TypeSpecificationHandle>();
+    // Issue #420 (P3-9): key by TypeIdentityComparer so that the same logical
+    // type reached through different MetadataLoadContext paths collapses to
+    // one TypeRef row instead of producing duplicates.
+    private readonly Dictionary<Type, TypeReferenceHandle> typeRefs = new Dictionary<Type, TypeReferenceHandle>(TypeIdentityComparer.Instance);
+    private readonly Dictionary<Type, TypeSpecificationHandle> typeSpecs = new Dictionary<Type, TypeSpecificationHandle>(TypeIdentityComparer.Instance);
     private readonly Dictionary<MethodInfo, MemberReferenceHandle> methodRefs = new Dictionary<MethodInfo, MemberReferenceHandle>();
     private readonly Dictionary<MethodInfo, MethodSpecificationHandle> methodSpecs = new Dictionary<MethodInfo, MethodSpecificationHandle>();
     private readonly Dictionary<ConstructorInfo, MemberReferenceHandle> ctorRefs = new Dictionary<ConstructorInfo, MemberReferenceHandle>();

--- a/src/Core/CodeAnalysis/Emit/TypeIdentityComparer.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeIdentityComparer.cs
@@ -1,0 +1,77 @@
+// <copyright file="TypeIdentityComparer.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+
+namespace GSharp.Core.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #420 (P3-9): compares <see cref="Type"/> instances by structural
+/// identity (assembly-qualified name) rather than reference equality.
+///
+/// The emitter resolves CLR <see cref="Type"/> objects through
+/// <see cref="System.Reflection.MetadataLoadContext"/>. The same logical type
+/// can be returned as two distinct <see cref="Type"/> instances when it is
+/// reached through different reference paths (e.g. via different
+/// MetadataLoadContext lookups for the same assembly identity, or when the
+/// same type is observed both from a directly loaded assembly and from a
+/// transitively loaded one). Reference-equality-keyed caches then mint a
+/// duplicate <c>TypeRef</c> row for each occurrence, producing valid but
+/// bloated metadata that tools like ILSpy render as separate rows.
+///
+/// Using assembly-qualified name as the identity key collapses these
+/// duplicates into a single cache entry — and therefore a single <c>TypeRef</c>
+/// row — without affecting types that genuinely differ.
+/// </summary>
+internal sealed class TypeIdentityComparer : IEqualityComparer<Type>
+{
+    public static readonly TypeIdentityComparer Instance = new TypeIdentityComparer();
+
+    private TypeIdentityComparer()
+    {
+    }
+
+    public bool Equals(Type x, Type y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        var keyX = GetKey(x);
+        var keyY = GetKey(y);
+        return string.Equals(keyX, keyY, StringComparison.Ordinal);
+    }
+
+    public int GetHashCode(Type obj)
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        return StringComparer.Ordinal.GetHashCode(GetKey(obj));
+    }
+
+    private static string GetKey(Type type)
+    {
+        // AssemblyQualifiedName encodes namespace, name (including nesting via
+        // '+'), generic arity, generic arguments, array/pointer/byref suffixes,
+        // and the full assembly identity. That makes it a faithful structural
+        // key: two Type instances that describe the same logical type from
+        // different MetadataLoadContext paths share the same string here.
+        // Fall back to FullName/Name when AssemblyQualifiedName is unavailable
+        // (e.g. generic type parameters), preferring the most specific
+        // identifier we can build.
+        return type.AssemblyQualifiedName
+            ?? type.FullName
+            ?? type.Name;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/TypeRefDeduplicationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/TypeRefDeduplicationTests.cs
@@ -1,0 +1,155 @@
+// <copyright file="TypeRefDeduplicationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Emit;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #420 (P3-9): the TypeRef cache previously keyed on reference
+/// equality, so the same logical CLR type reached through different
+/// <c>MetadataLoadContext</c> paths produced duplicate <c>TypeRef</c> rows.
+/// These tests pin the new structural-identity behaviour both at the
+/// comparer level and end-to-end against the emitted PE metadata.
+/// </summary>
+public class TypeRefDeduplicationTests
+{
+    [Fact]
+    public void TypeIdentityComparer_TreatsSameRuntimeTypeAsEqual()
+    {
+        // Reference-equal types are trivially equal; this is just a baseline
+        // sanity check guarding the fast path.
+        Assert.True(TypeIdentityComparer.Instance.Equals(typeof(int), typeof(int)));
+        Assert.Equal(
+            TypeIdentityComparer.Instance.GetHashCode(typeof(int)),
+            TypeIdentityComparer.Instance.GetHashCode(typeof(int)));
+    }
+
+    [Fact]
+    public void TypeIdentityComparer_TreatsDifferentTypesAsDistinct()
+    {
+        Assert.False(TypeIdentityComparer.Instance.Equals(typeof(int), typeof(long)));
+        Assert.False(TypeIdentityComparer.Instance.Equals(typeof(string), typeof(object)));
+    }
+
+    [Fact]
+    public void TypeIdentityComparer_TreatsTypesFromDistinctLoadContextsAsEqual()
+    {
+        // Simulate the real bug: load the same assembly twice through two
+        // distinct MetadataLoadContext instances. Reflection returns two
+        // different Type instances for the same logical type, but they share
+        // an assembly-qualified name and so must compare equal.
+        var coreAssemblies = System.IO.Directory
+            .GetFiles(System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(), "*.dll")
+            .ToList();
+
+        using var ctxA = new System.Reflection.MetadataLoadContext(new PathAssemblyResolver(coreAssemblies));
+        using var ctxB = new System.Reflection.MetadataLoadContext(new PathAssemblyResolver(coreAssemblies));
+
+        var objectFromA = ctxA.CoreAssembly!.GetType("System.Object");
+        var objectFromB = ctxB.CoreAssembly!.GetType("System.Object");
+
+        Assert.NotNull(objectFromA);
+        Assert.NotNull(objectFromB);
+        Assert.NotSame(objectFromA, objectFromB);
+        Assert.True(
+            TypeIdentityComparer.Instance.Equals(objectFromA, objectFromB),
+            "Same logical type from two MetadataLoadContext instances should be equal.");
+        Assert.Equal(
+            TypeIdentityComparer.Instance.GetHashCode(objectFromA!),
+            TypeIdentityComparer.Instance.GetHashCode(objectFromB!));
+    }
+
+    [Fact]
+    public void TypeIdentityComparer_NullHandling()
+    {
+        Assert.True(TypeIdentityComparer.Instance.Equals(null, null));
+        Assert.False(TypeIdentityComparer.Instance.Equals(null, typeof(int)));
+        Assert.False(TypeIdentityComparer.Instance.Equals(typeof(int), null));
+    }
+
+    [Fact]
+    public void TypeIdentityComparer_BackingDictionary_DeduplicatesAcrossLoadContexts()
+    {
+        var coreAssemblies = System.IO.Directory
+            .GetFiles(System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(), "*.dll")
+            .ToList();
+
+        using var ctxA = new System.Reflection.MetadataLoadContext(new PathAssemblyResolver(coreAssemblies));
+        using var ctxB = new System.Reflection.MetadataLoadContext(new PathAssemblyResolver(coreAssemblies));
+
+        var dict = new Dictionary<Type, int>(TypeIdentityComparer.Instance);
+        dict[ctxA.CoreAssembly!.GetType("System.Object")!] = 1;
+        dict[ctxB.CoreAssembly!.GetType("System.Object")!] = 2;
+        dict[ctxA.CoreAssembly!.GetType("System.String")!] = 3;
+
+        Assert.Equal(2, dict.Count);
+        Assert.Equal(2, dict[ctxA.CoreAssembly!.GetType("System.Object")!]);
+    }
+
+    [Fact]
+    public void EmittedAssembly_HasNoDuplicateTypeRefRows()
+    {
+        // End-to-end check: compile a small program that exercises several
+        // BCL types (Console, String, Int32) and verify the TypeRef table in
+        // the emitted PE contains no duplicate (resolutionScope, namespace,
+        // name) triples. Prior to the fix the same logical BCL type could
+        // appear multiple times.
+        const string source = @"
+package TypeRefDedupTest
+import System
+
+func main() {
+    Console.WriteLine(""hello"")
+    Console.WriteLine(42)
+    Console.WriteLine(""world"")
+    Console.WriteLine(1 + 2)
+}
+";
+
+        using var peStream = new MemoryStream();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        using var peReader = new PEReader(peStream);
+        var reader = peReader.GetMetadataReader();
+
+        var seen = new HashSet<(int Scope, string Namespace, string Name)>();
+        var duplicates = new List<(int Scope, string Namespace, string Name)>();
+
+        foreach (var handle in reader.TypeReferences)
+        {
+            var typeRef = reader.GetTypeReference(handle);
+            var key = (
+                Scope: MetadataTokens.GetToken(typeRef.ResolutionScope),
+                Namespace: reader.GetString(typeRef.Namespace),
+                Name: reader.GetString(typeRef.Name));
+            if (!seen.Add(key))
+            {
+                duplicates.Add(key);
+            }
+        }
+
+        Assert.True(
+            duplicates.Count == 0,
+            "TypeRef table contains duplicate rows: "
+                + string.Join(", ", duplicates.Select(d => $"{d.Namespace}.{d.Name}@0x{d.Scope:X8}")));
+    }
+}


### PR DESCRIPTION
Fixes the P3-9 sub-issue of #420.

## Problem

`Dictionary<Type, TypeReferenceHandle>` in `ReflectionMetadataEmitter` keyed on reference equality. The same logical CLR type reached through different `MetadataLoadContext` paths is returned as two distinct `Type` instances, so the cache minted a duplicate `TypeRef` row for each occurrence. Metadata stayed valid but bloated, and consumers like ILSpy rendered the duplicates.

## Fix

- New `TypeIdentityComparer : IEqualityComparer<Type>` that compares types by `AssemblyQualifiedName` (with `FullName` / `Name` fallbacks for edge cases like generic parameters).
- Applied the comparer to both the `typeRefs` and `typeSpecs` caches in `ReflectionMetadataEmitter` so the deduplication is consistent across the TypeRef and TypeSpec paths.

## Tests

`test/Core.Tests/CodeAnalysis/Emit/TypeRefDeduplicationTests.cs` covers:
- Comparer baseline equality / inequality / null handling.
- Bug repro: two distinct `MetadataLoadContext` instances yield non-reference-equal `Type` objects for `System.Object`, but the comparer treats them as equal and a dictionary keyed by the comparer dedupes them.
- End-to-end: compile a small program touching several BCL types and assert the `TypeRef` table in the emitted PE contains no duplicate (resolutionScope, namespace, name) triples.

## Validation

- `dotnet build GSharp.sln -nologo -clp:NoSummary` — succeeds.
- `dotnet test GSharp.sln --no-restore --nologo` — all 2289 tests pass.