### PR TITLE
Fix: for-in over IReadOnlyList<T>/IEnumerable<T>/ICollection<T> silently fails (#538)

### DIFF
--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -2115,6 +2115,18 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0267", $"No overload of '{name}' is applicable to the given argument list.");
     }
 
+    /// <summary>
+    /// Reports that a <c>for x in expr</c> loop cannot be lowered because the
+    /// collection type does not expose a usable <c>GetEnumerator()</c> method.
+    /// </summary>
+    /// <param name="location">The collection expression location.</param>
+    /// <param name="type">The collection type.</param>
+    public void ReportTypeNotIterable(TextLocation location, TypeSymbol type)
+    {
+        var message = $"Type '{type.Name}' does not implement a usable 'GetEnumerator()' method and cannot be iterated with 'for ... in'.";
+        Report(location, "GS0268", message);
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -12698,6 +12698,15 @@ internal sealed class ReflectionMetadataEmitter
                 case BoundDefaultExpression defaultExpr:
                     this.EmitDefault(defaultExpr);
                     break;
+                case BoundErrorExpression:
+                    // GS0268: a BoundErrorExpression leaked from lowering into emit.
+                    // This typically means the lowerer could not resolve a required
+                    // method (e.g. GetEnumerator) for a for-in loop. Throw a
+                    // descriptive exception so BuildEmitFailureDiagnostic surfaces
+                    // a clear GS9998 message instead of an opaque MSB4181.
+                    throw new InvalidOperationException(
+                        "Internal compiler error (GS0268): a for-in loop over an enumerable type could not be lowered. " +
+                        "The collection type may not expose a resolvable GetEnumerator()/MoveNext()/Current pattern.");
                 default:
                     throw new NotSupportedException(
                         $"Bound expression kind '{expression.Kind}' is not yet supported by the emitter.");

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -859,12 +859,7 @@ public sealed class Lowerer : BoundTreeRewriter
         var clrType = collection.Type.ClrType;
         if (clrType != null)
         {
-            var getEnumerator = clrType.GetMethod(
-                "GetEnumerator",
-                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public,
-                binder: null,
-                types: System.Type.EmptyTypes,
-                modifiers: null);
+            var getEnumerator = ResolveGetEnumerator(clrType);
             if (getEnumerator != null)
             {
                 enumeratorType = TypeSymbol.FromClrType(getEnumerator.ReturnType);
@@ -894,6 +889,84 @@ public sealed class Lowerer : BoundTreeRewriter
         getEnumeratorCall = null;
         enumeratorType = null;
         return false;
+    }
+
+    /// <summary>
+    /// Resolves the best <c>GetEnumerator()</c> method on a CLR type,
+    /// searching implemented interfaces when the type itself (e.g. an
+    /// interface like <c>IReadOnlyList&lt;T&gt;</c>) does not directly
+    /// declare the method. Prefers the generic
+    /// <c>IEnumerable&lt;T&gt;.GetEnumerator()</c> over the non-generic one.
+    /// </summary>
+    private static System.Reflection.MethodInfo ResolveGetEnumerator(System.Type clrType)
+    {
+        // First: direct lookup on the type itself (works for concrete types).
+        var direct = clrType.GetMethod(
+            "GetEnumerator",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public,
+            binder: null,
+            types: System.Type.EmptyTypes,
+            modifiers: null);
+        if (direct != null)
+        {
+            return direct;
+        }
+
+        // For interfaces (e.g. IReadOnlyList<T>, ICollection<T>), the method
+        // lives on a parent interface. Search for the generic IEnumerable<T>
+        // first (so we get the strongly-typed IEnumerator<T>), then fall back
+        // to non-generic IEnumerable.
+        // NOTE: We compare by name rather than by Type identity because the
+        // referenced BCL types may come from a different assembly load context
+        // than the compiler's own runtime.
+        System.Reflection.MethodInfo nonGenericFallback = null;
+        foreach (var iface in clrType.GetInterfaces())
+        {
+            if (iface.IsGenericType &&
+                iface.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IEnumerable`1")
+            {
+                return iface.GetMethod(
+                    "GetEnumerator",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public,
+                    binder: null,
+                    types: System.Type.EmptyTypes,
+                    modifiers: null);
+            }
+
+            if (iface.FullName == "System.Collections.IEnumerable")
+            {
+                nonGenericFallback = iface.GetMethod(
+                    "GetEnumerator",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public,
+                    binder: null,
+                    types: System.Type.EmptyTypes,
+                    modifiers: null);
+            }
+        }
+
+        // Also check if the type itself is the generic IEnumerable<T>.
+        if (clrType.IsGenericType &&
+            clrType.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IEnumerable`1")
+        {
+            return clrType.GetMethod(
+                "GetEnumerator",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public,
+                binder: null,
+                types: System.Type.EmptyTypes,
+                modifiers: null);
+        }
+
+        if (clrType.FullName == "System.Collections.IEnumerable")
+        {
+            return clrType.GetMethod(
+                "GetEnumerator",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public,
+                binder: null,
+                types: System.Type.EmptyTypes,
+                modifiers: null);
+        }
+
+        return nonGenericFallback;
     }
 
     private static bool TryBuildMoveNextAndCurrent(

--- a/test/Compiler.Tests/Emit/Issue538ForInEnumerableEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue538ForInEnumerableEmitTests.cs
@@ -1,0 +1,452 @@
+// <copyright file="Issue538ForInEnumerableEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Regression tests for issue #538: <c>for x in expr</c> where <c>expr</c> is
+/// typed as an interface (<c>IReadOnlyList&lt;T&gt;</c>, <c>IEnumerable&lt;T&gt;</c>,
+/// <c>ICollection&lt;T&gt;</c>) silently crashed the emit phase with MSB4181
+/// because the lowerer could not resolve <c>GetEnumerator()</c> on interface types.
+///
+/// The fix teaches <c>Lowerer.ResolveGetEnumerator</c> to search implemented
+/// interfaces when the type itself does not directly declare the method.
+/// </summary>
+public class Issue538ForInEnumerableEmitTests
+{
+    [Fact]
+    public void ForIn_IReadOnlyList_String_CountAndContents()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue538_rolist_").FullName;
+        try
+        {
+            var helperPath = BuildProbeAssembly(tempDir);
+
+            var source = """
+                package P
+                import System
+                import Probe
+
+                var items = EnumerableSource.GetReadOnlyList()
+                var n = 0
+                for s in items {
+                  Console.WriteLine(s)
+                  n = n + 1
+                }
+                Console.WriteLine(n)
+                """;
+
+            var output = CompileAndRunWithHelper(source, tempDir, helperPath);
+            Assert.Equal("alpha\nbeta\ngamma\n3\n", output);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ForIn_IEnumerable_Int_TypedValueType()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue538_ienum_").FullName;
+        try
+        {
+            var helperPath = BuildProbeAssembly(tempDir);
+
+            var source = """
+                package P
+                import System
+                import Probe
+
+                var nums = EnumerableSource.GetNumbers()
+                var sum = 0
+                for n in nums {
+                  sum = sum + n
+                }
+                Console.WriteLine(sum)
+                """;
+
+            var output = CompileAndRunWithHelper(source, tempDir, helperPath);
+            Assert.Equal("15\n", output);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ForIn_ICollection_String()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue538_icoll_").FullName;
+        try
+        {
+            var helperPath = BuildProbeAssembly(tempDir);
+
+            var source = """
+                package P
+                import System
+                import Probe
+
+                var coll = EnumerableSource.GetCollection()
+                var n = 0
+                for s in coll {
+                  Console.WriteLine(s)
+                  n = n + 1
+                }
+                Console.WriteLine(n)
+                """;
+
+            var output = CompileAndRunWithHelper(source, tempDir, helperPath);
+            Assert.Equal("x\ny\n2\n", output);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ForIn_EmptyIReadOnlyList_ZeroIterations()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue538_empty_").FullName;
+        try
+        {
+            var helperPath = BuildProbeAssembly(tempDir);
+
+            var source = """
+                package P
+                import System
+                import Probe
+
+                var items = EnumerableSource.GetEmptyReadOnlyList()
+                var n = 0
+                for s in items { n = n + 1 }
+                Console.WriteLine(n)
+                """;
+
+            var output = CompileAndRunWithHelper(source, tempDir, helperPath);
+            Assert.Equal("0\n", output);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ForIn_CustomIEnumerable_DispatchesCorrectly()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue538_custom_").FullName;
+        try
+        {
+            var helperPath = BuildProbeAssembly(tempDir);
+
+            var source = """
+                package P
+                import System
+                import Probe
+
+                var custom = EnumerableSource.GetCustomEnumerable()
+                var n = 0
+                for v in custom {
+                  Console.WriteLine(v)
+                  n = n + 1
+                }
+                Console.WriteLine(n)
+                """;
+
+            var output = CompileAndRunWithHelper(source, tempDir, helperPath);
+            Assert.Equal("10\n20\n30\n3\n", output);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ForIn_ConcreteList_RegressionGuard()
+    {
+        // Concrete List<T> should still use the existing fast path.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            var list = List[string]()
+            list.Add("a")
+            list.Add("b")
+            var n = 0
+            for s in list {
+              Console.WriteLine(s)
+              n = n + 1
+            }
+            Console.WriteLine(n)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("a\nb\n2\n", output);
+    }
+
+    [Fact]
+    public void ForIn_ClrArray_RegressionGuard()
+    {
+        var source = """
+            package P
+            import System
+
+            var arr = "hello world".Split(' ')
+            for s in arr {
+              Console.WriteLine(s)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello\nworld\n", output);
+    }
+
+    [Fact]
+    public void ForIn_String_RegressionGuard()
+    {
+        var source = """
+            package P
+            import System
+
+            for c in "abc" {
+              Console.WriteLine(int32(c))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("97\n98\n99\n", output);
+    }
+
+    /// <summary>
+    /// Builds the Probe.dll assembly with:
+    /// - EnumerableSource.GetReadOnlyList() -> IReadOnlyList&lt;string&gt;
+    /// - EnumerableSource.GetNumbers() -> IEnumerable&lt;int&gt;
+    /// - EnumerableSource.GetCollection() -> ICollection&lt;string&gt;
+    /// - EnumerableSource.GetEmptyReadOnlyList() -> IReadOnlyList&lt;string&gt;
+    /// - EnumerableSource.GetCustomEnumerable() -> IEnumerable&lt;int&gt; (custom impl)
+    /// </summary>
+    private static string BuildProbeAssembly(string dir)
+    {
+        // Use a real C# compilation via Roslyn to build the probe DLL since
+        // we need generic interface return types and custom IEnumerable<T> impl.
+        var csSource = """
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+
+            namespace Probe
+            {
+                public static class EnumerableSource
+                {
+                    public static IReadOnlyList<string> GetReadOnlyList()
+                        => new[] { "alpha", "beta", "gamma" };
+
+                    public static IEnumerable<int> GetNumbers()
+                        => new[] { 1, 2, 3, 4, 5 };
+
+                    public static ICollection<string> GetCollection()
+                        => new List<string> { "x", "y" };
+
+                    public static IReadOnlyList<string> GetEmptyReadOnlyList()
+                        => Array.Empty<string>();
+
+                    public static IEnumerable<int> GetCustomEnumerable()
+                        => new CustomEnumerable();
+                }
+
+                public class CustomEnumerable : IEnumerable<int>
+                {
+                    private readonly int[] data = new[] { 10, 20, 30 };
+
+                    public IEnumerator<int> GetEnumerator() => new CustomEnumerator(data);
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+
+                public class CustomEnumerator : IEnumerator<int>
+                {
+                    private readonly int[] data;
+                    private int index = -1;
+
+                    public CustomEnumerator(int[] data) { this.data = data; }
+
+                    public int Current => data[index];
+
+                    object IEnumerator.Current => Current;
+
+                    public bool MoveNext() => ++index < data.Length;
+
+                    public void Reset() => index = -1;
+
+                    public void Dispose() { }
+                }
+            }
+            """;
+
+        var csPath = Path.Combine(dir, "Probe.cs");
+        File.WriteAllText(csPath, csSource);
+
+        var probeProjPath = Path.Combine(dir, "Probe.csproj");
+        File.WriteAllText(probeProjPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <OutputType>Library</OutputType>
+                <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+                <AnalysisLevel>none</AnalysisLevel>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = dir,
+        };
+        psi.ArgumentList.Add("build");
+        psi.ArgumentList.Add("--nologo");
+        psi.ArgumentList.Add("-c");
+        psi.ArgumentList.Add("Release");
+        psi.ArgumentList.Add("-o");
+        psi.ArgumentList.Add(dir);
+
+        using var proc = Process.Start(psi);
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(60_000), "dotnet build timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"Probe build failed (exit {proc.ExitCode}):\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+        var probeDll = Path.Combine(dir, "Probe.dll");
+        Assert.True(File.Exists(probeDll), $"Probe.dll not found at {probeDll}");
+        return probeDll;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue538_").FullName;
+        try
+        {
+            return CompileAndRunImpl(source, tempDir, helperPath: null);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRunWithHelper(string source, string tempDir, string helperPath)
+    {
+        return CompileAndRunImpl(source, tempDir, helperPath);
+    }
+
+    private static string CompileAndRunImpl(string source, string tempDir, string helperPath)
+    {
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+        };
+
+        if (helperPath != null)
+        {
+            args.Add("/reference:" + helperPath);
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add("/nowarn:GS9100");
+        }
+
+        args.Add(srcPath);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        var extraRefs = helperPath != null ? new[] { helperPath } : null;
+        IlVerifier.Verify(outPath, extraRefs);
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = tempDir,
+        };
+        psi.ArgumentList.Add("exec");
+        psi.ArgumentList.Add("--runtimeconfig");
+        psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+        psi.ArgumentList.Add(outPath);
+
+        using var proc = Process.Start(psi);
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+        return stdout.Replace("\r\n", "\n");
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue538ForInEnumerableEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue538ForInEnumerableEmitTests.cs
@@ -244,8 +244,13 @@ public class Issue538ForInEnumerableEmitTests
     /// </summary>
     private static string BuildProbeAssembly(string dir)
     {
-        // Use a real C# compilation via Roslyn to build the probe DLL since
-        // we need generic interface return types and custom IEnumerable<T> impl.
+        // Build the probe in a subdirectory to avoid interaction between the
+        // project file, intermediate build artifacts, and the test files that
+        // are written into `dir` by CompileAndRunImpl. This matches the
+        // pattern used by Issue529 tests which reliably passes on CI (Linux).
+        var csDir = Path.Combine(dir, "csref");
+        Directory.CreateDirectory(csDir);
+
         var csSource = """
             using System;
             using System.Collections;
@@ -300,46 +305,48 @@ public class Issue538ForInEnumerableEmitTests
             }
             """;
 
-        var csPath = Path.Combine(dir, "Probe.cs");
-        File.WriteAllText(csPath, csSource);
-
-        var probeProjPath = Path.Combine(dir, "Probe.csproj");
-        File.WriteAllText(probeProjPath, """
+        File.WriteAllText(Path.Combine(csDir, "Probe.cs"), csSource);
+        File.WriteAllText(Path.Combine(csDir, "Probe.csproj"), """
             <Project Sdk="Microsoft.NET.Sdk">
               <PropertyGroup>
-                <TargetFramework>net10.0</TargetFramework>
                 <OutputType>Library</OutputType>
-                <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
-                <AnalysisLevel>none</AnalysisLevel>
+                <TargetFramework>net10.0</TargetFramework>
+                <AssemblyName>Probe</AssemblyName>
+                <RootNamespace>Probe</RootNamespace>
               </PropertyGroup>
             </Project>
             """);
 
+        RunDotnet(csDir, "restore");
+        RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+
+        var probeDll = Path.Combine(csDir, "bin", "Release", "net10.0", "Probe.dll");
+        Assert.True(File.Exists(probeDll), $"Probe.dll not found at {probeDll}");
+        return probeDll;
+    }
+
+    private static void RunDotnet(string workingDir, params string[] args)
+    {
         var psi = new ProcessStartInfo("dotnet")
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
-            WorkingDirectory = dir,
+            WorkingDirectory = workingDir,
         };
-        psi.ArgumentList.Add("build");
-        psi.ArgumentList.Add("--nologo");
-        psi.ArgumentList.Add("-c");
-        psi.ArgumentList.Add("Release");
-        psi.ArgumentList.Add("-o");
-        psi.ArgumentList.Add(dir);
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
 
-        using var proc = Process.Start(psi);
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
         var stdout = proc.StandardOutput.ReadToEnd();
         var stderr = proc.StandardError.ReadToEnd();
-        Assert.True(proc.WaitForExit(60_000), "dotnet build timed out");
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
         Assert.True(
             proc.ExitCode == 0,
-            $"Probe build failed (exit {proc.ExitCode}):\nstdout:\n{stdout}\nstderr:\n{stderr}");
-
-        var probeDll = Path.Combine(dir, "Probe.dll");
-        Assert.True(File.Exists(probeDll), $"Probe.dll not found at {probeDll}");
-        return probeDll;
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
     }
 
     private static string CompileAndRun(string source)
@@ -409,6 +416,13 @@ public class Issue538ForInEnumerableEmitTests
 
         var extraRefs = helperPath != null ? new[] { helperPath } : null;
         IlVerifier.Verify(outPath, extraRefs);
+
+        // Copy the helper assembly next to the output so the runtime can
+        // resolve it when `dotnet exec` loads the compiled test assembly.
+        if (helperPath != null)
+        {
+            File.Copy(helperPath, Path.Combine(tempDir, Path.GetFileName(helperPath)), overwrite: true);
+        }
 
         var psi = new ProcessStartInfo("dotnet")
         {


### PR DESCRIPTION
## Summary

Fixes #538

`for x in expr` where `expr` is typed as an interface (`IReadOnlyList<T>`, `IEnumerable<T>`, `ICollection<T>`) silently crashed the emit phase with MSB4181 because the lowerer could not resolve `GetEnumerator()` on interface types.

## Root Cause

`TryBuildGetEnumeratorCall` in the lowerer used a direct `Type.GetMethod("GetEnumerator", ...)` lookup which returns null for interface types — `GetEnumerator()` is declared on `IEnumerable<T>` (a parent interface), not on `IReadOnlyList<T>` itself.

## Fix

- **Lowerer:** Extract `ResolveGetEnumerator` helper that first tries a direct method lookup (fast path for concrete types), then searches implemented interfaces for `IEnumerable<T>.GetEnumerator()` (generic preferred) or `IEnumerable.GetEnumerator()` as a fallback. Uses `FullName` comparison instead of Type identity since referenced BCL types may load in a separate assembly context.

- **Emitter safety net:** Add `BoundErrorExpression` case in `EmitExpression` so that if a lowering failure leaks through, users see a clear GS9998/GS0268 message instead of an opaque MSB4181.

- **Diagnostics:** Add `GS0268` diagnostic (`ReportTypeNotIterable`) to DiagnosticBag for future use.

## Tests Added

`Issue538ForInEnumerableEmitTests` — 8 test cases:
1. `IReadOnlyList<string>` — count and contents
2. `IEnumerable<int>` — typed value-type element  
3. `ICollection<string>`
4. Empty `IReadOnlyList<string>` — zero iterations
5. Custom `IEnumerable<int>` with user-defined enumerator (GetEnumerator/MoveNext/Current/Dispose)
6. Concrete `List<T>` — regression guard (existing fast path)
7. CLR array — regression guard
8. String — regression guard

All tests verify IlVerify passes on the emitted assembly.

## Verification

- All 30 for-range related tests pass (Issue538 + Issue520 + Issue537 + ForRange + Issue529)
- All other test projects pass (Core: 2023, Interpreter: 72, LanguageServer: 229, Sdk: 24)
- Compiler emit tests that fail are all due to pre-existing macOS resource limits ("Too many open files") unrelated to this change