### PR TITLE
Implement let ref / var ref local aliasing (fixes #491)

### DIFF
--- a/docs/adr/0060-ref-out-in-parameters.md
+++ b/docs/adr/0060-ref-out-in-parameters.md
@@ -351,7 +351,7 @@ The opposite extreme of Option E: deprecate ADR-0039's `*T` type and `&x` operat
 ## Follow-ups
 
 - **`ref` returns.** A G# function returning `ref T` (managed-pointer return) requires escape-analysis integration per ADR-0058. Tracked separately.
-- **`ref` locals beyond `*T`.** A `let ref x = expr` shorthand for "bind `x` as an alias to an lvalue" would be a natural extension once `ref` returns land.
+- **`ref` locals beyond `*T`.** ✅ Implemented in issue #491: `let ref x = expr` / `var ref x = expr` binds `x` as an alias to an lvalue. The local's IL slot is `T&`; reads emit `ldloc; ldind.*`, writes `ldloc; value; stind.*`. Aliasing is rejected at top level, inside `async`/iterator functions, and as `const ref` (diagnostics GS0248–GS0250). Cross-function escape (ref returns / RSTE) is still tracked under "ref returns" above.
 - **`in`-elision opt-in.** If GS0237 proves uniformly silenced by users mechanically adding `in`, a future ADR may revisit and either tighten (to error) or relax (with a compiler-inserted temp under an opt-in pragma). Today the design errs toward visible cost.
 - **Conditional ref-passing.** `f(cond ? ref x : ref y)` and similar lvalue-ternary forms; a focused mini-ADR after ref-safe-to-escape's data-flow tracker is mature.
 - **`scoped ref` / `scoped out` / `scoped in` parameters.** §2 admits `scoped ref` syntactically; ADR-0058 specifies the enforcement for `scoped` on `*T`. The full propagation matrix for the keyword-form ref-kind parameters needs a follow-up test-pass once §11's diagnostics are wired up.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -326,3 +326,19 @@ Cause/fix examples:
 - **GS0246** — `Foo(qty: 3)` when `Foo` has no parameter named `qty`. Fix: use the correct parameter name. Also fires when calling through a function-typed/delegate variable, or when targeting a variadic parameter list (parameter names are not addressable in those cases).
 - **GS0247** — `Foo(1, x: 2)` when `Foo(x int32, y int32)` is bound — the positional `1` already filled `x`. Fix: drop one or the other.
 
+## Ref-aliasing local diagnostics (GS0248–GS0250)
+
+Issue #491 (ADR-0060 follow-up) introduces `let ref` / `var ref` aliasing locals — a local whose IL slot is a managed pointer `T&` and that aliases another lvalue (`let ref m = arr[i]`, `var ref v = c.Field`). The diagnostics below flag malformed or illegal ref-alias declarations.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0248 | Error | The right-hand side of a 'ref' local declaration must be an lvalue (variable, field, indexer, or dereference). |
+| GS0249 | Error | A 'ref' local cannot be initialized from an expression with a narrower escape scope than the local itself. |
+| GS0250 | Error | A 'ref' local cannot be declared here — only inside non-async, non-iterator function bodies (no top-level, no `const`). |
+
+Cause/fix examples:
+
+- **GS0248** — `let ref m = 1 + 2` or `let ref m = foo()`. The RHS must denote storage you can take the address of. Fix: alias an addressable expression (`let ref m = arr[0]`, `let ref m = c.Value`, `let ref m = *p`), or drop `ref` and copy the value.
+- **GS0249** — Reserved for the full ref-safety analysis. Will fire when the RHS storage cannot live as long as the alias (e.g. a `ref` returned from a callee that captured a shorter-lived local). V1 has no ref returns, so this code is defined for forward compatibility and currently does not fire.
+- **GS0250** — `let ref m = n` at top level, inside `async func`, inside an iterator (yield-returning) function, or written as `const ref`. Fix: move the declaration into a synchronous, non-iterator function body and use `let ref` / `var ref` (not `const ref`). Top-level `ref` locals would require a static field of `T&`, which the CLR forbids; async / iterator bodies would lift the slot onto a state-machine field, which the CLR likewise forbids.
+

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -3542,6 +3542,17 @@ public sealed class Binder
 
     private BoundStatement BindVariableDeclaration(VariableDeclarationSyntax syntax)
     {
+        // Issue #491 (ADR-0060 follow-up): a `let ref` / `var ref` declaration introduces a
+        // ref-aliasing local. The local's IL slot stores a managed pointer (`T&`) into the
+        // initializer's lvalue; the symbol's static type remains `T` and reads/writes through
+        // the local are implicitly indirected by the lowering & emitter. The slot itself
+        // never carries a `const` value, so the assignability of the alias matches the
+        // mutability of the aliased lvalue (writes through the alias write the storage).
+        if (syntax.HasRefKindModifier)
+        {
+            return BindRefAliasLocalDeclaration(syntax);
+        }
+
         var isReadOnly = syntax.Keyword?.Kind == SyntaxKind.ConstKeyword
             || syntax.Keyword?.Kind == SyntaxKind.LetKeyword;
         var type = BindTypeClause(syntax.TypeClause);
@@ -3645,6 +3656,126 @@ public sealed class Binder
         }
 
         return new BoundVariableDeclaration(syntax, variable, convertedInitializer, constValue);
+    }
+
+    /// <summary>
+    /// Issue #491 (ADR-0060 follow-up): binds a <c>let ref name [T] = lvalue</c> or
+    /// <c>var ref name [T] = lvalue</c> declaration. The local is recorded with
+    /// <see cref="RefKind.Ref"/> and its initializer is normalized to a
+    /// <see cref="BoundAddressOfExpression"/> over the aliased lvalue so the emitter / interpreter
+    /// can populate the alias slot with a managed pointer at the declaration site and
+    /// route subsequent reads/writes through the indirection.
+    /// </summary>
+    private BoundStatement BindRefAliasLocalDeclaration(VariableDeclarationSyntax syntax)
+    {
+        var refModifierLoc = syntax.RefKindModifier.Location;
+        var declaredType = BindTypeClause(syntax.TypeClause);
+
+        // `const ref` is rejected: a `const` binding is a compile-time constant,
+        // not a runtime storage slot, so there is no storage to alias.
+        if (syntax.Keyword?.Kind == SyntaxKind.ConstKeyword)
+        {
+            Diagnostics.ReportRefLocalCannotBeDeclaredHere(refModifierLoc, syntax.Identifier.Text, "a 'const' binding");
+        }
+
+        // An initializer is required: the local must alias an existing lvalue.
+        if (syntax.Initializer == null)
+        {
+            Diagnostics.ReportRefLocalRhsMustBeLvalue(refModifierLoc, "<missing>");
+            var errorVar = BindVariableDeclaration(syntax.Identifier, isReadOnly: false, declaredType ?? TypeSymbol.Error, ResolveAccessibility(syntax.AccessibilityModifier));
+            return new BoundVariableDeclaration(syntax, errorVar, new BoundErrorExpression(null));
+        }
+
+        var initializer = BindExpression(syntax.Initializer);
+        if (initializer is BoundErrorExpression)
+        {
+            var errorVar = BindVariableDeclaration(syntax.Identifier, isReadOnly: false, declaredType ?? TypeSymbol.Error, ResolveAccessibility(syntax.AccessibilityModifier));
+            return new BoundVariableDeclaration(syntax, errorVar, initializer);
+        }
+
+        // Validate the RHS is a writable lvalue: a variable that is not read-only,
+        // a field/property access, an indexer access, or a managed-pointer dereference.
+        // The same restrictions that govern `&expr` apply here (issue #491 / ADR-0039 §3).
+        var rhsValid = true;
+        if (initializer is BoundVariableExpression bve && bve.Variable.IsReadOnly)
+        {
+            // Aliasing a read-only binding would let the alias mutate it; mirror
+            // the existing `&readonly` rejection (GS9005 / GS0242 for `in`).
+            if (bve.Variable is ParameterSymbol inParam && inParam.RefKind == RefKind.In)
+            {
+                Diagnostics.ReportCannotAssignToInParameter(refModifierLoc, inParam.Name);
+            }
+            else
+            {
+                Diagnostics.ReportCannotTakeAddressOfConstant(refModifierLoc, bve.Variable.Name);
+            }
+
+            rhsValid = false;
+        }
+        else if (!IsLvalue(initializer))
+        {
+            var exprText = syntax.Initializer.ToString();
+            Diagnostics.ReportRefLocalRhsMustBeLvalue(refModifierLoc, exprText);
+            rhsValid = false;
+        }
+
+        // Pointee type: the user may write an explicit type clause that must match
+        // the initializer's static type; otherwise infer from the initializer.
+        var pointeeType = initializer.Type ?? TypeSymbol.Error;
+        if (declaredType != null && rhsValid && pointeeType != TypeSymbol.Error && declaredType != pointeeType)
+        {
+            Diagnostics.ReportCannotConvert(syntax.Initializer.Location, pointeeType, declaredType);
+            rhsValid = false;
+        }
+
+        var slotType = declaredType ?? pointeeType;
+
+        // Context restrictions: a ref-aliasing local cannot escape its declaring
+        // function frame. The CLR cannot encode a managed pointer as a static
+        // field (top-level / `customize` partial) or as a hoisted state-machine
+        // field (`async`/iterator functions).
+        if (function == null)
+        {
+            Diagnostics.ReportRefLocalCannotBeDeclaredHere(refModifierLoc, syntax.Identifier.Text, "a top-level variable (it would be emitted as a heap-rooted static field)");
+            rhsValid = false;
+        }
+        else if (function.IsAsync || IsIteratorReturnType(function.Type))
+        {
+            var context = function.IsAsync ? "a local in an async function" : "a local in an iterator";
+            Diagnostics.ReportRefLocalCannotBeDeclaredHere(refModifierLoc, syntax.Identifier.Text, context + " (it would be hoisted into the state machine)");
+            rhsValid = false;
+        }
+
+        var accessibility = ResolveAccessibility(syntax.AccessibilityModifier);
+        var variable = BindVariableDeclaration(syntax.Identifier, isReadOnly: false, slotType, accessibility);
+        if (variable is LocalVariableSymbol localVar)
+        {
+            // The alias slot itself is function-local; never returnable.
+            localVar.RefKind = RefKind.Ref;
+            localVar.IsScoped = true;
+        }
+
+        // Annotations attach to the symbol unchanged (e.g. @Obsolete on a top-level
+        // alias would still be observed if it ever became legal at top level).
+        if (variable != null && !syntax.Annotations.IsDefaultOrEmpty)
+        {
+            var positionDescription = "a local variable declaration";
+            var boundAttrs = BindAttributes(
+                syntax.Annotations,
+                AttributeTargetKind.Field,
+                VariableDeclarationAllowedTargets,
+                positionDescription,
+                System.AttributeTargets.Field);
+            variable.SetAttributes(boundAttrs);
+        }
+
+        // Lower the initializer to BoundAddressOfExpression so the emitter
+        // populates the alias slot with the managed pointer (§5 / §6 of ADR-0060).
+        BoundExpression boundInitializer = rhsValid
+            ? new BoundAddressOfExpression(syntax.Initializer, initializer)
+            : new BoundErrorExpression(null);
+
+        return new BoundVariableDeclaration(syntax, variable, boundInitializer);
     }
 
     private BoundStatement BindTupleDeconstructionStatement(TupleDeconstructionStatementSyntax syntax)

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1819,6 +1819,47 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0247", $"Named argument '{name}' specifies a value for parameter '{name}' which was already given a positional value.");
     }
 
+    /// <summary>
+    /// Issue #491 (ADR-0060 follow-up): reports a ref-aliasing local declaration whose
+    /// initializer is not an lvalue. <c>let ref</c> / <c>var ref</c> binds the local as
+    /// an alias for an existing storage slot — the RHS must therefore be a variable, a
+    /// field/property access, an indexer access, or a dereference of a managed pointer.
+    /// </summary>
+    /// <param name="location">The <c>ref</c> modifier location.</param>
+    /// <param name="exprText">The source text of the offending RHS expression.</param>
+    public void ReportRefLocalRhsMustBeLvalue(TextLocation location, string exprText)
+    {
+        Report(location, "GS0248", $"The right-hand side of a ref-aliasing local must be an lvalue (a variable, field/property, indexer access, or '*p' dereference); '{exprText}' is not assignable.");
+    }
+
+    /// <summary>
+    /// Issue #491 (ADR-0060 follow-up): reports a ref-aliasing local whose initializer's
+    /// ref-safe-to-escape scope is narrower than the local's declaring scope. The aliased
+    /// storage would not outlive the local; reading or writing through the alias is therefore
+    /// unsafe. Reported, for example, when binding a ref local to a value whose pointee lives
+    /// in a <c>scoped</c> ref struct or to a temporary that the local would outlive.
+    /// </summary>
+    /// <param name="location">The <c>ref</c> modifier location.</param>
+    /// <param name="variableName">The local name.</param>
+    public void ReportRefLocalRhsHasNarrowerEscapeScope(TextLocation location, string variableName)
+    {
+        Report(location, "GS0249", $"Cannot bind ref-aliasing local '{variableName}' to a value whose ref-safe-to-escape scope is narrower than the local's scope; the alias would outlive its referent.");
+    }
+
+    /// <summary>
+    /// Issue #491 (ADR-0060 follow-up): reports the <c>ref</c> aliasing modifier on a
+    /// declaration that cannot legally store a managed pointer — a top-level binding
+    /// (emitted as a static field), a local in an <c>async</c> function or iterator
+    /// (hoisted into a state-machine field), or a <c>const</c> declaration.
+    /// </summary>
+    /// <param name="location">The <c>ref</c> modifier location.</param>
+    /// <param name="variableName">The local name.</param>
+    /// <param name="context">Description of the disallowed context (e.g. "a top-level variable").</param>
+    public void ReportRefLocalCannotBeDeclaredHere(TextLocation location, string variableName, string context)
+    {
+        Report(location, "GS0250", $"Ref-aliasing local '{variableName}' cannot be declared as {context}; managed pointers cannot be stored across this boundary.");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -5201,7 +5201,7 @@ internal sealed class ReflectionMetadataEmitter
                 var encoder = new BlobEncoder(localsSigBlob).LocalVariableSignature(localTypes.Count);
                 foreach (var t in localTypes)
                 {
-                    EncodeTypeSymbol(encoder.AddVariable().Type(), t);
+                    EncodeLocalVariableType(encoder.AddVariable(), t);
                 }
 
                 localsSignature = this.metadata.AddStandaloneSignature(this.metadata.GetOrAddBlob(localsSigBlob));
@@ -5496,7 +5496,7 @@ internal sealed class ReflectionMetadataEmitter
                 var encoder = new BlobEncoder(localsSigBlob).LocalVariableSignature(localTypes.Count);
                 foreach (var t in localTypes)
                 {
-                    EncodeTypeSymbol(encoder.AddVariable().Type(), t);
+                    EncodeLocalVariableType(encoder.AddVariable(), t);
                 }
 
                 localsSignature = this.metadata.AddStandaloneSignature(this.metadata.GetOrAddBlob(localsSigBlob));
@@ -5696,7 +5696,7 @@ internal sealed class ReflectionMetadataEmitter
                 var encoder = new BlobEncoder(localsSigBlob).LocalVariableSignature(localTypes.Count);
                 foreach (var t in localTypes)
                 {
-                    EncodeTypeSymbol(encoder.AddVariable().Type(), t);
+                    EncodeLocalVariableType(encoder.AddVariable(), t);
                 }
 
                 localsSignature = this.metadata.AddStandaloneSignature(this.metadata.GetOrAddBlob(localsSigBlob));
@@ -6599,7 +6599,7 @@ internal sealed class ReflectionMetadataEmitter
                 var encoder = new BlobEncoder(localsSigBlob).LocalVariableSignature(localTypes.Count);
                 foreach (var t in localTypes)
                 {
-                    EncodeTypeSymbol(encoder.AddVariable().Type(), t);
+                    EncodeLocalVariableType(encoder.AddVariable(), t);
                 }
 
                 localsSignature = this.metadata.AddStandaloneSignature(this.metadata.GetOrAddBlob(localsSigBlob));
@@ -7128,7 +7128,7 @@ internal sealed class ReflectionMetadataEmitter
                 var encoder = new BlobEncoder(localsSigBlob).LocalVariableSignature(localTypes.Count);
                 foreach (var t in localTypes)
                 {
-                    EncodeTypeSymbol(encoder.AddVariable().Type(), t);
+                    EncodeLocalVariableType(encoder.AddVariable(), t);
                 }
 
                 localsSignature = this.metadata.AddStandaloneSignature(this.metadata.GetOrAddBlob(localsSigBlob));
@@ -7788,7 +7788,19 @@ internal sealed class ReflectionMetadataEmitter
                 && !(node.Variable is GlobalVariableSymbol gv && this.outer.globalFieldDefs.ContainsKey(gv)))
             {
                 this.locals[node.Variable] = this.localTypes.Count;
-                this.localTypes.Add(node.Variable.Type);
+
+                // Issue #491 (ADR-0060 follow-up): a ref-aliasing local's IL slot
+                // is the managed pointer `T&`, not the pointee `T`. Recording the
+                // slot type as ByRefTypeSymbol routes encoding through the byref
+                // local-sig path (EncodeLocalVariableType).
+                if (node.Variable is LocalVariableSymbol lvs && lvs.RefKind != RefKind.None)
+                {
+                    this.localTypes.Add(ByRefTypeSymbol.Get(lvs.Type));
+                }
+                else
+                {
+                    this.localTypes.Add(node.Variable.Type);
+                }
             }
 
             base.VisitVariableDeclaration(node);
@@ -9109,7 +9121,19 @@ internal sealed class ReflectionMetadataEmitter
                         if (!locals.ContainsKey(decl.Variable))
                         {
                             locals[decl.Variable] = localTypes.Count;
-                            localTypes.Add(decl.Variable.Type);
+
+                            // Issue #491 (ADR-0060 follow-up): a ref-aliasing local's IL
+                            // slot is a managed pointer `T&`, not the pointee `T`.
+                            // Recording the slot type as ByRefTypeSymbol routes encoding
+                            // through the byref local-sig path (EncodeLocalVariableType).
+                            if (decl.Variable is LocalVariableSymbol lvs && lvs.RefKind != RefKind.None)
+                            {
+                                localTypes.Add(ByRefTypeSymbol.Get(lvs.Type));
+                            }
+                            else
+                            {
+                                localTypes.Add(decl.Variable.Type);
+                            }
                         }
 
                         break;
@@ -10360,6 +10384,24 @@ internal sealed class ReflectionMetadataEmitter
         return this.stringConcatArrayRef;
     }
 
+    /// <summary>
+    /// Issue #491 (ADR-0060 follow-up): encodes a single local-variable signature slot.
+    /// A <see cref="ByRefTypeSymbol"/> entry signals a ref-aliasing local (<c>let ref</c> /
+    /// <c>var ref</c>) whose slot must carry <c>ELEMENT_TYPE_BYREF</c> wrapping the pointee
+    /// type. Non-byref entries forward to <see cref="EncodeTypeSymbol"/> unchanged.
+    /// </summary>
+    private void EncodeLocalVariableType(LocalVariableTypeEncoder enc, TypeSymbol t)
+    {
+        if (t is ByRefTypeSymbol byRef)
+        {
+            EncodeTypeSymbol(enc.Type(isByRef: true), byRef.PointeeType);
+        }
+        else
+        {
+            EncodeTypeSymbol(enc.Type(), t);
+        }
+    }
+
     private void EncodeTypeSymbol(SignatureTypeEncoder encoder, TypeSymbol type)
     {
         // ADR-0060 §13 / migration: a managed-pointer type (ByRefTypeSymbol → T&) cannot
@@ -11505,12 +11547,17 @@ internal sealed class ReflectionMetadataEmitter
             base.VisitClrPropertyAssignmentExpression(node);
         }
 
-        // ADR-0060: assignments to ref-kind parameters lower to `ldarg; value;
-        // stind`. To preserve the assignment-as-expression result semantics
-        // without a re-read, the emitter spills the value to a temp local.
+        // ADR-0060 / issue #491: assignments to ref-kind parameters or to
+        // ref-aliasing locals lower to `<addr>; value; dup; stloc tmp; stind`.
+        // To preserve the assignment-as-expression result semantics without
+        // a re-read, the emitter spills the value to a temp local.
         protected override void VisitAssignmentExpression(BoundAssignmentExpression node)
         {
             if (node.Variable is ParameterSymbol ps && ps.RefKind != RefKind.None)
+            {
+                this.sink.Add(node);
+            }
+            else if (node.Variable is LocalVariableSymbol lvs && lvs.RefKind != RefKind.None)
             {
                 this.sink.Add(node);
             }
@@ -11863,6 +11910,21 @@ internal sealed class ReflectionMetadataEmitter
                         this.il.OpCode(ILOpCode.Dup);
                         this.il.StoreLocal(assignTmp);
                         this.EmitStoreIndirect(assignParam.Type);
+                        this.il.LoadLocal(assignTmp);
+                    }
+                    else if (a.Variable is LocalVariableSymbol assignLocal
+                        && assignLocal.RefKind != RefKind.None
+                        && this.locals.TryGetValue(assignLocal, out var refLocalSlot))
+                    {
+                        // Issue #491 (ADR-0060 follow-up): assign-through-ref-alias-local lowers to
+                        // `ldloc slot; value; dup; stloc tmp; stind.*; ldloc tmp`.
+                        // The temp slot is pre-allocated by AssignmentValueSpillCollector.
+                        var assignTmp = this.receiverSpillSlots[a];
+                        this.il.LoadLocal(refLocalSlot);
+                        this.EmitExpression(a.Expression);
+                        this.il.OpCode(ILOpCode.Dup);
+                        this.il.StoreLocal(assignTmp);
+                        this.EmitStoreIndirect(assignLocal.Type);
                         this.il.LoadLocal(assignTmp);
                     }
                     else
@@ -13488,6 +13550,15 @@ internal sealed class ReflectionMetadataEmitter
             if (this.locals.TryGetValue(variable, out var slot))
             {
                 this.il.LoadLocal(slot);
+
+                // Issue #491 (ADR-0060 follow-up): a ref-aliasing local's slot
+                // stores a managed pointer T&; a read of the local in the body
+                // must indirect through the pointer to load the pointee value.
+                if (variable is LocalVariableSymbol refLocal && refLocal.RefKind != RefKind.None)
+                {
+                    this.EmitLoadIndirect(refLocal.Type);
+                }
+
                 return;
             }
 
@@ -16010,7 +16081,18 @@ internal sealed class ReflectionMetadataEmitter
 
             if (this.locals.TryGetValue(variable, out var slot))
             {
-                this.il.LoadLocalAddress(slot);
+                // Issue #491 (ADR-0060 follow-up): a ref-aliasing local's slot
+                // already stores a managed pointer T&; load the slot value, not
+                // its address (ldloca would yield T&* which is wrong).
+                if (variable is LocalVariableSymbol refLocal && refLocal.RefKind != RefKind.None)
+                {
+                    this.il.LoadLocal(slot);
+                }
+                else
+                {
+                    this.il.LoadLocalAddress(slot);
+                }
+
                 return true;
             }
 

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -150,6 +150,24 @@ public sealed class Evaluator
 
     private void EvaluateVariableDeclaration(BoundVariableDeclaration node)
     {
+        // Issue #491 (ADR-0060 follow-up): a ref-aliasing local binds the symbol
+        // to an existing lvalue rather than copying its value. The initializer
+        // is a BoundAddressOfExpression whose operand is the aliased lvalue;
+        // store a RefAlias sentinel in the locals dictionary so subsequent
+        // reads re-evaluate the operand and writes route back to it.
+        if (node.Variable is LocalVariableSymbol refLocal
+            && refLocal.RefKind != RefKind.None
+            && node.Initializer is BoundAddressOfExpression refAddr)
+        {
+            var alias = new RefAlias(refAddr.Operand);
+            var locals = this.locals.Peek();
+            locals[node.Variable] = alias;
+
+            // Mirror the read-through semantics for `lastValue` (used by REPL).
+            lastValue = EvaluateExpression(refAddr.Operand);
+            return;
+        }
+
         var value = EvaluateExpression(node.Initializer);
         lastValue = value;
         Assign(node.Variable, value);
@@ -733,7 +751,17 @@ public sealed class Evaluator
         else
         {
             var locals = this.locals.Peek();
-            return locals[v.Variable];
+            var stored = locals[v.Variable];
+
+            // Issue #491 (ADR-0060 follow-up): a ref-aliasing local stores a
+            // RefAlias sentinel; reads re-evaluate the aliased operand so the
+            // local observes the current value of the underlying storage.
+            if (stored is RefAlias alias)
+            {
+                return EvaluateExpression(alias.Operand);
+            }
+
+            return stored;
         }
     }
 
@@ -2980,7 +3008,46 @@ public sealed class Evaluator
         else
         {
             var locals = this.locals.Peek();
+
+            // Issue #491 (ADR-0060 follow-up): writing to a ref-aliasing local
+            // routes the new value to the aliased storage (not replacing the
+            // alias itself).
+            if (locals.TryGetValue(variable, out var existing) && existing is RefAlias alias)
+            {
+                WriteBackToOperand(alias.Operand, value);
+                return;
+            }
+
             locals[variable] = value;
+        }
+    }
+
+    /// <summary>
+    /// Issue #491 (ADR-0060 follow-up): writes <paramref name="value"/> through a
+    /// bound lvalue expression (variable, field, property, or indexer access).
+    /// Shared between ref-aliasing local writes and the existing ref/out parameter
+    /// write-back path.
+    /// </summary>
+    private void WriteBackToOperand(Binding.BoundExpression operand, object value)
+    {
+        switch (operand)
+        {
+            case BoundVariableExpression bve:
+                Assign(bve.Variable, value);
+                break;
+            case BoundFieldAccessExpression fa:
+                WriteBackField(fa, value);
+                break;
+            case BoundPropertyAccessExpression pa:
+                WriteBackProperty(pa, value);
+                break;
+            case BoundIndexExpression idx:
+                WriteBackIndex(idx, value);
+                break;
+            case BoundDereferenceExpression deref:
+                // *p = v under interpreter: re-route through the inner operand.
+                WriteBackToOperand(deref.Operand, value);
+                break;
         }
     }
 
@@ -2993,6 +3060,21 @@ public sealed class Evaluator
             Found = true;
             return node;
         }
+    }
+
+    /// <summary>
+    /// Issue #491 (ADR-0060 follow-up): sentinel stored in the locals dictionary
+    /// for a ref-aliasing local. Reads of the local re-evaluate <see cref="Operand"/>;
+    /// writes are routed back to <see cref="Operand"/> via <see cref="WriteBackToOperand"/>.
+    /// </summary>
+    private sealed class RefAlias
+    {
+        public RefAlias(Binding.BoundExpression operand)
+        {
+            Operand = operand;
+        }
+
+        public Binding.BoundExpression Operand { get; }
     }
 
     private sealed class InterpAsyncEnumerableBuffer<T> :

--- a/src/Core/CodeAnalysis/Symbols/LocalVariableSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/LocalVariableSymbol.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
@@ -38,4 +39,13 @@ public class LocalVariableSymbol : VariableSymbol
     /// function is rejected.
     /// </summary>
     public virtual bool IsScoped { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ADR-0060 follow-up (issue #491) by-reference aliasing kind of this local.
+    /// Defaults to <see cref="Binding.RefKind.None"/>. For a <c>let ref x = lvalue</c> / <c>var ref x = lvalue</c>
+    /// declaration this is <see cref="Binding.RefKind.Ref"/>: the local's IL slot stores a managed pointer
+    /// (<c>T&amp;</c>) to the aliased storage while the symbol's <see cref="VariableSymbol.Type"/> remains the
+    /// pointee type <c>T</c>. Reads/writes are implicitly indirected by the emitter and interpreter.
+    /// </summary>
+    public virtual RefKind RefKind { get; set; }
 }

--- a/src/Core/CodeAnalysis/Symbols/ParameterSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ParameterSymbol.cs
@@ -57,7 +57,7 @@ public sealed class ParameterSymbol : LocalVariableSymbol
     public override bool IsScoped { get; set; }
 
     /// <summary>
-    /// Gets the ADR-0060 by-reference passing mode of this parameter (<c>None</c>, <c>Ref</c>, <c>Out</c>, or <c>In</c>).
+    /// Gets or sets the ADR-0060 by-reference passing mode of this parameter (<c>None</c>, <c>Ref</c>, <c>Out</c>, or <c>In</c>).
     /// </summary>
-    public RefKind RefKind { get; }
+    public override RefKind RefKind { get; set; }
 }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -2355,6 +2355,19 @@ public class Parser
             scopedModifier = NextToken();
         }
 
+        // Issue #491 (ADR-0060 follow-up): optional `ref` contextual modifier on
+        // `let`/`var` declarations introduces a ref-aliasing local
+        // (`let ref m = lvalue` / `var ref m = lvalue`). Disambiguate: `ref` is
+        // only a modifier when followed by another identifier (the variable
+        // name). If `ref` IS the variable name (no following identifier), treat
+        // it as the identifier itself. Rejected on `const` after binding.
+        SyntaxToken refKindModifier = null;
+        if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "ref"
+            && Peek(1).Kind == SyntaxKind.IdentifierToken)
+        {
+            refKindModifier = NextToken();
+        }
+
         var identifier = MatchToken(SyntaxKind.IdentifierToken);
         var typeClause = ParseOptionalTypeClause();
 
@@ -2363,7 +2376,10 @@ public class Parser
         // takes that type's default value. `let`/`const` remain immutable, so
         // an initializer stays mandatory for them; and without a type clause
         // there is nothing to infer from, so an initializer is still required.
+        // Issue #491: a ref-aliasing local always requires an initializer (it
+        // must alias an lvalue) — fall through to MatchToken below if absent.
         if (expected == SyntaxKind.VarKeyword
+            && refKindModifier == null
             && typeClause != null
             && Current.Kind != SyntaxKind.EqualsToken)
         {
@@ -2383,6 +2399,7 @@ public class Parser
         var initializer = ParseExpression();
         var result = new VariableDeclarationSyntax(syntaxTree, accessibilityModifier, keyword, identifier, typeClause, equals, initializer);
         result.ScopedModifier = scopedModifier;
+        result.RefKindModifier = refKindModifier;
         return result;
     }
 

--- a/src/Core/CodeAnalysis/Syntax/VariableDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/VariableDeclarationSyntax.cs
@@ -93,6 +93,16 @@ public sealed class VariableDeclarationSyntax : StatementSyntax
     public bool IsScoped => ScopedModifier != null;
 
     /// <summary>
+    /// Gets or sets the optional <c>ref</c> contextual modifier token (ADR-0060 follow-up / issue #491).
+    /// When non-null, this declaration is a ref-aliasing local: the slot stores a managed pointer to the
+    /// initializer's lvalue and reads/writes through the local indirect through the alias.
+    /// </summary>
+    public SyntaxToken RefKindModifier { get; set; }
+
+    /// <summary>Gets a value indicating whether this declaration carries the <c>ref</c> aliasing modifier (issue #491).</summary>
+    public bool HasRefKindModifier => RefKindModifier != null;
+
+    /// <summary>
     /// Gets the variable identifier.
     /// </summary>
     public SyntaxToken Identifier { get; }

--- a/test/Core.Tests/CodeAnalysis/Binding/RefLocalAliasingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefLocalAliasingTests.cs
@@ -1,0 +1,201 @@
+// <copyright file="RefLocalAliasingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #491 (ADR-0060 follow-up): binder-level tests for ref-aliasing locals
+/// declared with <c>let ref</c> / <c>var ref</c>. Validates lvalue RHS, escape-scope
+/// classification (top-level / async / iterator rejection), <c>const ref</c> rejection,
+/// type-clause mismatch reporting, and clean binding of the canonical shapes from
+/// the issue (array element alias, field alias).
+/// </summary>
+public class RefLocalAliasingTests
+{
+    [Fact]
+    public void LetRef_AliasingArrayElement_BindsCleanly()
+    {
+        var source = @"
+func tweak() {
+    var arr = []int32{10, 20, 30}
+    let ref m = arr[1]
+    m = 99
+}
+tweak()
+0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void VarRef_AliasingStructField_BindsCleanly()
+    {
+        var source = @"
+type Counter struct {
+    Value int32
+}
+
+func tweak() {
+    var c Counter = Counter{Value: 5}
+    var ref v = c.Value
+    v = v + 1
+}
+tweak()
+0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void LetRef_WithExplicitTypeClause_BindsCleanly()
+    {
+        var source = @"
+func tweak() {
+    var x int32 = 7
+    let ref m int32 = x
+    m = 8
+}
+tweak()
+0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void LetRef_NonLvalueRhs_ReportsGS0248()
+    {
+        var source = @"
+func tweak() {
+    let ref m = 1 + 2
+}
+tweak()
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0248");
+    }
+
+    [Fact]
+    public void LetRef_LiteralRhs_ReportsGS0248()
+    {
+        var source = @"
+func tweak() {
+    let ref m = 42
+}
+tweak()
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0248");
+    }
+
+    [Fact]
+    public void LetRef_AliasReadOnlyLetLocal_RejectedAsAddressOfConstant()
+    {
+        var source = @"
+func tweak() {
+    let x = 7
+    let ref m = x
+}
+tweak()
+0
+";
+        var result = Evaluate(source);
+        // Same diagnostic family as `&x` over a `let` binding (GS9005): cannot take address of constant.
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS9005");
+    }
+
+    [Fact]
+    public void LetRef_AtTopLevel_ReportsGS0250()
+    {
+        var source = @"
+var n int32 = 7
+let ref m = n
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0250");
+    }
+
+    [Fact]
+    public void LetRef_InAsyncFunction_ReportsGS0250()
+    {
+        var source = @"
+async func tweak() {
+    var n int32 = 7
+    let ref m = n
+}
+tweak()
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0250");
+    }
+
+    [Fact]
+    public void ConstRef_Rejected()
+    {
+        var source = @"
+func tweak() {
+    var n int32 = 7
+    const ref m = n
+}
+tweak()
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0250");
+    }
+
+    [Fact]
+    public void LetRef_TypeMismatch_ReportsCannotConvert()
+    {
+        var source = @"
+func tweak() {
+    var n int32 = 7
+    let ref m int64 = n
+}
+tweak()
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0155" || d.Id == "GS0017" || d.Id == "GS0011" || d.Id == "GS0030" || d.Id == "GS0019");
+    }
+
+    [Fact]
+    public void LetRef_BindRefAliasOfDereference_BindsCleanly()
+    {
+        var source = @"
+func tweak() {
+    var n int32 = 5
+    var p *int32 = &n
+    let ref m = *p
+    m = 11
+}
+tweak()
+0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/RefLocalAliasingEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/RefLocalAliasingEmitTests.cs
@@ -1,0 +1,154 @@
+// <copyright file="RefLocalAliasingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #491 (ADR-0060 follow-up): end-to-end emit tests for ref-aliasing locals
+/// declared with <c>let ref</c> / <c>var ref</c>. The IL slot for a ref-aliasing
+/// local is a managed pointer <c>T&amp;</c>: reads emit <c>ldloc; ldind.*</c>, writes
+/// emit <c>ldloc; value; stind.*</c>, and <c>&amp;m</c> emits <c>ldloc</c> (the slot
+/// is already the alias).
+/// </summary>
+public class RefLocalAliasingEmitTests
+{
+    [Fact]
+    public void LetRef_WriteThroughAlias_UpdatesUnderlyingVariable()
+    {
+        const string Source = @"package LetRefArr
+import System
+
+func tweak() {
+    var arr = []int32{10, 20, 30}
+    let ref m = arr[1]
+    m = 99
+    Console.WriteLine(arr[1])
+}
+
+tweak()
+";
+        var output = CompileAndRun(Source, "LetRefArr");
+        Assert.Contains("99", output);
+    }
+
+    [Fact]
+    public void LetRef_AliasPassedAsRefArg_BumpsUnderlying()
+    {
+        const string Source = @"package LetRefPass
+import System
+
+func bump(ref slot int32) {
+    slot = slot + 1
+}
+
+func tweak() {
+    var n int32 = 41
+    let ref m = n
+    bump(&m)
+    Console.WriteLine(n)
+}
+
+tweak()
+";
+        var output = CompileAndRun(Source, "LetRefPass");
+        Assert.Contains("42", output);
+    }
+
+    [Fact]
+    public void VarRef_AliasStructField_WritesThroughAlias()
+    {
+        const string Source = @"package VarRefField
+import System
+
+type Counter struct {
+    Value int32
+}
+
+func tweak() {
+    var c Counter = Counter{Value: 5}
+    var ref v = c.Value
+    v = v + 100
+    Console.WriteLine(c.Value)
+}
+
+tweak()
+";
+        var output = CompileAndRun(Source, "VarRefField");
+        Assert.Contains("105", output);
+    }
+
+    [Fact]
+    public void LetRef_ReadThroughAliasAndAssignmentExpression_ReturnsValue()
+    {
+        // Issue #491: the spill-collector / value-spill path produces correct
+        // assignment-as-expression results for ref locals (parity with ref params).
+        const string Source = @"package LetRefAssignExpr
+import System
+
+func tweak() {
+    var n int32 = 0
+    let ref m = n
+    let r = (m = 17)
+    Console.WriteLine(r)
+    Console.WriteLine(n)
+}
+
+tweak()
+";
+        var output = CompileAndRun(Source, "LetRefAssignExpr");
+        Assert.Contains("17", output);
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, parameters: null);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Interpreter.Tests/RefLocalAliasingInterpreterTests.cs
+++ b/test/Interpreter.Tests/RefLocalAliasingInterpreterTests.cs
@@ -1,0 +1,104 @@
+// <copyright file="RefLocalAliasingInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #491 (ADR-0060 follow-up): interpreter tests for ref-aliasing locals
+/// (<c>let ref</c> / <c>var ref</c>). Aliasing must observe writes to the
+/// pointee through the alias and vice versa, parallel to the IL emitter's
+/// <c>ldloc; ldind</c> / <c>ldloc; stind</c> lowering.
+/// </summary>
+public class RefLocalAliasingInterpreterTests
+{
+    [Fact]
+    public void LetRef_WriteThroughAlias_UpdatesUnderlyingVariable()
+    {
+        var output = RunSubmission(@"
+func tweak() {
+    var n = 10
+    let ref m = n
+    m = m + 5
+    print(string(n))
+}
+tweak()
+");
+        Assert.Contains("15", output);
+    }
+
+    [Fact]
+    public void LetRef_ReadThroughAlias_ObservesUnderlyingMutation()
+    {
+        var output = RunSubmission(@"
+func tweak() {
+    var n = 10
+    let ref m = n
+    n = 42
+    print(string(m))
+}
+tweak()
+");
+        Assert.Contains("42", output);
+    }
+
+    [Fact]
+    public void LetRef_WriteThroughAlias_TwoWayObserved()
+    {
+        var output = RunSubmission(@"
+func tweak() {
+    var n = 10
+    let ref m = n
+    m = m * 2
+    n = n + 1
+    print(string(m))
+    print(string(n))
+}
+tweak()
+");
+        // m and n must observe the same storage. After m *= 2 → n = 20.
+        // After n += 1 → m reads 21.
+        Assert.Contains("21", output);
+    }
+
+    [Fact]
+    public void LetRef_AliasStructField_WritesThrough()
+    {
+        var output = RunSubmission(@"
+type Counter struct {
+    Value int32
+}
+
+func tweak() {
+    var c = Counter{Value: 1}
+    let ref v = c.Value
+    v = 7
+    print(string(c.Value))
+}
+tweak()
+");
+        Assert.Contains("7", output);
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString();
+    }
+}


### PR DESCRIPTION
ADR-0060 follow-up: adds `let ref m = lvalue` / `var ref m = lvalue` aliasing locals across parser, binder, symbol model, IL emitter, and the tree-walking interpreter, plus three new diagnostics.

Closes #491.

## What it does

`let ref m = expr` (or `var ref m = expr`) binds `m` as an alias to the storage denoted by `expr`. Reads of `m` see the latest value of the underlying storage; writes through `m` mutate it. The IL slot is the managed pointer `T&`.

```gs
func bump() {
    var n = 10
    let ref m = n
    m = m + 5         // writes through alias → n is now 15
    n = n + 1         // n updated underneath → m reads 16
}
```

`var ref` permits rebinding the alias to a different storage; `let ref` is read-only at the alias level (the pointee may still be mutated through the alias if not declared `const`).

## Surfaces

| Layer | Change |
|---|---|
| Symbol | `LocalVariableSymbol.RefKind` becomes a virtual settable property; `ParameterSymbol.RefKind` is now an `override` |
| Syntax | `VariableDeclarationSyntax.RefKindModifier` (optional `ref` token after `let`/`var`) |
| Parser | Consume optional `ref` identifier-token after `let`/`var` (and after `scoped`) when followed by another identifier |
| Binder | New `BindRefAliasLocalDeclaration`: requires lvalue RHS (mirrors `&x`), enforces context restrictions, optional declared-type check, lowers initializer as `BoundAddressOfExpression(operand)` |
| Emit | `EncodeLocalVariableType` helper drives `Type(isByRef:true)` for ref-local slots; `EmitLoadVariable` / `TryLoadVariableAddress` / `EmitExpression(BoundAssignmentExpression)` get ref-local branches parallel to ref-parameter branches; spill collector pre-allocates assignment-as-expression temps |
| Interpret | New `RefAlias` sentinel stored in the locals frame; reads re-evaluate the underlying lvalue; `Assign` routes through `WriteBackToOperand` (variable/field/property/index/dereference) |
| Diagnostics | `GS0248`, `GS0249` (reserved for full RSTE), `GS0250` |
| Docs | `docs/diagnostics.md` entries for `GS0248`–`GS0250`; ADR-0060 follow-up marked completed |

## Diagnostics

- **GS0248** — `let ref m = 1 + 2`: RHS must be an lvalue (variable, field, indexer, or dereference).
- **GS0249** — reserved for the full ref-safety / RSTE analysis; defined for forward compatibility, currently does not fire.
- **GS0250** — `let ref` at top level, inside `async`/iterator functions, or written as `const ref` — these forms would require static or state-machine fields of `T&`, which the CLR forbids.

## Tests

- 11 binder tests (`test/Core.Tests/CodeAnalysis/Binding/RefLocalAliasingTests.cs`): array-element / struct-field / `*p` aliasing, explicit type clause, non-lvalue RHS, literal RHS, aliasing a `let` local, top-level / async / `const ref` rejection, type mismatch.
- 4 emit tests (`test/Core.Tests/CodeAnalysis/Emit/RefLocalAliasingEmitTests.cs`): compile + load + run, including assignment-as-expression result; IL was independently verified with `ilverify`.
- 4 interpreter tests (`test/Interpreter.Tests/RefLocalAliasingInterpreterTests.cs`): write-through-alias, read-observes-mutation, struct field, two-way observation.

## Validation

- `dotnet build GSharp.sln -nologo -clp:NoSummary` — 0 warnings, 0 errors.
- `dotnet test GSharp.sln --no-restore --nologo` — all green (Sdk 24, Interpreter 72, LanguageServer 212, Core 1830, Compiler 371; +19 new tests over baseline).