### PR TITLE
Allow G# classes to implement imported CLR interfaces (fixes #525)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1323,6 +1323,7 @@ public sealed class Binder
         StructSymbol baseClassSymbol = null;
         TypeSymbol importedBaseType = null;
         var implementedInterfaces = ImmutableArray.CreateBuilder<InterfaceSymbol>();
+        var implementedClrInterfaces = ImmutableArray.CreateBuilder<TypeSymbol>();
         if (syntax.HasBaseType)
         {
             if (!syntax.IsClass)
@@ -1359,12 +1360,23 @@ public sealed class Binder
                         // user-declared GSharp type, so consult the same imported
                         // type resolution used for construction / static access.
                         // Only the first identifier (the base-class slot) may be
-                        // a CLR class; the rest are interfaces (CLR interface
-                        // implementation is out of scope here).
+                        // a CLR class.
                         if (i == 0 && !hasAttributeSugar
                             && TryResolveImportedBaseType(baseName, out var importedBase))
                         {
                             importedBaseType = importedBase;
+                            continue;
+                        }
+
+                        // Issue #525: any non-first identifier (and the first
+                        // when no CLR base class matched) may be an imported
+                        // CLR interface. Resolve through the same import-aware
+                        // lookup used for expression-type contexts so a `class
+                        // : IClrInterface { ... }` form works against any
+                        // reachable CLR interface (e.g. System.IDisposable).
+                        if (TryResolveImportedInterface(baseName, out var importedIface))
+                        {
+                            implementedClrInterfaces.Add(importedIface);
                             continue;
                         }
 
@@ -2491,6 +2503,19 @@ public sealed class Binder
             pendingInterfaceImplementationChecks.Add((syntax, structSymbol));
         }
 
+        // Issue #525: record imported CLR interfaces from the base-type
+        // clause and queue the same deferred verification used for G#
+        // interfaces. The check is deferred because class methods may not
+        // have been bound yet when this declaration is processed.
+        if (implementedClrInterfaces.Count > 0)
+        {
+            structSymbol.SetImplementedClrInterfaces(implementedClrInterfaces.ToImmutable());
+            if (implementedInterfaces.Count == 0)
+            {
+                pendingInterfaceImplementationChecks.Add((syntax, structSymbol));
+            }
+        }
+
         // Issue #306: bind standalone user-defined constructors (`init(...)`).
         BindConstructorDeclarations(syntax, structSymbol, package, baseClassSymbol, importedBaseType);
     }
@@ -2608,7 +2633,153 @@ public sealed class Binder
                     }
                 }
             }
+
+            // Issue #525: verify CLR interfaces declared in the base-type clause.
+            // Walks each public abstract member on the imported interface and
+            // confirms the G# class provides a same-name, same-CLR-signature
+            // method or property. Diagnostic uses the same GS0187 channel.
+            VerifyClrInterfaceImplementations(syntax, structSymbol);
         }
+    }
+
+    private void VerifyClrInterfaceImplementations(StructDeclarationSyntax syntax, StructSymbol structSymbol)
+    {
+        if (structSymbol.ImplementedClrInterfaces.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        foreach (var ifaceSym in structSymbol.ImplementedClrInterfaces)
+        {
+            var clrIface = ifaceSym.ClrType;
+            if (clrIface == null)
+            {
+                continue;
+            }
+
+            // Methods excluding property/event accessors (those are validated
+            // through their owning property / event below).
+            foreach (var clrMethod in clrIface.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
+            {
+                if (clrMethod.IsSpecialName)
+                {
+                    continue;
+                }
+
+                if (HasMatchingMethodForClrSignature(structSymbol, clrMethod))
+                {
+                    continue;
+                }
+
+                Diagnostics.ReportInterfaceMethodNotImplemented(
+                    syntax.Identifier.Location,
+                    structSymbol.Name,
+                    clrIface.FullName ?? clrIface.Name,
+                    FormatClrMethodSignature(clrMethod));
+            }
+
+            // Properties.
+            foreach (var clrProp in clrIface.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
+            {
+                var implProp = FindMatchingProperty(structSymbol, clrProp);
+                if (implProp == null)
+                {
+                    Diagnostics.ReportInterfaceMethodNotImplemented(
+                        syntax.Identifier.Location,
+                        structSymbol.Name,
+                        clrIface.FullName ?? clrIface.Name,
+                        clrProp.Name);
+                    continue;
+                }
+
+                if (clrProp.GetMethod != null && !implProp.HasGetter)
+                {
+                    Diagnostics.ReportInterfaceMethodNotImplemented(
+                        syntax.Identifier.Location,
+                        structSymbol.Name,
+                        clrIface.FullName ?? clrIface.Name,
+                        clrProp.Name + " (getter)");
+                }
+
+                if (clrProp.SetMethod != null && !implProp.HasSetter)
+                {
+                    Diagnostics.ReportInterfaceMethodNotImplemented(
+                        syntax.Identifier.Location,
+                        structSymbol.Name,
+                        clrIface.FullName ?? clrIface.Name,
+                        clrProp.Name + " (setter)");
+                }
+            }
+        }
+    }
+
+    private static bool HasMatchingMethodForClrSignature(StructSymbol structSymbol, System.Reflection.MethodInfo clrMethod)
+    {
+        var clrParams = clrMethod.GetParameters();
+        foreach (var candidate in structSymbol.GetMethodsIncludingInherited(clrMethod.Name))
+        {
+            var callable = GetCallableParameters(candidate);
+            if (callable.Length != clrParams.Length)
+            {
+                continue;
+            }
+
+            if (!ClrTypesEquivalent(candidate.Type?.ClrType, clrMethod.ReturnType))
+            {
+                continue;
+            }
+
+            var allMatch = true;
+            for (var i = 0; i < callable.Length; i++)
+            {
+                if (!ClrTypesEquivalent(callable[i].Type?.ClrType, clrParams[i].ParameterType))
+                {
+                    allMatch = false;
+                    break;
+                }
+            }
+
+            if (allMatch)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static PropertySymbol FindMatchingProperty(StructSymbol structSymbol, System.Reflection.PropertyInfo clrProp)
+    {
+        foreach (var implProp in structSymbol.Properties)
+        {
+            if (implProp.Name == clrProp.Name
+                && ClrTypesEquivalent(implProp.Type?.ClrType, clrProp.PropertyType))
+            {
+                return implProp;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool ClrTypesEquivalent(System.Type a, System.Type b)
+        => ClrTypeUtilities.AreSame(a, b);
+
+    private static string FormatClrMethodSignature(System.Reflection.MethodInfo method)
+    {
+        var ps = method.GetParameters();
+        if (ps.Length == 0)
+        {
+            return method.Name;
+        }
+
+        var names = new string[ps.Length];
+        for (var i = 0; i < ps.Length; i++)
+        {
+            names[i] = ps[i].ParameterType.Name;
+        }
+
+        return $"{method.Name}({string.Join(", ", names)})";
     }
 
     private static bool TryGetPropertyIncludingInherited(StructSymbol type, string name, out PropertySymbol property)
@@ -16292,6 +16463,48 @@ public sealed class Binder
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Issue #525: resolves a class declaration's base-type identifier to an
+    /// imported CLR interface. Honors imports and aliases (via
+    /// <see cref="LookupType"/>) for simple names and falls back to direct
+    /// fully-qualified resolution against the reference set. Only public
+    /// CLR interface types are accepted; classes, value types, and other
+    /// references are rejected so the regular "cannot find type" diagnostic
+    /// still applies.
+    /// </summary>
+    /// <param name="name">The identifier text as written in the base clause.</param>
+    /// <param name="importedInterface">The resolved CLR interface type symbol on success.</param>
+    /// <returns><see langword="true"/> when the name resolves to an imported CLR interface; otherwise <see langword="false"/>.</returns>
+    private bool TryResolveImportedInterface(string name, out TypeSymbol importedInterface)
+    {
+        importedInterface = null;
+
+        // Simple name honoring imports/aliases. This is the same path used
+        // by expression-type contexts (e.g. `var g IClrInterface = ...`),
+        // which is why those contexts already find the interface today.
+        var candidate = LookupType(name)?.ClrType;
+
+        // Fully-qualified fallback against the reference set
+        // (e.g. `System.IDisposable`).
+        if (candidate == null && scope.References.TryResolveType(name, out var resolved))
+        {
+            candidate = resolved;
+        }
+
+        // TODO(issue-525): generic CLR interfaces (e.g. `IComparable<T>`)
+        // require a base-type clause grammar that accepts a type-argument
+        // list. The single-identifier base-type syntax can only name the
+        // open definition, which is rejected here; closing it requires
+        // additional parser work and is left for a follow-up issue.
+        if (candidate == null || !candidate.IsInterface || candidate.IsGenericTypeDefinition)
+        {
+            return false;
+        }
+
+        importedInterface = TypeSymbol.FromClrType(candidate);
+        return importedInterface?.ClrType != null;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -342,6 +342,34 @@ public sealed class Conversion
                 }
             }
 
+            // Issue #525: a G# class implicitly upcasts to any imported CLR
+            // interface that appears in its base-type clause (or any base
+            // class's base-type clause). The G# class has no ClrType during
+            // binding, so the general #521 rule below cannot fire — match
+            // structurally against `ImplementedClrInterfaces` and use the
+            // CLR's IsAssignableFrom to cover interface inheritance from the
+            // imported side (e.g. implementing `IList<T>` also satisfies
+            // `IEnumerable<T>`).
+            if (to?.ClrType != null && to.ClrType.IsInterface)
+            {
+                for (var c = fromClass; c != null; c = c.BaseClass)
+                {
+                    foreach (var iface in c.ImplementedClrInterfaces)
+                    {
+                        var ifaceClr = iface?.ClrType;
+                        if (ifaceClr == null)
+                        {
+                            continue;
+                        }
+
+                        if (ifaceClr == to.ClrType || to.ClrType.IsAssignableFrom(ifaceClr))
+                        {
+                            return Conversion.Implicit;
+                        }
+                    }
+                }
+            }
+
             if (to is StructSymbol toClass && toClass.IsClass)
             {
                 for (var c = fromClass.BaseClass; c != null; c = c.BaseClass)

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -978,6 +978,23 @@ internal sealed class ReflectionMetadataEmitter
                     }
                 }
             }
+
+            // Issue #525: emit InterfaceImpl rows for imported CLR interfaces
+            // declared in the base-type clause so the resulting class is a
+            // real CLR implementer (`Type.GetInterfaces()` surfaces them and
+            // dispatch through an interface receiver hits the G# method).
+            if (!c.ImplementedClrInterfaces.IsDefaultOrEmpty)
+            {
+                foreach (var ifaceSym in c.ImplementedClrInterfaces)
+                {
+                    if (ifaceSym?.ClrType is System.Type clrIface)
+                    {
+                        this.metadata.AddInterfaceImplementation(
+                            this.structTypeDefs[c],
+                            this.GetTypeHandleForMember(clrIface));
+                    }
+                }
+            }
         }
 
         foreach (var s in nonSmStructs)
@@ -2934,23 +2951,44 @@ internal sealed class ReflectionMetadataEmitter
     /// </summary>
     private bool PropertyImplicitlyImplementsInterface(StructSymbol structSym, PropertySymbol prop)
     {
-        if (structSym.Interfaces.IsDefaultOrEmpty)
+        if (!structSym.Interfaces.IsDefaultOrEmpty)
         {
-            return false;
+            foreach (var iface in structSym.Interfaces)
+            {
+                if (iface.Properties.IsDefaultOrEmpty)
+                {
+                    continue;
+                }
+
+                foreach (var ifaceProp in iface.Properties)
+                {
+                    if (ifaceProp.Name == prop.Name)
+                    {
+                        return true;
+                    }
+                }
+            }
         }
 
-        foreach (var iface in structSym.Interfaces)
+        // Issue #525: imported CLR interfaces from the base-type clause also
+        // trigger the implicit-implementation virtual-slot promotion.
+        if (!structSym.ImplementedClrInterfaces.IsDefaultOrEmpty)
         {
-            if (iface.Properties.IsDefaultOrEmpty)
+            var propClr = prop.Type?.ClrType;
+            foreach (var ifaceSym in structSym.ImplementedClrInterfaces)
             {
-                continue;
-            }
-
-            foreach (var ifaceProp in iface.Properties)
-            {
-                if (ifaceProp.Name == prop.Name)
+                var clrIface = ifaceSym?.ClrType;
+                if (clrIface == null)
                 {
-                    return true;
+                    continue;
+                }
+
+                foreach (var clrProp in clrIface.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
+                {
+                    if (clrProp.Name == prop.Name && (propClr == null || ClrTypeUtilities.AreSame(propClr, clrProp.PropertyType)))
+                    {
+                        return true;
+                    }
                 }
             }
         }
@@ -2974,27 +3012,77 @@ internal sealed class ReflectionMetadataEmitter
 
     /// <summary>
     /// Determines whether a method on a class/struct implicitly implements an
-    /// interface method (same name, parameters, and return type).
+    /// interface method (same name, parameters, and return type). Considers
+    /// both G# interfaces (<see cref="StructSymbol.Interfaces"/>) and imported
+    /// CLR interfaces (<see cref="StructSymbol.ImplementedClrInterfaces"/>,
+    /// issue #525).
     /// </summary>
     private static bool MethodImplicitlyImplementsInterface(StructSymbol structSym, FunctionSymbol method)
     {
-        if (structSym.Interfaces.IsDefaultOrEmpty)
+        if (!structSym.Interfaces.IsDefaultOrEmpty)
         {
-            return false;
+            foreach (var iface in structSym.Interfaces)
+            {
+                if (iface.Methods.IsDefaultOrEmpty)
+                {
+                    continue;
+                }
+
+                foreach (var ifaceMethod in iface.Methods)
+                {
+                    if (MethodSignaturesMatch(ifaceMethod, method))
+                    {
+                        return true;
+                    }
+                }
+            }
         }
 
-        foreach (var iface in structSym.Interfaces)
+        if (!structSym.ImplementedClrInterfaces.IsDefaultOrEmpty)
         {
-            if (iface.Methods.IsDefaultOrEmpty)
+            var callable = CallableParameters(method);
+            var returnClr = method.Type?.ClrType;
+            foreach (var ifaceSym in structSym.ImplementedClrInterfaces)
             {
-                continue;
-            }
-
-            foreach (var ifaceMethod in iface.Methods)
-            {
-                if (MethodSignaturesMatch(ifaceMethod, method))
+                var clrIface = ifaceSym?.ClrType;
+                if (clrIface == null)
                 {
-                    return true;
+                    continue;
+                }
+
+                foreach (var clrMethod in clrIface.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
+                {
+                    if (clrMethod.IsSpecialName || clrMethod.Name != method.Name)
+                    {
+                        continue;
+                    }
+
+                    var clrParams = clrMethod.GetParameters();
+                    if (clrParams.Length != callable.Length)
+                    {
+                        continue;
+                    }
+
+                    if (returnClr != null && !ClrTypeUtilities.AreSame(returnClr, clrMethod.ReturnType))
+                    {
+                        continue;
+                    }
+
+                    var allMatch = true;
+                    for (var i = 0; i < clrParams.Length; i++)
+                    {
+                        var paramClr = callable[i].Type?.ClrType;
+                        if (paramClr == null || !ClrTypeUtilities.AreSame(paramClr, clrParams[i].ParameterType))
+                        {
+                            allMatch = false;
+                            break;
+                        }
+                    }
+
+                    if (allMatch)
+                    {
+                        return true;
+                    }
                 }
             }
         }
@@ -13445,6 +13533,31 @@ internal sealed class ReflectionMetadataEmitter
                     foreach (var iface in c.Interfaces)
                     {
                         if (iface == targetIface)
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            // Issue #525: class → imported CLR interface upcast. The G#
+            // class has no ClrType during emit, so the general #521 rule
+            // below cannot match; recognise the implementation structurally
+            // through `ImplementedClrInterfaces`.
+            if (a is StructSymbol srcClass2 && srcClass2.IsClass
+                && b?.ClrType != null && b.ClrType.IsInterface)
+            {
+                for (var c = srcClass2; c != null; c = c.BaseClass)
+                {
+                    foreach (var iface in c.ImplementedClrInterfaces)
+                    {
+                        var ifaceClr = iface?.ClrType;
+                        if (ifaceClr == null)
+                        {
+                            continue;
+                        }
+
+                        if (ifaceClr == b.ClrType || b.ClrType.IsAssignableFrom(ifaceClr))
                         {
                             return true;
                         }

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -190,6 +190,17 @@ public sealed class StructSymbol : TypeSymbol
     /// <summary>Gets the interfaces this type implements (Phase 3.B.4). Populated by the binder after the symbol is constructed; defaults to empty.</summary>
     public ImmutableArray<InterfaceSymbol> Interfaces { get; private set; }
 
+    /// <summary>
+    /// Gets the imported (CLR) interfaces this class implements (issue #525).
+    /// Each entry's <see cref="TypeSymbol.ClrType"/> is guaranteed to be an
+    /// interface type. Populated by the binder when the base-type clause
+    /// names a reachable imported CLR interface; defaults to empty.
+    /// When set, the emitter writes an <c>InterfaceImpl</c> row per entry so
+    /// the resulting class is a real CLR implementer (<c>Type.GetInterfaces()</c>
+    /// surfaces the interface and dispatch through interface receivers works).
+    /// </summary>
+    public ImmutableArray<TypeSymbol> ImplementedClrInterfaces { get; private set; } = ImmutableArray<TypeSymbol>.Empty;
+
     /// <summary>Gets the methods declared inside the class body (Phase 3.B.3 sub-step 2b). Populated by the binder after the symbol is constructed; defaults to empty.</summary>
     public ImmutableArray<FunctionSymbol> Methods { get; private set; } = ImmutableArray<FunctionSymbol>.Empty;
 
@@ -320,6 +331,18 @@ public sealed class StructSymbol : TypeSymbol
     public void SetInterfaces(ImmutableArray<InterfaceSymbol> interfaces)
     {
         Interfaces = interfaces;
+    }
+
+    /// <summary>
+    /// Issue #525: sets <see cref="ImplementedClrInterfaces"/> after binding
+    /// the base-type clause. Intended to be called exactly once by the binder
+    /// for a class whose base-type clause names one or more imported CLR
+    /// interfaces.
+    /// </summary>
+    /// <param name="interfaces">The imported CLR interface types this class implements directly.</param>
+    public void SetImplementedClrInterfaces(ImmutableArray<TypeSymbol> interfaces)
+    {
+        ImplementedClrInterfaces = interfaces.IsDefault ? ImmutableArray<TypeSymbol>.Empty : interfaces;
     }
 
     /// <summary>Sets <see cref="Methods"/> after binding class-body methods.</summary>

--- a/test/Compiler.Tests/Emit/Issue525ClassImplementsClrInterfaceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue525ClassImplementsClrInterfaceEmitTests.cs
@@ -1,0 +1,579 @@
+// <copyright file="Issue525ClassImplementsClrInterfaceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #525: a G# class declaring <c>type X class : ISomething { ... }</c>
+/// against a reachable CLR interface must (1) bind without GS0157, (2) emit
+/// real <c>InterfaceImpl</c> metadata so the produced TypeDef is a CLR
+/// implementer of the interface, and (3) dispatch through an interface
+/// receiver to the G# class's implementation at runtime.
+///
+/// Each happy-path test compiles via <c>gsc</c>, runs <c>ilverify</c> on the
+/// produced assembly, then either reflects the emitted metadata or runs the
+/// assembly under <c>dotnet exec</c> to assert end-to-end behavior.
+/// </summary>
+public class Issue525ClassImplementsClrInterfaceEmitTests
+{
+    [Fact]
+    public void GSharpClass_ImplementsBclInterface_RunsAndIlVerifies()
+    {
+        // Canonical happy-path: G# class declares it implements a CLR
+        // single-method interface (IDisposable), provides the method, and
+        // dispatch through an interface-typed local hits the G# body.
+        var source = """
+            package Probe
+            import System
+
+            type MyDisposable class : IDisposable {
+                func Dispose() {
+                    Console.WriteLine("disposed")
+                }
+            }
+
+            var d IDisposable = MyDisposable{}
+            d.Dispose()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("disposed\n", output);
+    }
+
+    [Fact]
+    public void GSharpClass_MetadataDeclaresInterfaceImpl()
+    {
+        // Reflect over the emitted assembly with a MetadataLoadContext to
+        // confirm the resulting TypeDef carries an InterfaceImpl row for
+        // System.IDisposable (so consumers see a real CLR implementer).
+        var source = """
+            package Probe
+            import System
+
+            type MyDisposable class : IDisposable {
+                func Dispose() {
+                    Console.WriteLine("disposed")
+                }
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        try
+        {
+            // Use a MetadataLoadContext so we can introspect the emitted
+            // type without locking the assembly or polluting the test
+            // process's AppDomain.
+            var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+            var resolver = new PathAssemblyResolver(
+                Directory.GetFiles(runtimeDir, "*.dll")
+                    .Concat(new[] { dllPath }));
+            using var mlc = new MetadataLoadContext(resolver, "System.Private.CoreLib");
+            var asm = mlc.LoadFromAssemblyPath(dllPath);
+            var type = asm.GetType("Probe.MyDisposable")
+                ?? throw new InvalidOperationException("type not found");
+
+            var interfaces = type.GetInterfaces().Select(i => i.FullName).ToArray();
+            Assert.Contains("System.IDisposable", interfaces);
+
+            // The method must be virtual+newslot so the CLR vtable wires it
+            // to IDisposable.Dispose for interface dispatch.
+            var method = type.GetMethod("Dispose")
+                ?? throw new InvalidOperationException("Dispose not found");
+            Assert.True(method.IsVirtual, "Dispose() must be virtual to implement the interface");
+        }
+        finally
+        {
+            TryCleanup(dllPath);
+        }
+    }
+
+    [Fact]
+    public void GSharpClass_ImplementsMultipleClrInterfaces_BothReachable()
+    {
+        // The base-type clause carries TWO CLR interfaces: IDisposable and
+        // ICloneable. Both must be wired as InterfaceImpl rows so dispatch
+        // works through either contract.
+        var source = """
+            package Probe
+            import System
+
+            type Box class : IDisposable, ICloneable {
+                func Dispose() {
+                    Console.WriteLine("gone")
+                }
+                func Clone() object {
+                    return "clone"
+                }
+            }
+
+            var b = Box{}
+            var c ICloneable = b
+            Console.WriteLine(c.Clone())
+            var d IDisposable = b
+            d.Dispose()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("clone\ngone\n", output);
+    }
+
+    [Fact]
+    public void GSharpClass_ImplementsClrInterfaceWithReadOnlyProperty_DispatchesGetter()
+    {
+        // IPropertyShape exposes a single readable property. The G# class
+        // declares an auto-property of the matching name and type; the
+        // emitter must promote the getter to virtual+newslot so the
+        // property accessor satisfies the interface slot.
+        //
+        // We can't easily synthesise a custom property-only BCL interface,
+        // so cover the "has a property" shape with a sibling C# library
+        // and have the G# code implement it.
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface ILabel
+                {
+                    string Label { get; }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            type Boxed class : ILabel {
+                prop Label string { get { return "hello" } }
+            }
+
+            var b = Boxed{}
+            var l ILabel = b
+            Console.WriteLine(l.Label)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Equal("hello\n", output);
+    }
+
+    [Fact]
+    public void GSharpClass_ImplementsSiblingCSharpInterface_IssueRepro()
+    {
+        // Exact shape from the issue body: a sibling C# library exposes
+        // IGreeter; the G# class implements it and is consumed through
+        // the interface receiver.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IGreeter
+                {
+                    string Greet(string name);
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type MyGreeter class : IGreeter {
+                func Greet(name string) string { return "hi " + name }
+            }
+
+            var g IGreeter = MyGreeter{}
+            Console.WriteLine(g.Greet("world"))
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("hi world\n", output);
+    }
+
+    [Fact]
+    public void ClrInterface_FromNonImportedNamespace_ReportsGS0157()
+    {
+        // A typo / non-existent identifier in the base clause must still
+        // surface GS0157 — the new CLR-interface resolution path must not
+        // silently swallow unknown base names.
+        var source = """
+            package Probe
+
+            type Oops class : INotAnInterfaceThatExistsAnywhere {
+                func Foo() {}
+            }
+            """;
+
+        var diagnostics = CompileExpectingErrors(source);
+        Assert.Contains(
+            diagnostics,
+            d => d.Contains("GS0157") && d.Contains("INotAnInterfaceThatExistsAnywhere"));
+    }
+
+    [Fact]
+    public void GSharpClassHierarchy_StillCompiles_RegressionGuard()
+    {
+        // Regression guard: a G#-only class hierarchy (no CLR interfaces)
+        // must continue to work exactly as before — the new CLR-interface
+        // resolution must not break the existing base-clause behavior.
+        var source = """
+            package Probe
+            import System
+
+            type Animal open class {
+                func Sound() string { return "generic" }
+            }
+
+            type Dog class : Animal {
+                func Bark() string { return "woof" }
+            }
+
+            var d = Dog{}
+            Console.WriteLine(d.Bark())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("woof\n", output);
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue525_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue525_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static List<string> CompileExpectingErrors(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue525_err_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit != 0, "expected gsc to report errors but it succeeded");
+
+            // gsc writes diagnostics to stdout in this repo; surface both
+            // streams so a brittle test failure is easy to diagnose.
+            var combined = compileOut.ToString() + compileErr.ToString();
+            return combined.Split('\n').Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue525_sib_").FullName;
+        try
+        {
+            // Step 1: compile the sibling C# library.
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            // Step 2: compile the G# code referencing the sibling.
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+
+            // Passing /reference: switches gsc to closed-world reference mode
+            // (only explicit refs are loaded), so the full BCL closure from
+            // the host's TPA must be enumerated as well. Matches the pattern
+            // in Issue520ClrArrayForRangeTests.
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            // Place the sibling next to the produced assembly so the
+            // probing path resolves it at runtime.
+            File.Copy(siblingDll, Path.Combine(tempDir, Path.GetFileName(siblingDll)), overwrite: true);
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { siblingDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string BuildCsProject(string csDir, string siblingName)
+    {
+        // Restore + build the sibling C# library and return the produced
+        // assembly path. Done in two `dotnet` invocations so failures
+        // surface a clean error message.
+        RunDotnet(csDir, "restore");
+
+        var stdout = RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+        _ = stdout; // unused; kept for diagnostics on failure
+
+        var dll = Path.Combine(csDir, "bin", "Release", "net10.0", siblingName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static string RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #525.

`type X class : IClrInterface { ... }` previously failed binding with
`GS0157: Cannot find type IClrInterface` even when the interface was
reachable through an `import`. The base-type clause resolver only looked
for a CLR *class* (and explicitly rejected interfaces), while the same
identifier in expression-typed contexts (`var g IClrInterface = ...`) was
resolved through `LookupType` and worked. This PR teaches the base-clause
path to find imported CLR interfaces, stores them on the class symbol,
emits `InterfaceImpl` metadata, and adds the implicit upcast from a G#
class to a CLR interface.

## Root cause

`Binder.BindStructDeclarationBody`'s base-type loop only resolved CLR
base classes via `TryResolveImportedBaseType`. Identifiers that didn't
resolve to a G# `InterfaceSymbol` and weren't a CLR base class fell
through to the "cannot find type" diagnostic. CLR interfaces never had
a resolution path on the base-clause side.

## Fix surface

- **Binder** (`src/Core/CodeAnalysis/Binding/Binder.cs`)
  - New `TryResolveImportedInterface` honors imports/aliases via
    `LookupType` and falls back to the reference resolver. Generic open
    definitions are rejected with a `TODO(issue-525)` (see *Scope notes*).
  - Base-clause loop now collects CLR interfaces and stores them on the
    `StructSymbol`.
  - New `VerifyClrInterfaceImplementations` walks every public abstract
    member on each imported interface and reuses GS0187 for missing
    implementations.
  - CLR signature comparison uses `ClrTypeUtilities.AreSame` so types
    loaded via `MetadataLoadContext` (gsc's reference resolver) compare
    correctly against host runtime types.
- **Symbols** (`src/Core/CodeAnalysis/Symbols/StructSymbol.cs`)
  - New `ImplementedClrInterfaces` collection + `SetImplementedClrInterfaces`
    setter so emit can find the resolved interface types.
- **Conversion** (`src/Core/CodeAnalysis/Binding/Conversion.cs`)
  - New branch in `Classify` for G# class -> CLR interface upcasts so
    interface-typed locals/fields/return slots accept a G# class instance.
- **Emit** (`src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs`)
  - `AddInterfaceImplementation` rows emitted for every entry in
    `ImplementedClrInterfaces`.
  - `MethodImplicitlyImplementsInterface` /
    `PropertyImplicitlyImplementsInterface` extended to recognize CLR
    interface members so accessors get `Virtual|NewSlot` and value-type
    contexts pick the right method attributes.
  - `IsReferenceCompatible` mirrors the new binder upcast for
    cross-context type comparisons during IL emission.

## Tests

Seven xUnit tests in
`test/Compiler.Tests/Emit/Issue525ClassImplementsClrInterfaceEmitTests.cs`:

1. `GSharpClass_ImplementsBclInterface_RunsAndIlVerifies` — G# class
   implements `System.IDisposable`, dispatch through an interface-typed
   local runs the G# body. `ilverify` is run on the output.
2. `GSharpClass_MetadataDeclaresInterfaceImpl` — reflects the emitted
   assembly via `MetadataLoadContext` and asserts the TypeDef carries
   `System.IDisposable` and that `Dispose()` is `IsVirtual`.
3. `GSharpClass_ImplementsMultipleClrInterfaces_BothReachable` — two
   interfaces (`IDisposable`, `ICloneable`) reachable through separate
   interface-typed locals.
4. `GSharpClass_ImplementsClrInterfaceWithReadOnlyProperty_DispatchesGetter`
   — sibling C# library exposing a read-only property interface; G#
   class implements it via `prop Label string { get { ... } }`.
5. `GSharpClass_ImplementsSiblingCSharpInterface_IssueRepro` — exact
   shape from the issue body (sibling C# `IGreeter`).
6. `ClrInterface_FromNonImportedNamespace_ReportsGS0157` — unknown
   identifier in the base clause still surfaces GS0157.
7. `GSharpClassHierarchy_StillCompiles_RegressionGuard` — regression
   guard for an existing G#-only class hierarchy.

Full suite (`dotnet test GSharp.sln --no-restore --nologo`) passes
locally: **Core 1988, Compiler 526, LanguageServer 226, Interpreter 72,
Sdk 24 — total 2836 passed, 0 failed**.

## Scope notes

**Covered**

- Non-generic CLR interfaces (single and multiple) in the base-type clause.
- Method members (with signature matching across reflection contexts).
- Read-only property members (matched by name + property type).
- Imports/aliases via `LookupType` and fully-qualified fallback via
  `ReferenceResolver.TryResolveType`.
- `InterfaceImpl` rows + virtual-slot promotion for accessors.
- Class -> CLR-interface implicit conversion (binder + emitter).
- Missing-member diagnostic (reuses GS0187).
- `ilverify` runs on every emitted assembly in the new tests.

**Deferred (with explicit `TODO(issue-525)`)**

- Generic CLR interfaces (e.g. `IComparable[T]`) in the base-type
  clause. The current base-type grammar is a single identifier; the
  closed form needs a type-argument list. Resolution intentionally
  rejects open generic definitions today. Worth a follow-up issue if
  you want generic-interface support.
- Property setters from CLR interfaces are validated but the G#
  `prop` accessor surface for emitting an interface-required setter
  wasn't exercised in the new tests (the only sibling-C# property test
  is read-only). Should work end-to-end via the existing accessor
  emission, but if you find a gap I can extend.

## Verification

- `dotnet build GSharp.sln -nologo -clp:NoSummary` — 0 warnings, 0 errors.
- `dotnet test GSharp.sln --no-restore --nologo` — 2836 passed, 0 failed.
- `dotnet tool restore` — `dotnet-ilverify` 10.0.8 available; called from
  every new emit-and-run test.
