### PR TITLE
Fix: nil literal can now be passed to nullable CLR parameters

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -12265,6 +12265,17 @@ public sealed class Binder
 
                 hasErrors = true;
             }
+            else if (argument.Type != expectedType
+                && expectedType is NullableTypeSymbol ntConv
+                && ntConv.UnderlyingType?.ClrType is { IsValueType: true })
+            {
+                // Issue #533: conversions to a value-type Nullable<T> parameter
+                // need explicit lowering:
+                // - nil → Nullable<T> becomes BoundDefaultExpression (initobj)
+                // - T → Nullable<T> becomes BoundConversionExpression (newobj ctor)
+                var argLoc = i < parameterSyntax.Length ? parameterSyntax[i].Location : syntax.Identifier.Location;
+                boundArguments[i] = BindConversion(argLoc, argument, expectedType);
+            }
         }
 
         // Phase 4.8: type-check trailing variadic arguments against the slice
@@ -12959,8 +12970,11 @@ public sealed class Binder
         for (var i = 0; i < boundArguments.Count; i++)
         {
             // Issue #530: use GetEffectiveArgumentClrType (see instance method path).
+            // Issue #533: allow null (nil literal) to flow through; overload
+            // resolution now handles null source as compatible with reference
+            // types and Nullable<T>.
             var t = GetEffectiveArgumentClrType(boundArguments[i].Type);
-            if (t == null)
+            if (t == null && boundArguments[i].Type != TypeSymbol.Null)
             {
                 argsAllTyped = false;
                 break;
@@ -14306,8 +14320,9 @@ public sealed class Binder
                 // Issue #530: use GetEffectiveArgumentClrType so that a
                 // nullable value type argument (e.g. `int32?`) is matched
                 // as `Nullable<T>` in overload resolution.
+                // Issue #533: allow null (nil literal) through.
                 var t = GetEffectiveArgumentClrType(arguments[i].Type);
-                if (t == null)
+                if (t == null && arguments[i].Type != TypeSymbol.Null)
                 {
                     argsAllTyped = false;
                     break;
@@ -14600,8 +14615,9 @@ public sealed class Binder
         for (var i = 0; i < arguments.Length; i++)
         {
             // Issue #530: use GetEffectiveArgumentClrType (see instance method path).
+            // Issue #533: allow null (nil literal) through.
             var t = GetEffectiveArgumentClrType(arguments[i].Type);
-            if (t == null)
+            if (t == null && arguments[i].Type != TypeSymbol.Null)
             {
                 return false;
             }
@@ -14860,8 +14876,9 @@ public sealed class Binder
         for (var i = 0; i < arguments.Length; i++)
         {
             // Issue #530: use GetEffectiveArgumentClrType (see instance method path).
+            // Issue #533: allow null (nil literal) through.
             var t = GetEffectiveArgumentClrType(arguments[i].Type);
-            if (t == null)
+            if (t == null && arguments[i].Type != TypeSymbol.Null)
             {
                 return false;
             }
@@ -17280,8 +17297,9 @@ public sealed class Binder
         for (var i = 0; i < boundArguments.Count; i++)
         {
             // Issue #530: use GetEffectiveArgumentClrType (see instance method path).
+            // Issue #533: allow null (nil literal) through.
             var t = GetEffectiveArgumentClrType(boundArguments[i].Type);
-            if (t == null)
+            if (t == null && boundArguments[i].Type != TypeSymbol.Null)
             {
                 argsAllTyped = false;
                 break;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -138,8 +138,33 @@ internal static class OverloadResolution
     /// <returns>The conversion classification.</returns>
     public static ImplicitConversionKind ClassifyImplicit(Type target, Type source)
     {
-        if (target is null || source is null)
+        if (target is null)
         {
+            return ImplicitConversionKind.None;
+        }
+
+        // Issue #533: a null source represents the `nil` literal in G#.
+        // `nil` is implicitly assignable to any reference type and to
+        // `Nullable<T>` (value-type nullable), mirroring C#'s null literal
+        // compatibility rules.
+        if (source is null)
+        {
+            // Peel by-ref for the target (ref/out/in parameter).
+            var t = target.IsByRef ? target.GetElementType()! : target;
+
+            // Nullable<T> (value-type nullable)
+            if (t.IsGenericType
+                && string.Equals(t.GetGenericTypeDefinition().FullName, "System.Nullable`1", StringComparison.Ordinal))
+            {
+                return ImplicitConversionKind.NullableWrap;
+            }
+
+            // Any reference type (class, interface, array, delegate, string)
+            if (!t.IsValueType)
+            {
+                return ImplicitConversionKind.Reference;
+            }
+
             return ImplicitConversionKind.None;
         }
 

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -167,8 +167,11 @@ public sealed class ImportedClassSymbol : Symbol
         {
             // Issue #530: use effective CLR type so nullable value types
             // (e.g. int32?) are matched as Nullable<T> in overload resolution.
+            // Issue #533: allow null (nil literal) through; overload resolution
+            // now classifies null source as compatible with reference types and
+            // Nullable<T>.
             var t = NullableTypeSymbol.GetEffectiveClrType(arguments[i].Type);
-            if (t == null)
+            if (t == null && arguments[i].Type != TypeSymbol.Null)
             {
                 return false;
             }

--- a/test/Compiler.Tests/Emit/Issue533NullToNullableParameterEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue533NullToNullableParameterEmitTests.cs
@@ -1,0 +1,330 @@
+// <copyright file="Issue533NullToNullableParameterEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #533: passing <c>nil</c> to a CLR method/constructor whose parameter
+/// is typed as <c>T?</c> (either nullable reference type like <c>string?</c>,
+/// or nullable value type like <c>int?</c>) produces GS0130. These tests verify
+/// that overload resolution now accepts <c>nil</c> for nullable parameters and
+/// that emit produces valid IL (verified via ilverify).
+/// </summary>
+public class Issue533NullToNullableParameterEmitTests
+{
+    [Fact]
+    public void Nil_To_CLR_Static_Method_StringParam()
+    {
+        // String.IsNullOrEmpty takes a `string?` parameter (NRT annotation
+        // on `string`). Passing nil must succeed.
+        var source = """
+            package P
+
+            import System
+
+            var result = String.IsNullOrEmpty(nil)
+            Console.WriteLine(result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void Nil_To_CLR_Constructor_StringParam()
+    {
+        // System.Uri constructor takes a `string` parameter. Passing nil
+        // should compile and emit valid IL (runtime will throw, but the
+        // binder and emitter should produce valid code).
+        // Instead, use StringBuilder(string?) which accepts null at runtime.
+        var source = """
+            package P
+
+            import System
+            import System.Text
+
+            var sb = StringBuilder(nil)
+            Console.WriteLine(sb.Length)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n", output);
+    }
+
+    [Fact]
+    public void Nil_To_User_Function_NullableInt_Param()
+    {
+        // A G# function taking Nullable[int32], called with nil directly.
+        var source = """
+            package P
+
+            import System
+
+            func check(n Nullable[int32]) {
+                Console.WriteLine(n.HasValue)
+            }
+
+            check(nil)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("False\n", output);
+    }
+
+    [Fact]
+    public void Nil_To_User_Function_NullableString_Param()
+    {
+        // A G# function taking string?, called with nil directly.
+        var source = """
+            package P
+
+            import System
+
+            func check(s string?) {
+                Console.WriteLine(s == nil)
+            }
+
+            check(nil)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void Nil_To_CLR_Class_Constructor_NullableValueType()
+    {
+        // Pass nil to a G# class constructor that takes an int32? parameter.
+        // This exercises the CLR constructor overload resolution path.
+        var source = """
+            package P
+
+            import System
+
+            type Box class {
+                Value int32?
+
+                init(v int32?) {
+                    Value = v
+                }
+            }
+
+            var b = Box(nil)
+            Console.WriteLine(b.Value.HasValue)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("False\n", output);
+    }
+
+    [Fact]
+    public void Nil_To_CLR_Class_Constructor_NullableRefType()
+    {
+        // Pass nil to a G# class constructor that takes a string? parameter.
+        var source = """
+            package P
+
+            import System
+
+            type Wrapper class {
+                Text string?
+
+                init(t string?) {
+                    Text = t
+                }
+            }
+
+            var w = Wrapper(nil)
+            Console.WriteLine(w.Text == nil)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void Nil_To_CLR_Instance_Method_StringParam()
+    {
+        // List<string>.Contains takes a `string?` / `string` parameter.
+        // Passing nil should compile and emit valid IL.
+        var source = """
+            package P
+
+            import System
+            import System.Collections.Generic
+
+            var xs = List[string]()
+            xs.Add("hello")
+            var result = xs.Contains(nil)
+            Console.WriteLine(result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("False\n", output);
+    }
+
+    [Fact]
+    public void Concrete_String_Value_Still_Works()
+    {
+        // Regression: passing a non-nil string to String.IsNullOrEmpty.
+        var source = """
+            package P
+
+            import System
+
+            var result = String.IsNullOrEmpty("hello")
+            Console.WriteLine(result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("False\n", output);
+    }
+
+    [Fact]
+    public void Concrete_NullableInt_Value_Still_Works()
+    {
+        // Regression: passing a concrete int to a Nullable[int32] parameter.
+        var source = """
+            package P
+
+            import System
+
+            func check(n Nullable[int32]) {
+                Console.WriteLine(n.HasValue)
+                Console.WriteLine(n.GetValueOrDefault())
+            }
+
+            check(42)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n42\n", output);
+    }
+
+    [Fact]
+    public void Task_Of_NullableInt_Regression_From_Issue530()
+    {
+        // Regression guard: the existing Task<int?> path from #530 still works.
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            let t = Task.FromResult[int32?](99)
+            let r = t.Result
+            Console.WriteLine(r)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_533_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}


### PR DESCRIPTION
## Summary

Fixes #533 — `nil` can now be passed as an argument to any CLR method/constructor parameter typed `string?`, `int?`, or any `Nullable<T>`.

## Root cause

The overload resolver rejected `nil` (`TypeSymbol.Null`) because:

1. `ClassifyImplicit` returned `None` when the source CLR type was `null` (nil has no CLR type).
2. All five `argTypes` construction sites in `Binder.cs` (and one in `ImportedClassSymbol.cs`) bailed out entirely when `GetEffectiveArgumentClrType` returned `null`.
3. The user-function call path never lowered nil to `BoundDefaultExpression` for value-type `Nullable<T>` targets → invalid IL.

## Fix

| File | Change |
|------|--------|
| `OverloadResolution.cs` | `ClassifyImplicit`: null source → Reference (ref types) / NullableWrap (`Nullable<T>`) |
| `Binder.cs` (5 sites) | Allow null entries in argTypes for `TypeSymbol.Null` arguments |
| `ImportedClassSymbol.cs` | Same null-allowing fix for static method resolution |
| `Binder.cs` (user func path) | Lower nil → `BoundDefaultExpression` for `Nullable<T>` params (correct `initobj` IL) |

## Tests added

`Issue533NullToNullableParameterEmitTests.cs` — 10 tests:
- nil → `string` CLR static method (`String.IsNullOrEmpty`)
- nil → `string?` CLR constructor
- nil → `Nullable<int>` user function
- nil → `string?` user function
- nil → `int?` class constructor
- nil → `string?` class constructor
- nil → `string` CLR instance method
- Concrete `string` regression (still works)
- Concrete `int?` regression (still works)
- `Task<int?>` regression from #530

## Verification

- All 334 Compiler.Tests pass ✅
- All 2023 Core.Tests pass ✅
- All 72 Interpreter.Tests pass ✅
- All 226 LanguageServer.Tests pass ✅
- ilverify passes on all emitted assemblies ✅
