### PR TITLE
Fix inherited interface member lookup for CLR types

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -7726,13 +7726,13 @@ public sealed class Binder
         if (receiverType is not StructSymbol && receiverType is not NullableTypeSymbol && receiverType.ClrType != null)
         {
             var clrReceiverType = receiverType.ClrType;
-            MemberInfo instanceMember = ClrTypeUtilities.SafeGetProperty(clrReceiverType, propertyName, BindingFlags.Public | BindingFlags.Instance);
+            MemberInfo instanceMember = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, propertyName, BindingFlags.Public | BindingFlags.Instance);
             if (instanceMember is PropertyInfo idxProp && idxProp.GetIndexParameters().Length != 0)
             {
                 instanceMember = null;
             }
 
-            instanceMember ??= ClrTypeUtilities.SafeGetField(clrReceiverType, propertyName, BindingFlags.Public | BindingFlags.Instance);
+            instanceMember ??= ClrTypeUtilities.SafeGetFieldIncludingInterfaces(clrReceiverType, propertyName, BindingFlags.Public | BindingFlags.Instance);
             if (instanceMember == null)
             {
                 Diagnostics.ReportUnableToFindMember(initSyntax.PropertyIdentifier.Location, propertyName);
@@ -8174,13 +8174,13 @@ public sealed class Binder
         {
             var clrReceiverType = variable.Type.ClrType;
             var fieldName = syntax.FieldIdentifier.Text;
-            MemberInfo instanceMember = ClrTypeUtilities.SafeGetProperty(clrReceiverType, fieldName, BindingFlags.Public | BindingFlags.Instance);
+            MemberInfo instanceMember = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, fieldName, BindingFlags.Public | BindingFlags.Instance);
             if (instanceMember is PropertyInfo prop && prop.GetIndexParameters().Length != 0)
             {
                 instanceMember = null;
             }
 
-            instanceMember ??= ClrTypeUtilities.SafeGetField(clrReceiverType, fieldName, BindingFlags.Public | BindingFlags.Instance);
+            instanceMember ??= ClrTypeUtilities.SafeGetFieldIncludingInterfaces(clrReceiverType, fieldName, BindingFlags.Public | BindingFlags.Instance);
             if (instanceMember == null)
             {
                 Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
@@ -13898,7 +13898,11 @@ public sealed class Binder
                     // receivers must be narrowed or use `?.` before this path.
                     var clrReceiverType = receiver.Type.ClrType;
                     var memberName = ne.IdentifierToken.Text;
-                    var prop = ClrTypeUtilities.SafeGetProperty(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
+
+                    // Issue #529: use interface-aware lookup so that members
+                    // declared on a base interface (e.g. IReadOnlyCollection<T>.Count
+                    // surfaced through IReadOnlyList<T>) are found.
+                    var prop = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
                     if (prop != null && prop.GetIndexParameters().Length == 0 && prop.CanRead)
                     {
                         // Issue #504 follow-up: properties with NRT
@@ -13915,7 +13919,7 @@ public sealed class Binder
                         return AutoDereferenceRefReturn(new BoundClrPropertyAccessExpression(null, receiver, prop, propType));
                     }
 
-                    var fld = ClrTypeUtilities.SafeGetField(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
+                    var fld = ClrTypeUtilities.SafeGetFieldIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
                     if (fld != null)
                     {
                         return new BoundClrPropertyAccessExpression(null, receiver, fld, ClrNullability.GetFieldTypeSymbol(fld));
@@ -14277,7 +14281,12 @@ public sealed class Binder
             && TryGetNullableConstructedType(nullableInnerVt, out var nullableConstructed)
             ? nullableConstructed
             : receiver.Type.ClrType;
-        var candidates = clrType.GetMethods(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public)
+
+        // Issue #529: use interface-aware method enumeration so that
+        // methods declared on a base interface (e.g.
+        // IEnumerable<T>.GetEnumerator() surfaced through
+        // IReadOnlyList<T>) are found.
+        var candidates = ClrTypeUtilities.SafeGetMethodsIncludingInterfaces(clrType, System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public)
             .Where(m => m.Name == methodName)
             .ToList();
         if (candidates.Count > 0)
@@ -16668,7 +16677,11 @@ public sealed class Binder
 
         var flags = BindingFlags.Public | (wantStatic ? BindingFlags.Static : BindingFlags.Instance);
         var candidates = ImmutableArray.CreateBuilder<MethodInfo>();
-        foreach (var method in declaringType.GetMethods(flags))
+
+        // Issue #529: use interface-aware method enumeration so that
+        // methods declared on a base interface are included in the
+        // method group for delegate conversions / member access.
+        foreach (var method in ClrTypeUtilities.SafeGetMethodsIncludingInterfaces(declaringType, flags))
         {
             if (!string.Equals(method.Name, name, StringComparison.Ordinal))
             {

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -310,6 +310,109 @@ internal static class ClrTypeUtilities
     public static EventInfo SafeGetEvent(Type type, string name, BindingFlags flags)
         => SafeGetMember(type, name, flags, (t, f) => t.GetEvent(name, f), SafeGetEvents);
 
+    /// <summary>
+    /// Issue #529: looks up a property by name, walking the transitive
+    /// interface hierarchy when <paramref name="type"/> is an interface.
+    /// CLR reflection does not include inherited interface members in
+    /// <see cref="Type.GetProperties(BindingFlags)"/> for interface types,
+    /// so this helper explicitly walks <see cref="Type.GetInterfaces()"/>.
+    /// </summary>
+    /// <param name="type">The type to search.</param>
+    /// <param name="name">The property name.</param>
+    /// <param name="flags">The binding flags controlling visibility.</param>
+    /// <returns>The matching property, or <c>null</c> when none is found.</returns>
+    public static PropertyInfo SafeGetPropertyIncludingInterfaces(Type type, string name, BindingFlags flags)
+    {
+        var direct = SafeGetProperty(type, name, flags);
+        if (direct != null)
+        {
+            return direct;
+        }
+
+        if (type is null || !type.IsInterface)
+        {
+            return null;
+        }
+
+        foreach (var iface in SafeGetInterfaces(type))
+        {
+            var inherited = SafeGetProperty(iface, name, flags);
+            if (inherited != null)
+            {
+                return inherited;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Issue #529: looks up a field by name, walking the transitive
+    /// interface hierarchy when <paramref name="type"/> is an interface.
+    /// </summary>
+    /// <param name="type">The type to search.</param>
+    /// <param name="name">The field name.</param>
+    /// <param name="flags">The binding flags controlling visibility.</param>
+    /// <returns>The matching field, or <c>null</c> when none is found.</returns>
+    public static FieldInfo SafeGetFieldIncludingInterfaces(Type type, string name, BindingFlags flags)
+    {
+        var direct = SafeGetField(type, name, flags);
+        if (direct != null)
+        {
+            return direct;
+        }
+
+        if (type is null || !type.IsInterface)
+        {
+            return null;
+        }
+
+        foreach (var iface in SafeGetInterfaces(type))
+        {
+            var inherited = SafeGetField(iface, name, flags);
+            if (inherited != null)
+            {
+                return inherited;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Issue #529: enumerates methods including those declared on
+    /// transitive base interfaces when <paramref name="type"/> is an
+    /// interface. For non-interface types, this is equivalent to
+    /// <see cref="SafeGetMethods"/>. Methods from base interfaces that
+    /// are hidden by a same-name-and-parameter-types method on a
+    /// more-derived interface are excluded (mirrors C# hiding rules).
+    /// </summary>
+    /// <param name="type">The type to enumerate.</param>
+    /// <param name="flags">The binding flags controlling visibility.</param>
+    /// <returns>The methods whose signatures load cleanly.</returns>
+    public static MethodInfo[] SafeGetMethodsIncludingInterfaces(Type type, BindingFlags flags)
+    {
+        var direct = SafeGetMethods(type, flags);
+        if (type is null || !type.IsInterface)
+        {
+            return direct;
+        }
+
+        var all = new List<MethodInfo>(direct);
+        foreach (var iface in SafeGetInterfaces(type))
+        {
+            foreach (var m in SafeGetMethods(iface, flags))
+            {
+                if (!IsHiddenByExisting(all, m))
+                {
+                    all.Add(m);
+                }
+            }
+        }
+
+        return all.ToArray();
+    }
+
     private static TMember[] SafeEnumerate<TMember>(Type type, Func<Type, TMember[]> getAll)
         where TMember : MemberInfo
     {
@@ -373,5 +476,72 @@ internal static class ClrTypeUtilities
 
             return null;
         }
+    }
+
+    /// <summary>
+    /// Issue #529: tolerantly retrieves the transitive interface set
+    /// for a type, guarding against metadata-load failures.
+    /// </summary>
+    /// <param name="type">The type whose interfaces to retrieve.</param>
+    /// <returns>The transitive interface set, or empty on failure.</returns>
+    private static Type[] SafeGetInterfaces(Type type)
+    {
+        if (type is null)
+        {
+            return Array.Empty<Type>();
+        }
+
+        try
+        {
+            return type.GetInterfaces();
+        }
+        catch (Exception ex) when (IsMetadataLoadFailure(ex))
+        {
+            return Array.Empty<Type>();
+        }
+    }
+
+    /// <summary>
+    /// Issue #529: returns whether <paramref name="candidate"/> is hidden
+    /// by any method already in <paramref name="existing"/>. A method is
+    /// hidden when another method with the same name and same parameter
+    /// types is already present (C# interface hiding semantics).
+    /// </summary>
+    /// <param name="existing">The methods found so far.</param>
+    /// <param name="candidate">The candidate from a base interface.</param>
+    /// <returns><c>true</c> when the candidate is hidden.</returns>
+    private static bool IsHiddenByExisting(List<MethodInfo> existing, MethodInfo candidate)
+    {
+        foreach (var m in existing)
+        {
+            if (!string.Equals(m.Name, candidate.Name, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var existingParams = m.GetParameters();
+            var candidateParams = candidate.GetParameters();
+            if (existingParams.Length != candidateParams.Length)
+            {
+                continue;
+            }
+
+            var match = true;
+            for (var i = 0; i < existingParams.Length; i++)
+            {
+                if (!AreSame(existingParams[i].ParameterType, candidateParams[i].ParameterType))
+                {
+                    match = false;
+                    break;
+                }
+            }
+
+            if (match)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/test/Compiler.Tests/Emit/Issue529InheritedInterfaceMembersEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue529InheritedInterfaceMembersEmitTests.cs
@@ -1,0 +1,507 @@
+// <copyright file="Issue529InheritedInterfaceMembersEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #529: member lookup on a CLR interface type must walk the
+/// inherited interface chain. <c>IReadOnlyList&lt;T&gt;.Count</c> is
+/// declared on <c>IReadOnlyCollection&lt;T&gt;</c> but must be
+/// accessible through an <c>IReadOnlyList&lt;T&gt;</c>-typed receiver.
+/// The same applies to methods (e.g. <c>GetEnumerator()</c> inherited
+/// via <c>IEnumerable&lt;T&gt;</c>).
+/// </summary>
+public class Issue529InheritedInterfaceMembersEmitTests
+{
+    // ---------------------------------------------------------------
+    // BCL interface hierarchy: IReadOnlyList<T>
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void IReadOnlyList_Count_InheritedFromIReadOnlyCollection()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            var xs = List[string]()
+            xs.Add("a")
+            xs.Add("b")
+            let items IReadOnlyList[string] = xs
+            Console.WriteLine(items.Count)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void IReadOnlyList_GetEnumerator_InheritedViaIEnumerable()
+    {
+        // GetEnumerator() is declared on IEnumerable<T> which
+        // IReadOnlyList<T> inherits. The non-generic IEnumerable
+        // version is hidden by C# interface hiding rules.
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            var xs = List[string]()
+            xs.Add("hello")
+            let items IReadOnlyList[string] = xs
+            let e = items.GetEnumerator()
+            e.MoveNext()
+            Console.WriteLine(e.Current)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello\n", output);
+    }
+
+    // ---------------------------------------------------------------
+    // Sibling C# probe: custom interface hierarchy (method)
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void SiblingCSharp_MethodInherited_IA_CalledThroughIB()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IA
+                {
+                    string M();
+                }
+
+                public interface IB : IA
+                {
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type Impl class : IA, IB {
+                func M() string { return "from IA via IB" }
+            }
+
+            let x IB = Impl{}
+            Console.WriteLine(x.M())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("from IA via IB\n", output);
+    }
+
+    // ---------------------------------------------------------------
+    // Sibling C# probe: custom interface hierarchy (property)
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void SiblingCSharp_PropertyInherited_IA_ReadThroughIB()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IA
+                {
+                    string Name { get; }
+                }
+
+                public interface IB : IA
+                {
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type Named class : IA, IB {
+                prop Name string { get { return "hello" } }
+            }
+
+            let x IB = Named{}
+            Console.WriteLine(x.Name)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("hello\n", output);
+    }
+
+    // ---------------------------------------------------------------
+    // Three-level interface hierarchy
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void SiblingCSharp_ThreeLevelHierarchy_MethodOnBaseReachable()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IBase
+                {
+                    string Root();
+                }
+
+                public interface IMid : IBase
+                {
+                }
+
+                public interface ILeaf : IMid
+                {
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type Deep class : IBase, IMid, ILeaf {
+                func Root() string { return "deep" }
+            }
+
+            let x ILeaf = Deep{}
+            Console.WriteLine(x.Root())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("deep\n", output);
+    }
+
+    // ---------------------------------------------------------------
+    // Regression: members directly declared on the interface bind
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void Regression_DirectMembersOnInterface_StillBind()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IDirect
+                {
+                    string DirectMethod();
+                    string DirectProp { get; }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type DirectImpl class : IDirect {
+                func DirectMethod() string { return "dm" }
+                prop DirectProp string { get { return "dp" } }
+            }
+
+            let x IDirect = DirectImpl{}
+            Console.WriteLine(x.DirectMethod())
+            Console.WriteLine(x.DirectProp)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("dm\ndp\n", output);
+    }
+
+    // ---------------------------------------------------------------
+    // Regression: concrete class member lookup unchanged
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void Regression_ConcreteClassMemberLookup_Unchanged()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            var items = List[string]()
+            items.Add("a")
+            items.Add("b")
+            items.Add("c")
+            Console.WriteLine(items.Count)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n", output);
+    }
+
+    // ---------------------------------------------------------------
+    // Sibling C# probe: IB extends IA, IB also declares own members
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void SiblingCSharp_IBHasOwnAndInheritedMembers()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IA
+                {
+                    string FromA();
+                }
+
+                public interface IB : IA
+                {
+                    string FromB();
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type Both class : IA, IB {
+                func FromA() string { return "a" }
+                func FromB() string { return "b" }
+            }
+
+            let x IB = Both{}
+            Console.WriteLine(x.FromA())
+            Console.WriteLine(x.FromB())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("a\nb\n", output);
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers (mirror Issue525 pattern)
+    // ---------------------------------------------------------------
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue529_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue529_sib_").FullName;
+        try
+        {
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            File.Copy(siblingDll, Path.Combine(tempDir, Path.GetFileName(siblingDll)), overwrite: true);
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { siblingDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string BuildCsProject(string csDir, string siblingName)
+    {
+        RunDotnet(csDir, "restore");
+        RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+
+        var dll = Path.Combine(csDir, "bin", "Release", "net10.0", siblingName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static void RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Member lookup on a CLR interface type now walks `Type.GetInterfaces()` transitively when the member is not found directly on the interface. This matches C# semantics where e.g. `IReadOnlyList<T>.Count` (declared on `IReadOnlyCollection<T>`) is accessible through an `IReadOnlyList<T>` receiver.

## Changes

### `ClrTypeUtilities.cs`
- Added `SafeGetPropertyIncludingInterfaces`, `SafeGetFieldIncludingInterfaces`, `SafeGetMethodsIncludingInterfaces` — interface-aware variants that walk base interfaces for interface types.
- Added `IsHiddenByExisting` — suppresses base interface methods hidden by a same-name-same-parameter-types method on a more-derived interface (prevents spurious ambiguity on e.g. `GetEnumerator`).

### `Binder.cs`
- All CLR member access sites (property read, field read, property assignment, method call, method group) now use the interface-aware helpers.

## Tests Added (`Issue529InheritedInterfaceMembersEmitTests.cs`)

| Test | Coverage |
|------|----------|
| `IReadOnlyList_Count_InheritedFromIReadOnlyCollection` | Property inherited from `IReadOnlyCollection<T>` via `IReadOnlyList<T>` |
| `IReadOnlyList_GetEnumerator_InheritedViaIEnumerable` | Method inherited from `IEnumerable<T>` via `IReadOnlyList<T>` |
| `SiblingCSharp_MethodInherited_IA_CalledThroughIB` | Custom `IB : IA` — method on `IA` called through `IB` |
| `SiblingCSharp_PropertyInherited_IA_ReadThroughIB` | Custom `IB : IA` — property on `IA` read through `IB` |
| `SiblingCSharp_ThreeLevelHierarchy_MethodOnBaseReachable` | Three-level `ILeaf : IMid : IBase` hierarchy |
| `SiblingCSharp_IBHasOwnAndInheritedMembers` | `IB` has own + inherited members, both accessible |
| `Regression_DirectMembersOnInterface_StillBind` | Direct members still bind correctly |
| `Regression_ConcreteClassMemberLookup_Unchanged` | Concrete class member lookup unchanged |

All tests compile, pass ilverify, and execute end-to-end.

Fixes #529