### PR TITLE
Implement backslash escape sequences in double-quoted string literals

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -429,3 +429,9 @@ Cause/fix examples:
 - **GS0265** — a default-value expression that is not constant, a parameter whose default depends on another parameter, an optional parameter preceding a required one without all trailing parameters also optional, or an optional ref/out parameter. Fix: use a compile-time-constant default, place optional parameters at the end of the list, and avoid combining `ref`/`out` with defaults.
 - **GS0266** — `Greet("ada")` when both `Greet(string)` and `Greet(name string)` are visible via different paths. Fix: rename one, change one signature, or use a named argument that only one overload accepts.
 - **GS0267** — `Greet(42)` when only `Greet(string)` is declared. Fix: pass a value of the expected type, or add an overload covering the new argument shape.
+
+## String escape diagnostics (GS0269)
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0269 | Error | Unrecognised escape sequence `\X` in string literal. | `"\q"` — `\q` is not a valid escape. Use `\\` for a literal backslash. |

--- a/docs/lexical.md
+++ b/docs/lexical.md
@@ -96,7 +96,27 @@ A character literal is a single Unicode code unit enclosed in single quotes (`'`
 
 GSharp has two string forms:
 
-1. **Interpreted strings** delimited by `"…"`. Escape sequences are processed.
+1. **Interpreted strings** delimited by `"…"`. Backslash escape sequences are processed — the same set as character literals:
+
+   | Escape | Value |
+   | ------ | ----- |
+   | `\\` | backslash (U+005C) |
+   | `\"` | double quote (U+0022) |
+   | `\'` | single quote (U+0027) |
+   | `\0` | NUL (U+0000) |
+   | `\a` | BEL (U+0007) |
+   | `\b` | BS (U+0008) |
+   | `\f` | FF (U+000C) |
+   | `\n` | LF (U+000A) |
+   | `\r` | CR (U+000D) |
+   | `\t` | HT (U+0009) |
+   | `\v` | VT (U+000B) |
+   | `\xH…HHHH` | 1–4 hex digit Unicode code point (C# semantics) |
+   | `\uHHHH` | exactly 4 hex digits |
+   | `\UHHHHHHHH` | exactly 8 hex digits (must be ≤ U+FFFF) |
+
+   Any other `\<char>` is a diagnostic (**GS0269**). To embed a literal backslash, write `\\`.
+
 2. **Raw strings** delimited by backticks (`` `…` ``). Contents are taken verbatim with no escape processing. Multi-line raw strings are allowed; CR and CRLF in the source are normalized to LF in the literal value. Embedded backticks are not representable; concatenate with `+` if needed.
 
 ### String interpolation

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1278,6 +1278,19 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Reports an unrecognized backslash escape sequence inside a double-quoted
+    /// string literal. Issue #531: interpreted strings now process C#/Go style
+    /// escape sequences; any <c>\X</c> that is not in the recognized set is an
+    /// error.
+    /// </summary>
+    /// <param name="location">The source location of the escape sequence.</param>
+    /// <param name="escapeChar">The character following the backslash.</param>
+    public void ReportInvalidStringEscape(TextLocation location, char escapeChar)
+    {
+        Report(location, "GS0269", $"Unrecognised escape sequence '\\{escapeChar}' in string literal.");
+    }
+
+    /// <summary>
     /// Reports an annotation lead-in (<c>@</c>) that is not followed by an
     /// identifier or a use-site target qualifier (ADR-0047 §1).
     /// </summary>

--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -659,15 +659,61 @@ public sealed class Lexer
                     done = true;
                     break;
                 case '"':
-                    if (Lookahead == '"')
+                    position++;
+                    done = true;
+                    break;
+                case '\\':
+                    // Backslash escape sequences (C#/Go style).
+                    position++; // consume '\'
+                    switch (Current)
                     {
-                        sb.Append(Current);
-                        position += 2;
-                    }
-                    else
-                    {
-                        position++;
-                        done = true;
+                        case '\'': sb.Append('\''); position++; break;
+                        case '"': sb.Append('"'); position++; break;
+                        case '\\': sb.Append('\\'); position++; break;
+                        case '0': sb.Append('\0'); position++; break;
+                        case 'a': sb.Append('\a'); position++; break;
+                        case 'b': sb.Append('\b'); position++; break;
+                        case 'f': sb.Append('\f'); position++; break;
+                        case 'n': sb.Append('\n'); position++; break;
+                        case 'r': sb.Append('\r'); position++; break;
+                        case 't': sb.Append('\t'); position++; break;
+                        case 'v': sb.Append('\v'); position++; break;
+                        case 'x':
+                        {
+                            position++;
+                            bool hexErr = false;
+                            sb.Append(ReadHexEscape(start, minDigits: 1, maxDigits: 4, ref hexErr));
+                            break;
+                        }
+
+                        case 'u':
+                        {
+                            position++;
+                            bool hexErr = false;
+                            sb.Append(ReadHexEscape(start, minDigits: 4, maxDigits: 4, ref hexErr));
+                            break;
+                        }
+
+                        case 'U':
+                        {
+                            position++;
+                            bool hexErr = false;
+                            sb.Append(ReadLongUnicodeEscape(start, ref hexErr));
+                            break;
+                        }
+
+                        default:
+                        {
+                            var escLoc = new TextLocation(this.text, new TextSpan(position - 1, 2));
+                            Diagnostics.ReportInvalidStringEscape(escLoc, Current);
+                            if (Current != '\0' && Current != '\r' && Current != '\n' && Current != '"')
+                            {
+                                sb.Append(Current);
+                                position++;
+                            }
+
+                            break;
+                        }
                     }
 
                     break;
@@ -842,8 +888,8 @@ public sealed class Lexer
 
     /// <summary>
     /// Skips a nested string or character literal inside an interpolation hole.
-    /// Mirrors the real literal lexers: a double-quoted string escapes a quote
-    /// via <c>""</c> (no backslash escapes) and may itself contain a nested
+    /// Mirrors the real literal lexers: a double-quoted string uses backslash
+    /// escapes (<c>\"</c>) and may itself contain a nested
     /// <c>${ … }</c> interpolation; a single-quoted char literal uses backslash
     /// escapes. <see cref="position"/> starts on the opening delimiter.
     /// </summary>
@@ -855,14 +901,14 @@ public sealed class Lexer
         {
             while (Current != '\0' && Current != '\r' && Current != '\n')
             {
+                if (Current == '\\' && Lookahead != '\0')
+                {
+                    position += 2; // skip escaped character
+                    continue;
+                }
+
                 if (Current == '"')
                 {
-                    if (Lookahead == '"')
-                    {
-                        position += 2; // escaped quote ""
-                        continue;
-                    }
-
                     position++; // closing quote
                     return;
                 }

--- a/test/Compiler.Tests/Emit/StringEscapeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/StringEscapeEmitTests.cs
@@ -1,0 +1,196 @@
+// <copyright file="StringEscapeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #531: end-to-end emit-and-execute coverage for backslash escape
+/// sequences in double-quoted string literals.
+/// </summary>
+public class StringEscapeEmitTests
+{
+    [Fact]
+    public void Newline_Escape_ProducesLength3()
+    {
+        var source = """
+            package P
+            import System
+
+            let s = "a\nb"
+            Console.WriteLine(s.Length)
+            """;
+
+        Assert.Equal("3\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Tab_Escape_ProducesTab()
+    {
+        var source = """
+            package P
+            import System
+
+            let s = "a\tb"
+            Console.WriteLine(s)
+            """;
+
+        Assert.Equal("a\tb\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Unicode_Escape_ProducesCharacter()
+    {
+        var source = """
+            package P
+            import System
+
+            let s = "\u00e9"
+            Console.WriteLine(s)
+            """;
+
+        Assert.Equal("\u00e9\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Backslash_Escape_ProducesLiteral()
+    {
+        var source = """
+            package P
+            import System
+
+            let s = "a\\b"
+            Console.WriteLine(s.Length)
+            """;
+
+        Assert.Equal("3\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Quote_Escape_ProducesQuote()
+    {
+        var source = """
+            package P
+            import System
+
+            let s = "say \"hi\""
+            Console.WriteLine(s)
+            """;
+
+        Assert.Equal("say \"hi\"\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Hex_Escape_ProducesCharacter()
+    {
+        var source = """
+            package P
+            import System
+
+            let s = "\x41"
+            Console.WriteLine(s)
+            """;
+
+        Assert.Equal("A\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void RawString_DoesNotProcessEscapes()
+    {
+        var source = """
+            package P
+            import System
+
+            let s = `a\nb`
+            Console.WriteLine(s.Length)
+            """;
+
+        Assert.Equal("4\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InterpolatedString_EscapesInLiteralSegment()
+    {
+        var source = """
+            package P
+            import System
+
+            let x = 42
+            let s = "val:\t${x}\n"
+            Console.WriteLine(s.Length)
+            """;
+
+        // "val:\t" = 5 chars + "42" = 2 chars + "\n" = 1 char = 8
+        Assert.Equal("8\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_str_esc_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System.Collections.Immutable;
 using System.Linq;
 using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
@@ -318,5 +319,81 @@ public class LexerTests
         var tokens = SyntaxTree.ParseTokens("// this is a comment\nx");
         Assert.Contains(tokens, t => t.Kind == SyntaxKind.CommentToken);
         Assert.Contains(tokens, t => t.Kind == SyntaxKind.IdentifierToken && t.Text == "x");
+    }
+
+    [Theory]
+    [InlineData("\"a\\nb\"", "a\nb")]
+    [InlineData("\"a\\rb\"", "a\rb")]
+    [InlineData("\"a\\tb\"", "a\tb")]
+    [InlineData("\"a\\\\b\"", "a\\b")]
+    [InlineData("\"a\\\"b\"", "a\"b")]
+    [InlineData("\"a\\'b\"", "a'b")]
+    [InlineData("\"a\\0b\"", "a\0b")]
+    [InlineData("\"a\\ab\"", "a\ab")]
+    [InlineData("\"a\\bb\"", "a\bb")]
+    [InlineData("\"a\\fb\"", "a\fb")]
+    [InlineData("\"a\\vb\"", "a\vb")]
+    [InlineData("\"\\x41\"", "A")]
+    [InlineData("\"\\x041\"", "A")]
+    [InlineData("\"\\x0041\"", "A")]
+    [InlineData("\"\\x4\"", "\x4")]
+    [InlineData("\"\\u0041\"", "A")]
+    [InlineData("\"\\u00e9\"", "\u00e9")]
+    [InlineData("\"\\U00000041\"", "A")]
+    public void Lexes_StringEscapeSequence(string text, string expectedValue)
+    {
+        var tokens = SyntaxTree.ParseTokens(text, out var diagnostics);
+        var token = Assert.Single(tokens);
+        Assert.Empty(diagnostics);
+        Assert.Equal(SyntaxKind.StringToken, token.Kind);
+        Assert.Equal(expectedValue, token.Value);
+    }
+
+    [Fact]
+    public void String_Escape_Newline_HasCorrectLength()
+    {
+        // Issue #531: "a\nb".Length == 3, not 4.
+        var tokens = SyntaxTree.ParseTokens("\"a\\nb\"", out var diagnostics);
+        var token = Assert.Single(tokens);
+        Assert.Empty(diagnostics);
+        Assert.Equal(3, ((string)token.Value).Length);
+    }
+
+    [Theory]
+    [InlineData("\"\\q\"", "Unrecognised escape")]
+    [InlineData("\"\\z\"", "Unrecognised escape")]
+    [InlineData("\"\\u41\"", "Malformed Unicode escape")]
+    [InlineData("\"\\U00110000\"", "Malformed Unicode escape")]
+    public void Invalid_StringEscape_ReportsDiagnostic(string text, string expectedFragment)
+    {
+        SyntaxTree.ParseTokens(text, out var diagnostics);
+        Assert.Contains(diagnostics, d => d.Message.Contains(expectedFragment, System.StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("`no \\n escapes here`", "no \\n escapes here")]
+    [InlineData("`a\\tb`", "a\\tb")]
+    [InlineData("`\\\\`", "\\\\")]
+    public void RawString_DoesNotProcessEscapes(string text, string expectedValue)
+    {
+        var tokens = SyntaxTree.ParseTokens(text, out var diagnostics);
+        var token = Assert.Single(tokens);
+        Assert.Empty(diagnostics);
+        Assert.Equal(SyntaxKind.StringToken, token.Kind);
+        Assert.Equal(expectedValue, token.Value);
+    }
+
+    [Fact]
+    public void InterpolatedString_ProcessesEscapesInLiteralSegments()
+    {
+        // "hello\\n$name" should have the literal segment "hello\n" with an actual newline.
+        var tokens = SyntaxTree.ParseTokens("\"hello\\n$name\"", out var diagnostics);
+        var token = Assert.Single(tokens);
+        Assert.Empty(diagnostics);
+        Assert.Equal(SyntaxKind.InterpolatedStringToken, token.Kind);
+        var fragments = (ImmutableArray<InterpolationFragment>)token.Value;
+        Assert.Equal(2, fragments.Length);
+        Assert.False(fragments[0].IsExpression);
+        Assert.Equal("hello\n", fragments[0].Text);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #531 — double-quoted string literals now interpret backslash escape sequences (C#/Go style).

## Breaking spec change

This is a **breaking change**: interpreted `"…"` strings previously treated backslash as a literal character (and used `""` to embed a quote). They now process the following escapes:

| Escape | Value |
| ------ | ----- |
| `\\` | backslash (U+005C) |
| `\"` | double quote (U+0022) |
| `'` | single quote (U+0027) |
| `\0` | NUL (U+0000) |
| `\a` | BEL (U+0007) |
| `\b` | BS (U+0008) |
| `\f` | FF (U+000C) |
| `\n` | LF (U+000A) |
| `\r` | CR (U+000D) |
| `\t` | HT (U+0009) |
| `\v` | VT (U+000B) |
| `\xH…HHHH` | 1–4 hex digit code point |
| `\uHHHH` | exactly 4 hex digits |
| `\UHHHHHHHH` | exactly 8 hex digits (≤ U+FFFF) |

Raw backtick strings (`` `…` ``) remain verbatim — no escape processing.

## Diagnostic for unknown escapes

**GS0269**: `Unrecognised escape sequence X in string literal.` — emitted for any `\<char>` that is not in the recognized set. This replaces the old silent pass-through behaviour that was the core footgun.

## Migration sweep

Scanned all `.gs` files in `samples/` and test fixtures:
- `samples/RawString.gs` — uses backtick raw string, unaffected.
- `samples/Exceptions.gs`, `samples/Defer.gs` — use `""` (empty string), unaffected (just open+close quote with no content).
- No existing G# source file uses backslash-based content in double-quoted strings that would change meaning.

## Tests added

**Lexer tests** (`test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs`):
- `Lexes_StringEscapeSequence` — 17 Theory cases covering `\n`, `\r`, `\t`, `\\`, `\"`, `'`, `\0`, `\a`, `\b`, `\f`, `\v`, `\x`, `\u`, `\U`
- `String_Escape_Newline_HasCorrectLength` — verifies `"a\nb".Length == 3`
- `Invalid_StringEscape_ReportsDiagnostic` — 4 Theory cases: `\q`, `\z`, short `\u`, out-of-range `\U`
- `RawString_DoesNotProcessEscapes` — 3 regression guard cases
- `InterpolatedString_ProcessesEscapesInLiteralSegments` — validates escape in literal portion between holes

**Emit tests** (`test/Compiler.Tests/Emit/StringEscapeEmitTests.cs`):
- 8 end-to-end compile+IlVerify+execute tests: newline length, tab output, unicode char, backslash length, embedded quote, hex escape, raw string regression, interpolated string with escapes

## Files modified

- `src/Core/CodeAnalysis/Syntax/Lexer.cs` — escape processing in `ReadString()`, updated `SkipInterpolationNestedLiteral`
- `src/Core/CodeAnalysis/DiagnosticBag.cs` — added `ReportInvalidStringEscape` (GS0269)
- `docs/lexical.md` — expanded string literal section with escape table
- `docs/diagnostics.md` — added GS0269 entry
- `test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs` — 27 new test cases
- `test/Compiler.Tests/Emit/StringEscapeEmitTests.cs` — new file, 8 emit tests