### PR TITLE
docs/website/vscode: refresh for ADR-0029, 0055–0063 and tooling updates

### DIFF
--- a/docs/adr/0060-ref-out-in-parameters.md
+++ b/docs/adr/0060-ref-out-in-parameters.md
@@ -1,7 +1,8 @@
 # ADR-0060: `ref`, `out`, and `in` parameters — call-site modifiers and method-definition syntax
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-06-05
+- **Implemented**: 2026-06-05 (PR [#489](https://github.com/DavidObando/gsharp/pull/489))
 - **Phase**: Phase 8 — language ergonomics / CLR-interop surface
 - **Related**: issue #341 (`out` parameters at call sites), issue #342 (`ref` / `in` parameters at call sites); ADR-0039 (managed by-ref pointers `&`/`*` / `ByRefTypeSymbol`), ADR-0034 (imported CLR interop), ADR-0038 (generic method inference), ADR-0058 (ref-safe-to-escape), ADR-0017 (method virtuality), ADR-0018 (interface defaults), ADR-0021 (generic variance — established `in`/`out` as contextual keywords)
 

--- a/docs/adr/0061-conditional-ref-arguments.md
+++ b/docs/adr/0061-conditional-ref-arguments.md
@@ -1,7 +1,8 @@
 # ADR-0061: Conditional ref-arguments — `cond ? lvalue : lvalue` at ref-argument positions
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-06-05
+- **Implemented**: 2026-06-05 (PR [#495](https://github.com/DavidObando/gsharp/pull/495))
 - **Phase**: Phase 8 — language ergonomics / CLR-interop surface
 - **Related**: issue #492 (conditional ref-passing follow-up to ADR-0060); ADR-0060 (`ref`/`out`/`in` parameters), ADR-0058 (ref-safe-to-escape), ADR-0039 (managed by-ref pointers `&`/`*` / `ByRefTypeSymbol`), ADR-0062 (generalized ternary expression)
 

--- a/docs/adr/0062-generalized-ternary-expression.md
+++ b/docs/adr/0062-generalized-ternary-expression.md
@@ -1,7 +1,8 @@
 # ADR-0062: Generalized ternary expression — `cond ? ifTrue : ifFalse`
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-06-05
+- **Implemented**: 2026-06-05 (PR [#497](https://github.com/DavidObando/gsharp/pull/497))
 - **Phase**: Phase 8 — language ergonomics / expression surface
 - **Related**: issue #495 (limited ref-only ternary), ADR-0061 (conditional ref-arguments), ADR-0060 (`ref`/`out`/`in` parameters), ADR-0058 (ref-safe-to-escape), ADR-0037 (numeric tie-breaking)
 

--- a/docs/adr/0063-method-overloading-and-optional-parameters.md
+++ b/docs/adr/0063-method-overloading-and-optional-parameters.md
@@ -1,7 +1,8 @@
 # ADR-0063: Method overloading and optional parameters
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-06-06
+- **Implemented**: 2026-06-05 (PR [#498](https://github.com/DavidObando/gsharp/pull/498))
 - **Phase**: Phase 9 — language depth / call binding
 - **Related**: ADR-0034 (imported CLR interop); ADR-0037 (numeric tie-breaking); ADR-0038 (generic method inference); ADR-0017 (method virtuality); ADR-0019 (extension functions); ADR-0024 (methods vs. extensions canonical style); ADR-0060 (`ref`/`out`/`in` parameters)
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -173,7 +173,30 @@ ADR-0047 introduces Kotlin-style attribute syntax (`@Foo(...)`) and the `@Attrib
 | GS0204 | **Warning** (Error if `IsError=true`) | Reference to a symbol marked `[Obsolete]`. | Calling a function, instantiating a class (`Old(5)`), writing a struct literal (`Old{}`), naming a struct/class/interface/enum in a type clause, reading an obsolete parameter, reading/writing an obsolete `var`/`let`/`const`, reading an obsolete enum member (`Color.Red`), or reading/writing an obsolete struct/class field (`p.Old`) — all declared with `@Obsolete("use Bar")`. Severity is promoted to error when the attribute's second argument is `true`. |
 | GS0205 | Error | Attribute is reserved for compiler synthesis. | `@CompilerGenerated`, `@Extension`, `@AsyncStateMachine`, `@Nullable`, or `@NullableContext` written in user source. |
 | GS0206 | Error | Annotations are only allowed on variable declarations, not on this statement. | `@Obsolete\nreturn` inside a function body — annotations may precede `var`/`let`/`const` but no other statement kind. |
+| GS0207 | Error | Parameter `{name}` is annotated `@EnumeratorCancellation` but has type `{type}`; only `System.Threading.CancellationToken` parameters can carry this annotation. | `@EnumeratorCancellation` placed on a `string` parameter. |
+| GS0208 | Error | Parameter `{name}` is annotated `@EnumeratorCancellation` but its enclosing function is not an async sequence (does not return `IAsyncEnumerable[T]`). | `@EnumeratorCancellation` on a sync function or a non-sequence async function. |
+| GS0209 | Error | Attribute `{name}` is not valid on this position; its `[AttributeUsage]` permits only: `{targets}`. | Applying a `@field`-targeted attribute to a method. |
+| GS0210 | Error | Duplicate attribute `{name}`; this attribute type does not allow multiple applications (`AllowMultiple = false`). | Two `@Trace(...)` annotations on the same declaration. |
 | GS0211 | Error | Attribute `[DllImport]` is recognised but not supported in v1.0; P/Invoke (extern function bodies) is a post-v1.0 feature. | `@DllImport("user32.dll") func MessageBox() {}` — emit support and the `extern` body marker arrive after v1.0. |
+| GS0212 | Error | Function `{name}` is marked `@Conditional` but does not return `void`; conditional methods must return `void` because calls may be elided at the call site. | `@Conditional("DEBUG") func Probe() int32 { return 0 }`. |
+
+### Class / constructor diagnostics (GS0213–GS0217)
+
+Issue #306 covers user class constructor flow — explicit `init(...)` constructors, primary constructors, and `base(...)` initializers.
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0213 | Error | A base-constructor argument list requires an explicit base class. | `init() : base(1) { }` written on a class with no `: BaseType` clause. |
+| GS0214 | Error | Class `{base}` has no accessible constructor that takes `{N}` argument(s). | `init() : base(1, 2)` when the base only declares `init()`. |
+| GS0215 | Error | Class `{name}` cannot declare both a primary constructor and an explicit `init` constructor. | `type Customer class(id int32) { init(name string) { } }`. |
+| GS0216 | Error | Class `{name}` declares multiple `init` constructors; only a single explicit constructor is supported. | Two `init(...)` declarations in the same class body. |
+| GS0217 | Error | Generic class `{name}` with an explicit `init` constructor cannot be constructed; generic explicit constructors are not supported. | `type Box[T] class { init(x T) { } }` then `Box[int32](42)`. |
+
+### Delegate conversion diagnostics (GS0218)
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0218 | Error | Cannot convert method group `{name}` to `{type}`. No overload matches the target delegate signature. | `var a Action = SomeOverloaded` where no overload of `SomeOverloaded` has signature `() -> void`. |
 
 ### String interpolation diagnostics (GS0220–GS0225)
 
@@ -237,6 +260,7 @@ ADR-0056 §1/§2 makes spans indexable: a `Span[T]` / `ReadOnlySpan[T]` indexer 
 | GS9004 | Error | By-ref value cannot escape its declaration scope. | Returning a `*T` (managed-pointer) value from a function, capturing a `*T` local in a closure, hoisting a `*T` local into an `async`/iterator state machine, or using a `*T` return type in a function literal. Also raised when returning a `ref struct` parameter annotated as `scoped`. |
 | GS9005 | Error | Cannot take the address of a constant. | `&myConst` where `myConst` is declared `const`. |
 | GS9006 | Error | Pointer type cannot be a field type. | A struct or class field (including static `shared` fields and top-level globals) declared with a `*T` (managed-pointer) type. |
+| GS9007 | Error | A type may contain at most one `shared` block. | A class or struct with two `shared { ... }` blocks; merge them into one. |
 
 ### Reference closure diagnostics (GS9100)
 
@@ -258,10 +282,10 @@ These diagnostics indicate an internal compiler problem. If you encounter them, 
 | Code | Severity | Message |
 |------|----------|---------|
 | GS0227 | Warning | Documentation comment is not attached to a declaration. |
-| GS0228 | Warning | Missing documentation comment on public member '{name}'. (opt-in) |
-| GS0229 | Warning | Documentation @param '{name}' does not match any parameter of '{symbol}'. |
-| GS0230 | Warning | Unsupported documentation Markdown: {detail}. |
-| GS0231 | Warning | Unknown documentation tag '{tag}'. Valid tags are: @param, @typeparam, @returns, @remarks, @value, @exception, @seealso. |
+| GS0228 | Warning | Missing documentation comment on public member `{name}`. (opt-in) |
+| GS0229 | Warning | Documentation @param `{name}` does not match any parameter of `{symbol}`. |
+| GS0230 | Warning | Unsupported documentation Markdown: `{detail}`. |
+| GS0231 | Warning | Unknown documentation tag `{tag}`. Valid tags are: @param, @typeparam, @returns, @remarks, @value, @exception, @seealso. |
 
 ## Data struct diagnostics (GS0232)
 
@@ -269,7 +293,7 @@ ADR-0029 / Issue #410: every `data struct` synthesizes a fixed contract of value
 
 | Code | Severity | Message |
 |------|----------|---------|
-| GS0232 | Error | Data struct '{type}' synthesizes member '{member}'; it cannot be declared explicitly. |
+| GS0232 | Error | Data struct `{type}` synthesizes member `{member}`; it cannot be declared explicitly. |
 
 ## Named delegate type diagnostics (GS0233–GS0234)
 
@@ -278,7 +302,7 @@ ADR-0059 / Issue #255: `type Name = delegate func(...)` declares a real CLR `Mul
 | Code | Severity | Message |
 |------|----------|---------|
 | GS0233 | Error | Named delegate declaration requires 'func(...)' after 'delegate' (e.g. 'type Name = delegate func(sender Object, e EventArgs)'). |
-| GS0234 | Error | Generic delegate declaration '{name}' is not yet supported; declare a non-generic named delegate type (ADR-0059 follow-up). |
+| GS0234 | Error | Generic delegate declaration `{name}` is not yet supported; declare a non-generic named delegate type (ADR-0059 follow-up). |
 
 ## Ref-kind parameter diagnostics (GS0235–GS0243)
 
@@ -286,14 +310,14 @@ ADR-0060 introduces explicit `ref`, `out`, and `in` parameter passing modes at b
 
 | Code | Severity | Message |
 |------|----------|---------|
-| GS0235 | Error | Argument {index} (parameter '{name}') passes with ref-kind '{actual}' but the parameter is declared '{expected}'. |
+| GS0235 | Error | Argument `{index}` (parameter `{name}`) passes with ref-kind `{actual}` but the parameter is declared `{expected}`. |
 | GS0236 | Error | An 'out var/let/_' inline declaration is only valid on an 'out' argument. |
-| GS0237 | Error | Cannot assign to 'in' parameter '{name}' — it is read-only. |
-| GS0238 | Error | The 'out' parameter '{name}' must be assigned on every path before the function returns. |
-| GS0239 | Error | The variable '{name}' must be definitely assigned before it can be passed by 'ref'. |
-| GS0240 | Error | Override of '{name}' must match the base ref-kind on parameter '{parameter}' ('{baseKind}' vs '{overrideKind}'). |
+| GS0237 | Error | Cannot assign to 'in' parameter `{name}` — it is read-only. |
+| GS0238 | Error | The 'out' parameter `{name}` must be assigned on every path before the function returns. |
+| GS0239 | Error | The variable `{name}` must be definitely assigned before it can be passed by 'ref'. |
+| GS0240 | Error | Override of `{name}` must match the base ref-kind on parameter `{parameter}` (`{baseKind}` vs `{overrideKind}`). |
 | GS0241 | Error | A variadic parameter cannot carry a ref-kind modifier ('ref'/'out'/'in'). |
-| GS0242 | Warning | Argument {index} (parameter '{name}') is passed by 'in' implicitly; add 'in' at the call site to make the read-only pass explicit. |
+| GS0242 | Warning | Argument `{index}` (parameter `{name}`) is passed by 'in' implicitly; add 'in' at the call site to make the read-only pass explicit. |
 | GS0243 | Error | A pointer type '*T' is not a valid parameter type; use the appropriate ref-kind modifier instead (e.g. 'ref T', 'out T', 'in T'). |
 
 Cause/fix examples:
@@ -315,9 +339,9 @@ Issue #343 introduces named arguments at call sites — `Foo(timeout: 30, retrie
 | Code | Severity | Message |
 |------|----------|---------|
 | GS0244 | Error | Positional argument cannot follow a named argument. |
-| GS0245 | Error | Named argument '{name}' is specified more than once. |
-| GS0246 | Error | The best overload of '{callee}' does not have a parameter named '{name}'. |
-| GS0247 | Error | Named argument '{name}' specifies a parameter for which a positional argument has already been given. |
+| GS0245 | Error | Named argument `{name}` is specified more than once. |
+| GS0246 | Error | The best overload of `{callee}` does not have a parameter named `{name}`. |
+| GS0247 | Error | Named argument `{name}` specifies a parameter for which a positional argument has already been given. |
 
 Cause/fix examples:
 
@@ -350,10 +374,10 @@ ADR-0061 introduced a narrow ref-only ternary form (`cond ? a : b` only inside `
 | Code | Severity | Message |
 |------|----------|---------|
 | GS0259 | Error (retired by ADR-0062) | Conditional lvalue expression (`cond ? a : b`) is only legal as the payload of a 'ref'/'out'/'in' argument modifier or as the operand of '&'. Now only fires for the legacy inner-ref-modifier shape outside ref context. |
-| GS0260 | Error | Both branches of a conditional ref-argument must produce lvalues of the same type, but the true branch is '{trueType}' and the false branch is '{falseType}'. |
+| GS0260 | Error | Both branches of a conditional ref-argument must produce lvalues of the same type, but the true branch is `{trueType}` and the false branch is `{falseType}`. |
 | GS0261 | Error | An 'out var'/'out let'/'out _' inline declaration cannot appear inside a branch of a conditional ref-argument (the new local would only conditionally exist). Declare the local before the call instead. |
-| GS0262 | Error | Inner ref-kind modifier '{innerModifier}' on a conditional ref-argument branch must match the outer modifier '{outerModifier}'. |
-| GS0263 | Error | Conditional expression branches have no common result type — the true branch is '{trueType}' and the false branch is '{falseType}'. Add an explicit conversion to align the two arms. |
+| GS0262 | Error | Inner ref-kind modifier `{innerModifier}` on a conditional ref-argument branch must match the outer modifier `{outerModifier}`. |
+| GS0263 | Error | Conditional expression branches have no common result type — the true branch is `{trueType}` and the false branch is `{falseType}`. Add an explicit conversion to align the two arms. |
 
 Cause/fix examples:
 
@@ -361,3 +385,47 @@ Cause/fix examples:
 - **GS0261** — `produce(out true ? a : out var n)` — the inline `out var n` would declare a local that only exists on one branch. Fix: declare `var n int32` before the call.
 - **GS0262** — `bump(ref true ? in a : ref b)` — the inner `in` does not match the outer `ref`. Fix: use `bump(ref true ? a : b)` (the generalized ADR-0062 form requires no inner modifiers).
 - **GS0263** — `var x = pick ? true : "no"` — `bool` and `string` have no common type. Fix: explicitly convert one arm (e.g. `pick ? "yes" : "no"`).
+
+## Ref-return diagnostics (GS0248–GS0255)
+
+Issue #490 (ADR-0060 follow-up) introduces `ref`-returning functions — declarations of the form `func f(...) ref T { ... }` that return a managed pointer `T&` rather than a copied value, paired with the `return ref <expr>` statement form. The diagnostics below guard the declaration and return-site rules.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0248 | Error | A 'ref' return modifier requires an explicit return type clause (e.g. 'ref int32'). |
+| GS0249 | Error | 'ref' return is not legal on an `{async/iterator}` function; the state-machine rewriter cannot hoist a managed pointer. |
+| GS0250 | Error | 'ref' return modifier is redundant when the declared return type is already a managed pointer ('*T'); write 'ref T' instead. |
+| GS0251 | Error | 'return ref' is not allowed in `{functionName}` because its declaration does not specify a 'ref' return type. |
+| GS0252 | Error | Function `{functionName}` returns by reference; use `return ref <expr>` instead of a plain 'return'. |
+| GS0253 | Error | The operand of 'return ref' must be an lvalue (variable, field, array element, or '*p'). |
+| GS0254 | Error | Cannot return a managed pointer to function-local storage; the reference would dangle once the function returns. |
+| GS0255 | Error | Override of `{memberName}` must match the base return ref-kind: base returns `{expected}`, this declaration returns `{actual}`. |
+
+Cause/fix examples:
+
+- **GS0248** — `func f(x int32) ref { return ref x }` — `ref` requires the element type. Fix: `func f(x int32) ref int32`.
+- **GS0249** — `async func f() ref int32 { ... }` or a yield-iterator body. Fix: drop `ref` from the return — `async` / iterator state-machine fields cannot hold managed pointers.
+- **GS0250** — `func f(p *int32) ref *int32 { return p }`. Fix: write `ref int32` (or drop `ref` and return the pointer).
+- **GS0251** — a `return ref x` statement in a function whose declaration is `func f() int32`. Fix: add `ref` to the return type, or drop `ref` from the return statement.
+- **GS0252** — a plain `return x` in a `ref`-returning function. Fix: write `return ref x`.
+- **GS0253** — `return ref (a + b)` or `return ref Foo()`. Fix: alias an addressable expression first (`let ref t = arr[i]; return ref t`) or restructure to return a pointer to durable storage.
+- **GS0254** — `func f() ref int32 { var x = 0; return ref x }`. Fix: do not return references to function locals; consume the value by copy or alias storage that outlives the call.
+- **GS0255** — overriding a base method declared `int32` with a `ref int32` override (or vice versa). Fix: match the base return ref-kind exactly.
+
+## Method-overloading and optional-parameter diagnostics (GS0264–GS0267)
+
+ADR-0063 lifts the v0 "one declaration per name" rule, so G# user functions can carry overload sets (differing by parameter types or ref-kinds) and optional parameters with default values. The diagnostics below cover overload-set construction and overload resolution.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0264 | Error | An overload of `{name}` with signature `{signature}` is already declared. Two overloads must differ by parameter types or ref-kinds. |
+| GS0265 | Error | Optional parameter `{parameterName}` is invalid: `{reason}`. |
+| GS0266 | Error | Call to `{name}` is ambiguous between multiple overloads. Disambiguate with explicit types or named arguments. |
+| GS0267 | Error | No overload of `{name}` is applicable to the given argument list. |
+
+Cause/fix examples:
+
+- **GS0264** — two `func F(x int32) {}` declarations, or two declarations that differ only in return type. Fix: change the parameter list (different types, arity, or ref-kinds); return type alone is not a distinguishing signature.
+- **GS0265** — a default-value expression that is not constant, a parameter whose default depends on another parameter, an optional parameter preceding a required one without all trailing parameters also optional, or an optional ref/out parameter. Fix: use a compile-time-constant default, place optional parameters at the end of the list, and avoid combining `ref`/`out` with defaults.
+- **GS0266** — `Greet("ada")` when both `Greet(string)` and `Greet(name string)` are visible via different paths. Fix: rename one, change one signature, or use a named argument that only one overload accepts.
+- **GS0267** — `Greet(42)` when only `Greet(string)` is declared. Fix: pass a value of the expected type, or add an overload covering the new argument shape.

--- a/docs/lexical.md
+++ b/docs/lexical.md
@@ -133,7 +133,13 @@ A *contextual target type* is supplied by a typed `let` declaration, a function 
 
 ## Comments
 
-Single-line comments start with `//` and run to the end of the line. (Block-comment syntax is not yet implemented; see the execution plan.)
+GSharp supports three comment forms:
+
+* **Single-line comments** start with `//` and run to the end of the line.
+* **Block comments** start with `/*` and end with `*/`. They do not nest. An unterminated block comment is **GS0002**. The lexer handles them in `Lexer.ReadMultiLineComment`.
+* **Documentation comments** start with `///` and run to the end of the line. Each line contributes one paragraph of authored doc text after one optional leading space is stripped (`Lexer.ReadDocumentationComment`). The tokens emit as `DocumentationCommentToken` and are later attached to the following declaration, parsed as Markdown, and lowered to CLR XML doc. See ADR-0057 and `docs/lsp.md` (hover).
+
+Doc-comment authoring uses Markdown with a small set of `@`-prefixed block tags drawn from the CLR XML-doc vocabulary: `@summary` (the default; usually elided so prose-only `///` comments become the summary), `@param name`, `@typeparam name`, `@returns`, `@value`, `@remarks`, `@exception TypeName`, and `@seealso TypeName`. The fenced `xmldoc` info string lets the author drop raw `<...>` XML through unchanged for constructs Markdown cannot express. Unknown tags warn as **GS0231**; floating (unattached) doc comments warn as **GS0227**; `@param`/`@typeparam` mismatches as **GS0229**; unsupported Markdown as **GS0230**; and optional missing-doc warnings on public members ship as **GS0228**.
 
 ## Annotation lead-ins
 
@@ -153,3 +159,4 @@ Spaces, tabs, and line terminators are insignificant outside of string literals.
 * `docs/adr/0045-object-universal-upper-bound.md` — `object` as the universal upper bound.
 * `docs/adr/0046-char-literal-grammar.md` — `char` literals and escape grammar.
 * `docs/adr/0047-attribute-syntax-and-declaration.md` — Kotlin-style attribute syntax (`@Foo(...)`) and `@Attribute` declaration sugar.
+* `docs/adr/0057-documentation-comments.md` — Markdown-authored `///` documentation comments with lossless CLR XML-doc round-trip.

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -7,7 +7,7 @@ The GSharp Language Server provides rich IDE features for `.gs` files via the [L
 | Feature | LSP Method | Description |
 |---------|-----------|-------------|
 | Diagnostics | `textDocument/diagnostic` | Live syntax, semantic, and binding errors pulled as you type (with `workspace/diagnostic/refresh` for cross-file edits) |
-| Hover | `textDocument/hover` | Type signature and symbol kind for the token under the cursor |
+| Hover | `textDocument/hover` | Type signature and symbol kind for the token under the cursor; renders CLR XML documentation (from `*.xml` files alongside referenced assemblies) and G# `///` Markdown doc comments as MarkdownContent |
 | Go-to-definition | `textDocument/declaration` | Jump from a symbol usage to its declaration |
 | Find references | `textDocument/references` | Find all usages of a symbol within the document |
 | Document symbols | `textDocument/documentSymbol` | Outline view: functions, variables, structs, enums with children |

--- a/docs/vscode-gsharp-spec.md
+++ b/docs/vscode-gsharp-spec.md
@@ -76,11 +76,15 @@ This document specifies the design and implementation plan for a Visual Studio C
 
 A TextMate grammar (`syntaxes/gsharp.tmLanguage.json`) provides tokenization for syntax highlighting. The grammar should cover:
 
-- Keywords (from `SyntaxFacts.GetKeywordKind` in the parser): `async`, `await`, `break`, `case`, `catch`, `chan`, `class`, `const`, `continue`, `default`, `defer`, `else`, `enum`, `fallthrough`, `false`, `finally`, `for`, `func`, `go`, `goto`, `if`, `import`, `interface`, `internal`, `is`, `let`, `map`, `nil`, `open`, `operator`, `override`, `package`, `private`, `public`, `range`, `return`, `scope`, `sealed`, `select`, `sequence`, `struct`, `switch`, `throw`, `true`, `try`, `type`, `using`, `var`
+- Keywords (from `SyntaxFacts.GetKeywordKind` in the parser): `async`, `await`, `break`, `case`, `catch`, `chan`, `class`, `const`, `continue`, `default`, `defer`, `else`, `enum`, `fallthrough`, `false`, `finally`, `for`, `func`, `go`, `goto`, `if`, `import`, `interface`, `internal`, `is`, `let`, `map`, `nil`, `open`, `operator`, `override`, `package`, `private`, `public`, `range`, `return`, `scope`, `sealed`, `select`, `sequence`, `struct`, `switch`, `throw`, `true`, `try`, `type`, `using`, `var`, `with`, `yield`, `from`, `where`, `when`
+- Contextual modifiers (matched as identifiers in the parser but colorized as `storage.modifier.gsharp`): `data`, `inline`, `record`, `delegate`, `event`, `prop`, `init`, `shared`, `partial`, `readonly`, `static`, `abstract`, `virtual`, `extern`, `scoped`
+- Ref-kind modifiers: `ref`, `out` (and `in` as a clause keyword via `keyword.control.gsharp`)
+- Accessor names (inside property/event bodies): `get`, `set`, `add`, `remove`, `raise`
 - Built-in types (from `TypeSymbol` statics): `bool`, `uint8`, `int8`, `int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`, `nint`, `nuint`, `float32`, `float64`, `decimal`, `char`, `string`, `object`, `void`
-- Operators: arithmetic, comparison, logical, assignment, bitwise
-- Literals: integers, floats, strings (including interpolated), characters
-- Comments: `//` line comments; we still don't support `/* */` block comments
+- Operators: arithmetic, comparison, logical, assignment, bitwise, plus G#-specific `:=` (short variable declaration), `?.` (null-conditional), `??`/`??=` (null-coalescing), `?` and `:` (ternary, ADR-0062), `!!` (null-forgiving), `...` (range), `->` (switch arm), `=>` (lambda arrow)
+- Literals: integers (with `lLuU` suffixes), floats (with `fFdDmM` suffixes), hex (`0x`), binary (`0b`), strings (interpreted and raw-backtick), characters
+- Comments: `//` line comments, `/* … */` block comments (`ReadMultiLineComment`), and `///` documentation comments (`ReadDocumentationComment`, ADR-0057). Doc comments are scoped `comment.line.documentation.gsharp` and additionally highlight the `@summary`, `@param`, `@typeparam`, `@returns`, `@value`, `@remarks`, `@exception`, `@seealso`, `@inheritdoc` block tags.
+- Annotations: `@Identifier(args)` patterns scoped `meta.annotation.gsharp` with the leading `@` as `punctuation.definition.annotation.gsharp` and the name as `storage.type.annotation.gsharp`.
 - Identifiers, function calls, type annotations
 
 G# is sigil-free for interpolation (ADR-0055): interpolation lives inside an ordinary interpreted string `"…"`, not a `$"…"` literal. The `strings` repository therefore distinguishes two forms and emits these scopes:
@@ -88,7 +92,7 @@ G# is sigil-free for interpolation (ADR-0055): interpolation lives inside an ord
 - `string.quoted.double.gsharp` — an interpreted `"…"` string. `applyEndPatternLast` is set so a doubled-quote escape `""` (`constant.character.escape.quote.gsharp`) is consumed before the closing `"`. A literal-`$` escape `$$` is `constant.character.escape.dollar.gsharp`.
 - `string.quoted.raw.backtick.gsharp` — a raw backtick string `` `…` ``; it is **non-interpolating** (no `$` patterns apply inside it).
 - `variable.other.interpolation.gsharp` — the identifier of a `$ident` hole; the `$` is `punctuation.definition.interpolation.begin.gsharp`.
-- `meta.interpolation.gsharp` — a `${ … }` hole. `${` / `}` are `punctuation.definition.interpolation.begin/end.gsharp`; the body recursively includes `source.gsharp`, so the hole expression is highlighted as real code (and a nested `"…"` literal or balanced inner `{ … }` block does not prematurely end the hole).
+- `meta.interpolation.gsharp` — a `${ … }` hole. `${` / `}` are `punctuation.definition.interpolation.begin/end.gsharp`; the body recursively includes `source.gsharp`, so the hole expression is highlighted as real code (and a nested `"…"` literal or balanced inner `{ … }` block does not prematurely end the hole). Inside the hole, an alignment clause `,-?N` is `constant.numeric.alignment.gsharp` and a format clause `:fmt` is `string.unquoted.format.gsharp`.
 
 
 ```jsonc
@@ -111,27 +115,56 @@ Provide a `snippets/gsharp.json` file with common patterns:
 
 | Prefix | Description |
 | --- | --- |
+| `pkg` | `package` + `import` header |
 | `fn` | Function declaration |
+| `afn` | Async function declaration |
+| `extfn` | Extension function (receiver clause) |
+| `lambda` | Anonymous `func(...)` literal |
+| `main` | Explicit `Main` entry point |
 | `if` | If statement |
 | `ife` | If/else statement |
-| `for` | For loop |
-| `while` | While loop |
-| `class` | Class declaration |
+| `for` | C-style for loop |
+| `forin` | For-range over a sequence |
+| `while` | While loop (`for cond { … }`) |
+| `class` | Class declaration (`type X class { … }`) |
+| `classp` | Class with primary constructor |
 | `struct` | Struct declaration |
+| `datastruct` | `data struct` (value-semantics record) |
+| `inlinestruct` | `inline struct(field T)` wrapper |
+| `record` | Record declaration |
 | `enum` | Enum declaration |
-| `match` | Match/pattern expression |
-| `async` | Async function |
-| `try` | Try/catch/finally |
-| `main` | Entry point (top-level program) |
+| `interface` | Interface declaration |
+| `delegate` | Named delegate type (ADR-0059) |
+| `prop` | Property with explicit `get`/`set` |
+| `autoprop` | Auto-implemented property |
+| `event` | Event declaration |
+| `shared` | `shared { … }` block (per-type static) |
+| `match` | `switch` with brace-block cases |
+| `matchexpr` | Switch *expression* with `->` arms |
+| `ternary` | Generalized ternary (ADR-0062) |
+| `try` | Try/catch block |
+| `defer` | Deferred call |
+| `go` | Spawn a concurrent call |
+| `scope` | Structured-concurrency scope |
+| `select` | Channel `select` statement |
+| `chan` | `make(chan T)` channel creation |
+| `using` | Scoped resource (Dispose at exit) |
+| `refparam` | Function with a `ref` parameter (ADR-0060) |
+| `outparam` | Function with an `out` parameter (ADR-0060) |
+| `letref` | `let ref` aliasing local |
+| `doc` | Documentation comment (ADR-0057) |
+| `ann` | Kotlin-style annotation |
 
 ### 3.4 Themes
 
-Ship two bundled color themes optimized for GSharp's semantic token types:
+Ship six bundled color themes inspired by the G# logo, optimized for GSharp's semantic token types. Each palette ships a dark and light variant:
 
-- `GSharp Dark` — dark theme based on VS 2022 dark
-- `GSharp Light` — light theme based on VS 2022 light
+- `GSharp Ember Dark` / `GSharp Ember Light` — warm reds and amber glows.
+- `GSharp Magma Dark` / `GSharp Magma Light` — saturated lava palette.
+- `GSharp Synthwave Dark` / `GSharp Synthwave Light` — high-contrast neon pinks/cyans.
 
 ### 3.5 Configuration Settings
+
 
 ```jsonc
 {

--- a/src/vscode-gsharp/CHANGELOG.md
+++ b/src/vscode-gsharp/CHANGELOG.md
@@ -8,26 +8,28 @@ All notable changes to the GSharp VS Code extension will be documented in this f
 
 - Language registration for `.gs` files
 - `.gsproj` project files recognized and colorized as XML (like `.csproj`)
-- TextMate grammar for syntax highlighting (keywords, types, operators, literals, comments, strings)
-- Language configuration (brackets, comments, indentation, folding)
+- TextMate grammar for syntax highlighting: keywords (including contextual modifiers `data`, `inline`, `record`, `scoped`, accessor names `get`/`set`/`add`/`remove`/`raise`, and ref-kinds `ref`/`out`), declaration keywords (`event`, `prop`, `init`, `delegate`), operators (`:=`, `?.`, `??`, `?`/`:`, `!!`, `...`, `=>`), `@Annotation` scope, and `///` documentation-comment scope with `@tag` highlighting
+- Interpolation-hole sub-grammar that styles the alignment integer and `:format` clause inside `${expr,N:fmt}`
+- Language configuration (brackets, comments including `///`, indentation, folding)
 - LSP client connecting to the GSharp Language Server (stdio transport)
-- Hover, completion, go-to-definition, references, rename
+- Hover (incl. CLR XML-doc rendering, chained-member hover, `this` hover), completion, go-to-definition, references, rename
 - Document symbols, document highlight, folding ranges
 - Code actions (quick fixes)
 - Signature help
-- Push diagnostics (errors/warnings as you type)
+- Pull-based diagnostics (live errors/warnings, including `///` doc-comment diagnostics GS0227–GS0231)
 - Document formatting, range formatting, on-type formatting
 - Semantic tokens (full semantic highlighting)
 - Inlay hints (parameter names, inferred types)
-- CodeLens (reference counts)
+- CodeLens (reference counts, including on members of structs, interfaces, and enums; 0-refs and stale-tree fixes)
 - Workspace symbol search
-- Code snippets (fn, if, ife, for, while, class, struct, enum, match, async, try, main)
+- Code snippets covering the current grammar: `pkg`, `fn`, `afn`, `extfn`, `lambda`, `main`, `if`, `ife`, `for`, `forin`, `while`, `class`, `classp`, `struct`, `datastruct`, `inlinestruct`, `record`, `enum`, `interface`, `delegate`, `prop`, `autoprop`, `event`, `shared`, `match`, `matchexpr`, `ternary`, `try`, `defer`, `go`, `scope`, `select`, `chan`, `using`, `refparam`, `outparam`, `letref`, `doc`, `ann`
 - Debug configuration provider (gsharp → coreclr)
 - Auto-generate launch.json and tasks.json
 - Test explorer integration
 - Build/run commands with task integration
 - Build diagnostics from dotnet build output
-- Color themes inspired by the G# logo: Ember, Magma, and Synthwave (Dark + Light each)
+- Six color themes inspired by the G# logo: Ember, Magma, and Synthwave (Dark + Light each)
+- `gsharp.reportIssue` command and Language Server output channel
 - Server crash recovery with exponential backoff
 - Language status bar item (Starting → Ready → Error)
 - Project context status bar item

--- a/src/vscode-gsharp/snippets/gsharp.json
+++ b/src/vscode-gsharp/snippets/gsharp.json
@@ -1,4 +1,15 @@
 {
+  "Package + import header": {
+    "prefix": "pkg",
+    "body": [
+      "package ${1:GSharp.Example}",
+      "",
+      "import ${2:System}",
+      "",
+      "$0"
+    ],
+    "description": "Top-of-file package + import header."
+  },
   "Function declaration": {
     "prefix": "fn",
     "body": [
@@ -6,7 +17,43 @@
       "\t$0",
       "}"
     ],
-    "description": "Function declaration"
+    "description": "Function declaration."
+  },
+  "Async function": {
+    "prefix": "afn",
+    "body": [
+      "async func ${1:name}(${2:params}) ${3:Task} {",
+      "\t$0",
+      "}"
+    ],
+    "description": "Async function declaration."
+  },
+  "Extension function": {
+    "prefix": "extfn",
+    "body": [
+      "func (${1:self} ${2:Type}) ${3:Name}(${4:params}) ${5:returnType} {",
+      "\t$0",
+      "}"
+    ],
+    "description": "Extension function with a receiver clause."
+  },
+  "Func literal (lambda)": {
+    "prefix": "lambda",
+    "body": [
+      "func(${1:params}) ${2:returnType} {",
+      "\t$0",
+      "}"
+    ],
+    "description": "Anonymous func literal."
+  },
+  "Main entry point": {
+    "prefix": "main",
+    "body": [
+      "func Main() {",
+      "\t$0",
+      "}"
+    ],
+    "description": "Explicit entry-point function."
   },
   "If statement": {
     "prefix": "if",
@@ -15,7 +62,7 @@
       "\t$0",
       "}"
     ],
-    "description": "If statement"
+    "description": "If statement."
   },
   "If/else statement": {
     "prefix": "ife",
@@ -26,16 +73,25 @@
       "\t$0",
       "}"
     ],
-    "description": "If/else statement"
+    "description": "If/else statement."
   },
-  "For loop": {
+  "For loop (C-style)": {
     "prefix": "for",
     "body": [
       "for ${1:i} := ${2:0}; ${1:i} < ${3:count}; ${1:i}++ {",
       "\t$0",
       "}"
     ],
-    "description": "For loop"
+    "description": "C-style for loop."
+  },
+  "For-range loop": {
+    "prefix": "forin",
+    "body": [
+      "for ${1:item} := range ${2:collection} {",
+      "\t$0",
+      "}"
+    ],
+    "description": "For-range over a sequence."
   },
   "While loop": {
     "prefix": "while",
@@ -44,75 +100,256 @@
       "\t$0",
       "}"
     ],
-    "description": "While loop (for with condition)"
+    "description": "While loop (for with condition only)."
   },
   "Class declaration": {
     "prefix": "class",
     "body": [
-      "class ${1:Name} {",
+      "type ${1:Name} class {",
       "\t$0",
       "}"
     ],
-    "description": "Class declaration"
+    "description": "Class declaration."
+  },
+  "Class with primary constructor": {
+    "prefix": "classp",
+    "body": [
+      "type ${1:Name} class(${2:params}) {",
+      "\t$0",
+      "}"
+    ],
+    "description": "Class declaration with a primary constructor."
   },
   "Struct declaration": {
     "prefix": "struct",
     "body": [
-      "struct ${1:Name} {",
+      "type ${1:Name} struct {",
       "\t$0",
       "}"
     ],
-    "description": "Struct declaration"
+    "description": "Struct declaration."
+  },
+  "Data struct declaration": {
+    "prefix": "datastruct",
+    "body": [
+      "type ${1:Name} data struct {",
+      "\t$0",
+      "}"
+    ],
+    "description": "Data struct (value semantics, synthesized members)."
+  },
+  "Inline struct declaration": {
+    "prefix": "inlinestruct",
+    "body": [
+      "type ${1:Name} inline struct(${2:value} ${3:int32})"
+    ],
+    "description": "Inline (single-field) struct wrapper."
+  },
+  "Record declaration": {
+    "prefix": "record",
+    "body": [
+      "type ${1:Name} record {",
+      "\t$0",
+      "}"
+    ],
+    "description": "Record declaration."
   },
   "Enum declaration": {
     "prefix": "enum",
     "body": [
-      "enum ${1:Name} {",
+      "type ${1:Name} enum {",
       "\t${2:Value1},",
-      "\t${3:Value2},",
+      "\t${3:Value2}",
       "\t$0",
       "}"
     ],
-    "description": "Enum declaration"
+    "description": "Enum declaration."
   },
-  "Match expression": {
+  "Interface declaration": {
+    "prefix": "interface",
+    "body": [
+      "type ${1:Name} interface {",
+      "\t$0",
+      "}"
+    ],
+    "description": "Interface declaration."
+  },
+  "Named delegate type": {
+    "prefix": "delegate",
+    "body": [
+      "type ${1:Name} = delegate func(${2:params}) ${3:returnType}"
+    ],
+    "description": "Named delegate type (ADR-0059)."
+  },
+  "Property declaration": {
+    "prefix": "prop",
+    "body": [
+      "prop ${1:Name} ${2:Type} {",
+      "\tget { $0 }",
+      "\tset { }",
+      "}"
+    ],
+    "description": "Property with explicit get/set."
+  },
+  "Auto property": {
+    "prefix": "autoprop",
+    "body": [
+      "prop ${1:Name} ${2:Type} { get; set; }"
+    ],
+    "description": "Auto-implemented property."
+  },
+  "Event declaration": {
+    "prefix": "event",
+    "body": [
+      "event ${1:Name} ${2:DelegateType}"
+    ],
+    "description": "Event declaration."
+  },
+  "Shared block": {
+    "prefix": "shared",
+    "body": [
+      "shared {",
+      "\t$0",
+      "}"
+    ],
+    "description": "Per-type shared (static) block."
+  },
+  "Switch / pattern match": {
     "prefix": "match",
     "body": [
       "switch ${1:value} {",
-      "\tcase ${2:pattern}:",
+      "\tcase ${2:pattern} {",
       "\t\t$0",
-      "\tdefault:",
+      "\t}",
+      "\tdefault {",
       "\t\t",
+      "\t}",
       "}"
     ],
-    "description": "Match/switch expression"
+    "description": "Switch statement with pattern cases (brace-block arms)."
   },
-  "Async function": {
-    "prefix": "async",
+  "Switch expression arrow": {
+    "prefix": "matchexpr",
     "body": [
-      "async func ${1:name}(${2:params}) ${3:returnType} {",
-      "\t$0",
+      "let ${1:result} = switch ${2:value} {",
+      "\tcase ${3:pattern} -> ${4:expr}",
+      "\tdefault -> ${5:expr}",
       "}"
     ],
-    "description": "Async function declaration"
+    "description": "Switch expression with `->` arms."
   },
-  "Try/catch/finally": {
+  "Ternary expression": {
+    "prefix": "ternary",
+    "body": [
+      "${1:condition} ? ${2:whenTrue} : ${3:whenFalse}"
+    ],
+    "description": "Generalized ternary expression (ADR-0062)."
+  },
+  "Try/catch": {
     "prefix": "try",
     "body": [
       "try {",
       "\t$1",
-      "} catch (${2:ex}) {",
+      "} catch (${2:ex} ${3:Exception}) {",
       "\t$0",
       "}"
     ],
-    "description": "Try/catch/finally block"
+    "description": "Try/catch block."
   },
-  "Main entry point": {
-    "prefix": "main",
+  "Defer statement": {
+    "prefix": "defer",
     "body": [
-      "// Main entry point",
-      "$0"
+      "defer ${1:expr}"
     ],
-    "description": "Entry point (top-level program)"
+    "description": "Defer a call until scope exit."
+  },
+  "Go (spawn) statement": {
+    "prefix": "go",
+    "body": [
+      "go ${1:expr}"
+    ],
+    "description": "Spawn a concurrent call."
+  },
+  "Scope block": {
+    "prefix": "scope",
+    "body": [
+      "scope ${1:s} {",
+      "\t$0",
+      "}"
+    ],
+    "description": "Structured concurrency scope."
+  },
+  "Select statement": {
+    "prefix": "select",
+    "body": [
+      "select {",
+      "\tcase ${1:value} := <-${2:ch} {",
+      "\t\t$0",
+      "\t}",
+      "\tdefault {",
+      "\t\t",
+      "\t}",
+      "}"
+    ],
+    "description": "Select on channel operations."
+  },
+  "Channel creation": {
+    "prefix": "chan",
+    "body": [
+      "${1:ch} := make(chan ${2:int32}${3:, ${4:cap}})"
+    ],
+    "description": "Create a channel via make()."
+  },
+  "Using statement": {
+    "prefix": "using",
+    "body": [
+      "using ${1:resource} := ${2:expr} {",
+      "\t$0",
+      "}"
+    ],
+    "description": "Scoped resource (Dispose at exit)."
+  },
+  "Ref parameter": {
+    "prefix": "refparam",
+    "body": [
+      "func ${1:name}(ref ${2:p} ${3:Type}) ${4:returnType} {",
+      "\t$0",
+      "}"
+    ],
+    "description": "Function with a `ref` parameter (ADR-0060)."
+  },
+  "Out parameter": {
+    "prefix": "outparam",
+    "body": [
+      "func ${1:name}(out ${2:p} ${3:Type}) ${4:returnType} {",
+      "\t$2 = ${5:default}",
+      "\t$0",
+      "}"
+    ],
+    "description": "Function with an `out` parameter (ADR-0060)."
+  },
+  "Ref-aliasing local": {
+    "prefix": "letref",
+    "body": [
+      "let ref ${1:alias} = ${2:lvalue}"
+    ],
+    "description": "Immutable ref-aliasing local (ADR-0060 follow-up)."
+  },
+  "Documentation comment": {
+    "prefix": "doc",
+    "body": [
+      "/// ${1:Summary line.}",
+      "/// ",
+      "/// @param ${2:name} ${3:Description.}",
+      "/// @returns ${4:Description.}"
+    ],
+    "description": "Markdown documentation comment (ADR-0057)."
+  },
+  "Annotation": {
+    "prefix": "ann",
+    "body": [
+      "@${1:Name}(${2:args})"
+    ],
+    "description": "Kotlin-style attribute annotation."
   }
 }

--- a/src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json
+++ b/src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json
@@ -7,6 +7,7 @@
     { "include": "#strings" },
     { "include": "#characters" },
     { "include": "#numbers" },
+    { "include": "#annotations" },
     { "include": "#keywords" },
     { "include": "#types" },
     { "include": "#constants" },
@@ -18,6 +19,20 @@
   "repository": {
     "comments": {
       "patterns": [
+        {
+          "name": "comment.line.documentation.gsharp",
+          "begin": "///",
+          "end": "$",
+          "beginCaptures": {
+            "0": { "name": "punctuation.definition.comment.documentation.gsharp" }
+          },
+          "patterns": [
+            {
+              "name": "storage.type.class.gsharp.doc",
+              "match": "@(summary|remarks|param|typeparam|returns|value|exception|seealso|inheritdoc)\\b"
+            }
+          ]
+        },
         {
           "name": "comment.block.gsharp",
           "begin": "/\\*",
@@ -69,9 +84,23 @@
         "0": { "name": "punctuation.definition.interpolation.end.gsharp" }
       },
       "patterns": [
+        { "include": "#interpolation-format" },
+        { "include": "#interpolation-alignment" },
         { "include": "#interpolation-nested-braces" },
         { "include": "source.gsharp" }
       ]
+    },
+    "interpolation-alignment": {
+      "match": ",\\s*(-?[0-9]+)",
+      "captures": {
+        "1": { "name": "constant.numeric.alignment.gsharp" }
+      }
+    },
+    "interpolation-format": {
+      "match": ":([^}]*)",
+      "captures": {
+        "1": { "name": "string.unquoted.format.gsharp" }
+      }
     },
     "interpolation-nested-braces": {
       "begin": "\\{",
@@ -116,11 +145,23 @@
         }
       ]
     },
+    "annotations": {
+      "patterns": [
+        {
+          "name": "meta.annotation.gsharp",
+          "match": "(@)([A-Za-z_][A-Za-z0-9_]*)",
+          "captures": {
+            "1": { "name": "punctuation.definition.annotation.gsharp" },
+            "2": { "name": "storage.type.annotation.gsharp" }
+          }
+        }
+      ]
+    },
     "keywords": {
       "patterns": [
         {
           "name": "keyword.control.gsharp",
-          "match": "\\b(if|else|for|switch|case|default|break|continue|return|goto|fallthrough|range|select)\\b"
+          "match": "\\b(if|else|for|switch|case|default|break|continue|return|goto|fallthrough|range|select|in|from|where|when|yield)\\b"
         },
         {
           "name": "keyword.control.flow.gsharp",
@@ -132,15 +173,23 @@
         },
         {
           "name": "keyword.declaration.gsharp",
-          "match": "\\b(func|class|struct|enum|interface|type|operator|sequence)\\b"
+          "match": "\\b(func|class|struct|enum|interface|type|operator|sequence|record|delegate|event|prop|init)\\b"
         },
         {
-          "name": "keyword.modifier.gsharp",
-          "match": "\\b(public|private|internal|open|sealed|override|const|shared)\\b"
+          "name": "storage.modifier.gsharp",
+          "match": "\\b(public|private|internal|protected|open|sealed|override|abstract|virtual|static|const|shared|partial|readonly|data|inline|extern|scoped)\\b"
+        },
+        {
+          "name": "storage.modifier.refkind.gsharp",
+          "match": "\\b(ref|out)\\b"
+        },
+        {
+          "name": "keyword.other.accessor.gsharp",
+          "match": "\\b(get|set|add|remove|raise)\\b"
         },
         {
           "name": "keyword.other.gsharp",
-          "match": "\\b(import|package|using|var|let|is|scope|chan|map)\\b"
+          "match": "\\b(import|package|using|var|let|is|as|scope|chan|map|with|make|nameof|typeof)\\b"
         }
       ]
     },
@@ -148,7 +197,7 @@
       "patterns": [
         {
           "name": "support.type.primitive.gsharp",
-          "match": "\\b(bool|uint8|int8|int16|uint16|int32|uint32|int64|uint64|nint|nuint|float32|float64|decimal|char|string|object|void)\\b"
+          "match": "\\b(bool|uint8|int8|int16|uint16|int32|uint32|int64|uint64|nint|nuint|float32|float64|decimal|char|string|object|void|byte|sbyte|ushort|short|uint|long|ulong|float|double)\\b"
         }
       ]
     },
@@ -164,12 +213,40 @@
         },
         {
           "name": "constant.language.null.gsharp",
-          "match": "\\bnil\\b"
+          "match": "\\b(nil|null)\\b"
+        },
+        {
+          "name": "variable.language.this.gsharp",
+          "match": "\\b(this|base)\\b"
         }
       ]
     },
     "operators": {
       "patterns": [
+        {
+          "name": "keyword.operator.range.gsharp",
+          "match": "\\.\\.\\."
+        },
+        {
+          "name": "keyword.operator.short-declaration.gsharp",
+          "match": ":="
+        },
+        {
+          "name": "keyword.operator.null-coalescing.gsharp",
+          "match": "\\?\\?=|\\?\\?"
+        },
+        {
+          "name": "keyword.operator.null-conditional.gsharp",
+          "match": "\\?\\."
+        },
+        {
+          "name": "keyword.operator.null-forgiving.gsharp",
+          "match": "!!"
+        },
+        {
+          "name": "keyword.operator.ternary.gsharp",
+          "match": "\\?|:"
+        },
         {
           "name": "keyword.operator.comparison.gsharp",
           "match": "(==|!=|<=|>=|<|>)"
@@ -192,7 +269,7 @@
         },
         {
           "name": "keyword.operator.arrow.gsharp",
-          "match": "(->)"
+          "match": "(->|=>)"
         }
       ]
     },

--- a/website/docs/bridges/gsharp-for-csharp-developers.md
+++ b/website/docs/bridges/gsharp-for-csharp-developers.md
@@ -28,7 +28,15 @@ G# is a .NET language with Go-inspired syntax. It emits CLR assemblies, imports 
 | `IEnumerable<T>` iterator | `sequence[T]` with `yield` | Async streams use `async sequence[T]`. |
 | `lock` and tasks | `go`, `chan T`, `select`, `scope` | G# adds Go-shaped structured concurrency. |
 | `using var` or `using (...)` | `using` and `defer` | Defer and using cleanup at block exit. |
-| optional parameter defaults | imported CLR optional args only | G# user functions do not define default parameter values. |
+| `void M(int x = 0)` | `func M(x int32 = 0)` | G# functions support optional parameters with constant defaults (ADR-0063). |
+| `void M(int x, int y); void M(int x);` | overloads of `M(int32, int32)` / `M(int32)` | G# functions support overloading on parameter shape (ADR-0063); duplicates report `GS0264`. |
+| named arg `M(timeout: 30)` | `M(timeout: 30)` (or `M(timeout = 30)` legacy) | Named arguments at call sites for user functions, methods, constructors, extensions, and CLR methods. |
+| `ref int M(int[] a, int i)` | `func M(a []int32, i int32) ref int32` paired with `return ref a[i]` | Ref returns (ADR-0060 follow-up). |
+| `ref int local = ref arr[i]` | `let ref local = arr[i]` or `var ref local = arr[i]` | Ref-aliasing locals. |
+| `out int n` parameter / `M(out var n)` | `out n int32` / `M(out var n)` | Ref-kind parameters and inline `out` declarations (ADR-0060). |
+| `delegate void Handler(object sender)` | `type Handler = delegate func(sender Object)` | Named delegate types (ADR-0059). |
+| `cond ? a : b` | `cond ? a : b` | Ternary expression (ADR-0062). |
+| `/// <summary>…</summary>` XML doc | `/// summary text` Markdown doc | Markdown documentation comments round-trip to CLR XML (ADR-0057). |
 | lambda `x => x + 1` | `func(x int32) int32 { return x + 1 }` | Func literals are the lambda form; parameters and return type are explicit. |
 | extension method | `func (r Receiver) M()` | A receiver clause declares a CLR-visible extension method. |
 
@@ -60,9 +68,29 @@ func add(a int32, b int32) int32 {
 
 C# source uses aliases such as `int` and `long`. G# spells the widths: `int32`, `int64`, `uint32`, `float64`, and so on. This makes interop signatures visually match CLR metadata.
 
-## Defaults and optional arguments differ
+## Defaults, named arguments, and overloading
 
-G# user-defined functions do not declare default parameter values. Imported CLR methods and extension methods can still expose optional arguments from metadata, and G# callers may omit those arguments.
+G# user functions support optional parameters with compile-time-constant defaults, named arguments at the call site, and overload sets — all introduced in ADR-0063 and complementary issues:
+
+```gsharp
+func greet(name string = "world", excited bool = false) string {
+    return excited ? "hi, $name!" : "hi, $name"
+}
+
+// Default values: both optional.
+let a = greet()                      // "hi, world"
+let b = greet("Ada")                 // "hi, Ada"
+
+// Named arguments: arrive in any order, skip leading defaults.
+let c = greet(excited: true)         // "hi, world!"
+let d = greet(name: "Ada", excited: true)
+
+// Overloading by parameter shape.
+func area(width int32, height int32) int32 { return width * height }
+func area(side int32) int32                { return side * side }
+```
+
+Imported CLR methods that expose `[Optional]` arguments work the same way G# defaults do, and CLR overload sets resolve identically. The legacy `name = value` named-argument form is still accepted for `.copy(...)` calls and attribute argument lists.
 
 ## Data shapes are richer than plain classes
 

--- a/website/docs/design-decisions.md
+++ b/website/docs/design-decisions.md
@@ -80,6 +80,8 @@ This is a curated reference index of the Architecture Decision Records in the re
 | [0014](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0014-visibility-default.md) | Visibility defaults — `public` for top-level declarations | Makes unmodified top-level declarations public by default. |
 | [0054](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0054-postfix-member-access-on-primary-expressions.md) | Postfix member/index access on primary expressions | Chains `.`/`?.`/`[]` after any primary except a bare numeric literal (`(42).Member`). |
 | [0055](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0055-string-interpolation-revamp.md) | String interpolation revamp | Delimiter-aware multiline holes, alignment/format clauses, late context-driven lowering (`DefaultInterpolatedStringHandler`/`FormattableString`), and full IDE support inside holes. |
+| [0057](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0057-documentation-comments.md) | Documentation comments | Markdown-authored `///` documentation comments with lossless CLR XML-doc round-trip; hover renders the merged XML on imported APIs. Diagnostics `GS0227`–`GS0231`. |
+| [0062](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0062-generalized-ternary-expression.md) | Generalized ternary expression | Promotes `cond ? a : b` from the narrow ADR-0061 ref form to a normal expression; retires `GS0259` in value contexts and adds `GS0263`. |
 
 ## CLR interop
 
@@ -94,6 +96,11 @@ This is a curated reference index of the Architecture Decision Records in the re
 | [0039](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0039-byref-pointers-and-clr-interop.md) | By-ref pointers and CLR interop for `ref` / `out` / `in` parameters | Introduces `*T`, `&`, dereference, `ref` arguments, and related diagnostics. |
 | [0047](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0047-attribute-syntax-and-declaration.md) | Attribute consumption and declaration (Kotlin-style annotations) | Defines `@` annotation syntax, use-site targets, attribute arguments, and `@Attribute` sugar. |
 | [0056](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0056-span-consumption-v1.md) | Span consumption v1 — ref-returning members, span element access, closed generic value-type fields | Auto-dereferences ref-returning members in rvalue position, makes spans indexable (read/write), applies `[]T → Span[T]` conversion in argument position, and gives closed generic value-type fields real layout. |
+| [0058](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0058-ref-safe-to-escape.md) | Ref-safe-to-escape and the `scoped` modifier | Adds the `scoped` parameter modifier and the supporting `GS9004`/`GS9006` ref-pointer escape diagnostics. |
+| [0059](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0059-named-delegate-types.md) | Named delegate types | `type Name = delegate func(...)` declares a real CLR `MulticastDelegate`-derived type; diagnostics `GS0233`–`GS0234`. |
+| [0060](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0060-ref-out-in-parameters.md) | `ref`/`out`/`in` parameters | Declaration-site and call-site ref-kind modifiers with diagnostics `GS0235`–`GS0243`; ref-aliasing locals (`let ref`/`var ref`) and ref returns are follow-ups (`GS0248`–`GS0258`). |
+| [0061](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0061-conditional-ref-arguments.md) | Conditional ref-arguments | Narrow `ref cond ? a : b` form inside ref-kind argument payloads; diagnostics `GS0259`–`GS0262`. |
+| [0063](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0063-method-overloading-and-optional-parameters.md) | Method overloading and optional parameters | Lifts the v0 "one declaration per name" rule and adds default parameter values; diagnostics `GS0264`–`GS0267`. |
 
 ## Emit and tooling
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -47,9 +47,15 @@ G# combines a Go-shaped surface with .NET primitives. `go f()` starts a concurre
 
 `async func` and `await` exist for direct .NET interop with `Task`, `Task[T]`, and compatible awaitable shapes. In emitted code, G# lowers async functions and lambdas to .NET state machines; in the interpreter, awaits block on the awaiter for simple test and REPL behavior. See [ADR-0023](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0023-async-state-machine.md).
 
-## Why are there no default or optional parameter values in G# functions?
+## How do optional parameters, named arguments, and overloading work in G# functions?
 
-User-defined G# function declarations do not have parameter default-value syntax. Calls may use named arguments only in limited supported cases, such as data-struct copy ergonomics and imported CLR methods that already declare optional or default arguments. This keeps G# function declarations simple while preserving compatibility with .NET APIs that expose optional parameters.
+User-defined G# functions support all three:
+
+- **Optional parameters**: declare a default value with `=` after the type — `func greet(name string = "world")` (ADR-0063). Defaults must be compile-time constants and trailing optional parameters cannot precede required ones. Misuse reports `GS0265`.
+- **Named arguments**: any call site can name an argument — `greet(name: "Ada")` — for free functions, user methods, user constructors, extension functions, and inherited CLR methods. The call-site form is `name: value` (the older `name = value` is still accepted for `.copy(...)` and attribute arg lists). Indirect calls through a function-typed variable and variadic call sites do not accept names because the target does not preserve parameter names. Diagnostics `GS0244`–`GS0247`.
+- **Overloading**: two declarations of the same function name are allowed as long as they differ by parameter types, arity, or ref-kinds (ADR-0063). Duplicate signatures report `GS0264`; ambiguous calls report `GS0266`; no-applicable-overload reports `GS0267`.
+
+This is a recent change — earlier docs described G# as having no parameter defaults and only "partial" named-argument support. That is no longer accurate.
 
 ## How do generics work?
 

--- a/website/docs/guide/declarations-and-packages.md
+++ b/website/docs/guide/declarations-and-packages.md
@@ -68,7 +68,42 @@ func (p Point) LengthSquared() int32 {
 }
 ```
 
-Generic functions use bracketed type parameters and bracketed type arguments. Parameters do not support default values in G# declarations today, though imported CLR optional/default arguments are supported in interop scenarios.
+Generic functions use bracketed type parameters and bracketed type arguments.
+
+Parameters may carry a ref-kind modifier (`ref`, `out`, `in`, or `scoped`) and may declare a compile-time-constant default value to become optional. Two functions sharing a name are overloads when they differ by parameter types, arity, or ref-kinds; differing by return type alone is not a distinguishing signature. See ADR-0060 (ref parameters), ADR-0063 (overloading and optional parameters), and the [feature matrix](/docs/ref/feature-matrix) for the full capability table.
+
+```gsharp
+func greet(name string = "world", excited bool = false) string {
+    return excited ? "hi, $name!" : "hi, $name"
+}
+
+// Overloads — differ by arity.
+func area(width int32, height int32) int32 { return width * height }
+func area(side int32) int32                { return side * side }
+
+// Ref-kind parameters.
+func swap[T](ref a T, ref b T) {
+    let t = a
+    a = b
+    b = t
+}
+
+func tryParse(s string, out value int32) bool {
+    value = 0
+    if Int32.TryParse(s, out value) { return true }
+    return false
+}
+```
+
+A function can declare a managed-pointer return with `ref` before the return type clause — `func at(arr []int32, i int32) ref int32 { return ref arr[i] }`. Diagnostics `GS0248`–`GS0255` cover the supporting rules.
+
+A named delegate type is a top-level type alias whose RHS is `delegate func(...)`:
+
+```gsharp
+type Handler = delegate func(sender Object, e EventArgs)
+```
+
+Named delegates emit as real CLR `MulticastDelegate`-derived types so C# consumers see a conventional handler type and G# events can carry first-class custom delegate types (ADR-0059).
 
 ## Type declarations
 

--- a/website/docs/guide/expressions-and-statements.md
+++ b/website/docs/guide/expressions-and-statements.md
@@ -10,11 +10,13 @@ G# expression syntax is compact and Go-like, with CLR-oriented additions for nul
 
 ## Operators
 
-Unary operators include numeric identity and negation, logical not, bitwise complement, address-of, dereference, channel receive, and `await`. Binary operators are left-associative. Multiplicative, shift, bitwise, additive, comparison, logical-and, logical-or, and null-coalescing levels are implemented. User operator overloads are supported through receiver `operator` declarations; see [ADR-0026](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0026-operator-by-name-deferral.md) and [ADR-0035](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0035-user-operator-overloads.md).
+Unary operators include numeric identity and negation, logical not, bitwise complement, address-of, dereference, channel receive, and `await`. Binary operators are left-associative. Multiplicative, shift, bitwise, additive, comparison, logical-and, logical-or, and null-coalescing levels are implemented. The conditional (ternary) expression `cond ? whenTrue : whenFalse` is a normal expression (ADR-0062); both arms must share a common type, otherwise `GS0263` fires. User operator overloads are supported through receiver `operator` declarations; see [ADR-0026](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0026-operator-by-name-deferral.md) and [ADR-0035](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0035-user-operator-overloads.md).
 
 ## Calls, access, and literals
 
 Calls use parentheses. Generic calls use bracketed type arguments. Member access uses `.`, null-conditional access uses `?.`, and indexing uses brackets. These postfix operators chain after any primary expression, including a parenthesized one — `(a + b).GetType()`, `(nums)[0]`, and `("s").Length` are all valid. The one exception is a bare numeric literal: write `(42).ToString()` rather than `42.ToString()`, which is ambiguous with float-literal lexing (see [ADR-0054](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0054-postfix-member-access-on-primary-expressions.md)). Struct literals use field labels; data structs can be copied with `with` updates.
+
+Arguments may be positional, named (`f(timeout: 30, retries: 3)`), or ref-kind-prefixed (`f(ref x)`, `f(out var n)`, `f(in z)`). Named arguments work for free functions, user methods, user constructors, extension functions, and inherited CLR methods (including delegate `Invoke`); indirect calls through a function-typed variable and variadic call sites do not accept names. Ref-kind modifiers must match the parameter declaration (`GS0235`); passing a value to an `in` parameter requires an explicit `in` at the call site (`GS0242`).
 
 ```gsharp
 let p = Point{X: 3, Y: 4}

--- a/website/docs/guide/types-and-values.md
+++ b/website/docs/guide/types-and-values.md
@@ -75,6 +75,16 @@ type Status enum { Pending, Complete, Failed }
 
 Function types use `func(...) R`. Async function type clauses use `async func(...) R` and represent task-returning functions. Function values can convert to compatible CLR delegate types, including named delegates and common `Action` or `Func` shapes.
 
+A **named delegate type** is declared with `type Name = delegate func(...)` (ADR-0059) and emits as a real CLR `MulticastDelegate`-derived type. Use a named delegate when you want a stable, C#-visible handler type (for example, as the type of a G# `event`):
+
+```gsharp
+type Handler = delegate func(sender Object, e EventArgs)
+
+type Button class {
+    event Click Handler
+}
+```
+
 ## Generics and variance
 
 G# uses bracketed generics: declarations such as `type Box[T any] class { ... }` and instantiations such as `Box[int32]`. Type parameters can use `in` and `out` variance markers and named constraints. The implementation supports metadata specs and inference, but some open or partially constructed generic shapes are erased to `object` in emit paths. See [ADR-0004](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0004-generics-scope.md), [ADR-0020](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0020-generic-brackets.md), and [ADR-0021](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0021-generic-variance.md).

--- a/website/docs/ref/clr-interop.md
+++ b/website/docs/ref/clr-interop.md
@@ -56,7 +56,7 @@ counts["g"] = 1
 Console.WriteLine(counts.ContainsKey("g"))
 ```
 
-Overload resolution considers imported methods, constructors, conversion operators, optional/default parameters, and numeric better-conversion tie breaking. Named arguments are parsed generally and are accepted for imported optional/default argument scenarios.
+Overload resolution considers imported methods, constructors, conversion operators, optional/default parameters (G# and CLR-supplied), ref-kind matching, numeric better-conversion tie breaking, and overload sets on user functions (ADR-0063). Named arguments are accepted at the call site (`F(timeout: 30)`) for free functions, user methods, user constructors, extension functions, and inherited CLR methods (including delegate `Invoke`); indirect calls through a function-typed variable and variadic call sites do not accept names because the call target does not preserve parameter names. Diagnostics `GS0244`–`GS0247` and `GS0264`–`GS0267` cover the related failure modes.
 
 ## Extension methods
 
@@ -183,7 +183,7 @@ At the CLR metadata level, `*T` maps to `ELEMENT_TYPE_BYREF` — a managed refer
 
 ### Limitations
 
-The by-ref surface is deliberately scoped to managed references for CLR interop. Per ADR-0039 the following are out of scope today: unmanaged pointers, pointer arithmetic, and `unsafe` blocks; by-ref returns from G# functions (`func foo() *int { return &x }`); and the full Roslyn-style `ref-safe-to-escape` / `safe-to-escape` two-level escape analysis, which is deferred to [issue #376](https://github.com/DavidObando/gsharp/issues/376). V1 uses a simpler rule: by-ref values cannot escape their declaring scope.
+The by-ref surface is deliberately scoped to managed references for CLR interop. Per ADR-0039 the following are out of scope today: unmanaged pointers, pointer arithmetic, and `unsafe` blocks. By-ref returns from G# functions (`func f(...) ref T`) have since landed via ADR-0060's follow-up work (diagnostics `GS0248`–`GS0255`), and the `scoped` parameter modifier from [ADR-0058](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0058-ref-safe-to-escape.md) is wired up; the full Roslyn-style `ref-safe-to-escape` / `safe-to-escape` two-level escape analysis is still deferred to [issue #376](https://github.com/DavidObando/gsharp/issues/376). V1 uses a simpler rule: by-ref values cannot escape their declaring scope, and a `scoped` parameter cannot be returned.
 
 ### Diagnostics
 
@@ -254,7 +254,7 @@ Such a field is emitted with its real layout (`valuetype ReadOnlySpan<int32>`, n
 
 ### Limitations
 
-Per ADR-0056, the following remain out of scope: by-ref returns from G# functions and the full two-level `ref-safe-to-escape` analysis (`scoped`, `[UnscopedRef]`), deferred to [issue #376](https://github.com/DavidObando/gsharp/issues/376); open generic value-type `ref struct` fields (`type Buffer[T] ref struct { data ReadOnlySpan[T] }`); `stackalloc` and other span-*creation* primitives; and a lowercase `span[T]` alias (spans are imported CLR types `Span[T]` / `ReadOnlySpan[T]`, requiring `import System`).
+Per ADR-0056, the following remain out of scope: the full two-level `ref-safe-to-escape` analysis (including `[UnscopedRef]`), deferred to [issue #376](https://github.com/DavidObando/gsharp/issues/376) — though the `scoped` parameter modifier from [ADR-0058](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0058-ref-safe-to-escape.md) is wired up; open generic value-type `ref struct` fields (`type Buffer[T] ref struct { data ReadOnlySpan[T] }`); `stackalloc` and other span-*creation* primitives; and a lowercase `span[T]` alias (spans are imported CLR types `Span[T]` / `ReadOnlySpan[T]`, requiring `import System`).
 
 ## Generics interop
 

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -8,7 +8,6 @@ draft: false
 
 This page mirrors the authoritative diagnostic catalogue in [`docs/diagnostics.md`](https://github.com/DavidObando/gsharp/blob/main/docs/diagnostics.md). Preserve these `GS####` meanings when configuring suppressions, warning promotion, or tooling.
 
-
 Every diagnostic emitted by `gsc` carries a stable `GS####` identifier, a severity level, a human-readable message, and a source location (file, line, column). This document enumerates all identifiers so that project files can suppress or promote them using standard MSBuild properties.
 
 ## Severity levels
@@ -182,7 +181,30 @@ ADR-0047 introduces Kotlin-style attribute syntax (`@Foo(...)`) and the `@Attrib
 | GS0204 | **Warning** (Error if `IsError=true`) | Reference to a symbol marked `[Obsolete]`. | Calling a function, instantiating a class (`Old(5)`), writing a struct literal (`Old{}`), naming a struct/class/interface/enum in a type clause, reading an obsolete parameter, reading/writing an obsolete `var`/`let`/`const`, reading an obsolete enum member (`Color.Red`), or reading/writing an obsolete struct/class field (`p.Old`) — all declared with `@Obsolete("use Bar")`. Severity is promoted to error when the attribute's second argument is `true`. |
 | GS0205 | Error | Attribute is reserved for compiler synthesis. | `@CompilerGenerated`, `@Extension`, `@AsyncStateMachine`, `@Nullable`, or `@NullableContext` written in user source. |
 | GS0206 | Error | Annotations are only allowed on variable declarations, not on this statement. | `@Obsolete\nreturn` inside a function body — annotations may precede `var`/`let`/`const` but no other statement kind. |
+| GS0207 | Error | Parameter `{name}` is annotated `@EnumeratorCancellation` but has type `{type}`; only `System.Threading.CancellationToken` parameters can carry this annotation. | `@EnumeratorCancellation` placed on a `string` parameter. |
+| GS0208 | Error | Parameter `{name}` is annotated `@EnumeratorCancellation` but its enclosing function is not an async sequence (does not return `IAsyncEnumerable[T]`). | `@EnumeratorCancellation` on a sync function or a non-sequence async function. |
+| GS0209 | Error | Attribute `{name}` is not valid on this position; its `[AttributeUsage]` permits only: `{targets}`. | Applying a `@field`-targeted attribute to a method. |
+| GS0210 | Error | Duplicate attribute `{name}`; this attribute type does not allow multiple applications (`AllowMultiple = false`). | Two `@Trace(...)` annotations on the same declaration. |
 | GS0211 | Error | Attribute `[DllImport]` is recognised but not supported in v1.0; P/Invoke (extern function bodies) is a post-v1.0 feature. | `@DllImport("user32.dll") func MessageBox() {}` — emit support and the `extern` body marker arrive after v1.0. |
+| GS0212 | Error | Function `{name}` is marked `@Conditional` but does not return `void`; conditional methods must return `void` because calls may be elided at the call site. | `@Conditional("DEBUG") func Probe() int32 { return 0 }`. |
+
+### Class / constructor diagnostics (GS0213–GS0217)
+
+Issue #306 covers user class constructor flow — explicit `init(...)` constructors, primary constructors, and `base(...)` initializers.
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0213 | Error | A base-constructor argument list requires an explicit base class. | `init() : base(1) { }` written on a class with no `: BaseType` clause. |
+| GS0214 | Error | Class `{base}` has no accessible constructor that takes `{N}` argument(s). | `init() : base(1, 2)` when the base only declares `init()`. |
+| GS0215 | Error | Class `{name}` cannot declare both a primary constructor and an explicit `init` constructor. | `type Customer class(id int32) { init(name string) { } }`. |
+| GS0216 | Error | Class `{name}` declares multiple `init` constructors; only a single explicit constructor is supported. | Two `init(...)` declarations in the same class body. |
+| GS0217 | Error | Generic class `{name}` with an explicit `init` constructor cannot be constructed; generic explicit constructors are not supported. | `type Box[T] class { init(x T) { } }` then `Box[int32](42)`. |
+
+### Delegate conversion diagnostics (GS0218)
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0218 | Error | Cannot convert method group `{name}` to `{type}`. No overload matches the target delegate signature. | `var a Action = SomeOverloaded` where no overload of `SomeOverloaded` has signature `() -> void`. |
 
 ### String interpolation diagnostics (GS0220–GS0225)
 
@@ -201,15 +223,36 @@ ADR-0055 interpolation holes (`${expr,alignment:format}`) and the issue #368 int
 
 ### By-ref-like (`ref struct`) diagnostics (GS0219)
 
-A by-ref-like type — a CLR `ref struct` carrying `System.Runtime.CompilerServices.IsByRefLikeAttribute`, such as `System.Span[T]`, `System.ReadOnlySpan[T]`, or `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler` — is stack-only (issue #367). G# permits declaring and using such a value as an ordinary local (including a user-declared `type X ref struct { … }`), but the CLR forbids any use that would let it reach the heap.
+A by-ref-like type — a CLR `ref struct` carrying `System.Runtime.CompilerServices.IsByRefLikeAttribute`, such as `System.Span[T]`, `System.ReadOnlySpan[T]`, or `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler` — is stack-only (issue #367). G# permits declaring and using such a value as an ordinary local, but the CLR forbids any use that would let it reach the heap. Those escapes are rejected with GS0219.
+
+G# can also **declare** its own by-ref-like value types with a `ref` modifier on a `struct` declaration:
+
+```gsharp
+type Window ref struct {
+    Items ReadOnlySpan[int32]   // a ref struct may hold by-ref-like fields
+    Label string
+}
+```
+
+Such a type is emitted with `System.Runtime.CompilerServices.IsByRefLikeAttribute` (and the C# compiler's `[Obsolete]` guard marker), so the CLR treats it as stack-only. The same escape rules below apply to user-declared `ref struct` types exactly as they do to imported ones. The only relaxation is that a `ref struct` may itself hold by-ref-like fields (it is stack-only too); a static field of a `ref struct` is still rejected.
 
 | ID | Severity | Description | Example trigger |
 |----|----------|-------------|-----------------|
-| GS0219 | Error | A by-ref-like (`ref struct`) value is used in a position that would let it escape the stack: boxing / converting it to a reference type, storing it in a field of a non-`ref struct` (instance, primary-constructor, or static), capturing it in a closure, declaring it as a local in an `async` function or iterator (where it would be hoisted into the heap-allocated state machine), using it as a generic type argument, declaring it as a top-level global, or returning it from a function when the parameter is annotated `scoped`. | `var o object = span` (box); a `class` field typed `Span[int32]`; capturing a `ReadOnlySpan[char]` local inside `func() { … }`; a `Span[int32]` local in an `async` function; `List[ReadOnlySpan[int32]]`; `func f(scoped s Span[int32]) Span[int32] { return s }`. |
+| GS0219 | Error | A by-ref-like (`ref struct`) value is used in a position that would let it escape the stack: boxing / converting it to a reference type (`object`, an interface, a delegate base), storing it in a field of a non-ref-struct (instance, primary-constructor, or static), capturing it in a closure, declaring it as a local in an `async` function or an iterator (where it would be hoisted into the heap-allocated state machine), using it as a generic type argument, or returning it from a function when the parameter is annotated `scoped`. | `var o object = span` (box); a `class`/`struct` field typed `Span[int32]`; capturing a `ReadOnlySpan[char]` local inside `func() { ... }`; declaring a `Span[int32]` local in an `async` function; `List[ReadOnlySpan[int32]]`; `func f(scoped s Span[int32]) Span[int32] { return s }`. |
+
+The `scoped` modifier can be placed on a parameter to indicate that the `ref struct` (or managed-pointer) value must not be returned or stored beyond the call site:
+
+```gsharp
+import System
+// `scoped` means `s` cannot be returned or escape.
+func firstElement(scoped s ReadOnlySpan[int32]) int32 {
+    return s[0]
+}
+```
 
 ### Span element access diagnostics (GS0226)
 
-ADR-0056 §1/§2 makes spans indexable: a `Span[T]` / `ReadOnlySpan[T]` indexer returns a managed pointer (`ref T` / `ref readonly T`), and a read in rvalue position auto-dereferences to the pointee `T`. A `Span[T]` element write `s[i] = v` stores through the `ref T`; a `ReadOnlySpan[T]` element is `ref readonly T`, so writing through it is rejected.
+ADR-0056 §1/§2 makes spans indexable: a `Span[T]` / `ReadOnlySpan[T]` indexer returns a managed pointer (`ref T` / `ref readonly T`), and a read in rvalue position auto-dereferences to the pointee `T` (§1). A `Span[T]` element write `span[i] = v` stores through the `ref T`. A `ReadOnlySpan[T]` element is `ref readonly T`, so writing through it is a hard error (GS0226); reading it is always permitted.
 
 | ID | Severity | Description | Example trigger |
 |----|----------|-------------|-----------------|
@@ -225,6 +268,7 @@ ADR-0056 §1/§2 makes spans indexable: a `Span[T]` / `ReadOnlySpan[T]` indexer 
 | GS9004 | Error | By-ref value cannot escape its declaration scope. | Returning a `*T` (managed-pointer) value from a function, capturing a `*T` local in a closure, hoisting a `*T` local into an `async`/iterator state machine, or using a `*T` return type in a function literal. Also raised when returning a `ref struct` parameter annotated as `scoped`. |
 | GS9005 | Error | Cannot take the address of a constant. | `&myConst` where `myConst` is declared `const`. |
 | GS9006 | Error | Pointer type cannot be a field type. | A struct or class field (including static `shared` fields and top-level globals) declared with a `*T` (managed-pointer) type. |
+| GS9007 | Error | A type may contain at most one `shared` block. | A class or struct with two `shared { ... }` blocks; merge them into one. |
 
 ### Reference closure diagnostics (GS9100)
 
@@ -240,3 +284,156 @@ These diagnostics indicate an internal compiler problem. If you encounter them, 
 |----|----------|-------------|
 | GS9998 | Error | An unexpected `NotSupportedException` or `InvalidOperationException` was raised during IL emission. The message text contains the original exception message. |
 | GS9999 | Error | An unexpected exception was caught by the evaluator. The message text contains the original exception message. |
+
+## Documentation diagnostics (GS0227–GS0231)
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0227 | Warning | Documentation comment is not attached to a declaration. |
+| GS0228 | Warning | Missing documentation comment on public member `{name}`. (opt-in) |
+| GS0229 | Warning | Documentation @param `{name}` does not match any parameter of `{symbol}`. |
+| GS0230 | Warning | Unsupported documentation Markdown: `{detail}`. |
+| GS0231 | Warning | Unknown documentation tag `{tag}`. Valid tags are: @param, @typeparam, @returns, @remarks, @value, @exception, @seealso. |
+
+## Data struct diagnostics (GS0232)
+
+ADR-0029 / Issue #410: every `data struct` synthesizes a fixed contract of value-semantics members — `Equals(object)`, `Equals(Name)`, `GetHashCode()`, `ToString()`, `op_Equality(Name, Name)`, `op_Inequality(Name, Name)`, and `Deconstruct(out T1, out T2, …)`. Hand-written versions are rejected so the contract stays predictable and so consumers (G# and external .NET) can rely on the synthesized IL.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0232 | Error | Data struct `{type}` synthesizes member `{member}`; it cannot be declared explicitly. |
+
+## Named delegate type diagnostics (GS0233–GS0234)
+
+ADR-0059 / Issue #255: `type Name = delegate func(...)` declares a real CLR `MulticastDelegate`-derived named delegate type so C# consumers see a conventional handler type (and so G# events can carry first-class custom delegate types). Anything other than a function signature on the right-hand side is rejected, and generic delegate types are reserved for v2.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0233 | Error | Named delegate declaration requires 'func(...)' after 'delegate' (e.g. 'type Name = delegate func(sender Object, e EventArgs)'). |
+| GS0234 | Error | Generic delegate declaration `{name}` is not yet supported; declare a non-generic named delegate type (ADR-0059 follow-up). |
+
+## Ref-kind parameter diagnostics (GS0235–GS0243)
+
+ADR-0060 introduces explicit `ref`, `out`, and `in` parameter passing modes at both call sites and method-definition sites. The ADR (§8) originally enumerated diagnostics GS0230–GS0238, but those codes were already in use by ADR-0029 / ADR-0030 / ADR-0056 / ADR-0059; the ADR-0060 diagnostics ship at the next free range, GS0235–GS0243, with a 1:1 mapping (GS0230→GS0235, GS0231→GS0236, …, GS0238→GS0243). The async/iterator ban (§10) reuses the existing GS0226 family.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0235 | Error | Argument `{index}` (parameter `{name}`) passes with ref-kind `{actual}` but the parameter is declared `{expected}`. |
+| GS0236 | Error | An 'out var/let/_' inline declaration is only valid on an 'out' argument. |
+| GS0237 | Error | Cannot assign to 'in' parameter `{name}` — it is read-only. |
+| GS0238 | Error | The 'out' parameter `{name}` must be assigned on every path before the function returns. |
+| GS0239 | Error | The variable `{name}` must be definitely assigned before it can be passed by 'ref'. |
+| GS0240 | Error | Override of `{name}` must match the base ref-kind on parameter `{parameter}` (`{baseKind}` vs `{overrideKind}`). |
+| GS0241 | Error | A variadic parameter cannot carry a ref-kind modifier ('ref'/'out'/'in'). |
+| GS0242 | Warning | Argument `{index}` (parameter `{name}`) is passed by 'in' implicitly; add 'in' at the call site to make the read-only pass explicit. |
+| GS0243 | Error | A pointer type '*T' is not a valid parameter type; use the appropriate ref-kind modifier instead (e.g. 'ref T', 'out T', 'in T'). |
+
+Cause/fix examples:
+
+- **GS0235** — fire when the call-site modifier doesn't match the declaration: `f(x)` where `f(ref x int32)` requires `f(&x)` or `f(ref x)`. Fix: add the matching modifier; if the parameter is by-value, drop any unwanted `ref`/`out`/`in`.
+- **GS0236** — `out var n` outside an `out` argument: e.g. `func g(int32) {}` then `g(out var n)`. Fix: only use the inline declaration when the parameter is declared `out`.
+- **GS0237** — assignment to an `in` parameter inside the body: `func h(in p int32) { p = 0 }`. Fix: copy to a local for any mutation, or change the parameter to `ref`.
+- **GS0238** — a missing write before return on an `out` parameter: `func k(out r int32) bool { if cond { r = 1; return true } return false }` — the `false` branch fails to assign `r`. Fix: assign on every path.
+- **GS0239** — passing an uninitialized variable by `ref`: `var x int32; f(ref x)` with no prior assignment. Fix: assign before the call (e.g. `var x = 0`).
+- **GS0240** — override changes the ref-kind of an inherited parameter: `func override f(in p int32) { … }` when the base declares `f(ref p int32)`. Fix: match the base declaration.
+- **GS0241** — variadic combined with ref-kind: `func g(ref values ...int32) {}`. Fix: remove the modifier or remove the variadic decoration.
+- **GS0242** (warning) — passing a plain identifier to an `in` parameter without writing `in`: `f(x)` where `f(in x int32)`. Fix: write `f(in x)` to make the pass-by-readonly-ref explicit. The compiler does NOT silently spill the value (a deliberate departure from C#).
+- **GS0243** — declaring a parameter whose type is the raw pointer `*T`: `func f(p *int32)`. Fix: use a ref-kind modifier instead — `func f(ref p int32)` (or `in`/`out`).
+
+## Named-argument diagnostics (GS0244–GS0247)
+
+Issue #343 introduces named arguments at call sites — `Foo(timeout: 30, retries: 3)` — for free functions, user methods, user constructors, user extension functions, imported CLR methods and constructors, imported extension methods, and inherited CLR instance methods (including delegate `Invoke`). Indirect calls through a function-typed or delegate-typed variable, and variadic call sites, intentionally do not accept named arguments because the call target does not preserve parameter names. The diagnostics below flag malformed or unresolvable named-argument call sites.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0244 | Error | Positional argument cannot follow a named argument. |
+| GS0245 | Error | Named argument `{name}` is specified more than once. |
+| GS0246 | Error | The best overload of `{callee}` does not have a parameter named `{name}`. |
+| GS0247 | Error | Named argument `{name}` specifies a parameter for which a positional argument has already been given. |
+
+Cause/fix examples:
+
+- **GS0244** — `Foo(1, name: "a", 2)`. Fix: move every named argument to the trailing positions, or pass the named one positionally.
+- **GS0245** — `Foo(timeout: 1, timeout: 2)`. Fix: remove the duplicate.
+- **GS0246** — `Foo(qty: 3)` when `Foo` has no parameter named `qty`. Fix: use the correct parameter name. Also fires when calling through a function-typed/delegate variable, or when targeting a variadic parameter list (parameter names are not addressable in those cases).
+- **GS0247** — `Foo(1, x: 2)` when `Foo(x int32, y int32)` is bound — the positional `1` already filled `x`. Fix: drop one or the other.
+
+## Ref-aliasing local diagnostics (GS0256–GS0258)
+
+Issue #491 (ADR-0060 follow-up) introduces `let ref` / `var ref` aliasing locals — a local whose IL slot is a managed pointer `T&` and that aliases another lvalue (`let ref m = arr[i]`, `var ref v = c.Field`). The diagnostics below flag malformed or illegal ref-alias declarations.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0256 | Error | The right-hand side of a 'ref' local declaration must be an lvalue (variable, field, indexer, or dereference). |
+| GS0257 | Error | A 'ref' local cannot be initialized from an expression with a narrower escape scope than the local itself. |
+| GS0258 | Error | A 'ref' local cannot be declared here — only inside non-async, non-iterator function bodies (no top-level, no `const`). |
+
+Cause/fix examples:
+
+- **GS0256** — `let ref m = 1 + 2` or `let ref m = foo()`. The RHS must denote storage you can take the address of. Fix: alias an addressable expression (`let ref m = arr[0]`, `let ref m = c.Value`, `let ref m = *p`), or drop `ref` and copy the value.
+- **GS0257** — Reserved for the full ref-safety analysis. Will fire when the RHS storage cannot live as long as the alias (e.g. a `ref` returned from a callee that captured a shorter-lived local). V1 has no ref returns, so this code is defined for forward compatibility and currently does not fire.
+- **GS0258** — `let ref m = n` at top level, inside `async func`, inside an iterator (yield-returning) function, or written as `const ref`. Fix: move the declaration into a synchronous, non-iterator function body and use `let ref` / `var ref` (not `const ref`). Top-level `ref` locals would require a static field of `T&`, which the CLR forbids; async / iterator bodies would lift the slot onto a state-machine field, which the CLR likewise forbids.
+
+
+## Conditional expression diagnostics (GS0259–GS0263)
+
+ADR-0061 introduced a narrow ref-only ternary form (`cond ? a : b` only inside `ref`/`out`/`in` argument payloads and `&` operands) with diagnostics GS0259–GS0262. ADR-0062 generalises the ternary into a normal expression form. The conditional-outside-ref diagnostic GS0259 is therefore retired: a value-context `cond ? a : b` is now legal. The remaining ADR-0061 diagnostics still fire in their byref contexts; the new GS0263 covers the value-context "no common type" failure.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0259 | Error (retired by ADR-0062) | Conditional lvalue expression (`cond ? a : b`) is only legal as the payload of a 'ref'/'out'/'in' argument modifier or as the operand of '&'. Now only fires for the legacy inner-ref-modifier shape outside ref context. |
+| GS0260 | Error | Both branches of a conditional ref-argument must produce lvalues of the same type, but the true branch is `{trueType}` and the false branch is `{falseType}`. |
+| GS0261 | Error | An 'out var'/'out let'/'out _' inline declaration cannot appear inside a branch of a conditional ref-argument (the new local would only conditionally exist). Declare the local before the call instead. |
+| GS0262 | Error | Inner ref-kind modifier `{innerModifier}` on a conditional ref-argument branch must match the outer modifier `{outerModifier}`. |
+| GS0263 | Error | Conditional expression branches have no common result type — the true branch is `{trueType}` and the false branch is `{falseType}`. Add an explicit conversion to align the two arms. |
+
+Cause/fix examples:
+
+- **GS0260** — `bump(ref true ? a32 : b64)` where `a32 int32` and `b64 int64`. Fix: align the branch types (e.g. introduce a local of the wider type or use a value ternary outside the `ref`).
+- **GS0261** — `produce(out true ? a : out var n)` — the inline `out var n` would declare a local that only exists on one branch. Fix: declare `var n int32` before the call.
+- **GS0262** — `bump(ref true ? in a : ref b)` — the inner `in` does not match the outer `ref`. Fix: use `bump(ref true ? a : b)` (the generalized ADR-0062 form requires no inner modifiers).
+- **GS0263** — `var x = pick ? true : "no"` — `bool` and `string` have no common type. Fix: explicitly convert one arm (e.g. `pick ? "yes" : "no"`).
+
+## Ref-return diagnostics (GS0248–GS0255)
+
+Issue #490 (ADR-0060 follow-up) introduces `ref`-returning functions — declarations of the form `func f(...) ref T { ... }` that return a managed pointer `T&` rather than a copied value, paired with the `return ref <expr>` statement form. The diagnostics below guard the declaration and return-site rules.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0248 | Error | A 'ref' return modifier requires an explicit return type clause (e.g. 'ref int32'). |
+| GS0249 | Error | 'ref' return is not legal on an `{async/iterator}` function; the state-machine rewriter cannot hoist a managed pointer. |
+| GS0250 | Error | 'ref' return modifier is redundant when the declared return type is already a managed pointer ('*T'); write 'ref T' instead. |
+| GS0251 | Error | 'return ref' is not allowed in `{functionName}` because its declaration does not specify a 'ref' return type. |
+| GS0252 | Error | Function `{functionName}` returns by reference; use `return ref <expr>` instead of a plain 'return'. |
+| GS0253 | Error | The operand of 'return ref' must be an lvalue (variable, field, array element, or '*p'). |
+| GS0254 | Error | Cannot return a managed pointer to function-local storage; the reference would dangle once the function returns. |
+| GS0255 | Error | Override of `{memberName}` must match the base return ref-kind: base returns `{expected}`, this declaration returns `{actual}`. |
+
+Cause/fix examples:
+
+- **GS0248** — `func f(x int32) ref { return ref x }` — `ref` requires the element type. Fix: `func f(x int32) ref int32`.
+- **GS0249** — `async func f() ref int32 { ... }` or a yield-iterator body. Fix: drop `ref` from the return — `async` / iterator state-machine fields cannot hold managed pointers.
+- **GS0250** — `func f(p *int32) ref *int32 { return p }`. Fix: write `ref int32` (or drop `ref` and return the pointer).
+- **GS0251** — a `return ref x` statement in a function whose declaration is `func f() int32`. Fix: add `ref` to the return type, or drop `ref` from the return statement.
+- **GS0252** — a plain `return x` in a `ref`-returning function. Fix: write `return ref x`.
+- **GS0253** — `return ref (a + b)` or `return ref Foo()`. Fix: alias an addressable expression first (`let ref t = arr[i]; return ref t`) or restructure to return a pointer to durable storage.
+- **GS0254** — `func f() ref int32 { var x = 0; return ref x }`. Fix: do not return references to function locals; consume the value by copy or alias storage that outlives the call.
+- **GS0255** — overriding a base method declared `int32` with a `ref int32` override (or vice versa). Fix: match the base return ref-kind exactly.
+
+## Method-overloading and optional-parameter diagnostics (GS0264–GS0267)
+
+ADR-0063 lifts the v0 "one declaration per name" rule, so G# user functions can carry overload sets (differing by parameter types or ref-kinds) and optional parameters with default values. The diagnostics below cover overload-set construction and overload resolution.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0264 | Error | An overload of `{name}` with signature `{signature}` is already declared. Two overloads must differ by parameter types or ref-kinds. |
+| GS0265 | Error | Optional parameter `{parameterName}` is invalid: `{reason}`. |
+| GS0266 | Error | Call to `{name}` is ambiguous between multiple overloads. Disambiguate with explicit types or named arguments. |
+| GS0267 | Error | No overload of `{name}` is applicable to the given argument list. |
+
+Cause/fix examples:
+
+- **GS0264** — two `func F(x int32) {}` declarations, or two declarations that differ only in return type. Fix: change the parameter list (different types, arity, or ref-kinds); return type alone is not a distinguishing signature.
+- **GS0265** — a default-value expression that is not constant, a parameter whose default depends on another parameter, an optional parameter preceding a required one without all trailing parameters also optional, or an optional ref/out parameter. Fix: use a compile-time-constant default, place optional parameters at the end of the list, and avoid combining `ref`/`out` with defaults.
+- **GS0266** — `Greet("ada")` when both `Greet(string)` and `Greet(name string)` are visible via different paths. Fix: rename one, change one signature, or use a named argument that only one overload accepts.
+- **GS0267** — `Greet(42)` when only `Greet(string)` is declared. Fix: pass a value of the expected type, or add an overload covering the new argument shape.

--- a/website/docs/ref/feature-matrix.md
+++ b/website/docs/ref/feature-matrix.md
@@ -16,9 +16,10 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Packages, imports, import aliases | Supported | Supported | Emit supports multi-package assemblies; interpreter binds the same model. |
 | Implicit `System` import | Supported | Supported | Enabled by default; disabled with `/noimplicitimports` or `/no-implicit-imports`. |
 | Top-level statements and `func Main` | Supported | Supported | Mixing top-level statements and explicit `Main` is diagnosed by `GS0165`/`GS0166`. |
-| Comments | Supported | Supported | Line and block comments are accepted by the compiler lexer; editor grammar may lag. |
+| Comments | Supported | Supported | Line (`//`), block (`/* … */`), and Markdown documentation (`///`, ADR-0057) comments. |
 | String, raw string, and interpolated string literals | Supported | Supported | Sigil-free interpolation with `$name`/`${expr,alignment:format}`, delimiter-aware multiline holes, and `DefaultInterpolatedStringHandler`/`FormattableString` lowering (ADR-0055). |
 | Character literals | Supported | Supported | Character diagnostics are `GS0191` through `GS0195`. |
+| Documentation comments | Supported | Supported | `///` Markdown comments round-trip to CLR XML doc; hover renders CLR XML docs for imported APIs. Diagnostics `GS0227`–`GS0231`. |
 
 ## Types and values
 
@@ -45,6 +46,10 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Generics and method inference | Supported | Supported for binding/evaluation | Metadata specs plus type-erased handling for open type-parameter-containing shapes. |
 | Variance and constraints | Supported semantically | Supported semantically | Diagnostics include `GS0150` through `GS0153`. |
 | By-ref and pointers | Partial | Limited/not supported | `&` / `*` / `*T` for CLR `ref`/`out`/`in` interop (ADR-0039); ref returns auto-dereference in rvalue position (ADR-0056 §1). Evaluator rejects generic address/deref execution. |
+| `ref`/`out`/`in` parameters | Supported | Supported | Declaration-site and call-site modifiers per ADR-0060; diagnostics `GS0235`–`GS0243`. Includes `out var/let/_` inline declarations. |
+| Ref-aliasing locals (`let ref` / `var ref`) | Supported | Supported | Local whose IL slot is `T&` and aliases another lvalue. Diagnostics `GS0256`–`GS0258`. |
+| `ref`-returning functions | Supported | Supported | `func f(...) ref T { ... }` paired with `return ref <lvalue>`. Diagnostics `GS0248`–`GS0255`. |
+| `scoped` parameter modifier | Supported | Supported | Constrains a `ref struct` / managed-pointer parameter from escaping; enforced by `GS9004` / `GS9006`. |
 | Spans and `ref struct` types | Mostly supported | Limited | Stack-only consumption of `Span[T]` / `ReadOnlySpan[T]` and user `type X ref struct`: element read/write, `[]T`→span conversion, closed generic value-type fields (ADR-0056). Escape rules are `GS0219`; `ReadOnlySpan[T]` writes are `GS0226`. Full ref-safe-to-escape analysis is deferred (#376). |
 
 ## Declarations and members
@@ -57,7 +62,9 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Operator declarations | Supported | Supported where evaluator invokes user/CLR op paths | Receiver `operator` declarations map to CLR `op_*` names. |
 | Interface implementation | Supported | Supported for checks/upcasts | Missing members and sealed-interface violations are diagnosed. |
 | Inheritance and overrides | Supported | Partially supported | Base classes must be `open`; override diagnostics are implemented. |
-| Default parameter values in G# declarations | Not supported | Not supported | Parser parameter grammar has no initializer. |
+| Default parameter values in G# declarations | Supported | Supported | ADR-0063. Optional parameters carry compile-time-constant defaults; rule violations report `GS0265`. |
+| Method overloading (user functions) | Supported | Supported | ADR-0063. Functions can carry overload sets differing by parameter types or ref-kinds; duplicates report `GS0264`, ambiguous calls report `GS0266`, no-applicable reports `GS0267`. |
+| Named delegate types | Supported | Supported | ADR-0059. `type X = delegate func(...)` declares a real CLR `MulticastDelegate`-derived type; diagnostics `GS0233`–`GS0234`. |
 
 ## Statements and control flow
 
@@ -83,7 +90,9 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Feature | Emit (`gsc`) | Interpreter | Notes |
 | --- | --- | --- | --- |
 | Calls and generic calls | Supported | Supported | Bracketed type arguments. |
-| Named arguments | Partial | Partial | Accepted for data-struct copy and imported optional/default argument scenarios. |
+| Named arguments | Supported | Supported | `Foo(timeout: 30, retries: 3)` for free functions, user methods/constructors, extension functions, and inherited CLR methods (including delegate `Invoke`). Indirect calls through a function-typed variable and variadic targets are excluded. Diagnostics `GS0244`–`GS0247`. |
+| Conditional (`?:`) ternary expression | Supported | Supported | Generalized in ADR-0062; `cond ? a : b` is a normal expression. `GS0263` covers the "no common type" failure. |
+| Conditional ref-arguments (`ref cond ? a : b`) | Supported | Supported | ADR-0061. Branches must produce same-typed lvalues. Diagnostics `GS0260`–`GS0262`. |
 | Struct, array, and map literals | Supported | Supported | Map literals bind to `Dictionary[K,V]` backing. |
 | Indexing and index assignment | Supported | Supported | Arrays, slices, maps, and imported CLR indexers. |
 | Null-conditional access | Supported | Supported | `?.` represented in the bound tree. |
@@ -129,4 +138,5 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Reference assemblies | Supported | N/A | SDK can produce reference assemblies. |
 | SDK `.gsproj` build/run/pack | Supported | N/A | `Gsharp.NET.Sdk` integrates with MSBuild and `dotnet`. |
 | REPL | N/A | Supported | Interpreter executable starts a REPL with no file argument. |
-| Language server and VS Code extension | N/A | N/A | Tooling uses parser/binder services and provides rich editor capabilities. |
+| Language server and VS Code extension | N/A | N/A | Pull-based diagnostics, semantic tokens, hover for CLR XML docs, CodeLens reference counts on members of types/structs/interfaces/enums, signature help, inlay hints, completion, go-to-definition, references, rename, formatting, debug + test integration. |
+| VS Code color themes | N/A | N/A | Six bundled themes (Ember, Magma, Synthwave — Dark + Light each). |

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -22,7 +22,7 @@ A compilation unit consists of an optional package declaration, zero or more imp
 
 ### Comments
 
-Line comments begin with `//` and run to the end of the line. Block comments begin with `/*` and end with `*/`; they do not nest. An unterminated block comment is a lexical diagnostic.
+Line comments begin with `//` and run to the end of the line. Block comments begin with `/*` and end with `*/`; they do not nest. An unterminated block comment is a lexical diagnostic. Documentation comments begin with `///` and run to the end of the line; consecutive `///` lines are concatenated, the first leading space is stripped, and the block is attached to the following declaration where it is parsed as Markdown and lowered to CLR XML doc. See [Documentation comments](#documentation-comments).
 
 ### Tokens
 
@@ -299,25 +299,30 @@ Annotation   = "@" ( AnnotationTarget ":" )? identifier { "." identifier } ( "("
 
 ### Functions and methods
 
-Functions use `func`. Receiver clauses declare receiver-style methods and extension functions. Operator overloads use `operator` followed by the operator token and map to CLR operator names downstream. Parameters do not have default-value syntax in G# declarations.
+Functions use `func`. Receiver clauses declare receiver-style methods and extension functions. Operator overloads use `operator` followed by the operator token and map to CLR operator names downstream. Parameters may carry a ref-kind modifier (`ref`, `out`, or `in`, ADR-0060) and may declare a compile-time-constant default value to become optional (ADR-0063). User functions may be overloaded as long as overloads differ by parameter types, arity, or ref-kinds; two declarations that differ only in return type are rejected as `GS0264`.
 
 ```ebnf
-FunctionDecl      = "func" ReceiverClause? ( identifier | OperatorName ) TypeParamList? "(" Parameters? ")" TypeClause? Block .
+FunctionDecl      = "func" ReceiverClause? ( identifier | OperatorName ) TypeParamList? "(" Parameters? ")" RefReturnClause? Block .
 AsyncFunctionDecl = "async" FunctionDecl .
 ReceiverClause    = "(" Parameter ")" .
 OperatorName      = "operator" OperatorToken .
 TypeParamList     = "[" TypeParameter { "," TypeParameter } "]" .
 TypeParameter     = ( "in" | "out" )? identifier ConstraintName? .
 Parameters        = Parameter { "," Parameter } .
-Parameter         = Annotation* identifier "..."? TypeClause .
+Parameter         = Annotation* ParameterModifier? identifier "..."? TypeClause ( "=" ConstantExpression )? .
+ParameterModifier = "ref" | "out" | "in" | "scoped" .
+RefReturnClause   = "ref"? TypeClause .
 ```
+
+A function declared `func f(...) ref T` returns a managed pointer and pairs with the `return ref <lvalue>` statement form (diagnostics `GS0248`–`GS0255`). The `scoped` modifier on a `ref struct` / managed-pointer parameter constrains the value from escaping the call (enforced by the by-ref-like rules in `GS9004` / `GS9006`).
 
 ### Type declarations
 
 ```ebnf
-TypeDecl          = "type" identifier TypeParamList? ( TypeAliasTail | StructDeclTail | ClassDeclTail | EnumDeclTail | InterfaceDeclTail ) .
+TypeDecl          = "type" identifier TypeParamList? ( TypeAliasTail | DelegateAliasTail | StructDeclTail | ClassDeclTail | EnumDeclTail | InterfaceDeclTail ) .
 TypeAliasTail     = "=" identifier .
-StructDeclTail    = Data? Inline? Open? "struct" PrimaryCtor? StructBody .
+DelegateAliasTail = "=" "delegate" "func" "(" Parameters? ")" TypeClause? .
+StructDeclTail    = Data? Inline? Open? Ref? "struct" PrimaryCtor? StructBody .
 ClassDeclTail     = Open? "class" PrimaryCtor? BaseClause? StructBody .
 RecordDeclTail    = ( "record" | Data? "record" ) StructBody .
 EnumDeclTail      = "enum" "{" EnumMemberList? "}" .
@@ -325,6 +330,8 @@ InterfaceDeclTail = Sealed? "interface" InterfaceBody .
 PrimaryCtor       = "(" Parameters? ")" .
 BaseClause        = ":" QualifiedTypeName ( "(" Arguments? ")" )? { "," QualifiedTypeName } .
 ```
+
+A `DelegateAliasTail` declares a real CLR `MulticastDelegate`-derived named delegate type (ADR-0059), so C# consumers see a conventional handler type and G# events can carry first-class custom delegate types. Diagnostics `GS0233`–`GS0234` cover malformed declarations.
 
 ### Members
 
@@ -351,18 +358,24 @@ Unary operators bind tighter than binary operators. Binary operators are left-as
 
 | Precedence | Operators | Meaning |
 | --- | --- | --- |
-| 6 | `+`, `-`, `!`, `^`, `*`, `&`, `<-`, `await` | unary |
-| 5 | `*`, `/`, `%`, `<<`, `>>`, `&`, `&^` | multiplicative, shifts, bitwise and, bit clear |
-| 4 | `+`, `-`, `\|`, `^` | additive, bitwise or, xor |
-| 3 | `==`, `!=`, `<`, `<=`, `>`, `>=` | equality and comparison |
-| 2 | `&&` | logical and |
-| 1 | `\|\|`, `?:` | logical or and null coalescing |
+| 7 | `+`, `-`, `!`, `^`, `*`, `&`, `<-`, `await` | unary |
+| 6 | `*`, `/`, `%`, `<<`, `>>`, `&`, `&^` | multiplicative, shifts, bitwise and, bit clear |
+| 5 | `+`, `-`, `\|`, `^` | additive, bitwise or, xor |
+| 4 | `==`, `!=`, `<`, `<=`, `>`, `>=` | equality and comparison |
+| 3 | `&&` | logical and |
+| 2 | `\|\|`, `?:` | logical or and null coalescing |
+| 1 | `?` … `:` … | conditional (ternary, right-associative) |
+
+The conditional expression `cond ? whenTrue : whenFalse` (ADR-0062) requires `cond` to be `bool` and the two branches to share a common type. Mismatched branches report `GS0263`. The narrow ADR-0061 form `ref cond ? lhs : rhs` (and its `out` / `in` siblings) survives as a payload to a ref-kind argument; diagnostics `GS0260`–`GS0262` apply there.
 
 Postfix `!!`, member access `.`, null-conditional access `?.`, indexing, calls, and generic instantiation are parsed greedily on primary expressions. This applies to **any** primary, including a parenthesized expression — for example `(a + b).GetType()`, `(nums)[0]`, and `("s").Length` are all valid. The sole exception is a bare numeric literal: `42.Member` is not accepted because it is ambiguous with float-literal lexing; wrap it as `(42).Member` instead (see ADR-0054).
 
 ### Primary expressions and calls
 
-Primary expressions include literals, identifiers, calls, generic calls, struct literals, array or slice literals, map literals, function literals, switch expressions, tuple literals, `make(chan ...)`, `typeof(...)`, and `nameof(...)`. Calls support positional and named arguments syntactically; named arguments are accepted semantically for data-struct copy and imported CLR optional/default-argument scenarios, while normal G# calls reject unexpected named arguments.
+Primary expressions include literals, identifiers, calls, generic calls, struct literals, array or slice literals, map literals, function literals, switch expressions, tuple literals, `make(chan ...)`, `typeof(...)`, and `nameof(...)`. Calls accept positional, named, and ref-kind-prefixed arguments:
+
+- **Named arguments** — `Foo(timeout: 30, retries: 3)` (or the legacy `Foo(timeout = 30)` shape) for free functions, user methods, user constructors, user extension functions, imported CLR methods and constructors, imported extension methods, and inherited CLR instance methods (including delegate `Invoke`). Indirect calls through a function-typed or delegate-typed variable, and variadic call sites, do not accept named arguments because the call target does not preserve parameter names. Diagnostics `GS0244`–`GS0247` cover ordering, duplicates, and unknown names.
+- **Ref-kind arguments** — `f(ref x)`, `f(out var n)`, `f(in z)` (ADR-0060). The call-site modifier must match the parameter's declared kind (`GS0235`); `in` requires an explicit `in` at the call site to prevent silent spilling (`GS0242`).
 
 Generic instantiation uses brackets and bounded lookahead to distinguish type arguments from indexing. Examples include `Id[int32](1)` and `Box[string]{Value: "x"}`.
 
@@ -432,6 +445,12 @@ Statement = Block | Annotation* VariableDecl | IfStmt | ForStmt | BreakStmt | Co
 
 Short declaration is `name := expr`. Multi-target assignment supports `a, b = x, y` and `a, b := x, y` for identifier target lists. Increment and decrement are statements, not expressions.
 
+A `let` or `var` may carry a `ref` prefix to declare a **ref-aliasing local** (ADR-0060 follow-up): `let ref m = arr[i]` produces a local whose IL slot is a managed pointer (`T&`) that aliases the right-hand-side storage. The RHS must be an lvalue (`GS0256`); ref locals are illegal at top level, inside `async` / iterator bodies, and as `const` (`GS0258`). Reads and writes through the alias forward to the underlying storage.
+
+```ebnf
+RefLocalDecl = ( "let" | "var" ) "ref" identifier "=" Expression .
+```
+
 ### If statements
 
 `if` accepts an optional simple statement before a semicolon, then a condition and body, with an optional `else` body.
@@ -463,7 +482,7 @@ ForStmt = "for" Statement
 
 ### Return and yield
 
-`return` may have no expression, one expression, or a comma-separated expression list, which is represented as a tuple literal. `yield expr` is contextual and valid in iterator functions returning `sequence[T]` or async sequence forms as appropriate.
+`return` may have no expression, one expression, or a comma-separated expression list, which is represented as a tuple literal. In a `ref`-returning function (`func f(...) ref T`), the return statement form is `return ref <lvalue>` — plain `return expr` reports `GS0252`, and a non-lvalue operand reports `GS0253`. `yield expr` is contextual and valid in iterator functions returning `sequence[T]` or async sequence forms as appropriate.
 
 ### Defer and using
 
@@ -526,6 +545,36 @@ G# imports can resolve CLR namespaces and metadata references. CLR primitive typ
 Attributes use `@Name(...)` and optional use-site targets such as `@field:`, `@param:`, and `@return:`. The current implementation recognizes attributes, but user P/Invoke or extern declarations are not supported.
 
 Interpolated strings interoperate with the CLR formatting types. By default they lower to `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler` (value-type holes are not boxed); a string targeted at `IFormattable` or `FormattableString` lowers to `FormattableStringFactory.Create` for deferred, culture-aware formatting; and a parameter annotated with `[InterpolatedStringHandler]` receives the handler directly, including `[InterpolatedStringHandlerArgument]` forwarding.
+
+## Documentation comments
+
+ADR-0057 introduces Markdown-authored documentation comments that round-trip losslessly to CLR XML doc. A documentation comment is a run of consecutive `///` lines; each line contributes one paragraph of authored text after one optional leading space is stripped. The block is attached to the immediately following declaration (free function, type, member, or top-level constant) and is parsed as Markdown plus a small set of `@`-prefixed block tags drawn from the CLR XML-doc vocabulary.
+
+Recognised tags:
+
+| Tag | Meaning |
+| --- | --- |
+| `@summary` | Default; usually elided. Prose-only `///` blocks become the summary. |
+| `@param name` | Documents parameter `name`. |
+| `@typeparam name` | Documents type parameter `name`. |
+| `@returns` | Documents the return value. |
+| `@value` | Documents a property's value. |
+| `@remarks` | Long-form remarks. |
+| `@exception TypeName` | Documents a thrown exception. |
+| `@seealso TypeName` | Cross-reference. |
+| `@inheritdoc` | Inherit documentation from a base/interface member. |
+
+Authors can drop raw `<...>` XML through unchanged by writing it inside a fenced ```` ```xmldoc ```` code block, for constructs Markdown cannot express.
+
+The compiler renders the merged documentation in hover for both G# declarations and imported CLR APIs (their `.xml` doc files are ingested and rendered identically). Diagnostics:
+
+| Code | Severity | Cause |
+| --- | --- | --- |
+| `GS0227` | Warning | Documentation comment is not attached to a declaration. |
+| `GS0228` | Warning (opt-in) | Missing documentation on a public member. |
+| `GS0229` | Warning | `@param` / `@typeparam` name does not match any parameter. |
+| `GS0230` | Warning | Unsupported documentation Markdown construct. |
+| `GS0231` | Warning | Unknown documentation tag. |
 
 ## Appendix: full parser grammar
 

--- a/website/docs/release-notes.md
+++ b/website/docs/release-notes.md
@@ -9,20 +9,40 @@ G# is pre-1.0. The repository's version base is currently `0.1`, and product ver
 
 ## Unreleased
 
-This documentation set is the initial public documentation release for the G# website. The language and tooling are under active development, so future entries should call out breaking changes clearly and link to the relevant design decision or reference page.
+The G# compiler, language server, and VS Code extension absorbed a large stack of additions this cycle. The summary below groups them by area; each item links to the design decision (ADR) or implementation reference.
 
 ### Added
 
-- Authored public documentation pages for the FAQ and release notes.
-- Established this page as the release-history location for future G# documentation updates.
+- **Documentation comments** ([ADR-0057](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0057-documentation-comments.md)) — Markdown-authored `///` documentation comments that round-trip losslessly to CLR XML doc. Hover renders the merged documentation for both G# declarations and imported CLR APIs. New warnings: `GS0227` (unattached), `GS0228` (missing on public, opt-in), `GS0229` (`@param` mismatch), `GS0230` (unsupported Markdown), `GS0231` (unknown tag).
+- **Named delegate types** ([ADR-0059](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0059-named-delegate-types.md)) — `type Name = delegate func(...)` declares a real CLR `MulticastDelegate`-derived type so C# consumers see a conventional handler type and G# events can carry first-class custom delegate types. Diagnostics `GS0233`–`GS0234`.
+- **`ref`/`out`/`in` parameters** ([ADR-0060](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0060-ref-out-in-parameters.md)) — Declaration-site and call-site ref-kind modifiers, including inline `out var/let/_` declarations. Diagnostics `GS0235`–`GS0243`. Passing a value to an `in` parameter without writing `in` at the call site is the warning `GS0242` rather than a silent spill (a deliberate departure from C#).
+- **Ref-aliasing locals** (ADR-0060 follow-up) — `let ref m = arr[i]` / `var ref v = c.Field` produces a local whose IL slot is `T&` and aliases another lvalue. Diagnostics `GS0256`–`GS0258`.
+- **Ref returns** (ADR-0060 follow-up, issue #490) — `func f(...) ref T { return ref <expr> }`. Diagnostics `GS0248`–`GS0255` cover the surrounding rules (escape, async/iterator ban, override match).
+- **Conditional ref-arguments** ([ADR-0061](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0061-conditional-ref-arguments.md)) — narrow `ref cond ? a : b` form inside ref-kind argument payloads; diagnostics `GS0260`–`GS0262`.
+- **Generalized ternary expression** ([ADR-0062](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0062-generalized-ternary-expression.md)) — `cond ? a : b` is now a normal expression. `GS0259` is retired in value contexts; the new `GS0263` covers the "no common type" failure.
+- **Method overloading and optional parameters** ([ADR-0063](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0063-method-overloading-and-optional-parameters.md)) — user G# functions can carry overload sets (differing by parameter types or ref-kinds) and optional parameters with compile-time-constant defaults. Diagnostics `GS0264`–`GS0267`.
+- **Named arguments at call sites** (issue #343) — `Foo(timeout: 30, retries: 3)` for free functions, user methods, user constructors, extension functions, and inherited CLR methods (including delegate `Invoke`). Diagnostics `GS0244`–`GS0247`. The legacy `name = value` form is still accepted for `.copy(...)` and attribute argument lists.
+- **`scoped` parameter modifier** ([ADR-0058](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0058-ref-safe-to-escape.md)) — constrains a `ref struct` / managed-pointer parameter from escaping; enforced by `GS9004` / `GS9006`.
+- **`data struct` synthesis completed** ([ADR-0029](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0029-data-struct-synthesized-members.md), issue #410) — every `data struct` synthesizes `Equals(object)`, `Equals(T)`, `GetHashCode()`, `ToString()`, `op_Equality`, `op_Inequality`, and `Deconstruct(...)`. Hand-written versions are rejected (`GS0232`).
+- **Editor features** — hover for CLR XML docs (#397), live pull-based diagnostics (#362), CodeLens reference counts on members of structs, interfaces, and enums (#403), implicit `this` for properties/methods/events (#412), hover for `this` (#413), bare static-member access from instance methods (#485), chained-member hover (#402), and six VS Code color themes inspired by the G# logo (Ember, Magma, Synthwave — Dark + Light each, #357).
 
 ### Changed
 
-- No runtime or language change is implied by this documentation entry.
+- The website spec, feature matrix, FAQ, bridges page, guide pages, and design-decisions index were refreshed to match the compiler ground truth — most visibly, "Parameters do not have default-value syntax" and "Named arguments — Partial" are no longer correct and were rewritten.
+- The repo `docs/lexical.md` block-comment paragraph (which incorrectly claimed block comments were not implemented) is corrected, and a documentation-comments subsection was added.
+- The VS Code TextMate grammar adds the missing contextual keywords (`data`, `inline`, `record`, `delegate`, `event`, `prop`, `init`, `shared`, `scoped`, accessor names `get`/`set`/`add`/`remove`/`raise`, ref-kinds `ref`/`out`), operators (`:=`, `?.`, `??`, `?`/`:`, `!!`, `...`, `=>`), an `@Annotation` scope, and a `///` documentation-comment scope with `@tag` highlighting. The VS Code snippet set was rewritten to match current grammar.
 
 ### Fixed
 
-- No product fixes are recorded in this documentation entry.
+- Numerous IL-emit hardening rounds (issues #418, #419, #420, #421) and a new `ilverify` gate (#478) ensure emitted assemblies pass CLR verification.
+- Determinism golden test (#475) freezes emitted bytes for byte-for-byte reproducibility.
+- `FieldAccessException` on class auto-properties (#399).
+- CodeLens 0-refs and stale-tree fixes (#414).
+
+### Known issues
+
+- The full ref-safe-to-escape escape analysis is partial; `GS0257` is reserved for a future pass.
+- Async state-machine emit shapes that are not yet supported continue to report `GS0190`.
 
 ## 0.1
 

--- a/website/versioned_docs/version-0.1/bridges/gsharp-for-csharp-developers.md
+++ b/website/versioned_docs/version-0.1/bridges/gsharp-for-csharp-developers.md
@@ -28,7 +28,15 @@ G# is a .NET language with Go-inspired syntax. It emits CLR assemblies, imports 
 | `IEnumerable<T>` iterator | `sequence[T]` with `yield` | Async streams use `async sequence[T]`. |
 | `lock` and tasks | `go`, `chan T`, `select`, `scope` | G# adds Go-shaped structured concurrency. |
 | `using var` or `using (...)` | `using` and `defer` | Defer and using cleanup at block exit. |
-| optional parameter defaults | imported CLR optional args only | G# user functions do not define default parameter values. |
+| `void M(int x = 0)` | `func M(x int32 = 0)` | G# functions support optional parameters with constant defaults (ADR-0063). |
+| `void M(int x, int y); void M(int x);` | overloads of `M(int32, int32)` / `M(int32)` | G# functions support overloading on parameter shape (ADR-0063); duplicates report `GS0264`. |
+| named arg `M(timeout: 30)` | `M(timeout: 30)` (or `M(timeout = 30)` legacy) | Named arguments at call sites for user functions, methods, constructors, extensions, and CLR methods. |
+| `ref int M(int[] a, int i)` | `func M(a []int32, i int32) ref int32` paired with `return ref a[i]` | Ref returns (ADR-0060 follow-up). |
+| `ref int local = ref arr[i]` | `let ref local = arr[i]` or `var ref local = arr[i]` | Ref-aliasing locals. |
+| `out int n` parameter / `M(out var n)` | `out n int32` / `M(out var n)` | Ref-kind parameters and inline `out` declarations (ADR-0060). |
+| `delegate void Handler(object sender)` | `type Handler = delegate func(sender Object)` | Named delegate types (ADR-0059). |
+| `cond ? a : b` | `cond ? a : b` | Ternary expression (ADR-0062). |
+| `/// <summary>…</summary>` XML doc | `/// summary text` Markdown doc | Markdown documentation comments round-trip to CLR XML (ADR-0057). |
 | lambda `x => x + 1` | `func(x int32) int32 { return x + 1 }` | Func literals are the lambda form; parameters and return type are explicit. |
 | extension method | `func (r Receiver) M()` | A receiver clause declares a CLR-visible extension method. |
 
@@ -60,9 +68,29 @@ func add(a int32, b int32) int32 {
 
 C# source uses aliases such as `int` and `long`. G# spells the widths: `int32`, `int64`, `uint32`, `float64`, and so on. This makes interop signatures visually match CLR metadata.
 
-## Defaults and optional arguments differ
+## Defaults, named arguments, and overloading
 
-G# user-defined functions do not declare default parameter values. Imported CLR methods and extension methods can still expose optional arguments from metadata, and G# callers may omit those arguments.
+G# user functions support optional parameters with compile-time-constant defaults, named arguments at the call site, and overload sets — all introduced in ADR-0063 and complementary issues:
+
+```gsharp
+func greet(name string = "world", excited bool = false) string {
+    return excited ? "hi, $name!" : "hi, $name"
+}
+
+// Default values: both optional.
+let a = greet()                      // "hi, world"
+let b = greet("Ada")                 // "hi, Ada"
+
+// Named arguments: arrive in any order, skip leading defaults.
+let c = greet(excited: true)         // "hi, world!"
+let d = greet(name: "Ada", excited: true)
+
+// Overloading by parameter shape.
+func area(width int32, height int32) int32 { return width * height }
+func area(side int32) int32                { return side * side }
+```
+
+Imported CLR methods that expose `[Optional]` arguments work the same way G# defaults do, and CLR overload sets resolve identically. The legacy `name = value` named-argument form is still accepted for `.copy(...)` calls and attribute argument lists.
 
 ## Data shapes are richer than plain classes
 

--- a/website/versioned_docs/version-0.1/design-decisions.md
+++ b/website/versioned_docs/version-0.1/design-decisions.md
@@ -80,6 +80,8 @@ This is a curated reference index of the Architecture Decision Records in the re
 | [0014](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0014-visibility-default.md) | Visibility defaults — `public` for top-level declarations | Makes unmodified top-level declarations public by default. |
 | [0054](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0054-postfix-member-access-on-primary-expressions.md) | Postfix member/index access on primary expressions | Chains `.`/`?.`/`[]` after any primary except a bare numeric literal (`(42).Member`). |
 | [0055](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0055-string-interpolation-revamp.md) | String interpolation revamp | Delimiter-aware multiline holes, alignment/format clauses, late context-driven lowering (`DefaultInterpolatedStringHandler`/`FormattableString`), and full IDE support inside holes. |
+| [0057](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0057-documentation-comments.md) | Documentation comments | Markdown-authored `///` documentation comments with lossless CLR XML-doc round-trip; hover renders the merged XML on imported APIs. Diagnostics `GS0227`–`GS0231`. |
+| [0062](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0062-generalized-ternary-expression.md) | Generalized ternary expression | Promotes `cond ? a : b` from the narrow ADR-0061 ref form to a normal expression; retires `GS0259` in value contexts and adds `GS0263`. |
 
 ## CLR interop
 
@@ -94,6 +96,11 @@ This is a curated reference index of the Architecture Decision Records in the re
 | [0039](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0039-byref-pointers-and-clr-interop.md) | By-ref pointers and CLR interop for `ref` / `out` / `in` parameters | Introduces `*T`, `&`, dereference, `ref` arguments, and related diagnostics. |
 | [0047](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0047-attribute-syntax-and-declaration.md) | Attribute consumption and declaration (Kotlin-style annotations) | Defines `@` annotation syntax, use-site targets, attribute arguments, and `@Attribute` sugar. |
 | [0056](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0056-span-consumption-v1.md) | Span consumption v1 — ref-returning members, span element access, closed generic value-type fields | Auto-dereferences ref-returning members in rvalue position, makes spans indexable (read/write), applies `[]T → Span[T]` conversion in argument position, and gives closed generic value-type fields real layout. |
+| [0058](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0058-ref-safe-to-escape.md) | Ref-safe-to-escape and the `scoped` modifier | Adds the `scoped` parameter modifier and the supporting `GS9004`/`GS9006` ref-pointer escape diagnostics. |
+| [0059](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0059-named-delegate-types.md) | Named delegate types | `type Name = delegate func(...)` declares a real CLR `MulticastDelegate`-derived type; diagnostics `GS0233`–`GS0234`. |
+| [0060](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0060-ref-out-in-parameters.md) | `ref`/`out`/`in` parameters | Declaration-site and call-site ref-kind modifiers with diagnostics `GS0235`–`GS0243`; ref-aliasing locals (`let ref`/`var ref`) and ref returns are follow-ups (`GS0248`–`GS0258`). |
+| [0061](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0061-conditional-ref-arguments.md) | Conditional ref-arguments | Narrow `ref cond ? a : b` form inside ref-kind argument payloads; diagnostics `GS0259`–`GS0262`. |
+| [0063](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0063-method-overloading-and-optional-parameters.md) | Method overloading and optional parameters | Lifts the v0 "one declaration per name" rule and adds default parameter values; diagnostics `GS0264`–`GS0267`. |
 
 ## Emit and tooling
 

--- a/website/versioned_docs/version-0.1/faq.md
+++ b/website/versioned_docs/version-0.1/faq.md
@@ -47,9 +47,15 @@ G# combines a Go-shaped surface with .NET primitives. `go f()` starts a concurre
 
 `async func` and `await` exist for direct .NET interop with `Task`, `Task[T]`, and compatible awaitable shapes. In emitted code, G# lowers async functions and lambdas to .NET state machines; in the interpreter, awaits block on the awaiter for simple test and REPL behavior. See [ADR-0023](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0023-async-state-machine.md).
 
-## Why are there no default or optional parameter values in G# functions?
+## How do optional parameters, named arguments, and overloading work in G# functions?
 
-User-defined G# function declarations do not have parameter default-value syntax. Calls may use named arguments only in limited supported cases, such as data-struct copy ergonomics and imported CLR methods that already declare optional or default arguments. This keeps G# function declarations simple while preserving compatibility with .NET APIs that expose optional parameters.
+User-defined G# functions support all three:
+
+- **Optional parameters**: declare a default value with `=` after the type — `func greet(name string = "world")` (ADR-0063). Defaults must be compile-time constants and trailing optional parameters cannot precede required ones. Misuse reports `GS0265`.
+- **Named arguments**: any call site can name an argument — `greet(name: "Ada")` — for free functions, user methods, user constructors, extension functions, and inherited CLR methods. The call-site form is `name: value` (the older `name = value` is still accepted for `.copy(...)` and attribute arg lists). Indirect calls through a function-typed variable and variadic call sites do not accept names because the target does not preserve parameter names. Diagnostics `GS0244`–`GS0247`.
+- **Overloading**: two declarations of the same function name are allowed as long as they differ by parameter types, arity, or ref-kinds (ADR-0063). Duplicate signatures report `GS0264`; ambiguous calls report `GS0266`; no-applicable-overload reports `GS0267`.
+
+This is a recent change — earlier docs described G# as having no parameter defaults and only "partial" named-argument support. That is no longer accurate.
 
 ## How do generics work?
 

--- a/website/versioned_docs/version-0.1/guide/declarations-and-packages.md
+++ b/website/versioned_docs/version-0.1/guide/declarations-and-packages.md
@@ -68,7 +68,42 @@ func (p Point) LengthSquared() int32 {
 }
 ```
 
-Generic functions use bracketed type parameters and bracketed type arguments. Parameters do not support default values in G# declarations today, though imported CLR optional/default arguments are supported in interop scenarios.
+Generic functions use bracketed type parameters and bracketed type arguments.
+
+Parameters may carry a ref-kind modifier (`ref`, `out`, `in`, or `scoped`) and may declare a compile-time-constant default value to become optional. Two functions sharing a name are overloads when they differ by parameter types, arity, or ref-kinds; differing by return type alone is not a distinguishing signature. See ADR-0060 (ref parameters), ADR-0063 (overloading and optional parameters), and the [feature matrix](/docs/ref/feature-matrix) for the full capability table.
+
+```gsharp
+func greet(name string = "world", excited bool = false) string {
+    return excited ? "hi, $name!" : "hi, $name"
+}
+
+// Overloads — differ by arity.
+func area(width int32, height int32) int32 { return width * height }
+func area(side int32) int32                { return side * side }
+
+// Ref-kind parameters.
+func swap[T](ref a T, ref b T) {
+    let t = a
+    a = b
+    b = t
+}
+
+func tryParse(s string, out value int32) bool {
+    value = 0
+    if Int32.TryParse(s, out value) { return true }
+    return false
+}
+```
+
+A function can declare a managed-pointer return with `ref` before the return type clause — `func at(arr []int32, i int32) ref int32 { return ref arr[i] }`. Diagnostics `GS0248`–`GS0255` cover the supporting rules.
+
+A named delegate type is a top-level type alias whose RHS is `delegate func(...)`:
+
+```gsharp
+type Handler = delegate func(sender Object, e EventArgs)
+```
+
+Named delegates emit as real CLR `MulticastDelegate`-derived types so C# consumers see a conventional handler type and G# events can carry first-class custom delegate types (ADR-0059).
 
 ## Type declarations
 

--- a/website/versioned_docs/version-0.1/guide/expressions-and-statements.md
+++ b/website/versioned_docs/version-0.1/guide/expressions-and-statements.md
@@ -10,11 +10,13 @@ G# expression syntax is compact and Go-like, with CLR-oriented additions for nul
 
 ## Operators
 
-Unary operators include numeric identity and negation, logical not, bitwise complement, address-of, dereference, channel receive, and `await`. Binary operators are left-associative. Multiplicative, shift, bitwise, additive, comparison, logical-and, logical-or, and null-coalescing levels are implemented. User operator overloads are supported through receiver `operator` declarations; see [ADR-0026](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0026-operator-by-name-deferral.md) and [ADR-0035](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0035-user-operator-overloads.md).
+Unary operators include numeric identity and negation, logical not, bitwise complement, address-of, dereference, channel receive, and `await`. Binary operators are left-associative. Multiplicative, shift, bitwise, additive, comparison, logical-and, logical-or, and null-coalescing levels are implemented. The conditional (ternary) expression `cond ? whenTrue : whenFalse` is a normal expression (ADR-0062); both arms must share a common type, otherwise `GS0263` fires. User operator overloads are supported through receiver `operator` declarations; see [ADR-0026](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0026-operator-by-name-deferral.md) and [ADR-0035](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0035-user-operator-overloads.md).
 
 ## Calls, access, and literals
 
 Calls use parentheses. Generic calls use bracketed type arguments. Member access uses `.`, null-conditional access uses `?.`, and indexing uses brackets. These postfix operators chain after any primary expression, including a parenthesized one — `(a + b).GetType()`, `(nums)[0]`, and `("s").Length` are all valid. The one exception is a bare numeric literal: write `(42).ToString()` rather than `42.ToString()`, which is ambiguous with float-literal lexing (see [ADR-0054](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0054-postfix-member-access-on-primary-expressions.md)). Struct literals use field labels; data structs can be copied with `with` updates.
+
+Arguments may be positional, named (`f(timeout: 30, retries: 3)`), or ref-kind-prefixed (`f(ref x)`, `f(out var n)`, `f(in z)`). Named arguments work for free functions, user methods, user constructors, extension functions, and inherited CLR methods (including delegate `Invoke`); indirect calls through a function-typed variable and variadic call sites do not accept names. Ref-kind modifiers must match the parameter declaration (`GS0235`); passing a value to an `in` parameter requires an explicit `in` at the call site (`GS0242`).
 
 ```gsharp
 let p = Point{X: 3, Y: 4}

--- a/website/versioned_docs/version-0.1/guide/types-and-values.md
+++ b/website/versioned_docs/version-0.1/guide/types-and-values.md
@@ -75,6 +75,16 @@ type Status enum { Pending, Complete, Failed }
 
 Function types use `func(...) R`. Async function type clauses use `async func(...) R` and represent task-returning functions. Function values can convert to compatible CLR delegate types, including named delegates and common `Action` or `Func` shapes.
 
+A **named delegate type** is declared with `type Name = delegate func(...)` (ADR-0059) and emits as a real CLR `MulticastDelegate`-derived type. Use a named delegate when you want a stable, C#-visible handler type (for example, as the type of a G# `event`):
+
+```gsharp
+type Handler = delegate func(sender Object, e EventArgs)
+
+type Button class {
+    event Click Handler
+}
+```
+
 ## Generics and variance
 
 G# uses bracketed generics: declarations such as `type Box[T any] class { ... }` and instantiations such as `Box[int32]`. Type parameters can use `in` and `out` variance markers and named constraints. The implementation supports metadata specs and inference, but some open or partially constructed generic shapes are erased to `object` in emit paths. See [ADR-0004](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0004-generics-scope.md), [ADR-0020](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0020-generic-brackets.md), and [ADR-0021](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0021-generic-variance.md).

--- a/website/versioned_docs/version-0.1/ref/clr-interop.md
+++ b/website/versioned_docs/version-0.1/ref/clr-interop.md
@@ -56,7 +56,7 @@ counts["g"] = 1
 Console.WriteLine(counts.ContainsKey("g"))
 ```
 
-Overload resolution considers imported methods, constructors, conversion operators, optional/default parameters, and numeric better-conversion tie breaking. Named arguments are parsed generally and are accepted for imported optional/default argument scenarios.
+Overload resolution considers imported methods, constructors, conversion operators, optional/default parameters (G# and CLR-supplied), ref-kind matching, numeric better-conversion tie breaking, and overload sets on user functions (ADR-0063). Named arguments are accepted at the call site (`F(timeout: 30)`) for free functions, user methods, user constructors, extension functions, and inherited CLR methods (including delegate `Invoke`); indirect calls through a function-typed variable and variadic call sites do not accept names because the call target does not preserve parameter names. Diagnostics `GS0244`–`GS0247` and `GS0264`–`GS0267` cover the related failure modes.
 
 ## Extension methods
 
@@ -183,7 +183,7 @@ At the CLR metadata level, `*T` maps to `ELEMENT_TYPE_BYREF` — a managed refer
 
 ### Limitations
 
-The by-ref surface is deliberately scoped to managed references for CLR interop. Per ADR-0039 the following are out of scope today: unmanaged pointers, pointer arithmetic, and `unsafe` blocks; by-ref returns from G# functions (`func foo() *int { return &x }`); and the full Roslyn-style `ref-safe-to-escape` / `safe-to-escape` two-level escape analysis, which is deferred to [issue #376](https://github.com/DavidObando/gsharp/issues/376). V1 uses a simpler rule: by-ref values cannot escape their declaring scope.
+The by-ref surface is deliberately scoped to managed references for CLR interop. Per ADR-0039 the following are out of scope today: unmanaged pointers, pointer arithmetic, and `unsafe` blocks. By-ref returns from G# functions (`func f(...) ref T`) have since landed via ADR-0060's follow-up work (diagnostics `GS0248`–`GS0255`), and the `scoped` parameter modifier from [ADR-0058](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0058-ref-safe-to-escape.md) is wired up; the full Roslyn-style `ref-safe-to-escape` / `safe-to-escape` two-level escape analysis is still deferred to [issue #376](https://github.com/DavidObando/gsharp/issues/376). V1 uses a simpler rule: by-ref values cannot escape their declaring scope, and a `scoped` parameter cannot be returned.
 
 ### Diagnostics
 
@@ -254,7 +254,7 @@ Such a field is emitted with its real layout (`valuetype ReadOnlySpan<int32>`, n
 
 ### Limitations
 
-Per ADR-0056, the following remain out of scope: by-ref returns from G# functions and the full two-level `ref-safe-to-escape` analysis (`scoped`, `[UnscopedRef]`), deferred to [issue #376](https://github.com/DavidObando/gsharp/issues/376); open generic value-type `ref struct` fields (`type Buffer[T] ref struct { data ReadOnlySpan[T] }`); `stackalloc` and other span-*creation* primitives; and a lowercase `span[T]` alias (spans are imported CLR types `Span[T]` / `ReadOnlySpan[T]`, requiring `import System`).
+Per ADR-0056, the following remain out of scope: the full two-level `ref-safe-to-escape` analysis (including `[UnscopedRef]`), deferred to [issue #376](https://github.com/DavidObando/gsharp/issues/376) — though the `scoped` parameter modifier from [ADR-0058](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0058-ref-safe-to-escape.md) is wired up; open generic value-type `ref struct` fields (`type Buffer[T] ref struct { data ReadOnlySpan[T] }`); `stackalloc` and other span-*creation* primitives; and a lowercase `span[T]` alias (spans are imported CLR types `Span[T]` / `ReadOnlySpan[T]`, requiring `import System`).
 
 ## Generics interop
 

--- a/website/versioned_docs/version-0.1/ref/diagnostics.md
+++ b/website/versioned_docs/version-0.1/ref/diagnostics.md
@@ -8,7 +8,6 @@ draft: false
 
 This page mirrors the authoritative diagnostic catalogue in [`docs/diagnostics.md`](https://github.com/DavidObando/gsharp/blob/main/docs/diagnostics.md). Preserve these `GS####` meanings when configuring suppressions, warning promotion, or tooling.
 
-
 Every diagnostic emitted by `gsc` carries a stable `GS####` identifier, a severity level, a human-readable message, and a source location (file, line, column). This document enumerates all identifiers so that project files can suppress or promote them using standard MSBuild properties.
 
 ## Severity levels
@@ -182,7 +181,30 @@ ADR-0047 introduces Kotlin-style attribute syntax (`@Foo(...)`) and the `@Attrib
 | GS0204 | **Warning** (Error if `IsError=true`) | Reference to a symbol marked `[Obsolete]`. | Calling a function, instantiating a class (`Old(5)`), writing a struct literal (`Old{}`), naming a struct/class/interface/enum in a type clause, reading an obsolete parameter, reading/writing an obsolete `var`/`let`/`const`, reading an obsolete enum member (`Color.Red`), or reading/writing an obsolete struct/class field (`p.Old`) — all declared with `@Obsolete("use Bar")`. Severity is promoted to error when the attribute's second argument is `true`. |
 | GS0205 | Error | Attribute is reserved for compiler synthesis. | `@CompilerGenerated`, `@Extension`, `@AsyncStateMachine`, `@Nullable`, or `@NullableContext` written in user source. |
 | GS0206 | Error | Annotations are only allowed on variable declarations, not on this statement. | `@Obsolete\nreturn` inside a function body — annotations may precede `var`/`let`/`const` but no other statement kind. |
+| GS0207 | Error | Parameter `{name}` is annotated `@EnumeratorCancellation` but has type `{type}`; only `System.Threading.CancellationToken` parameters can carry this annotation. | `@EnumeratorCancellation` placed on a `string` parameter. |
+| GS0208 | Error | Parameter `{name}` is annotated `@EnumeratorCancellation` but its enclosing function is not an async sequence (does not return `IAsyncEnumerable[T]`). | `@EnumeratorCancellation` on a sync function or a non-sequence async function. |
+| GS0209 | Error | Attribute `{name}` is not valid on this position; its `[AttributeUsage]` permits only: `{targets}`. | Applying a `@field`-targeted attribute to a method. |
+| GS0210 | Error | Duplicate attribute `{name}`; this attribute type does not allow multiple applications (`AllowMultiple = false`). | Two `@Trace(...)` annotations on the same declaration. |
 | GS0211 | Error | Attribute `[DllImport]` is recognised but not supported in v1.0; P/Invoke (extern function bodies) is a post-v1.0 feature. | `@DllImport("user32.dll") func MessageBox() {}` — emit support and the `extern` body marker arrive after v1.0. |
+| GS0212 | Error | Function `{name}` is marked `@Conditional` but does not return `void`; conditional methods must return `void` because calls may be elided at the call site. | `@Conditional("DEBUG") func Probe() int32 { return 0 }`. |
+
+### Class / constructor diagnostics (GS0213–GS0217)
+
+Issue #306 covers user class constructor flow — explicit `init(...)` constructors, primary constructors, and `base(...)` initializers.
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0213 | Error | A base-constructor argument list requires an explicit base class. | `init() : base(1) { }` written on a class with no `: BaseType` clause. |
+| GS0214 | Error | Class `{base}` has no accessible constructor that takes `{N}` argument(s). | `init() : base(1, 2)` when the base only declares `init()`. |
+| GS0215 | Error | Class `{name}` cannot declare both a primary constructor and an explicit `init` constructor. | `type Customer class(id int32) { init(name string) { } }`. |
+| GS0216 | Error | Class `{name}` declares multiple `init` constructors; only a single explicit constructor is supported. | Two `init(...)` declarations in the same class body. |
+| GS0217 | Error | Generic class `{name}` with an explicit `init` constructor cannot be constructed; generic explicit constructors are not supported. | `type Box[T] class { init(x T) { } }` then `Box[int32](42)`. |
+
+### Delegate conversion diagnostics (GS0218)
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0218 | Error | Cannot convert method group `{name}` to `{type}`. No overload matches the target delegate signature. | `var a Action = SomeOverloaded` where no overload of `SomeOverloaded` has signature `() -> void`. |
 
 ### String interpolation diagnostics (GS0220–GS0225)
 
@@ -201,15 +223,36 @@ ADR-0055 interpolation holes (`${expr,alignment:format}`) and the issue #368 int
 
 ### By-ref-like (`ref struct`) diagnostics (GS0219)
 
-A by-ref-like type — a CLR `ref struct` carrying `System.Runtime.CompilerServices.IsByRefLikeAttribute`, such as `System.Span[T]`, `System.ReadOnlySpan[T]`, or `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler` — is stack-only (issue #367). G# permits declaring and using such a value as an ordinary local (including a user-declared `type X ref struct { … }`), but the CLR forbids any use that would let it reach the heap.
+A by-ref-like type — a CLR `ref struct` carrying `System.Runtime.CompilerServices.IsByRefLikeAttribute`, such as `System.Span[T]`, `System.ReadOnlySpan[T]`, or `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler` — is stack-only (issue #367). G# permits declaring and using such a value as an ordinary local, but the CLR forbids any use that would let it reach the heap. Those escapes are rejected with GS0219.
+
+G# can also **declare** its own by-ref-like value types with a `ref` modifier on a `struct` declaration:
+
+```gsharp
+type Window ref struct {
+    Items ReadOnlySpan[int32]   // a ref struct may hold by-ref-like fields
+    Label string
+}
+```
+
+Such a type is emitted with `System.Runtime.CompilerServices.IsByRefLikeAttribute` (and the C# compiler's `[Obsolete]` guard marker), so the CLR treats it as stack-only. The same escape rules below apply to user-declared `ref struct` types exactly as they do to imported ones. The only relaxation is that a `ref struct` may itself hold by-ref-like fields (it is stack-only too); a static field of a `ref struct` is still rejected.
 
 | ID | Severity | Description | Example trigger |
 |----|----------|-------------|-----------------|
-| GS0219 | Error | A by-ref-like (`ref struct`) value is used in a position that would let it escape the stack: boxing / converting it to a reference type, storing it in a field of a non-`ref struct` (instance, primary-constructor, or static), capturing it in a closure, declaring it as a local in an `async` function or iterator (where it would be hoisted into the heap-allocated state machine), using it as a generic type argument, declaring it as a top-level global, or returning it from a function when the parameter is annotated `scoped`. | `var o object = span` (box); a `class` field typed `Span[int32]`; capturing a `ReadOnlySpan[char]` local inside `func() { … }`; a `Span[int32]` local in an `async` function; `List[ReadOnlySpan[int32]]`; `func f(scoped s Span[int32]) Span[int32] { return s }`. |
+| GS0219 | Error | A by-ref-like (`ref struct`) value is used in a position that would let it escape the stack: boxing / converting it to a reference type (`object`, an interface, a delegate base), storing it in a field of a non-ref-struct (instance, primary-constructor, or static), capturing it in a closure, declaring it as a local in an `async` function or an iterator (where it would be hoisted into the heap-allocated state machine), using it as a generic type argument, or returning it from a function when the parameter is annotated `scoped`. | `var o object = span` (box); a `class`/`struct` field typed `Span[int32]`; capturing a `ReadOnlySpan[char]` local inside `func() { ... }`; declaring a `Span[int32]` local in an `async` function; `List[ReadOnlySpan[int32]]`; `func f(scoped s Span[int32]) Span[int32] { return s }`. |
+
+The `scoped` modifier can be placed on a parameter to indicate that the `ref struct` (or managed-pointer) value must not be returned or stored beyond the call site:
+
+```gsharp
+import System
+// `scoped` means `s` cannot be returned or escape.
+func firstElement(scoped s ReadOnlySpan[int32]) int32 {
+    return s[0]
+}
+```
 
 ### Span element access diagnostics (GS0226)
 
-ADR-0056 §1/§2 makes spans indexable: a `Span[T]` / `ReadOnlySpan[T]` indexer returns a managed pointer (`ref T` / `ref readonly T`), and a read in rvalue position auto-dereferences to the pointee `T`. A `Span[T]` element write `s[i] = v` stores through the `ref T`; a `ReadOnlySpan[T]` element is `ref readonly T`, so writing through it is rejected.
+ADR-0056 §1/§2 makes spans indexable: a `Span[T]` / `ReadOnlySpan[T]` indexer returns a managed pointer (`ref T` / `ref readonly T`), and a read in rvalue position auto-dereferences to the pointee `T` (§1). A `Span[T]` element write `span[i] = v` stores through the `ref T`. A `ReadOnlySpan[T]` element is `ref readonly T`, so writing through it is a hard error (GS0226); reading it is always permitted.
 
 | ID | Severity | Description | Example trigger |
 |----|----------|-------------|-----------------|
@@ -225,6 +268,7 @@ ADR-0056 §1/§2 makes spans indexable: a `Span[T]` / `ReadOnlySpan[T]` indexer 
 | GS9004 | Error | By-ref value cannot escape its declaration scope. | Returning a `*T` (managed-pointer) value from a function, capturing a `*T` local in a closure, hoisting a `*T` local into an `async`/iterator state machine, or using a `*T` return type in a function literal. Also raised when returning a `ref struct` parameter annotated as `scoped`. |
 | GS9005 | Error | Cannot take the address of a constant. | `&myConst` where `myConst` is declared `const`. |
 | GS9006 | Error | Pointer type cannot be a field type. | A struct or class field (including static `shared` fields and top-level globals) declared with a `*T` (managed-pointer) type. |
+| GS9007 | Error | A type may contain at most one `shared` block. | A class or struct with two `shared { ... }` blocks; merge them into one. |
 
 ### Reference closure diagnostics (GS9100)
 
@@ -240,3 +284,156 @@ These diagnostics indicate an internal compiler problem. If you encounter them, 
 |----|----------|-------------|
 | GS9998 | Error | An unexpected `NotSupportedException` or `InvalidOperationException` was raised during IL emission. The message text contains the original exception message. |
 | GS9999 | Error | An unexpected exception was caught by the evaluator. The message text contains the original exception message. |
+
+## Documentation diagnostics (GS0227–GS0231)
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0227 | Warning | Documentation comment is not attached to a declaration. |
+| GS0228 | Warning | Missing documentation comment on public member `{name}`. (opt-in) |
+| GS0229 | Warning | Documentation @param `{name}` does not match any parameter of `{symbol}`. |
+| GS0230 | Warning | Unsupported documentation Markdown: `{detail}`. |
+| GS0231 | Warning | Unknown documentation tag `{tag}`. Valid tags are: @param, @typeparam, @returns, @remarks, @value, @exception, @seealso. |
+
+## Data struct diagnostics (GS0232)
+
+ADR-0029 / Issue #410: every `data struct` synthesizes a fixed contract of value-semantics members — `Equals(object)`, `Equals(Name)`, `GetHashCode()`, `ToString()`, `op_Equality(Name, Name)`, `op_Inequality(Name, Name)`, and `Deconstruct(out T1, out T2, …)`. Hand-written versions are rejected so the contract stays predictable and so consumers (G# and external .NET) can rely on the synthesized IL.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0232 | Error | Data struct `{type}` synthesizes member `{member}`; it cannot be declared explicitly. |
+
+## Named delegate type diagnostics (GS0233–GS0234)
+
+ADR-0059 / Issue #255: `type Name = delegate func(...)` declares a real CLR `MulticastDelegate`-derived named delegate type so C# consumers see a conventional handler type (and so G# events can carry first-class custom delegate types). Anything other than a function signature on the right-hand side is rejected, and generic delegate types are reserved for v2.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0233 | Error | Named delegate declaration requires 'func(...)' after 'delegate' (e.g. 'type Name = delegate func(sender Object, e EventArgs)'). |
+| GS0234 | Error | Generic delegate declaration `{name}` is not yet supported; declare a non-generic named delegate type (ADR-0059 follow-up). |
+
+## Ref-kind parameter diagnostics (GS0235–GS0243)
+
+ADR-0060 introduces explicit `ref`, `out`, and `in` parameter passing modes at both call sites and method-definition sites. The ADR (§8) originally enumerated diagnostics GS0230–GS0238, but those codes were already in use by ADR-0029 / ADR-0030 / ADR-0056 / ADR-0059; the ADR-0060 diagnostics ship at the next free range, GS0235–GS0243, with a 1:1 mapping (GS0230→GS0235, GS0231→GS0236, …, GS0238→GS0243). The async/iterator ban (§10) reuses the existing GS0226 family.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0235 | Error | Argument `{index}` (parameter `{name}`) passes with ref-kind `{actual}` but the parameter is declared `{expected}`. |
+| GS0236 | Error | An 'out var/let/_' inline declaration is only valid on an 'out' argument. |
+| GS0237 | Error | Cannot assign to 'in' parameter `{name}` — it is read-only. |
+| GS0238 | Error | The 'out' parameter `{name}` must be assigned on every path before the function returns. |
+| GS0239 | Error | The variable `{name}` must be definitely assigned before it can be passed by 'ref'. |
+| GS0240 | Error | Override of `{name}` must match the base ref-kind on parameter `{parameter}` (`{baseKind}` vs `{overrideKind}`). |
+| GS0241 | Error | A variadic parameter cannot carry a ref-kind modifier ('ref'/'out'/'in'). |
+| GS0242 | Warning | Argument `{index}` (parameter `{name}`) is passed by 'in' implicitly; add 'in' at the call site to make the read-only pass explicit. |
+| GS0243 | Error | A pointer type '*T' is not a valid parameter type; use the appropriate ref-kind modifier instead (e.g. 'ref T', 'out T', 'in T'). |
+
+Cause/fix examples:
+
+- **GS0235** — fire when the call-site modifier doesn't match the declaration: `f(x)` where `f(ref x int32)` requires `f(&x)` or `f(ref x)`. Fix: add the matching modifier; if the parameter is by-value, drop any unwanted `ref`/`out`/`in`.
+- **GS0236** — `out var n` outside an `out` argument: e.g. `func g(int32) {}` then `g(out var n)`. Fix: only use the inline declaration when the parameter is declared `out`.
+- **GS0237** — assignment to an `in` parameter inside the body: `func h(in p int32) { p = 0 }`. Fix: copy to a local for any mutation, or change the parameter to `ref`.
+- **GS0238** — a missing write before return on an `out` parameter: `func k(out r int32) bool { if cond { r = 1; return true } return false }` — the `false` branch fails to assign `r`. Fix: assign on every path.
+- **GS0239** — passing an uninitialized variable by `ref`: `var x int32; f(ref x)` with no prior assignment. Fix: assign before the call (e.g. `var x = 0`).
+- **GS0240** — override changes the ref-kind of an inherited parameter: `func override f(in p int32) { … }` when the base declares `f(ref p int32)`. Fix: match the base declaration.
+- **GS0241** — variadic combined with ref-kind: `func g(ref values ...int32) {}`. Fix: remove the modifier or remove the variadic decoration.
+- **GS0242** (warning) — passing a plain identifier to an `in` parameter without writing `in`: `f(x)` where `f(in x int32)`. Fix: write `f(in x)` to make the pass-by-readonly-ref explicit. The compiler does NOT silently spill the value (a deliberate departure from C#).
+- **GS0243** — declaring a parameter whose type is the raw pointer `*T`: `func f(p *int32)`. Fix: use a ref-kind modifier instead — `func f(ref p int32)` (or `in`/`out`).
+
+## Named-argument diagnostics (GS0244–GS0247)
+
+Issue #343 introduces named arguments at call sites — `Foo(timeout: 30, retries: 3)` — for free functions, user methods, user constructors, user extension functions, imported CLR methods and constructors, imported extension methods, and inherited CLR instance methods (including delegate `Invoke`). Indirect calls through a function-typed or delegate-typed variable, and variadic call sites, intentionally do not accept named arguments because the call target does not preserve parameter names. The diagnostics below flag malformed or unresolvable named-argument call sites.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0244 | Error | Positional argument cannot follow a named argument. |
+| GS0245 | Error | Named argument `{name}` is specified more than once. |
+| GS0246 | Error | The best overload of `{callee}` does not have a parameter named `{name}`. |
+| GS0247 | Error | Named argument `{name}` specifies a parameter for which a positional argument has already been given. |
+
+Cause/fix examples:
+
+- **GS0244** — `Foo(1, name: "a", 2)`. Fix: move every named argument to the trailing positions, or pass the named one positionally.
+- **GS0245** — `Foo(timeout: 1, timeout: 2)`. Fix: remove the duplicate.
+- **GS0246** — `Foo(qty: 3)` when `Foo` has no parameter named `qty`. Fix: use the correct parameter name. Also fires when calling through a function-typed/delegate variable, or when targeting a variadic parameter list (parameter names are not addressable in those cases).
+- **GS0247** — `Foo(1, x: 2)` when `Foo(x int32, y int32)` is bound — the positional `1` already filled `x`. Fix: drop one or the other.
+
+## Ref-aliasing local diagnostics (GS0256–GS0258)
+
+Issue #491 (ADR-0060 follow-up) introduces `let ref` / `var ref` aliasing locals — a local whose IL slot is a managed pointer `T&` and that aliases another lvalue (`let ref m = arr[i]`, `var ref v = c.Field`). The diagnostics below flag malformed or illegal ref-alias declarations.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0256 | Error | The right-hand side of a 'ref' local declaration must be an lvalue (variable, field, indexer, or dereference). |
+| GS0257 | Error | A 'ref' local cannot be initialized from an expression with a narrower escape scope than the local itself. |
+| GS0258 | Error | A 'ref' local cannot be declared here — only inside non-async, non-iterator function bodies (no top-level, no `const`). |
+
+Cause/fix examples:
+
+- **GS0256** — `let ref m = 1 + 2` or `let ref m = foo()`. The RHS must denote storage you can take the address of. Fix: alias an addressable expression (`let ref m = arr[0]`, `let ref m = c.Value`, `let ref m = *p`), or drop `ref` and copy the value.
+- **GS0257** — Reserved for the full ref-safety analysis. Will fire when the RHS storage cannot live as long as the alias (e.g. a `ref` returned from a callee that captured a shorter-lived local). V1 has no ref returns, so this code is defined for forward compatibility and currently does not fire.
+- **GS0258** — `let ref m = n` at top level, inside `async func`, inside an iterator (yield-returning) function, or written as `const ref`. Fix: move the declaration into a synchronous, non-iterator function body and use `let ref` / `var ref` (not `const ref`). Top-level `ref` locals would require a static field of `T&`, which the CLR forbids; async / iterator bodies would lift the slot onto a state-machine field, which the CLR likewise forbids.
+
+
+## Conditional expression diagnostics (GS0259–GS0263)
+
+ADR-0061 introduced a narrow ref-only ternary form (`cond ? a : b` only inside `ref`/`out`/`in` argument payloads and `&` operands) with diagnostics GS0259–GS0262. ADR-0062 generalises the ternary into a normal expression form. The conditional-outside-ref diagnostic GS0259 is therefore retired: a value-context `cond ? a : b` is now legal. The remaining ADR-0061 diagnostics still fire in their byref contexts; the new GS0263 covers the value-context "no common type" failure.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0259 | Error (retired by ADR-0062) | Conditional lvalue expression (`cond ? a : b`) is only legal as the payload of a 'ref'/'out'/'in' argument modifier or as the operand of '&'. Now only fires for the legacy inner-ref-modifier shape outside ref context. |
+| GS0260 | Error | Both branches of a conditional ref-argument must produce lvalues of the same type, but the true branch is `{trueType}` and the false branch is `{falseType}`. |
+| GS0261 | Error | An 'out var'/'out let'/'out _' inline declaration cannot appear inside a branch of a conditional ref-argument (the new local would only conditionally exist). Declare the local before the call instead. |
+| GS0262 | Error | Inner ref-kind modifier `{innerModifier}` on a conditional ref-argument branch must match the outer modifier `{outerModifier}`. |
+| GS0263 | Error | Conditional expression branches have no common result type — the true branch is `{trueType}` and the false branch is `{falseType}`. Add an explicit conversion to align the two arms. |
+
+Cause/fix examples:
+
+- **GS0260** — `bump(ref true ? a32 : b64)` where `a32 int32` and `b64 int64`. Fix: align the branch types (e.g. introduce a local of the wider type or use a value ternary outside the `ref`).
+- **GS0261** — `produce(out true ? a : out var n)` — the inline `out var n` would declare a local that only exists on one branch. Fix: declare `var n int32` before the call.
+- **GS0262** — `bump(ref true ? in a : ref b)` — the inner `in` does not match the outer `ref`. Fix: use `bump(ref true ? a : b)` (the generalized ADR-0062 form requires no inner modifiers).
+- **GS0263** — `var x = pick ? true : "no"` — `bool` and `string` have no common type. Fix: explicitly convert one arm (e.g. `pick ? "yes" : "no"`).
+
+## Ref-return diagnostics (GS0248–GS0255)
+
+Issue #490 (ADR-0060 follow-up) introduces `ref`-returning functions — declarations of the form `func f(...) ref T { ... }` that return a managed pointer `T&` rather than a copied value, paired with the `return ref <expr>` statement form. The diagnostics below guard the declaration and return-site rules.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0248 | Error | A 'ref' return modifier requires an explicit return type clause (e.g. 'ref int32'). |
+| GS0249 | Error | 'ref' return is not legal on an `{async/iterator}` function; the state-machine rewriter cannot hoist a managed pointer. |
+| GS0250 | Error | 'ref' return modifier is redundant when the declared return type is already a managed pointer ('*T'); write 'ref T' instead. |
+| GS0251 | Error | 'return ref' is not allowed in `{functionName}` because its declaration does not specify a 'ref' return type. |
+| GS0252 | Error | Function `{functionName}` returns by reference; use `return ref <expr>` instead of a plain 'return'. |
+| GS0253 | Error | The operand of 'return ref' must be an lvalue (variable, field, array element, or '*p'). |
+| GS0254 | Error | Cannot return a managed pointer to function-local storage; the reference would dangle once the function returns. |
+| GS0255 | Error | Override of `{memberName}` must match the base return ref-kind: base returns `{expected}`, this declaration returns `{actual}`. |
+
+Cause/fix examples:
+
+- **GS0248** — `func f(x int32) ref { return ref x }` — `ref` requires the element type. Fix: `func f(x int32) ref int32`.
+- **GS0249** — `async func f() ref int32 { ... }` or a yield-iterator body. Fix: drop `ref` from the return — `async` / iterator state-machine fields cannot hold managed pointers.
+- **GS0250** — `func f(p *int32) ref *int32 { return p }`. Fix: write `ref int32` (or drop `ref` and return the pointer).
+- **GS0251** — a `return ref x` statement in a function whose declaration is `func f() int32`. Fix: add `ref` to the return type, or drop `ref` from the return statement.
+- **GS0252** — a plain `return x` in a `ref`-returning function. Fix: write `return ref x`.
+- **GS0253** — `return ref (a + b)` or `return ref Foo()`. Fix: alias an addressable expression first (`let ref t = arr[i]; return ref t`) or restructure to return a pointer to durable storage.
+- **GS0254** — `func f() ref int32 { var x = 0; return ref x }`. Fix: do not return references to function locals; consume the value by copy or alias storage that outlives the call.
+- **GS0255** — overriding a base method declared `int32` with a `ref int32` override (or vice versa). Fix: match the base return ref-kind exactly.
+
+## Method-overloading and optional-parameter diagnostics (GS0264–GS0267)
+
+ADR-0063 lifts the v0 "one declaration per name" rule, so G# user functions can carry overload sets (differing by parameter types or ref-kinds) and optional parameters with default values. The diagnostics below cover overload-set construction and overload resolution.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0264 | Error | An overload of `{name}` with signature `{signature}` is already declared. Two overloads must differ by parameter types or ref-kinds. |
+| GS0265 | Error | Optional parameter `{parameterName}` is invalid: `{reason}`. |
+| GS0266 | Error | Call to `{name}` is ambiguous between multiple overloads. Disambiguate with explicit types or named arguments. |
+| GS0267 | Error | No overload of `{name}` is applicable to the given argument list. |
+
+Cause/fix examples:
+
+- **GS0264** — two `func F(x int32) {}` declarations, or two declarations that differ only in return type. Fix: change the parameter list (different types, arity, or ref-kinds); return type alone is not a distinguishing signature.
+- **GS0265** — a default-value expression that is not constant, a parameter whose default depends on another parameter, an optional parameter preceding a required one without all trailing parameters also optional, or an optional ref/out parameter. Fix: use a compile-time-constant default, place optional parameters at the end of the list, and avoid combining `ref`/`out` with defaults.
+- **GS0266** — `Greet("ada")` when both `Greet(string)` and `Greet(name string)` are visible via different paths. Fix: rename one, change one signature, or use a named argument that only one overload accepts.
+- **GS0267** — `Greet(42)` when only `Greet(string)` is declared. Fix: pass a value of the expected type, or add an overload covering the new argument shape.

--- a/website/versioned_docs/version-0.1/ref/feature-matrix.md
+++ b/website/versioned_docs/version-0.1/ref/feature-matrix.md
@@ -16,9 +16,10 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Packages, imports, import aliases | Supported | Supported | Emit supports multi-package assemblies; interpreter binds the same model. |
 | Implicit `System` import | Supported | Supported | Enabled by default; disabled with `/noimplicitimports` or `/no-implicit-imports`. |
 | Top-level statements and `func Main` | Supported | Supported | Mixing top-level statements and explicit `Main` is diagnosed by `GS0165`/`GS0166`. |
-| Comments | Supported | Supported | Line and block comments are accepted by the compiler lexer; editor grammar may lag. |
+| Comments | Supported | Supported | Line (`//`), block (`/* … */`), and Markdown documentation (`///`, ADR-0057) comments. |
 | String, raw string, and interpolated string literals | Supported | Supported | Sigil-free interpolation with `$name`/`${expr,alignment:format}`, delimiter-aware multiline holes, and `DefaultInterpolatedStringHandler`/`FormattableString` lowering (ADR-0055). |
 | Character literals | Supported | Supported | Character diagnostics are `GS0191` through `GS0195`. |
+| Documentation comments | Supported | Supported | `///` Markdown comments round-trip to CLR XML doc; hover renders CLR XML docs for imported APIs. Diagnostics `GS0227`–`GS0231`. |
 
 ## Types and values
 
@@ -45,6 +46,10 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Generics and method inference | Supported | Supported for binding/evaluation | Metadata specs plus type-erased handling for open type-parameter-containing shapes. |
 | Variance and constraints | Supported semantically | Supported semantically | Diagnostics include `GS0150` through `GS0153`. |
 | By-ref and pointers | Partial | Limited/not supported | `&` / `*` / `*T` for CLR `ref`/`out`/`in` interop (ADR-0039); ref returns auto-dereference in rvalue position (ADR-0056 §1). Evaluator rejects generic address/deref execution. |
+| `ref`/`out`/`in` parameters | Supported | Supported | Declaration-site and call-site modifiers per ADR-0060; diagnostics `GS0235`–`GS0243`. Includes `out var/let/_` inline declarations. |
+| Ref-aliasing locals (`let ref` / `var ref`) | Supported | Supported | Local whose IL slot is `T&` and aliases another lvalue. Diagnostics `GS0256`–`GS0258`. |
+| `ref`-returning functions | Supported | Supported | `func f(...) ref T { ... }` paired with `return ref <lvalue>`. Diagnostics `GS0248`–`GS0255`. |
+| `scoped` parameter modifier | Supported | Supported | Constrains a `ref struct` / managed-pointer parameter from escaping; enforced by `GS9004` / `GS9006`. |
 | Spans and `ref struct` types | Mostly supported | Limited | Stack-only consumption of `Span[T]` / `ReadOnlySpan[T]` and user `type X ref struct`: element read/write, `[]T`→span conversion, closed generic value-type fields (ADR-0056). Escape rules are `GS0219`; `ReadOnlySpan[T]` writes are `GS0226`. Full ref-safe-to-escape analysis is deferred (#376). |
 
 ## Declarations and members
@@ -57,7 +62,9 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Operator declarations | Supported | Supported where evaluator invokes user/CLR op paths | Receiver `operator` declarations map to CLR `op_*` names. |
 | Interface implementation | Supported | Supported for checks/upcasts | Missing members and sealed-interface violations are diagnosed. |
 | Inheritance and overrides | Supported | Partially supported | Base classes must be `open`; override diagnostics are implemented. |
-| Default parameter values in G# declarations | Not supported | Not supported | Parser parameter grammar has no initializer. |
+| Default parameter values in G# declarations | Supported | Supported | ADR-0063. Optional parameters carry compile-time-constant defaults; rule violations report `GS0265`. |
+| Method overloading (user functions) | Supported | Supported | ADR-0063. Functions can carry overload sets differing by parameter types or ref-kinds; duplicates report `GS0264`, ambiguous calls report `GS0266`, no-applicable reports `GS0267`. |
+| Named delegate types | Supported | Supported | ADR-0059. `type X = delegate func(...)` declares a real CLR `MulticastDelegate`-derived type; diagnostics `GS0233`–`GS0234`. |
 
 ## Statements and control flow
 
@@ -83,7 +90,9 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Feature | Emit (`gsc`) | Interpreter | Notes |
 | --- | --- | --- | --- |
 | Calls and generic calls | Supported | Supported | Bracketed type arguments. |
-| Named arguments | Partial | Partial | Accepted for data-struct copy and imported optional/default argument scenarios. |
+| Named arguments | Supported | Supported | `Foo(timeout: 30, retries: 3)` for free functions, user methods/constructors, extension functions, and inherited CLR methods (including delegate `Invoke`). Indirect calls through a function-typed variable and variadic targets are excluded. Diagnostics `GS0244`–`GS0247`. |
+| Conditional (`?:`) ternary expression | Supported | Supported | Generalized in ADR-0062; `cond ? a : b` is a normal expression. `GS0263` covers the "no common type" failure. |
+| Conditional ref-arguments (`ref cond ? a : b`) | Supported | Supported | ADR-0061. Branches must produce same-typed lvalues. Diagnostics `GS0260`–`GS0262`. |
 | Struct, array, and map literals | Supported | Supported | Map literals bind to `Dictionary[K,V]` backing. |
 | Indexing and index assignment | Supported | Supported | Arrays, slices, maps, and imported CLR indexers. |
 | Null-conditional access | Supported | Supported | `?.` represented in the bound tree. |
@@ -129,4 +138,5 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Reference assemblies | Supported | N/A | SDK can produce reference assemblies. |
 | SDK `.gsproj` build/run/pack | Supported | N/A | `Gsharp.NET.Sdk` integrates with MSBuild and `dotnet`. |
 | REPL | N/A | Supported | Interpreter executable starts a REPL with no file argument. |
-| Language server and VS Code extension | N/A | N/A | Tooling uses parser/binder services and provides rich editor capabilities. |
+| Language server and VS Code extension | N/A | N/A | Pull-based diagnostics, semantic tokens, hover for CLR XML docs, CodeLens reference counts on members of types/structs/interfaces/enums, signature help, inlay hints, completion, go-to-definition, references, rename, formatting, debug + test integration. |
+| VS Code color themes | N/A | N/A | Six bundled themes (Ember, Magma, Synthwave — Dark + Light each). |

--- a/website/versioned_docs/version-0.1/ref/spec.md
+++ b/website/versioned_docs/version-0.1/ref/spec.md
@@ -22,7 +22,7 @@ A compilation unit consists of an optional package declaration, zero or more imp
 
 ### Comments
 
-Line comments begin with `//` and run to the end of the line. Block comments begin with `/*` and end with `*/`; they do not nest. An unterminated block comment is a lexical diagnostic.
+Line comments begin with `//` and run to the end of the line. Block comments begin with `/*` and end with `*/`; they do not nest. An unterminated block comment is a lexical diagnostic. Documentation comments begin with `///` and run to the end of the line; consecutive `///` lines are concatenated, the first leading space is stripped, and the block is attached to the following declaration where it is parsed as Markdown and lowered to CLR XML doc. See [Documentation comments](#documentation-comments).
 
 ### Tokens
 
@@ -299,25 +299,30 @@ Annotation   = "@" ( AnnotationTarget ":" )? identifier { "." identifier } ( "("
 
 ### Functions and methods
 
-Functions use `func`. Receiver clauses declare receiver-style methods and extension functions. Operator overloads use `operator` followed by the operator token and map to CLR operator names downstream. Parameters do not have default-value syntax in G# declarations.
+Functions use `func`. Receiver clauses declare receiver-style methods and extension functions. Operator overloads use `operator` followed by the operator token and map to CLR operator names downstream. Parameters may carry a ref-kind modifier (`ref`, `out`, or `in`, ADR-0060) and may declare a compile-time-constant default value to become optional (ADR-0063). User functions may be overloaded as long as overloads differ by parameter types, arity, or ref-kinds; two declarations that differ only in return type are rejected as `GS0264`.
 
 ```ebnf
-FunctionDecl      = "func" ReceiverClause? ( identifier | OperatorName ) TypeParamList? "(" Parameters? ")" TypeClause? Block .
+FunctionDecl      = "func" ReceiverClause? ( identifier | OperatorName ) TypeParamList? "(" Parameters? ")" RefReturnClause? Block .
 AsyncFunctionDecl = "async" FunctionDecl .
 ReceiverClause    = "(" Parameter ")" .
 OperatorName      = "operator" OperatorToken .
 TypeParamList     = "[" TypeParameter { "," TypeParameter } "]" .
 TypeParameter     = ( "in" | "out" )? identifier ConstraintName? .
 Parameters        = Parameter { "," Parameter } .
-Parameter         = Annotation* identifier "..."? TypeClause .
+Parameter         = Annotation* ParameterModifier? identifier "..."? TypeClause ( "=" ConstantExpression )? .
+ParameterModifier = "ref" | "out" | "in" | "scoped" .
+RefReturnClause   = "ref"? TypeClause .
 ```
+
+A function declared `func f(...) ref T` returns a managed pointer and pairs with the `return ref <lvalue>` statement form (diagnostics `GS0248`–`GS0255`). The `scoped` modifier on a `ref struct` / managed-pointer parameter constrains the value from escaping the call (enforced by the by-ref-like rules in `GS9004` / `GS9006`).
 
 ### Type declarations
 
 ```ebnf
-TypeDecl          = "type" identifier TypeParamList? ( TypeAliasTail | StructDeclTail | ClassDeclTail | EnumDeclTail | InterfaceDeclTail ) .
+TypeDecl          = "type" identifier TypeParamList? ( TypeAliasTail | DelegateAliasTail | StructDeclTail | ClassDeclTail | EnumDeclTail | InterfaceDeclTail ) .
 TypeAliasTail     = "=" identifier .
-StructDeclTail    = Data? Inline? Open? "struct" PrimaryCtor? StructBody .
+DelegateAliasTail = "=" "delegate" "func" "(" Parameters? ")" TypeClause? .
+StructDeclTail    = Data? Inline? Open? Ref? "struct" PrimaryCtor? StructBody .
 ClassDeclTail     = Open? "class" PrimaryCtor? BaseClause? StructBody .
 RecordDeclTail    = ( "record" | Data? "record" ) StructBody .
 EnumDeclTail      = "enum" "{" EnumMemberList? "}" .
@@ -325,6 +330,8 @@ InterfaceDeclTail = Sealed? "interface" InterfaceBody .
 PrimaryCtor       = "(" Parameters? ")" .
 BaseClause        = ":" QualifiedTypeName ( "(" Arguments? ")" )? { "," QualifiedTypeName } .
 ```
+
+A `DelegateAliasTail` declares a real CLR `MulticastDelegate`-derived named delegate type (ADR-0059), so C# consumers see a conventional handler type and G# events can carry first-class custom delegate types. Diagnostics `GS0233`–`GS0234` cover malformed declarations.
 
 ### Members
 
@@ -351,18 +358,24 @@ Unary operators bind tighter than binary operators. Binary operators are left-as
 
 | Precedence | Operators | Meaning |
 | --- | --- | --- |
-| 6 | `+`, `-`, `!`, `^`, `*`, `&`, `<-`, `await` | unary |
-| 5 | `*`, `/`, `%`, `<<`, `>>`, `&`, `&^` | multiplicative, shifts, bitwise and, bit clear |
-| 4 | `+`, `-`, `\|`, `^` | additive, bitwise or, xor |
-| 3 | `==`, `!=`, `<`, `<=`, `>`, `>=` | equality and comparison |
-| 2 | `&&` | logical and |
-| 1 | `\|\|`, `?:` | logical or and null coalescing |
+| 7 | `+`, `-`, `!`, `^`, `*`, `&`, `<-`, `await` | unary |
+| 6 | `*`, `/`, `%`, `<<`, `>>`, `&`, `&^` | multiplicative, shifts, bitwise and, bit clear |
+| 5 | `+`, `-`, `\|`, `^` | additive, bitwise or, xor |
+| 4 | `==`, `!=`, `<`, `<=`, `>`, `>=` | equality and comparison |
+| 3 | `&&` | logical and |
+| 2 | `\|\|`, `?:` | logical or and null coalescing |
+| 1 | `?` … `:` … | conditional (ternary, right-associative) |
+
+The conditional expression `cond ? whenTrue : whenFalse` (ADR-0062) requires `cond` to be `bool` and the two branches to share a common type. Mismatched branches report `GS0263`. The narrow ADR-0061 form `ref cond ? lhs : rhs` (and its `out` / `in` siblings) survives as a payload to a ref-kind argument; diagnostics `GS0260`–`GS0262` apply there.
 
 Postfix `!!`, member access `.`, null-conditional access `?.`, indexing, calls, and generic instantiation are parsed greedily on primary expressions. This applies to **any** primary, including a parenthesized expression — for example `(a + b).GetType()`, `(nums)[0]`, and `("s").Length` are all valid. The sole exception is a bare numeric literal: `42.Member` is not accepted because it is ambiguous with float-literal lexing; wrap it as `(42).Member` instead (see ADR-0054).
 
 ### Primary expressions and calls
 
-Primary expressions include literals, identifiers, calls, generic calls, struct literals, array or slice literals, map literals, function literals, switch expressions, tuple literals, `make(chan ...)`, `typeof(...)`, and `nameof(...)`. Calls support positional and named arguments syntactically; named arguments are accepted semantically for data-struct copy and imported CLR optional/default-argument scenarios, while normal G# calls reject unexpected named arguments.
+Primary expressions include literals, identifiers, calls, generic calls, struct literals, array or slice literals, map literals, function literals, switch expressions, tuple literals, `make(chan ...)`, `typeof(...)`, and `nameof(...)`. Calls accept positional, named, and ref-kind-prefixed arguments:
+
+- **Named arguments** — `Foo(timeout: 30, retries: 3)` (or the legacy `Foo(timeout = 30)` shape) for free functions, user methods, user constructors, user extension functions, imported CLR methods and constructors, imported extension methods, and inherited CLR instance methods (including delegate `Invoke`). Indirect calls through a function-typed or delegate-typed variable, and variadic call sites, do not accept named arguments because the call target does not preserve parameter names. Diagnostics `GS0244`–`GS0247` cover ordering, duplicates, and unknown names.
+- **Ref-kind arguments** — `f(ref x)`, `f(out var n)`, `f(in z)` (ADR-0060). The call-site modifier must match the parameter's declared kind (`GS0235`); `in` requires an explicit `in` at the call site to prevent silent spilling (`GS0242`).
 
 Generic instantiation uses brackets and bounded lookahead to distinguish type arguments from indexing. Examples include `Id[int32](1)` and `Box[string]{Value: "x"}`.
 
@@ -432,6 +445,12 @@ Statement = Block | Annotation* VariableDecl | IfStmt | ForStmt | BreakStmt | Co
 
 Short declaration is `name := expr`. Multi-target assignment supports `a, b = x, y` and `a, b := x, y` for identifier target lists. Increment and decrement are statements, not expressions.
 
+A `let` or `var` may carry a `ref` prefix to declare a **ref-aliasing local** (ADR-0060 follow-up): `let ref m = arr[i]` produces a local whose IL slot is a managed pointer (`T&`) that aliases the right-hand-side storage. The RHS must be an lvalue (`GS0256`); ref locals are illegal at top level, inside `async` / iterator bodies, and as `const` (`GS0258`). Reads and writes through the alias forward to the underlying storage.
+
+```ebnf
+RefLocalDecl = ( "let" | "var" ) "ref" identifier "=" Expression .
+```
+
 ### If statements
 
 `if` accepts an optional simple statement before a semicolon, then a condition and body, with an optional `else` body.
@@ -463,7 +482,7 @@ ForStmt = "for" Statement
 
 ### Return and yield
 
-`return` may have no expression, one expression, or a comma-separated expression list, which is represented as a tuple literal. `yield expr` is contextual and valid in iterator functions returning `sequence[T]` or async sequence forms as appropriate.
+`return` may have no expression, one expression, or a comma-separated expression list, which is represented as a tuple literal. In a `ref`-returning function (`func f(...) ref T`), the return statement form is `return ref <lvalue>` — plain `return expr` reports `GS0252`, and a non-lvalue operand reports `GS0253`. `yield expr` is contextual and valid in iterator functions returning `sequence[T]` or async sequence forms as appropriate.
 
 ### Defer and using
 
@@ -526,6 +545,36 @@ G# imports can resolve CLR namespaces and metadata references. CLR primitive typ
 Attributes use `@Name(...)` and optional use-site targets such as `@field:`, `@param:`, and `@return:`. The current implementation recognizes attributes, but user P/Invoke or extern declarations are not supported.
 
 Interpolated strings interoperate with the CLR formatting types. By default they lower to `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler` (value-type holes are not boxed); a string targeted at `IFormattable` or `FormattableString` lowers to `FormattableStringFactory.Create` for deferred, culture-aware formatting; and a parameter annotated with `[InterpolatedStringHandler]` receives the handler directly, including `[InterpolatedStringHandlerArgument]` forwarding.
+
+## Documentation comments
+
+ADR-0057 introduces Markdown-authored documentation comments that round-trip losslessly to CLR XML doc. A documentation comment is a run of consecutive `///` lines; each line contributes one paragraph of authored text after one optional leading space is stripped. The block is attached to the immediately following declaration (free function, type, member, or top-level constant) and is parsed as Markdown plus a small set of `@`-prefixed block tags drawn from the CLR XML-doc vocabulary.
+
+Recognised tags:
+
+| Tag | Meaning |
+| --- | --- |
+| `@summary` | Default; usually elided. Prose-only `///` blocks become the summary. |
+| `@param name` | Documents parameter `name`. |
+| `@typeparam name` | Documents type parameter `name`. |
+| `@returns` | Documents the return value. |
+| `@value` | Documents a property's value. |
+| `@remarks` | Long-form remarks. |
+| `@exception TypeName` | Documents a thrown exception. |
+| `@seealso TypeName` | Cross-reference. |
+| `@inheritdoc` | Inherit documentation from a base/interface member. |
+
+Authors can drop raw `<...>` XML through unchanged by writing it inside a fenced ```` ```xmldoc ```` code block, for constructs Markdown cannot express.
+
+The compiler renders the merged documentation in hover for both G# declarations and imported CLR APIs (their `.xml` doc files are ingested and rendered identically). Diagnostics:
+
+| Code | Severity | Cause |
+| --- | --- | --- |
+| `GS0227` | Warning | Documentation comment is not attached to a declaration. |
+| `GS0228` | Warning (opt-in) | Missing documentation on a public member. |
+| `GS0229` | Warning | `@param` / `@typeparam` name does not match any parameter. |
+| `GS0230` | Warning | Unsupported documentation Markdown construct. |
+| `GS0231` | Warning | Unknown documentation tag. |
 
 ## Appendix: full parser grammar
 

--- a/website/versioned_docs/version-0.1/release-notes.md
+++ b/website/versioned_docs/version-0.1/release-notes.md
@@ -9,20 +9,40 @@ G# is pre-1.0. The repository's version base is currently `0.1`, and product ver
 
 ## Unreleased
 
-This documentation set is the initial public documentation release for the G# website. The language and tooling are under active development, so future entries should call out breaking changes clearly and link to the relevant design decision or reference page.
+The G# compiler, language server, and VS Code extension absorbed a large stack of additions this cycle. The summary below groups them by area; each item links to the design decision (ADR) or implementation reference.
 
 ### Added
 
-- Authored public documentation pages for the FAQ and release notes.
-- Established this page as the release-history location for future G# documentation updates.
+- **Documentation comments** ([ADR-0057](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0057-documentation-comments.md)) — Markdown-authored `///` documentation comments that round-trip losslessly to CLR XML doc. Hover renders the merged documentation for both G# declarations and imported CLR APIs. New warnings: `GS0227` (unattached), `GS0228` (missing on public, opt-in), `GS0229` (`@param` mismatch), `GS0230` (unsupported Markdown), `GS0231` (unknown tag).
+- **Named delegate types** ([ADR-0059](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0059-named-delegate-types.md)) — `type Name = delegate func(...)` declares a real CLR `MulticastDelegate`-derived type so C# consumers see a conventional handler type and G# events can carry first-class custom delegate types. Diagnostics `GS0233`–`GS0234`.
+- **`ref`/`out`/`in` parameters** ([ADR-0060](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0060-ref-out-in-parameters.md)) — Declaration-site and call-site ref-kind modifiers, including inline `out var/let/_` declarations. Diagnostics `GS0235`–`GS0243`. Passing a value to an `in` parameter without writing `in` at the call site is the warning `GS0242` rather than a silent spill (a deliberate departure from C#).
+- **Ref-aliasing locals** (ADR-0060 follow-up) — `let ref m = arr[i]` / `var ref v = c.Field` produces a local whose IL slot is `T&` and aliases another lvalue. Diagnostics `GS0256`–`GS0258`.
+- **Ref returns** (ADR-0060 follow-up, issue #490) — `func f(...) ref T { return ref <expr> }`. Diagnostics `GS0248`–`GS0255` cover the surrounding rules (escape, async/iterator ban, override match).
+- **Conditional ref-arguments** ([ADR-0061](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0061-conditional-ref-arguments.md)) — narrow `ref cond ? a : b` form inside ref-kind argument payloads; diagnostics `GS0260`–`GS0262`.
+- **Generalized ternary expression** ([ADR-0062](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0062-generalized-ternary-expression.md)) — `cond ? a : b` is now a normal expression. `GS0259` is retired in value contexts; the new `GS0263` covers the "no common type" failure.
+- **Method overloading and optional parameters** ([ADR-0063](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0063-method-overloading-and-optional-parameters.md)) — user G# functions can carry overload sets (differing by parameter types or ref-kinds) and optional parameters with compile-time-constant defaults. Diagnostics `GS0264`–`GS0267`.
+- **Named arguments at call sites** (issue #343) — `Foo(timeout: 30, retries: 3)` for free functions, user methods, user constructors, extension functions, and inherited CLR methods (including delegate `Invoke`). Diagnostics `GS0244`–`GS0247`. The legacy `name = value` form is still accepted for `.copy(...)` and attribute argument lists.
+- **`scoped` parameter modifier** ([ADR-0058](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0058-ref-safe-to-escape.md)) — constrains a `ref struct` / managed-pointer parameter from escaping; enforced by `GS9004` / `GS9006`.
+- **`data struct` synthesis completed** ([ADR-0029](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0029-data-struct-synthesized-members.md), issue #410) — every `data struct` synthesizes `Equals(object)`, `Equals(T)`, `GetHashCode()`, `ToString()`, `op_Equality`, `op_Inequality`, and `Deconstruct(...)`. Hand-written versions are rejected (`GS0232`).
+- **Editor features** — hover for CLR XML docs (#397), live pull-based diagnostics (#362), CodeLens reference counts on members of structs, interfaces, and enums (#403), implicit `this` for properties/methods/events (#412), hover for `this` (#413), bare static-member access from instance methods (#485), chained-member hover (#402), and six VS Code color themes inspired by the G# logo (Ember, Magma, Synthwave — Dark + Light each, #357).
 
 ### Changed
 
-- No runtime or language change is implied by this documentation entry.
+- The website spec, feature matrix, FAQ, bridges page, guide pages, and design-decisions index were refreshed to match the compiler ground truth — most visibly, "Parameters do not have default-value syntax" and "Named arguments — Partial" are no longer correct and were rewritten.
+- The repo `docs/lexical.md` block-comment paragraph (which incorrectly claimed block comments were not implemented) is corrected, and a documentation-comments subsection was added.
+- The VS Code TextMate grammar adds the missing contextual keywords (`data`, `inline`, `record`, `delegate`, `event`, `prop`, `init`, `shared`, `scoped`, accessor names `get`/`set`/`add`/`remove`/`raise`, ref-kinds `ref`/`out`), operators (`:=`, `?.`, `??`, `?`/`:`, `!!`, `...`, `=>`), an `@Annotation` scope, and a `///` documentation-comment scope with `@tag` highlighting. The VS Code snippet set was rewritten to match current grammar.
 
 ### Fixed
 
-- No product fixes are recorded in this documentation entry.
+- Numerous IL-emit hardening rounds (issues #418, #419, #420, #421) and a new `ilverify` gate (#478) ensure emitted assemblies pass CLR verification.
+- Determinism golden test (#475) freezes emitted bytes for byte-for-byte reproducibility.
+- `FieldAccessException` on class auto-properties (#399).
+- CodeLens 0-refs and stale-tree fixes (#414).
+
+### Known issues
+
+- The full ref-safe-to-escape escape analysis is partial; `GS0257` is reserved for a future pass.
+- Async state-machine emit shapes that are not yet supported continue to report `GS0190`.
 
 ## 0.1
 


### PR DESCRIPTION
## Why

Over the past week the compiler landed a large batch of language and tooling work (ADRs 0029, 0055–0063, plus implicit `this`, ref-aliasing locals, live pull diagnostics, hover for CLR XML, and six VS Code themes). The reference docs, the Docusaurus site, and the VS Code extension had all drifted from that reality. This sweep brings them back in sync — no compiler or library code changes.

## What

**Repo docs (`docs/`)**

- Flipped ADRs 0060, 0061, 0062, 0063 from Proposed → Accepted with `Implemented` lines (#489, #495, #497, #498).
- `lexical.md` — dropped the stale "block comments not implemented" claim and added a Documentation comments subsection (ADR-0057).
- `diagnostics.md` — documented GS0207–0210, 0212, 0213–0218, 0248–0255, 0264–0267, and 9007.
- `lsp.md` — noted that hover renders CLR XML and G# Markdown doc comments as MarkupContent.
- `vscode-gsharp-spec.md` — refreshed §3.2 (grammar), §3.3 (snippets), §3.4 (six themes).

**VS Code extension (`src/vscode-gsharp/`)**

- Full rewrite of `syntaxes/gsharp.tmLanguage.json` (current keyword/modifier/accessor sets, operators `:=`, `?.`, `??`, `?`/`:`, `!!`, `...`, `=>`, `@Annotation` scope, `///` doc comments with `@tag` highlighting, alignment/format styling inside `${expr,N:fmt}`).
- Full rewrite of `snippets/gsharp.json` — 37 snippets covering current surface syntax.
- Updated `CHANGELOG.md` Unreleased.

**Website (`website/docs/`)**

- `ref/spec.md` — rewrote Functions (defaults/overloading/ref kinds/scoped + RefReturnClause), Type declarations (named DelegateAliasTail), Precedence (ternary level), Primary expressions (named args + ref-kind args), Comments, Statements (`RefLocalDecl`), Return/yield (`return ref`), and added a Documentation comments top-level section.
- `ref/feature-matrix.md` — flipped Named arguments and Default values to Supported; added rows for overloading, ref/out/in/scoped, ref returns, ref-aliasing locals, named delegates, ternary, conditional ref-arguments, doc comments, hover for CLR XML, six themes.
- `ref/diagnostics.md` — mirrored from `docs/diagnostics.md` (preserving Docusaurus frontmatter).
- `ref/clr-interop.md` — generalized the named-arguments paragraph; corrected the ADR-0039 and ADR-0056 "out of scope" caveats to acknowledge ref returns and the `scoped` modifier.
- `faq.md` — replaced the "no default/optional parameter values" Q&A.
- `bridges/gsharp-for-csharp-developers.md` — fixed the comparison table rows and rewrote the defaults/named-args/overloading section.
- `guide/declarations-and-packages.md`, `guide/expressions-and-statements.md`, `guide/types-and-values.md` — prose + samples for overloading, ref kinds, named delegate types, ternary, named args.
- `design-decisions.md` — added ADRs 0057–0063 to the relevant tables.
- `release-notes.md` — rewrote the Unreleased section as a comprehensive Added / Changed / Fixed block.
- `versioned_docs/version-0.1/` — re-mirrored every changed page via the manual `cp` pattern from PR #387.

**MDX-3 hardening (diagnostics tables)**

- Wrapped `'{placeholder}'`-style parameters (`{name}`, `{functionName}`, `{type}`, etc.) in backticks so MDX 3 stops parsing them as JSX expressions.
- Backticked `<expr>` (previously `<lvalue>`) and `{async/iterator}` in GS0249 / GS0252 so they no longer parse as JSX tags / expressions.

## Verification

- `dotnet tool restore`
- `dotnet build GSharp.sln -nologo -clp:NoSummary` → 0 errors
- `dotnet test GSharp.sln --no-restore --nologo` → **2566/2566 pass** (Sdk 24, Interpreter 72, LanguageServer 212, Core 1887, Compiler 371)
- `cd website && npm install && npm run build` → SUCCESS
- VS Code extension JSON assets validated with `json.load`

## Not in scope

- No source changes under `src/Core` or `src/Compiler`.
- `website/package-lock.json` was intentionally reverted to keep this a pure docs/extension PR.
- A handful of opt-in or polish items (ternary tutorial walk-through, deeper homepage redesign, ADR-0050 trailing-arrow lambda surfacing once implemented) are deferred to follow-up PRs.
