### PR TITLE
Fix #455: assert emit preconditions for currently-unreachable feature paths (P3 cluster #1)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -5617,6 +5617,18 @@ internal sealed class ReflectionMetadataEmitter
 
     private void EmitInlineEqualsTyped(StructSymbol structSym, FieldSymbol field, FieldDefinitionHandle fieldHandle)
     {
+        // Issue #420 / #455 (P3-10): the emitted IL takes the receiver and the
+        // typed argument by address (`ldarga`) and reads the field directly.
+        // The signature encoded below also passes the typed argument by value
+        // through EncodeTypeSymbol, which assumes a value-type StructSymbol.
+        // If reference-type structs/records are ever introduced the IL and the
+        // signature both need to switch (load by reference, no `ldarga`); make
+        // the value-type precondition explicit so a future change trips loudly
+        // in Debug instead of producing invalid IL.
+        Debug.Assert(
+            !structSym.IsClass,
+            "EmitInlineEqualsTyped precondition violated: StructSymbol must be a value-type struct — see issue #420 / P3-10.");
+
         var il = new InstructionEncoder(new BlobBuilder());
         if (!this.metadataOnly)
         {
@@ -5681,6 +5693,16 @@ internal sealed class ReflectionMetadataEmitter
 
     private void EmitInlineEqualityOperator(StructSymbol structSym, FieldSymbol field, FieldDefinitionHandle fieldHandle, bool isInequality)
     {
+        // Issue #420 / #455 (P3-10): the emitted IL uses `ldarga` on both
+        // operands to read fields directly, which requires the operands to be
+        // value-type structs. If reference-type structs/records are ever
+        // introduced this helper must switch to `ldarg` / `ldfld` chains and
+        // re-encode the parameter signature; assert the value-type precondition
+        // explicitly so any future change trips loudly in Debug.
+        Debug.Assert(
+            !structSym.IsClass,
+            "EmitInlineEqualityOperator precondition violated: StructSymbol must be a value-type struct — see issue #420 / P3-10.");
+
         var il = new InstructionEncoder(new BlobBuilder());
         if (!this.metadataOnly)
         {
@@ -13376,6 +13398,19 @@ internal sealed class ReflectionMetadataEmitter
 
         private void EmitFieldAssignment(BoundFieldAssignmentExpression fas)
         {
+            // Issue #420 / #455 (P3-4): top-of-method precondition. The
+            // non-static paths below evaluate `fas.Value` between two reads of
+            // `fas.Receiver`. That is only safe when the value expression does
+            // not reassign the receiver variable. The binder does not produce
+            // such shapes today (see ValueExpressionMutatesReceiver helper).
+            // Repeat the check at the top of the method so the invariant is
+            // visible without scrolling past the static-field fast path; the
+            // per-receiver assertion further down remains for the targeted
+            // diagnostic message.
+            Debug.Assert(
+                fas.Receiver == null || !ValueExpressionMutatesReceiver(fas.Value, fas.Receiver),
+                $"EmitFieldAssignment precondition violated: BoundFieldAssignmentExpression value must not reassign the receiver variable for field '{fas.Field.Name}' — see issue #420 / P3-4.");
+
             if (!this.outer.structFieldDefs.TryGetValue(fas.Field, out var fieldHandle))
             {
                 throw new InvalidOperationException(


### PR DESCRIPTION
## Summary

Fixes #455 — the cross-cutting cluster #1 ("Future-feature fragility") from the P3 review (#420).

Issue #455 tracks **P3-1, P3-2, P3-4, P3-5, P3-6, P3-10** as a group. Each sub-issue was individually resolved in its own PR (#468, #467, #462, #466, #464, #470) with the chosen mitigation — either a `Debug.Assert`, a thrown `InvalidOperationException` for release builds where the alternative would be invalid IL, or a defensive safe-IL fallback (box-before-`ldvirtftn` for P3-1, defensive `pop` for P3-6).

This PR finishes the work asked for in #455 ("add a `Debug.Assert` at the top of the emit method that states the precondition explicitly") for the three spots where the in-body guard was previously the only marker.

## Changes

| Sub-issue | Method | Change |
|---|---|---|
| P3-4 | `EmitFieldAssignment` | New top-of-method `Debug.Assert` over `ValueExpressionMutatesReceiver` so the invariant is visible immediately, not after the static-field fast path. The per-receiver assertion further down stays for its targeted diagnostic message. |
| P3-10 | `EmitInlineEqualsTyped` | New top-of-method `Debug.Assert(!structSym.IsClass, …)` mirroring the existing one on `EmitInlineEqualsObject`. The IL uses `ldarga` + `ldfld` and the encoded parameter signature passes the typed argument by value, both of which assume a value-type `StructSymbol`. |
| P3-10 | `EmitInlineEqualityOperator` | Same treatment as above: `ldarga` on both operands requires value-type structs. |

## What was *not* changed and why

- **P3-1** (`EmitClrMethodGroup`) — already defensively boxes value-type receivers so the emitted sequence stays verifiable. Adding a `Debug.Assert` here would contradict the chosen safe-IL strategy. Existing comment cites P3-1.
- **P3-2** (`EmitTypePattern`) — already throws `InvalidOperationException` mid-method for the Nullable<value-type> shape; the existing regression test `NullableTypePatternEmitTests` exercises this path and would conflict with a top-of-method `Debug.Assert` (it would fire `DebugAssertException` instead of the expected throw).
- **P3-5** (null-coalesce in `EmitBinary`) — `Debug.Assert(false, …)` + `throw NotSupportedException` are already at the start of the null-coalesce switch arm, which is the equivalent of "top-of-method" for an inline branch.
- **P3-6** (`EmitCatchClauses`) — emits a defensive `pop` for elided catch variables so the handler stays stack-balanced. The existing regression test `CatchElidedVariableEmitTests.Catch_With_Elided_Variable_Emits_Pop_And_Runs` deliberately mutates the bound tree to simulate the future binder change and verifies the defensive `pop` works; a top-of-method `Debug.Assert` would contradict that test contract.

In every case the existing in-body guard already satisfies #455's intent ("loud rather than silently invalid IL").

## Validation

```
dotnet build GSharp.sln -nologo -clp:NoSummary
  Build succeeded.
      0 Warning(s)
      0 Error(s)

dotnet test GSharp.sln --no-restore --nologo
  Passed!  - Failed: 0, Passed: 1702 — GSharp.Core.Tests
  Passed!  - Failed: 0, Passed:  338 — GSharp.Compiler.Tests
  Passed!  - Failed: 0, Passed:   64 — GSharp.Interpreter.Tests
  Passed!  - Failed: 0, Passed:  212 — GSharp.LanguageServer.Tests
```

All 2,316 tests pass.