### PR TITLE
Binder: invoke delegate-typed fields/properties on CLR structs and G# types (Fixes #527)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -14193,6 +14193,16 @@ public sealed class Binder
 
                     return BindUserInstanceCall(receiver, userMethod, arguments, ce, argumentNames);
                 }
+
+                // Issue #527: fall back to a delegate/function-typed field on
+                // the user struct/class. This is the same delegate-as-callable
+                // dispatch used for the imported-CLR path below; here the
+                // receiver's ClrType is null (the user type has not yet been
+                // emitted) so we have to handle the symbol-only shape too.
+                if (TryBindUserStructDelegateFieldInvocation(receiver, userClass, methodName, arguments, ce, out var userDelegateFieldCall))
+                {
+                    return userDelegateFieldCall;
+                }
             }
 
             // Phase 3.B.6 / ADR-0019: extension function fallback for
@@ -14242,6 +14252,17 @@ public sealed class Binder
                 }
 
                 return BindUserInstanceCall(receiver, userMethodPriority, arguments, ce, argumentNames);
+            }
+
+            // Issue #527: a G#-defined struct/class field whose type is a
+            // function (or named delegate) is invokable through the same
+            // call syntax as a bare function-typed variable. Lower to a load
+            // of the field value followed by an indirect call. Field lookup
+            // walks the inheritance chain (a class can inherit a delegate
+            // field from a base class).
+            if (TryBindUserStructDelegateFieldInvocation(receiver, userClassPriority, methodName, arguments, ce, out var userDelegateCall))
+            {
+                return userDelegateCall;
             }
         }
 
@@ -14305,6 +14326,21 @@ public sealed class Binder
             }
         }
 
+        // Issue #527: a public field or property whose type is a CLR delegate
+        // (e.g. `public Func<string> OnAsk;`) is invokable through the same
+        // call syntax used on the variable itself — `bag.OnAsk()`. Method
+        // lookup above only consulted methods named `OnAsk`, so the delegate
+        // member would otherwise miss. Lower to a load of the delegate value
+        // followed by an `Invoke(args)` dispatch (mirrors the bare-delegate
+        // call path in BindCallExpression at #325). This must come before the
+        // extension-function fallbacks so an in-scope extension method does
+        // not shadow a real delegate-typed member on the type.
+        if (receiver != null
+            && TryBindClrDelegateMemberInvocation(receiver, clrType, methodName, arguments, ce, argumentNames, out var delegateMemberCall))
+        {
+            return delegateMemberCall;
+        }
+
         // Phase 3.B.6 / ADR-0019: extension function fallback. After all
         // instance/static lookups fail, try matching by (receiverType, name).
         if (receiver != null && scope.TryLookupExtensionFunction(receiver.Type, methodName, out var extFn))
@@ -14332,6 +14368,183 @@ public sealed class Binder
 
         Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
         return new BoundErrorExpression(null);
+    }
+
+    /// <summary>
+    /// Issue #527 (G#-defined struct/class arm): when a member-style call
+    /// <c>receiver.Member(args)</c> does not match a method on the user
+    /// struct/class, fall back to a field whose type is a function value or
+    /// named delegate. Lowers to a load of the field followed by a
+    /// <see cref="BoundIndirectCallExpression"/> through the function shape.
+    /// Returns <see langword="true"/> when a callable field matched (the
+    /// resulting expression may be a <see cref="BoundErrorExpression"/> if
+    /// arity is wrong).
+    /// </summary>
+    private bool TryBindUserStructDelegateFieldInvocation(
+        BoundExpression receiver,
+        StructSymbol receiverStruct,
+        string methodName,
+        ImmutableArray<BoundExpression> arguments,
+        CallExpressionSyntax ce,
+        out BoundExpression result)
+    {
+        result = null;
+
+        // Walk the base chain so an inherited delegate field on a base class
+        // is invokable on a derived instance.
+        FieldSymbol matchedField = null;
+        StructSymbol declaringType = null;
+        for (var c = receiverStruct; c != null; c = c.BaseClass)
+        {
+            if (c.TryGetField(methodName, out var f))
+            {
+                matchedField = f;
+                declaringType = c;
+                break;
+            }
+        }
+
+        if (matchedField == null)
+        {
+            return false;
+        }
+
+        FunctionTypeSymbol functionType;
+        if (matchedField.Type is FunctionTypeSymbol fts)
+        {
+            functionType = fts;
+        }
+        else if (matchedField.Type is DelegateTypeSymbol nds)
+        {
+            functionType = nds.EquivalentFunctionType;
+        }
+        else if (matchedField.Type?.ClrType is System.Type fieldClrType
+            && ClrTypeUtilities.IsDelegateType(fieldClrType)
+            && TryGetDelegateFunctionType(fieldClrType, out var clrFn))
+        {
+            functionType = clrFn;
+        }
+        else
+        {
+            return false;
+        }
+
+        if (arguments.Length != functionType.ParameterTypes.Length)
+        {
+            Diagnostics.ReportWrongArgumentCount(ce.Location, methodName, functionType.ParameterTypes.Length, arguments.Length);
+            result = new BoundErrorExpression(null);
+            return true;
+        }
+
+        var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            convertedArgs.Add(BindConversion(ce.Arguments[i].Location, arguments[i], functionType.ParameterTypes[i]));
+        }
+
+        var fieldLoad = new BoundFieldAccessExpression(null, receiver, declaringType, matchedField);
+        result = new BoundIndirectCallExpression(null, fieldLoad, functionType, convertedArgs.MoveToImmutable());
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #527: when an accessor-style call <c>receiver.Member(args)</c>
+    /// matches no method on the CLR receiver type, fall back to a public
+    /// field or property of the same name whose type is a CLR delegate.
+    /// Lowers to a load of the delegate value (<c>ldfld</c> / property getter)
+    /// followed by an <c>Invoke(args)</c> call. Returns <see langword="true"/>
+    /// when a delegate-typed member matched and the call was bound (the
+    /// resulting expression may be a <see cref="BoundErrorExpression"/> if
+    /// argument resolution failed).
+    /// </summary>
+    private bool TryBindClrDelegateMemberInvocation(
+        BoundExpression receiver,
+        System.Type clrType,
+        string methodName,
+        ImmutableArray<BoundExpression> arguments,
+        CallExpressionSyntax ce,
+        ImmutableArray<string> argumentNames,
+        out BoundExpression result)
+    {
+        result = null;
+        if (clrType == null)
+        {
+            return false;
+        }
+
+        // Prefer a property of the right name over a field — the same
+        // precedence used by the read path in BindAccessorStep (properties
+        // first, fields fallback). Indexer properties (those with parameters)
+        // are not member-style invocable, so skip them.
+        System.Reflection.MemberInfo member = ClrTypeUtilities.SafeGetProperty(clrType, methodName, BindingFlags.Public | BindingFlags.Instance);
+        if (member is System.Reflection.PropertyInfo prop && (prop.GetIndexParameters().Length != 0 || !prop.CanRead))
+        {
+            member = null;
+        }
+
+        member ??= ClrTypeUtilities.SafeGetField(clrType, methodName, BindingFlags.Public | BindingFlags.Instance);
+        if (member == null)
+        {
+            return false;
+        }
+
+        System.Type memberClrType = member switch
+        {
+            System.Reflection.PropertyInfo p => p.PropertyType,
+            System.Reflection.FieldInfo f => f.FieldType,
+            _ => null,
+        };
+        if (memberClrType == null || !ClrTypeUtilities.IsDelegateType(memberClrType))
+        {
+            return false;
+        }
+
+        TypeSymbol memberTypeSymbol = member switch
+        {
+            System.Reflection.PropertyInfo p2 => ClrNullability.GetPropertyTypeSymbol(p2),
+            System.Reflection.FieldInfo f2 => ClrNullability.GetFieldTypeSymbol(f2),
+            _ => TypeSymbol.FromClrType(memberClrType),
+        };
+
+        // The delegate value load — `ldfld` for a field, `call get_X` for a
+        // property. The shared BoundClrPropertyAccessExpression node carries
+        // either MemberInfo shape, and EmitClrPropertyAccess already handles
+        // both (including the value-type-receiver `ldloca` step we need for
+        // a CLR struct field).
+        var delegateLoad = new BoundClrPropertyAccessExpression(null, receiver, member, memberTypeSymbol);
+
+        // Strip nullable annotation when dispatching through Invoke — the
+        // delegate value is loaded as-is from the field; the call would
+        // dereference null at runtime if the member is unassigned. This
+        // matches CLR semantics for `del()` on a null `Func<T>`.
+        var underlyingDelegateClr = memberClrType;
+
+        // Reuse the same Invoke-overload-resolution path that the bare
+        // delegate-variable call uses at #325 (BindCallExpression), so
+        // generic delegate arguments, named arguments, and ref/in/out are
+        // all handled uniformly.
+        if (TryBindInheritedClrInstanceCall(delegateLoad, underlyingDelegateClr, "Invoke", arguments, ce, out var invokeCall, argumentNames: argumentNames))
+        {
+            result = invokeCall;
+            return true;
+        }
+
+        // No applicable Invoke overload — most likely an argument-count or
+        // type mismatch. Report against the member name (not "Invoke") so the
+        // diagnostic points to what the user wrote.
+        var invoke = memberClrType.GetMethod("Invoke");
+        var expectedArity = invoke?.GetParameters().Length ?? 0;
+        if (arguments.Length != expectedArity)
+        {
+            Diagnostics.ReportWrongArgumentCount(ce.Location, methodName, expectedArity, arguments.Length);
+        }
+        else
+        {
+            Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
+        }
+
+        result = new BoundErrorExpression(null);
+        return true;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue527StructDelegateFieldEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue527StructDelegateFieldEmitTests.cs
@@ -1,0 +1,467 @@
+// <copyright file="Issue527StructDelegateFieldEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #527: public fields on a CLR <c>struct</c> imported through a sibling
+/// assembly were unreachable from G#. Reading the field reported
+/// <c>GS0158: Cannot find member</c>; assigning to it likewise reported
+/// <c>GS0158</c>; and an invocation on a delegate-typed field
+/// (<c>bag.OnAsk()</c>) reported <c>GS0159: Cannot find function</c>. After
+/// the fix, public fields on CLR structs behave like public fields on CLR
+/// classes: they are readable, writable, and (when delegate-typed) invokable.
+/// The emitter must produce verifiable IL for all three forms.
+/// </summary>
+public class Issue527StructDelegateFieldEmitTests
+{
+    [Fact]
+    public void ClrStruct_Int32Field_ReadWrite_RoundTrips()
+    {
+        // The simplest case: a public int field on a CLR struct. Before the
+        // fix, even this failed because the binder/emitter took a
+        // value-typed receiver path that lost track of public fields.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public struct CounterBag
+                {
+                    public int Counter;
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            var bag = CounterBag()
+            bag.Counter = 42
+            Console.WriteLine(bag.Counter)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void ClrStruct_StringField_ReadWrite_RoundTrips()
+    {
+        // A reference-typed field still needs to round-trip; the field
+        // store/load IL must use the right `stfld`/`ldfld` rather than a
+        // boxed surrogate.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public struct NameBag
+                {
+                    public string Name;
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            var bag = NameBag()
+            bag.Name = "hello"
+            Console.WriteLine(bag.Name)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("hello\n", output);
+    }
+
+    [Fact]
+    public void ClrStruct_DelegateField_AssignReadInvoke_Works()
+    {
+        // The exact issue-body repro plus a read of the delegate value: the
+        // field is assigned a function literal, read back into a local
+        // (`var f = bag.OnAsk`), invoked through the local, and invoked
+        // through the field directly. All three steps must compile and
+        // produce verifiable IL.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public struct CallbackBag
+                {
+                    public System.Func<string> OnAsk;
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            var bag = CallbackBag()
+            bag.OnAsk = func() string { return "hello" }
+            var f = bag.OnAsk
+            Console.WriteLine(f())
+            Console.WriteLine(bag.OnAsk())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("hello\nhello\n", output);
+    }
+
+    [Fact]
+    public void ClrStruct_PassedByValue_MutationsDoNotEscape()
+    {
+        // CLR semantics: passing a struct by value copies it, so any
+        // mutations made inside the callee must not be visible to the
+        // caller. This is a behavioral regression guard — the emitter must
+        // not accidentally pass the struct by reference.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public struct CounterBag
+                {
+                    public int Counter;
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            func Bump(b CounterBag) {
+                b.Counter = b.Counter + 100
+            }
+
+            var bag = CounterBag()
+            bag.Counter = 1
+            Bump(bag)
+            Console.WriteLine(bag.Counter)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void ClrStruct_DelegateField_InsideMethodBody_AssignReadInvoke_Works()
+    {
+        // The exact issue-body repro: a G# class method body invokes the
+        // delegate field on a local CLR-struct value. This mirrors the
+        // shape from the bug report (GS0158 on the assignment, GS0159 on
+        // the invocation). Confirms that the fix carries through to
+        // method-body binding (Stream A's accessor chain) just like the
+        // top-level binding path.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public struct CallbackBag
+                {
+                    public System.Func<string> OnAsk;
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            type StructFieldProbe class {
+                func Test() string {
+                    var bag = CallbackBag()
+                    bag.OnAsk = func() string { return "hello" }
+                    return bag.OnAsk()
+                }
+            }
+
+            var probe = StructFieldProbe{}
+            Console.WriteLine(probe.Test())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("hello\n", output);
+    }
+
+    [Fact]
+    public void ClrClass_DelegateField_AssignReadInvoke_Works_RegressionGuard()
+    {
+        // Regression guard: the same scenario on a CLR class (not a struct)
+        // already worked before the fix and must keep working after it. If
+        // the fix accidentally re-routes class field access, this catches it.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public class CallbackHolder
+                {
+                    public System.Func<string> OnAsk;
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            var holder = CallbackHolder()
+            holder.OnAsk = func() string { return "world" }
+            Console.WriteLine(holder.OnAsk())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("world\n", output);
+    }
+
+    [Fact]
+    public void GSharpStruct_DelegateField_AssignReadInvoke_Works()
+    {
+        // G#-defined struct with a delegate-typed field exercises the same
+        // call-as-field path through the binder/emitter without crossing the
+        // import boundary. The struct is value-typed, so the field load
+        // emits `ldloca; ldfld` (the by-ref-receiver path for value types).
+        var source = """
+            package Probe.Tests
+            import System
+
+            type CallbackBag struct {
+                OnAsk func() string
+            }
+
+            var bag = CallbackBag{ OnAsk: func() string { return "hi" } }
+            Console.WriteLine(bag.OnAsk())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue527_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue527_sib_").FullName;
+        try
+        {
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            File.Copy(siblingDll, Path.Combine(tempDir, Path.GetFileName(siblingDll)), overwrite: true);
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { siblingDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string BuildCsProject(string csDir, string siblingName)
+    {
+        RunDotnet(csDir, "restore");
+
+        var stdout = RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+        _ = stdout;
+
+        var dll = Path.Combine(csDir, "bin", "Release", "net10.0", siblingName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static string RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #527.

## Problem

A public field or property whose type is a delegate (CLR `Func`/`Action`, a named user delegate, or a G# `func`-typed field) was unreachable through member-call syntax. The issue-body repro:

```gsharp
type StructFieldProbe class {
    func Test() {
        var bag = CallbackBag()                          // CLR struct with public Func<string> OnAsk
        bag.OnAsk = func() string { return "hello" }
        var s = bag.OnAsk()                              // was: GS0159 Cannot find function OnAsk.
    }
}
```

`BindAccessorCall` consulted only methods with that name on the receiver type, so a delegate-typed field was never found and resolution fell through to `Diagnostics.ReportUnableToFindFunction`.

## Fix

Two new fallbacks live at the end of method resolution in `Binder.BindAccessorCall`. They run after overload resolution misses and **before** extension-function fallbacks, so an in-scope extension cannot shadow a real delegate-typed member.

### `TryBindClrDelegateMemberInvocation` — CLR receiver arm

* Resolves a public field (or non-indexer property) of the requested name on the CLR receiver type.
* Verifies the member's type is a delegate via `ClrTypeUtilities.IsDelegateType`.
* Builds a `BoundClrPropertyAccessExpression` for the load — that already handles the value-type-receiver `ldloca; ldfld` step needed for CLR structs.
* Dispatches the call through the delegate's `Invoke` `MethodInfo` via `TryBindInheritedClrInstanceCall`, exactly the same path used for a bare delegate variable in `BindCallExpression` (#325). This yields a direct `callvirt System.Func<T>.Invoke()` against the actual loaded delegate value.

### `TryBindUserStructDelegateFieldInvocation` — user-type arm

For a G#-defined struct or class the receiver's `ClrType` is `null` until after emission, so the CLR path above never fires. This helper:

* Walks the base chain so an inherited delegate field on a base class is also invokable.
* Accepts `FunctionTypeSymbol`, `DelegateTypeSymbol`, and reflected CLR delegate field types.
* Lowers to a `BoundFieldAccessExpression` load wrapped in a `BoundIndirectCallExpression` over the function shape — the existing emit path handles both `FunctionTypeSymbol`-typed targets and value-type-receiver field loads.

## Tests

`test/Compiler.Tests/Emit/Issue527StructDelegateFieldEmitTests.cs` adds seven end-to-end tests that compile via `gsc`, IL-verify, and run under `dotnet exec`:

1. `ClrStruct_Int32Field_ReadWrite_RoundTrips` — int field on a CLR struct (read/write).
2. `ClrStruct_StringField_ReadWrite_RoundTrips` — reference-typed field on a CLR struct.
3. `ClrStruct_DelegateField_AssignReadInvoke_Works` — assign a function literal to a `Func<string>` field, read it back into a local, invoke both the local and `bag.OnAsk()` directly.
4. `ClrStruct_DelegateField_InsideMethodBody_AssignReadInvoke_Works` — the exact issue-body repro shape (G# class method body, local CLR-struct value).
5. `ClrStruct_PassedByValue_MutationsDoNotEscape` — behavioral guard that struct-by-value semantics are preserved.
6. `ClrClass_DelegateField_AssignReadInvoke_Works_RegressionGuard` — same scenario on a CLR class; the previously-working class path must keep working.
7. `GSharpStruct_DelegateField_AssignReadInvoke_Works` — G#-defined struct with a `func() string` field, exercising the symbol-only arm.

## Verification

* `dotnet build GSharp.sln -nologo -clp:NoSummary` — clean (0 warnings, 0 errors).
* `dotnet test GSharp.sln --no-restore --nologo` — all 2,858 tests pass (Sdk 24, Interpreter 72, LanguageServer 226, Core 1996, Compiler 540).
* All seven Issue527 tests pass `ilverify` (invoked by the test harness on every emitted assembly).
