### PR TITLE
Capture closures by reference (Fixes #523)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -17464,15 +17464,26 @@ public sealed class Binder
             return base.RewriteVariableDeclaration(node);
         }
 
+        protected override BoundExpression RewriteAssignmentExpression(BoundAssignmentExpression node)
+        {
+            // Issue #523: an assignment LHS is a USE of the variable that
+            // must contribute to the capture set, exactly like a
+            // BoundVariableExpression. The base rewriter intentionally
+            // doesn't visit `node.Variable`, so the binder otherwise
+            // silently treats write-only captures (e.g. `func(x) { n = x }`)
+            // as having no captures — which crashes the emitter when the
+            // body still references the (boxed) target.
+            this.RecordReference(node.Variable);
+            return base.RewriteAssignmentExpression(node);
+        }
+
         protected override BoundExpression RewriteVariableExpression(BoundVariableExpression node)
         {
-            if (!this.parameters.Contains(node.Variable)
-                && !this.declared.Contains(node.Variable)
-                && this.seen.Add(node.Variable))
-            {
-                this.captured.Add(node.Variable);
-            }
-
+            // Issue #523 (side fix): globals already live in a static field and
+            // are addressable from any lambda body via ldsfld/stsfld — capturing
+            // them into a closure-class field would re-introduce the snapshot
+            // bug. Skip globals so the lambda reads them directly at every use.
+            this.RecordReference(node.Variable);
             return node;
         }
 
@@ -17489,6 +17500,12 @@ public sealed class Binder
             // #503 closures inside nested lambdas).
             foreach (var nestedCapture in node.CapturedVariables)
             {
+                // Issue #523 (side fix): see RewriteVariableExpression above.
+                if (nestedCapture is GlobalVariableSymbol)
+                {
+                    continue;
+                }
+
                 if (!this.parameters.Contains(nestedCapture)
                     && !this.declared.Contains(nestedCapture)
                     && this.seen.Add(nestedCapture))
@@ -17498,6 +17515,22 @@ public sealed class Binder
             }
 
             return node;
+        }
+
+        private void RecordReference(VariableSymbol variable)
+        {
+            // Globals are read live (see RewriteVariableExpression).
+            if (variable is GlobalVariableSymbol)
+            {
+                return;
+            }
+
+            if (!this.parameters.Contains(variable)
+                && !this.declared.Contains(variable)
+                && this.seen.Add(variable))
+            {
+                this.captured.Add(variable);
+            }
         }
     }
 }

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -313,6 +313,13 @@ public class Compilation
         // participate in hoist-set computation.
         program = Lowering.SideEffectSpiller.Lower(program);
 
+        // Issue #523: hoist captured locals/parameters into per-variable
+        // box classes so function literals see writes to the variable cell
+        // (Go/C# closure semantics). Must run after side-effect spilling
+        // and before the async / iterator state-machine lowerers so they
+        // see the boxed captures rather than the snapshot-by-value pattern.
+        program = Lowering.CaptureBoxingRewriter.Lower(program);
+
         var (lowered, lowerDiagnostics) = LowerForEmit(program, References ?? Symbols.ReferenceResolver.Default());
         if (lowerDiagnostics.Any(d => d.IsError))
         {
@@ -415,6 +422,13 @@ public class Compilation
         // iterator state machine rewriters so the spilled temps
         // participate in hoist-set computation.
         program = Lowering.SideEffectSpiller.Lower(program);
+
+        // Issue #523: hoist captured locals/parameters into per-variable
+        // box classes so function literals see writes to the variable cell
+        // (Go/C# closure semantics). Must run after side-effect spilling
+        // and before the async / iterator state-machine lowerers so they
+        // see the boxed captures rather than the snapshot-by-value pattern.
+        program = Lowering.CaptureBoxingRewriter.Lower(program);
 
         var (lowered, lowerDiagnostics) = LowerForEmit(program, References ?? Symbols.ReferenceResolver.Default());
         if (lowerDiagnostics.Any(d => d.IsError))

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1185,16 +1185,27 @@ internal sealed class ReflectionMetadataEmitter
         // (same trick used for SM classes above). The actual ctor body is
         // still emitted in the planned row order during the main nonSmClasses
         // loop below.
+        //
+        // Issue #523: the same hazard applies to capture-box classes. A box
+        // class has no explicit ctor and no primary ctor, so its
+        // EmitClassDefaultConstructor row is the one reserved at classCtorRows
+        // — pre-register that handle so any earlier-emitted method body
+        // can `newobj` the box before its body is materialized.
         foreach (var c in nonSmClasses)
         {
-            if (!this.synthesizedClosureClasses.Contains(c))
+            var isSynthesizedClosure = this.synthesizedClosureClasses.Contains(c);
+            var hasDefaultOnlyCtor = c.ExplicitConstructor == null
+                && c.BaseConstructorInitializer == null
+                && !c.HasPrimaryConstructor;
+
+            if (!isSynthesizedClosure && !hasDefaultOnlyCtor)
             {
                 continue;
             }
 
-            if (classCtorRows.TryGetValue(c, out var closureCtorRow))
+            if (classCtorRows.TryGetValue(c, out var classCtorRow))
             {
-                this.classCtorHandles[c] = MetadataTokens.MethodDefinitionHandle(closureCtorRow);
+                this.classCtorHandles[c] = MetadataTokens.MethodDefinitionHandle(classCtorRow);
             }
         }
 
@@ -14857,8 +14868,20 @@ internal sealed class ReflectionMetadataEmitter
             }
             else if (!this.outer.classPrimaryCtorHandles.TryGetValue(call.StructType, out ctorHandle))
             {
-                throw new InvalidOperationException(
-                    $"Type '{call.StructType.Name}' has no emitted primary ctor.");
+                // Issue #523: synthesized classes (e.g. capture boxes) declare
+                // no primary constructor; for a zero-argument newobj we fall
+                // back to the parameterless default ctor that PHASE B emitted
+                // into classCtorHandles.
+                if (call.Arguments.IsDefaultOrEmpty
+                    && this.outer.classCtorHandles.TryGetValue(call.StructType, out var defaultCtorHandle))
+                {
+                    ctorHandle = defaultCtorHandle;
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        $"Type '{call.StructType.Name}' has no emitted primary ctor.");
+                }
             }
 
             // Phase 4 emit parity (F2, type-erased generic user types): the

--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -1,0 +1,460 @@
+// <copyright file="CaptureBoxingRewriter.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Lowering;
+
+/// <summary>
+/// Issue #523: a function literal that captures a value-type local of its
+/// enclosing scope must observe subsequent writes to that local — both Go
+/// and C# capture closures over the variable cell, not its value at
+/// construction time. The historical emit pipeline snapshotted captured
+/// values into closure-class fields, so an outer reassignment was
+/// invisible to the lambda.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This pass hoists every captured local / captured parameter into a
+/// synthesized single-field reference class (<c>&lt;&gt;__Box_&lt;name&gt;_&lt;n&gt;</c>),
+/// inserts the allocation at the local's declaration site (or at function
+/// entry for captured parameters), and rewrites every read and write of
+/// the captured variable — including reads/writes inside the lambda body
+/// — to go through the shared box.
+/// </para>
+/// <para>
+/// Because the box is a reference type, the lambda's existing
+/// snapshot-by-value emit (which copies the captured variable into the
+/// closure class's field at <c>newobj</c> time) now copies a *reference*
+/// to the box. The outer scope and every lambda that captures the
+/// variable therefore share the same cell. Multiple lambdas in the same
+/// scope share state automatically; nested lambdas continue to work via
+/// the existing transitive-capture propagation
+/// (<c>CapturedVariableCollector.RewriteFunctionLiteralExpression</c>).
+/// </para>
+/// <para>
+/// Globals (<see cref="GlobalVariableSymbol"/>) are excluded as a side
+/// fix: they are already addressable as static fields, so capturing them
+/// into a closure field would just re-introduce the snapshot bug; the
+/// pass instead rewrites the lambda's capture list to omit them, leaving
+/// the lambda body to read the static field directly at every use.
+/// </para>
+/// <para>
+/// For-range key/value variables are intentionally not boxed: the
+/// existing snapshot emit happens to match C#'s
+/// per-iteration-fresh-variable semantics for <c>foreach</c>, so leaving
+/// them alone is both correct and cheaper.
+/// </para>
+/// </remarks>
+internal static class CaptureBoxingRewriter
+{
+    /// <summary>
+    /// Lowers captured-variable semantics in <paramref name="program"/> so
+    /// that captures of locals/parameters share a heap cell with the
+    /// outer scope. Returns the original instance unchanged when no
+    /// function body required boxing.
+    /// </summary>
+    /// <param name="program">The bound program to lower.</param>
+    /// <returns>The lowered program (or the original when nothing changed).</returns>
+    public static BoundProgram Lower(BoundProgram program)
+    {
+        var counter = 0;
+        var newStructs = new List<StructSymbol>();
+        var newFunctions = ImmutableDictionary.CreateBuilder<FunctionSymbol, BoundBlockStatement>();
+        var changed = false;
+
+        foreach (var pair in program.Functions)
+        {
+            var newBody = RewriteFunctionBody(pair.Key, pair.Value, program, newStructs, ref counter);
+            newFunctions[pair.Key] = newBody;
+            if (!ReferenceEquals(newBody, pair.Value))
+            {
+                changed = true;
+            }
+        }
+
+        if (!changed)
+        {
+            return program;
+        }
+
+        var combinedStructs = program.Structs.AddRange(newStructs);
+
+        var result = new BoundProgram(
+            program.EntryPointPackage,
+            program.Packages,
+            program.Diagnostics,
+            newFunctions.ToImmutable(),
+            program.EntryPoint,
+            program.Statement,
+            combinedStructs,
+            program.Interfaces,
+            program.Enums,
+            program.Globals,
+            program.Delegates)
+        {
+            Imports = program.Imports,
+        };
+
+        return result;
+    }
+
+    private static BoundBlockStatement RewriteFunctionBody(
+        FunctionSymbol function,
+        BoundBlockStatement body,
+        BoundProgram program,
+        List<StructSymbol> newStructs,
+        ref int counter)
+    {
+        // Step 1: collect every captured variable touched by any function
+        // literal in this body (transitively). This is the union over all
+        // BoundFunctionLiteralExpression.CapturedVariables reachable from
+        // this body, minus the literals' own parameters and locals — which
+        // the binder's CapturedVariableCollector has already pruned.
+        var capturedSet = new HashSet<VariableSymbol>();
+        CaptureWalker.Collect(body, capturedSet);
+
+        if (capturedSet.Count == 0)
+        {
+            return body;
+        }
+
+        // Step 2: classify each captured variable.
+        //   - boxable      → hoisted to a Box class; reads/writes rewritten.
+        //   - drop-capture → captured set entry removed (globals).
+        //   - leave alone  → kept as-is (refs, ref-likes, this).
+        var boxInfo = new Dictionary<VariableSymbol, BoxedVariable>();
+        var dropFromCapture = new HashSet<VariableSymbol>();
+        var packageName = function.Package?.Name ?? program.PackageName ?? string.Empty;
+
+        foreach (var variable in capturedSet)
+        {
+            if (variable is GlobalVariableSymbol)
+            {
+                // Globals already live in a static field — capturing them by
+                // snapshot is just as wrong as for locals (#523), but the fix
+                // is the opposite: the lambda should read the global directly,
+                // not via a closure field. Strip the capture so emit treats
+                // every reference inside the lambda as a static-field load.
+                dropFromCapture.Add(variable);
+                continue;
+            }
+
+            if (!IsBoxable(variable, function))
+            {
+                continue;
+            }
+
+            counter++;
+            var boxClass = CreateBoxClass(variable, counter, packageName);
+            var fieldSymbol = boxClass.Fields[0];
+
+            // For captured locals: a new LocalVariableSymbol of the box type
+            // replaces the original; the binder-emitted slot is reclaimed
+            // for the box reference.
+            // For captured parameters: the parameter remains in the function
+            // signature; a sibling local of the box type is added at entry
+            // and its contents are seeded from the parameter once.
+            var slotName = variable is ParameterSymbol p
+                ? "<>__boxed_" + p.Name
+                : variable.Name;
+            var boxLocal = new LocalVariableSymbol(slotName, isReadOnly: false, type: boxClass);
+
+            boxInfo[variable] = new BoxedVariable(variable, boxLocal, boxClass, fieldSymbol);
+            newStructs.Add(boxClass);
+        }
+
+        if (boxInfo.Count == 0 && dropFromCapture.Count == 0)
+        {
+            return body;
+        }
+
+        // Step 3: rewrite the body — locals, reads, writes, and lambdas.
+        var rewriter = new BoxingRewriter(boxInfo, dropFromCapture);
+        var rewritten = (BoundBlockStatement)rewriter.RewriteStatement(body);
+
+        // Step 4: prepend per-parameter box allocation + seed.
+        var paramBoxes = new List<BoxedVariable>();
+        foreach (var bi in boxInfo.Values)
+        {
+            if (bi.Original is ParameterSymbol)
+            {
+                paramBoxes.Add(bi);
+            }
+        }
+
+        if (paramBoxes.Count > 0)
+        {
+            // Keep parameter boxes in source-declaration order for a stable
+            // local-signature row layout (Issue #456 determinism).
+            paramBoxes.Sort((a, b) => string.CompareOrdinal(a.Original.Name, b.Original.Name));
+
+            var prologue = ImmutableArray.CreateBuilder<BoundStatement>((paramBoxes.Count * 2) + rewritten.Statements.Length);
+            foreach (var bi in paramBoxes)
+            {
+                prologue.Add(new BoundVariableDeclaration(
+                    null,
+                    bi.BoxLocal,
+                    new BoundConstructorCallExpression(
+                        null,
+                        bi.BoxClass,
+                        ImmutableArray<BoundExpression>.Empty)));
+                prologue.Add(new BoundExpressionStatement(
+                    null,
+                    new BoundFieldAssignmentExpression(
+                        null,
+                        bi.BoxLocal,
+                        bi.BoxClass,
+                        bi.BoxField,
+                        new BoundVariableExpression(null, bi.Original))));
+            }
+
+            prologue.AddRange(rewritten.Statements);
+            rewritten = new BoundBlockStatement(null, prologue.ToImmutable());
+        }
+
+        return rewritten;
+    }
+
+    private static bool IsBoxable(VariableSymbol variable, FunctionSymbol function)
+    {
+        // Only locals and parameters (parameters are LocalVariableSymbols).
+        if (variable is not LocalVariableSymbol local)
+        {
+            return false;
+        }
+
+        // The synthesized `this` parameter for instance methods is a stable
+        // reference and never reassigned; snapshotting it is fine.
+        if (variable == function.ThisParameter)
+        {
+            return false;
+        }
+
+        // ADR-0060 / issue #491: ref-aliasing locals carry a managed pointer
+        // in their slot; boxing would break the aliasing semantics.
+        if (local.RefKind != RefKind.None)
+        {
+            return false;
+        }
+
+        // ADR-0058 / issue #376: managed pointer (T&) — binder rejects capture
+        // already, but guard against future paths.
+        if (local.Type is ByRefTypeSymbol)
+        {
+            return false;
+        }
+
+        // Issue #367: by-ref-like types cannot be boxed.
+        if (TypeSymbol.IsByRefLike(local.Type))
+        {
+            return false;
+        }
+
+        // Parameters are boxable only when they belong to *this* function:
+        // a captured parameter from an enclosing function is the responsibility
+        // of that outer pass.
+        if (local is ParameterSymbol parameter && !function.Parameters.Contains(parameter))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static StructSymbol CreateBoxClass(VariableSymbol variable, int counter, string packageName)
+    {
+        var valueField = new FieldSymbol("Value", variable.Type, Accessibility.Public);
+        var name = "<>__Box_" + variable.Name + "_" + counter.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        return new StructSymbol(
+            name,
+            ImmutableArray.Create(valueField),
+            Accessibility.Internal,
+            declaration: null,
+            packageName: packageName,
+            isData: false,
+            isInline: false,
+            isClass: true);
+    }
+
+    private sealed class BoxedVariable
+    {
+        public BoxedVariable(VariableSymbol original, LocalVariableSymbol boxLocal, StructSymbol boxClass, FieldSymbol boxField)
+        {
+            Original = original;
+            BoxLocal = boxLocal;
+            BoxClass = boxClass;
+            BoxField = boxField;
+        }
+
+        public VariableSymbol Original { get; }
+
+        public LocalVariableSymbol BoxLocal { get; }
+
+        public StructSymbol BoxClass { get; }
+
+        public FieldSymbol BoxField { get; }
+    }
+
+    private sealed class CaptureWalker : BoundTreeRewriter
+    {
+        private readonly HashSet<VariableSymbol> sink;
+
+        private CaptureWalker(HashSet<VariableSymbol> sink)
+        {
+            this.sink = sink;
+        }
+
+        public static void Collect(BoundStatement root, HashSet<VariableSymbol> sink)
+        {
+            new CaptureWalker(sink).RewriteStatement(root);
+        }
+
+        /// <inheritdoc/>
+        protected override BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+        {
+            foreach (var captured in node.CapturedVariables)
+            {
+                this.sink.Add(captured);
+            }
+
+            // BoundTreeRewriter intentionally treats a function literal as a
+            // leaf (the body is a separate lexical scope). Recurse explicitly
+            // so nested lambdas-in-lambdas also contribute — defensive: the
+            // binder already propagates captures transitively, but this keeps
+            // the pass robust against future BoundTree changes.
+            this.RewriteStatement(node.Body);
+            return node;
+        }
+    }
+
+    private sealed class BoxingRewriter : BoundTreeRewriter
+    {
+        private readonly Dictionary<VariableSymbol, BoxedVariable> boxInfo;
+        private readonly HashSet<VariableSymbol> dropFromCapture;
+
+        public BoxingRewriter(
+            Dictionary<VariableSymbol, BoxedVariable> boxInfo,
+            HashSet<VariableSymbol> dropFromCapture)
+        {
+            this.boxInfo = boxInfo;
+            this.dropFromCapture = dropFromCapture;
+        }
+
+        /// <inheritdoc/>
+        protected override BoundExpression RewriteVariableExpression(BoundVariableExpression node)
+        {
+            if (this.boxInfo.TryGetValue(node.Variable, out var bi))
+            {
+                return new BoundFieldAccessExpression(
+                    null,
+                    new BoundVariableExpression(null, bi.BoxLocal),
+                    bi.BoxClass,
+                    bi.BoxField);
+            }
+
+            return node;
+        }
+
+        /// <inheritdoc/>
+        protected override BoundExpression RewriteAssignmentExpression(BoundAssignmentExpression node)
+        {
+            if (this.boxInfo.TryGetValue(node.Variable, out var bi))
+            {
+                var value = this.RewriteExpression(node.Expression);
+                return new BoundFieldAssignmentExpression(
+                    null,
+                    bi.BoxLocal,
+                    bi.BoxClass,
+                    bi.BoxField,
+                    value);
+            }
+
+            return base.RewriteAssignmentExpression(node);
+        }
+
+        /// <inheritdoc/>
+        protected override BoundStatement RewriteVariableDeclaration(BoundVariableDeclaration node)
+        {
+            if (this.boxInfo.TryGetValue(node.Variable, out var bi) && bi.Original == node.Variable)
+            {
+                // `var n = e` (where n is captured) lowers to:
+                //   var <n_slot> = new Box_n()
+                //   <n_slot>.Value = e
+                // The original `n`'s slot is reclaimed by the new LocalVariableSymbol
+                // of type Box_n. Note `Lowerer.Flatten` will inline this nested
+                // block into the enclosing block during the post-binding lower pass.
+                var initializer = this.RewriteExpression(node.Initializer);
+                var stmts = ImmutableArray.Create<BoundStatement>(
+                    new BoundVariableDeclaration(
+                        null,
+                        bi.BoxLocal,
+                        new BoundConstructorCallExpression(
+                            null,
+                            bi.BoxClass,
+                            ImmutableArray<BoundExpression>.Empty)),
+                    new BoundExpressionStatement(
+                        null,
+                        new BoundFieldAssignmentExpression(
+                            null,
+                            bi.BoxLocal,
+                            bi.BoxClass,
+                            bi.BoxField,
+                            initializer)));
+                return new BoundBlockStatement(null, stmts);
+            }
+
+            return base.RewriteVariableDeclaration(node);
+        }
+
+        /// <inheritdoc/>
+        protected override BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+        {
+            // Descend into the lambda's body so reads/writes of captured outer
+            // variables become reads/writes through the box. The base
+            // BoundTreeRewriter intentionally skips the body (separate
+            // lexical scope), so we override and recurse explicitly.
+            var newBody = (BoundBlockStatement)this.RewriteStatement(node.Body);
+
+            // Update the lambda's capture list:
+            //   - rewrite each boxed variable to its box-local;
+            //   - drop globals so the lambda reads them directly via ldsfld.
+            var newCaptured = ImmutableArray.CreateBuilder<VariableSymbol>(node.CapturedVariables.Length);
+            var anyCaptureChange = false;
+            foreach (var cv in node.CapturedVariables)
+            {
+                if (this.dropFromCapture.Contains(cv))
+                {
+                    anyCaptureChange = true;
+                    continue;
+                }
+
+                if (this.boxInfo.TryGetValue(cv, out var bi))
+                {
+                    newCaptured.Add(bi.BoxLocal);
+                    anyCaptureChange = true;
+                }
+                else
+                {
+                    newCaptured.Add(cv);
+                }
+            }
+
+            if (ReferenceEquals(newBody, node.Body) && !anyCaptureChange)
+            {
+                return node;
+            }
+
+            return new BoundFunctionLiteralExpression(
+                node.Syntax,
+                node.Function,
+                node.FunctionType,
+                newBody,
+                newCaptured.ToImmutable());
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/ClosureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/ClosureEmitTests.cs
@@ -20,9 +20,11 @@ namespace GSharp.Compiler.Tests.Emit;
 /// newobj Func|Action::.ctor(object, IntPtr)</c>.
 /// </para>
 /// <para>
-/// Capture semantics are snapshot-by-value at literal evaluation time —
-/// the same behavior the interpreter implements. Writes inside the lambda
-/// mutate the closure's field only; the outer variable is unaffected.
+/// Capture semantics (issue #523) are by reference over the variable cell —
+/// matching Go and C#. Captured locals/parameters are hoisted into a
+/// per-variable box class by the <c>CaptureBoxingRewriter</c> lowering pass;
+/// the closure class holds a reference to the box, so writes inside the
+/// lambda and writes in the outer scope are mutually visible.
 /// </para>
 /// </summary>
 public class ClosureEmitTests
@@ -85,11 +87,12 @@ public class ClosureEmitTests
     }
 
     [Fact]
-    public void SnapshotByValue_MutationInLambdaDoesNotAffectOuter()
+    public void StatefulCounter_LambdaMutationPersistsAcrossCalls()
     {
-        // Inside the lambda, `c = c + 1` updates the closure field, not the
-        // outer variable. The outer `c` is unchanged after the calls; the
-        // closure carries its own copy.
+        // Issue #523: `c` is captured by reference. Each call to the returned
+        // lambda updates the shared cell, so consecutive invocations see the
+        // accumulated state. Two separate `makeCounter` calls still get
+        // independent cells (covered by `CaptureAcrossSeparateCalls_AreIndependent`).
         var source = """
             package P
             import System
@@ -108,8 +111,8 @@ public class ClosureEmitTests
             """;
 
         var output = CompileAndRun(source);
-        // First call: closure-local c becomes 11, returns 11.
-        // Second call: closure-local c becomes 12, returns 12.
+        // First call: shared c becomes 11, returns 11.
+        // Second call: shared c becomes 12, returns 12.
         Assert.Equal("11\n12\n", output);
     }
 

--- a/test/Compiler.Tests/Emit/Issue503ClosureCaptureRegressionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue503ClosureCaptureRegressionTests.cs
@@ -350,11 +350,13 @@ public class Issue503ClosureCaptureRegressionTests
     }
 
     // -----------------------------------------------------------------------
-    // Snapshot capture semantics — pinned for future intentional change.
+    // Reference-capture semantics — issue #523. A lambda captures the
+    // *cell*, not the value at construction time; reassigning the local
+    // after subscription is observed by the lambda body.
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void CapturedLocalReassignedAfterSubscription_SnapshotsAtSubscriptionTime()
+    public void CapturedLocalReassignedAfterSubscription_LambdaObservesNewBinding()
     {
         var source = """
             package MyLib
@@ -374,6 +376,7 @@ public class Issue503ClosureCaptureRegressionTests
             type Probe class {
                 Src Source
                 Original Counter
+                Replacement Counter
                 init() {
                     Src = Source()
                     var c = Counter()
@@ -381,10 +384,12 @@ public class Issue503ClosureCaptureRegressionTests
                     Src.Changed += func(sender object, e EventArgs) {
                         c.Increment()
                     }
-                    // Reassign after subscription. Whatever the capture
-                    // semantics, the build must not silently abort and the
-                    // closure must fire on raise.
+                    // Reassign after subscription. Reference-capture
+                    // semantics (issue #523): the lambda holds the variable
+                    // cell, so it observes the new binding and `c.Increment()`
+                    // hits the replacement instance, not the original.
                     c = Counter()
+                    Replacement = c
                 }
             }
             """;
@@ -397,13 +402,15 @@ public class Issue503ClosureCaptureRegressionTests
         var probe = Activator.CreateInstance(probeType)!;
         var src = probeType.GetField("Src")!.GetValue(probe)!;
         var original = probeType.GetField("Original")!.GetValue(probe)!;
+        var replacement = probeType.GetField("Replacement")!.GetValue(probe)!;
 
         InvokeBackingDelegate(sourceType, src, "Changed");
 
-        // Snapshot-capture semantics: the original counter (captured at
-        // subscription time) was incremented. This pins current behavior
-        // so a future change to reference-capture semantics is intentional.
-        Assert.Equal(1, (int)counterType.GetField("Value")!.GetValue(original)!);
+        // Reference-capture (issue #523): the lambda follows the cell, so the
+        // post-subscription assignment is the one observed. The original
+        // counter is untouched; the replacement is the one that fires.
+        Assert.Equal(0, (int)counterType.GetField("Value")!.GetValue(original)!);
+        Assert.Equal(1, (int)counterType.GetField("Value")!.GetValue(replacement)!);
     }
 
     // -----------------------------------------------------------------------

--- a/test/Compiler.Tests/Emit/Issue523ClosureCaptureByRefTests.cs
+++ b/test/Compiler.Tests/Emit/Issue523ClosureCaptureByRefTests.cs
@@ -1,0 +1,340 @@
+// <copyright file="Issue523ClosureCaptureByRefTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Regression coverage for issue #523: function literals must capture their
+/// enclosing locals/parameters by reference (over the variable cell), not
+/// by value at literal-construction time. Each test compiles an end-to-end
+/// program, runs it with <c>dotnet exec</c>, runs <c>ilverify</c> against
+/// the emitted assembly, and asserts on stdout.
+/// </summary>
+public class Issue523ClosureCaptureByRefTests
+{
+    /// <summary>
+    /// The exact repro from the issue body: a captured value-type local that
+    /// is reassigned after the lambda is constructed must be visible to the
+    /// lambda body.
+    /// </summary>
+    [Fact]
+    public void IssueRepro_ValueTypeLocal_LambdaSeesPostConstructionWrite()
+    {
+        var source = """
+            package P
+            import System
+
+            func probe() {
+                var n = 1
+                var getter = func() int32 { return n }
+                n = 99
+                Console.WriteLine(getter())
+            }
+
+            probe()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    [Fact]
+    public void TwoLambdasShareCapturedCell()
+    {
+        var source = """
+            package P
+            import System
+
+            func main2() {
+                var n = 1
+                var read = func() int32 { return n }
+                var write = func(x int32) { n = x }
+                Console.WriteLine(read())
+                write(42)
+                Console.WriteLine(read())
+                n = 7
+                Console.WriteLine(read())
+            }
+
+            main2()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n42\n7\n", output);
+    }
+
+    [Fact]
+    public void CapturedParameter_LambdaObservesOuterWrites()
+    {
+        var source = """
+            package P
+            import System
+
+            func makeCounter(start int32) func() int32 {
+                var n = start
+                var inc = func() int32 {
+                    n = n + 1
+                    return n
+                }
+                // Pre-bump the param-derived local: the lambda must see the
+                // update because both this scope and the lambda share the
+                // same cell.
+                n = n + 10
+                return inc
+            }
+
+            var c = makeCounter(0)
+            Console.WriteLine(c())
+            Console.WriteLine(c())
+            Console.WriteLine(c())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("11\n12\n13\n", output);
+    }
+
+    [Fact]
+    public void NestedLambda_InnerSeesOuterReassignment()
+    {
+        var source = """
+            package P
+            import System
+
+            func make() func() func() int32 {
+                var n = 0
+                var outer = func() func() int32 {
+                    var inner = func() int32 { return n }
+                    return inner
+                }
+                n = 5
+                return outer
+            }
+
+            var g = make()
+            var f = g()
+            Console.WriteLine(f())
+            """;
+
+        var output = CompileAndRun(source);
+        // n is shared through the box; the inner lambda is built when outer
+        // runs, but it still resolves n through the same cell that the
+        // outermost write `n = 5` touched.
+        Assert.Equal("5\n", output);
+    }
+
+    [Fact]
+    public void CaptureSurvivesAcrossCallBoundary_LambdaMutatesAfterRoundTrip()
+    {
+        var source = """
+            package P
+            import System
+
+            func bumpTwice(f func()) {
+                f()
+                f()
+            }
+
+            func main3() {
+                var n = 10
+                var inc = func() { n = n + 1 }
+                bumpTwice(inc)
+                bumpTwice(inc)
+                Console.WriteLine(n)
+            }
+
+            main3()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("14\n", output);
+    }
+
+    [Fact]
+    public void BoolCapture_LambdaSeesFlip()
+    {
+        var source = """
+            package P
+            import System
+
+            func main4() {
+                var flag = false
+                var read = func() bool { return flag }
+                Console.WriteLine(read())
+                flag = true
+                Console.WriteLine(read())
+            }
+
+            main4()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("False\nTrue\n", output);
+    }
+
+    [Fact]
+    public void ReferenceTypeCapture_LambdaSeesReassignment()
+    {
+        var source = """
+            package P
+            import System
+            import System.Text
+
+            func main5() {
+                var sb = StringBuilder()
+                sb.Append("first")
+                var read = func() string { return sb.ToString() }
+                Console.WriteLine(read())
+                sb = StringBuilder()
+                sb.Append("second")
+                Console.WriteLine(read())
+            }
+
+            main5()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("first\nsecond\n", output);
+    }
+
+    [Fact]
+    public void CapturedLocalInsideLoop_FreshCellPerIteration()
+    {
+        // Each iteration of a `for…in` body re-runs the inner `var`
+        // declaration, so the box allocation runs per-iteration — matching
+        // C# semantics for a variable declared inside a loop body. Capture
+        // two lambdas from successive iterations and verify each carries
+        // its own cell.
+        var source = """
+            package P
+            import System
+
+            type Holder class {
+                public First func() int32
+                public Second func() int32
+                init() {}
+            }
+
+            func main6() {
+                var h = Holder()
+                for i in []int32{0, 1} {
+                    var n = i
+                    var f = func() int32 { return n }
+                    if i == 0 {
+                        h.First = f
+                    } else {
+                        h.Second = f
+                    }
+                }
+                var a = h.First
+                var b = h.Second
+                Console.WriteLine(a())
+                Console.WriteLine(b())
+            }
+
+            main6()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n1\n", output);
+    }
+
+    [Fact]
+    public void GlobalVar_ReadsLiveValueFromStaticField()
+    {
+        // Issue #523 (side fix): globals are addressable as static fields,
+        // so the lambda must read them live (ldsfld) rather than snapshot
+        // them into a closure field at literal-construction time.
+        var source = """
+            package P
+            import System
+
+            var g = 1
+
+            func makeReader() func() int32 {
+                return func() int32 { return g }
+            }
+
+            var r = makeReader()
+            Console.WriteLine(r())
+            g = 99
+            Console.WriteLine(r())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n99\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_523_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncLambdaEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncLambdaEmitTests.cs
@@ -64,9 +64,10 @@ t.Wait()
 Console.WriteLine(t.Result)
 ";
         var output = CompileAndRun(Source, "AsyncLambdaTest2");
-        // Capture semantics are snapshot-at-creation (per GSharp design).
-        // The lambda captures x=100 at the point the literal is evaluated.
-        Assert.Contains("100", output);
+        // Issue #523: closures capture the variable cell (Go/C# semantics),
+        // not its value at literal-evaluation time. Top-level `var x` is a
+        // static field, so the async lambda reads the latest value (200).
+        Assert.Contains("200", output);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncStateMachineTypedefTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncStateMachineTypedefTests.cs
@@ -228,16 +228,22 @@ Console.WriteLine(t.Result)
     [Fact]
     public void AsyncLambdaWithCapture_StateMachine_NestsInsideClosureClass()
     {
+        // Issue #523: globals are read live via static fields and are not
+        // captured into a closure class. Use a function-scoped local so this
+        // test exercises the closure-class nesting it's designed to check.
         const string Source = @"package SmClosureNestTest
 import System
 import System.Threading.Tasks
 
-var x = 42
-var f = async func() int32 {
-    await Task.CompletedTask
-    return x
+func make() func() Task[int32] {
+    var x = 42
+    return async func() int32 {
+        await Task.CompletedTask
+        return x
+    }
 }
 
+var f = make()
 var t = f()
 t.Wait()
 Console.WriteLine(t.Result)


### PR DESCRIPTION
Fixes #523.

## Summary

Function literals now capture their enclosing locals/parameters by reference (over the variable cell) rather than by value at literal-construction time, matching Go and C# semantics. Subsequent writes to the captured variable are visible inside the lambda body, and writes inside the lambda are visible to the outer scope.

The exact repro from the issue now passes:

```gsharp
var n = 1
var getter = func() int32 { return n }
n = 99
Assert.Equal(99, getter())   // was 1; now 99
```

## Root cause

The closure emit pipeline lowered each capturing lambda into a synthesized display class whose constructor took a snapshot of every captured variable. Reassignments after the `newobj` were therefore invisible to the lambda body.

## Approach

A new lowering pass, `CaptureBoxingRewriter`, runs after `SideEffectSpiller` and before the async/iterator lowerers. For every variable captured by any nested lambda in a function body it:

1. Synthesizes a per-variable `internal sealed class <>__Box_<name>_<n>` with one public `Value` field of the original type.
2. Replaces the original local's slot with one of the box type (and prepends `new box; box.Value = arg` at function entry for captured parameters).
3. Rewrites every read of the variable to `box.Value` and every write to `box.Value = …`.
4. Rewrites the lambda's `CapturedVariables` to point at the box-local, so the existing display-class emit captures a reference to the shared box rather than a snapshot.

### Skip-list

| Kind | Why |
| --- | --- |
| `ref`/`out`/`in` locals (`RefKind != None`) | Ref-aliasing (issue #491). |
| `T&` / by-ref-like types | Boxing illegal at IL level (issues #376 / #367). |
| `this` parameter | Stable reference, never reassigned. |
| `GlobalVariableSymbol` | Already in a static field — read live via `ldsfld`/`stsfld`. |

### Side fixes

- `CapturedVariableCollector` (binder) now also treats an assignment LHS as a use, so a write-only capture like `func(x) { n = x }` correctly records `n` in the capture set. Previously the base rewriter never visited the LHS variable, which silently dropped the capture and would crash emit once boxes were introduced.
- Globals are no longer added to the capture set at all; each lambda body now reads the live static field at every use.
- `EmitConstructorCall` falls back to the parameterless class ctor when a class has no primary ctor, and the planner pre-registers default-ctor handles for all such classes so a box can be `newobj`'d from a method body emitted earlier in the `nonSmClasses` pass (same trick already used for closure classes — generalised).

## Tests

New end-to-end suite `test/Compiler.Tests/Emit/Issue523ClosureCaptureByRefTests.cs` (9 tests). Each test compiles a `.gs` program, runs `ilverify` against the emitted DLL via the existing `IlVerifier` harness, executes it under `dotnet exec`, and asserts stdout:

- `IssueRepro_ValueTypeLocal_LambdaSeesPostConstructionWrite` — the exact issue repro.
- `TwoLambdasShareCapturedCell` — two lambdas (read + write) in the same scope share one cell.
- `CapturedParameter_LambdaObservesOuterWrites` — value-type param promoted to a local; outer writes seen by the lambda.
- `NestedLambda_InnerSeesOuterReassignment` — inner lambda built inside outer still resolves the captured local through the shared cell.
- `CaptureSurvivesAcrossCallBoundary_LambdaMutatesAfterRoundTrip` — lambda passed to another function still mutates the original local.
- `BoolCapture_LambdaSeesFlip` — `bool` value-type case.
- `ReferenceTypeCapture_LambdaSeesReassignment` — reassigning a captured reference-type variable is observed.
- `CapturedLocalInsideLoop_FreshCellPerIteration` — per-iteration box allocation (matches C# `var n = …` inside a loop body).
- `GlobalVar_ReadsLiveValueFromStaticField` — globals are not captured into closure fields; lambda reads the live static.

### Updated existing tests

- `ClosureEmitTests.SnapshotByValue_MutationInLambdaDoesNotAffectOuter` → renamed to `StatefulCounter_LambdaMutationPersistsAcrossCalls`; same assertions, doc-comment updated to describe by-ref semantics.
- `Issue503ClosureCaptureRegressionTests.CapturedLocalReassignedAfterSubscription_SnapshotsAtSubscriptionTime` → renamed to `CapturedLocalReassignedAfterSubscription_LambdaObservesNewBinding`; now asserts that the *replacement* counter (not the original) fires on the event.
- `AsyncLambdaEmitTests.AsyncLambda_CapturesLocal_ReadsLatestValue_AcrossAwait` — the test name already promised the new behaviour; comment + assertion updated from `100` to `200`.
- `AsyncStateMachineTypedefTests.AsyncLambdaWithCapture_StateMachine_NestsInsideClosureClass` — refactored to use a function-scoped local so a closure class is actually synthesized (globals no longer drive closure-class creation).

### Suite

Full local run (`dotnet test GSharp.sln --no-restore --nologo`): **2809 passed, 0 failed** across all five projects (Core, Compiler, LanguageServer, Interpreter, Sdk).

## Files changed

- `src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs` (new pass)
- `src/Core/CodeAnalysis/Compilation/Compilation.cs` (wire pass into both `Emit` overloads)
- `src/Core/CodeAnalysis/Binding/Binder.cs` (`CapturedVariableCollector`: assignment-LHS capture + global skip)
- `src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs` (default-ctor pre-register + `BoundConstructorCallExpression` fallback)
- `test/Compiler.Tests/Emit/Issue523ClosureCaptureByRefTests.cs` (new tests)
- 4 existing tests updated for the new semantics.
