### PR TITLE
Emit: fix nested-closure transitive capture in event subscriptions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -17224,5 +17224,29 @@ public sealed class Binder
 
             return node;
         }
+
+        protected override BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+        {
+            // Issue #503 follow-up: a nested function literal's captures
+            // must transitively contribute to the *outer* literal's capture
+            // set whenever they're satisfied by neither outer parameters
+            // nor outer-body local declarations. Without this, the outer
+            // closure's display class has no field for the inner's free
+            // variable, so the inner-literal construction inside the outer
+            // Invoke body cannot locate the variable to pass to the inner
+            // closure's ctor (the silent-GS9998 failure surfaced by issue
+            // #503 closures inside nested lambdas).
+            foreach (var nestedCapture in node.CapturedVariables)
+            {
+                if (!this.parameters.Contains(nestedCapture)
+                    && !this.declared.Contains(nestedCapture)
+                    && this.seen.Add(nestedCapture))
+                {
+                    this.captured.Add(nestedCapture);
+                }
+            }
+
+            return node;
+        }
     }
 }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -174,6 +174,15 @@ internal sealed class ReflectionMetadataEmitter
     // with an InvokeAction instance method that Task.Run can bind to an Action.
     private readonly Dictionary<BoundGoStatement, ClosureInfo> goClosureInfos = new Dictionary<BoundGoStatement, ClosureInfo>();
     private readonly List<StructSymbol> synthesizedClosureClasses = new List<StructSymbol>();
+
+    // Issue #503 follow-up (nested-closure transitive capture): reverse map
+    // from a closure's Invoke method symbol to its ClosureInfo, so that when
+    // the BodyEmitter for that Invoke method emits a NESTED function-literal
+    // construction, it can route a captured-variable load through the
+    // enclosing closure's display-class field. Without this, the nested
+    // load fell through EmitLoadVariable's slot/parameter/global lookup and
+    // surfaced as GS9998 "no local slot or parameter index" at compile time.
+    private readonly Dictionary<FunctionSymbol, ClosureInfo> closureInvokeToInfo = new Dictionary<FunctionSymbol, ClosureInfo>();
     private readonly Dictionary<FunctionSymbol, BoundBlockStatement> iteratorKickoffBodies = new Dictionary<FunctionSymbol, BoundBlockStatement>();
     private readonly Dictionary<StructSymbol, IteratorStateMachineInfo> iteratorStateMachineInfos = new Dictionary<StructSymbol, IteratorStateMachineInfo>();
     private int closureCounter;
@@ -7248,6 +7257,7 @@ internal sealed class ReflectionMetadataEmitter
                 structThis = function.ThisParameter;
             }
 
+            var enclosingClosureInfo = this.closureInvokeToInfo.TryGetValue(function, out var ec) ? ec : null;
             var emitter = new BodyEmitter(
                 this,
                 il,
@@ -7269,7 +7279,8 @@ internal sealed class ReflectionMetadataEmitter
                 goEnclosingScopes,
                 constValues: constValues,
                 structThisParameter: structThis,
-                asyncIteratorEmitCtx: aiEmitCtx);
+                asyncIteratorEmitCtx: aiEmitCtx,
+                enclosingClosure: enclosingClosureInfo);
             emitter.EmitBlock(body);
 
             // Always cap with a trailing ret. Lowering does not guarantee one for void.
@@ -9161,7 +9172,9 @@ internal sealed class ReflectionMetadataEmitter
 
         this.lambdaBodies[invokeMethod] = rewrittenBody;
         this.synthesizedClosureClasses.Add(closureClass);
-        return new ClosureInfo(closureClass, invokeMethod, captureFields);
+        var info = new ClosureInfo(closureClass, invokeMethod, captureFields);
+        this.closureInvokeToInfo[invokeMethod] = info;
+        return info;
     }
 
     private static ImmutableArray<VariableSymbol> CollectCapturedVariables(BoundExpression expression)
@@ -11773,6 +11786,13 @@ internal sealed class ReflectionMetadataEmitter
         private readonly AsyncIteratorEmitContext asyncIteratorEmitCtx;
         private readonly Dictionary<VariableSymbol, object> constValues;
 
+        // Issue #503 follow-up: when this BodyEmitter is emitting the Invoke
+        // method of a synthesized closure class, captures of the *enclosing*
+        // closure are loaded/stored through `this`'s display-class fields
+        // instead of looking for a local slot or parameter index. Null when
+        // the current method isn't a closure Invoke.
+        private readonly ClosureInfo enclosingClosure;
+
         // Stack of currently-active protected regions; each entry holds the set of
         // bound labels defined lexically within that region (including nested
         // protected sub-regions). Used to translate goto/conditional-goto whose
@@ -11810,7 +11830,8 @@ internal sealed class ReflectionMetadataEmitter
             Lowering.Async.AsyncStateMachineFieldMap asyncFieldMap = null,
             Lowering.Async.AsyncStateMachinePlan asyncPlan = null,
             AsyncIteratorEmitContext asyncIteratorEmitCtx = null,
-            Dictionary<VariableSymbol, object> constValues = null)
+            Dictionary<VariableSymbol, object> constValues = null,
+            ClosureInfo enclosingClosure = null)
         {
             this.outer = outer;
             this.il = il;
@@ -11835,6 +11856,7 @@ internal sealed class ReflectionMetadataEmitter
             this.asyncPlan = asyncPlan;
             this.asyncIteratorEmitCtx = asyncIteratorEmitCtx;
             this.constValues = constValues;
+            this.enclosingClosure = enclosingClosure;
         }
 
         public IReadOnlyList<SequencePoint> SequencePoints => this.sequencePoints;
@@ -13801,8 +13823,74 @@ internal sealed class ReflectionMetadataEmitter
                 return;
             }
 
+            // Issue #503 follow-up (nested-closure transitive capture): the
+            // current method is a closure's Invoke and `variable` is one of
+            // the enclosing closure's captured outer locals. Load it via
+            // `ldarg.0; ldfld <displayClass>::<capField>`.
+            if (this.TryLoadFromEnclosingClosure(variable))
+            {
+                return;
+            }
+
             throw new InvalidOperationException(
                 $"Variable '{variable.Name}' has no local slot or parameter index in the current method.");
+        }
+
+        private bool TryLoadFromEnclosingClosure(VariableSymbol variable)
+        {
+            if (this.enclosingClosure == null
+                || !this.enclosingClosure.CaptureFields.TryGetValue(variable, out var capField)
+                || !this.outer.structFieldDefs.TryGetValue(capField, out var capFieldHandle))
+            {
+                return false;
+            }
+
+            this.il.OpCode(ILOpCode.Ldarg_0);
+            this.il.OpCode(ILOpCode.Ldfld);
+            this.il.Token(capFieldHandle);
+            return true;
+        }
+
+        private bool TryStoreToEnclosingClosure(VariableSymbol variable)
+        {
+            // The store value is already on the stack; we need to push the
+            // closure receiver UNDER it. Use a temp local of the value type
+            // to swap stack order without spawning a scratch local field.
+            if (this.enclosingClosure == null
+                || !this.enclosingClosure.CaptureFields.TryGetValue(variable, out var capField)
+                || !this.outer.structFieldDefs.TryGetValue(capField, out var capFieldHandle))
+            {
+                return false;
+            }
+
+            // Stack on entry: [..., value]
+            // Need:            [..., this, value] before stfld.
+            // Use a synthesized temp slot: stloc temp; ldarg.0; ldloc temp; stfld.
+            // The locals dictionary doesn't support adding synthetic slots
+            // after pre-scan, but for the closure-capture case the value is
+            // typed identically to the captured variable, so use the
+            // dedicated receiverSpillSlots mechanism — fallback: use IL
+            // dup/swap via a transient ValueType pattern. Cleanest:
+            //   stloc <temp>  // not feasible without pre-allocation
+            // Instead emit: dup; ldarg.0; swap-by-stloc/ldloc pair.
+            //
+            // We don't have a guaranteed scratch slot, so use the simpler
+            // pattern: emit a delegate-style store via box-then-cast — no.
+            //
+            // The pragmatic fix: synthesize a scratch local on first use by
+            // appending it to the IL locals signature. The metadata locals
+            // signature is sealed before EmitBlock starts, so this path is
+            // not viable for stores. As a result, captured-by-enclosing-
+            // closure stores are restricted to the rewritten field path
+            // (handled in CaptureRewriter for the inner literal body) and
+            // never reach EmitStoreVariable from inside the inner Invoke.
+            //
+            // For the rare case where an outer-closure body assigns to a
+            // captured variable that's NOT one of its own locals, we fall
+            // through and let EmitStoreVariable's error surface — that
+            // shape is currently unreachable from the binder.
+            _ = capFieldHandle;
+            return false;
         }
 
         private bool HasStorageSlot(VariableSymbol variable)
@@ -13819,6 +13907,15 @@ internal sealed class ReflectionMetadataEmitter
 
             if (variable is GlobalVariableSymbol gv
                 && this.outer.globalFieldDefs.ContainsKey(gv))
+            {
+                return true;
+            }
+
+            // Issue #503 follow-up: an enclosing closure's display-class
+            // field counts as storage for the captured variable when this
+            // method is the closure's Invoke.
+            if (this.enclosingClosure != null
+                && this.enclosingClosure.CaptureFields.ContainsKey(variable))
             {
                 return true;
             }

--- a/test/Compiler.Tests/Emit/Issue503ClosureCaptureRegressionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue503ClosureCaptureRegressionTests.cs
@@ -1,0 +1,623 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+// Regression coverage for #503 ("closure-capturing lambda bound to a CLR event
+// silently fails with MSB4181"). The base single-level capture case was fixed
+// up-stream; this file pins the additional shapes I discovered while
+// reproducing the bug end to end, including the nested-closure transitive
+// capture path that previously surfaced as GS9998 "compiler-internal error".
+//
+// Each test compiles a small G# source to a real DLL, IL-verifies it, loads
+// it into the current AppDomain, and exercises the closure via reflection.
+// `Assembly.Load(byte[])` is used deliberately — multiple fixtures share the
+// "MyLib" assembly name, and `Assembly.LoadFrom` would collide.
+public class Issue503ClosureCaptureRegressionTests
+{
+    // -----------------------------------------------------------------------
+    // Single-level closure capture — must compile, IL-verify, and fire.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void CapturedLocal_InInstanceMethod_UserEvent_FiresAndIncrements()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Source class {
+                public event Changed EventHandler
+                init() { }
+            }
+
+            type Counter class {
+                Value int32
+                init() { Value = 0 }
+                func Increment() { Value = Value + 1 }
+            }
+
+            type Probe class {
+                Src Source
+                Cnt Counter
+                init() {
+                    Src = Source()
+                    Cnt = Counter()
+                }
+                func Subscribe() {
+                    var src = Src
+                    var counter = Cnt
+                    src.Changed += func(sender object, e EventArgs) {
+                        counter.Increment()
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var probeType = assembly.GetTypes().Single(t => t.Name == "Probe");
+        var sourceType = assembly.GetTypes().Single(t => t.Name == "Source");
+        var counterType = assembly.GetTypes().Single(t => t.Name == "Counter");
+
+        var probe = Activator.CreateInstance(probeType)!;
+        probeType.GetMethod("Subscribe")!.Invoke(probe, Array.Empty<object>());
+
+        var src = probeType.GetField("Src")!.GetValue(probe)!;
+        var cnt = probeType.GetField("Cnt")!.GetValue(probe)!;
+
+        InvokeBackingDelegate(sourceType, src, "Changed");
+        Assert.Equal(1, (int)counterType.GetField("Value")!.GetValue(cnt)!);
+    }
+
+    [Fact]
+    public void CapturedLocal_InLoopBody_UserEvent_FiresOncePerSubscription()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Source class {
+                public event Changed EventHandler
+                init() { }
+            }
+
+            type Counter class {
+                Value int32
+                init() { Value = 0 }
+                func Increment() { Value = Value + 1 }
+            }
+
+            type Probe class {
+                Src Source
+                Cnt Counter
+                init() {
+                    Src = Source()
+                    Cnt = Counter()
+                    var i = 0
+                    for i < 3 {
+                        var counter = Cnt
+                        Src.Changed += func(sender object, e EventArgs) {
+                            counter.Increment()
+                        }
+                        i = i + 1
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var probeType = assembly.GetTypes().Single(t => t.Name == "Probe");
+        var sourceType = assembly.GetTypes().Single(t => t.Name == "Source");
+        var counterType = assembly.GetTypes().Single(t => t.Name == "Counter");
+
+        var probe = Activator.CreateInstance(probeType)!;
+        var src = probeType.GetField("Src")!.GetValue(probe)!;
+        var cnt = probeType.GetField("Cnt")!.GetValue(probe)!;
+
+        InvokeBackingDelegate(sourceType, src, "Changed");
+        Assert.Equal(3, (int)counterType.GetField("Value")!.GetValue(cnt)!);
+    }
+
+    [Fact]
+    public void CapturedField_AsClosureVariable_UserEvent_Fires()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Source class {
+                public event Changed EventHandler
+                init() { }
+            }
+
+            type Counter class {
+                Value int32
+                init() { Value = 0 }
+                func Increment() { Value = Value + 1 }
+            }
+
+            type Probe class {
+                Src Source
+                Cnt Counter
+                init() {
+                    Src = Source()
+                    Cnt = Counter()
+                    Src.Changed += func(sender object, e EventArgs) {
+                        Cnt.Increment()
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var probeType = assembly.GetTypes().Single(t => t.Name == "Probe");
+        var sourceType = assembly.GetTypes().Single(t => t.Name == "Source");
+        var counterType = assembly.GetTypes().Single(t => t.Name == "Counter");
+
+        var probe = Activator.CreateInstance(probeType)!;
+        var src = probeType.GetField("Src")!.GetValue(probe)!;
+        var cnt = probeType.GetField("Cnt")!.GetValue(probe)!;
+
+        InvokeBackingDelegate(sourceType, src, "Changed");
+        Assert.Equal(1, (int)counterType.GetField("Value")!.GetValue(cnt)!);
+    }
+
+    [Fact]
+    public void CapturesThis_UserEvent_Fires()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Source class {
+                public event Changed EventHandler
+                init() { }
+            }
+
+            type Probe class {
+                Src Source
+                Hits int32
+                init() {
+                    Src = Source()
+                    Hits = 0
+                    var me = this
+                    Src.Changed += func(sender object, e EventArgs) {
+                        me.Bump()
+                    }
+                }
+                func Bump() { Hits = Hits + 1 }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var probeType = assembly.GetTypes().Single(t => t.Name == "Probe");
+        var sourceType = assembly.GetTypes().Single(t => t.Name == "Source");
+
+        var probe = Activator.CreateInstance(probeType)!;
+        var src = probeType.GetField("Src")!.GetValue(probe)!;
+
+        InvokeBackingDelegate(sourceType, src, "Changed");
+        Assert.Equal(1, (int)probeType.GetField("Hits")!.GetValue(probe)!);
+    }
+
+    [Fact]
+    public void MultipleCaptures_InOneLambda_AllObserved()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Counter class {
+                Value int32
+                init() { Value = 0 }
+                func Add(n int32) { Value = Value + n }
+            }
+
+            type Source class {
+                public event Changed EventHandler
+                init() { }
+            }
+
+            type Probe class {
+                Src Source
+                A Counter
+                B Counter
+                init() {
+                    Src = Source()
+                    A = Counter()
+                    B = Counter()
+                    var a = A
+                    var b = B
+                    var step = 3
+                    Src.Changed += func(sender object, e EventArgs) {
+                        a.Add(step)
+                        b.Add(step + 1)
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var probeType = assembly.GetTypes().Single(t => t.Name == "Probe");
+        var sourceType = assembly.GetTypes().Single(t => t.Name == "Source");
+        var counterType = assembly.GetTypes().Single(t => t.Name == "Counter");
+
+        var probe = Activator.CreateInstance(probeType)!;
+        var src = probeType.GetField("Src")!.GetValue(probe)!;
+        var a = probeType.GetField("A")!.GetValue(probe)!;
+        var b = probeType.GetField("B")!.GetValue(probe)!;
+
+        InvokeBackingDelegate(sourceType, src, "Changed");
+        Assert.Equal(3, (int)counterType.GetField("Value")!.GetValue(a)!);
+        Assert.Equal(4, (int)counterType.GetField("Value")!.GetValue(b)!);
+    }
+
+    // -----------------------------------------------------------------------
+    // CLR (BCL) event sinks — closure must subscribe without aborting emit.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ClrEvent_InsideInstanceMethod_CapturingLocal_CompilesAndVerifies()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Counter class {
+                Value int32
+                init() { Value = 0 }
+                func Increment() { Value = Value + 1 }
+            }
+
+            type Probe class {
+                init() { }
+                func Subscribe() {
+                    var counter = Counter()
+                    var domain = AppDomain.CurrentDomain
+                    domain.ProcessExit += func(sender object, e EventArgs) {
+                        counter.Increment()
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        Assert.NotNull(assembly);
+    }
+
+    [Fact]
+    public void ClrEvent_ChainedReceiver_CapturingLocal_CompilesAndVerifies()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Counter class {
+                Value int32
+                init() { Value = 0 }
+                func Increment() { Value = Value + 1 }
+            }
+
+            type Probe class {
+                init() { }
+                func Subscribe() {
+                    var counter = Counter()
+                    AppDomain.CurrentDomain.ProcessExit += func(sender object, e EventArgs) {
+                        counter.Increment()
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        Assert.NotNull(assembly);
+    }
+
+    // -----------------------------------------------------------------------
+    // Top-level statement program — closure-into-event from script-style code.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void TopLevel_LocalCapture_UserEvent_CompilesAndVerifies()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Source class {
+                public event Changed EventHandler
+                init() { }
+            }
+
+            type Counter class {
+                Value int32
+                init() { Value = 0 }
+                func Increment() { Value = Value + 1 }
+            }
+
+            var src = Source()
+            var counter = Counter()
+            src.Changed += func(sender object, e EventArgs) {
+                counter.Increment()
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        Assert.NotNull(assembly);
+    }
+
+    // -----------------------------------------------------------------------
+    // Snapshot capture semantics — pinned for future intentional change.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void CapturedLocalReassignedAfterSubscription_SnapshotsAtSubscriptionTime()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Counter class {
+                Value int32
+                init() { Value = 0 }
+                func Increment() { Value = Value + 1 }
+            }
+
+            type Source class {
+                public event Changed EventHandler
+                init() { }
+            }
+
+            type Probe class {
+                Src Source
+                Original Counter
+                init() {
+                    Src = Source()
+                    var c = Counter()
+                    Original = c
+                    Src.Changed += func(sender object, e EventArgs) {
+                        c.Increment()
+                    }
+                    // Reassign after subscription. Whatever the capture
+                    // semantics, the build must not silently abort and the
+                    // closure must fire on raise.
+                    c = Counter()
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var probeType = assembly.GetTypes().Single(t => t.Name == "Probe");
+        var sourceType = assembly.GetTypes().Single(t => t.Name == "Source");
+        var counterType = assembly.GetTypes().Single(t => t.Name == "Counter");
+
+        var probe = Activator.CreateInstance(probeType)!;
+        var src = probeType.GetField("Src")!.GetValue(probe)!;
+        var original = probeType.GetField("Original")!.GetValue(probe)!;
+
+        InvokeBackingDelegate(sourceType, src, "Changed");
+
+        // Snapshot-capture semantics: the original counter (captured at
+        // subscription time) was incremented. This pins current behavior
+        // so a future change to reference-capture semantics is intentional.
+        Assert.Equal(1, (int)counterType.GetField("Value")!.GetValue(original)!);
+    }
+
+    // -----------------------------------------------------------------------
+    // Nested closures — outer lambda body contains an inner lambda that
+    // captures (transitively) a variable from the enclosing method. This is
+    // the path that previously surfaced as GS9998 "compiler-internal error:
+    // Variable 'counter' has no local slot or parameter index in the current
+    // method." It is the broader fix landed alongside #503.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void NestedClosure_NoEvent_TransitiveCapture_CompilesAndVerifies()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Counter class {
+                Value int32
+                init() { Value = 0 }
+                func Increment() { Value = Value + 1 }
+            }
+
+            type Probe class {
+                Cnt Counter
+                init() {
+                    Cnt = Counter()
+                    var counter = Cnt
+                    var outer = func() {
+                        var inner = func() {
+                            counter.Increment()
+                        }
+                        inner()
+                    }
+                    outer()
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var probeType = assembly.GetTypes().Single(t => t.Name == "Probe");
+        var counterType = assembly.GetTypes().Single(t => t.Name == "Counter");
+
+        var probe = Activator.CreateInstance(probeType)!;
+        var cnt = probeType.GetField("Cnt")!.GetValue(probe)!;
+        Assert.Equal(1, (int)counterType.GetField("Value")!.GetValue(cnt)!);
+    }
+
+    [Fact]
+    public void NestedClosure_OuterCapture_InnerSubscribesEvent_FiresAndIncrements()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Counter class {
+                Value int32
+                init() { Value = 0 }
+                func Increment() { Value = Value + 1 }
+            }
+
+            type Source class {
+                public event Changed EventHandler
+                init() { }
+            }
+
+            type Probe class {
+                Src Source
+                Cnt Counter
+                init() {
+                    Src = Source()
+                    Cnt = Counter()
+                    var src = Src
+                    var counter = Cnt
+                    var subscribe = func() {
+                        src.Changed += func(sender object, e EventArgs) {
+                            counter.Increment()
+                        }
+                    }
+                    subscribe()
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var probeType = assembly.GetTypes().Single(t => t.Name == "Probe");
+        var sourceType = assembly.GetTypes().Single(t => t.Name == "Source");
+        var counterType = assembly.GetTypes().Single(t => t.Name == "Counter");
+
+        var probe = Activator.CreateInstance(probeType)!;
+        var src = probeType.GetField("Src")!.GetValue(probe)!;
+        var cnt = probeType.GetField("Cnt")!.GetValue(probe)!;
+
+        InvokeBackingDelegate(sourceType, src, "Changed");
+        Assert.Equal(1, (int)counterType.GetField("Value")!.GetValue(cnt)!);
+    }
+
+    // -----------------------------------------------------------------------
+    // Negative guard — a type error inside a capturing lambda must produce a
+    // precise GS#### diagnostic, never a silent MSB4181-style abort.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void LambdaBodyTypeError_InCapturingLambda_ProducesGSDiagnostic()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            type Counter class {
+                Value int32
+                init() { Value = 0 }
+                func Increment() { Value = Value + 1 }
+            }
+
+            type Source class {
+                public event Changed EventHandler
+                init() { }
+            }
+
+            type Probe class {
+                init() {
+                    var s = Source()
+                    var c = Counter()
+                    s.Changed += func(sender object, e EventArgs) {
+                        c.NotARealMethod()
+                    }
+                }
+            }
+            """;
+
+        var tempDir = Directory.CreateTempSubdirectory("gs_503_neg_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var compileOut = new StringWriter();
+        var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.NotEqual(0, compileExit);
+        var combined = compileOut.ToString() + compileErr.ToString();
+        // Must surface as a GS#### code, not as a swallowed exception.
+        Assert.Matches(@"GS\d{4}", combined);
+    }
+
+    // -----------------------------------------------------------------------
+    // Shared helpers.
+    // -----------------------------------------------------------------------
+
+    private static void InvokeBackingDelegate(Type containingType, object instance, string eventName)
+    {
+        var backingField = containingType.GetField(
+            eventName,
+            BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public);
+        Assert.NotNull(backingField);
+        var del = (Delegate)backingField!.GetValue(instance)!;
+        del.DynamicInvoke(instance, EventArgs.Empty);
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_503_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}


### PR DESCRIPTION
Fixes #503.

## Symptom

A function literal that captures any outer variable, bound to a CLR
event with `+=`, could abort the emit phase silently with
`MSB4181: The "BuildTask" task returned false but did not log an
error.` No `GS####` diagnostic was produced.

The base single-level capture case (`var counter = Counter(); src.Changed += func(s, e) { counter.Increment() }`)
was fixed in a prior pass. The remaining failure mode I uncovered
while reproducing the issue end-to-end is the **nested-closure
transitive capture** path:

```gsharp
var counter = Counter()
var subscribe = func() {
    src.Changed += func(sender object, e EventArgs) {
        counter.Increment()    // inner lambda captures counter,
                                // which is also captured by the
                                // enclosing 'subscribe' lambda
    }
}
subscribe()
```

Previously this surfaced as `GS9998: Variable 'counter' has no local
slot or parameter index in the current method` (with bogus location
`(1,1,1,1)`), and in some host configurations as a silent MSB4181.
The bug was not event-specific — any nested closure that transitively
captured a variable failed the same way.

## Fix

Two surgical changes:

* **`Binder.CapturedVariableCollector`** now overrides
  `RewriteFunctionLiteralExpression` so a nested literal's
  `CapturedVariables` transitively contribute to the outer literal's
  capture set (filtered by the outer's own parameters and declared
  locals). Without this, the outer closure's synthesized struct had no
  field to relay the variable to the inner closure.

* **`ReflectionMetadataEmitter.BodyEmitter`** takes an optional
  `enclosingClosure` `ClosureInfo` wired by `EmitFunction` from a
  new `closureInvokeToInfo` reverse map. `EmitLoadVariable` (and the
  parallel `HasStorageSlot` probe) falls back to
  `ldarg.0; ldfld <capField>` when the variable is satisfied by the
  enclosing closure's display-class field rather than a local slot.

## Tests

New regression coverage in
`test/Compiler.Tests/Emit/Issue503ClosureCaptureRegressionTests.cs`
exercises:

* single-level capture in instance methods and loop bodies
* field-as-closure-variable
* `this` capture
* multi-capture
* CLR (BCL) event sinks with chained receivers
  (`AppDomain.CurrentDomain.ProcessExit`)
* top-level statement programs
* snapshot capture semantics (pinned)
* nested-closure transitive capture both **without** and **with**
  event subscription
* a negative guard that asserts a precise `GS####` diagnostic — not a
  silent MSB4181 — when a capturing lambda body has a type error.

Every test compiles to a real DLL, runs `dotnet-ilverify`, loads the
assembly into the AppDomain (via `Assembly.Load(byte[])` to avoid the
`MyLib` name collision), and exercises the closure via reflection.

## Verification

* `dotnet build GSharp.sln -nologo -clp:NoSummary` — clean.
* `dotnet test GSharp.sln --no-restore --nologo` — **all green**
  (442 Compiler.Tests + 1913 Core.Tests + 72 Interpreter.Tests +
  226 LanguageServer.Tests + 24 Sdk.Tests).
* All 24 `Issue503_*` tests pass (12 existing + 12 new).

## Deferred

Nothing within scope of #503.

One unrelated finding I observed while investigating: invoking a CLR
event as a member from inside the declaring class
(`Changed?.Invoke(this, EventArgs.Empty)` in the repro body) is
rejected by the binder with `GS0158: Cannot find member Changed`.
That is a separate bug about events not being accessible by name from
within their declaring type, not a closure/emit issue, and is out of
scope for this PR.