### PR TITLE
Fix Task<T?>.Result and other members not binding on nullable type args

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -4533,7 +4533,9 @@ public sealed class Binder
                 // set so they share clrOpenType's load context (its
                 // MetadataLoadContext when references are supplied via /r:),
                 // which MakeGenericType requires.
-                clrArgs[i] = scope.References.MapClrTypeToReferences(ta.ClrType);
+                // Issue #530: use ResolveClrTypeForGenericArg so that
+                // `int32?` resolves to `Nullable<int>` (not bare `int`).
+                clrArgs[i] = ResolveClrTypeForGenericArg(ta) ?? scope.References.MapClrTypeToReferences(ta.ClrType);
             }
 
             try
@@ -4917,7 +4919,7 @@ public sealed class Binder
                 return null;
             }
 
-            clrArgs[i] = scope.References.MapClrTypeToReferences(ta.ClrType);
+            clrArgs[i] = ResolveClrTypeForGenericArg(ta) ?? scope.References.MapClrTypeToReferences(ta.ClrType);
         }
 
         try
@@ -12465,7 +12467,10 @@ public sealed class Binder
             // MetadataLoadContext, and MakeGenericType requires the type
             // argument to originate from that same context (issues #290 and
             // #291: value-returning async funcs and imported-Task<T> awaits).
-            var elementClr = scope.References.MapClrTypeToReferences(clr);
+            // Issue #530: use ResolveClrTypeForGenericArg so that a nullable
+            // value type (e.g. `int32?`) correctly wraps as
+            // `Task<Nullable<int>>` rather than `Task<int>`.
+            var elementClr = ResolveClrTypeForGenericArg(element) ?? scope.References.MapClrTypeToReferences(clr);
             var closed = taskOpen.MakeGenericType(elementClr);
             return ImportedTypeSymbol.Get(closed);
         }
@@ -12953,7 +12958,8 @@ public sealed class Binder
         var argsAllTyped = true;
         for (var i = 0; i < boundArguments.Count; i++)
         {
-            var t = boundArguments[i].Type?.ClrType;
+            // Issue #530: use GetEffectiveArgumentClrType (see instance method path).
+            var t = GetEffectiveArgumentClrType(boundArguments[i].Type);
             if (t == null)
             {
                 argsAllTyped = false;
@@ -13998,7 +14004,9 @@ public sealed class Binder
                 // reference set so it shares the open generic method's load
                 // context, exactly as the generic-construction path does before
                 // MakeGenericType / MakeGenericMethod.
-                resolved[i] = scope.References.MapClrTypeToReferences(ta.ClrType);
+                // Issue #530: use ResolveClrTypeForGenericArg so that
+                // `int32?` resolves to `Nullable<int>` (not bare `int`).
+                resolved[i] = ResolveClrTypeForGenericArg(ta) ?? scope.References.MapClrTypeToReferences(ta.ClrType);
             }
             else
             {
@@ -14295,7 +14303,10 @@ public sealed class Binder
             var argsAllTyped = true;
             for (var i = 0; i < arguments.Length; i++)
             {
-                var t = arguments[i].Type?.ClrType;
+                // Issue #530: use GetEffectiveArgumentClrType so that a
+                // nullable value type argument (e.g. `int32?`) is matched
+                // as `Nullable<T>` in overload resolution.
+                var t = GetEffectiveArgumentClrType(arguments[i].Type);
                 if (t == null)
                 {
                     argsAllTyped = false;
@@ -14588,7 +14599,8 @@ public sealed class Binder
         var argTypes = new System.Type[arguments.Length];
         for (var i = 0; i < arguments.Length; i++)
         {
-            var t = arguments[i].Type?.ClrType;
+            // Issue #530: use GetEffectiveArgumentClrType (see instance method path).
+            var t = GetEffectiveArgumentClrType(arguments[i].Type);
             if (t == null)
             {
                 return false;
@@ -14847,7 +14859,8 @@ public sealed class Binder
         argTypes[0] = receiverClrType;
         for (var i = 0; i < arguments.Length; i++)
         {
-            var t = arguments[i].Type?.ClrType;
+            // Issue #530: use GetEffectiveArgumentClrType (see instance method path).
+            var t = GetEffectiveArgumentClrType(arguments[i].Type);
             if (t == null)
             {
                 return false;
@@ -16666,6 +16679,42 @@ public sealed class Binder
         }
     }
 
+    /// <summary>
+    /// Issue #530: returns the CLR type to use when <paramref name="typeSymbol"/>
+    /// appears as a generic type argument (e.g. <c>Task[int32?]</c> or
+    /// <c>FromResult[string?]</c>). For a <see cref="NullableTypeSymbol"/>
+    /// wrapping a value type the result is <c>Nullable&lt;T&gt;</c>; for a
+    /// nullable reference type the result is the underlying reference type
+    /// (since CLR has no separate <c>string?</c> type).
+    /// </summary>
+    /// <param name="typeSymbol">The type symbol to resolve.</param>
+    /// <returns>
+    /// The CLR type projected onto the reference load context, or <c>null</c>
+    /// when the symbol has no CLR type.
+    /// </returns>
+    private Type ResolveClrTypeForGenericArg(TypeSymbol typeSymbol)
+    {
+        if (typeSymbol is NullableTypeSymbol nullable
+            && nullable.UnderlyingType?.ClrType is { IsValueType: true } innerVt
+            && TryGetNullableConstructedType(innerVt, out var nullableClr))
+        {
+            return nullableClr;
+        }
+
+        var clr = typeSymbol?.ClrType;
+        return clr != null ? scope.References.MapClrTypeToReferences(clr) : null;
+    }
+
+    /// <summary>
+    /// Issue #530: returns the effective CLR <see cref="Type"/> to use when
+    /// matching an argument in overload resolution. Delegates to
+    /// <see cref="NullableTypeSymbol.GetEffectiveClrType"/>.
+    /// </summary>
+    private Type GetEffectiveArgumentClrType(TypeSymbol typeSymbol)
+    {
+        return NullableTypeSymbol.GetEffectiveClrType(typeSymbol);
+    }
+
     private bool TryBindClrMethodGroup(BoundExpression receiver, Type declaringType, bool wantStatic, string name, out BoundExpression methodGroup)
     {
         methodGroup = null;
@@ -17230,7 +17279,8 @@ public sealed class Binder
         var argsAllTyped = true;
         for (var i = 0; i < boundArguments.Count; i++)
         {
-            var t = boundArguments[i].Type?.ClrType;
+            // Issue #530: use GetEffectiveArgumentClrType (see instance method path).
+            var t = GetEffectiveArgumentClrType(boundArguments[i].Type);
             if (t == null)
             {
                 argsAllTyped = false;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -1481,6 +1481,25 @@ internal static class OverloadResolution
             }
         }
 
+        // Phase 2d — issue #530: when multiple candidates survive with identical
+        // parameter types but different declaring types (e.g. Task<T>.GetAwaiter()
+        // vs. inherited Task.GetAwaiter()), prefer the most-derived declaring type.
+        // This mirrors C#'s "method hiding" rule: a derived-class method hides any
+        // base-class method with the same signature.
+        if (pool.Count > 1)
+        {
+            var mostDerived = FilterToMostDerivedDeclaringType(pool);
+            if (mostDerived.Count >= 1 && mostDerived.Count < pool.Count)
+            {
+                pool = mostDerived;
+            }
+
+            if (pool.Count == 1)
+            {
+                return Result<T>.Single(pool[0].Method, BuildMappingArray(pool[0].Mapping, argumentNames), pool[0].IsExpanded);
+            }
+        }
+
         // If nothing dominated above, report the surviving pool as ambiguous.
         var ambiguous = pool
             .Select(c => c.Method)
@@ -1490,6 +1509,77 @@ internal static class OverloadResolution
 
     private static bool IsGenericMethod(MethodBase method)
         => method is MethodInfo mi && mi.IsGenericMethod;
+
+    /// <summary>
+    /// Issue #530: when multiple surviving candidates have the same parameter
+    /// types but different declaring types (e.g. <c>Task&lt;T&gt;.GetAwaiter()</c>
+    /// hiding <c>Task.GetAwaiter()</c>), keep only those declared on the
+    /// most-derived type. This mirrors C#'s method-hiding semantics: a derived
+    /// class method with the same signature as a base class method hides it.
+    /// </summary>
+    private static List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> FilterToMostDerivedDeclaringType<T>(
+        List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> pool)
+    {
+        var result = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)>(pool.Count);
+        foreach (var candidate in pool)
+        {
+            var declaringType = (candidate.Method as MethodBase)?.DeclaringType;
+            if (declaringType == null)
+            {
+                result.Add(candidate);
+                continue;
+            }
+
+            // Check if any other candidate in the pool is declared on a
+            // more-derived type (i.e., a type that inherits from this one).
+            bool isHidden = false;
+            foreach (var other in pool)
+            {
+                if (ReferenceEquals(candidate.Method as MethodBase, other.Method as MethodBase))
+                {
+                    continue;
+                }
+
+                var otherDeclaring = (other.Method as MethodBase)?.DeclaringType;
+                if (otherDeclaring != null && otherDeclaring != declaringType && IsSubclassOf(otherDeclaring, declaringType))
+                {
+                    isHidden = true;
+                    break;
+                }
+            }
+
+            if (!isHidden)
+            {
+                result.Add(candidate);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Checks whether <paramref name="derived"/> is a subclass of
+    /// <paramref name="baseType"/>, using FullName comparison for cross-context
+    /// type compatibility (MetadataLoadContext vs. runtime types).
+    /// </summary>
+    private static bool IsSubclassOf(Type derived, Type baseType)
+    {
+        if (derived == null || baseType == null)
+        {
+            return false;
+        }
+
+        var baseFullName = baseType.FullName;
+        for (var current = derived.BaseType; current != null; current = current.BaseType)
+        {
+            if (current == baseType || current.FullName == baseFullName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     private static bool IsAtLeastAsGoodAs(
         ImplicitConversionKind[] a,

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
@@ -198,17 +198,35 @@ public static class AsyncStateMachineTypeBuilder
             return references.TryResolveType("System.Threading.Tasks.Task", out var taskType) ? taskType : null;
         }
 
-        var inner = kickoff.Type?.ClrType;
-        if (inner == null)
+        // Issue #530: for a nullable value type (e.g. `int32?`), the CLR type
+        // argument must be `Nullable<T>` (not bare `T`) so the async state
+        // machine's builder type (`Task<Nullable<int>>`) matches the kickoff's
+        // return type produced by WrapAsTask.
+        Type inner;
+        if (kickoff.Type is NullableTypeSymbol nullable
+            && nullable.UnderlyingType?.ClrType is { IsValueType: true } innerVt)
         {
-            return null;
-        }
+            if (!references.TryResolveType("System.Nullable`1", out var nullableOpen) || nullableOpen == null)
+            {
+                return null;
+            }
 
-        // Project the element CLR type onto the resolver's reference set before
-        // constructing Task`1. Under the SDK build path Task`1 is loaded via a
-        // MetadataLoadContext, and MakeGenericType requires the type argument to
-        // come from that same context (issues #290 and #291).
-        inner = references.MapClrTypeToReferences(inner);
+            inner = nullableOpen.MakeGenericType(references.MapClrTypeToReferences(innerVt));
+        }
+        else
+        {
+            inner = kickoff.Type?.ClrType;
+            if (inner == null)
+            {
+                return null;
+            }
+
+            // Project the element CLR type onto the resolver's reference set before
+            // constructing Task`1. Under the SDK build path Task`1 is loaded via a
+            // MetadataLoadContext, and MakeGenericType requires the type argument to
+            // come from that same context (issues #290 and #291).
+            inner = references.MapClrTypeToReferences(inner);
+        }
 
         return references.TryResolveType("System.Threading.Tasks.Task`1", out var open)
             ? open.MakeGenericType(inner)

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -165,7 +165,9 @@ public sealed class ImportedClassSymbol : Symbol
         var argTypes = new Type[arguments.Length];
         for (var i = 0; i < arguments.Length; i++)
         {
-            var t = arguments[i].Type?.ClrType;
+            // Issue #530: use effective CLR type so nullable value types
+            // (e.g. int32?) are matched as Nullable<T> in overload resolution.
+            var t = NullableTypeSymbol.GetEffectiveClrType(arguments[i].Type);
             if (t == null)
             {
                 return false;

--- a/src/Core/CodeAnalysis/Symbols/NullableTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullableTypeSymbol.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Concurrent;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
@@ -39,5 +40,27 @@ public sealed class NullableTypeSymbol : TypeSymbol
         }
 
         return Cache.GetOrAdd(underlyingType, t => new NullableTypeSymbol(t));
+    }
+
+    /// <summary>
+    /// Issue #530: returns the effective CLR <see cref="Type"/> to use when
+    /// matching <paramref name="typeSymbol"/> as a method argument in overload
+    /// resolution. For a <see cref="NullableTypeSymbol"/> wrapping a value
+    /// type, this returns <c>Nullable&lt;T&gt;</c> rather than the underlying
+    /// <c>T</c>, because the emitter encodes the local as <c>Nullable&lt;T&gt;</c>
+    /// and the selected overload must accept that type on the evaluation stack.
+    /// For all other types the result equals <c>typeSymbol?.ClrType</c>.
+    /// </summary>
+    /// <param name="typeSymbol">The type symbol to resolve.</param>
+    /// <returns>The CLR <see cref="Type"/> to use for overload resolution, or <see langword="null"/> if <paramref name="typeSymbol"/> is <see langword="null"/>.</returns>
+    public static Type GetEffectiveClrType(TypeSymbol typeSymbol)
+    {
+        if (typeSymbol is NullableTypeSymbol nullable
+            && nullable.UnderlyingType?.ClrType is { IsValueType: true } innerVt)
+        {
+            return typeof(Nullable<>).MakeGenericType(innerVt);
+        }
+
+        return typeSymbol?.ClrType;
     }
 }

--- a/test/Compiler.Tests/Emit/Issue530TaskOfNullableMembersEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue530TaskOfNullableMembersEmitTests.cs
@@ -1,0 +1,263 @@
+// <copyright file="Issue530TaskOfNullableMembersEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #530: <c>Task&lt;T?&gt;.Result</c> (and other members like
+/// <c>.GetAwaiter()</c>) fail to bind when the type argument is nullable.
+/// These tests exercise both nullable reference types (<c>string?</c>) and
+/// nullable value types (<c>int32?</c>), plus a non-nullable regression guard.
+/// </summary>
+public class Issue530TaskOfNullableMembersEmitTests
+{
+    [Fact]
+    public void Result_On_Task_Of_NullableString_Returns_Value()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            let t = Task.FromResult[string?]("hi")
+            let r = t.Result
+            Console.WriteLine(r)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi\n", output);
+    }
+
+    [Fact]
+    public void GetAwaiter_On_Task_Of_NullableString_Returns_Value()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            let t = Task.FromResult[string?]("hello")
+            let awaiter = t.GetAwaiter()
+            let r = awaiter.GetResult()
+            Console.WriteLine(r)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello\n", output);
+    }
+
+    [Fact]
+    public void Result_On_Task_Of_NullableInt32_Returns_Value()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            let t = Task.FromResult[int32?](42)
+            let r = t.Result
+            Console.WriteLine(r)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void Await_Task_Of_NullableString_Returns_Value()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            async func getVal() string? {
+                let t = Task.FromResult[string?]("awaited")
+                return await t
+            }
+
+            let r = getVal().Result
+            Console.WriteLine(r)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("awaited\n", output);
+    }
+
+    [Fact]
+    public void Await_Task_Of_NullableInt32_Returns_Value()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            async func getVal() int32? {
+                let t = Task.FromResult[int32?](99)
+                return await t
+            }
+
+            let r = getVal().Result
+            Console.WriteLine(r)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    [Fact]
+    public void Result_On_Task_Of_NonNullableString_Regression()
+    {
+        // Non-nullable T regression guard — must still work.
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            let t = Task.FromResult[string]("world")
+            let r = t.Result
+            Console.WriteLine(r)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("world\n", output);
+    }
+
+    [Fact]
+    public void ConfigureAwait_On_Task_Of_NullableString()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            async func getVal() string? {
+                let t = Task.FromResult[string?]("configured")
+                return await t.ConfigureAwait(false)
+            }
+
+            let r = getVal().Result
+            Console.WriteLine(r)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("configured\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: true);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(
+        string source,
+        bool expectSuccess)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_530_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}


### PR DESCRIPTION
## Summary

Fixes #530: `Task<T?>.Result`, `.GetAwaiter()`, and `.ConfigureAwait()` now bind correctly when the type argument is nullable (both nullable reference types like `string?` and nullable value types like `int32?`).

## Root causes fixed

### 1. Overload resolution ambiguity on `Task<T>` members
`Type.GetMethods(BindingFlags.Instance | BindingFlags.Public)` on `Task<string>` returns methods from **both** `Task<T>` and inherited `Task` — e.g., two `GetAwaiter()` methods and four `ConfigureAwait` overloads. The overload resolver treated these as ambiguous because they have identical parameter lists (differing only in declaring type and return type).

**Fix:** Added Phase 2d most-derived-declaring-type filter in `OverloadResolution.cs` that prefers the derived class method when parameter signatures are otherwise identical (mirrors C# `new`-keyword hiding).

### 2. Nullable value type generic arguments
`Task.FromResult[int32?](42)` was closing as `Task.FromResult<int>` instead of `Task.FromResult<Nullable<int>>` because `NullableTypeSymbol.ClrType` returns the underlying value type.

**Fix:** Added `ResolveClrTypeForGenericArg` helper in `Binder.cs` that maps `NullableTypeSymbol(ValueType)` → `Nullable<T>` for CLR generic type argument construction. Updated `TryResolveExplicitMethodTypeArgs`, two generic type construction paths, and `WrapAsTask`. Also updated `AsyncStateMachineTypeBuilder.ResolveAsyncReturnClrType` to construct `Task<Nullable<T>>` for async methods returning nullable value types.

### 3. Overload resolution with nullable value type arguments
When resolving method overloads for calls like `Console.WriteLine(r)` where `r` is `int32?`, the binder was using `NullableTypeSymbol.ClrType` (which returns `typeof(int)`) instead of `typeof(Nullable<int>)`. This caused the wrong overload to be selected, producing IL type mismatches.

**Fix:** Added `NullableTypeSymbol.GetEffectiveClrType` static helper and updated all argument-type resolution sites in `Binder.cs` and `ImportedClassSymbol.cs`.

## Files changed

| File | Change |
|------|--------|
| `OverloadResolution.cs` | Phase 2d most-derived filter + helper methods |
| `Binder.cs` | `ResolveClrTypeForGenericArg`, `GetEffectiveArgumentClrType`, updated 6 call sites |
| `NullableTypeSymbol.cs` | `GetEffectiveClrType` static helper |
| `ImportedClassSymbol.cs` | Use effective CLR type for overload resolution |
| `AsyncStateMachineTypeBuilder.cs` | Nullable value type support in async return type |
| `Issue530TaskOfNullableMembersEmitTests.cs` | 7 regression tests |

## Tests added

- `Result_On_Task_Of_NullableString_Returns_Value` — `Task[string?].Result`
- `GetAwaiter_On_Task_Of_NullableString_Returns_Value` — `Task[string?].GetAwaiter()`
- `ConfigureAwait_On_Task_Of_NullableString` — `Task[string?].ConfigureAwait(false)`
- `Await_Task_Of_NullableString_Returns_Value` — async/await with `Task[string?]`
- `Result_On_Task_Of_NullableInt32_Returns_Value` — `Task[int32?].Result`
- `Await_Task_Of_NullableInt32_Returns_Value` — async/await with `Task[int32?]`
- `Result_On_Task_Of_NonNullableString_Regression` — regression guard for non-nullable T

All tests include ilverify validation and runtime execution.