### PR TITLE
Fix #420 (P3-6): defensive pop for elided catch variable in EmitCatchClauses

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -8231,7 +8231,11 @@ internal sealed class ReflectionMetadataEmitter
                         this.CollectStatements(((BoundBlockStatement)t.TryBlock).Statements, function, locals, localTypes, labels, appendSlots, il, pass);
                         foreach (var clause in t.CatchClauses)
                         {
-                            if (!locals.ContainsKey(clause.Variable))
+                            // Issue #420 (P3-6): tolerate an elided catch variable
+                            // in the local-slot pre-pass (the corresponding emit-
+                            // time path in EmitCatchClauses emits a defensive
+                            // `pop` to maintain stack balance).
+                            if (clause.Variable != null && !locals.ContainsKey(clause.Variable))
                             {
                                 locals[clause.Variable] = localTypes.Count;
                                 localTypes.Add(clause.Variable.Type);
@@ -11810,6 +11814,27 @@ internal sealed class ReflectionMetadataEmitter
                 $"Variable '{variable.Name}' has no local slot or parameter index in the current method.");
         }
 
+        private bool HasStorageSlot(VariableSymbol variable)
+        {
+            if (variable is ParameterSymbol ps && this.parameters.ContainsKey(ps))
+            {
+                return true;
+            }
+
+            if (this.locals.ContainsKey(variable))
+            {
+                return true;
+            }
+
+            if (variable is GlobalVariableSymbol gv
+                && this.outer.globalFieldDefs.ContainsKey(gv))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         private void EmitStoreVariable(VariableSymbol variable)
         {
             if (variable is ParameterSymbol ps && this.parameters.TryGetValue(ps, out var argIndex))
@@ -12150,7 +12175,22 @@ internal sealed class ReflectionMetadataEmitter
                 this.il.MarkLabel(handlerStart);
 
                 // Stack contains the caught exception; store into the catch variable.
-                this.EmitStoreVariable(clause.Variable);
+                // Issue #420 (P3-6): the binder is currently expected to always
+                // provide a catch variable with an allocated slot, but if a future
+                // binder pass elides an unused catch variable (or leaves it without
+                // a slot) we still need to consume the exception object the CLR
+                // pushed onto the evaluation stack on entry to the handler --
+                // otherwise the handler starts with an unbalanced stack and the
+                // generated IL becomes unverifiable. Defensively emit `pop` in
+                // that case instead of dereferencing a null variable.
+                if (clause.Variable is null || !this.HasStorageSlot(clause.Variable))
+                {
+                    this.il.OpCode(ILOpCode.Pop);
+                }
+                else
+                {
+                    this.EmitStoreVariable(clause.Variable);
+                }
 
                 this.EmitProtectedRegion((BoundBlockStatement)clause.Body);
                 this.il.Branch(ILOpCode.Leave, leaveTarget);

--- a/test/Core.Tests/CodeAnalysis/Emit/CatchElidedVariableEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/CatchElidedVariableEmitTests.cs
@@ -1,0 +1,190 @@
+// <copyright file="CatchElidedVariableEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Emit;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Regression tests for issue #420 (P3-6): <c>ReflectionMetadataEmitter.EmitCatchClauses</c>
+/// previously assumed <c>BoundCatchClause.Variable</c> was non-null and had a
+/// local slot allocated. If a future binder pass elides an unused catch
+/// variable, the emitter would NRE and/or leave the exception object on the
+/// evaluation stack producing unverifiable IL. These tests verify both the
+/// normal positive path and the defensive <c>pop</c> path.
+/// </summary>
+public class CatchElidedVariableEmitTests
+{
+    [Fact]
+    public void Normal_Catch_With_Variable_Still_Works()
+    {
+        const string Source = @"package CatchNormal
+import System
+
+func run() int32 {
+    var result = 0
+    try {
+        var n = Int32.Parse(""bad"")
+        result = n
+    } catch (e Exception) {
+        result = 42
+    }
+    return result
+}
+
+Console.WriteLine(run())
+";
+        var output = CompileAndRun(Source, "CatchNormal");
+        Assert.Contains("42", output);
+    }
+
+    [Fact]
+    public void Catch_With_Elided_Variable_Emits_Pop_And_Runs()
+    {
+        // Simulate a future binder pass that elides the catch variable: bind the
+        // program normally then mutate every BoundCatchClause to drop its
+        // Variable before emitting. Without the defensive Pop in EmitCatchClauses
+        // this would either NRE during emit (Variable == null) or produce
+        // unverifiable IL (exception object left on the evaluation stack on
+        // handler entry).
+        const string Source = @"package CatchElided
+import System
+
+func run() int32 {
+    var result = 0
+    try {
+        var n = Int32.Parse(""bad"")
+        result = n
+    } catch (e Exception) {
+        result = 42
+    }
+    return result
+}
+
+Console.WriteLine(run())
+";
+        var output = CompileAndRunMutated(Source, "CatchElided");
+        Assert.Contains("42", output);
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        return LoadAndExecute(peStream, contextName);
+    }
+
+    private static string CompileAndRunMutated(string source, string contextName)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+
+        var syntaxDiagnostics = compilation.GlobalScope.Diagnostics;
+        Assert.False(
+            syntaxDiagnostics.Any(d => d.IsError),
+            "no syntax errors: " + string.Join("; ", syntaxDiagnostics.Select(d => d.Message)));
+
+        var program = GSharp.Core.CodeAnalysis.Binding.Binder.BindProgram(compilation.GlobalScope);
+        Assert.False(
+            program.Diagnostics.Any(d => d.IsError),
+            "no binding errors: " + string.Join("; ", program.Diagnostics.Select(d => d.Message)));
+
+        var mutated = 0;
+        foreach (var body in program.Functions.Values)
+        {
+            var walker = new CatchClauseElider();
+            walker.Visit(body);
+            mutated += walker.MutatedCount;
+        }
+
+        Assert.True(mutated > 0, "expected to find at least one catch clause to mutate");
+
+        using var peStream = new MemoryStream();
+        ReflectionMetadataEmitter.Emit(program, peStream);
+        return LoadAndExecute(peStream, contextName);
+    }
+
+    private sealed class CatchClauseElider : BoundTreeWalker
+    {
+        private static readonly FieldInfo VariableBackingField =
+            typeof(BoundCatchClause).GetField(
+                "<Variable>k__BackingField",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        public int MutatedCount { get; private set; }
+
+        protected override void VisitTryStatement(BoundTryStatement node)
+        {
+            foreach (var clause in node.CatchClauses)
+            {
+                Assert.NotNull(VariableBackingField);
+                if (VariableBackingField.GetValue(clause) is not null)
+                {
+                    VariableBackingField.SetValue(clause, null);
+                    this.MutatedCount++;
+                }
+            }
+
+            base.VisitTryStatement(node);
+        }
+    }
+
+    private static string LoadAndExecute(MemoryStream peStream, string contextName)
+    {
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, parameters: null);
+            }
+            catch (TargetInvocationException tie)
+            {
+                Console.SetOut(stdout);
+                throw new Exception(
+                    $"Entry point threw: {tie.InnerException?.GetType().Name}: {tie.InnerException?.Message}",
+                    tie.InnerException);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Addresses item P3-6 from issue #420: `EmitCatchClauses` assumed `clause.Variable` was non-null and had an allocated slot. If a future binder pass elides an unused catch variable the emitter would either NRE (Variable == null) or store into a missing slot and leave the exception object on the evaluation stack — producing unverifiable IL.

## Changes

- **`ReflectionMetadataEmitter.EmitCatchClauses`**: when `clause.Variable` is null or has no allocated storage slot, emit a defensive `pop` to consume the exception object the CLR pushes on handler entry, keeping the evaluation stack balanced. Added explanatory comment.
- **`ReflectionMetadataEmitter.CollectStatements` (BoundTryStatement case)**: tolerate a null `clause.Variable` in the local-slot pre-pass that runs before emit.
- **New helper `HasStorageSlot`**: mirrors `EmitStoreVariable`'s lookup so the new branch is hit only when no parameter/local/global slot exists.

## Tests

`test/Core.Tests/CodeAnalysis/Emit/CatchElidedVariableEmitTests.cs`:

1. `Normal_Catch_With_Variable_Still_Works` — round-trips a regular `try/catch (e Exception)` through the PE writer to confirm no regression.
2. `Catch_With_Elided_Variable_Emits_Pop_And_Runs` — binds normally, then uses reflection on `BoundCatchClause.Variable`'s backing field to simulate the binder eliding the catch variable, re-emits via `ReflectionMetadataEmitter.Emit`, loads the assembly and invokes the entry point. Passes only with the defensive `pop` (without it the IL is unverifiable / NREs at emit).

Full `dotnet test GSharp.sln` passes (Core 1684, Compiler 311, Interpreter 54, LanguageServer 212, Sdk 24).

Closes part of #420 (P3-6).