### PR TITLE
Named delegate types (`type X = delegate func(...)`) — issue #255

### DIFF
--- a/docs/adr/0059-named-delegate-types.md
+++ b/docs/adr/0059-named-delegate-types.md
@@ -1,0 +1,128 @@
+# ADR-0059: Named delegate types — `type Name = delegate func(...)`
+
+- **Status**: Accepted
+- **Date**: 2026-06-05
+- **Phase**: Phase 9 — language depth (post-primitive)
+- **Related**: ADR-0052 (event declarations); ADR-0036 (event subscription); issue #255; issue #140
+
+## Context
+
+ADR-0052 introduced the `event` keyword for declaring CLR events on user types, but the ADR pragmatically restricted handler types to `Action<…>` / `Func<…>` (the same shape `func(…) R` already lowers to). ADR-0052 §Follow-up Work explicitly defers user-declared *named* delegate types to a later ADR. Issue #255 raises that follow-up: C# / F# consumers expect events to carry **named** delegate types (`EventHandler`, `PropertyChangedEventHandler`, etc.) — partly for self-documentation, partly because some BCL idioms (e.g. `INotifyPropertyChanged`) name their handler type as part of the contract.
+
+GSharp already plays the delegate game on the consumption side. A `FunctionTypeSymbol` (`func(T1, T2) R`) is implicitly convertible to any compatible CLR delegate type — Action/Func/Predicate as well as named delegates imported from C# assemblies (`Conversion.cs:IsFunctionToDelegateConvertible`). What is missing is the *declaration* side: there is no GSharp syntax that emits a real CLR delegate class. This ADR fills the gap.
+
+## Decision
+
+Introduce a delegate-typed form of the `type` declaration. The grammar reuses the existing `type Name = …` alias surface and adds the contextual keyword **`delegate`** in front of a function-type clause:
+
+```
+delegate_declaration =
+    annotations? accessibility_modifier? "type" identifier
+    type_parameter_list? "=" "delegate" "func" "(" parameter_list? ")" type_clause?
+```
+
+A declaration of this form produces a new TypeDef in metadata: a `sealed class` whose base is `System.MulticastDelegate`, plus a `.ctor(object, IntPtr)` and an `Invoke(params...) ret` method, both flagged `MethodImplAttributes.Runtime | Managed` (no IL body — the CLR provides the implementation). The name is registered on the declaring package's scope just like a `struct`/`class`/`interface` so it can be used wherever a type clause is legal — including as the handler type for an `event`.
+
+### Grammar examples
+
+```gs
+// Simple handler shape — emits a sealed MulticastDelegate-derived class.
+public type ClickHandler = delegate func(sender Object, e EventArgs)
+
+// Returning a value — same shape, with a return type.
+type Mapper = delegate func(input string) int32
+```
+
+Generic delegate declarations (`type Predicate[T any] = delegate func(value T) bool`) are accepted by the parser but rejected by the binder in v1; they are listed as follow-up work below.
+
+A function literal of a compatible shape converts implicitly to a named delegate:
+
+```gs
+var handler ClickHandler = func(sender Object, e EventArgs) {
+    System.Console.WriteLine("clicked")
+}
+button.Click += handler
+```
+
+A named delegate may serve as an `event` handler type, replacing the previous `Action<…>` shape (ADR-0052 carve-out):
+
+```gs
+public type PropertyChangedHandler = delegate func(sender Object, e PropertyChangedEventArgs)
+
+type Button class {
+    public event Changed PropertyChangedHandler
+}
+```
+
+### Parameter naming
+
+`func(...)`-shaped function types currently use anonymous positional parameters (the binder synthesises names `arg0`, `arg1`, …). For *named* delegates the parameter names matter to consumers — C# uses them in IntelliSense for `+=` handler tab-completion. The grammar therefore allows the same `name type` syntax used in `func` declarations:
+
+```gs
+public type MouseHandler = delegate func(sender Object, e MouseEventArgs)
+```
+
+When no name is provided the emitter falls back to `arg0`/`arg1`/…, matching what C# emits for unnamed delegate parameters.
+
+### CLR metadata shape
+
+For `public type ClickHandler = delegate func(sender Object, e EventArgs)`:
+
+| Metadata row | Content |
+|--------------|---------|
+| TypeDef | `public sealed class ClickHandler` extends `System.MulticastDelegate` |
+| MethodDef | `public hidebysig specialname rtspecialname instance void .ctor(object, native int)` with `methImpl = Runtime \| Managed`, no IL |
+| MethodDef | `public hidebysig virtual newslot instance void Invoke(object sender, class [System.Runtime]System.EventArgs e)` with `methImpl = Runtime \| Managed`, no IL |
+
+`BeginInvoke` / `EndInvoke` are intentionally *not* emitted; modern Roslyn omits them for portable assemblies and the CLR no longer requires them for delegate invocation. (Async UI patterns that historically relied on those methods have moved to `Task` / `Task<T>` since .NET 4.5.) Adding them later is a non-breaking change if a consumer asks.
+
+### Conversion rules
+
+1. A `FunctionTypeSymbol` value (a `func` literal or any variable typed `func(P) R`) implicitly converts to a named delegate when the shapes match, via the existing `IsFunctionToDelegateConvertible` path. The emitter materialises the conversion the same way it materialises `func → Action<…>` today (`func` value → delegate ctor).
+2. Two *distinct* named delegates do **not** silently convert into each other, even when their shapes match. This mirrors CLR rules: `Action` and `ThreadStart` are unrelated even though both are `void()`. Going from one named delegate to another requires extracting the underlying function value (`var f func() = a; var b OtherDelegate = f`).
+3. Any named-delegate value widens implicitly to `System.Delegate` and `System.MulticastDelegate`, identical to the existing rule for `Action`/`Func` (`Conversion.cs:IsSystemDelegateBaseType`).
+
+### Why a separate `delegate` keyword
+
+`type Name = func(…) R` could in principle re-mean "emit a CLR delegate." It does not, because the existing `type Name = SomeOtherName` alias surface is *erased* at bind time (ADR-0058's words: "Aliases are not emitted into CIL"). Adding emit semantics to plain `type Name = func(…)` would silently change the meaning of existing code and conflict with users who rely on alias erasure to give a domain-specific name to a function shape without paying for a TypeDef. The `delegate` keyword keeps the two cases visually and semantically distinct:
+
+| Form | Meaning |
+|------|---------|
+| `type Handler = func(string) int32` | Type alias — `Handler` is `func(string) int32`, erased at emit, no new TypeDef. |
+| `type Handler = delegate func(string) int32` | Delegate declaration — emits a sealed `MulticastDelegate`-derived TypeDef called `Handler`. |
+
+### Why a contextual keyword
+
+`delegate` is recognised by the parser only after `=` in a `type … =` declaration. Outside that position it remains a valid identifier. Treating it as a contextual keyword (a `Text == "delegate"` check on an `IdentifierToken`) avoids breaking any code that uses `delegate` as a variable, parameter, or member name.
+
+### Interaction with events (ADR-0052)
+
+ADR-0052 §1 said the event's `type_clause` "must resolve to a function type (`func(…) …`)." This ADR extends that to include named delegate types: an `event Name Handler` declaration may also bind a `Handler` that is a user-declared delegate type or an imported CLR delegate. Field-like events use the supplied delegate type directly as their backing-field type. Explicit-accessor events do the same. The synthesised `add_X` / `remove_X` accessors take a parameter of that delegate type. This is exactly what C# does.
+
+## Alternatives considered
+
+1. **Reuse the alias surface (`type Name = func(...)` emits a delegate).** Rejected — silently changes the meaning of existing aliases and breaks the "alias is erased" property documented in the type-alias syntax. The new keyword keeps both shapes addressable.
+
+2. **`delegate Name(...)` top-level declaration (C# style).** Rejected — GSharp uses `type Name = …` as the single entry point for every nominal type. A bare `delegate` member kind would be the only declaration that bypasses `type`. Consistency wins.
+
+3. **Treat every `FunctionTypeSymbol` as its own implicit named delegate.** Rejected — `func(int32) int32` is structural, and forcing a fresh TypeDef per occurrence would balloon the metadata table and produce non-interchangeable delegate identities (same shape, two named TypeDefs, no implicit conversion between them). Action/Func continue to handle the structural case; named delegates are opt-in.
+
+4. **Emit `BeginInvoke` / `EndInvoke` for compatibility with .NET Framework asynchronous-callback patterns.** Rejected — Roslyn dropped these in C# 4.0 emit for portable / .NET Core targets, and the CLR no longer requires them. Adding them later would be a non-breaking change.
+
+## Consequences
+
+- New SyntaxKind `DelegateKeyword` (contextual `delegate`) and `DelegateDeclaration` (the declaration node), plus matching parser / binder / emit support. Coverage matrix updated.
+- New `DelegateTypeSymbol` (sibling of `StructSymbol` / `InterfaceSymbol` / `EnumSymbol`) registered through `TryDeclareTypeAlias` so `LookupType` finds it for free.
+- New `BoundGlobalScope.Delegates` and `Binder.BindDelegateDeclaration`; declared delegate types flow through to the emitter.
+- The `ReflectionMetadataEmitter` reserves 2 method rows + N parameter rows per delegate (after interface methods, before non-SM class ctors) and emits the TypeDef between interfaces and non-SM classes.
+- `EncodeTypeSymbol` learns to route a `DelegateTypeSymbol` reference to its emitted `TypeDef` (a `Class`-encoded reference type).
+- The existing `func → delegate` conversion path picks up named delegates automatically — `IsFunctionToDelegateConvertible` already inspects the CLR `Invoke` signature.
+- New diagnostic **GS0233** — surfaced when `type Name = delegate …` is not followed by `func(...)`; the parser recovers and the binder skips the declaration.
+- ADR-0052's "delegate question" follow-up is closed; events may now carry a named delegate type or continue to carry `Action`/`Func`.
+
+## Follow-up work (out of scope)
+
+- Generic delegate declarations (`type Predicate[T any] = delegate func(value T) bool`); the parser accepts them but the binder rejects them with **GS0234** in v1 because the emitter does not yet thread `GenericParam` rows through delegate TypeDefs. Lifting this is mechanical follow-up work once the existing struct/class generic emit support is generalised.
+- A `where T : delegate` constraint to make `Predicate[T]` instantiations of a generic delegate work as a generic-type-parameter constraint target.
+- Emitting `BeginInvoke` / `EndInvoke` if a project enables a legacy-delegate compatibility flag.
+- Variance annotations on generic delegate type parameters (`type Func[in T, out R] = delegate func(value T) R`).

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -51,6 +51,7 @@ ContinueStatement
 DefaultKeyword
 DeferKeyword
 DeferStatement
+DelegateDeclaration
 DiscardPattern
 DocumentationCommentToken
 DotToken

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -270,3 +270,12 @@ ADR-0029 / Issue #410: every `data struct` synthesizes a fixed contract of value
 | Code | Severity | Message |
 |------|----------|---------|
 | GS0232 | Error | Data struct '{type}' synthesizes member '{member}'; it cannot be declared explicitly. |
+
+## Named delegate type diagnostics (GS0233–GS0234)
+
+ADR-0059 / Issue #255: `type Name = delegate func(...)` declares a real CLR `MulticastDelegate`-derived named delegate type so C# consumers see a conventional handler type (and so G# events can carry first-class custom delegate types). Anything other than a function signature on the right-hand side is rejected, and generic delegate types are reserved for v2.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0233 | Error | Named delegate declaration requires 'func(...)' after 'delegate' (e.g. 'type Name = delegate func(sender Object, e EventArgs)'). |
+| GS0234 | Error | Generic delegate declaration '{name}' is not yet supported; declare a non-generic named delegate type (ADR-0059 follow-up). |

--- a/samples/NamedDelegate.golden
+++ b/samples/NamedDelegate.golden
@@ -1,0 +1,2 @@
+hello, world
+42

--- a/samples/NamedDelegate.gs
+++ b/samples/NamedDelegate.gs
@@ -1,0 +1,35 @@
+// file: NamedDelegate.gs
+//
+// ADR-0059 / issue #255: a user-declared named delegate type is emitted as a
+// real CLR `sealed class MulticastDelegate`-derived TypeDef with runtime-
+// implemented `.ctor(object, IntPtr)` and `Invoke(params...) ret` methods,
+// so C# consumers see a conventional handler type (e.g. `MyHandler`) and so
+// GSharp events can carry first-class custom delegate types instead of
+// always projecting through `Action`/`Func`.
+//
+// This sample declares two named delegate types — one void-returning and
+// one with a return value — assigns a `func(...)` literal to each, and
+// invokes them.
+
+package GSharp.Samples.NamedDelegate
+
+import System
+
+// `void`-returning named delegate.
+type Greeter = delegate func(name string)
+
+// Value-returning named delegate.
+type Combine = delegate func(a int32, b int32) int32
+
+// A `func` literal converts implicitly to the matching named delegate type,
+// just like it converts to Action/Func today (issue #295).
+var hello Greeter = func(name string) {
+    Console.WriteLine("hello, " + name)
+}
+
+var sum Combine = func(a int32, b int32) int32 {
+    return a + b
+}
+
+hello.Invoke("world")
+Console.WriteLine(sum.Invoke(2, 40))

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -375,6 +375,17 @@ public sealed class Binder
             binder.BindTypeAliasDeclaration(typeAlias);
         }
 
+        // ADR-0059 / issue #255: declare named delegate types BEFORE
+        // interfaces/structs/enums so that interface methods, struct fields,
+        // event handler types, etc. can reference a named delegate by name.
+        var delegateDeclarations = syntaxTrees.SelectMany(st => st.Root.Members)
+                                              .OfType<DelegateDeclarationSyntax>();
+        foreach (var delegateSyntax in delegateDeclarations)
+        {
+            var owningPackage = packageByTree[delegateSyntax.SyntaxTree];
+            binder.BindDelegateDeclaration(delegateSyntax, owningPackage);
+        }
+
         var interfaceDeclarations = syntaxTrees.SelectMany(st => st.Root.Members)
                                                .OfType<InterfaceDeclarationSyntax>();
 
@@ -465,7 +476,9 @@ public sealed class Binder
             diagnostics = diagnostics.InsertRange(0, previous.Diagnostics);
         }
 
-        var result = new BoundGlobalScope(previous, entryPointPackage, packagesInOrder.ToImmutable(), diagnostics, imports, functions, variables, typeAliases, structs, interfaces, enums, entryPoint, statements.ToImmutable());
+        var delegates = binder.scope.GetDeclaredDelegates();
+
+        var result = new BoundGlobalScope(previous, entryPointPackage, packagesInOrder.ToImmutable(), diagnostics, imports, functions, variables, typeAliases, structs, interfaces, enums, delegates, entryPoint, statements.ToImmutable());
         result.PreprocessorSymbols = preprocessorSymbols ?? ImmutableHashSet<string>.Empty;
         return result;
     }
@@ -771,7 +784,7 @@ public sealed class Binder
             .Where(g => !g.Name.StartsWith("<>"))
             .ToImmutableArray();
 
-        return new BoundProgram(globalScope.Package, globalScope.Packages, diagnostics.ToImmutable(), functionBodies.ToImmutable(), globalScope.EntryPoint, statement, globalScope.Structs, globalScope.Interfaces, globalScope.Enums, globals)
+        return new BoundProgram(globalScope.Package, globalScope.Packages, diagnostics.ToImmutable(), functionBodies.ToImmutable(), globalScope.EntryPoint, statement, globalScope.Structs, globalScope.Interfaces, globalScope.Enums, globals, globalScope.Delegates)
         {
             Imports = globalScope.Imports,
         };
@@ -936,6 +949,93 @@ public sealed class Binder
             System.AttributeTargets.Class);
 
         if (!scope.TryDeclareTypeAlias(name, aliasedType))
+        {
+            Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
+        }
+    }
+
+    /// <summary>
+    /// ADR-0059 / issue #255: binds a <c>type Name = delegate func(...)</c>
+    /// declaration into a <see cref="DelegateTypeSymbol"/> registered with the
+    /// current scope. Unlike a plain type alias, a named delegate produces a
+    /// real CLR TypeDef at emit time.
+    /// </summary>
+    private void BindDelegateDeclaration(DelegateDeclarationSyntax syntax, PackageSymbol package)
+    {
+        var name = syntax.Identifier.Text;
+
+        // Reject shadowing of primitive type names — same rule as struct/enum.
+        if (IsPrimitiveTypeName(name))
+        {
+            Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
+            return;
+        }
+
+        // ADR-0059 v1 limitation: generic delegate declarations are accepted
+        // syntactically but rejected by the binder (the emitter does not yet
+        // thread GenericParam rows through delegate TypeDefs). Surface a clear
+        // diagnostic so users know it's a deliberate not-yet-supported case.
+        if (syntax.TypeParameterList != null)
+        {
+            Diagnostics.ReportGenericDelegateNotSupported(syntax.Identifier.Location, name);
+            return;
+        }
+
+        var accessibility = ResolveAccessibility(syntax.AccessibilityModifier);
+
+        var parameters = ImmutableArray.CreateBuilder<ParameterSymbol>();
+        var seenParameterNames = new HashSet<string>();
+        for (var pIndex = 0; pIndex < syntax.Parameters.Count; pIndex++)
+        {
+            var parameterSyntax = syntax.Parameters[pIndex];
+            var parameterName = parameterSyntax.Identifier.Text;
+            var parameterType = BindTypeClause(parameterSyntax.Type) ?? TypeSymbol.Error;
+            if (!seenParameterNames.Add(parameterName))
+            {
+                Diagnostics.ReportParameterAlreadyDeclared(parameterSyntax.Location, parameterName);
+                continue;
+            }
+
+            parameters.Add(new ParameterSymbol(parameterName, parameterType, declaringSyntax: parameterSyntax.Identifier));
+        }
+
+        // Variadic / `scoped` parameters are deliberately not supported in v1
+        // (the CLR delegate's Invoke signature has no analogue). Flag the
+        // first occurrence with the existing variadic-must-be-last check.
+        for (var i = 0; i < syntax.Parameters.Count; i++)
+        {
+            if (syntax.Parameters[i].IsVariadic)
+            {
+                Diagnostics.ReportVariadicParameterMustBeLast(syntax.Parameters[i].Location, syntax.Parameters[i].Identifier.Text);
+            }
+        }
+
+        var returnType = syntax.ReturnType != null ? BindTypeClause(syntax.ReturnType) : TypeSymbol.Void;
+        if (returnType == null)
+        {
+            returnType = TypeSymbol.Void;
+        }
+
+        // ADR-0047: annotations on a delegate declaration default to the Type
+        // target — identical to a struct/class/interface/enum.
+        var delegateAttributes = BindAttributes(
+            syntax.Annotations,
+            AttributeTargetKind.Type,
+            TypeDeclarationAllowedTargets,
+            "a delegate declaration",
+            System.AttributeTargets.Class);
+
+        var delegateSymbol = new DelegateTypeSymbol(
+            name,
+            package.Name,
+            accessibility,
+            parameters.ToImmutable(),
+            returnType,
+            syntax);
+        delegateSymbol.SetAttributes(delegateAttributes);
+        AttachDocumentation(delegateSymbol, syntax);
+
+        if (!scope.TryDeclareTypeAlias(name, delegateSymbol))
         {
             Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
         }
@@ -7982,6 +8082,26 @@ public sealed class Binder
             return new BoundIndirectCallExpression(null, new BoundVariableExpression(null, variable), fnType, convertedArgs.MoveToImmutable());
         }
 
+        // ADR-0059 / issue #255: direct call syntax `h(args)` on a variable
+        // of a user-declared named delegate type. Mirrors the CLR-delegate
+        // branch below — both end up dispatching through Invoke.
+        if (symbol is VariableSymbol namedDelegateVar && namedDelegateVar.Type is DelegateTypeSymbol namedDelegateSym)
+        {
+            if (syntax.Arguments.Count != namedDelegateSym.Parameters.Length)
+            {
+                Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, namedDelegateVar.Name, namedDelegateSym.Parameters.Length, syntax.Arguments.Count);
+                return new BoundErrorExpression(null);
+            }
+
+            var convertedNamedArgs = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
+            for (var i = 0; i < syntax.Arguments.Count; i++)
+            {
+                convertedNamedArgs.Add(BindConversion(syntax.Arguments[i].Location, boundArguments[i], namedDelegateSym.Parameters[i].Type));
+            }
+
+            return new BoundIndirectCallExpression(null, new BoundVariableExpression(null, namedDelegateVar), namedDelegateSym.EquivalentFunctionType, convertedNamedArgs.MoveToImmutable());
+        }
+
         // #325: a variable whose type is a CLR delegate (e.g. `Func[int32,
         // int32]`, `RequestDelegate`) is callable with call syntax `f(x)`,
         // mirroring native func-typed variables. Lower the call to an
@@ -9850,6 +9970,17 @@ public sealed class Binder
 
         if (receiver == null || receiver.Type?.ClrType == null)
         {
+            // ADR-0059 / issue #255: a value of a user-declared named delegate
+            // type supports member-style invocation `del.Invoke(args)` (same as
+            // any CLR delegate). Lower to a BoundIndirectCallExpression whose
+            // function shape mirrors the delegate's declared signature; the
+            // emitter recognises a DelegateTypeSymbol target and dispatches
+            // through the delegate's runtime-implemented Invoke MethodDef.
+            if (receiver != null && receiver.Type is DelegateTypeSymbol delRecv && string.Equals(methodName, "Invoke", System.StringComparison.Ordinal))
+            {
+                return BindNamedDelegateInvokeCall(receiver, delRecv, arguments, ce);
+            }
+
             // Phase 3.B.4: dispatch to a user-defined interface method when
             // the static receiver type is an interface.
             if (receiver != null && receiver.Type is InterfaceSymbol ifaceRecv && ifaceRecv.TryGetMethod(methodName, out var ifaceMethod))
@@ -10039,6 +10170,31 @@ public sealed class Binder
             default:
                 return false;
         }
+    }
+
+    /// <summary>
+    /// ADR-0059 / issue #255: lowers a <c>delegateValue.Invoke(args)</c>
+    /// call against a value of <see cref="DelegateTypeSymbol"/> into a
+    /// <see cref="BoundIndirectCallExpression"/> whose function shape is the
+    /// delegate's equivalent <see cref="FunctionTypeSymbol"/>. The emitter
+    /// recognises a DelegateTypeSymbol target and routes the call through
+    /// the delegate's runtime-implemented Invoke MethodDef.
+    /// </summary>
+    private BoundExpression BindNamedDelegateInvokeCall(BoundExpression receiver, DelegateTypeSymbol delegateSym, ImmutableArray<BoundExpression> arguments, CallExpressionSyntax ce)
+    {
+        if (arguments.Length != delegateSym.Parameters.Length)
+        {
+            Diagnostics.ReportWrongArgumentCount(ce.Location, delegateSym.Name, delegateSym.Parameters.Length, arguments.Length);
+            return new BoundErrorExpression(null);
+        }
+
+        var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            convertedArgs.Add(BindConversion(ce.Arguments[i].Location, arguments[i], delegateSym.Parameters[i].Type));
+        }
+
+        return new BoundIndirectCallExpression(null, receiver, delegateSym.EquivalentFunctionType, convertedArgs.MoveToImmutable());
     }
 
     private BoundExpression BindExtensionFunctionCall(BoundExpression receiver, FunctionSymbol extension, ImmutableArray<BoundExpression> arguments, CallExpressionSyntax ce)

--- a/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
@@ -101,6 +101,42 @@ public sealed class BoundGlobalScope
         ImmutableArray<EnumSymbol> enums,
         FunctionSymbol entryPoint,
         ImmutableArray<BoundStatement> statements)
+        : this(previous, package, packages, diagnostics, imports, functions, variables, typeAliases, structs, interfaces, enums, ImmutableArray<DelegateTypeSymbol>.Empty, entryPoint, statements)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundGlobalScope"/> class with declared named delegate types (ADR-0059 / issue #255).
+    /// </summary>
+    /// <param name="previous">Previous compilation global scope.</param>
+    /// <param name="package">The entry-point package for the current compilation.</param>
+    /// <param name="packages">All distinct packages declared in the current compilation, in declaration order.</param>
+    /// <param name="diagnostics">Diagnostics for the current compilation.</param>
+    /// <param name="imports">Imports in the current compilation.</param>
+    /// <param name="functions">Functions in the current compilation.</param>
+    /// <param name="variables">Variables in the current compilation.</param>
+    /// <param name="typeAliases">Type aliases declared in the current compilation.</param>
+    /// <param name="structs">User-defined struct types declared in the current compilation.</param>
+    /// <param name="interfaces">User-defined interface types declared in the current compilation (Phase 3.B.4).</param>
+    /// <param name="enums">User-defined enum types declared in the current compilation (#193).</param>
+    /// <param name="delegates">User-declared named delegate types in the current compilation (ADR-0059).</param>
+    /// <param name="entryPoint">The entry-point function for this compilation, or null if the compilation is a library.</param>
+    /// <param name="statements">Statements in the current compilation.</param>
+    public BoundGlobalScope(
+        BoundGlobalScope previous,
+        PackageSymbol package,
+        ImmutableArray<PackageSymbol> packages,
+        ImmutableArray<Diagnostic> diagnostics,
+        ImmutableArray<ImportSymbol> imports,
+        ImmutableArray<FunctionSymbol> functions,
+        ImmutableArray<VariableSymbol> variables,
+        ImmutableDictionary<string, TypeSymbol> typeAliases,
+        ImmutableArray<StructSymbol> structs,
+        ImmutableArray<InterfaceSymbol> interfaces,
+        ImmutableArray<EnumSymbol> enums,
+        ImmutableArray<DelegateTypeSymbol> delegates,
+        FunctionSymbol entryPoint,
+        ImmutableArray<BoundStatement> statements)
     {
         Previous = previous;
         Package = package;
@@ -113,6 +149,7 @@ public sealed class BoundGlobalScope
         Structs = structs;
         Interfaces = interfaces;
         Enums = enums;
+        Delegates = delegates.IsDefault ? ImmutableArray<DelegateTypeSymbol>.Empty : delegates;
         EntryPoint = entryPoint;
         Statements = statements;
     }
@@ -208,6 +245,11 @@ public sealed class BoundGlobalScope
     /// Gets the user-defined enum types declared in the current compilation (#193).
     /// </summary>
     public ImmutableArray<EnumSymbol> Enums { get; }
+
+    /// <summary>
+    /// Gets the user-declared named delegate types in the current compilation (ADR-0059 / issue #255).
+    /// </summary>
+    public ImmutableArray<DelegateTypeSymbol> Delegates { get; }
 
     /// <summary>
     /// Gets the synthesized or explicit entry-point function for this compilation,

--- a/src/Core/CodeAnalysis/Binding/BoundProgram.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundProgram.cs
@@ -107,6 +107,36 @@ public sealed class BoundProgram
         ImmutableArray<InterfaceSymbol> interfaces,
         ImmutableArray<EnumSymbol> enums,
         ImmutableArray<GlobalVariableSymbol> globals)
+        : this(entryPointPackage, packages, diagnostics, functions, entryPoint, statement, structs, interfaces, enums, globals, ImmutableArray<DelegateTypeSymbol>.Empty)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundProgram"/> class with declared named delegate types (ADR-0059 / issue #255).
+    /// </summary>
+    /// <param name="entryPointPackage">The entry-point package; its name is exposed via <see cref="PackageName"/> for back-compat.</param>
+    /// <param name="packages">All distinct packages in this program, in declaration order.</param>
+    /// <param name="diagnostics">The diagnostics.</param>
+    /// <param name="functions">The functions. Each <see cref="FunctionSymbol"/> key carries its owning package via <see cref="FunctionSymbol.Package"/>.</param>
+    /// <param name="entryPoint">The entry-point function, or null if the compilation is a library.</param>
+    /// <param name="statement">The statements.</param>
+    /// <param name="structs">User-defined struct types declared in this program, grouped by declaring package.</param>
+    /// <param name="interfaces">User-defined interface types declared in this program (Phase 3.B.4).</param>
+    /// <param name="enums">User-defined enum types declared in this program (#193).</param>
+    /// <param name="globals">User-declared top-level <c>var</c>/<c>let</c>/<c>const</c> declarations (#191).</param>
+    /// <param name="delegates">User-declared named delegate types in this program (ADR-0059).</param>
+    public BoundProgram(
+        PackageSymbol entryPointPackage,
+        ImmutableArray<PackageSymbol> packages,
+        ImmutableArray<Diagnostic> diagnostics,
+        ImmutableDictionary<FunctionSymbol, BoundBlockStatement> functions,
+        FunctionSymbol entryPoint,
+        BoundBlockStatement statement,
+        ImmutableArray<StructSymbol> structs,
+        ImmutableArray<InterfaceSymbol> interfaces,
+        ImmutableArray<EnumSymbol> enums,
+        ImmutableArray<GlobalVariableSymbol> globals,
+        ImmutableArray<DelegateTypeSymbol> delegates)
     {
         EntryPointPackage = entryPointPackage;
         Packages = packages;
@@ -118,6 +148,7 @@ public sealed class BoundProgram
         Interfaces = interfaces;
         Enums = enums;
         Globals = globals;
+        Delegates = delegates.IsDefault ? ImmutableArray<DelegateTypeSymbol>.Empty : delegates;
     }
 
     /// <summary>
@@ -211,6 +242,14 @@ public sealed class BoundProgram
     /// observable from other assemblies.
     /// </summary>
     public ImmutableArray<GlobalVariableSymbol> Globals { get; }
+
+    /// <summary>
+    /// Gets the user-declared named delegate types in this program (ADR-0059 / issue #255).
+    /// Each delegate is emitted as a sealed CLR <c>TypeDef</c> deriving from
+    /// <c>System.MulticastDelegate</c> with a runtime-implemented
+    /// <c>.ctor</c> and <c>Invoke</c>.
+    /// </summary>
+    public ImmutableArray<DelegateTypeSymbol> Delegates { get; }
 
     /// <summary>
     /// Gets the explicit (user-written) import symbols declared across all

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -369,6 +369,15 @@ public sealed class BoundScope
             ? ImmutableArray<EnumSymbol>.Empty
             : typeAliases.Values.OfType<EnumSymbol>().ToImmutableArray();
 
+    /// <summary>
+    /// Gets the set of declared user-defined named delegate types in this scope chain (ADR-0059 / issue #255).
+    /// </summary>
+    /// <returns>The named delegate types in declaration order.</returns>
+    public ImmutableArray<DelegateTypeSymbol> GetDeclaredDelegates()
+        => typeAliases == null
+            ? ImmutableArray<DelegateTypeSymbol>.Empty
+            : typeAliases.Values.OfType<DelegateTypeSymbol>().ToImmutableArray();
+
     private bool TryDeclareSymbol<TSymbol>(TSymbol symbol)
         where TSymbol : Symbol
     {

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -184,6 +184,23 @@ public sealed class Conversion
             return Conversion.Implicit;
         }
 
+        // ADR-0059 / issue #255: same rule for user-declared named delegate
+        // types. They have no ClrType during binding, so the func→delegate
+        // path above does not fire — classify the conversion structurally
+        // against the delegate's parameter/return signature instead.
+        if (from is FunctionTypeSymbol fnSource2 && to is DelegateTypeSymbol toDelegate
+            && IsFunctionStructurallyAssignable(fnSource2, toDelegate))
+        {
+            return Conversion.Implicit;
+        }
+
+        // ADR-0059: a named delegate VALUE (variable typed as a
+        // DelegateTypeSymbol) is structurally a delegate; widening to
+        // System.Delegate / System.MulticastDelegate follows the existing
+        // rule and is handled below. Conversions BETWEEN two distinct
+        // DelegateTypeSymbol instances are explicitly *not* implicit, per
+        // CLR rules — the user must round-trip through a func value.
+
         // Issue #323: any delegate-typed value widens implicitly to
         // System.Delegate (and System.MulticastDelegate), since every CLR
         // delegate derives from those base types. This covers both a GSharp
@@ -199,6 +216,11 @@ public sealed class Conversion
             }
 
             if (from?.ClrType != null && ClrTypeUtilities.IsDelegateType(from.ClrType))
+            {
+                return Conversion.Implicit;
+            }
+
+            if (from is DelegateTypeSymbol)
             {
                 return Conversion.Implicit;
             }
@@ -395,6 +417,56 @@ public sealed class Conversion
         var fullName = type.FullName;
         return string.Equals(fullName, "System.Delegate", StringComparison.Ordinal)
             || string.Equals(fullName, "System.MulticastDelegate", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// ADR-0059 / issue #255: structural compatibility check between a
+    /// G# function-typed value and a user-declared named delegate
+    /// (<see cref="DelegateTypeSymbol"/>). Used in lieu of the CLR-Type-based
+    /// <see cref="IsFunctionToDelegateConvertible"/> because the delegate has
+    /// no <c>ClrType</c> during binding — its TypeDef is materialized at emit.
+    /// </summary>
+    private static bool IsFunctionStructurallyAssignable(FunctionTypeSymbol fn, DelegateTypeSymbol target)
+    {
+        var parameters = target.Parameters;
+        if (parameters.Length != fn.ParameterTypes.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            var fromType = fn.ParameterTypes[i];
+            var toType = parameters[i].Type;
+            if (fromType == null || toType == null)
+            {
+                return false;
+            }
+
+            // Parameter types are contravariant in C#; G# v1 mirrors the
+            // existing CLR-typed func→delegate rule, which is name-based
+            // assignability — i.e., identity or an implicit conversion.
+            var conv = Classify(fromType, toType);
+            if (!conv.Exists || !conv.IsImplicit)
+            {
+                return false;
+            }
+        }
+
+        var fnReturn = fn.ReturnType ?? TypeSymbol.Void;
+        var targetReturn = target.ReturnType ?? TypeSymbol.Void;
+        if (fnReturn == TypeSymbol.Void)
+        {
+            return targetReturn == TypeSymbol.Void;
+        }
+
+        if (targetReturn == TypeSymbol.Void)
+        {
+            return false;
+        }
+
+        var retConv = Classify(fnReturn, targetReturn);
+        return retConv.Exists && retConv.IsImplicit;
     }
 
     // Issue #421 P2-5: enum⇄numeric and enum⇄enum conversions. Both

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1610,6 +1610,31 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0232", message);
     }
 
+    /// <summary>
+    /// ADR-0059 / issue #255: reports that a delegate declaration
+    /// (<c>type Name = delegate …</c>) was not followed by a <c>func(...)</c>
+    /// signature. Named delegates must take the shape
+    /// <c>type Name = delegate func(params) ret</c>.
+    /// </summary>
+    /// <param name="location">The text location of the offending token.</param>
+    public void ReportDelegateDeclarationRequiresFunc(TextLocation location)
+    {
+        Report(location, "GS0233", "Named delegate declaration requires 'func(...)' after 'delegate' (e.g. 'type Name = delegate func(sender Object, e EventArgs)').");
+    }
+
+    /// <summary>
+    /// ADR-0059 / issue #255: reports a generic delegate declaration (e.g.
+    /// <c>type Predicate[T any] = delegate func(value T) bool</c>) — generic
+    /// delegate emit is not yet supported in v1 and is tracked as ADR-0059
+    /// follow-up work.
+    /// </summary>
+    /// <param name="location">The text location of the delegate identifier.</param>
+    /// <param name="typeName">The delegate type name.</param>
+    public void ReportGenericDelegateNotSupported(TextLocation location, string typeName)
+    {
+        Report(location, "GS0234", $"Generic delegate declaration '{typeName}' is not yet supported; declare a non-generic named delegate type (ADR-0059 follow-up).");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -98,6 +98,15 @@ internal sealed class ReflectionMetadataEmitter
     private readonly Dictionary<EnumSymbol, TypeDefinitionHandle> enumTypeDefs = new Dictionary<EnumSymbol, TypeDefinitionHandle>();
     private readonly Dictionary<EnumMemberSymbol, FieldDefinitionHandle> enumMemberFieldDefs = new Dictionary<EnumMemberSymbol, FieldDefinitionHandle>();
 
+    // ADR-0059 / issue #255: user-defined named delegate TypeDefs. Each
+    // DelegateTypeSymbol is emitted as a sealed reference type deriving from
+    // System.MulticastDelegate with a runtime-implemented `.ctor(object, IntPtr)`
+    // plus a runtime-implemented `Invoke` whose signature mirrors the
+    // delegate's declared parameters and return type.
+    private readonly Dictionary<DelegateTypeSymbol, TypeDefinitionHandle> delegateTypeDefs = new Dictionary<DelegateTypeSymbol, TypeDefinitionHandle>();
+    private readonly Dictionary<DelegateTypeSymbol, MethodDefinitionHandle> delegateInvokeHandles = new Dictionary<DelegateTypeSymbol, MethodDefinitionHandle>();
+    private readonly Dictionary<DelegateTypeSymbol, MethodDefinitionHandle> delegateCtorHandles = new Dictionary<DelegateTypeSymbol, MethodDefinitionHandle>();
+
     // Issue #191: each user-declared top-level var/let/const becomes a static
     // FieldDef on the entry-point package's <Program> TypeDef. Mapping symbol
     // → field handle so EmitLoadVariable/EmitStoreVariable can route through
@@ -206,6 +215,8 @@ internal sealed class ReflectionMetadataEmitter
     private Type coreSystemType;
     private Type coreRuntimeTypeHandleType;
     private Type coreEnumType;
+    private Type coreMulticastDelegateType;
+    private Type coreIntPtrType;
     private TypeReferenceHandle objectTypeRef;
     private TypeReferenceHandle valueTypeRef;
     private MemberReferenceHandle objectCtorRef;
@@ -392,6 +403,10 @@ internal sealed class ReflectionMetadataEmitter
         this.coreSystemType = this.ResolveCoreType("System.Type", typeof(System.Type));
         this.coreRuntimeTypeHandleType = this.ResolveCoreType("System.RuntimeTypeHandle", typeof(System.RuntimeTypeHandle));
         this.coreEnumType = this.ResolveCoreType("System.Enum", typeof(System.Enum));
+        // ADR-0059 / issue #255: cache the base type and `IntPtr` parameter
+        // type for user-declared named delegate emission.
+        this.coreMulticastDelegateType = this.ResolveCoreType("System.MulticastDelegate", typeof(System.MulticastDelegate));
+        this.coreIntPtrType = this.ResolveCoreType("System.IntPtr", typeof(System.IntPtr));
         this.objectTypeRef = this.GetTypeReference(this.coreObjectType);
         this.valueTypeRef = this.GetTypeReference(this.coreValueType);
         this.objectCtorRef = this.GetObjectDefaultCtorReference();
@@ -690,6 +705,20 @@ internal sealed class ReflectionMetadataEmitter
             }
         }
 
+        // ADR-0059 / issue #255: plan method rows for each named delegate
+        // (one ctor + one Invoke per delegate) AFTER interface methods and
+        // BEFORE non-SM class ctors. The delegate TypeDef rows themselves are
+        // emitted immediately after interfaces so methodList pointers stay
+        // monotone non-decreasing across the table.
+        var delegates = this.program.Delegates;
+        var delegateCtorRows = new Dictionary<DelegateTypeSymbol, int>();
+        var delegateInvokeRows = new Dictionary<DelegateTypeSymbol, int>();
+        foreach (var d in delegates)
+        {
+            delegateCtorRows[d] = methodRow++;
+            delegateInvokeRows[d] = methodRow++;
+        }
+
         // Plan method rows for non-SM class ctors + instance methods.
         var classCtorRows = new Dictionary<StructSymbol, int>();
         var classPrimaryCtorRows = new Dictionary<StructSymbol, int>();
@@ -907,6 +936,16 @@ internal sealed class ReflectionMetadataEmitter
         foreach (var i in interfaces)
         {
             this.EmitInterfaceTypeDef(i, interfaceFirstMethodRow[i], 1);
+        }
+
+        // ADR-0059 / issue #255: emit named delegate TypeDefs immediately
+        // after interfaces and before non-SM classes/structs. Each delegate's
+        // TypeDef methodList points at the ctor row reserved above; the
+        // runtime-implemented ctor and Invoke MethodDefs are added inside
+        // EmitDelegateTypeDef.
+        foreach (var d in delegates)
+        {
+            this.EmitDelegateTypeDef(d, delegateCtorRows[d]);
         }
 
         // 2b. Emit non-SM class TypeDefs (so methodLists stay non-decreasing),
@@ -4605,6 +4644,133 @@ internal sealed class ReflectionMetadataEmitter
 
         // Phase 3 of #141: user annotations targeting the type land on this TypeDef.
         this.EmitUserAttributes(handle, ifaceSym, AttributeTargetKind.Type);
+    }
+
+    /// <summary>
+    /// ADR-0059 / issue #255: emits a user-declared named delegate as a sealed
+    /// reference type deriving from <c>System.MulticastDelegate</c> with two
+    /// runtime-implemented methods:
+    /// <list type="bullet">
+    ///   <item><c>.ctor(object, native int)</c> — the standard delegate
+    ///     constructor recognised by the CLR for delegate creation
+    ///     (<c>newobj</c>) and binding.</item>
+    ///   <item><c>Invoke(params...) ret</c> — the delegate's call signature
+    ///     used by both managed callers and the CLR's delegate dispatch.</item>
+    /// </list>
+    /// Both methods carry <c>MethodImplAttributes.Runtime | Managed</c> and
+    /// have no IL body — the runtime supplies the implementation. We
+    /// intentionally do NOT emit <c>BeginInvoke</c>/<c>EndInvoke</c>, matching
+    /// Roslyn's portable-assembly convention.
+    /// </summary>
+    /// <param name="delegateSym">The named delegate symbol.</param>
+    /// <param name="firstMethodRow">The pre-reserved method row of the
+    /// delegate's <c>.ctor</c> (the second reserved row is its
+    /// <c>Invoke</c>).</param>
+    private void EmitDelegateTypeDef(DelegateTypeSymbol delegateSym, int firstMethodRow)
+    {
+        var multicastTypeRef = this.GetTypeReference(this.coreMulticastDelegateType);
+
+        // Delegates own no fields; their fieldList points at the next
+        // FieldDef row, which is the first field of whatever TypeDef follows
+        // in row order. We mirror the EmitEnumTypeDef pattern of capturing
+        // the *next* row from the current FieldDef table count.
+        var firstFieldHandle = MetadataTokens.FieldDefinitionHandle(this.metadata.GetRowCount(TableIndex.Field) + 1);
+
+        var typeAttrs = TypeAttributes.Class | TypeAttributes.Sealed
+            | TypeAttributes.AnsiClass | TypeAttributes.AutoLayout
+            | MapTypeAccessibility(delegateSym.Accessibility);
+
+        var delegateTypeDef = this.metadata.AddTypeDefinition(
+            attributes: typeAttrs,
+            @namespace: this.metadata.GetOrAddString(delegateSym.PackageName ?? string.Empty),
+            name: this.metadata.GetOrAddString(delegateSym.Name),
+            baseType: multicastTypeRef,
+            fieldList: firstFieldHandle,
+            methodList: MetadataTokens.MethodDefinitionHandle(firstMethodRow));
+        this.delegateTypeDefs[delegateSym] = delegateTypeDef;
+
+        // ---- .ctor(object, native int) ----
+        var ctorSigBlob = new BlobBuilder();
+        new BlobEncoder(ctorSigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(2, r => r.Void(), ps =>
+            {
+                ps.AddParameter().Type().Object();
+                ps.AddParameter().Type().IntPtr();
+            });
+
+        var ctorFirstParamHandle = this.NextParameterHandle();
+        this.metadata.AddParameter(
+            attributes: ParameterAttributes.None,
+            name: this.metadata.GetOrAddString("object"),
+            sequenceNumber: 1);
+        this.metadata.AddParameter(
+            attributes: ParameterAttributes.None,
+            name: this.metadata.GetOrAddString("method"),
+            sequenceNumber: 2);
+
+        var ctorAttrs = MethodAttributes.Public | MethodAttributes.HideBySig
+            | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName;
+
+        var ctorHandle = this.metadata.AddMethodDefinition(
+            attributes: ctorAttrs,
+            implAttributes: MethodImplAttributes.Runtime | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString(".ctor"),
+            signature: this.metadata.GetOrAddBlob(ctorSigBlob),
+            bodyOffset: -1,
+            parameterList: ctorFirstParamHandle);
+        this.delegateCtorHandles[delegateSym] = ctorHandle;
+
+        // Sanity check: the actual .ctor row must match the row reserved by
+        // the scheduler so the TypeDef's methodList pointer is valid.
+        if (MetadataTokens.GetRowNumber(ctorHandle) != firstMethodRow)
+        {
+            throw new InvalidOperationException(
+                $"Delegate '{delegateSym.Name}' .ctor MethodDef row {MetadataTokens.GetRowNumber(ctorHandle)} did not match the reserved row {firstMethodRow}. This indicates another emitter inserted method rows between scheduling and delegate emission.");
+        }
+
+        // ---- Invoke(params...) ret ----
+        var invokeSigBlob = new BlobBuilder();
+        new BlobEncoder(invokeSigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                delegateSym.Parameters.Length,
+                r => this.EncodeReturnSymbol(r, delegateSym.ReturnType ?? TypeSymbol.Void),
+                ps =>
+                {
+                    foreach (var p in delegateSym.Parameters)
+                    {
+                        this.EncodeTypeSymbol(ps.AddParameter().Type(), p.Type);
+                    }
+                });
+
+        var invokeFirstParamHandle = this.NextParameterHandle();
+        for (var i = 0; i < delegateSym.Parameters.Length; i++)
+        {
+            var p = delegateSym.Parameters[i];
+            this.metadata.AddParameter(
+                attributes: ParameterAttributes.None,
+                name: this.metadata.GetOrAddString(p.Name ?? $"arg{i + 1}"),
+                sequenceNumber: (ushort)(i + 1));
+        }
+
+        var invokeAttrs = MethodAttributes.Public | MethodAttributes.HideBySig
+            | MethodAttributes.Virtual | MethodAttributes.NewSlot;
+
+        var invokeParamList = delegateSym.Parameters.Length > 0
+            ? invokeFirstParamHandle
+            : this.NextParameterHandle();
+
+        var invokeHandle = this.metadata.AddMethodDefinition(
+            attributes: invokeAttrs,
+            implAttributes: MethodImplAttributes.Runtime | MethodImplAttributes.Managed,
+            name: this.metadata.GetOrAddString("Invoke"),
+            signature: this.metadata.GetOrAddBlob(invokeSigBlob),
+            bodyOffset: -1,
+            parameterList: invokeParamList);
+        this.delegateInvokeHandles[delegateSym] = invokeHandle;
+
+        // ADR-0047 §3: user annotations targeting the delegate type land on
+        // the TypeDef row (same as struct/interface/enum).
+        this.EmitUserAttributes(delegateTypeDef, delegateSym, AttributeTargetKind.Type);
     }
 
     /// <summary>
@@ -10143,6 +10309,18 @@ internal sealed class ReflectionMetadataEmitter
 
             encoder.Type(ifaceDef, isValueType: false);
         }
+        else if (type is DelegateTypeSymbol delegateSym)
+        {
+            // ADR-0059 / issue #255: a user-declared named delegate type
+            // encodes as a reference type referring to its own TypeDef
+            // (a sealed class deriving from System.MulticastDelegate).
+            if (!this.delegateTypeDefs.TryGetValue(delegateSym, out var delegateDef))
+            {
+                throw new InvalidOperationException($"Delegate '{delegateSym.Name}' has no emitted TypeDef.");
+            }
+
+            encoder.Type(delegateDef, isValueType: false);
+        }
         else if (type is ChannelTypeSymbol chType)
         {
             // Phase E: chan T -> System.Threading.Channels.Channel<T>.
@@ -11758,6 +11936,20 @@ internal sealed class ReflectionMetadataEmitter
 
         private void EmitConversion(BoundConversionExpression conv)
         {
+            // ADR-0059 / issue #255: GSharp function value → user-declared
+            // named delegate type. The named delegate has no ClrType (its
+            // TypeDef only exists in the assembly being emitted), so the
+            // CLR-delegate path below cannot fire; emit the same
+            // `ldnull/ldftn/newobj` (or closure `dup/ldftn/newobj`) sequence
+            // but referencing the delegate's emitted ctor MethodDef handle
+            // instead of a CLR ConstructorInfo.
+            if (conv.Expression.Type is FunctionTypeSymbol namedSourceFn
+                && conv.Type is DelegateTypeSymbol namedTargetDelegate)
+            {
+                this.EmitFunctionToNamedDelegateConversion(conv.Expression, namedSourceFn, namedTargetDelegate);
+                return;
+            }
+
             // Issue #295: GSharp function value → CLR delegate. This is the
             // general materialization that previously only happened in
             // argument position; routing it through EmitConversion makes
@@ -11963,6 +12155,149 @@ internal sealed class ReflectionMetadataEmitter
             this.il.Token(this.outer.GetMethodReference(sourceInvoke));
             this.il.OpCode(ILOpCode.Newobj);
             this.il.Token(this.outer.GetCtorReference(targetCtor));
+        }
+
+        /// <summary>
+        /// ADR-0059 / issue #255: emits a GSharp function value → user-declared
+        /// named delegate type conversion. The delegate has no CLR Type during
+        /// emit; we reference its emitted <c>.ctor</c> MethodDef directly
+        /// instead of looking up a <see cref="ConstructorInfo"/> on a runtime
+        /// <see cref="Type"/>.
+        /// </summary>
+        private void EmitFunctionToNamedDelegateConversion(BoundExpression source, FunctionTypeSymbol sourceFn, DelegateTypeSymbol targetDelegate)
+        {
+            if (!this.outer.delegateCtorHandles.TryGetValue(targetDelegate, out var ctorHandle))
+            {
+                throw new InvalidOperationException(
+                    $"Named delegate '{targetDelegate.Name}' has no emitted .ctor MethodDef.");
+            }
+
+            if (source is BoundFunctionLiteralExpression literal)
+            {
+                this.EmitFunctionLiteralToNamedDelegate(literal, ctorHandle);
+                return;
+            }
+
+            if (source is BoundMethodGroupExpression methodGroup)
+            {
+                this.EmitMethodGroupToNamedDelegate(methodGroup, ctorHandle);
+                return;
+            }
+
+            // Delegate-to-delegate adaptation (CLR delegate value → named
+            // delegate): wrap the source delegate's Invoke in a new named
+            // delegate instance using `dup; ldvirtftn; newobj`.
+            if (sourceFn?.ClrType != null && ClrTypeUtilities.IsDelegateType(sourceFn.ClrType))
+            {
+                var sourceDelegateType = this.outer.ResolveDelegateClrType(sourceFn);
+                var sourceInvoke = sourceDelegateType.GetMethod("Invoke")
+                    ?? throw new InvalidOperationException(
+                        $"Delegate type '{sourceDelegateType.FullName}' has no Invoke method.");
+
+                this.EmitExpression(source);
+                this.il.OpCode(ILOpCode.Dup);
+                this.il.OpCode(ILOpCode.Ldvirtftn);
+                this.il.Token(this.outer.GetMethodReference(sourceInvoke));
+                this.il.OpCode(ILOpCode.Newobj);
+                this.il.Token(ctorHandle);
+                return;
+            }
+
+            throw new NotSupportedException(
+                $"Cannot convert function value of type '{sourceFn?.Name}' to named delegate '{targetDelegate.Name}'.");
+        }
+
+        /// <summary>
+        /// ADR-0059 / issue #255: emits a <see cref="BoundFunctionLiteralExpression"/>
+        /// bound to a user-declared named delegate type whose <c>.ctor</c>
+        /// MethodDef handle is supplied directly. Mirrors
+        /// <see cref="EmitFunctionLiteral(BoundFunctionLiteralExpression, Type)"/>
+        /// but uses a metadata handle instead of a runtime <see cref="Type"/>.
+        /// </summary>
+        private void EmitFunctionLiteralToNamedDelegate(BoundFunctionLiteralExpression literal, MethodDefinitionHandle delegateCtorHandle)
+        {
+            if (this.outer.closureInfos.TryGetValue(literal, out var closure))
+            {
+                if (!this.outer.classCtorHandles.TryGetValue(closure.ClassSym, out var closureCtor))
+                {
+                    throw new InvalidOperationException(
+                        $"Closure class '{closure.ClassSym.Name}' has no emitted constructor.");
+                }
+
+                if (!this.outer.methodHandles.TryGetValue(closure.InvokeMethod, out var closureInvoke))
+                {
+                    throw new InvalidOperationException(
+                        $"Closure invoke method '{closure.InvokeMethod.Name}' has no emitted MethodDef.");
+                }
+
+                this.il.OpCode(ILOpCode.Newobj);
+                this.il.Token(closureCtor);
+
+                foreach (var captured in literal.CapturedVariables)
+                {
+                    if (!closure.CaptureFields.TryGetValue(captured, out var field))
+                    {
+                        throw new InvalidOperationException(
+                            $"Closure for '{literal.Function.Name}' has no field for captured '{captured.Name}'.");
+                    }
+
+                    if (!this.outer.structFieldDefs.TryGetValue(field, out var fieldHandle))
+                    {
+                        throw new InvalidOperationException(
+                            $"Closure field '{field.Name}' has no emitted FieldDef.");
+                    }
+
+                    this.il.OpCode(ILOpCode.Dup);
+                    this.EmitCapturedVariableLoad(captured);
+                    this.il.OpCode(ILOpCode.Stfld);
+                    this.il.Token(fieldHandle);
+                }
+
+                this.il.OpCode(ILOpCode.Ldftn);
+                this.il.Token(closureInvoke);
+                this.il.OpCode(ILOpCode.Newobj);
+                this.il.Token(delegateCtorHandle);
+                return;
+            }
+
+            if (literal.CapturedVariables.Length > 0)
+            {
+                throw new NotSupportedException(
+                    $"Function literal '{literal.Function.Name}' captures outer variables; closure emit fell through synthesis.");
+            }
+
+            if (!this.outer.functionHandles.TryGetValue(literal.Function, out var methodHandle))
+            {
+                throw new InvalidOperationException(
+                    $"Function literal '{literal.Function.Name}' has no emitted MethodDef.");
+            }
+
+            this.il.OpCode(ILOpCode.Ldnull);
+            this.il.OpCode(ILOpCode.Ldftn);
+            this.il.Token(methodHandle);
+            this.il.OpCode(ILOpCode.Newobj);
+            this.il.Token(delegateCtorHandle);
+        }
+
+        /// <summary>
+        /// ADR-0059 / issue #255: emits a static method group bound to a
+        /// user-declared named delegate type using its emitted <c>.ctor</c>
+        /// MethodDef handle. Mirrors
+        /// <see cref="EmitMethodGroup(BoundMethodGroupExpression, Type)"/>.
+        /// </summary>
+        private void EmitMethodGroupToNamedDelegate(BoundMethodGroupExpression methodGroup, MethodDefinitionHandle delegateCtorHandle)
+        {
+            if (!this.outer.functionHandles.TryGetValue(methodGroup.Function, out var staticHandle))
+            {
+                throw new InvalidOperationException(
+                    $"Method group '{methodGroup.Function.Name}' has no emitted MethodDef.");
+            }
+
+            this.il.OpCode(ILOpCode.Ldnull);
+            this.il.OpCode(ILOpCode.Ldftn);
+            this.il.Token(staticHandle);
+            this.il.OpCode(ILOpCode.Newobj);
+            this.il.Token(delegateCtorHandle);
         }
 
         // ADR-0044 numeric conversions. Maps the from/to CLR pair to the
@@ -15163,6 +15498,29 @@ internal sealed class ReflectionMetadataEmitter
         // `callvirt`.
         private void EmitIndirectCall(BoundIndirectCallExpression call)
         {
+            // ADR-0059 / issue #255: a call through a value typed as a
+            // user-declared named delegate dispatches through that delegate's
+            // emitted Invoke MethodDef directly (no DynamicInvoke marshalling
+            // needed — the signature is concrete, not type-erased).
+            if (call.Target.Type is DelegateTypeSymbol namedDelegate)
+            {
+                if (!this.outer.delegateInvokeHandles.TryGetValue(namedDelegate, out var namedInvokeHandle))
+                {
+                    throw new InvalidOperationException(
+                        $"Delegate '{namedDelegate.Name}' has no emitted Invoke MethodDef.");
+                }
+
+                this.EmitExpression(call.Target);
+                foreach (var arg in call.Arguments)
+                {
+                    this.EmitExpression(arg);
+                }
+
+                this.il.OpCode(ILOpCode.Callvirt);
+                this.il.Token(namedInvokeHandle);
+                return;
+            }
+
             // Phase 4 emit parity (F1, type-erased generics): a delegate whose
             // parameter or return types reference open type parameters (e.g.
             // `func(T) U`) is encoded as `System.Func<object, object>`, but the

--- a/src/Core/CodeAnalysis/Symbols/DelegateTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/DelegateTypeSymbol.cs
@@ -1,0 +1,98 @@
+// <copyright file="DelegateTypeSymbol.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Represents a user-declared named delegate type (ADR-0059 / issue #255).
+/// A <c>type Name = delegate func(...)</c> declaration produces a
+/// <see cref="DelegateTypeSymbol"/> that the emitter materialises as a sealed
+/// CLR class deriving from <c>System.MulticastDelegate</c> with a
+/// runtime-implemented <c>.ctor</c> + <c>Invoke</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Like <see cref="StructSymbol"/> and <see cref="InterfaceSymbol"/>, a delegate
+/// declared in source has no <see cref="TypeSymbol.ClrType"/> at bind time —
+/// the underlying CLR type only comes into being once the emitter has produced
+/// the corresponding TypeDef row. Callers that need a CLR <see cref="Type"/>
+/// (for example, conversion classification) should fall back to the
+/// <see cref="EquivalentFunctionType"/> shape exposed below, which projects the
+/// delegate onto an <c>Action&lt;…&gt;</c> / <c>Func&lt;…&gt;</c> instance.
+/// </para>
+/// </remarks>
+public sealed class DelegateTypeSymbol : TypeSymbol
+{
+    private FunctionTypeSymbol equivalentFunctionType;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DelegateTypeSymbol"/> class.
+    /// </summary>
+    /// <param name="name">The delegate type name (the identifier from <c>type Name = …</c>).</param>
+    /// <param name="packageName">The package owning the delegate.</param>
+    /// <param name="accessibility">The CLR accessibility of the emitted TypeDef.</param>
+    /// <param name="parameters">The delegate's parameter symbols (names preserved for emit so consumers see meaningful names).</param>
+    /// <param name="returnType">The delegate's return type. Use <see cref="TypeSymbol.Void"/> for a void delegate.</param>
+    /// <param name="declaration">The declaring syntax node (used to surface diagnostics later).</param>
+    public DelegateTypeSymbol(
+        string name,
+        string packageName,
+        Accessibility accessibility,
+        ImmutableArray<ParameterSymbol> parameters,
+        TypeSymbol returnType,
+        DelegateDeclarationSyntax declaration)
+        : base(name)
+    {
+        PackageName = packageName;
+        Accessibility = accessibility;
+        Parameters = parameters.IsDefault ? ImmutableArray<ParameterSymbol>.Empty : parameters;
+        ReturnType = returnType ?? Void;
+        Declaration = declaration;
+    }
+
+    /// <summary>Gets the package the delegate is declared in.</summary>
+    public string PackageName { get; }
+
+    /// <summary>Gets the CLR accessibility of the emitted delegate type.</summary>
+    public Accessibility Accessibility { get; }
+
+    /// <summary>Gets the delegate's named parameters in declaration order.</summary>
+    public ImmutableArray<ParameterSymbol> Parameters { get; }
+
+    /// <summary>Gets the delegate's return type (<see cref="TypeSymbol.Void"/> for a void delegate).</summary>
+    public TypeSymbol ReturnType { get; }
+
+    /// <summary>Gets the declaring syntax node.</summary>
+    public DelegateDeclarationSyntax Declaration { get; }
+
+    /// <summary>
+    /// Gets the structural <see cref="FunctionTypeSymbol"/> equivalent to this
+    /// named delegate. The equivalent function type shares parameter and
+    /// return types and lets existing func-based binder paths (overload
+    /// resolution, conversion classification, type display) operate on a
+    /// named delegate without per-symbol special-casing.
+    /// </summary>
+    public FunctionTypeSymbol EquivalentFunctionType
+    {
+        get
+        {
+            if (equivalentFunctionType == null)
+            {
+                var paramTypes = ImmutableArray.CreateBuilder<TypeSymbol>(Parameters.Length);
+                foreach (var p in Parameters)
+                {
+                    paramTypes.Add(p.Type);
+                }
+
+                equivalentFunctionType = FunctionTypeSymbol.Get(paramTypes.MoveToImmutable(), ReturnType);
+            }
+
+            return equivalentFunctionType;
+        }
+    }
+}

--- a/src/Core/CodeAnalysis/Syntax/DelegateDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/DelegateDeclarationSyntax.cs
@@ -1,0 +1,95 @@
+// <copyright file="DelegateDeclarationSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents a named delegate type declaration of the form
+/// <c>type Name = delegate func(params...) ret</c> (ADR-0059 / issue #255).
+/// Unlike an erased type alias, this form emits a real CLR TypeDef that derives
+/// from <c>System.MulticastDelegate</c>.
+/// </summary>
+public sealed class DelegateDeclarationSyntax : MemberSyntax
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DelegateDeclarationSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="accessibilityModifier">The optional accessibility modifier (<c>public</c>, <c>internal</c>, <c>private</c>).</param>
+    /// <param name="typeKeyword">The <c>type</c> keyword that opens the declaration.</param>
+    /// <param name="identifier">The delegate type name.</param>
+    /// <param name="typeParameterList">Optional generic type-parameter list (<c>[T any]</c>).</param>
+    /// <param name="equalsToken">The <c>=</c> token between the name and the delegate form.</param>
+    /// <param name="delegateKeyword">The contextual <c>delegate</c> identifier token marking the delegate form.</param>
+    /// <param name="funcKeyword">The <c>func</c> keyword that opens the delegate signature.</param>
+    /// <param name="openParenToken">The <c>(</c> token opening the parameter list.</param>
+    /// <param name="parameters">The (possibly empty) parameter list.</param>
+    /// <param name="closeParenToken">The <c>)</c> token closing the parameter list.</param>
+    /// <param name="returnType">Optional return type clause; <c>null</c> for void.</param>
+    public DelegateDeclarationSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken accessibilityModifier,
+        SyntaxToken typeKeyword,
+        SyntaxToken identifier,
+        TypeParameterListSyntax typeParameterList,
+        SyntaxToken equalsToken,
+        SyntaxToken delegateKeyword,
+        SyntaxToken funcKeyword,
+        SyntaxToken openParenToken,
+        SeparatedSyntaxList<ParameterSyntax> parameters,
+        SyntaxToken closeParenToken,
+        TypeClauseSyntax returnType)
+        : base(syntaxTree)
+    {
+        AccessibilityModifier = accessibilityModifier;
+        TypeKeyword = typeKeyword;
+        Identifier = identifier;
+        TypeParameterList = typeParameterList;
+        EqualsToken = equalsToken;
+        DelegateKeyword = delegateKeyword;
+        FuncKeyword = funcKeyword;
+        OpenParenToken = openParenToken;
+        Parameters = parameters;
+        CloseParenToken = closeParenToken;
+        ReturnType = returnType;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.DelegateDeclaration;
+
+    /// <summary>Gets the optional accessibility modifier token.</summary>
+    public SyntaxToken AccessibilityModifier { get; }
+
+    /// <summary>Gets the <c>type</c> keyword.</summary>
+    public SyntaxToken TypeKeyword { get; }
+
+    /// <summary>Gets the delegate type identifier.</summary>
+    public SyntaxToken Identifier { get; }
+
+    /// <summary>Gets the optional generic type-parameter list.</summary>
+    public TypeParameterListSyntax TypeParameterList { get; }
+
+    /// <summary>Gets the <c>=</c> token.</summary>
+    public SyntaxToken EqualsToken { get; }
+
+    /// <summary>Gets the contextual <c>delegate</c> identifier token.</summary>
+    public SyntaxToken DelegateKeyword { get; }
+
+    /// <summary>Gets the <c>func</c> keyword.</summary>
+    public SyntaxToken FuncKeyword { get; }
+
+    /// <summary>Gets the opening parenthesis token.</summary>
+    public SyntaxToken OpenParenToken { get; }
+
+    /// <summary>Gets the parameter list (may be empty).</summary>
+    public SeparatedSyntaxList<ParameterSyntax> Parameters { get; }
+
+    /// <summary>Gets the closing parenthesis token.</summary>
+    public SyntaxToken CloseParenToken { get; }
+
+    /// <summary>Gets the optional return type clause; <c>null</c> for a <c>void</c>-returning delegate.</summary>
+    public TypeClauseSyntax ReturnType { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -541,9 +541,92 @@ public class Parser
         }
 
         var equalsToken = MatchToken(SyntaxKind.EqualsToken);
+
+        // ADR-0059 / issue #255: `type Name [TParams] = delegate func(...) R`
+        // declares a named CLR delegate type. The `delegate` contextual keyword
+        // (an IdentifierToken whose text is "delegate") differentiates this
+        // case from the erased type-alias form below. We require `func` to
+        // immediately follow `delegate`; anything else trips GS0233.
+        if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "delegate")
+        {
+            return ParseDelegateDeclaration(accessibilityModifier, typeKeyword, identifier, typeParameterList, equalsToken);
+        }
+
         var aliasedIdentifier = MatchToken(SyntaxKind.IdentifierToken);
         var aliasedType = new TypeClauseSyntax(syntaxTree, aliasedIdentifier);
         return new TypeAliasDeclarationSyntax(syntaxTree, accessibilityModifier, typeKeyword, identifier, equalsToken, aliasedType);
+    }
+
+    private MemberSyntax ParseDelegateDeclaration(
+        SyntaxToken accessibilityModifier,
+        SyntaxToken typeKeyword,
+        SyntaxToken identifier,
+        TypeParameterListSyntax typeParameterList,
+        SyntaxToken equalsToken)
+    {
+        // `delegate` is a contextual keyword that stays as an IdentifierToken
+        // — mirrors the existing data/record/inline/ref contextual-modifier
+        // handling in ParseTypeAliasDeclaration. We DO NOT promote it to a
+        // dedicated SyntaxKind because that would force adding it to
+        // SyntaxFacts.GetKeywordKind, breaking any future use of `delegate`
+        // as a plain identifier.
+        var delegateKeyword = NextToken();
+
+        if (Current.Kind != SyntaxKind.FuncKeyword)
+        {
+            Diagnostics.ReportDelegateDeclarationRequiresFunc(Current.Location);
+        }
+
+        var funcKeyword = MatchToken(SyntaxKind.FuncKeyword);
+        var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
+        var parameters = ParseParameterList();
+        var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+
+        // Return type clause is optional; absence means `void` per the existing
+        // `func` declaration convention.
+        TypeClauseSyntax returnType = null;
+        if (CanStartTypeClause(Current))
+        {
+            returnType = ParseTypeClause();
+        }
+
+        return new DelegateDeclarationSyntax(
+            syntaxTree,
+            accessibilityModifier,
+            typeKeyword,
+            identifier,
+            typeParameterList,
+            equalsToken,
+            delegateKeyword,
+            funcKeyword,
+            openParen,
+            parameters,
+            closeParen,
+            returnType);
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="token"/> can start a TypeClauseSyntax.
+    /// Used by the delegate declaration parser to decide whether the optional
+    /// return type clause is present.
+    /// </summary>
+    private static bool CanStartTypeClause(SyntaxToken token)
+    {
+        switch (token.Kind)
+        {
+            case SyntaxKind.IdentifierToken:
+            case SyntaxKind.FuncKeyword:
+            case SyntaxKind.OpenParenthesisToken:
+            case SyntaxKind.OpenSquareBracketToken:
+            case SyntaxKind.MapKeyword:
+            case SyntaxKind.ChanKeyword:
+            case SyntaxKind.SequenceKeyword:
+            case SyntaxKind.AsyncKeyword:
+            case SyntaxKind.StarToken:
+                return true;
+            default:
+                return false;
+        }
     }
 
     private EnumDeclarationSyntax ParseEnumDeclaration(
@@ -1479,6 +1562,7 @@ public class Parser
                 || follow.Kind == SyntaxKind.InterfaceKeyword
                 || follow.Kind == SyntaxKind.SealedKeyword
                 || follow.Kind == SyntaxKind.OpenKeyword
+                || follow.Kind == SyntaxKind.EqualsToken // ADR-0059: `type X[T any] = delegate func(...)` (rejected by binder as GS0234).
                 || (follow.Kind == SyntaxKind.IdentifierToken && (follow.Text == "data" || follow.Text == "record")))
             {
                 return true;

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -242,6 +242,13 @@ public enum SyntaxKind
 
     // Issue #306: standalone user-defined constructor declarations (`init(...)`)
     ConstructorDeclaration,
+
+    // ADR-0059 / issue #255: named delegate type declarations
+    // (`type Name = delegate func(...)`). `delegate` is a contextual
+    // keyword — kept as IdentifierToken at lex time; the parser recognises
+    // it inside `type Name = ...` (mirroring the data/record/inline/ref
+    // contextual-modifier pattern in ParseTypeAliasDeclaration).
+    DelegateDeclaration,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/test/Compiler.Tests/Emit/NamedDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/NamedDelegateEmitTests.cs
@@ -1,0 +1,151 @@
+// <copyright file="NamedDelegateEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// ADR-0059 / issue #255: compiler emit tests for named delegate type
+/// declarations.
+/// </summary>
+public class NamedDelegateEmitTests
+{
+    [Fact]
+    public void NamedDelegate_EmitsSealedMulticastDelegateTypeDef()
+    {
+        var source = """
+            package MyLib
+
+            type MyHandler = delegate func(a int32, b int32) int32
+            """;
+
+        var assembly = CompileToAssembly(source);
+
+        var handler = assembly.GetTypes().Single(t => t.Name == "MyHandler");
+
+        Assert.True(handler.IsSealed, $"{handler.FullName} should be sealed");
+        Assert.True(handler.IsClass, $"{handler.FullName} should be a class");
+        Assert.NotNull(handler.BaseType);
+        Assert.Equal("System.MulticastDelegate", handler.BaseType!.FullName);
+    }
+
+    [Fact]
+    public void NamedDelegate_EmitsRuntimeCtorWithObjectAndIntPtr()
+    {
+        var source = """
+            package MyLib
+
+            type MyHandler = delegate func(a int32, b int32) int32
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var handler = assembly.GetTypes().Single(t => t.Name == "MyHandler");
+
+        var ctor = handler.GetConstructors(BindingFlags.Public | BindingFlags.Instance).Single();
+        Assert.True(ctor.IsSpecialName);
+
+        var implFlags = ctor.GetMethodImplementationFlags();
+        Assert.True(
+            (implFlags & MethodImplAttributes.Runtime) == MethodImplAttributes.Runtime,
+            "Delegate .ctor must have MethodImplAttributes.Runtime");
+
+        var parms = ctor.GetParameters();
+        Assert.Equal(2, parms.Length);
+        Assert.Equal(typeof(object), parms[0].ParameterType);
+        Assert.Equal(typeof(IntPtr), parms[1].ParameterType);
+    }
+
+    [Fact]
+    public void NamedDelegate_EmitsRuntimeInvokeMatchingSignature()
+    {
+        var source = """
+            package MyLib
+
+            type MyHandler = delegate func(a int32, b int32) int32
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var handler = assembly.GetTypes().Single(t => t.Name == "MyHandler");
+
+        var invoke = handler.GetMethod("Invoke", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(invoke);
+        Assert.True(invoke!.IsVirtual);
+        Assert.False(invoke.IsAbstract);
+
+        var implFlags = invoke.GetMethodImplementationFlags();
+        Assert.True(
+            (implFlags & MethodImplAttributes.Runtime) == MethodImplAttributes.Runtime,
+            "Delegate Invoke must have MethodImplAttributes.Runtime");
+
+        Assert.Equal(typeof(int), invoke.ReturnType);
+        var parms = invoke.GetParameters();
+        Assert.Equal(2, parms.Length);
+        Assert.Equal(typeof(int), parms[0].ParameterType);
+        Assert.Equal(typeof(int), parms[1].ParameterType);
+        Assert.Equal("a", parms[0].Name);
+        Assert.Equal("b", parms[1].Name);
+    }
+
+    [Fact]
+    public void VoidNamedDelegate_InvokeReturnsVoid()
+    {
+        var source = """
+            package MyLib
+
+            type Greeter = delegate func(name string)
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var greeter = assembly.GetTypes().Single(t => t.Name == "Greeter");
+
+        var invoke = greeter.GetMethod("Invoke")!;
+        Assert.Equal(typeof(void), invoke.ReturnType);
+        Assert.Single(invoke.GetParameters());
+        Assert.Equal(typeof(string), invoke.GetParameters()[0].ParameterType);
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_named_delegate_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/NamedDelegateBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NamedDelegateBindingTests.cs
@@ -1,0 +1,81 @@
+// <copyright file="NamedDelegateBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0059 / issue #255: binder tests for named delegate type declarations.
+/// </summary>
+public class NamedDelegateBindingTests
+{
+    [Fact]
+    public void DeclareAndUse_NamedDelegate_Binds_Without_Diagnostics()
+    {
+        var source = @"
+package P
+import System
+
+type Combine = delegate func(a int32, b int32) int32
+
+var sum Combine = func(a int32, b int32) int32 {
+    return a + b
+}
+
+Console.WriteLine(sum.Invoke(2, 40))
+";
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void GenericDelegate_Reports_GS0234()
+    {
+        var source = @"
+package P
+
+type Box[T any] = delegate func(value T) T
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0234");
+    }
+
+    [Fact]
+    public void DelegateDeclaration_Without_Func_Reports_GS0233()
+    {
+        var source = @"
+package P
+
+type Bad = delegate int32
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0233");
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        if (tree.Diagnostics.Any())
+        {
+            return tree.Diagnostics;
+        }
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+}
+

--- a/test/Core.Tests/CodeAnalysis/Syntax/DelegateDeclarationParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/DelegateDeclarationParserTests.cs
@@ -1,0 +1,52 @@
+// <copyright file="DelegateDeclarationParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// ADR-0059 / issue #255: parser tests for named delegate type declarations.
+/// </summary>
+public class DelegateDeclarationParserTests
+{
+    [Fact]
+    public void ParsesVoidDelegate()
+    {
+        const string source = "package P\ntype Greeter = delegate func(name string)\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var decl = Assert.IsType<DelegateDeclarationSyntax>(
+            tree.Root.Members.First(m => m is DelegateDeclarationSyntax));
+        Assert.Equal("Greeter", decl.Identifier.Text);
+        Assert.Single(decl.Parameters);
+        Assert.Null(decl.ReturnType);
+    }
+
+    [Fact]
+    public void ParsesValueReturningDelegate()
+    {
+        const string source = "package P\ntype Combine = delegate func(a int32, b int32) int32\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var decl = Assert.IsType<DelegateDeclarationSyntax>(
+            tree.Root.Members.First(m => m is DelegateDeclarationSyntax));
+        Assert.Equal("Combine", decl.Identifier.Text);
+        Assert.Equal(2, decl.Parameters.Count);
+        Assert.NotNull(decl.ReturnType);
+    }
+
+    [Fact]
+    public void Reports_GS0233_WhenFuncKeywordMissing()
+    {
+        const string source = "package P\ntype Bad = delegate int32\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Contains(tree.Diagnostics, d => d.Id == "GS0233");
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -51,6 +51,7 @@ ContinueStatement
 DefaultKeyword
 DeferKeyword
 DeferStatement
+DelegateDeclaration
 DiscardPattern
 DocumentationCommentToken
 DotToken


### PR DESCRIPTION
Closes #255. Implements ADR-0059.

## Summary

Adds a `type Name = delegate func(...) ret` declaration form that emits a real CLR `sealed class` MulticastDelegate-derived TypeDef with runtime-implemented `.ctor(object, IntPtr)` and `Invoke` — so C# consumers see a conventional named handler type, and G# events can carry first-class custom delegate types instead of always projecting through `Action`/`Func`.

```gs
type Greeter = delegate func(name string)
type Combine = delegate func(a int32, b int32) int32

var hello Greeter = func(name string) { Console.WriteLine("hello, " + name) }
var sum Combine = func(a int32, b int32) int32 { return a + b }

hello.Invoke("world")
Console.WriteLine(sum.Invoke(2, 40))
```

## Surface area

- **Parser** — contextual `delegate` after `=` dispatches to `ParseDelegateDeclaration`; generic header parses (`type Box[T any] = delegate ...`) and is rejected by the binder as GS0234.
- **Symbols** — new `DelegateTypeSymbol` exposing the equivalent `FunctionTypeSymbol` shape so existing function-typed binder paths apply.
- **Binder** — registers each delegate in scope; supports `var h Greeter = func(...)`, `h(args)`, and `h.Invoke(args)`.
- **Conversion** — structural func → named delegate; named delegate → `System.Delegate`/`MulticastDelegate` widening.
- **Emit** — schedules a TypeDef per declared delegate; emits the runtime ctor + Invoke; routes function-literal / method-group → named delegate using the emitted ctor MethodDef. `EmitIndirectCall` prefers the delegate's emitted Invoke handle over the type-erased DynamicInvoke path.

## Diagnostics

| Code   | Severity | Meaning |
|--------|----------|---------|
| GS0233 | Error    | `type X = delegate <something>` without `func(...)` |
| GS0234 | Error    | Generic delegate not yet supported (deferred to v2) |

## Tests

- New parser, binder, and emit unit tests cover the success path and both diagnostics (10 new tests).
- `samples/NamedDelegate.gs` exercises end-to-end with golden output; full sample-conformance + `ilverify` coverage runs in CI.

**Full suite: 2416 / 2416 passing.**

## Out of scope (deferred to v2)

- Generic named delegates (`type Box[T any] = delegate func(T)`).
- Delegate combination operators (`+=`/`-=` on delegate values).
- Variance modifiers (`in`/`out` on type parameters).
