### PR TITLE
Fix #420 (P3-7): fix MethodSpec cache equality for user-type generic args

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -18,6 +18,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Lowering;
@@ -56,6 +57,14 @@ internal sealed class ReflectionMetadataEmitter
     private readonly Dictionary<Type, TypeSpecificationHandle> typeSpecs = new Dictionary<Type, TypeSpecificationHandle>();
     private readonly Dictionary<MethodInfo, MemberReferenceHandle> methodRefs = new Dictionary<MethodInfo, MemberReferenceHandle>();
     private readonly Dictionary<MethodInfo, MethodSpecificationHandle> methodSpecs = new Dictionary<MethodInfo, MethodSpecificationHandle>();
+
+    // Issue #420 (P3-7): cache for MethodSpec rows whose generic arguments include
+    // user-defined type symbols. The placeholder-closed MethodInfo is identical for
+    // all symbol arguments, so we must key by (MethodInfo, symbol arg list) with
+    // structural equality on the symbol array.
+    private readonly Dictionary<MethodSpecSymbolKey, MethodSpecificationHandle> methodSpecsWithSymbolArgs
+        = new Dictionary<MethodSpecSymbolKey, MethodSpecificationHandle>();
+
     private readonly Dictionary<ConstructorInfo, MemberReferenceHandle> ctorRefs = new Dictionary<ConstructorInfo, MemberReferenceHandle>();
     private readonly Dictionary<FieldInfo, MemberReferenceHandle> fieldRefs = new Dictionary<FieldInfo, MemberReferenceHandle>();
     private readonly Dictionary<FunctionSymbol, MethodDefinitionHandle> functionHandles = new Dictionary<FunctionSymbol, MethodDefinitionHandle>();
@@ -8920,12 +8929,26 @@ internal sealed class ReflectionMetadataEmitter
 
         // The placeholder-closed MethodInfo is identical across distinct
         // user-type arguments (all close to <object>), so the cache must be keyed
-        // by the symbol arguments too. Only cache the plain (symbol-free) case.
+        // by the symbol arguments too. Issue #420 (P3-7): previously this case
+        // bypassed the cache entirely, producing duplicate MethodSpec rows when
+        // the same generic method was referenced multiple times with the same
+        // user-type generic args.
         var hasSymbolArgs = !typeArgSymbols.IsDefaultOrEmpty
             && typeArgSymbols.Any(s => s is StructSymbol or InterfaceSymbol or EnumSymbol);
-        if (!hasSymbolArgs && this.methodSpecs.TryGetValue(method, out var existing))
+        if (!hasSymbolArgs)
         {
-            return existing;
+            if (this.methodSpecs.TryGetValue(method, out var existing))
+            {
+                return existing;
+            }
+        }
+        else
+        {
+            var symbolKey = new MethodSpecSymbolKey(method, typeArgSymbols);
+            if (this.methodSpecsWithSymbolArgs.TryGetValue(symbolKey, out var existingSym))
+            {
+                return existingSym;
+            }
         }
 
         var openDef = method.GetGenericMethodDefinition();
@@ -8954,6 +8977,10 @@ internal sealed class ReflectionMetadataEmitter
         if (!hasSymbolArgs)
         {
             this.methodSpecs[method] = spec;
+        }
+        else
+        {
+            this.methodSpecsWithSymbolArgs[new MethodSpecSymbolKey(method, typeArgSymbols)] = spec;
         }
 
         return spec;
@@ -14984,6 +15011,58 @@ internal sealed class ReflectionMetadataEmitter
                 this.il.OpCode(ILOpCode.Ldnull);
                 this.il.StoreLocal(slot);
             }
+        }
+    }
+
+    // Issue #420 (P3-7): structural cache key for MethodSpec rows whose generic
+    // arguments include user-defined type symbols. Uses reference equality on the
+    // contained TypeSymbol entries (declared user types are interned per
+    // compilation), combined with structural equality on the array.
+    private readonly struct MethodSpecSymbolKey : IEquatable<MethodSpecSymbolKey>
+    {
+        private readonly MethodInfo method;
+        private readonly ImmutableArray<TypeSymbol> typeArgs;
+
+        public MethodSpecSymbolKey(MethodInfo method, ImmutableArray<TypeSymbol> typeArgs)
+        {
+            this.method = method;
+            this.typeArgs = typeArgs.IsDefault ? ImmutableArray<TypeSymbol>.Empty : typeArgs;
+        }
+
+        public bool Equals(MethodSpecSymbolKey other)
+        {
+            if (!ReferenceEquals(this.method, other.method))
+            {
+                return false;
+            }
+
+            if (this.typeArgs.Length != other.typeArgs.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < this.typeArgs.Length; i++)
+            {
+                if (!ReferenceEquals(this.typeArgs[i], other.typeArgs[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override bool Equals(object obj) => obj is MethodSpecSymbolKey other && this.Equals(other);
+
+        public override int GetHashCode()
+        {
+            var hash = RuntimeHelpers.GetHashCode(this.method);
+            for (var i = 0; i < this.typeArgs.Length; i++)
+            {
+                hash = unchecked((hash * 31) + RuntimeHelpers.GetHashCode(this.typeArgs[i]));
+            }
+
+            return hash;
         }
     }
 }

--- a/test/Compiler.Tests/Emit/MethodSpecCacheUserTypeArgsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/MethodSpecCacheUserTypeArgsEmitTests.cs
@@ -1,0 +1,142 @@
+// <copyright file="MethodSpecCacheUserTypeArgsEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #420 (P3-7): regression test verifying that the
+/// <c>ReflectionMetadataEmitter</c> MethodSpec cache deduplicates rows when the
+/// same generic method is referenced multiple times with the same user-defined
+/// type as the generic argument. Previously the cache was bypassed entirely
+/// whenever any generic argument was a user-type symbol, producing duplicate
+/// MethodSpec rows. The metadata was still valid but bloated.
+/// </summary>
+public class MethodSpecCacheUserTypeArgsEmitTests
+{
+    [Fact]
+    public void RepeatedGenericCallWithSameUserTypeArg_EmitsSingleMethodSpecRow()
+    {
+        // Three calls to Array.Empty[Clock]() — they must all resolve to the
+        // same MethodSpec row, not three distinct rows.
+        var source = """
+            package P
+            import System
+
+            type Clock class {
+                Ticks int32
+            }
+
+            var a = Array.Empty[Clock]()
+            var b = Array.Empty[Clock]()
+            var c = Array.Empty[Clock]()
+            Console.WriteLine(a.Length + b.Length + c.Length)
+            """;
+
+        var outPath = CompileToDll(source);
+
+        using var pe = new PEReader(File.OpenRead(outPath));
+        var reader = pe.GetMetadataReader();
+
+        // Count MethodSpec rows whose parent MemberRef name is "Empty".
+        var emptySpecCount = CountMethodSpecsByName(reader, "Empty");
+        Assert.Equal(1, emptySpecCount);
+    }
+
+    [Fact]
+    public void DistinctUserTypeArgs_StillProduceDistinctMethodSpecRows()
+    {
+        // Two distinct user types as generic args must still emit two
+        // separate MethodSpec rows — the cache fix must not over-deduplicate.
+        var source = """
+            package P
+            import System
+
+            type ClockA class {
+                Ticks int32
+            }
+
+            type ClockB class {
+                Ticks int32
+            }
+
+            var a = Array.Empty[ClockA]()
+            var b = Array.Empty[ClockB]()
+            Console.WriteLine(a.Length + b.Length)
+            """;
+
+        var outPath = CompileToDll(source);
+
+        using var pe = new PEReader(File.OpenRead(outPath));
+        var reader = pe.GetMetadataReader();
+
+        var emptySpecCount = CountMethodSpecsByName(reader, "Empty");
+        Assert.Equal(2, emptySpecCount);
+    }
+
+    private static int CountMethodSpecsByName(MetadataReader reader, string name)
+    {
+        var count = 0;
+        var rowCount = reader.GetTableRowCount(TableIndex.MethodSpec);
+        for (var rid = 1; rid <= rowCount; rid++)
+        {
+            var handle = MetadataTokens.MethodSpecificationHandle(rid);
+            var spec = reader.GetMethodSpecification(handle);
+            if (spec.Method.Kind != HandleKind.MemberReference)
+            {
+                continue;
+            }
+
+            var memberRef = reader.GetMemberReference((MemberReferenceHandle)spec.Method);
+            if (reader.GetString(memberRef.Name) == name)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static string CompileToDll(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_methodspec_cache_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = System.Console.Out;
+        var prevErr = System.Console.Error;
+        System.Console.SetOut(compileOut);
+        System.Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            System.Console.SetOut(prevOut);
+            System.Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        return outPath;
+    }
+}


### PR DESCRIPTION
Resolves the P3-7 task from issue #420.

## Problem
The MethodSpec cache in `ReflectionMetadataEmitter` was bypassed whenever any generic argument was a user-defined type symbol (`StructSymbol`/`InterfaceSymbol`/`EnumSymbol`). Repeated references to the same generic method with the same user-type generic args produced duplicate MethodSpec rows. Metadata stayed valid but bloated.

The previous `Dictionary<MethodInfo, MethodSpecificationHandle>` cache could not key these correctly because the placeholder-closed `MethodInfo` is identical across all user-type symbol arguments (all close to `<object>`), so caching by `MethodInfo` alone would over-deduplicate distinct symbol arg lists.

## Fix
Add a structural cache key `MethodSpecSymbolKey` over `(MethodInfo, ImmutableArray<TypeSymbol>)` with reference equality on contained `TypeSymbol` entries (declared user types are interned per compilation) plus structural equality on the array. Add a parallel `methodSpecsWithSymbolArgs` dictionary for the user-type case.

Repeated calls to the same generic method with the same user-type generic args now share a single MethodSpec row; distinct user-type generic args still produce distinct rows.

## Tests
New `MethodSpecCacheUserTypeArgsEmitTests`:
- `RepeatedGenericCallWithSameUserTypeArg_EmitsSingleMethodSpecRow` — three `Array.Empty[Clock]()` calls produce exactly 1 `Empty` MethodSpec row.
- `DistinctUserTypeArgs_StillProduceDistinctMethodSpecRows` — `Array.Empty[ClockA]()` and `Array.Empty[ClockB]()` produce 2 distinct rows (no over-deduplication).

Full suite passes: Core 1682, Compiler 313, LanguageServer 212, Interpreter 54, Sdk 24.