### PR TITLE
Fix #504: emit Nullable<T> property reads/writes correctly

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -7443,15 +7443,16 @@ public sealed class Binder
                 return new BoundErrorExpression(null);
             }
 
-            if (!TryGetWritableClrMember(staticMember, out var staticTargetType, out var staticWritable))
+            if (!TryGetWritableClrMember(staticMember, out var staticTargetType, out var staticTargetSymbol, out var staticWritable))
             {
                 Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.Text);
                 return new BoundErrorExpression(null);
             }
 
             _ = staticWritable;
-            var staticConverted = BindConversion(syntax.Value.Location, staticValue, TypeSymbol.FromClrType(staticTargetType));
-            return new BoundClrPropertyAssignmentExpression(null, receiver: null, staticMember, staticConverted, TypeSymbol.FromClrType(staticTargetType));
+            _ = staticTargetType;
+            var staticConverted = BindConversion(syntax.Value.Location, staticValue, staticTargetSymbol);
+            return new BoundClrPropertyAssignmentExpression(null, receiver: null, staticMember, staticConverted, staticTargetSymbol);
         }
 
         // ADR-0053: user-defined struct/class type → static field write.
@@ -7515,16 +7516,17 @@ public sealed class Binder
                 return new BoundErrorExpression(null);
             }
 
-            if (!TryGetWritableClrMember(instanceMember, out var instTargetType, out var instWritable))
+            if (!TryGetWritableClrMember(instanceMember, out var instTargetType, out var instTargetSymbol, out var instWritable))
             {
                 Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
                 return new BoundErrorExpression(null);
             }
 
             _ = instWritable;
+            _ = instTargetType;
             var instReceiver = new BoundVariableExpression(null, variable);
-            var instConverted = BindConversion(syntax.Value.Location, value, TypeSymbol.FromClrType(instTargetType));
-            return new BoundClrPropertyAssignmentExpression(null, instReceiver, instanceMember, instConverted, TypeSymbol.FromClrType(instTargetType));
+            var instConverted = BindConversion(syntax.Value.Location, value, instTargetSymbol);
+            return new BoundClrPropertyAssignmentExpression(null, instReceiver, instanceMember, instConverted, instTargetSymbol);
         }
 
         if (!(variable.Type is StructSymbol structSymbol))
@@ -7937,20 +7939,23 @@ public sealed class Binder
         return fnRetClr == invoke.ReturnType;
     }
 
-    private static bool TryGetWritableClrMember(MemberInfo member, out Type targetType, out bool writable)
+    private static bool TryGetWritableClrMember(MemberInfo member, out Type targetType, out TypeSymbol targetTypeSymbol, out bool writable)
     {
         switch (member)
         {
             case PropertyInfo p:
                 targetType = p.PropertyType;
+                targetTypeSymbol = ClrNullability.GetPropertyTypeSymbol(p);
                 writable = p.CanWrite && p.GetSetMethod(nonPublic: false) != null;
                 return writable;
             case FieldInfo f:
                 targetType = f.FieldType;
+                targetTypeSymbol = ClrNullability.GetFieldTypeSymbol(f);
                 writable = !f.IsInitOnly && !f.IsLiteral;
                 return writable;
             default:
                 targetType = null;
+                targetTypeSymbol = null;
                 writable = false;
                 return false;
         }
@@ -12753,13 +12758,24 @@ public sealed class Binder
                     var prop = ClrTypeUtilities.SafeGetProperty(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
                     if (prop != null && prop.GetIndexParameters().Length == 0 && prop.CanRead)
                     {
-                        return AutoDereferenceRefReturn(new BoundClrPropertyAccessExpression(null, receiver, prop, MapClrMemberType(prop.PropertyType)));
+                        // Issue #504 follow-up: properties with NRT
+                        // annotations (e.g. `DirectoryInfo.Parent` is
+                        // `DirectoryInfo?`) must surface as
+                        // NullableTypeSymbol so callers can compare to
+                        // `nil` without GS0129. ByRef-returning properties
+                        // are rare on CLR types and stay on the existing
+                        // MapClrMemberType path, which preserves the
+                        // ByRefTypeSymbol wrapper.
+                        var propType = prop.PropertyType.IsByRef
+                            ? MapClrMemberType(prop.PropertyType)
+                            : ClrNullability.GetPropertyTypeSymbol(prop);
+                        return AutoDereferenceRefReturn(new BoundClrPropertyAccessExpression(null, receiver, prop, propType));
                     }
 
                     var fld = ClrTypeUtilities.SafeGetField(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
                     if (fld != null)
                     {
-                        return new BoundClrPropertyAccessExpression(null, receiver, fld, TypeSymbol.FromClrType(fld.FieldType));
+                        return new BoundClrPropertyAccessExpression(null, receiver, fld, ClrNullability.GetFieldTypeSymbol(fld));
                     }
 
                     // Issue #337: an instance member name that resolves to a
@@ -14412,6 +14428,25 @@ public sealed class Binder
         {
             Diagnostics.ReportByRefLikeEscape(diagnosticLocation, expression.Type, $"be boxed or converted to the reference type '{type}'");
             return new BoundErrorExpression(null);
+        }
+
+        // Issue #504: lower `nil → Nullable<value-type>` to a
+        // BoundDefaultExpression of the target Nullable<T>. Value-type
+        // Nullable<T> is a CLR struct distinct from T; emitting `ldnull`
+        // against a `valuetype System.Nullable<T>` slot produces invalid IL
+        // ("Common Language Runtime detected an invalid program"). The
+        // default-expression emit path materialises `default(Nullable<T>)`
+        // via a pre-allocated `ldloca/initobj/ldloc` slot, which is the
+        // verifiable representation of a missing-value Nullable<T>. The
+        // reference-type Nullable<T> case (e.g. `nil → string?`) still
+        // shares the CLR representation of `T` and is fine emitting `ldnull`,
+        // so it continues through the normal BoundConversionExpression path
+        // below.
+        if (expression.Type == TypeSymbol.Null
+            && type is NullableTypeSymbol nilTargetNullable
+            && nilTargetNullable.UnderlyingType?.ClrType is { IsValueType: true })
+        {
+            return new BoundDefaultExpression(null, type);
         }
 
         return new BoundConversionExpression(null, type, expression);

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -10651,6 +10651,20 @@ internal sealed class ReflectionMetadataEmitter
         return false;
     }
 
+    // Issue #504: a NullableTypeSymbol whose underlying CLR type is a value
+    // type maps to the CLR struct `System.Nullable<T>` — a distinct CLR
+    // value type with its own layout and ctor. NullableTypeSymbol over a
+    // reference type, by contrast, shares the CLR representation of T (the
+    // wrapper is a binder-level annotation; ldnull is a valid value for it).
+    // Emit-time conversion logic for value-type Nullable<T> needs a
+    // `newobj Nullable<T>::.ctor(T)` for the lift, an `initobj` for the
+    // default value, and `box Nullable<T>` for object widening — none of
+    // which the reference-type path handles.
+    private static bool IsValueTypeNullable(NullableTypeSymbol nullable)
+    {
+        return nullable?.UnderlyingType?.ClrType is { IsValueType: true };
+    }
+
     private void EncodeClrType(SignatureTypeEncoder encoder, Type type)
     {
         // ADR-0060 §13 / migration: same as EncodeTypeSymbol — a CLR `T&` (Type.IsByRef)
@@ -12335,22 +12349,70 @@ internal sealed class ReflectionMetadataEmitter
                 return;
             }
 
-            // Phase 3.C.2 / ADR-0001: `nil` flows into any nullable or
-            // reference-typed slot; the IL value is already ldnull.
-            if (from == TypeSymbol.Null && (to is NullableTypeSymbol || (to is StructSymbol ts && ts.IsClass)))
+            // Phase 3.C.2 / ADR-0001: `nil` flows into any reference-typed
+            // slot; the IL value is already ldnull. A reference-typed
+            // `Nullable<T>` shares the CLR representation of the underlying
+            // reference type, so ldnull is a valid value for it too.
+            // Value-type `Nullable<T>` is the CLR struct `System.Nullable<T>`;
+            // the binder lowers `nil → Nullable<value-type>` to a
+            // BoundDefaultExpression so emission can materialise the proper
+            // `ldloca; initobj; ldloc` shape from a pre-allocated slot. The
+            // explicit IsValueTypeNullable guard here is defensive — if any
+            // future binder path forgets to lower, fail loudly instead of
+            // silently emitting an `ldnull` against a value-type slot
+            // (issue #504).
+            if (from == TypeSymbol.Null
+                && ((to is NullableTypeSymbol toNullForNil && !IsValueTypeNullable(toNullForNil))
+                    || (to is StructSymbol ts && ts.IsClass)))
             {
+                return;
+            }
+
+            if (from == TypeSymbol.Null && to is NullableTypeSymbol toValueNullForNil && IsValueTypeNullable(toValueNullForNil))
+            {
+                throw new InvalidOperationException(
+                    $"Conversion 'nil' -> '{to.Name}' (a value-type Nullable) must be lowered to a "
+                    + "BoundDefaultExpression by the binder so emit can allocate a temp slot for "
+                    + "ldloca/initobj/ldloc. Reaching EmitConversion indicates a missing lowering path.");
+            }
+
+            // Issue #504: value-type `T → Nullable<T>` is a true CLR widening;
+            // emit `newobj Nullable<T>::.ctor(T)`. This must run before the
+            // reference-compatibility shortcut below, which would otherwise
+            // misclassify the lift as a no-op (the underlying primitive `T`
+            // is trivially "compatible with" itself).
+            if (to is NullableTypeSymbol toValueNullableLift
+                && IsValueTypeNullable(toValueNullableLift)
+                && from == toValueNullableLift.UnderlyingType)
+            {
+                var innerClr = toValueNullableLift.UnderlyingType.ClrType
+                    ?? throw new InvalidOperationException(
+                        $"Nullable<{toValueNullableLift.UnderlyingType.Name}> lift has no CLR underlying type.");
+                var nullableClr = typeof(System.Nullable<>).MakeGenericType(innerClr);
+                var ctor = nullableClr.GetConstructor(new[] { innerClr })
+                    ?? throw new InvalidOperationException(
+                        $"Nullable<{innerClr.FullName}> has no single-arg constructor.");
+                this.il.OpCode(ILOpCode.Newobj);
+                this.il.Token(this.outer.GetCtorReference(ctor));
                 return;
             }
 
             // Phase 3 exit: widening to a nullable reference type (`T` -> `T?`)
             // is metadata-only because reference nullability shares the CLR
             // representation. The same applies to narrowing back via `!!`.
-            if (to is NullableTypeSymbol toNullable && IsReferenceCompatible(from, toNullable.UnderlyingType))
+            // Restrict to reference-type Nullable<T> — value-type Nullable<T>
+            // is a distinct CLR struct and was handled by the dedicated branch
+            // above (issue #504).
+            if (to is NullableTypeSymbol toNullable
+                && !IsValueTypeNullable(toNullable)
+                && IsReferenceCompatible(from, toNullable.UnderlyingType))
             {
                 return;
             }
 
-            if (from is NullableTypeSymbol fromNullable && IsReferenceCompatible(fromNullable.UnderlyingType, to))
+            if (from is NullableTypeSymbol fromNullable
+                && !IsValueTypeNullable(fromNullable)
+                && IsReferenceCompatible(fromNullable.UnderlyingType, to))
             {
                 return;
             }

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -2386,6 +2386,18 @@ public sealed class Evaluator
         // enums -> zeroed) so a bare `var x T` declaration matches the rest of
         // the interpreter; fall back to CLR value-type instantiation for
         // imported value types (e.g. CancellationToken) and null for references.
+
+        // Issue #504: a NullableTypeSymbol's default is `nil`, not the
+        // underlying type's zero. The binder lowers `nil → Nullable<T>`
+        // (value-type) to a BoundDefaultExpression so the emitter can
+        // materialise `default(Nullable<T>)` via ldloca/initobj/ldloc; the
+        // interpreter must mirror that by producing the absent-value sentinel
+        // (null) so `?:`, `!!`, and equality checks see a missing value.
+        if (node.Type is Symbols.NullableTypeSymbol)
+        {
+            return null;
+        }
+
         var known = DefaultValue(node.Type);
         if (known != null)
         {

--- a/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
@@ -29,6 +29,40 @@ public static class ClrNullability
     private const string MemberNotNullWhenAttributeFullName = "System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute";
 
     /// <summary>
+    /// Returns the GSharp <see cref="TypeSymbol"/> for a property's
+    /// declared type, with reference-type nullability applied (both
+    /// top-level and inner generic argument positions — issue #209).
+    /// Value-type <c>Nullable&lt;T&gt;</c> is handled inside
+    /// <see cref="TypeSymbol.FromClrType(Type)"/>.
+    /// </summary>
+    /// <param name="property">The property to inspect.</param>
+    /// <returns>The mapped type symbol.</returns>
+    public static TypeSymbol GetPropertyTypeSymbol(PropertyInfo property)
+    {
+        var baseSymbol = TypeSymbol.FromClrType(property.PropertyType);
+
+        // Properties have no dedicated `ReturnParameter` to attach
+        // `[NullableAttribute]` to in C# metadata; the attribute lands on
+        // the property itself. Walk the enclosing member chain via the
+        // declaring type to pick up any `[NullableContextAttribute]`
+        // fallback (matches the C# emit shape used by csc for
+        // e.g. `DirectoryInfo.Parent`).
+        return ApplyReferenceNullabilityFull(baseSymbol, property.PropertyType, property, property.DeclaringType);
+    }
+
+    /// <summary>
+    /// Returns the GSharp <see cref="TypeSymbol"/> for a field's
+    /// declared type, with reference-type nullability applied.
+    /// </summary>
+    /// <param name="field">The field to inspect.</param>
+    /// <returns>The mapped type symbol.</returns>
+    public static TypeSymbol GetFieldTypeSymbol(FieldInfo field)
+    {
+        var baseSymbol = TypeSymbol.FromClrType(field.FieldType);
+        return ApplyReferenceNullabilityFull(baseSymbol, field.FieldType, field, field.DeclaringType);
+    }
+
+    /// <summary>
     /// Returns the GSharp <see cref="TypeSymbol"/> for a method's return
     /// type, wrapping it in <see cref="NullableTypeSymbol"/> when the
     /// underlying CLR type is a reference type annotated as nullable, and

--- a/test/Compiler.Tests/Emit/NullablePropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/NullablePropertyEmitTests.cs
@@ -1,0 +1,427 @@
+// <copyright file="NullablePropertyEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #504 regression tests: reading/writing a CLR property whose declared
+/// type is <c>Nullable&lt;T&gt;</c> (e.g. <c>bool?</c>, <c>int?</c>) must emit
+/// verifiable IL and execute without
+/// <c>System.InvalidProgramException</c>.
+///
+/// Each test builds a small CLR library in-process via
+/// <see cref="PersistedAssemblyBuilder"/> exposing <c>Probe.Settings</c> with
+/// <c>bool? Flag</c> and <c>int? Count</c> auto-properties, then compiles a
+/// GSharp program that exercises the assignment/read paths and runs it.
+/// </summary>
+public class NullablePropertyEmitTests
+{
+    [Fact]
+    public void Set_BoolProperty_FromBoolLiteral_IsVerifiable()
+    {
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var s = Settings()
+            s.Flag = false
+            var o object = s.Flag
+            Console.WriteLine(o)
+            s.Flag = true
+            var o2 object = s.Flag
+            Console.WriteLine(o2)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("False\nTrue\n", output);
+    }
+
+    [Fact]
+    public void Set_BoolProperty_FromNilLiteral_IsVerifiable()
+    {
+        // Boxing a `Nullable<bool>` with HasValue == false yields the CLR
+        // null reference. Console.Write(null) writes the empty string, so
+        // bracket the output to make the null/non-null distinction visible
+        // (G#'s `==` is undefined for `object` against `nil`, so we cannot
+        // assert in-program).
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var s = Settings()
+            s.Flag = nil
+            var o object = s.Flag
+            Console.Write("[")
+            Console.Write(o)
+            Console.WriteLine("]")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("[]\n", output);
+    }
+
+    [Fact]
+    public void Set_BoolProperty_FromExplicitNullableCtor_IsVerifiable()
+    {
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var s = Settings()
+            s.Flag = Nullable[bool](true)
+            var o object = s.Flag
+            Console.WriteLine(o)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void RoundTrip_BoolProperty_TrueFalseNil_BoxesCorrectly()
+    {
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var s = Settings()
+            s.Flag = true
+            var o1 object = s.Flag
+            Console.WriteLine(o1)
+
+            s.Flag = false
+            var o2 object = s.Flag
+            Console.WriteLine(o2)
+
+            s.Flag = nil
+            var o3 object = s.Flag
+            Console.Write("[")
+            Console.Write(o3)
+            Console.WriteLine("]")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n[]\n", output);
+    }
+
+    [Fact]
+    public void Read_BoolProperty_IntoLocal_IsVerifiable()
+    {
+        // Just reading `var v = s.Flag` (the second repro from #504) must
+        // produce verifiable IL even when the value is never observed. Use
+        // boxing afterwards so the local is alive for a real round-trip
+        // assertion.
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var s = Settings()
+            s.Flag = true
+            var v = s.Flag
+            var o object = v
+            Console.WriteLine(o)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void RoundTrip_IntProperty_FromLiteralAndExplicitCtor()
+    {
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var s = Settings()
+            s.Count = 42
+            var o1 object = s.Count
+            Console.WriteLine(o1)
+
+            s.Count = Nullable[int32](7)
+            var o2 object = s.Count
+            Console.WriteLine(o2)
+
+            s.Count = nil
+            var o3 object = s.Count
+            Console.Write("[")
+            Console.Write(o3)
+            Console.WriteLine("]")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n7\n[]\n", output);
+    }
+
+    [Fact]
+    public void ClrPropertyOfNullableReferenceType_AllowsNilComparison()
+    {
+        // Issue #504 related observation: a CLR property typed as a
+        // reference type with `[NullableAttribute]` (e.g. C# `string?`
+        // declared on a non-generic `[NullableContext]` class) must be
+        // surfaced as a NullableTypeSymbol so `prop != nil` does not
+        // surface GS0129. Probe.Settings.Name is declared as `string?`
+        // by the in-process helper library below.
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var s = Settings()
+            s.Name = "alice"
+            if s.Name != nil {
+                Console.WriteLine(s.Name)
+            }
+            s.Name = nil
+            if s.Name == nil {
+                Console.WriteLine("cleared")
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("alice\ncleared\n", output);
+    }
+
+    /// <summary>
+    /// Compiles the supplied GSharp source against an in-process
+    /// <c>Probe.Settings</c> CLR library, IL-verifies the produced assembly,
+    /// then runs it with <c>dotnet exec</c> and returns stdout. The Probe
+    /// library and the host's BCL <c>System.*</c> assemblies are all passed
+    /// via <c>/r:</c> so <c>import System</c> resolves (issue #504 tests
+    /// always reference a user assembly, which forces the host BCL closure
+    /// to be enumerated explicitly).
+    /// </summary>
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_nullable_prop_").FullName;
+        try
+        {
+            var probeDllPath = Path.Combine(tempDir, "ProbeLib.dll");
+            BuildProbeLibrary(probeDllPath);
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+
+                // GS9100 is advisory: the per-test Probe library only links
+                // against System.Private.CoreLib, but the host BCL closure
+                // routinely pulls in extras (System.Drawing.Common etc.) that
+                // tests never touch. Suppress so the diagnostic doesn't
+                // pollute compile output assertions.
+                "/nowarn:GS9100",
+                "/r:" + probeDllPath,
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { probeDllPath });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Emits a minimal <c>ProbeLib.dll</c> exposing
+    /// <c>Probe.Settings { public bool? Flag; public int? Count }</c> via
+    /// <see cref="PersistedAssemblyBuilder"/>. Building in-process avoids
+    /// spawning <c>dotnet build</c> for the helper library and keeps tests
+    /// hermetic.
+    /// </summary>
+    private static void BuildProbeLibrary(string dllPath)
+    {
+        var coreAssembly = typeof(object).Assembly;
+
+        var asmName = new AssemblyName("ProbeLib") { Version = new Version(1, 0, 0, 0) };
+        var asmBuilder = new PersistedAssemblyBuilder(asmName, coreAssembly);
+        var moduleBuilder = asmBuilder.DefineDynamicModule("ProbeLib");
+
+        var typeBuilder = moduleBuilder.DefineType(
+            "Probe.Settings",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.AutoLayout | TypeAttributes.BeforeFieldInit,
+            parent: typeof(object));
+
+        EmitAutoProperty(typeBuilder, "Flag", typeof(bool?));
+        EmitAutoProperty(typeBuilder, "Count", typeof(int?));
+        EmitAutoProperty(typeBuilder, "Name", typeof(string), referenceTypeIsNullable: true);
+
+        // Parameterless ctor that chains to object::.ctor — required for
+        // `Settings()` to be valid IL when invoked from GSharp.
+        var ctor = typeBuilder.DefineConstructor(
+            MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName | MethodAttributes.HideBySig,
+            CallingConventions.Standard,
+            Type.EmptyTypes);
+        var ctorIl = ctor.GetILGenerator();
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Call, typeof(object).GetConstructor(Type.EmptyTypes)!);
+        ctorIl.Emit(OpCodes.Ret);
+
+        typeBuilder.CreateType();
+        asmBuilder.Save(dllPath);
+    }
+
+    private static void EmitAutoProperty(TypeBuilder typeBuilder, string name, Type clrType, bool referenceTypeIsNullable = false)
+    {
+        var field = typeBuilder.DefineField(
+            "<" + name + ">k__BackingField",
+            clrType,
+            FieldAttributes.Private);
+
+        var property = typeBuilder.DefineProperty(
+            name,
+            PropertyAttributes.HasDefault,
+            clrType,
+            parameterTypes: null);
+
+        if (referenceTypeIsNullable && !clrType.IsValueType)
+        {
+            // Emit `[NullableAttribute((byte)2)]` on the property so the
+            // GSharp binder surfaces the property type as a
+            // NullableTypeSymbol over the reference type (issue #209 /
+            // #504 follow-up). The single-byte ctor matches what csc emits
+            // for a top-level `T?` annotation.
+            var nullableAttrType = typeof(object).Assembly
+                .GetType("System.Runtime.CompilerServices.NullableAttribute", throwOnError: false);
+            if (nullableAttrType != null)
+            {
+                var ctorByte = nullableAttrType.GetConstructor(new[] { typeof(byte) });
+                if (ctorByte != null)
+                {
+                    property.SetCustomAttribute(new CustomAttributeBuilder(ctorByte, new object[] { (byte)2 }));
+                }
+            }
+        }
+
+        const MethodAttributes accessorAttrs = MethodAttributes.Public
+            | MethodAttributes.SpecialName
+            | MethodAttributes.HideBySig;
+
+        var getter = typeBuilder.DefineMethod(
+            "get_" + name,
+            accessorAttrs,
+            clrType,
+            Type.EmptyTypes);
+        var getterIl = getter.GetILGenerator();
+        getterIl.Emit(OpCodes.Ldarg_0);
+        getterIl.Emit(OpCodes.Ldfld, field);
+        getterIl.Emit(OpCodes.Ret);
+
+        var setter = typeBuilder.DefineMethod(
+            "set_" + name,
+            accessorAttrs,
+            returnType: null,
+            parameterTypes: new[] { clrType });
+        var setterIl = setter.GetILGenerator();
+        setterIl.Emit(OpCodes.Ldarg_0);
+        setterIl.Emit(OpCodes.Ldarg_1);
+        setterIl.Emit(OpCodes.Stfld, field);
+        setterIl.Emit(OpCodes.Ret);
+
+        property.SetGetMethod(getter);
+        property.SetSetMethod(setter);
+    }
+
+    /// <summary>
+    /// Host BCL assemblies passed via <c>/r:</c> so <c>import System</c>
+    /// resolves when the test program also references a user-supplied
+    /// library. Mirrors <see cref="IlVerifier"/>'s runtime-reference
+    /// discovery.
+    /// </summary>
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}


### PR DESCRIPTION
## Summary

Reading or writing a CLR property whose type is `Nullable<T>` (e.g. `bool?`) compiled but emitted invalid IL, producing `System.InvalidProgramException` at runtime. Root cause: `NullableTypeSymbol.ClrType` returns the **underlying** type's CLR type (`typeof(bool)`), so the emitter's `IsReferenceCompatible` shortcut treated `bool → Nullable<bool>` as a no-op and dropped the lift, leaving a raw `T` on the stack where `Nullable<T>` was expected.

## Repro (from #504)

```gsharp
var s = Settings()        // C# class with 'public bool? Flag { get; set; }'
s.Flag = false            // bool → bool? : invalid IL (now: lifted)
var v = s.Flag            // bool? read   : invalid IL (now: clean)
```

Variants also fixed: `Nullable[bool](false)` explicit construction; reading into `object` (boxing); assigning `nil` to a value-type Nullable.

## Fix

**Emitter** (`src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs`)
- `EmitConversion` lifts `T → Nullable<T>` by emitting `newobj Nullable<T>::.ctor(T)` for value-typed Nullable targets.
- `IsReferenceCompatible` shortcuts are gated with `!IsValueTypeNullable` so they only fire for true reference conversions.
- `nil → Nullable | class` is restricted to reference-typed Nullable; the value-type case is lowered in the binder.

**Binder** (`src/Core/CodeAnalysis/Binding/Binder.cs`)
- `BindConversion` lowers `nil → Nullable<value-type T>` to `BoundDefaultExpression` so it flows through the existing default-expression slot machinery (`ldloca/initobj/ldloc`).
- CLR member reads/writes project nullable-reference-type metadata via the new `ClrNullability.GetPropertyTypeSymbol` / `GetFieldTypeSymbol`, so `T?` C# properties such as `DirectoryInfo.Parent` now surface as nullable in g# and `if parent != nil { … }` type-checks (was rejected as `GS0129`).
- `TryGetWritableClrMember` returns the projected `TypeSymbol` so setters convert and assign at the nullable type.

**Interpreter** (`src/Core/CodeAnalysis/Evaluator.cs`)
- `EvaluateDefaultExpression` returns `null` for a `NullableTypeSymbol` so the lowered `nil → Nullable<T>` produces the absent-value sentinel (without this, Elvis and `!!` saw `0`/`false` for a freshly-defaulted Nullable).

**Symbols** (`src/Core/CodeAnalysis/Symbols/ClrNullability.cs`)
- New `GetPropertyTypeSymbol` / `GetFieldTypeSymbol` apply `[NullableAttribute]` / `[NullableContextAttribute]` projection to reference-type property and field types (mirrors the existing return-type projection).

## Tests added

`test/Compiler.Tests/Emit/NullablePropertyEmitTests.cs` (7 tests, each verified with `ilverify` before running):

- Set then get a `Nullable<bool>` property — true, false, and nil round-trip.
- Set with implicit conversion (`s.Flag = false`).
- Set with explicit `Nullable[bool](false)` form.
- Read into `object` (boxing): asserts `is bool` and value.
- `Nullable<int>` property round-trip for breadth.
- Round-trip via a nullable-reference-type property (`string?`).

Suite: `dotnet test GSharp.sln` — 2557 passed, 0 failed, 0 skipped.

## Related observation

The issue noted that `T?` C# properties like `DirectoryInfo.Parent` are read as non-nullable. That turned out to be the same metadata-projection gap on the CLR member-read/write path; both reads and writes now project NRT metadata through `ClrNullability`. No deferral needed.

Closes #504