### PR TITLE
Implement ADR-0029 data struct synthesized members (#410)

### DIFF
--- a/docs/adr/0029-data-struct-synthesized-members.md
+++ b/docs/adr/0029-data-struct-synthesized-members.md
@@ -1,9 +1,10 @@
 # ADR-0029: `data struct` synthesized members
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-05-22
 - **Phase**: Phase 3 (lock before 3.B.2)
 - **Related**: ADR-0003 (OO surface); ADR-0017 (method virtuality); ADR-0026 (copy syntax, Phase 7); execution plan §3.B.2; gaps doc §3.2.1
+- **Implementation**: Issue [#410](https://github.com/DavidObando/gsharp/issues/410); see `EmitDataStructSynthesizedMembers` in `src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs` and diagnostic GS0232.
 
 ## Context
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -262,3 +262,11 @@ These diagnostics indicate an internal compiler problem. If you encounter them, 
 | GS0229 | Warning | Documentation @param '{name}' does not match any parameter of '{symbol}'. |
 | GS0230 | Warning | Unsupported documentation Markdown: {detail}. |
 | GS0231 | Warning | Unknown documentation tag '{tag}'. Valid tags are: @param, @typeparam, @returns, @remarks, @value, @exception, @seealso. |
+
+## Data struct diagnostics (GS0232)
+
+ADR-0029 / Issue #410: every `data struct` synthesizes a fixed contract of value-semantics members — `Equals(object)`, `Equals(Name)`, `GetHashCode()`, `ToString()`, `op_Equality(Name, Name)`, `op_Inequality(Name, Name)`, and `Deconstruct(out T1, out T2, …)`. Hand-written versions are rejected so the contract stays predictable and so consumers (G# and external .NET) can rely on the synthesized IL.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0232 | Error | Data struct '{type}' synthesizes member '{member}'; it cannot be declared explicitly. |

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1859,6 +1859,20 @@ public sealed class Binder
                     continue;
                 }
 
+                // Issue #410 / ADR-0029: forbid user-written synthesized members
+                // on data structs even when declared as shared/static methods.
+                if (structSymbol.IsData && IsDataStructSynthesizedMemberName(methodName))
+                {
+                    Diagnostics.ReportDataStructSynthesizedMemberConflict(methodSyntax.Identifier.Location, structSymbol.Name, methodName);
+                    continue;
+                }
+
+                if (structSymbol.IsInline && IsInlineSynthesizedMemberName(methodName))
+                {
+                    Diagnostics.ReportInlineStructSynthesizedMemberConflict(methodSyntax.Identifier.Location, structSymbol.Name, methodName);
+                    continue;
+                }
+
                 // Issue #312 / ADR-0020: support generic static methods too.
                 var methodTypeParameters = BindTypeParameterList(methodSyntax.TypeParameterList);
                 var enclosingTypeParameters = currentTypeParameters;
@@ -2736,6 +2750,12 @@ public sealed class Binder
                     return;
                 }
 
+                if (methodReceiverStruct.IsData && IsDataStructSynthesizedMemberName(methodName))
+                {
+                    Diagnostics.ReportDataStructSynthesizedMemberConflict(syntax.Identifier.Location, methodReceiverStruct.Name, methodName);
+                    return;
+                }
+
                 if (methodReceiverStruct.TryGetField(methodName, out _) || methodReceiverStruct.TryGetMethod(methodName, out _))
                 {
                     Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, methodName);
@@ -2796,6 +2816,17 @@ public sealed class Binder
             methodName == "op_Equality" ||
             methodName == "op_Inequality" ||
             methodName == "Deconstruct";
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: data structs synthesize the same six member
+    /// names as inline structs (<c>Equals</c>, <c>GetHashCode</c>,
+    /// <c>ToString</c>, <c>op_Equality</c>, <c>op_Inequality</c>,
+    /// <c>Deconstruct</c>). User code may not hand-write any of them.
+    /// </summary>
+    private static bool IsDataStructSynthesizedMemberName(string methodName)
+    {
+        return IsInlineSynthesizedMemberName(methodName);
     }
 
     private bool IsSamePackageNonAggregateReceiver(TypeClauseSyntax receiverSyntax, TypeSymbol receiverType, PackageSymbol package)

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1594,6 +1594,22 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0231", $"Unknown documentation tag '{tagName}'. Valid tags are: @param, @typeparam, @returns, @remarks, @value, @exception, @seealso.", DiagnosticSeverity.Warning);
     }
 
+    /// <summary>
+    /// Issue #410 / ADR-0029: reports that a synthesized data-struct member
+    /// (<c>Equals</c>, <c>GetHashCode</c>, <c>ToString</c>, <c>op_Equality</c>,
+    /// <c>op_Inequality</c>, or <c>Deconstruct</c>) was hand-written. The ADR
+    /// forbids user-written versions so the contract of <c>data struct</c> is
+    /// learnable and predictable.
+    /// </summary>
+    /// <param name="location">The text location of the member name.</param>
+    /// <param name="typeName">The data struct type name.</param>
+    /// <param name="memberName">The synthesized member name.</param>
+    public void ReportDataStructSynthesizedMemberConflict(TextLocation location, string typeName, string memberName)
+    {
+        var message = $"Data struct '{typeName}' synthesizes member '{memberName}'; it cannot be declared explicitly.";
+        Report(location, "GS0232", message);
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -215,6 +215,23 @@ internal sealed class ReflectionMetadataEmitter
     private MemberReferenceHandle objectInstanceToStringRef;
     private MemberReferenceHandle objectInstanceGetHashCodeRef;
     private MemberReferenceHandle nullRefExceptionCtorRef;
+
+    // Issue #410 / ADR-0029: cached member refs for data-struct synthesized members.
+    private MemberReferenceHandle stringConcatArrayRef;
+    private MemberReferenceHandle convertToStringRef;
+    private MemberReferenceHandle cultureInvariantGetterRef;
+    private MemberReferenceHandle hashCodeAddOpenRef;
+    private MemberReferenceHandle hashCodeToHashCodeRef;
+    private readonly MemberReferenceHandle?[] hashCodeCombineOpenRefs = new MemberReferenceHandle?[8];
+    private TypeReferenceHandle hashCodeTypeRef;
+    private StandaloneSignatureHandle hashCodeLocalSig;
+
+    // Per-data-struct op_Equality MethodDef handle (issue #410). Populated when
+    // the operator is synthesized so future call sites could route through it
+    // directly. Not currently used by the BoundBinaryExpression lowering
+    // (which still boxes and dispatches via Object.Equals) but kept for
+    // forward-compatibility with future perf work.
+    private readonly Dictionary<StructSymbol, MethodDefinitionHandle> dataStructOpEqualityHandles = new Dictionary<StructSymbol, MethodDefinitionHandle>();
     private EntityHandle? systemAttributeTypeRef;
     private MemberReferenceHandle? systemAttributeCtorRef;
 
@@ -775,7 +792,7 @@ internal sealed class ReflectionMetadataEmitter
         var structFirstMethodRows = new Dictionary<StructSymbol, int>();
         foreach (var s in nonSmStructs)
         {
-            if (s.Methods.IsDefaultOrEmpty && !s.IsInline && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty && s.StaticProperties.IsDefaultOrEmpty && s.StaticEvents.IsDefaultOrEmpty && s.StaticFieldInitializers.IsEmpty)
+            if (s.Methods.IsDefaultOrEmpty && !s.IsInline && !s.IsData && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty && s.StaticProperties.IsDefaultOrEmpty && s.StaticEvents.IsDefaultOrEmpty && s.StaticFieldInitializers.IsEmpty)
             {
                 continue;
             }
@@ -784,6 +801,13 @@ internal sealed class ReflectionMetadataEmitter
             if (s.IsInline)
             {
                 methodRow += 8;
+            }
+            else if (s.IsData)
+            {
+                // Issue #410 / ADR-0029: data structs synthesize 7 MethodDef
+                // rows: Equals(object), Equals(Name), GetHashCode, ToString,
+                // op_Equality, op_Inequality, Deconstruct.
+                methodRow += 7;
             }
 
             foreach (var m in s.Methods)
@@ -1284,6 +1308,13 @@ internal sealed class ReflectionMetadataEmitter
             if (s.IsInline)
             {
                 this.EmitInlineStructSynthesizedMembers(s);
+            }
+            else if (s.IsData)
+            {
+                // Issue #410 / ADR-0029: emit synthesized members BEFORE
+                // user-declared methods so the MethodDef rows match the
+                // planning order (the first 7 rows reserved by the planner).
+                this.EmitDataStructSynthesizedMembers(s);
             }
 
             if (s.Methods.IsDefaultOrEmpty && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty && s.StaticProperties.IsDefaultOrEmpty && s.StaticEvents.IsDefaultOrEmpty && s.StaticFieldInitializers.IsEmpty)
@@ -5803,6 +5834,422 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #410 / ADR-0029: emits the seven synthesized members for a
+    /// <c>data struct</c> type. The MethodDef rows are added in a fixed
+    /// order so they align 1:1 with the rows reserved by the method-row
+    /// planner: <c>Equals(Name)</c>, <c>Equals(object)</c>,
+    /// <c>GetHashCode</c>, <c>ToString</c>, <c>op_Equality</c>,
+    /// <c>op_Inequality</c>, <c>Deconstruct</c>.
+    /// <c>Equals(Name)</c> is emitted first so its MethodDef handle is
+    /// available when <c>Equals(object)</c> is emitted.
+    /// </summary>
+    /// <param name="structSym">The data-struct symbol to emit members for.</param>
+    private void EmitDataStructSynthesizedMembers(StructSymbol structSym)
+    {
+        // ADR-0029: data structs must have at least one field. This is
+        // enforced by the binder; assert here so the emit IL stays simple.
+        Debug.Assert(
+            !structSym.Fields.IsDefaultOrEmpty,
+            "Data structs must have at least one field; the binder should have rejected an empty data struct.");
+
+        var typeDef = this.structTypeDefs[structSym];
+        var equalsTypedHandle = this.EmitDataStructEqualsTyped(structSym);
+        this.EmitDataStructEqualsObject(structSym, typeDef, equalsTypedHandle);
+        this.EmitDataStructGetHashCode(structSym);
+        this.EmitDataStructToString(structSym);
+        this.dataStructOpEqualityHandles[structSym] = this.EmitDataStructEqualityOperator(structSym, isInequality: false);
+        this.EmitDataStructEqualityOperator(structSym, isInequality: true);
+        this.EmitDataStructDeconstruct(structSym);
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: emits
+    /// <c>public sealed override bool Equals(object other)</c> that performs
+    /// <c>other is Name p &amp;&amp; this.Equals(p)</c>. Sealed because struct
+    /// methods cannot be overridden in user code anyway, but the metadata
+    /// flag communicates intent.
+    /// </summary>
+    private void EmitDataStructEqualsObject(StructSymbol structSym, TypeDefinitionHandle typeDef, MethodDefinitionHandle equalsTypedHandle)
+    {
+        Debug.Assert(
+            !structSym.IsClass,
+            "EmitDataStructEqualsObject precondition violated: data struct must be a value type.");
+
+        var il = new InstructionEncoder(new BlobBuilder(), new ControlFlowBuilder());
+        if (!this.metadataOnly)
+        {
+            var retFalse = il.DefineLabel();
+            il.LoadArgument(1);
+            il.OpCode(ILOpCode.Isinst);
+            il.Token(typeDef);
+            il.Branch(ILOpCode.Brfalse, retFalse);
+            il.LoadArgument(0);
+            il.LoadArgument(1);
+            il.OpCode(ILOpCode.Unbox_any);
+            il.Token(typeDef);
+            il.OpCode(ILOpCode.Call);
+            il.Token(equalsTypedHandle);
+            il.OpCode(ILOpCode.Ret);
+            il.MarkLabel(retFalse);
+            il.LoadConstantI4(0);
+            il.OpCode(ILOpCode.Ret);
+        }
+
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: true)
+            .Parameters(1, r => r.Type().Boolean(), ps => ps.AddParameter().Type().Object());
+
+        this.metadata.AddMethodDefinition(
+            attributes: MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.HideBySig,
+            implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString("Equals"),
+            signature: this.metadata.GetOrAddBlob(sig),
+            bodyOffset: this.FinishInlineBody(il),
+            parameterList: this.NextParameterHandle());
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: emits
+    /// <c>public bool Equals(Name other)</c> that compares fields in source
+    /// declaration order via <c>Object.Equals(object, object)</c>, short
+    /// circuiting on first inequality. Value-type fields are boxed; type
+    /// parameters and reference-type fields are passed as objects directly.
+    /// </summary>
+    /// <returns>The MethodDef handle of the emitted method, so callers can
+    /// reference it from other synthesized members.</returns>
+    private MethodDefinitionHandle EmitDataStructEqualsTyped(StructSymbol structSym)
+    {
+        Debug.Assert(
+            !structSym.IsClass,
+            "EmitDataStructEqualsTyped precondition violated: data struct must be a value type.");
+
+        var il = new InstructionEncoder(new BlobBuilder(), new ControlFlowBuilder());
+        if (!this.metadataOnly)
+        {
+            var retFalse = il.DefineLabel();
+            foreach (var field in structSym.Fields)
+            {
+                var fieldHandle = this.structFieldDefs[field];
+                il.LoadArgument(0);
+                il.OpCode(ILOpCode.Ldfld);
+                il.Token(fieldHandle);
+                this.EmitBoxIfNeeded(il, field.Type);
+                il.LoadArgumentAddress(1);
+                il.OpCode(ILOpCode.Ldfld);
+                il.Token(fieldHandle);
+                this.EmitBoxIfNeeded(il, field.Type);
+                il.Call(this.GetObjectStaticEqualsReference());
+                il.Branch(ILOpCode.Brfalse, retFalse);
+            }
+
+            il.LoadConstantI4(1);
+            il.OpCode(ILOpCode.Ret);
+            il.MarkLabel(retFalse);
+            il.LoadConstantI4(0);
+            il.OpCode(ILOpCode.Ret);
+        }
+
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: true)
+            .Parameters(1, r => r.Type().Boolean(), ps => this.EncodeTypeSymbol(ps.AddParameter().Type(), structSym));
+
+        return this.metadata.AddMethodDefinition(
+            attributes: MethodAttributes.Public | MethodAttributes.HideBySig,
+            implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString("Equals"),
+            signature: this.metadata.GetOrAddBlob(sig),
+            bodyOffset: this.FinishInlineBody(il),
+            parameterList: this.NextParameterHandle());
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: emits
+    /// <c>public sealed override int GetHashCode()</c>. For up to 8 fields the
+    /// implementation calls <c>HashCode.Combine&lt;object,...,object&gt;</c>
+    /// after boxing each field; for &gt;8 fields it folds via a stack-allocated
+    /// <c>HashCode</c> local using <c>HashCode.Add&lt;object&gt;</c> per field
+    /// and finishes with <c>ToHashCode()</c>.
+    /// </summary>
+    private void EmitDataStructGetHashCode(StructSymbol structSym)
+    {
+        Debug.Assert(
+            !structSym.IsClass,
+            "EmitDataStructGetHashCode precondition violated: data struct must be a value type.");
+
+        var fields = structSym.Fields;
+        bool useFold = fields.Length > 8;
+
+        var il = new InstructionEncoder(new BlobBuilder());
+        StandaloneSignatureHandle localsSignature = default;
+        int bodyOffset = -1;
+
+        if (!this.metadataOnly)
+        {
+            if (!useFold)
+            {
+                foreach (var field in fields)
+                {
+                    var fieldHandle = this.structFieldDefs[field];
+                    il.LoadArgument(0);
+                    il.OpCode(ILOpCode.Ldfld);
+                    il.Token(fieldHandle);
+                    this.EmitBoxIfNeeded(il, field.Type);
+                }
+
+                il.OpCode(ILOpCode.Call);
+                il.Token(this.GetHashCodeCombineObjectSpec(fields.Length));
+                il.OpCode(ILOpCode.Ret);
+            }
+            else
+            {
+                // ldloca.s 0; initobj HashCode
+                il.LoadLocalAddress(0);
+                il.OpCode(ILOpCode.Initobj);
+                il.Token(this.GetHashCodeTypeReference());
+
+                var addSpec = this.GetHashCodeAddObjectSpec();
+                foreach (var field in fields)
+                {
+                    var fieldHandle = this.structFieldDefs[field];
+                    il.LoadLocalAddress(0);
+                    il.LoadArgument(0);
+                    il.OpCode(ILOpCode.Ldfld);
+                    il.Token(fieldHandle);
+                    this.EmitBoxIfNeeded(il, field.Type);
+                    il.OpCode(ILOpCode.Call);
+                    il.Token(addSpec);
+                }
+
+                il.LoadLocalAddress(0);
+                il.Call(this.GetHashCodeToHashCodeReference());
+                il.OpCode(ILOpCode.Ret);
+
+                localsSignature = this.GetHashCodeLocalSignature();
+            }
+
+            bodyOffset = this.methodBodyStream.AddMethodBody(il, localVariablesSignature: localsSignature);
+        }
+
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => r.Type().Int32(), _ => { });
+
+        this.metadata.AddMethodDefinition(
+            attributes: MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.HideBySig,
+            implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString("GetHashCode"),
+            signature: this.metadata.GetOrAddBlob(sig),
+            bodyOffset: bodyOffset,
+            parameterList: this.NextParameterHandle());
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: emits
+    /// <c>public sealed override string ToString()</c> rendering
+    /// <c>Name(F1=v1, F2=v2, …)</c>. Field values are converted via
+    /// <c>Convert.ToString(object, IFormatProvider)</c> with
+    /// <see cref="System.Globalization.CultureInfo.InvariantCulture"/> so
+    /// null reference fields render as the empty string and value-type
+    /// formatting is locale-independent. Pieces are assembled with
+    /// <c>String.Concat(string[])</c>.
+    /// </summary>
+    private void EmitDataStructToString(StructSymbol structSym)
+    {
+        Debug.Assert(
+            !structSym.IsClass,
+            "EmitDataStructToString precondition violated: data struct must be a value type.");
+
+        var fields = structSym.Fields;
+        int pieceCount = (2 * fields.Length) + 1;
+
+        var il = new InstructionEncoder(new BlobBuilder());
+        if (!this.metadataOnly)
+        {
+            var stringTypeRef = this.GetTypeReference(this.coreStringType);
+
+            il.LoadConstantI4(pieceCount);
+            il.OpCode(ILOpCode.Newarr);
+            il.Token(stringTypeRef);
+
+            // Piece 0: "Name(F1="
+            il.OpCode(ILOpCode.Dup);
+            il.LoadConstantI4(0);
+            il.LoadString(this.metadata.GetOrAddUserString(structSym.Name + "(" + fields[0].Name + "="));
+            il.OpCode(ILOpCode.Stelem_ref);
+
+            for (int i = 0; i < fields.Length; i++)
+            {
+                var field = fields[i];
+                var fieldHandle = this.structFieldDefs[field];
+
+                // Piece 2*i + 1: Convert.ToString(this.Fi, InvariantCulture)
+                il.OpCode(ILOpCode.Dup);
+                il.LoadConstantI4((2 * i) + 1);
+                il.LoadArgument(0);
+                il.OpCode(ILOpCode.Ldfld);
+                il.Token(fieldHandle);
+                this.EmitBoxIfNeeded(il, field.Type);
+                il.Call(this.GetCultureInvariantGetterReference());
+                il.Call(this.GetConvertToStringReference());
+                il.OpCode(ILOpCode.Stelem_ref);
+
+                // Piece 2*i + 2: separator (", F{i+1}=" if more fields, else ")")
+                il.OpCode(ILOpCode.Dup);
+                il.LoadConstantI4((2 * i) + 2);
+                string separator = i + 1 < fields.Length
+                    ? ", " + fields[i + 1].Name + "="
+                    : ")";
+                il.LoadString(this.metadata.GetOrAddUserString(separator));
+                il.OpCode(ILOpCode.Stelem_ref);
+            }
+
+            il.Call(this.GetStringConcatArrayReference());
+            il.OpCode(ILOpCode.Ret);
+        }
+
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => r.Type().String(), _ => { });
+
+        this.metadata.AddMethodDefinition(
+            attributes: MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.HideBySig,
+            implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString("ToString"),
+            signature: this.metadata.GetOrAddBlob(sig),
+            bodyOffset: this.FinishInlineBody(il),
+            parameterList: this.NextParameterHandle());
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: emits
+    /// <c>public static bool op_Equality(Name left, Name right)</c> (or
+    /// <c>op_Inequality</c> when <paramref name="isInequality"/> is true).
+    /// Both delegate to <see cref="EmitDataStructEqualsTyped"/> via
+    /// <c>Object.Equals(object, object)</c> on every field — equivalent to
+    /// calling <c>left.Equals(right)</c>, but avoids needing the
+    /// MethodDef handle for <c>Equals(Name)</c> ahead of time.
+    /// </summary>
+    /// <returns>The MethodDef handle of the emitted operator.</returns>
+    private MethodDefinitionHandle EmitDataStructEqualityOperator(StructSymbol structSym, bool isInequality)
+    {
+        Debug.Assert(
+            !structSym.IsClass,
+            "EmitDataStructEqualityOperator precondition violated: data struct must be a value type.");
+
+        var il = new InstructionEncoder(new BlobBuilder(), new ControlFlowBuilder());
+        if (!this.metadataOnly)
+        {
+            var retFalse = il.DefineLabel();
+            foreach (var field in structSym.Fields)
+            {
+                var fieldHandle = this.structFieldDefs[field];
+                il.LoadArgumentAddress(0);
+                il.OpCode(ILOpCode.Ldfld);
+                il.Token(fieldHandle);
+                this.EmitBoxIfNeeded(il, field.Type);
+                il.LoadArgumentAddress(1);
+                il.OpCode(ILOpCode.Ldfld);
+                il.Token(fieldHandle);
+                this.EmitBoxIfNeeded(il, field.Type);
+                il.Call(this.GetObjectStaticEqualsReference());
+                il.Branch(ILOpCode.Brfalse, retFalse);
+            }
+
+            il.LoadConstantI4(isInequality ? 0 : 1);
+            il.OpCode(ILOpCode.Ret);
+            il.MarkLabel(retFalse);
+            il.LoadConstantI4(isInequality ? 1 : 0);
+            il.OpCode(ILOpCode.Ret);
+        }
+
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
+            .Parameters(
+                2,
+                r => r.Type().Boolean(),
+                ps =>
+                {
+                    this.EncodeTypeSymbol(ps.AddParameter().Type(), structSym);
+                    this.EncodeTypeSymbol(ps.AddParameter().Type(), structSym);
+                });
+
+        return this.metadata.AddMethodDefinition(
+            attributes: MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+            implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString(isInequality ? "op_Inequality" : "op_Equality"),
+            signature: this.metadata.GetOrAddBlob(sig),
+            bodyOffset: this.FinishInlineBody(il),
+            parameterList: this.NextParameterHandle());
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: emits
+    /// <c>public void Deconstruct(out T1 F1, out T2 F2, …)</c> assigning each
+    /// field to the corresponding out parameter. Field names match the
+    /// declaration order so C# users get meaningful tooling hints when
+    /// destructuring positionally.
+    /// </summary>
+    private void EmitDataStructDeconstruct(StructSymbol structSym)
+    {
+        var fields = structSym.Fields;
+        var il = new InstructionEncoder(new BlobBuilder());
+        if (!this.metadataOnly)
+        {
+            for (int i = 0; i < fields.Length; i++)
+            {
+                var field = fields[i];
+                var fieldHandle = this.structFieldDefs[field];
+                il.LoadArgument(i + 1);
+                il.LoadArgument(0);
+                il.OpCode(ILOpCode.Ldfld);
+                il.Token(fieldHandle);
+
+                // ADR-0029 Phase 4-erased generics: TypeParameterSymbol
+                // fields are encoded as System.Object (see EncodeTypeSymbol),
+                // so the indirect store must use stind.ref. Concrete value
+                // types use stobj with the value-type token; concrete
+                // reference types use stind.ref.
+                if (field.Type is TypeParameterSymbol)
+                {
+                    il.OpCode(ILOpCode.Stind_ref);
+                }
+                else if (IsValueTypeSymbol(field.Type))
+                {
+                    il.OpCode(ILOpCode.Stobj);
+                    il.Token(this.GetElementTypeToken(field.Type));
+                }
+                else
+                {
+                    il.OpCode(ILOpCode.Stind_ref);
+                }
+            }
+
+            il.OpCode(ILOpCode.Ret);
+        }
+
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                fields.Length,
+                r => r.Void(),
+                ps =>
+                {
+                    foreach (var field in fields)
+                    {
+                        this.EncodeTypeSymbol(ps.AddParameter().Type(isByRef: true), field.Type);
+                    }
+                });
+
+        this.metadata.AddMethodDefinition(
+            attributes: MethodAttributes.Public | MethodAttributes.HideBySig,
+            implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString("Deconstruct"),
+            signature: this.metadata.GetOrAddBlob(sig),
+            bodyOffset: this.FinishInlineBody(il),
+            parameterList: this.NextParameterHandle());
+    }
+
+    /// <summary>
     /// Emits the <c>MoveNext</c> method for an async state machine using the
     /// rewritten bound-tree body produced by <see cref="MoveNextBodyRewriter"/>.
     /// </summary>
@@ -9329,6 +9776,261 @@ internal sealed class ReflectionMetadataEmitter
             name: this.metadata.GetOrAddString("Equals"),
             signature: this.metadata.GetOrAddBlob(sigBlob));
         return this.objectStaticEqualsRef;
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: returns a TypeRef for <c>System.HashCode</c>,
+    /// used by data-struct <c>GetHashCode</c> synthesis. Cached because
+    /// <see cref="GetTypeReference(Type)"/> already caches by Type, but the
+    /// data-struct helpers need a strongly-typed handle.
+    /// </summary>
+    private TypeReferenceHandle GetHashCodeTypeReference()
+    {
+        if (!this.hashCodeTypeRef.IsNil)
+        {
+            return this.hashCodeTypeRef;
+        }
+
+        this.hashCodeTypeRef = this.GetTypeReference(typeof(System.HashCode));
+        return this.hashCodeTypeRef;
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: resolves an open MemberRef for the
+    /// <c>System.HashCode.Combine&lt;T1, ..., Tn&gt;</c> overload with the
+    /// given arity (1 ≤ <paramref name="arity"/> ≤ 8). Each open parameter
+    /// is encoded as a generic method parameter (<c>!!i</c>) and instantiated
+    /// to <see cref="object"/> via a MethodSpec at the call site.
+    /// </summary>
+    private MemberReferenceHandle GetHashCodeCombineOpenReference(int arity)
+    {
+        if (arity < 1 || arity > 8)
+        {
+            throw new ArgumentOutOfRangeException(nameof(arity), arity, "HashCode.Combine supports arities 1 through 8.");
+        }
+
+        var cached = this.hashCodeCombineOpenRefs[arity - 1];
+        if (cached.HasValue)
+        {
+            return cached.Value;
+        }
+
+        var hashCodeRef = this.GetHashCodeTypeReference();
+
+        // Signature: static int Combine<T1,...,Tn>(T1, ..., Tn) with `arity`
+        // generic method parameters. In open form each Ti is !!i.
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false, genericParameterCount: arity)
+            .Parameters(
+                arity,
+                r => r.Type().Int32(),
+                ps =>
+                {
+                    for (int i = 0; i < arity; i++)
+                    {
+                        ps.AddParameter().Type().GenericMethodTypeParameter(i);
+                    }
+                });
+
+        var openRef = this.metadata.AddMemberReference(
+            hashCodeRef,
+            this.metadata.GetOrAddString("Combine"),
+            this.metadata.GetOrAddBlob(sig));
+        this.hashCodeCombineOpenRefs[arity - 1] = openRef;
+        return openRef;
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: produces a MethodSpec instantiating
+    /// <c>HashCode.Combine&lt;T1,...,Tn&gt;</c> with <see cref="object"/> for
+    /// each generic parameter. The data-struct emitter always boxes field
+    /// values, so a single object-typed instantiation suffices regardless of
+    /// the field types, dramatically reducing the number of unique MethodSpec
+    /// rows the metadata builder has to track.
+    /// </summary>
+    private EntityHandle GetHashCodeCombineObjectSpec(int arity)
+    {
+        var openRef = this.GetHashCodeCombineOpenReference(arity);
+        var sigBlob = new BlobBuilder();
+        var argsEncoder = new BlobEncoder(sigBlob).MethodSpecificationSignature(arity);
+        for (int i = 0; i < arity; i++)
+        {
+            argsEncoder.AddArgument().Object();
+        }
+
+        return this.metadata.AddMethodSpecification(openRef, this.metadata.GetOrAddBlob(sigBlob));
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: resolves the open MemberRef for the instance
+    /// method <c>System.HashCode.Add&lt;T&gt;(T)</c>, used by the &gt;8-field
+    /// fold path for <c>GetHashCode</c>.
+    /// </summary>
+    private MemberReferenceHandle GetHashCodeAddOpenReference()
+    {
+        if (!this.hashCodeAddOpenRef.IsNil)
+        {
+            return this.hashCodeAddOpenRef;
+        }
+
+        var hashCodeRef = this.GetHashCodeTypeReference();
+
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: true, genericParameterCount: 1)
+            .Parameters(
+                1,
+                r => r.Void(),
+                ps => ps.AddParameter().Type().GenericMethodTypeParameter(0));
+
+        this.hashCodeAddOpenRef = this.metadata.AddMemberReference(
+            hashCodeRef,
+            this.metadata.GetOrAddString("Add"),
+            this.metadata.GetOrAddBlob(sig));
+        return this.hashCodeAddOpenRef;
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: produces a MethodSpec for
+    /// <c>HashCode.Add&lt;object&gt;(object)</c>.
+    /// </summary>
+    private EntityHandle GetHashCodeAddObjectSpec()
+    {
+        var openRef = this.GetHashCodeAddOpenReference();
+        var sigBlob = new BlobBuilder();
+        var argsEncoder = new BlobEncoder(sigBlob).MethodSpecificationSignature(1);
+        argsEncoder.AddArgument().Object();
+        return this.metadata.AddMethodSpecification(openRef, this.metadata.GetOrAddBlob(sigBlob));
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: resolves the MemberRef for instance method
+    /// <c>System.HashCode.ToHashCode()</c>.
+    /// </summary>
+    private MemberReferenceHandle GetHashCodeToHashCodeReference()
+    {
+        if (!this.hashCodeToHashCodeRef.IsNil)
+        {
+            return this.hashCodeToHashCodeRef;
+        }
+
+        var hashCodeRef = this.GetHashCodeTypeReference();
+
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => r.Type().Int32(), _ => { });
+
+        this.hashCodeToHashCodeRef = this.metadata.AddMemberReference(
+            hashCodeRef,
+            this.metadata.GetOrAddString("ToHashCode"),
+            this.metadata.GetOrAddBlob(sig));
+        return this.hashCodeToHashCodeRef;
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: returns a standalone signature with one
+    /// <c>System.HashCode</c> local, used by the &gt;8-field
+    /// <c>GetHashCode</c> fold path.
+    /// </summary>
+    private StandaloneSignatureHandle GetHashCodeLocalSignature()
+    {
+        if (!this.hashCodeLocalSig.IsNil)
+        {
+            return this.hashCodeLocalSig;
+        }
+
+        var hashCodeRef = this.GetHashCodeTypeReference();
+        var sigBlob = new BlobBuilder();
+        var encoder = new BlobEncoder(sigBlob).LocalVariableSignature(1);
+        encoder.AddVariable().Type().Type(hashCodeRef, isValueType: true);
+        this.hashCodeLocalSig = this.metadata.AddStandaloneSignature(this.metadata.GetOrAddBlob(sigBlob));
+        return this.hashCodeLocalSig;
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: resolves the MemberRef for the static
+    /// <c>System.Convert.ToString(object, IFormatProvider)</c> overload used
+    /// by data-struct <c>ToString</c> synthesis. Handles null reference-type
+    /// fields gracefully (returns the empty string) per the ADR.
+    /// </summary>
+    private MemberReferenceHandle GetConvertToStringReference()
+    {
+        if (!this.convertToStringRef.IsNil)
+        {
+            return this.convertToStringRef;
+        }
+
+        var convertRef = this.GetTypeReference(typeof(System.Convert));
+        var ifpRef = this.GetTypeReference(typeof(System.IFormatProvider));
+
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
+            .Parameters(
+                2,
+                r => r.Type().String(),
+                ps =>
+                {
+                    ps.AddParameter().Type().Object();
+                    ps.AddParameter().Type().Type(ifpRef, isValueType: false);
+                });
+
+        this.convertToStringRef = this.metadata.AddMemberReference(
+            convertRef,
+            this.metadata.GetOrAddString("ToString"),
+            this.metadata.GetOrAddBlob(sig));
+        return this.convertToStringRef;
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: resolves the MemberRef for the static
+    /// property getter <c>System.Globalization.CultureInfo::get_InvariantCulture</c>,
+    /// used to thread an invariant <see cref="System.IFormatProvider"/> into
+    /// <c>Convert.ToString</c> during data-struct <c>ToString</c> synthesis.
+    /// </summary>
+    private MemberReferenceHandle GetCultureInvariantGetterReference()
+    {
+        if (!this.cultureInvariantGetterRef.IsNil)
+        {
+            return this.cultureInvariantGetterRef;
+        }
+
+        var cultureInfoRef = this.GetTypeReference(typeof(System.Globalization.CultureInfo));
+
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
+            .Parameters(0, r => r.Type().Type(cultureInfoRef, isValueType: false), _ => { });
+
+        this.cultureInvariantGetterRef = this.metadata.AddMemberReference(
+            cultureInfoRef,
+            this.metadata.GetOrAddString("get_InvariantCulture"),
+            this.metadata.GetOrAddBlob(sig));
+        return this.cultureInvariantGetterRef;
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: resolves the MemberRef for the static
+    /// <c>System.String.Concat(string[])</c> overload used to assemble the
+    /// data-struct <c>ToString</c> output from a per-field array of pieces.
+    /// </summary>
+    private MemberReferenceHandle GetStringConcatArrayReference()
+    {
+        if (!this.stringConcatArrayRef.IsNil)
+        {
+            return this.stringConcatArrayRef;
+        }
+
+        var stringTypeRef = this.GetTypeReference(this.coreStringType);
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
+            .Parameters(
+                1,
+                r => r.Type().String(),
+                ps => ps.AddParameter().Type().SZArray().String());
+
+        this.stringConcatArrayRef = this.metadata.AddMemberReference(
+            stringTypeRef,
+            this.metadata.GetOrAddString("Concat"),
+            this.metadata.GetOrAddBlob(sig));
+        return this.stringConcatArrayRef;
     }
 
     private void EncodeTypeSymbol(SignatureTypeEncoder encoder, TypeSymbol type)

--- a/test/Compiler.Tests/Emit/DataStructInteropTests.cs
+++ b/test/Compiler.Tests/Emit/DataStructInteropTests.cs
@@ -74,9 +74,12 @@ public class DataStructInteropTests
     [Fact]
     public void DataStruct_CoexistsWithInlineStruct_WithoutTypeLoadException()
     {
-        // Issue #242 root cause: when a data struct (no methods) preceded an
-        // inline struct (8 synthesized methods, including its ctor) in the TypeDef table, the
-        // methodList pointers violated ECMA-335 monotonicity.
+        // Issue #242 root cause: when a data struct preceded an inline struct
+        // in the TypeDef table, the methodList pointers violated ECMA-335
+        // monotonicity. As of ADR-0029 / Issue #410 a data struct emits 7
+        // synthesized methods and an inline struct emits 7 + ctor, so both
+        // contribute non-empty method ranges; this test pins the monotonicity
+        // invariant so any future change to the method count surfaces here.
         var source = """
             package MyLib
             import System

--- a/test/Compiler.Tests/Emit/DataStructSynthesizedMembersTests.cs
+++ b/test/Compiler.Tests/Emit/DataStructSynthesizedMembersTests.cs
@@ -1,0 +1,455 @@
+// <copyright file="DataStructSynthesizedMembersTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #410 / ADR-0029: validates the seven synthesized members emitted for
+/// every <c>data struct</c> — <c>Equals(Name)</c>, <c>Equals(object)</c>,
+/// <c>GetHashCode</c>, <c>ToString</c>, <c>op_Equality</c>,
+/// <c>op_Inequality</c>, and <c>Deconstruct</c>. These tests exercise the
+/// generated IL via reflection to ensure structural value semantics work both
+/// from G# and from cross-language consumers.
+/// </summary>
+public class DataStructSynthesizedMembersTests
+{
+    [Fact]
+    public void DataStruct_EmitsSevenSynthesizedMethods_PlusCtor()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Point data struct {
+                X int32
+                Y int32
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var point = assembly.GetTypes().Single(t => t.Name == "Point");
+
+        Assert.NotNull(point.GetMethod("Equals", new[] { typeof(object) }));
+        Assert.NotNull(point.GetMethod("Equals", new[] { point }));
+        Assert.NotNull(point.GetMethod("GetHashCode", Type.EmptyTypes));
+        Assert.NotNull(point.GetMethod("ToString", Type.EmptyTypes));
+        Assert.NotNull(point.GetMethod("op_Equality", new[] { point, point }));
+        Assert.NotNull(point.GetMethod("op_Inequality", new[] { point, point }));
+        Assert.NotNull(point.GetMethod("Deconstruct", BindingFlags.Public | BindingFlags.Instance));
+    }
+
+    [Fact]
+    public void DataStruct_EqualsTyped_ReturnsTrueForEqualValues_FalseOtherwise()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Point data struct {
+                X int32
+                Y int32
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var point = assembly.GetTypes().Single(t => t.Name == "Point");
+
+        var a = MakePoint(point, 3, 4);
+        var b = MakePoint(point, 3, 4);
+        var c = MakePoint(point, 3, 5);
+
+        var equalsTyped = point.GetMethod("Equals", new[] { point });
+        Assert.NotNull(equalsTyped);
+        Assert.True((bool)equalsTyped!.Invoke(a, new[] { b })!);
+        Assert.False((bool)equalsTyped.Invoke(a, new[] { c })!);
+    }
+
+    [Fact]
+    public void DataStruct_EqualsObject_HandlesNullWrongTypeAndCorrectType()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Point data struct {
+                X int32
+                Y int32
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var point = assembly.GetTypes().Single(t => t.Name == "Point");
+
+        var a = MakePoint(point, 1, 2);
+        var b = MakePoint(point, 1, 2);
+
+        var equalsObject = point.GetMethod("Equals", new[] { typeof(object) });
+        Assert.NotNull(equalsObject);
+        Assert.True((bool)equalsObject!.Invoke(a, new[] { b })!);
+        Assert.False((bool)equalsObject.Invoke(a, new object[] { null! })!);
+        Assert.False((bool)equalsObject.Invoke(a, new object[] { "not a Point" })!);
+    }
+
+    [Fact]
+    public void DataStruct_GetHashCode_IsStableForEqualValues()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Point data struct {
+                X int32
+                Y int32
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var point = assembly.GetTypes().Single(t => t.Name == "Point");
+
+        var a = MakePoint(point, 13, 27);
+        var b = MakePoint(point, 13, 27);
+        var c = MakePoint(point, 13, 28);
+
+        var getHashCode = point.GetMethod("GetHashCode", Type.EmptyTypes);
+        Assert.NotNull(getHashCode);
+        var ha = (int)getHashCode!.Invoke(a, null)!;
+        var hb = (int)getHashCode.Invoke(b, null)!;
+        var hc = (int)getHashCode.Invoke(c, null)!;
+        Assert.Equal(ha, hb);
+        Assert.NotEqual(ha, hc); // not guaranteed by contract, but extremely likely for HashCode.Combine
+    }
+
+    [Fact]
+    public void DataStruct_ToString_FormatsAsNameWithFieldEqualsValuePairs()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Point data struct {
+                X int32
+                Y int32
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var point = assembly.GetTypes().Single(t => t.Name == "Point");
+
+        var p = MakePoint(point, 3, 4);
+        var toString = point.GetMethod("ToString", Type.EmptyTypes);
+        Assert.NotNull(toString);
+        var actual = (string)toString!.Invoke(p, null)!;
+        Assert.Equal("Point(X=3, Y=4)", actual);
+    }
+
+    [Fact]
+    public void DataStruct_ToString_NullReferenceField_DoesNotThrow()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Pair data struct {
+                Name string
+                Count int32
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var pair = assembly.GetTypes().Single(t => t.Name == "Pair");
+
+        var instance = Activator.CreateInstance(pair)!;
+        // leave Name null, set Count to 0 (default)
+        var toString = pair.GetMethod("ToString", Type.EmptyTypes);
+        Assert.NotNull(toString);
+        var actual = (string)toString!.Invoke(instance, null)!;
+        // Convert.ToString(null, InvariantCulture) returns string.Empty (not "null").
+        Assert.Equal("Pair(Name=, Count=0)", actual);
+    }
+
+    [Fact]
+    public void DataStruct_OpEquality_AndInequality_RoundTrip()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Point data struct {
+                X int32
+                Y int32
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var point = assembly.GetTypes().Single(t => t.Name == "Point");
+
+        var a = MakePoint(point, 5, 6);
+        var b = MakePoint(point, 5, 6);
+        var c = MakePoint(point, 5, 7);
+
+        var opEq = point.GetMethod("op_Equality", new[] { point, point });
+        var opNe = point.GetMethod("op_Inequality", new[] { point, point });
+        Assert.NotNull(opEq);
+        Assert.NotNull(opNe);
+
+        Assert.True((bool)opEq!.Invoke(null, new[] { a, b })!);
+        Assert.False((bool)opEq.Invoke(null, new[] { a, c })!);
+        Assert.False((bool)opNe!.Invoke(null, new[] { a, b })!);
+        Assert.True((bool)opNe.Invoke(null, new[] { a, c })!);
+    }
+
+    [Fact]
+    public void DataStruct_Deconstruct_AssignsAllFields()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Point data struct {
+                X int32
+                Y int32
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var point = assembly.GetTypes().Single(t => t.Name == "Point");
+
+        var p = MakePoint(point, 11, 22);
+        var deconstruct = point.GetMethod("Deconstruct", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(deconstruct);
+
+        var args = new object[] { 0, 0 };
+        deconstruct!.Invoke(p, args);
+        Assert.Equal(11, args[0]);
+        Assert.Equal(22, args[1]);
+    }
+
+    [Fact]
+    public void DataStruct_Deconstruct_MixedFieldTypes()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Pair data struct {
+                Name string
+                Count int32
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var pair = assembly.GetTypes().Single(t => t.Name == "Pair");
+
+        var instance = Activator.CreateInstance(pair)!;
+        pair.GetField("Name")!.SetValue(instance, "abc");
+        pair.GetField("Count")!.SetValue(instance, 42);
+
+        var deconstruct = pair.GetMethod("Deconstruct", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(deconstruct);
+        var args = new object[] { null!, 0 };
+        deconstruct!.Invoke(instance, args);
+        Assert.Equal("abc", args[0]);
+        Assert.Equal(42, args[1]);
+    }
+
+    [Fact]
+    public void DataStruct_GetHashCode_FoldPath_For9Fields()
+    {
+        // ADR-0029: ≤8 fields → HashCode.Combine; >8 fields → fold via
+        // HashCode.Add + ToHashCode. Exercise the fold path with 9 fields.
+        var source = """
+            package MyLib
+            import System
+
+            type Big data struct {
+                A int32
+                B int32
+                C int32
+                D int32
+                E int32
+                F int32
+                G int32
+                H int32
+                I int32
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var big = assembly.GetTypes().Single(t => t.Name == "Big");
+
+        var instance1 = Activator.CreateInstance(big)!;
+        var instance2 = Activator.CreateInstance(big)!;
+        foreach (var fname in new[] { "A", "B", "C", "D", "E", "F", "G", "H", "I" })
+        {
+            big.GetField(fname)!.SetValue(instance1, 7);
+            big.GetField(fname)!.SetValue(instance2, 7);
+        }
+
+        var getHashCode = big.GetMethod("GetHashCode", Type.EmptyTypes);
+        Assert.NotNull(getHashCode);
+        var h1 = (int)getHashCode!.Invoke(instance1, null)!;
+        var h2 = (int)getHashCode.Invoke(instance2, null)!;
+        Assert.Equal(h1, h2);
+
+        // Change the last field; hash should (almost certainly) differ.
+        big.GetField("I")!.SetValue(instance2, 8);
+        var h3 = (int)getHashCode.Invoke(instance2, null)!;
+        Assert.NotEqual(h1, h3);
+
+        // Equals(Name) on the modified instance should now return false.
+        var equalsTyped = big.GetMethod("Equals", new[] { big });
+        Assert.NotNull(equalsTyped);
+        Assert.False((bool)equalsTyped!.Invoke(instance1, new[] { instance2 })!);
+    }
+
+    [Fact]
+    public void DataStruct_EqualsTyped_MixedFieldTypes()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Pair data struct {
+                Name string
+                Count int32
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var pair = assembly.GetTypes().Single(t => t.Name == "Pair");
+
+        var a = Activator.CreateInstance(pair)!;
+        pair.GetField("Name")!.SetValue(a, "abc");
+        pair.GetField("Count")!.SetValue(a, 1);
+
+        var b = Activator.CreateInstance(pair)!;
+        pair.GetField("Name")!.SetValue(b, "abc");
+        pair.GetField("Count")!.SetValue(b, 1);
+
+        var c = Activator.CreateInstance(pair)!;
+        pair.GetField("Name")!.SetValue(c, "abc");
+        pair.GetField("Count")!.SetValue(c, 2);
+
+        var d = Activator.CreateInstance(pair)!;
+        pair.GetField("Name")!.SetValue(d, null);
+        pair.GetField("Count")!.SetValue(d, 1);
+
+        var equalsTyped = pair.GetMethod("Equals", new[] { pair });
+        Assert.NotNull(equalsTyped);
+        Assert.True((bool)equalsTyped!.Invoke(a, new[] { b })!);
+        Assert.False((bool)equalsTyped.Invoke(a, new[] { c })!);
+        Assert.False((bool)equalsTyped.Invoke(a, new[] { d })!);
+    }
+
+    [Fact]
+    public void DataStruct_EqualsObject_DispatchesThroughOverride_NotValueTypeReflection()
+    {
+        // Sanity check: the override is marked virtual + final, and instance
+        // dispatch through System.ValueType's slot must land on the emitted
+        // override rather than reflection-based ValueType.Equals.
+        var source = """
+            package MyLib
+            import System
+
+            type Point data struct {
+                X int32
+                Y int32
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var point = assembly.GetTypes().Single(t => t.Name == "Point");
+        var equalsObject = point.GetMethod("Equals", new[] { typeof(object) })!;
+        Assert.True(equalsObject.IsVirtual);
+        Assert.True(equalsObject.IsFinal);
+    }
+
+    [Fact]
+    public void GenericDataStruct_EqualsAndHashCode_WorkOverErasedFields()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Box[T any] data struct {
+                Value T
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var box = assembly.GetTypes().Single(t => t.Name == "Box");
+
+        var a = Activator.CreateInstance(box)!;
+        var b = Activator.CreateInstance(box)!;
+        var c = Activator.CreateInstance(box)!;
+        // T is type-erased to object; the field's CLR type is System.Object.
+        box.GetField("Value")!.SetValue(a, 42);
+        box.GetField("Value")!.SetValue(b, 42);
+        box.GetField("Value")!.SetValue(c, 43);
+
+        var equalsTyped = box.GetMethod("Equals", new[] { box });
+        Assert.NotNull(equalsTyped);
+        Assert.True((bool)equalsTyped!.Invoke(a, new[] { b })!);
+        Assert.False((bool)equalsTyped.Invoke(a, new[] { c })!);
+
+        var getHashCode = box.GetMethod("GetHashCode", Type.EmptyTypes);
+        Assert.NotNull(getHashCode);
+        var ha = (int)getHashCode!.Invoke(a, null)!;
+        var hb = (int)getHashCode.Invoke(b, null)!;
+        Assert.Equal(ha, hb);
+    }
+
+    private static object MakePoint(Type pointType, int x, int y)
+    {
+        var instance = Activator.CreateInstance(pointType)!;
+        pointType.GetField("X")!.SetValue(instance, x);
+        pointType.GetField("Y")!.SetValue(instance, y);
+        return instance;
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_datastruct_synth_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/DataStructTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/DataStructTests.cs
@@ -158,6 +158,63 @@ p
         _ = compilation;
     }
 
+    [Fact]
+    public void DataStruct_ExplicitEqualsObject_ReportsGS0232()
+    {
+        // ADR-0029 / Issue #410: Equals/GetHashCode/ToString/op_Equality/
+        // op_Inequality/Deconstruct are synthesized for data structs and
+        // cannot be hand-written, so the structural contract stays
+        // predictable.
+        var source = @"
+type Point data struct {
+    X int32
+    Y int32
+}
+
+func (p Point) Equals(other any) bool {
+    return false
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0232");
+    }
+
+    [Fact]
+    public void DataStruct_ExplicitGetHashCode_ReportsGS0232()
+    {
+        var source = @"
+type Point data struct {
+    X int32
+    Y int32
+}
+
+func (p Point) GetHashCode() int32 {
+    return 0
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0232");
+    }
+
+    [Fact]
+    public void DataStruct_ExplicitDeconstruct_ReportsGS0232()
+    {
+        var source = @"
+type Point data struct {
+    X int32
+    Y int32
+}
+
+func (p Point) Deconstruct() {
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0232");
+    }
+
     private static StructSymbol BuildPoint(out Compilation compilation)
     {
         var source = @"


### PR DESCRIPTION
Closes #410.

Implements the seven members ADR-0029 fixes as the `data struct` contract, so structural equality, hashing, `ToString`, `==`/`!=`, and destructuring work both from G# and from external .NET consumers (C#/F#).

## What was missing

Before this change, `data struct` types emitted only the TypeDef + fields; `==`/`!=` worked only because the binder lowered them through boxing + `Object.Equals` to `ValueType.Equals` (reflection-based). There was no `Equals(Name)`, no override of `GetHashCode` or `ToString`, no `op_Equality`/`op_Inequality` MethodDef rows, and no `Deconstruct`. The ADR's contract was effectively undocumented in IL.

## What was added

Seven synthesized members per data struct, emitted in a fixed order so MethodDef rows align 1:1 with the rows reserved by the method-row planner (ECMA-335 monotonicity; Issue #242 invariant):

1. `public bool Equals(Name other)` — field-by-field via `Object.Equals(object,object)`, short-circuiting on first inequality.
2. `public sealed override bool Equals(object)` — `isinst + unbox.any + Equals(Name)`.
3. `public sealed override int GetHashCode()` — `HashCode.Combine<object,…>` for ≤8 fields; `HashCode.Add` fold via a stack-allocated `HashCode` local + `ToHashCode()` for >8.
4. `public sealed override string ToString()` — `Name(F1=v1, F2=v2, …)` via `String.Concat(string[])` with `Convert.ToString(obj, CultureInfo.InvariantCulture)` (null-safe for reference fields).
5. `public static bool op_Equality(Name, Name)`
6. `public static bool op_Inequality(Name, Name)`
7. `public void Deconstruct(out T1, out T2, …)` — `stobj` for value-type fields; `stind.ref` for reference and type-parameter fields.

## Generics

Type-parameter fields are type-erased to `System.Object` (Phase 4 emit model), so `EmitBoxIfNeeded` is a no-op for them and `Deconstruct` uses `stind.ref` instead of `stobj`. The existing `GenericDataStruct_*` tests pass unchanged and a new test exercises `Equals`/`GetHashCode` over an erased field.

## Diagnostic GS0232

Hand-written `Equals`/`GetHashCode`/`ToString`/`op_Equality`/`op_Inequality`/`Deconstruct` on a data struct are rejected so the synthesized contract stays predictable. Check fires for both receiver methods (`func (p Point) Equals(...) bool`) and shared/static methods.

## Tests

- `test/Compiler.Tests/Emit/DataStructSynthesizedMembersTests.cs` (NEW, 13 tests): each synthesized member via reflection on a compiled assembly, mixed field types, null-reference `ToString`, the >8-field `HashCode` fold path, generic data structs, and ILVerifier on every assembly.
- `test/Core.Tests/CodeAnalysis/Binding/DataStructTests.cs` (+3 tests): GS0232 for `Equals`, `GetHashCode`, `Deconstruct`.

## Docs

- `docs/adr/0029-data-struct-synthesized-members.md`: Status → **Accepted**, links to implementation.
- `docs/diagnostics.md`: GS0232 documented.

## Verification

- Build: 0 warnings, 0 errors.
- Full test suite: **2381 / 2381 pass** (1745 Core + 360 Compiler + 212 LanguageServer + 64 Interpreter).
- ILVerifier passes on every emitted assembly produced by the new test cases.