### PR TITLE
Emit: type-aware ldelem/stelem on CLR array element loads (Fixes #520)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -5932,7 +5932,21 @@ public sealed class Binder
             // flags; extract element/key/value types using those flags so that
             // `for k, v := range dict` sees the proper nullable types.
             case NullabilityAnnotatedTypeSymbol annotated when annotated.ClrType != null:
-                if (TryGetClrDictionaryTypes(annotated.ClrType, out var aDKey, out var aDVal))
+                // Issue #520: CLR SZ arrays (`T[]`) implement IEnumerable<T> via
+                // runtime magic but `Array.GetEnumerator()` returns the non-generic
+                // IEnumerator whose Current is System.Object. Routing them through
+                // the Enumerable path would assign a boxed reference into the
+                // value-typed loop variable (the pointer's low 32 bits surface as
+                // garbage). Use the Indexed path instead so we emit `ldelem <T>`
+                // with the array's actual element type — same lowering C#'s
+                // `foreach (T x in arr)` produces.
+                if (annotated.ClrType.IsArray && annotated.ClrType.GetArrayRank() == 1)
+                {
+                    iterationKind = ForRangeKind.Indexed;
+                    keyType = TypeSymbol.Int32;
+                    valueType = annotated.GetTypeArgumentSymbolForClrType(annotated.ClrType.GetElementType());
+                }
+                else if (TryGetClrDictionaryTypes(annotated.ClrType, out var aDKey, out var aDVal))
                 {
                     iterationKind = ForRangeKind.Dictionary;
                     keyType = annotated.GetTypeArgumentSymbolForClrType(aDKey);
@@ -5958,7 +5972,17 @@ public sealed class Binder
 
                 break;
             case ImportedTypeSymbol imp when imp.ClrType != null:
-                if (TryGetClrDictionaryTypes(imp.ClrType, out var dKey, out var dVal))
+                // Issue #520: CLR SZ arrays (`T[]`) — see the matching note in the
+                // NullabilityAnnotatedTypeSymbol branch above. Detect first and
+                // route to the Indexed path so iteration emits `ldelem <T>`
+                // (type-aware) rather than walking a boxing IEnumerator.
+                if (imp.ClrType.IsArray && imp.ClrType.GetArrayRank() == 1)
+                {
+                    iterationKind = ForRangeKind.Indexed;
+                    keyType = TypeSymbol.Int32;
+                    valueType = TypeSymbol.FromClrType(imp.ClrType.GetElementType());
+                }
+                else if (TryGetClrDictionaryTypes(imp.ClrType, out var dKey, out var dVal))
                 {
                     iterationKind = ForRangeKind.Dictionary;
                     keyType = TypeSymbol.FromClrType(dKey);

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -14381,20 +14381,62 @@ internal sealed class ReflectionMetadataEmitter
 
         private void EmitLoadElement(TypeSymbol elementType)
         {
+            // Issue #520: prefer the typed short-form ldelem opcodes for
+            // every CIL primitive. `ldelem <token>` for small ints leaves a
+            // sub-int32 value on the eval stack and ilverify rejects it
+            // ([StackUnexpected]: found Short/Byte). The short forms widen
+            // to int32 as ECMA-335 requires for arithmetic continuation.
             if (elementType == TypeSymbol.Int32)
             {
                 this.il.OpCode(ILOpCode.Ldelem_i4);
             }
-            else if (elementType == TypeSymbol.Bool)
+            else if (elementType == TypeSymbol.UInt32)
+            {
+                this.il.OpCode(ILOpCode.Ldelem_u4);
+            }
+            else if (elementType == TypeSymbol.Int64 || elementType == TypeSymbol.UInt64)
+            {
+                this.il.OpCode(ILOpCode.Ldelem_i8);
+            }
+            else if (elementType == TypeSymbol.Int16)
+            {
+                this.il.OpCode(ILOpCode.Ldelem_i2);
+            }
+            else if (elementType == TypeSymbol.UInt16 || elementType == TypeSymbol.Char)
+            {
+                this.il.OpCode(ILOpCode.Ldelem_u2);
+            }
+            else if (elementType == TypeSymbol.Int8)
+            {
+                this.il.OpCode(ILOpCode.Ldelem_i1);
+            }
+            else if (elementType == TypeSymbol.UInt8 || elementType == TypeSymbol.Bool)
             {
                 this.il.OpCode(ILOpCode.Ldelem_u1);
             }
-            else if (elementType == TypeSymbol.String)
+            else if (elementType == TypeSymbol.Float32)
             {
+                this.il.OpCode(ILOpCode.Ldelem_r4);
+            }
+            else if (elementType == TypeSymbol.Float64)
+            {
+                this.il.OpCode(ILOpCode.Ldelem_r8);
+            }
+            else if (elementType == TypeSymbol.NInt || elementType == TypeSymbol.NUInt)
+            {
+                this.il.OpCode(ILOpCode.Ldelem_i);
+            }
+            else if (elementType == TypeSymbol.String || IsReferenceTypeElement(elementType))
+            {
+                // Reference-type element (string or any other class/interface):
+                // ldelem.ref is the only correct form.
                 this.il.OpCode(ILOpCode.Ldelem_ref);
             }
             else
             {
+                // Arbitrary value type — enums (whose underlying type the JIT
+                // honors), structs, etc. `ldelem <token>` works for these
+                // because the verifier matches the static element type.
                 this.il.OpCode(ILOpCode.Ldelem);
                 this.il.Token(this.outer.GetElementTypeToken(elementType));
             }
@@ -14402,15 +14444,42 @@ internal sealed class ReflectionMetadataEmitter
 
         private void EmitStoreElement(TypeSymbol elementType)
         {
-            if (elementType == TypeSymbol.Int32)
+            // Issue #520: mirror EmitLoadElement — use the typed short-form
+            // stelem opcodes for every CIL primitive so the stack truncation
+            // rules match what the verifier expects.
+            if (elementType == TypeSymbol.Int32 || elementType == TypeSymbol.UInt32)
             {
                 this.il.OpCode(ILOpCode.Stelem_i4);
             }
-            else if (elementType == TypeSymbol.Bool)
+            else if (elementType == TypeSymbol.Int64 || elementType == TypeSymbol.UInt64)
+            {
+                this.il.OpCode(ILOpCode.Stelem_i8);
+            }
+            else if (elementType == TypeSymbol.Int16 ||
+                     elementType == TypeSymbol.UInt16 ||
+                     elementType == TypeSymbol.Char)
+            {
+                this.il.OpCode(ILOpCode.Stelem_i2);
+            }
+            else if (elementType == TypeSymbol.Int8 ||
+                     elementType == TypeSymbol.UInt8 ||
+                     elementType == TypeSymbol.Bool)
             {
                 this.il.OpCode(ILOpCode.Stelem_i1);
             }
-            else if (elementType == TypeSymbol.String)
+            else if (elementType == TypeSymbol.Float32)
+            {
+                this.il.OpCode(ILOpCode.Stelem_r4);
+            }
+            else if (elementType == TypeSymbol.Float64)
+            {
+                this.il.OpCode(ILOpCode.Stelem_r8);
+            }
+            else if (elementType == TypeSymbol.NInt || elementType == TypeSymbol.NUInt)
+            {
+                this.il.OpCode(ILOpCode.Stelem_i);
+            }
+            else if (elementType == TypeSymbol.String || IsReferenceTypeElement(elementType))
             {
                 this.il.OpCode(ILOpCode.Stelem_ref);
             }
@@ -14419,6 +14488,23 @@ internal sealed class ReflectionMetadataEmitter
                 this.il.OpCode(ILOpCode.Stelem);
                 this.il.Token(this.outer.GetElementTypeToken(elementType));
             }
+        }
+
+        // Issue #520: the EmitLoad/StoreElement helpers need to distinguish
+        // class/interface element types (require stelem.ref / ldelem.ref) from
+        // value-type element types (require the typed `stelem/ldelem <token>`
+        // forms when no short-form opcode matches). All G#-native non-string
+        // primitives have a TypeSymbol fast-path above; anything left over is
+        // user-defined or imported and we can ask the underlying CLR type.
+        private static bool IsReferenceTypeElement(TypeSymbol elementType)
+        {
+            if (elementType == TypeSymbol.Object)
+            {
+                return true;
+            }
+
+            var clr = elementType?.ClrType;
+            return clr != null && !clr.IsValueType && !clr.IsGenericParameter;
         }
 
         private void EmitTryStatement(BoundTryStatement node)

--- a/test/Compiler.Tests/Emit/Issue520ClrArrayForRangeTests.cs
+++ b/test/Compiler.Tests/Emit/Issue520ClrArrayForRangeTests.cs
@@ -1,0 +1,365 @@
+// <copyright file="Issue520ClrArrayForRangeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Regression tests for issue #520 (and the duplicate #536): <c>for x := range coll</c>
+/// over a CLR SZ array (<c>T[]</c>) used to walk the array via
+/// <see cref="System.Array.GetEnumerator"/>, which returns the non-generic
+/// <see cref="System.Collections.IEnumerator"/> whose <c>Current</c> property
+/// returns <see cref="object"/>. For value-typed element arrays
+/// (<c>Color[]</c>, <c>char[]</c>, <c>int[]</c>) the loop body then stored
+/// a boxed reference into a value-typed local — the low 32 bits of the
+/// managed pointer surfaced as garbage values (pointer-like integers in the
+/// ~900M range) and downstream casts crashed with
+/// <see cref="System.AccessViolationException"/>.
+///
+/// The fix (see <c>Binder.BindForRangeStatement</c>) detects SZ-array
+/// <see cref="System.Type.IsArray"/> on the CLR side and routes through the
+/// Indexed strategy, which emits <c>ldelem &lt;T&gt;</c> via the array's
+/// actual element type — the same lowering Roslyn emits for
+/// <c>foreach (T x in arr)</c>.
+/// </summary>
+public class Issue520ClrArrayForRangeTests
+{
+    [Fact]
+    public void ForRange_OverClrEnumArray_YieldsDeclaredMembersInOrder()
+    {
+        // The original repro: enumerating a `Region[]` returned by a CLR helper
+        // used to surface heap addresses (pointer-like ints in the ~900M range)
+        // instead of the enum members. With the indexed lowering it produces
+        // ldelem <Region> against the underlying int32 storage, so each load
+        // reconstitutes the value-type element exactly.
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue520_enum_").FullName;
+        try
+        {
+            var helperPath = BuildClrArrayHelperAssembly(tempDir);
+
+            var source = """
+                package P
+                import System
+                import Probe
+
+                var arr = Helper.GetColors()
+                for c := range arr {
+                  Console.WriteLine(int32(c))
+                }
+                """;
+
+            var output = CompileAndRunWithHelper(source, tempDir, helperPath, verifyIl: true);
+            Assert.Equal("0\n1\n2\n", output);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ForRange_OverClrEnumArray_EnumIsDefinedHoldsForEveryElement()
+    {
+        // Tighter check matching the user's `Enum.IsDefined[T](r)` assertion
+        // from the issue — under the bug every element was a heap-pointer-cast
+        // int, so IsDefined returned false on every iteration.
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue520_isdef_").FullName;
+        try
+        {
+            var helperPath = BuildClrArrayHelperAssembly(tempDir);
+
+            var source = """
+                package P
+                import System
+                import Probe
+
+                var arr = Helper.GetColors()
+                for c := range arr {
+                  if Enum.IsDefined(typeof(Color), c) {
+                    Console.WriteLine("ok")
+                  } else {
+                    Console.WriteLine("bad")
+                  }
+                }
+                """;
+
+            var output = CompileAndRunWithHelper(source, tempDir, helperPath, verifyIl: false);
+            Assert.Equal("ok\nok\nok\n", output);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ForRange_OverClrCharArray_YieldsExactChars()
+    {
+        // Doubles as the issue #536 repro: `for c in charArr` over `char[]`
+        // produced garbled values for the same reason — `char` is a value type
+        // and the loop variable was holding the boxed-object pointer's low
+        // bits. The fix routes char[] through `ldelem.u2`.
+        var source = """
+            package P
+            import System
+
+            var ca = "abc".ToCharArray()
+            for c := range ca {
+              Console.WriteLine(int32(c))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("97\n98\n99\n", output);
+    }
+
+    [Fact]
+    public void ForRange_OverClrIntArray_YieldsExactInts()
+    {
+        // Value-type element regression guard via `int[]`. Pre-fix this
+        // dereferenced a heap address as an int32 and printed garbage.
+        var source = """
+            package P
+            import System
+            import System.Linq
+
+            var ia = Enumerable.ToArray[int32](Enumerable.Range(10, 3))
+            for i := range ia {
+              Console.WriteLine(i)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("10\n11\n12\n", output);
+    }
+
+    [Fact]
+    public void ForRange_OverClrStringArray_YieldsExactStrings()
+    {
+        // Reference-type element regression guard — the indexed lowering still
+        // has to emit `ldelem.ref` for `string[]`. This pins that we didn't
+        // regress the reference-type path while fixing the value-type one.
+        var source = """
+            package P
+            import System
+
+            var sa = "x y z".Split(' ')
+            for s := range sa {
+              Console.WriteLine(s)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("x\ny\nz\n", output);
+    }
+
+    [Fact]
+    public void ForRange_OverClrStringArray_FromEnumGetNames_YieldsExactStrings()
+    {
+        // Tighter regression of the original issue surface area — the user's
+        // repro hung off `Enum.GetValues`. We can't bind to the generic
+        // `Enum.GetValues<T>()` from G# today, but `Enum.GetNames(typeof(T))`
+        // is the same shape (a CLR `string[]`) and exercises the same lowering.
+        var source = """
+            package P
+            import System
+
+            type Region enum { Us, Uk, De, Fr, Es, It, Pt, Pl, Cz, At, Nl }
+
+            var names = Enum.GetNames(typeof(Region))
+            for n := range names {
+              Console.WriteLine(n)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Us\nUk\nDe\nFr\nEs\nIt\nPt\nPl\nCz\nAt\nNl\n", output);
+    }
+
+    /// <summary>
+    /// Builds a tiny CLR helper assembly that declares
+    /// <c>Probe.Color { Red=0, Green=1, Blue=2 }</c> and
+    /// <c>Probe.Helper.GetColors() : Color[]</c>, returning
+    /// <c>new[] { Color.Red, Color.Green, Color.Blue }</c>.
+    /// Used by the enum-array tests because G# can't construct a CLR
+    /// SZ array of a value type directly — only via a CLR factory.
+    /// </summary>
+    private static string BuildClrArrayHelperAssembly(string dir)
+    {
+        var coreAssembly = typeof(object).Assembly;
+
+        var name = new AssemblyName("Probe") { Version = new Version(1, 0, 0, 0) };
+        var builder = new PersistedAssemblyBuilder(name, coreAssembly);
+        var module = builder.DefineDynamicModule("Probe");
+
+        // public enum Probe.Color : int { Red = 0, Green = 1, Blue = 2 }
+        var color = module.DefineEnum("Probe.Color", TypeAttributes.Public, typeof(int));
+        color.DefineLiteral("Red", 0);
+        color.DefineLiteral("Green", 1);
+        color.DefineLiteral("Blue", 2);
+        var colorType = color.CreateType();
+
+        // public static class Probe.Helper { public static Color[] GetColors() => new[]{Red,Green,Blue}; }
+        var helper = module.DefineType(
+            "Probe.Helper",
+            TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed | TypeAttributes.Class);
+        var getColors = helper.DefineMethod(
+            "GetColors",
+            MethodAttributes.Public | MethodAttributes.Static,
+            colorType.MakeArrayType(),
+            Type.EmptyTypes);
+        var il = getColors.GetILGenerator();
+
+        // new Color[3] { Red, Green, Blue }
+        il.Emit(OpCodes.Ldc_I4_3);
+        il.Emit(OpCodes.Newarr, colorType);
+        for (var i = 0; i < 3; i++)
+        {
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4, i);
+            il.Emit(OpCodes.Ldc_I4, i);
+            il.Emit(OpCodes.Stelem_I4);
+        }
+
+        il.Emit(OpCodes.Ret);
+        helper.CreateType();
+
+        var path = Path.Combine(dir, "Probe.dll");
+        builder.Save(path);
+        return path;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue520_").FullName;
+        try
+        {
+            return CompileAndRunImpl(source, tempDir, helperPath: null, verifyIl: true);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRunWithHelper(string source, string tempDir, string helperPath, bool verifyIl)
+    {
+        return CompileAndRunImpl(source, tempDir, helperPath, verifyIl);
+    }
+
+    private static string CompileAndRunImpl(string source, string tempDir, string helperPath, bool verifyIl)
+    {
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+        };
+
+        if (helperPath != null)
+        {
+            // Passing /r: switches gsc to closed-world mode (only the explicit
+            // refs are loaded), so we also have to enumerate the full BCL
+            // closure from the host's TPA. Matches the pattern in
+            // XunitAssertOverloadResolutionTests.
+            args.Add("/reference:" + helperPath);
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add("/nowarn:GS9100");
+        }
+
+        args.Add(srcPath);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        if (verifyIl)
+        {
+            var extraRefs = helperPath != null ? new[] { helperPath } : null;
+            IlVerifier.Verify(outPath, extraRefs);
+        }
+
+        // The helper DLL must sit beside the test exe so the runtime can
+        // locate it at load time (we don't ship a deps.json with it).
+        if (helperPath != null)
+        {
+            var target = Path.Combine(tempDir, Path.GetFileName(helperPath));
+            if (!File.Exists(target))
+            {
+                File.Copy(helperPath, target);
+            }
+        }
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = tempDir,
+        };
+        psi.ArgumentList.Add("exec");
+        psi.ArgumentList.Add("--runtimeconfig");
+        psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+        psi.ArgumentList.Add(outPath);
+
+        using var proc = Process.Start(psi);
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+        return stdout.Replace("\r\n", "\n");
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #520.

## Symptom

`for x := range arr` over a CLR SZ array (`T[]`) yielded pointer-like garbage values for value-typed elements:

```gsharp
for r := range Enum.GetValues[Region]() {   // or any T[] from a CLR helper
  Console.WriteLine("value = $r (int = ${int32(r)})")
  Assert.True(Enum.IsDefined[Region](r))    // always false
}
```

Loop count was correct, but each `r` was a heap address truncated to 32 bits (~900M-range integers, ~120 bytes apart — the SZArray cell stride of boxed Region pointers). `int32(r)` and `Enum.IsDefined[T](r)` both crashed or returned false.

## Root cause

`Region[]` came in as an `ImportedTypeSymbol` and `Binder.BindForRangeStatement` routed every CLR-imported collection through `ForRangeKind.Enumerable`. That path lowers to `coll.GetEnumerator() / MoveNext() / Current`, and `System.Array.GetEnumerator()` returns the **non-generic** `IEnumerator` whose `Current` is `object`. For a value-typed loop variable the lowering stored a boxed reference into a value-typed local — the managed pointer's low 32 bits surfaced as the "garbage".

Why the user's symptom *also* hit `char[]` (the bug in #536): same root cause — `char[]`'s `GetEnumerator()` is non-generic on `System.Array`.

## Fix

Two coordinated changes:

1. **`Binder.BindForRangeStatement`** — detect SZ-array CLR types (`IsArray && GetArrayRank() == 1`) on both `ImportedTypeSymbol` and `NullabilityAnnotatedTypeSymbol` *before* falling through to the enumerable probe, and route them through `ForRangeKind.Indexed` with the array's actual element type. Same lowering Roslyn emits for C# `foreach (T x in arr)` — `Length` + `ldelem <T>`, no enumerator allocation, no virtual dispatch, no boxing.
2. **`ReflectionMetadataEmitter.EmitLoadElement` / `EmitStoreElement`** — expand to the typed short-form opcodes for every CIL primitive (`ldelem.u2` for char/uint16, `ldelem.i2` for int16, `ldelem.i8` for int64/uint64, `ldelem.r4/r8` for floats, `ldelem.i` for nint/nuint, etc.). The unparameterised `ldelem <token>` for small ints leaves a sub-int32 value on the eval stack and ilverify rejects it (`[StackUnexpected]: found Short`); the typed forms zero/sign-extend to int32 as ECMA-335 requires. Reference-type elements still go through `ldelem.ref` / `stelem.ref`; user value types and enums fall through to the parameterised form (the JIT honors the underlying storage size for enums).

## Tests

New `test/Compiler.Tests/Emit/Issue520ClrArrayForRangeTests.cs`:

- `ForRange_OverClrEnumArray_YieldsDeclaredMembersInOrder` — builds a Reflection.Emit-side `Probe.Color { Red=0, Green=1, Blue=2 }` enum + `Probe.Helper.GetColors() : Color[]` helper assembly, references it, asserts `0\n1\n2\n`. **Pre-fix output: three pointer-cast integers.**
- `ForRange_OverClrEnumArray_EnumIsDefinedHoldsForEveryElement` — mirror of the user's `Enum.IsDefined[T](r)` assertion. **Pre-fix: every iteration printed "bad".**
- `ForRange_OverClrCharArray_YieldsExactChars` — `"abc".ToCharArray()` → `97\n98\n99\n`. **This is also the issue #536 repro.**
- `ForRange_OverClrIntArray_YieldsExactInts` — `Enumerable.ToArray[int32](Enumerable.Range(10, 3))` → `10\n11\n12\n`.
- `ForRange_OverClrStringArray_YieldsExactStrings` — reference-type element regression guard (`"x y z".Split(' ')`).
- `ForRange_OverClrStringArray_FromEnumGetNames_YieldsExactStrings` — `Enum.GetNames(typeof(Region))`.

All compiled assemblies are ilverified.

## Scope

- Likely also closes **#536** (`for c in charArr over char[] produces garbled values`) — same root cause; the `char[]` test pins it. Leaving `Closes #536` off so a human can verify on the linked repro.
- Issue **#538** (silent MSB4181 on `for x in y` over `IReadOnlyList<T>` / `IEnumerable<T>`) is a separate codepath (interface enumeration, not array indexing) and is *not* addressed here.

## Validation

- `dotnet build GSharp.sln -nologo -clp:NoSummary` — clean.
- `dotnet test GSharp.sln --no-restore --nologo` — 2758 / 2758 pass (Compiler.Tests 487, Core.Tests 1949, Interpreter.Tests 72, LanguageServer.Tests 226, Sdk.Tests 24).
- ilverify is enabled on the new tests.

Nothing deferred.
