### PR TITLE
Implement ADR-0062 generalized ternary expression

### DIFF
--- a/docs/adr/0061-conditional-ref-arguments.md
+++ b/docs/adr/0061-conditional-ref-arguments.md
@@ -3,7 +3,7 @@
 - **Status**: Proposed
 - **Date**: 2026-06-05
 - **Phase**: Phase 8 — language ergonomics / CLR-interop surface
-- **Related**: issue #492 (conditional ref-passing follow-up to ADR-0060); ADR-0060 (`ref`/`out`/`in` parameters), ADR-0058 (ref-safe-to-escape), ADR-0039 (managed by-ref pointers `&`/`*` / `ByRefTypeSymbol`)
+- **Related**: issue #492 (conditional ref-passing follow-up to ADR-0060); ADR-0060 (`ref`/`out`/`in` parameters), ADR-0058 (ref-safe-to-escape), ADR-0039 (managed by-ref pointers `&`/`*` / `ByRefTypeSymbol`), ADR-0062 (generalized ternary expression)
 
 ## Context
 
@@ -143,7 +143,7 @@ A conditional ref-argument may appear as the value of a named argument: `f(targe
 
 ## Follow-ups
 
-- **General ternary expression.** Sibling proposal once there is broader call for value-producing two-arm conditionals beyond ref positions. Would also generalise `let ref x = cond ? &a : &b`.
+- **General ternary expression.** Covered by ADR-0062. The binder/parser path here can be folded into the general conditional-expression pipeline once ADR-0062 is implemented.
 - **Composition with `let ref x = expr`.** Pairs naturally with the aliasing-locals follow-up.
 
 ## References

--- a/docs/adr/0062-generalized-ternary-expression.md
+++ b/docs/adr/0062-generalized-ternary-expression.md
@@ -1,0 +1,120 @@
+# ADR-0062: Generalized ternary expression — `cond ? ifTrue : ifFalse`
+
+- **Status**: Proposed
+- **Date**: 2026-06-05
+- **Phase**: Phase 8 — language ergonomics / expression surface
+- **Related**: issue #495 (limited ref-only ternary), ADR-0061 (conditional ref-arguments), ADR-0060 (`ref`/`out`/`in` parameters), ADR-0058 (ref-safe-to-escape), ADR-0037 (numeric tie-breaking)
+
+## Context
+
+G# currently has no general value-producing two-arm conditional expression. ADR-0061 introduced `cond ? a : b` only in ref-address contexts (`ref`/`out`/`in` payloads and `&` operands) as a narrow ergonomic fix for byref call sites. That solved the immediate interop pain but left normal expression code without a concise conditional operator.
+
+This split now creates two problems: users must learn a special-purpose ternary that works only in ref contexts, and parser/binder logic carries a context-sensitive branch instead of a single conditional-expression model. A generalized ternary should preserve ADR-0061 behavior while making `?:` available as a normal expression everywhere an expression is allowed.
+
+Constraints:
+
+- Preserve existing ADR-0061 source compatibility and diagnostics intent.
+- Keep `?` in type clauses (`T?`) unambiguous from expression ternary.
+- Avoid introducing hidden evaluation or reordering; only one arm may execute.
+- Keep byref safety rules from ADR-0058 intact for ref/out/in and `&` usage.
+
+## Decision
+
+Introduce a general conditional expression form:
+
+```gsharp
+ConditionalExpression := LogicalOrExpression ['?' Expression ':' ConditionalExpression]
+```
+
+It is right-associative (`a ? b : c ? d : e` parses as `a ? b : (c ? d : e)`), has lower precedence than logical-or and higher precedence than assignment, and is valid in any expression position.
+
+### 1. Syntax and parsing
+
+Add `ConditionalExpressionSyntax` (`Condition`, `QuestionToken`, `WhenTrue`, `ColonToken`, `WhenFalse`) and parse it after binary/logical parsing, before assignment binding. The parser no longer needs a ref-only syntax node (`ConditionalRefArgumentExpressionSyntax`) once migration is complete.
+
+`&`/`ref`/`out`/`in` contexts continue to accept ternary payloads naturally because they now consume general expressions. No dedicated parser hook is required for `&cond ? a : b`; it parses as `&(cond ? a : b)` by precedence.
+
+### 2. Value semantics
+
+Binding `cond ? x : y` in value context enforces:
+
+1. `cond` must be `bool` (existing non-bool condition diagnostic path).
+2. Only one branch executes at runtime (short-circuit by branch).
+3. Result type is chosen by common-type rules:
+   - If `Tx == Ty`, result is `Tx`.
+   - Else if `Tx -> Ty` implicit and not `Ty -> Tx`, result is `Ty` (convert true arm).
+   - Else if `Ty -> Tx` implicit and not `Tx -> Ty`, result is `Tx` (convert false arm).
+   - Else if both are implicit numeric conversions, use existing numeric tie-break precedence (ADR-0037) to choose the wider canonical numeric target.
+   - Else if one arm is `nil` and the other is nullable/reference-compatible, use the non-`nil` arm type.
+   - Else emit a new diagnostic (`GS0263`: no common conditional result type).
+
+Produce a new `BoundConditionalExpression` node for value semantics.
+
+### 3. Ref/address semantics (subsuming ADR-0061)
+
+In ref-kind argument positions and address-of contexts, if the operand is a conditional expression and both arms are valid lvalues of the same pointee type, bind to `BoundConditionalAddressExpression` (existing ADR-0061 node/emit path) instead of `BoundConditionalExpression`.
+
+Rules stay aligned with ADR-0061:
+
+- Both branches must be lvalues.
+- Branch pointee types must match exactly (no cross-branch value-conversion for byref).
+- `ref`/`out`/`&` require writable branches; `in` may target read-only branches.
+- Ref-safe-to-escape is computed per branch; combined scope is the narrower one.
+- `out var`/`out let`/`out _` inside a branch remains rejected (existing GS0261 behavior).
+
+Inner branch modifiers (`ref`/`out`/`in` within branches) become unnecessary in the generalized form and are removed from the grammar. The canonical source form is:
+
+```gsharp
+f(ref (cond ? a : b))
+f(out (cond ? a : b))
+f(in  (cond ? a : b))
+let p = &(cond ? a : b)
+```
+
+For compatibility, legacy branch modifiers may be accepted behind a transitional parser path and normalized away, but they are not part of the long-term grammar.
+
+### 4. Emit/lowering
+
+`BoundConditionalExpression` lowers to branch-based value selection with a join temporary only when needed by surrounding context. `BoundConditionalAddressExpression` keeps existing ADR-0061 emit (`brfalse`/`br` selecting one `T&` on the evaluation stack before call/use).
+
+No runtime helper is required.
+
+### 5. Diagnostics
+
+Keep existing ADR-0061 diagnostics where applicable (notably branch type mismatch for byref and inline declaration in branch). Add:
+
+- **GS0263**: conditional expression branches have no common result type.
+
+Retire/refactor:
+
+- **GS0259** (conditional outside ref context) is removed once generalized ternary is enabled, because the expression is now valid in general contexts.
+
+## Consequences
+
+- **Positive**: one coherent ternary model for both value and byref use; simpler mental model and better ergonomics in everyday expressions.
+- **Positive**: ADR-0061 behavior is preserved by binding strategy, not parser special-casing.
+- **Positive**: parser architecture becomes cleaner (no ref-only conditional syntax category).
+- **Neutral**: introduces one new bound node (`BoundConditionalExpression`) and conversion/type-selection logic similar to existing binary-expression conversion decisions.
+- **Negative**: migration requires coordinated parser, binder, diagnostics, and tests to avoid regressions around `?` precedence and byref safety.
+
+## Alternatives considered
+
+1. Keep ADR-0061 ref-only conditional and do not add general ternary. Rejected because it preserves a context-sensitive language irregularity and leaves non-ref code verbose.
+2. Reuse `switch` expression only. Rejected because two-arm conditionals are much more common and `switch` is heavier syntactically and semantically.
+3. Add ternary only for value expressions and keep separate ref-only syntax. Rejected because two parallel conditional syntaxes increase complexity and divergence.
+
+## Rollout plan
+
+1. Add `ConditionalExpressionSyntax` and parser precedence integration.
+2. Add `BoundConditionalExpression` + common-type binding and conversion insertion.
+3. Route ref/out/in and `&` contexts to existing `BoundConditionalAddressExpression` when conditional operands are lvalue-compatible.
+4. Keep legacy ADR-0061 parser form temporarily; emit a deprecation diagnostic if desired; remove after one release window.
+5. Update tests: parser precedence/associativity, value-typed ternaries, ref/out/in/byref ternaries, diagnostics (`GS0263`, retirement of GS0259).
+
+## References
+
+- Issue #495
+- ADR-0061
+- ADR-0060
+- ADR-0058
+- ADR-0037

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -43,6 +43,7 @@ ColonToken
 CommaToken
 CommentToken
 CompilationUnit
+ConditionalExpression
 ConditionalRefArgumentExpression
 ConstKeyword
 ConstantPattern
@@ -242,6 +243,7 @@ ClrPropertyAssignmentExpression
 ClrStaticCallExpression
 ClrUnaryOperatorExpression
 ConditionalAddressExpression
+ConditionalExpression
 ConditionalGotoStatement
 ConstantPattern
 ConstructorCallExpression

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -342,3 +342,22 @@ Cause/fix examples:
 - **GS0257** — Reserved for the full ref-safety analysis. Will fire when the RHS storage cannot live as long as the alias (e.g. a `ref` returned from a callee that captured a shorter-lived local). V1 has no ref returns, so this code is defined for forward compatibility and currently does not fire.
 - **GS0258** — `let ref m = n` at top level, inside `async func`, inside an iterator (yield-returning) function, or written as `const ref`. Fix: move the declaration into a synchronous, non-iterator function body and use `let ref` / `var ref` (not `const ref`). Top-level `ref` locals would require a static field of `T&`, which the CLR forbids; async / iterator bodies would lift the slot onto a state-machine field, which the CLR likewise forbids.
 
+
+## Conditional expression diagnostics (GS0259–GS0263)
+
+ADR-0061 introduced a narrow ref-only ternary form (`cond ? a : b` only inside `ref`/`out`/`in` argument payloads and `&` operands) with diagnostics GS0259–GS0262. ADR-0062 generalises the ternary into a normal expression form. The conditional-outside-ref diagnostic GS0259 is therefore retired: a value-context `cond ? a : b` is now legal. The remaining ADR-0061 diagnostics still fire in their byref contexts; the new GS0263 covers the value-context "no common type" failure.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0259 | Error (retired by ADR-0062) | Conditional lvalue expression (`cond ? a : b`) is only legal as the payload of a 'ref'/'out'/'in' argument modifier or as the operand of '&'. Now only fires for the legacy inner-ref-modifier shape outside ref context. |
+| GS0260 | Error | Both branches of a conditional ref-argument must produce lvalues of the same type, but the true branch is '{trueType}' and the false branch is '{falseType}'. |
+| GS0261 | Error | An 'out var'/'out let'/'out _' inline declaration cannot appear inside a branch of a conditional ref-argument (the new local would only conditionally exist). Declare the local before the call instead. |
+| GS0262 | Error | Inner ref-kind modifier '{innerModifier}' on a conditional ref-argument branch must match the outer modifier '{outerModifier}'. |
+| GS0263 | Error | Conditional expression branches have no common result type — the true branch is '{trueType}' and the false branch is '{falseType}'. Add an explicit conversion to align the two arms. |
+
+Cause/fix examples:
+
+- **GS0260** — `bump(ref true ? a32 : b64)` where `a32 int32` and `b64 int64`. Fix: align the branch types (e.g. introduce a local of the wider type or use a value ternary outside the `ref`).
+- **GS0261** — `produce(out true ? a : out var n)` — the inline `out var n` would declare a local that only exists on one branch. Fix: declare `var n int32` before the call.
+- **GS0262** — `bump(ref true ? in a : ref b)` — the inner `in` does not match the outer `ref`. Fix: use `bump(ref true ? a : b)` (the generalized ADR-0062 form requires no inner modifiers).
+- **GS0263** — `var x = pick ? true : "no"` — `bool` and `string` have no common type. Fix: explicitly convert one arm (e.g. `pick ? "yes" : "no"`).

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -6354,12 +6354,19 @@ public sealed class Binder
                 Diagnostics.ReportOutDeclarationOutsideOutArgument(syntax.Location);
                 return new BoundErrorExpression(null);
             case SyntaxKind.ConditionalRefArgumentExpression:
-                // ADR-0061: a conditional ref-argument expression is only
-                // valid as the payload of a ref-kind modifier or as the
-                // operand of `&`. Those sites dispatch to the dedicated
-                // binders below; anywhere else is a hard error.
+                // ADR-0061: a legacy conditional ref-argument expression
+                // (with inner ref-kind modifiers) is only valid as the
+                // payload of a ref-kind modifier or as the operand of `&`.
+                // Those sites dispatch to the dedicated binders below;
+                // anywhere else is a hard error.
                 Diagnostics.ReportConditionalRefArgumentOutsideRefContext(syntax.Location);
                 return new BoundErrorExpression(null);
+            case SyntaxKind.ConditionalExpression:
+                // ADR-0062: general two-arm conditional in value context.
+                // In ref-kind argument payloads and as the operand of `&`,
+                // the call sites short-circuit to BindConditionalAddress
+                // before reaching this dispatch.
+                return BindConditionalExpression((ConditionalExpressionSyntax)syntax);
             case SyntaxKind.IndirectAssignmentExpression:
                 return BindIndirectAssignmentExpression((IndirectAssignmentExpressionSyntax)syntax);
             default:
@@ -7882,6 +7889,14 @@ public sealed class Binder
             return BindConditionalRefArgument(condOperand, outerModifier: null);
         }
 
+        // ADR-0062: a general conditional expression as the operand of `&`
+        // binds to the conditional-address path (preserving ADR-0061 byref
+        // safety) when both arms are lvalues of a common pointee type.
+        if (rawOperand is ConditionalExpressionSyntax generalCond)
+        {
+            return BindConditionalAddressFromGeneral(generalCond, outerModifier: null);
+        }
+
         var operand = BindExpression(syntax.Operand);
         if (operand is BoundErrorExpression)
         {
@@ -8069,6 +8084,14 @@ public sealed class Binder
             return BindConditionalRefArgument(condSyntax, syntax.RefKindModifier);
         }
 
+        // ADR-0062: a general conditional expression as the payload of
+        // ref/out/in binds to the conditional-address path (preserving
+        // ADR-0061 byref safety).
+        if (rawExpr is ConditionalExpressionSyntax generalCondSyntax)
+        {
+            return BindConditionalAddressFromGeneral(generalCondSyntax, syntax.RefKindModifier);
+        }
+
         var operand = BindExpression(syntax.Expression);
         if (operand is BoundErrorExpression)
         {
@@ -8207,6 +8230,262 @@ public sealed class Binder
         }
 
         return new BoundConditionalAddressExpression(null, condition, whenTrue, whenFalse, whenTrue.Type);
+    }
+
+    /// <summary>
+    /// ADR-0062: binds a general conditional expression as a conditional
+    /// address-of when used as the payload of a ref-kind modifier or as the
+    /// operand of <c>&amp;</c>. Reuses the same validation rules as
+    /// <see cref="BindConditionalRefArgument"/> minus the inner-modifier
+    /// checks (which the generalized syntax does not carry).
+    /// </summary>
+    /// <param name="syntax">The general conditional expression syntax.</param>
+    /// <param name="outerModifier">The outer ref-kind modifier token (<see langword="null"/> for the bare <c>&amp;</c> operand form).</param>
+    /// <returns>The bound conditional address expression, or a <see cref="BoundErrorExpression"/> on failure.</returns>
+    private BoundExpression BindConditionalAddressFromGeneral(
+        ConditionalExpressionSyntax syntax,
+        SyntaxToken outerModifier)
+    {
+        // Condition must be bool.
+        var condition = BindExpression(syntax.Condition, TypeSymbol.Bool);
+
+        var whenTrue = BindExpression(syntax.WhenTrue);
+        var whenFalse = BindExpression(syntax.WhenFalse);
+
+        if (whenTrue is BoundErrorExpression || whenFalse is BoundErrorExpression || condition is BoundErrorExpression)
+        {
+            return new BoundErrorExpression(null);
+        }
+
+        if (!IsLvalue(whenTrue))
+        {
+            Diagnostics.ReportCannotTakeAddressOfNonLvalue(syntax.WhenTrue.Location, syntax.WhenTrue.ToString());
+            return new BoundErrorExpression(null);
+        }
+
+        if (!IsLvalue(whenFalse))
+        {
+            Diagnostics.ReportCannotTakeAddressOfNonLvalue(syntax.WhenFalse.Location, syntax.WhenFalse.ToString());
+            return new BoundErrorExpression(null);
+        }
+
+        // Branch types must match exactly — no implicit widening, since the
+        // resulting byref selects between slots whose physical type must agree.
+        if (!ReferenceEquals(whenTrue.Type, whenFalse.Type)
+            && !string.Equals(whenTrue.Type?.Name, whenFalse.Type?.Name, System.StringComparison.Ordinal))
+        {
+            Diagnostics.ReportConditionalRefArgumentBranchTypeMismatch(
+                syntax.Location,
+                whenTrue.Type?.Name ?? "?",
+                whenFalse.Type?.Name ?? "?");
+            return new BoundErrorExpression(null);
+        }
+
+        string outerText = outerModifier?.Text ?? "&";
+        bool requiresWritable = outerText == "ref" || outerText == "out" || outerText == "&";
+        if (requiresWritable)
+        {
+            if (whenTrue is BoundVariableExpression wtVar && wtVar.Variable.IsReadOnly)
+            {
+                Diagnostics.ReportCannotTakeAddressOfConstant(syntax.WhenTrue.Location, wtVar.Variable.Name);
+                return new BoundErrorExpression(null);
+            }
+
+            if (whenFalse is BoundVariableExpression wfVar && wfVar.Variable.IsReadOnly)
+            {
+                Diagnostics.ReportCannotTakeAddressOfConstant(syntax.WhenFalse.Location, wfVar.Variable.Name);
+                return new BoundErrorExpression(null);
+            }
+        }
+
+        return new BoundConditionalAddressExpression(null, condition, whenTrue, whenFalse, whenTrue.Type);
+    }
+
+    /// <summary>
+    /// ADR-0062: binds a general two-arm conditional expression in value
+    /// context. Validates the condition is <c>bool</c>, computes a common
+    /// result type using identity / one-way implicit conversion / numeric
+    /// tie-break rules, and produces a <see cref="BoundConditionalExpression"/>.
+    /// </summary>
+    /// <param name="syntax">The conditional expression syntax.</param>
+    /// <returns>The bound conditional expression, or a <see cref="BoundErrorExpression"/> on failure.</returns>
+    private BoundExpression BindConditionalExpression(ConditionalExpressionSyntax syntax)
+    {
+        var condition = BindExpression(syntax.Condition, TypeSymbol.Bool);
+        var whenTrue = BindExpression(syntax.WhenTrue);
+        var whenFalse = BindExpression(syntax.WhenFalse);
+
+        if (condition is BoundErrorExpression || whenTrue is BoundErrorExpression || whenFalse is BoundErrorExpression)
+        {
+            return new BoundErrorExpression(null);
+        }
+
+        var resultType = ComputeConditionalCommonType(whenTrue.Type, whenFalse.Type);
+        if (resultType == null)
+        {
+            Diagnostics.ReportConditionalNoCommonResultType(
+                syntax.Location,
+                whenTrue.Type?.Name ?? "?",
+                whenFalse.Type?.Name ?? "?");
+            return new BoundErrorExpression(null);
+        }
+
+        var convertedTrue = ConvertConditionalBranch(syntax.WhenTrue.Location, whenTrue, resultType);
+        var convertedFalse = ConvertConditionalBranch(syntax.WhenFalse.Location, whenFalse, resultType);
+        if (convertedTrue is BoundErrorExpression || convertedFalse is BoundErrorExpression)
+        {
+            return new BoundErrorExpression(null);
+        }
+
+        return new BoundConditionalExpression(null, condition, convertedTrue, convertedFalse, resultType);
+    }
+
+    /// <summary>
+    /// ADR-0062: chooses a common result type for two conditional branches
+    /// using the following ordered rules (mirroring the ADR §2 common-type
+    /// procedure):
+    /// <list type="number">
+    ///   <item><description>Identity (<c>Tx == Ty</c>).</description></item>
+    ///   <item><description>One-way implicit conversion (<c>Tx → Ty</c> but not <c>Ty → Tx</c>, or vice versa).</description></item>
+    ///   <item><description>Both convertible implicitly — pick the wider via the numeric tie-break rule (ADR-0037) when both are numeric; otherwise no common type.</description></item>
+    ///   <item><description><c>nil</c> compatibility — when one arm is the nil/null sentinel and the other is reference- or nullable-compatible, use the other arm's type.</description></item>
+    /// </list>
+    /// Returns <see langword="null"/> when no common type exists.
+    /// </summary>
+    /// <param name="left">The true-arm type.</param>
+    /// <param name="right">The false-arm type.</param>
+    /// <returns>The chosen common type, or <see langword="null"/>.</returns>
+    private static TypeSymbol ComputeConditionalCommonType(TypeSymbol left, TypeSymbol right)
+    {
+        if (left == null || right == null)
+        {
+            return null;
+        }
+
+        if (left == TypeSymbol.Error || right == TypeSymbol.Error)
+        {
+            return TypeSymbol.Error;
+        }
+
+        // Identity.
+        if (ReferenceEquals(left, right))
+        {
+            return left;
+        }
+
+        // Nil/null compatibility: when one arm is the null sentinel and the
+        // other is non-null, pick the non-null. The conversion machinery
+        // accepts the trivial null → reference/nullable widening.
+        if (left == TypeSymbol.Null)
+        {
+            return right;
+        }
+
+        if (right == TypeSymbol.Null)
+        {
+            return left;
+        }
+
+        var leftToRight = Conversion.Classify(left, right);
+        var rightToLeft = Conversion.Classify(right, left);
+
+        bool leftImplicit = leftToRight.IsImplicit;
+        bool rightImplicit = rightToLeft.IsImplicit;
+
+        // Identity already handled; treat IsIdentity here as implicit too.
+        if (leftImplicit && !rightImplicit)
+        {
+            return right;
+        }
+
+        if (rightImplicit && !leftImplicit)
+        {
+            return left;
+        }
+
+        if (leftImplicit && rightImplicit)
+        {
+            // ADR-0037 numeric tie-break: prefer the wider canonical numeric
+            // target when both arms are numeric.
+            var widened = TryNumericTieBreak(left, right);
+            if (widened != null)
+            {
+                return widened;
+            }
+
+            // Both convert to each other and neither is numeric — they're
+            // effectively identical; pick the left arm deterministically.
+            return left;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// ADR-0037-style numeric tie-break: when both arms are numeric primitives,
+    /// pick the wider canonical type using a simple rank. Returns
+    /// <see langword="null"/> when either type isn't a recognised primitive.
+    /// </summary>
+    private static TypeSymbol TryNumericTieBreak(TypeSymbol a, TypeSymbol b)
+    {
+        int ra = NumericRank(a);
+        int rb = NumericRank(b);
+        if (ra == 0 || rb == 0)
+        {
+            return null;
+        }
+
+        return ra >= rb ? a : b;
+    }
+
+    private static int NumericRank(TypeSymbol t)
+    {
+        if (t == TypeSymbol.Int8 || t == TypeSymbol.UInt8)
+        {
+            return 1;
+        }
+
+        if (t == TypeSymbol.Int16 || t == TypeSymbol.UInt16)
+        {
+            return 2;
+        }
+
+        if (t == TypeSymbol.Int32 || t == TypeSymbol.UInt32)
+        {
+            return 3;
+        }
+
+        if (t == TypeSymbol.Int64 || t == TypeSymbol.UInt64)
+        {
+            return 4;
+        }
+
+        if (t == TypeSymbol.Float32)
+        {
+            return 5;
+        }
+
+        if (t == TypeSymbol.Float64)
+        {
+            return 6;
+        }
+
+        return 0;
+    }
+
+    private BoundExpression ConvertConditionalBranch(TextLocation location, BoundExpression branch, TypeSymbol target)
+    {
+        if (target == TypeSymbol.Error || branch.Type == TypeSymbol.Error)
+        {
+            return branch;
+        }
+
+        if (ReferenceEquals(branch.Type, target))
+        {
+            return branch;
+        }
+
+        return BindConversion(location, branch, target);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/BoundConditionalExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundConditionalExpression.cs
@@ -1,0 +1,55 @@
+// <copyright file="BoundConditionalExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0062: bound representation of a general two-arm conditional (ternary)
+/// expression of the form <c>&lt;cond&gt; ? &lt;ifTrue&gt; : &lt;ifFalse&gt;</c>.
+/// Only one arm is evaluated at runtime. The result type is the common type
+/// chosen by the binder using identity / implicit conversion / numeric
+/// tie-break rules; both arm values are already converted to that result type.
+/// </summary>
+public sealed class BoundConditionalExpression : BoundExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundConditionalExpression"/> class.
+    /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
+    /// <param name="condition">The bound condition (typed <c>bool</c>).</param>
+    /// <param name="whenTrue">The bound true-branch expression, already converted to <paramref name="type"/>.</param>
+    /// <param name="whenFalse">The bound false-branch expression, already converted to <paramref name="type"/>.</param>
+    /// <param name="type">The common result type chosen for the conditional.</param>
+    public BoundConditionalExpression(
+        SyntaxNode syntax,
+        BoundExpression condition,
+        BoundExpression whenTrue,
+        BoundExpression whenFalse,
+        TypeSymbol type)
+        : base(syntax)
+    {
+        Condition = condition;
+        WhenTrue = whenTrue;
+        WhenFalse = whenFalse;
+        Type = type;
+    }
+
+    /// <inheritdoc/>
+    public override BoundNodeKind Kind => BoundNodeKind.ConditionalExpression;
+
+    /// <inheritdoc/>
+    public override TypeSymbol Type { get; }
+
+    /// <summary>Gets the bound condition (typed <c>bool</c>).</summary>
+    public BoundExpression Condition { get; }
+
+    /// <summary>Gets the bound true-branch expression.</summary>
+    public BoundExpression WhenTrue { get; }
+
+    /// <summary>Gets the bound false-branch expression.</summary>
+    public BoundExpression WhenFalse { get; }
+}

--- a/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -91,6 +91,12 @@ public enum BoundNodeKind
     // address-of forms feeding a single byref onto the evaluation stack.
     ConditionalAddressExpression,
 
+    // ADR-0062: a general two-arm conditional (ternary) value expression
+    // of the form `<cond> ? <ifTrue> : <ifFalse>`. Lowered to a CIL branch
+    // around two arm values feeding a single value onto the evaluation
+    // stack. Both arms are already converted to the result type by the binder.
+    ConditionalExpression,
+
     // ADR-0060 §13: indirect assignment `*p = expr` — stores a value
     // through a managed pointer. Lowered to `<load-address> <value>
     // stind.*` by the emitter. Used both for direct `*T`-local stores

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -262,6 +262,12 @@ public static class BoundNodePrinter
             case BoundNodeKind.AddressOfExpression:
                 WriteAddressOfExpression((BoundAddressOfExpression)node, writer);
                 break;
+            case BoundNodeKind.ConditionalAddressExpression:
+                WriteConditionalAddressExpression((BoundConditionalAddressExpression)node, writer);
+                break;
+            case BoundNodeKind.ConditionalExpression:
+                WriteConditionalExpression((BoundConditionalExpression)node, writer);
+                break;
             case BoundNodeKind.DereferenceExpression:
                 WriteDereferenceExpression((BoundDereferenceExpression)node, writer);
                 break;
@@ -1481,6 +1487,35 @@ public static class BoundNodePrinter
     {
         writer.WritePunctuation(SyntaxKind.AmpersandToken);
         node.Operand.WriteTo(writer);
+    }
+
+    private static void WriteConditionalAddressExpression(BoundConditionalAddressExpression node, IndentedTextWriter writer)
+    {
+        writer.WritePunctuation(SyntaxKind.AmpersandToken);
+        writer.WritePunctuation(SyntaxKind.OpenParenthesisToken);
+        node.Condition.WriteTo(writer);
+        writer.WriteSpace();
+        writer.WritePunctuation(SyntaxKind.QuestionToken);
+        writer.WriteSpace();
+        node.WhenTrueOperand.WriteTo(writer);
+        writer.WriteSpace();
+        writer.WritePunctuation(SyntaxKind.ColonToken);
+        writer.WriteSpace();
+        node.WhenFalseOperand.WriteTo(writer);
+        writer.WritePunctuation(SyntaxKind.CloseParenthesisToken);
+    }
+
+    private static void WriteConditionalExpression(BoundConditionalExpression node, IndentedTextWriter writer)
+    {
+        node.Condition.WriteTo(writer);
+        writer.WriteSpace();
+        writer.WritePunctuation(SyntaxKind.QuestionToken);
+        writer.WriteSpace();
+        node.WhenTrue.WriteTo(writer);
+        writer.WriteSpace();
+        writer.WritePunctuation(SyntaxKind.ColonToken);
+        writer.WriteSpace();
+        node.WhenFalse.WriteTo(writer);
     }
 
     private static void WriteDereferenceExpression(BoundDereferenceExpression node, IndentedTextWriter writer)

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -426,6 +426,8 @@ public abstract class BoundTreeRewriter
                 return RewriteAddressOfExpression((BoundAddressOfExpression)node);
             case BoundNodeKind.ConditionalAddressExpression:
                 return RewriteConditionalAddressExpression((BoundConditionalAddressExpression)node);
+            case BoundNodeKind.ConditionalExpression:
+                return RewriteConditionalExpression((BoundConditionalExpression)node);
             case BoundNodeKind.DereferenceExpression:
                 return RewriteDereferenceExpression((BoundDereferenceExpression)node);
             case BoundNodeKind.IndirectAssignmentExpression:
@@ -914,6 +916,24 @@ public abstract class BoundTreeRewriter
         }
 
         return new BoundConditionalAddressExpression(null, condition, whenTrue, whenFalse, node.PointeeType);
+    }
+
+    /// <summary>
+    /// ADR-0062: Rewrites a general two-arm conditional (ternary) expression.
+    /// </summary>
+    /// <param name="node">The conditional expression to rewrite.</param>
+    /// <returns>The rewritten expression.</returns>
+    protected virtual BoundExpression RewriteConditionalExpression(BoundConditionalExpression node)
+    {
+        var condition = RewriteExpression(node.Condition);
+        var whenTrue = RewriteExpression(node.WhenTrue);
+        var whenFalse = RewriteExpression(node.WhenFalse);
+        if (condition == node.Condition && whenTrue == node.WhenTrue && whenFalse == node.WhenFalse)
+        {
+            return node;
+        }
+
+        return new BoundConditionalExpression(null, condition, whenTrue, whenFalse, node.Type);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
@@ -299,6 +299,9 @@ public abstract class BoundTreeWalker
             case BoundNodeKind.ConditionalAddressExpression:
                 VisitConditionalAddressExpression((BoundConditionalAddressExpression)node);
                 break;
+            case BoundNodeKind.ConditionalExpression:
+                VisitConditionalExpression((BoundConditionalExpression)node);
+                break;
             case BoundNodeKind.DereferenceExpression:
                 VisitDereferenceExpression((BoundDereferenceExpression)node);
                 break;
@@ -803,6 +806,15 @@ public abstract class BoundTreeWalker
         VisitExpression(node.Condition);
         VisitExpression(node.WhenTrueOperand);
         VisitExpression(node.WhenFalseOperand);
+    }
+
+    /// <summary>ADR-0062: visits a general two-arm conditional (ternary) expression.</summary>
+    /// <param name="node">The conditional expression.</param>
+    protected virtual void VisitConditionalExpression(BoundConditionalExpression node)
+    {
+        VisitExpression(node.Condition);
+        VisitExpression(node.WhenTrue);
+        VisitExpression(node.WhenFalse);
     }
 
     protected virtual void VisitDereferenceExpression(BoundDereferenceExpression node)

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1996,6 +1996,18 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0262", $"Inner ref-kind modifier '{innerModifier}' on a conditional ref-argument branch must match the outer modifier '{outerModifier}'.");
     }
 
+    /// <summary>
+    /// ADR-0062: reports a general two-arm conditional whose branch types have no
+    /// common result type under the conditional's common-type selection rules.
+    /// </summary>
+    /// <param name="location">The text location of the conditional expression.</param>
+    /// <param name="trueType">The type of the true-branch expression.</param>
+    /// <param name="falseType">The type of the false-branch expression.</param>
+    public void ReportConditionalNoCommonResultType(TextLocation location, string trueType, string falseType)
+    {
+        Report(location, "GS0263", $"Conditional expression branches have no common result type — the true branch is '{trueType}' and the false branch is '{falseType}'. Add an explicit conversion to align the two arms.");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -12096,6 +12096,10 @@ internal sealed class ReflectionMetadataEmitter
                     // ADR-0061: conditional address-of (`cond ? &a : &b`).
                     this.EmitConditionalAddress(conditionalAddress);
                     break;
+                case BoundConditionalExpression conditionalValue:
+                    // ADR-0062: general two-arm conditional value expression.
+                    this.EmitConditional(conditionalValue);
+                    break;
                 case BoundDereferenceExpression deref:
                     this.EmitDereference(deref);
                     break;
@@ -16230,6 +16234,27 @@ internal sealed class ReflectionMetadataEmitter
             this.EmitAddressOf(new BoundAddressOfExpression(null, node.WhenFalseOperand));
 
             // doneLabel:
+            this.il.MarkLabel(doneLabel);
+        }
+
+        /// <summary>
+        /// ADR-0062: Emits a general two-arm conditional (ternary) as a CIL
+        /// branch that selects one of two value-producing arms onto the
+        /// evaluation stack. Both arms have already been converted to the
+        /// node's result type by the binder.
+        /// </summary>
+        /// <param name="node">The conditional expression bound node.</param>
+        private void EmitConditional(BoundConditionalExpression node)
+        {
+            var falseLabel = this.il.DefineLabel();
+            var doneLabel = this.il.DefineLabel();
+
+            this.EmitExpression(node.Condition);
+            this.il.Branch(ILOpCode.Brfalse, falseLabel);
+            this.EmitExpression(node.WhenTrue);
+            this.il.Branch(ILOpCode.Br, doneLabel);
+            this.il.MarkLabel(falseLabel);
+            this.EmitExpression(node.WhenFalse);
             this.il.MarkLabel(doneLabel);
         }
 

--- a/src/Core/CodeAnalysis/Lowering/SideEffectAnalyzer.cs
+++ b/src/Core/CodeAnalysis/Lowering/SideEffectAnalyzer.cs
@@ -105,6 +105,17 @@ internal static class SideEffectAnalyzer
                     || HasObservableSideEffect(ca.WhenFalseOperand);
             }
 
+            case BoundNodeKind.ConditionalExpression:
+            {
+                // ADR-0062: a general ternary is pure when all three
+                // sub-expressions are pure — the lowering is a CIL branch
+                // around two value-producing arms.
+                var c = (BoundConditionalExpression)expression;
+                return HasObservableSideEffect(c.Condition)
+                    || HasObservableSideEffect(c.WhenTrue)
+                    || HasObservableSideEffect(c.WhenFalse);
+            }
+
             case BoundNodeKind.DereferenceExpression:
                 return HasObservableSideEffect(((BoundDereferenceExpression)expression).Operand);
 

--- a/src/Core/CodeAnalysis/Syntax/ConditionalExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/ConditionalExpressionSyntax.cs
@@ -1,0 +1,63 @@
+// <copyright file="ConditionalExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// ADR-0062: a general two-arm conditional (ternary) expression of the form
+/// <c>&lt;cond&gt; ? &lt;ifTrue&gt; : &lt;ifFalse&gt;</c>. Valid in any expression
+/// position. The operator is right-associative and binds at a lower precedence
+/// than logical-or but higher than assignment.
+/// </summary>
+/// <remarks>
+/// In ref-kind argument payloads (<c>ref</c>/<c>out</c>/<c>in</c>) and as the
+/// operand of <c>&amp;</c>, this same syntax is reinterpreted by the binder as
+/// a conditional address-of (<see cref="GSharp.Core.CodeAnalysis.Binding.BoundConditionalAddressExpression"/>),
+/// preserving ADR-0061's byref semantics.
+/// </remarks>
+public sealed class ConditionalExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConditionalExpressionSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="condition">The condition expression.</param>
+    /// <param name="questionToken">The literal <c>?</c> token.</param>
+    /// <param name="whenTrue">The expression evaluated when the condition is <c>true</c>.</param>
+    /// <param name="colonToken">The literal <c>:</c> token.</param>
+    /// <param name="whenFalse">The expression evaluated when the condition is <c>false</c>.</param>
+    public ConditionalExpressionSyntax(
+        SyntaxTree syntaxTree,
+        ExpressionSyntax condition,
+        SyntaxToken questionToken,
+        ExpressionSyntax whenTrue,
+        SyntaxToken colonToken,
+        ExpressionSyntax whenFalse)
+        : base(syntaxTree)
+    {
+        Condition = condition;
+        QuestionToken = questionToken;
+        WhenTrue = whenTrue;
+        ColonToken = colonToken;
+        WhenFalse = whenFalse;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.ConditionalExpression;
+
+    /// <summary>Gets the condition expression.</summary>
+    public ExpressionSyntax Condition { get; }
+
+    /// <summary>Gets the literal <c>?</c> token.</summary>
+    public SyntaxToken QuestionToken { get; }
+
+    /// <summary>Gets the expression evaluated when the condition is <c>true</c>.</summary>
+    public ExpressionSyntax WhenTrue { get; }
+
+    /// <summary>Gets the literal <c>:</c> token.</summary>
+    public SyntaxToken ColonToken { get; }
+
+    /// <summary>Gets the expression evaluated when the condition is <c>false</c>.</summary>
+    public ExpressionSyntax WhenFalse { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -3295,6 +3295,18 @@ public class Parser
 
         var expression = ParseBinaryExpression();
 
+        // ADR-0062: general two-arm conditional (ternary) expression
+        // `cond ? a : b`. Right-associative; lower precedence than
+        // logical-or and higher than assignment. When the `?` tail
+        // matches the legacy ADR-0061 inner-modifier form
+        // (`cond ? ref a : ref b`), produce a ConditionalRefArgumentExpression
+        // for backward compatibility; otherwise produce the general
+        // ConditionalExpressionSyntax.
+        if (Current.Kind == SyntaxKind.QuestionToken)
+        {
+            expression = ParseConditionalTail(expression);
+        }
+
         // ADR-0060 §13: indirect assignment `*p = expr`. Detected when the
         // parsed primary is a unary `*` dereference followed by `=`. The
         // binder produces a `BoundIndirectAssignmentExpression` which the
@@ -4135,12 +4147,48 @@ public class Parser
         return true;
     }
 
-    // ADR-0061: when the current token is `?`, treat <paramref name="condition"/>
-    // as the condition of a conditional lvalue and parse `?  [ref|in|out]? lvalue
-    // : [ref|in|out]? lvalue`. The outer modifier (when known — null for the
-    // bare `&` form) is recorded for inner-modifier mismatch diagnostics at
-    // bind time. When the current token is not `?`, the original expression
-    // is returned unchanged.
+    // ADR-0062: parse a ternary tail `? a : b` starting at the current `?`
+    // token, given the already-parsed condition expression. Right-associative.
+    // When the inner branches use legacy ADR-0061 inner ref-kind modifiers,
+    // returns a ConditionalRefArgumentExpressionSyntax (for back-compat) so
+    // the binder can reject mismatches; otherwise returns the general
+    // ConditionalExpressionSyntax (ADR-0062).
+    private ExpressionSyntax ParseConditionalTail(ExpressionSyntax condition)
+    {
+        var questionToken = NextToken();
+        var whenTrueMod = TryConsumeInnerRefModifier();
+        var whenTrue = ParseAssignmentExpression();
+        var colonToken = MatchToken(SyntaxKind.ColonToken);
+        var whenFalseMod = TryConsumeInnerRefModifier();
+        var whenFalse = ParseAssignmentExpression();
+
+        if (whenTrueMod != null || whenFalseMod != null)
+        {
+            // Legacy ADR-0061 inner-modifier shape: keep producing the
+            // dedicated ref-arg node so the binder retains GS0262 etc.
+            return new ConditionalRefArgumentExpressionSyntax(
+                syntaxTree,
+                condition,
+                questionToken,
+                whenTrueMod,
+                whenTrue,
+                colonToken,
+                whenFalseMod,
+                whenFalse);
+        }
+
+        return new ConditionalExpressionSyntax(
+            syntaxTree,
+            condition,
+            questionToken,
+            whenTrue,
+            colonToken,
+            whenFalse);
+    }
+
+    // ADR-0061 transitional: kept only to avoid touching the few callers
+    // that still want the legacy ref-only node when the `?` follows
+    // certain ref-context shapes. Forwards to ParseConditionalTail.
     private ExpressionSyntax MaybeParseConditionalRefArgumentTail(ExpressionSyntax condition, SyntaxToken outerModifier)
     {
         if (Current.Kind != SyntaxKind.QuestionToken)
@@ -4148,23 +4196,8 @@ public class Parser
             return condition;
         }
 
-        var questionToken = NextToken();
-        var whenTrueMod = TryConsumeInnerRefModifier();
-        var whenTrue = ParseExpression();
-        var colonToken = MatchToken(SyntaxKind.ColonToken);
-        var whenFalseMod = TryConsumeInnerRefModifier();
-        var whenFalse = ParseExpression();
-
         _ = outerModifier; // bind-time check uses outer modifier; parser only records.
-        return new ConditionalRefArgumentExpressionSyntax(
-            syntaxTree,
-            condition,
-            questionToken,
-            whenTrueMod,
-            whenTrue,
-            colonToken,
-            whenFalseMod,
-            whenFalse);
+        return ParseConditionalTail(condition);
     }
 
     // ADR-0061: parse an optional inner `ref`/`in`/`out` modifier on a branch

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -261,8 +261,17 @@ public enum SyntaxKind
     // `<cond> ? <lvalue> : <lvalue>` recognised inside the payload of a
     // ref-kind modifier (`ref`/`out`/`in`) and as the operand of `&`.
     // The two branches may optionally carry a matching inner ref-kind
-    // modifier (e.g. `ref c ? ref a : ref b`).
+    // modifier (e.g. `ref c ? ref a : ref b`). Retained for backward
+    // compatibility with the inner-modifier shape; ADR-0062 supersedes
+    // the general case with `ConditionalExpression`.
     ConditionalRefArgumentExpression,
+
+    // ADR-0062: a general two-arm conditional (ternary) expression of
+    // the form `<cond> ? <ifTrue> : <ifFalse>`. Valid in any expression
+    // position. In ref-kind argument payloads and as the operand of `&`,
+    // the binder reinterprets this syntax as a conditional address-of
+    // (preserving ADR-0061's byref semantics).
+    ConditionalExpression,
 
     // ADR-0060 §13: indirect assignment `*p = expr`. The LHS is a
     // pointer dereference; the emitter lowers to `<load-address> <value>

--- a/test/Core.Tests/CodeAnalysis/Emit/ConditionalExpressionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/ConditionalExpressionTests.cs
@@ -1,0 +1,211 @@
+// <copyright file="ConditionalExpressionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// ADR-0062: end-to-end emit and binder tests for the generalized two-arm
+/// conditional (ternary) expression <c>cond ? a : b</c> in value context.
+/// Byref/lvalue ref-arg ternaries continue to be covered by
+/// <see cref="ConditionalRefArgumentEmitTests"/>.
+/// </summary>
+public class ConditionalExpressionTests
+{
+    [Fact]
+    public void Ternary_ValueContext_TrueArmSelected()
+    {
+        const string Source = @"package CondTern1
+import System
+
+var pick = true
+var x = pick ? 11 : 22
+Console.WriteLine(x)
+";
+        var output = CompileAndRun(Source, "CondTern1");
+        Assert.Contains("11", output);
+    }
+
+    [Fact]
+    public void Ternary_ValueContext_FalseArmSelected()
+    {
+        const string Source = @"package CondTern2
+import System
+
+var pick = false
+var x = pick ? 11 : 22
+Console.WriteLine(x)
+";
+        var output = CompileAndRun(Source, "CondTern2");
+        Assert.Contains("22", output);
+    }
+
+    [Fact]
+    public void Ternary_StringArms()
+    {
+        const string Source = @"package CondTernStr
+import System
+
+var pick = true
+Console.WriteLine(pick ? ""yes"" : ""no"")
+";
+        var output = CompileAndRun(Source, "CondTernStr");
+        Assert.Contains("yes", output);
+    }
+
+    [Fact]
+    public void Ternary_NumericTieBreak_PicksWiderType()
+    {
+        // int32 + int64 => int64 via the numeric tie-break.
+        const string Source = @"package CondTernWiden
+import System
+
+var pick = true
+var a int32 = 1
+var b int64 = 2
+var c = pick ? a : b
+Console.WriteLine(c)
+";
+        var output = CompileAndRun(Source, "CondTernWiden");
+        Assert.Contains("1", output);
+    }
+
+    [Fact]
+    public void Ternary_RightAssociative_NestedFalseBranch()
+    {
+        // `a ? b : c ? d : e` parses as `a ? b : (c ? d : e)`.
+        const string Source = @"package CondTernNest
+import System
+
+var a = false
+var c = false
+var v = a ? 1 : (c ? 2 : 3)
+Console.WriteLine(v)
+";
+        var output = CompileAndRun(Source, "CondTernNest");
+        Assert.Contains("3", output);
+    }
+
+    [Fact]
+    public void Ternary_AsCallArgument()
+    {
+        const string Source = @"package CondTernArg
+import System
+
+var pick = true
+Console.WriteLine(pick ? 10 : 20)
+";
+        var output = CompileAndRun(Source, "CondTernArg");
+        Assert.Contains("10", output);
+    }
+
+    [Fact]
+    public void Ternary_NoCommonType_ReportsGS0263()
+    {
+        // bool and string have no common type.
+        const string Source = @"package CondTernNoCommon
+
+var pick = true
+var v = pick ? true : ""no""
+";
+        var diags = CompileExpectingDiagnostics(Source);
+        Assert.Contains(diags, d => d.Id == "GS0263");
+    }
+
+    [Fact]
+    public void Ternary_NonBoolCondition_Reports()
+    {
+        const string Source = @"package CondTernBadCond
+
+var v = 1 ? 2 : 3
+";
+        var diags = CompileExpectingDiagnostics(Source);
+        Assert.NotEmpty(diags);
+    }
+
+    [Fact]
+    public void Ternary_InRefArgContext_StillUsesAddressPath()
+    {
+        // ADR-0062 §3: the generalized ternary in a ref-arg payload is
+        // bound to the conditional-address path, preserving ADR-0061.
+        const string Source = @"package CondTernRef
+import System
+
+func bump(ref c int32) {
+    c = c + 1
+}
+
+var a = 0
+var b = 0
+var pick = true
+bump(ref pick ? a : b)
+Console.WriteLine(a)
+Console.WriteLine(b)
+";
+        var output = CompileAndRun(Source, "CondTernRef");
+        Assert.Contains("1", output);
+        Assert.Contains("0", output);
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, parameters: null);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static System.Collections.Generic.IReadOnlyList<GSharp.Core.CodeAnalysis.Diagnostic> CompileExpectingDiagnostics(string source)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.False(result.Success, "compilation was expected to fail: " + string.Join("; ", result.Diagnostics.Select(d => d.Id + ":" + d.Message)));
+        return result.Diagnostics;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/ConditionalRefArgumentEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/ConditionalRefArgumentEmitTests.cs
@@ -247,19 +247,21 @@ produce(out true ? a : out var n)
     }
 
     [Fact]
-    public void ConditionalRefArgument_OutsideRefContext_ReportsDiagnostic()
+    public void ConditionalRefArgument_OutsideRefContext_IsNowValidValueExpression()
     {
+        // ADR-0062 supersedes GS0259: a `cond ? a : b` expression is now
+        // legal in any expression position; both arms select an int value.
         const string Source = @"package CondOutsideRef
 import System
 
-var a = 0
-var b = 0
+var a = 1
+var b = 2
 var useA = true
 var picked = (useA ? a : b)
 Console.WriteLine(picked)
 ";
-        var diags = CompileExpectingDiagnostics(Source);
-        Assert.Contains(diags, d => d.Id == "GS0259");
+        var output = CompileAndRun(Source, "CondOutsideRef");
+        Assert.Contains("1", output);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Syntax/ParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/ParserTests.cs
@@ -160,6 +160,47 @@ let x = switch v { case 1 -> ""a"" default -> ""b"" }
         Assert.IsType<CallExpressionSyntax>(accessor.RightPart);
     }
 
+    [Fact]
+    public void Parses_GeneralTernary_AsConditionalExpression()
+    {
+        // ADR-0062: `cond ? a : b` is a ConditionalExpressionSyntax.
+        var expr = ParseExpressionStatement("true ? 1 : 2");
+        var cond = Assert.IsType<ConditionalExpressionSyntax>(expr);
+        Assert.IsType<LiteralExpressionSyntax>(cond.Condition);
+        Assert.IsType<LiteralExpressionSyntax>(cond.WhenTrue);
+        Assert.IsType<LiteralExpressionSyntax>(cond.WhenFalse);
+    }
+
+    [Fact]
+    public void Ternary_IsRightAssociative()
+    {
+        // `a ? b : c ? d : e` parses as `a ? b : (c ? d : e)`.
+        var expr = ParseExpressionStatement("true ? 1 : false ? 2 : 3");
+        var outer = Assert.IsType<ConditionalExpressionSyntax>(expr);
+        Assert.IsType<LiteralExpressionSyntax>(outer.WhenTrue);
+        var inner = Assert.IsType<ConditionalExpressionSyntax>(outer.WhenFalse);
+        Assert.IsType<LiteralExpressionSyntax>(inner.WhenTrue);
+        Assert.IsType<LiteralExpressionSyntax>(inner.WhenFalse);
+    }
+
+    [Fact]
+    public void Ternary_HasLowerPrecedenceThanLogicalOr()
+    {
+        // `a || b ? 1 : 2` parses as `(a || b) ? 1 : 2`.
+        var expr = ParseExpressionStatement("true || false ? 1 : 2");
+        var cond = Assert.IsType<ConditionalExpressionSyntax>(expr);
+        Assert.IsType<BinaryExpressionSyntax>(cond.Condition);
+    }
+
+    [Fact]
+    public void Ternary_LegacyInnerRef_StillRoutesToConditionalRefArg()
+    {
+        // ADR-0061 back-compat: `cond ? ref a : ref b` keeps producing the
+        // legacy ConditionalRefArgumentExpressionSyntax for the binder.
+        var expr = ParseExpressionStatement("true ? ref a : ref b");
+        Assert.IsType<ConditionalRefArgumentExpressionSyntax>(expr);
+    }
+
     private static ExpressionSyntax ParseExpressionStatement(string source)
     {
         var tree = SyntaxTree.Parse(source);

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -43,6 +43,7 @@ ColonToken
 CommaToken
 CommentToken
 CompilationUnit
+ConditionalExpression
 ConditionalRefArgumentExpression
 ConstKeyword
 ConstantPattern
@@ -242,6 +243,7 @@ ClrPropertyAssignmentExpression
 ClrStaticCallExpression
 ClrUnaryOperatorExpression
 ConditionalAddressExpression
+ConditionalExpression
 ConditionalGotoStatement
 ConstantPattern
 ConstructorCallExpression


### PR DESCRIPTION
Implements ADR-0062 with generalized conditional expression support across parser, binder, lowering, emit, diagnostics, docs, and tests. Related to #495.