### PR TITLE
Fix #420 (P3-3): assert slot dictionary uniqueness for node identity

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -6596,6 +6597,7 @@ internal sealed class ReflectionMetadataEmitter
 
             var slot = localTypes.Count;
             localTypes.Add(literal.StructType);
+            Debug.Assert(!structLiteralSlots.ContainsKey(literal), "Bound struct literal node aliased across emit positions; rekey structLiteralSlots by (node, parentContext) if lowering ever shares nodes.");
             structLiteralSlots[literal] = slot;
         }
 
@@ -6606,6 +6608,7 @@ internal sealed class ReflectionMetadataEmitter
         {
             var slot = localTypes.Count;
             localTypes.Add(idx.Type);
+            Debug.Assert(!mapIndexSlots.ContainsKey(idx), "Bound map index expression aliased across emit positions; rekey mapIndexSlots by (node, parentContext) if lowering ever shares nodes.");
             mapIndexSlots[idx] = slot;
         }
 
@@ -6626,6 +6629,7 @@ internal sealed class ReflectionMetadataEmitter
 
             var slot = localTypes.Count;
             localTypes.Add(def.Type);
+            Debug.Assert(!defaultExpressionSlots.ContainsKey(def), "Bound default expression aliased across emit positions; rekey defaultExpressionSlots by (node, parentContext) if lowering ever shares nodes.");
             defaultExpressionSlots[def] = slot;
         }
 

--- a/test/Core.Tests/CodeAnalysis/Emit/SlotDictionaryAliasingAssertionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/SlotDictionaryAliasingAssertionTests.cs
@@ -1,0 +1,155 @@
+// <copyright file="SlotDictionaryAliasingAssertionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #420 (P3-3): pre-allocated slot dictionaries
+/// (<c>structLiteralSlots</c>, <c>receiverSpillSlots</c>,
+/// <c>defaultExpressionSlots</c>, <c>mapIndexSlots</c>) in
+/// <c>ReflectionMetadataEmitter</c> are keyed by bound-node identity. If a
+/// future lowering pass started sharing the same bound-node instance across
+/// two emit positions, the slot dictionaries would silently alias.
+///
+/// These tests guard the defensive <c>Debug.Assert</c> calls that were
+/// added at the allocation sites, and verify that the normal (non-aliased)
+/// compile paths exercising every slot kind still emit and execute
+/// correctly.
+/// </summary>
+public class SlotDictionaryAliasingAssertionTests
+{
+    [Fact]
+    public void StructLiteral_DefaultExpression_And_MapIndex_AllExercised_DoesNotTripAssertion()
+    {
+        // Combined program exercises:
+        //  * struct literal slots (Point{X:1, Y:2}),
+        //  * default-expression slots (default(Point)),
+        //  * map index read slots (m[k]).
+        // A successful compile + execute proves the Debug.Assert calls in
+        // CollectSlots do not fire on the normal binder/lowering path.
+        var source = @"
+package SlotComboTest
+import System
+
+type Point struct {
+    X int32
+    Y int32
+}
+
+func makePoint() Point {
+    return Point{X: 10, Y: 20}
+}
+
+var p = makePoint()
+var z Point
+var m = map[string]int32{}
+m[""hello""] = 7
+var v = m[""hello""]
+var miss = m[""nope""]
+Console.WriteLine(p.X + p.Y + z.X + z.Y + v + miss)
+";
+        var output = CompileLoadInvokeCaptureStdout(
+            source,
+            nameof(StructLiteral_DefaultExpression_And_MapIndex_AllExercised_DoesNotTripAssertion));
+        Assert.Contains("37", output);
+    }
+
+    [Fact]
+    public void EmitterSource_ContainsAliasingAssertions_ForAllFourSlotDictionaries()
+    {
+        // Documentation test: scan the emitter source for the four
+        // assertion sites added for issue #420 (P3-3). If a future refactor
+        // removes one, this test fails loudly so the defensive guarantee
+        // cannot be silently dropped.
+        var emitterSourcePath = LocateEmitterSource();
+        var text = File.ReadAllText(emitterSourcePath);
+
+        Assert.Contains("!structLiteralSlots.ContainsKey(literal)", text);
+        Assert.Contains("!mapIndexSlots.ContainsKey(idx)", text);
+        Assert.Contains("!defaultExpressionSlots.ContainsKey(def)", text);
+
+        // receiverSpillSlots intentionally deduplicates via a `ContainsKey`
+        // guard at the allocation site — aliased receivers across spill
+        // positions share a slot by design. Make sure that explicit guard
+        // is still present so that aliasing remains safe.
+        Assert.Contains("if (receiverSpillSlots.ContainsKey(receiver))", text);
+        Assert.Contains("if (receiverSpillSlots.ContainsKey(assn))", text);
+    }
+
+    private static string LocateEmitterSource()
+    {
+        // Tests run with CWD = <bin>/<tfm>/. Walk up to repo root and
+        // resolve the well-known path.
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 10 && dir is not null; i++)
+        {
+            var candidate = Path.Combine(dir, "src", "Core", "CodeAnalysis", "Emit", "ReflectionMetadataEmitter.cs");
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new FileNotFoundException("Could not locate ReflectionMetadataEmitter.cs by walking up from " + AppContext.BaseDirectory);
+    }
+
+    private static EmitResult Compile(string source, Stream peStream)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Emit(peStream);
+    }
+
+    private static string CompileLoadInvokeCaptureStdout(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var result = Compile(source, peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, parameters: null);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Issue #420 (P3-3) flagged that four pre-allocated slot dictionaries in `ReflectionMetadataEmitter` — `structLiteralSlots`, `receiverSpillSlots`, `defaultExpressionSlots`, and `mapIndexSlots` — are one-shot and keyed by bound-node identity. If a future binder/lowering pass ever started sharing the same bound-node instance across two emit positions, the dictionaries would silently alias slots.

This PR adds defensive `Debug.Assert` calls at the allocation sites for the three dictionaries that are supposed to be strictly one-shot, so any such aliasing would trip loudly in Debug builds instead of producing subtly wrong IL.

## Changes

- `src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs`
  - Added `using System.Diagnostics;`
  - `CollectSlots`: added `Debug.Assert(!dict.ContainsKey(node), ...)` before the slot assignment for:
    - `structLiteralSlots[literal]`
    - `mapIndexSlots[idx]`
    - `defaultExpressionSlots[def]`
  - `receiverSpillSlots` already has an explicit `if (ContainsKey) continue;` guard at its allocation sites. That deduplication is intentional: aliased receivers across spill positions are supposed to share a slot. The existing guard is left in place (and exercised by the documentation test below) so no separate assertion is needed.

## Tests

New `test/Core.Tests/CodeAnalysis/Emit/SlotDictionaryAliasingAssertionTests.cs`:

1. `StructLiteral_DefaultExpression_And_MapIndex_AllExercised_DoesNotTripAssertion` — compiles and runs a single program that exercises all three slot kinds (struct literal, bare-`var` default value of a struct, map index read). A successful compile + execute proves the new assertions do not fire on the normal binder/lowering path.
2. `EmitterSource_ContainsAliasingAssertions_ForAllFourSlotDictionaries` — documentation test that scans the emitter source for the four guard expressions so that the defensive guarantee cannot be silently removed by a future refactor.

## Verification

- `dotnet build GSharp.sln -nologo -clp:NoSummary` → 0 errors, 0 warnings
- `dotnet test GSharp.sln --no-restore --nologo` → all 2285 tests pass

Closes #420 (P3-3 only).