### PR TITLE
Fix hover for @ attribute annotations

### DIFF
--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -100,7 +100,11 @@ public static class HoverComputer
             return null;
         }
 
-        var clrType = SemanticLookup.ResolveImportedClrType(tree, compilation, token.Text);
+        var clrType = SemanticLookup.ResolveImportedClrType(
+            tree,
+            compilation,
+            token.Text,
+            includeAttributeSuffixFallback: IsAnnotationNameToken(tree.Root, token));
         if (clrType != null)
         {
             var signature = SymbolDisplay.ToDisplayString(clrType, SymbolDisplayFormat.Hover);
@@ -134,6 +138,27 @@ public static class HoverComputer
                 overloadCount),
             _ => null,
         };
+    }
+
+    private static bool IsAnnotationNameToken(SyntaxNode root, SyntaxToken token)
+    {
+        if (token == null || token.Kind != SyntaxKind.IdentifierToken)
+        {
+            return false;
+        }
+
+        foreach (var annotation in FindNodes<AnnotationSyntax>(root))
+        {
+            foreach (var segment in annotation.NameSegments)
+            {
+                if (MatchesToken(segment, token))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private static HoverModel BuildLiteralModel(SyntaxToken token)

--- a/src/LanguageServer/SemanticLookup.cs
+++ b/src/LanguageServer/SemanticLookup.cs
@@ -150,8 +150,16 @@ public static class SemanticLookup
     /// <param name="tree">The syntax tree providing import context.</param>
     /// <param name="compilation">The compilation supplying the reference resolver.</param>
     /// <param name="name">The simple or aliased type name to resolve.</param>
+    /// <param name="includeAttributeSuffixFallback">
+    /// When <see langword="true"/>, also tries the C#-style
+    /// <c>&lt;name&gt;Attribute</c> fallback (used for annotation hover, e.g. <c>@Obsolete</c>).
+    /// </param>
     /// <returns>The resolved CLR type, or <c>null</c> when no match is found.</returns>
-    public static Type ResolveImportedClrType(SyntaxTree tree, Compilation compilation, string name)
+    public static Type ResolveImportedClrType(
+        SyntaxTree tree,
+        Compilation compilation,
+        string name,
+        bool includeAttributeSuffixFallback = false)
     {
         if (string.IsNullOrEmpty(name))
         {
@@ -164,6 +172,17 @@ public static class SemanticLookup
             if (resolver.TryResolveType(candidate, out var type))
             {
                 return type;
+            }
+        }
+
+        if (includeAttributeSuffixFallback && !name.EndsWith("Attribute", StringComparison.Ordinal))
+        {
+            foreach (var candidate in GetCandidateTypeNames(tree, name + "Attribute"))
+            {
+                if (resolver.TryResolveType(candidate, out var type))
+                {
+                    return type;
+                }
             }
         }
 

--- a/test/LanguageServer.Tests/HoverHandlerTests.cs
+++ b/test/LanguageServer.Tests/HoverHandlerTests.cs
@@ -215,6 +215,19 @@ public class HoverHandlerTests
     }
 
     [Fact]
+    public void ComputeHover_ResolvesAnnotationName_WithAttributeSuffixFallback()
+    {
+        const string source = "@Obsolete(\"Use NewApi\")\nfunc OldApi() { }\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "Obsolete"));
+
+        Assert.NotNull(hover);
+        var value = hover.Contents.ToString();
+        Assert.Contains("ObsoleteAttribute", value, System.StringComparison.Ordinal);
+        Assert.Contains("System", value, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void AssemblyDocumentationProvider_ResolvesClrMemberDocsFromReferencePack()
     {
         var resolver = CreateReferencePackResolver();


### PR DESCRIPTION
## Summary
- fix hover over annotation identifiers (e.g. `@Obsolete`) by enabling C#-style `Foo`/`FooAttribute` lookup when hovering annotation name tokens
- keep regular CLR type/member hover behavior unchanged for non-annotation identifiers
- add a regression test covering `@Obsolete` hover resolution

## Validation
- `dotnet build GSharp.sln -nologo -clp:NoSummary`
- `dotnet test test/LanguageServer.Tests/LanguageServer.Tests.csproj --no-restore --nologo --filter "FullyQualifiedName~HoverHandlerTests.ComputeHover_ResolvesAnnotationName_WithAttributeSuffixFallback|FullyQualifiedName~HoverHandlerTests.ComputeHover_RendersImportedClrMethodDocumentation"`
- `dotnet test test/LanguageServer.Tests/LanguageServer.Tests.csproj --no-restore --nologo --filter "FullyQualifiedName~HoverHandlerTests"`