### PR TITLE
Fixes #521: bind reference upcast from concrete class to base/interface across CLR + G# types

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -354,6 +354,22 @@ public sealed class Conversion
             }
         }
 
+        // Issue #521: standard CLR identity / reference upcast — a
+        // reference-typed expression of CLR type `from` widens implicitly
+        // to any base class or implemented interface `to`. The CLR
+        // satisfies the contract at the reference level (no IL op
+        // required), so the emitter treats this as a no-op. Restricted to
+        // genuine reference types on both sides to avoid colliding with
+        // the boxing / unboxing / value-type-to-interface rules above.
+        if (from?.ClrType != null && to?.ClrType != null
+            && !from.ClrType.IsValueType && !to.ClrType.IsValueType
+            && !from.ClrType.IsPointer && !to.ClrType.IsPointer
+            && !from.ClrType.IsByRef && !to.ClrType.IsByRef
+            && ClrTypeUtilities.IsAssignableByName(to.ClrType, from.ClrType))
+        {
+            return Conversion.Implicit;
+        }
+
         return Conversion.None;
     }
 

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -13433,6 +13433,17 @@ internal sealed class ReflectionMetadataEmitter
                 return true;
             }
 
+            // Issue #521: standard CLR reference upcast. A reference-typed
+            // value of CLR type `a` widens to any base class or implemented
+            // CLR interface `b` as a no-op at the IL level (the reference
+            // already satisfies the wider static type).
+            if (a?.ClrType != null && b?.ClrType != null
+                && !a.ClrType.IsValueType && !b.ClrType.IsValueType
+                && ClrTypeUtilities.IsAssignableByName(b.ClrType, a.ClrType))
+            {
+                return true;
+            }
+
             return false;
         }
 

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -2911,12 +2911,14 @@ public sealed class Evaluator
         }
         else if (node.Type == TypeSymbol.Object
             || node.Type is InterfaceSymbol
-            || (node.Type is StructSymbol upcastTarget && upcastTarget.IsClass))
+            || (node.Type is StructSymbol upcastTarget && upcastTarget.IsClass)
+            || (node.Type?.ClrType != null && !node.Type.ClrType.IsValueType))
         {
             // Reference upcast (class → implemented interface, derived class
-            // → base class, or any → object). The interpreter stores
-            // instances as boxed objects, so the upcast is a no-op at
-            // runtime — only the bind-time static type changes.
+            // → base class, or any → object). Also covers issue #521: a CLR
+            // class or interface widening. The interpreter stores instances
+            // as boxed objects, so the upcast is a no-op at runtime — only
+            // the bind-time static type changes.
             return value;
         }
         else if (node.Type?.ClrType != null && IsSupportedNumericClrType(node.Type.ClrType))

--- a/test/Compiler.Tests/Emit/Issue521ClassToInterfaceUpcastEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue521ClassToInterfaceUpcastEmitTests.cs
@@ -1,0 +1,277 @@
+// <copyright file="Issue521ClassToInterfaceUpcastEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #521: end-to-end emit + execute coverage for the general CLR
+/// reference upcast — a concrete class is implicitly assignable to any
+/// interface it implements (or any of its base classes). The binder fix
+/// lives in <c>Conversion.Classify</c>; the emit side widens via a no-op
+/// reference upcast (no <c>castclass</c>) since the runtime object already
+/// satisfies the wider static type.
+///
+/// Each test compiles via <c>gsc</c>, ilverifies the produced PE, then
+/// runs the assembly under <c>dotnet exec</c> and asserts on the captured
+/// stdout. ilverify catches any spurious <c>castclass</c> / stack-type
+/// mismatch we might have introduced.
+/// </summary>
+public class Issue521ClassToInterfaceUpcastEmitTests
+{
+    [Fact]
+    public void GSharpClass_To_GSharpInterface_DispatchesImpl()
+    {
+        // User-defined class assigned to user-defined interface, then
+        // method dispatched through the interface receiver — the runtime
+        // type is HelloGreeter so the implementation runs.
+        var source = """
+            package P
+            import System
+
+            type IGreeter interface {
+                func Greet(name string) string
+            }
+
+            type HelloGreeter class : IGreeter {
+                func Greet(name string) string { return "Hello, " + name }
+            }
+
+            var g IGreeter = HelloGreeter{}
+            Console.WriteLine(g.Greet("world"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Hello, world\n", output);
+    }
+
+    [Fact]
+    public void GSharpClass_To_GSharpInterface_AsArgument_DispatchesImpl()
+    {
+        // Passing a concrete class where an interface parameter is
+        // expected exercises the conversion at the call site rather than
+        // at an assignment.
+        var source = """
+            package P
+            import System
+
+            type IGreeter interface {
+                func Greet(name string) string
+            }
+
+            type HelloGreeter class : IGreeter {
+                func Greet(name string) string { return "Hi, " + name }
+            }
+
+            func Run(g IGreeter, name string) {
+                Console.WriteLine(g.Greet(name))
+            }
+
+            Run(HelloGreeter{}, "ada")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Hi, ada\n", output);
+    }
+
+    [Fact]
+    public void GSharpClass_To_GSharpInterface_AsReturnType_DispatchesImpl()
+    {
+        // Returning a concrete class where the function declares an
+        // interface return type — the return-value upcast lowers to the
+        // same no-op widening as the assignment / argument shapes.
+        var source = """
+            package P
+            import System
+
+            type IGreeter interface {
+                func Greet(name string) string
+            }
+
+            type HelloGreeter class : IGreeter {
+                func Greet(name string) string { return "Hey, " + name }
+            }
+
+            func Make() IGreeter {
+                return HelloGreeter{}
+            }
+
+            Console.WriteLine(Make().Greet("bob"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Hey, bob\n", output);
+    }
+
+    [Fact]
+    public void GSharpClass_To_GSharpInterface_ExplicitCast_DispatchesImpl()
+    {
+        // Explicit-cast form `IGreeter(HelloGreeter{})` reaches
+        // `BindConversion` with `allowExplicit: true` but the underlying
+        // classification is the same implicit upcast — verify the cast
+        // form emits the same widening.
+        var source = """
+            package P
+            import System
+
+            type IGreeter interface {
+                func Greet(name string) string
+            }
+
+            type HelloGreeter class : IGreeter {
+                func Greet(name string) string { return "Yo, " + name }
+            }
+
+            var g = IGreeter(HelloGreeter{})
+            Console.WriteLine(g.Greet("sam"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Yo, sam\n", output);
+    }
+
+    [Fact]
+    public void ClrList_To_IReadOnlyList_Indexer_ReturnsExpectedElement()
+    {
+        // The repro from the issue body: `List<string>` to
+        // `IReadOnlyList<string>` was rejected with GS0155. With the fix
+        // the assignment binds, the upcast emits as a no-op, and the
+        // indexer call dispatches through the interface to the same
+        // backing List.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            var mut = List[string]()
+            mut.Add("first")
+            mut.Add("second")
+            var r IReadOnlyList[string] = mut
+            Console.WriteLine(r[1])
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("second\n", output);
+    }
+
+    [Fact]
+    public void ClrList_To_IEnumerable_IterationViaForRange_VisitsEveryElement()
+    {
+        // Generic variance is *not* required here — `List<int32>` simply
+        // implements `IEnumerable<int32>`. Asserting that `for x := range
+        // iface` walks the upcast value end-to-end pins the no-op widening
+        // through the iterator lowering path too.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            var mut = List[int32]()
+            mut.Add(10)
+            mut.Add(20)
+            mut.Add(30)
+            var e IEnumerable[int32] = mut
+            for x := range e {
+                Console.WriteLine(x)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("10\n20\n30\n", output);
+    }
+
+    [Fact]
+    public void ClrString_To_IComparable_Assignment_Roundtrips()
+    {
+        // BCL identity / reference-upcast for a plain string -> IComparable.
+        // The CLR holds the same reference on the stack; the interface
+        // method (CompareTo) dispatches to System.String's implementation.
+        var source = """
+            package P
+            import System
+
+            var s = "abc"
+            var c IComparable = s
+            Console.WriteLine(c.CompareTo("abc"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue521_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue521ClassToInterfaceConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue521ClassToInterfaceConversionTests.cs
@@ -1,0 +1,261 @@
+// <copyright file="Issue521ClassToInterfaceConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #521: the binder used to reject a concrete-class → implemented-interface
+/// assignment with <c>GS0155</c> for every CLR-typed shape (e.g.
+/// <c>List&lt;string&gt;</c> to <c>IReadOnlyList&lt;string&gt;</c>) because the
+/// reference-upcast rule in <see cref="Conversion.Classify"/> only walked the
+/// G# class <see cref="StructSymbol.Interfaces"/> list. The fix layers a
+/// general CLR-reference upcast on top so the binder accepts any
+/// <c>from.ClrType</c> → <c>to.ClrType</c> that
+/// <see cref="ClrTypeUtilities.IsAssignableByName"/> reports as
+/// assignment-compatible, covering BCL classes, CLR interfaces, and the
+/// user-class → user-interface path that already worked.
+///
+/// Scope tested here (binder classification only; the emit + execute shape
+/// lives in <c>Issue521ClassToInterfaceUpcastEmitTests</c>):
+/// <list type="bullet">
+///   <item>G# class implementing G# interface — assignment, argument passing,
+///         return widening, explicit cast.</item>
+///   <item>CLR class implementing CLR interface — <c>List&lt;T&gt;</c> to
+///         <c>IReadOnlyList&lt;T&gt;</c>, <c>IEnumerable&lt;T&gt;</c>, and
+///         <c>ICollection&lt;T&gt;</c>.</item>
+///   <item>CLR class implementing CLR interface — <c>string</c> to
+///         <c>IComparable</c>.</item>
+///   <item>Negative: assigning an unrelated reference type still produces
+///         a precise <c>GS0155</c>.</item>
+/// </list>
+/// </summary>
+public class Issue521ClassToInterfaceConversionTests
+{
+    [Fact]
+    public void GSharpClass_To_GSharpInterface_Assignment_Binds()
+    {
+        var source = @"
+type IGreeter interface {
+    func Greet(name string) string
+}
+
+type HelloGreeter class : IGreeter {
+    func Greet(name string) string { return ""Hello, "" + name }
+}
+
+var g IGreeter = HelloGreeter{}
+g.Greet(""world"")
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Hello, world", result.Value);
+    }
+
+    [Fact]
+    public void GSharpClass_To_GSharpInterface_AsArgument_Binds()
+    {
+        var source = @"
+type IGreeter interface {
+    func Greet(name string) string
+}
+
+type HelloGreeter class : IGreeter {
+    func Greet(name string) string { return ""Hi, "" + name }
+}
+
+func Run(g IGreeter, name string) string {
+    return g.Greet(name)
+}
+
+Run(HelloGreeter{}, ""ada"")
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Hi, ada", result.Value);
+    }
+
+    [Fact]
+    public void GSharpClass_To_GSharpInterface_AsReturnType_Binds()
+    {
+        var source = @"
+type IGreeter interface {
+    func Greet(name string) string
+}
+
+type HelloGreeter class : IGreeter {
+    func Greet(name string) string { return ""Hey, "" + name }
+}
+
+func Make() IGreeter {
+    return HelloGreeter{}
+}
+
+Make().Greet(""bob"")
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Hey, bob", result.Value);
+    }
+
+    [Fact]
+    public void GSharpClass_To_GSharpInterface_ExplicitCast_Binds()
+    {
+        var source = @"
+type IGreeter interface {
+    func Greet(name string) string
+}
+
+type HelloGreeter class : IGreeter {
+    func Greet(name string) string { return ""Yo, "" + name }
+}
+
+var g = IGreeter(HelloGreeter{})
+g.Greet(""sam"")
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Yo, sam", result.Value);
+    }
+
+    [Fact]
+    public void ClrList_To_IReadOnlyList_Assignment_Binds()
+    {
+        var source = @"
+import System.Collections.Generic
+
+var mut = List[string]()
+mut.Add(""a"")
+mut.Add(""b"")
+var r IReadOnlyList[string] = mut
+mut.Count
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(2, result.Value);
+    }
+
+    [Fact]
+    public void ClrList_To_ICollection_Assignment_Binds()
+    {
+        var source = @"
+import System.Collections.Generic
+
+var mut = List[int32]()
+mut.Add(10)
+mut.Add(20)
+var c ICollection[int32] = mut
+c.Count
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(2, result.Value);
+    }
+
+    [Fact]
+    public void ClrList_To_IEnumerable_Assignment_Binds()
+    {
+        var source = @"
+import System.Collections.Generic
+
+var mut = List[int32]()
+mut.Add(1)
+mut.Add(2)
+var e IEnumerable[int32] = mut
+mut.Count
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(2, result.Value);
+    }
+
+    [Fact]
+    public void ClrString_To_IComparable_Assignment_Binds()
+    {
+        var source = @"
+import System
+
+var s = ""abc""
+var c IComparable = s
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ClrList_To_IReadOnlyList_AsArgument_Binds()
+    {
+        // Member lookup through inherited interface bases isn't part of
+        // #521 — verify the upcast itself by computing the count on the
+        // backing list inside the function.
+        var source = @"
+import System.Collections.Generic
+
+func ConsumeReadOnly(r IReadOnlyList[string], mut List[string]) int32 {
+    return mut.Count
+}
+
+var l = List[string]()
+l.Add(""x"")
+l.Add(""y"")
+l.Add(""z"")
+ConsumeReadOnly(l, l)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(3, result.Value);
+    }
+
+    [Fact]
+    public void UnrelatedReferenceAssignment_StillReports_GS0155()
+    {
+        // The CLR has no relationship between `string` and `Random`, so a
+        // direct assignment must still surface as the precise GS0155
+        // diagnostic — not silently succeed under the broader rule.
+        var source = @"
+import System
+
+var s = ""abc""
+var r Random = s
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot convert type"));
+    }
+
+    [Fact]
+    public void ClrList_To_IReadOnlyList_DispatchesIndexer()
+    {
+        // Index through the interface — exercises that the upcast value
+        // remains a runtime List<string> and the indexer call binds to the
+        // IReadOnlyList<T>.Item member.
+        var source = @"
+import System.Collections.Generic
+
+var mut = List[string]()
+mut.Add(""first"")
+mut.Add(""second"")
+var r IReadOnlyList[string] = mut
+r[1]
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("second", result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #521.

## Problem

Concrete class to implemented-interface assignment (or argument passing, or return widening, or explicit cast) was rejected with `GS0155: Cannot convert type 'C' to 'I'` whenever either side carried a CLR `Type`:

```gsharp
import System.Collections.Generic

let mut = List[string]()
mut.Add("a")
let l IReadOnlyList[string] = mut       // GS0155
```

```gsharp
import System
var s = "abc"
var c IComparable = s                   // GS0155
```

The existing rule in `Conversion.Classify` only walked the user-class `StructSymbol.Interfaces` list — `ImportedTypeSymbol` -> `ImportedTypeSymbol` and `ImportedTypeSymbol` -> `InterfaceSymbol` shapes had no path and fell through to `Conversion.None`.

## Fix

Layer a general CLR identity / reference upcast on top of the existing rule, in three places that must agree:

1. **`Conversion.Classify`** (binder classifier): when both sides have non-pointer, non-by-ref reference-type `ClrType`s and `ClrTypeUtilities.IsAssignableByName(to, from)` returns true, classify as implicit.
2. **`ReflectionMetadataEmitter.IsReferenceCompatible`**: the same predicate, so `EmitConversion` lowers the widening to a no-op (the reference already satisfies the wider static type — no `castclass` is needed and ilverify is happy).
3. **`Evaluator.EvaluateConversionExpression`**: any reference-type target with a CLR type is a no-op upcast for the interpreter, which already stores instances as boxed objects.

Restricting the new rule to genuine reference types on both sides keeps it from colliding with the boxing / unboxing / value-type-to-interface / numeric / enum rules above.

## Coverage

Regression tests live in two places:

- `test/Core.Tests/CodeAnalysis/Binding/Issue521ClassToInterfaceConversionTests.cs` (11 tests, binder classification + interpreter end-to-end):
  - G# class to G# interface — assignment, argument, return widening, explicit cast.
  - `List[string]` to `IReadOnlyList[string]`, `ICollection[int32]`, `IEnumerable[int32]`.
  - `string` to `IComparable`.
  - Negative: `string` -> `Random` still produces `GS0155`.
  - `r[1]` on the upcast-typed receiver dispatches to the runtime `List`.
- `test/Compiler.Tests/Emit/Issue521ClassToInterfaceUpcastEmitTests.cs` (7 tests, full compile + ilverify + execute):
  - The four G# class -> G# interface shapes (assignment, argument, return, explicit cast) with method dispatch through the interface.
  - `List[string]` -> `IReadOnlyList[string]` with indexer dispatch.
  - `List[int32]` -> `IEnumerable[int32]` walked with `for x := range`.
  - `string` -> `IComparable` with `CompareTo` dispatch.

All emit tests gate on `ilverify`, so any spurious `castclass` or stack-type mismatch would surface as a verification failure.

## Out of scope

The companion issue **#525** (`type X class : IClrInterface { ... }` is rejected even when the CLR interface is imported) was *not* subsumed — declaring a G# class with a CLR-interface base still fails at bind time, so the tests use shapes the binder already accepts (G# class : G# interface; CLR class -> CLR interface).

## Validation

- `dotnet build GSharp.sln -nologo -clp:NoSummary`: clean.
- `dotnet test GSharp.sln --no-restore --nologo`: green. Sdk 24 + Interpreter 72 + LanguageServer 226 + Core 1960 + Compiler 494 = **2776 tests pass** (was 2758; +18 new).
- New emit tests run `dotnet tool run ilverify` against every produced PE.
