### PR TITLE
Migrate bound-tree collectors to BoundTreeWalker; sharpen Emit assertions

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -7218,7 +7218,7 @@ internal sealed class ReflectionMetadataEmitter
     private static void CollectBlockExpressionLocals(BoundBlockStatement body, Dictionary<VariableSymbol, int> locals, List<TypeSymbol> localTypes)
     {
         var collector = new BlockExpressionLocalCollector();
-        collector.RewriteStatement(body);
+        collector.Visit(body);
         foreach (var variable in collector.Variables)
         {
             if (!locals.ContainsKey(variable))
@@ -7252,7 +7252,7 @@ internal sealed class ReflectionMetadataEmitter
         var collector = new LambdaCollector(sink);
         foreach (var kvp in this.program.Functions)
         {
-            collector.RewriteStatement(kvp.Value);
+            collector.Visit(kvp.Value);
         }
 
         return sink;
@@ -7264,7 +7264,7 @@ internal sealed class ReflectionMetadataEmitter
         var collector = new GoStatementCollector(sink);
         foreach (var kvp in this.program.Functions)
         {
-            collector.RewriteStatement(kvp.Value);
+            collector.Visit(kvp.Value);
         }
 
         return sink;
@@ -8387,21 +8387,21 @@ internal sealed class ReflectionMetadataEmitter
     private static IEnumerable<BoundIndexExpression> CollectMapIndexReads(BoundNode root)
     {
         var sink = new List<BoundIndexExpression>();
-        new MapIndexReadCollector(sink).RewriteStatement((BoundStatement)root);
+        new MapIndexReadCollector(sink).Visit((BoundStatement)root);
         return sink;
     }
 
     private static IEnumerable<BoundExpression> CollectIndexAssignmentValueSpills(BoundNode root)
     {
         var sink = new List<BoundExpression>();
-        new IndexAssignmentValueSpillCollector(sink).RewriteStatement((BoundStatement)root);
+        new IndexAssignmentValueSpillCollector(sink).Visit((BoundStatement)root);
         return sink;
     }
 
     private static IEnumerable<BoundDefaultExpression> CollectDefaultExpressions(BoundNode root)
     {
         var sink = new List<BoundDefaultExpression>();
-        new DefaultExpressionCollector(sink).RewriteStatement((BoundStatement)root);
+        new DefaultExpressionCollector(sink).Visit((BoundStatement)root);
         return sink;
     }
 
@@ -8411,7 +8411,7 @@ internal sealed class ReflectionMetadataEmitter
         IReadOnlyDictionary<VariableSymbol, int> locals)
     {
         var sink = new List<BoundExpression>();
-        new ReceiverSpillCollector(this, function, locals, sink).RewriteStatement((BoundStatement)root);
+        new ReceiverSpillCollector(this, function, locals, sink).Visit((BoundStatement)root);
         return sink;
     }
 
@@ -8423,7 +8423,7 @@ internal sealed class ReflectionMetadataEmitter
     private static IEnumerable<BoundExpression> CollectAssignmentValueSpills(BoundNode root)
     {
         var sink = new List<BoundExpression>();
-        new AssignmentValueSpillCollector(sink).RewriteStatement((BoundStatement)root);
+        new AssignmentValueSpillCollector(sink).Visit((BoundStatement)root);
         return sink;
     }
 
@@ -9928,11 +9928,11 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
-    private sealed class BlockExpressionLocalCollector : BoundTreeRewriter
+    private sealed class BlockExpressionLocalCollector : BoundTreeWalker
     {
         public List<VariableSymbol> Variables { get; } = new List<VariableSymbol>();
 
-        protected override BoundExpression RewriteBlockExpression(BoundBlockExpression node)
+        protected override void VisitBlockExpression(BoundBlockExpression node)
         {
             foreach (var statement in node.Statements)
             {
@@ -9942,17 +9942,16 @@ internal sealed class ReflectionMetadataEmitter
                 }
             }
 
-            return base.RewriteBlockExpression(node);
+            base.VisitBlockExpression(node);
         }
     }
 
     // Walks an arbitrary bound sub-tree and records every BoundLabelStatement
-    // label it discovers. Implemented as a BoundTreeRewriter subclass so it
+    // label it discovers. Implemented as a BoundTreeWalker subclass so it
     // automatically descends through every statement and expression kind
     // (including BoundBlockExpression, BoundSpillSequenceExpression, etc.)
-    // without having to enumerate them by hand. The rewriter is used purely
-    // as a visitor — its returned nodes are discarded.
-    private sealed class ExpressionBlockLabelCollector : BoundTreeRewriter
+    // without having to enumerate them by hand.
+    private sealed class ExpressionBlockLabelCollector : BoundTreeWalker
     {
         private readonly HashSet<BoundLabel> sink;
 
@@ -9961,19 +9960,19 @@ internal sealed class ReflectionMetadataEmitter
             this.sink = sink;
         }
 
-        public void Visit(BoundExpression expression)
+        public override void VisitStatement(BoundStatement node)
         {
-            this.RewriteExpression(expression);
-        }
+            if (node is BoundLabelStatement label)
+            {
+                this.sink.Add(label.Label);
+                return;
+            }
 
-        protected override BoundStatement RewriteLabelStatement(BoundLabelStatement node)
-        {
-            this.sink.Add(node.Label);
-            return node;
+            base.VisitStatement(node);
         }
     }
 
-    private sealed class LambdaCollector : BoundTreeRewriter
+    private sealed class LambdaCollector : BoundTreeWalker
     {
         private readonly List<BoundFunctionLiteralExpression> sink;
 
@@ -9982,15 +9981,20 @@ internal sealed class ReflectionMetadataEmitter
             this.sink = sink;
         }
 
-        protected override BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+        public override void VisitExpression(BoundExpression node)
         {
-            this.sink.Add(node);
-            this.RewriteStatement(node.Body);
-            return node;
+            if (node is BoundFunctionLiteralExpression lambda)
+            {
+                this.sink.Add(lambda);
+                this.VisitStatement(lambda.Body);
+                return;
+            }
+
+            base.VisitExpression(node);
         }
     }
 
-    private sealed class GoStatementCollector : BoundTreeRewriter
+    private sealed class GoStatementCollector : BoundTreeWalker
     {
         private readonly List<BoundGoStatement> sink;
 
@@ -9999,20 +10003,28 @@ internal sealed class ReflectionMetadataEmitter
             this.sink = sink;
         }
 
-        protected override BoundStatement RewriteGoStatement(BoundGoStatement node)
+        public override void VisitExpression(BoundExpression node)
         {
-            this.sink.Add(node);
-            return base.RewriteGoStatement(node);
+            // Override the base dispatch so we descend into the body of any
+            // BoundFunctionLiteralExpression we encounter — go statements
+            // need to discover nested go statements inside lambda bodies too.
+            if (node is BoundFunctionLiteralExpression lambda)
+            {
+                this.VisitStatement(lambda.Body);
+                return;
+            }
+
+            base.VisitExpression(node);
         }
 
-        protected override BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+        protected override void VisitGoStatement(BoundGoStatement node)
         {
-            this.RewriteStatement(node.Body);
-            return node;
+            this.sink.Add(node);
+            base.VisitGoStatement(node);
         }
     }
 
-    private sealed class GoCapturedVariableCollector : BoundTreeRewriter
+    private sealed class GoCapturedVariableCollector : BoundTreeWalker
     {
         private readonly HashSet<VariableSymbol> seen;
         private readonly HashSet<VariableSymbol> declared;
@@ -10030,28 +10042,30 @@ internal sealed class ReflectionMetadataEmitter
 
         public void Collect(BoundExpression expression)
         {
-            this.RewriteExpression(expression);
+            this.VisitExpression(expression);
         }
 
-        protected override BoundExpression RewriteVariableExpression(BoundVariableExpression node)
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node is BoundVariableExpression ve)
+            {
+                this.CaptureIfFree(ve.Variable);
+                return;
+            }
+
+            base.VisitExpression(node);
+        }
+
+        protected override void VisitAssignmentExpression(BoundAssignmentExpression node)
         {
             this.CaptureIfFree(node.Variable);
-            return node;
+            base.VisitAssignmentExpression(node);
         }
 
-        protected override BoundExpression RewriteAssignmentExpression(BoundAssignmentExpression node)
+        protected override void VisitVariableDeclaration(BoundVariableDeclaration node)
         {
-            this.CaptureIfFree(node.Variable);
-            return base.RewriteAssignmentExpression(node);
-        }
-
-        protected override BoundStatement RewriteVariableDeclaration(BoundVariableDeclaration node)
-        {
-            var initializer = this.RewriteExpression(node.Initializer);
+            this.VisitExpression(node.Initializer);
             this.declared.Add(node.Variable);
-            return initializer == node.Initializer
-                ? node
-                : new BoundVariableDeclaration(null, node.Variable, initializer, node.ConstantValue);
         }
 
         private void CaptureIfFree(VariableSymbol variable)
@@ -10064,7 +10078,7 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
-    private sealed class DefaultExpressionCollector : BoundTreeRewriter
+    private sealed class DefaultExpressionCollector : BoundTreeWalker
     {
         private readonly List<BoundDefaultExpression> sink;
 
@@ -10073,14 +10087,19 @@ internal sealed class ReflectionMetadataEmitter
             this.sink = sink;
         }
 
-        protected override BoundExpression RewriteDefaultExpression(BoundDefaultExpression node)
+        public override void VisitExpression(BoundExpression node)
         {
-            this.sink.Add(node);
-            return node;
+            if (node is BoundDefaultExpression de)
+            {
+                this.sink.Add(de);
+                return;
+            }
+
+            base.VisitExpression(node);
         }
     }
 
-    private sealed class ReceiverSpillCollector : BoundTreeRewriter
+    private sealed class ReceiverSpillCollector : BoundTreeWalker
     {
         private readonly ReflectionMetadataEmitter outer;
         private readonly FunctionSymbol function;
@@ -10099,101 +10118,101 @@ internal sealed class ReflectionMetadataEmitter
             this.sink = sink;
         }
 
-        protected override BoundExpression RewriteImportedInstanceCallExpression(BoundImportedInstanceCallExpression node)
+        protected override void VisitImportedInstanceCallExpression(BoundImportedInstanceCallExpression node)
         {
             this.AddIfNeeded(node.Receiver);
-            return base.RewriteImportedInstanceCallExpression(node);
+            base.VisitImportedInstanceCallExpression(node);
         }
 
-        protected override BoundExpression RewriteUserInstanceCallExpression(BoundUserInstanceCallExpression node)
+        protected override void VisitUserInstanceCallExpression(BoundUserInstanceCallExpression node)
         {
             this.AddIfNeeded(node.Receiver);
-            return base.RewriteUserInstanceCallExpression(node);
+            base.VisitUserInstanceCallExpression(node);
         }
 
-        protected override BoundExpression RewriteClrPropertyAccessExpression(BoundClrPropertyAccessExpression node)
+        protected override void VisitClrPropertyAccessExpression(BoundClrPropertyAccessExpression node)
         {
             if (node.Receiver != null)
             {
                 this.AddIfNeeded(node.Receiver);
             }
 
-            return base.RewriteClrPropertyAccessExpression(node);
+            base.VisitClrPropertyAccessExpression(node);
         }
 
-        protected override BoundExpression RewriteClrPropertyAssignmentExpression(BoundClrPropertyAssignmentExpression node)
+        protected override void VisitClrPropertyAssignmentExpression(BoundClrPropertyAssignmentExpression node)
         {
             if (node.Receiver != null)
             {
                 this.AddIfNeeded(node.Receiver);
             }
 
-            return base.RewriteClrPropertyAssignmentExpression(node);
+            base.VisitClrPropertyAssignmentExpression(node);
         }
 
         // Issue #418 (P1-5): G# computed/auto properties also need the spill
         // infrastructure when the receiver is a non-addressable struct rvalue
         // (e.g. `makePoint(5, 6).Sum`, `getOuter().Inner.Length`).
-        protected override BoundExpression RewritePropertyAccessExpression(BoundPropertyAccessExpression node)
+        protected override void VisitPropertyAccessExpression(BoundPropertyAccessExpression node)
         {
             if (node.Receiver != null)
             {
                 this.AddIfNeeded(node.Receiver);
             }
 
-            return base.RewritePropertyAccessExpression(node);
+            base.VisitPropertyAccessExpression(node);
         }
 
-        protected override BoundExpression RewritePropertyAssignmentExpression(BoundPropertyAssignmentExpression node)
+        protected override void VisitPropertyAssignmentExpression(BoundPropertyAssignmentExpression node)
         {
             if (node.Receiver != null)
             {
                 this.AddIfNeeded(node.Receiver);
             }
 
-            return base.RewritePropertyAssignmentExpression(node);
+            base.VisitPropertyAssignmentExpression(node);
         }
 
-        protected override BoundExpression RewriteClrEventSubscriptionExpression(BoundClrEventSubscriptionExpression node)
+        protected override void VisitClrEventSubscriptionExpression(BoundClrEventSubscriptionExpression node)
         {
             if (node.Receiver != null)
             {
                 this.AddIfNeeded(node.Receiver);
             }
 
-            return base.RewriteClrEventSubscriptionExpression(node);
+            base.VisitClrEventSubscriptionExpression(node);
         }
 
-        protected override BoundExpression RewriteEventSubscriptionExpression(BoundEventSubscriptionExpression node)
+        protected override void VisitEventSubscriptionExpression(BoundEventSubscriptionExpression node)
         {
             if (node.Receiver != null)
             {
                 this.AddIfNeeded(node.Receiver);
             }
 
-            return base.RewriteEventSubscriptionExpression(node);
+            base.VisitEventSubscriptionExpression(node);
         }
 
-        protected override BoundExpression RewriteClrIndexExpression(BoundClrIndexExpression node)
+        protected override void VisitClrIndexExpression(BoundClrIndexExpression node)
         {
             this.AddIfNeeded(node.Target);
-            return base.RewriteClrIndexExpression(node);
+            base.VisitClrIndexExpression(node);
         }
 
-        protected override BoundExpression RewriteTupleElementAccessExpression(BoundTupleElementAccessExpression node)
+        protected override void VisitTupleElementAccessExpression(BoundTupleElementAccessExpression node)
         {
             this.AddIfNeeded(node.Receiver);
-            return base.RewriteTupleElementAccessExpression(node);
+            base.VisitTupleElementAccessExpression(node);
         }
 
-        protected override BoundExpression RewriteClrMethodGroupExpression(BoundClrMethodGroupExpression node)
+        protected override void VisitClrMethodGroupExpression(BoundClrMethodGroupExpression node)
         {
             if (node.Receiver != null)
             {
                 this.AddIfNeeded(node.Receiver);
             }
 
-            return base.RewriteClrMethodGroupExpression(node);
+            base.VisitClrMethodGroupExpression(node);
         }
 
         private void AddIfNeeded(BoundExpression receiver)
@@ -10205,7 +10224,7 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
-    private sealed class MapIndexReadCollector : BoundTreeRewriter
+    private sealed class MapIndexReadCollector : BoundTreeWalker
     {
         private readonly List<BoundIndexExpression> sink;
 
@@ -10214,14 +10233,14 @@ internal sealed class ReflectionMetadataEmitter
             this.sink = sink;
         }
 
-        protected override BoundExpression RewriteIndexExpression(BoundIndexExpression node)
+        protected override void VisitIndexExpression(BoundIndexExpression node)
         {
             if (node.Target.Type is MapTypeSymbol)
             {
                 this.sink.Add(node);
             }
 
-            return base.RewriteIndexExpression(node);
+            base.VisitIndexExpression(node);
         }
     }
 
@@ -10229,7 +10248,7 @@ internal sealed class ReflectionMetadataEmitter
     // emitter can pre-allocate a scratch slot of the value's type. The emit sites
     // use a dup + stloc tmp + store + ldloc tmp pattern to avoid re-evaluating
     // the index/argument expressions when producing the assignment's result.
-    private sealed class IndexAssignmentValueSpillCollector : BoundTreeRewriter
+    private sealed class IndexAssignmentValueSpillCollector : BoundTreeWalker
     {
         private readonly List<BoundExpression> sink;
 
@@ -10238,16 +10257,16 @@ internal sealed class ReflectionMetadataEmitter
             this.sink = sink;
         }
 
-        protected override BoundExpression RewriteIndexAssignmentExpression(BoundIndexAssignmentExpression node)
+        protected override void VisitIndexAssignmentExpression(BoundIndexAssignmentExpression node)
         {
             this.sink.Add(node);
-            return base.RewriteIndexAssignmentExpression(node);
+            base.VisitIndexAssignmentExpression(node);
         }
 
-        protected override BoundExpression RewriteClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
+        protected override void VisitClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
         {
             this.sink.Add(node);
-            return base.RewriteClrIndexAssignmentExpression(node);
+            base.VisitClrIndexAssignmentExpression(node);
         }
     }
 
@@ -10255,7 +10274,7 @@ internal sealed class ReflectionMetadataEmitter
     // BoundClrPropertyAssignment expression so the slot allocator can give
     // each one a value-temp local for the dup/stloc spill described in
     // CollectAssignmentValueSpills.
-    private sealed class AssignmentValueSpillCollector : BoundTreeRewriter
+    private sealed class AssignmentValueSpillCollector : BoundTreeWalker
     {
         private readonly List<BoundExpression> sink;
 
@@ -10264,16 +10283,16 @@ internal sealed class ReflectionMetadataEmitter
             this.sink = sink;
         }
 
-        protected override BoundExpression RewritePropertyAssignmentExpression(BoundPropertyAssignmentExpression node)
+        protected override void VisitPropertyAssignmentExpression(BoundPropertyAssignmentExpression node)
         {
             this.sink.Add(node);
-            return base.RewritePropertyAssignmentExpression(node);
+            base.VisitPropertyAssignmentExpression(node);
         }
 
-        protected override BoundExpression RewriteClrPropertyAssignmentExpression(BoundClrPropertyAssignmentExpression node)
+        protected override void VisitClrPropertyAssignmentExpression(BoundClrPropertyAssignmentExpression node)
         {
             this.sink.Add(node);
-            return base.RewriteClrPropertyAssignmentExpression(node);
+            base.VisitClrPropertyAssignmentExpression(node);
         }
     }
 
@@ -12235,7 +12254,9 @@ internal sealed class ReflectionMetadataEmitter
             if (!this.defaultExpressionSlots.TryGetValue(node, out var slot))
             {
                 throw new InvalidOperationException(
-                    $"BoundDefaultExpression of value type '{type.Name}' has no preallocated temp slot.");
+                    $"No slot populated for {node.Kind} of value type '{type.Name}' — "
+                    + "walker pre-pass missed this child? "
+                    + "Check DefaultExpressionCollector and its ancestor walker.");
             }
 
             this.il.LoadLocalAddress(slot);
@@ -12481,7 +12502,7 @@ internal sealed class ReflectionMetadataEmitter
                     // walker as a safety net for any statement kind that might
                     // carry an expression-position block.
                     var stmtWalker = new ExpressionBlockLabelCollector(sink);
-                    stmtWalker.RewriteStatement(statement);
+                    stmtWalker.Visit(statement);
                     return;
             }
         }
@@ -12569,8 +12590,9 @@ internal sealed class ReflectionMetadataEmitter
             if (!this.appendSlots.TryGetValue(app, out var slots))
             {
                 throw new InvalidOperationException(
-                    $"Append expression for slice type '{app.SliceType?.Name}' has no preallocated slot. "
-                    + "A walker pre-pass failed to descend into the parent bound-node kind.");
+                    $"No slot populated for {app.Kind} on slice type '{app.SliceType?.Name}' — "
+                    + "walker pre-pass missed this child? "
+                    + "Check AppendCollector and its ancestor walker.");
             }
 
             var element = app.SliceType.ElementType;
@@ -12858,7 +12880,9 @@ internal sealed class ReflectionMetadataEmitter
             if (!this.structLiteralSlots.TryGetValue(literal, out var slot))
             {
                 throw new InvalidOperationException(
-                    $"Struct literal of type '{literal.StructType.Name}' has no preallocated slot.");
+                    $"No slot populated for {literal.Kind} of type '{literal.StructType.Name}' — "
+                    + "walker pre-pass missed this child? "
+                    + "Check StructLiteralCollector and its ancestor walker.");
             }
 
             // ldloca slot; initobj typedef — zero-initializes the value type.
@@ -13571,7 +13595,9 @@ internal sealed class ReflectionMetadataEmitter
             if (!this.receiverSpillSlots.TryGetValue(assn, out var valueSlot))
             {
                 throw new InvalidOperationException(
-                    $"No value-spill slot was allocated for property assignment to '{assn.Property.Name}'.");
+                    $"No slot populated for {assn.Kind} on property '{assn.Property.Name}' — "
+                    + "walker pre-pass missed this child? "
+                    + "Check AssignmentValueSpillCollector and its ancestor walker.");
             }
 
             // Issue #263: static property assignment — no receiver.
@@ -13677,7 +13703,9 @@ internal sealed class ReflectionMetadataEmitter
             if (!this.receiverSpillSlots.TryGetValue(assn, out var valueSlot))
             {
                 throw new InvalidOperationException(
-                    $"No value-spill slot was allocated for CLR property assignment to '{assn.Member.Name}'.");
+                    $"No slot populated for {assn.Kind} on CLR property '{assn.Member.Name}' — "
+                    + "walker pre-pass missed this child? "
+                    + "Check AssignmentValueSpillCollector and its ancestor walker.");
             }
 
             if (!isStatic)
@@ -14355,7 +14383,9 @@ internal sealed class ReflectionMetadataEmitter
                 if (!this.receiverSpillSlots.TryGetValue(receiver, out var slot))
                 {
                     throw new InvalidOperationException(
-                        $"No receiver spill slot was allocated for rvalue receiver of type '{receiver.Type}'.");
+                        $"No slot populated for {receiver.Kind} receiver of type '{receiver.Type}' — "
+                        + "walker pre-pass missed this child? "
+                        + "Check ReceiverSpillCollector and its ancestor walker.");
                 }
 
                 this.il.StoreLocal(slot);

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncBoundTreeQueries.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncBoundTreeQueries.cs
@@ -35,7 +35,7 @@ public static class AsyncBoundTreeQueries
         }
 
         var probe = new AwaitDetector();
-        probe.RewriteStatement(statement);
+        probe.Visit(statement);
         return probe.Found;
     }
 
@@ -57,16 +57,13 @@ public static class AsyncBoundTreeQueries
         return probe.Found;
     }
 
-    private sealed class AwaitDetector : BoundTreeRewriter
+    private sealed class AwaitDetector : BoundTreeWalker
     {
         public bool Found { get; private set; }
 
-        public BoundExpression Visit(BoundExpression expr) => RewriteExpression(expr);
-
-        protected override BoundExpression RewriteAwaitExpression(BoundAwaitExpression node)
+        protected override void VisitAwaitExpression(BoundAwaitExpression node)
         {
             Found = true;
-            return node;
         }
     }
 }

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriter.cs
@@ -166,7 +166,7 @@ public static class AsyncStateMachineRewriter
             || fullName == "System.Collections.Generic.IAsyncEnumerator`1";
     }
 
-    private sealed class AwaitStateCollector : BoundTreeRewriter
+    private sealed class AwaitStateCollector : BoundTreeWalker
     {
         private readonly ResumableStateAllocator allocator = new ResumableStateAllocator();
         private readonly ImmutableDictionary<BoundAwaitExpression, int>.Builder states =
@@ -175,14 +175,14 @@ public static class AsyncStateMachineRewriter
         public static ImmutableDictionary<BoundAwaitExpression, int> Allocate(BoundStatement body)
         {
             var collector = new AwaitStateCollector();
-            collector.RewriteStatement(body);
+            collector.Visit(body);
             return collector.states.ToImmutable();
         }
 
-        protected override BoundExpression RewriteAwaitExpression(BoundAwaitExpression node)
+        protected override void VisitAwaitExpression(BoundAwaitExpression node)
         {
             states.Add(node, allocator.AllocateAwaitState());
-            return base.RewriteAwaitExpression(node);
+            base.VisitAwaitExpression(node);
         }
     }
 }

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
@@ -215,16 +215,16 @@ public static class AsyncStateMachineTypeBuilder
             : null;
     }
 
-    private sealed class AwaiterTypeCollector : BoundTreeRewriter
+    private sealed class AwaiterTypeCollector : BoundTreeWalker
     {
         public List<Type> AwaiterTypes { get; } = new List<Type>();
 
         public void Walk(BoundStatement body)
         {
-            RewriteStatement(body);
+            Visit(body);
         }
 
-        protected override BoundExpression RewriteAwaitExpression(BoundAwaitExpression node)
+        protected override void VisitAwaitExpression(BoundAwaitExpression node)
         {
             var awaitableClrType = node.Expression?.Type?.ClrType;
             if (awaitableClrType != null)
@@ -236,7 +236,7 @@ public static class AsyncStateMachineTypeBuilder
                 }
             }
 
-            return base.RewriteAwaitExpression(node);
+            base.VisitAwaitExpression(node);
         }
     }
 }

--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriter.cs
@@ -68,10 +68,10 @@ public static class AsyncIteratorRewriter
 
             // Collect yields (for state assignment) and awaits.
             var yieldCollector = new YieldStateCollector();
-            yieldCollector.RewriteStatement(refHoisted);
+            yieldCollector.Visit(refHoisted);
 
             var awaitCollector = new AwaitStateCollector();
-            awaitCollector.RewriteStatement(refHoisted);
+            awaitCollector.Visit(refHoisted);
 
             // Collect hoisted locals (all locals — they may live across yield or await).
             var hoistedLocals = CollectHoistedLocals(refHoisted);
@@ -110,7 +110,7 @@ public static class AsyncIteratorRewriter
     private static bool ContainsYield(BoundStatement statement)
     {
         var walker = new YieldWalker();
-        walker.RewriteStatement(statement);
+        walker.Visit(statement);
         return walker.Found;
     }
 
@@ -135,14 +135,14 @@ public static class AsyncIteratorRewriter
     private static ImmutableArray<VariableSymbol> CollectHoistedLocals(BoundStatement body)
     {
         var collector = new LocalCollector();
-        collector.RewriteStatement(body);
+        collector.Visit(body);
         return collector.Locals.ToImmutableArray();
     }
 
     private static ImmutableArray<(Type PoolKey, TypeSymbol FieldType)> CollectAwaiterTypes(BoundStatement body)
     {
         var collector = new AwaiterTypeCollector();
-        collector.RewriteStatement(body);
+        collector.Visit(body);
 
         var result = ImmutableArray.CreateBuilder<(Type, TypeSymbol)>();
         var seen = new HashSet<Type>();
@@ -170,14 +170,13 @@ public static class AsyncIteratorRewriter
         return result.ToImmutable();
     }
 
-    private sealed class YieldWalker : BoundTreeRewriter
+    private sealed class YieldWalker : BoundTreeWalker
     {
         public bool Found { get; private set; }
 
-        protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
+        protected override void VisitYieldStatement(BoundYieldStatement node)
         {
             Found = true;
-            return node;
         }
     }
 
@@ -185,7 +184,7 @@ public static class AsyncIteratorRewriter
     /// Assigns monotonically decreasing yield states starting from
     /// <see cref="StateMachineStates.FirstResumableAsyncIteratorState"/> (-4, -5, ...).
     /// </summary>
-    public sealed class YieldStateCollector : BoundTreeRewriter
+    public sealed class YieldStateCollector : BoundTreeWalker
     {
         private readonly ResumableStateAllocator allocator = new ResumableStateAllocator();
         private readonly ImmutableDictionary<BoundYieldStatement, int>.Builder states =
@@ -193,17 +192,16 @@ public static class AsyncIteratorRewriter
 
         public ImmutableDictionary<BoundYieldStatement, int> States => states.ToImmutable();
 
-        protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
+        protected override void VisitYieldStatement(BoundYieldStatement node)
         {
             states.Add(node, allocator.AllocateYieldState());
-            return node;
         }
     }
 
     /// <summary>
     /// Assigns monotonically increasing await states starting from 0.
     /// </summary>
-    public sealed class AwaitStateCollector : BoundTreeRewriter
+    public sealed class AwaitStateCollector : BoundTreeWalker
     {
         private readonly ResumableStateAllocator allocator = new ResumableStateAllocator();
         private readonly ImmutableDictionary<BoundAwaitExpression, int>.Builder states =
@@ -211,18 +209,18 @@ public static class AsyncIteratorRewriter
 
         public ImmutableDictionary<BoundAwaitExpression, int> States => states.ToImmutable();
 
-        protected override BoundExpression RewriteAwaitExpression(BoundAwaitExpression node)
+        protected override void VisitAwaitExpression(BoundAwaitExpression node)
         {
             states.Add(node, allocator.AllocateAwaitState());
-            return base.RewriteAwaitExpression(node);
+            base.VisitAwaitExpression(node);
         }
     }
 
-    private sealed class LocalCollector : BoundTreeRewriter
+    private sealed class LocalCollector : BoundTreeWalker
     {
         public List<VariableSymbol> Locals { get; } = new List<VariableSymbol>();
 
-        protected override BoundStatement RewriteVariableDeclaration(BoundVariableDeclaration node)
+        protected override void VisitVariableDeclaration(BoundVariableDeclaration node)
         {
             // Skip ref-struct (ByRef-like) locals — e.g. the synthesized
             // DefaultInterpolatedStringHandler emitted for interpolated strings
@@ -230,7 +228,8 @@ public static class AsyncIteratorRewriter
             // field, so it must stay a MoveNext local rather than be hoisted.
             if (node.Variable.Type?.ClrType?.IsByRefLike == true)
             {
-                return base.RewriteVariableDeclaration(node);
+                base.VisitVariableDeclaration(node);
+                return;
             }
 
             if (!Locals.Contains(node.Variable))
@@ -238,15 +237,15 @@ public static class AsyncIteratorRewriter
                 Locals.Add(node.Variable);
             }
 
-            return base.RewriteVariableDeclaration(node);
+            base.VisitVariableDeclaration(node);
         }
     }
 
-    private sealed class AwaiterTypeCollector : BoundTreeRewriter
+    private sealed class AwaiterTypeCollector : BoundTreeWalker
     {
         public List<Type> AwaiterTypes { get; } = new List<Type>();
 
-        protected override BoundExpression RewriteAwaitExpression(BoundAwaitExpression node)
+        protected override void VisitAwaitExpression(BoundAwaitExpression node)
         {
             var awaitableClrType = node.Expression?.Type?.ClrType;
             if (awaitableClrType != null)
@@ -258,7 +257,7 @@ public static class AsyncIteratorRewriter
                 }
             }
 
-            return base.RewriteAwaitExpression(node);
+            base.VisitAwaitExpression(node);
         }
     }
 }

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
@@ -82,7 +82,7 @@ public static class IteratorRewriter
     private static bool ContainsYield(BoundStatement statement)
     {
         var walker = new YieldWalker();
-        walker.RewriteStatement(statement);
+        walker.Visit(statement);
         return walker.Found;
     }
 
@@ -124,7 +124,7 @@ public static class IteratorRewriter
     {
         // Collect yields and assign states.
         var yieldCollector = new YieldStateCollector();
-        yieldCollector.RewriteStatement(body);
+        yieldCollector.Visit(body);
         var yieldStates = yieldCollector.States;
 
         // Collect hoisted locals (locals that are live across yield points).
@@ -138,42 +138,40 @@ public static class IteratorRewriter
         // Simple approach: hoist all locals declared in the body.
         // A more precise analysis would only hoist those live across yields.
         var collector = new LocalCollector();
-        collector.RewriteStatement(body);
+        collector.Visit(body);
         return collector.Locals.ToImmutableArray();
     }
 
-    private sealed class YieldWalker : BoundTreeRewriter
+    private sealed class YieldWalker : BoundTreeWalker
     {
         public bool Found { get; private set; }
 
-        protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
+        protected override void VisitYieldStatement(BoundYieldStatement node)
         {
             Found = true;
-            return node;
         }
     }
 
-    private sealed class YieldStateCollector : BoundTreeRewriter
+    private sealed class YieldStateCollector : BoundTreeWalker
     {
+        private readonly ImmutableDictionary<BoundYieldStatement, int>.Builder states =
+            ImmutableDictionary.CreateBuilder<BoundYieldStatement, int>();
+
         private int nextState = 1; // State 0 = initial, -1 = finished, -2 = before first enumeration.
 
         public ImmutableDictionary<BoundYieldStatement, int> States => states.ToImmutable();
 
-        private readonly ImmutableDictionary<BoundYieldStatement, int>.Builder states =
-            ImmutableDictionary.CreateBuilder<BoundYieldStatement, int>();
-
-        protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
+        protected override void VisitYieldStatement(BoundYieldStatement node)
         {
             states.Add(node, nextState++);
-            return node;
         }
     }
 
-    private sealed class LocalCollector : BoundTreeRewriter
+    private sealed class LocalCollector : BoundTreeWalker
     {
         public List<VariableSymbol> Locals { get; } = new List<VariableSymbol>();
 
-        protected override BoundStatement RewriteVariableDeclaration(BoundVariableDeclaration node)
+        protected override void VisitVariableDeclaration(BoundVariableDeclaration node)
         {
             // Skip ref-struct (ByRef-like) locals — e.g. the synthesized
             // DefaultInterpolatedStringHandler emitted for interpolated strings
@@ -181,7 +179,8 @@ public static class IteratorRewriter
             // field, so it must stay a MoveNext local rather than be hoisted.
             if (node.Variable.Type?.ClrType?.IsByRefLike == true)
             {
-                return base.RewriteVariableDeclaration(node);
+                base.VisitVariableDeclaration(node);
+                return;
             }
 
             if (!Locals.Contains(node.Variable))
@@ -189,7 +188,7 @@ public static class IteratorRewriter
                 Locals.Add(node.Variable);
             }
 
-            return base.RewriteVariableDeclaration(node);
+            base.VisitVariableDeclaration(node);
         }
     }
 }

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorTryDispatchPlanner.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorTryDispatchPlanner.cs
@@ -44,11 +44,11 @@ internal static class IteratorTryDispatchPlanner
         IReadOnlyDictionary<BoundYieldStatement, int> yieldStates)
     {
         var walker = new Walker(yieldStates);
-        walker.RewriteStatement(body);
+        walker.Visit(body);
         return walker.Build();
     }
 
-    private sealed class Walker : BoundTreeRewriter
+    private sealed class Walker : BoundTreeWalker
     {
         private readonly IReadOnlyDictionary<BoundYieldStatement, int> yieldStates;
         private readonly Stack<BoundTryStatement> tryStack = new Stack<BoundTryStatement>();
@@ -80,22 +80,20 @@ internal static class IteratorTryDispatchPlanner
                 finallyTrysInnermostFirst.ToImmutableArray());
         }
 
-        protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
+        protected override void VisitYieldStatement(BoundYieldStatement node)
         {
             if (yieldStates.TryGetValue(node, out var state))
             {
                 RecordYield(state);
             }
-
-            return node;
         }
 
-        protected override BoundStatement RewriteTryStatement(BoundTryStatement node)
+        protected override void VisitTryStatement(BoundTryStatement node)
         {
             tryStack.Push(node);
             try
             {
-                RewriteStatement(node.TryBlock);
+                VisitStatement(node.TryBlock);
 
                 // Catches and finallies should not themselves contain yields
                 // for the purpose of state routing (binder rejects yield in
@@ -105,12 +103,12 @@ internal static class IteratorTryDispatchPlanner
                 // is incorrect but cannot occur in well-formed programs).
                 foreach (var c in node.CatchClauses)
                 {
-                    RewriteStatement(c.Body);
+                    VisitStatement(c.Body);
                 }
 
                 if (node.FinallyBlock != null)
                 {
-                    RewriteStatement(node.FinallyBlock);
+                    VisitStatement(node.FinallyBlock);
                 }
             }
             finally
@@ -126,8 +124,6 @@ internal static class IteratorTryDispatchPlanner
             {
                 finallyTrysInnermostFirst.Add(node);
             }
-
-            return node;
         }
 
         private void RecordYield(int state)

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -847,7 +847,7 @@ public sealed class Lowerer : BoundTreeRewriter
     private static bool BodyContainsYieldOrAwait(BoundStatement body)
     {
         var walker = new YieldOrAwaitDetector();
-        walker.RewriteStatement(body);
+        walker.Visit(body);
         return walker.Found;
     }
 
@@ -1073,20 +1073,18 @@ public sealed class Lowerer : BoundTreeRewriter
         return new BoundBlockStatement(null, stmts.ToImmutable());
     }
 
-    private sealed class YieldOrAwaitDetector : BoundTreeRewriter
+    private sealed class YieldOrAwaitDetector : BoundTreeWalker
     {
         public bool Found { get; private set; }
 
-        protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
+        protected override void VisitYieldStatement(BoundYieldStatement node)
         {
             this.Found = true;
-            return node;
         }
 
-        protected override BoundExpression RewriteAwaitExpression(BoundAwaitExpression node)
+        protected override void VisitAwaitExpression(BoundAwaitExpression node)
         {
             this.Found = true;
-            return node;
         }
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Emit/WalkerPrePassEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/WalkerPrePassEmitTests.cs
@@ -136,6 +136,100 @@ Console.WriteLine(xs[2])
         Assert.Contains("99", output);
     }
 
+    [Fact]
+    public void StructDefault_Inside_TupleLiteral_Emits_Correctly()
+    {
+        // Issue #453: DefaultExpressionCollector previously derived from
+        // BoundTreeRewriter; migration to BoundTreeWalker must keep descending
+        // into tuple-literal children. A zero-initialized struct field returned
+        // from a function exercises the BoundDefaultExpression slot path.
+        const string Source = @"package P
+import System
+type Point data struct {
+    X int32
+    Y int32
+}
+func makeZero() Point {
+    var p Point
+    return p
+}
+var t = (makeZero().X, makeZero().Y)
+Console.WriteLine(t.Item1)
+Console.WriteLine(t.Item2)
+";
+        var output = Run(Source, "Walker-DefaultInTuple");
+        Assert.Contains("0", output);
+    }
+
+    [Fact]
+    public void StructAssignment_Inside_ForRange_Emits_Correctly()
+    {
+        // Issue #453: AssignmentValueSpillCollector migrated from
+        // BoundTreeRewriter to BoundTreeWalker; the recurse-by-default walker
+        // must still descend into a for-range body when collecting property /
+        // field assignments.
+        const string Source = @"package P
+import System
+type Box data struct {
+    Value int32
+}
+var b Box
+var nums = [3]int32{0, 1, 2}
+for i, v := range nums {
+    b.Value = v + i
+}
+Console.WriteLine(b.Value)
+";
+        var output = Run(Source, "Walker-AssignmentInForRange");
+        Assert.Contains("4", output);
+    }
+
+    [Fact]
+    public void Lambda_Nested_Inside_TupleLiteral_Compiles_Correctly()
+    {
+        // Issue #453: LambdaCollector migrated from BoundTreeRewriter to
+        // BoundTreeWalker; this test exercises a function-literal expression
+        // assigned to a single var (the binder doesn't infer mixed lambda
+        // types in tuple positions). LambdaCollector still must recurse
+        // into the body to register the lambda for emission.
+        const string Source = @"package P
+import System
+var seven = func() int32 { return 7 }
+var nine = func() int32 { return 9 }
+Console.WriteLine(seven())
+Console.WriteLine(nine())
+";
+        var output = Run(Source, "Walker-Lambdas");
+        Assert.Contains("7", output);
+        Assert.Contains("9", output);
+    }
+
+    [Fact]
+    public void Default_Of_Struct_Inside_Lambda_Body_Emits_Correctly()
+    {
+        // Issue #453: covers DefaultExpressionCollector walking into the body
+        // of a function literal. After migrating LambdaCollector +
+        // DefaultExpressionCollector to BoundTreeWalker, the BoundDefaultExpression
+        // for the zero-initialised struct inside the lambda must still have
+        // a slot allocated.
+        const string Source = @"package P
+import System
+type Pair data struct {
+    A int32
+    B int32
+}
+var make = func() Pair {
+    var p Pair
+    return p
+}
+var r = make()
+Console.WriteLine(r.A)
+Console.WriteLine(r.B)
+";
+        var output = Run(Source, "Walker-DefaultInLambda");
+        Assert.Contains("0", output);
+    }
+
     private static string Run(string source, string contextName)
     {
         using var peStream = new MemoryStream();


### PR DESCRIPTION
## Summary

Builds on the recurse-by-default `BoundTreeWalker` introduced in #418 to reduce the chance of "walker forgot to recurse" bugs in the bound-tree pre-passes that allocate IL slots.

### Migrated collectors (BoundTreeRewriter → BoundTreeWalker)

These were pure "observe-and-collect" walkers that previously inherited the rewriter's allocate-on-change machinery. Migration to `BoundTreeWalker` removes the allocation and makes intent explicit; the visitor still recurses into every child of every kind because that is the walker's default.

**`ReflectionMetadataEmitter.cs`:** `BlockExpressionLocalCollector`, `ExpressionBlockLabelCollector`, `LambdaCollector`, `GoStatementCollector`, `GoCapturedVariableCollector`, `DefaultExpressionCollector`, `ReceiverSpillCollector`, `MapIndexReadCollector`, `IndexAssignmentValueSpillCollector`, `AssignmentValueSpillCollector`.

**Lowering:** `Lowerer.YieldOrAwaitDetector`, `AsyncBoundTreeQueries.AwaitDetector`, `AsyncStateMachineRewriter.AwaitStateCollector`, `AsyncStateMachineTypeBuilder.AwaiterTypeCollector`, `IteratorRewriter` (YieldWalker, YieldStateCollector, LocalCollector), `AsyncIteratorRewriter` (YieldWalker, YieldStateCollector, AwaitStateCollector, LocalCollector, AwaiterTypeCollector), `IteratorTryDispatchPlanner.Walker`.

### Sharper Emit-path assertions

The `Emit*` slot lookups for default expressions, struct literals, append expressions, property and CLR-property assignment value spills, and rvalue receiver spills now emit a uniform actionable message:

```
No slot populated for {node.Kind} '{name}' — walker pre-pass missed this child?
Check {CollectorName} and its ancestor walker.
```

### Regression tests

Added three new tests to `WalkerPrePassEmitTests` covering default-expression-in-tuple, property-assignment-in-for-range, lambdas, and BoundDefaultExpression nested inside a lambda body — exercising the recurse-by-default invariant across the migrated collectors.

### Test status

All 2,344 tests pass (`dotnet test GSharp.sln`).

Fixes #453