### PR TITLE
Implement ADR-0063: method overloading and optional parameters

### DIFF
--- a/docs/adr/0063-method-overloading-and-optional-parameters.md
+++ b/docs/adr/0063-method-overloading-and-optional-parameters.md
@@ -275,6 +275,16 @@ Neutral:
 4. Update override/interface validation to search overload families by exact signature.
 5. Emit CLR optional-parameter metadata and expand tests for overload lookup, ambiguity, sparse optional omission, named arguments, constructor overloads, interface matching, and metadata round-tripping.
 
+### Status (post-implementation)
+
+The initial implementation landed in PR #498. Items 1–5 above are all implemented in `Binder.cs`, `BoundScope.cs`, `StructSymbol.cs`, `InterfaceSymbol.cs`, and `ReflectionMetadataEmitter.cs`. The following follow-up gaps that were briefly deferred have since been closed:
+
+- Instance-method call sites (`BindUserInstanceCall`) now perform overload selection by argument signature instead of "first by name."
+- Method-group → delegate conversion preserves the full overload set and final selection happens in `BindConversion` against the target delegate signature.
+- Multiple explicit `init(...)` constructors per class are now supported end-to-end (binding, overload resolution, emission, evaluation).
+- Override-by-signature matching now correctly handles base classes that declare same-name overloads.
+- Optional parameters are now accepted on free functions, instance methods, static methods, interface methods, explicit constructors, primary constructors, delegate declarations, and function literals (lambdas). Property accessors and indexers have no user-declared parameter list that admits defaults.
+
 ## References
 
 - `src/Core/CodeAnalysis/Binding/OverloadResolution.cs`

--- a/docs/adr/0063-method-overloading-and-optional-parameters.md
+++ b/docs/adr/0063-method-overloading-and-optional-parameters.md
@@ -1,0 +1,285 @@
+# ADR-0063: Method overloading and optional parameters
+
+- **Status**: Proposed
+- **Date**: 2026-06-06
+- **Phase**: Phase 9 — language depth / call binding
+- **Related**: ADR-0034 (imported CLR interop); ADR-0037 (numeric tie-breaking); ADR-0038 (generic method inference); ADR-0017 (method virtuality); ADR-0019 (extension functions); ADR-0024 (methods vs. extensions canonical style); ADR-0060 (`ref`/`out`/`in` parameters)
+
+## Context
+
+G# already consumes overloaded CLR APIs successfully. Imported methods and constructors flow through `OverloadResolution.Resolve(...)`, which already knows how to rank candidates, infer generic type arguments, respect named arguments, and permit omitted trailing optional parameters when the target member comes from CLR metadata. This means the *consumer-side* semantics for overloading and optional parameters mostly already exist.
+
+What G# does not yet support cleanly is the *declaration-side* of the same model for user code.
+
+Today, several core data structures treat a user-defined callable name as if it could map to only one symbol:
+
+- `BoundScope.TryDeclareFunction` stores top-level functions by name, so a second `func Parse(...)` is diagnosed as a duplicate declaration.
+- `StructSymbol.TryGetMethod(...)` and `InterfaceSymbol.TryGetMethod(...)` return a single `FunctionSymbol`, not an overload set.
+- `BoundMethodGroupExpression` represents one method, not a same-name candidate group.
+- `Binder.TryReorderUserCallArguments(...)` explicitly assumes every user-defined parameter must be supplied because user-defined callables have no default values.
+
+This leaves G# in an awkward asymmetry relative to the CLR target it compiles to: imported .NET APIs can expose natural overload families such as `Console.WriteLine`, but G# packages cannot author the same shape themselves.
+
+The missing feature is particularly visible now that G# already has named arguments, `ref`/`out`/`in` parameter distinctions, generic method inference, constructors, same-package receiver methods, extension functions, and CLR metadata/documentation-id generation. Any design for overloading and optional parameters therefore has to align with those existing implementation choices rather than pretending the language starts from a blank slate.
+
+## Decision
+
+G# adopts CLR-style method overloading and trailing optional parameters for user-defined callables.
+
+The design has two linked parts:
+
+1. **Overload sets**: multiple same-name callables may coexist in the same declaration space when their signatures differ.
+2. **Optional parameters**: a callable parameter may declare a default value, permitting certain trailing arguments to be omitted at the call site.
+
+The feature applies to user-defined top-level functions, in-body methods, same-package receiver methods, extension functions, constructors declared with `init(...)`, and interface methods. It does **not** apply in v1 to lambdas, property accessors, indexers, or delegate type declarations.
+
+### 1. Signature identity
+
+A callable's overload identity is:
+
+- containing declaration space,
+- member name,
+- generic arity,
+- callable parameter count,
+- each callable parameter's type,
+- each callable parameter's `ref`-kind (`value`, `ref`, `out`, `in`), and
+- for methods, whether the callable is static/instance as already determined by its declaration form.
+
+A callable's return type, parameter names, accessibility, and default values are **not** part of overload identity.
+
+Consequences:
+
+- Two declarations that differ only by return type remain illegal.
+- Two declarations that differ only by parameter names remain illegal.
+- Two declarations that differ only by default values remain illegal.
+- Two declarations that differ by parameter `ref`-kind are distinct overloads, consistent with ADR-0060 and CLR signature identity.
+- Documentation IDs remain parameter-list-based; optional defaults do not affect the DocID, but overloads become distinguishable because their parameter types/ref-kinds differ.
+
+### 2. Surface syntax for optional parameters
+
+A parameter may include a default-value clause after its type:
+
+```gsharp
+func Open(path string, mode FileMode = FileMode.Open, share FileShare = FileShare.Read) FileHandle { ... }
+```
+
+Grammar sketch:
+
+```ebnf
+parameter = identifier ellipsis? type_clause ('=' constant_expression)?
+```
+
+`=` is chosen because parameter declarations in G# already use the `name type` order, so the natural place for a default is after the type. This also avoids overloading the call-site `:` named-argument spelling with a declaration-side meaning.
+
+### 3. Optional-parameter restrictions
+
+In v1, an optional parameter must satisfy all of the following:
+
+1. Its default value is a compile-time constant representable in CLR parameter metadata: numeric literal, `bool`, `char`, `string`, enum constant, or `nil` for a nullable/reference-compatible parameter.
+2. It is not marked `ref`, `out`, or `in`.
+3. It is not variadic (`...`).
+4. It is not the receiver parameter of a receiver method or extension function.
+
+Optional and required parameters may therefore be interleaved. A call is applicable if every required parameter receives an argument and every unsupplied parameter is optional.
+
+These restrictions are deliberate. They preserve faithful CLR emission (`Optional`/`HasDefault` plus a Constant row) while keeping omitted-argument lowering purely compile-time. Non-constant defaults, defaults that reference earlier parameters, and `default(T)`-style generalized expressions are deferred.
+
+### 4. Call-site semantics
+
+Optional parameters are **call-site sugar**. When binding a call that omits optional arguments, the binder synthesizes explicit bound constant expressions for each unsupplied optional parameter slot, just as it already does for imported CLR optional parameters.
+
+This means:
+
+- The callee does not inspect “was an argument omitted?” at runtime.
+- After argument-to-parameter mapping is established, omitted slots behave exactly as if the caller had written the default constant explicitly.
+- Changing a default value is a source-compatible but binary-behavioral change in the same way it is in C#: already-compiled callers continue to pass the old substituted constant until recompiled.
+
+### 5. Named arguments and omission rule
+
+Named arguments continue to reorder into parameter order before final applicability checks.
+
+In v1, any optional parameter may be omitted. Omission is therefore not restricted to a trailing suffix: after argument mapping, every unbound parameter position is filled from its declared default value, provided that parameter is optional.
+
+Examples:
+
+```gsharp
+func Draw(width int32, height int32 = 0, color string = "black") { ... }
+
+Draw(10)                         // ok: omits [height, color]
+Draw(10, color: "red")          // ok: substitutes default for height
+Draw(width: 10, height: 20)      // ok: omits [color]
+Draw(width: 10, color: "red")   // ok: substitutes default for height
+```
+
+This intentionally goes beyond the current imported-member implementation strategy. The binder's user-defined call path — and ideally the shared overload-resolution machinery — should be generalized from prefix/suffix omission to true per-parameter argument mapping.
+
+### 6. Overload resolution model
+
+User-defined overloads reuse the existing CLR-oriented overload-resolution concepts rather than inventing a separate ranking system.
+
+For a candidate set with the same name, the binder:
+
+1. collects all same-name user-defined candidates in the applicable declaration space,
+2. filters candidates by arity, generic arity, named-argument compatibility, `ref`-kind compatibility, and optional-parameter applicability,
+3. performs generic inference where needed (reusing ADR-0038 behavior),
+4. inserts required implicit conversions,
+5. ranks the remaining candidates using the existing better-function-member rules, including ADR-0037 numeric tie-breaking, and
+6. breaks remaining ties in favor of the candidate that expands the fewest optional parameters.
+
+If no unique best candidate exists, the binder reports an ambiguity diagnostic.
+
+This specifically means that a user-defined overload family and an imported CLR overload family behave the same way from the caller's point of view.
+
+### 7. Member lookup precedence
+
+This ADR does **not** change the existing precedence between real methods and extension functions.
+
+For member-call syntax `x.Foo(...)`:
+
+1. resolve against instance/static members on the receiver type (including inherited members and user-defined overload sets),
+2. only if no viable member candidate exists, consider extension functions,
+3. then continue with existing CLR/imported fallback behavior.
+
+Extension functions therefore remain lower priority than real members, even if an extension overload would otherwise be applicable.
+
+### 8. Overrides and interface implementation
+
+Overloading does not change the override model from ADR-0017: an `override` still targets exactly one inherited base method, matched by same name and same signature.
+
+For interface implementation and overrides:
+
+- overload families may exist on the interface/base type,
+- the implementing/overriding declaration must match exactly one inherited member by signature,
+- default values are **not** part of the matching signature,
+- an override or interface implementation may omit the default clause or repeat the inherited default, but it may not change the default value.
+
+The binder normalizes defaults from the introducing declaration so the overload slot remains stable and metadata emitted for the implementation stays consistent with the visible contract.
+
+### 9. Constructors
+
+User-defined constructors declared with `init(...)` participate in overload sets and may declare trailing optional parameters under the same rules.
+
+Example:
+
+```gsharp
+type FileStream class {
+    init(path string)
+    init(path string, mode FileMode = FileMode.Open)
+}
+```
+
+Constructor overload resolution uses the same candidate-selection rules as ordinary calls.
+
+### 10. CLR emission
+
+For user-defined overloads, CLR emission mostly becomes *less* special: same-name methods with different signatures already map naturally to distinct MethodDef rows.
+
+For optional parameters, the emitter stamps the chosen parameter rows with:
+
+- `ParameterAttributes.Optional`,
+- `ParameterAttributes.HasDefault`, and
+- a Constant row carrying the encoded default value.
+
+This gives C#, reflection, and any other CLR consumer the same omission behavior they already have for C#-authored optional parameters.
+
+Because optional defaults are call-site-substituted in both G# and C#, cross-language behavior remains aligned:
+
+- a G# caller of a G# method substitutes the constant during binding,
+- a C# caller of the emitted method reads the constant from metadata and substitutes it during C# compilation,
+- reflection sees the parameter as optional and exposes the default value.
+
+Defaults outside the CLR Constant-table model are intentionally rejected in v1 so the metadata contract remains lossless and unsurprising.
+
+### 11. Symbol-model changes
+
+Implementing this ADR requires the user-defined callable lookup model to move from “name → single symbol” to “name → overload set”. Concretely:
+
+- `BoundScope` function storage becomes name → immutable array/list of `FunctionSymbol`.
+- `StructSymbol` / `InterfaceSymbol` same-name method lookup returns overload groups rather than a single `FunctionSymbol`.
+- `BoundMethodGroupExpression` becomes an overload-set carrier so later binding can choose a best candidate.
+- duplicate-declaration diagnostics compare full signature identity, not just the member name.
+- interface-conformance and override validation search within a same-name overload family for an exact-signature match.
+
+This is the minimum architectural change needed to make user-defined lookup structurally resemble the already-working CLR/imported path.
+
+### 12. Diagnostics
+
+This ADR requires three diagnostic classes:
+
+1. **Duplicate overload signature**: same-name declaration already exists with the same signature (including `ref`-kinds, excluding defaults).
+2. **Invalid optional parameter declaration**: non-trailing default, unsupported default-value expression, optional `ref`/`out`/`in`, or optional variadic parameter.
+3. **Ambiguous overload resolution**: multiple candidates remain equally good after inference/conversion/optional-parameter ranking.
+
+Existing diagnostics for duplicate simple names, bad named arguments, and failed conversion remain in place and should be reused where the condition has not changed.
+
+## Examples
+
+### User-defined overloads
+
+```gsharp
+func Parse(text string) int32 { ... }
+func Parse(text string, style NumberStyle) int32 { ... }
+func Parse(text ReadOnlySpan[char]) int32 { ... }
+```
+
+### `ref`-kind as part of signature
+
+```gsharp
+func Visit(value string)
+func Visit(ref value StringBuilder)
+```
+
+These are distinct overloads because the callable parameter shapes differ.
+
+### Optional parameters with overload families
+
+```gsharp
+func Connect(host string, port int32 = 5432)
+func Connect(uri Uri)
+```
+
+`Connect("db")` picks the first overload and substitutes `5432`; `Connect(uri)` picks the second.
+
+## Consequences
+
+Positive:
+
+- G# can author the same ergonomic API shapes it already consumes from the BCL and other CLR libraries.
+- The proposal reuses existing implementation investments: named arguments, generic inference, numeric tie-breaking, optional imported-parameter lowering, and CLR metadata/documentation-id machinery.
+- Same-name receiver methods, constructors, interface members, and top-level functions all converge on one call-binding story.
+
+Negative:
+
+- Binder and symbol-table internals become more complex because “lookup by name” is no longer enough for user-defined callables.
+- Sparse optional-argument omission requires the call binder and overload-resolution pipeline to track argument-to-parameter mapping by slot, not just by a contiguous supplied prefix.
+- Default values inherit the usual CLR caveat that changing a default does not retroactively affect already-compiled callers.
+
+Neutral:
+
+- Return-type-only overloading remains unsupported, matching CLR method identity and avoiding a whole class of contextual-typing ambiguities.
+- Default values are part of the callable contract surface but not part of its overload signature.
+
+## Alternatives considered
+
+1. **Overloading without optional parameters.** Rejected because the binder/emitter work overlaps heavily, and G# already has imported optional-parameter behavior worth reusing.
+2. **Optional parameters without overloading.** Rejected because it would preserve the asymmetry where user code can omit imported arguments but cannot model the usual overloaded-vs-defaulted API trade-off itself.
+3. **Make defaults runtime-evaluated inside the callee body.** Rejected because it diverges from CLR/C# semantics, breaks metadata round-tripping, and complicates evaluation ordering.
+4. **Restrict v1 to trailing-only omission.** Rejected because G# already has caller-side named-argument reordering, and a trailing-only rule would make optional parameters feel artificially weaker than the CLR/C# model users already know. If a parameter is optional, callers should be able to omit it and fill it by name independently of position.
+5. **Include default values in signature identity.** Rejected because CLR signatures do not, documentation IDs do not, and it would make benign default changes source-breaking for overload declaration.
+
+## Rollout plan
+
+1. Generalize user-defined callable storage and lookup to overload sets.
+2. Extend parameter syntax/symbols to carry optional-default metadata.
+3. Reuse and widen the existing overload-resolution engine for user-defined candidates, replacing prefix/suffix omission assumptions with explicit parameter-slot mapping.
+4. Update override/interface validation to search overload families by exact signature.
+5. Emit CLR optional-parameter metadata and expand tests for overload lookup, ambiguity, sparse optional omission, named arguments, constructor overloads, interface matching, and metadata round-tripping.
+
+## References
+
+- `src/Core/CodeAnalysis/Binding/OverloadResolution.cs`
+- `src/Core/CodeAnalysis/Binding/Binder.cs`
+- `src/Core/CodeAnalysis/Binding/BoundScope.cs`
+- `src/Core/CodeAnalysis/Symbols/StructSymbol.cs`
+- `src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs`
+- `src/Core/CodeAnalysis/Documentation/SymbolDocumentationIdProvider.cs`

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -560,19 +560,23 @@ public sealed class Binder
         // instance methods, the constructor body sees `this`, the constructor
         // parameters, and the class's fields (via bare names). The body is keyed
         // in functionBodies by the constructor's underlying FunctionSymbol.
+        // ADR-0063 §9: a class may declare multiple init(...) constructors; each
+        // body is bound independently.
         foreach (var structSym in globalScope.Structs)
         {
-            var ctor = structSym.ExplicitConstructor;
-            if (ctor == null)
+            if (structSym.ExplicitConstructors.IsDefaultOrEmpty)
             {
                 continue;
             }
 
-            var ctorBinder = new Binder(parentScope, ctor.Function);
-            var ctorBody = ctorBinder.BindStatement(ctor.Declaration.Body);
-            var ctorLoweredBody = Lowerer.Lower(ctorBody, structSym);
-            functionBodies.Add(ctor.Function, ctorLoweredBody);
-            diagnostics.AddRange(ctorBinder.Diagnostics);
+            foreach (var ctor in structSym.ExplicitConstructors)
+            {
+                var ctorBinder = new Binder(parentScope, ctor.Function);
+                var ctorBody = ctorBinder.BindStatement(ctor.Declaration.Body);
+                var ctorLoweredBody = Lowerer.Lower(ctorBody, structSym);
+                functionBodies.Add(ctor.Function, ctorLoweredBody);
+                diagnostics.AddRange(ctorBinder.Diagnostics);
+            }
         }
 
         // ADR-0051: bind computed property accessor bodies. These are analogous
@@ -1541,21 +1545,47 @@ public sealed class Binder
                     FunctionSymbol overriddenMethod = null;
                     if (methodSyntax.IsOverride)
                     {
-                        if (structSymbol.BaseClass == null || !structSymbol.BaseClass.TryGetMethodIncludingInherited(methodName, out var baseMethod))
+                        // ADR-0063 §8: when the base exposes a name-overload set, the
+                        // override targets the entry whose signature matches exactly;
+                        // an unrelated same-name overload no longer steals the slot.
+                        var baseOverloads = structSymbol.BaseClass?.GetMethodsIncludingInherited(methodName)
+                            ?? System.Collections.Immutable.ImmutableArray<FunctionSymbol>.Empty;
+                        FunctionSymbol baseMethod = null;
+                        FunctionSymbol baseSignatureMatch = null;
+                        foreach (var candidate in baseOverloads)
+                        {
+                            baseMethod ??= candidate;
+                            if (SignaturesMatch(candidate, methodParameters, returnType, methodReturnRefKind))
+                            {
+                                baseSignatureMatch = candidate;
+                                break;
+                            }
+                        }
+
+                        if (baseMethod == null)
                         {
                             Diagnostics.ReportNoBaseMethodToOverride(methodSyntax.Identifier.Location, methodName);
+                        }
+                        else if (baseSignatureMatch != null)
+                        {
+                            if (!baseSignatureMatch.IsOpen)
+                            {
+                                Diagnostics.ReportOverrideOfSealedMethod(methodSyntax.Identifier.Location, methodName);
+                            }
+                            else
+                            {
+                                overriddenMethod = baseSignatureMatch;
+                            }
                         }
                         else if (!baseMethod.IsOpen)
                         {
                             Diagnostics.ReportOverrideOfSealedMethod(methodSyntax.Identifier.Location, methodName);
                         }
-                        else if (!SignaturesMatch(baseMethod, methodParameters, returnType, methodReturnRefKind))
+                        else
                         {
-                            // ADR-0060 §9: distinguish a pure ref-kind mismatch (GS0240) from
-                            // a general signature mismatch (the existing diagnostic), so the
-                            // user sees the specific parameter and modifier that disagree.
-                            // Issue #490: also surface a dedicated diagnostic when only the
-                            // *return* ref-kind disagrees.
+                            // No matching overload signature: surface the most specific
+                            // diagnostic against the first (this-first) base overload to
+                            // preserve the existing error message shape.
                             if (baseMethod.Type == returnType && baseMethod.ReturnRefKind != methodReturnRefKind)
                             {
                                 Diagnostics.ReportOverrideReturnRefKindMismatch(
@@ -1583,17 +1613,27 @@ public sealed class Binder
                                 }
                             }
                         }
-                        else
-                        {
-                            overriddenMethod = baseMethod;
-                        }
                     }
-                    else if (structSymbol.BaseClass != null
-                        && structSymbol.BaseClass.TryGetMethodIncludingInherited(methodName, out var shadowed)
-                        && shadowed.IsOpen)
+                    else if (structSymbol.BaseClass != null)
                     {
-                        // Method shadows an overridable base method without `override`.
-                        Diagnostics.ReportMissingOverride(methodSyntax.Identifier.Location, shadowed.ReceiverType.Name, methodName);
+                        // ADR-0063 §8: only diagnose missing-override against a base
+                        // overload whose signature is the same as the new declaration.
+                        // A new same-name overload that does not match any base entry
+                        // is a brand-new overload, not an accidental shadow.
+                        var baseOverloads = structSymbol.BaseClass.GetMethodsIncludingInherited(methodName);
+                        foreach (var shadowed in baseOverloads)
+                        {
+                            if (!shadowed.IsOpen)
+                            {
+                                continue;
+                            }
+
+                            if (SignaturesMatch(shadowed, methodParameters, returnType, methodReturnRefKind))
+                            {
+                                Diagnostics.ReportMissingOverride(methodSyntax.Identifier.Location, shadowed.ReceiverType.Name, methodName);
+                                break;
+                            }
+                        }
                     }
 
                     var methodSymbol = new FunctionSymbol(
@@ -2453,7 +2493,23 @@ public sealed class Binder
             {
                 foreach (var imethod in iface.Methods)
                 {
-                    if (!structSymbol.TryGetMethodIncludingInherited(imethod.Name, out var impl))
+                    // ADR-0063 §8: implementing class may have multiple methods
+                    // with the same name; pick the one whose signature matches
+                    // this specific interface overload exactly.
+                    var implCandidates = structSymbol.GetMethodsIncludingInherited(imethod.Name);
+                    FunctionSymbol impl = null;
+                    FunctionSymbol signatureMatch = null;
+                    foreach (var candidate in implCandidates)
+                    {
+                        impl ??= candidate;
+                        if (SignaturesMatch(imethod, GetCallableParameters(candidate), candidate.Type, candidate.ReturnRefKind))
+                        {
+                            signatureMatch = candidate;
+                            break;
+                        }
+                    }
+
+                    if (impl == null)
                     {
                         Diagnostics.ReportInterfaceMethodNotImplemented(
                             syntax.Identifier.Location,
@@ -2461,7 +2517,7 @@ public sealed class Binder
                             iface.Name,
                             imethod.Name);
                     }
-                    else if (!SignaturesMatch(imethod, GetCallableParameters(impl), impl.Type, impl.ReturnRefKind))
+                    else if (signatureMatch == null)
                     {
                         // ADR-0060 §9: distinguish a pure ref-kind mismatch (GS0240) from
                         // an unrelated signature mismatch (the existing diagnostic).
@@ -8958,13 +9014,82 @@ public sealed class Binder
     }
 
     /// <summary>
-    /// ADR-0063 §6: simple best-overload selector for user-defined functions.
-    /// Filters the candidate set by applicability (arity / optional / variadic
-    /// reach + named-argument names match a parameter), then picks the one
-    /// whose argument types best match. Sets <paramref name="ambiguous"/>
-    /// when two candidates tie.
+    /// ADR-0063: thin wrapper around <see cref="SelectBestInstanceOverload"/>
+    /// that reports the standard ambiguity / no-applicable-overload diagnostics
+    /// when more than one candidate is supplied. When a single candidate is
+    /// supplied the wrapper returns it unchanged so legacy single-overload
+    /// callsites keep their existing diagnostics (wrong arity, etc.).
     /// </summary>
+    private FunctionSymbol SelectInstanceOverloadOrReport(
+        ImmutableArray<FunctionSymbol> overloads,
+        ImmutableArray<BoundExpression> arguments,
+        CallExpressionSyntax ce,
+        string methodName,
+        ImmutableArray<string> argumentNames)
+    {
+        if (overloads.Length <= 1)
+        {
+            return overloads.Length == 1 ? overloads[0] : null;
+        }
+
+        var selected = SelectBestInstanceOverload(overloads, arguments.Length, argumentNames, arguments, out var ambiguous);
+        if (selected != null)
+        {
+            return selected;
+        }
+
+        if (ambiguous)
+        {
+            Diagnostics.ReportAmbiguousOverloadResolution(ce.Identifier.Location, methodName);
+        }
+        else
+        {
+            Diagnostics.ReportNoApplicableOverload(ce.Identifier.Location, methodName);
+        }
+
+        return null;
+    }
+
     private FunctionSymbol SelectBestUserOverload(
+        ImmutableArray<FunctionSymbol> candidates,
+        int argumentCount,
+        ImmutableArray<string> argumentNames,
+        ImmutableArray<BoundExpression>.Builder boundArguments,
+        out bool ambiguous)
+    {
+        return SelectBestUserOverloadCore(candidates, argumentCount, argumentNames, boundArguments, out ambiguous);
+    }
+
+    /// <summary>
+    /// ADR-0063 §6: instance-method overload selection. Filters a candidate set
+    /// of methods (each may or may not carry an explicit receiver parameter) by
+    /// callable arity, named-argument compatibility, and optional-parameter
+    /// applicability, then ranks by exact-type matches and defaulted slots.
+    /// </summary>
+    private FunctionSymbol SelectBestInstanceOverload(
+        ImmutableArray<FunctionSymbol> candidates,
+        int argumentCount,
+        ImmutableArray<string> argumentNames,
+        ImmutableArray<BoundExpression> boundArguments,
+        out bool ambiguous)
+    {
+        ambiguous = false;
+        if (candidates.Length == 0)
+        {
+            return null;
+        }
+
+        if (candidates.Length == 1)
+        {
+            return candidates[0];
+        }
+
+        var builder = ImmutableArray.CreateBuilder<BoundExpression>(boundArguments.Length);
+        builder.AddRange(boundArguments);
+        return SelectBestUserOverloadCore(candidates, argumentCount, argumentNames, builder, out ambiguous);
+    }
+
+    private FunctionSymbol SelectBestUserOverloadCore(
         ImmutableArray<FunctionSymbol> candidates,
         int argumentCount,
         ImmutableArray<string> argumentNames,
@@ -9001,8 +9126,9 @@ public sealed class Binder
         var tie = false;
         foreach (var cand in applicable)
         {
-            var paramLen = cand.Parameters.Length;
-            var isVariadic = paramLen > 0 && cand.Parameters[paramLen - 1].IsVariadic;
+            var parameterOffset = cand.ExplicitReceiverParameter == null ? 0 : 1;
+            var paramLen = cand.Parameters.Length - parameterOffset;
+            var isVariadic = paramLen > 0 && cand.Parameters[cand.Parameters.Length - 1].IsVariadic;
             var paramCountForScore = isVariadic ? paramLen - 1 : paramLen;
             var defaultsUsed = paramCountForScore - argumentCount;
             if (defaultsUsed < 0)
@@ -9017,7 +9143,7 @@ public sealed class Binder
             for (var i = 0; i < paramCountForScore && i < boundArguments.Count; i++)
             {
                 var argType = boundArguments[i]?.Type;
-                var paramType = cand.Parameters[i].Type;
+                var paramType = cand.Parameters[i + parameterOffset].Type;
                 if (argType != null && paramType != null && argType == paramType)
                 {
                     score -= 10;
@@ -9051,15 +9177,16 @@ public sealed class Binder
     /// </summary>
     private static bool IsApplicableUserCallable(FunctionSymbol candidate, int argumentCount, ImmutableArray<string> argumentNames)
     {
-        var paramLen = candidate.Parameters.Length;
-        var isVariadic = paramLen > 0 && candidate.Parameters[paramLen - 1].IsVariadic;
+        var parameterOffset = candidate.ExplicitReceiverParameter == null ? 0 : 1;
+        var paramLen = candidate.Parameters.Length - parameterOffset;
+        var isVariadic = paramLen > 0 && candidate.Parameters[candidate.Parameters.Length - 1].IsVariadic;
         var fixedParamCount = isVariadic ? paramLen - 1 : paramLen;
 
         // Compute required (non-optional) leading-parameter count.
         var requiredParamCount = paramLen;
         for (var i = paramLen - 1; i >= 0; i--)
         {
-            if (candidate.Parameters[i].HasExplicitDefaultValue)
+            if (candidate.Parameters[i + parameterOffset].HasExplicitDefaultValue)
             {
                 requiredParamCount = i;
             }
@@ -9095,7 +9222,7 @@ public sealed class Binder
                 var found = false;
                 for (var p = 0; p < paramLen; p++)
                 {
-                    if (candidate.Parameters[p].Name == n)
+                    if (candidate.Parameters[p + parameterOffset].Name == n)
                     {
                         found = true;
                         break;
@@ -10190,41 +10317,124 @@ public sealed class Binder
             return new BoundErrorExpression(syntax);
         }
 
-        var parameters = classType.ExplicitConstructor.Parameters;
-        var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
+        // ADR-0063 §9: when the class declares multiple init(...) constructors,
+        // bind the arguments first, then pick the constructor whose signature
+        // best matches the call. With a single constructor the existing
+        // single-overload diagnostics (wrong arity) still fire below.
+        var ctorOverloads = classType.ExplicitConstructors;
+        var boundArgumentsBuilder = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
         for (var ai = 0; ai < syntax.Arguments.Count; ai++)
         {
             // Issue #343: peel any named-argument wrapper before binding so the
             // value is bound in source order. We will permute below.
             var argument = UnwrapNamedArgumentValue(syntax.Arguments[ai]);
-            ParameterSymbol parameterForArg = ai < parameters.Length ? parameters[ai] : null;
+            ParameterSymbol parameterForArg = null;
+            if (ctorOverloads.Length == 1 && ai < ctorOverloads[0].Parameters.Length)
+            {
+                parameterForArg = ctorOverloads[0].Parameters[ai];
+            }
+
             if (argument is RefArgumentExpressionSyntax refArg)
             {
-                boundArguments.Add(BindRefArgumentExpression(refArg, parameterForArg));
+                boundArgumentsBuilder.Add(BindRefArgumentExpression(refArg, parameterForArg));
             }
             else
             {
-                boundArguments.Add(BindExpression(argument));
+                boundArgumentsBuilder.Add(BindExpression(argument));
             }
         }
 
-        if (syntax.Arguments.Count != parameters.Length)
+        ConstructorSymbol selectedCtor;
+        if (ctorOverloads.Length <= 1)
         {
-            Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, classType.Name, parameters.Length, syntax.Arguments.Count);
+            selectedCtor = classType.ExplicitConstructor;
+        }
+        else
+        {
+            var ctorFunctions = ImmutableArray.CreateBuilder<FunctionSymbol>(ctorOverloads.Length);
+            foreach (var c in ctorOverloads)
+            {
+                ctorFunctions.Add(c.Function);
+            }
+
+            var selectedFn = SelectBestInstanceOverload(
+                ctorFunctions.MoveToImmutable(),
+                syntax.Arguments.Count,
+                argumentNames,
+                boundArgumentsBuilder.ToImmutable(),
+                out var ambiguous);
+
+            if (selectedFn == null)
+            {
+                if (ambiguous)
+                {
+                    Diagnostics.ReportAmbiguousOverloadResolution(syntax.Identifier.Location, classType.Name);
+                }
+                else
+                {
+                    Diagnostics.ReportNoApplicableOverload(syntax.Identifier.Location, classType.Name);
+                }
+
+                return new BoundErrorExpression(syntax);
+            }
+
+            selectedCtor = null;
+            foreach (var c in ctorOverloads)
+            {
+                if (ReferenceEquals(c.Function, selectedFn))
+                {
+                    selectedCtor = c;
+                    break;
+                }
+            }
+        }
+
+        var parameters = selectedCtor.Parameters;
+
+        // ADR-0063: synthesize defaults for any unsupplied trailing/middle
+        // optional parameters. Both arity-with-named-omission and
+        // trailing-omission go through this path.
+        var requestedArgCount = syntax.Arguments.Count;
+        if (requestedArgCount < parameters.Length)
+        {
+            var minRequired = parameters.Length;
+            for (var i = parameters.Length - 1; i >= 0; i--)
+            {
+                if (parameters[i].HasExplicitDefaultValue)
+                {
+                    minRequired = i;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (requestedArgCount < minRequired)
+            {
+                Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, classType.Name, parameters.Length, requestedArgCount);
+                return new BoundErrorExpression(syntax);
+            }
+        }
+        else if (requestedArgCount > parameters.Length)
+        {
+            Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, classType.Name, parameters.Length, requestedArgCount);
             return new BoundErrorExpression(syntax);
         }
 
         // Issue #343: reorder into parameter order when the call mixes
-        // positional and named arguments.
+        // positional and named arguments. ADR-0063: also slot defaults for
+        // unsupplied optional parameters.
         ExpressionSyntax[] parameterSyntax;
-        if (!argumentNames.IsDefault)
+        var boundArguments = boundArgumentsBuilder;
+        if (!argumentNames.IsDefault || requestedArgCount < parameters.Length)
         {
-            if (!TryReorderUserCallArguments(
+            if (!TryReorderUserCallArgumentsWithDefaults(
                     syntax.Arguments,
                     boundArguments.ToImmutable(),
-                    parameters.Length,
-                    p => parameters[p].Name,
+                    parameters,
                     classType.Name,
+                    syntax.Identifier.Location,
                     out parameterSyntax,
                     out var permutedBound))
             {
@@ -10255,7 +10465,8 @@ public sealed class Binder
 
             // ADR-0055 Tier 4 (#369): re-lower an interpolated-string argument
             // targeting an IFormattable/FormattableString parameter.
-            if (parameterSyntax[i] is InterpolatedStringExpressionSyntax interpolatedCtorArg
+            if (i < parameterSyntax.Length
+                && parameterSyntax[i] is InterpolatedStringExpressionSyntax interpolatedCtorArg
                 && IsFormattableStringTargetType(parameter.Type))
             {
                 convertedArguments.Add(BindInterpolatedStringAsFormattable(interpolatedCtorArg, parameter.Type));
@@ -10286,6 +10497,7 @@ public sealed class Binder
                 }
             }
 
+            var argLocation = i < parameterSyntax.Length ? parameterSyntax[i].Location : syntax.Identifier.Location;
             if (argument.Type != parameter.Type
                 && !Conversion.Classify(argument.Type, parameter.Type).IsImplicit)
             {
@@ -10297,7 +10509,7 @@ public sealed class Binder
 
                 if (argument.Type != TypeSymbol.Error)
                 {
-                    Diagnostics.ReportWrongArgumentType(parameterSyntax[i].Location, parameter.Name, parameter.Type, argument.Type);
+                    Diagnostics.ReportWrongArgumentType(argLocation, parameter.Name, parameter.Type, argument.Type);
                 }
 
                 hasErrors = true;
@@ -10305,7 +10517,7 @@ public sealed class Binder
             }
             else
             {
-                convertedArguments.Add(BindConversion(parameterSyntax[i].Location, argument, parameter.Type));
+                convertedArguments.Add(BindConversion(argLocation, argument, parameter.Type));
             }
         }
 
@@ -10314,7 +10526,110 @@ public sealed class Binder
             return new BoundErrorExpression(syntax);
         }
 
-        return new BoundConstructorCallExpression(syntax, classType, convertedArguments.ToImmutable());
+        return new BoundConstructorCallExpression(syntax, classType, convertedArguments.ToImmutable(), selectedCtor);
+    }
+
+    /// <summary>
+    /// ADR-0063 §9: variant of <c>TryReorderUserCallArguments</c> for constructor
+    /// calls that may omit trailing or middle optional parameters. For each
+    /// parameter slot not filled by a positional/named argument we synthesize a
+    /// default-value bound expression from the parameter symbol.
+    /// </summary>
+    private bool TryReorderUserCallArgumentsWithDefaults(
+        SeparatedSyntaxList<ExpressionSyntax> rawArguments,
+        ImmutableArray<BoundExpression> boundPositionalAndNamed,
+        ImmutableArray<ParameterSymbol> parameters,
+        string callableName,
+        TextLocation diagnosticLocation,
+        out ExpressionSyntax[] parameterSyntax,
+        out ImmutableArray<BoundExpression> permutedBound)
+    {
+        parameterSyntax = new ExpressionSyntax[parameters.Length];
+        var slotted = new BoundExpression[parameters.Length];
+        var filled = new bool[parameters.Length];
+
+        var firstNamedIndex = -1;
+        for (var i = 0; i < rawArguments.Count; i++)
+        {
+            if (rawArguments[i] is NamedArgumentExpressionSyntax)
+            {
+                firstNamedIndex = i;
+                break;
+            }
+        }
+
+        var positionalCount = firstNamedIndex >= 0 ? firstNamedIndex : rawArguments.Count;
+        if (positionalCount > parameters.Length)
+        {
+            Diagnostics.ReportWrongArgumentCount(diagnosticLocation, callableName, parameters.Length, rawArguments.Count);
+            permutedBound = ImmutableArray<BoundExpression>.Empty;
+            return false;
+        }
+
+        for (var i = 0; i < positionalCount; i++)
+        {
+            slotted[i] = boundPositionalAndNamed[i];
+            filled[i] = true;
+            parameterSyntax[i] = rawArguments[i];
+        }
+
+        for (var i = positionalCount; i < rawArguments.Count; i++)
+        {
+            if (rawArguments[i] is not NamedArgumentExpressionSyntax named)
+            {
+                Diagnostics.ReportPositionalArgumentAfterNamedArgument(rawArguments[i].Location);
+                permutedBound = ImmutableArray<BoundExpression>.Empty;
+                return false;
+            }
+
+            var name = named.NameToken.Text;
+            var matched = false;
+            for (var p = 0; p < parameters.Length; p++)
+            {
+                if (parameters[p].Name == name)
+                {
+                    if (filled[p])
+                    {
+                        Diagnostics.ReportDuplicateNamedArgument(named.NameToken.Location, name);
+                        permutedBound = ImmutableArray<BoundExpression>.Empty;
+                        return false;
+                    }
+
+                    slotted[p] = boundPositionalAndNamed[i];
+                    filled[p] = true;
+                    parameterSyntax[p] = rawArguments[i];
+                    matched = true;
+                    break;
+                }
+            }
+
+            if (!matched)
+            {
+                Diagnostics.ReportNamedArgumentParameterNotFound(named.NameToken.Location, callableName, name);
+                permutedBound = ImmutableArray<BoundExpression>.Empty;
+                return false;
+            }
+        }
+
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            if (filled[i])
+            {
+                continue;
+            }
+
+            if (!parameters[i].HasExplicitDefaultValue)
+            {
+                Diagnostics.ReportWrongArgumentCount(diagnosticLocation, callableName, parameters.Length, rawArguments.Count);
+                permutedBound = ImmutableArray<BoundExpression>.Empty;
+                return false;
+            }
+
+            slotted[i] = CreateOptionalUserDefaultArgument(parameters[i]);
+        }
+
+        permutedBound = ImmutableArray.Create(slotted);
+        return true;
     }
 
     private BoundExpression BindCallExpression(CallExpressionSyntax syntax)
@@ -10399,11 +10714,20 @@ public sealed class Binder
             // name matches a sibling method on the receiver type, dispatch via
             // `this.<method>(args)` automatically.
             if (this.function?.ThisParameter != null
-                && this.function.ReceiverType is StructSymbol implicitReceiverStruct
-                && implicitReceiverStruct.TryGetMethodIncludingInherited(syntax.Identifier.Text, out var implicitMethod))
+                && this.function.ReceiverType is StructSymbol implicitReceiverStruct)
             {
-                var implicitReceiver = new BoundVariableExpression(null, this.function.ThisParameter);
-                return BindUserInstanceCall(implicitReceiver, implicitMethod, boundArguments.ToImmutable(), syntax, argumentNames);
+                var implicitOverloads = implicitReceiverStruct.GetMethodsIncludingInherited(syntax.Identifier.Text);
+                if (implicitOverloads.Length > 0)
+                {
+                    var implicitMethod = SelectInstanceOverloadOrReport(implicitOverloads, boundArguments.ToImmutable(), syntax, syntax.Identifier.Text, argumentNames);
+                    if (implicitMethod == null)
+                    {
+                        return new BoundErrorExpression(null);
+                    }
+
+                    var implicitReceiver = new BoundVariableExpression(null, this.function.ThisParameter);
+                    return BindUserInstanceCall(implicitReceiver, implicitMethod, boundArguments.ToImmutable(), syntax, argumentNames);
+                }
             }
 
             Diagnostics.ReportUndefinedFunction(syntax.Identifier.Location, syntax.Identifier.Text);
@@ -12579,25 +12903,54 @@ public sealed class Binder
 
             // Phase 3.B.4: dispatch to a user-defined interface method when
             // the static receiver type is an interface.
-            if (receiver != null && receiver.Type is InterfaceSymbol ifaceRecv && ifaceRecv.TryGetMethod(methodName, out var ifaceMethod))
+            if (receiver != null && receiver.Type is InterfaceSymbol ifaceRecv)
             {
-                return BindUserInstanceCall(receiver, ifaceMethod, arguments, ce, argumentNames);
+                var ifaceOverloads = ifaceRecv.GetMethods(methodName);
+                if (ifaceOverloads.Length > 0)
+                {
+                    var ifaceMethod = SelectInstanceOverloadOrReport(ifaceOverloads, arguments, ce, methodName, argumentNames);
+                    if (ifaceMethod == null)
+                    {
+                        return new BoundErrorExpression(null);
+                    }
+
+                    return BindUserInstanceCall(receiver, ifaceMethod, arguments, ce, argumentNames);
+                }
             }
 
             // Phase 4.2b / ADR-0020: dispatch through a type parameter's
             // sealed-interface constraint, just as if the receiver were
             // typed as the interface itself.
-            if (receiver != null && receiver.Type is TypeParameterSymbol tpRecv && tpRecv.InterfaceConstraint != null
-                && tpRecv.InterfaceConstraint.TryGetMethod(methodName, out var tpIfaceMethod))
+            if (receiver != null && receiver.Type is TypeParameterSymbol tpRecv && tpRecv.InterfaceConstraint != null)
             {
-                return BindUserInstanceCall(receiver, tpIfaceMethod, arguments, ce, argumentNames);
+                var tpOverloads = tpRecv.InterfaceConstraint.GetMethods(methodName);
+                if (tpOverloads.Length > 0)
+                {
+                    var tpIfaceMethod = SelectInstanceOverloadOrReport(tpOverloads, arguments, ce, methodName, argumentNames);
+                    if (tpIfaceMethod == null)
+                    {
+                        return new BoundErrorExpression(null);
+                    }
+
+                    return BindUserInstanceCall(receiver, tpIfaceMethod, arguments, ce, argumentNames);
+                }
             }
 
             // Phase 3.B.3 sub-step 2b: dispatch to a user-defined class method
             // if receiver is a user struct symbol.
-            if (receiver != null && receiver.Type is StructSymbol userClass && userClass.TryGetMethodIncludingInherited(methodName, out var userMethod))
+            if (receiver != null && receiver.Type is StructSymbol userClass)
             {
-                return BindUserInstanceCall(receiver, userMethod, arguments, ce, argumentNames);
+                var userOverloads = userClass.GetMethodsIncludingInherited(methodName);
+                if (userOverloads.Length > 0)
+                {
+                    var userMethod = SelectInstanceOverloadOrReport(userOverloads, arguments, ce, methodName, argumentNames);
+                    if (userMethod == null)
+                    {
+                        return new BoundErrorExpression(null);
+                    }
+
+                    return BindUserInstanceCall(receiver, userMethod, arguments, ce, argumentNames);
+                }
             }
 
             // Phase 3.B.6 / ADR-0019: extension function fallback for
@@ -12635,9 +12988,19 @@ public sealed class Binder
         // Prefer a user-defined class method when the receiver is a user
         // class symbol that has one with this name. (BCL lookup is the
         // fallback for imported CLR types.)
-        if (receiver.Type is StructSymbol userClassPriority && userClassPriority.TryGetMethodIncludingInherited(methodName, out var userMethodPriority))
+        if (receiver.Type is StructSymbol userClassPriority)
         {
-            return BindUserInstanceCall(receiver, userMethodPriority, arguments, ce, argumentNames);
+            var priorityOverloads = userClassPriority.GetMethodsIncludingInherited(methodName);
+            if (priorityOverloads.Length > 0)
+            {
+                var userMethodPriority = SelectInstanceOverloadOrReport(priorityOverloads, arguments, ce, methodName, argumentNames);
+                if (userMethodPriority == null)
+                {
+                    return new BoundErrorExpression(null);
+                }
+
+                return BindUserInstanceCall(receiver, userMethodPriority, arguments, ce, argumentNames);
+            }
         }
 
         var clrType = receiver.Type.ClrType;
@@ -14747,15 +15110,57 @@ public sealed class Binder
             return;
         }
 
-        // Only a single explicit constructor is supported today; additional
-        // declarations are diagnosed rather than silently dropped.
-        for (var c = 1; c < syntax.Constructors.Length; c++)
+        // ADR-0063 §9: bind every declared init(...) constructor. Duplicate
+        // signatures are diagnosed as GS0264 the same way as duplicate method
+        // overloads, so each surviving ConstructorSymbol carries a unique
+        // signature within the overload family.
+        var ctorBuilder = ImmutableArray.CreateBuilder<ConstructorSymbol>();
+        foreach (var ctorSyntax in syntax.Constructors)
         {
-            Diagnostics.ReportMultipleConstructorsUnsupported(syntax.Constructors[c].InitKeyword.Location, structSymbol.Name);
+            var ctor = BindSingleConstructorDeclaration(ctorSyntax, structSymbol, package, baseClassSymbol, importedBaseType);
+            if (ctor == null)
+            {
+                continue;
+            }
+
+            var duplicate = false;
+            foreach (var existing in ctorBuilder)
+            {
+                if (BoundScope.FunctionSignaturesEqual(existing.Function, ctor.Function))
+                {
+                    duplicate = true;
+                    break;
+                }
+            }
+
+            if (duplicate)
+            {
+                Diagnostics.ReportDuplicateOverloadSignature(
+                    ctorSyntax.InitKeyword.Location,
+                    "init",
+                    FormatOverloadSignature(ctor.Function));
+                continue;
+            }
+
+            ctorBuilder.Add(ctor);
         }
 
-        var ctorSyntax = syntax.Constructors[0];
+        structSymbol.SetExplicitConstructors(ctorBuilder.ToImmutable());
+    }
 
+    /// <summary>
+    /// ADR-0063 §9: binds a single <c>init(...)</c> constructor declaration into a
+    /// <see cref="ConstructorSymbol"/> with the optional <c>: base(args)</c> initializer
+    /// resolved. The caller is responsible for collecting all constructors and
+    /// rejecting same-signature duplicates.
+    /// </summary>
+    private ConstructorSymbol BindSingleConstructorDeclaration(
+        ConstructorDeclarationSyntax ctorSyntax,
+        StructSymbol structSymbol,
+        PackageSymbol package,
+        StructSymbol baseClassSymbol,
+        TypeSymbol importedBaseType)
+    {
         var parameters = ImmutableArray.CreateBuilder<ParameterSymbol>();
         var seenParameterNames = new HashSet<string>();
         foreach (var parameterSyntax in ctorSyntax.Parameters)
@@ -14845,7 +15250,7 @@ public sealed class Binder
             }
         }
 
-        structSymbol.SetExplicitConstructor(constructorSymbol);
+        return constructorSymbol;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1005,11 +1005,17 @@ public sealed class Binder
                 continue;
             }
 
-            parameters.Add(new ParameterSymbol(
+            var delegateParam = new ParameterSymbol(
                 parameterName,
                 parameterType,
                 declaringSyntax: parameterSyntax.Identifier,
-                refKind: BindAndValidateParameterRefKind(parameterSyntax, parameterName, parameterType, isVariadic: false, asyncOrIteratorKind: null)));
+                refKind: BindAndValidateParameterRefKind(parameterSyntax, parameterName, parameterType, isVariadic: false, asyncOrIteratorKind: null));
+
+            // ADR-0063 §5: delegate declarations can declare default-valued
+            // parameters; the value is recorded on the parameter symbol for
+            // call-site default substitution.
+            BindAndAttachParameterDefaultValue(parameterSyntax, delegateParam);
+            parameters.Add(delegateParam);
         }
 
         // Variadic / `scoped` parameters are deliberately not supported in v1
@@ -1216,7 +1222,9 @@ public sealed class Binder
                     Diagnostics.ReportRefKindOnPrimaryCtorParameter(paramSyntax.RefKindModifier.Location, paramName);
                 }
 
-                ctorBuilder.Add(new ParameterSymbol(paramName, paramType, declaringSyntax: paramSyntax.Identifier, isScoped: paramSyntax.IsScoped));
+                var primaryCtorParam = new ParameterSymbol(paramName, paramType, declaringSyntax: paramSyntax.Identifier, isScoped: paramSyntax.IsScoped);
+                BindAndAttachParameterDefaultValue(paramSyntax, primaryCtorParam);
+                ctorBuilder.Add(primaryCtorParam);
                 fields.Add(new FieldSymbol(paramName, paramType, Accessibility.Public, isReadOnly: syntax.IsInline));
             }
 
@@ -7329,7 +7337,13 @@ public sealed class Binder
                 Diagnostics.ReportParameterAlreadyDeclared(p.Location, pname);
             }
 
-            parameterSymbols.Add(new ParameterSymbol(pname, ptype, declaringSyntax: p.Identifier, isScoped: p.IsScoped));
+            var lambdaParam = new ParameterSymbol(pname, ptype, declaringSyntax: p.Identifier, isScoped: p.IsScoped);
+
+            // ADR-0063 §5: function-literal (lambda) parameters can declare a
+            // default value; lambdas can be invoked through their delegate type
+            // which honors the default at the call site.
+            BindAndAttachParameterDefaultValue(p, lambdaParam);
+            parameterSymbols.Add(lambdaParam);
             parameterTypes.Add(ptype);
         }
 
@@ -10174,6 +10188,63 @@ public sealed class Binder
         {
             // Issue #343: bind the value behind any named-argument wrapper.
             boundArguments.Add(BindExpression(UnwrapNamedArgumentValue(argument)));
+        }
+
+        // ADR-0063 §5: primary constructors now honor optional parameters. When
+        // the caller omits a value for a parameter that declared one, use the
+        // overload-style permutation helper that fills defaults.
+        var primaryHasOptional = false;
+        for (var pi = 0; pi < parameters.Length; pi++)
+        {
+            if (parameters[pi].HasExplicitDefaultValue)
+            {
+                primaryHasOptional = true;
+                break;
+            }
+        }
+
+        if (primaryHasOptional)
+        {
+            if (!TryReorderUserCallArgumentsWithDefaults(
+                    syntax.Arguments,
+                    boundArguments.ToImmutable(),
+                    parameters,
+                    classType.Name,
+                    syntax.Location,
+                    out var primaryParameterSyntax,
+                    out var primaryPermutedBound))
+            {
+                return new BoundErrorExpression(syntax);
+            }
+
+            boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(primaryPermutedBound.Length);
+            for (var i = 0; i < primaryPermutedBound.Length; i++)
+            {
+                boundArguments.Add(primaryPermutedBound[i]);
+            }
+
+            var hasErrorsP = false;
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                var argument = boundArguments[i];
+                var parameter = parameters[i];
+                var converted = BindConversion(primaryParameterSyntax[i]?.Location ?? syntax.Location, argument, parameter.Type, allowExplicit: false);
+                if (ReferenceEquals(converted.Type, TypeSymbol.Error))
+                {
+                    hasErrorsP = true;
+                }
+                else
+                {
+                    boundArguments[i] = converted;
+                }
+            }
+
+            if (hasErrorsP)
+            {
+                return new BoundErrorExpression(syntax);
+            }
+
+            return new BoundConstructorCallExpression(syntax, classType, boundArguments.ToImmutable());
         }
 
         if (syntax.Arguments.Count != parameters.Length)
@@ -14283,6 +14354,13 @@ public sealed class Binder
             return BindClrMethodGroupConversion(diagnosticLocation, clrMethodGroup, type);
         }
 
+        // ADR-0063 §9: a user-function method group with multiple candidates
+        // resolves here against the target delegate/function-type signature.
+        if (expression is BoundMethodGroupExpression { FunctionType: null } userMethodGroup)
+        {
+            return BindUserMethodGroupConversion(diagnosticLocation, userMethodGroup, type);
+        }
+
         if (expression is BoundFunctionLiteralExpression literal
             && type is FunctionTypeSymbol targetFunctionType
             && TypeSymbol.ContainsTypeParameter(targetFunctionType))
@@ -14618,11 +14696,47 @@ public sealed class Binder
     {
         methodGroup = null;
 
+        // ADR-0063 §9: a name may resolve to multiple user-function overloads.
+        // Gather every candidate so BindConversion can pick the one matching the
+        // target delegate signature. Fall back to TryLookupSymbol for cases
+        // where the name maps to a function not surfaced via the function
+        // overload tables (legacy lookup behavior).
+        var overloads = scope.TryLookupFunctions(name);
+        if (!overloads.IsDefaultOrEmpty)
+        {
+            var usable = ImmutableArray.CreateBuilder<FunctionSymbol>();
+            foreach (var candidate in overloads)
+            {
+                if (!IsMethodGroupCandidateUsable(candidate))
+                {
+                    continue;
+                }
+
+                usable.Add(candidate);
+            }
+
+            if (usable.Count == 1)
+            {
+                return TryBindSingleMethodGroup(usable[0], out methodGroup);
+            }
+
+            if (usable.Count > 1)
+            {
+                methodGroup = new BoundMethodGroupExpression(null, usable.ToImmutable());
+                return true;
+            }
+        }
+
         if (scope.TryLookupSymbol(name) is not FunctionSymbol function)
         {
             return false;
         }
 
+        return TryBindSingleMethodGroup(function, out methodGroup);
+    }
+
+    private static bool IsMethodGroupCandidateUsable(FunctionSymbol function)
+    {
         if (function.IsInstanceMethod
             || function.IsGeneric
             || function.IsExtension
@@ -14633,14 +14747,29 @@ public sealed class Binder
             return false;
         }
 
-        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(function.Parameters.Length);
         foreach (var parameter in function.Parameters)
         {
             if (parameter.IsVariadic)
             {
                 return false;
             }
+        }
 
+        return true;
+    }
+
+    private static bool TryBindSingleMethodGroup(FunctionSymbol function, out BoundExpression methodGroup)
+    {
+        methodGroup = null;
+
+        if (!IsMethodGroupCandidateUsable(function))
+        {
+            return false;
+        }
+
+        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(function.Parameters.Length);
+        foreach (var parameter in function.Parameters)
+        {
             parameterTypes.Add(parameter.Type);
         }
 
@@ -14778,6 +14907,119 @@ public sealed class Binder
         }
 
         return ClrTypeUtilities.IsAssignableByName(invokeReturn, methodReturn);
+    }
+
+    // ADR-0063 §9: resolve a multi-overload user-function method group against
+    // a target delegate or native function type. The pick is the unique
+    // candidate whose parameter types and return type exactly match the
+    // target's invoke signature. When zero or multiple candidates match, a
+    // GS0218 ("cannot convert method group") diagnostic is reported.
+    private BoundExpression BindUserMethodGroupConversion(TextLocation diagnosticLocation, BoundMethodGroupExpression group, TypeSymbol targetType)
+    {
+        var groupName = group.Function?.Name ?? "<method group>";
+
+        ImmutableArray<TypeSymbol> targetParameterTypes;
+        TypeSymbol targetReturnType;
+        if (targetType is FunctionTypeSymbol nativeFn)
+        {
+            targetParameterTypes = nativeFn.ParameterTypes;
+            targetReturnType = nativeFn.ReturnType;
+        }
+        else if (targetType is DelegateTypeSymbol userDelegate)
+        {
+            var pb = ImmutableArray.CreateBuilder<TypeSymbol>(userDelegate.Parameters.Length);
+            foreach (var p in userDelegate.Parameters)
+            {
+                pb.Add(p.Type);
+            }
+
+            targetParameterTypes = pb.MoveToImmutable();
+            targetReturnType = userDelegate.ReturnType;
+        }
+        else
+        {
+            if (targetType != null && targetType != TypeSymbol.Error)
+            {
+                Diagnostics.ReportCannotConvertMethodGroup(diagnosticLocation, groupName, targetType);
+            }
+
+            return new BoundErrorExpression(null);
+        }
+
+        FunctionSymbol pick = null;
+        foreach (var candidate in group.Candidates)
+        {
+            if (candidate.Parameters.Length != targetParameterTypes.Length)
+            {
+                continue;
+            }
+
+            var paramsMatch = true;
+            for (var i = 0; i < candidate.Parameters.Length; i++)
+            {
+                if (!ReferenceEquals(candidate.Parameters[i].Type, targetParameterTypes[i]))
+                {
+                    paramsMatch = false;
+                    break;
+                }
+            }
+
+            if (!paramsMatch)
+            {
+                continue;
+            }
+
+            var candidateReturn = candidate.Type ?? TypeSymbol.Void;
+            if (!ReferenceEquals(candidateReturn, targetReturnType))
+            {
+                continue;
+            }
+
+            if (pick != null)
+            {
+                Diagnostics.ReportCannotConvertMethodGroup(diagnosticLocation, groupName, targetType);
+                return new BoundErrorExpression(null);
+            }
+
+            pick = candidate;
+        }
+
+        if (pick == null)
+        {
+            Diagnostics.ReportCannotConvertMethodGroup(diagnosticLocation, groupName, targetType);
+            return new BoundErrorExpression(null);
+        }
+
+        var pickParams = ImmutableArray.CreateBuilder<TypeSymbol>(pick.Parameters.Length);
+        foreach (var p in pick.Parameters)
+        {
+            pickParams.Add(p.Type);
+        }
+
+        var pickFnType = FunctionTypeSymbol.Get(pickParams.MoveToImmutable(), pick.Type ?? TypeSymbol.Void);
+        var resolvedGroup = new BoundMethodGroupExpression(group.Syntax, pick, pickFnType);
+
+        // If the target is the native function type matching the pick exactly,
+        // identity-convert; otherwise let the regular conversion machinery turn
+        // the function-typed value into the user delegate.
+        if (ReferenceEquals(targetType, pickFnType))
+        {
+            return resolvedGroup;
+        }
+
+        var conversion = Conversion.Classify(pickFnType, targetType);
+        if (!conversion.Exists)
+        {
+            Diagnostics.ReportCannotConvertMethodGroup(diagnosticLocation, groupName, targetType);
+            return new BoundErrorExpression(null);
+        }
+
+        if (conversion.IsIdentity)
+        {
+            return resolvedGroup;
+        }
+
+        return new BoundConversionExpression(null, targetType, resolvedGroup);
     }
 
     // ADR-0047 §6 / #175: if <paramref name="symbol"/> carries an

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1468,7 +1468,12 @@ public sealed class Binder
             foreach (var methodSyntax in syntax.Methods)
             {
                 var methodName = methodSyntax.Identifier.Text;
-                if (!existingNames.Add(methodName))
+
+                // ADR-0063: allow same-name overloads on a class body. The duplicate
+                // check is replaced by a signature-identity check applied below, after
+                // the parameter list has been bound. A name collision with an existing
+                // field or non-method member is still rejected here.
+                if (structSymbol.TryGetField(methodName, out _))
                 {
                     Diagnostics.ReportSymbolAlreadyDeclared(methodSyntax.Identifier.Location, methodName);
                     continue;
@@ -1520,7 +1525,9 @@ public sealed class Binder
                         }
                         else
                         {
-                            parameters.Add(new ParameterSymbol(parameterName, parameterType, declaringSyntax: parameterSyntax.Identifier, isScoped: parameterSyntax.IsScoped, refKind: parameterRefKind));
+                            var classMethodParam = new ParameterSymbol(parameterName, parameterType, declaringSyntax: parameterSyntax.Identifier, isScoped: parameterSyntax.IsScoped, refKind: parameterRefKind);
+                            BindAndAttachParameterDefaultValue(parameterSyntax, classMethodParam);
+                            parameters.Add(classMethodParam);
                         }
                     }
 
@@ -1615,7 +1622,25 @@ public sealed class Binder
                         methodSymbol.SetAttributes(methodAttributes);
                     }
 
-                    methodsBuilder.Add(methodSymbol);
+                    // ADR-0063 §11: detect duplicate-signature within the class.
+                    var hasDuplicateSig = false;
+                    foreach (var existingMethod in methodsBuilder)
+                    {
+                        if (BoundScope.FunctionSignaturesEqual(existingMethod, methodSymbol))
+                        {
+                            Diagnostics.ReportDuplicateOverloadSignature(
+                                methodSyntax.Identifier.Location,
+                                methodName,
+                                FormatOverloadSignature(methodSymbol));
+                            hasDuplicateSig = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasDuplicateSig)
+                    {
+                        methodsBuilder.Add(methodSymbol);
+                    }
                 }
                 finally
                 {
@@ -2010,7 +2035,10 @@ public sealed class Binder
             foreach (var methodSyntax in syntax.SharedBlock.Methods)
             {
                 var methodName = methodSyntax.Identifier.Text;
-                if (!existingNames.Add(methodName))
+
+                // ADR-0063: allow same-name overloads in a shared block; only reject
+                // collision with a non-method member of the same name (field/property/event).
+                if (existingNames.Contains(methodName))
                 {
                     Diagnostics.ReportSymbolAlreadyDeclared(methodSyntax.Identifier.Location, methodName);
                     continue;
@@ -2070,7 +2098,9 @@ public sealed class Binder
                         }
                         else
                         {
-                            parameters.Add(new ParameterSymbol(parameterName, parameterType, declaringSyntax: parameterSyntax.Identifier, isScoped: parameterSyntax.IsScoped, refKind: parameterRefKind));
+                            var staticMethodParam = new ParameterSymbol(parameterName, parameterType, declaringSyntax: parameterSyntax.Identifier, isScoped: parameterSyntax.IsScoped, refKind: parameterRefKind);
+                            BindAndAttachParameterDefaultValue(parameterSyntax, staticMethodParam);
+                            parameters.Add(staticMethodParam);
                         }
                     }
 
@@ -2104,7 +2134,25 @@ public sealed class Binder
 
                     AttachDocumentation(methodSymbol, methodSyntax);
 
-                    staticMethodsBuilder.Add(methodSymbol);
+                    // ADR-0063 §11: detect duplicate-signature within the static block.
+                    var hasDupSig = false;
+                    foreach (var existingMethod in staticMethodsBuilder)
+                    {
+                        if (BoundScope.FunctionSignaturesEqual(existingMethod, methodSymbol))
+                        {
+                            Diagnostics.ReportDuplicateOverloadSignature(
+                                methodSyntax.Identifier.Location,
+                                methodName,
+                                FormatOverloadSignature(methodSymbol));
+                            hasDupSig = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasDupSig)
+                    {
+                        staticMethodsBuilder.Add(methodSymbol);
+                    }
                 }
                 finally
                 {
@@ -2588,12 +2636,11 @@ public sealed class Binder
         foreach (var methodSyntax in syntax.Methods)
         {
             var methodName = methodSyntax.Identifier.Text;
-            if (!seenNames.Add(methodName))
-            {
-                Diagnostics.ReportSymbolAlreadyDeclared(methodSyntax.Identifier.Location, methodName);
-                continue;
-            }
 
+            // ADR-0063: overloads are allowed on interfaces; the post-bind signature
+            // check below detects duplicate signatures. Name collision with a
+            // property/event member of the same name is still rejected (handled later
+            // via seenNames when properties/events are added).
             var parameters = ImmutableArray.CreateBuilder<ParameterSymbol>();
             var seenParameterNames = new HashSet<string>();
             foreach (var parameterSyntax in methodSyntax.Parameters)
@@ -2618,7 +2665,9 @@ public sealed class Binder
                 }
                 else
                 {
-                    parameters.Add(new ParameterSymbol(parameterName, parameterType, declaringSyntax: parameterSyntax.Identifier, isScoped: parameterSyntax.IsScoped, refKind: parameterRefKind));
+                    var ifaceMethodParam = new ParameterSymbol(parameterName, parameterType, declaringSyntax: parameterSyntax.Identifier, isScoped: parameterSyntax.IsScoped, refKind: parameterRefKind);
+                    BindAndAttachParameterDefaultValue(parameterSyntax, ifaceMethodParam);
+                    parameters.Add(ifaceMethodParam);
                 }
             }
 
@@ -2634,7 +2683,27 @@ public sealed class Binder
                 receiverType: null);
             methodSymbol.ReturnRefKind = methodReturnRefKind;
             AttachDocumentation(methodSymbol, methodSyntax);
-            methodsBuilder.Add(methodSymbol);
+
+            // ADR-0063 §11: detect duplicate-signature overloads on the interface.
+            var hasDupSig = false;
+            foreach (var existingMethod in methodsBuilder)
+            {
+                if (BoundScope.FunctionSignaturesEqual(existingMethod, methodSymbol))
+                {
+                    Diagnostics.ReportDuplicateOverloadSignature(
+                        methodSyntax.Identifier.Location,
+                        methodName,
+                        FormatOverloadSignature(methodSymbol));
+                    hasDupSig = true;
+                    break;
+                }
+            }
+
+            if (!hasDupSig)
+            {
+                seenNames.Add(methodName);
+                methodsBuilder.Add(methodSymbol);
+            }
         }
 
         interfaceSymbol.SetMethods(methodsBuilder.ToImmutable());
@@ -2868,6 +2937,7 @@ public sealed class Binder
                         syntax.IsAsync ? "async" : null);
 
                     var parameter = new ParameterSymbol(parameterName, parameterType, isVariadic, declaringSyntax: parameterSyntax.Identifier, isScoped: parameterSyntax.IsScoped, refKind: parameterRefKind);
+                    BindAndAttachParameterDefaultValue(parameterSyntax, parameter);
                     parameters.Add(parameter);
                     parameterSymbolBySyntax[pIndex] = parameter;
                 }
@@ -2999,7 +3069,7 @@ public sealed class Binder
                     return;
                 }
 
-                if (methodReceiverStruct.TryGetField(methodName, out _) || methodReceiverStruct.TryGetMethod(methodName, out _))
+                if (methodReceiverStruct.TryGetField(methodName, out _))
                 {
                     Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, methodName);
                     return;
@@ -3019,6 +3089,20 @@ public sealed class Binder
                 function.ReturnRefKind = returnRefKind;
                 AttachDocumentation(function, syntax);
                 function.SetAttributes(functionAttributes);
+
+                // ADR-0063 §11: detect duplicate-signature against existing methods on the receiver.
+                foreach (var existingMethod in methodReceiverStruct.Methods)
+                {
+                    if (BoundScope.FunctionSignaturesEqual(existingMethod, function))
+                    {
+                        Diagnostics.ReportDuplicateOverloadSignature(
+                            syntax.Identifier.Location,
+                            methodName,
+                            FormatOverloadSignature(function));
+                        return;
+                    }
+                }
+
                 methodReceiverStruct.AddMethods(ImmutableArray.Create(function));
                 return;
             }
@@ -3044,7 +3128,28 @@ public sealed class Binder
 
             if (function.Declaration.Identifier.Text != null && !scope.TryDeclareFunction(function))
             {
-                Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, function.Name);
+                // ADR-0063 §11: if the collision is with another callable of
+                // the same name, it is a duplicate-signature error rather
+                // than a generic redeclaration.
+                var existingOverloads = scope.TryLookupFunctions(function.Name);
+                var duplicateSig = false;
+                foreach (var existing in existingOverloads)
+                {
+                    if (BoundScope.FunctionSignaturesEqual(existing, function))
+                    {
+                        duplicateSig = true;
+                        break;
+                    }
+                }
+
+                if (duplicateSig)
+                {
+                    Diagnostics.ReportDuplicateOverloadSignature(syntax.Identifier.Location, function.Name, FormatOverloadSignature(function));
+                }
+                else
+                {
+                    Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, function.Name);
+                }
             }
         }
         finally
@@ -8518,6 +8623,35 @@ public sealed class Binder
     };
 
     /// <summary>
+    /// ADR-0063: render a function's signature in a human-readable form for diagnostics.
+    /// </summary>
+    private static string FormatOverloadSignature(FunctionSymbol function)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append(function.Name);
+        sb.Append('(');
+        for (var i = 0; i < function.Parameters.Length; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(", ");
+            }
+
+            var p = function.Parameters[i];
+            if (p.RefKind != RefKind.None)
+            {
+                sb.Append(RefKindToString(p.RefKind));
+                sb.Append(' ');
+            }
+
+            sb.Append(p.Type?.Name ?? "?");
+        }
+
+        sb.Append(')');
+        return sb.ToString();
+    }
+
+    /// <summary>
     /// ADR-0060: maps a ref-kind modifier syntax token to a <see cref="RefKind"/> value.
     /// </summary>
     /// <param name="modifier">The <c>ref</c>/<c>out</c>/<c>in</c> contextual-keyword token (<see langword="null"/> for none).</param>
@@ -8824,6 +8958,183 @@ public sealed class Binder
     }
 
     /// <summary>
+    /// ADR-0063 §6: simple best-overload selector for user-defined functions.
+    /// Filters the candidate set by applicability (arity / optional / variadic
+    /// reach + named-argument names match a parameter), then picks the one
+    /// whose argument types best match. Sets <paramref name="ambiguous"/>
+    /// when two candidates tie.
+    /// </summary>
+    private FunctionSymbol SelectBestUserOverload(
+        ImmutableArray<FunctionSymbol> candidates,
+        int argumentCount,
+        ImmutableArray<string> argumentNames,
+        ImmutableArray<BoundExpression>.Builder boundArguments,
+        out bool ambiguous)
+    {
+        ambiguous = false;
+
+        // Phase 1: applicability.
+        var applicable = new List<FunctionSymbol>();
+        foreach (var cand in candidates)
+        {
+            if (IsApplicableUserCallable(cand, argumentCount, argumentNames))
+            {
+                applicable.Add(cand);
+            }
+        }
+
+        if (applicable.Count == 0)
+        {
+            return null;
+        }
+
+        if (applicable.Count == 1)
+        {
+            return applicable[0];
+        }
+
+        // Phase 2: prefer candidates with the fewest defaulted parameters (an
+        // exact-arity overload beats one that relies on defaults). Also prefer
+        // a non-variadic candidate over a variadic one when both apply.
+        var bestScore = int.MaxValue;
+        FunctionSymbol best = null;
+        var tie = false;
+        foreach (var cand in applicable)
+        {
+            var paramLen = cand.Parameters.Length;
+            var isVariadic = paramLen > 0 && cand.Parameters[paramLen - 1].IsVariadic;
+            var paramCountForScore = isVariadic ? paramLen - 1 : paramLen;
+            var defaultsUsed = paramCountForScore - argumentCount;
+            if (defaultsUsed < 0)
+            {
+                defaultsUsed = 0;
+            }
+
+            // Apply a small penalty to variadic candidates (per ADR §6.6).
+            var score = defaultsUsed + (isVariadic ? 1 : 0);
+
+            // Score argument-type compatibility: +1 per exact-type match.
+            for (var i = 0; i < paramCountForScore && i < boundArguments.Count; i++)
+            {
+                var argType = boundArguments[i]?.Type;
+                var paramType = cand.Parameters[i].Type;
+                if (argType != null && paramType != null && argType == paramType)
+                {
+                    score -= 10;
+                }
+            }
+
+            if (score < bestScore)
+            {
+                bestScore = score;
+                best = cand;
+                tie = false;
+            }
+            else if (score == bestScore)
+            {
+                tie = true;
+            }
+        }
+
+        if (tie)
+        {
+            ambiguous = true;
+            return null;
+        }
+
+        return best;
+    }
+
+    /// <summary>
+    /// ADR-0063: returns true when the supplied argument count + names could
+    /// reach the parameter list of the candidate.
+    /// </summary>
+    private static bool IsApplicableUserCallable(FunctionSymbol candidate, int argumentCount, ImmutableArray<string> argumentNames)
+    {
+        var paramLen = candidate.Parameters.Length;
+        var isVariadic = paramLen > 0 && candidate.Parameters[paramLen - 1].IsVariadic;
+        var fixedParamCount = isVariadic ? paramLen - 1 : paramLen;
+
+        // Compute required (non-optional) leading-parameter count.
+        var requiredParamCount = paramLen;
+        for (var i = paramLen - 1; i >= 0; i--)
+        {
+            if (candidate.Parameters[i].HasExplicitDefaultValue)
+            {
+                requiredParamCount = i;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        if (isVariadic)
+        {
+            if (argumentCount < fixedParamCount)
+            {
+                return false;
+            }
+        }
+        else if (argumentCount < requiredParamCount || argumentCount > paramLen)
+        {
+            return false;
+        }
+
+        // Named-argument names must each correspond to a parameter.
+        if (!argumentNames.IsDefault)
+        {
+            for (var i = 0; i < argumentNames.Length; i++)
+            {
+                var n = argumentNames[i];
+                if (n == null)
+                {
+                    continue;
+                }
+
+                var found = false;
+                for (var p = 0; p < paramLen; p++)
+                {
+                    if (candidate.Parameters[p].Name == n)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// ADR-0063: synthesizes a bound default-value argument for a user-defined
+    /// optional parameter. The default is a CLR-Constant-table representable
+    /// primitive/string previously captured on the parameter symbol; <c>nil</c>
+    /// becomes a <see cref="BoundDefaultExpression"/>.
+    /// </summary>
+    private static BoundExpression CreateOptionalUserDefaultArgument(ParameterSymbol parameter)
+    {
+        if (!parameter.HasExplicitDefaultValue)
+        {
+            return new BoundDefaultExpression(null, parameter.Type);
+        }
+
+        var v = parameter.ExplicitDefaultValue;
+        if (v == null)
+        {
+            return new BoundDefaultExpression(null, parameter.Type);
+        }
+
+        return new BoundLiteralExpression(null, v, parameter.Type);
+    }
+
+    /// <summary>
     /// Issue #327: reads a primitive/string constant default from an optional
     /// parameter's metadata, when present. Returns <c>false</c> for
     /// <c>= default</c>, <c>= null</c>, or non-primitive constants so the caller
@@ -8871,6 +9182,128 @@ public sealed class Binder
                 value = raw;
                 return true;
             default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// ADR-0063: binds, validates, and (when valid) records a user-declared optional
+    /// default value on <paramref name="parameter"/>. Enforces the v1 restrictions:
+    /// the default must be a compile-time constant representable in CLR parameter
+    /// metadata, the parameter must not be <c>ref</c>/<c>out</c>/<c>in</c>, must not
+    /// be variadic, and must not be the receiver parameter. Reports
+    /// <see cref="DiagnosticBag.ReportInvalidOptionalParameter"/> on misuse.
+    /// </summary>
+    /// <param name="parameterSyntax">The parameter syntax carrying the default clause.</param>
+    /// <param name="parameter">The bound parameter symbol to attach the default to.</param>
+    /// <param name="isReceiver">True when the parameter is a method's source receiver.</param>
+    private void BindAndAttachParameterDefaultValue(ParameterSyntax parameterSyntax, ParameterSymbol parameter, bool isReceiver = false)
+    {
+        if (parameterSyntax == null || !parameterSyntax.HasDefaultValue || parameter == null)
+        {
+            return;
+        }
+
+        var location = parameterSyntax.DefaultValue?.Location ?? parameterSyntax.Location;
+
+        if (isReceiver)
+        {
+            Diagnostics.ReportInvalidOptionalParameter(location, parameter.Name, "the receiver parameter cannot declare a default value.");
+            return;
+        }
+
+        if (parameter.IsVariadic)
+        {
+            Diagnostics.ReportInvalidOptionalParameter(location, parameter.Name, "a variadic parameter cannot declare a default value.");
+            return;
+        }
+
+        if (parameter.RefKind != RefKind.None)
+        {
+            Diagnostics.ReportInvalidOptionalParameter(location, parameter.Name, $"a '{RefKindToString(parameter.RefKind)}' parameter cannot declare a default value.");
+            return;
+        }
+
+        // Bind the default-value expression in the surrounding scope. Diagnostics
+        // (undefined symbol, etc.) bubble through normally.
+        var bound = BindExpression(parameterSyntax.DefaultValue);
+        if (bound == null || bound is BoundErrorExpression || parameter.Type == TypeSymbol.Error)
+        {
+            return;
+        }
+
+        // The default must be a compile-time constant of one of the kinds the CLR
+        // parameter Constant table can represent.
+        if (!TryExtractConstantDefault(bound, parameter.Type, out var constant, out var reason))
+        {
+            Diagnostics.ReportInvalidOptionalParameter(location, parameter.Name, reason);
+            return;
+        }
+
+        parameter.SetExplicitDefaultValue(constant);
+    }
+
+    /// <summary>
+    /// ADR-0063: extracts a CLR-Constant-table representable default value from a
+    /// bound expression, applying limited implicit conversion to the parameter type
+    /// (numeric widening / nil → reference|nullable). Returns false with a
+    /// human-visible reason otherwise.
+    /// </summary>
+    private static bool TryExtractConstantDefault(BoundExpression bound, TypeSymbol parameterType, out object value, out string reason)
+    {
+        value = null;
+        reason = null;
+
+        // Unwrap a conversion that the binder may have inserted around a literal.
+        var inner = bound;
+        while (inner is BoundConversionExpression bce)
+        {
+            inner = bce.Expression;
+        }
+
+        if (inner is BoundLiteralExpression lit)
+        {
+            value = lit.Value;
+        }
+        else
+        {
+            reason = "the default value must be a compile-time constant (numeric, bool, char, string, enum, or nil).";
+            return false;
+        }
+
+        // `nil` is only valid for a reference-compatible or nullable parameter type.
+        if (value == null)
+        {
+            if (parameterType is NullableTypeSymbol || (parameterType.ClrType is System.Type ct && !ct.IsValueType))
+            {
+                return true;
+            }
+
+            reason = $"'nil' is not a valid default for value-type parameter of type '{parameterType.Name}'.";
+            value = null;
+            return false;
+        }
+
+        // Numeric / bool / char / string / enum-underlying types are CLR Constant-table representable.
+        switch (value)
+        {
+            case bool:
+            case sbyte:
+            case byte:
+            case short:
+            case ushort:
+            case int:
+            case uint:
+            case long:
+            case ulong:
+            case float:
+            case double:
+            case char:
+            case string:
+                return true;
+            default:
+                reason = $"the default value type '{value.GetType().Name}' is not representable in CLR parameter metadata.";
+                value = null;
                 return false;
         }
     }
@@ -9021,6 +9454,31 @@ public sealed class Binder
         string calleeName,
         out ExpressionSyntax[] permutedSyntax,
         out ImmutableArray<BoundExpression> permutedBound)
+        => TryReorderUserCallArguments(
+            sourceArguments,
+            sourceBound,
+            parameterCount,
+            parameterNameAt,
+            isOptionalAt: null,
+            calleeName,
+            out permutedSyntax,
+            out permutedBound);
+
+    /// <summary>
+    /// ADR-0063: reorders and pads call arguments to match the parameter list.
+    /// When <paramref name="isOptionalAt"/> is non-null, omitted optional slots
+    /// are left as <see langword="null"/> in the result for callers to fill with
+    /// default-value substitutions.
+    /// </summary>
+    private bool TryReorderUserCallArguments(
+        SeparatedSyntaxList<ExpressionSyntax> sourceArguments,
+        ImmutableArray<BoundExpression> sourceBound,
+        int parameterCount,
+        System.Func<int, string> parameterNameAt,
+        System.Func<int, bool> isOptionalAt,
+        string calleeName,
+        out ExpressionSyntax[] permutedSyntax,
+        out ImmutableArray<BoundExpression> permutedBound)
     {
         permutedSyntax = null;
         permutedBound = default;
@@ -9032,14 +9490,32 @@ public sealed class Binder
 
         if (argumentNames.IsDefault)
         {
-            var identitySyntax = new ExpressionSyntax[sourceArguments.Count];
-            for (var i = 0; i < sourceArguments.Count; i++)
+            // Pure positional: pad with nulls when fewer args than parameters and
+            // optional slots are permitted.
+            if (sourceArguments.Count == parameterCount || isOptionalAt == null)
             {
-                identitySyntax[i] = sourceArguments[i];
+                var identitySyntax = new ExpressionSyntax[sourceArguments.Count];
+                for (var i = 0; i < sourceArguments.Count; i++)
+                {
+                    identitySyntax[i] = sourceArguments[i];
+                }
+
+                permutedSyntax = identitySyntax;
+                permutedBound = sourceBound;
+                return true;
             }
 
-            permutedSyntax = identitySyntax;
-            permutedBound = sourceBound;
+            var paddedSyntax = new ExpressionSyntax[parameterCount];
+            var paddedBound = new BoundExpression[parameterCount];
+            var supplied = sourceArguments.Count < parameterCount ? sourceArguments.Count : parameterCount;
+            for (var i = 0; i < supplied; i++)
+            {
+                paddedSyntax[i] = sourceArguments[i];
+                paddedBound[i] = sourceBound[i];
+            }
+
+            permutedSyntax = paddedSyntax;
+            permutedBound = ImmutableArray.Create(paddedBound);
             return true;
         }
 
@@ -9109,6 +9585,13 @@ public sealed class Binder
         {
             if (slotSyntax[p] == null)
             {
+                // ADR-0063: empty slot is only OK when the parameter is optional;
+                // the caller substitutes the default value.
+                if (isOptionalAt != null && isOptionalAt(p))
+                {
+                    continue;
+                }
+
                 // Caller's count check should have prevented this; defensive.
                 return false;
             }
@@ -10017,10 +10500,50 @@ public sealed class Binder
             return new BoundErrorExpression(null);
         }
 
+        // ADR-0063 §11: when multiple top-level functions share this name,
+        // perform overload selection over the supplied argument shape (count
+        // and, where useful, types). The legacy `TryLookupSymbol` returned the
+        // first declared overload; we now consult the overload-set store.
+        var overloadSet = scope.TryLookupFunctions(syntax.Identifier.Text);
+        if (overloadSet.Length > 1)
+        {
+            var selected = SelectBestUserOverload(overloadSet, syntax.Arguments.Count, argumentNames, boundArguments, out var overloadAmbiguous);
+            if (selected == null)
+            {
+                if (overloadAmbiguous)
+                {
+                    Diagnostics.ReportAmbiguousOverloadResolution(syntax.Identifier.Location, syntax.Identifier.Text);
+                }
+                else
+                {
+                    Diagnostics.ReportNoApplicableOverload(syntax.Identifier.Location, syntax.Identifier.Text);
+                }
+
+                return new BoundErrorExpression(null);
+            }
+
+            function = selected;
+        }
+
         ReportObsoleteUseIfApplicable(syntax.Identifier.Location, function, function.Name);
 
         var isVariadic = function.Parameters.Length > 0 && function.Parameters[function.Parameters.Length - 1].IsVariadic;
         var fixedParamCount = isVariadic ? function.Parameters.Length - 1 : function.Parameters.Length;
+
+        // ADR-0063: count of leading non-optional parameters (the minimum a
+        // call must supply when there are no variadic parameters).
+        var requiredParamCount = function.Parameters.Length;
+        for (var i = function.Parameters.Length - 1; i >= 0; i--)
+        {
+            if (function.Parameters[i].HasExplicitDefaultValue)
+            {
+                requiredParamCount = i;
+            }
+            else
+            {
+                break;
+            }
+        }
 
         // Issue #343: variadic functions and named arguments do not compose:
         // there is no way to "name" the variadic slot at a call site.
@@ -10038,7 +10561,7 @@ public sealed class Binder
                 return new BoundErrorExpression(null);
             }
         }
-        else if (syntax.Arguments.Count != function.Parameters.Length)
+        else if (syntax.Arguments.Count < requiredParamCount || syntax.Arguments.Count > function.Parameters.Length)
         {
             TextSpan span;
             if (syntax.Arguments.Count > function.Parameters.Length)
@@ -10070,14 +10593,19 @@ public sealed class Binder
         // the existing per-position passes operate as if every argument were
         // positional. `parameterSyntax[i]` carries the source-syntax node at
         // parameter position `i` (preserving locations for diagnostics).
+        // ADR-0063: when there are optional parameters, omitted slots are left
+        // empty in the reorder output, then filled with default-value
+        // BoundLiteralExpression here.
         ExpressionSyntax[] parameterSyntax;
-        if (!argumentNames.IsDefault)
+        var hasOptional = function.Parameters.Length > 0 && requiredParamCount < function.Parameters.Length && !isVariadic;
+        if (!argumentNames.IsDefault || (hasOptional && syntax.Arguments.Count < function.Parameters.Length))
         {
             if (!TryReorderUserCallArguments(
                     syntax.Arguments,
                     boundArguments.ToImmutable(),
                     function.Parameters.Length,
                     p => function.Parameters[p].Name,
+                    hasOptional ? (p => function.Parameters[p].HasExplicitDefaultValue) : (System.Func<int, bool>)null,
                     function.Name,
                     out parameterSyntax,
                     out var permutedBound))
@@ -10088,7 +10616,15 @@ public sealed class Binder
             boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(permutedBound.Length);
             for (var i = 0; i < permutedBound.Length; i++)
             {
-                boundArguments.Add(permutedBound[i]);
+                if (permutedBound[i] == null)
+                {
+                    // ADR-0063: fill the omitted optional slot with the parameter's default.
+                    boundArguments.Add(CreateOptionalUserDefaultArgument(function.Parameters[i]));
+                }
+                else
+                {
+                    boundArguments.Add(permutedBound[i]);
+                }
             }
         }
         else
@@ -14244,7 +14780,9 @@ public sealed class Binder
             }
             else
             {
-                parameters.Add(new ParameterSymbol(parameterName, parameterType, declaringSyntax: parameterSyntax.Identifier, isScoped: parameterSyntax.IsScoped, refKind: parameterRefKind));
+                var ctorParam = new ParameterSymbol(parameterName, parameterType, declaringSyntax: parameterSyntax.Identifier, isScoped: parameterSyntax.IsScoped, refKind: parameterRefKind);
+                BindAndAttachParameterDefaultValue(parameterSyntax, ctorParam);
+                parameters.Add(ctorParam);
             }
         }
 

--- a/src/Core/CodeAnalysis/Binding/BoundConstructorCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundConstructorCallExpression.cs
@@ -17,18 +17,33 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// correspond 1:1 with <see cref="StructSymbol.PrimaryConstructorParameters"/>
 /// and are assigned to the same-named fields of the new instance.
 /// </summary>
+/// <remarks>
+/// ADR-0063 §9: when the receiving class declares an overload family of
+/// <c>init(...)</c> constructors, <see cref="SelectedConstructor"/> identifies
+/// the specific overload picked by call-site overload resolution. Primary-ctor
+/// and parameterless paths leave it <see langword="null"/>.
+/// </remarks>
 public sealed class BoundConstructorCallExpression : BoundExpression
 {
     public BoundConstructorCallExpression(SyntaxNode syntax, StructSymbol structType, ImmutableArray<BoundExpression> arguments)
+        : this(syntax, structType, arguments, selectedConstructor: null)
+    {
+    }
+
+    public BoundConstructorCallExpression(SyntaxNode syntax, StructSymbol structType, ImmutableArray<BoundExpression> arguments, ConstructorSymbol selectedConstructor)
         : base(syntax)
     {
         StructType = structType;
         Arguments = arguments;
+        SelectedConstructor = selectedConstructor;
     }
 
     public StructSymbol StructType { get; }
 
     public ImmutableArray<BoundExpression> Arguments { get; }
+
+    /// <summary>Gets the chosen explicit <c>init(...)</c> overload, per ADR-0063 §9, or <see langword="null"/> when not applicable.</summary>
+    public ConstructorSymbol SelectedConstructor { get; }
 
     public override TypeSymbol Type => StructType;
 

--- a/src/Core/CodeAnalysis/Binding/BoundMethodGroupExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundMethodGroupExpression.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 
@@ -11,13 +12,13 @@ using GSharp.Core.CodeAnalysis.Syntax;
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
-/// Issue #324: a bare reference to a named function used in a value context
-/// (C#/F# "method group"). Its type is the <see cref="FunctionTypeSymbol"/>
-/// describing the function's signature, so the existing function-value →
-/// delegate conversion machinery materializes it as a delegate (native
-/// <c>func(...)</c> slots via identity, <c>Func[...]</c>/<c>Action[...]</c>
-/// slots via the function → delegate conversion). The emitter loads the
-/// function's address with <c>ldftn</c> and constructs the delegate directly.
+/// Issue #324 / ADR-0063 §9: a bare reference to a named function used in a
+/// value context (C#/F# "method group"). When the name resolves to a single
+/// candidate, <see cref="Function"/> is bound eagerly and <see cref="FunctionType"/>
+/// is its signature. When the name resolves to multiple overloads,
+/// <see cref="Candidates"/> contains every overload and final overload
+/// selection is deferred to <c>BindConversion</c>, where the target delegate
+/// signature drives the pick.
 /// </summary>
 public sealed class BoundMethodGroupExpression : BoundExpression
 {
@@ -26,13 +27,28 @@ public sealed class BoundMethodGroupExpression : BoundExpression
     {
         Function = function;
         FunctionType = type;
+        Candidates = ImmutableArray.Create(function);
+    }
+
+    public BoundMethodGroupExpression(SyntaxNode syntax, ImmutableArray<FunctionSymbol> candidates)
+        : base(syntax)
+    {
+        Function = candidates.IsDefaultOrEmpty ? null : candidates[0];
+        FunctionType = null;
+        Candidates = candidates;
     }
 
     public FunctionSymbol Function { get; }
 
     public FunctionTypeSymbol FunctionType { get; }
 
-    public override TypeSymbol Type => FunctionType;
+    /// <summary>
+    /// Gets every candidate overload sharing the source name. Equals
+    /// <c>[Function]</c> when there is a single candidate.
+    /// </summary>
+    public ImmutableArray<FunctionSymbol> Candidates { get; }
+
+    public override TypeSymbol Type => FunctionType ?? (TypeSymbol)TypeSymbol.Error;
 
     public override BoundNodeKind Kind => BoundNodeKind.MethodGroupExpression;
 }

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -17,6 +17,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundScope
 {
     private Dictionary<string, Symbol> symbols;
+    private Dictionary<string, List<FunctionSymbol>> functions;
     private List<ImportSymbol> imports;
     private Dictionary<string, TypeSymbol> typeAliases;
     private List<FunctionSymbol> extensionFunctions;
@@ -108,7 +109,128 @@ public sealed class BoundScope
     /// <param name="function">The function to declare.</param>
     /// <returns>Whether the function was declared or not.</returns>
     public bool TryDeclareFunction(FunctionSymbol function)
-        => TryDeclareSymbol(function);
+    {
+        if (function?.Name == null)
+        {
+            return false;
+        }
+
+        // ADR-0063 §11: user-defined callable storage is name → overload set.
+        // A name conflict with a non-function symbol (variable, etc.) is still a
+        // hard duplicate. A second function with the same name is allowed if and
+        // only if its signature differs from every existing overload.
+        if (symbols != null && symbols.TryGetValue(function.Name, out var existing) && existing is not FunctionSymbol)
+        {
+            return false;
+        }
+
+        functions ??= new Dictionary<string, List<FunctionSymbol>>();
+        if (!functions.TryGetValue(function.Name, out var bucket))
+        {
+            bucket = new List<FunctionSymbol>();
+            functions.Add(function.Name, bucket);
+        }
+        else
+        {
+            foreach (var f in bucket)
+            {
+                if (FunctionSignaturesEqual(f, function))
+                {
+                    return false;
+                }
+            }
+        }
+
+        bucket.Add(function);
+
+        // Keep the first overload visible through the legacy `symbols` map so
+        // existing TryLookupSymbol/Get*<FunctionSymbol> callers see the name.
+        symbols ??= new Dictionary<string, Symbol>();
+        if (!symbols.ContainsKey(function.Name))
+        {
+            symbols.Add(function.Name, function);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// ADR-0063 §11: returns every overload of the given function name visible
+    /// from this scope (walks parent scopes). Empty when no function with that
+    /// name is in scope.
+    /// </summary>
+    /// <param name="name">The function name.</param>
+    /// <returns>The overload set in declaration order (innermost scope first).</returns>
+    public ImmutableArray<FunctionSymbol> TryLookupFunctions(string name)
+    {
+        if (name == null)
+        {
+            return ImmutableArray<FunctionSymbol>.Empty;
+        }
+
+        ImmutableArray<FunctionSymbol>.Builder builder = null;
+        for (var s = this; s != null; s = s.Parent)
+        {
+            if (s.functions != null && s.functions.TryGetValue(name, out var bucket) && bucket.Count > 0)
+            {
+                builder ??= ImmutableArray.CreateBuilder<FunctionSymbol>();
+                builder.AddRange(bucket);
+            }
+        }
+
+        return builder == null ? ImmutableArray<FunctionSymbol>.Empty : builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// ADR-0063 §1: compares two function symbols for overload-identity equality —
+    /// member name, callable parameter count, each parameter's type, and each
+    /// parameter's ref-kind. Return type, parameter names, accessibility, and
+    /// default values are deliberately not part of identity.
+    /// </summary>
+    /// <param name="a">First function symbol.</param>
+    /// <param name="b">Second function symbol.</param>
+    /// <returns>Whether the two functions share an overload signature.</returns>
+    public static bool FunctionSignaturesEqual(FunctionSymbol a, FunctionSymbol b)
+    {
+        if (a == null || b == null)
+        {
+            return false;
+        }
+
+        if (!string.Equals(a.Name, b.Name, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var ap = SigCallableParameters(a);
+        var bp = SigCallableParameters(b);
+        if (ap.Length != bp.Length)
+        {
+            return false;
+        }
+
+        var aTypeParams = a.TypeParameters.IsDefault ? 0 : a.TypeParameters.Length;
+        var bTypeParams = b.TypeParameters.IsDefault ? 0 : b.TypeParameters.Length;
+        if (aTypeParams != bTypeParams)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < ap.Length; i++)
+        {
+            if (ap[i].RefKind != bp[i].RefKind)
+            {
+                return false;
+            }
+
+            if (!SigTypesEquivalent(ap[i].Type, bp[i].Type, a, b))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /// <summary>
     /// Tries to declare an extension function (Phase 3.B.6 / ADR-0019). Extension
@@ -278,11 +400,25 @@ public sealed class BoundScope
         => GetDeclaredSymbols<VariableSymbol>();
 
     /// <summary>
-    /// Gets an immutable array of all the declared functions.
+    /// Gets an immutable array of all the declared functions, including every
+    /// overload registered via <see cref="TryDeclareFunction"/> (ADR-0063 §11).
     /// </summary>
-    /// <returns>The declared functions.</returns>
+    /// <returns>The declared functions in declaration order.</returns>
     public ImmutableArray<FunctionSymbol> GetDeclaredFunctions()
-        => GetDeclaredSymbols<FunctionSymbol>();
+    {
+        if (functions == null || functions.Count == 0)
+        {
+            return ImmutableArray<FunctionSymbol>.Empty;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<FunctionSymbol>();
+        foreach (var bucket in functions.Values)
+        {
+            builder.AddRange(bucket);
+        }
+
+        return builder.ToImmutable();
+    }
 
     /// <summary>
     /// Gets an immutable array of all the declared imports.
@@ -377,6 +513,49 @@ public sealed class BoundScope
         => typeAliases == null
             ? ImmutableArray<DelegateTypeSymbol>.Empty
             : typeAliases.Values.OfType<DelegateTypeSymbol>().ToImmutableArray();
+
+    private static ImmutableArray<ParameterSymbol> SigCallableParameters(FunctionSymbol f)
+        => f.ExplicitReceiverParameter == null ? f.Parameters : f.Parameters.RemoveAt(0);
+
+    private static bool SigTypesEquivalent(TypeSymbol x, TypeSymbol y, FunctionSymbol fx, FunctionSymbol fy)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
+        if (x == null || y == null)
+        {
+            return false;
+        }
+
+        if (x is TypeParameterSymbol xtp && y is TypeParameterSymbol ytp)
+        {
+            var xi = SigIndexOfTypeParameter(fx, xtp);
+            var yi = SigIndexOfTypeParameter(fy, ytp);
+            return xi >= 0 && xi == yi;
+        }
+
+        return x.Name == y.Name;
+    }
+
+    private static int SigIndexOfTypeParameter(FunctionSymbol f, TypeParameterSymbol tp)
+    {
+        if (f.TypeParameters.IsDefault)
+        {
+            return -1;
+        }
+
+        for (var i = 0; i < f.TypeParameters.Length; i++)
+        {
+            if (ReferenceEquals(f.TypeParameters[i], tp))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
 
     private bool TryDeclareSymbol<TSymbol>(TSymbol symbol)
         where TSymbol : Symbol

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1308,7 +1308,7 @@ public abstract class BoundTreeRewriter
             }
         }
 
-        return builder == null ? node : new BoundConstructorCallExpression(null, node.StructType, builder.ToImmutable());
+        return builder == null ? node : new BoundConstructorCallExpression(null, node.StructType, builder.ToImmutable(), node.SelectedConstructor);
     }
 
     /// <summary>Rewrites a CLR constructor call (Phase 4 exit).</summary>

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -2008,6 +2008,57 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0263", $"Conditional expression branches have no common result type — the true branch is '{trueType}' and the false branch is '{falseType}'. Add an explicit conversion to align the two arms.");
     }
 
+    /// <summary>
+    /// ADR-0063: reports a second user-defined callable declaration whose signature
+    /// (parameter types + ref-kinds, excluding defaults and return type) duplicates an
+    /// already-declared overload in the same declaration space.
+    /// </summary>
+    /// <param name="location">The location of the offending declaration.</param>
+    /// <param name="name">The callable name.</param>
+    /// <param name="signature">A short rendering of the duplicated signature.</param>
+    public void ReportDuplicateOverloadSignature(TextLocation location, string name, string signature)
+    {
+        Report(location, "GS0264", $"An overload of '{name}' with signature '{signature}' is already declared. Two overloads must differ by parameter types or ref-kinds.");
+    }
+
+    /// <summary>
+    /// ADR-0063 §3: reports an optional-parameter declaration that violates a v1
+    /// restriction (non-constant default, optional <c>ref</c>/<c>out</c>/<c>in</c>, optional
+    /// variadic, default on the receiver parameter, or unrepresentable constant for
+    /// the parameter type).
+    /// </summary>
+    /// <param name="location">The location of the offending parameter clause.</param>
+    /// <param name="parameterName">The parameter's source name.</param>
+    /// <param name="reason">A short, user-visible reason for the rejection.</param>
+    public void ReportInvalidOptionalParameter(TextLocation location, string parameterName, string reason)
+    {
+        Report(location, "GS0265", $"Optional parameter '{parameterName}' is invalid: {reason}");
+    }
+
+    /// <summary>
+    /// ADR-0063 §6: reports a call whose argument list matches more than one applicable
+    /// overload after generic inference, conversion, optional-parameter ranking, and the
+    /// "fewest expanded defaults" tie-break.
+    /// </summary>
+    /// <param name="location">The call-site location.</param>
+    /// <param name="name">The callable name.</param>
+    public void ReportAmbiguousOverloadResolution(TextLocation location, string name)
+    {
+        Report(location, "GS0266", $"Call to '{name}' is ambiguous between multiple overloads. Disambiguate with explicit types or named arguments.");
+    }
+
+    /// <summary>
+    /// ADR-0063 §6: reports a call to a name that resolves to an overload set, but
+    /// no overload is applicable to the given argument list (after applying defaults
+    /// and named-argument reordering).
+    /// </summary>
+    /// <param name="location">The call-site location.</param>
+    /// <param name="name">The callable name.</param>
+    public void ReportNoApplicableOverload(TextLocation location, string name)
+    {
+        Report(location, "GS0267", $"No overload of '{name}' is applicable to the given argument list.");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Documentation/DocumentationFileEmitter.cs
+++ b/src/Core/CodeAnalysis/Documentation/DocumentationFileEmitter.cs
@@ -114,7 +114,7 @@ internal static class DocumentationFileEmitter
                 AddIfDocumented(members, method);
             }
 
-            if (type.ExplicitConstructor is { } constructor)
+            foreach (var constructor in type.ExplicitConstructors)
             {
                 AddIfDocumented(members, constructor.Function);
             }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -7338,6 +7338,13 @@ internal sealed class ReflectionMetadataEmitter
                 paramAttributes |= ParameterAttributes.In;
             }
 
+            // ADR-0063 §10: optional parameters with a compile-time constant
+            // default get the Optional+HasDefault flags plus a Constant row.
+            if (p.HasExplicitDefaultValue)
+            {
+                paramAttributes |= ParameterAttributes.Optional | ParameterAttributes.HasDefault;
+            }
+
             var paramHandle = this.metadata.AddParameter(
                 attributes: paramAttributes,
                 name: this.metadata.GetOrAddString(p.Name ?? string.Empty),
@@ -7346,6 +7353,12 @@ internal sealed class ReflectionMetadataEmitter
             if (p.RefKind == RefKind.In)
             {
                 this.EmitIsReadOnlyAttributeOnParameter(paramHandle);
+            }
+
+            // ADR-0063 §10: emit the Constant row carrying the default value.
+            if (p.HasExplicitDefaultValue)
+            {
+                this.metadata.AddConstant(paramHandle, p.ExplicitDefaultValue);
             }
 
             paramHandles.Add((p, paramHandle));

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -85,6 +85,11 @@ internal sealed class ReflectionMetadataEmitter
     private readonly Dictionary<StructSymbol, MethodDefinitionHandle> classCtorHandles = new Dictionary<StructSymbol, MethodDefinitionHandle>();
     private readonly Dictionary<StructSymbol, MethodDefinitionHandle> classPrimaryCtorHandles = new Dictionary<StructSymbol, MethodDefinitionHandle>();
 
+    // ADR-0063 §9: when a class declares multiple init(...) overloads, each
+    // ConstructorSymbol gets its own MethodDef. The first overload doubles as
+    // the entry in classCtorHandles for legacy lookups.
+    private readonly Dictionary<ConstructorSymbol, MethodDefinitionHandle> explicitCtorHandles = new Dictionary<ConstructorSymbol, MethodDefinitionHandle>();
+
     // Issue #262: .cctor (type initializer) handles for types with static field initializers.
     private readonly Dictionary<StructSymbol, MethodDefinitionHandle> cctorHandles = new Dictionary<StructSymbol, MethodDefinitionHandle>();
 
@@ -1261,12 +1266,24 @@ internal sealed class ReflectionMetadataEmitter
         {
             if (c.ExplicitConstructor != null)
             {
-                // Issue #306: a class with an explicit `init(...)` constructor
-                // emits exactly one `.ctor` (the user constructor). It serves as
-                // both the base-chain target and the `newobj` target.
-                var explicitHandle = this.EmitClassConstructorWithBody(c);
-                this.classCtorHandles[c] = explicitHandle;
-                this.classPrimaryCtorHandles[c] = explicitHandle;
+                // Issue #306 / ADR-0063 §9: a class with explicit `init(...)`
+                // constructors emits one `.ctor` per declared overload. The first
+                // overload also serves as the legacy classCtor/primaryCtor handle.
+                MethodDefinitionHandle firstHandle = default;
+                var firstAssigned = false;
+                foreach (var explicitCtor in c.ExplicitConstructors)
+                {
+                    var ctorHandle = this.EmitClassConstructorWithBody(c, explicitCtor);
+                    this.explicitCtorHandles[explicitCtor] = ctorHandle;
+                    if (!firstAssigned)
+                    {
+                        firstHandle = ctorHandle;
+                        firstAssigned = true;
+                    }
+                }
+
+                this.classCtorHandles[c] = firstHandle;
+                this.classPrimaryCtorHandles[c] = firstHandle;
             }
             else if (c.BaseConstructorInitializer != null)
             {
@@ -5592,9 +5609,10 @@ internal sealed class ReflectionMetadataEmitter
     /// fields (as bare names).
     /// </summary>
     /// <param name="classSym">The class whose explicit constructor is being emitted.</param>
-    private MethodDefinitionHandle EmitClassConstructorWithBody(StructSymbol classSym)
+    /// <param name="ctor">The specific explicit ctor overload to emit. When <see langword="null"/> the legacy single-ctor entry on the class is used.</param>
+    private MethodDefinitionHandle EmitClassConstructorWithBody(StructSymbol classSym, ConstructorSymbol ctor = null)
     {
-        var ctor = classSym.ExplicitConstructor;
+        ctor ??= classSym.ExplicitConstructor;
         var function = ctor.Function;
         var body = this.program.Functions[function];
         var init = ctor.BaseInitializer;
@@ -14215,7 +14233,15 @@ internal sealed class ReflectionMetadataEmitter
 
         private void EmitConstructorCall(BoundConstructorCallExpression call)
         {
-            if (!this.outer.classPrimaryCtorHandles.TryGetValue(call.StructType, out var ctorHandle))
+            MethodDefinitionHandle ctorHandle;
+            if (call.SelectedConstructor != null
+                && this.outer.explicitCtorHandles.TryGetValue(call.SelectedConstructor, out var selectedHandle))
+            {
+                // ADR-0063 §9: bind-time overload resolution picked this exact
+                // ctor; emit a newobj against its specific MethodDef.
+                ctorHandle = selectedHandle;
+            }
+            else if (!this.outer.classPrimaryCtorHandles.TryGetValue(call.StructType, out ctorHandle))
             {
                 throw new InvalidOperationException(
                     $"Type '{call.StructType.Name}' has no emitted primary ctor.");

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -1083,7 +1083,10 @@ public sealed class Evaluator
         // its bound body with `this`, the constructor parameters, and the class
         // fields in scope. The base initializer (when GSharp) is forwarded first,
         // mirroring `ldarg.0; <base args>; call base..ctor` in the emitter.
-        if (node.StructType.ExplicitConstructor is ConstructorSymbol explicitCtor)
+        // ADR-0063 §9: when call-site overload resolution selected a specific
+        // ctor overload, use it; otherwise fall back to the legacy single-ctor.
+        var explicitCtor = node.SelectedConstructor ?? node.StructType.ExplicitConstructor;
+        if (explicitCtor != null)
         {
             var ctorFunction = explicitCtor.Function;
             var frame = new Dictionary<VariableSymbol, object>

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -131,6 +131,30 @@ public sealed class InterfaceSymbol : TypeSymbol
     }
 
     /// <summary>
+    /// ADR-0063: returns every interface method whose name equals <paramref name="name"/> (the overload set).
+    /// </summary>
+    /// <param name="name">The method name.</param>
+    /// <returns>The overload set; empty if none.</returns>
+    public ImmutableArray<FunctionSymbol> GetMethods(string name)
+    {
+        if (Methods.IsDefaultOrEmpty)
+        {
+            return ImmutableArray<FunctionSymbol>.Empty;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<FunctionSymbol>();
+        foreach (var m in Methods)
+        {
+            if (m.Name == name)
+            {
+                builder.Add(m);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
     /// Constructs a closed instance of a generic interface definition with the supplied type arguments
     /// (Phase 4.3c / ADR-0020). Method signatures are substituted; identity is cached so two calls with
     /// the same definition + arguments return the same <see cref="InterfaceSymbol"/> reference.
@@ -183,7 +207,15 @@ public sealed class InterfaceSymbol : TypeSymbol
             var substParams = ImmutableArray.CreateBuilder<ParameterSymbol>(m.Parameters.Length);
             foreach (var p in m.Parameters)
             {
-                substParams.Add(new ParameterSymbol(p.Name, SubstituteType(p.Type, subst), isVariadic: p.IsVariadic, isScoped: p.IsScoped));
+                var newParam = new ParameterSymbol(p.Name, SubstituteType(p.Type, subst), isVariadic: p.IsVariadic, isScoped: p.IsScoped, refKind: p.RefKind);
+
+                // ADR-0063: propagate explicit default values across generic substitution.
+                if (p.HasExplicitDefaultValue)
+                {
+                    newParam.SetExplicitDefaultValue(p.ExplicitDefaultValue);
+                }
+
+                substParams.Add(newParam);
             }
 
             var substReturn = SubstituteType(m.Type, subst);

--- a/src/Core/CodeAnalysis/Symbols/ParameterSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ParameterSymbol.cs
@@ -60,4 +60,32 @@ public sealed class ParameterSymbol : LocalVariableSymbol
     /// Gets or sets the ADR-0060 by-reference passing mode of this parameter (<c>None</c>, <c>Ref</c>, <c>Out</c>, or <c>In</c>).
     /// </summary>
     public override RefKind RefKind { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this parameter declares an explicit default value (ADR-0063).
+    /// When <see langword="true"/>, callers may omit a corresponding argument and the binder
+    /// substitutes <see cref="ExplicitDefaultValue"/> at the call site.
+    /// </summary>
+    public bool HasExplicitDefaultValue { get; private set; }
+
+    /// <summary>
+    /// Gets the constant default value declared on this parameter (ADR-0063).
+    /// Only meaningful when <see cref="HasExplicitDefaultValue"/> is <see langword="true"/>.
+    /// Value kinds: numeric primitive, <see cref="bool"/>, <see cref="char"/>,
+    /// <see cref="string"/>, enum constant (carried as its underlying integral value),
+    /// or <see langword="null"/> for a nullable/reference parameter.
+    /// </summary>
+    public object ExplicitDefaultValue { get; private set; }
+
+    /// <summary>
+    /// Records the constant default value for this parameter (ADR-0063). Called exactly
+    /// once by the binder when the parameter syntax includes a <c>= constant</c> clause
+    /// and the constant has passed all ADR-0063 §3 restrictions.
+    /// </summary>
+    /// <param name="value">The encoded constant default. May be <see langword="null"/> to represent the source-level <c>nil</c> default.</param>
+    public void SetExplicitDefaultValue(object value)
+    {
+        HasExplicitDefaultValue = true;
+        ExplicitDefaultValue = value;
+    }
 }

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -262,7 +262,21 @@ public sealed class StructSymbol : TypeSymbol
     /// the emitter materializes exactly one <c>.ctor</c> (this constructor) and
     /// suppresses the auto-generated parameterless / primary constructor.
     /// </summary>
+    /// <remarks>
+    /// ADR-0063: when the class declares an overload family of <c>init(...)</c>
+    /// constructors, <see cref="ExplicitConstructor"/> still surfaces the
+    /// <em>first</em> declaration so single-constructor callers keep working;
+    /// the full overload set lives on <see cref="ExplicitConstructors"/>.
+    /// </remarks>
     public ConstructorSymbol ExplicitConstructor { get; private set; }
+
+    /// <summary>
+    /// Gets every user-defined <c>init(...)</c> constructor declared on
+    /// this class in declaration order (ADR-0063). Empty when the class has no
+    /// explicit constructor declarations. The first element always equals
+    /// <see cref="ExplicitConstructor"/>.
+    /// </summary>
+    public ImmutableArray<ConstructorSymbol> ExplicitConstructors { get; private set; } = ImmutableArray<ConstructorSymbol>.Empty;
 
     /// <summary>Sets <see cref="ImportedBaseType"/> after binding (issue #296). Intended to be called exactly once by the binder for a class inheriting an imported CLR base.</summary>
     /// <param name="importedBaseType">The imported CLR base type symbol.</param>
@@ -283,6 +297,22 @@ public sealed class StructSymbol : TypeSymbol
     public void SetExplicitConstructor(ConstructorSymbol constructor)
     {
         ExplicitConstructor = constructor;
+        ExplicitConstructors = constructor == null
+            ? ImmutableArray<ConstructorSymbol>.Empty
+            : ImmutableArray.Create(constructor);
+    }
+
+    /// <summary>
+    /// ADR-0063: sets <see cref="ExplicitConstructors"/> (and surfaces the first
+    /// declaration as the legacy <see cref="ExplicitConstructor"/>). Intended to
+    /// be called exactly once by the binder for a class that declares one or
+    /// more <c>init(...)</c> constructors.
+    /// </summary>
+    /// <param name="constructors">The resolved standalone constructors in declaration order.</param>
+    public void SetExplicitConstructors(ImmutableArray<ConstructorSymbol> constructors)
+    {
+        ExplicitConstructors = constructors.IsDefault ? ImmutableArray<ConstructorSymbol>.Empty : constructors;
+        ExplicitConstructor = ExplicitConstructors.Length == 0 ? null : ExplicitConstructors[0];
     }
 
     /// <summary>Sets <see cref="Interfaces"/> after binding. Intended to be called exactly once by the binder during <c>BindStructDeclaration</c>.</summary>
@@ -502,6 +532,60 @@ public sealed class StructSymbol : TypeSymbol
         }
 
         return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// ADR-0063: returns every method named <paramref name="name"/> visible on this
+    /// class, walking the inheritance chain this-first. Derived methods that share
+    /// a signature with a base method (i.e. real overrides) hide the base entry so
+    /// the overload set surfaced to overload resolution contains exactly one
+    /// FunctionSymbol per visible signature.
+    /// </summary>
+    /// <param name="name">The method name.</param>
+    /// <returns>The merged overload set; empty if none found.</returns>
+    public System.Collections.Immutable.ImmutableArray<FunctionSymbol> GetMethodsIncludingInherited(string name)
+    {
+        System.Collections.Immutable.ImmutableArray<FunctionSymbol>.Builder builder = null;
+        for (var c = this; c != null; c = c.BaseClass)
+        {
+            if (c.Methods.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            foreach (var m in c.Methods)
+            {
+                if (m.Name != name)
+                {
+                    continue;
+                }
+
+                if (builder != null)
+                {
+                    var hiddenByDerived = false;
+                    foreach (var existing in builder)
+                    {
+                        if (BoundScope.FunctionSignaturesEqual(existing, m))
+                        {
+                            hiddenByDerived = true;
+                            break;
+                        }
+                    }
+
+                    if (hiddenByDerived)
+                    {
+                        continue;
+                    }
+                }
+
+                builder ??= System.Collections.Immutable.ImmutableArray.CreateBuilder<FunctionSymbol>();
+                builder.Add(m);
+            }
+        }
+
+        return builder == null
+            ? System.Collections.Immutable.ImmutableArray<FunctionSymbol>.Empty
+            : builder.ToImmutable();
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -480,6 +480,54 @@ public sealed class StructSymbol : TypeSymbol
         return false;
     }
 
+    /// <summary>
+    /// ADR-0063: returns every instance method whose name equals <paramref name="name"/> (the overload set).
+    /// </summary>
+    /// <param name="name">The method name.</param>
+    /// <returns>The overload set; empty if none.</returns>
+    public System.Collections.Immutable.ImmutableArray<FunctionSymbol> GetMethods(string name)
+    {
+        if (Methods.IsDefaultOrEmpty)
+        {
+            return System.Collections.Immutable.ImmutableArray<FunctionSymbol>.Empty;
+        }
+
+        var builder = System.Collections.Immutable.ImmutableArray.CreateBuilder<FunctionSymbol>();
+        foreach (var m in Methods)
+        {
+            if (m.Name == name)
+            {
+                builder.Add(m);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// ADR-0063: returns every shared/static method whose name equals <paramref name="name"/> (the overload set).
+    /// </summary>
+    /// <param name="name">The method name.</param>
+    /// <returns>The overload set; empty if none.</returns>
+    public System.Collections.Immutable.ImmutableArray<FunctionSymbol> GetStaticMethods(string name)
+    {
+        if (StaticMethods.IsDefaultOrEmpty)
+        {
+            return System.Collections.Immutable.ImmutableArray<FunctionSymbol>.Empty;
+        }
+
+        var builder = System.Collections.Immutable.ImmutableArray.CreateBuilder<FunctionSymbol>();
+        foreach (var m in StaticMethods)
+        {
+            if (m.Name == name)
+            {
+                builder.Add(m);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
     /// <summary>Tries to find a field by name.</summary>
     /// <param name="name">The field name.</param>
     /// <param name="field">The found field on success.</param>

--- a/src/Core/CodeAnalysis/Syntax/ParameterSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/ParameterSyntax.cs
@@ -85,6 +85,23 @@ public sealed class ParameterSyntax : SyntaxNode
     /// <summary>Gets a value indicating whether this parameter carries a <c>ref</c>/<c>out</c>/<c>in</c> modifier (ADR-0060).</summary>
     public bool HasRefKindModifier => RefKindModifier != null;
 
+    /// <summary>
+    /// Gets or sets the ADR-0063 <c>=</c> token preceding the default-value expression.
+    /// When non-null the parameter declares a default value, making it optional at call sites.
+    /// </summary>
+    public SyntaxToken EqualsToken { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ADR-0063 default-value expression for an optional parameter.
+    /// Restricted by the binder to a compile-time constant representable in CLR
+    /// parameter metadata (numeric/bool/char/string/enum constant, or <c>nil</c>
+    /// for a nullable/reference type).
+    /// </summary>
+    public ExpressionSyntax DefaultValue { get; set; }
+
+    /// <summary>Gets a value indicating whether this parameter declares a default value (ADR-0063).</summary>
+    public bool HasDefaultValue => EqualsToken != null && DefaultValue != null;
+
     /// <summary>Attaches the given annotation list to this parameter and returns this same instance for fluent parser use.</summary>
     /// <param name="annotations">The annotation list to attach (may be empty).</param>
     /// <returns>This same <see cref="ParameterSyntax"/>, with <see cref="Annotations"/> updated.</returns>

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -1769,9 +1769,23 @@ public class Parser
         }
 
         var type = ParseTypeClause();
+
+        // ADR-0063: optional default-value clause. Parsed as a general expression here;
+        // the binder enforces the "compile-time constant representable in CLR parameter
+        // metadata" rule and emits diagnostics on misuse.
+        SyntaxToken equalsToken = null;
+        ExpressionSyntax defaultValue = null;
+        if (Current.Kind == SyntaxKind.EqualsToken)
+        {
+            equalsToken = NextToken();
+            defaultValue = ParseExpression();
+        }
+
         var parameter = new ParameterSyntax(syntaxTree, identifier, ellipsis, type).WithAnnotations(annotations);
         parameter.ScopedModifier = scopedModifier;
         parameter.RefKindModifier = refKindModifier;
+        parameter.EqualsToken = equalsToken;
+        parameter.DefaultValue = defaultValue;
         return parameter;
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
@@ -634,24 +634,26 @@ type Bad class(X int32) {
     }
 
     [Fact]
-    public void ExplicitConstructor_MultipleInit_Diagnoses()
+    public void ExplicitConstructor_MultipleInit_Selects_Overload()
     {
-        // Issue #306: GS0216 — only a single explicit `init` constructor is
-        // supported today.
+        // ADR-0063 §9: multiple `init(...)` overloads are now supported. The
+        // call site selects the best match by argument arity/type.
         var source = @"
-type Bad class {
+type Bag class {
     X int32
     init(a int32) {
         X = a
     }
     init(a int32, b int32) {
-        X = a
+        X = a + b
     }
 }
-0
+var b = Bag(2, 3)
+b.X
 ";
         var result = Evaluate(source);
-        Assert.Contains(result.Diagnostics, d => d.Message.Contains("multiple 'init' constructors"));
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
     }
 
     private static EvaluationResult Evaluate(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/MethodWithReceiverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/MethodWithReceiverTests.cs
@@ -113,7 +113,11 @@ type Point class {
 func (p Point) Sum() int32 { return 2 }
 ";
         var result = Evaluate(source);
-        Assert.Contains(result.Diagnostics, d => d.Message.Contains("'Sum' is already declared."));
+
+        // ADR-0063: two `Sum()` methods on Point share the same signature, so the
+        // duplicate-overload diagnostic fires instead of the older
+        // "symbol already declared" one.
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("'Sum'") && (d.Message.Contains("already declared") || d.Message.Contains("overload")));
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadAndOptionalParameterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadAndOptionalParameterTests.cs
@@ -147,6 +147,103 @@ type IOps interface {
         Assert.Empty(result.Diagnostics);
     }
 
+    [Fact]
+    public void InstanceMethod_OverloadResolution_PicksByArity()
+    {
+        // ADR-0063 §9: instance-method overload resolution at call sites now
+        // chooses by arity/type rather than first-by-name.
+        var source = @"
+type Calc class(seed int32) {
+    func add(x int32) int32 { return x + seed }
+    func add(x int32, y int32) int32 { return x + y + seed }
+}
+let c = Calc(1)
+c.add(10)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(11, result.Value);
+    }
+
+    [Fact]
+    public void InstanceMethod_OverloadResolution_PicksTwoArg()
+    {
+        var source = @"
+type Calc class(seed int32) {
+    func add(x int32) int32 { return x + seed }
+    func add(x int32, y int32) int32 { return x + y + seed }
+}
+let c = Calc(0)
+c.add(7, 8)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(15, result.Value);
+    }
+
+    [Fact]
+    public void PrimaryConstructor_OptionalParameter_OmitsTrailing()
+    {
+        // ADR-0063 §5: primary constructors honor optional parameters.
+        var source = @"
+type P class(X int32, Y int32 = 5) {}
+let p = P(1)
+p.Y
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void MultipleInitConstructors_SelectsByArgCount()
+    {
+        // ADR-0063 §9: multiple init(...) overloads, overload-resolved at call site.
+        var source = @"
+type Box class {
+    X int32
+    init(a int32) { X = a }
+    init(a int32, b int32) { X = a * b }
+}
+let b = Box(3, 4)
+b.X
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(12, result.Value);
+    }
+
+    [Fact]
+    public void MultipleInitConstructors_DuplicateSignature_Diagnoses()
+    {
+        var source = @"
+type Box class {
+    X int32
+    init(a int32) { X = a }
+    init(a int32) { X = a + 1 }
+}
+";
+        var result = Evaluate(source);
+        AssertHasDiagnosticId(result.Diagnostics, "GS0264");
+    }
+
+    [Fact]
+    public void MethodGroup_OverloadResolution_PicksByDelegateSignature()
+    {
+        // ADR-0063 §9: a method-group reference whose name has multiple
+        // overloads resolves against the target delegate signature.
+        var source = @"
+func op(x int32) int32 { return x + 1 }
+func op(x int32, y int32) int32 { return x + y }
+
+let f func(int32) int32 = op
+f(10)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(11, result.Value);
+    }
+
     private static void AssertHasDiagnosticId(ImmutableArray<Diagnostic> diagnostics, string id)
     {
         Assert.Contains(diagnostics, d => d.Id == id);

--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadAndOptionalParameterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadAndOptionalParameterTests.cs
@@ -1,0 +1,161 @@
+// <copyright file="OverloadAndOptionalParameterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0063: tests for user-defined method overloading and optional parameters
+/// with compile-time-constant defaults. Covers free-function overload sets,
+/// duplicate-signature rejection (GS0264), invalid-default diagnostics (GS0265),
+/// ambiguous-resolution (GS0266), no-applicable-overload (GS0267), and the
+/// happy-path "omit trailing optional" + "omit middle optional via named arg"
+/// patterns from §3 / §6 of the ADR.
+/// </summary>
+public class OverloadAndOptionalParameterTests
+{
+    [Fact]
+    public void TopLevelFunctions_DistinctArity_BothBindOK()
+    {
+        var source = @"
+func choose(x int32) int32 { return x }
+func choose(x int32, y int32) int32 { return x + y }
+
+let a = choose(7)
+let b = choose(3, 4)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void TopLevelFunctions_DuplicateSignature_DiagnosesGS0264()
+    {
+        var source = @"
+func dup(x int32) int32 { return x }
+func dup(x int32) int32 { return x + 1 }
+";
+        var result = Evaluate(source);
+        AssertHasDiagnosticId(result.Diagnostics, "GS0264");
+    }
+
+    [Fact]
+    public void OptionalParameter_TrailingOmitted_UsesDefault()
+    {
+        var source = @"
+func greet(prefix string, count int32 = 2) int32 {
+    return count
+}
+
+let n = greet(""hi"")
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(2, result.Value);
+    }
+
+    [Fact]
+    public void OptionalParameter_NamedOmission_MiddleSlotUsesDefault()
+    {
+        var source = @"
+func three(a int32, b int32 = 10, c int32 = 100) int32 {
+    return a + b + c
+}
+
+let n = three(1, c: 1000)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1011, result.Value);
+    }
+
+    [Fact]
+    public void OptionalParameter_OnRefKind_DiagnosesGS0265()
+    {
+        var source = @"
+func f(ref x int32 = 0) int32 { return x }
+";
+        var result = Evaluate(source);
+        AssertHasDiagnosticId(result.Diagnostics, "GS0265");
+    }
+
+    [Fact]
+    public void OptionalParameter_OnVariadic_DiagnosesGS0265()
+    {
+        var source = @"
+func f(xs ...int32 = 0) int32 { return 0 }
+";
+        var result = Evaluate(source);
+        AssertHasDiagnosticId(result.Diagnostics, "GS0265");
+    }
+
+    [Fact]
+    public void OptionalParameter_NonConstantDefault_DiagnosesGS0265()
+    {
+        var source = @"
+func f(x int32 = 1 + 2) int32 { return x }
+";
+        var result = Evaluate(source);
+        AssertHasDiagnosticId(result.Diagnostics, "GS0265");
+    }
+
+    [Fact]
+    public void ClassMethods_DistinctSignatures_BothBindOK()
+    {
+        var source = @"
+type Calc class {
+    func add(x int32) int32 { return x }
+    func add(x int32, y int32) int32 { return x + y }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ClassMethods_DuplicateSignature_DiagnosesGS0264()
+    {
+        var source = @"
+type Calc class {
+    func sum(x int32) int32 { return x }
+    func sum(x int32) int32 { return x + 1 }
+}
+";
+        var result = Evaluate(source);
+        AssertHasDiagnosticId(result.Diagnostics, "GS0264");
+    }
+
+    [Fact]
+    public void InterfaceMethods_DistinctSignatures_BothBindOK()
+    {
+        var source = @"
+type IOps interface {
+    func op(x int32) int32
+    func op(x int32, y int32) int32
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static void AssertHasDiagnosticId(ImmutableArray<Diagnostic> diagnostics, string id)
+    {
+        Assert.Contains(diagnostics, d => d.Id == id);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Implements [ADR-0063](docs/adr/0063-method-overloading-and-optional-parameters.md): user-defined method overloading and optional parameters with compile-time-constant defaults.

## What changed

### Syntax & symbols
- `ParameterSyntax` carries a new optional `= <expr>` default-value slot.
- `Parser.ParseParameter` consumes the new clause.
- `ParameterSymbol` exposes `HasExplicitDefaultValue` / `ExplicitDefaultValue` / `SetExplicitDefaultValue`.
- `StructSymbol` and `InterfaceSymbol` expose `GetMethods(name)` / `GetStaticMethods(name)` / `GetMethodsIncludingInherited(name)` overload-set queries; existing `TryGetMethod(name)` kept for back-compat.
- `InterfaceSymbol.Construct` propagates parameter defaults through generic substitution.

### Scope & overload bookkeeping
- `BoundScope` now stores an overload-list per name and exposes `TryLookupFunctions(name)` plus a public `FunctionSignaturesEqual(a, b)` helper (signature = name + arity + parameter types + ref-kinds + generic-arity; ignores return type, names, defaults).
- `TryDeclareFunction` rejects duplicate signatures but accepts distinct ones.

### Binder
- Default-value expressions are bound and validated at every method/function/interface/ctor/primary-ctor/lambda/delegate parameter site; `BindAndAttachParameterDefaultValue` + `TryExtractConstantDefault` enforce the CLR-Constant-table representability rule.
- Class methods, shared methods, interface methods, and receiver-clause methods now use `FunctionSignaturesEqual` for duplicate detection instead of name-only.
- `BindCallExpression` (free-function call path) performs best-overload selection across `TryLookupFunctions`, relaxes the argument-count gate to `[required, total]`, and fills omitted optional slots with synthesized default-value `BoundLiteralExpression` / `BoundDefaultExpression` arguments.
- Instance-call sites (`BindUserInstanceCall`) perform overload selection via `SelectBestInstanceOverload`.
- Constructor call sites (`BindExplicitConstructorCallExpression`) perform overload selection and support optional-parameter omission.
- `TryReorderUserCallArguments` gained an `isOptionalAt` overload that leaves omitted optional slots empty for callers to fill.
- Method-group → delegate conversion: `BoundMethodGroupExpression` carries the full `Candidates` set; `BindConversion` resolves against target delegate/function-type signature.
- Override-by-signature matching: `StructSymbol.GetMethodsIncludingInherited` walks base chain with signature-based override dedupe.

### Emission
- `ReflectionMetadataEmitter.EmitFunction` stamps `ParameterAttributes.Optional | HasDefault` and emits a `Constant` row for each optional parameter, making the defaults visible to C# / IL tooling.
- Multiple `init(...)` constructors per class emit distinct MethodDef rows.

### Diagnostics
- `GS0264` duplicate overload signature
- `GS0265` invalid optional parameter (receiver / ref-kind / variadic / non-constant default)
- `GS0266` ambiguous overload resolution
- `GS0267` no applicable overload

### Tests
`OverloadAndOptionalParameterTests` covers:
- distinct-arity top-level overloads
- duplicate-signature (`GS0264`)
- trailing optional default
- sparse named omission of middle optional
- ref-kind / variadic / non-constant default (`GS0265`)
- class-method overload set acceptance
- duplicate class-method signature (`GS0264`)
- interface overload set acceptance
- instance-method overload selection
- primary-constructor optional-parameter omission
- multiple explicit `init(...)` constructor overload selection
- method-group overload resolution

One existing test (`TopLevelMethod_CollidingWithInBodyMethod_Diagnoses`) was updated to reflect the more informative GS0264 message.

## Validation

- `dotnet build GSharp.sln -nologo -clp:NoSummary` — clean
- `dotnet test GSharp.sln --no-restore --nologo` — **2,566 tests pass, 0 failed**

## Implementation status

All planned ADR-0063 features are implemented across three commits:
1. Core infrastructure (9a847e5)
2. Instance/constructor overload selection, override-by-signature, multi-init constructors (487de92)
3. Method-group overload resolution, optional params on additional surfaces (f4a85d2)

No deferred work remains. Property accessors and indexers were deemed N/A (they have no user-declared parameter list that admits defaults in G#).
