### PR TITLE
Fix #506: lower `params T[]` from positional args

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -9236,12 +9236,14 @@ public sealed class Binder
     /// <param name="parameters">The resolved method's parameter list.</param>
     /// <param name="callSyntax">The originating call expression; used to surface conversion diagnostics for individual variadic elements when present.</param>
     /// <param name="receiverArgCount">The number of leading argument slots reserved for a synthesised receiver (0 for plain calls, 1 for imported extension calls).</param>
+    /// <param name="parameterMapping">Issue #506 follow-up: when non-default, the source-order mapping from each input argument to its parameter slot, as produced by overload resolution for calls combining named arguments with expanded <c>params</c> form. Causes the expander to emit arguments already in parameter order with optional slots filled by their defaults.</param>
     /// <returns>An argument list of length <paramref name="parameters"/>.Length whose final element is the packed array.</returns>
     private ImmutableArray<BoundExpression> ExpandParamsArguments(
         ImmutableArray<BoundExpression> arguments,
         System.Reflection.ParameterInfo[] parameters,
         CallExpressionSyntax callSyntax,
-        int receiverArgCount = 0)
+        int receiverArgCount = 0,
+        ImmutableArray<int> parameterMapping = default)
     {
         var paramsIndex = parameters.Length - 1;
         var paramArrayType = parameters[paramsIndex].ParameterType;
@@ -9250,6 +9252,44 @@ public sealed class Binder
             ? TypeSymbol.Object
             : TypeSymbol.FromClrType(elementClrType);
         var sliceType = SliceTypeSymbol.Get(elementTypeSymbol);
+
+        // Issue #506 follow-up: when a parameter mapping is supplied (named
+        // arguments combined with `params` expansion) the input arguments are
+        // in source order and may bind to any non-params parameter; the source
+        // positions that map to the params slot must be packed. The result is
+        // built in parameter order so the downstream binding pipeline can drop
+        // its own reorder step.
+        if (!parameterMapping.IsDefault)
+        {
+            var ordered = new BoundExpression[parameters.Length];
+            var paramsElementBuilder = ImmutableArray.CreateBuilder<BoundExpression>();
+            var paramsSourceIndices = new List<int>();
+            for (var i = 0; i < arguments.Length; i++)
+            {
+                var slot = parameterMapping[i];
+                if (slot == paramsIndex)
+                {
+                    paramsSourceIndices.Add(i);
+                }
+                else
+                {
+                    ordered[slot] = arguments[i];
+                }
+            }
+
+            foreach (var sourceIndex in paramsSourceIndices)
+            {
+                paramsElementBuilder.Add(ConvertParamsElement(arguments[sourceIndex], elementTypeSymbol, callSyntax, sourceIndex, receiverArgCount));
+            }
+
+            ordered[paramsIndex] = new BoundArrayCreationExpression(callSyntax, sliceType, paramsElementBuilder.ToImmutable());
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                ordered[i] ??= CreateOptionalDefaultArgument(parameters[i]);
+            }
+
+            return ImmutableArray.Create(ordered);
+        }
 
         var fixedCount = paramsIndex;
         var tailCount = arguments.Length - fixedCount;
@@ -9265,34 +9305,7 @@ public sealed class Binder
         for (var i = 0; i < tailCount; i++)
         {
             var sourceIndex = fixedCount + i;
-            var arg = arguments[sourceIndex];
-            var converted = arg;
-            if (arg.Type != null && arg.Type != TypeSymbol.Error && arg.Type != elementTypeSymbol)
-            {
-                if (Conversion.Classify(arg.Type, elementTypeSymbol).Exists)
-                {
-                    var conversionSyntaxIndex = sourceIndex - receiverArgCount;
-                    TextLocation location;
-                    if (callSyntax != null
-                        && conversionSyntaxIndex >= 0
-                        && conversionSyntaxIndex < callSyntax.Arguments.Count)
-                    {
-                        location = callSyntax.Arguments[conversionSyntaxIndex].Location;
-                    }
-                    else
-                    {
-                        location = callSyntax?.Location ?? default;
-                    }
-
-                    converted = BindConversion(location, arg, elementTypeSymbol, allowExplicit: true);
-                }
-                else if (TryApplyUserDefinedImplicitArgumentConversion(arg, elementTypeSymbol, out var udc))
-                {
-                    converted = udc;
-                }
-            }
-
-            packed.Add(converted);
+            packed.Add(ConvertParamsElement(arguments[sourceIndex], elementTypeSymbol, callSyntax, sourceIndex, receiverArgCount));
         }
 
         var arrayExpr = new BoundArrayCreationExpression(callSyntax, sliceType, packed.MoveToImmutable());
@@ -9305,6 +9318,44 @@ public sealed class Binder
 
         result.Add(arrayExpr);
         return result.MoveToImmutable();
+    }
+
+    /// <summary>
+    /// Issue #506: converts a single positional argument intended for a
+    /// <c>params T[]</c> element slot to the element type, threading the
+    /// originating source location for diagnostic reporting.
+    /// </summary>
+    private BoundExpression ConvertParamsElement(BoundExpression arg, TypeSymbol elementTypeSymbol, CallExpressionSyntax callSyntax, int sourceIndex, int receiverArgCount)
+    {
+        if (arg.Type == null || arg.Type == TypeSymbol.Error || arg.Type == elementTypeSymbol)
+        {
+            return arg;
+        }
+
+        if (Conversion.Classify(arg.Type, elementTypeSymbol).Exists)
+        {
+            var conversionSyntaxIndex = sourceIndex - receiverArgCount;
+            TextLocation location;
+            if (callSyntax != null
+                && conversionSyntaxIndex >= 0
+                && conversionSyntaxIndex < callSyntax.Arguments.Count)
+            {
+                location = callSyntax.Arguments[conversionSyntaxIndex].Location;
+            }
+            else
+            {
+                location = callSyntax?.Location ?? default;
+            }
+
+            return BindConversion(location, arg, elementTypeSymbol, allowExplicit: true);
+        }
+
+        if (TryApplyUserDefinedImplicitArgumentConversion(arg, elementTypeSymbol, out var udc))
+        {
+            return udc;
+        }
+
+        return arg;
     }
 
     /// <summary>
@@ -12251,11 +12302,23 @@ public sealed class Binder
         var ctorRefKinds = ComputeArgumentRefKinds(ctorParameters);
         var ctorRawArgs = boundArguments.MoveToImmutable();
         var ctorExpandedArgs = ctorIsExpanded
-            ? ExpandParamsArguments(ctorRawArgs, ctorParameters, syntax)
+            ? ExpandParamsArguments(ctorRawArgs, ctorParameters, syntax, parameterMapping: ctorMapping)
             : ctorRawArgs;
-        var ctorRebound = RebindFormattableInterpolationArguments(ctorExpandedArgs, syntax.Arguments, ctorParameters, ctorMapping);
-        var ctorHandlerArgs = ApplyInterpolatedStringHandlers(ctorParameters, ctorRebound, receiver: null, syntax.Location, ctorMapping);
-        var ctorArgs = BuildOrderedCallArguments(ctorHandlerArgs, ctorMapping, ctorParameters);
+
+        // Issue #506 follow-up: when expanded form fires (with or without
+        // named arguments), the expander emits the arguments already in
+        // parameter order with optional slots filled — downstream reorderers
+        // therefore consume an identity mapping.
+        var ctorDownstreamMapping = ctorIsExpanded ? default : ctorMapping;
+        var ctorRebound = RebindFormattableInterpolationArguments(ctorExpandedArgs, syntax.Arguments, ctorParameters, ctorDownstreamMapping);
+        var ctorHandlerArgs = ApplyInterpolatedStringHandlers(ctorParameters, ctorRebound, receiver: null, syntax.Location, ctorDownstreamMapping);
+
+        // Issue #506 follow-up: fixed-arity CLR ctor overloads expecting an
+        // `object` parameter from a value-type argument require a boxing
+        // conversion in IL; route through BindClrParameterConversions so the
+        // emitter sees a BoundConversionExpression and emits `box <T>`.
+        var ctorConvertedArgs = BindClrParameterConversions(ctorHandlerArgs, ctorParameters, syntax, ctorDownstreamMapping);
+        var ctorArgs = BuildOrderedCallArguments(ctorConvertedArgs, ctorDownstreamMapping, ctorParameters);
         if (!ctorRefKinds.IsDefault)
         {
             ValidateRefArguments(ctorArgs, ctorRefKinds, clrType.Name, syntax.Location);
@@ -13281,11 +13344,17 @@ public sealed class Binder
             {
                 var staticParameters = staticFn.Method.GetParameters();
                 var staticExpandedArgs = staticIsExpanded
-                    ? ExpandParamsArguments(arguments, staticParameters, ce)
+                    ? ExpandParamsArguments(arguments, staticParameters, ce, parameterMapping: staticMapping)
                     : arguments;
-                var staticRebound = RebindFormattableInterpolationArguments(staticExpandedArgs, ce.Arguments, staticParameters, staticMapping);
-                var staticHandlerArgs = ApplyInterpolatedStringHandlers(staticParameters, staticRebound, receiver: null, ce.Location, staticMapping);
-                var staticArguments = BuildOrderedCallArguments(staticHandlerArgs, staticMapping, staticParameters);
+                var staticDownstreamMapping = staticIsExpanded ? default : staticMapping;
+                var staticRebound = RebindFormattableInterpolationArguments(staticExpandedArgs, ce.Arguments, staticParameters, staticDownstreamMapping);
+                var staticHandlerArgs = ApplyInterpolatedStringHandlers(staticParameters, staticRebound, receiver: null, ce.Location, staticDownstreamMapping);
+
+                // Issue #506 follow-up: ensure value-type → object boxing fires
+                // for fixed-arity CLR static calls (e.g. `String.Format("{0}", 42)`
+                // selecting the fixed `(string, object)` overload).
+                var staticConvertedArgs = BindClrParameterConversions(staticHandlerArgs, staticParameters, ce, staticDownstreamMapping);
+                var staticArguments = BuildOrderedCallArguments(staticConvertedArgs, staticDownstreamMapping, staticParameters);
                 var refKinds = ComputeArgumentRefKinds(staticParameters);
                 ValidateRefArguments(staticArguments, refKinds, methodName, ce.Location);
                 return new BoundImportedCallExpression(null, staticFn, staticArguments, refKinds, typeArgSymbols);
@@ -13457,13 +13526,14 @@ public sealed class Binder
                         var instParameters = resolution.Best.GetParameters();
                         var instMapping = resolution.ParameterMapping;
                         var instExpandedArgs = resolution.IsExpanded
-                            ? ExpandParamsArguments(arguments, instParameters, ce)
+                            ? ExpandParamsArguments(arguments, instParameters, ce, parameterMapping: instMapping)
                             : arguments;
-                        var instRebound = RebindFormattableInterpolationArguments(instExpandedArgs, ce.Arguments, instParameters, instMapping);
-                        var instHandlerArgs = ApplyInterpolatedStringHandlers(instParameters, instRebound, receiver, ce.Location, instMapping);
-                        var instDelegateArgs = RebindFunctionLiteralDelegateArguments(instHandlerArgs, instParameters, instMapping);
-                        var instConvertedArgs = BindClrParameterConversions(instDelegateArgs, instParameters, ce, instMapping);
-                        var instArguments = BuildOrderedCallArguments(instConvertedArgs, instMapping, instParameters);
+                        var instDownstreamMapping = resolution.IsExpanded ? default : instMapping;
+                        var instRebound = RebindFormattableInterpolationArguments(instExpandedArgs, ce.Arguments, instParameters, instDownstreamMapping);
+                        var instHandlerArgs = ApplyInterpolatedStringHandlers(instParameters, instRebound, receiver, ce.Location, instDownstreamMapping);
+                        var instDelegateArgs = RebindFunctionLiteralDelegateArguments(instHandlerArgs, instParameters, instDownstreamMapping);
+                        var instConvertedArgs = BindClrParameterConversions(instDelegateArgs, instParameters, ce, instDownstreamMapping);
+                        var instArguments = BuildOrderedCallArguments(instConvertedArgs, instDownstreamMapping, instParameters);
                         var instRefKinds = ComputeArgumentRefKinds(instParameters);
                         ValidateRefArguments(instArguments, instRefKinds, methodName, ce.Location);
                         return AutoDereferenceRefReturn(new BoundImportedInstanceCallExpression(null, receiver, resolution.Best, returnType, instArguments, instRefKinds, typeArgSymbols));
@@ -13554,12 +13624,13 @@ public sealed class Binder
                 var inheritedParameters = resolution.Best.GetParameters();
                 var inheritedMapping = resolution.ParameterMapping;
                 var inheritedExpandedArgs = resolution.IsExpanded
-                    ? ExpandParamsArguments(arguments, inheritedParameters, ce)
+                    ? ExpandParamsArguments(arguments, inheritedParameters, ce, parameterMapping: inheritedMapping)
                     : arguments;
-                var inheritedHandlerArgs = ApplyInterpolatedStringHandlers(inheritedParameters, inheritedExpandedArgs, receiver, ce.Location, inheritedMapping);
-                var inheritedDelegateArgs = RebindFunctionLiteralDelegateArguments(inheritedHandlerArgs, inheritedParameters, inheritedMapping);
-                var inheritedConvertedArgs = BindClrParameterConversions(inheritedDelegateArgs, inheritedParameters, ce, inheritedMapping);
-                var inheritedArguments = BuildOrderedCallArguments(inheritedConvertedArgs, inheritedMapping, inheritedParameters);
+                var inheritedDownstreamMapping = resolution.IsExpanded ? default : inheritedMapping;
+                var inheritedHandlerArgs = ApplyInterpolatedStringHandlers(inheritedParameters, inheritedExpandedArgs, receiver, ce.Location, inheritedDownstreamMapping);
+                var inheritedDelegateArgs = RebindFunctionLiteralDelegateArguments(inheritedHandlerArgs, inheritedParameters, inheritedDownstreamMapping);
+                var inheritedConvertedArgs = BindClrParameterConversions(inheritedDelegateArgs, inheritedParameters, ce, inheritedDownstreamMapping);
+                var inheritedArguments = BuildOrderedCallArguments(inheritedConvertedArgs, inheritedDownstreamMapping, inheritedParameters);
                 var refKinds = ComputeArgumentRefKinds(inheritedParameters);
                 ValidateRefArguments(inheritedArguments, refKinds, methodName, ce.Location);
                 result = new BoundImportedInstanceCallExpression(null, receiver, resolution.Best, returnType, inheritedArguments, refKinds, typeArgSymbols);
@@ -13865,17 +13936,40 @@ public sealed class Binder
         // params string[] tail)` called with positional tail args), pack the
         // trailing positional arguments into a synthesised slice/array first.
         // The receiver occupies parameter slot 0; the params slot is always
-        // the last parameter, so it never collides with the receiver.
+        // the last parameter, so it never collides with the receiver. Named
+        // arguments against an expanded-form extension are funnelled through
+        // an offset mapping so the receiver position lines up with bound[0].
         var parameters = best.GetParameters();
         if (resolution.IsExpanded)
         {
-            bound = ExpandParamsArguments(bound, parameters, ce, receiverArgCount: 1);
+            ImmutableArray<int> expandedMapping = default;
+            if (!resolution.ParameterMapping.IsDefault)
+            {
+                var offset = ImmutableArray.CreateBuilder<int>(bound.Length);
+                offset.Add(0);
+                for (var i = 0; i < resolution.ParameterMapping.Length; i++)
+                {
+                    offset.Add(resolution.ParameterMapping[i]);
+                }
+
+                expandedMapping = offset.MoveToImmutable();
+            }
+
+            bound = ExpandParamsArguments(bound, parameters, ce, receiverArgCount: 1, parameterMapping: expandedMapping);
         }
+
+        var downstreamMapping = resolution.IsExpanded ? default : resolution.ParameterMapping;
+
+        // Issue #506 follow-up: route through BindClrParameterConversions so
+        // value-type → object boxing fires for fixed-arity imported extension
+        // calls too. The receiver occupies arg slot 0 (and is already typed
+        // correctly via the extension dispatch).
+        bound = BindClrParameterConversions(bound, parameters, ce, downstreamMapping, receiverArgCount: 1);
 
         // Issue #327 / #343: re-order arguments into parameter positions when
         // named arguments were used; otherwise fall through to the existing
         // trailing-optional fill.
-        bound = BuildOrderedCallArguments(bound, resolution.ParameterMapping, parameters);
+        bound = BuildOrderedCallArguments(bound, downstreamMapping, parameters);
 
         var refKinds = ComputeArgumentRefKinds(parameters);
         ValidateRefArguments(bound, refKinds, methodName, ce.Location);
@@ -15246,7 +15340,8 @@ public sealed class Binder
         ImmutableArray<BoundExpression> arguments,
         ParameterInfo[] parameters,
         CallExpressionSyntax call,
-        ImmutableArray<int> parameterMapping = default)
+        ImmutableArray<int> parameterMapping = default,
+        int receiverArgCount = 0)
     {
         ImmutableArray<BoundExpression>.Builder builder = null;
         for (var i = 0; i < arguments.Length; i++)
@@ -15260,9 +15355,21 @@ public sealed class Binder
                 if (!parameterType.IsByRef && argument.Type != TypeSymbol.Error)
                 {
                     var targetType = TypeSymbol.FromClrType(parameterType);
-                    if (argument.Type != targetType && Conversion.Classify(argument.Type, targetType).Exists)
+                    if (argument.Type != targetType
+                        && Conversion.Classify(argument.Type, targetType).Exists
+                        && NeedsBindClrParameterConversion(argument.Type, parameterType))
                     {
-                        rebound = BindConversion(call.Arguments[i].Location, argument, targetType, allowExplicit: true);
+                        // Issue #506: the source-argument list may not align with
+                        // the bound-argument list when a synthesised receiver
+                        // occupies leading slots (imported extension calls) or
+                        // when params expansion has replaced N positional source
+                        // args with one synthesised array. Fall back to the
+                        // overall call location when the source slot is absent.
+                        var sourceIndex = i - receiverArgCount;
+                        var location = call != null && sourceIndex >= 0 && sourceIndex < call.Arguments.Count
+                            ? call.Arguments[sourceIndex].Location
+                            : call?.Location ?? default;
+                        rebound = BindConversion(location, argument, targetType, allowExplicit: true);
                     }
                 }
             }
@@ -15290,6 +15397,39 @@ public sealed class Binder
         }
 
         return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Issue #506 follow-up: returns <see langword="true"/> when the bound
+    /// argument's static type needs an actual IL-visible conversion to land in
+    /// the CLR parameter's slot (boxing, numeric coercion, func→delegate
+    /// materialisation, etc.). Skips no-op rewraps where the source and
+    /// destination share the same CLR type — for example
+    /// <c>string?</c> → <c>string</c>, where the difference is purely the
+    /// nullability wrapper and emit is identical. Those no-op rewraps would
+    /// otherwise wrap a <see cref="BoundVariableExpression"/> argument in a
+    /// <see cref="BoundConversionExpression"/>, defeating nullable-flow
+    /// narrowing patterns (e.g. <c>!String.IsNullOrEmpty(s)</c> can no longer
+    /// strip <c>s</c>'s nullability).
+    /// </summary>
+    /// <param name="from">The bound argument's static type.</param>
+    /// <param name="targetParameterType">The CLR parameter type.</param>
+    /// <returns>Whether a rebinding conversion is required.</returns>
+    private static bool NeedsBindClrParameterConversion(TypeSymbol from, Type targetParameterType)
+    {
+        if (from == null || targetParameterType == null)
+        {
+            return false;
+        }
+
+        // FunctionTypeSymbol carries no ClrType but always needs delegate
+        // materialisation when handed to a CLR delegate parameter.
+        if (from.ClrType == null)
+        {
+            return true;
+        }
+
+        return from.ClrType != targetParameterType;
     }
 
     private static bool TryGetDelegateFunctionType(Type delegateType, out FunctionTypeSymbol functionType)
@@ -15954,6 +16094,7 @@ public sealed class Binder
         }
 
         ConstructorInfo bestCtor = null;
+        var isExpanded = false;
         if (argsAllTyped)
         {
             var resolution = OverloadResolution.Resolve(ctors, argTypes);
@@ -15961,6 +16102,7 @@ public sealed class Binder
             {
                 case OverloadResolution.ResolutionOutcome.Resolved:
                     bestCtor = resolution.Best as ConstructorInfo;
+                    isExpanded = resolution.IsExpanded;
                     break;
                 case OverloadResolution.ResolutionOutcome.Ambiguous:
                     Diagnostics.ReportAmbiguousOverload(location, clrBase.Name, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
@@ -15980,9 +16122,64 @@ public sealed class Binder
         // For a by-ref parameter the bound argument must already be an address-of
         // expression (`&x`); the emitter forwards the address rather than a value.
         var ctorParams = bestCtor.GetParameters();
-        var refKindsBuilder = ImmutableArray.CreateBuilder<RefKind>(boundArguments.Count);
-        var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(boundArguments.Count);
-        for (var i = 0; i < boundArguments.Count; i++)
+
+        // Issue #506 follow-up: when overload resolution selected the expanded
+        // form of a `params T[]` base ctor (e.g. `init() : base(1, 2, 3, 4)`
+        // flowing into a C# `Base(int x, params int[] tail)`), pack the trailing
+        // positional arguments into a synthesised slice/array first. The fixed
+        // leading parameters and the synthesised array slot then go through the
+        // same per-parameter ref/conversion loop as the normal-form path.
+        ImmutableArray<BoundExpression> orderedArgs;
+        if (isExpanded)
+        {
+            var paramsIndex = ctorParams.Length - 1;
+            var paramArrayType = ctorParams[paramsIndex].ParameterType;
+            var elementClrType = paramArrayType.GetElementType();
+            var elementTypeSymbol = elementClrType == null
+                ? TypeSymbol.Object
+                : TypeSymbol.FromClrType(elementClrType);
+            var sliceType = SliceTypeSymbol.Get(elementTypeSymbol);
+
+            var tailCount = boundArguments.Count - paramsIndex;
+            var packed = ImmutableArray.CreateBuilder<BoundExpression>(tailCount);
+            for (var j = 0; j < tailCount; j++)
+            {
+                var srcIndex = paramsIndex + j;
+                var element = boundArguments[srcIndex];
+                if (element.Type != null && element.Type != TypeSymbol.Error && element.Type != elementTypeSymbol)
+                {
+                    if (Conversion.Classify(element.Type, elementTypeSymbol).Exists)
+                    {
+                        element = BindConversion(argLocation(srcIndex), element, elementTypeSymbol, allowExplicit: true);
+                    }
+                    else if (TryApplyUserDefinedImplicitArgumentConversion(element, elementTypeSymbol, out var udc))
+                    {
+                        element = udc;
+                    }
+                }
+
+                packed.Add(element);
+            }
+
+            var arrayExpr = new BoundArrayCreationExpression(syntax: null, sliceType, packed.MoveToImmutable());
+
+            var expandedBuilder = ImmutableArray.CreateBuilder<BoundExpression>(ctorParams.Length);
+            for (var i = 0; i < paramsIndex; i++)
+            {
+                expandedBuilder.Add(boundArguments[i]);
+            }
+
+            expandedBuilder.Add(arrayExpr);
+            orderedArgs = expandedBuilder.MoveToImmutable();
+        }
+        else
+        {
+            orderedArgs = boundArguments.ToImmutable();
+        }
+
+        var refKindsBuilder = ImmutableArray.CreateBuilder<RefKind>(ctorParams.Length);
+        var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(ctorParams.Length);
+        for (var i = 0; i < ctorParams.Length; i++)
         {
             var clrParamType = ctorParams[i].ParameterType;
             if (clrParamType.IsByRef)
@@ -15994,13 +16191,29 @@ public sealed class Binder
 
                 // A by-ref argument is forwarded as-is (it is already a managed
                 // pointer, e.g. the result of `&x`); no value conversion applies.
-                convertedArgs.Add(boundArguments[i]);
+                convertedArgs.Add(orderedArgs[i]);
                 continue;
             }
 
             refKindsBuilder.Add(RefKind.None);
             var targetType = TypeSymbol.FromClrType(clrParamType);
-            convertedArgs.Add(BindConversion(argLocation(i), boundArguments[i], targetType));
+            var argLoc = isExpanded && i == ctorParams.Length - 1
+                ? location
+                : argLocation(i);
+            var orderedArg = orderedArgs[i];
+
+            // Issue #506 follow-up: when the synthesised params array already
+            // carries the exact CLR type of the parameter (SliceTypeSymbol(T)
+            // → T[]), skip the rebinding so the emitter sees the original
+            // array-creation expression without an extra conversion wrapper.
+            if (orderedArg.Type?.ClrType != null && orderedArg.Type.ClrType == clrParamType)
+            {
+                convertedArgs.Add(orderedArg);
+            }
+            else
+            {
+                convertedArgs.Add(BindConversion(argLoc, orderedArg, targetType));
+            }
         }
 
         return new BaseConstructorInitializer(convertedArgs.ToImmutable(), bestCtor, refKindsBuilder.ToImmutable());

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -9223,6 +9223,91 @@ public sealed class Binder
     }
 
     /// <summary>
+    /// Issue #506: synthesises C#-style <c>params T[]</c> expansion for a CLR
+    /// call site that won overload resolution in expanded form. The trailing
+    /// positional arguments (those mapped to the final <c>params</c> parameter)
+    /// are individually converted to the element type and packed into a
+    /// <see cref="BoundArrayCreationExpression"/>; the returned argument list
+    /// has length equal to <paramref name="parameters"/>.Length so the
+    /// remaining call-binding pipeline (handler rewrite, ref-kind validation,
+    /// ordered-mapping fill) treats the call uniformly with normal-form calls.
+    /// </summary>
+    /// <param name="arguments">The source-order bound arguments. Includes a synthesised receiver slot for imported extension calls; the receiver always sits at the leading parameter positions, never the params slot.</param>
+    /// <param name="parameters">The resolved method's parameter list.</param>
+    /// <param name="callSyntax">The originating call expression; used to surface conversion diagnostics for individual variadic elements when present.</param>
+    /// <param name="receiverArgCount">The number of leading argument slots reserved for a synthesised receiver (0 for plain calls, 1 for imported extension calls).</param>
+    /// <returns>An argument list of length <paramref name="parameters"/>.Length whose final element is the packed array.</returns>
+    private ImmutableArray<BoundExpression> ExpandParamsArguments(
+        ImmutableArray<BoundExpression> arguments,
+        System.Reflection.ParameterInfo[] parameters,
+        CallExpressionSyntax callSyntax,
+        int receiverArgCount = 0)
+    {
+        var paramsIndex = parameters.Length - 1;
+        var paramArrayType = parameters[paramsIndex].ParameterType;
+        var elementClrType = paramArrayType.GetElementType();
+        var elementTypeSymbol = elementClrType == null
+            ? TypeSymbol.Object
+            : TypeSymbol.FromClrType(elementClrType);
+        var sliceType = SliceTypeSymbol.Get(elementTypeSymbol);
+
+        var fixedCount = paramsIndex;
+        var tailCount = arguments.Length - fixedCount;
+        if (tailCount < 0)
+        {
+            // Shouldn't happen: overload resolution rejects expanded-form
+            // candidates whose fixed leading parameters are not all supplied.
+            // Defensive fallback: leave the arguments unchanged.
+            return arguments;
+        }
+
+        var packed = ImmutableArray.CreateBuilder<BoundExpression>(tailCount);
+        for (var i = 0; i < tailCount; i++)
+        {
+            var sourceIndex = fixedCount + i;
+            var arg = arguments[sourceIndex];
+            var converted = arg;
+            if (arg.Type != null && arg.Type != TypeSymbol.Error && arg.Type != elementTypeSymbol)
+            {
+                if (Conversion.Classify(arg.Type, elementTypeSymbol).Exists)
+                {
+                    var conversionSyntaxIndex = sourceIndex - receiverArgCount;
+                    TextLocation location;
+                    if (callSyntax != null
+                        && conversionSyntaxIndex >= 0
+                        && conversionSyntaxIndex < callSyntax.Arguments.Count)
+                    {
+                        location = callSyntax.Arguments[conversionSyntaxIndex].Location;
+                    }
+                    else
+                    {
+                        location = callSyntax?.Location ?? default;
+                    }
+
+                    converted = BindConversion(location, arg, elementTypeSymbol, allowExplicit: true);
+                }
+                else if (TryApplyUserDefinedImplicitArgumentConversion(arg, elementTypeSymbol, out var udc))
+                {
+                    converted = udc;
+                }
+            }
+
+            packed.Add(converted);
+        }
+
+        var arrayExpr = new BoundArrayCreationExpression(callSyntax, sliceType, packed.MoveToImmutable());
+
+        var result = ImmutableArray.CreateBuilder<BoundExpression>(parameters.Length);
+        for (var i = 0; i < fixedCount; i++)
+        {
+            result.Add(arguments[i]);
+        }
+
+        result.Add(arrayExpr);
+        return result.MoveToImmutable();
+    }
+
+    /// <summary>
     /// ADR-0063: thin wrapper around <see cref="SelectBestInstanceOverload"/>
     /// that reports the standard ambiguity / no-applicable-overload diagnostics
     /// when more than one candidate is supplied. When a single candidate is
@@ -12128,6 +12213,7 @@ public sealed class Binder
 
         ConstructorInfo bestCtor = null;
         ImmutableArray<int> ctorMapping = default;
+        bool ctorIsExpanded = false;
         if (argsAllTyped)
         {
             var resolution = OverloadResolution.Resolve(ctors, argTypes, interpolatedStringArgs: ComputeInterpolatedStringArgFlags(syntax.Arguments, boundArguments.Count), argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
@@ -12136,6 +12222,7 @@ public sealed class Binder
                 case OverloadResolution.ResolutionOutcome.Resolved:
                     bestCtor = resolution.Best;
                     ctorMapping = resolution.ParameterMapping;
+                    ctorIsExpanded = resolution.IsExpanded;
                     break;
                 case OverloadResolution.ResolutionOutcome.Ambiguous:
                     Diagnostics.ReportAmbiguousOverload(syntax.Location, clrType.Name, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
@@ -12162,7 +12249,11 @@ public sealed class Binder
 
         var ctorParameters = bestCtor.GetParameters();
         var ctorRefKinds = ComputeArgumentRefKinds(ctorParameters);
-        var ctorRebound = RebindFormattableInterpolationArguments(boundArguments.MoveToImmutable(), syntax.Arguments, ctorParameters, ctorMapping);
+        var ctorRawArgs = boundArguments.MoveToImmutable();
+        var ctorExpandedArgs = ctorIsExpanded
+            ? ExpandParamsArguments(ctorRawArgs, ctorParameters, syntax)
+            : ctorRawArgs;
+        var ctorRebound = RebindFormattableInterpolationArguments(ctorExpandedArgs, syntax.Arguments, ctorParameters, ctorMapping);
         var ctorHandlerArgs = ApplyInterpolatedStringHandlers(ctorParameters, ctorRebound, receiver: null, syntax.Location, ctorMapping);
         var ctorArgs = BuildOrderedCallArguments(ctorHandlerArgs, ctorMapping, ctorParameters);
         if (!ctorRefKinds.IsDefault)
@@ -13186,10 +13277,13 @@ public sealed class Binder
 
         if (classSymbol != null)
         {
-            if (classSymbol.TryLookupFunction(methodName, ce, arguments, out var staticFn, out var staticMapping, out var staticAmbiguous, out var staticAmbiguousMethods, explicitTypeArgs, typeArgSymbols, scope.References.MapClrTypeToReferences, argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames))
+            if (classSymbol.TryLookupFunction(methodName, ce, arguments, out var staticFn, out var staticMapping, out var staticAmbiguous, out var staticAmbiguousMethods, out var staticIsExpanded, explicitTypeArgs, typeArgSymbols, scope.References.MapClrTypeToReferences, argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames))
             {
                 var staticParameters = staticFn.Method.GetParameters();
-                var staticRebound = RebindFormattableInterpolationArguments(arguments, ce.Arguments, staticParameters, staticMapping);
+                var staticExpandedArgs = staticIsExpanded
+                    ? ExpandParamsArguments(arguments, staticParameters, ce)
+                    : arguments;
+                var staticRebound = RebindFormattableInterpolationArguments(staticExpandedArgs, ce.Arguments, staticParameters, staticMapping);
                 var staticHandlerArgs = ApplyInterpolatedStringHandlers(staticParameters, staticRebound, receiver: null, ce.Location, staticMapping);
                 var staticArguments = BuildOrderedCallArguments(staticHandlerArgs, staticMapping, staticParameters);
                 var refKinds = ComputeArgumentRefKinds(staticParameters);
@@ -13362,7 +13456,10 @@ public sealed class Binder
                         var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols) ?? MapClrMemberType(resolution.Best.ReturnType);
                         var instParameters = resolution.Best.GetParameters();
                         var instMapping = resolution.ParameterMapping;
-                        var instRebound = RebindFormattableInterpolationArguments(arguments, ce.Arguments, instParameters, instMapping);
+                        var instExpandedArgs = resolution.IsExpanded
+                            ? ExpandParamsArguments(arguments, instParameters, ce)
+                            : arguments;
+                        var instRebound = RebindFormattableInterpolationArguments(instExpandedArgs, ce.Arguments, instParameters, instMapping);
                         var instHandlerArgs = ApplyInterpolatedStringHandlers(instParameters, instRebound, receiver, ce.Location, instMapping);
                         var instDelegateArgs = RebindFunctionLiteralDelegateArguments(instHandlerArgs, instParameters, instMapping);
                         var instConvertedArgs = BindClrParameterConversions(instDelegateArgs, instParameters, ce, instMapping);
@@ -13456,7 +13553,10 @@ public sealed class Binder
                 var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols) ?? TypeSymbol.FromClrType(resolution.Best.ReturnType);
                 var inheritedParameters = resolution.Best.GetParameters();
                 var inheritedMapping = resolution.ParameterMapping;
-                var inheritedHandlerArgs = ApplyInterpolatedStringHandlers(inheritedParameters, arguments, receiver, ce.Location, inheritedMapping);
+                var inheritedExpandedArgs = resolution.IsExpanded
+                    ? ExpandParamsArguments(arguments, inheritedParameters, ce)
+                    : arguments;
+                var inheritedHandlerArgs = ApplyInterpolatedStringHandlers(inheritedParameters, inheritedExpandedArgs, receiver, ce.Location, inheritedMapping);
                 var inheritedDelegateArgs = RebindFunctionLiteralDelegateArguments(inheritedHandlerArgs, inheritedParameters, inheritedMapping);
                 var inheritedConvertedArgs = BindClrParameterConversions(inheritedDelegateArgs, inheritedParameters, ce, inheritedMapping);
                 var inheritedArguments = BuildOrderedCallArguments(inheritedConvertedArgs, inheritedMapping, inheritedParameters);
@@ -13760,10 +13860,21 @@ public sealed class Binder
         allArguments.AddRange(arguments);
         var bound = allArguments.MoveToImmutable();
 
+        // Issue #506: when overload resolution selected the expanded form of a
+        // `params T[]` extension method (e.g. `MyEnumerable.Concat(this src,
+        // params string[] tail)` called with positional tail args), pack the
+        // trailing positional arguments into a synthesised slice/array first.
+        // The receiver occupies parameter slot 0; the params slot is always
+        // the last parameter, so it never collides with the receiver.
+        var parameters = best.GetParameters();
+        if (resolution.IsExpanded)
+        {
+            bound = ExpandParamsArguments(bound, parameters, ce, receiverArgCount: 1);
+        }
+
         // Issue #327 / #343: re-order arguments into parameter positions when
         // named arguments were used; otherwise fall through to the existing
         // trailing-optional fill.
-        var parameters = best.GetParameters();
         bound = BuildOrderedCallArguments(bound, resolution.ParameterMapping, parameters);
 
         var refKinds = ComputeArgumentRefKinds(parameters);

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -304,8 +304,14 @@ internal static class OverloadResolution
     public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs = null, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null)
         where T : MethodBase
     {
-        var applicable = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping)>();
-        foreach (var rawCandidate in candidates)
+        var applicable = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)>();
+
+        // Materialize the candidate set so we can run both the normal-form pass
+        // and (if necessary) a second params-expansion pass without re-querying
+        // the underlying enumerable.
+        var candidateList = candidates as IReadOnlyCollection<T> ?? candidates.ToList();
+
+        foreach (var rawCandidate in candidateList)
         {
             // Issue #321: an overload's signature may reference types that cannot
             // be loaded or projected under the MetadataLoadContext used for
@@ -327,6 +333,27 @@ internal static class OverloadResolution
             }
         }
 
+        // Issue #506: when no candidate applies in its normal (non-expanded)
+        // form, attempt C#-style `params T[]` expansion. The expanded form is
+        // only ever considered as a fallback so that a normal-form candidate
+        // always beats an expanded-form one (C# §7.5.3.2 better-function-member
+        // rule). Expanded form is only considered for positional calls — mixing
+        // named arguments with params expansion is out of scope.
+        if (applicable.Count == 0 && !HasAnyNamedArgument(argumentNames))
+        {
+            foreach (var rawCandidate in candidateList)
+            {
+                try
+                {
+                    EvaluateExpandedParamsCandidate(rawCandidate, argTypes, applicable);
+                }
+                catch (Exception ex) when (IsMetadataLoadFailure(ex))
+                {
+                    continue;
+                }
+            }
+        }
+
         if (applicable.Count == 0)
         {
             return Result<T>.NoneApplicable();
@@ -335,10 +362,91 @@ internal static class OverloadResolution
         if (applicable.Count == 1)
         {
             var only = applicable[0];
-            return Result<T>.Single(only.Method, BuildMappingArray(only.Mapping, argumentNames));
+            return Result<T>.Single(only.Method, BuildMappingArray(only.Mapping, argumentNames), only.IsExpanded);
         }
 
         return RankApplicable(applicable, argTypes, argumentNames);
+    }
+
+    /// <summary>
+    /// Issue #506: returns <see langword="true"/> when <paramref name="parameter"/>
+    /// is the trailing <c>params T[]</c> parameter — i.e. carries the
+    /// <see cref="ParamArrayAttribute"/> marker and is a single-dimensional
+    /// array. Detected via <see cref="CustomAttributeData"/> so the check works
+    /// even when the candidate is reflected through a MetadataLoadContext.
+    /// </summary>
+    /// <param name="parameter">The parameter to inspect.</param>
+    /// <returns>Whether the parameter is a <c>params</c> array.</returns>
+    public static bool IsParamsArrayParameter(ParameterInfo parameter)
+    {
+        if (parameter == null)
+        {
+            return false;
+        }
+
+        var paramType = parameter.ParameterType;
+        if (paramType == null || !paramType.IsArray || paramType.GetArrayRank() != 1)
+        {
+            return false;
+        }
+
+        IList<CustomAttributeData> attrs;
+        try
+        {
+            attrs = parameter.GetCustomAttributesData();
+        }
+        catch (Exception ex) when (IsMetadataLoadFailure(ex))
+        {
+            return false;
+        }
+
+        if (attrs == null)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < attrs.Count; i++)
+        {
+            var name = attrs[i]?.AttributeType?.FullName;
+            if (string.Equals(name, "System.ParamArrayAttribute", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #506: returns the position of the trailing <c>params T[]</c>
+    /// parameter on <paramref name="method"/>, or -1 when there is none.
+    /// </summary>
+    /// <param name="method">The method to inspect.</param>
+    /// <returns>The params parameter position, or -1.</returns>
+    public static int GetParamsParameterIndex(MethodBase method)
+    {
+        if (method == null)
+        {
+            return -1;
+        }
+
+        ParameterInfo[] parameters;
+        try
+        {
+            parameters = method.GetParameters();
+        }
+        catch (Exception ex) when (IsMetadataLoadFailure(ex))
+        {
+            return -1;
+        }
+
+        if (parameters.Length == 0)
+        {
+            return -1;
+        }
+
+        var lastIndex = parameters.Length - 1;
+        return IsParamsArrayParameter(parameters[lastIndex]) ? lastIndex : -1;
     }
 
     /// <summary>
@@ -579,7 +687,7 @@ internal static class OverloadResolution
     /// so the per-candidate work can be guarded against reflection load
     /// failures (issue #321) without disturbing the surrounding control flow.
     /// </summary>
-    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null)
+    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null)
         where T : MethodBase
     {
         {
@@ -732,9 +840,72 @@ internal static class OverloadResolution
 
             if (ok)
             {
-                applicable.Add((candidate, conversions, paramTypes, mapping));
+                applicable.Add((candidate, conversions, paramTypes, mapping, false));
             }
         }
+    }
+
+    /// <summary>
+    /// Issue #506: evaluates a candidate in <em>expanded</em> form — the trailing
+    /// <c>params T[]</c> parameter accepts zero or more positional arguments, each
+    /// assignable to the element type <c>T</c>. Only non-generic and already-closed
+    /// generic methods are considered; open generic <c>params</c> methods are out
+    /// of scope (inference would need to consume the variadic tail). Mirrors the
+    /// applicability check in <see cref="EvaluateCandidate"/> but rewrites the
+    /// trailing parameter type to the element type for ranking purposes.
+    /// </summary>
+    private static void EvaluateExpandedParamsCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable)
+        where T : MethodBase
+    {
+        // Open generic params methods would require co-inferring T from the
+        // variadic tail. Skip; the closed/non-generic cases (Path.Combine,
+        // String.Format, Console.WriteLine, Task.WhenAll) cover the issue.
+        if (rawCandidate is MethodInfo mi && mi.IsGenericMethodDefinition)
+        {
+            return;
+        }
+
+        var parameters = rawCandidate.GetParameters();
+        if (parameters.Length == 0)
+        {
+            return;
+        }
+
+        var paramsIndex = parameters.Length - 1;
+        if (!IsParamsArrayParameter(parameters[paramsIndex]))
+        {
+            return;
+        }
+
+        // Need at least the fixed leading parameters covered by supplied
+        // positional arguments. Zero trailing args is valid (empty array).
+        if (argTypes.Count < paramsIndex)
+        {
+            return;
+        }
+
+        var elementType = parameters[paramsIndex].ParameterType.GetElementType();
+        if (elementType == null)
+        {
+            return;
+        }
+
+        var conversions = new ImplicitConversionKind[argTypes.Count];
+        var paramTypes = new Type[argTypes.Count];
+        for (var i = 0; i < argTypes.Count; i++)
+        {
+            var target = i < paramsIndex ? parameters[i].ParameterType : elementType;
+            paramTypes[i] = target;
+            var conv = ClassifyImplicit(target, argTypes[i]);
+            if (conv == ImplicitConversionKind.None)
+            {
+                return;
+            }
+
+            conversions[i] = conv;
+        }
+
+        applicable.Add((rawCandidate, conversions, paramTypes, null, true));
     }
 
     /// <summary>
@@ -965,15 +1136,18 @@ internal static class OverloadResolution
     ///     parameter types, then non-generic-over-generic.</description>
     ///   </item>
     /// </list>
+    /// Issue #506: the tuple carries an <c>IsExpanded</c> flag so the winning
+    /// candidate's <c>params T[]</c>-expanded form is propagated to the
+    /// caller through <see cref="Result{T}.IsExpanded"/>.
     /// </remarks>
-    private static Result<T> RankApplicable<T>(List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping)> applicable, IReadOnlyList<Type> argTypes, IReadOnlyList<string> argumentNames)
+    private static Result<T> RankApplicable<T>(List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<Type> argTypes, IReadOnlyList<string> argumentNames)
         where T : MethodBase
     {
         // Phase 1 — drop candidates that are strictly dominated by another.
         // C# §7.5.3.2: a candidate c is the best iff no other candidate is
         // strictly better than c. Equivalently, c survives iff for every other
         // candidate `other`, !IsStrictlyBetter(other, c).
-        var nonDominated = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping)>();
+        var nonDominated = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)>();
         foreach (var c in applicable)
         {
             var dominated = false;
@@ -999,7 +1173,7 @@ internal static class OverloadResolution
 
         if (nonDominated.Count == 1)
         {
-            return Result<T>.Single(nonDominated[0].Method, BuildMappingArray(nonDominated[0].Mapping, argumentNames));
+            return Result<T>.Single(nonDominated[0].Method, BuildMappingArray(nonDominated[0].Mapping, argumentNames), nonDominated[0].IsExpanded);
         }
 
         var pool = nonDominated.Count > 0 ? nonDominated : applicable;
@@ -1021,7 +1195,7 @@ internal static class OverloadResolution
 
             if (pool.Count == 1)
             {
-                return Result<T>.Single(pool[0].Method, BuildMappingArray(pool[0].Mapping, argumentNames));
+                return Result<T>.Single(pool[0].Method, BuildMappingArray(pool[0].Mapping, argumentNames), pool[0].IsExpanded);
             }
         }
 
@@ -1040,7 +1214,7 @@ internal static class OverloadResolution
 
             if (pool.Count == 1)
             {
-                return Result<T>.Single(pool[0].Method, BuildMappingArray(pool[0].Mapping, argumentNames));
+                return Result<T>.Single(pool[0].Method, BuildMappingArray(pool[0].Mapping, argumentNames), pool[0].IsExpanded);
             }
         }
 
@@ -1060,7 +1234,7 @@ internal static class OverloadResolution
 
             if (pool.Count == 1)
             {
-                return Result<T>.Single(pool[0].Method, BuildMappingArray(pool[0].Mapping, argumentNames));
+                return Result<T>.Single(pool[0].Method, BuildMappingArray(pool[0].Mapping, argumentNames), pool[0].IsExpanded);
             }
         }
 
@@ -1366,12 +1540,13 @@ internal static class OverloadResolution
     public readonly struct Result<T>
         where T : MethodBase
     {
-        private Result(ResolutionOutcome outcome, T best, ImmutableArray<T> ambiguous, ImmutableArray<int> parameterMapping)
+        private Result(ResolutionOutcome outcome, T best, ImmutableArray<T> ambiguous, ImmutableArray<int> parameterMapping, bool isExpanded)
         {
             Outcome = outcome;
             Best = best;
             Ambiguous = ambiguous;
             ParameterMapping = parameterMapping;
+            IsExpanded = isExpanded;
         }
 
         /// <summary>Gets the resolution outcome.</summary>
@@ -1392,12 +1567,25 @@ internal static class OverloadResolution
         /// </summary>
         public ImmutableArray<int> ParameterMapping { get; }
 
-        internal static Result<T> NoneApplicable() => new(ResolutionOutcome.NoneApplicable, default, ImmutableArray<T>.Empty, default);
+        /// <summary>
+        /// Gets a value indicating whether issue #506: the resolved candidate
+        /// was selected in <em>expanded</em> form, i.e. the trailing
+        /// <c>params T[]</c> parameter packs zero or more positional arguments
+        /// from the call site into a synthesised <c>T[]</c>. Callers must
+        /// repack the trailing arguments into a slice/array creation before
+        /// emit. Always <see langword="false"/> when <see cref="Outcome"/> is
+        /// not <see cref="ResolutionOutcome.Resolved"/>.
+        /// </summary>
+        public bool IsExpanded { get; }
 
-        internal static Result<T> Single(T best) => new(ResolutionOutcome.Resolved, best, ImmutableArray<T>.Empty, default);
+        internal static Result<T> NoneApplicable() => new(ResolutionOutcome.NoneApplicable, default, ImmutableArray<T>.Empty, default, false);
 
-        internal static Result<T> Single(T best, ImmutableArray<int> parameterMapping) => new(ResolutionOutcome.Resolved, best, ImmutableArray<T>.Empty, parameterMapping);
+        internal static Result<T> Single(T best) => new(ResolutionOutcome.Resolved, best, ImmutableArray<T>.Empty, default, false);
 
-        internal static Result<T> AmbiguousResult(ImmutableArray<T> tied) => new(ResolutionOutcome.Ambiguous, default, tied, default);
+        internal static Result<T> Single(T best, ImmutableArray<int> parameterMapping) => new(ResolutionOutcome.Resolved, best, ImmutableArray<T>.Empty, parameterMapping, false);
+
+        internal static Result<T> Single(T best, ImmutableArray<int> parameterMapping, bool isExpanded) => new(ResolutionOutcome.Resolved, best, ImmutableArray<T>.Empty, parameterMapping, isExpanded);
+
+        internal static Result<T> AmbiguousResult(ImmutableArray<T> tied) => new(ResolutionOutcome.Ambiguous, default, tied, default, false);
     }
 }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -337,15 +337,14 @@ internal static class OverloadResolution
         // form, attempt C#-style `params T[]` expansion. The expanded form is
         // only ever considered as a fallback so that a normal-form candidate
         // always beats an expanded-form one (C# §7.5.3.2 better-function-member
-        // rule). Expanded form is only considered for positional calls — mixing
-        // named arguments with params expansion is out of scope.
-        if (applicable.Count == 0 && !HasAnyNamedArgument(argumentNames))
+        // rule).
+        if (applicable.Count == 0)
         {
             foreach (var rawCandidate in candidateList)
             {
                 try
                 {
-                    EvaluateExpandedParamsCandidate(rawCandidate, argTypes, applicable);
+                    EvaluateExpandedParamsCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, argumentNames);
                 }
                 catch (Exception ex) when (IsMetadataLoadFailure(ex))
                 {
@@ -848,24 +847,77 @@ internal static class OverloadResolution
     /// <summary>
     /// Issue #506: evaluates a candidate in <em>expanded</em> form — the trailing
     /// <c>params T[]</c> parameter accepts zero or more positional arguments, each
-    /// assignable to the element type <c>T</c>. Only non-generic and already-closed
-    /// generic methods are considered; open generic <c>params</c> methods are out
-    /// of scope (inference would need to consume the variadic tail). Mirrors the
+    /// assignable to the element type <c>T</c>. Closes open generic candidates
+    /// (e.g. <c>Bar&lt;T&gt;(params T[] items)</c>) by inferring <c>T</c> from
+    /// the trailing arguments via the same unification used by
+    /// <see cref="TryInferTypeArguments"/>. Honours named arguments that bind to
+    /// a leading fixed parameter (the params parameter itself is never nameable
+    /// from caller-side under G#'s positional-before-named layout); the leftover
+    /// positional surplus is packed into the synthesised array. Mirrors the
     /// applicability check in <see cref="EvaluateCandidate"/> but rewrites the
     /// trailing parameter type to the element type for ranking purposes.
     /// </summary>
-    private static void EvaluateExpandedParamsCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable)
+    private static void EvaluateExpandedParamsCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<string> argumentNames = null)
         where T : MethodBase
     {
-        // Open generic params methods would require co-inferring T from the
-        // variadic tail. Skip; the closed/non-generic cases (Path.Combine,
-        // String.Format, Console.WriteLine, Task.WhenAll) cover the issue.
-        if (rawCandidate is MethodInfo mi && mi.IsGenericMethodDefinition)
+        T candidate = rawCandidate;
+
+        // Issue #506 follow-up: close open generic candidates before applicability
+        // classification. Explicit type arguments win; otherwise infer from the
+        // supplied positional/named args (trailing positionals beyond the params
+        // index unify against T).
+        if (explicitTypeArgs != null)
         {
-            return;
+            if (rawCandidate is MethodInfo gmi
+                && gmi.IsGenericMethodDefinition
+                && gmi.GetGenericArguments().Length == explicitTypeArgs.Count)
+            {
+                MethodInfo closed;
+                try
+                {
+                    closed = gmi.MakeGenericMethod(explicitTypeArgs.ToArray());
+                }
+                catch (ArgumentException)
+                {
+                    return;
+                }
+
+                candidate = (T)(MethodBase)closed;
+            }
+            else
+            {
+                return;
+            }
+        }
+        else if (rawCandidate is MethodInfo mi && mi.IsGenericMethodDefinition)
+        {
+            if (!TryInferTypeArgumentsForExpandedParams(mi, argTypes, argumentNames, out var typeArgs))
+            {
+                return;
+            }
+
+            if (projectTypeArgument != null)
+            {
+                for (var t = 0; t < typeArgs.Length; t++)
+                {
+                    typeArgs[t] = projectTypeArgument(typeArgs[t]) ?? typeArgs[t];
+                }
+            }
+
+            MethodInfo closed;
+            try
+            {
+                closed = mi.MakeGenericMethod(typeArgs);
+            }
+            catch (ArgumentException)
+            {
+                return;
+            }
+
+            candidate = (T)(MethodBase)closed;
         }
 
-        var parameters = rawCandidate.GetParameters();
+        var parameters = candidate.GetParameters();
         if (parameters.Length == 0)
         {
             return;
@@ -877,24 +929,102 @@ internal static class OverloadResolution
             return;
         }
 
-        // Need at least the fixed leading parameters covered by supplied
-        // positional arguments. Zero trailing args is valid (empty array).
-        if (argTypes.Count < paramsIndex)
-        {
-            return;
-        }
-
         var elementType = parameters[paramsIndex].ParameterType.GetElementType();
         if (elementType == null)
         {
             return;
         }
 
+        // G#'s positional-before-named rule guarantees the layout
+        //   [positional_0 … positional_{P-1}, named_0 … named_{N-1}].
+        // The leading positionals fill slots 0..min(P, paramsIndex)-1; the
+        // surplus past the params slot (positionals at indices
+        // [paramsIndex..P-1]) is packed into the synthesised array; the named
+        // arguments fill the remaining fixed slots by parameter name. A named
+        // argument that targets the params parameter or a slot already filled
+        // positionally rejects the candidate.
+        var positionalCount = argTypes.Count;
+        var hasNamed = argumentNames != null && HasAnyNamedArgument(argumentNames);
+        if (hasNamed)
+        {
+            positionalCount = 0;
+            while (positionalCount < argTypes.Count && argumentNames[positionalCount] == null)
+            {
+                positionalCount++;
+            }
+
+            for (var i = positionalCount; i < argTypes.Count; i++)
+            {
+                if (argumentNames[i] == null)
+                {
+                    return;
+                }
+            }
+        }
+
+        var fixedFilledByPositional = positionalCount < paramsIndex ? positionalCount : paramsIndex;
+        var tailCount = positionalCount > paramsIndex ? positionalCount - paramsIndex : 0;
+
+        var mapping = new int[argTypes.Count];
+        var filled = new bool[parameters.Length];
+        for (var i = 0; i < fixedFilledByPositional; i++)
+        {
+            mapping[i] = i;
+            filled[i] = true;
+        }
+
+        for (var i = fixedFilledByPositional; i < positionalCount; i++)
+        {
+            mapping[i] = paramsIndex;
+        }
+
+        if (tailCount > 0)
+        {
+            filled[paramsIndex] = true;
+        }
+
+        if (hasNamed)
+        {
+            for (var i = positionalCount; i < argTypes.Count; i++)
+            {
+                var name = argumentNames[i];
+                var paramIdx = FindParameterIndex(parameters, name);
+                if (paramIdx < 0 || paramIdx == paramsIndex || filled[paramIdx])
+                {
+                    return;
+                }
+
+                mapping[i] = paramIdx;
+                filled[paramIdx] = true;
+            }
+        }
+
+        // Every non-params fixed slot left empty must be optional. The params
+        // slot is virtually optional in expanded form (zero trailing args
+        // allocates an empty array).
+        for (var i = 0; i < paramsIndex; i++)
+        {
+            if (!filled[i] && !parameters[i].IsOptional)
+            {
+                return;
+            }
+        }
+
         var conversions = new ImplicitConversionKind[argTypes.Count];
         var paramTypes = new Type[argTypes.Count];
         for (var i = 0; i < argTypes.Count; i++)
         {
-            var target = i < paramsIndex ? parameters[i].ParameterType : elementType;
+            var slot = mapping[i];
+            Type target;
+            if (slot == paramsIndex && i >= fixedFilledByPositional)
+            {
+                target = elementType;
+            }
+            else
+            {
+                target = parameters[slot].ParameterType;
+            }
+
             paramTypes[i] = target;
             var conv = ClassifyImplicit(target, argTypes[i]);
             if (conv == ImplicitConversionKind.None)
@@ -905,7 +1035,120 @@ internal static class OverloadResolution
             conversions[i] = conv;
         }
 
-        applicable.Add((rawCandidate, conversions, paramTypes, null, true));
+        // When all arguments are purely positional, drop the mapping so the
+        // existing ExpandParamsArguments fast path remains the canonical
+        // post-resolution lowering (matches the prior signature).
+        var storedMapping = hasNamed ? mapping : null;
+        applicable.Add((candidate, conversions, paramTypes, storedMapping, true));
+    }
+
+    /// <summary>
+    /// Issue #506 follow-up: infers method type arguments for an open generic
+    /// candidate in <c>params T[]</c> expanded form. Each fixed leading
+    /// parameter unifies against its positional/named argument; trailing
+    /// positionals beyond the params index unify against the params element
+    /// type. Returns <see langword="false"/> when any type parameter cannot
+    /// be bound.
+    /// </summary>
+    private static bool TryInferTypeArgumentsForExpandedParams(MethodInfo openMethod, IReadOnlyList<Type> argTypes, IReadOnlyList<string> argumentNames, out Type[] typeArgs)
+    {
+        typeArgs = null;
+        var parameters = openMethod.GetParameters();
+        if (parameters.Length == 0)
+        {
+            return false;
+        }
+
+        var paramsIndex = parameters.Length - 1;
+        if (!IsParamsArrayParameter(parameters[paramsIndex]))
+        {
+            return false;
+        }
+
+        var elementType = parameters[paramsIndex].ParameterType.GetElementType();
+        if (elementType == null)
+        {
+            return false;
+        }
+
+        var positionalCount = argTypes.Count;
+        var hasNamed = argumentNames != null && HasAnyNamedArgument(argumentNames);
+        if (hasNamed)
+        {
+            positionalCount = 0;
+            while (positionalCount < argTypes.Count && argumentNames[positionalCount] == null)
+            {
+                positionalCount++;
+            }
+        }
+
+        var typeParams = openMethod.GetGenericArguments();
+        var bounds = new Dictionary<string, Type>(StringComparer.Ordinal);
+
+        var fixedFilledByPositional = positionalCount < paramsIndex ? positionalCount : paramsIndex;
+
+        for (var i = 0; i < fixedFilledByPositional; i++)
+        {
+            if (argTypes[i] == null)
+            {
+                continue;
+            }
+
+            if (!UnifyForInference(parameters[i].ParameterType, argTypes[i], bounds))
+            {
+                return false;
+            }
+        }
+
+        for (var i = fixedFilledByPositional; i < positionalCount; i++)
+        {
+            if (argTypes[i] == null)
+            {
+                continue;
+            }
+
+            if (!UnifyForInference(elementType, argTypes[i], bounds))
+            {
+                return false;
+            }
+        }
+
+        if (hasNamed)
+        {
+            for (var i = positionalCount; i < argTypes.Count; i++)
+            {
+                var name = argumentNames[i];
+                var paramIdx = FindParameterIndex(parameters, name);
+                if (paramIdx < 0 || paramIdx == paramsIndex)
+                {
+                    return false;
+                }
+
+                if (argTypes[i] == null)
+                {
+                    continue;
+                }
+
+                if (!UnifyForInference(parameters[paramIdx].ParameterType, argTypes[i], bounds))
+                {
+                    return false;
+                }
+            }
+        }
+
+        var result = new Type[typeParams.Length];
+        for (var i = 0; i < typeParams.Length; i++)
+        {
+            if (!bounds.TryGetValue(typeParams[i].Name, out var bound))
+            {
+                return false;
+            }
+
+            result[i] = bound;
+        }
+
+        typeArgs = result;
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -107,12 +107,12 @@ public sealed class ImportedClassSymbol : Symbol
     /// </param>
     /// <returns>Whether we found a matching function or not.</returns>
     public bool TryLookupFunction(string text, CallExpressionSyntax callExpression, ImmutableArray<BoundExpression> arguments, out ImportedFunctionSymbol function, out ImmutableArray<int> parameterMapping, out bool isAmbiguous, Type[] explicitTypeArgs = null, ImmutableArray<TypeSymbol> typeArgSymbols = default, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<string> argumentNames = null)
-        => TryLookupFunction(text, callExpression, arguments, out function, out parameterMapping, out isAmbiguous, out _, explicitTypeArgs, typeArgSymbols, projectTypeArgument, argumentNames);
+        => TryLookupFunction(text, callExpression, arguments, out function, out parameterMapping, out isAmbiguous, out _, out _, explicitTypeArgs, typeArgSymbols, projectTypeArgument, argumentNames);
 
     /// <summary>
-    /// Issue #505: extended overload that, on ambiguity, also returns the
-    /// applicable candidate set so the caller can surface the competing
-    /// signatures in the GS0160 diagnostic.
+    /// Issue #506: backwards-compatible overload retaining the issue #505
+    /// signature without the <c>isExpanded</c> flag. Discards the expanded
+    /// flag.
     /// </summary>
     /// <param name="text">The name of the function.</param>
     /// <param name="callExpression">The call expression.</param>
@@ -127,11 +127,34 @@ public sealed class ImportedClassSymbol : Symbol
     /// <param name="argumentNames">Per-source-argument names parallel to <paramref name="arguments"/>.</param>
     /// <returns>Whether we found a matching function or not.</returns>
     public bool TryLookupFunction(string text, CallExpressionSyntax callExpression, ImmutableArray<BoundExpression> arguments, out ImportedFunctionSymbol function, out ImmutableArray<int> parameterMapping, out bool isAmbiguous, out ImmutableArray<MethodInfo> ambiguousMethods, Type[] explicitTypeArgs = null, ImmutableArray<TypeSymbol> typeArgSymbols = default, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<string> argumentNames = null)
+        => TryLookupFunction(text, callExpression, arguments, out function, out parameterMapping, out isAmbiguous, out ambiguousMethods, out _, explicitTypeArgs, typeArgSymbols, projectTypeArgument, argumentNames);
+
+    /// <summary>
+    /// Issues #505 + #506: extended overload that, on ambiguity, returns the
+    /// applicable candidate set (so the caller can surface competing
+    /// signatures in the GS0160 diagnostic) and also reports whether the
+    /// selected candidate was resolved in <c>params T[]</c> expanded form.
+    /// </summary>
+    /// <param name="text">The name of the function.</param>
+    /// <param name="callExpression">The call expression.</param>
+    /// <param name="arguments">The bound arguments.</param>
+    /// <param name="function">The resulting function, if one is found.</param>
+    /// <param name="parameterMapping">Per-source-argument → parameter-position map (issue #343); default when none.</param>
+    /// <param name="isAmbiguous">Set to <see langword="true"/> when two or more candidates tied under "better function member" rules.</param>
+    /// <param name="ambiguousMethods">When <paramref name="isAmbiguous"/> is set, the tied candidates in source-encounter order; otherwise the empty array.</param>
+    /// <param name="isExpanded">Issue #506: set to <see langword="true"/> when overload resolution selected the candidate in <c>params T[]</c> expanded form, signalling the caller to pack the trailing positional arguments into a synthesised array before emit.</param>
+    /// <param name="explicitTypeArgs">Resolved CLR type arguments from an explicit type-argument list.</param>
+    /// <param name="typeArgSymbols">Explicit type-argument symbols in source order, or default.</param>
+    /// <param name="projectTypeArgument">Projects an inferred type argument onto the reference load context, or <see langword="null"/>.</param>
+    /// <param name="argumentNames">Per-source-argument names parallel to <paramref name="arguments"/>.</param>
+    /// <returns>Whether we found a matching function or not.</returns>
+    public bool TryLookupFunction(string text, CallExpressionSyntax callExpression, ImmutableArray<BoundExpression> arguments, out ImportedFunctionSymbol function, out ImmutableArray<int> parameterMapping, out bool isAmbiguous, out ImmutableArray<MethodInfo> ambiguousMethods, out bool isExpanded, Type[] explicitTypeArgs = null, ImmutableArray<TypeSymbol> typeArgSymbols = default, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<string> argumentNames = null)
     {
         function = null;
         parameterMapping = default;
         isAmbiguous = false;
         ambiguousMethods = ImmutableArray<MethodInfo>.Empty;
+        isExpanded = false;
         var methods = ClrTypeUtilities.SafeGetMethods(ClassType, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public);
         var nameMatches = methods.Where(m => m.Name == text).ToList();
         if (nameMatches.Count == 0)
@@ -170,6 +193,7 @@ public sealed class ImportedClassSymbol : Symbol
 
                 function = new ImportedFunctionSymbol(text, this, result.Best, callExpression, returnOverride);
                 parameterMapping = result.ParameterMapping;
+                isExpanded = result.IsExpanded;
                 return true;
             case OverloadResolution.ResolutionOutcome.Ambiguous:
                 isAmbiguous = true;

--- a/test/Compiler.Tests/Emit/ParamsExpansionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/ParamsExpansionEmitTests.cs
@@ -153,6 +153,104 @@ public class ParamsExpansionEmitTests
         Assert.Equal("done\n", output);
     }
 
+    [Fact]
+    public void StringFormat_FixedArityBoxesInt32IntoObjectSlot()
+    {
+        // Issue #506 follow-up: fixed-arity `String.Format(string, object)`
+        // selected for `("{0}", 42)` must emit a `box int32` so the call to
+        // a method expecting `object` produces valid IL. Without the boxing
+        // wiring the generated IL fails ilverify.
+        var source = """
+            package P
+            import System
+
+            let one = String.Format("{0}", 42)
+            let two = String.Format("{0} {1}", 1, "x")
+            Console.WriteLine(one)
+            Console.WriteLine(two)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n1 x\n", output);
+    }
+
+    [Fact]
+    public void StringFormat_NamedFormatAndProviderExpandsWithEmptyTail()
+    {
+        // Issue #506 follow-up: named arguments + expanded params. With both
+        // `provider` and `format` supplied by name and no positional args,
+        // no fixed-arity overload matches; overload resolution must fall back
+        // to `String.Format(IFormatProvider, string, params object[])` in
+        // expanded form, allocating an empty object[]. The call format string
+        // intentionally has no holes so the empty array is sufficient.
+        var source = """
+            package P
+            import System
+            import System.Globalization
+
+            let s = String.Format(provider: CultureInfo.InvariantCulture, format: "no holes")
+            Console.WriteLine(s)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("no holes\n", output);
+    }
+
+    [Fact]
+    public void ImmutableArrayCreate_OpenGenericParamsInfersElementType()
+    {
+        // Issue #506 follow-up: open-generic params. ImmutableArray.Create<T>(
+        // params T[] items) is a generic params definition; expanded-form
+        // overload resolution must infer T from the trailing argument types
+        // before closing the candidate. With three int32 arguments the binder
+        // should select ImmutableArray.Create<int>(params int[]).
+        var source = """
+            package P
+            import System
+            import System.Collections.Immutable
+
+            let arr = ImmutableArray.Create(10, 20, 30)
+            Console.WriteLine(arr.Length)
+            Console.WriteLine(arr[0])
+            Console.WriteLine(arr[1])
+            Console.WriteLine(arr[2])
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n10\n20\n30\n", output);
+    }
+
+    [Fact]
+    public void BaseConstructorInitializer_ParamsArrayExpansion()
+    {
+        // Issue #506 follow-up: `init() : base(...)` must use the same
+        // two-pass overload resolution / params expansion as other CLR call
+        // sites. AggregateException(params Exception[]) is the canonical BCL
+        // ctor of this shape; the derived class supplies three exceptions
+        // positionally so the params tail must be packed.
+        var source = """
+            package P
+            import System
+
+            type MyAgg class : AggregateException {
+                init(a Exception, b Exception, c Exception) : base(a, b, c) {
+                }
+            }
+
+            let e1 = Exception("first")
+            let e2 = Exception("second")
+            let e3 = Exception("third")
+            let agg = MyAgg(e1, e2, e3)
+            Console.WriteLine(agg.InnerExceptions.Count)
+            for inner in agg.InnerExceptions {
+                Console.WriteLine(inner.Message)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\nfirst\nsecond\nthird\n", output);
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_params_emit_").FullName;

--- a/test/Compiler.Tests/Emit/ParamsExpansionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/ParamsExpansionEmitTests.cs
@@ -1,0 +1,220 @@
+// <copyright file="ParamsExpansionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #506: C#-style <c>params T[]</c> expansion. Calls to CLR methods
+/// whose final parameter is a <c>params</c> array must auto-collect trailing
+/// positional arguments into a synthesised array when no fixed-arity overload
+/// matches, while still honoring the normal form when a pre-built
+/// <c>[]T{...}</c> is passed directly.
+/// </summary>
+public class ParamsExpansionEmitTests
+{
+    [Fact]
+    public void PathCombine_SevenStringsExpandsToParamsStringArray()
+    {
+        // No fixed-arity Path.Combine overload accepts seven strings; this must
+        // bind to Combine(params string[]) by packing the trailing args.
+        var source = """
+            package P
+            import System
+            import System.IO
+
+            let combined = Path.Combine("a", "b", "..", "..", "src", "lib", "out.dll")
+            Console.WriteLine(combined)
+            """;
+
+        var output = CompileAndRun(source);
+        var expected = Path.Combine("a", "b", "..", "..", "src", "lib", "out.dll");
+        Assert.Equal(expected + "\n", output);
+    }
+
+    [Fact]
+    public void StringFormat_FourHolesExpandsToParamsObjectArray()
+    {
+        // String.Format(string, params object[]) — four object-typed trailing
+        // args must pack into an object[] (each string element reference-converts
+        // into the object element type).
+        var source = """
+            package P
+            import System
+
+            let s = String.Format("{0} {1} {2} {3}", "a", "b", "c", "d")
+            Console.WriteLine(s)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("a b c d\n", output);
+    }
+
+    [Fact]
+    public void ConsoleWriteLine_FormatPlusFourTrailingArgs()
+    {
+        // Console.WriteLine has fixed overloads up to (string, object, object,
+        // object); 4 trailing positional args force selection of the
+        // (string, params object[]) overload and exercise expansion at a
+        // void-returning CLR static. Strings reference-convert into the
+        // object element slot so the test does not depend on value-type
+        // boxing in callee-side parameter conversions.
+        var source = """
+            package P
+            import System
+
+            Console.WriteLine("{0}-{1}-{2}-{3}", "a", "b", "c", "d")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("a-b-c-d\n", output);
+    }
+
+    [Fact]
+    public void StringJoin_ZeroTrailingArgsAllocatesEmptyArray()
+    {
+        // String.Join(string, params string[]) with zero trailing args must
+        // still bind in expanded form and allocate an empty array.
+        var source = """
+            package P
+            import System
+
+            let s = String.Join(",")
+            Console.WriteLine("[" + s + "]")
+            Console.WriteLine(s.Length)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("[]\n0\n", output);
+    }
+
+    [Fact]
+    public void PathCombine_PrebuiltStringSliceStillBindsNormalForm()
+    {
+        // Regression guard: passing an explicit []string slice as a single
+        // argument must still bind via the normal (non-expanded) form.
+        var source = """
+            package P
+            import System
+            import System.IO
+
+            let parts = []string{"a", "b", "..", "..", "src", "x.dll"}
+            let combined = Path.Combine(parts)
+            Console.WriteLine(combined)
+            """;
+
+        var output = CompileAndRun(source);
+        var expected = Path.Combine(new[] { "a", "b", "..", "..", "src", "x.dll" });
+        Assert.Equal(expected + "\n", output);
+    }
+
+    [Fact]
+    public void StringConcat_PrebuiltObjectSliceBindsNormalFormOverloads()
+    {
+        // Regression guard: a fixed-arity Concat(string,string) overload must
+        // still beat the expanded params form when arg count matches a fixed
+        // overload.
+        var source = """
+            package P
+            import System
+
+            let s = String.Concat("hello", " world")
+            Console.WriteLine(s)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello world\n", output);
+    }
+
+    [Fact]
+    public void TaskWhenAll_ParamsTaskArrayExpansion()
+    {
+        // Task.WhenAll(params Task[]) with multiple trailing task args expands.
+        var source = """
+            package P
+            import System
+            import System.Threading.Tasks
+
+            func makeTask(value int32) Task {
+                return Task.CompletedTask
+            }
+
+            let t = Task.WhenAll(makeTask(1), makeTask(2), makeTask(3))
+            t.Wait()
+            Console.WriteLine("done")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("done\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_params_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Closes #506.

## Problem

CLR methods whose final parameter is `params T[]` (e.g. `Path.Combine(params string[])`, `String.Format(string, params object[])`, `Console.WriteLine(string, params object[])`, `Task.WhenAll(params Task[])`) failed to bind from positional G# call sites with trailing arguments. The compiler emitted `GS0159: Cannot find function …` because no fixed-arity overload of that arity exists.

### Repro (before this PR)

```gsharp
package P
import System
import System.IO

let combined = Path.Combine("a", "b", "..", "..", "src", "lib", "out.dll")
//             ^^^^^^^^^^^^ GS0159: Cannot find function Combine
```

Workaround was to hand-allocate a slice:

```gsharp
let parts = []string{"a", "b", "..", "..", "src", "lib", "out.dll"}
let combined = Path.Combine(parts)
```

## Fix

Implement C#-style `params T[]` expansion during overload resolution and call lowering for CLR methods. Trailing positional arguments are auto-packed into a synthesised `T[]` whenever no fixed-arity overload matches. The follow-up work in the second commit completes the four items the original change left deferred (see the **Follow-up** section below).

### `OverloadResolution.cs`

`Resolve<T>` performs a two-pass walk:

1. **Normal-form pass** — classifies applicability exactly as before.
2. **Expanded-form pass** — runs only when the normal-form pass produced no applicable candidates. Each candidate's `params T[]` parameter is treated as N synthesised T-typed slots (one per trailing positional argument), with the fixed parameters classified normally.

This ordering structurally enforces C# §7.5.3.2's "normal form beats expanded form" rule. `IsExpanded` is plumbed through `Result<T>` so callers can lower the call appropriately. The expanded pass also:

- closes open-generic candidates (e.g. `ImmutableArray.Create<T>(params T[] items)`) by inferring `T` from each trailing positional argument unified against the params element type, and
- honours named arguments that bind to a leading fixed parameter (the params parameter itself is never nameable from caller-side under G#'s positional-before-named layout) — surplus positionals pack into the synthesised array, named args fill the remaining fixed slots by name, and a named arg targeting the params parameter or a positionally-filled slot rejects the candidate.

`params` detection uses `ParameterInfo.GetCustomAttributesData()` checking for `System.ParamArrayAttribute` — MetadataLoadContext-safe (the same pattern used elsewhere for inspecting CLR attributes during binding).

### `Binder.cs`

`ExpandParamsArguments` synthesises a `BoundArrayCreationExpression` over `SliceTypeSymbol.Get(elementType)`. The slice symbol's IL representation (`elementType.ClrType.MakeArrayType()`) is bit-identical to a `T[]` parameter slot, so emit needs no changes. Each trailing argument is converted to the element type via `BindConversion` (with a `TryApplyUserDefinedImplicitArgumentConversion` fallback for user-defined implicit conversions). A `parameterMapping` overload emits arguments already in parameter order with optional slots defaulted, so downstream reorderers consume an identity mapping when expanded+named fire together.

The helper is wired into every CLR call entry point so all paths honour `params` expansion uniformly:

- CLR constructor calls
- CLR static calls
- CLR instance calls
- Inherited-base CLR instance calls
- Imported extension calls (with `receiverArgCount: 1` accounting for the synthesised receiver slot)
- **Base constructor initialiser (`init() : base(...)`)** — `ResolveClrBaseConstructor` now captures `IsExpanded` and packs trailing positionals before the per-parameter ref/conversion loop.

`BindClrParameterConversions` (plus the `NeedsBindClrParameterConversion` guard) routes every CLR call argument through `Conversion.Classify` / `BindConversion`. This closes the **value-type → object boxing** gap in fixed-arity CLR overloads: `String.Format("{0}", 42)` now correctly emits `box int32` for the `(string, object)` overload (and similarly for the ctor, static, instance, inherited-base, and imported-extension paths). The `NeedsBindClrParameterConversion` guard skips the rebinding when the CLR parameter type already matches the bound argument's `ClrType`, preserving flow-narrowing patterns such as `if !String.IsNullOrEmpty(s) { … }`.

### `ImportedClassSymbol.cs`

`TryLookupFunction` gains an `out bool isExpanded` overload; the existing signature is preserved as a forwarding shim so non-CLR call sites stay source-compatible.

## Tests

`test/Compiler.Tests/Emit/ParamsExpansionEmitTests.cs` (11 tests). All compile through `gsc`, pass `ilverify`, and execute end-to-end via `dotnet exec`:

| Test | What it exercises |
| --- | --- |
| `PathCombine_SevenStringsExpandsToParamsStringArray` | `Path.Combine(a, b, "..", "..", "src", "lib", "out.dll")` — 7-string call; verifies runtime output matches `Path.Combine(string[])`. |
| `StringFormat_FourHolesExpandsToParamsObjectArray` | `String.Format("{0} {1} {2} {3}", a, b, c, d)` — `params object[]` with 4 elements. |
| `ConsoleWriteLine_FormatPlusFourTrailingArgs` | `Console.WriteLine("{0}-{1}-{2}-{3}", a, b, c, d)` — 4 trailing args force selection of the expanded `(string, params object[])` overload past the fixed-arity 3-object form. |
| `StringJoin_ZeroTrailingArgsAllocatesEmptyArray` | `String.Join(",")` — zero trailing args; expanded form allocates an empty `string[]`. |
| `PathCombine_PrebuiltStringSliceStillBindsNormalForm` | Regression guard — `Path.Combine(parts)` with a pre-built `[]string{...}` still binds to the normal form. |
| `StringConcat_PrebuiltObjectSliceBindsNormalFormOverloads` | Regression guard — fixed-arity `Concat(string, string)` still beats the expanded `params string[]` form. |
| `TaskWhenAll_ParamsTaskArrayExpansion` | `Task.WhenAll(makeTask(1), makeTask(2), makeTask(3))` — non-`object` params element type. |
| `StringFormat_FixedArityBoxesInt32IntoObjectSlot` | `String.Format("{0}", 42)` and `String.Format("{0} {1}", 1, "x")` — fixed-arity `(string, object)` / `(string, object, object)` overloads with int32 args; verifies value-type → object boxing fires for fixed-arity CLR overloads. |
| `StringFormat_NamedFormatAndProviderExpandsWithEmptyTail` | `String.Format(provider: …, format: "no holes")` — named-args-only call falls back to expanded `String.Format(IFormatProvider, string, params object[])` allocating an empty params array. |
| `ImmutableArrayCreate_OpenGenericParamsInfersElementType` | `ImmutableArray.Create(10, 20, 30)` — open-generic `Create<T>(params T[] items)`; verifies `T` is inferred as `int32` and the params tail packs correctly. |
| `BaseConstructorInitializer_ParamsArrayExpansion` | G# class deriving from `AggregateException`, `init(...) : base(a, b, c)` — verifies the base ctor init path expands trailing positionals into the `params Exception[]` slot. |

Full test run: **2,585 passed, 0 failed** (Sdk.Tests 24, Interpreter.Tests 72, LanguageServer.Tests 212, Core.Tests 1,894, Compiler.Tests 383).

## Follow-up commit

The second commit on this branch completes the four items the original change explicitly deferred:

1. **Named arguments + expanded form** — relaxed the named-arg gate in `EvaluateExpandedParamsCandidate`, with G#'s positional-before-named rule honoured.
2. **Open-generic params** — `Bar<T>(params T[] items)` now closes via the same `UnifyForInference` pass used by the normal form.
3. **Base-ctor-init params expansion** — wired through `ResolveClrBaseConstructor`.
4. **Value-type → object boxing in fixed-arity overloads** — `BindClrParameterConversions` is now called on every CLR call path (`String.Format("{0}", 42)` and friends compile cleanly).

## Deferred

None. All four originally-deferred items are completed in this PR.
