### PR TITLE
Fix #502: allow `async func` as a class instance member

### DIFF
--- a/samples/AsyncClassMethod.golden
+++ b/samples/AsyncClassMethod.golden
@@ -1,0 +1,4 @@
+base = 40
+bumped = 42
+tripled = 42
+done

--- a/samples/AsyncClassMethod.gs
+++ b/samples/AsyncClassMethod.gs
@@ -1,0 +1,46 @@
+// file: AsyncClassMethod.gs
+//
+// Issue #502 exit sample. `async func` declared as an instance member of a
+// `type X class { ... }` body — and also inside a `shared { ... }` static
+// block — parses, binds, and emits the same Task / Task<T> shape as a
+// top-level `async func` (see AsyncTask.gs).
+//
+// This is the natural xUnit shape for I/O-bound tests (`[Fact] async func`)
+// and a prerequisite for porting C# test suites whose Task-returning
+// methods sit on a class.
+
+package GSharp.Samples.AsyncClassMethod
+
+import System
+import System.Threading.Tasks
+
+type Adder class(Base int32) {
+    async func Bump(n int32) int32 {
+        await Task.Delay(1)
+        return Base + n
+    }
+
+    async func Print() {
+        await Task.Delay(1)
+        Console.WriteLine("base = $Base")
+    }
+}
+
+type Math2 class {
+    shared {
+        async func Triple(n int32) int32 {
+            await Task.Delay(1)
+            return n * 3
+        }
+    }
+}
+
+let a = Adder(40)
+a.Print().Wait()
+let bumped = a.Bump(2).Result
+Console.WriteLine("bumped = $bumped")
+
+let tripled = Math2.Triple(14).Result
+Console.WriteLine("tripled = $tripled")
+
+Console.WriteLine("done")

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1657,6 +1657,7 @@ public sealed class Binder
                     methodSymbol.OverriddenMethod = overriddenMethod;
                     methodSymbol.TypeParameters = methodTypeParameters;
                     methodSymbol.ReturnRefKind = methodReturnRefKind;
+                    methodSymbol.IsAsync = methodSyntax.IsAsync || IsAsyncIteratorReturnType(returnType);
                     AttachDocumentation(methodSymbol, methodSyntax);
 
                     if (!methodSyntax.Annotations.IsDefaultOrEmpty)
@@ -2168,6 +2169,7 @@ public sealed class Binder
                     methodSymbol.StaticOwnerType = structSymbol;
                     methodSymbol.TypeParameters = methodTypeParameters;
                     methodSymbol.ReturnRefKind = methodReturnRefKind;
+                    methodSymbol.IsAsync = methodSyntax.IsAsync || IsAsyncIteratorReturnType(returnType);
 
                     if (!methodSyntax.Annotations.IsDefaultOrEmpty)
                     {
@@ -2746,6 +2748,7 @@ public sealed class Binder
                 Accessibility.Public,
                 receiverType: null);
             methodSymbol.ReturnRefKind = methodReturnRefKind;
+            methodSymbol.IsAsync = methodSyntax.IsAsync || IsAsyncIteratorReturnType(returnType);
             AttachDocumentation(methodSymbol, methodSyntax);
 
             // ADR-0063 §11: detect duplicate-signature overloads on the interface.
@@ -12604,10 +12607,22 @@ public sealed class Binder
             if (substitution != null)
             {
                 var substitutedReturn = SubstituteType(method.Type, substitution);
+                if (method.IsAsync && !IsAsyncIteratorReturnType(method.Type))
+                {
+                    substitutedReturn = WrapAsTask(substitutedReturn);
+                    return new BoundCallExpression(null, method, convertedArgs.ToImmutable(), substitutedReturn);
+                }
+
                 if (!ReferenceEquals(substitutedReturn, method.Type))
                 {
                     return new BoundCallExpression(null, method, convertedArgs.ToImmutable(), substitutedReturn);
                 }
+            }
+
+            if (method.IsAsync && !IsAsyncIteratorReturnType(method.Type))
+            {
+                var asyncReturn = WrapAsTask(method.Type);
+                return new BoundCallExpression(null, method, convertedArgs.ToImmutable(), asyncReturn);
             }
 
             return new BoundCallExpression(null, method, convertedArgs.ToImmutable());
@@ -13832,10 +13847,25 @@ public sealed class Binder
         if (substitution != null)
         {
             var substitutedReturn = SubstituteType(method.Type, substitution);
+            if (method.IsAsync && !IsAsyncIteratorReturnType(method.Type))
+            {
+                substitutedReturn = WrapAsTask(substitutedReturn);
+                return new BoundUserInstanceCallExpression(null, receiver, method, convertedArgs.ToImmutable(), substitutedReturn);
+            }
+
             if (!ReferenceEquals(substitutedReturn, method.Type))
             {
                 return new BoundUserInstanceCallExpression(null, receiver, method, convertedArgs.ToImmutable(), substitutedReturn);
             }
+        }
+
+        // Issue #502: an async instance method's call-site return type is
+        // Task / Task[T], not the underlying T. Wrap here so the call
+        // expression's static type matches the kickoff method's return type.
+        if (method.IsAsync && !IsAsyncIteratorReturnType(method.Type))
+        {
+            var asyncReturn = WrapAsTask(method.Type);
+            return new BoundUserInstanceCallExpression(null, receiver, method, convertedArgs.ToImmutable(), asyncReturn);
         }
 
         return new BoundUserInstanceCallExpression(null, receiver, method, convertedArgs.ToImmutable());

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1489,13 +1489,21 @@ internal sealed class ReflectionMetadataEmitter
 
         // NestedType entries. Each SM is nested inside its declaring type:
         // capture-bearing async lambda SMs inside their closure class,
-        // all others inside the per-package <Program>.
+        // an instance-method kickoff's SM inside the receiver type (so the
+        // kickoff method retains access to the SM's `<>t__builder` field —
+        // issue #502), and all others inside the per-package <Program>.
         var hostPkg = entryPointPackage ?? (packages.IsDefaultOrEmpty ? null : packages[0]);
         var defaultProgramHandle = hostPkg != null && programTypeDefHandles.TryGetValue(hostPkg, out var h) ? h : default;
 
         foreach (var c in smClasses)
         {
             var nestedHandle = this.structTypeDefs[c];
+            if (TryGetUserKickoffReceiverHandle(c, out var receiverEnclosing))
+            {
+                this.metadata.AddNestedType(nestedHandle, receiverEnclosing);
+                continue;
+            }
+
             var smPkg = this.GetSmPackage(c, packages, entryPointPackage);
             var enclosingHandle = programTypeDefHandles.TryGetValue(smPkg, out var ph) ? ph : defaultProgramHandle;
             this.metadata.AddNestedType(nestedHandle, enclosingHandle);
@@ -1508,6 +1516,10 @@ internal sealed class ReflectionMetadataEmitter
                 && this.structTypeDefs.TryGetValue(closureSym, out var closureHandle))
             {
                 this.metadata.AddNestedType(nestedHandle, closureHandle);
+            }
+            else if (TryGetUserKickoffReceiverHandle(s, out var receiverEnclosing))
+            {
+                this.metadata.AddNestedType(nestedHandle, receiverEnclosing);
             }
             else
             {
@@ -3848,6 +3860,48 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         return entryPointPackage ?? (packages.IsDefaultOrEmpty ? null : packages[0]);
+    }
+
+    /// <summary>
+    /// Issue #502: when an async kickoff method is declared as an instance or
+    /// static member of a user-defined class, its synthesized state-machine
+    /// type must be nested inside that class — not the per-package
+    /// <c>&lt;Program&gt;</c> — so the kickoff method retains CLR access to
+    /// the SM's <c>NestedPrivate</c> fields (most importantly
+    /// <c>&lt;&gt;t__builder</c>). Lambda SMs already nest inside their
+    /// closure class; this helper covers the named-method case.
+    /// </summary>
+    /// <param name="smSym">The synthesized state-machine struct or class.</param>
+    /// <param name="enclosingHandle">Set to the receiver type's TypeDef handle when applicable.</param>
+    /// <returns><see langword="true"/> when the SM should nest under a user receiver type.</returns>
+    private bool TryGetUserKickoffReceiverHandle(StructSymbol smSym, out TypeDefinitionHandle enclosingHandle)
+    {
+        enclosingHandle = default;
+        FunctionSymbol kickoff = null;
+        foreach (var plan in this.asyncStateMachinePlans)
+        {
+            if (ReferenceEquals(plan.StateMachine.MaterializeAsStructSymbol(), smSym))
+            {
+                kickoff = plan.KickoffMethod;
+                break;
+            }
+        }
+
+        if (kickoff == null)
+        {
+            return false;
+        }
+
+        // Instance methods (ReceiverType set) and shared-block static methods
+        // (StaticOwnerType set) both live on a user-defined class TypeDef.
+        var owner = (kickoff.ReceiverType as StructSymbol)
+            ?? (kickoff.StaticOwnerType as StructSymbol);
+        if (owner == null)
+        {
+            return false;
+        }
+
+        return this.structTypeDefs.TryGetValue(owner, out enclosingHandle);
     }
 
     /// <summary>Emits <c>System.Runtime.CompilerServices.IsReadOnlyAttribute</c> on an inline struct TypeDef.</summary>

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -881,9 +881,15 @@ public class Parser
                 Current.Kind == SyntaxKind.PrivateKeyword)
             {
                 // Accessibility modifier may be followed by an optional
-                // `open`/`override` and then `func`, `prop`, or `event`.
+                // `open`/`override` and an optional `async` (only meaningful
+                // before `func`), then `func`, `prop`, or `event`.
                 var ahead = 1;
                 while (Peek(ahead).Kind == SyntaxKind.OpenKeyword || Peek(ahead).Kind == SyntaxKind.OverrideKeyword)
+                {
+                    ahead++;
+                }
+
+                if (Peek(ahead).Kind == SyntaxKind.AsyncKeyword && Peek(ahead + 1).Kind == SyntaxKind.FuncKeyword)
                 {
                     ahead++;
                 }
@@ -919,6 +925,17 @@ public class Parser
                 }
             }
 
+            // Issue #502 / ADR-0023: an optional `async` modifier may precede
+            // `func` on a class instance method, mirroring the top-level path
+            // in ParseMember. The modifier is consumed only when immediately
+            // followed by `func`; otherwise it is left for ParseFieldDeclaration
+            // (or another fallback) to surface a diagnostic.
+            SyntaxToken memberAsyncModifier = null;
+            if (Current.Kind == SyntaxKind.AsyncKeyword && Peek(1).Kind == SyntaxKind.FuncKeyword)
+            {
+                memberAsyncModifier = NextToken();
+            }
+
             if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "init" && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
             {
                 // Issue #306: standalone user-defined constructor
@@ -927,6 +944,11 @@ public class Parser
                 {
                     var loc = (memberOpenModifier ?? memberOverrideModifier).Location;
                     Diagnostics.ReportUnexpectedToken(loc, SyntaxKind.OpenKeyword, SyntaxKind.OpenParenthesisToken);
+                }
+
+                if (memberAsyncModifier != null)
+                {
+                    Diagnostics.ReportUnexpectedToken(memberAsyncModifier.Location, SyntaxKind.AsyncKeyword, SyntaxKind.FuncKeyword);
                 }
 
                 if (structOrClassKeyword.Kind != SyntaxKind.ClassKeyword)
@@ -941,12 +963,22 @@ public class Parser
             else if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "prop")
             {
                 // ADR-0051: property declaration inside struct/class body.
+                if (memberAsyncModifier != null)
+                {
+                    Diagnostics.ReportUnexpectedToken(memberAsyncModifier.Location, SyntaxKind.AsyncKeyword, SyntaxKind.FuncKeyword);
+                }
+
                 var property = ParsePropertyDeclaration(memberAccessibility, memberOpenModifier, memberOverrideModifier);
                 property.WithAnnotations(memberAnnotations);
                 properties.Add(property);
             }
             else if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "event")
             {
+                if (memberAsyncModifier != null)
+                {
+                    Diagnostics.ReportUnexpectedToken(memberAsyncModifier.Location, SyntaxKind.AsyncKeyword, SyntaxKind.FuncKeyword);
+                }
+
                 var eventDecl = ParseEventDeclaration(memberAccessibility, memberOpenModifier, memberOverrideModifier);
                 eventDecl.WithAnnotations(memberAnnotations);
                 events.Add(eventDecl);
@@ -958,6 +990,11 @@ public class Parser
                 {
                     var loc = (memberAccessibility ?? memberOpenModifier ?? memberOverrideModifier).Location;
                     Diagnostics.ReportUnexpectedToken(loc, SyntaxKind.IdentifierToken, SyntaxKind.OpenBraceToken);
+                }
+
+                if (memberAsyncModifier != null)
+                {
+                    Diagnostics.ReportUnexpectedToken(memberAsyncModifier.Location, SyntaxKind.AsyncKeyword, SyntaxKind.FuncKeyword);
                 }
 
                 var sharedBlock = ParseSharedBlock();
@@ -977,7 +1014,7 @@ public class Parser
                     Diagnostics.ReportUnexpectedToken(Current.Location, Current.Kind, SyntaxKind.IdentifierToken);
                 }
 
-                var method = (FunctionDeclarationSyntax)ParseFunctionDeclaration(memberAccessibility, memberOpenModifier, memberOverrideModifier);
+                var method = (FunctionDeclarationSyntax)ParseFunctionDeclaration(memberAccessibility, memberOpenModifier, memberOverrideModifier, memberAsyncModifier);
                 method.WithAnnotations(memberAnnotations);
                 methods.Add(method);
             }
@@ -987,6 +1024,12 @@ public class Parser
                 {
                     var loc = (memberOpenModifier ?? memberOverrideModifier).Location;
                     Diagnostics.ReportUnexpectedToken(loc, SyntaxKind.OpenKeyword, SyntaxKind.FuncKeyword);
+                }
+
+                if (memberAsyncModifier != null)
+                {
+                    // `async` not followed by `func` — surface as an unexpected token.
+                    Diagnostics.ReportUnexpectedToken(memberAsyncModifier.Location, SyntaxKind.AsyncKeyword, SyntaxKind.FuncKeyword);
                 }
 
                 fields.Add(ParseFieldDeclaration().WithAnnotations(memberAnnotations));
@@ -1095,6 +1138,11 @@ public class Parser
                     ahead++;
                 }
 
+                if (Peek(ahead).Kind == SyntaxKind.AsyncKeyword && Peek(ahead + 1).Kind == SyntaxKind.FuncKeyword)
+                {
+                    ahead++;
+                }
+
                 if (Peek(ahead).Kind == SyntaxKind.FuncKeyword ||
                     (Peek(ahead).Kind == SyntaxKind.IdentifierToken && Peek(ahead).Text == "prop") ||
                     (Peek(ahead).Kind == SyntaxKind.IdentifierToken && Peek(ahead).Text == "event"))
@@ -1103,20 +1151,43 @@ public class Parser
                 }
             }
 
+            // Issue #502: `async` modifier is allowed on static methods inside
+            // a `shared` block, mirroring the instance-method path above.
+            SyntaxToken sharedMemberAsyncModifier = null;
+            if (Current.Kind == SyntaxKind.AsyncKeyword && Peek(1).Kind == SyntaxKind.FuncKeyword)
+            {
+                sharedMemberAsyncModifier = NextToken();
+            }
+
             if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "prop")
             {
+                if (sharedMemberAsyncModifier != null)
+                {
+                    Diagnostics.ReportUnexpectedToken(sharedMemberAsyncModifier.Location, SyntaxKind.AsyncKeyword, SyntaxKind.FuncKeyword);
+                }
+
                 properties.Add(ParsePropertyDeclaration(memberAccessibility, null, null));
             }
             else if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "event")
             {
+                if (sharedMemberAsyncModifier != null)
+                {
+                    Diagnostics.ReportUnexpectedToken(sharedMemberAsyncModifier.Location, SyntaxKind.AsyncKeyword, SyntaxKind.FuncKeyword);
+                }
+
                 events.Add(ParseEventDeclaration(memberAccessibility, null, null));
             }
             else if (Current.Kind == SyntaxKind.FuncKeyword)
             {
-                methods.Add((FunctionDeclarationSyntax)ParseFunctionDeclaration(memberAccessibility, null, null));
+                methods.Add((FunctionDeclarationSyntax)ParseFunctionDeclaration(memberAccessibility, openModifier: null, overrideModifier: null, sharedMemberAsyncModifier));
             }
             else
             {
+                if (sharedMemberAsyncModifier != null)
+                {
+                    Diagnostics.ReportUnexpectedToken(sharedMemberAsyncModifier.Location, SyntaxKind.AsyncKeyword, SyntaxKind.FuncKeyword);
+                }
+
                 fields.Add(ParseFieldDeclaration());
             }
 

--- a/test/Compiler.Tests/Emit/AsyncInstanceMethodEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AsyncInstanceMethodEmitTests.cs
@@ -1,0 +1,310 @@
+// <copyright file="AsyncInstanceMethodEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #502: `async func` declared as an instance (or shared/static) member
+/// of a <c>type X class { ... }</c> body parses, binds, and emits the same way
+/// as a top-level <c>async func</c>. Each case asserts the call site sees a
+/// <c>Task</c>/<c>Task&lt;T&gt;</c> return type, that the kickoff method
+/// signature on the user type is <c>Task</c>-shaped, and that the assembly
+/// runs end-to-end without an access-check failure on the synthesized
+/// state-machine's <c>&lt;&gt;t__builder</c> field (the regression in #502).
+/// </summary>
+public class AsyncInstanceMethodEmitTests
+{
+    [Fact]
+    public void Async_Instance_Method_Returning_Void_Becomes_Task_Returning_Method()
+    {
+        var source = """
+            package P
+
+            import System.Threading.Tasks
+
+            type Greeter class(Name string) {
+                async func Greet() {
+                    await Task.Delay(1)
+                }
+            }
+
+            public var result = ""
+            let g = Greeter("world")
+            let t = g.Greet()
+            t.Wait()
+            result = "ok"
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var greeter = assembly.GetTypes().Single(t => t.Name == "Greeter");
+        var greet = greeter.GetMethod("Greet", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(greet);
+        Assert.Equal(typeof(Task), greet!.ReturnType);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField("result", BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, null);
+        Assert.Equal("ok", (string)resultField!.GetValue(null)!);
+    }
+
+    [Fact]
+    public void Async_Instance_Method_Returning_Int_Becomes_TaskOfInt()
+    {
+        var source = """
+            package P
+
+            import System.Threading.Tasks
+
+            type Calc class {
+                init() {}
+
+                async func Double(n int32) int32 {
+                    await Task.Delay(1)
+                    return n * 2
+                }
+            }
+
+            public var result = 0
+            let c = Calc()
+            result = c.Double(21).Result
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var calc = assembly.GetTypes().Single(t => t.Name == "Calc");
+        var doubleMethod = calc.GetMethod("Double", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(doubleMethod);
+        Assert.Equal(typeof(Task<int>), doubleMethod!.ReturnType);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField("result", BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, null);
+        Assert.Equal(42, (int)resultField!.GetValue(null)!);
+    }
+
+    [Fact]
+    public void Async_Instance_Method_With_Multiple_Parameters_Round_Trips()
+    {
+        var source = """
+            package P
+
+            import System.Threading.Tasks
+
+            type Calc class {
+                init() {}
+
+                async func Add(a int32, b int32) int32 {
+                    await Task.Delay(1)
+                    return a + b
+                }
+            }
+
+            public var result = 0
+            let c = Calc()
+            result = c.Add(7, 35).Result
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var calc = assembly.GetTypes().Single(t => t.Name == "Calc");
+        var add = calc.GetMethod("Add", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(add);
+        Assert.Equal(typeof(Task<int>), add!.ReturnType);
+        Assert.Equal(2, add.GetParameters().Length);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField("result", BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, null);
+        Assert.Equal(42, (int)resultField!.GetValue(null)!);
+    }
+
+    [Fact]
+    public void Async_Instance_Method_With_Visibility_Modifier_Parses_And_Emits()
+    {
+        // The `public async func` shape is the exact form a port from C# would
+        // produce. The accessibility look-ahead must allow `async` between the
+        // accessibility modifier and `func`.
+        var source = """
+            package P
+
+            import System.Threading.Tasks
+
+            type Tagged class {
+                init() {}
+
+                public async func Tag(n int32) int32 {
+                    await Task.Delay(1)
+                    return n + 100
+                }
+            }
+
+            public var result = 0
+            let t = Tagged()
+            result = t.Tag(42).Result
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var tagged = assembly.GetTypes().Single(t => t.Name == "Tagged");
+        var tag = tagged.GetMethod("Tag", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(tag);
+        Assert.Equal(typeof(Task<int>), tag!.ReturnType);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField("result", BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, null);
+        Assert.Equal(142, (int)resultField!.GetValue(null)!);
+    }
+
+    [Fact]
+    public void Async_Instance_Method_Captures_Receiver_Field_Through_State_Machine()
+    {
+        // The kickoff hoists `this` into the state machine, so the awaited
+        // continuation must read the primary-ctor field `Base` from the
+        // captured receiver, not from a stale stack slot.
+        var source = """
+            package P
+
+            import System.Threading.Tasks
+
+            type Adder class(Base int32) {
+                async func Bump(n int32) int32 {
+                    await Task.Delay(1)
+                    return Base + n
+                }
+            }
+
+            public var result = 0
+            let a = Adder(40)
+            result = a.Bump(2).Result
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField("result", BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, null);
+        Assert.Equal(42, (int)resultField!.GetValue(null)!);
+    }
+
+    [Fact]
+    public void Async_Shared_Method_Becomes_Task_Returning_Static_Method()
+    {
+        // ADR-0053 shared (static) member: `async func` inside `shared { }`
+        // mirrors the instance-method path.
+        var source = """
+            package P
+
+            import System.Threading.Tasks
+
+            type Math2 class {
+                shared {
+                    async func Triple(n int32) int32 {
+                        await Task.Delay(1)
+                        return n * 3
+                    }
+                }
+            }
+
+            public var result = 0
+            result = Math2.Triple(14).Result
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var math2 = assembly.GetTypes().Single(t => t.Name == "Math2");
+        var triple = math2.GetMethod("Triple", BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(triple);
+        Assert.Equal(typeof(Task<int>), triple!.ReturnType);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField("result", BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, null);
+        Assert.Equal(42, (int)resultField!.GetValue(null)!);
+    }
+
+    [Fact]
+    public void State_Machine_Type_Is_Nested_Inside_Declaring_User_Class()
+    {
+        // Issue #502 regression: an instance-method state machine nested
+        // inside the per-package `<Program>` causes the kickoff method on
+        // the user class to trip a FieldAccessException when it touches the
+        // SM's NestedPrivate `<>t__builder` field. Confirm the SM type now
+        // nests inside its declaring class so the kickoff retains access.
+        var source = """
+            package P
+
+            import System.Threading.Tasks
+
+            type Box class {
+                init() {}
+
+                async func Inc(n int32) int32 {
+                    await Task.Delay(1)
+                    return n + 1
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var box = assembly.GetTypes().Single(t => t.Name == "Box");
+
+        var nested = box.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.Contains(nested, t => t.Name.Contains("Inc") && t.Name.Contains("d__"));
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_async_instance_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}


### PR DESCRIPTION
## Summary

`async func` declared as an instance member of a `type X class { ... }` body failed to parse, producing `GS0005: Unexpected token <AsyncKeyword>`. Top-level `async func` worked (see `samples/AsyncTask.gs`), but the class-body parser only consumed accessibility / open / override before `func`. This PR threads `async` through the class-member parse path, the binder, and the IL emitter so an instance method declared `async func Foo()` parses, binds, and emits a `Task`-returning instance method, the same way it does at the top level.

## Repro (from the issue)

```gsharp
package Probe

import System.Threading.Tasks
import Xunit

type SmokeTests class {
    @Fact
    async func Async_Class_Method_Works() {
        await Task.Delay(1)
    }
}
```

Before this change:
```
SmokeTests.gs(8,5,8,10): error GS0005: Unexpected token <AsyncKeyword>, expected <IdentifierToken>.
SmokeTests.gs(8,16,8,24): error GS0113: Type 'Async_Class_Method_Works' doesn't exist.
```

After: parses cleanly, the call site sees `Task`/`Task<T>`, and the assembly runs end-to-end.

## Changes

**Parser (`src/Core/CodeAnalysis/Syntax/Parser.cs`)**
- In the struct/class body parser, accept an optional `async` modifier before `func`, with or without an accessibility / `open` / `override` modifier in front of it. The accessibility look-ahead was extended so the leading `public`/`internal`/`private` is consumed even when `async` sits between it and `func`.
- Mirror the same async-consumption logic inside `shared { }` blocks so static methods can be async too (ADR-0053).
- Diagnose stray `async` on `init`, `prop`, `event`, `shared`, or a bare field declaration (mirrors the existing top-level diagnostic).

**Binder (`src/Core/CodeAnalysis/Binding/Binder.cs`)**
- Propagate `methodSyntax.IsAsync` onto the synthesized `FunctionSymbol` in three previously-overlooked paths: class instance methods, shared (static) class methods, and interface methods. Without this the async-state-machine rewriter never saw the method.
- Wrap the call-site return type as `Task`/`Task<T>` in `BindUserInstanceCall` and the user-class branch of `BindAccessorCall`, matching the existing top-level path. Otherwise an `async` void instance method appeared as void at the call site (GS0124).

**Emitter (`src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs`)**
- Nest the synthesized state-machine TypeDef inside the kickoff method's declaring user class (for both instance and shared methods), not the per-package `<Program>`. Async lambda SMs already nest inside their closure class; named async methods now follow the same rule. Without this the kickoff method on the user class cannot reach the SM's `NestedPrivate` `<>t__builder` field and the runtime throws `FieldAccessException` on the first call.

## Tests

New `test/Compiler.Tests/Emit/AsyncInstanceMethodEmitTests.cs` covers:
- `async func` instance method returning void → kickoff returns `Task`
- `async func` instance method returning `int32` → kickoff returns `Task<int>`
- `async func` with multiple parameters
- `public async func` (visibility modifier present)
- Receiver-capture: `Base` field read across an `await` boundary
- `async func` inside a `shared { }` block → kickoff is `public static Task<T>`
- Regression: SM type is nested inside the declaring user class, not `<Program>`

All cases use `await Task.Delay(1)` for genuine async suspension and assert the emitted method's CLR return type via reflection.

New sample `samples/AsyncClassMethod.gs` + `.golden` is picked up by the existing sample-conformance harness for end-to-end coverage.

## Verification

- `dotnet build GSharp.sln -nologo -clp:NoSummary` — success, 0 warnings, 0 errors.
- `dotnet test GSharp.sln --no-restore --nologo` — all green: Compiler.Tests 380/380 (7 new unit + 1 new sample-conformance), Core.Tests 1894/1894, LanguageServer.Tests 212/212, Interpreter.Tests 72/72, Sdk.Tests 24/24.

Closes #502