### PR TITLE
Emit: lower `?:` over `Nullable<T>` to verifiable IL

### DIFF
--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -333,8 +333,7 @@ public class Compilation
         }
         catch (Exception ex) when (ex is NotSupportedException || ex is InvalidOperationException)
         {
-            var location = new TextLocation(SourceText.From(string.Empty), new TextSpan(0, 0));
-            var diagnostic = new Diagnostic(location, "GS9998", DiagnosticSeverity.Error, ex.Message);
+            var diagnostic = BuildEmitFailureDiagnostic(ex);
             return new EmitResult(success: false, ImmutableArray.Create(diagnostic));
         }
 
@@ -452,8 +451,7 @@ public class Compilation
         }
         catch (Exception ex) when (ex is NotSupportedException || ex is InvalidOperationException)
         {
-            var location = new TextLocation(SourceText.From(string.Empty), new TextSpan(0, 0));
-            var diagnostic = new Diagnostic(location, "GS9998", DiagnosticSeverity.Error, ex.Message);
+            var diagnostic = BuildEmitFailureDiagnostic(ex);
             return new EmitResult(success: false, ImmutableArray.Create(diagnostic));
         }
 
@@ -471,6 +469,24 @@ public class Compilation
     /// <returns>An emit result.</returns>
     public EmitResult Emit(Stream peStream, Stream refStream) =>
         Emit(peStream, pdbStream: null, refStream, docStream: null, assemblyName: null);
+
+    // Issue #519: the SDK BuildTask's diagnostic regex requires a non-empty
+    // file prefix to recognise a `gsc` stdout line as a diagnostic. A GS9998
+    // anchored at an empty-source location ("(1,1,1,1): error GS9998: ...")
+    // failed that regex and was logged only as a low-importance message, so
+    // BuildTask returned false without `Log.HasLoggedErrors` and surfaced as
+    // a silent MSB4181 instead of the intended GS diagnostic. Anchor the
+    // synthetic location at the first syntax tree (or a file-named empty
+    // SourceText when none is available) so the regex always matches and
+    // the failure surfaces.
+    private Diagnostic BuildEmitFailureDiagnostic(Exception ex)
+    {
+        var firstTree = SyntaxTrees.FirstOrDefault();
+        var sourceText = firstTree?.Text
+            ?? SourceText.From(string.Empty, fileName: "gsc");
+        var location = new TextLocation(sourceText, new TextSpan(0, 0));
+        return new Diagnostic(location, "GS9998", DiagnosticSeverity.Error, ex.Message);
+    }
 
     /// <summary>
     /// The canonical async/iterator lowering pipeline. Runs all rewriter

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -7714,6 +7714,24 @@ internal sealed class ReflectionMetadataEmitter
             localTypes.Add(unwrap.Operand.Type);
             receiverSpillSlots[unwrap] = slot;
         }
+
+        // Issue #519: `?:` whose LHS is a value-type `Nullable<T>` lowers at
+        // emit time to a HasValue/Value sequence that needs a `Nullable<T>`-
+        // typed temp slot (it cannot use `dup; brtrue`, which is invalid IL
+        // for value-type stack shapes). The slot is keyed by the binary
+        // expression node and typed as the LHS's NullableTypeSymbol so
+        // EncodeTypeSymbol emits the proper `System.Nullable<T>` token.
+        foreach (var coalesce in CollectNullableValueTypeCoalesces(body))
+        {
+            if (receiverSpillSlots.ContainsKey(coalesce))
+            {
+                continue;
+            }
+
+            var slot = localTypes.Count;
+            localTypes.Add(coalesce.Left.Type);
+            receiverSpillSlots[coalesce] = slot;
+        }
     }
 
     // Phase B: walks the bound body to find every BoundPatternSwitchStatement
@@ -9448,6 +9466,18 @@ internal sealed class ReflectionMetadataEmitter
         return sink;
     }
 
+    // Issue #519: each `?:` whose LHS is a value-type `Nullable<T>` lowers at
+    // emit time to a HasValue branch that needs a `Nullable<T>`-typed temp
+    // slot. The slot is keyed by the binary expression node and typed as the
+    // LHS's NullableTypeSymbol so `EncodeTypeSymbol` emits the proper
+    // `System.Nullable<T>` token in the local-sig blob.
+    private static IEnumerable<BoundBinaryExpression> CollectNullableValueTypeCoalesces(BoundNode root)
+    {
+        var sink = new List<BoundBinaryExpression>();
+        new NullableValueTypeCoalesceCollector(sink).Visit((BoundStatement)root);
+        return sink;
+    }
+
     private bool NeedsRvalueReceiverSpill(
         BoundExpression receiver,
         FunctionSymbol function,
@@ -9699,6 +9729,25 @@ internal sealed class ReflectionMetadataEmitter
             ?? throw new InvalidOperationException(
                 $"System.Nullable<{underlyingValueType.FullName}>::get_Value() is not resolvable.");
         return this.GetMethodReference(getValue);
+    }
+
+    // Issue #519: returns a callable MemberRef for `System.Nullable<T>::get_HasValue`
+    // closed over the supplied value-type underlying CLR type. Used by `?:` emit
+    // on a value-type `Nullable<T>` operand to branch on the presence flag without
+    // box/dup tricks (which are illegal on a struct stack value).
+    private MemberReferenceHandle GetNullableGetHasValueReference(Type underlyingValueType)
+    {
+        if (underlyingValueType == null || !underlyingValueType.IsValueType)
+        {
+            throw new InvalidOperationException(
+                $"GetNullableGetHasValueReference: '{underlyingValueType?.FullName}' is not a value type.");
+        }
+
+        var nullableClr = typeof(System.Nullable<>).MakeGenericType(underlyingValueType);
+        var getHasValue = nullableClr.GetMethod("get_HasValue", Type.EmptyTypes)
+            ?? throw new InvalidOperationException(
+                $"System.Nullable<{underlyingValueType.FullName}>::get_HasValue() is not resolvable.");
+        return this.GetMethodReference(getHasValue);
     }
 
     private MemberReferenceHandle GetStringLengthReference()
@@ -11799,6 +11848,37 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
+    // Issue #519: walks the bound tree collecting every `BoundBinaryExpression`
+    // whose operator is `NullCoalesce` (`?:`) and whose LHS is a value-type
+    // `Nullable<T>`. Each such site needs a `Nullable<T>`-typed temp slot so
+    // the emitter can spill the LHS once, call `Nullable<T>::get_HasValue`
+    // off the slot's address, and either reload the slot (when the result
+    // type is `Nullable<T>`) or call `Nullable<T>::get_Value` off the slot's
+    // address (when the result type is the underlying `T`). The reference-
+    // type `?:` path uses the existing `dup; brtrue; pop; rhs` pattern and
+    // needs no slot.
+    private sealed class NullableValueTypeCoalesceCollector : BoundTreeWalker
+    {
+        private readonly List<BoundBinaryExpression> sink;
+
+        public NullableValueTypeCoalesceCollector(List<BoundBinaryExpression> sink)
+        {
+            this.sink = sink;
+        }
+
+        protected override void VisitBinaryExpression(BoundBinaryExpression node)
+        {
+            if (node.Op.Kind == BoundBinaryOperatorKind.NullCoalesce
+                && node.Left.Type is NullableTypeSymbol n
+                && n.UnderlyingType?.ClrType is { IsValueType: true })
+            {
+                this.sink.Add(node);
+            }
+
+            base.VisitBinaryExpression(node);
+        }
+    }
+
     private sealed class SelectSlots
     {
         public SelectSlots(
@@ -13473,31 +13553,77 @@ internal sealed class ReflectionMetadataEmitter
             {
                 // P3-5 / Issue #420: `dup; brtrue` is only legal for object
                 // references and primitive integers — it is invalid IL for
-                // struct stack values. If the left operand's stack type is a
-                // value type (raw struct/enum, or `Nullable<T>` over a value
-                // type), this short-circuit pattern emits invalid IL the
-                // moment the binder/encoder lets such expressions through.
-                //
-                // Today the encoder rejects nullable user-defined structs/
-                // enums (see EncodeTypeSymbol), so the only reachable risky
-                // case is `Nullable<primitive>` (e.g. `int? ?? 5`). When
-                // nullable value types are wired up end-to-end the correct
-                // strategy is to spill the left to a local and emit a
-                // `call Nullable<T>::get_HasValue` / `call get_ValueOrDefault`
-                // pair, or to box before the brtrue. Until that is in place,
-                // fail fast with a clear diagnostic instead of producing
-                // PEVerify-rejected IL.
+                // struct stack values. When the LHS is a value-type
+                // `Nullable<T>` (issue #519), spill it to a `Nullable<T>`-
+                // typed temp slot and branch on `Nullable<T>::get_HasValue`
+                // instead. The non-null branch either reloads the slot
+                // (when the result type is `Nullable<T>`) or unwraps via
+                // `Nullable<T>::get_Value()` (when the result type is the
+                // underlying `T`); both shapes leave a verifiable stack
+                // matching the operator's declared result type.
+                if (b.Left.Type is NullableTypeSymbol leftNullable
+                    && leftNullable.UnderlyingType?.ClrType is { IsValueType: true } innerClr)
+                {
+                    if (!this.receiverSpillSlots.TryGetValue(b, out var slot))
+                    {
+                        throw new InvalidOperationException(
+                            "No scratch slot pre-allocated for value-type Nullable<T> '?:' LHS — "
+                            + "check NullableValueTypeCoalesceCollector and the prepass in CollectLocalsAndLabels.");
+                    }
+
+                    this.EmitExpression(b.Left);
+                    this.il.StoreLocal(slot);
+                    this.il.LoadLocalAddress(slot);
+                    this.il.OpCode(ILOpCode.Call);
+                    this.il.Token(this.outer.GetNullableGetHasValueReference(innerClr));
+                    var fallback = this.il.DefineLabel();
+                    var end = this.il.DefineLabel();
+                    this.il.Branch(ILOpCode.Brfalse, fallback);
+
+                    // Non-null branch: reproduce the operator's result type.
+                    if (b.Type is NullableTypeSymbol)
+                    {
+                        // Result is `Nullable<T>` — push the spilled wrapper as
+                        // a value. Reloading the slot preserves the present
+                        // wrapper (`HasValue == true`) so the consumer sees
+                        // the same boxed/wrapped shape it would have observed
+                        // had the coalesce been absent.
+                        this.il.LoadLocal(slot);
+                    }
+                    else
+                    {
+                        // Result is the underlying `T` — call `get_Value()`
+                        // off the slot's address. `HasValue == true` was just
+                        // observed, so the call cannot throw; routing through
+                        // get_Value (rather than a field-style unwrap) keeps
+                        // the IL shape consistent with the `!!` emit path
+                        // introduced in PR #541 and uses no extra slots.
+                        this.il.LoadLocalAddress(slot);
+                        this.il.OpCode(ILOpCode.Call);
+                        this.il.Token(this.outer.GetNullableGetValueReference(innerClr));
+                    }
+
+                    this.il.Branch(ILOpCode.Br, end);
+
+                    // Null branch: evaluate RHS, which the binder typed to
+                    // match the operator's result (either `T` or `Nullable<T>`).
+                    this.il.MarkLabel(fallback);
+                    this.EmitExpression(b.Right);
+                    this.il.MarkLabel(end);
+                    return;
+                }
+
+                // Defensive: any other value-typed LHS (raw struct or enum)
+                // remains unsupported by `?:`. Today the encoder rejects
+                // nullable user-defined structs/enums, so this branch is
+                // unreachable from valid source, but fail loudly rather
+                // than silently producing PEVerify-rejected IL.
                 var leftType = b.Left.Type;
                 if (IsValueTypeSymbol(leftType))
                 {
-                    var assertMsg = "Null-coalesce `??` emit uses `dup; brtrue` which is illegal IL for value-type stack values "
-                        + "(struct, enum, or Nullable<valueType>). This path needs a HasValue/ValueOrDefault "
-                        + "(or box-before-brtrue) strategy when nullable value types are wired up end-to-end. "
-                        + $"Left operand type was '{leftType?.Name}'.";
-                    System.Diagnostics.Debug.Assert(false, assertMsg);
                     throw new NotSupportedException(
-                        $"Null-coalesce '??' over value-type operand '{leftType?.Name}' is not yet supported by the emitter. "
-                        + "The current `dup; brtrue` short-circuit is invalid IL for struct stack values; a HasValue/ValueOrDefault "
+                        $"Null-coalesce '?:' over value-type operand '{leftType?.Name}' is not yet supported by the emitter. "
+                        + "The current `dup; brtrue` short-circuit is invalid IL for struct stack values; a HasValue/Value "
                         + "(or box-before-brtrue) emit path is required when nullable value types are supported.");
                 }
 

--- a/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
+++ b/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
@@ -255,6 +255,29 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
         proc.BeginErrorReadLine();
         proc.WaitForExit();
 
+        // Issue #519: when gsc exits non-zero but no structured diagnostic
+        // was logged (for example, an unhandled emitter exception that
+        // bypassed the GS9998 wrapper, or a stdout-only diagnostic whose
+        // location prefix did not match `DiagnosticLine`), MSBuild would
+        // otherwise see `Execute` return false without any logged error and
+        // surface a bare MSB4181. Log a synthetic GS9998 carrying the
+        // observed exit code so the failure is at least visible in the
+        // error list (and project files can suppress/promote it via the
+        // normal NoWarn/WarnAsError plumbing).
+        if (proc.ExitCode != 0 && !this.Log.HasLoggedErrors)
+        {
+            this.Log.LogError(
+                subcategory: null,
+                errorCode: "GS9998",
+                helpKeyword: null,
+                file: this.GsharpCompilerFullPath ?? "gsc",
+                lineNumber: 0,
+                columnNumber: 0,
+                endLineNumber: 0,
+                endColumnNumber: 0,
+                message: $"gsc exited with code {proc.ExitCode} but did not log a diagnostic. This typically indicates an unhandled compiler exception; please file an issue.");
+        }
+
         return proc.ExitCode == 0 && !this.Log.HasLoggedErrors;
     }
 

--- a/test/Compiler.Tests/Emit/Issue519CoalesceNullableEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue519CoalesceNullableEmitTests.cs
@@ -1,0 +1,536 @@
+// <copyright file="Issue519CoalesceNullableEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #519: applying the null-coalescing operator <c>?:</c> to a CLR
+/// <c>Nullable&lt;T&gt;</c> value previously crashed the emit phase silently
+/// (<c>MSB4181</c> with no <c>GS####</c> diagnostic). The cause was the value-
+/// type guard at the binary emit site rejecting any nullable value-type LHS
+/// because <c>dup; brtrue</c> is invalid IL for a struct stack value, plus a
+/// missing <c>HasValue</c>/<c>get_Value</c> lowering path.
+///
+/// These tests pin down the new behaviour:
+/// <list type="bullet">
+///   <item><c>Nullable&lt;T&gt; ?: T</c> for <c>bool?</c> and <c>int32?</c>, both
+///   the present and absent branches, against locals and CLR properties.</item>
+///   <item><c>Nullable&lt;T&gt; ?: Nullable&lt;T&gt;</c> preserves the wrapper
+///   shape and threads <c>nil</c> through both sides.</item>
+///   <item>Chained <c>a ?: b ?: c</c> over nullable operands routes through the
+///   right operand correctly when the LHSs are <c>nil</c>.</item>
+///   <item>Reference-typed nullables (<c>string?</c>) continue to use the
+///   existing <c>dup; brtrue</c> path and are not regressed.</item>
+/// </list>
+/// Each test compiles via <c>gsc</c>, runs <c>ilverify</c> against the produced
+/// PE, then executes the assembly under <c>dotnet exec</c> and asserts on the
+/// captured stdout (so any invalid IL surfaces as a verification failure
+/// rather than silently passing).
+/// </summary>
+public class Issue519CoalesceNullableEmitTests
+{
+    [Fact]
+    public void CoalesceNullableBool_HasValue_Local_ReturnsLeftUnderlying()
+    {
+        var source = """
+            package P
+
+            import System
+
+            var a bool? = true
+            var v bool = a ?: false
+            Console.WriteLine(v)
+
+            var b bool? = false
+            var w bool = b ?: true
+            Console.WriteLine(w)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void CoalesceNullableBool_NoValue_Local_ReturnsRightLiteral()
+    {
+        var source = """
+            package P
+
+            import System
+
+            var a bool? = nil
+            var v bool = a ?: true
+            Console.WriteLine(v)
+
+            var b bool? = nil
+            var w bool = b ?: false
+            Console.WriteLine(w)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void CoalesceNullableInt_HasValue_Local_ReturnsLeftUnderlying()
+    {
+        var source = """
+            package P
+
+            import System
+
+            var a int32? = 7
+            var v int32 = a ?: 99
+            Console.WriteLine(v)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void CoalesceNullableInt_NoValue_Local_ReturnsRightLiteral()
+    {
+        var source = """
+            package P
+
+            import System
+
+            var a int32? = nil
+            var v int32 = a ?: 99
+            Console.WriteLine(v)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    [Fact]
+    public void CoalesceNullableInt_BothNullable_HasValue_PreservesLeftWrapper()
+    {
+        // RHS is also `int32?`, so the operator's result type is the wrapper
+        // `Nullable<int32>` rather than `int32`. The non-null branch must
+        // reload the spilled `Nullable<T>` value (not unwrap and re-wrap),
+        // so that `r` observes the original wrapper's identity.
+        var source = """
+            package P
+
+            import System
+
+            var a int32? = 7
+            var b int32? = 99
+            var r int32? = a ?: b
+            Console.WriteLine(r!!)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void CoalesceNullableInt_BothNullable_LeftNil_UsesRightWrapper()
+    {
+        var source = """
+            package P
+
+            import System
+
+            var a int32? = nil
+            var b int32? = 42
+            var r int32? = a ?: b
+            Console.WriteLine(r!!)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void CoalesceNullableInt_BothNullable_BothNil_PropagatesAbsence()
+    {
+        // When both sides carry no value, the result must remain absent —
+        // a literal `nil` wrapper must reach the consumer (here observed
+        // through `object` widening so `Console.Write` prints empty).
+        var source = """
+            package P
+
+            import System
+
+            var a int32? = nil
+            var b int32? = nil
+            var r int32? = a ?: b
+            var o object = r
+            Console.Write("[")
+            Console.Write(o)
+            Console.WriteLine("]")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("[]\n", output);
+    }
+
+    [Fact]
+    public void CoalesceNullableInt_Chained_AllNil_ReturnsLastLiteral()
+    {
+        // `a ?: b ?: c` parses right-associatively as `a ?: (b ?: c)`.
+        // Both `a` and `b` are value-type Nullable<int>, so the emitter
+        // pre-allocates two separate scratch slots (one per BoundBinary
+        // expression). When all left operands are nil the final literal
+        // wins.
+        var source = """
+            package P
+
+            import System
+
+            var a int32? = nil
+            var b int32? = nil
+            var c int32 = 99
+            var r int32 = a ?: b ?: c
+            Console.WriteLine(r)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    [Fact]
+    public void CoalesceNullableInt_Chained_MiddleHasValue_ReturnsMiddle()
+    {
+        var source = """
+            package P
+
+            import System
+
+            var a int32? = nil
+            var b int32? = 7
+            var c int32 = 99
+            var r int32 = a ?: b ?: c
+            Console.WriteLine(r)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void CoalesceNullableInt_Chained_FirstHasValue_ReturnsFirst()
+    {
+        var source = """
+            package P
+
+            import System
+
+            var a int32? = 1
+            var b int32? = 7
+            var c int32 = 99
+            var r int32 = a ?: b ?: c
+            Console.WriteLine(r)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void CoalesceClrNullableBoolProperty_HasValue_ReturnsUnderlying()
+    {
+        // End-to-end reproducer mirroring the issue: a sibling CLR type
+        // exposes `bool? Flag`. GSharp reads through the getter and
+        // coalesces with a literal. Each step must produce verifiable IL —
+        // before #519 the compile crashed silently as MSB4181.
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var s = Settings()
+            s.Flag = true
+            var v bool = s.Flag ?: false
+            Console.WriteLine(v)
+
+            s.Flag = false
+            var w bool = s.Flag ?: true
+            Console.WriteLine(w)
+            """;
+
+        var output = CompileAndRunWithProbe(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void CoalesceClrNullableBoolProperty_NoValue_ReturnsFallback()
+    {
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var s = Settings()
+            s.Flag = nil
+            var v bool = s.Flag ?: true
+            Console.WriteLine(v)
+
+            s.Flag = nil
+            var w bool = s.Flag ?: false
+            Console.WriteLine(w)
+            """;
+
+        var output = CompileAndRunWithProbe(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void CoalesceClrNullableIntProperty_RoundTripsThroughCoalesce()
+    {
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var s = Settings()
+            s.Count = 7
+            var v int32 = s.Count ?: 99
+            Console.WriteLine(v)
+
+            s.Count = nil
+            var w int32 = s.Count ?: 99
+            Console.WriteLine(w)
+            """;
+
+        var output = CompileAndRunWithProbe(source);
+        Assert.Equal("7\n99\n", output);
+    }
+
+    [Fact]
+    public void CoalesceReferenceNullableString_StillUsesShortCircuitPath()
+    {
+        // Regression guard: a reference-typed nullable continues to use the
+        // existing `dup; brtrue; pop; rhs` short-circuit, which is legal IL
+        // for object references. The value-type emit branch added for #519
+        // must not capture this case.
+        var source = """
+            package P
+
+            import System
+
+            var s string? = "hello"
+            var r string = s ?: "fallback"
+            Console.WriteLine(r)
+
+            var t string? = nil
+            var u string = t ?: "fallback"
+            Console.WriteLine(u)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello\nfallback\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: true);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static string CompileAndRunWithProbe(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: true, withProbe: true);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(
+        string source,
+        bool expectSuccess,
+        bool withProbe = false)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue519_").FullName;
+        try
+        {
+            string probeDllPath = null;
+            if (withProbe)
+            {
+                probeDllPath = Path.Combine(tempDir, "ProbeLib.dll");
+                BuildProbeLibrary(probeDllPath);
+            }
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+            if (probeDllPath != null)
+            {
+                args.Add("/r:" + probeDllPath);
+            }
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            var verifyRefs = probeDllPath != null ? new[] { probeDllPath } : null;
+            IlVerifier.Verify(outPath, additionalReferences: verifyRefs);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void BuildProbeLibrary(string dllPath)
+    {
+        var coreAssembly = typeof(object).Assembly;
+
+        var asmName = new AssemblyName("ProbeLib") { Version = new Version(1, 0, 0, 0) };
+        var asmBuilder = new PersistedAssemblyBuilder(asmName, coreAssembly);
+        var moduleBuilder = asmBuilder.DefineDynamicModule("ProbeLib");
+
+        var typeBuilder = moduleBuilder.DefineType(
+            "Probe.Settings",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.AutoLayout | TypeAttributes.BeforeFieldInit,
+            parent: typeof(object));
+
+        EmitAutoProperty(typeBuilder, "Flag", typeof(bool?));
+        EmitAutoProperty(typeBuilder, "Count", typeof(int?));
+
+        var ctor = typeBuilder.DefineConstructor(
+            MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName | MethodAttributes.HideBySig,
+            CallingConventions.Standard,
+            Type.EmptyTypes);
+        var ctorIl = ctor.GetILGenerator();
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Call, typeof(object).GetConstructor(Type.EmptyTypes)!);
+        ctorIl.Emit(OpCodes.Ret);
+
+        typeBuilder.CreateType();
+        asmBuilder.Save(dllPath);
+    }
+
+    private static void EmitAutoProperty(TypeBuilder typeBuilder, string name, Type clrType)
+    {
+        var field = typeBuilder.DefineField(
+            "<" + name + ">k__BackingField",
+            clrType,
+            FieldAttributes.Private);
+
+        var property = typeBuilder.DefineProperty(
+            name,
+            PropertyAttributes.HasDefault,
+            clrType,
+            parameterTypes: null);
+
+        const MethodAttributes accessorAttrs = MethodAttributes.Public
+            | MethodAttributes.SpecialName
+            | MethodAttributes.HideBySig;
+
+        var getter = typeBuilder.DefineMethod(
+            "get_" + name,
+            accessorAttrs,
+            clrType,
+            Type.EmptyTypes);
+        var getterIl = getter.GetILGenerator();
+        getterIl.Emit(OpCodes.Ldarg_0);
+        getterIl.Emit(OpCodes.Ldfld, field);
+        getterIl.Emit(OpCodes.Ret);
+
+        var setter = typeBuilder.DefineMethod(
+            "set_" + name,
+            accessorAttrs,
+            returnType: null,
+            parameterTypes: new[] { clrType });
+        var setterIl = setter.GetILGenerator();
+        setterIl.Emit(OpCodes.Ldarg_0);
+        setterIl.Emit(OpCodes.Ldarg_1);
+        setterIl.Emit(OpCodes.Stfld, field);
+        setterIl.Emit(OpCodes.Ret);
+
+        property.SetGetMethod(getter);
+        property.SetSetMethod(setter);
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/NullCoalesceValueTypeGuardTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/NullCoalesceValueTypeGuardTests.cs
@@ -18,14 +18,19 @@ namespace GSharp.Core.Tests.CodeAnalysis.Emit;
 /// Issue #420 / P3-5: the null-coalesce (<c>??</c> / <c>?:</c>) emit path uses
 /// <c>dup; brtrue</c> which is only legal for object references and primitive
 /// integers — it is invalid IL for struct stack values (including
-/// <c>Nullable&lt;T&gt;</c> over a value type). This file pins down two
-/// behaviours:
+/// <c>Nullable&lt;T&gt;</c> over a value type).
+///
+/// Issue #519 retired the historical fail-fast guard for value-type
+/// <c>Nullable&lt;T&gt;</c> operands by lowering them to a HasValue/get_Value
+/// sequence over a pre-allocated scratch slot. This file now pins down both
+/// behaviours that survived the change:
 /// <list type="bullet">
 ///   <item>Reference-type operands continue to short-circuit correctly via the
 ///   existing <c>dup; brtrue</c> pattern.</item>
-///   <item>Value-type left operands are rejected loudly at emit time
-///   (<see cref="NotSupportedException"/>) so the emitter never produces
-///   PEVerify-rejected IL even if the binder/encoder accept the expression.</item>
+///   <item>Value-type <c>Nullable&lt;T&gt;</c> operands now compile and run
+///   correctly through the HasValue path (and produce verifiable IL — see
+///   <c>Issue519CoalesceNullableEmitTests</c> in the Compiler.Tests project for
+///   the ilverify-gated end-to-end shape).</item>
 /// </list>
 /// </summary>
 public class NullCoalesceValueTypeGuardTests
@@ -57,59 +62,38 @@ Console.WriteLine(r)
     }
 
     [Fact]
-    public void NullCoalesce_ValueType_LeftNullableInt_RejectedByEmitter()
+    public void NullCoalesce_ValueType_LeftNullableInt_LeftNil_ReturnsRight()
     {
-        // `int? ?: 0` would compile the left to a `Nullable<int>` stack value
-        // (P2-7's wrapping). `dup; brtrue` on a struct is invalid IL, so the
-        // P3-5 guard must reject this at emit time rather than silently
-        // producing bad metadata.
-        const string Source = @"package NullCoalesceValueTypeGuard
+        // Issue #519: `int? ?: 0` previously aborted emit because `dup;
+        // brtrue` is invalid IL for the `Nullable<int>` struct on the
+        // stack. The emitter now spills the LHS into a pre-allocated
+        // `Nullable<int>` slot and branches on `Nullable<T>::get_HasValue`,
+        // producing verifiable IL that returns the right operand when the
+        // left is absent.
+        const string Source = @"package NullCoalesceValueTypeNil
 import System
 var n int32? = nil
-var r int32 = n ?: 0
+var r int32 = n ?: 99
 Console.WriteLine(r)
 ";
-        var tree = SyntaxTree.Parse(SourceText.From(Source));
-        var compilation = new Compilation(tree);
-        using var peStream = new MemoryStream();
+        var stdout = CompileLoadInvokeCaptureStdout(Source, nameof(NullCoalesce_ValueType_LeftNullableInt_LeftNil_ReturnsRight));
+        Assert.Equal("99", stdout.Trim());
+    }
 
-        // The guard fires twice. In Debug builds `Debug.Assert(false, ...)`
-        // raises a DebugAssertException, which escapes `Compilation.Emit`
-        // because the `catch when (ex is NotSupportedException || ...)` filter
-        // does not match it. In Release builds the assert is a no-op, so the
-        // subsequent `throw new NotSupportedException(...)` is caught by that
-        // filter and surfaced as a GS9998 emit diagnostic on the returned
-        // EmitResult. Accept either shape, and in both cases verify the
-        // diagnostic explains the value-type / dup-brtrue issue.
-        string message;
-        var ex = Record.Exception(() =>
-        {
-            var result = compilation.Emit(peStream);
-            if (!result.Success)
-            {
-                // Re-throw the emit-time NotSupportedException surfaced as a
-                // diagnostic so the test below can assert on its message.
-                var diag = result.Diagnostics.FirstOrDefault(d => d.IsError);
-                throw new NotSupportedException(diag?.Message ?? "<no diagnostic message>");
-            }
-        });
-        Assert.NotNull(ex);
-
-        var actual = ex!;
-        while (actual.InnerException is not null
-               && actual is not NotSupportedException
-               && actual.GetType().Name != "DebugAssertException")
-        {
-            actual = actual.InnerException;
-        }
-
-        var typeName = actual.GetType().Name;
-        Assert.True(
-            actual is NotSupportedException || typeName == "DebugAssertException",
-            $"expected NotSupportedException or DebugAssertException, got {actual.GetType().FullName}: {actual.Message}");
-        message = actual.Message;
-        Assert.Contains("Null-coalesce", message, StringComparison.Ordinal);
-        Assert.Contains("value-type", message, StringComparison.Ordinal);
+    [Fact]
+    public void NullCoalesce_ValueType_LeftNullableInt_LeftPresent_ReturnsUnderlying()
+    {
+        // Symmetric case: when the LHS carries a value, the result is the
+        // underlying primitive — fetched via `Nullable<T>::get_Value()` off
+        // the spilled slot's address (the same path PR #541 added for `!!`).
+        const string Source = @"package NullCoalesceValueTypePresent
+import System
+var n int32? = 7
+var r int32 = n ?: 99
+Console.WriteLine(r)
+";
+        var stdout = CompileLoadInvokeCaptureStdout(Source, nameof(NullCoalesce_ValueType_LeftNullableInt_LeftPresent_ReturnsUnderlying));
+        Assert.Equal("7", stdout.Trim());
     }
 
     private static string CompileLoadInvokeCaptureStdout(string source, string contextName)


### PR DESCRIPTION
Fixes #519.

## Problem

Applying `?:` to a CLR `Nullable<T>` value aborted IL emission via a fail-fast guard introduced by #420 — `dup; brtrue` is invalid IL for struct stack values, and no `HasValue`/`get_Value` lowering existed for value-type nullables. The thrown `NotSupportedException` was caught by `Compilation.Emit` and surfaced as a `GS9998` diagnostic anchored at an empty source location, which then failed the SDK `BuildTask`'s diagnostic regex and surfaced as a bare `MSB4181` with no `GS####` diagnostic in the build error list.

## Design

**Emit (`ReflectionMetadataEmitter.cs`).** Lower `?:` whose LHS is a value-type `Nullable<T>` to a verifiable HasValue branch over a pre-allocated `Nullable<T>` scratch slot:

```
EmitExpression(Left);
stloc tmp                          ; tmp : Nullable<T>
ldloca tmp
call Nullable<T>::get_HasValue()
brfalse fallback
; result type == Nullable<T> → reload wrapper:
ldloc tmp
; OR result type == underlying T → unwrap via Value:
ldloca tmp ; call Nullable<T>::get_Value()
br end
fallback:
EmitExpression(Right);
end:
```

A new `NullableValueTypeCoalesceCollector` mirrors the unwrap collector from PR #541 and registers one `Nullable<T>`-typed slot per qualifying binary expression in `receiverSpillSlots` (keyed by `BoundBinaryExpression`, distinct from receiver / assignment / `!!` keys). Reference-type nullables continue to use the existing `dup; brtrue` pattern. Other value-typed LHSs (raw struct / enum) remain rejected — they are unreachable from valid source today and the existing encoder gate ensures it stays that way.

**Silent abort eradication.**

- `Compilation.Emit` anchors the `GS9998` synthetic location at the first syntax tree's `SourceText` (with a file-named fallback when no trees exist) so `BuildTask`'s `DiagnosticLine` regex matches and the error reaches the MSBuild logger.
- `BuildTask.Execute` logs a structured `GS9998` when `gsc` exits non-zero with no error already on the MSBuild logger — covering exception types that escape the `NotSupportedException`/`InvalidOperationException` filter in `Compilation.Emit`. No more silent `MSB4181` for emitter crashes.

## Tests

`test/Compiler.Tests/Emit/Issue519CoalesceNullableEmitTests.cs` (14 tests, all gated by `ilverify` and executed under `dotnet exec`):

- `Nullable<bool> ?: bool` and `Nullable<int32> ?: int32` — both `HasValue == true` and `HasValue == false` branches.
- `Nullable<int32> ?: Nullable<int32>` — preserves the wrapper, threads `nil` through both sides.
- Chained `a ?: b ?: c` across nullable LHSs (all-nil, middle present, first present).
- CLR-property `bool?` end-to-end mirroring the original reproducer (`s.Flag ?: false`).
- CLR-property `int?` round-trip through the coalesce.
- Reference-type `string?` regression guard to ensure the existing short-circuit path is not captured by the new value-type branch.

`test/Core.Tests/CodeAnalysis/Emit/NullCoalesceValueTypeGuardTests.cs` — the pre-existing fail-fast guard test is repurposed to assert the new pass-through behaviour for present / absent value-type `Nullable<int>` LHSs.

## Verification

```
$ dotnet build GSharp.sln -nologo -clp:NoSummary
Build succeeded. 0 Warning(s) 0 Error(s)

$ dotnet test GSharp.sln --no-restore --nologo
Passed!  Sdk.Tests             24/24
Passed!  Interpreter.Tests     72/72
Passed!  LanguageServer.Tests  226/226
Passed!  Core.Tests            1949/1949
Passed!  Compiler.Tests        481/481
```

Nothing deferred.
