### PR TITLE
Fix #522: init-only property emit + object initializer syntax

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -132,6 +132,7 @@ NamedDeconstructionField
 NamedDeconstructionStatement
 NilKeyword
 NumberToken
+ObjectCreationExpression
 OpenBraceToken
 OpenKeyword
 OpenParenthesisToken
@@ -153,6 +154,7 @@ PlusToken
 PrivateKeyword
 PropertyAccessor
 PropertyDeclaration
+PropertyInitializer
 PropertyPattern
 PropertyPatternField
 PublicKeyword

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -6524,6 +6524,8 @@ public sealed class Binder
                 return BindBinaryExpression((BinaryExpressionSyntax)syntax);
             case SyntaxKind.CallExpression:
                 return BindCallExpression((CallExpressionSyntax)syntax);
+            case SyntaxKind.ObjectCreationExpression:
+                return BindObjectCreationExpression((ObjectCreationExpressionSyntax)syntax);
             case SyntaxKind.AccessorExpression:
                 return BindAccessorExpression((AccessorExpressionSyntax)syntax);
             case SyntaxKind.ArrayCreationExpression:
@@ -7188,6 +7190,162 @@ public sealed class Binder
         var declaration = new BoundVariableDeclaration(null, tempVar, receiver);
         var literal = new BoundStructLiteralExpression(null, structType, initializers.ToImmutable());
         return new BoundBlockExpression(null, ImmutableArray.Create<BoundStatement>(declaration), literal);
+    }
+
+    // Issue #522: bind `T(args) { Prop1 = v1, Prop2 = v2, … }` object
+    // initializer. The construction is lowered to a synthetic local plus a
+    // sequence of property assignments:
+    //   { var $tmp = T(args); $tmp.Prop1 = v1; $tmp.Prop2 = v2; $tmp }
+    // Init-only setters are emitted via the regular setter call path; the
+    // emit-side modreq fix (EncodeReturnClr) makes the resulting IL valid.
+    private BoundExpression BindObjectCreationExpression(ObjectCreationExpressionSyntax syntax)
+    {
+        var target = BindExpression(syntax.Target);
+        if (target.Type == TypeSymbol.Error || target.Type == null)
+        {
+            // Still drain the initializer values so they report their own
+            // diagnostics (e.g. unresolved names inside the RHS expressions).
+            foreach (var init in syntax.Initializers)
+            {
+                _ = BindExpression(init.Value);
+            }
+
+            return new BoundErrorExpression(null);
+        }
+
+        var resultType = target.Type;
+
+        var tempName = "$objinit" + System.Threading.Interlocked.Increment(ref syntheticLocalCounter).ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var tempVar = new LocalVariableSymbol(tempName, isReadOnly: true, resultType);
+        scope.TryDeclareVariable(tempVar);
+
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        statements.Add(new BoundVariableDeclaration(syntax, tempVar, target));
+
+        var seen = new HashSet<string>();
+        foreach (var initSyntax in syntax.Initializers)
+        {
+            var propertyName = initSyntax.PropertyIdentifier.Text;
+            if (!seen.Add(propertyName))
+            {
+                Diagnostics.ReportSymbolAlreadyDeclared(initSyntax.PropertyIdentifier.Location, propertyName);
+                continue;
+            }
+
+            var assignment = BindObjectInitializerAssignment(tempVar, resultType, initSyntax);
+            if (assignment == null)
+            {
+                continue;
+            }
+
+            statements.Add(new BoundExpressionStatement(initSyntax, assignment));
+        }
+
+        var resultExpr = new BoundVariableExpression(syntax, tempVar);
+        return new BoundBlockExpression(syntax, statements.ToImmutable(), resultExpr);
+    }
+
+    // Issue #522: bind a single `Prop = value` initializer against a known
+    // receiver local. Mirrors the property/field write logic in
+    // BindFieldAssignmentExpression so init-only setters, regular setters,
+    // user-defined struct properties, and CLR-base inherited members all
+    // route through the same lowering.
+    private BoundExpression BindObjectInitializerAssignment(LocalVariableSymbol receiverLocal, TypeSymbol receiverType, PropertyInitializerSyntax initSyntax)
+    {
+        var propertyName = initSyntax.PropertyIdentifier.Text;
+
+        // Receiver-side type discriminator mirrors the receiver dispatch in
+        // BindFieldAssignmentExpression: pure CLR types go through reflection;
+        // user-defined StructSymbols use the symbol tables; both can fall
+        // through to ImportedBaseType lookup for inherited CLR members.
+        if (receiverType is not StructSymbol && receiverType is not NullableTypeSymbol && receiverType.ClrType != null)
+        {
+            var clrReceiverType = receiverType.ClrType;
+            MemberInfo instanceMember = ClrTypeUtilities.SafeGetProperty(clrReceiverType, propertyName, BindingFlags.Public | BindingFlags.Instance);
+            if (instanceMember is PropertyInfo idxProp && idxProp.GetIndexParameters().Length != 0)
+            {
+                instanceMember = null;
+            }
+
+            instanceMember ??= ClrTypeUtilities.SafeGetField(clrReceiverType, propertyName, BindingFlags.Public | BindingFlags.Instance);
+            if (instanceMember == null)
+            {
+                Diagnostics.ReportUnableToFindMember(initSyntax.PropertyIdentifier.Location, propertyName);
+                _ = BindExpression(initSyntax.Value);
+                return null;
+            }
+
+            if (!TryGetWritableClrMember(instanceMember, out _, out var instTargetSymbol, out _))
+            {
+                Diagnostics.ReportCannotAssign(initSyntax.EqualsToken.Location, propertyName);
+                _ = BindExpression(initSyntax.Value);
+                return null;
+            }
+
+            var value = BindExpression(initSyntax.Value);
+            var converted = BindConversion(initSyntax.Value.Location, value, instTargetSymbol);
+            var receiverExpr = new BoundVariableExpression(initSyntax, receiverLocal);
+            return new BoundClrPropertyAssignmentExpression(initSyntax, receiverExpr, instanceMember, converted, instTargetSymbol);
+        }
+
+        if (receiverType is StructSymbol structSymbol)
+        {
+            if (structSymbol.TryGetFieldIncludingInherited(propertyName, out var field, out _))
+            {
+                var value = BindExpression(initSyntax.Value);
+                var converted = BindConversion(initSyntax.Value.Location, value, field.Type);
+                return new BoundFieldAssignmentExpression(initSyntax, receiverLocal, structSymbol, field, converted);
+            }
+
+            if (TryGetPropertyIncludingInherited(structSymbol, propertyName, out var prop))
+            {
+                if (!prop.HasSetter)
+                {
+                    Diagnostics.ReportCannotAssign(initSyntax.EqualsToken.Location, propertyName);
+                    _ = BindExpression(initSyntax.Value);
+                    return null;
+                }
+
+                var value = BindExpression(initSyntax.Value);
+                var converted = BindConversion(initSyntax.Value.Location, value, prop.Type);
+                var receiverExpr = new BoundVariableExpression(initSyntax, receiverLocal);
+                return new BoundPropertyAssignmentExpression(initSyntax, receiverExpr, structSymbol, prop, converted);
+            }
+
+            // Issue #319 parity: fall through to imported base CLR members.
+            if (structSymbol.ImportedBaseType?.ClrType is Type inheritedBaseClr)
+            {
+                MemberInfo inhMember = ClrTypeUtilities.SafeGetProperty(inheritedBaseClr, propertyName, BindingFlags.Public | BindingFlags.Instance);
+                if (inhMember is PropertyInfo inhIdxProp && inhIdxProp.GetIndexParameters().Length != 0)
+                {
+                    inhMember = null;
+                }
+
+                inhMember ??= ClrTypeUtilities.SafeGetField(inheritedBaseClr, propertyName, BindingFlags.Public | BindingFlags.Instance);
+                if (inhMember != null)
+                {
+                    if (!TryGetWritableClrMember(inhMember, out _, out var inhTargetSymbol, out _))
+                    {
+                        Diagnostics.ReportCannotAssign(initSyntax.EqualsToken.Location, propertyName);
+                        _ = BindExpression(initSyntax.Value);
+                        return null;
+                    }
+
+                    var value = BindExpression(initSyntax.Value);
+                    var converted = BindConversion(initSyntax.Value.Location, value, inhTargetSymbol);
+                    var receiverExpr = new BoundVariableExpression(initSyntax, receiverLocal);
+                    return new BoundClrPropertyAssignmentExpression(initSyntax, receiverExpr, inhMember, converted, inhTargetSymbol);
+                }
+            }
+
+            Diagnostics.ReportUnableToFindMember(initSyntax.PropertyIdentifier.Location, propertyName);
+            _ = BindExpression(initSyntax.Value);
+            return null;
+        }
+
+        Diagnostics.ReportUnableToFindMember(initSyntax.PropertyIdentifier.Location, propertyName);
+        _ = BindExpression(initSyntax.Value);
+        return null;
     }
 
     private static bool TryGetCopyOverrides(CallExpressionSyntax call, out SeparatedSyntaxList<FieldInitializerSyntax> overrides)

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -10997,6 +10997,23 @@ internal sealed class ReflectionMetadataEmitter
     {
         if (type?.FullName == "System.Void")
         {
+            // Issue #522: a void return may still carry required custom
+            // modifiers — most notably C# 9 init-only property setters emit
+            // `modreq(System.Runtime.CompilerServices.IsExternalInit)` on the
+            // setter's void return. The modreq is part of the method
+            // signature; if we omit it the MemberRef fails to resolve at
+            // runtime (System.MissingMethodException). Mirrors the byref
+            // branch below — encode modreqs first, then the void slot.
+            var voidRequiredModifiers = returnParameter?.GetRequiredCustomModifiers() ?? Type.EmptyTypes;
+            if (voidRequiredModifiers.Length > 0)
+            {
+                var modifiers = encoder.CustomModifiers();
+                foreach (var modifier in voidRequiredModifiers)
+                {
+                    modifiers.AddModifier(this.GetTypeReference(modifier), isOptional: false);
+                }
+            }
+
             encoder.Void();
         }
         else if (type != null && type.IsByRef)

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -924,6 +924,15 @@ public sealed class Evaluator
                 continue;
             }
 
+            // Issue #522: object initializer lowering may produce expression
+            // statements (`$tmp.Prop = value`) in addition to the synthetic
+            // local declaration.
+            if (statement is BoundExpressionStatement exprStmt)
+            {
+                EvaluateExpression(exprStmt.Expression);
+                continue;
+            }
+
             throw new EvaluatorException($"Unexpected block-expression statement {statement.Kind}", statement);
         }
 

--- a/src/Core/CodeAnalysis/Syntax/ObjectCreationExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/ObjectCreationExpressionSyntax.cs
@@ -1,0 +1,57 @@
+// <copyright file="ObjectCreationExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #522: a constructor invocation with a trailing C#-style object
+/// initializer, e.g. <c>WithInit(args) { Asin = "X", Title = "T" }</c> or
+/// <c>List[int](){ Capacity = 16 }</c>. The <see cref="Target"/> is the
+/// already-parsed call expression (positional + named ctor args); each
+/// element in <see cref="Initializers"/> assigns a property/field on the
+/// constructed instance. The binder lowers this to a
+/// <see cref="GSharp.Core.CodeAnalysis.Binding.BoundBlockExpression"/> that
+/// constructs into a synthetic local, performs the assignments, and yields
+/// the local — so init-only setters are legal here even though they would be
+/// disallowed at a free-standing assignment site.
+/// </summary>
+public sealed class ObjectCreationExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObjectCreationExpressionSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="target">The underlying constructor call expression.</param>
+    /// <param name="openBraceToken">The '{' opening the initializer list.</param>
+    /// <param name="initializers">The property initializers.</param>
+    /// <param name="closeBraceToken">The matching '}'.</param>
+    public ObjectCreationExpressionSyntax(
+        SyntaxTree syntaxTree,
+        ExpressionSyntax target,
+        SyntaxToken openBraceToken,
+        SeparatedSyntaxList<PropertyInitializerSyntax> initializers,
+        SyntaxToken closeBraceToken)
+        : base(syntaxTree)
+    {
+        Target = target;
+        OpenBraceToken = openBraceToken;
+        Initializers = initializers;
+        CloseBraceToken = closeBraceToken;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.ObjectCreationExpression;
+
+    /// <summary>Gets the underlying constructor call expression (a <see cref="CallExpressionSyntax"/>).</summary>
+    public ExpressionSyntax Target { get; }
+
+    /// <summary>Gets the '{' opening the initializer list.</summary>
+    public SyntaxToken OpenBraceToken { get; }
+
+    /// <summary>Gets the property initializers (zero or more).</summary>
+    public SeparatedSyntaxList<PropertyInitializerSyntax> Initializers { get; }
+
+    /// <summary>Gets the '}' closing the initializer list.</summary>
+    public SyntaxToken CloseBraceToken { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -18,6 +18,19 @@ public class Parser
     private readonly ImmutableArray<SyntaxToken> tokens;
     private int position;
 
+    // Issue #522: depth counter that suppresses trailing object-initializer
+    // wrapping (`Call(args) { Prop = value }`). The default of zero allows
+    // wrapping in regular expression contexts (variable declarations, return
+    // statements, etc.). Body-header parsers (`if Cond { … }`, `for x := range
+    // Coll { … }`, `switch Expr { … }`, etc.) push the counter via
+    // <see cref="WithSuppressedObjectInitializer"/> so the following `{` is
+    // recognised as the body, not as an initializer.
+    //
+    // Nested expression contexts (parens, brackets, argument lists) call
+    // <see cref="WithAllowedObjectInitializer"/> to save+clear the counter so
+    // an inner `T() { … }` still works inside `if Foo(T() { X = 1 }) { … }`.
+    private int suppressTrailingObjectInitializer;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="Parser"/> class.
     /// </summary>
@@ -2568,7 +2581,7 @@ public class Parser
             semicolon = MatchToken(SyntaxKind.SemicolonToken);
         }
 
-        var condition = ParseExpression();
+        var condition = ParseExpressionInBodyHeader();
         var statement = ParseStatement();
         var elseClause = ParseElseClause();
         return new IfStatementSyntax(syntaxTree, keyword, initializer, semicolon, condition, statement, elseClause);
@@ -2770,7 +2783,7 @@ public class Parser
     private StatementSyntax ParseForConditionStatement()
     {
         var keyword = MatchToken(SyntaxKind.ForKeyword);
-        var condition = ParseExpression();
+        var condition = ParseExpressionInBodyHeader();
         var body = ParseStatement();
         return new ForConditionStatementSyntax(syntaxTree, keyword, condition, body);
     }
@@ -2790,7 +2803,7 @@ public class Parser
         ExpressionSyntax condition = null;
         if (Current.Kind != SyntaxKind.SemicolonToken)
         {
-            condition = ParseExpression();
+            condition = ParseExpressionInBodyHeader();
         }
 
         var secondSemicolon = MatchToken(SyntaxKind.SemicolonToken);
@@ -2859,7 +2872,7 @@ public class Parser
             rangeKeyword = MatchToken(SyntaxKind.RangeKeyword);
         }
 
-        var collection = ParseExpression();
+        var collection = ParseExpressionInBodyHeader();
         var body = ParseStatement();
         return new ForRangeStatementSyntax(syntaxTree, keyword, firstIdentifier, commaToken, secondIdentifier, colonEqualsToken, rangeKeyword, inToken, collection, body);
     }
@@ -2869,9 +2882,9 @@ public class Parser
         var keyword = MatchToken(SyntaxKind.ForKeyword);
         var identifier = MatchToken(SyntaxKind.IdentifierToken);
         var colonEqualsToken = MatchToken(SyntaxKind.ColonEqualsToken);
-        var lowerBound = ParseExpression();
+        var lowerBound = ParseExpressionInBodyHeader();
         var toKeyword = MatchToken(SyntaxKind.EllipsisToken);
-        var upperBound = ParseExpression();
+        var upperBound = ParseExpressionInBodyHeader();
         var body = ParseStatement();
         return new ForEllipsisStatementSyntax(syntaxTree, keyword, identifier, colonEqualsToken, lowerBound, toKeyword, upperBound, body);
     }
@@ -2950,7 +2963,7 @@ public class Parser
     private StatementSyntax ParseSwitchStatement()
     {
         var switchKeyword = MatchToken(SyntaxKind.SwitchKeyword);
-        var expression = ParseExpression();
+        var expression = ParseExpressionInBodyHeader();
         var openBrace = MatchToken(SyntaxKind.OpenBraceToken);
 
         var cases = ImmutableArray.CreateBuilder<SwitchCaseSyntax>();
@@ -3180,7 +3193,7 @@ public class Parser
             rangeKeyword = MatchToken(SyntaxKind.RangeKeyword);
         }
 
-        var stream = ParseExpression();
+        var stream = ParseExpressionInBodyHeader();
         var body = ParseBlockStatement();
         return new AwaitForRangeStatementSyntax(
             syntaxTree, awaitKeyword, forKeyword, identifier, colonEquals, rangeKeyword, inToken, stream, body);
@@ -3603,7 +3616,20 @@ public class Parser
             else if (Current.Kind == SyntaxKind.OpenSquareBracketToken)
             {
                 var openBracket = MatchToken(SyntaxKind.OpenSquareBracketToken);
-                var index = ParseExpression();
+
+                // Issue #522: an indexer is a fresh inner expression context.
+                var savedSuppress = suppressTrailingObjectInitializer;
+                suppressTrailingObjectInitializer = 0;
+                ExpressionSyntax index;
+                try
+                {
+                    index = ParseExpression();
+                }
+                finally
+                {
+                    suppressTrailingObjectInitializer = savedSuppress;
+                }
+
                 var closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
                 current = new IndexExpressionSyntax(syntaxTree, current, openBracket, index, closeBracket);
             }
@@ -3682,7 +3708,7 @@ public class Parser
     private ExpressionSyntax ParseSwitchExpression()
     {
         var switchKeyword = MatchToken(SyntaxKind.SwitchKeyword);
-        var expression = ParseExpression();
+        var expression = ParseExpressionInBodyHeader();
         var openBrace = MatchToken(SyntaxKind.OpenBraceToken);
 
         var arms = ImmutableArray.CreateBuilder<SwitchExpressionArmSyntax>();
@@ -3863,12 +3889,14 @@ public class Parser
         else if (Current.Kind == SyntaxKind.IdentifierToken && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
         {
             current = ParseCallExpression();
+            current = MaybeWrapWithObjectInitializer(current);
         }
         else if (Current.Kind == SyntaxKind.IdentifierToken
             && Peek(1).Kind == SyntaxKind.OpenSquareBracketToken
             && LooksLikeGenericCallSite(1))
         {
             current = ParseGenericCallExpression();
+            current = MaybeWrapWithObjectInitializer(current);
         }
         else if (Current.Kind == SyntaxKind.IdentifierToken
             && Peek(1).Kind == SyntaxKind.OpenBraceToken
@@ -4052,6 +4080,111 @@ public class Parser
         return new CallExpressionSyntax(syntaxTree, identifier, openParenthesisToken, arguments, closeParenthesisToken);
     }
 
+    // Issue #522: when the token following a constructor call's `)` is `{`
+    // and the brace contents look like an object initializer (`Identifier =`
+    // or empty `}`), wrap the call in an ObjectCreationExpressionSyntax. We
+    // peek with the same surgical lookahead used by IsStructLiteralFollowingBrace
+    // so unrelated trailing braces (e.g. an `if Cond() { body }` statement
+    // body) are not mis-eaten.
+    private ExpressionSyntax MaybeWrapWithObjectInitializer(ExpressionSyntax target)
+    {
+        if (Current.Kind != SyntaxKind.OpenBraceToken)
+        {
+            return target;
+        }
+
+        // Body-header contexts (if/for/while/switch condition) suppress the
+        // wrap so the following `{` is recognised as the statement body.
+        if (suppressTrailingObjectInitializer > 0)
+        {
+            return target;
+        }
+
+        if (!LooksLikeObjectInitializerBrace())
+        {
+            return target;
+        }
+
+        var openBrace = MatchToken(SyntaxKind.OpenBraceToken);
+        var initializers = ParseObjectInitializerList();
+        var closeBrace = MatchToken(SyntaxKind.CloseBraceToken);
+        return new ObjectCreationExpressionSyntax(syntaxTree, target, openBrace, initializers, closeBrace);
+    }
+
+    // Recognises an object-initializer `{` after a constructor call. To avoid
+    // colliding with statement-bodied constructs of the form `if Cond() { ... }`
+    // we require either `{}` (empty) or `{ Identifier =` so a `{ Identifier .`
+    // (member access in a body) is not absorbed.
+    private bool LooksLikeObjectInitializerBrace()
+    {
+        var k1 = Peek(1).Kind;
+        if (k1 == SyntaxKind.CloseBraceToken)
+        {
+            return true;
+        }
+
+        return k1 == SyntaxKind.IdentifierToken && Peek(2).Kind == SyntaxKind.EqualsToken;
+    }
+
+    private SeparatedSyntaxList<PropertyInitializerSyntax> ParseObjectInitializerList()
+    {
+        var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+        var parseNext = Current.Kind != SyntaxKind.CloseBraceToken;
+        while (parseNext
+               && Current.Kind != SyntaxKind.CloseBraceToken
+               && Current.Kind != SyntaxKind.EndOfFileToken)
+        {
+            var propertyId = MatchToken(SyntaxKind.IdentifierToken);
+            var equals = MatchToken(SyntaxKind.EqualsToken);
+
+            // Initializer values live inside the braces — a fresh expression
+            // context where trailing object initializers are again allowed
+            // (so a nested `Inner = U() { X = 1 }` works even when the outer
+            // object initializer was parsed inside a body-header context).
+            ExpressionSyntax value;
+            var savedSuppress = suppressTrailingObjectInitializer;
+            suppressTrailingObjectInitializer = 0;
+            try
+            {
+                value = ParseExpression();
+            }
+            finally
+            {
+                suppressTrailingObjectInitializer = savedSuppress;
+            }
+
+            nodesAndSeparators.Add(new PropertyInitializerSyntax(syntaxTree, propertyId, equals, value));
+
+            if (Current.Kind == SyntaxKind.CommaToken)
+            {
+                nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
+            }
+            else
+            {
+                parseNext = false;
+            }
+        }
+
+        return new SeparatedSyntaxList<PropertyInitializerSyntax>(nodesAndSeparators.ToImmutable());
+    }
+
+    // Parses an expression in a body-header context (the condition of an `if`,
+    // the collection of a `for-range`, etc.) — trailing `Call() { ... }`
+    // object initializers are suppressed so the following `{` is recognised
+    // as the body of the surrounding statement.
+    private ExpressionSyntax ParseExpressionInBodyHeader()
+    {
+        suppressTrailingObjectInitializer++;
+        try
+        {
+            return ParseExpression();
+        }
+        finally
+        {
+            suppressTrailingObjectInitializer--;
+        }
+    }
+
     private ExpressionSyntax ParseMakeChannelExpression()
     {
         // Phase 5.4 / ADR-0022: `make(chan T)` / `make(chan T, capacity)`.
@@ -4137,6 +4270,24 @@ public class Parser
     }
 
     private SeparatedSyntaxList<ExpressionSyntax> ParseArguments()
+    {
+        // Issue #522: arguments are fresh expression contexts — even when the
+        // surrounding statement is a body-header (`if`/`for`/`switch`), a
+        // call argument such as `Foo(T() { X = 1 })` should still admit a
+        // trailing object initializer.
+        var savedSuppress = suppressTrailingObjectInitializer;
+        suppressTrailingObjectInitializer = 0;
+        try
+        {
+            return ParseArgumentsCore();
+        }
+        finally
+        {
+            suppressTrailingObjectInitializer = savedSuppress;
+        }
+    }
+
+    private SeparatedSyntaxList<ExpressionSyntax> ParseArgumentsCore()
     {
         var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
 
@@ -4512,7 +4663,21 @@ public class Parser
     private ExpressionSyntax ParseParenthesizedExpression()
     {
         var left = MatchToken(SyntaxKind.OpenParenthesisToken);
-        var expression = ParseExpression();
+
+        // Issue #522: a parenthesised expression is a fresh inner context —
+        // even inside an `if (T() { X = 1 }) { body }` style header, the
+        // inner call should still admit a trailing object initializer.
+        ExpressionSyntax expression;
+        var savedSuppress = suppressTrailingObjectInitializer;
+        suppressTrailingObjectInitializer = 0;
+        try
+        {
+            expression = ParseExpression();
+        }
+        finally
+        {
+            suppressTrailingObjectInitializer = savedSuppress;
+        }
 
         // ADR-0061: `(cond ? lvalue : lvalue)` parses as a conditional ref-arg
         // expression when a `?` immediately follows the inner expression. The

--- a/src/Core/CodeAnalysis/Syntax/PropertyInitializerSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/PropertyInitializerSyntax.cs
@@ -1,0 +1,46 @@
+// <copyright file="PropertyInitializerSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #522: a single <c>PropertyName = value</c> element inside a C#-style
+/// object initializer suffix (<c>T(args) { P1 = v1, P2 = v2 }</c>). Distinct
+/// from <see cref="FieldInitializerSyntax"/> only in that the property name
+/// must bind to a writable instance property/field of the constructed type
+/// (init-only setters are allowed); the syntactic shape is identical.
+/// </summary>
+public sealed class PropertyInitializerSyntax : SyntaxNode
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertyInitializerSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="propertyIdentifier">The property name.</param>
+    /// <param name="equalsToken">The '=' separator.</param>
+    /// <param name="value">The value expression.</param>
+    public PropertyInitializerSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken propertyIdentifier,
+        SyntaxToken equalsToken,
+        ExpressionSyntax value)
+        : base(syntaxTree)
+    {
+        PropertyIdentifier = propertyIdentifier;
+        EqualsToken = equalsToken;
+        Value = value;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.PropertyInitializer;
+
+    /// <summary>Gets the property identifier.</summary>
+    public SyntaxToken PropertyIdentifier { get; }
+
+    /// <summary>Gets the '=' separator token.</summary>
+    public SyntaxToken EqualsToken { get; }
+
+    /// <summary>Gets the value expression.</summary>
+    public ExpressionSyntax Value { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -280,6 +280,14 @@ public enum SyntaxKind
     // stind.*`. Necessary for §5's body-side lowering of `ref`/`out`
     // parameter writes and for direct `*T`-local stores.
     IndirectAssignmentExpression,
+
+    // Issue #522: a C#-style object initializer applied to a constructor
+    // call, e.g. `T(args) { Prop1 = v1, Prop2 = v2 }`. Each initializer is
+    // a `PropertyInitializer` ('Identifier = Expression'). Lowers in the
+    // binder to a `BoundBlockExpression` that constructs into a synthetic
+    // local, assigns each property, and yields the local.
+    ObjectCreationExpression,
+    PropertyInitializer,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/test/Compiler.Tests/Emit/Issue522InitOnlyPropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue522InitOnlyPropertyEmitTests.cs
@@ -1,0 +1,342 @@
+// <copyright file="Issue522InitOnlyPropertyEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #522 regression tests. Two facets are exercised end-to-end:
+///   * Facet 1 — plain assignment to a CLR <c>init</c>-only property must
+///     emit IL whose setter reference carries the
+///     <c>modreq(IsExternalInit)</c> signature; previously the modreq was
+///     dropped and the runtime failed with <c>MissingMethodException</c>.
+///   * Facet 2 — the C#-style object initializer suffix
+///     <c>T(args) { Prop1 = v1, … }</c> must parse, bind, and execute,
+///     covering init-only and regular setters, the zero-property degenerate,
+///     and a writable-field regression guard.
+/// Each test builds a hermetic <c>ProbeLib.dll</c> in-process with
+/// <see cref="PersistedAssemblyBuilder"/>, compiles a small G# program
+/// against it, ilverifies the produced assembly, and runs it with
+/// <c>dotnet exec</c>.
+/// </summary>
+public class Issue522InitOnlyPropertyEmitTests
+{
+    [Fact]
+    public void PlainAssignment_ToInitOnlyProperty_RunsWithoutMissingMethodException()
+    {
+        // Facet 1: the emitter previously dropped modreq(IsExternalInit) on
+        // the setter return parameter, so the runtime couldn't resolve
+        // set_Asin and threw MissingMethodException.
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var w = WithInit()
+            w.Asin = "X"
+            Console.WriteLine(w.Asin)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("X\n", output);
+    }
+
+    [Fact]
+    public void ObjectInitializer_SetsInitOnlyAndRegularProperties()
+    {
+        // Facet 2: object initializer suffix lowers to a synthetic local plus
+        // a chain of property assignments. Mixes init-only (Asin) and regular
+        // set (Title) — both reach their setters on the constructed instance.
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var w = WithInit() { Asin = "Y", Title = "T" }
+            Console.WriteLine(w.Asin)
+            Console.WriteLine(w.Title)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Y\nT\n", output);
+    }
+
+    [Fact]
+    public void ObjectInitializer_ZeroProperties_IsDegenerateButLegal()
+    {
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var w = WithInit() { }
+            Console.WriteLine(w.Asin)
+            """;
+
+        var output = CompileAndRun(source);
+
+        // Asin defaults to null because the auto-property backing field is
+        // never assigned. Console.WriteLine renders that as an empty line.
+        Assert.Equal("\n", output);
+    }
+
+    [Fact]
+    public void ObjectInitializer_SinglePropertyForm_Parses()
+    {
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var w = WithInit() { Title = "only" }
+            Console.WriteLine(w.Title)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("only\n", output);
+    }
+
+    [Fact]
+    public void PlainAssignment_ToRegularSetterProperty_StillWorks()
+    {
+        // Regression guard: the modreq encoding now runs for every void
+        // setter; this test pins that the no-modreq path still emits a
+        // method reference the runtime can resolve.
+        var source = """
+            package P
+
+            import System
+            import Probe
+
+            var w = WithInit()
+            w.Title = "Z"
+            Console.WriteLine(w.Title)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Z\n", output);
+    }
+
+    /// <summary>
+    /// Compiles the supplied G# source against an in-process
+    /// <c>Probe.WithInit</c> CLR library, IL-verifies the produced
+    /// assembly, then runs it with <c>dotnet exec</c> and returns stdout.
+    /// </summary>
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue522_").FullName;
+        try
+        {
+            var probeDllPath = Path.Combine(tempDir, "ProbeLib.dll");
+            BuildProbeLibrary(probeDllPath);
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                "/r:" + probeDllPath,
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { probeDllPath });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup; the OS will reclaim per-test scratch
+                // directories on the next reboot.
+            }
+        }
+    }
+
+    /// <summary>
+    /// Emits a minimal <c>ProbeLib.dll</c> exposing
+    /// <c>Probe.WithInit { public string Asin { get; init; } public string Title { get; set; } }</c>.
+    /// The init-only accessor is materialised by tagging the setter's
+    /// return-parameter with <c>modreq(System.Runtime.CompilerServices.IsExternalInit)</c>,
+    /// matching what the C# compiler emits for a <c>{ init; }</c> accessor.
+    /// </summary>
+    private static void BuildProbeLibrary(string dllPath)
+    {
+        var coreAssembly = typeof(object).Assembly;
+
+        var asmName = new AssemblyName("ProbeLib") { Version = new Version(1, 0, 0, 0) };
+        var asmBuilder = new PersistedAssemblyBuilder(asmName, coreAssembly);
+        var moduleBuilder = asmBuilder.DefineDynamicModule("ProbeLib");
+
+        var typeBuilder = moduleBuilder.DefineType(
+            "Probe.WithInit",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.AutoLayout | TypeAttributes.BeforeFieldInit,
+            parent: typeof(object));
+
+        EmitProperty(typeBuilder, "Asin", typeof(string), initOnly: true);
+        EmitProperty(typeBuilder, "Title", typeof(string), initOnly: false);
+
+        var ctor = typeBuilder.DefineConstructor(
+            MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName | MethodAttributes.HideBySig,
+            CallingConventions.Standard,
+            Type.EmptyTypes);
+        var ctorIl = ctor.GetILGenerator();
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Call, typeof(object).GetConstructor(Type.EmptyTypes)!);
+        ctorIl.Emit(OpCodes.Ret);
+
+        typeBuilder.CreateType();
+        asmBuilder.Save(dllPath);
+    }
+
+    private static void EmitProperty(TypeBuilder typeBuilder, string name, Type clrType, bool initOnly)
+    {
+        var field = typeBuilder.DefineField(
+            "<" + name + ">k__BackingField",
+            clrType,
+            FieldAttributes.Private);
+
+        var property = typeBuilder.DefineProperty(
+            name,
+            PropertyAttributes.HasDefault,
+            clrType,
+            parameterTypes: null);
+
+        const MethodAttributes accessorAttrs = MethodAttributes.Public
+            | MethodAttributes.SpecialName
+            | MethodAttributes.HideBySig;
+
+        var getter = typeBuilder.DefineMethod(
+            "get_" + name,
+            accessorAttrs,
+            clrType,
+            Type.EmptyTypes);
+        var getterIl = getter.GetILGenerator();
+        getterIl.Emit(OpCodes.Ldarg_0);
+        getterIl.Emit(OpCodes.Ldfld, field);
+        getterIl.Emit(OpCodes.Ret);
+
+        // Init-only setters carry modreq(IsExternalInit) on the void return
+        // type. PersistedAssemblyBuilder.DefineMethod's overload taking
+        // returnTypeRequiredCustomModifiers encodes this directly into the
+        // method's metadata signature — which is exactly what set-property
+        // reference resolution in the runtime uses to bind the call.
+        var isExternalInit = coreOf(typeof(object)).GetType(
+            "System.Runtime.CompilerServices.IsExternalInit",
+            throwOnError: false);
+
+        var returnRequiredMods = initOnly && isExternalInit != null
+            ? new[] { isExternalInit }
+            : Type.EmptyTypes;
+
+        var setter = typeBuilder.DefineMethod(
+            "set_" + name,
+            accessorAttrs,
+            CallingConventions.HasThis,
+            returnType: null,
+            returnTypeRequiredCustomModifiers: returnRequiredMods,
+            returnTypeOptionalCustomModifiers: null,
+            parameterTypes: new[] { clrType },
+            parameterTypeRequiredCustomModifiers: null,
+            parameterTypeOptionalCustomModifiers: null);
+        var setterIl = setter.GetILGenerator();
+        setterIl.Emit(OpCodes.Ldarg_0);
+        setterIl.Emit(OpCodes.Ldarg_1);
+        setterIl.Emit(OpCodes.Stfld, field);
+        setterIl.Emit(OpCodes.Ret);
+
+        property.SetGetMethod(getter);
+        property.SetSetMethod(setter);
+    }
+
+    private static Assembly coreOf(Type t) => t.Assembly;
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/ObjectInitializerBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ObjectInitializerBinderTests.cs
@@ -1,0 +1,132 @@
+// <copyright file="ObjectInitializerBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #522: binder tests for the C#-style object-initializer suffix.
+/// Confirms that:
+///   * Initializers against a user-defined class assign the named fields.
+///   * Initializers against a writable property succeed.
+///   * Initializers against an unknown member surface a precise diagnostic.
+///   * Initializers against a non-writable member surface a precise
+///     diagnostic.
+/// </summary>
+public class ObjectInitializerBinderTests
+{
+    [Fact]
+    public void Binds_AgainstUserDefinedClassFields()
+    {
+        var source = @"
+type Box class {
+    Width int32
+    Height int32
+    init() { }
+}
+
+var b = Box() { Width = 3, Height = 4 }
+b.Width + b.Height
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void Binds_AgainstUserDefinedClassProperty()
+    {
+        var source = @"
+type Box class {
+    prop Width int32
+    prop Height int32
+    init() { }
+}
+
+var b = Box() { Width = 5, Height = 6 }
+b.Width + b.Height
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(11, result.Value);
+    }
+
+    [Fact]
+    public void Binds_EmptyInitializerListYieldsConstructedInstance()
+    {
+        var source = @"
+type Box class {
+    Width int32
+    init() { }
+}
+
+var b = Box() { }
+b.Width
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+
+    [Fact]
+    public void Diagnoses_UnknownMemberName()
+    {
+        var source = @"
+type Box class {
+    Width int32
+    init() { }
+}
+
+var b = Box() { Unknown = 1 }
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Unknown"));
+    }
+
+    [Fact]
+    public void Diagnoses_DuplicatePropertyName()
+    {
+        var source = @"
+type Box class {
+    Width int32
+    init() { }
+}
+
+var b = Box() { Width = 1, Width = 2 }
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Diagnoses_NonWritableProperty()
+    {
+        var source = @"
+type Box class {
+    prop Width int32 { get }
+    init() { }
+}
+
+var b = Box() { Width = 1 }
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/ObjectInitializerParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/ObjectInitializerParserTests.cs
@@ -1,0 +1,158 @@
+// <copyright file="ObjectInitializerParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #522: parser tests for the C#-style object-initializer suffix
+/// (<c>T(args) { Prop = value, … }</c>). Confirms that the new grammar is
+/// recognised in expression positions without regressing the existing
+/// body-header parsers (if/for/while/switch braces remain statement bodies).
+/// </summary>
+public class ObjectInitializerParserTests
+{
+    [Fact]
+    public void Parses_EmptyInitializerList()
+    {
+        const string source = "package P\nfunc Main() {\n  var w = WithInit() { }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void Parses_SinglePropertyInitializer()
+    {
+        const string source = "package P\nfunc Main() {\n  var w = WithInit() { Asin = \"X\" }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void Parses_MultiplePropertyInitializers()
+    {
+        const string source = "package P\nfunc Main() {\n  var w = WithInit() { Asin = \"X\", Title = \"T\" }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void Parses_TrailingComma()
+    {
+        // Trailing comma is allowed for consistency with argument lists,
+        // tuple literals, struct literals, and array initializers.
+        const string source = "package P\nfunc Main() {\n  var w = WithInit() { Asin = \"X\", Title = \"T\", }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void Parses_NestedObjectInitializer()
+    {
+        const string source = "package P\nfunc Main() {\n  var w = Outer() { Inner = Inner() { X = 1 } }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void Parses_WithIntegerProperty()
+    {
+        const string source = "package P\nfunc Main() {\n  var w = Box() { Value = 1 }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void DoesNotEat_IfStatementBody()
+    {
+        // The body-header suppression flag keeps `if Cond() { … }` parsing as
+        // a regular `if` with a body block, even though the body's first
+        // statement is `Identifier = expr` (the shape that would otherwise
+        // be mis-eaten as an object initializer).
+        const string source = "package P\nfunc Main() {\n  var x = 0\n  if Cond() {\n    x = 1\n  }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void DoesNotEat_ForRangeStatementBody()
+    {
+        const string source = "package P\nfunc Main() {\n  var total = 0\n  for v := range Items() {\n    total = total + v\n  }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void DoesNotEat_ForConditionStatementBody()
+    {
+        const string source = "package P\nfunc Main() {\n  var x = 0\n  for Cond() {\n    x = x + 1\n  }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void DoesNotEat_SwitchStatementBody()
+    {
+        const string source = "package P\nfunc Main() {\n  var x = 0\n  switch Cond() {\n  default {\n    x = 1\n  }\n  }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void AllowsObjectInitializer_InsideArgumentInBodyHeader()
+    {
+        // Even though `if Cond() { … }` suppresses the trailing initializer
+        // at the body-header level, the inner call argument is a fresh
+        // expression context that re-allows initializers.
+        const string source = "package P\nfunc Main() {\n  if Process(Build() { X = 1 }) {\n    Noop()\n  }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void AllowsObjectInitializer_InsideParensInBodyHeader()
+    {
+        const string source = "package P\nfunc Main() {\n  if (Build() { X = 1 }) != nil {\n    Noop()\n  }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void ProducesObjectCreationExpression_NodeKind()
+    {
+        const string source = "package P\nfunc Main() {\n  var w = WithInit() { Asin = \"X\" }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var objectCreation = FindFirst<ObjectCreationExpressionSyntax>(tree.Root);
+        Assert.NotNull(objectCreation);
+        Assert.Equal(SyntaxKind.ObjectCreationExpression, objectCreation.Kind);
+        var init = objectCreation.Initializers.Single();
+        Assert.Equal("Asin", init.PropertyIdentifier.Text);
+        Assert.Equal(SyntaxKind.EqualsToken, init.EqualsToken.Kind);
+    }
+
+    private static T FindFirst<T>(SyntaxNode root)
+        where T : SyntaxNode
+    {
+        if (root is T match)
+        {
+            return match;
+        }
+
+        foreach (var child in root.GetChildren())
+        {
+            var found = FindFirst<T>(child);
+            if (found != null)
+            {
+                return found;
+            }
+        }
+
+        return null;
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -132,6 +132,7 @@ NamedDeconstructionField
 NamedDeconstructionStatement
 NilKeyword
 NumberToken
+ObjectCreationExpression
 OpenBraceToken
 OpenKeyword
 OpenParenthesisToken
@@ -153,6 +154,7 @@ PlusToken
 PrivateKeyword
 PropertyAccessor
 PropertyDeclaration
+PropertyInitializer
 PropertyPattern
 PropertyPatternField
 PublicKeyword


### PR DESCRIPTION
Fixes #522.

Two facets reported on the issue; both fixed.

## Facet 1 — runtime crash on init-only assignment

```gsharp
var w = WithInit()
w.Asin = "X"   // System.MissingMethodException: Method not found: 'Void Probe.WithInit.set_Asin(System.String)'
```

**Root cause:** the C# init-only setter carries `modreq([mscorlib]System.Runtime.CompilerServices.IsExternalInit)` on its void return parameter. `ReflectionMetadataEmitter.EncodeReturnClr` only honoured required custom modifiers for byref returns; for the more common void return it called `encoder.Void()` without first encoding the modreq. The resulting MemberRef signature didn't match what's actually on the type, so the runtime threw `MissingMethodException` even though the method exists.

**Fix:** when encoding a void return, also walk `returnParameter.GetRequiredCustomModifiers()` and emit each one as `modreq` before the void byte (ECMA-335 II.23.2.1: modreqs precede the type encoding).

### Direction A vs B

I chose **direction B (lenient)**: G# continues to permit setter calls from any site, and the emitted IL is now correct everywhere. Rationale:

* G# has no formal "construction context" concept (no `required`, no automatic detection of "inside same type / inside an init accessor"), so a faithful CS8852 port would either over-reject or require a fresh design that isn't justified by this bug.
* Direction A would *require* the new object-initializer syntax for every init-only set — including in test code where the receiver is constructed elsewhere — which is more surface for a single regression.
* B is purely an IL fix; the surface remains identical for callers that already worked.

## Facet 2 — object initializer syntax doesn't parse

```gsharp
var w = WithInit() { Asin = "Y", Title = "T" }   // GS0005: Unexpected token <CommaToken>
```

**Implementation:**

* New `SyntaxKind` values `ObjectCreationExpression` and `PropertyInitializer`.
* New nodes `PropertyInitializerSyntax` and `ObjectCreationExpressionSyntax` (wraps a constructor call target + initializer list, so existing `CallExpressionSyntax` is left untouched).
* Parser: `ParseNameOrCallExpression` wraps both the plain and generic call branches via `MaybeWrapWithObjectInitializer`, which peeks for `{` + `Identifier =` (or empty `{}`).
* Binder: new `BindObjectCreationExpression` lowers `T(args) { P1 = v1, P2 = v2 }` to
  `{ var $tmp = T(args); $tmp.P1 = v1; $tmp.P2 = v2; $tmp }` reusing `BoundBlockExpression`. Init-only setters are legal here even though the binder treats them like regular setters.
* Evaluator: `EvaluateBlockExpression` learnt to drive `BoundExpressionStatement` items in addition to `BoundVariableDeclaration` (the lowering produces both).

### Parser ambiguity

`Call() { Body }` collides with statement bodies (`if Cond() { body }`, `for x := range Coll() { body }`, etc.). A `suppressTrailingObjectInitializer` counter is incremented by body-header parsers — `ParseIfStatement`, `ParseForRangeStatement`, `ParseForEllipsisStatement`, `ParseForConditionStatement`, `ParseForClauseStatement`, `ParseSwitchStatement`, `ParseAwaitForRangeStatement`, `ParseSwitchExpression` — around their condition expression. Nested expression contexts (`ParseArguments`, `ParseParenthesizedExpression`, the postfix indexer, the initializer-value sub-expression itself) save+clear the counter so an inner `Process(Build() { X = 1 })` inside an `if` still wraps.

Edge cases covered by tests:
* Zero properties (`T() { }`) — legal, yields a default-initialised instance.
* Trailing comma — allowed, for consistency with arg lists / tuples / array initializers.
* Nested object initializers (`T() { Inner = U() { X = 1 } }`).
* Mix of init-only and regular setters.
* `get`-only property — rejected with GS0127 ("Cannot assign").
* Unknown property name — rejected with GS0158 ("Cannot find member").
* Duplicate property name — rejected with GS0026.

## Tests

* `test/Core.Tests/CodeAnalysis/Syntax/ObjectInitializerParserTests.cs` (13 tests) — parse positive / negative shapes and body-header regression guards.
* `test/Core.Tests/CodeAnalysis/Binding/ObjectInitializerBinderTests.cs` (6 tests) — fields, properties, diagnostics for unknown / duplicate / non-writable.
* `test/Compiler.Tests/Emit/Issue522InitOnlyPropertyEmitTests.cs` (5 tests) — builds an in-process `Probe.WithInit` with init-only `Asin` + regular `Title`, then for each scenario compiles, ilverifies, and runs end-to-end:
  - plain `w.Asin = "X"` (the original crash, now succeeds);
  - `WithInit() { Asin = "Y", Title = "T" }` (mixed);
  - zero-property degenerate;
  - single-property form;
  - plain `w.Title = "Z"` regression guard for regular setters.

## Verification

```
dotnet build GSharp.sln -nologo -clp:NoSummary    → clean
dotnet test GSharp.sln --no-restore --nologo      → Passed: 2800, Failed: 0
```

The coverage-matrix golden and `docs/coverage-matrix.md` are updated for the two new `SyntaxKind` values.

Nothing deferred.