### PR TITLE
Fix #504: emit Nullable<T> '!!' unwrap via Nullable<T>::get_Value

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -7693,6 +7693,27 @@ internal sealed class ReflectionMetadataEmitter
             localTypes.Add(assn.Type);
             receiverSpillSlots[assn] = slot;
         }
+
+        // Issue #504: `!!` on a value-type `Nullable<T>` lowers to a
+        // `stloc tmp; ldloca tmp; call Nullable<T>::get_Value` sequence; the
+        // temp must be typed as `Nullable<T>` (not the unwrapped T). Reuse
+        // receiverSpillSlots — the dictionary already aggregates several
+        // distinct-by-node-identity scratch-slot kinds (receiver spills and
+        // assignment-value spills) and BoundUnaryExpression keys cannot
+        // collide with either. The slot is typed as the operand's
+        // NullableTypeSymbol, which `EncodeTypeSymbol` lowers to
+        // `System.Nullable<T>` in the local-sig blob.
+        foreach (var unwrap in CollectNullableValueTypeUnwraps(body))
+        {
+            if (receiverSpillSlots.ContainsKey(unwrap))
+            {
+                continue;
+            }
+
+            var slot = localTypes.Count;
+            localTypes.Add(unwrap.Operand.Type);
+            receiverSpillSlots[unwrap] = slot;
+        }
     }
 
     // Phase B: walks the bound body to find every BoundPatternSwitchStatement
@@ -9415,6 +9436,18 @@ internal sealed class ReflectionMetadataEmitter
         return sink;
     }
 
+    // Issue #504: each `!!` applied to a value-type `Nullable<T>` lowers at
+    // emit time to `stloc tmp; ldloca tmp; call Nullable<T>::get_Value`. The
+    // temp slot must be typed as `Nullable<T>` (so the local-sig blob encodes
+    // the struct) and pre-allocated alongside the other body-emit scratch
+    // locals so it appears in the locals signature.
+    private static IEnumerable<BoundUnaryExpression> CollectNullableValueTypeUnwraps(BoundNode root)
+    {
+        var sink = new List<BoundUnaryExpression>();
+        new NullableValueTypeUnwrapCollector(sink).Visit((BoundStatement)root);
+        return sink;
+    }
+
     private bool NeedsRvalueReceiverSpill(
         BoundExpression receiver,
         FunctionSymbol function,
@@ -9647,6 +9680,25 @@ internal sealed class ReflectionMetadataEmitter
             name: this.metadata.GetOrAddString(".ctor"),
             signature: this.metadata.GetOrAddBlob(sigBlob));
         return this.nullRefExceptionCtorRef;
+    }
+
+    // Issue #504: returns a callable MemberRef for `System.Nullable<T>::get_Value`
+    // closed over the supplied value-type underlying CLR type. Used by `!!` emit
+    // to unwrap a `Nullable<T>` operand (throws `InvalidOperationException` at
+    // runtime when `HasValue` is false, matching the BCL property).
+    private MemberReferenceHandle GetNullableGetValueReference(Type underlyingValueType)
+    {
+        if (underlyingValueType == null || !underlyingValueType.IsValueType)
+        {
+            throw new InvalidOperationException(
+                $"GetNullableGetValueReference: '{underlyingValueType?.FullName}' is not a value type.");
+        }
+
+        var nullableClr = typeof(System.Nullable<>).MakeGenericType(underlyingValueType);
+        var getValue = nullableClr.GetMethod("get_Value", Type.EmptyTypes)
+            ?? throw new InvalidOperationException(
+                $"System.Nullable<{underlyingValueType.FullName}>::get_Value() is not resolvable.");
+        return this.GetMethodReference(getValue);
     }
 
     private MemberReferenceHandle GetStringLengthReference()
@@ -11718,6 +11770,35 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
+    // Issue #504: walks the bound tree collecting every `BoundUnaryExpression`
+    // whose operator is `NullAssertion` (`!!`) and whose operand is a
+    // value-type `Nullable<T>`. Each such site needs a `Nullable<T>`-typed
+    // temp slot so the emitter can spill the operand and call
+    // `Nullable<T>::get_Value` (which yields the underlying `T` or throws
+    // `InvalidOperationException`). The reference-type `!!` path uses the
+    // existing `dup; brtrue; throw NRE` pattern and needs no slot.
+    private sealed class NullableValueTypeUnwrapCollector : BoundTreeWalker
+    {
+        private readonly List<BoundUnaryExpression> sink;
+
+        public NullableValueTypeUnwrapCollector(List<BoundUnaryExpression> sink)
+        {
+            this.sink = sink;
+        }
+
+        protected override void VisitUnaryExpression(BoundUnaryExpression node)
+        {
+            if (node.Op.Kind == BoundUnaryOperatorKind.NullAssertion
+                && node.Operand.Type is NullableTypeSymbol n
+                && n.UnderlyingType?.ClrType is { IsValueType: true })
+            {
+                this.sink.Add(node);
+            }
+
+            base.VisitUnaryExpression(node);
+        }
+    }
+
     private sealed class SelectSlots
     {
         public SelectSlots(
@@ -13294,6 +13375,32 @@ internal sealed class ReflectionMetadataEmitter
             // dependency on stack tracking inside the operand.
             if (u.Op.Kind == BoundUnaryOperatorKind.NullAssertion)
             {
+                // Issue #504: a value-type `Nullable<T>` operand cannot use
+                // `dup; brtrue` (the `Nullable<T>` struct on the stack has no
+                // valid `brtrue` interpretation — it produces invalid IL).
+                // Instead, spill the struct to a pre-allocated `Nullable<T>`
+                // slot, take its address, and call `Nullable<T>::get_Value()`,
+                // which returns the underlying T or throws
+                // `InvalidOperationException` when `HasValue == false`. This
+                // matches the BCL `Nullable<T>.Value` property's semantics.
+                if (u.Operand.Type is NullableTypeSymbol operandNullable
+                    && operandNullable.UnderlyingType?.ClrType is { IsValueType: true } innerClr)
+                {
+                    if (!this.receiverSpillSlots.TryGetValue(u, out var unwrapSlot))
+                    {
+                        throw new InvalidOperationException(
+                            "No scratch slot pre-allocated for value-type Nullable<T> '!!' operand — "
+                            + "check NullableValueTypeUnwrapCollector and the prepass in CollectLocalsAndLabels.");
+                    }
+
+                    this.EmitExpression(u.Operand);
+                    this.il.StoreLocal(unwrapSlot);
+                    this.il.LoadLocalAddress(unwrapSlot);
+                    this.il.OpCode(ILOpCode.Call);
+                    this.il.Token(this.outer.GetNullableGetValueReference(innerClr));
+                    return;
+                }
+
                 this.EmitExpression(u.Operand);
                 this.il.OpCode(ILOpCode.Dup);
                 var nonNull = this.il.DefineLabel();

--- a/test/Compiler.Tests/Emit/NullableValueEmitTests.cs
+++ b/test/Compiler.Tests/Emit/NullableValueEmitTests.cs
@@ -1,0 +1,490 @@
+// <copyright file="NullableValueEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #504 (remaining emit-side gaps after PR #513): exercises code paths
+/// that move <c>Nullable&lt;T&gt;</c> values through the emitter — `!!`
+/// unwrap, generic call boundaries (type-erased boxing), and the full
+/// CLR-property write/read/unwrap pipeline used by the original reproducer.
+///
+/// Each test compiles the GSharp source with gsc, runs <c>ilverify</c> against
+/// the produced PE to confirm the IL is verifiable (the original bugs all
+/// emitted invalid IL that the JIT caught at runtime as
+/// <c>InvalidProgramException</c>), then executes the assembly under
+/// <c>dotnet exec</c> and asserts on the captured stdout.
+/// </summary>
+public class NullableValueEmitTests
+{
+    [Fact]
+    public void UnwrapBangBang_OnNullableBool_HasValue_ReturnsUnderlying()
+    {
+        // Original reproducer from #504 follow-up: `s.ExportToAax!!` (where
+        // the property is `bool?`) compiled successfully but threw
+        // InvalidProgramException at runtime because the emitter used the
+        // reference-type `dup; brtrue` pattern on a struct stack value.
+        // Modelled here without the CLR property dependency — see
+        // RoundTripWriteReadUnwrap_OnClrNullableBoolProperty for the
+        // end-to-end shape.
+        var source = """
+            package P
+
+            import System
+
+            var a Nullable[bool] = true
+            var v = a!!
+            Console.WriteLine(v)
+
+            var b Nullable[bool] = false
+            var w = b!!
+            Console.WriteLine(w)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void UnwrapBangBang_OnNullableInt_HasValue_ReturnsUnderlying()
+    {
+        // Verifies the same path for a value type with a non-trivial size
+        // (Nullable<int32> is 8 bytes — the `Nullable<T>::get_Value` call
+        // must take the slot's address, not its value).
+        var source = """
+            package P
+
+            import System
+
+            var a Nullable[int32] = 42
+            var v = a!!
+            Console.WriteLine(v)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void UnwrapBangBang_OnNullableBool_NoValue_ThrowsInvalidOperation()
+    {
+        // The emitted IL routes the unwrap through
+        // `Nullable<T>::get_Value()`, which the BCL implements as
+        // `if (!HasValue) throw new InvalidOperationException(...);` — match
+        // that exact behaviour so `!!` on a value-type Nullable mirrors the
+        // C# `nullable.Value` property surface, and so the failure mode is
+        // surfaced to the user (not silently zeroed).
+        var source = """
+            package P
+
+            import System
+
+            var a Nullable[bool] = nil
+            var v = a!!
+            Console.WriteLine(v)
+            """;
+
+        var (exitCode, _, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("InvalidOperationException", stderr);
+    }
+
+    [Fact]
+    public void GenericMethod_PassNullableArg_RoundTripsThroughObjectBoundary()
+    {
+        // Phase 4 emit treats generic functions as type-erased — every `T`
+        // parameter is encoded as `System.Object`, so value-type arguments
+        // are boxed at the call boundary and unboxed at the return. Issue
+        // #504 originally claimed `Assert.Equal[bool?](a, b)` (both bool?)
+        // hit InvalidProgramException through this same code path. Confirm
+        // the boundary handles a `Nullable<T>` argument correctly: the CLR
+        // boxes a `Nullable<T>` as either a boxed T or a null reference.
+        // Route everything through an `object` slot before printing so the
+        // test asserts only on the box/unbox round-trip, not on
+        // overload-resolution for Console.WriteLine(Nullable<bool>).
+        var source = """
+            package P
+
+            import System
+
+            func Id[T](a T) T {
+                return a
+            }
+
+            var a Nullable[bool] = false
+            var r1 Nullable[bool] = Id[Nullable[bool]](a)
+            var o1 object = r1
+            Console.WriteLine(o1)
+
+            var b Nullable[bool] = nil
+            var r2 Nullable[bool] = Id[Nullable[bool]](b)
+            var o2 object = r2
+            Console.Write("[")
+            Console.Write(o2)
+            Console.WriteLine("]")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("False\n[]\n", output);
+    }
+
+    [Fact]
+    public void GenericMethod_TwoNullableArgs_PassedAsObjectsRoundTrip()
+    {
+        // Mirrors the reported `Assert.Equal[bool?](a, b)` shape: two
+        // distinct `Nullable<bool>` locals threaded through a generic
+        // method whose body re-emits `box Nullable<bool>` on each arg.
+        // Each call boundary must box `Nullable<T>` correctly so the call
+        // site's stack shape matches the type-erased `(object, object)`
+        // signature, and the return must `unbox.any` back to `Nullable<T>`.
+        var source = """
+            package P
+
+            import System
+
+            func TwoArgs[T](a T, b T) T {
+                return a
+            }
+
+            var x Nullable[bool] = true
+            var y Nullable[bool] = false
+            var first Nullable[bool] = TwoArgs[Nullable[bool]](x, y)
+            var o1 object = first
+            Console.WriteLine(o1)
+
+            var second Nullable[bool] = TwoArgs[Nullable[bool]](y, x)
+            var o2 object = second
+            Console.WriteLine(o2)
+
+            var nilHs Nullable[bool] = nil
+            var third Nullable[bool] = TwoArgs[Nullable[bool]](nilHs, x)
+            var o3 object = third
+            Console.Write("[")
+            Console.Write(o3)
+            Console.WriteLine("]")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n[]\n", output);
+    }
+
+    [Fact]
+    public void BoxNullable_ToObject_PreservesPresenceAndUnderlyingValue()
+    {
+        // `box Nullable<T>` is CLR-special-cased: the result is either a
+        // boxed T (when HasValue) or a null reference (when !HasValue). The
+        // emitter must therefore emit `box Nullable<T>` (not `box T`) on a
+        // `Nullable<T>` stack value crossing into an `object` slot.
+        var source = """
+            package P
+
+            import System
+
+            var a Nullable[bool] = true
+            var o1 object = a
+            Console.WriteLine(o1)
+
+            var b Nullable[bool] = false
+            var o2 object = b
+            Console.WriteLine(o2)
+
+            var c Nullable[bool] = nil
+            var o3 object = c
+            Console.Write("[")
+            Console.Write(o3)
+            Console.WriteLine("]")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n[]\n", output);
+    }
+
+    [Fact]
+    public void UnboxNullable_FromObject_ThroughGenericIdentity()
+    {
+        // The "unbox.any Nullable<T>" path is hit on the return value of a
+        // generic method whose return is `T`. The emitter's
+        // EmitErasedObjectReturnWidening must select the right closed
+        // `Nullable<T>` token when widening the `object` placeholder back
+        // to the caller's expected slot type.
+        var source = """
+            package P
+
+            import System
+
+            func Echo[T](a T) T {
+                return a
+            }
+
+            var src Nullable[int32] = 7
+            var dst Nullable[int32] = Echo[Nullable[int32]](src)
+            Console.WriteLine(dst!!)
+
+            var srcNil Nullable[int32] = nil
+            var dstNil Nullable[int32] = Echo[Nullable[int32]](srcNil)
+            var o object = dstNil
+            Console.Write("[")
+            Console.Write(o)
+            Console.WriteLine("]")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n[]\n", output);
+    }
+
+    [Fact]
+    public void RoundTripWriteReadUnwrap_OnClrNullableBoolProperty()
+    {
+        // End-to-end reproducer mirroring the original issue: a sibling CLR
+        // type exposes `bool? Flag`. GSharp writes through the setter,
+        // reads back through the getter, and unwraps with `!!`. Each step
+        // must produce verifiable IL.
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var s = Settings()
+            s.Flag = true
+            var v = s.Flag!!
+            Console.WriteLine(v)
+
+            s.Flag = false
+            var v2 = s.Flag!!
+            Console.WriteLine(v2)
+            """;
+
+        var output = CompileAndRunWithProbe(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void UnwrapClrNullableProperty_NoValue_ThrowsInvalidOperation()
+    {
+        // `s.Flag!!` when the underlying value is `nil` must throw
+        // InvalidOperationException (not InvalidProgramException, not
+        // NullReferenceException) so the call surface matches
+        // `Nullable<T>.Value`.
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var s = Settings()
+            s.Flag = nil
+            var v = s.Flag!!
+            Console.WriteLine(v)
+            """;
+
+        var (exitCode, _, stderr) = CompileAndRunRaw(source, expectSuccess: false, withProbe: true);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("InvalidOperationException", stderr);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: true);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static string CompileAndRunWithProbe(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: true, withProbe: true);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(
+        string source,
+        bool expectSuccess,
+        bool withProbe = false)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_nullable_value_").FullName;
+        try
+        {
+            string probeDllPath = null;
+            if (withProbe)
+            {
+                probeDllPath = Path.Combine(tempDir, "ProbeLib.dll");
+                BuildProbeLibrary(probeDllPath);
+            }
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+            if (probeDllPath != null)
+            {
+                args.Add("/r:" + probeDllPath);
+            }
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            var verifyRefs = probeDllPath != null ? new[] { probeDllPath } : null;
+            IlVerifier.Verify(outPath, additionalReferences: verifyRefs);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void BuildProbeLibrary(string dllPath)
+    {
+        var coreAssembly = typeof(object).Assembly;
+
+        var asmName = new AssemblyName("ProbeLib") { Version = new Version(1, 0, 0, 0) };
+        var asmBuilder = new PersistedAssemblyBuilder(asmName, coreAssembly);
+        var moduleBuilder = asmBuilder.DefineDynamicModule("ProbeLib");
+
+        var typeBuilder = moduleBuilder.DefineType(
+            "Probe.Settings",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.AutoLayout | TypeAttributes.BeforeFieldInit,
+            parent: typeof(object));
+
+        EmitAutoProperty(typeBuilder, "Flag", typeof(bool?));
+        EmitAutoProperty(typeBuilder, "Count", typeof(int?));
+
+        var ctor = typeBuilder.DefineConstructor(
+            MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName | MethodAttributes.HideBySig,
+            CallingConventions.Standard,
+            Type.EmptyTypes);
+        var ctorIl = ctor.GetILGenerator();
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Call, typeof(object).GetConstructor(Type.EmptyTypes)!);
+        ctorIl.Emit(OpCodes.Ret);
+
+        typeBuilder.CreateType();
+        asmBuilder.Save(dllPath);
+    }
+
+    private static void EmitAutoProperty(TypeBuilder typeBuilder, string name, Type clrType)
+    {
+        var field = typeBuilder.DefineField(
+            "<" + name + ">k__BackingField",
+            clrType,
+            FieldAttributes.Private);
+
+        var property = typeBuilder.DefineProperty(
+            name,
+            PropertyAttributes.HasDefault,
+            clrType,
+            parameterTypes: null);
+
+        const MethodAttributes accessorAttrs = MethodAttributes.Public
+            | MethodAttributes.SpecialName
+            | MethodAttributes.HideBySig;
+
+        var getter = typeBuilder.DefineMethod(
+            "get_" + name,
+            accessorAttrs,
+            clrType,
+            Type.EmptyTypes);
+        var getterIl = getter.GetILGenerator();
+        getterIl.Emit(OpCodes.Ldarg_0);
+        getterIl.Emit(OpCodes.Ldfld, field);
+        getterIl.Emit(OpCodes.Ret);
+
+        var setter = typeBuilder.DefineMethod(
+            "set_" + name,
+            accessorAttrs,
+            returnType: null,
+            parameterTypes: new[] { clrType });
+        var setterIl = setter.GetILGenerator();
+        setterIl.Emit(OpCodes.Ldarg_0);
+        setterIl.Emit(OpCodes.Ldarg_1);
+        setterIl.Emit(OpCodes.Stfld, field);
+        setterIl.Emit(OpCodes.Ret);
+
+        property.SetGetMethod(getter);
+        property.SetSetMethod(setter);
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}


### PR DESCRIPTION
Fixes #504.

PR #513 fixed reading/writing CLR `Nullable<T>` properties end-to-end, but the
follow-up note on the issue called out that **`!!` on a value-type `Nullable<T>`
still emitted invalid IL** (`System.InvalidProgramException` at runtime). This
PR closes that emit-side gap.

## Root cause

`EmitUnary` lowers `!!` (a runtime null-assertion) as:

```
<operand IL>
dup
brtrue nonNull
pop
newobj NullReferenceException
throw
nonNull:
```

That sequence is correct for reference-type operands (and for `NullableTypeSymbol`
over a reference type, which shares its CLR repr with the underlying `T`), but
`Nullable<T>` over a value type lives on the stack as a `System.Nullable<T>`
struct. `dup; brtrue` on a struct value is **not legal IL** — ilverify rejects
it and the JIT throws `InvalidProgramException`.

## Fix

`EmitUnary`'s `NullAssertion` branch now detects a value-type `Nullable<T>`
operand and emits a different sequence:

```
<operand IL>           ; pushes Nullable<T>
stloc tmp              ; spill to a Nullable<T>-typed scratch slot
ldloca tmp
call instance !0 System.Nullable<T>::get_Value
```

`Nullable<T>::get_Value` returns the underlying `T` when `HasValue` is true and
throws `System.InvalidOperationException` otherwise — exact parity with the BCL
`Nullable<T>.Value` property.

The scratch slot is allocated by a new `NullableValueTypeUnwrapCollector`
prepass that runs alongside the existing scratch-slot collectors in
`CollectLocalsAndLabels`. The slot is typed as the operand's
`NullableTypeSymbol` so `EncodeLocalVariableType` / `EncodeTypeSymbol` emit the
correct `System.Nullable<T>` element in the local-variable signature blob. The
allocation is recorded on the existing `receiverSpillSlots` dictionary (already
shared by receiver-spill and assignment-value-spill collectors keyed by
distinct node identity) to avoid threading a brand-new dictionary through
every body-emit site.

A small `GetNullableGetValueReference(Type)` helper resolves and caches the
`MemberReference` for the closed `Nullable<T>::get_Value` method.

## Tests

`test/Compiler.Tests/Emit/NullableValueEmitTests.cs` (new): nine end-to-end
tests, each one running `ilverify` against the emitted PE before execution so
any future regression fails at the IL level instead of at runtime:

* `!!` on a `Nullable<bool>` local — both `HasValue=true` literals exercise the
  underlying-T return path.
* `!!` on a `Nullable<int32>` local — ensures the `ldloca` / `call` address
  path works for a wider value type.
* `!!` on a `Nullable<bool>` with `HasValue=false` — asserts the runtime
  exception is `InvalidOperationException` (not `InvalidProgramException` or
  `NullReferenceException`).
* Generic call boundary with a single `Nullable<T>` argument round-tripped
  through a type-erased `Id[T]` — covers `box Nullable<T>` at the call and
  `unbox.any Nullable<T>` at the return.
* Generic call boundary with two `Nullable<T>` arguments — mirrors the
  `Assert.Equal[bool?](a, b)` reproducer shape.
* Box-to-`object` of `Nullable<bool>` in all three states (true / false / nil)
  — asserts CLR-special-cased `box Nullable<T>` → boxed-T or null reference.
* Unbox-from-`object` via a generic identity function — exercises
  `EmitErasedObjectReturnWidening` for a `Nullable<T>` return.
* End-to-end CLR property: `s.Flag = true; s.Flag!!` (where `Flag` is C# `bool?`).
  Builds a sibling Probe library in-process via `PersistedAssemblyBuilder` to
  keep the test hermetic, matching the existing `NullablePropertyEmitTests`
  pattern.
* `s.Flag = nil; s.Flag!!` throws `InvalidOperationException` end-to-end.

## Verification

* `dotnet build GSharp.sln -nologo -clp:NoSummary` — clean.
* `dotnet test GSharp.sln --no-restore --nologo` — 2,692 / 2,692 passing
  (Sdk.Tests 24, Interpreter.Tests 72, LanguageServer.Tests 226, Core.Tests
  1915, Compiler.Tests 455).
* `ilverify` is invoked from every new test, so the new emit shape is
  verifiable IL by construction.

## Out of scope

* Bind-side `Nullable<T>.Value` / `.HasValue` member exposure — tracked as
  #517.
* `?:` null-coalesce on a value-type `Nullable<T>` — tracked as #519
  (`EmitBinary`'s `NullCoalesce` branch still throws `NotSupportedException`
  for value-type operands, with the existing diagnostic explaining the
  HasValue/ValueOrDefault rewrite that is needed).
* Surfacing CLR reference-type `T?` properties as nullable (e.g.
  `DirectoryInfo.Parent`) — already fixed by PR #513 and exercised by an
  existing test (`ClrPropertyOfNullableReferenceType_AllowsNilComparison`).