### PR TITLE
Fix #420 (P3-8): use actual TypeDef handle for enum instead of speculative row count

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -3601,6 +3601,29 @@ internal sealed class ReflectionMetadataEmitter
     {
         var enumTypeRef = this.GetTypeReference(this.coreEnumType);
 
+        // P3-8 (#420): emit the TypeDef row *before* its FieldDef rows so the
+        // literal-field signatures can refer to the enum's actual TypeDef
+        // handle returned by AddTypeDefinition, rather than a speculative
+        // row-count+1 value that breaks silently if the emit order ever
+        // changes. The TypeDef's fieldList must still point at the first
+        // FieldDef row that will belong to this enum, which is the next row
+        // about to be added — we capture it via GetRowCount + 1 here and
+        // assert below that the first AddFieldDefinition call matches.
+        var firstFieldHandle = MetadataTokens.FieldDefinitionHandle(this.metadata.GetRowCount(TableIndex.Field) + 1);
+
+        var typeAttrs = TypeAttributes.Class | TypeAttributes.Sealed
+            | TypeAttributes.AnsiClass | TypeAttributes.AutoLayout
+            | MapTypeAccessibility(enumSym.Accessibility);
+
+        var enumTypeDef = this.metadata.AddTypeDefinition(
+            attributes: typeAttrs,
+            @namespace: this.metadata.GetOrAddString(enumSym.PackageName ?? string.Empty),
+            name: this.metadata.GetOrAddString(enumSym.Name),
+            baseType: enumTypeRef,
+            fieldList: firstFieldHandle,
+            methodList: MetadataTokens.MethodDefinitionHandle(methodListRow));
+        this.enumTypeDefs[enumSym] = enumTypeDef;
+
         // Field 1: instance int32 'value__' with SpecialName | RTSpecialName.
         var valueFieldSigBlob = new BlobBuilder();
         new BlobEncoder(valueFieldSigBlob).FieldSignature().Int32();
@@ -3608,24 +3631,21 @@ internal sealed class ReflectionMetadataEmitter
             attributes: FieldAttributes.Public | FieldAttributes.SpecialName | FieldAttributes.RTSpecialName,
             name: this.metadata.GetOrAddString("value__"),
             signature: this.metadata.GetOrAddBlob(valueFieldSigBlob));
+        if (valueFieldHandle != firstFieldHandle)
+        {
+            throw new InvalidOperationException(
+                $"Enum '{enumSym.Name}' value__ FieldDef row {MetadataTokens.GetRowNumber(valueFieldHandle)} did not match the fieldList row {MetadataTokens.GetRowNumber(firstFieldHandle)} stamped on its TypeDef. This indicates another emitter inserted FieldDef rows between TypeDef creation and field emission.");
+        }
 
         // Fields 2..N: one public static literal field per member, signature
         // is the enum's own typedef (the standard CLR convention for enum
         // literals). The Constant row is added below after all field rows
         // have been emitted so they remain in increasing parent-token order.
         var memberFieldHandles = new List<FieldDefinitionHandle>(enumSym.Members.Length);
-        TypeDefinitionHandle enumTypeDef = default;
-
-        // The literal-field signature references the enum's own TypeDef; we
-        // need to reserve the TypeDef handle first so the FieldSig encoder
-        // can refer to it. AddTypeDefinition is monotone, so the next-row
-        // handle gives us the soon-to-be-emitted handle.
-        var pendingTypeDef = MetadataTokens.TypeDefinitionHandle(this.metadata.GetRowCount(TableIndex.TypeDef) + 1);
-
         foreach (var member in enumSym.Members)
         {
             var memberSigBlob = new BlobBuilder();
-            new BlobEncoder(memberSigBlob).FieldSignature().Type(pendingTypeDef, isValueType: true);
+            new BlobEncoder(memberSigBlob).FieldSignature().Type(enumTypeDef, isValueType: true);
             var memberFieldHandle = this.metadata.AddFieldDefinition(
                 attributes: FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.Literal | FieldAttributes.HasDefault,
                 name: this.metadata.GetOrAddString(member.Name),
@@ -3633,19 +3653,6 @@ internal sealed class ReflectionMetadataEmitter
             memberFieldHandles.Add(memberFieldHandle);
             this.enumMemberFieldDefs[member] = memberFieldHandle;
         }
-
-        var typeAttrs = TypeAttributes.Class | TypeAttributes.Sealed
-            | TypeAttributes.AnsiClass | TypeAttributes.AutoLayout
-            | MapTypeAccessibility(enumSym.Accessibility);
-
-        enumTypeDef = this.metadata.AddTypeDefinition(
-            attributes: typeAttrs,
-            @namespace: this.metadata.GetOrAddString(enumSym.PackageName ?? string.Empty),
-            name: this.metadata.GetOrAddString(enumSym.Name),
-            baseType: enumTypeRef,
-            fieldList: valueFieldHandle,
-            methodList: MetadataTokens.MethodDefinitionHandle(methodListRow));
-        this.enumTypeDefs[enumSym] = enumTypeDef;
 
         // Constant rows must be added in increasing parent FieldDefinition
         // order; iterating the literal fields in declaration order naturally

--- a/test/Compiler.Tests/Emit/EnumEmitTests.cs
+++ b/test/Compiler.Tests/Emit/EnumEmitTests.cs
@@ -153,6 +153,99 @@ public class EnumEmitTests
         Assert.Equal(color, pick.ReturnType);
     }
 
+    [Fact]
+    public void Enum_Literal_Field_Type_Is_Enum_TypeDef_With_Preceding_Structs()
+    {
+        // Issue #420 (P3-8): the literal field signatures must reference the
+        // enum's own TypeDef. Previously this handle was computed
+        // speculatively from GetRowCount(TypeDef)+1 before the row was
+        // added; this test exercises the case where multiple structs (with
+        // their own field rows) are emitted before the enum so a row-count
+        // off-by-one would surface as a wrong literal field type.
+        var source = """
+            package P
+            import System
+
+            type S1 data struct {
+                A int32
+                B int32
+            }
+            type S2 data struct {
+                X int32
+                Y int32
+                Z int32
+            }
+            type S3 data struct {
+                N int32
+            }
+
+            type Color enum { Red, Green, Blue }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var color = assembly.GetTypes().Single(t => t.Name == "Color");
+
+        // value__ is int32; literal members must be typed as Color itself.
+        var literalFields = color.GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(f => f.IsLiteral)
+            .ToArray();
+        Assert.Equal(3, literalFields.Length);
+        foreach (var lit in literalFields)
+        {
+            Assert.Equal(color, lit.FieldType);
+        }
+
+        // Reading the values via reflection must work (CLR validates the
+        // literal field signature points at the enum's actual TypeDef).
+        var red = Enum.Parse(color, "Red");
+        var green = Enum.Parse(color, "Green");
+        var blue = Enum.Parse(color, "Blue");
+        Assert.Equal(0, Convert.ToInt32(red));
+        Assert.Equal(1, Convert.ToInt32(green));
+        Assert.Equal(2, Convert.ToInt32(blue));
+    }
+
+    [Fact]
+    public void Multiple_Enums_Each_Use_Their_Own_TypeDef_For_Literals()
+    {
+        // If TypeDef handles were computed speculatively and the emit order
+        // changed, two adjacent enums could end up with their literal fields
+        // typed against the wrong sibling enum. Verify each enum's literals
+        // resolve to that enum's own TypeDef.
+        var source = """
+            package P
+            import System
+
+            type A enum { A0, A1 }
+            type B enum { B0, B1, B2 }
+            type C enum { C0 }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var a = assembly.GetTypes().Single(t => t.Name == "A");
+        var b = assembly.GetTypes().Single(t => t.Name == "B");
+        var c = assembly.GetTypes().Single(t => t.Name == "C");
+
+        foreach (var lit in a.GetFields(BindingFlags.Public | BindingFlags.Static).Where(f => f.IsLiteral))
+        {
+            Assert.Equal(a, lit.FieldType);
+        }
+
+        foreach (var lit in b.GetFields(BindingFlags.Public | BindingFlags.Static).Where(f => f.IsLiteral))
+        {
+            Assert.Equal(b, lit.FieldType);
+        }
+
+        foreach (var lit in c.GetFields(BindingFlags.Public | BindingFlags.Static).Where(f => f.IsLiteral))
+        {
+            Assert.Equal(c, lit.FieldType);
+        }
+
+        Assert.Equal(new[] { "A0", "A1" }, Enum.GetNames(a));
+        Assert.Equal(new[] { "B0", "B1", "B2" }, Enum.GetNames(b));
+        Assert.Equal(new[] { "C0" }, Enum.GetNames(c));
+    }
+
     private static Assembly CompileToAssembly(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_enum_emit_").FullName;


### PR DESCRIPTION
## Summary

Addresses P3-8 from #420.

The enum TypeDef handle was previously computed speculatively as `GetRowCount(TypeDef)+1` *before* the row was actually added. If anyone reordered the type-emit pass, the handle would silently become off-by-one with no compile-time error.

## Fix

Restructured `EmitEnumTypeDef` in `ReflectionMetadataEmitter.cs` to:

1. Add the enum's TypeDef row **first**, using `AddTypeDefinition` — `enumTypeDef` is now the actual handle returned by the metadata builder.
2. Compute the (still speculative) `firstFieldHandle` for the TypeDef's `fieldList` immediately before adding the TypeDef, and **verify** at runtime that the next `AddFieldDefinition` for `value__` returns exactly that handle — if anything inserts FieldDef rows in between, we throw `InvalidOperationException` with a precise message instead of silently producing a malformed PE.
3. Use `enumTypeDef` (the real handle) for the literal-member field signatures — no more speculative TypeDef row math.

## Tests

Added two new tests in `EnumEmitTests.cs`:

- `Enum_Literal_Field_Type_Is_Enum_TypeDef_With_Preceding_Structs` — emits multiple structs (with their own field rows) before the enum so a row-count off-by-one would surface as a wrong literal field type.
- `Multiple_Enums_Each_Use_Their_Own_TypeDef_For_Literals` — verifies each of three adjacent enums has its literal fields typed against itself, not a sibling enum.

All 2261 tests pass.