### PR TITLE
Fix #502: preserve async call return-type override during lowering

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1570,7 +1570,15 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundUserInstanceCallExpression(null, receiver, node.Method, builder?.ToImmutable() ?? node.Arguments);
+        // Issue #502 (sub-bug 502-a/b): preserve the call's return-type override
+        // (e.g. the Task / Task[T] lift applied by BindUserInstanceCall for async
+        // members). Dropping it here caused the rewritten call's static type to
+        // collapse to the bare method-declared type (e.g. int32 instead of
+        // Task[int32]), which then mis-typed the receiver of `GetAwaiter()` and
+        // produced an invalid box at the call boundary — leading to a hang
+        // because the inner async member's task never visibly completed from
+        // the caller's perspective.
+        return new BoundUserInstanceCallExpression(null, receiver, node.Method, builder?.ToImmutable() ?? node.Arguments, node.Type);
     }
 
     /// <summary>Rewrites a field read.</summary>

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -629,7 +629,7 @@ public static class SpillSequenceSpiller
                 return Trivial(call);
             }
 
-            var value = new BoundUserInstanceCallExpression(null, receiver, call.Method, args.ToImmutable());
+            var value = new BoundUserInstanceCallExpression(null, receiver, call.Method, args.ToImmutable(), call.Type);
             return new BoundSpillSequenceExpression(
                 null,
                 locals.ToImmutable(),

--- a/test/Compiler.Tests/Emit/AsyncInstanceMethodEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AsyncInstanceMethodEmitTests.cs
@@ -268,6 +268,235 @@ public class AsyncInstanceMethodEmitTests
         Assert.Contains(nested, t => t.Name.Contains("Inc") && t.Name.Contains("d__"));
     }
 
+    // Issue #502 follow-up (sub-bug 502-a): an `async func ... T { ... }`
+    // declared as an instance member must lift the call-site type to Task[T]
+    // not just at the top-level call site, but also when the call is awaited
+    // from inside another async member of the same class. The previous fix
+    // wrapped the call's static type in `BindUserInstanceCall`; this test
+    // exercises the lowering path that re-builds the call node when the
+    // implicit `this` receiver is replaced (e.g. by the state-machine
+    // rewriter's hoisted-`<>4__this`). If the call-type override is dropped
+    // there, the receiver of the subsequent `GetAwaiter()` is mis-typed and
+    // the program either crashes or hangs.
+    [Fact]
+    public void Async_Instance_Method_Returning_Int_Is_Awaitable_From_Sibling_Member()
+    {
+        var source = """
+            package P
+
+            import System.Threading.Tasks
+
+            type Probe class {
+                init() {}
+
+                async func ReturnInt() int32 {
+                    await Task.Delay(1)
+                    return 42
+                }
+
+                async func CallIt() int32 {
+                    var r = await ReturnInt()
+                    return r
+                }
+            }
+
+            public var result = 0
+            let p = Probe()
+            result = p.CallIt().Result
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var probe = assembly.GetTypes().Single(t => t.Name == "Probe");
+        var returnInt = probe.GetMethod("ReturnInt", BindingFlags.Public | BindingFlags.Instance);
+        var callIt = probe.GetMethod("CallIt", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(returnInt);
+        Assert.NotNull(callIt);
+
+        // Both members must be lifted to Task[int].
+        Assert.Equal(typeof(Task<int>), returnInt!.ReturnType);
+        Assert.Equal(typeof(Task<int>), callIt!.ReturnType);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField("result", BindingFlags.Public | BindingFlags.Static);
+
+        // Bound a hard timeout around the entry-point so a regression of
+        // bug 502-b (the awaited inner async member never resolving) fails
+        // the test loudly rather than hanging the test host.
+        InvokeWithHangGuard(entry!);
+        Assert.Equal(42, (int)resultField!.GetValue(null)!);
+    }
+
+    // Issue #502 follow-up (sub-bug 502-b): a void-returning `async func`
+    // class member must lift to `Task` and the returned Task must actually
+    // complete when the body awaits another async member. Without the fix,
+    // the call from one async member to another mis-typed the awaited
+    // receiver, the inner Task never visibly completed from the caller's
+    // perspective, and `Task.Wait()` deadlocked. We assert end-to-end
+    // execution under a short timeout to detect any future hang regression.
+    [Fact]
+    public void Void_Async_Instance_Method_Awaiting_Sibling_Returns_Completed_Task()
+    {
+        var source = """
+            package P
+
+            import System.Threading.Tasks
+
+            type Probe class {
+                init() {}
+
+                async func Inner() int32 {
+                    await Task.Delay(1)
+                    return 7
+                }
+
+                async func Outer() {
+                    var v = await Inner()
+                    captured = v
+                }
+            }
+
+            public var captured = 0
+            let p = Probe()
+            let t = p.Outer()
+            t.Wait()
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var probe = assembly.GetTypes().Single(t => t.Name == "Probe");
+        var outerMethod = probe.GetMethod("Outer", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(outerMethod);
+
+        // Void-returning async member should lift to non-generic Task.
+        Assert.Equal(typeof(Task), outerMethod!.ReturnType);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var capturedField = program.GetField("captured", BindingFlags.Public | BindingFlags.Static);
+
+        InvokeWithHangGuard(entry!);
+        Assert.Equal(7, (int)capturedField!.GetValue(null)!);
+    }
+
+    // The originally-reported parse repro from issue #502: an annotated
+    // `async func` class member should parse and bind clean, with the
+    // emitted kickoff method returning a `Task` (no value channel).
+    [Fact]
+    public void Annotated_Async_Instance_Member_With_No_Return_Lifts_To_Task()
+    {
+        var source = """
+            package P
+
+            import System.Threading.Tasks
+
+            type SmokeTests class {
+                init() {}
+
+                @Obsolete
+                async func DoIt() {
+                    await Task.Delay(1)
+                }
+            }
+
+            public var ok = false
+            let t = SmokeTests()
+            t.DoIt().Wait()
+            ok = true
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var smoke = assembly.GetTypes().Single(t => t.Name == "SmokeTests");
+        var doIt = smoke.GetMethod("DoIt", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(doIt);
+        Assert.Equal(typeof(Task), doIt!.ReturnType);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var okField = program.GetField("ok", BindingFlags.Public | BindingFlags.Static);
+
+        InvokeWithHangGuard(entry!);
+        Assert.True((bool)okField!.GetValue(null)!);
+    }
+
+    // Combined coverage: an async member chains through an explicit
+    // `this.Other()` receiver, exercising the same lowering path as the
+    // implicit-`this` form but with the call's receiver materialized
+    // up-front in binding.
+    [Fact]
+    public void Async_Instance_Method_Awaits_Sibling_Through_Explicit_This_Receiver()
+    {
+        var source = """
+            package P
+
+            import System.Threading.Tasks
+
+            type Chain class {
+                init() {}
+
+                async func Add1(n int32) int32 {
+                    await Task.Delay(1)
+                    return n + 1
+                }
+
+                async func Add3(n int32) int32 {
+                    var a = await this.Add1(n)
+                    var b = await this.Add1(a)
+                    var c = await this.Add1(b)
+                    return c
+                }
+            }
+
+            public var result = 0
+            let c = Chain()
+            result = c.Add3(10).Result
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var chain = assembly.GetTypes().Single(t => t.Name == "Chain");
+        var add3 = chain.GetMethod("Add3", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(add3);
+        Assert.Equal(typeof(Task<int>), add3!.ReturnType);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField("result", BindingFlags.Public | BindingFlags.Static);
+
+        InvokeWithHangGuard(entry!);
+        Assert.Equal(13, (int)resultField!.GetValue(null)!);
+    }
+
+    // Issue #502 hang-guard: invoke the compiled entry on a worker thread
+    // with a hard timeout. A hang in async lowering would otherwise deadlock
+    // the test host until xunit's per-collection timeout (or worse, never).
+    private static void InvokeWithHangGuard(MethodInfo entry, int timeoutMs = 5_000)
+    {
+        Exception captured = null;
+        var thread = new System.Threading.Thread(() =>
+        {
+            try
+            {
+                entry.Invoke(null, null);
+            }
+            catch (Exception ex)
+            {
+                captured = ex;
+            }
+        });
+        thread.IsBackground = true;
+        thread.Start();
+        var finished = thread.Join(timeoutMs);
+        Assert.True(
+            finished,
+            "Compiled entry-point did not complete within "
+                + timeoutMs
+                + " ms — async lowering hang (bug #502 sub-bug 502-b regression).");
+
+        if (captured != null)
+        {
+            throw new InvalidOperationException("Compiled entry-point threw.", captured);
+        }
+    }
+
     private static Assembly CompileToAssembly(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_async_instance_emit_").FullName;

--- a/test/Core.Tests/CodeAnalysis/Binding/AsyncAwaitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AsyncAwaitTests.cs
@@ -93,6 +93,52 @@ tick()
         Assert.Empty(result.Diagnostics);
     }
 
+    // Issue #502 (original parse repro from the issue body): an `async func`
+    // class instance member must parse and bind without `GS0005`. The
+    // member-level parse fix shipped previously; this guard prevents a
+    // future regression that would block #502's worked example.
+    [Fact]
+    public void AsyncClassMember_ParsesAndBinds()
+    {
+        var source = @"
+type SmokeTests class {
+    init() {}
+    async func DoIt() {
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    // Issue #502 sub-bug 502-a: an `async func ... T` declared as a class
+    // instance member must be awaitable from a sibling instance member.
+    // Before the fix, the rewriter dropped the call-site Task[T] wrap on the
+    // user-instance call when its receiver was rewritten (e.g. by the async
+    // state-machine rewriter hoisting `this`), producing GS0133-style
+    // mismatch downstream. We assert clean binding here as the binder-level
+    // regression guard.
+    [Fact]
+    public void AsyncClassMember_AwaitsSiblingAsyncMember_NoDiagnostics()
+    {
+        var source = @"
+type Probe class {
+    init() {}
+
+    async func ReturnInt() int32 {
+        return 42
+    }
+
+    async func CallIt() int32 {
+        let r = await ReturnInt()
+        return r
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
Fixes #502 by addressing two emit-side sub-bugs that survived the initial parse/bind fix (commit 66c86d6).

## Root cause

The previous fix wrapped the call-site return type as `Task` / `Task[T]` in `BindUserInstanceCall` and stored it as a `returnTypeOverride` on `BoundUserInstanceCallExpression`. That override was then silently dropped every time the bound tree was rewritten with a different receiver — notably when `AsyncStateMachineRewriter`'s `InnerRewriter` hoisted `this` into a state-machine field. With the override gone, the rewritten call's static type collapsed back to the bare `int32` (or `void`), the emitter mis-typed the receiver of the synthesized `GetAwaiter()` call, and the IL boxed a `Task[int]` as `int32` — which the verifier rejects (`Expected I4, but got O`).

Symptoms reported on the issue:

- **502-a:** `var r = await ReturnInt()` from a sibling async member produced GS0133 / wrong-typed IL.
- **502-b:** Void-returning async members that awaited another async member produced a `Task` that never completed, deadlocking `Task.Wait()` / `Task.Result` (and `xunit --blame-hang-timeout` killing the test host).

## Fix

- `BoundTreeRewriter.RewriteUserInstanceCallExpression` now threads `node.Type` (= `returnTypeOverride ?? Method.Type`) into the rebuilt node. Lossless when there was no override.
- `SpillSequenceSpiller.SpillUserInstanceCall` does the same when constructing the spilled replacement.

## Tests

- `AsyncAwaitTests.AsyncClassMember_ParsesAndBinds` — guard for the original parse repro.
- `AsyncAwaitTests.AsyncClassMember_AwaitsSiblingAsyncMember_NoDiagnostics` — binder-level guard for 502-a.
- `AsyncInstanceMethodEmitTests.Async_Instance_Method_Returning_Int_Is_Awaitable_From_Sibling_Member` — end-to-end 502-a coverage.
- `AsyncInstanceMethodEmitTests.Void_Async_Instance_Method_Awaiting_Sibling_Returns_Completed_Task` — end-to-end 502-b coverage, gated by a hard thread-join timeout so any future deadlock regression fails the test instead of hanging the host.
- `AsyncInstanceMethodEmitTests.Annotated_Async_Instance_Member_With_No_Return_Lifts_To_Task` — mirrors the originally-reported `@Fact async func ... { ... }` shape.
- `AsyncInstanceMethodEmitTests.Async_Instance_Method_Awaits_Sibling_Through_Explicit_This_Receiver` — explicit `this.Foo()` form.

## Verification

- `dotnet build GSharp.sln` clean.
- `dotnet test GSharp.sln`: **2,662 / 2,662 passing** (Compiler 434, Core 1906, LanguageServer 226, Interpreter 72, Sdk 24).