### PR TITLE
Add ilverify gate to Compiler.Tests

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ilverify": {
+      "version": "10.0.8",
+      "commands": [
+        "ilverify"
+      ],
+      "rollForward": true
+    }
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Restore
         run: dotnet restore GSharp.sln
 
+      - name: Restore .NET local tools
+        # Brings in `dotnet-ilverify`, which Compiler.Tests invokes via
+        # `IlVerifier.Verify` to mechanically validate every assembly emitted
+        # by gsc against ECMA-335. The manifest is at .config/dotnet-tools.json.
+        run: dotnet tool restore
+
       - name: Show Nerdbank.GitVersioning version
         # Surface the version nbgv will stamp on assemblies / NuGet packages so
         # that, when a build from `main` is green, the printed NuGetPackageVersion

--- a/docs/emit-pipeline.md
+++ b/docs/emit-pipeline.md
@@ -167,3 +167,30 @@ The in-process `Evaluator` remains the canonical reference for language semantic
 | `src/Compiler/Program.cs` | `gsc` command-line driver, response-file expansion, runtimeconfig.json generation. |
 | `src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets` | MSBuild `CoreCompile` override that invokes `gsc.dll` via the SDK's build task. |
 | `src/Sdk/Gsharp.NET.Sdk/BuildTask.cs` | MSBuild task that materializes a response file and shells out to `dotnet gsc.dll`. |
+
+## IL verification gate (Compiler.Tests)
+
+`Compiler.Tests` runs every test-emitted assembly through `dotnet-ilverify`
+immediately after `gsc` writes the PE. This catches IL-correctness regressions
+(callvirt-on-value-type, stack-type mismatches, init-only writes, ref-struct
+escapes, …) at unit-test granularity instead of waiting for a runtime
+`InvalidProgramException` or a JIT failure.
+
+The integration lives in
+[`test/Compiler.Tests/IlVerifier.cs`](../test/Compiler.Tests/IlVerifier.cs).
+Every test compile helper calls
+`IlVerifier.Verify(outPath, ignoredErrorCodes: …)` right after asserting that
+`gsc` exited successfully, so a verification failure is attributed to the
+specific test that emitted the bad IL.
+
+- The tool is declared in [`.config/dotnet-tools.json`](../.config/dotnet-tools.json)
+  and is restored in CI via `dotnet tool restore` (see
+  [`.github/workflows/build.yml`](../.github/workflows/build.yml)).
+- `IlVerifier.KnownIssues` enumerates compiler bugs that currently produce
+  non-strict-conforming IL (async lowering, generic value-type dispatch,
+  ref-struct emission). Tests that exercise those paths opt in to the
+  matching ignore list; the goal is to **shrink** these lists as the
+  underlying bugs are fixed.
+- To bypass the gate while iterating locally, set
+  `GSHARP_SKIP_ILVERIFY=1` in the environment. CI must run with the gate
+  enabled — there is no opt-out in `build.yml`.

--- a/test/Compiler.Tests/Acceptance/StackTraceTests.cs
+++ b/test/Compiler.Tests/Acceptance/StackTraceTests.cs
@@ -259,6 +259,7 @@ public class StackTraceTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(asmPath, ignoredErrorCodes: IlVerifier.KnownIssues.AsyncStateMachine);
         Assert.True(File.Exists(asmPath), $"missing PE: {asmPath}");
         Assert.True(File.Exists(pdbPath), $"missing PDB: {pdbPath}");
 

--- a/test/Compiler.Tests/AsyncGoScopeReferenceTests.cs
+++ b/test/Compiler.Tests/AsyncGoScopeReferenceTests.cs
@@ -108,6 +108,7 @@ Console.WriteLine(""done"")
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.KnownIssues.AsyncStateMachine);
             Assert.True(File.Exists(outPath), "expected emitted assembly");
 
             var psi = new ProcessStartInfo("dotnet")

--- a/test/Compiler.Tests/Emit/AsyncValueReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AsyncValueReturnEmitTests.cs
@@ -121,6 +121,7 @@ public class AsyncValueReturnEmitTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.KnownIssues.AsyncStateMachine);
             Assert.True(File.Exists(outPath), $"expected emitted assembly at {outPath}");
 
             var psi = new ProcessStartInfo("dotnet")

--- a/test/Compiler.Tests/Emit/AttributeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AttributeEmitTests.cs
@@ -475,6 +475,7 @@ public class AttributeEmitTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
 
         // Read all bytes so the file isn't locked, then load via Assembly.Load.
         var bytes = File.ReadAllBytes(outPath);

--- a/test/Compiler.Tests/Emit/ClosureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/ClosureEmitTests.cs
@@ -167,6 +167,7 @@ public class ClosureEmitTests
             }
 
             Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
 
             // Drop a minimal runtimeconfig so `dotnet exec` can host the .dll.
             var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");

--- a/test/Compiler.Tests/Emit/ClrInteropEmitTests.cs
+++ b/test/Compiler.Tests/Emit/ClrInteropEmitTests.cs
@@ -200,6 +200,7 @@ public class ClrInteropEmitTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/ConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/ConversionEmitTests.cs
@@ -152,6 +152,7 @@ public class ConversionEmitTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
 
         var bytes = File.ReadAllBytes(outPath);
         return Assembly.Load(bytes);

--- a/test/Compiler.Tests/Emit/DataStructInteropTests.cs
+++ b/test/Compiler.Tests/Emit/DataStructInteropTests.cs
@@ -172,6 +172,7 @@ public class DataStructInteropTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.KnownIssues.GenericValueTypeDispatch);
 
         var bytes = File.ReadAllBytes(outPath);
         return Assembly.Load(bytes);

--- a/test/Compiler.Tests/Emit/EnumEmitTests.cs
+++ b/test/Compiler.Tests/Emit/EnumEmitTests.cs
@@ -279,6 +279,7 @@ public class EnumEmitTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
 
         var bytes = File.ReadAllBytes(outPath);
         return Assembly.Load(bytes);

--- a/test/Compiler.Tests/Emit/EventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/EventEmitTests.cs
@@ -323,6 +323,7 @@ public class EventEmitTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
 
         var bytes = File.ReadAllBytes(outPath);
         return Assembly.Load(bytes);

--- a/test/Compiler.Tests/Emit/FieldAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/FieldAssignmentEmitTests.cs
@@ -177,6 +177,7 @@ public class FieldAssignmentEmitTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
 
         var bytes = File.ReadAllBytes(outPath);
         return Assembly.Load(bytes);

--- a/test/Compiler.Tests/Emit/ForRangeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/ForRangeEmitTests.cs
@@ -140,6 +140,7 @@ public class ForRangeEmitTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {
@@ -297,6 +298,7 @@ public class ForRangeEmitTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
 
             using var fs = File.OpenRead(outPath);
             using var pe = new PEReader(fs);

--- a/test/Compiler.Tests/Emit/GenericFunctionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/GenericFunctionEmitTests.cs
@@ -194,6 +194,7 @@ public class GenericFunctionEmitTests
             }
 
             Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.KnownIssues.GenericValueTypeDispatch);
 
             var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
             File.WriteAllText(runtimeConfigPath, """

--- a/test/Compiler.Tests/Emit/GenericMethodTypeArgsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/GenericMethodTypeArgsEmitTests.cs
@@ -141,6 +141,7 @@ public class GenericMethodTypeArgsEmitTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/GenericTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/GenericTypeEmitTests.cs
@@ -171,6 +171,7 @@ public class GenericTypeEmitTests
             }
 
             Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.KnownIssues.GenericValueTypeDispatch);
 
             var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
             File.WriteAllText(runtimeConfigPath, """

--- a/test/Compiler.Tests/Emit/GlobalVariableEmitTests.cs
+++ b/test/Compiler.Tests/Emit/GlobalVariableEmitTests.cs
@@ -267,6 +267,7 @@ public class GlobalVariableEmitTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
 
         var bytes = File.ReadAllBytes(outPath);
         return Assembly.Load(bytes);

--- a/test/Compiler.Tests/Emit/InlineStructEqualsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/InlineStructEqualsEmitTests.cs
@@ -113,6 +113,7 @@ public class InlineStructEqualsEmitTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
 
         var bytes = File.ReadAllBytes(outPath);
         return Assembly.Load(bytes);

--- a/test/Compiler.Tests/Emit/LambdaEmitTests.cs
+++ b/test/Compiler.Tests/Emit/LambdaEmitTests.cs
@@ -146,6 +146,7 @@ public class LambdaEmitTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/MapEmitTests.cs
+++ b/test/Compiler.Tests/Emit/MapEmitTests.cs
@@ -176,6 +176,7 @@ public class MapEmitTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/MethodSpecCacheUserTypeArgsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/MethodSpecCacheUserTypeArgsEmitTests.cs
@@ -136,6 +136,7 @@ public class MethodSpecCacheUserTypeArgsEmitTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
 
         return outPath;
     }

--- a/test/Compiler.Tests/Emit/PrimitiveLiteralEmitTests.cs
+++ b/test/Compiler.Tests/Emit/PrimitiveLiteralEmitTests.cs
@@ -210,6 +210,7 @@ public class PrimitiveLiteralEmitTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/PrimitiveOperatorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/PrimitiveOperatorEmitTests.cs
@@ -209,6 +209,7 @@ public class PrimitiveOperatorEmitTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/PropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/PropertyEmitTests.cs
@@ -396,6 +396,7 @@ public class PropertyEmitTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
 
         var bytes = File.ReadAllBytes(outPath);
         return Assembly.Load(bytes);

--- a/test/Compiler.Tests/Emit/PropertyInteropTests.cs
+++ b/test/Compiler.Tests/Emit/PropertyInteropTests.cs
@@ -402,6 +402,7 @@ public class PropertyInteropTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(gsDllPath);
 
             Assert.True(File.Exists(gsDllPath), $"GSharp DLL not found at {gsDllPath}");
 

--- a/test/Compiler.Tests/Emit/ReturnInTryFinallyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/ReturnInTryFinallyEmitTests.cs
@@ -198,6 +198,7 @@ public class ReturnInTryFinallyEmitTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/TupleEmitTests.cs
+++ b/test/Compiler.Tests/Emit/TupleEmitTests.cs
@@ -104,6 +104,7 @@ public class TupleEmitTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/UserDefinedExceptionCatchEmitTests.cs
+++ b/test/Compiler.Tests/Emit/UserDefinedExceptionCatchEmitTests.cs
@@ -115,6 +115,7 @@ public class UserDefinedExceptionCatchEmitTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/UserStructMethodEmitTests.cs
+++ b/test/Compiler.Tests/Emit/UserStructMethodEmitTests.cs
@@ -425,6 +425,7 @@ public class UserStructMethodEmitTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.KnownIssues.RefStruct);
 
         var bytes = File.ReadAllBytes(outPath);
         return Assembly.Load(bytes);

--- a/test/Compiler.Tests/Emit/UserStructPropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/UserStructPropertyEmitTests.cs
@@ -263,6 +263,7 @@ public class UserStructPropertyEmitTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
 
         var bytes = File.ReadAllBytes(outPath);
         return Assembly.Load(bytes);

--- a/test/Compiler.Tests/Emit/VariadicEmitTests.cs
+++ b/test/Compiler.Tests/Emit/VariadicEmitTests.cs
@@ -124,6 +124,7 @@ public class VariadicEmitTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
 
             var psi = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/IlVerifier.cs
+++ b/test/Compiler.Tests/IlVerifier.cs
@@ -1,0 +1,468 @@
+// <copyright file="IlVerifier.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Xunit.Sdk;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Mechanical IL verification gate for assemblies emitted by Compiler.Tests.
+///
+/// Wraps the <c>dotnet-ilverify</c> local tool (declared in
+/// <c>.config/dotnet-tools.json</c>) and runs it against a freshly-emitted
+/// assembly. Tests should call <see cref="Verify(string, IEnumerable{string})"/>
+/// immediately after a successful compile so that any invalid IL produced by
+/// gsc is attributed to the test that emitted it.
+///
+/// Behavior:
+/// <list type="bullet">
+///   <item>The host runtime's <c>System.*.dll</c>, <c>mscorlib.dll</c>,
+///         <c>netstandard.dll</c> and <c>System.Private.CoreLib.dll</c> are
+///         always added to the reference set, so callers only need to pass
+///         user-supplied or test-built references.</item>
+///   <item>Verification can be globally skipped by setting the environment
+///         variable <c>GSHARP_SKIP_ILVERIFY=1</c>. This is intended for local
+///         debugging only; CI must run with verification enabled so invalid IL
+///         is caught on every PR.</item>
+///   <item>If the <c>ilverify</c> tool cannot be located, the helper throws
+///         (instead of silently passing) so CI failures are obvious. To bypass
+///         in environments without the tool, set <c>GSHARP_SKIP_ILVERIFY=1</c>.</item>
+/// </list>
+/// </summary>
+internal static class IlVerifier
+{
+    private const string SkipEnvVar = "GSHARP_SKIP_ILVERIFY";
+
+    private static readonly object ToolLocateSync = new();
+    private static readonly Lazy<IReadOnlyList<string>> RuntimeReferences =
+        new(BuildDefaultRuntimeReferences);
+
+    private static string? cachedToolCommand;
+    private static IReadOnlyList<string>? cachedToolArgs;
+
+    /// <summary>
+    /// Verifies the IL of the assembly at <paramref name="assemblyPath"/> using
+    /// <c>dotnet-ilverify</c>. Throws (failing the test) on any verification
+    /// error. The host runtime's BCL assemblies are added to the reference set
+    /// automatically; callers only need to pass additional, test-specific
+    /// references (for example, a user library the assembly under test depends
+    /// on).
+    /// </summary>
+    /// <param name="assemblyPath">Path to the .dll to verify.</param>
+    /// <param name="additionalReferences">Optional extra reference assemblies
+    /// the assembly under test depends on. May be null or empty.</param>
+    /// <param name="ignoredErrorCodes">Optional ECMA-335 error codes that
+    /// ilverify should treat as non-fatal. Use this to mark known compiler
+    /// bugs so the gate catches NEW regressions without failing on
+    /// already-tracked issues. Each entry should be the bracketed identifier
+    /// from ilverify output (for example, <c>"CallVirtOnValueType"</c>); the
+    /// helper translates it into the matching regex.</param>
+    public static void Verify(
+        string assemblyPath,
+        IEnumerable<string>? additionalReferences = null,
+        IEnumerable<string>? ignoredErrorCodes = null)
+    {
+        if (Environment.GetEnvironmentVariable(SkipEnvVar) == "1")
+        {
+            return;
+        }
+
+        if (!File.Exists(assemblyPath))
+        {
+            throw new XunitException($"ilverify: assembly not found at '{assemblyPath}'");
+        }
+
+        var (command, leadingArgs) = LocateTool();
+        var references = BuildReferenceSet(assemblyPath, additionalReferences);
+
+        var args = new List<string>(leadingArgs)
+        {
+            assemblyPath,
+            "-s",
+            "System.Private.CoreLib",
+        };
+        foreach (var reference in references)
+        {
+            args.Add("-r");
+            args.Add(reference);
+        }
+
+        if (ignoredErrorCodes is not null)
+        {
+            foreach (var code in ignoredErrorCodes)
+            {
+                if (string.IsNullOrWhiteSpace(code))
+                {
+                    continue;
+                }
+
+                // ilverify's --ignore-error matches its regex against the
+                // error category name (e.g., "CallVirtOnValueType"), NOT
+                // against the rendered "[IL]: Error [code]: ..." line. Pass
+                // the bare code so a partial-substring regex hits cleanly.
+                args.Add("-g");
+                args.Add(code);
+            }
+        }
+
+        var psi = new ProcessStartInfo(command)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            // When using `dotnet tool run`, the manifest is discovered relative
+            // to the current directory. Tests routinely emit assemblies into a
+            // per-test temp dir with no manifest, so anchor the tool lookup at
+            // the repo root. All paths passed to ilverify are absolute.
+            WorkingDirectory = FindRepoRoot(),
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new XunitException($"ilverify: failed to start '{command}'");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        proc.WaitForExit();
+
+        if (proc.ExitCode != 0)
+        {
+            // ilverify writes one line per IL error. Surface its full output so
+            // a CI failure points directly at the offending opcode/method.
+            var message = new StringBuilder()
+                .Append("ilverify detected invalid IL in '")
+                .Append(assemblyPath)
+                .Append("' (exit ")
+                .Append(proc.ExitCode)
+                .AppendLine("):")
+                .AppendLine(stdout.TrimEnd())
+                .Append(stderr.TrimEnd())
+                .ToString();
+            throw new XunitException(message);
+        }
+    }
+
+    /// <summary>
+    /// Returns true when IL verification is enabled for this test run. Tests
+    /// can use this to skip emitting an assembly path that ilverify cannot
+    /// handle (for example, executables targeting a host the tool does not
+    /// support). The default is true; set <c>GSHARP_SKIP_ILVERIFY=1</c> to
+    /// disable.
+    /// </summary>
+    public static bool IsEnabled => Environment.GetEnvironmentVariable(SkipEnvVar) != "1";
+
+    /// <summary>
+    /// Pre-computed ilverify error-code bundles for compiler-emission patterns
+    /// that currently produce non-strict-conforming IL. Each bundle should map
+    /// to an open GitHub issue (see comments). As bugs are fixed, the matching
+    /// bundle should shrink — and once empty, the gate is fully closed.
+    /// </summary>
+    public static class KnownIssues
+    {
+        /// <summary>
+        /// Async lowering emits a state machine whose <c>MoveNext</c> method
+        /// uses <c>callvirt</c> on value-type awaiters (instead of the
+        /// <c>constrained.</c> + <c>callvirt</c> sequence the spec requires)
+        /// and produces stack-type mismatches around the awaiter dispatch.
+        /// Tracked separately as a follow-up to the IL gate work.
+        /// </summary>
+        public static readonly string[] AsyncStateMachine =
+        {
+            "CallVirtOnValueType",
+            "StackUnexpected",
+        };
+
+        /// <summary>
+        /// Generic dispatch on value-typed receivers emits a bare
+        /// <c>callvirt</c> instead of <c>constrained.</c> + <c>callvirt</c>,
+        /// and generic-delegate construction sometimes loses the variance
+        /// adjustment, producing stack-type mismatches between
+        /// <c>Action&lt;T&gt;</c> instantiations. Surfaces in generic
+        /// data-structs and generic delegate invokes.
+        /// </summary>
+        public static readonly string[] GenericValueTypeDispatch =
+        {
+            "CallVirtOnValueType",
+            "StackUnexpected",
+        };
+
+        /// <summary>
+        /// Ref-struct receivers and stack-allocated return paths trip
+        /// ilverify's escape-analysis checks. See ADR/issue tracking ref
+        /// struct ergonomics.
+        /// </summary>
+        public static readonly string[] RefStruct =
+        {
+            "ReturnPtrToStack",
+            "InitOnly",
+            "StackUnexpected",
+        };
+    }
+
+    /// <summary>
+    /// Maps a sample name (as it appears under <c>samples/</c>) to the bundle
+    /// of ilverify error codes that the conformance harness should treat as
+    /// known issues. Samples not present in this map are verified strictly.
+    /// Keys are matched case-insensitively against the sample's base name
+    /// without extension.
+    /// </summary>
+    public static IReadOnlyList<string> GetKnownIssuesForSample(string sampleBaseName)
+    {
+        var key = sampleBaseName.TrimEnd('/');
+        if (SampleKnownIssues.TryGetValue(key, out var codes))
+        {
+            return codes;
+        }
+
+        return Array.Empty<string>();
+    }
+
+    private static readonly Dictionary<string, string[]> SampleKnownIssues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Async lowering: see KnownIssues.AsyncStateMachine.
+        ["AsyncAwaitInLoop"] = KnownIssues.AsyncStateMachine,
+        ["AsyncAwaitInNestedLoop"] = KnownIssues.AsyncStateMachine,
+        ["AsyncGoScopeJoin"] = KnownIssues.AsyncStateMachine,
+        ["AsyncMultiAwaitInLoop"] = KnownIssues.AsyncStateMachine,
+        ["AsyncTask"] = KnownIssues.AsyncStateMachine,
+        ["AsyncValueReturns"] = KnownIssues.AsyncStateMachine,
+
+        // Generic value-type dispatch: see KnownIssues.GenericValueTypeDispatch.
+        ["GenericMethodDelegates"] = KnownIssues.GenericValueTypeDispatch,
+        ["GenericMethods"] = KnownIssues.GenericValueTypeDispatch,
+        ["NullableFlow"] = KnownIssues.GenericValueTypeDispatch,
+        ["ImportedBaseClass"] = KnownIssues.GenericValueTypeDispatch,
+        ["ExpressionEval"] = KnownIssues.GenericValueTypeDispatch,
+        ["PatternSwitch"] = KnownIssues.GenericValueTypeDispatch,
+        ["SwitchExpression"] = KnownIssues.GenericValueTypeDispatch,
+        ["InlineStruct"] = new[] { "InitOnly" },
+
+        // Ref struct emission: see KnownIssues.RefStruct.
+        ["UserRefStruct"] = KnownIssues.RefStruct,
+    };
+
+    private static (string Command, IReadOnlyList<string> LeadingArgs) LocateTool()
+    {
+        // Discovering the tool requires a `dotnet` lookup that may walk up the
+        // directory tree (the local manifest lives at the repo root). Cache the
+        // result on first use so we don't pay that cost per test.
+        if (cachedToolCommand is not null && cachedToolArgs is not null)
+        {
+            return (cachedToolCommand, cachedToolArgs);
+        }
+
+        lock (ToolLocateSync)
+        {
+            if (cachedToolCommand is not null && cachedToolArgs is not null)
+            {
+                return (cachedToolCommand, cachedToolArgs);
+            }
+
+            // 1) Prefer the local-tool manifest entry: `dotnet tool run ilverify`.
+            //    This is what CI restores via `dotnet tool restore`.
+            if (TryProbeDotnetToolRun(out var args))
+            {
+                cachedToolCommand = "dotnet";
+                cachedToolArgs = args;
+                return (cachedToolCommand, cachedToolArgs);
+            }
+
+            // 2) Fall back to a globally-installed `ilverify` on PATH (or in
+            //    $HOME/.dotnet/tools, which dotnet adds for global tools).
+            if (TryProbeOnPath("ilverify"))
+            {
+                cachedToolCommand = "ilverify";
+                cachedToolArgs = Array.Empty<string>();
+                return (cachedToolCommand, cachedToolArgs);
+            }
+
+            throw new XunitException(
+                "ilverify is required by the test suite but was not found. " +
+                "Run `dotnet tool restore` at the repository root, or install it globally with " +
+                "`dotnet tool install -g dotnet-ilverify`. To skip verification for local debugging only, " +
+                $"set {SkipEnvVar}=1.");
+        }
+    }
+
+    private static bool TryProbeDotnetToolRun(out IReadOnlyList<string> args)
+    {
+        // `dotnet tool run ilverify --version` returns 0 when the local
+        // manifest knows about the tool. The version flag avoids printing the
+        // full help text on success.
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = FindRepoRoot(),
+        };
+        psi.ArgumentList.Add("tool");
+        psi.ArgumentList.Add("run");
+        psi.ArgumentList.Add("ilverify");
+        psi.ArgumentList.Add("--version");
+
+        try
+        {
+            using var proc = Process.Start(psi);
+            if (proc is null)
+            {
+                args = Array.Empty<string>();
+                return false;
+            }
+
+            proc.StandardOutput.ReadToEnd();
+            proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode == 0)
+            {
+                args = new[] { "tool", "run", "ilverify" };
+                return true;
+            }
+        }
+        catch
+        {
+            // Fall through to the next probe.
+        }
+
+        args = Array.Empty<string>();
+        return false;
+    }
+
+    private static bool TryProbeOnPath(string command)
+    {
+        var psi = new ProcessStartInfo(command)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        psi.ArgumentList.Add("--version");
+
+        try
+        {
+            using var proc = Process.Start(psi);
+            if (proc is null)
+            {
+                return false;
+            }
+
+            proc.StandardOutput.ReadToEnd();
+            proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            return proc.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        // Walk up from this assembly's location until we find a directory
+        // containing `.config/dotnet-tools.json`. This keeps tool discovery
+        // working regardless of the runner's current directory.
+        var dir = Path.GetDirectoryName(typeof(IlVerifier).Assembly.Location);
+        while (!string.IsNullOrEmpty(dir))
+        {
+            if (File.Exists(Path.Combine(dir, ".config", "dotnet-tools.json")))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        return Environment.CurrentDirectory;
+    }
+
+    private static IReadOnlyList<string> BuildReferenceSet(
+        string assemblyPath,
+        IEnumerable<string>? additionalReferences)
+    {
+        // Use an ordinal-ignore-case set so we don't double-pass the same DLL
+        // when an additional reference also lives in the runtime directory.
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var ordered = new List<string>();
+
+        void Add(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return;
+            }
+
+            // ilverify treats the verified assembly itself as the "primary"
+            // input; don't also pass it via -r (that confuses metadata loading).
+            if (string.Equals(
+                    Path.GetFullPath(path),
+                    Path.GetFullPath(assemblyPath),
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            if (seen.Add(path))
+            {
+                ordered.Add(path);
+            }
+        }
+
+        foreach (var r in RuntimeReferences.Value)
+        {
+            Add(r);
+        }
+
+        if (additionalReferences is not null)
+        {
+            foreach (var r in additionalReferences)
+            {
+                Add(r);
+            }
+        }
+
+        return ordered;
+    }
+
+    private static IReadOnlyList<string> BuildDefaultRuntimeReferences()
+    {
+        // The host runtime directory is the simplest stable source of refs that
+        // matches what Compiler.Tests typically passes to gsc via /reference:.
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        var refs = new List<string>();
+        foreach (var path in Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly))
+        {
+            var name = Path.GetFileName(path);
+            if (name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "Microsoft.CSharp.dll", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "Microsoft.VisualBasic.Core.dll", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "Microsoft.Win32.Primitives.dll", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "Microsoft.Win32.Registry.dll", StringComparison.OrdinalIgnoreCase))
+            {
+                refs.Add(path);
+            }
+        }
+
+        return refs;
+    }
+}

--- a/test/Compiler.Tests/IlVerifierTests.cs
+++ b/test/Compiler.Tests/IlVerifierTests.cs
@@ -1,0 +1,84 @@
+// <copyright file="IlVerifierTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.IO;
+using Xunit;
+using Xunit.Sdk;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Smoke tests for the <see cref="IlVerifier"/> helper itself. These guard the
+/// gate: if these break, every Compile…+Verify call elsewhere in this assembly
+/// is producing meaningless results.
+/// </summary>
+public class IlVerifierTests
+{
+    [Fact]
+    public void Verify_AcceptsValidEmittedAssembly_DoesNotThrow()
+    {
+        // Compile the smallest possible gs program and verify the result.
+        // This is the actual usage pattern for Compile…Verify() helpers, and
+        // guards against regressions in IlVerifier itself (e.g., wrong system
+        // module name, missing reference probe).
+        var tempDir = Directory.CreateTempSubdirectory("gs_ilv_smoke_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "smoke.gs");
+            var outPath = Path.Combine(tempDir, "smoke.dll");
+            File.WriteAllText(srcPath, "package P\n\nfunc Main() {\n}\n");
+
+            var exit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(outPath), $"expected output at {outPath}");
+
+            IlVerifier.Verify(outPath);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    [Fact]
+    public void Verify_MissingAssembly_Throws()
+    {
+        var bogus = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}.dll");
+        Assert.Throws<XunitException>(() => IlVerifier.Verify(bogus));
+    }
+
+    [Fact]
+    public void Verify_RespectsSkipEnvVar()
+    {
+        var prev = Environment.GetEnvironmentVariable("GSHARP_SKIP_ILVERIFY");
+        Environment.SetEnvironmentVariable("GSHARP_SKIP_ILVERIFY", "1");
+        try
+        {
+            // With the gate disabled, even a missing assembly is a no-op so
+            // developers can locally bypass the tool requirement.
+            var bogus = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}.dll");
+            IlVerifier.Verify(bogus);
+            Assert.False(IlVerifier.IsEnabled);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GSHARP_SKIP_ILVERIFY", prev);
+        }
+    }
+}

--- a/test/Compiler.Tests/LanguageConformance/MultiPackageEmitShapeTests.cs
+++ b/test/Compiler.Tests/LanguageConformance/MultiPackageEmitShapeTests.cs
@@ -39,6 +39,7 @@ public class MultiPackageEmitShapeTests
             });
             Assert.Equal(0, exit);
             Assert.True(File.Exists(outPath));
+            IlVerifier.Verify(outPath);
 
             using var pe = new PEReader(File.OpenRead(outPath));
             var reader = pe.GetMetadataReader();

--- a/test/Compiler.Tests/LanguageConformance/SampleConformanceTests.cs
+++ b/test/Compiler.Tests/LanguageConformance/SampleConformanceTests.cs
@@ -122,6 +122,7 @@ public class SampleConformanceTests
             Assert.True(
                 compileExit == 0,
                 $"gsc failed for {sampleName}:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.GetKnownIssuesForSample(baseName));
             Assert.True(File.Exists(outPath), $"expected emitted assembly at {outPath}");
 
             var psi = new ProcessStartInfo("dotnet")

--- a/test/Compiler.Tests/ProgramTests.cs
+++ b/test/Compiler.Tests/ProgramTests.cs
@@ -97,6 +97,7 @@ public class ProgramTests
             var exit = Program.Main(new[] { "/out:" + outPath, "/target:exe", "/targetframework:net10.0", sample });
             Assert.Equal(0, exit);
             Assert.True(File.Exists(outPath), "expected output assembly to exist");
+            IlVerifier.Verify(outPath);
             var runtimeConfig = Path.ChangeExtension(outPath, ".runtimeconfig.json");
             Assert.True(File.Exists(runtimeConfig), "expected runtimeconfig.json beside output");
             Assert.Contains("Microsoft.NETCore.App", File.ReadAllText(runtimeConfig));
@@ -122,6 +123,7 @@ public class ProgramTests
             var exit = Program.Main(new[] { "/out:" + outPath, "/target:library", sample });
             Assert.Equal(0, exit);
             Assert.True(File.Exists(outPath));
+            IlVerifier.Verify(outPath);
             Assert.False(File.Exists(Path.ChangeExtension(outPath, ".runtimeconfig.json")));
         }
         finally
@@ -145,6 +147,7 @@ public class ProgramTests
             var exit = Program.Main(new[] { "@" + rspPath });
             Assert.Equal(0, exit);
             Assert.True(File.Exists(outPath));
+            IlVerifier.Verify(outPath);
         }
         finally
         {
@@ -233,6 +236,7 @@ public class ProgramTests
             var exit = GSharp.Compiler.Program.Main(new[] { "@" + rspPath });
             Assert.Equal(0, exit);
             Assert.True(File.Exists(outPath), $"expected output at '{outPath}'");
+            IlVerifier.Verify(outPath);
         }
         finally
         {
@@ -425,6 +429,7 @@ public class ProgramTests
             var exit = Program.Main(new[] { "/out:" + outPath, "/target:library", debugFlag, sample });
             Assert.Equal(0, exit);
             Assert.True(File.Exists(outPath));
+            IlVerifier.Verify(outPath);
             var pdbPath = Path.ChangeExtension(outPath, ".pdb");
             Assert.Equal(expectPdb, File.Exists(pdbPath));
         }
@@ -448,6 +453,7 @@ public class ProgramTests
             var exit = Program.Main(new[] { "/out:" + outPath, "/target:library", "/pdb:" + pdbPath, sample });
             Assert.Equal(0, exit);
             Assert.True(File.Exists(outPath));
+            IlVerifier.Verify(outPath);
             Assert.True(File.Exists(pdbPath), "explicit /pdb:<path> sidecar should exist");
             // The default {PE}.pdb should NOT have been written when /pdb redirected it.
             Assert.False(File.Exists(Path.ChangeExtension(outPath, ".pdb")));
@@ -473,6 +479,7 @@ public class ProgramTests
             var exit = Program.Main(new[] { "/out:" + outPath, "/target:library", "/pdb:" + pdbPath, "/debug-", sample });
             Assert.Equal(0, exit);
             Assert.True(File.Exists(outPath));
+            IlVerifier.Verify(outPath);
             Assert.False(File.Exists(pdbPath));
         }
         finally


### PR DESCRIPTION
Fixes #451

## What this adds

Every assembly emitted by `Compiler.Tests` is now mechanically verified with `dotnet-ilverify` immediately after `gsc` writes it. A verification failure is attributed to the test that emitted the bad IL, so regressions point at a specific test rather than at a runtime `InvalidProgramException` or a JIT failure.

## Mechanism

- **Tool manifest.** `.config/dotnet-tools.json` pins `dotnet-ilverify` (10.0.8, `rollForward: true`).
- **Helper.** `test/Compiler.Tests/IlVerifier.cs` locates the tool (via `dotnet tool run ilverify` from the repo root, or via PATH), builds a reference set from the host runtime BCL (`System.*.dll`, `mscorlib.dll`, `netstandard.dll`, `System.Private.CoreLib.dll`), and runs `ilverify <assembly> -s System.Private.CoreLib -r <refs>…`.
- **Per-test attribution.** `IlVerifier.Verify(outPath, …)` is wired into **every** `Compile…` helper in `Compiler.Tests` (Acceptance, Emit, LanguageConformance, plus the top-level `Program`/`AsyncGoScope` tests) — 41 call sites total. The call sits directly after the existing `compileExit == 0` assertion, so a verification failure prints the failing test name *and* the offending IL opcode/method.
- **CI.** Added `dotnet tool restore` to `.github/workflows/build.yml` so the verifier is available before `dotnet test` runs.
- **Per-test opt-in to known bugs.** `IlVerifier.KnownIssues` enumerates currently-tracked compiler bugs that produce non-strict-conforming IL: `AsyncStateMachine` (async lowering callvirt-on-value-type / stack mismatches), `GenericValueTypeDispatch` (generic data-structs and generic delegate invokes), and `RefStruct` (return-by-ref escapes). The handful of tests that exercise those paths opt in to the matching ignore list via the new `ignoredErrorCodes` parameter; the conformance harness maps a small set of named samples to the appropriate bundle. **New** error classes still fail the gate — the goal is to *shrink* these lists as the bugs are fixed.
- **Smoke tests.** `IlVerifierTests.cs` covers a valid round-trip, a missing-assembly error, and the `GSHARP_SKIP_ILVERIFY=1` escape hatch.

## Local opt-out

Set `GSHARP_SKIP_ILVERIFY=1` to disable the gate while iterating locally. CI has no opt-out.

## Validation

```
dotnet test GSharp.sln --no-restore --nologo
…
Passed!  - Failed: 0, Passed: 341, Skipped: 0, Total: 341  (GSharp.Compiler.Tests.dll)
Passed!  - Failed: 0, Passed:  64, Skipped: 0, Total:  64  (GSharp.Interpreter.Tests.dll)
Passed!  - Failed: 0, Passed: 212, Skipped: 0, Total: 212  (GSharp.LanguageServer.Tests.dll)
Passed!  - Failed: 0, Passed:1702, Skipped: 0, Total:1702  (GSharp.Core.Tests.dll)
Passed!  - Failed: 0, Passed:  24, Skipped: 0, Total:  24  (GSharp.Sdk.Tests.dll)
```

## Docs

Added an "IL verification gate" section to `docs/emit-pipeline.md`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>