### PR TITLE
Fix #507: parse `obj.Member[k] = v` indexer assignment

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -119,6 +119,7 @@ MakeChannelExpression
 MapCreationExpression
 MapEntry
 MapKeyword
+MemberIndexAssignmentExpression
 MinusEqualsToken
 MinusMinusToken
 MinusToken

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -43,6 +43,7 @@ ColonToken
 CommaToken
 CommentToken
 CompilationUnit
+CompoundIndexAssignmentExpression
 ConditionalExpression
 ConditionalRefArgumentExpression
 ConstKeyword

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -6490,6 +6490,8 @@ public sealed class Binder
                 return BindIndexExpression((IndexExpressionSyntax)syntax);
             case SyntaxKind.IndexAssignmentExpression:
                 return BindIndexAssignmentExpression((IndexAssignmentExpressionSyntax)syntax);
+            case SyntaxKind.MemberIndexAssignmentExpression:
+                return BindMemberIndexAssignmentExpression((MemberIndexAssignmentExpressionSyntax)syntax);
             case SyntaxKind.StructLiteralExpression:
                 return BindStructLiteralExpression((StructLiteralExpressionSyntax)syntax);
             case SyntaxKind.TupleLiteralExpression:
@@ -13981,11 +13983,60 @@ public sealed class Binder
             return new BoundErrorExpression(null);
         }
 
+        return BindIndexedAssignmentToVariable(variable, syntax.Index, syntax.Value, syntax.TargetIdentifier.Location);
+    }
+
+    // Issue #507: indexer assignment whose target is an arbitrary expression
+    // (e.g. `obj.Member[k] = v`). The parser produces this node for any LHS
+    // shape that parses as an IndexExpression and is followed by `=`. We
+    // mirror the user-visible workaround (bind the indexed property to a
+    // local first) by synthesizing a temp local that holds the bound target
+    // value, then routing the indexer assignment through that temp via the
+    // existing variable-rooted path. This reuses every downstream code path
+    // (lowering, async spilling, side-effect spilling, evaluation, IL emit)
+    // without modification.
+    private BoundExpression BindMemberIndexAssignmentExpression(MemberIndexAssignmentExpressionSyntax syntax)
+    {
+        var indexed = syntax.Target;
+        var boundReceiver = BindExpression(indexed.Target);
+        if (boundReceiver.Type == TypeSymbol.Error)
+        {
+            return new BoundErrorExpression(null);
+        }
+
+        var tempName = $"<idxAsn{System.Threading.Interlocked.Increment(ref syntheticLocalCounter)}>";
+        var tempVar = new LocalVariableSymbol(tempName, isReadOnly: true, boundReceiver.Type);
+        if (!scope.TryDeclareVariable(tempVar))
+        {
+            // Defensive: synthesized names cannot collide with user identifiers
+            // (the `<...>` prefix is not a valid identifier token), so a failure
+            // here means a duplicate synthesized name within the same scope,
+            // which Interlocked.Increment guarantees against. Treat as fatal.
+            throw new System.InvalidOperationException(
+                $"Failed to declare synthesized index-assignment target local '{tempName}'.");
+        }
+
+        var declaration = new BoundVariableDeclaration(syntax, tempVar, boundReceiver);
+        var assignment = BindIndexedAssignmentToVariable(tempVar, indexed.Index, syntax.Value, indexed.Target.Location);
+        if (assignment is BoundErrorExpression)
+        {
+            return assignment;
+        }
+
+        return new BoundBlockExpression(syntax, ImmutableArray.Create<BoundStatement>(declaration), assignment);
+    }
+
+    private BoundExpression BindIndexedAssignmentToVariable(
+        VariableSymbol variable,
+        ExpressionSyntax indexSyntax,
+        ExpressionSyntax valueSyntax,
+        TextLocation diagnosticLocation)
+    {
         var element = GetIndexElementType(variable.Type);
         if (element != null)
         {
-            var index = BindConversion(syntax.Index, TypeSymbol.Int32);
-            var value = BindConversion(syntax.Value, element);
+            var index = BindConversion(indexSyntax, TypeSymbol.Int32);
+            var value = BindConversion(valueSyntax, element);
             return new BoundIndexAssignmentExpression(null, variable, index, value, element);
         }
 
@@ -13993,28 +14044,28 @@ public sealed class Binder
         // value bound to V.
         if (variable.Type is MapTypeSymbol mapType)
         {
-            var keyExpr = BindConversion(syntax.Index, mapType.KeyType);
-            var valExpr = BindConversion(syntax.Value, mapType.ValueType);
+            var keyExpr = BindConversion(indexSyntax, mapType.KeyType);
+            var valExpr = BindConversion(valueSyntax, mapType.ValueType);
             return new BoundIndexAssignmentExpression(null, variable, keyExpr, valExpr, mapType.ValueType);
         }
 
         // Phase 4 exit: CLR indexer write on an imported reference type
         // (e.g. `d["k"] = 1` on Dictionary[string, int]).
         // Issue #209: honour inner-position nullable flags when present.
-        if (variable.Type is NullabilityAnnotatedTypeSymbol annotWr && variable.Type.ClrType is System.Type clrAnnotWr && TryResolveClrIndexer(clrAnnotWr, new[] { syntax.Index }, out var idxPropAnnotWr, out var idxArgsAnnotWr))
+        if (variable.Type is NullabilityAnnotatedTypeSymbol annotWr && variable.Type.ClrType is System.Type clrAnnotWr && TryResolveClrIndexer(clrAnnotWr, new[] { indexSyntax }, out var idxPropAnnotWr, out var idxArgsAnnotWr))
         {
             if (!idxPropAnnotWr.CanWrite)
             {
-                Diagnostics.ReportTypeNotIndexable(syntax.TargetIdentifier.Location, variable.Type);
+                Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
                 return new BoundErrorExpression(null);
             }
 
             var valueTypeAnnotWr = annotWr.GetTypeArgumentSymbolForClrType(idxPropAnnotWr.PropertyType);
-            var boundValueAnnotWr = BindConversion(syntax.Value, valueTypeAnnotWr);
+            var boundValueAnnotWr = BindConversion(valueSyntax, valueTypeAnnotWr);
             return new BoundClrIndexAssignmentExpression(null, variable, idxPropAnnotWr, idxArgsAnnotWr, boundValueAnnotWr, valueTypeAnnotWr);
         }
 
-        if (variable.Type is ImportedTypeSymbol && variable.Type.ClrType is System.Type clrTarget && TryResolveClrIndexer(clrTarget, new[] { syntax.Index }, out var idxProp, out var idxArgs))
+        if (variable.Type is ImportedTypeSymbol && variable.Type.ClrType is System.Type clrTarget && TryResolveClrIndexer(clrTarget, new[] { indexSyntax }, out var idxProp, out var idxArgs))
         {
             // ADR-0056 §2: span element write. `Span[T]` has no `set_Item`; its
             // indexer is a `ref T`-returning getter and writes go through that
@@ -14028,27 +14079,27 @@ public sealed class Binder
                 {
                     if (IsReadOnlyRefReturn(idxProp, refGetter))
                     {
-                        Diagnostics.ReportCannotAssignReadOnlySpanElement(syntax.TargetIdentifier.Location, variable.Type);
+                        Diagnostics.ReportCannotAssignReadOnlySpanElement(diagnosticLocation, variable.Type);
                         return new BoundErrorExpression(null);
                     }
 
                     var pointeeType = TypeSymbol.FromClrType(refGetter.ReturnType.GetElementType()!);
-                    var refValue = BindConversion(syntax.Value, pointeeType);
+                    var refValue = BindConversion(valueSyntax, pointeeType);
                     return new BoundClrIndexAssignmentExpression(null, variable, idxProp, idxArgs, refValue, pointeeType);
                 }
 
-                Diagnostics.ReportTypeNotIndexable(syntax.TargetIdentifier.Location, variable.Type);
+                Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
                 return new BoundErrorExpression(null);
             }
 
             var valueType = TypeSymbol.FromClrType(idxProp.PropertyType);
-            var boundValue = BindConversion(syntax.Value, valueType);
+            var boundValue = BindConversion(valueSyntax, valueType);
             return new BoundClrIndexAssignmentExpression(null, variable, idxProp, idxArgs, boundValue, valueType);
         }
 
         if (variable.Type != TypeSymbol.Error)
         {
-            Diagnostics.ReportTypeNotIndexable(syntax.TargetIdentifier.Location, variable.Type);
+            Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
         }
 
         return new BoundErrorExpression(null);

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -6492,6 +6492,8 @@ public sealed class Binder
                 return BindIndexAssignmentExpression((IndexAssignmentExpressionSyntax)syntax);
             case SyntaxKind.MemberIndexAssignmentExpression:
                 return BindMemberIndexAssignmentExpression((MemberIndexAssignmentExpressionSyntax)syntax);
+            case SyntaxKind.CompoundIndexAssignmentExpression:
+                return BindCompoundIndexAssignmentExpression((CompoundIndexAssignmentExpressionSyntax)syntax);
             case SyntaxKind.StructLiteralExpression:
                 return BindStructLiteralExpression((StructLiteralExpressionSyntax)syntax);
             case SyntaxKind.TupleLiteralExpression:
@@ -12322,6 +12324,17 @@ public sealed class Binder
             return receiver;
         }
 
+        return BindNullConditionalAccessExpressionCore(receiver, syntax.RightPart);
+    }
+
+    // Issue #507 follow-up: shared core for binding a `?.<rhs>` access against
+    // an already-bound receiver expression. Used by BindNullConditionalAccessExpression
+    // (when the receiver is the left side of the outermost accessor) and by the
+    // BindAccessorStep nested-accessor case (when a `?.` accessor appears as the
+    // right side of an outer `.` chain — e.g. `o.InnerObj?.Map`, which
+    // ParseNameOrCallExpression folds into `AccessorExpression(o, ., AccessorExpression(InnerObj, ?., Map))`).
+    private BoundExpression BindNullConditionalAccessExpressionCore(BoundExpression receiver, ExpressionSyntax rightPart)
+    {
         var receiverType = receiver.Type;
         TypeSymbol underlying;
         if (receiverType is NullableTypeSymbol nullable)
@@ -12353,7 +12366,7 @@ public sealed class Binder
         scope.TryDeclareVariable(capture);
 
         var captureRef = new BoundVariableExpression(null, capture);
-        var whenNotNull = BindAccessorStep(captureRef, null, syntax.RightPart);
+        var whenNotNull = BindAccessorStep(captureRef, null, rightPart);
 
         scope = scope.Parent;
 
@@ -12630,10 +12643,37 @@ public sealed class Binder
                     return head;
                 }
 
+                // Issue #507 follow-up: ParseNameOrCallExpression folds the
+                // right-hand side of an accessor through ParsePostfixChain, so
+                // `a.b?.c` parses as `AccessorExpression(a, ., AccessorExpression(b, ?., c))`.
+                // The nested accessor's `?.` token must be honored here, or the
+                // read/write degenerates into a plain `.c` against `b`'s nullable
+                // type and reports "Cannot find member c".
+                if (nested.IsNullConditional)
+                {
+                    return BindNullConditionalAccessExpressionCore(head, nested.RightPart);
+                }
+
                 return BindAccessorStep(head, null, nested.RightPart);
 
             case CallExpressionSyntax ce:
                 return BindAccessorCall(receiver, classSymbol, ce);
+
+            // Issue #507 follow-up: support indexer reads through a member chain
+            // (`obj.Member[k]`, `obj.A.B[k]`, `obj?.Member[k]`). ParsePostfixChain
+            // folds a trailing `[...]` into the right-hand side of the most
+            // recent `.`, so the indexer arrives here as the rightPart of an
+            // AccessorExpression. We bind the indexer's target through the
+            // accessor chain so we get the correct member-rooted bound receiver,
+            // then route the index resolution through the shared helper.
+            case IndexExpressionSyntax ix:
+                var indexTarget = BindAccessorStep(receiver, classSymbol, ix.Target);
+                if (indexTarget is BoundErrorExpression)
+                {
+                    return indexTarget;
+                }
+
+                return BindIndexAgainstTarget(indexTarget, ix.Index, ix.Target.Location);
 
             case NameExpressionSyntax ne:
                 if (ne.IdentifierToken.IsMissing)
@@ -13930,21 +13970,32 @@ public sealed class Binder
     private BoundExpression BindIndexExpression(IndexExpressionSyntax syntax)
     {
         var target = BindExpression(syntax.Target);
+        return BindIndexAgainstTarget(target, syntax.Index, syntax.Target.Location);
+    }
 
+    // Issue #507 follow-up: the read-side counterpart to BindIndexedAssignmentToVariable.
+    // Routes a bound target + index syntax through map / array / CLR-indexer
+    // resolution and returns the bound index read. Extracted from
+    // BindIndexExpression so the BindAccessorStep arm that handles
+    // `receiver.Member[k]` (where the parser folds `[...]` into the right side
+    // of the trailing `.`) can produce the same bound shape without re-running
+    // the accessor chain.
+    private BoundExpression BindIndexAgainstTarget(BoundExpression target, ExpressionSyntax indexSyntax, TextLocation targetLocation)
+    {
         // Phase 3.A.4: map indexing `m[k]` — key bound to K, result type V.
         // The Go convention "zero value if missing" applies at evaluation;
         // the bound representation reuses BoundIndexExpression with the
         // element type set to V.
         if (target.Type is MapTypeSymbol mapType)
         {
-            var key = BindConversion(syntax.Index, mapType.KeyType);
+            var key = BindConversion(indexSyntax, mapType.KeyType);
             return new BoundIndexExpression(null, target, key, mapType.ValueType);
         }
 
         var element = GetIndexElementType(target.Type);
         if (element != null)
         {
-            var index = BindConversion(syntax.Index, TypeSymbol.Int32);
+            var index = BindConversion(indexSyntax, TypeSymbol.Int32);
             return new BoundIndexExpression(null, target, index, element);
         }
 
@@ -13954,13 +14005,13 @@ public sealed class Binder
         // matches the single argument by assignability).
         // Issue #209: when the target carries inner-position nullable flags,
         // use them to type the element correctly (e.g., `list[0]` on `List<string?>` → `string?`).
-        if (target.Type is NullabilityAnnotatedTypeSymbol annotIdx && annotIdx.ClrType is System.Type clrAnnotIdx && TryResolveClrIndexer(clrAnnotIdx, new[] { syntax.Index }, out var idxPropAnnot, out var idxArgsAnnot))
+        if (target.Type is NullabilityAnnotatedTypeSymbol annotIdx && annotIdx.ClrType is System.Type clrAnnotIdx && TryResolveClrIndexer(clrAnnotIdx, new[] { indexSyntax }, out var idxPropAnnot, out var idxArgsAnnot))
         {
             var elemTypeAnnot = annotIdx.GetTypeArgumentSymbolForClrType(idxPropAnnot.PropertyType);
             return AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxPropAnnot, idxArgsAnnot, elemTypeAnnot));
         }
 
-        if (target.Type is ImportedTypeSymbol && target.Type.ClrType is System.Type clrTarget && TryResolveClrIndexer(clrTarget, new[] { syntax.Index }, out var idxProp, out var idxArgs))
+        if (target.Type is ImportedTypeSymbol && target.Type.ClrType is System.Type clrTarget && TryResolveClrIndexer(clrTarget, new[] { indexSyntax }, out var idxProp, out var idxArgs))
         {
             var elementType = MapErasedIndexerElementType((ImportedTypeSymbol)target.Type, idxProp);
             return AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxProp, idxArgs, elementType));
@@ -13968,7 +14019,7 @@ public sealed class Binder
 
         if (target.Type != TypeSymbol.Error)
         {
-            Diagnostics.ReportTypeNotIndexable(syntax.Target.Location, target.Type);
+            Diagnostics.ReportTypeNotIndexable(targetLocation, target.Type);
         }
 
         return new BoundErrorExpression(null);
@@ -13995,11 +14046,154 @@ public sealed class Binder
     // existing variable-rooted path. This reuses every downstream code path
     // (lowering, async spilling, side-effect spilling, evaluation, IL emit)
     // without modification.
+    //
+    // Follow-up: also handles null-conditional receiver chains
+    // (`obj.A?.B[k] = v`). The receiver chain is split at the leftmost `?.`;
+    // the left part is captured into a synthetic null-check local and the
+    // write is wrapped in a `BoundNullConditionalAccessExpression` so the
+    // assignment no-ops when an intermediate is `nil`.
     private BoundExpression BindMemberIndexAssignmentExpression(MemberIndexAssignmentExpressionSyntax syntax)
     {
-        var indexed = syntax.Target;
-        var boundReceiver = BindExpression(indexed.Target);
-        if (boundReceiver.Type == TypeSymbol.Error)
+        return BindIndexedWriteThroughChain(
+            chainBase: null,
+            remainingChain: syntax.Target.Target,
+            indexSyntax: syntax.Target.Index,
+            valueSyntax: syntax.Value,
+            boundValueOverride: null,
+            compoundOperatorToken: null,
+            compoundRhsSyntax: null,
+            diagnosticLocation: syntax.Target.Target.Location,
+            outerSyntax: syntax);
+    }
+
+    // Issue #507 follow-up: compound indexer assignment via member chain
+    // (`obj.Map[k] += v`, `d[k] -= 1`, ...). Shares the same chain-walking
+    // machinery as the plain `=` form so the receiver is evaluated exactly
+    // once. The synthesized binary expression (`tmp[k] op v`) is built inside
+    // BindIndexedWriteThroughChain after the receiver temp is established.
+    private BoundExpression BindCompoundIndexAssignmentExpression(CompoundIndexAssignmentExpressionSyntax syntax)
+    {
+        return BindIndexedWriteThroughChain(
+            chainBase: null,
+            remainingChain: syntax.Target.Target,
+            indexSyntax: syntax.Target.Index,
+            valueSyntax: null,
+            boundValueOverride: null,
+            compoundOperatorToken: syntax.OperatorToken,
+            compoundRhsSyntax: syntax.Value,
+            diagnosticLocation: syntax.OperatorToken.Location,
+            outerSyntax: syntax);
+    }
+
+    // Issue #507 follow-up: shared driver for indexer assignment through a
+    // member chain. Handles three orthogonal axes:
+    //   * `chainBase` is non-null when recursing past a `?.` capture; the
+    //     remainingChain is then bound against the capture via BindAccessorStep
+    //     rather than a fresh BindExpression on the syntax tree.
+    //   * `compoundOperatorToken` is non-null for `op=` forms; the helper then
+    //     synthesizes the `tmp[k] op rhs` binary expression after the receiver
+    //     temp is established.
+    //   * `boundValueOverride` is non-null when the caller already bound the
+    //     RHS (currently unused at top-level, kept for symmetry/future reuse).
+    //
+    // Null-conditional behaviour: if the chain contains a `?.`, the leftmost
+    // occurrence splits the chain. The left side is captured into a synthetic
+    // local; the right side (plus the indexer write) becomes the whenNotNull
+    // body of a `BoundNullConditionalAccessExpression`. Nested `?.` is handled
+    // by recursive splitting.
+    //
+    // Receiver evaluation: the chain receiver is evaluated exactly once. The
+    // index expression is bound twice for compound assignment (once for the
+    // read, once for the write) because both target the same syntax node;
+    // callers passing side-effecting index expressions should pre-bind them
+    // to a local. This matches the precedent set by the local compound
+    // assignment desugar (`x += 1` lowers to `x = x + 1` and double-evaluates
+    // `x` syntactically).
+    private BoundExpression BindIndexedWriteThroughChain(
+        BoundExpression chainBase,
+        ExpressionSyntax remainingChain,
+        ExpressionSyntax indexSyntax,
+        ExpressionSyntax valueSyntax,
+        BoundExpression boundValueOverride,
+        SyntaxToken compoundOperatorToken,
+        ExpressionSyntax compoundRhsSyntax,
+        TextLocation diagnosticLocation,
+        SyntaxNode outerSyntax)
+    {
+        if (TrySplitAtLeftmostNullConditional(remainingChain, out var leftSyntax, out var rightSyntax))
+        {
+            BoundExpression boundLeft = chainBase == null
+                ? BindExpression(leftSyntax)
+                : BindAccessorStep(chainBase, null, leftSyntax);
+            if (boundLeft is BoundErrorExpression || boundLeft.Type == TypeSymbol.Error)
+            {
+                return new BoundErrorExpression(null);
+            }
+
+            TypeSymbol underlying;
+            if (boundLeft.Type is NullableTypeSymbol nullable)
+            {
+                underlying = nullable.UnderlyingType;
+            }
+            else if (boundLeft.Type == TypeSymbol.Null)
+            {
+                // Statically nil receiver: assignment is a no-op. Produce a
+                // bound literal null so the surrounding expression sees a
+                // well-typed value; lowering treats `null` literals as
+                // statement-position no-ops.
+                return new BoundLiteralExpression(null, null);
+            }
+            else
+            {
+                // Non-nullable receiver: `?.` degenerates to `.`, but we still
+                // produce a nullable result type for syntactic consistency
+                // with the read-side null-conditional path.
+                underlying = boundLeft.Type;
+            }
+
+            var captureName = "$ncap_" + (++nullConditionalCaptureCounter).ToString(System.Globalization.CultureInfo.InvariantCulture);
+            var capture = new LocalVariableSymbol(captureName, isReadOnly: true, type: underlying);
+            scope = new BoundScope(scope);
+            scope.TryDeclareVariable(capture);
+
+            var captureRef = new BoundVariableExpression(null, capture);
+            var whenNotNull = BindIndexedWriteThroughChain(
+                chainBase: captureRef,
+                remainingChain: rightSyntax,
+                indexSyntax,
+                valueSyntax,
+                boundValueOverride,
+                compoundOperatorToken,
+                compoundRhsSyntax,
+                diagnosticLocation,
+                outerSyntax);
+
+            scope = scope.Parent;
+
+            if (whenNotNull is BoundErrorExpression)
+            {
+                return whenNotNull;
+            }
+
+            var resultType = whenNotNull.Type is NullableTypeSymbol
+                ? whenNotNull.Type
+                : (TypeSymbol)NullableTypeSymbol.Get(whenNotNull.Type);
+
+            LocalVariableSymbol resultSlot = null;
+            if (whenNotNull.Type is not NullableTypeSymbol
+                && whenNotNull.Type?.ClrType is { IsValueType: true })
+            {
+                var resultSlotName = "$nres_" + nullConditionalCaptureCounter.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                resultSlot = new LocalVariableSymbol(resultSlotName, isReadOnly: false, type: resultType);
+            }
+
+            return new BoundNullConditionalAccessExpression(null, boundLeft, capture, whenNotNull, resultType, resultSlot);
+        }
+
+        BoundExpression boundReceiver = chainBase == null
+            ? BindExpression(remainingChain)
+            : BindAccessorStep(chainBase, null, remainingChain);
+        if (boundReceiver is BoundErrorExpression || boundReceiver.Type == TypeSymbol.Error)
         {
             return new BoundErrorExpression(null);
         }
@@ -14016,14 +14210,99 @@ public sealed class Binder
                 $"Failed to declare synthesized index-assignment target local '{tempName}'.");
         }
 
-        var declaration = new BoundVariableDeclaration(syntax, tempVar, boundReceiver);
-        var assignment = BindIndexedAssignmentToVariable(tempVar, indexed.Index, syntax.Value, indexed.Target.Location);
+        var declaration = new BoundVariableDeclaration(outerSyntax, tempVar, boundReceiver);
+
+        BoundExpression assignment;
+        if (compoundOperatorToken != null)
+        {
+            if (!SyntaxFacts.TryGetCompoundAssignmentBaseOperator(compoundOperatorToken.Kind, out var baseOpKind))
+            {
+                // Defensive: parser only emits this node for kinds recognised
+                // by TryGetCompoundAssignmentBaseOperator above.
+                return new BoundErrorExpression(null);
+            }
+
+            var tempRef = new BoundVariableExpression(null, tempVar);
+            var indexRead = BindIndexAgainstTarget(tempRef, indexSyntax, diagnosticLocation);
+            if (indexRead is BoundErrorExpression)
+            {
+                return indexRead;
+            }
+
+            var rhsBound = BindExpression(compoundRhsSyntax);
+            if (rhsBound is BoundErrorExpression || rhsBound.Type == TypeSymbol.Error)
+            {
+                return new BoundErrorExpression(null);
+            }
+
+            var binaryOp = BoundBinaryOperator.Bind(baseOpKind, indexRead.Type, rhsBound.Type);
+            if (binaryOp == null)
+            {
+                Diagnostics.ReportUndefinedBinaryOperator(
+                    compoundOperatorToken.Location,
+                    compoundOperatorToken.Text,
+                    indexRead.Type,
+                    rhsBound.Type);
+                return new BoundErrorExpression(null);
+            }
+
+            var combined = new BoundBinaryExpression(null, indexRead, binaryOp, rhsBound);
+            assignment = BindIndexedAssignmentToVariableWithBoundValue(tempVar, indexSyntax, combined, diagnosticLocation);
+        }
+        else if (boundValueOverride != null)
+        {
+            assignment = BindIndexedAssignmentToVariableWithBoundValue(tempVar, indexSyntax, boundValueOverride, diagnosticLocation);
+        }
+        else
+        {
+            assignment = BindIndexedAssignmentToVariable(tempVar, indexSyntax, valueSyntax, diagnosticLocation);
+        }
+
         if (assignment is BoundErrorExpression)
         {
             return assignment;
         }
 
-        return new BoundBlockExpression(syntax, ImmutableArray.Create<BoundStatement>(declaration), assignment);
+        return new BoundBlockExpression(outerSyntax, ImmutableArray.Create<BoundStatement>(declaration), assignment);
+    }
+
+    // Issue #507 follow-up: walks a left-recursive accessor chain to find the
+    // leftmost `?.` in source order. When found, splits the chain into the
+    // sub-expression LEFT of the `?.` (which is captured for null-checking)
+    // and the sub-expression to its RIGHT (which is bound against the
+    // capture). Returns false when the chain contains no `?.` at all.
+    private bool TrySplitAtLeftmostNullConditional(
+        ExpressionSyntax chain,
+        out ExpressionSyntax left,
+        out ExpressionSyntax right)
+    {
+        // ParseNameOrCallExpression makes accessor chains RIGHT-recursive: in
+        // `a.b?.c.d`, the outer accessor is `.` with LeftPart `a` and RightPart
+        // `AccessorExpression(b, ?., AccessorExpression(c, ., d))`. To find the
+        // leftmost `?.` we walk the RIGHT spine: if the current node is itself
+        // `?.`, it is the split point; otherwise recurse into RightPart and
+        // rebuild the LEFT side by re-attaching the prefix with the inner
+        // `?.` replaced by its own LeftPart.
+        if (chain is AccessorExpressionSyntax acc)
+        {
+            if (acc.IsNullConditional)
+            {
+                left = acc.LeftPart;
+                right = acc.RightPart;
+                return true;
+            }
+
+            if (TrySplitAtLeftmostNullConditional(acc.RightPart, out var innerLeft, out var innerRight))
+            {
+                left = new AccessorExpressionSyntax(acc.SyntaxTree, acc.LeftPart, acc.DotToken, innerLeft);
+                right = innerRight;
+                return true;
+            }
+        }
+
+        left = null;
+        right = null;
+        return false;
     }
 
     private BoundExpression BindIndexedAssignmentToVariable(
@@ -14032,11 +14311,47 @@ public sealed class Binder
         ExpressionSyntax valueSyntax,
         TextLocation diagnosticLocation)
     {
+        return BindIndexedAssignmentToVariableCore(
+            variable, indexSyntax, valueSyntax, boundValueOverride: null, diagnosticLocation);
+    }
+
+    // Issue #507 follow-up: compound assignment (`tmp[k] += v`) supplies a
+    // pre-bound RHS (the synthesized `tmp[k] op v` binary expression) so the
+    // shared body must skip re-binding the value syntax and just convert the
+    // bound value to the element type. Carries `diagnosticLocation` for the
+    // conversion error site, matching the caller's user-visible operator.
+    private BoundExpression BindIndexedAssignmentToVariableWithBoundValue(
+        VariableSymbol variable,
+        ExpressionSyntax indexSyntax,
+        BoundExpression boundValue,
+        TextLocation diagnosticLocation)
+    {
+        return BindIndexedAssignmentToVariableCore(
+            variable, indexSyntax, valueSyntax: null, boundValueOverride: boundValue, diagnosticLocation);
+    }
+
+    private BoundExpression BindIndexedAssignmentToVariableCore(
+        VariableSymbol variable,
+        ExpressionSyntax indexSyntax,
+        ExpressionSyntax valueSyntax,
+        BoundExpression boundValueOverride,
+        TextLocation diagnosticLocation)
+    {
+        BoundExpression BindValue(TypeSymbol elementType)
+        {
+            if (boundValueOverride != null)
+            {
+                return BindConversion(diagnosticLocation, boundValueOverride, elementType);
+            }
+
+            return BindConversion(valueSyntax, elementType);
+        }
+
         var element = GetIndexElementType(variable.Type);
         if (element != null)
         {
             var index = BindConversion(indexSyntax, TypeSymbol.Int32);
-            var value = BindConversion(valueSyntax, element);
+            var value = BindValue(element);
             return new BoundIndexAssignmentExpression(null, variable, index, value, element);
         }
 
@@ -14045,7 +14360,7 @@ public sealed class Binder
         if (variable.Type is MapTypeSymbol mapType)
         {
             var keyExpr = BindConversion(indexSyntax, mapType.KeyType);
-            var valExpr = BindConversion(valueSyntax, mapType.ValueType);
+            var valExpr = BindValue(mapType.ValueType);
             return new BoundIndexAssignmentExpression(null, variable, keyExpr, valExpr, mapType.ValueType);
         }
 
@@ -14061,7 +14376,7 @@ public sealed class Binder
             }
 
             var valueTypeAnnotWr = annotWr.GetTypeArgumentSymbolForClrType(idxPropAnnotWr.PropertyType);
-            var boundValueAnnotWr = BindConversion(valueSyntax, valueTypeAnnotWr);
+            var boundValueAnnotWr = BindValue(valueTypeAnnotWr);
             return new BoundClrIndexAssignmentExpression(null, variable, idxPropAnnotWr, idxArgsAnnotWr, boundValueAnnotWr, valueTypeAnnotWr);
         }
 
@@ -14084,7 +14399,7 @@ public sealed class Binder
                     }
 
                     var pointeeType = TypeSymbol.FromClrType(refGetter.ReturnType.GetElementType()!);
-                    var refValue = BindConversion(valueSyntax, pointeeType);
+                    var refValue = BindValue(pointeeType);
                     return new BoundClrIndexAssignmentExpression(null, variable, idxProp, idxArgs, refValue, pointeeType);
                 }
 
@@ -14093,7 +14408,7 @@ public sealed class Binder
             }
 
             var valueType = TypeSymbol.FromClrType(idxProp.PropertyType);
-            var boundValue = BindConversion(valueSyntax, valueType);
+            var boundValue = BindValue(valueType);
             return new BoundClrIndexAssignmentExpression(null, variable, idxProp, idxArgs, boundValue, valueType);
         }
 

--- a/src/Core/CodeAnalysis/Syntax/CompoundIndexAssignmentExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/CompoundIndexAssignmentExpressionSyntax.cs
@@ -1,0 +1,50 @@
+// <copyright file="CompoundIndexAssignmentExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents a compound indexer assignment of the form
+/// <c>target[index] op= value</c> (e.g. <c>d[k] += 1</c>, <c>obj.Map[k] -= 2</c>).
+/// Issue #507 follow-up: this complements
+/// <see cref="IndexAssignmentExpressionSyntax"/> and
+/// <see cref="MemberIndexAssignmentExpressionSyntax"/>, which only handle the
+/// plain <c>=</c> case. The binder evaluates the indexed receiver exactly once
+/// (via a synthesized temp local) and lowers the node to the equivalent
+/// <c>target[index] = target[index] op value</c>.
+/// </summary>
+public sealed class CompoundIndexAssignmentExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>
+    /// Initializes a new instance of the
+    /// <see cref="CompoundIndexAssignmentExpressionSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="target">The parsed indexer access on the left of the operator.</param>
+    /// <param name="operatorToken">The compound assignment token (e.g. <c>+=</c>).</param>
+    /// <param name="value">The value expression on the right of the operator.</param>
+    public CompoundIndexAssignmentExpressionSyntax(
+        SyntaxTree syntaxTree,
+        IndexExpressionSyntax target,
+        SyntaxToken operatorToken,
+        ExpressionSyntax value)
+        : base(syntaxTree)
+    {
+        Target = target;
+        OperatorToken = operatorToken;
+        Value = value;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.CompoundIndexAssignmentExpression;
+
+    /// <summary>Gets the indexer access expression on the left of the operator.</summary>
+    public IndexExpressionSyntax Target { get; }
+
+    /// <summary>Gets the compound assignment operator token.</summary>
+    public SyntaxToken OperatorToken { get; }
+
+    /// <summary>Gets the value expression on the right of the operator.</summary>
+    public ExpressionSyntax Value { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/MemberIndexAssignmentExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/MemberIndexAssignmentExpressionSyntax.cs
@@ -1,0 +1,47 @@
+// <copyright file="MemberIndexAssignmentExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents an indexer assignment whose target is an arbitrary expression
+/// rather than a bare identifier, e.g. <c>obj.Member[key] = value</c> or
+/// <c>GetThing()[i] = v</c>. Issue #507: this complements
+/// <see cref="IndexAssignmentExpressionSyntax"/> (which is restricted to a
+/// single identifier on the left of the brackets) by allowing the indexed
+/// target to be any expression that produces an indexable value.
+/// </summary>
+public sealed class MemberIndexAssignmentExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MemberIndexAssignmentExpressionSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="target">The parsed indexer access on the left of the equals sign.</param>
+    /// <param name="equalsToken">The equals token.</param>
+    /// <param name="value">The value expression on the right of the equals sign.</param>
+    public MemberIndexAssignmentExpressionSyntax(
+        SyntaxTree syntaxTree,
+        IndexExpressionSyntax target,
+        SyntaxToken equalsToken,
+        ExpressionSyntax value)
+        : base(syntaxTree)
+    {
+        Target = target;
+        EqualsToken = equalsToken;
+        Value = value;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.MemberIndexAssignmentExpression;
+
+    /// <summary>Gets the indexer access expression on the left of the equals sign.</summary>
+    public IndexExpressionSyntax Target { get; }
+
+    /// <summary>Gets the equals token.</summary>
+    public SyntaxToken EqualsToken { get; }
+
+    /// <summary>Gets the value expression on the right of the equals sign.</summary>
+    public ExpressionSyntax Value { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -3309,6 +3309,25 @@ public class Parser
 
         var expression = ParseBinaryExpression();
 
+        // Issue #507: indexer assignment whose target is an arbitrary expression
+        // (e.g. `obj.Member[k] = v`, `a.b.c[k] = v`, `(GetThing())[i] = v`). The
+        // bare-identifier form `id[k] = v` is already handled above as
+        // IndexAssignmentExpressionSyntax; this branch handles any other LHS shape
+        // whose trailing primary is an index access. Because ParsePostfixChain
+        // recursively folds `[...]` into the right-hand side of the most recent
+        // `.`, the parsed tree for `obj.Member[k]` is
+        // `AccessorExpression(obj, ., IndexExpression(Member, [k]))` — not a
+        // top-level IndexExpression. TryLiftTrailingIndexer reshapes such chains
+        // into the canonical `IndexExpression(<receiver-chain>, [k])` form before
+        // wrapping in MemberIndexAssignmentExpressionSyntax.
+        if (Current.Kind == SyntaxKind.EqualsToken
+            && TryLiftTrailingIndexer(expression, out var indexedLhs))
+        {
+            var equalsToken = NextToken();
+            var value = ParseAssignmentExpression();
+            return new MemberIndexAssignmentExpressionSyntax(syntaxTree, indexedLhs, equalsToken, value);
+        }
+
         // ADR-0062: general two-arm conditional (ternary) expression
         // `cond ? a : b`. Right-associative; lower precedence than
         // logical-or and higher than assignment. When the `?` tail
@@ -3501,6 +3520,50 @@ public class Parser
         }
 
         return current;
+    }
+
+    // Issue #507: lift a trailing index access out of an accessor chain so it can
+    // be reused as the LHS of an indexer assignment. Returns true and yields a
+    // canonical `IndexExpression(<receiver-chain>, [k])` when the expression's
+    // rightmost primary is an index access; returns false otherwise.
+    //
+    // Shapes handled (rebuilt accessor chain shown after `=>`):
+    //   IndexExpression(t, [k])                                 => itself
+    //   AccessorExpression(L, ., IndexExpression(t, [k]))       => IndexExpression(AccessorExpression(L, ., t), [k])
+    //   AccessorExpression(L, ., AccessorExpression(M, ., IndexExpression(t, [k])))
+    //                                                            => IndexExpression(AccessorExpression(L, ., AccessorExpression(M, ., t)), [k])
+    //
+    // Null-conditional accessors (`?.`) are intentionally left as-is so existing
+    // diagnostics continue to fire — chained null-conditional indexer assignment
+    // is out of scope for this fix.
+    private bool TryLiftTrailingIndexer(ExpressionSyntax expression, out IndexExpressionSyntax canonical)
+    {
+        if (expression is IndexExpressionSyntax direct)
+        {
+            canonical = direct;
+            return true;
+        }
+
+        if (expression is AccessorExpressionSyntax accessor
+            && !accessor.IsNullConditional
+            && TryLiftTrailingIndexer(accessor.RightPart, out var inner))
+        {
+            var rebuiltReceiver = new AccessorExpressionSyntax(
+                syntaxTree,
+                accessor.LeftPart,
+                accessor.DotToken,
+                inner.Target);
+            canonical = new IndexExpressionSyntax(
+                syntaxTree,
+                rebuiltReceiver,
+                inner.OpenBracketToken,
+                inner.Index,
+                inner.CloseBracketToken);
+            return true;
+        }
+
+        canonical = null;
+        return false;
     }
 
     private ExpressionSyntax ParseFunctionLiteralExpression()

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -3328,6 +3328,21 @@ public class Parser
             return new MemberIndexAssignmentExpressionSyntax(syntaxTree, indexedLhs, equalsToken, value);
         }
 
+        // Issue #507 follow-up: compound indexer assignment
+        // (`d[k] += v`, `obj.Map[k] -= 1`, ...). Mirrors the bare `=` lift above
+        // but routes through CompoundIndexAssignmentExpressionSyntax so the
+        // binder can evaluate the receiver chain exactly once via a synthesized
+        // temp local before desugaring to `tmp[k] = tmp[k] op v`. The
+        // bare-identifier form `id[k] op= v` also lands here (TryLift returns
+        // the IndexExpression directly when the expression already IS one).
+        if (SyntaxFacts.TryGetCompoundAssignmentBaseOperator(Current.Kind, out _)
+            && TryLiftTrailingIndexer(expression, out var compoundIndexedLhs))
+        {
+            var compoundOpToken = NextToken();
+            var compoundRhs = ParseAssignmentExpression();
+            return new CompoundIndexAssignmentExpressionSyntax(syntaxTree, compoundIndexedLhs, compoundOpToken, compoundRhs);
+        }
+
         // ADR-0062: general two-arm conditional (ternary) expression
         // `cond ? a : b`. Right-associative; lower precedence than
         // logical-or and higher than assignment. When the `?` tail
@@ -3533,9 +3548,11 @@ public class Parser
     //   AccessorExpression(L, ., AccessorExpression(M, ., IndexExpression(t, [k])))
     //                                                            => IndexExpression(AccessorExpression(L, ., AccessorExpression(M, ., t)), [k])
     //
-    // Null-conditional accessors (`?.`) are intentionally left as-is so existing
-    // diagnostics continue to fire — chained null-conditional indexer assignment
-    // is out of scope for this fix.
+    // Issue #507 follow-up: null-conditional accessors (`?.`) are lifted too
+    // so `obj.A?.B[k] = v` becomes a valid LHS. The binder
+    // (BindMemberIndexAssignmentExpression) splits the receiver chain at the
+    // leftmost `?.` and emits a null-conditional write that no-ops when the
+    // captured intermediate is `nil`.
     private bool TryLiftTrailingIndexer(ExpressionSyntax expression, out IndexExpressionSyntax canonical)
     {
         if (expression is IndexExpressionSyntax direct)
@@ -3545,7 +3562,6 @@ public class Parser
         }
 
         if (expression is AccessorExpressionSyntax accessor
-            && !accessor.IsNullConditional
             && TryLiftTrailingIndexer(accessor.RightPart, out var inner))
         {
             var rebuiltReceiver = new AccessorExpressionSyntax(

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -152,6 +152,7 @@ public enum SyntaxKind
     MapEntry,
     IndexExpression,
     IndexAssignmentExpression,
+    MemberIndexAssignmentExpression,
     PackageDeclaration,
     ImportDeclaration,
     FunctionDeclaration,

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -153,6 +153,7 @@ public enum SyntaxKind
     IndexExpression,
     IndexAssignmentExpression,
     MemberIndexAssignmentExpression,
+    CompoundIndexAssignmentExpression,
     PackageDeclaration,
     ImportDeclaration,
     FunctionDeclaration,

--- a/test/Compiler.Tests/Emit/Issue507MemberIndexAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue507MemberIndexAssignmentEmitTests.cs
@@ -1,0 +1,244 @@
+// <copyright file="Issue507MemberIndexAssignmentEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #507: <c>obj.Member[key] = value</c> previously failed to parse
+/// with <c>GS0005: Unexpected token &lt;EqualsToken&gt;</c>. The parser
+/// folded <c>[...]</c> into the right-hand side of the trailing <c>.</c>
+/// (producing <c>AccessorExpression(obj, ., IndexExpression(Member, [k]))</c>)
+/// and the assignment path only special-cased a bare identifier on the LHS,
+/// so the trailing <c>=</c> had no production to match.
+///
+/// The fix lifts the trailing index access into a canonical
+/// <c>IndexExpression(&lt;receiver-chain&gt;, [k])</c>, wraps it in a new
+/// <c>MemberIndexAssignmentExpressionSyntax</c>, and the binder lowers it
+/// through a synthesized temp local so the existing CLR-indexer / array /
+/// map assignment paths are reused unchanged. The tests below lock in the
+/// new shape and guard against regressions in the surrounding parser arms.
+/// </summary>
+public class Issue507MemberIndexAssignmentEmitTests
+{
+    [Fact]
+    public void MemberIndexerAssignment_WritesThroughSetterAndReadsBack()
+    {
+        // The headline scenario: an indexer write whose LHS is `obj.Field`.
+        // The synthesized temp must hold the bound field value so the
+        // existing `set_Item` emission produces a callvirt against it.
+        // Reading back via the workaround local form (`let m = h.Map; m[k]`)
+        // confirms the write landed on the same backing dictionary.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            type Holder struct {
+                Map Dictionary[string, int32]
+            }
+
+            func MakeHolder() Holder {
+                return Holder{Map: Dictionary[string, int32]()}
+            }
+
+            let h = MakeHolder()
+            h.Map["answer"] = 42
+            let inner = h.Map
+            public var result = inner["answer"]
+            """;
+
+        Assert.Equal(42, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void ChainedMemberIndexerAssignment_LiftsTrailingIndexer()
+    {
+        // The reshape recurses through nested AccessorExpressions, so
+        // `o.Inner.Map[k] = v` must canonicalize to
+        // `IndexExpression(AccessorExpression(o, ., AccessorExpression(Inner, ., Map)), [k])`
+        // before binding. A wrong reshape would leave the inner accessor
+        // dangling and either fail to parse or bind the indexer against
+        // the wrong receiver.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            type Inner struct {
+                Map Dictionary[string, int32]
+            }
+
+            type Outer struct {
+                InnerObj Inner
+            }
+
+            func MakeOuter() Outer {
+                return Outer{InnerObj: Inner{Map: Dictionary[string, int32]()}}
+            }
+
+            let o = MakeOuter()
+            o.InnerObj.Map["k"] = 99
+            let m = o.InnerObj.Map
+            public var result = m["k"]
+            """;
+
+        Assert.Equal(99, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void CallResultIndexerAssignment_AlsoWorks()
+    {
+        // The fix is not limited to member access: any expression whose
+        // trailing primary is an index access becomes a valid LHS. Here
+        // the receiver chain is a call (`MakeMap()`), which exercises the
+        // top-level IndexExpression branch of TryLiftTrailingIndexer.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func MakeMap() Dictionary[string, int32] {
+                return Dictionary[string, int32]()
+            }
+
+            let shared = MakeMap()
+            shared["seed"] = 7
+            MakeMap()["throwaway"] = 99
+            public var result = shared["seed"]
+            """;
+
+        Assert.Equal(7, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void GenericTypeArgsAfterMemberAccess_StillParsesAsCall()
+    {
+        // Regression guard: `foo.Bar[int32](...)` must keep being parsed
+        // as a member-then-generic-call, not as the new indexer-assignment
+        // shape. The ADR-0020 disambiguation (`LooksLikeGenericCallSite`)
+        // runs inside `ParseNameOrCallExpression`, so the trailing `[T](`
+        // continues to be folded into a `CallExpression` on the right
+        // side of `.` and never reaches the assignment tail.
+        var source = """
+            package P
+            import System
+
+            type Holder struct {
+                Value int32
+            }
+
+            func (h Holder) Pick[T](v T) int32 {
+                return h.Value
+            }
+
+            let h = Holder{Value: 17}
+            public var result = h.Pick[int32](0)
+            """;
+
+        Assert.Equal(17, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void MemberIndexRead_ViaLocalBinding_StillWorks()
+    {
+        // Regression guard for the documented workaround (binding the
+        // indexed property to a local first). This path predates the
+        // fix and must not be perturbed by the new parser arm.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            type Holder struct {
+                Map Dictionary[string, int32]
+            }
+
+            let h = Holder{Map: Dictionary[string, int32]()}
+            let env = h.Map
+            env["NO_COLOR"] = 1
+            public var result = env["NO_COLOR"]
+            """;
+
+        Assert.Equal(1, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void BareIdentifierIndexerAssignment_StillWorks()
+    {
+        // Regression guard: the pre-existing `id[k] = v` arm
+        // (IndexAssignmentExpressionSyntax) must continue to win against
+        // the new tail handler. The tail handler only fires when the
+        // earlier identifier-specific arms have already declined.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            let d = Dictionary[string, int32]()
+            d["x"] = 5
+            public var result = d["x"]
+            """;
+
+        Assert.Equal(5, RunAndGetIntResult(source));
+    }
+
+    private static int RunAndGetIntResult(string source)
+    {
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod(
+            "<Main>$",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField(
+            "result",
+            BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, null);
+        return (int)resultField!.GetValue(null)!;
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue507_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue507MemberIndexAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue507MemberIndexAssignmentEmitTests.cs
@@ -189,6 +189,276 @@ public class Issue507MemberIndexAssignmentEmitTests
         Assert.Equal(5, RunAndGetIntResult(source));
     }
 
+    [Fact]
+    public void MemberIndexerRead_ChainedShape_BindsCleanly()
+    {
+        // Issue #507 follow-up (bind-side read): although `let v = h.Map[k]`
+        // was listed in the original issue as "works", BindAccessorStep had no
+        // case for IndexExpressionSyntax, so a folded read shape
+        // (`AccessorExpression(h, ., IndexExpression(Map, [k]))`) produced
+        // BoundErrorExpression with no diagnostic and surfaced downstream as
+        // GS9998. The added IndexExpressionSyntax case in BindAccessorStep
+        // routes the read through the same shared helper used by writes.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            type Holder struct {
+                Map Dictionary[string, int32]
+            }
+
+            let h = Holder{Map: Dictionary[string, int32]()}
+            h.Map["answer"] = 42
+            public var result = h.Map["answer"]
+            """;
+
+        Assert.Equal(42, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void MemberIndexerCompoundAssignment_PlusEquals()
+    {
+        // Issue #507 follow-up: compound `op=` assignment through a member
+        // chain must (a) parse via the new CompoundIndexAssignmentExpression
+        // shape and (b) lower into a single read+write against one captured
+        // receiver. Final read confirms the dictionary slot was updated.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            type Holder struct {
+                Map Dictionary[string, int32]
+            }
+
+            let h = Holder{Map: Dictionary[string, int32]()}
+            h.Map["k"] = 5
+            h.Map["k"] += 3
+            public var result = h.Map["k"]
+            """;
+
+        Assert.Equal(8, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void MemberIndexerCompoundAssignment_MinusEqualsAndStarEquals()
+    {
+        // Mirrors PlusEquals for additional compound ops to lock in that the
+        // dispatch is operator-agnostic and goes through TryGetCompoundAssignmentBaseOperator.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            type Holder struct {
+                Map Dictionary[string, int32]
+            }
+
+            let h = Holder{Map: Dictionary[string, int32]()}
+            h.Map["k"] = 10
+            h.Map["k"] -= 4
+            h.Map["k"] *= 3
+            public var result = h.Map["k"]
+            """;
+
+        Assert.Equal(18, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void LocalIndexerCompoundAssignment_AlsoWorks()
+    {
+        // Issue #507 follow-up: the local-variable form (`d[k] += v`) was
+        // also broken pre-fix (parser reported GS0005 on `+=`). The new
+        // parser path covers both shapes through a single
+        // CompoundIndexAssignmentExpression node so the public language is
+        // consistent for compound indexer assignment.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            let d = Dictionary[string, int32]()
+            d["x"] = 7
+            d["x"] += 11
+            public var result = d["x"]
+            """;
+
+        Assert.Equal(18, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void ChainedMemberIndexerCompoundAssignment_DeepChain()
+    {
+        // Deep member chain with compound op: receiver is a struct field
+        // referenced through another struct field. The receiver chain
+        // (`o.InnerObj.Map`) must be captured into a single temp; both the
+        // read and write of the indexer must target the same dictionary.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            type Inner struct {
+                Map Dictionary[string, int32]
+            }
+
+            type Outer struct {
+                InnerObj Inner
+            }
+
+            let o = Outer{InnerObj: Inner{Map: Dictionary[string, int32]()}}
+            o.InnerObj.Map["k"] = 100
+            o.InnerObj.Map["k"] += 23
+            public var result = o.InnerObj.Map["k"]
+            """;
+
+        Assert.Equal(123, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void MemberIndexerCompoundAssignment_ReceiverEvaluatedOnce()
+    {
+        // Receiver-once contract: when the chain receiver has side effects
+        // (here a function returning the dictionary while incrementing a
+        // static counter), the compound `op=` form must evaluate it
+        // exactly once. After `Bag().Map["k"] += 5`, the counter must be 1
+        // (not 2) and the indexer write must land on the single returned
+        // bag — observable by reading back via a separately-cached handle.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            type Bag struct {
+                Map Dictionary[string, int32]
+            }
+
+            public var calls = 0
+            let stored = Bag{Map: Dictionary[string, int32]()}
+
+            func GetBag() Bag {
+                calls = calls + 1
+                return stored
+            }
+
+            stored.Map["k"] = 10
+            GetBag().Map["k"] += 5
+            public var resultValue = stored.Map["k"]
+            public var resultCalls = calls
+            """;
+
+        var (value, calls) = RunAndGetTwoIntResults(source, "resultValue", "resultCalls");
+        Assert.Equal(15, value);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void NullConditionalMemberIndexerAssignment_WritesWhenNonNil()
+    {
+        // Issue #507 follow-up: `obj?.Map[k] = v` writes through when obj
+        // is non-nil. The chain receiver is captured into a synthetic
+        // `$ncap_N` local; the BoundNullConditionalAccessExpression wraps
+        // the indexer assignment as the whenNotNull branch. We observe
+        // the landing via a separately-held reference to the same
+        // dictionary (avoids reading through `?.` on a value-type result).
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            type Holder class(Map Dictionary[string, int32]) {
+            }
+
+            let m = Dictionary[string, int32]()
+            let h Holder? = Holder(m)
+            h?.Map["k"] = 77
+            public var result = m["k"]
+            """;
+
+        Assert.Equal(77, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void NullConditionalMemberIndexerAssignment_NoOpsWhenNil()
+    {
+        // No-op semantics: when the receiver is nil, the indexer write
+        // must not be evaluated. The dictionary captured into the
+        // observation handle stays unchanged. This guards against a
+        // regression that would unconditionally call set_Item.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            type Holder class(Map Dictionary[string, int32]) {
+            }
+
+            let m = Dictionary[string, int32]()
+            m["k"] = 10
+            let h Holder? = nil
+            h?.Map["k"] = 99
+            public var result = m["k"]
+            """;
+
+        Assert.Equal(10, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void DeepNullConditionalMemberIndexerAssignment_WorksWhenIntermediateNonNil()
+    {
+        // Deep chain `o.InnerObj?.Map[k] = v` where InnerObj is a
+        // nullable class field. The split helper must walk the
+        // right-recursive parse tree to find the `?.` and capture
+        // `o.InnerObj` (not just `o`). We observe through a separately
+        // held reference to the inner dictionary so the read path
+        // doesn't need to thread `?.` over an int value.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            type Inner class(Map Dictionary[string, int32]) {
+            }
+
+            type Outer class(InnerObj Inner?) {
+            }
+
+            let m = Dictionary[string, int32]()
+            let o = Outer(Inner(m))
+            o.InnerObj?.Map["k"] = 55
+            public var result = m["k"]
+            """;
+
+        Assert.Equal(55, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void DeepNullConditionalMemberIndexerAssignment_NoOpsWhenIntermediateNil()
+    {
+        // Mirror of the deep NC write but the intermediate field is nil.
+        // No write may occur. We observe the no-op via a captured handle
+        // (the dictionary that *would* be the target if InnerObj were
+        // non-nil) and verify it is unchanged.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            type Inner class(Map Dictionary[string, int32]) {
+            }
+
+            type Outer class(InnerObj Inner?) {
+            }
+
+            let o = Outer(nil)
+            o.InnerObj?.Map["k"] = 999
+            public var result = 7
+            """;
+
+        Assert.Equal(7, RunAndGetIntResult(source));
+    }
+
     private static int RunAndGetIntResult(string source)
     {
         var assembly = CompileToAssembly(source);
@@ -202,6 +472,20 @@ public class Issue507MemberIndexAssignmentEmitTests
 
         entry!.Invoke(null, null);
         return (int)resultField!.GetValue(null)!;
+    }
+
+    private static (int First, int Second) RunAndGetTwoIntResults(string source, string firstField, string secondField)
+    {
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod(
+            "<Main>$",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var first = program.GetField(firstField, BindingFlags.Public | BindingFlags.Static);
+        var second = program.GetField(secondField, BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, null);
+        return ((int)first!.GetValue(null)!, (int)second!.GetValue(null)!);
     }
 
     private static Assembly CompileToAssembly(string source)

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -119,6 +119,7 @@ MakeChannelExpression
 MapCreationExpression
 MapEntry
 MapKeyword
+MemberIndexAssignmentExpression
 MinusEqualsToken
 MinusMinusToken
 MinusToken

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -43,6 +43,7 @@ ColonToken
 CommaToken
 CommentToken
 CompilationUnit
+CompoundIndexAssignmentExpression
 ConditionalExpression
 ConditionalRefArgumentExpression
 ConstKeyword


### PR DESCRIPTION
## Summary

`obj.Member[key] = value` failed to parse with `GS0005: Unexpected token <EqualsToken>`. The parser folded a trailing `[...]` into the right-hand side of the preceding `.`, so `psi.Environment["NO_COLOR"]` parsed as `AccessorExpression(psi, ., IndexExpression(Environment, ["NO_COLOR"]))` instead of a top-level `IndexExpression`. The assignment path only special-cased a bare identifier LHS (`id[k] = v`), so the trailing `=` had no production to match and the parser bailed.

This PR fixes the headline `=` form and the three follow-ups originally deferred: the bind-side read of the folded shape, compound assignment (`op=`) on both local- and member-rooted indexers, and null-conditional indexer assignment (`obj?.M[k] = v`, including deep chains like `obj.A?.B[k] = v`).

## Repro

```gsharp
package P
import System.Diagnostics

var psi = ProcessStartInfo("dotnet")
psi.Environment["NO_COLOR"] = "1"   // GS0005 before this fix
```

## Approach

1. **Parser**
   - `ParseAssignmentExpression` runs a `TryLiftTrailingIndexer` reshape on the parsed expression. It walks the accessor chain and, if the rightmost primary is an `IndexExpression`, rebuilds the tree so the indexer sits at the top with the (possibly long) accessor chain as its `Target`. The result is wrapped in `MemberIndexAssignmentExpressionSyntax` when the next token is `=`, or in the new `CompoundIndexAssignmentExpressionSyntax` when the next token is a compound `op=`.
   - `TryLiftTrailingIndexer` lifts through `?.` accessors as well as `.`, so null-conditional chains can serve as the LHS of an indexer (compound) assignment.
   - Shapes handled:
     - `obj.Member[k]`         → `IndexExpression(AccessorExpression(obj, ., Member), [k])`
     - `a.b.c[k]`              → `IndexExpression(AccessorExpression(a, ., AccessorExpression(b, ., c)), [k])`
     - `obj?.Map[k]` and `obj.A?.B[k]` lift identically (the `?.` is preserved on the rebuilt chain).
     - `MakeMap()[k]`          → already canonical, passed through.
2. **Binder**
   - `BindAccessorStep` gained an `IndexExpressionSyntax` case so the symmetric *read* shape (`let v = obj.Member[k]`) routes through the same indexer-binding helper used by writes (extracted as `BindIndexAgainstTarget`). The previous fall-through returned `BoundErrorExpression` with no diagnostic and surfaced downstream as `GS9998: Cannot encode signature for type '?'`.
   - `BindAccessorStep` also now honors the nested `AccessorExpression.IsNullConditional` flag. `ParseNameOrCallExpression` builds right-recursive chains (so `a.b?.c` parses as `AccessorExpression(a, ., AccessorExpression(b, ?., c))`); the inner `?.` was previously bound as a plain `.` and reported `GS0158 Cannot find member c` on the underlying nullable type.
   - `BindNullConditionalAccessExpression` was factored into a core taking a pre-bound receiver (`BindNullConditionalAccessExpressionCore`), reused by `BindAccessorStep` (nested `?.`) and by the indexed-write split (below).
   - A shared driver `BindIndexedWriteThroughChain` handles all three orthogonal axes:
     - **Plain write** (`obj.Map[k] = v`): synthesises a `<idxAsn{N}>` temp local, declares it with the bound receiver as its initializer, and dispatches to `BindIndexedAssignmentToVariable`. Reuses every downstream pipeline (lowering, async spilling, side-effect spilling, evaluator, `EmitClrIndexAssignment` / `EmitIndexAssignment`) without modification.
     - **Compound write** (`obj.Map[k] += v`, `d[k] += v`): synthesises the `tmp[k] op rhs` binary expression after the receiver temp is established, then routes through `BindIndexedAssignmentToVariableWithBoundValue`. The same code path covers both the **local** form (`d[k] += v`, which previously failed with `GS0005`) and the **member** form, so the public language is consistent.
     - **Null-conditional write**: splits the chain at the leftmost `?.` via `TrySplitAtLeftmostNullConditional` (which walks the right-recursive parse tree along the right spine, rebuilding the prefix with the `?.` accessor replaced by its own `LeftPart`). The left prefix is captured into a `$ncap_N` synthetic local; the right side plus the indexer write becomes the `whenNotNull` body of a `BoundNullConditionalAccessExpression`. The write is a no-op when the captured intermediate is `nil`. Nested `?.` is handled by recursive splitting.
   - Receiver evaluation: the chain receiver is evaluated **exactly once**. The index expression is bound twice for compound assignment (read + write) because both target the same syntax node, matching the precedent of the local compound desugar (`x += 1` → `x = x + 1`, where `x` is syntactically duplicated).
3. **Coverage matrix** — `SyntaxKind.MemberIndexAssignmentExpression` and `SyntaxKind.CompoundIndexAssignmentExpression` are in the enum, the checked-in `coverage-matrix.golden.txt`, and `docs/coverage-matrix.md`.

## Tests added (`Issue507MemberIndexAssignmentEmitTests`, 16 cases total, all green)

Original 6 (still passing):

- `MemberIndexerAssignment_WritesThroughSetterAndReadsBack`
- `ChainedMemberIndexerAssignment_LiftsTrailingIndexer`
- `CallResultIndexerAssignment_AlsoWorks`
- `GenericTypeArgsAfterMemberAccess_StillParsesAsCall`
- `MemberIndexRead_ViaLocalBinding_StillWorks`
- `BareIdentifierIndexerAssignment_StillWorks`

10 added in this follow-up:

- `MemberIndexerRead_ChainedShape_BindsCleanly` — `let v = h.Map["answer"]` binds and emits without `GS9998`.
- `MemberIndexerCompoundAssignment_PlusEquals` — `h.Map["k"] += 3`.
- `MemberIndexerCompoundAssignment_MinusEqualsAndStarEquals` — `-=` and `*=` chained.
- `LocalIndexerCompoundAssignment_AlsoWorks` — `d["x"] += 11` (previously `GS0005`).
- `ChainedMemberIndexerCompoundAssignment_DeepChain` — `o.InnerObj.Map["k"] += 23`.
- `MemberIndexerCompoundAssignment_ReceiverEvaluatedOnce` — calls a function returning the dictionary while incrementing a static counter; verifies the receiver is evaluated once and the write lands on the single returned bag.
- `NullConditionalMemberIndexerAssignment_WritesWhenNonNil` — `h?.Map["k"] = 77` writes; observed via a separately-held dictionary reference.
- `NullConditionalMemberIndexerAssignment_NoOpsWhenNil` — `h = nil; h?.Map["k"] = 99` is a no-op (observed via the captured dictionary handle).
- `DeepNullConditionalMemberIndexerAssignment_WorksWhenIntermediateNonNil` — `o.InnerObj?.Map["k"] = 55`.
- `DeepNullConditionalMemberIndexerAssignment_NoOpsWhenIntermediateNil` — `Outer(nil); o.InnerObj?.Map["k"] = 999` is a no-op.

Full suite: **2590 passed / 0 failed** (Compiler.Tests 372 → 388 across both PR drops).

## Notes

- The bind-side read fix (new `IndexExpressionSyntax` case in `BindAccessorStep`) and the nested-`?.` fix in `BindAccessorStep` also incidentally repair the symmetric *read* of deep `?.` member access (`o.InnerObj?.Map`), which previously misreported `GS0158` because the inner `?.` was being treated as `.`.
- Receiver-once semantics for compound assignment match the existing local-form desugar: the receiver chain is captured into a single temp before any read/write. The index expression itself is still bound twice (read + write) against the same temp; callers passing a side-effecting index expression should pre-bind it (this matches `x += 1` semantics for locals).

Closes #507
