### PR TITLE
Support bitwise operators on CLR enum types

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -114,6 +114,24 @@ public sealed class BoundBinaryOperator
             return new BoundBinaryOperator(syntaxKind, enumKind, leftType, rightType, TypeSymbol.Bool);
         }
 
+        // Issue #534: bitwise |, &, ^ on same-type enum values.
+        // Both user-defined (EnumSymbol) and imported CLR enum types are
+        // supported. The result type is the enum type itself (matching C#
+        // §11.10.5). The IL is the same as for the underlying integer —
+        // enums are represented as their underlying int on the eval stack.
+        if ((syntaxKind == SyntaxKind.PipeToken || syntaxKind == SyntaxKind.AmpersandToken || syntaxKind == SyntaxKind.HatToken)
+            && leftType != null && leftType == rightType
+            && IsEnumType(leftType))
+        {
+            var bitwiseKind = syntaxKind switch
+            {
+                SyntaxKind.PipeToken => BoundBinaryOperatorKind.BitwiseOr,
+                SyntaxKind.AmpersandToken => BoundBinaryOperatorKind.BitwiseAnd,
+                _ => BoundBinaryOperatorKind.BitwiseXor,
+            };
+            return new BoundBinaryOperator(syntaxKind, bitwiseKind, leftType, rightType, leftType);
+        }
+
         // Phase 3.B.2 / ADR-0029 + ADR-0033: structural == / != on data and inline struct values.
         if (leftType is StructSymbol ls && rightType is StructSymbol rs && ls == rs && (ls.IsData || ls.IsInline))
         {
@@ -248,5 +266,21 @@ public sealed class BoundBinaryOperator
         list.Add(new BoundBinaryOperator(SyntaxKind.LessOrEqualsToken, BoundBinaryOperatorKind.LessOrEquals, t, t, TypeSymbol.Bool));
         list.Add(new BoundBinaryOperator(SyntaxKind.GreaterToken, BoundBinaryOperatorKind.Greater, t, t, TypeSymbol.Bool));
         list.Add(new BoundBinaryOperator(SyntaxKind.GreaterOrEqualsToken, BoundBinaryOperatorKind.GreaterOrEquals, t, t, TypeSymbol.Bool));
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="type"/> represents an enum
+    /// type — either a user-defined <see cref="EnumSymbol"/> or an imported
+    /// CLR enum (<see cref="ImportedTypeSymbol"/> whose <see cref="TypeSymbol.ClrType"/>
+    /// is an enum).
+    /// </summary>
+    private static bool IsEnumType(TypeSymbol type)
+    {
+        if (type is EnumSymbol)
+        {
+            return true;
+        }
+
+        return type?.ClrType != null && type.ClrType.IsEnum;
     }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundUnaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundUnaryOperator.cs
@@ -73,6 +73,13 @@ public sealed class BoundUnaryOperator
             }
         }
 
+        // Issue #534: ^ (ones complement) on enum values (CLR or user-defined).
+        // The result type is the enum type itself (matching C# §11.10.5).
+        if (syntaxKind == SyntaxKind.HatToken && IsEnumType(operandType))
+        {
+            return new BoundUnaryOperator(syntaxKind, BoundUnaryOperatorKind.OnesComplement, operandType);
+        }
+
         return null;
     }
 
@@ -113,5 +120,20 @@ public sealed class BoundUnaryOperator
         }
 
         return list.ToArray();
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="type"/> represents an enum
+    /// type — either a user-defined <see cref="EnumSymbol"/> or an imported
+    /// CLR enum.
+    /// </summary>
+    private static bool IsEnumType(TypeSymbol type)
+    {
+        if (type is EnumSymbol)
+        {
+            return true;
+        }
+
+        return type?.ClrType != null && type.ClrType.IsEnum;
     }
 }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -13678,23 +13678,7 @@ internal sealed class ReflectionMetadataEmitter
             if (u.Op.Kind == BoundUnaryOperatorKind.OnesComplement
                 || u.Op.Kind == BoundUnaryOperatorKind.Negation)
             {
-                var t = u.Op.Type;
-                if (t == TypeSymbol.Int8)
-                {
-                    this.il.OpCode(ILOpCode.Conv_i1);
-                }
-                else if (t == TypeSymbol.UInt8)
-                {
-                    this.il.OpCode(ILOpCode.Conv_u1);
-                }
-                else if (t == TypeSymbol.Int16)
-                {
-                    this.il.OpCode(ILOpCode.Conv_i2);
-                }
-                else if (t == TypeSymbol.UInt16 || t == TypeSymbol.Char)
-                {
-                    this.il.OpCode(ILOpCode.Conv_u2);
-                }
+                EmitSubI4Truncation(u.Op.Type);
             }
         }
 
@@ -14001,6 +13985,9 @@ internal sealed class ReflectionMetadataEmitter
             // opcodes on sub-i4 operands produce an i4 result that is not
             // truncated to the operand's natural width. For correctness of
             // sbyte/byte/short/ushort/char result types, narrow back.
+            //
+            // Issue #534: enum types whose underlying CLR type is sub-i4
+            // (e.g., a byte-backed [Flags] enum) need the same truncation.
             switch (kind)
             {
                 case BoundBinaryOperatorKind.Sum:
@@ -14014,23 +14001,7 @@ internal sealed class ReflectionMetadataEmitter
                 case BoundBinaryOperatorKind.BitwiseOr:
                 case BoundBinaryOperatorKind.BitwiseXor:
                 case BoundBinaryOperatorKind.BitClear:
-                    if (resultType == TypeSymbol.Int8)
-                    {
-                        this.il.OpCode(ILOpCode.Conv_i1);
-                    }
-                    else if (resultType == TypeSymbol.UInt8)
-                    {
-                        this.il.OpCode(ILOpCode.Conv_u1);
-                    }
-                    else if (resultType == TypeSymbol.Int16)
-                    {
-                        this.il.OpCode(ILOpCode.Conv_i2);
-                    }
-                    else if (resultType == TypeSymbol.UInt16 || resultType == TypeSymbol.Char)
-                    {
-                        this.il.OpCode(ILOpCode.Conv_u2);
-                    }
-
+                    EmitSubI4Truncation(resultType);
                     break;
             }
         }
@@ -14043,6 +14014,58 @@ internal sealed class ReflectionMetadataEmitter
                 || t == TypeSymbol.UInt64
                 || t == TypeSymbol.NUInt
                 || t == TypeSymbol.Char;
+        }
+
+        /// <summary>
+        /// Issue #534: emits a conv.i1 / conv.u1 / conv.i2 / conv.u2
+        /// truncation instruction when <paramref name="resultType"/> is a
+        /// sub-i4 primitive <em>or</em> a CLR enum whose underlying type is
+        /// sub-i4. This keeps the evaluation-stack value in the correct range
+        /// after arithmetic, bitwise, or shift opcodes that always produce
+        /// an i4 result.
+        /// </summary>
+        private void EmitSubI4Truncation(TypeSymbol resultType)
+        {
+            // Fast path: check built-in primitive types first.
+            if (resultType == TypeSymbol.Int8)
+            {
+                this.il.OpCode(ILOpCode.Conv_i1);
+            }
+            else if (resultType == TypeSymbol.UInt8)
+            {
+                this.il.OpCode(ILOpCode.Conv_u1);
+            }
+            else if (resultType == TypeSymbol.Int16)
+            {
+                this.il.OpCode(ILOpCode.Conv_i2);
+            }
+            else if (resultType == TypeSymbol.UInt16 || resultType == TypeSymbol.Char)
+            {
+                this.il.OpCode(ILOpCode.Conv_u2);
+            }
+            else if (resultType?.ClrType != null && resultType.ClrType.IsEnum)
+            {
+                // Resolve the enum's underlying integral type and truncate
+                // if it is narrower than i4.
+                var underlying = System.Enum.GetUnderlyingType(resultType.ClrType);
+                var underlyingFull = underlying.FullName;
+                if (underlyingFull == "System.SByte")
+                {
+                    this.il.OpCode(ILOpCode.Conv_i1);
+                }
+                else if (underlyingFull == "System.Byte")
+                {
+                    this.il.OpCode(ILOpCode.Conv_u1);
+                }
+                else if (underlyingFull == "System.Int16")
+                {
+                    this.il.OpCode(ILOpCode.Conv_i2);
+                }
+                else if (underlyingFull == "System.UInt16")
+                {
+                    this.il.OpCode(ILOpCode.Conv_u2);
+                }
+            }
         }
 
         // Issue #421 (P2-2): IL `shl`/`shr`/`shr_un` mask the shift count to

--- a/test/Compiler.Tests/Emit/Issue534EnumBitwiseEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue534EnumBitwiseEmitTests.cs
@@ -1,0 +1,575 @@
+// <copyright file="Issue534EnumBitwiseEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #534: bitwise operators |, &amp;, ^, and unary ^ (ones complement)
+/// must be defined for CLR enum types. Tests cover imported BCL enums
+/// (FileShare, FileAccess, RegexOptions, UnixFileMode), a user-defined C#
+/// probe enum with [Flags] and long underlying type, regression guards for
+/// existing int32/bool operators, and negative tests for mixed-enum and
+/// enum+int operand combinations.
+/// </summary>
+public class Issue534EnumBitwiseEmitTests
+{
+    // ── Positive: CLR enum bitwise OR ────────────────────────────────
+
+    [Fact]
+    public void FileShare_BitwiseOr_ProducesCorrectValue()
+    {
+        var source = """
+            package P
+            import System
+            import System.IO
+
+            var mode = FileShare.ReadWrite | FileShare.Delete
+            Console.WriteLine(int32(mode))
+            """;
+
+        // FileShare.ReadWrite = 3, FileShare.Delete = 4 → 3 | 4 = 7
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    // ── Positive: CLR enum bitwise AND ───────────────────────────────
+
+    [Fact]
+    public void FileAccess_BitwiseAnd_ProducesCorrectValue()
+    {
+        var source = """
+            package P
+            import System
+            import System.IO
+
+            var result = FileAccess.Read & FileAccess.ReadWrite
+            Console.WriteLine(int32(result))
+            """;
+
+        // FileAccess.Read = 1, FileAccess.ReadWrite = 3 → 1 & 3 = 1
+        Assert.Equal("1\n", CompileAndRun(source));
+    }
+
+    // ── Positive: CLR enum bitwise XOR ───────────────────────────────
+
+    [Fact]
+    public void RegexOptions_BitwiseXor_ProducesCorrectValue()
+    {
+        var source = """
+            package P
+            import System
+            import System.Text.RegularExpressions
+
+            var result = RegexOptions.IgnoreCase ^ RegexOptions.Multiline
+            Console.WriteLine(int32(result))
+            """;
+
+        // RegexOptions.IgnoreCase = 1, RegexOptions.Multiline = 2 → 1 ^ 2 = 3
+        Assert.Equal("3\n", CompileAndRun(source));
+    }
+
+    // ── Positive: CLR enum unary complement ──────────────────────────
+
+    [Fact]
+    public void FileShare_UnaryComplement_ProducesCorrectValue()
+    {
+        var source = """
+            package P
+            import System
+            import System.IO
+
+            var result = ^FileShare.None
+            Console.WriteLine(int32(result))
+            """;
+
+        // FileShare.None = 0 → ~0 = -1
+        Assert.Equal("-1\n", CompileAndRun(source));
+    }
+
+    // ── Positive: UnixFileMode (also int32-backed, different enum) ───
+
+    [Fact]
+    public void UnixFileMode_BitwiseOr_ProducesCorrectValue()
+    {
+        var source = """
+            package P
+            import System
+            import System.IO
+
+            var mode = UnixFileMode.UserRead | UnixFileMode.UserWrite
+            Console.WriteLine(int32(mode))
+            """;
+
+        // UnixFileMode.UserRead = 256, UnixFileMode.UserWrite = 128 → 256 | 128 = 384
+        Assert.Equal("384\n", CompileAndRun(source));
+    }
+
+    // ── Positive: user-defined C# probe enum with [Flags] : long ────
+
+    [Fact]
+    public void LongBackedFlagsEnum_BitwiseOr_ProducesCorrectValue()
+    {
+        var csSource = """
+            using System;
+
+            namespace Probe534
+            {
+                [Flags]
+                public enum LargeFlags : long
+                {
+                    None = 0,
+                    Alpha = 1L,
+                    Beta  = 2L,
+                    Gamma = 4L,
+                    Big   = 1L << 40,
+                }
+            }
+            """;
+
+        var gsSource = """
+            package P
+            import System
+            import Probe534
+
+            var combined = LargeFlags.Alpha | LargeFlags.Big
+            Console.WriteLine(int64(combined))
+            """;
+
+        // Alpha = 1, Big = 1 << 40 = 1099511627776 → 1 | 1099511627776 = 1099511627777
+        Assert.Equal("1099511627777\n", CompileAndRunWithSiblingCs(csSource, gsSource, "Probe534"));
+    }
+
+    [Fact]
+    public void LongBackedFlagsEnum_BitwiseAnd_ProducesCorrectValue()
+    {
+        var csSource = """
+            using System;
+
+            namespace Probe534
+            {
+                [Flags]
+                public enum LargeFlags : long
+                {
+                    None = 0,
+                    Alpha = 1L,
+                    Beta  = 2L,
+                    Gamma = 4L,
+                    Big   = 1L << 40,
+                }
+            }
+            """;
+
+        var gsSource = """
+            package P
+            import System
+            import Probe534
+
+            var all = LargeFlags.Alpha | LargeFlags.Beta | LargeFlags.Gamma
+            var mask = LargeFlags.Alpha | LargeFlags.Gamma
+            var result = all & mask
+            Console.WriteLine(int64(result))
+            """;
+
+        // all = 7, mask = 5 → 7 & 5 = 5
+        Assert.Equal("5\n", CompileAndRunWithSiblingCs(csSource, gsSource, "Probe534"));
+    }
+
+    [Fact]
+    public void LongBackedFlagsEnum_UnaryComplement_ProducesCorrectValue()
+    {
+        var csSource = """
+            using System;
+
+            namespace Probe534
+            {
+                [Flags]
+                public enum LargeFlags : long
+                {
+                    None = 0,
+                    Alpha = 1L,
+                    Beta  = 2L,
+                    Gamma = 4L,
+                    Big   = 1L << 40,
+                }
+            }
+            """;
+
+        var gsSource = """
+            package P
+            import System
+            import Probe534
+
+            var result = ^LargeFlags.None
+            Console.WriteLine(int64(result))
+            """;
+
+        // ~0L = -1
+        Assert.Equal("-1\n", CompileAndRunWithSiblingCs(csSource, gsSource, "Probe534"));
+    }
+
+    // ── Positive: byte-backed enum to exercise sub-i4 truncation ─────
+
+    [Fact]
+    public void ByteBackedEnum_BitwiseOr_ProducesCorrectValue()
+    {
+        var csSource = """
+            using System;
+
+            namespace Probe534
+            {
+                [Flags]
+                public enum SmallFlags : byte
+                {
+                    None = 0,
+                    A = 1,
+                    B = 2,
+                    C = 4,
+                }
+            }
+            """;
+
+        var gsSource = """
+            package P
+            import System
+            import Probe534
+
+            var combined = SmallFlags.A | SmallFlags.C
+            Console.WriteLine(int32(combined))
+            """;
+
+        // A = 1, C = 4 → 1 | 4 = 5
+        Assert.Equal("5\n", CompileAndRunWithSiblingCs(csSource, gsSource, "Probe534"));
+    }
+
+    // ── Regression: int32 | int32 still works ────────────────────────
+
+    [Fact]
+    public void Int32_BitwiseOr_StillWorks()
+    {
+        var source = """
+            package P
+            import System
+
+            Console.WriteLine(3 | 4)
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    // ── Regression: bool | bool still works ──────────────────────────
+
+    [Fact]
+    public void Bool_BitwiseOr_StillWorks()
+    {
+        var source = """
+            package P
+            import System
+
+            let a = true
+            let b = false
+            Console.WriteLine(a | b)
+            """;
+
+        Assert.Equal("True\n", CompileAndRun(source));
+    }
+
+    // ── Negative: mixed enum types → diagnostic ──────────────────────
+
+    [Fact]
+    public void MixedEnumTypes_BitwiseOr_ProducesDiagnostic()
+    {
+        var source = """
+            package P
+            import System
+            import System.IO
+
+            var bad = FileShare.Read | FileAccess.Read
+            """;
+
+        var diagnostics = CompileExpectingErrors(source);
+        Assert.Contains(diagnostics, d => d.Contains("'|'") && d.Contains("FileShare") && d.Contains("FileAccess"));
+    }
+
+    // ── Negative: enum + integer → diagnostic ────────────────────────
+
+    [Fact]
+    public void Enum_BitwiseOr_WithInt_ProducesDiagnostic()
+    {
+        var source = """
+            package P
+            import System
+            import System.IO
+
+            var bad = FileShare.Read | 1
+            """;
+
+        var diagnostics = CompileExpectingErrors(source);
+        Assert.Contains(diagnostics, d => d.Contains("'|'") && d.Contains("FileShare"));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue534_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static List<string> CompileExpectingErrors(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue534_neg_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:library",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit != 0, "expected gsc to report errors but it succeeded");
+
+            var combined = compileOut.ToString() + compileErr.ToString();
+            return combined.Split('\n').Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue534_sib_").FullName;
+        try
+        {
+            // Step 1: compile the sibling C# library.
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            // Step 2: compile the G# code referencing the sibling.
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            File.Copy(siblingDll, Path.Combine(tempDir, Path.GetFileName(siblingDll)), overwrite: true);
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { siblingDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string BuildCsProject(string csDir, string siblingName)
+    {
+        RunDotnet(csDir, "restore");
+        RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+
+        var dll = Path.Combine(csDir, "bin", "Release", "net10.0", siblingName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static void RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `|`, `&`, `^` (binary) and `^` (unary complement) for CLR enum types, matching C# §11.10.5 semantics. Both imported CLR enums (e.g. `FileShare`, `RegexOptions`) and user-defined GSharp enums are supported.

## Changes

- **BoundBinaryOperator.Bind**: recognize `|`, `&`, `^` when both operands are the same enum type (`EnumSymbol` or `ImportedTypeSymbol` with `IsEnum`). Result type is the enum type itself.
- **BoundUnaryOperator.Bind**: recognize `^` (ones complement) on enum types. Result type is the enum type itself.
- **ReflectionMetadataEmitter**: refactor sub-i4 truncation into a shared `EmitSubI4Truncation` helper that also handles CLR enums with narrow underlying types (byte, sbyte, short, ushort).

All emitted IL uses the same `or`/`and`/`xor`/`not` opcodes as for integer primitives — enums are represented as their underlying int on the evaluation stack, so no boxing/unboxing is needed. All emitted assemblies pass `ilverify`.

## Tests added (13)

| Test | Description |
|------|-------------|
| `FileShare_BitwiseOr` | `FileShare.ReadWrite \| FileShare.Delete` → 7 |
| `FileAccess_BitwiseAnd` | `FileAccess.Read & FileAccess.ReadWrite` → 1 |
| `RegexOptions_BitwiseXor` | `RegexOptions.IgnoreCase ^ RegexOptions.Multiline` → 3 |
| `FileShare_UnaryComplement` | `^FileShare.None` → -1 |
| `UnixFileMode_BitwiseOr` | `UnixFileMode.UserRead \| UnixFileMode.UserWrite` → 384 |
| `LongBackedFlagsEnum_BitwiseOr` | Sibling C# `[Flags] enum : long`, OR with `1L << 40` |
| `LongBackedFlagsEnum_BitwiseAnd` | Sibling C# `[Flags] enum : long`, AND mask |
| `LongBackedFlagsEnum_UnaryComplement` | Sibling C# `[Flags] enum : long`, `^None` |
| `ByteBackedEnum_BitwiseOr` | Sibling C# `[Flags] enum : byte`, sub-i4 truncation |
| `Int32_BitwiseOr_StillWorks` | Regression: `3 \| 4` → 7 |
| `Bool_BitwiseOr_StillWorks` | Regression: `true \| false` → True |
| `MixedEnumTypes_BitwiseOr_ProducesDiagnostic` | `FileShare \| FileAccess` → error |
| `Enum_BitwiseOr_WithInt_ProducesDiagnostic` | `FileShare \| 1` → error |

Fixes #534