### PR TITLE
Fix #319: interpreter models CLR-base instance state for user classes

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -5272,6 +5272,23 @@ public sealed class Binder
         if (exceptionType != null && expression.Type != TypeSymbol.Error)
         {
             var argClr = expression.Type?.ClrType;
+
+            // Issue #319: a GSharp class that inherits an imported CLR Exception
+            // type has no concrete ClrType until emit time, but its
+            // ImportedBaseType (walked transitively) is what determines
+            // assignability to System.Exception.
+            if (argClr == null && expression.Type is StructSymbol throwStruct)
+            {
+                for (var t = throwStruct; t != null; t = t.BaseClass)
+                {
+                    if (t.ImportedBaseType?.ClrType is System.Type clrBase)
+                    {
+                        argClr = clrBase;
+                        break;
+                    }
+                }
+            }
+
             if (argClr == null || !ClrTypeUtilities.IsAssignableByName(exceptionType.ClrType, argClr))
             {
                 Diagnostics.ReportCannotConvert(syntax.Expression.Location, expression.Type ?? TypeSymbol.Error, exceptionType);
@@ -7555,6 +7572,36 @@ public sealed class Binder
 
                 var propConverted = BindConversion(syntax.Value.Location, value, prop.Type);
                 return new BoundPropertyAssignmentExpression(null, new BoundVariableExpression(null, variable), structSymbol, prop, propConverted);
+            }
+
+            // Issue #319: a GSharp class inheriting an imported CLR base exposes
+            // the base's settable instance properties/fields. Fall back to CLR
+            // member lookup on the imported base type so `e.HResult = 42` style
+            // writes work the same as the read fallback further down.
+            if (structSymbol.ImportedBaseType?.ClrType is System.Type inheritedBaseClr)
+            {
+                var memberName = syntax.FieldIdentifier.Text;
+                MemberInfo clrMember = ClrTypeUtilities.SafeGetProperty(inheritedBaseClr, memberName, BindingFlags.Public | BindingFlags.Instance);
+                if (clrMember is PropertyInfo idxProp && idxProp.GetIndexParameters().Length != 0)
+                {
+                    clrMember = null;
+                }
+
+                clrMember ??= ClrTypeUtilities.SafeGetField(inheritedBaseClr, memberName, BindingFlags.Public | BindingFlags.Instance);
+                if (clrMember != null)
+                {
+                    if (!TryGetWritableClrMember(clrMember, out var inhTargetType, out var inhTargetSymbol, out var inhWritable))
+                    {
+                        Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, memberName);
+                        return new BoundErrorExpression(null);
+                    }
+
+                    _ = inhWritable;
+                    _ = inhTargetType;
+                    var inhReceiver = new BoundVariableExpression(null, variable);
+                    var inhConverted = BindConversion(syntax.Value.Location, value, inhTargetSymbol);
+                    return new BoundClrPropertyAssignmentExpression(null, inhReceiver, clrMember, inhConverted, inhTargetSymbol);
+                }
             }
 
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -438,6 +438,16 @@ public sealed class Evaluator
     private void EvaluateThrowStatement(BoundThrowStatement node)
     {
         var value = EvaluateExpression(node.Expression);
+
+        // Issue #319: a GSharp class that inherits a CLR Exception type carries a
+        // real CLR backing instance (allocated via AllocateClrBacking). Throw that
+        // backing so the runtime catch path observes the correct type and inherited
+        // members (e.g. Exception.Message). Otherwise fall back to legacy behavior.
+        if (value is StructValue sv && sv.ClrBacking is Exception backingEx)
+        {
+            throw backingEx;
+        }
+
         if (value is Exception ex)
         {
             throw ex;
@@ -1102,9 +1112,9 @@ public sealed class Evaluator
             locals.Push(frame);
             try
             {
-                // Forward the GSharp base initializer. CLR base initializers are a
-                // no-op when interpreted because the interpreter models classes as
-                // field dictionaries rather than real CLR objects (see issue #319).
+                // Forward the GSharp base initializer. CLR base initializers are
+                // routed through reflection by AllocateClrBacking (issue #319) so
+                // inherited CLR instance state is observable under interpretation.
                 if (explicitCtor.BaseInitializer is BaseConstructorInitializer ctorBaseInit
                     && ctorBaseInit.GSharpBaseType is StructSymbol ctorGsharpBase)
                 {
@@ -1114,6 +1124,8 @@ public sealed class Evaluator
                         sv.Fields[baseParams[i].Name] = EvaluateExpression(ctorBaseInit.Arguments[i]);
                     }
                 }
+
+                AllocateClrBacking(sv, node.StructType, explicitCtor.BaseInitializer);
 
                 var body = program.Functions[ctorFunction];
                 EvaluateStatement(body);
@@ -1137,7 +1149,8 @@ public sealed class Evaluator
         // this class's primary-constructor parameters, so evaluate them in a frame
         // where those parameters are bound to the just-assigned values.
         var baseInit = node.StructType.BaseConstructorInitializer;
-        if (baseInit != null && baseInit.GSharpBaseType is StructSymbol gsharpBase)
+        if (baseInit != null || node.StructType.ImportedBaseType != null
+            || HasClrAncestor(node.StructType))
         {
             var frame = new Dictionary<VariableSymbol, object>();
             for (var i = 0; i < parameters.Length; i++)
@@ -1148,11 +1161,19 @@ public sealed class Evaluator
             locals.Push(frame);
             try
             {
-                var baseParams = gsharpBase.PrimaryConstructorParameters;
-                for (var i = 0; i < baseParams.Length && i < baseInit.Arguments.Length; i++)
+                if (baseInit != null && baseInit.GSharpBaseType is StructSymbol gsharpBase)
                 {
-                    sv.Fields[baseParams[i].Name] = EvaluateExpression(baseInit.Arguments[i]);
+                    var baseParams = gsharpBase.PrimaryConstructorParameters;
+                    for (var i = 0; i < baseParams.Length && i < baseInit.Arguments.Length; i++)
+                    {
+                        sv.Fields[baseParams[i].Name] = EvaluateExpression(baseInit.Arguments[i]);
+                    }
                 }
+
+                // Issue #319: instantiate the CLR base instance (when the class
+                // ultimately derives from a CLR type) so inherited CLR instance
+                // state — such as Exception.Message — is set per the emit path.
+                AllocateClrBacking(sv, node.StructType, baseInit);
             }
             finally
             {
@@ -1161,6 +1182,107 @@ public sealed class Evaluator
         }
 
         return sv;
+    }
+
+    /// <summary>
+    /// Issue #319: instantiate the imported CLR base for a GSharp class instance
+    /// when the class ultimately derives from a CLR type, so inherited CLR
+    /// instance state (e.g. <see cref="System.Exception.Message"/>) is observable
+    /// under the interpreter. The chosen base constructor mirrors the emit path:
+    /// the resolved <see cref="BaseConstructorInitializer.ClrConstructor"/> when
+    /// the class declared <c>: Base(args)</c>, otherwise the imported base's
+    /// accessible parameterless constructor. The base-ctor argument expressions
+    /// must be evaluated within whatever frame the caller has just pushed.
+    /// </summary>
+    private void AllocateClrBacking(StructValue sv, StructSymbol structType, BaseConstructorInitializer activeInit)
+    {
+        // If an explicit `: base(args)` targets a CLR constructor, prefer that.
+        if (activeInit is { IsClrBase: true } clrInit && clrInit.ClrConstructor != null)
+        {
+            sv.ClrBacking = InvokeClrCtor(clrInit.ClrConstructor, clrInit.Arguments, clrInit.ArgumentRefKinds);
+            return;
+        }
+
+        // Otherwise walk the (G#) inheritance chain looking for an ancestor whose
+        // immediate base is an imported CLR type, and chain to that type's
+        // accessible parameterless constructor. Ancestor base-init args cannot be
+        // re-evaluated here (we are not running the ancestor's ctor body), so we
+        // intentionally restrict the parameterless path. If a deeper ancestor's
+        // : base(args) is required, the explicit/primary-ctor branches above
+        // handle it via activeInit.
+        for (var t = structType; t != null; t = t.BaseClass)
+        {
+            if (t.BaseConstructorInitializer is { IsClrBase: true } ancestorInit
+                && ancestorInit.ClrConstructor != null
+                && t != structType)
+            {
+                // Deeper ancestor : Base(args) where args reference *its* primary
+                // parameters. We cannot evaluate them here without spinning up the
+                // ancestor's primary-ctor frame, so leave the CLR backing null.
+                return;
+            }
+
+            if (t.ImportedBaseType?.ClrType is Type clrBase)
+            {
+                var parameterless = ResolveParameterlessCtor(clrBase);
+                if (parameterless != null)
+                {
+                    sv.ClrBacking = parameterless.Invoke(Array.Empty<object>());
+                }
+
+                return;
+            }
+        }
+    }
+
+    /// <summary>Issue #319: invoke a CLR base constructor with the bound G# argument expressions.</summary>
+    private object InvokeClrCtor(ConstructorInfo ctor, ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> argumentRefKinds)
+    {
+        var args = new object[arguments.Length];
+        var refSlots = BuildRefSlots(arguments, argumentRefKinds, args);
+        var instance = ctor.Invoke(args);
+        WriteBackRefSlots(refSlots, args);
+        return instance;
+    }
+
+    /// <summary>Issue #319: resolves the imported CLR base's accessible parameterless constructor (matches the emit path's <c>GetImportedBaseDefaultCtorReference</c>).</summary>
+    private static ConstructorInfo ResolveParameterlessCtor(Type clrBase)
+    {
+        foreach (var ctor in clrBase.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (ctor.GetParameters().Length == 0
+                && (ctor.IsPublic || ctor.IsFamily || ctor.IsFamilyOrAssembly))
+            {
+                return ctor;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Issue #319: returns true when any ancestor of <paramref name="structType"/> directly inherits an imported CLR type.</summary>
+    private static bool HasClrAncestor(StructSymbol structType)
+    {
+        for (var t = structType; t != null; t = t.BaseClass)
+        {
+            if (t.ImportedBaseType?.ClrType != null)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #319: unwraps a GSharp class value to its CLR backing instance when
+    /// the value carries one. Reflection-based reads/writes/calls against members
+    /// declared on an imported CLR base must target the real CLR object, not the
+    /// interpreter's <see cref="StructValue"/> field dictionary.
+    /// </summary>
+    private static object UnwrapClrReceiver(object value)
+    {
+        return value is StructValue sv && sv.ClrBacking != null ? sv.ClrBacking : value;
     }
 
     private object EvaluateClrConstructorCallExpression(BoundClrConstructorCallExpression node)
@@ -1176,6 +1298,7 @@ public sealed class Evaluator
     private object EvaluateClrPropertyAccessExpression(BoundClrPropertyAccessExpression node)
     {
         var receiver = node.Receiver == null ? null : EvaluateExpression(node.Receiver);
+        receiver = UnwrapClrReceiver(receiver);
         return node.Member switch
         {
             System.Reflection.PropertyInfo p => p.GetValue(receiver),
@@ -1187,6 +1310,7 @@ public sealed class Evaluator
     private object EvaluateClrPropertyAssignmentExpression(BoundClrPropertyAssignmentExpression node)
     {
         var receiver = node.Receiver == null ? null : EvaluateExpression(node.Receiver);
+        receiver = UnwrapClrReceiver(receiver);
         var value = EvaluateExpression(node.Value);
         switch (node.Member)
         {
@@ -1206,6 +1330,7 @@ public sealed class Evaluator
     private object EvaluateClrEventSubscriptionExpression(BoundClrEventSubscriptionExpression node)
     {
         var receiver = node.Receiver == null ? null : EvaluateExpression(node.Receiver);
+        receiver = UnwrapClrReceiver(receiver);
         var handlerValue = EvaluateExpression(node.Handler);
         var handler = handlerValue as Delegate;
         if (handler != null
@@ -2310,6 +2435,16 @@ public sealed class Evaluator
                 }
             }
 
+            // Issue #319: when a GSharp class carries a CLR backing (because it
+            // inherits an imported CLR base), the value's effective runtime type
+            // also includes the CLR base hierarchy — `is`/type patterns against
+            // those CLR types must succeed.
+            if (sv.ClrBacking != null && targetType.ClrType != null
+                && targetType.ClrType.IsInstanceOfType(sv.ClrBacking))
+            {
+                return true;
+            }
+
             return false;
         }
 
@@ -2852,6 +2987,7 @@ public sealed class Evaluator
     private object EvaluateImportedInstanceCallExpression(BoundImportedInstanceCallExpression node)
     {
         var receiver = EvaluateExpression(node.Receiver);
+        receiver = UnwrapClrReceiver(receiver);
         var args = new object[node.Arguments.Length];
         var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args);
 

--- a/src/Core/CodeAnalysis/StructValue.cs
+++ b/src/Core/CodeAnalysis/StructValue.cs
@@ -37,6 +37,17 @@ public sealed class StructValue
     /// <summary>Gets the mutable field dictionary backing this instance.</summary>
     public Dictionary<string, object> Fields { get; }
 
+    /// <summary>
+    /// Gets or sets the CLR backing instance for a GSharp class that inherits an
+    /// imported CLR base type (issue #319). When non-null, the interpreter routes
+    /// reflection-based access to inherited CLR instance state (properties, fields,
+    /// methods) through this real CLR object so the base constructor's side-effects
+    /// (e.g. <see cref="System.Exception.Message"/>) are observable. Always null
+    /// for value-type structs and for class instances whose ultimate base is
+    /// <c>object</c> or another GSharp class.
+    /// </summary>
+    public object ClrBacking { get; set; }
+
     /// <summary>Creates a shallow copy of this struct value (value-semantics).</summary>
     /// <returns>A new instance with the same fields.</returns>
     public StructValue Copy()
@@ -47,7 +58,14 @@ public sealed class StructValue
             copy[kvp.Key] = kvp.Value is StructValue inner ? inner.Copy() : kvp.Value;
         }
 
-        return new StructValue(StructType, copy);
+        return new StructValue(StructType, copy)
+        {
+            // Issue #319: copy carries the same CLR backing reference. A copy is
+            // only ever created for value-type structs (Evaluator.Assign skips it
+            // for classes), so the backing is expected to be null here; we copy
+            // it defensively for symmetry.
+            ClrBacking = this.ClrBacking,
+        };
     }
 
     /// <inheritdoc/>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue319ClrBaseInterpreterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue319ClrBaseInterpreterTests.cs
@@ -1,0 +1,214 @@
+// <copyright file="Issue319ClrBaseInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #319: regression tests proving the interpreter (Evaluator) actually
+/// invokes the CLR base constructor of a GSharp class that inherits an imported
+/// CLR base type, so inherited CLR instance state (properties, fields, methods)
+/// is observable through normal member access — matching the emit path.
+///
+/// Before the fix, `: base(args)` was a no-op under interpretation because the
+/// interpreter modelled class instances as plain field dictionaries; properties
+/// such as <c>Exception.Message</c> read as their defaults even though the same
+/// program produced the correct value when compiled and run.
+/// </summary>
+public class Issue319ClrBaseInterpreterTests
+{
+    [Fact]
+    public void InitConstructor_ChainingToClrException_InterpreterObservesBaseMessage()
+    {
+        // Explicit `init(...) : base(msg)` against System.Exception.
+        var source = @"
+import System
+type MyErr class : Exception {
+    Code int32
+    init(message string, code int32) : base(message) {
+        Code = code
+    }
+}
+var e = MyErr(""boom"", 42)
+e.Message
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("boom", result.Value);
+    }
+
+    [Fact]
+    public void InitConstructor_ChainingToClrException_BodyAlsoRuns()
+    {
+        // Confirms the body still runs (`Code` field gets set) after the CLR
+        // base ctor has run — the two were previously fighting for the same
+        // 'this' representation.
+        var source = @"
+import System
+type MyErr class : Exception {
+    Code int32
+    init(message string, code int32) : base(message) {
+        Code = code
+    }
+}
+var e = MyErr(""boom"", 42)
+e.Code
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void PrimaryConstructor_ChainingToClrException_InterpreterObservesBaseMessage()
+    {
+        // Kotlin-style primary ctor `: Exception(arg)` — the second of the two
+        // shapes covered by issue #306 / #319.
+        var source = @"
+import System
+type MyErr class(Detail string) : Exception(Detail) {
+}
+var e = MyErr(""nope"")
+e.Message
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("nope", result.Value);
+    }
+
+    [Fact]
+    public void PrimaryConstructor_ChainingToClrException_BaseArgIsAComputedExpression()
+    {
+        // Base-init argument is a non-trivial expression that references this
+        // class's primary-ctor parameter. The interpreter must evaluate it in a
+        // scope where the parameter is bound before invoking the CLR ctor.
+        var source = @"
+import System
+type LabeledErr class(Label string) : Exception(Label + ""!"") {
+}
+var e = LabeledErr(""oops"")
+e.Message
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("oops!", result.Value);
+    }
+
+    [Fact]
+    public void InheritedClrProperty_RoundTripsThroughWriteAndRead()
+    {
+        // Mutate an inherited CLR instance property (Exception.HResult) and
+        // read it back. Confirms both the read path (BoundClrPropertyAccess)
+        // and the write path (BoundClrPropertyAssignment) unwrap to the real
+        // CLR backing.
+        var source = @"
+import System
+type MyErr class(Detail string) : Exception(Detail) {
+}
+var e = MyErr(""x"")
+e.HResult = 123
+e.HResult
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(123, result.Value);
+    }
+
+    [Fact]
+    public void InheritedClrMethod_DispatchesAgainstBackingInstance()
+    {
+        // Calling an inherited CLR instance method (Exception.ToString()) must
+        // dispatch to the real backing instance so it sees the base ctor's
+        // state. Before the fix this threw a TargetException because the
+        // receiver was a StructValue, not a System.Exception.
+        var source = @"
+import System
+type MyErr class(Detail string) : Exception(Detail) {
+}
+var e = MyErr(""hello"")
+var s = e.ToString()
+s.Contains(""hello"")
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void NonExceptionClrBase_PrimaryCtor_InterpreterObservesBaseState()
+    {
+        // Non-Exception CLR base — proves the path is general, not Exception-
+        // specific. MemoryStream(int capacity) preallocates a backing buffer
+        // whose size is observable via the inherited `Capacity` property.
+        var source = @"
+import System.IO
+type SizedStream class(Cap int32) : MemoryStream(Cap) {
+}
+var s = SizedStream(128)
+s.Capacity
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(128, result.Value);
+    }
+
+    [Fact]
+    public void NonExceptionClrBase_InheritedMethodMutatesObservableState()
+    {
+        // Calling an inherited CLR instance method that mutates internal state
+        // (MemoryStream.SetLength) must be observable through a subsequent
+        // inherited property read (`Length`). Validates that read AND write
+        // routes share the same CLR backing.
+        var source = @"
+import System.IO
+type SizedStream class(Cap int32) : MemoryStream(Cap) {
+}
+var s = SizedStream(16)
+s.SetLength(7)
+s.Length
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7L, result.Value);
+    }
+
+    [Fact]
+    public void ThrowingUserClass_CarriesBaseMessageThroughCatch()
+    {
+        // Throwing a GSharp class that inherits System.Exception must surface
+        // the real CLR exception instance (carrying the base-set Message) so a
+        // `catch (e Exception)` clause sees the correct value. Before the fix
+        // the interpreter wrapped the StructValue in a new
+        // Exception(value.ToString()).
+        var source = @"
+import System
+type MyErr class(Detail string) : Exception(Detail) {
+}
+var msg = """"
+try {
+    throw MyErr(""kaboom"")
+} catch (e Exception) {
+    msg = e.Message
+}
+msg
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("kaboom", result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #319.

## Problem

The interpreter (`Evaluator`) modelled GSharp class instances as `StructValue` field dictionaries rather than real CLR objects. When a GSharp class inherited an imported CLR base type, the CLR base constructor never ran under interpretation, so inherited CLR instance state (e.g. `Exception.Message`, `HResult`, `MemoryStream.Capacity`) read as defaults — even though the same program produced the correct values when compiled and run via the emit path.

## Fix

Allocate a real CLR backing instance for each GSharp class whose ultimate base is a CLR type, stored alongside the field dictionary on `StructValue`. The chosen base constructor mirrors the emit path:
- `BaseConstructorInitializer.ClrConstructor` when the class declares `: Base(args)` (both `init(...) : base(args)` and primary-ctor `: Base(args)` forms).
- Otherwise, the imported base's accessible parameterless constructor (matching `GetImportedBaseDefaultCtorReference` in the emitter).

Bound base-init argument expressions are evaluated within the appropriate frame so they can reference the current class's constructor parameters.

Route reflection-based access to inherited CLR instance members through the backing instance:
- `BoundClrPropertyAccessExpression` — reads unwrap `StructValue.ClrBacking`.
- `BoundClrPropertyAssignmentExpression` — writes unwrap likewise.
- `BoundImportedInstanceCallExpression` — method dispatch unwraps likewise.
- `BoundClrEventSubscriptionExpression` — event subscription unwraps likewise.

Companion paths so user-visible behaviour is consistent:
- `throw` on a GSharp class with an `Exception` backing throws the real CLR `Exception` (carrying the base-set `Message`) rather than wrapping the `StructValue` in a fresh `Exception(value.ToString())`.
- Type-pattern matching (`value is Exception`) succeeds when the `StructValue`'s CLR backing is an instance of the target type.
- The binder now accepts `throw userClass` when the user class transitively inherits `Exception`, and accepts field-style writes to inherited CLR properties on a GSharp class receiver (mirroring the existing read fallback for inherited CLR members).

## Tests

New regression tests in `test/Core.Tests/CodeAnalysis/Binding/Issue319ClrBaseInterpreterTests.cs` (9 tests) cover:
- `init(...) : base(args)` against `System.Exception` — interpreter observes `Message`.
- Primary ctor `: Exception(arg)` — interpreter observes `Message`.
- Computed base-init argument expressions referencing the derived class's parameters.
- Read AND write of an inherited CLR instance property (`Exception.HResult`).
- Dispatch of an inherited CLR instance method (`Exception.ToString()`).
- Non-Exception CLR base (`System.IO.MemoryStream`) — interpreter observes inherited `Capacity`.
- Inherited method mutating internal state (`MemoryStream.SetLength`) observable via inherited `Length`.
- Throw/catch round-trip preserving `Exception.Message`.

Full suite is green: `dotnet test GSharp.sln --no-restore --nologo` → 1913 + 430 + 72 + 226 + 24 tests passed, 0 failed.