### PR TITLE
Close KnownIssues.GenericValueTypeDispatch ilverify bundle

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -7885,6 +7885,14 @@ public sealed class Binder
             var parameter = function.Parameters[i];
             var expectedType = substitution != null ? SubstituteType(parameter.Type, substitution) : parameter.Type;
 
+            if (substitution != null
+                && parameter.Type is FunctionTypeSymbol openFunctionParameter
+                && TryGetFunctionLiteral(argument, out var functionLiteralArgument))
+            {
+                boundArguments[i] = CreateErasedFunctionLiteralAdapter(functionLiteralArgument, openFunctionParameter);
+                continue;
+            }
+
             // ADR-0055 Tier 4 (#369): an interpolated-string argument bound
             // against an IFormattable/FormattableString parameter is re-lowered
             // to FormattableStringFactory.Create instead of an eager string. Only
@@ -9226,6 +9234,14 @@ public sealed class Binder
                     continue;
                 }
 
+                if (substitution != null
+                    && paramType is FunctionTypeSymbol openFunctionParameter
+                    && TryGetFunctionLiteral(arguments[i], out var functionLiteralArgument))
+                {
+                    convertedArgs.Add(CreateErasedFunctionLiteralAdapter(functionLiteralArgument, openFunctionParameter));
+                    continue;
+                }
+
                 var expectedType = substitution != null ? SubstituteType(paramType, substitution) : paramType;
                 convertedArgs.Add(BindConversion(ce.Arguments[i].Location, arguments[i], expectedType));
             }
@@ -9665,7 +9681,9 @@ public sealed class Binder
                         var instParameters = resolution.Best.GetParameters();
                         var instRebound = RebindFormattableInterpolationArguments(arguments, ce.Arguments, instParameters);
                         var instHandlerArgs = ApplyInterpolatedStringHandlers(instParameters, instRebound, receiver, ce.Location);
-                        var instArguments = AppendOmittedOptionalArguments(instHandlerArgs, instParameters);
+                        var instDelegateArgs = RebindFunctionLiteralDelegateArguments(instHandlerArgs, instParameters);
+                        var instConvertedArgs = BindClrParameterConversions(instDelegateArgs, instParameters, ce);
+                        var instArguments = AppendOmittedOptionalArguments(instConvertedArgs, instParameters);
                         var instRefKinds = ComputeArgumentRefKinds(instParameters);
                         ValidateRefArguments(instArguments, instRefKinds, methodName, ce.Location);
                         return AutoDereferenceRefReturn(new BoundImportedInstanceCallExpression(null, receiver, resolution.Best, returnType, instArguments, instRefKinds, typeArgSymbols));
@@ -9745,7 +9763,9 @@ public sealed class Binder
                 var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols) ?? TypeSymbol.FromClrType(resolution.Best.ReturnType);
                 var inheritedParameters = resolution.Best.GetParameters();
                 var inheritedHandlerArgs = ApplyInterpolatedStringHandlers(inheritedParameters, arguments, receiver, ce.Location);
-                var inheritedArguments = AppendOmittedOptionalArguments(inheritedHandlerArgs, inheritedParameters);
+                var inheritedDelegateArgs = RebindFunctionLiteralDelegateArguments(inheritedHandlerArgs, inheritedParameters);
+                var inheritedConvertedArgs = BindClrParameterConversions(inheritedDelegateArgs, inheritedParameters, ce);
+                var inheritedArguments = AppendOmittedOptionalArguments(inheritedConvertedArgs, inheritedParameters);
                 var refKinds = ComputeArgumentRefKinds(inheritedParameters);
                 ValidateRefArguments(inheritedArguments, refKinds, methodName, ce.Location);
                 result = new BoundImportedInstanceCallExpression(null, receiver, resolution.Best, returnType, inheritedArguments, refKinds, typeArgSymbols);
@@ -9852,6 +9872,13 @@ public sealed class Binder
             var paramType = extension.Parameters[i + 1].Type;
             if (substitution != null && TypeSymbol.ContainsTypeParameter(paramType))
             {
+                if (paramType is FunctionTypeSymbol openFunctionParameter
+                    && TryGetFunctionLiteral(arguments[i], out var functionLiteralArgument))
+                {
+                    convertedArgs.Add(CreateErasedFunctionLiteralAdapter(functionLiteralArgument, openFunctionParameter));
+                    continue;
+                }
+
                 // A parameter typed as an open T is encoded as System.Object in
                 // the emitted signature; pass the argument unconverted so the
                 // emitter inserts box / unbox.any around the erased boundary.
@@ -10224,6 +10251,23 @@ public sealed class Binder
             }
 
             var expectedType = substitution != null ? SubstituteType(paramType, substitution) : paramType;
+
+            if (substitution != null
+                && TryGetFunctionLiteral(arguments[i], out var functionLiteralArgument))
+            {
+                if (paramType is FunctionTypeSymbol openFunctionParameter)
+                {
+                    convertedArgs.Add(CreateErasedFunctionLiteralAdapter(functionLiteralArgument, openFunctionParameter));
+                    continue;
+                }
+
+                if (TryGetDelegateFunctionType(paramType.ClrType ?? expectedType.ClrType, out var targetDelegateFunctionType)
+                    && functionLiteralArgument.FunctionType != targetDelegateFunctionType)
+                {
+                    convertedArgs.Add(CreateErasedFunctionLiteralAdapter(functionLiteralArgument, targetDelegateFunctionType));
+                    continue;
+                }
+            }
 
             // ADR-0055 Tier 4 (#369): re-lower an interpolated-string argument to
             // FormattableStringFactory.Create when the parameter is
@@ -10763,6 +10807,13 @@ public sealed class Binder
             return BindClrMethodGroupConversion(diagnosticLocation, clrMethodGroup, type);
         }
 
+        if (expression is BoundFunctionLiteralExpression literal
+            && type is FunctionTypeSymbol targetFunctionType
+            && TypeSymbol.ContainsTypeParameter(targetFunctionType))
+        {
+            return CreateErasedFunctionLiteralAdapter(literal, targetFunctionType);
+        }
+
         var conversion = Conversion.Classify(expression.Type, type);
 
         if (!conversion.Exists)
@@ -10810,6 +10861,198 @@ public sealed class Binder
         }
 
         return new BoundConversionExpression(null, type, expression);
+    }
+
+    private BoundFunctionLiteralExpression CreateErasedFunctionLiteralAdapter(
+        BoundFunctionLiteralExpression literal,
+        FunctionTypeSymbol targetFunctionType)
+    {
+        var adapterParameters = ImmutableArray.CreateBuilder<ParameterSymbol>(literal.Function.Parameters.Length);
+        var replacementMap = new Dictionary<VariableSymbol, BoundExpression>();
+        for (var i = 0; i < literal.Function.Parameters.Length; i++)
+        {
+            var original = literal.Function.Parameters[i];
+            var adapterParameterType = i < targetFunctionType.ParameterTypes.Length
+                ? GetErasedDelegateSlotType(targetFunctionType.ParameterTypes[i])
+                : TypeSymbol.Object;
+            var adapterParameter = new ParameterSymbol(
+                original.Name,
+                adapterParameterType,
+                declaringSyntax: original.DeclaringSyntax,
+                isScoped: original.IsScoped);
+            adapterParameters.Add(adapterParameter);
+            replacementMap[original] = new BoundConversionExpression(
+                null,
+                original.Type,
+                new BoundVariableExpression(null, adapterParameter));
+        }
+
+        var adapterReturnType = targetFunctionType.ReturnType == TypeSymbol.Void
+            ? TypeSymbol.Void
+            : GetErasedDelegateSlotType(targetFunctionType.ReturnType);
+        var adapterFunctionType = FunctionTypeSymbol.Get(
+            adapterParameters.Select(p => p.Type).ToImmutableArray(),
+            adapterReturnType);
+        var adapterFunction = new FunctionSymbol(
+            $"<lambda_erased{System.Threading.Interlocked.Increment(ref syntheticLocalCounter)}>",
+            adapterParameters.ToImmutable(),
+            adapterReturnType,
+            package: literal.Function.Package);
+        adapterFunction.IsAsync = literal.Function.IsAsync;
+
+        var body = (BoundBlockStatement)new ErasedFunctionLiteralAdapterRewriter(replacementMap, adapterReturnType)
+            .RewriteStatement(literal.Body);
+
+        return new BoundFunctionLiteralExpression(
+            literal.Syntax,
+            adapterFunction,
+            adapterFunctionType,
+            body,
+            literal.CapturedVariables);
+    }
+
+    private static TypeSymbol GetErasedDelegateSlotType(TypeSymbol type)
+    {
+        return TypeSymbol.ContainsTypeParameter(type) ? TypeSymbol.Object : type;
+    }
+
+    private ImmutableArray<BoundExpression> RebindFunctionLiteralDelegateArguments(
+        ImmutableArray<BoundExpression> arguments,
+        ParameterInfo[] parameters)
+    {
+        ImmutableArray<BoundExpression>.Builder builder = null;
+        for (var i = 0; i < arguments.Length && i < parameters.Length; i++)
+        {
+            var argument = arguments[i];
+            var rebound = argument;
+            if (TryGetFunctionLiteral(argument, out var literal)
+                && TryGetDelegateFunctionType(parameters[i].ParameterType, out var targetFunctionType)
+                && literal.FunctionType != targetFunctionType)
+            {
+                rebound = CreateErasedFunctionLiteralAdapter(literal, targetFunctionType);
+            }
+
+            if (rebound != argument && builder == null)
+            {
+                builder = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
+                for (var j = 0; j < i; j++)
+                {
+                    builder.Add(arguments[j]);
+                }
+            }
+
+            builder?.Add(rebound);
+        }
+
+        if (builder == null)
+        {
+            return arguments;
+        }
+
+        for (var i = builder.Count; i < arguments.Length; i++)
+        {
+            builder.Add(arguments[i]);
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private ImmutableArray<BoundExpression> BindClrParameterConversions(
+        ImmutableArray<BoundExpression> arguments,
+        ParameterInfo[] parameters,
+        CallExpressionSyntax call)
+    {
+        ImmutableArray<BoundExpression>.Builder builder = null;
+        for (var i = 0; i < arguments.Length && i < parameters.Length; i++)
+        {
+            var argument = arguments[i];
+            var rebound = argument;
+            var parameterType = parameters[i].ParameterType;
+            if (!parameterType.IsByRef && argument.Type != TypeSymbol.Error)
+            {
+                var targetType = TypeSymbol.FromClrType(parameterType);
+                if (argument.Type != targetType && Conversion.Classify(argument.Type, targetType).Exists)
+                {
+                    rebound = BindConversion(call.Arguments[i].Location, argument, targetType, allowExplicit: true);
+                }
+            }
+
+            if (rebound != argument && builder == null)
+            {
+                builder = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
+                for (var j = 0; j < i; j++)
+                {
+                    builder.Add(arguments[j]);
+                }
+            }
+
+            builder?.Add(rebound);
+        }
+
+        if (builder == null)
+        {
+            return arguments;
+        }
+
+        for (var i = builder.Count; i < arguments.Length; i++)
+        {
+            builder.Add(arguments[i]);
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static bool TryGetDelegateFunctionType(Type delegateType, out FunctionTypeSymbol functionType)
+    {
+        functionType = null;
+        if (!ClrTypeUtilities.IsDelegateType(delegateType)
+            && !string.Equals(delegateType?.BaseType?.FullName, "System.MulticastDelegate", StringComparison.Ordinal)
+            && !(delegateType?.FullName?.StartsWith("System.Func`", StringComparison.Ordinal) == true)
+            && !(delegateType?.FullName?.StartsWith("System.Action`", StringComparison.Ordinal) == true))
+        {
+            return false;
+        }
+
+        var invoke = delegateType.GetMethod("Invoke");
+        if (invoke == null)
+        {
+            return false;
+        }
+
+        var parameters = invoke.GetParameters();
+        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(parameters.Length);
+        foreach (var parameter in parameters)
+        {
+            parameterTypes.Add(parameter.ParameterType.ContainsGenericParameters
+                ? TypeSymbol.Object
+                : TypeSymbol.FromClrType(parameter.ParameterType));
+        }
+
+        var returnType = invoke.ReturnType == typeof(void)
+            ? TypeSymbol.Void
+            : invoke.ReturnType.ContainsGenericParameters
+                ? TypeSymbol.Object
+                : TypeSymbol.FromClrType(invoke.ReturnType);
+        functionType = FunctionTypeSymbol.Get(parameterTypes.ToImmutable(), returnType);
+        return true;
+    }
+
+    private static bool TryGetFunctionLiteral(BoundExpression expression, out BoundFunctionLiteralExpression literal)
+    {
+        if (expression is BoundFunctionLiteralExpression direct)
+        {
+            literal = direct;
+            return true;
+        }
+
+        if (expression is BoundConversionExpression { Expression: BoundFunctionLiteralExpression converted })
+        {
+            literal = converted;
+            return true;
+        }
+
+        literal = null;
+        return false;
     }
 
     // ADR-0056 (#344), low-hanging-fruit item #3: a call argument whose declared
@@ -12140,6 +12383,45 @@ public sealed class Binder
 
         // Numeric / char widening between primitives (e.g. int → long).
         return Convert.ChangeType(value, elementType, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private sealed class ErasedFunctionLiteralAdapterRewriter : BoundTreeRewriter
+    {
+        private readonly Dictionary<VariableSymbol, BoundExpression> replacementMap;
+        private readonly TypeSymbol adapterReturnType;
+
+        public ErasedFunctionLiteralAdapterRewriter(
+            Dictionary<VariableSymbol, BoundExpression> replacementMap,
+            TypeSymbol adapterReturnType)
+        {
+            this.replacementMap = replacementMap;
+            this.adapterReturnType = adapterReturnType;
+        }
+
+        protected override BoundExpression RewriteVariableExpression(BoundVariableExpression node)
+        {
+            return this.replacementMap.TryGetValue(node.Variable, out var replacement)
+                ? replacement
+                : node;
+        }
+
+        protected override BoundStatement RewriteReturnStatement(BoundReturnStatement node)
+        {
+            var rewritten = (BoundReturnStatement)base.RewriteReturnStatement(node);
+            if (this.adapterReturnType == TypeSymbol.Void || rewritten.Expression == null)
+            {
+                return rewritten;
+            }
+
+            if (rewritten.Expression.Type == this.adapterReturnType)
+            {
+                return rewritten;
+            }
+
+            return new BoundReturnStatement(
+                null,
+                new BoundConversionExpression(null, this.adapterReturnType, rewritten.Expression));
+        }
     }
 
     private sealed class CapturedVariableCollector : BoundTreeRewriter

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -10780,41 +10780,22 @@ internal sealed class ReflectionMetadataEmitter
 
                     this.il.Call(fnHandle);
 
-                    // Phase 4 emit parity (F1, type-erased generics): a return
-                    // typed as an open T is encoded as System.Object. If the
-                    // call's substituted return type is a value type, unbox
-                    // the result so the rest of the IL sees the expected
-                    // primitive on stack.
-                    if (call.Function.Type is TypeParameterSymbol
-                        && call.Type is not TypeParameterSymbol
-                        && IsValueTypeSymbol(call.Type))
-                    {
-                        this.il.OpCode(ILOpCode.Unbox_any);
-                        this.il.Token(this.outer.GetElementTypeToken(call.Type));
-                    }
-                    else if (TypeSymbol.ContainsTypeParameter(call.Function.Type)
-                        && !TypeSymbol.ContainsTypeParameter(call.Type)
-                        && call.Type?.ClrType != null
-                        && !IsValueTypeSymbol(call.Type))
-                    {
-                        // #313: a return typed as an erased generic over a type
-                        // parameter (e.g. `func GetAll[T]() List[T]`) is encoded
-                        // as System.Object. When the substituted return type is
-                        // a concrete reference type (e.g. `List<int32>`), cast
-                        // the boxed-free reference back so the rest of the IL —
-                        // and any subsequent indexing/member access — sees it.
-                        this.il.OpCode(ILOpCode.Castclass);
-                        this.il.Token(this.outer.GetElementTypeToken(call.Type));
-                    }
+                    this.EmitErasedObjectReturnWidening(call.Function.Type, call.Type);
 
                     break;
                 case BoundImportedCallExpression impCall:
                     this.EmitImportedCallArguments(impCall.Arguments, impCall.ArgumentRefKinds);
                     this.il.Call(this.outer.GetMethodEntityHandle(impCall.Function.Method, impCall.TypeArgumentSymbols));
+                    this.EmitErasedObjectReturnWidening(
+                        TypeSymbol.FromClrType(impCall.Function.Method.ReturnType),
+                        impCall.Type);
                     break;
                 case BoundClrStaticCallExpression staticCall:
                     this.EmitImportedCallArguments(staticCall.Arguments, staticCall.ArgumentRefKinds);
                     this.il.Call(this.outer.GetMethodEntityHandle(staticCall.Method));
+                    this.EmitErasedObjectReturnWidening(
+                        TypeSymbol.FromClrType(staticCall.Method.ReturnType),
+                        staticCall.Type);
                     break;
                 case BoundImportedInstanceCallExpression instCall:
                 {
@@ -10857,6 +10838,9 @@ internal sealed class ReflectionMetadataEmitter
 
                     this.il.OpCode(useCall ? ILOpCode.Call : ILOpCode.Callvirt);
                     this.il.Token(instCallHandle);
+                    this.EmitErasedObjectReturnWidening(
+                        TypeSymbol.FromClrType(instCall.Method.ReturnType),
+                        instCall.Type);
                     break;
                 }
 
@@ -11128,6 +11112,16 @@ internal sealed class ReflectionMetadataEmitter
                 return;
             }
 
+            if (from?.ClrType == typeof(object)
+                && to?.ClrType != typeof(object)
+                && to is not TypeParameterSymbol
+                && !IsValueTypeSymbol(to))
+            {
+                this.il.OpCode(ILOpCode.Castclass);
+                this.il.Token(this.outer.GetElementTypeToken(to));
+                return;
+            }
+
             // Phase D: class → interface upcast is a CLR reference-level
             // no-op. The receiver already implements the interface; loading
             // the reference into an interface-typed slot needs no IL.
@@ -11138,6 +11132,42 @@ internal sealed class ReflectionMetadataEmitter
 
             throw new NotSupportedException(
                 $"Conversion from '{from.Name}' to '{to.Name}' is not yet supported by the emitter.");
+        }
+
+        private void EmitErasedObjectReturnWidening(TypeSymbol runtimeReturnType, TypeSymbol expectedType)
+        {
+            if (!IsObjectStackType(runtimeReturnType)
+                || expectedType == null
+                || expectedType == TypeSymbol.Void
+                || expectedType == TypeSymbol.Error
+                || expectedType is TypeParameterSymbol
+                || TypeSymbol.ContainsTypeParameter(expectedType)
+                || expectedType?.ClrType == typeof(object))
+            {
+                return;
+            }
+
+            if (IsValueTypeSymbol(expectedType))
+            {
+                this.il.OpCode(ILOpCode.Unbox_any);
+                this.il.Token(this.outer.GetElementTypeToken(expectedType));
+                return;
+            }
+
+            this.il.OpCode(ILOpCode.Castclass);
+            this.il.Token(this.outer.GetElementTypeToken(expectedType));
+        }
+
+        private static bool IsObjectStackType(TypeSymbol type)
+        {
+            if (type == TypeSymbol.Object || type?.ClrType == typeof(object))
+            {
+                return true;
+            }
+
+            return type is TypeParameterSymbol
+                || (type is ImportedTypeSymbol imported && imported.HasTypeParameterArgument)
+                || (type is FunctionTypeSymbol fn && TypeSymbol.ContainsTypeParameter(fn));
         }
 
         // Issue #295: emit a GSharp function value materialized as a CLR
@@ -12811,17 +12841,7 @@ internal sealed class ReflectionMetadataEmitter
             this.il.OpCode(receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
             this.il.Token(methodHandle);
 
-            // Issue #312 (emit parity, type-erased generics): a return typed as
-            // an open type parameter is encoded as System.Object. When the
-            // call's substituted return type is a value type, unbox the result
-            // so the rest of the IL sees the expected primitive on the stack.
-            if (call.Method.Type is TypeParameterSymbol
-                && call.Type is not TypeParameterSymbol
-                && IsValueTypeSymbol(call.Type))
-            {
-                this.il.OpCode(ILOpCode.Unbox_any);
-                this.il.Token(this.outer.GetElementTypeToken(call.Type));
-            }
+            this.EmitErasedObjectReturnWidening(call.Method.Type, call.Type);
         }
 
         private void EmitMapLiteral(BoundMapLiteralExpression literal)
@@ -13098,11 +13118,18 @@ internal sealed class ReflectionMetadataEmitter
 
                 if (defField != null
                     && defField.Type is TypeParameterSymbol
-                    && fa.Field.Type is not TypeParameterSymbol
-                    && IsValueTypeSymbol(fa.Field.Type))
+                    && fa.Field.Type is not TypeParameterSymbol)
                 {
-                    this.il.OpCode(ILOpCode.Unbox_any);
-                    this.il.Token(this.outer.GetElementTypeToken(fa.Field.Type));
+                    if (IsValueTypeSymbol(fa.Field.Type))
+                    {
+                        this.il.OpCode(ILOpCode.Unbox_any);
+                        this.il.Token(this.outer.GetElementTypeToken(fa.Field.Type));
+                    }
+                    else if (fa.Field.Type?.ClrType != typeof(object))
+                    {
+                        this.il.OpCode(ILOpCode.Castclass);
+                        this.il.Token(this.outer.GetElementTypeToken(fa.Field.Type));
+                    }
                 }
             }
         }
@@ -13390,6 +13417,11 @@ internal sealed class ReflectionMetadataEmitter
             if (IsValueTypeSymbol(tp.TargetType))
             {
                 this.il.OpCode(ILOpCode.Unbox_any);
+                this.il.Token(this.outer.GetElementTypeToken(tp.TargetType));
+            }
+            else if (tp.TargetType?.ClrType != typeof(object))
+            {
+                this.il.OpCode(ILOpCode.Castclass);
                 this.il.Token(this.outer.GetElementTypeToken(tp.TargetType));
             }
 
@@ -13811,6 +13843,9 @@ internal sealed class ReflectionMetadataEmitter
                     var getterRef = this.outer.GetMethodReference(getter);
                     this.il.OpCode(isStatic || receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
                     this.il.Token(getterRef);
+                    this.EmitErasedObjectReturnWidening(
+                        TypeSymbol.FromClrType(getter.ReturnType),
+                        access.Type);
                     break;
                 case FieldInfo field:
                     var fieldRef = this.outer.GetFieldReference(field);
@@ -13942,6 +13977,7 @@ internal sealed class ReflectionMetadataEmitter
             this.EmitExpression(op.Right);
             this.il.OpCode(ILOpCode.Call);
             this.il.Token(this.outer.GetMethodReference(op.Method));
+            this.EmitErasedObjectReturnWidening(TypeSymbol.FromClrType(op.Method.ReturnType), op.Type);
         }
 
         private void EmitClrUnaryOperator(BoundClrUnaryOperatorExpression op)
@@ -13950,6 +13986,7 @@ internal sealed class ReflectionMetadataEmitter
             this.EmitExpression(op.Operand);
             this.il.OpCode(ILOpCode.Call);
             this.il.Token(this.outer.GetMethodReference(op.Method));
+            this.EmitErasedObjectReturnWidening(TypeSymbol.FromClrType(op.Method.ReturnType), op.Type);
         }
 
         private void EmitClrConversionCall(BoundClrConversionCallExpression conv)
@@ -13959,6 +13996,7 @@ internal sealed class ReflectionMetadataEmitter
             this.EmitExpression(conv.Source);
             this.il.OpCode(ILOpCode.Call);
             this.il.Token(this.outer.GetMethodReference(conv.Method));
+            this.EmitErasedObjectReturnWidening(TypeSymbol.FromClrType(conv.Method.ReturnType), conv.Type);
         }
 
         private void EmitClrIndex(BoundClrIndexExpression idx)
@@ -13988,6 +14026,7 @@ internal sealed class ReflectionMetadataEmitter
                         .GetGetMethod();
                     this.il.OpCode(ILOpCode.Callvirt);
                     this.il.Token(this.outer.GetMethodReference(iListGetter));
+                    this.EmitErasedObjectReturnWidening(TypeSymbol.Object, idx.Type);
                     return;
                 }
 
@@ -14008,6 +14047,7 @@ internal sealed class ReflectionMetadataEmitter
                         .GetGetMethod();
                     this.il.OpCode(ILOpCode.Callvirt);
                     this.il.Token(this.outer.GetMethodReference(iDictGetter));
+                    this.EmitErasedObjectReturnWidening(TypeSymbol.Object, idx.Type);
                     return;
                 }
             }
@@ -14025,6 +14065,7 @@ internal sealed class ReflectionMetadataEmitter
             var receiverIsValueType = IsValueTypeSymbol(idx.Target.Type);
             this.il.OpCode(receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
             this.il.Token(this.outer.GetMethodReference(getter));
+            this.EmitErasedObjectReturnWidening(TypeSymbol.FromClrType(getter.ReturnType), idx.Type);
         }
 
         private void EmitClrIndexAssignment(BoundClrIndexAssignmentExpression ixa)

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -252,6 +252,16 @@ public class TypeSymbol : Symbol
                 return ContainsTypeParameter(a.ElementType);
             case MapTypeSymbol m:
                 return ContainsTypeParameter(m.KeyType) || ContainsTypeParameter(m.ValueType);
+            case FunctionTypeSymbol fn:
+                foreach (var param in fn.ParameterTypes)
+                {
+                    if (ContainsTypeParameter(param))
+                    {
+                        return true;
+                    }
+                }
+
+                return ContainsTypeParameter(fn.ReturnType);
             case ImportedTypeSymbol it when !it.TypeArguments.IsDefaultOrEmpty:
                 foreach (var arg in it.TypeArguments)
                 {

--- a/test/Compiler.Tests/Emit/DataStructInteropTests.cs
+++ b/test/Compiler.Tests/Emit/DataStructInteropTests.cs
@@ -172,7 +172,7 @@ public class DataStructInteropTests
         Assert.True(
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
-        IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.KnownIssues.GenericValueTypeDispatch);
+        IlVerifier.Verify(outPath);
 
         var bytes = File.ReadAllBytes(outPath);
         return Assembly.Load(bytes);

--- a/test/Compiler.Tests/Emit/GenericFunctionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/GenericFunctionEmitTests.cs
@@ -194,7 +194,7 @@ public class GenericFunctionEmitTests
             }
 
             Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
-            IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.KnownIssues.GenericValueTypeDispatch);
+            IlVerifier.Verify(outPath);
 
             var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
             File.WriteAllText(runtimeConfigPath, """

--- a/test/Compiler.Tests/Emit/GenericTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/GenericTypeEmitTests.cs
@@ -171,7 +171,7 @@ public class GenericTypeEmitTests
             }
 
             Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
-            IlVerifier.Verify(outPath, ignoredErrorCodes: IlVerifier.KnownIssues.GenericValueTypeDispatch);
+            IlVerifier.Verify(outPath);
 
             var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
             File.WriteAllText(runtimeConfigPath, """

--- a/test/Compiler.Tests/IlVerifier.cs
+++ b/test/Compiler.Tests/IlVerifier.cs
@@ -184,20 +184,6 @@ internal static class IlVerifier
         };
 
         /// <summary>
-        /// Generic dispatch on value-typed receivers emits a bare
-        /// <c>callvirt</c> instead of <c>constrained.</c> + <c>callvirt</c>,
-        /// and generic-delegate construction sometimes loses the variance
-        /// adjustment, producing stack-type mismatches between
-        /// <c>Action&lt;T&gt;</c> instantiations. Surfaces in generic
-        /// data-structs and generic delegate invokes.
-        /// </summary>
-        public static readonly string[] GenericValueTypeDispatch =
-        {
-            "CallVirtOnValueType",
-            "StackUnexpected",
-        };
-
-        /// <summary>
         /// Ref-struct receivers and stack-allocated return paths trip
         /// ilverify's escape-analysis checks. See ADR/issue tracking ref
         /// struct ergonomics.
@@ -238,14 +224,6 @@ internal static class IlVerifier
         ["AsyncTask"] = KnownIssues.AsyncStateMachine,
         ["AsyncValueReturns"] = KnownIssues.AsyncStateMachine,
 
-        // Generic value-type dispatch: see KnownIssues.GenericValueTypeDispatch.
-        ["GenericMethodDelegates"] = KnownIssues.GenericValueTypeDispatch,
-        ["GenericMethods"] = KnownIssues.GenericValueTypeDispatch,
-        ["NullableFlow"] = KnownIssues.GenericValueTypeDispatch,
-        ["ImportedBaseClass"] = KnownIssues.GenericValueTypeDispatch,
-        ["ExpressionEval"] = KnownIssues.GenericValueTypeDispatch,
-        ["PatternSwitch"] = KnownIssues.GenericValueTypeDispatch,
-        ["SwitchExpression"] = KnownIssues.GenericValueTypeDispatch,
         ["InlineStruct"] = new[] { "InitOnly" },
 
         // Ref struct emission: see KnownIssues.RefStruct.


### PR DESCRIPTION
Closes the `KnownIssues.GenericValueTypeDispatch` ilverify bundle by fixing `StackUnexpected` at the boundary between type-erased generics and concrete code.

### Two sub-fixes

1. **Reified-conversion insertion after erased calls** — when a type-erased call's runtime return is `object` but the bound expression's type is concrete, insert `castclass<T>` (for reference types) or `unbox.any<T>` (for value types) on the result.
2. **Erased function-literal trampoline** — emit function literals against the erased `(object,...)->object` signature when the contextual target is an erased open delegate (e.g. `System.Func<object, object, ...>`), reusing the existing per-arg box/unbox trampoline.

### Changes

- `src/Core/CodeAnalysis/Binding/Binder.cs` (+286)
- `src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs` (+123/-…)
- `src/Core/CodeAnalysis/Symbols/TypeSymbol.cs` (+10)
- Removed `KnownIssues.GenericValueTypeDispatch` and its seven `SampleKnownIssues` entries from `test/Compiler.Tests/IlVerifier.cs`.
- Removed the `ignoredErrorCodes` args in `GenericTypeEmitTests`, `DataStructInteropTests`, `GenericFunctionEmitTests`.

### Verification

- `dotnet build GSharp.sln -nologo -clp:NoSummary` — 0 errors
- `dotnet test GSharp.sln --no-restore --nologo` — 2368 passed
- All previously-muted generic samples verify clean against `dotnet-ilverify` 10.0.8.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
