### PR TITLE
Support cross-project Go-to-Definition in the language server

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -8,7 +8,7 @@ The GSharp Language Server provides rich IDE features for `.gs` files via the [L
 |---------|-----------|-------------|
 | Diagnostics | `textDocument/diagnostic` | Live syntax, semantic, and binding errors pulled as you type (with `workspace/diagnostic/refresh` for cross-file edits) |
 | Hover | `textDocument/hover` | Type signature and symbol kind for the token under the cursor; renders CLR XML documentation (from `*.xml` files alongside referenced assemblies) and G# `///` Markdown doc comments as MarkdownContent |
-| Go-to-definition | `textDocument/declaration` | Jump from a symbol usage to its declaration |
+| Go-to-definition | `textDocument/declaration` | Jump from a symbol usage to its declaration. Cross-project: navigates into sibling G# projects in the workspace (via in-memory syntax-tree lookup) and into C# / G# project references and NuGet packages (via portable PDB navigation when sequence points are available; `refint/`-prefixed paths transparently swap to the runtime DLL alongside its PDB). |
 | Find references | `textDocument/references` | Find all usages of a symbol within the document |
 | Document symbols | `textDocument/documentSymbol` | Outline view: functions, variables, structs, enums with children |
 | Document highlights | `textDocument/documentHighlight` | Highlight all occurrences of the symbol under cursor |
@@ -74,6 +74,8 @@ Logging is **opt-in**: when `--log` is not supplied, no log file is created. Fro
 - **`DocumentContentService`** — thread-safe in-memory store mapping document URIs to their latest `DocumentContent`.
 - **`SemanticLookup`** — builds a `SemanticModel` from a `Compilation`, resolves identifier tokens to symbols, finds references, and converts between offsets/ranges.
 - **`HoverComputer`**, **`DefinitionComputer`**, **`DocumentSymbolComputer`**, etc. — stateless computers, one per LSP feature.
+- **`CrossAssemblyDefinitionResolver`** — dispatches Go-to-Definition for `Imported*Symbol`s and CLR `MemberInfo`s. Tier 1 walks the matching sibling `.gsproj`'s syntax trees; Tier 2 falls back to portable-PDB lookup via **`PdbSourceLocator`**.
+- **`PdbSourceLocator`** — opens portable PDBs (sidecar or embedded) with `System.Reflection.Metadata`, caches `MetadataReader`s per assembly file keyed on last-write time, and maps a method's `MetadataToken` to its first sequence point. Transparently swaps `obj/.../refint/{Name}.dll` paths to the sibling runtime DLL so MSBuild's reference-assembly outputs still navigate to source.
 
 ## Diagnostics
 

--- a/src/LanguageServer/CrossAssemblyDefinitionResolver.cs
+++ b/src/LanguageServer/CrossAssemblyDefinitionResolver.cs
@@ -1,0 +1,577 @@
+// <copyright file="CrossAssemblyDefinitionResolver.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.LanguageServer.Protocol;
+using Range = GSharp.LanguageServer.Protocol.Range;
+
+namespace GSharp.LanguageServer;
+
+/// <summary>
+/// Resolves imported CLR <see cref="Type"/>s and <see cref="MemberInfo"/>s to
+/// source <see cref="Location"/>s. Implements two tiers of cross-project
+/// Go-to-Definition for the language server:
+/// <list type="number">
+/// <item><b>Tier 1 — Sibling G# project source walk.</b> When the supplied
+/// member belongs to an assembly produced by another <c>.gsproj</c> in the
+/// workspace, look the matching declaration up in that project's
+/// <see cref="Compilation"/> and return the in-source identifier token. This
+/// path is preferred because it does not require a portable PDB to exist on
+/// disk: a freshly-restored (but not yet built) sibling project still
+/// resolves.</item>
+/// <item><b>Tier 2 — Portable-PDB navigation.</b> For everything else (C# /
+/// F# / VB siblings, NuGet packages with embedded or sidecar PDBs, or G#
+/// siblings whose Tier 1 lookup did not match) delegate to
+/// <see cref="PdbSourceLocator"/>, which reads sequence points to recover the
+/// original source file and line.</item>
+/// </list>
+/// </summary>
+internal static class CrossAssemblyDefinitionResolver
+{
+    /// <summary>
+    /// Resolves an imported CLR <see cref="Type"/> (class, struct, enum,
+    /// interface, delegate) to its source location.
+    /// </summary>
+    /// <param name="workspace">The owning workspace; may be <see langword="null"/> in scenarios
+    /// without project discovery, in which case only Tier 2 is attempted.</param>
+    /// <param name="type">The CLR type to navigate to.</param>
+    /// <param name="location">The resolved source location on success.</param>
+    /// <returns>True when a location was resolved.</returns>
+    public static bool TryResolveType(WorkspaceState workspace, Type type, out Location location)
+    {
+        location = null;
+        if (type == null)
+        {
+            return false;
+        }
+
+        var assemblyPath = TryGetAssemblyPath(type.Assembly);
+        if (assemblyPath == null)
+        {
+            return false;
+        }
+
+        if (workspace != null
+            && workspace.TryGetProjectByOutputAssembly(assemblyPath, out var siblingProject)
+            && TryResolveTypeInSiblingProject(siblingProject, type, out location))
+        {
+            return true;
+        }
+
+        if (PdbSourceLocator.TryGetTypeSourceLocation(assemblyPath, type.MetadataToken, out var pdbLocation))
+        {
+            location = ToLocation(pdbLocation);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves an imported CLR <see cref="MethodInfo"/> to its source location.
+    /// </summary>
+    /// <param name="workspace">The owning workspace.</param>
+    /// <param name="method">The CLR method to navigate to.</param>
+    /// <param name="location">The resolved source location on success.</param>
+    /// <returns>True when a location was resolved.</returns>
+    public static bool TryResolveMethod(WorkspaceState workspace, MethodInfo method, out Location location)
+    {
+        location = null;
+        if (method == null)
+        {
+            return false;
+        }
+
+        var declaringType = method.DeclaringType;
+        var assemblyPath = TryGetAssemblyPath(declaringType?.Assembly ?? method.Module?.Assembly);
+        if (assemblyPath == null)
+        {
+            return false;
+        }
+
+        if (workspace != null
+            && declaringType != null
+            && workspace.TryGetProjectByOutputAssembly(assemblyPath, out var siblingProject)
+            && TryResolveMethodInSiblingProject(siblingProject, declaringType, method, out location))
+        {
+            return true;
+        }
+
+        if (PdbSourceLocator.TryGetMethodSourceLocation(assemblyPath, method.MetadataToken, out var pdbLocation))
+        {
+            location = ToLocation(pdbLocation);
+            return true;
+        }
+
+        // Fall back to the declaring type's source line — at least gets the user into the right file.
+        return declaringType != null && TryResolveType(workspace, declaringType, out location);
+    }
+
+    /// <summary>
+    /// Resolves an imported CLR <see cref="PropertyInfo"/> to its source
+    /// location. Tries Tier 1 against the sibling project's
+    /// <see cref="PropertySymbol"/> declaration, then falls back to PDB lookup
+    /// of the property's getter (or setter for write-only properties).
+    /// </summary>
+    /// <param name="workspace">The owning workspace.</param>
+    /// <param name="property">The CLR property to navigate to.</param>
+    /// <param name="location">The resolved source location on success.</param>
+    /// <returns>True when a location was resolved.</returns>
+    public static bool TryResolveProperty(WorkspaceState workspace, PropertyInfo property, out Location location)
+    {
+        location = null;
+        if (property == null)
+        {
+            return false;
+        }
+
+        var declaringType = property.DeclaringType;
+        var assemblyPath = TryGetAssemblyPath(declaringType?.Assembly);
+        if (assemblyPath == null)
+        {
+            return false;
+        }
+
+        if (workspace != null
+            && declaringType != null
+            && workspace.TryGetProjectByOutputAssembly(assemblyPath, out var siblingProject)
+            && TryResolvePropertyInSiblingProject(siblingProject, declaringType, property.Name, out location))
+        {
+            return true;
+        }
+
+        var accessor = property.GetGetMethod(nonPublic: true) ?? property.GetSetMethod(nonPublic: true);
+        if (accessor != null && PdbSourceLocator.TryGetMethodSourceLocation(assemblyPath, accessor.MetadataToken, out var pdbLocation))
+        {
+            location = ToLocation(pdbLocation);
+            return true;
+        }
+
+        return declaringType != null && TryResolveType(workspace, declaringType, out location);
+    }
+
+    /// <summary>
+    /// Resolves an imported CLR <see cref="FieldInfo"/> to its source location.
+    /// Portable PDBs do not record field-level sequence points, so Tier 2
+    /// falls back to the declaring type's source location.
+    /// </summary>
+    /// <param name="workspace">The owning workspace.</param>
+    /// <param name="field">The CLR field to navigate to.</param>
+    /// <param name="location">The resolved source location on success.</param>
+    /// <returns>True when a location was resolved.</returns>
+    public static bool TryResolveField(WorkspaceState workspace, FieldInfo field, out Location location)
+    {
+        location = null;
+        if (field == null)
+        {
+            return false;
+        }
+
+        var declaringType = field.DeclaringType;
+        var assemblyPath = TryGetAssemblyPath(declaringType?.Assembly);
+        if (assemblyPath == null)
+        {
+            return false;
+        }
+
+        if (workspace != null
+            && declaringType != null
+            && workspace.TryGetProjectByOutputAssembly(assemblyPath, out var siblingProject)
+            && TryResolveFieldInSiblingProject(siblingProject, declaringType, field.Name, out location))
+        {
+            return true;
+        }
+
+        return declaringType != null && TryResolveType(workspace, declaringType, out location);
+    }
+
+    /// <summary>
+    /// Resolves an imported CLR <see cref="EventInfo"/> to its source location.
+    /// </summary>
+    /// <param name="workspace">The owning workspace.</param>
+    /// <param name="evt">The CLR event to navigate to.</param>
+    /// <param name="location">The resolved source location on success.</param>
+    /// <returns>True when a location was resolved.</returns>
+    public static bool TryResolveEvent(WorkspaceState workspace, EventInfo evt, out Location location)
+    {
+        location = null;
+        if (evt == null)
+        {
+            return false;
+        }
+
+        var declaringType = evt.DeclaringType;
+        var assemblyPath = TryGetAssemblyPath(declaringType?.Assembly);
+        if (assemblyPath == null)
+        {
+            return false;
+        }
+
+        if (workspace != null
+            && declaringType != null
+            && workspace.TryGetProjectByOutputAssembly(assemblyPath, out var siblingProject)
+            && TryResolveEventInSiblingProject(siblingProject, declaringType, evt.Name, out location))
+        {
+            return true;
+        }
+
+        var accessor = evt.GetAddMethod(nonPublic: true) ?? evt.GetRemoveMethod(nonPublic: true);
+        if (accessor != null && PdbSourceLocator.TryGetMethodSourceLocation(assemblyPath, accessor.MetadataToken, out var pdbLocation))
+        {
+            location = ToLocation(pdbLocation);
+            return true;
+        }
+
+        return declaringType != null && TryResolveType(workspace, declaringType, out location);
+    }
+
+    private static bool TryResolveTypeInSiblingProject(ProjectState siblingProject, Type type, out Location location)
+    {
+        location = null;
+        var compilation = siblingProject?.GetCompilation();
+        if (compilation == null)
+        {
+            return false;
+        }
+
+        if (TryFindStructSymbol(compilation, type, out var structSymbol)
+            && structSymbol.Declaration != null)
+        {
+            location = ToLocation(structSymbol.Declaration.Identifier);
+            return location != null;
+        }
+
+        if (TryFindEnumSymbol(compilation, type, out var enumSymbol)
+            && enumSymbol.Declaration != null)
+        {
+            location = ToLocation(enumSymbol.Declaration.Identifier);
+            return location != null;
+        }
+
+        if (TryFindInterfaceSymbol(compilation, type, out var interfaceSymbol)
+            && interfaceSymbol.Declaration != null)
+        {
+            location = ToLocation(interfaceSymbol.Declaration.Identifier);
+            return location != null;
+        }
+
+        if (TryFindDelegateSymbol(compilation, type, out var delegateDeclaration))
+        {
+            location = ToLocation(delegateDeclaration.Identifier);
+            return location != null;
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveMethodInSiblingProject(ProjectState siblingProject, Type declaringType, MethodInfo method, out Location location)
+    {
+        location = null;
+        var compilation = siblingProject?.GetCompilation();
+        if (compilation == null)
+        {
+            return false;
+        }
+
+        if (TryFindStructSymbol(compilation, declaringType, out var structSymbol))
+        {
+            var candidates = structSymbol.Methods.Concat(structSymbol.StaticMethods)
+                .Where(fs => fs.Declaration != null && string.Equals(fs.Name, method.Name, StringComparison.Ordinal))
+                .ToArray();
+
+            var best = SelectMatchingMethod(candidates, method) ?? candidates.FirstOrDefault();
+            if (best?.Declaration != null)
+            {
+                location = ToLocation(best.Declaration.Identifier);
+                return location != null;
+            }
+        }
+
+        if (TryFindInterfaceSymbol(compilation, declaringType, out var interfaceSymbol))
+        {
+            var match = interfaceSymbol.Methods
+                .FirstOrDefault(fs => fs.Declaration != null && string.Equals(fs.Name, method.Name, StringComparison.Ordinal));
+            if (match?.Declaration != null)
+            {
+                location = ToLocation(match.Declaration.Identifier);
+                return location != null;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryResolvePropertyInSiblingProject(ProjectState siblingProject, Type declaringType, string propertyName, out Location location)
+    {
+        location = null;
+        var compilation = siblingProject?.GetCompilation();
+        if (compilation == null || !TryFindStructSymbol(compilation, declaringType, out var structSymbol))
+        {
+            return false;
+        }
+
+        var property = structSymbol.Properties.Concat(structSymbol.StaticProperties)
+            .FirstOrDefault(p => p.Declaration != null && string.Equals(p.Name, propertyName, StringComparison.Ordinal));
+        if (property?.Declaration != null)
+        {
+            location = ToLocation(property.Declaration.Identifier);
+            return location != null;
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveFieldInSiblingProject(ProjectState siblingProject, Type declaringType, string fieldName, out Location location)
+    {
+        location = null;
+        var compilation = siblingProject?.GetCompilation();
+        if (compilation == null || !TryFindStructSymbol(compilation, declaringType, out var structSymbol)
+            || structSymbol.Declaration == null)
+        {
+            return false;
+        }
+
+        foreach (var field in structSymbol.Declaration.Fields)
+        {
+            if (string.Equals(field.Identifier.Text, fieldName, StringComparison.Ordinal))
+            {
+                location = ToLocation(field.Identifier);
+                return location != null;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveEventInSiblingProject(ProjectState siblingProject, Type declaringType, string eventName, out Location location)
+    {
+        location = null;
+        var compilation = siblingProject?.GetCompilation();
+        if (compilation == null || !TryFindStructSymbol(compilation, declaringType, out var structSymbol))
+        {
+            return false;
+        }
+
+        var match = structSymbol.Events.Concat(structSymbol.StaticEvents)
+            .FirstOrDefault(e => e.Declaration != null && string.Equals(e.Name, eventName, StringComparison.Ordinal));
+        if (match?.Declaration != null)
+        {
+            location = ToLocation(match.Declaration.Identifier);
+            return location != null;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// When several G# methods match a CLR method by name (overloads), pick the
+    /// one whose parameter arity equals the CLR method's. Best-effort; the
+    /// caller will fall back to the first match when nothing better is found.
+    /// </summary>
+    private static FunctionSymbol SelectMatchingMethod(FunctionSymbol[] candidates, MethodInfo method)
+    {
+        if (candidates.Length <= 1)
+        {
+            return candidates.FirstOrDefault();
+        }
+
+        var parameterCount = method.GetParameters().Length;
+        var arityMatch = candidates.FirstOrDefault(c => c.Parameters.Length == parameterCount);
+        return arityMatch ?? candidates.FirstOrDefault();
+    }
+
+    private static bool TryFindStructSymbol(Compilation compilation, Type type, out StructSymbol structSymbol)
+    {
+        structSymbol = null;
+        if (compilation == null || type == null)
+        {
+            return false;
+        }
+
+        foreach (var candidate in compilation.GlobalScope.Structs)
+        {
+            if (MatchesByPackageAndName(candidate.Name, candidate.PackageName, type))
+            {
+                structSymbol = candidate;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryFindEnumSymbol(Compilation compilation, Type type, out EnumSymbol enumSymbol)
+    {
+        enumSymbol = null;
+        if (compilation == null || type == null)
+        {
+            return false;
+        }
+
+        foreach (var candidate in compilation.GlobalScope.Enums)
+        {
+            if (MatchesByPackageAndName(candidate.Name, candidate.PackageName, type))
+            {
+                enumSymbol = candidate;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryFindInterfaceSymbol(Compilation compilation, Type type, out InterfaceSymbol interfaceSymbol)
+    {
+        interfaceSymbol = null;
+        if (compilation == null || type == null)
+        {
+            return false;
+        }
+
+        foreach (var candidate in compilation.GlobalScope.Interfaces)
+        {
+            if (MatchesByPackageAndName(candidate.Name, candidate.PackageName, type))
+            {
+                interfaceSymbol = candidate;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryFindDelegateSymbol(Compilation compilation, Type type, out DelegateDeclarationSyntax declaration)
+    {
+        declaration = null;
+        if (compilation == null || type == null)
+        {
+            return false;
+        }
+
+        foreach (var candidate in compilation.GlobalScope.Delegates)
+        {
+            if (!string.Equals(candidate.Name, type.Name, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                var match = FindDelegateDeclaration(tree.Root, type.Name);
+                if (match != null)
+                {
+                    declaration = match;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static DelegateDeclarationSyntax FindDelegateDeclaration(SyntaxNode root, string name)
+    {
+        if (root is DelegateDeclarationSyntax decl && string.Equals(decl.Identifier.Text, name, StringComparison.Ordinal))
+        {
+            return decl;
+        }
+
+        foreach (var child in root.GetChildren())
+        {
+            var found = FindDelegateDeclaration(child, name);
+            if (found != null)
+            {
+                return found;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Matches a G# user-type symbol against a CLR <see cref="Type"/> by the
+    /// pair (namespace = G# package name, simple name). For generic types we
+    /// strip the CLR backtick-arity suffix (e.g. <c>List`1</c> → <c>List</c>)
+    /// because the G# symbol name omits it.
+    /// </summary>
+    private static bool MatchesByPackageAndName(string symbolName, string symbolPackage, Type type)
+    {
+        if (!string.Equals(symbolPackage ?? string.Empty, type.Namespace ?? string.Empty, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var clrSimpleName = type.Name;
+        var backtick = clrSimpleName.IndexOf('`');
+        if (backtick > 0)
+        {
+            clrSimpleName = clrSimpleName.Substring(0, backtick);
+        }
+
+        return string.Equals(symbolName, clrSimpleName, StringComparison.Ordinal);
+    }
+
+    private static Location ToLocation(SyntaxToken token)
+    {
+        if (token == null || token.IsMissing)
+        {
+            return null;
+        }
+
+        var filePath = token.SyntaxTree?.Text?.FileName;
+        if (string.IsNullOrEmpty(filePath))
+        {
+            return null;
+        }
+
+        return new Location
+        {
+            Uri = DocumentUri.FromFileSystemPath(filePath),
+            Range = SemanticLookup.ToRange(token),
+        };
+    }
+
+    private static Location ToLocation(PdbSourceLocator.SourceLocation source)
+    {
+        if (string.IsNullOrEmpty(source.FilePath))
+        {
+            return null;
+        }
+
+        // PDB sequence points are 1-based; LSP positions are 0-based.
+        var startLine = Math.Max(0, source.StartLine - 1);
+        var startCol = Math.Max(0, source.StartColumn - 1);
+        var endLine = Math.Max(0, source.EndLine - 1);
+        var endCol = Math.Max(0, source.EndColumn - 1);
+
+        return new Location
+        {
+            Uri = DocumentUri.FromFileSystemPath(source.FilePath),
+            Range = new Range(new Position(startLine, startCol), new Position(endLine, endCol)),
+        };
+    }
+
+    private static string TryGetAssemblyPath(Assembly assembly)
+    {
+        if (assembly == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var location = assembly.Location;
+            return string.IsNullOrEmpty(location) ? null : location;
+        }
+        catch (NotSupportedException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/LanguageServer/DiscoveredProject.cs
+++ b/src/LanguageServer/DiscoveredProject.cs
@@ -19,18 +19,21 @@ public sealed class DiscoveredProject
     /// <param name="projectReferences">Absolute paths to referenced <c>.gsproj</c> files.</param>
     /// <param name="references">Absolute paths to assembly references (from the MSBuild-emitted response file).</param>
     /// <param name="referenceSourcePath">Absolute path to the <c>.rsp</c> the references were parsed from, or <c>null</c> when none was found.</param>
+    /// <param name="assemblyName">The project's effective <c>AssemblyName</c> (i.e. the basename of the output DLL). Used by cross-project navigation to map an imported symbol's declaring assembly back to the owning project.</param>
     public DiscoveredProject(
         string projectFilePath,
         IReadOnlyList<string> sourceFiles,
         IReadOnlyList<string> projectReferences,
         IReadOnlyList<string> references = null,
-        string referenceSourcePath = null)
+        string referenceSourcePath = null,
+        string assemblyName = null)
     {
         ProjectFilePath = projectFilePath;
         SourceFiles = sourceFiles;
         ProjectReferences = projectReferences;
         References = references ?? System.Array.Empty<string>();
         ReferenceSourcePath = referenceSourcePath;
+        AssemblyName = assemblyName;
     }
 
     /// <summary>
@@ -63,4 +66,15 @@ public sealed class DiscoveredProject
     /// rewritten by a subsequent build.
     /// </summary>
     public string ReferenceSourcePath { get; }
+
+    /// <summary>
+    /// Gets the project's effective <c>AssemblyName</c> — the basename of the
+    /// output DLL (without extension) the SDK will emit for this project. Used
+    /// by cross-project Go-to-Definition (<c>WorkspaceState.TryGetProjectByOutputAssembly</c>)
+    /// to map an imported symbol's declaring assembly back to the owning
+    /// sibling project. May be <c>null</c> when the project file could not be
+    /// parsed; in that case the consumer typically falls back to the project
+    /// file's basename.
+    /// </summary>
+    public string AssemblyName { get; }
 }

--- a/src/LanguageServer/DocumentContent.cs
+++ b/src/LanguageServer/DocumentContent.cs
@@ -13,7 +13,10 @@ namespace GSharp.LanguageServer;
 /// <param name="syntaxTree">The <see cref="SyntaxTree"/> of the document.</param>
 /// <param name="lines">The position for line breaks in the document content.</param>
 /// <param name="project">The owning project state, if available.</param>
-public class DocumentContent(SyntaxTree syntaxTree, IReadOnlyList<int> lines, ProjectState project = null)
+/// <param name="workspace">The owning workspace state, if available. Threaded
+/// through so cross-project features (e.g. Go-to-Definition into a sibling
+/// <c>.gsproj</c>) can reach other projects from a per-document computer.</param>
+public class DocumentContent(SyntaxTree syntaxTree, IReadOnlyList<int> lines, ProjectState project = null, WorkspaceState workspace = null)
 {
     /// <summary>
     /// Gets the document syntax tree.
@@ -29,4 +32,13 @@ public class DocumentContent(SyntaxTree syntaxTree, IReadOnlyList<int> lines, Pr
     /// Gets the owning project state, or null if the file is not part of a project.
     /// </summary>
     public ProjectState Project { get; } = project;
+
+    /// <summary>
+    /// Gets the owning workspace state, or null when no workspace is attached
+    /// (single-file scenarios and most unit tests). Cross-project Go-to-Definition
+    /// reads this to locate sibling projects by their output assembly name; if
+    /// the workspace is missing, those features gracefully degrade to
+    /// PDB-based navigation or null.
+    /// </summary>
+    public WorkspaceState Workspace { get; } = workspace;
 }

--- a/src/LanguageServer/DocumentSyncHandler.cs
+++ b/src/LanguageServer/DocumentSyncHandler.cs
@@ -22,15 +22,20 @@ public static class DocumentSyncHandler
 {
     public static DiagnosticComputationResult ComputeDiagnostics(string text, bool skipBinding)
     {
-        return ComputeDiagnostics(text, skipBinding, project: null, filePath: null);
+        return ComputeDiagnostics(text, skipBinding, project: null, filePath: null, workspace: null);
     }
 
     public static DiagnosticComputationResult ComputeDiagnostics(string text, bool skipBinding, ProjectState project)
     {
-        return ComputeDiagnostics(text, skipBinding, project, filePath: null);
+        return ComputeDiagnostics(text, skipBinding, project, filePath: null, workspace: null);
     }
 
     public static DiagnosticComputationResult ComputeDiagnostics(string text, bool skipBinding, ProjectState project, string filePath)
+    {
+        return ComputeDiagnostics(text, skipBinding, project, filePath, workspace: null);
+    }
+
+    public static DiagnosticComputationResult ComputeDiagnostics(string text, bool skipBinding, ProjectState project, string filePath, WorkspaceState workspace)
     {
         var newLines = new List<int>();
         int nextNewLine = text.IndexOf('\n');
@@ -110,7 +115,7 @@ public static class DocumentSyncHandler
             }
         }
 
-        return new DiagnosticComputationResult(new DocumentContent(syntaxTree, newLines, project), diagnostics);
+        return new DiagnosticComputationResult(new DocumentContent(syntaxTree, newLines, project, workspace), diagnostics);
     }
 
     private static Diagnostic BuildDiagnostic(string code, string message, int start, int end, GSharp.Core.CodeAnalysis.Text.SourceText sourceText)

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -933,19 +933,80 @@ public static class DefinitionComputer
         var offset = SemanticLookup.ToOffset(content, position);
         var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
         var symbol = SemanticLookup.ResolveSymbol(compilation, token);
-        if (symbol == null)
+        var workspace = content.Workspace;
+
+        // Imported symbols (cross-assembly): try sibling-G#-project source walk
+        // first, then portable-PDB navigation. See CrossAssemblyDefinitionResolver.
+        if (TryResolveImportedSymbol(symbol, workspace, out var crossLocation))
         {
-            return null;
+            return crossLocation;
         }
 
-        var declarationToken = FindDeclarationToken(compilation, symbol);
-        if (declarationToken == null)
+        if (symbol != null)
         {
-            return null;
+            var declarationToken = FindDeclarationToken(compilation, symbol);
+            if (declarationToken != null)
+            {
+                var targetUri = GetDocumentUri(declarationToken, uri);
+                return new Location { Uri = targetUri, Range = SemanticLookup.ToRange(declarationToken) };
+            }
         }
 
-        var targetUri = GetDocumentUri(declarationToken, uri);
-        return new Location { Uri = targetUri, Range = SemanticLookup.ToRange(declarationToken) };
+        // Fallback: the token is on a CLR type name (e.g. `Console`) or a
+        // member access RHS (e.g. `WriteLine` in `Console.WriteLine`) that did
+        // not resolve to a G# symbol. Walk the import / member-access context
+        // the same way HoverComputer does and map the result to a Location via
+        // CrossAssemblyDefinitionResolver.
+        if (token != null && token.Kind == SyntaxKind.IdentifierToken)
+        {
+            if (ImportedClrMemberResolver.TryResolveClrType(content.SyntaxTree, compilation, token, out var clrType)
+                && CrossAssemblyDefinitionResolver.TryResolveType(workspace, clrType, out var typeLocation))
+            {
+                return typeLocation;
+            }
+
+            if (ImportedClrMemberResolver.TryResolveClrMember(content.SyntaxTree, compilation, token, out var clrMember)
+                && TryResolveClrMember(workspace, clrMember, out var memberLocation))
+            {
+                return memberLocation;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryResolveImportedSymbol(Symbol symbol, WorkspaceState workspace, out Location location)
+    {
+        location = null;
+        switch (symbol)
+        {
+            case ImportedClassSymbol importedClass:
+                return CrossAssemblyDefinitionResolver.TryResolveType(workspace, importedClass.ClassType, out location);
+            case ImportedTypeSymbol importedType:
+                return CrossAssemblyDefinitionResolver.TryResolveType(workspace, importedType.Type, out location);
+            case ImportedFunctionSymbol importedFunction:
+                return CrossAssemblyDefinitionResolver.TryResolveMethod(workspace, importedFunction.Method, out location);
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryResolveClrMember(WorkspaceState workspace, MemberInfo member, out Location location)
+    {
+        location = null;
+        switch (member)
+        {
+            case MethodInfo method:
+                return CrossAssemblyDefinitionResolver.TryResolveMethod(workspace, method, out location);
+            case PropertyInfo property:
+                return CrossAssemblyDefinitionResolver.TryResolveProperty(workspace, property, out location);
+            case FieldInfo field:
+                return CrossAssemblyDefinitionResolver.TryResolveField(workspace, field, out location);
+            case EventInfo @event:
+                return CrossAssemblyDefinitionResolver.TryResolveEvent(workspace, @event, out location);
+            default:
+                return false;
+        }
     }
 
     private static DocumentUri GetDocumentUri(SyntaxToken token, DocumentUri fallback)

--- a/src/LanguageServer/ImportedClrMemberResolver.cs
+++ b/src/LanguageServer/ImportedClrMemberResolver.cs
@@ -1,0 +1,336 @@
+// <copyright file="ImportedClrMemberResolver.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.LanguageServer;
+
+/// <summary>
+/// Resolves an identifier token under the cursor to its underlying CLR
+/// <see cref="Type"/> or <see cref="MemberInfo"/>, when no G# user-defined
+/// symbol matches.
+/// </summary>
+/// <remarks>
+/// This is used by cross-project Go-to-Definition when the token lands on
+/// either an imported type name (e.g. <c>Console</c>) or a member access on
+/// an imported type (e.g. <c>Console.WriteLine</c>). The path mirrors
+/// <c>HoverComputer.BuildImportedClrModel</c> intentionally: when the hover
+/// can describe a CLR member at a position, Go-to-Definition should be able
+/// to jump to it. The implementation intentionally only handles the chains
+/// whose intermediates are CLR types (the common case for Console/HttpClient/
+/// .NET BCL navigation); chains where an intermediate is a user-defined G#
+/// struct fall through to <see langword="false"/> and the caller's existing
+/// G#-member path takes over.
+/// </remarks>
+internal static class ImportedClrMemberResolver
+{
+    /// <summary>
+    /// Attempts to resolve the identifier under <paramref name="token"/> to an
+    /// imported CLR <see cref="Type"/>. Covers bare type-name tokens like the
+    /// <c>Console</c> in <c>Console.WriteLine</c>.
+    /// </summary>
+    /// <param name="tree">The syntax tree providing import context.</param>
+    /// <param name="compilation">The compilation.</param>
+    /// <param name="token">The token under the cursor.</param>
+    /// <param name="type">The resolved CLR type on success.</param>
+    /// <returns>True when a CLR type was resolved.</returns>
+    public static bool TryResolveClrType(SyntaxTree tree, Compilation compilation, SyntaxToken token, out Type type)
+    {
+        type = null;
+        if (token == null || token.Kind != SyntaxKind.IdentifierToken)
+        {
+            return false;
+        }
+
+        var includeAttributeSuffixFallback = IsAnnotationNameToken(tree.Root, token);
+        type = SemanticLookup.ResolveImportedClrType(tree, compilation, token.Text, includeAttributeSuffixFallback);
+        return type != null;
+    }
+
+    /// <summary>
+    /// Attempts to resolve the identifier under <paramref name="token"/> to a
+    /// CLR <see cref="MemberInfo"/> on an imported type. Covers member-access
+    /// RHS tokens like the <c>WriteLine</c> in <c>Console.WriteLine</c>.
+    /// </summary>
+    /// <param name="tree">The syntax tree providing context.</param>
+    /// <param name="compilation">The compilation.</param>
+    /// <param name="token">The token under the cursor.</param>
+    /// <param name="member">The resolved member on success.</param>
+    /// <returns>True when a CLR member was resolved.</returns>
+    public static bool TryResolveClrMember(SyntaxTree tree, Compilation compilation, SyntaxToken token, out MemberInfo member)
+    {
+        member = null;
+        if (token == null || token.Kind != SyntaxKind.IdentifierToken)
+        {
+            return false;
+        }
+
+        foreach (var context in FindAccessorMemberContexts(tree, token))
+        {
+            if (!TryResolveClrReceiver(tree, compilation, context.ReceiverExpression, out var receiverType, out var staticMembers))
+            {
+                continue;
+            }
+
+            var flags = BindingFlags.Public | (staticMembers ? BindingFlags.Static : BindingFlags.Instance);
+
+            var property = ClrTypeUtilities.SafeGetProperty(receiverType, context.MemberName, flags);
+            if (property != null && property.GetIndexParameters().Length == 0)
+            {
+                member = property;
+                return true;
+            }
+
+            var field = ClrTypeUtilities.SafeGetField(receiverType, context.MemberName, flags);
+            if (field != null)
+            {
+                member = field;
+                return true;
+            }
+
+            var @event = ClrTypeUtilities.SafeGetEvent(receiverType, context.MemberName, flags);
+            if (@event != null)
+            {
+                member = @event;
+                return true;
+            }
+
+            var methods = ClrTypeUtilities.SafeGetMethods(receiverType, flags)
+                .Where(m => m.Name == context.MemberName && !m.IsSpecialName)
+                .ToArray();
+            if (methods.Length > 0)
+            {
+                member = methods[0];
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveClrReceiver(SyntaxTree tree, Compilation compilation, ExpressionSyntax expression, out Type receiverType, out bool staticMembers)
+    {
+        receiverType = null;
+        staticMembers = false;
+        switch (expression)
+        {
+            case NameExpressionSyntax name:
+                var nameSymbol = SemanticLookup.ResolveSymbol(compilation, name.IdentifierToken);
+                if (TryGetClrTypeFromSymbol(nameSymbol, out receiverType))
+                {
+                    staticMembers = false;
+                    return true;
+                }
+
+                var imported = SemanticLookup.ResolveImportedClrType(tree, compilation, name.IdentifierToken.Text);
+                if (imported != null)
+                {
+                    receiverType = imported;
+                    staticMembers = true;
+                    return true;
+                }
+
+                return false;
+
+            case CallExpressionSyntax call:
+                var callSymbol = SemanticLookup.ResolveSymbol(compilation, call.Identifier);
+                if (TryGetClrTypeFromSymbol(callSymbol, out receiverType))
+                {
+                    staticMembers = false;
+                    return true;
+                }
+
+                return false;
+
+            case AccessorExpressionSyntax accessor:
+                // Chained access — walk the chain: receiver type of `a.b.c`
+                // for cursor on `c` requires the type of `a.b`. We resolve
+                // the left part's receiver first, then look up the member's
+                // type on it.
+                if (!TryGetAccessorMemberName(accessor.RightPart, out var intermediateName))
+                {
+                    return false;
+                }
+
+                if (!TryResolveClrReceiver(tree, compilation, accessor.LeftPart, out var outerType, out var outerStatic))
+                {
+                    return false;
+                }
+
+                var outerFlags = BindingFlags.Public | (outerStatic ? BindingFlags.Static : BindingFlags.Instance);
+                receiverType = ResolveMemberReturnType(outerType, intermediateName, outerFlags);
+                staticMembers = false;
+                return receiverType != null;
+
+            default:
+                return false;
+        }
+    }
+
+    private static Type ResolveMemberReturnType(Type receiverType, string memberName, BindingFlags flags)
+    {
+        if (receiverType == null)
+        {
+            return null;
+        }
+
+        var property = ClrTypeUtilities.SafeGetProperty(receiverType, memberName, flags);
+        if (property != null && property.GetIndexParameters().Length == 0)
+        {
+            return property.PropertyType;
+        }
+
+        var field = ClrTypeUtilities.SafeGetField(receiverType, memberName, flags);
+        if (field != null)
+        {
+            return field.FieldType;
+        }
+
+        var @event = ClrTypeUtilities.SafeGetEvent(receiverType, memberName, flags);
+        if (@event != null)
+        {
+            return @event.EventHandlerType;
+        }
+
+        var method = ClrTypeUtilities.SafeGetMethods(receiverType, flags)
+            .FirstOrDefault(m => m.Name == memberName && !m.IsSpecialName);
+        return method?.ReturnType;
+    }
+
+    private static bool TryGetClrTypeFromSymbol(Symbol symbol, out Type clrType)
+    {
+        clrType = symbol switch
+        {
+            ImportedClassSymbol importedClass => importedClass.ClassType,
+            ImportedTypeSymbol importedType => importedType.Type,
+            TypeSymbol typeSymbol => typeSymbol.ClrType,
+            VariableSymbol variable => variable.Type?.ClrType,
+            PropertySymbol property => property.Type?.ClrType,
+            FieldSymbol field => field.Type?.ClrType,
+            EventSymbol @event => @event.Type?.ClrType,
+            FunctionSymbol function => function.Type?.ClrType,
+            ImportedFunctionSymbol function => function.Type?.ClrType,
+            _ => null,
+        };
+
+        return clrType != null;
+    }
+
+    private static bool TryGetAccessorMemberName(ExpressionSyntax expression, out string memberName)
+    {
+        memberName = expression switch
+        {
+            NameExpressionSyntax name => name.IdentifierToken.Text,
+            CallExpressionSyntax call => call.Identifier.Text,
+            _ => null,
+        };
+
+        return memberName != null;
+    }
+
+    private static IEnumerable<(ExpressionSyntax ReceiverExpression, string MemberName)> FindAccessorMemberContexts(SyntaxTree tree, SyntaxToken token)
+    {
+        if (token == null || token.Kind != SyntaxKind.IdentifierToken)
+        {
+            yield break;
+        }
+
+        foreach (var accessor in FindNodes<AccessorExpressionSyntax>(tree.Root)
+                     .Where(a => a.RightPart.Span.Start <= token.Span.Start && token.Span.End <= a.RightPart.Span.End)
+                     .OrderBy(a => a.Span.Length))
+        {
+            if (TryResolveAccessorMemberContext(tree, accessor.RightPart, accessor.LeftPart, token, out var receiverExpression, out var memberName))
+            {
+                yield return (receiverExpression, memberName);
+            }
+        }
+    }
+
+    private static bool TryResolveAccessorMemberContext(
+        SyntaxTree tree,
+        ExpressionSyntax expression,
+        ExpressionSyntax receiver,
+        SyntaxToken token,
+        out ExpressionSyntax receiverExpression,
+        out string memberName)
+    {
+        receiverExpression = null;
+        memberName = null;
+
+        switch (expression)
+        {
+            case NameExpressionSyntax name when MatchesToken(name.IdentifierToken, token):
+                receiverExpression = receiver;
+                memberName = name.IdentifierToken.Text;
+                return true;
+            case CallExpressionSyntax call when MatchesToken(call.Identifier, token):
+                receiverExpression = receiver;
+                memberName = call.Identifier.Text;
+                return true;
+            case AccessorExpressionSyntax nested:
+                if (TryResolveAccessorMemberContext(tree, nested.LeftPart, receiver, token, out receiverExpression, out memberName))
+                {
+                    return true;
+                }
+
+                var nestedReceiver = new AccessorExpressionSyntax(tree, receiver, nested.DotToken, nested.LeftPart);
+                return TryResolveAccessorMemberContext(tree, nested.RightPart, nestedReceiver, token, out receiverExpression, out memberName);
+            default:
+                return false;
+        }
+    }
+
+    private static bool MatchesToken(SyntaxToken candidate, SyntaxToken token)
+    {
+        return ReferenceEquals(candidate, token)
+            || (candidate != null && token != null
+                && candidate.Span.Start == token.Span.Start
+                && candidate.Span.End == token.Span.End
+                && string.Equals(candidate.Text, token.Text, StringComparison.Ordinal));
+    }
+
+    private static bool IsAnnotationNameToken(SyntaxNode root, SyntaxToken token)
+    {
+        if (token == null || token.Kind != SyntaxKind.IdentifierToken)
+        {
+            return false;
+        }
+
+        foreach (var annotation in FindNodes<AnnotationSyntax>(root))
+        {
+            foreach (var segment in annotation.NameSegments)
+            {
+                if (MatchesToken(segment, token))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<T> FindNodes<T>(SyntaxNode root)
+        where T : SyntaxNode
+    {
+        if (root is T matched)
+        {
+            yield return matched;
+        }
+
+        foreach (var child in root.GetChildren())
+        {
+            foreach (var descendant in FindNodes<T>(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+}

--- a/src/LanguageServer/PdbSourceLocator.cs
+++ b/src/LanguageServer/PdbSourceLocator.cs
@@ -1,0 +1,377 @@
+// <copyright file="PdbSourceLocator.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace GSharp.LanguageServer;
+
+/// <summary>
+/// Tier 2 of cross-project Go-to-Definition: resolves a CLR member to a source
+/// file/line by reading its declaring assembly's portable PDB (sidecar
+/// <c>{Name}.pdb</c> or embedded in the PE).
+/// </summary>
+/// <remarks>
+/// Per-assembly readers are cached for the lifetime of the language server.
+/// The cache key is the resolved assembly path plus its last-write time, so a
+/// successful rebuild invalidates the cached PDB automatically on the next
+/// lookup. <see cref="MetadataReaderProvider"/> instances are intentionally not
+/// disposed: the LSP holds them open for as long as the workspace lives.
+/// <para>
+/// MSBuild emits the public-API <c>refint/{Name}.dll</c> for any project with
+/// <c>ProduceReferenceAssembly=true</c> (the SDK default for libraries), and
+/// that DLL has no method bodies — hence no sequence points. When the supplied
+/// path lives under a <c>refint</c> directory we transparently swap to the
+/// sibling runtime assembly one level up (<c>obj/.../{Name}.dll</c>), which
+/// the SDK writes alongside its PDB.
+/// </para>
+/// </remarks>
+public static class PdbSourceLocator
+{
+    private static readonly ConcurrentDictionary<string, CachedReader> ReaderCache = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Resolves a method's first sequence point to a source file and span.
+    /// Returns <see langword="false"/> when no portable PDB is reachable from
+    /// the supplied assembly path, or when the metadata token has no sequence
+    /// points (e.g. compiler-generated or PDB-less builds).
+    /// </summary>
+    /// <param name="assemblyFilePath">Absolute path to the imported assembly, as
+    /// it appears in the project's reference list.</param>
+    /// <param name="methodMetadataToken">A 0x06xxxxxx-typed
+    /// <c>MethodInfo.MetadataToken</c>.</param>
+    /// <param name="location">The resolved source location on success.</param>
+    /// <returns>True when a source location was found.</returns>
+    public static bool TryGetMethodSourceLocation(string assemblyFilePath, int methodMetadataToken, out SourceLocation location)
+    {
+        location = default;
+        if (string.IsNullOrEmpty(assemblyFilePath))
+        {
+            return false;
+        }
+
+        // Per cmt above: prefer the runtime assembly's PDB when the input is a refint shim.
+        var probePath = RebaseRefIntPath(assemblyFilePath);
+        var reader = GetOrLoadReader(probePath);
+        if (reader == null && !string.Equals(probePath, assemblyFilePath, StringComparison.OrdinalIgnoreCase))
+        {
+            reader = GetOrLoadReader(assemblyFilePath);
+        }
+
+        if (reader == null)
+        {
+            return false;
+        }
+
+        return TryReadFirstSequencePoint(reader, methodMetadataToken, out location);
+    }
+
+    /// <summary>
+    /// Resolves a type's source location by walking its methods (constructors
+    /// first, then declared methods) and returning the earliest sequence point
+    /// found. The earliest declaration is the best proxy for "where the type
+    /// is defined": even if the methods live in a partial across multiple
+    /// files, the first sequence point of the first non-synthetic method
+    /// reliably lands at or just inside the type's body.
+    /// </summary>
+    /// <param name="assemblyFilePath">Absolute path to the imported assembly.</param>
+    /// <param name="typeMetadataToken">A 0x02xxxxxx-typed <c>Type.MetadataToken</c>.</param>
+    /// <param name="location">The resolved source location on success.</param>
+    /// <returns>True when at least one sequence point was found for the type.</returns>
+    public static bool TryGetTypeSourceLocation(string assemblyFilePath, int typeMetadataToken, out SourceLocation location)
+    {
+        location = default;
+        if (string.IsNullOrEmpty(assemblyFilePath))
+        {
+            return false;
+        }
+
+        var probePath = RebaseRefIntPath(assemblyFilePath);
+        var reader = GetOrLoadReader(probePath);
+        if (reader == null && !string.Equals(probePath, assemblyFilePath, StringComparison.OrdinalIgnoreCase))
+        {
+            reader = GetOrLoadReader(assemblyFilePath);
+        }
+
+        if (reader == null)
+        {
+            return false;
+        }
+
+        // The PDB MethodDebugInformation table is parallel to the PE
+        // MethodDef table; we don't need the PE here because the supplied
+        // method tokens are already resolved by the caller from
+        // typeDef.GetMethods(). Resolve them via the PE alongside the PDB.
+        if (!TryReadTypeMethodTokens(probePath, typeMetadataToken, out var methodTokens))
+        {
+            if (!string.Equals(probePath, assemblyFilePath, StringComparison.OrdinalIgnoreCase))
+            {
+                if (!TryReadTypeMethodTokens(assemblyFilePath, typeMetadataToken, out methodTokens))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        SourceLocation? best = null;
+        foreach (var methodToken in methodTokens)
+        {
+            if (TryReadFirstSequencePoint(reader, methodToken, out var candidate))
+            {
+                if (best == null || IsEarlier(candidate, best.Value))
+                {
+                    best = candidate;
+                }
+            }
+        }
+
+        if (best == null)
+        {
+            return false;
+        }
+
+        location = best.Value;
+        return true;
+    }
+
+    private static bool IsEarlier(SourceLocation a, SourceLocation b)
+    {
+        var cmp = string.Compare(a.FilePath, b.FilePath, StringComparison.OrdinalIgnoreCase);
+        if (cmp != 0)
+        {
+            return cmp < 0;
+        }
+
+        if (a.StartLine != b.StartLine)
+        {
+            return a.StartLine < b.StartLine;
+        }
+
+        return a.StartColumn < b.StartColumn;
+    }
+
+    private static bool TryReadTypeMethodTokens(string assemblyFilePath, int typeMetadataToken, out IReadOnlyList<int> methodTokens)
+    {
+        methodTokens = Array.Empty<int>();
+        if (!File.Exists(assemblyFilePath))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var stream = new FileStream(assemblyFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+            {
+                return false;
+            }
+
+            var mdReader = peReader.GetMetadataReader();
+            var handle = MetadataTokens.EntityHandle(typeMetadataToken);
+            if (handle.Kind != HandleKind.TypeDefinition)
+            {
+                return false;
+            }
+
+            var typeDef = mdReader.GetTypeDefinition((TypeDefinitionHandle)handle);
+            var collected = new List<int>();
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                collected.Add(MetadataTokens.GetToken(methodHandle));
+            }
+
+            methodTokens = collected;
+            return collected.Count > 0;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (BadImageFormatException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryReadFirstSequencePoint(MetadataReader reader, int methodMetadataToken, out SourceLocation location)
+    {
+        location = default;
+        try
+        {
+            var entityHandle = MetadataTokens.EntityHandle(methodMetadataToken);
+            if (entityHandle.Kind != HandleKind.MethodDefinition)
+            {
+                return false;
+            }
+
+            var debugInfoHandle = ((MethodDefinitionHandle)entityHandle).ToDebugInformationHandle();
+            var debugInfo = reader.GetMethodDebugInformation(debugInfoHandle);
+            if (debugInfo.SequencePointsBlob.IsNil)
+            {
+                return false;
+            }
+
+            foreach (var sp in debugInfo.GetSequencePoints())
+            {
+                if (sp.IsHidden)
+                {
+                    continue;
+                }
+
+                var doc = reader.GetDocument(sp.Document);
+                var filePath = reader.GetString(doc.Name);
+                location = new SourceLocation(filePath, sp.StartLine, sp.StartColumn, sp.EndLine, sp.EndColumn);
+                return true;
+            }
+
+            return false;
+        }
+        catch (BadImageFormatException)
+        {
+            return false;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return false;
+        }
+    }
+
+    private static MetadataReader GetOrLoadReader(string assemblyFilePath)
+    {
+        if (!File.Exists(assemblyFilePath))
+        {
+            return null;
+        }
+
+        DateTime mtimeUtc;
+        try
+        {
+            mtimeUtc = File.GetLastWriteTimeUtc(assemblyFilePath);
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+
+        if (ReaderCache.TryGetValue(assemblyFilePath, out var cached) && cached.MtimeUtc == mtimeUtc)
+        {
+            return cached.Reader;
+        }
+
+        var loaded = LoadReader(assemblyFilePath);
+        if (loaded == null)
+        {
+            return null;
+        }
+
+        ReaderCache[assemblyFilePath] = new CachedReader(loaded, mtimeUtc);
+        return loaded;
+    }
+
+    private static MetadataReader LoadReader(string assemblyFilePath)
+    {
+        try
+        {
+            var sidecar = Path.ChangeExtension(assemblyFilePath, ".pdb");
+            if (File.Exists(sidecar))
+            {
+                // Read the file into memory so MetadataReaderProvider keeps the
+                // bytes alive after the underlying file handle is closed
+                // (FromPortablePdbImage stores the buffer directly).
+                var bytes = File.ReadAllBytes(sidecar);
+                var provider = MetadataReaderProvider.FromPortablePdbImage(System.Collections.Immutable.ImmutableArray.Create(bytes));
+                return provider.GetMetadataReader();
+            }
+
+            // Probe the PE for an embedded PDB.
+            using var stream = new FileStream(assemblyFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+            {
+                return null;
+            }
+
+            var debugDirectory = peReader.ReadDebugDirectory();
+            var embedded = debugDirectory.FirstOrDefault(e => e.Type == DebugDirectoryEntryType.EmbeddedPortablePdb);
+            if (embedded.DataSize == 0)
+            {
+                return null;
+            }
+
+            var embeddedProvider = peReader.ReadEmbeddedPortablePdbDebugDirectoryData(embedded);
+            return embeddedProvider.GetMetadataReader();
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Rewrites a path ending in <c>obj/.../refint/{Name}.dll</c> to the
+    /// sibling runtime DLL <c>obj/.../{Name}.dll</c>. Returns the input
+    /// unchanged when the segment <c>refint</c> is not present.
+    /// </summary>
+    private static string RebaseRefIntPath(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+
+        var directory = Path.GetDirectoryName(path);
+        if (string.IsNullOrEmpty(directory))
+        {
+            return path;
+        }
+
+        var leaf = Path.GetFileName(directory);
+        if (!string.Equals(leaf, "refint", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(leaf, "ref", StringComparison.OrdinalIgnoreCase))
+        {
+            return path;
+        }
+
+        var parent = Path.GetDirectoryName(directory);
+        if (string.IsNullOrEmpty(parent))
+        {
+            return path;
+        }
+
+        var candidate = Path.Combine(parent, Path.GetFileName(path));
+        return File.Exists(candidate) ? candidate : path;
+    }
+
+    /// <summary>
+    /// Source location returned by the PDB lookup. Lines and columns are
+    /// 1-based per the Portable PDB sequence-point convention; the caller is
+    /// expected to convert to LSP's 0-based <see cref="Protocol.Position"/>.
+    /// </summary>
+    public readonly record struct SourceLocation(string FilePath, int StartLine, int StartColumn, int EndLine, int EndColumn);
+
+    private readonly record struct CachedReader(MetadataReader Reader, DateTime MtimeUtc);
+}

--- a/src/LanguageServer/ProjectDiscovery.cs
+++ b/src/LanguageServer/ProjectDiscovery.cs
@@ -58,13 +58,15 @@ public static class ProjectDiscovery
         var sourceFiles = DiscoverSourceFiles(projectFilePath, projectDir);
         var projectReferences = DiscoverProjectReferences(projectFilePath, projectDir);
         var (references, referenceSourcePath) = DiscoverReferences(projectFilePath, projectDir);
+        var assemblyName = ResolveAssemblyName(projectFilePath);
 
         return new DiscoveredProject(
             Path.GetFullPath(projectFilePath),
             sourceFiles,
             projectReferences,
             references,
-            referenceSourcePath);
+            referenceSourcePath,
+            assemblyName);
     }
 
     /// <summary>
@@ -135,6 +137,34 @@ public static class ProjectDiscovery
         }
 
         return refs;
+    }
+
+    /// <summary>
+    /// Resolves the project's effective <c>AssemblyName</c>, which the SDK uses
+    /// as the base of the response-file name. Defaults to the project file's
+    /// base name (matching MSBuild's <c>$(TargetName)</c> default).
+    /// </summary>
+    /// <param name="projectFilePath">Absolute path to the <c>.gsproj</c>.</param>
+    /// <returns>The effective <c>AssemblyName</c>; never <c>null</c>.</returns>
+    internal static string ResolveAssemblyName(string projectFilePath)
+    {
+        var defaultName = Path.GetFileNameWithoutExtension(projectFilePath);
+        try
+        {
+            var doc = XDocument.Load(projectFilePath);
+            var explicitName = doc.Descendants()
+                .FirstOrDefault(e => e.Name.LocalName == "AssemblyName")?.Value;
+            if (!string.IsNullOrWhiteSpace(explicitName))
+            {
+                return explicitName.Trim();
+            }
+        }
+        catch (Exception)
+        {
+            // Fall through to the default below.
+        }
+
+        return defaultName;
     }
 
     /// <summary>
@@ -252,32 +282,6 @@ public static class ProjectDiscovery
 
         var references = ParseReferencesFromResponseFile(rspPath);
         return (references, Path.GetFullPath(rspPath));
-    }
-
-    /// <summary>
-    /// Resolves the project's effective <c>AssemblyName</c>, which the SDK uses
-    /// as the base of the response-file name. Defaults to the project file's
-    /// base name (matching MSBuild's <c>$(TargetName)</c> default).
-    /// </summary>
-    private static string ResolveAssemblyName(string projectFilePath)
-    {
-        var defaultName = Path.GetFileNameWithoutExtension(projectFilePath);
-        try
-        {
-            var doc = XDocument.Load(projectFilePath);
-            var explicitName = doc.Descendants()
-                .FirstOrDefault(e => e.Name.LocalName == "AssemblyName")?.Value;
-            if (!string.IsNullOrWhiteSpace(explicitName))
-            {
-                return explicitName.Trim();
-            }
-        }
-        catch (Exception)
-        {
-            // Fall through to the default below.
-        }
-
-        return defaultName;
     }
 
     private static bool IsDefaultCompileItemsDisabled(string projectFilePath)

--- a/src/LanguageServer/ProjectState.cs
+++ b/src/LanguageServer/ProjectState.cs
@@ -50,6 +50,17 @@ public class ProjectState
     public string ProjectDirectory { get; }
 
     /// <summary>
+    /// Gets or sets the project's effective <c>AssemblyName</c> — the basename
+    /// (without extension) of the output DLL the SDK emits for this project.
+    /// Defaults to <c>null</c> for projects constructed without discovery (e.g.
+    /// the implicit project for loose files and most unit-test scaffolding);
+    /// <see cref="WorkspaceInitializer"/> populates it for every project parsed
+    /// out of a <c>.gsproj</c>. Cross-project Go-to-Definition consults this
+    /// via <see cref="WorkspaceState.TryGetProjectByOutputAssembly"/>.
+    /// </summary>
+    public string AssemblyName { get; set; }
+
+    /// <summary>
     /// Gets the set of source file paths currently in this project.
     /// </summary>
     public IReadOnlyCollection<string> SourceFiles => syntaxTrees.Keys.ToList();

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -206,7 +206,7 @@ public sealed class LspServer
         }
 
         cancellationToken.ThrowIfCancellationRequested();
-        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding: false, project, filePath);
+        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding: false, project, filePath, this.workspaceState);
         cancellationToken.ThrowIfCancellationRequested();
 
         var resultId = ComputeResultId(result.Diagnostics);
@@ -445,7 +445,7 @@ public sealed class LspServer
 
         // Parse-only content (no binding) feeds the content service used by other features;
         // diagnostics are produced on demand by the textDocument/diagnostic pull handler.
-        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding: true, project, filePath);
+        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding: true, project, filePath, this.workspaceState);
         this.documentContentService.AddOrUpdate(uri.ToString(), result.Content);
     }
 
@@ -460,7 +460,7 @@ public sealed class LspServer
 
         var filePath = uri.GetFileSystemPath();
         var project = !string.IsNullOrEmpty(filePath) ? this.workspaceState.GetProjectForFile(filePath) : null;
-        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding, project, filePath);
+        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding, project, filePath, this.workspaceState);
 
         this.rpc?.NotifyWithParameterObjectAsync(
             "textDocument/publishDiagnostics",

--- a/src/LanguageServer/WorkspaceInitializer.cs
+++ b/src/LanguageServer/WorkspaceInitializer.cs
@@ -29,6 +29,7 @@ public static class WorkspaceInitializer
         foreach (var disc in discovered)
         {
             var project = workspaceState.AddProject(disc.ProjectFilePath);
+            project.AssemblyName = disc.AssemblyName;
             project.ProjectReferences = disc.ProjectReferences;
             project.ReferenceSourcePath = disc.ReferenceSourcePath;
             project.References = disc.References;

--- a/src/LanguageServer/WorkspaceState.cs
+++ b/src/LanguageServer/WorkspaceState.cs
@@ -168,4 +168,59 @@ public class WorkspaceState
 
         return result;
     }
+
+    /// <summary>
+    /// Maps an imported assembly's file path back to the sibling G# project
+    /// that produced it, if any. Cross-project Go-to-Definition uses this to
+    /// jump from an <c>Imported*Symbol</c> loaded out of <c>obj/.../Lib.dll</c>
+    /// (or <c>obj/.../refint/Lib.dll</c>) into the originating <c>.gsproj</c>
+    /// project's syntax trees without having to read the PDB.
+    /// </summary>
+    /// <remarks>
+    /// Matching is by basename (case-insensitive on Windows): the SDK names the
+    /// emitted DLL after <c>$(AssemblyName)</c>, which defaults to
+    /// <c>$(TargetName)</c>, which in turn defaults to the project file's base
+    /// name. Each <see cref="ProjectState.AssemblyName"/> is populated by
+    /// <see cref="WorkspaceInitializer.Initialize"/> from
+    /// <see cref="ProjectDiscovery.DiscoverProject(string)"/>; projects added
+    /// outside of discovery (test scaffolding, the implicit project for loose
+    /// files) fall through and return <c>false</c>.
+    /// </remarks>
+    /// <param name="assemblyFilePath">Absolute path to the imported assembly,
+    /// as it appears in a
+    /// <see cref="GSharp.Core.CodeAnalysis.Symbols.ReferenceResolver"/>
+    /// reference list.</param>
+    /// <param name="project">The matching sibling project on success.</param>
+    /// <returns><see langword="true"/> when a sibling G# project matched.</returns>
+    public bool TryGetProjectByOutputAssembly(string assemblyFilePath, out ProjectState project)
+    {
+        project = null;
+        if (string.IsNullOrEmpty(assemblyFilePath))
+        {
+            return false;
+        }
+
+        var assemblyName = Path.GetFileNameWithoutExtension(assemblyFilePath);
+        if (string.IsNullOrEmpty(assemblyName))
+        {
+            return false;
+        }
+
+        foreach (var candidate in projects.Values)
+        {
+            var candidateName = candidate.AssemblyName;
+            if (string.IsNullOrEmpty(candidateName))
+            {
+                continue;
+            }
+
+            if (string.Equals(candidateName, assemblyName, StringComparison.OrdinalIgnoreCase))
+            {
+                project = candidate;
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/test/LanguageServer.Tests/CrossProjectDefinitionTests.cs
+++ b/test/LanguageServer.Tests/CrossProjectDefinitionTests.cs
@@ -1,0 +1,451 @@
+// <copyright file="CrossProjectDefinitionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using System.Reflection;
+using GSharp.LanguageServer.Protocol;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+public class CrossProjectDefinitionTests
+{
+    /// <summary>
+    /// Tier 1 — Sibling G# project: when a workspace owns a sibling project
+    /// whose AssemblyName matches the assembly an <see cref="System.Type"/>
+    /// was loaded from, the resolver should walk that project's syntax trees
+    /// and return the in-source identifier token.
+    /// </summary>
+    [Fact]
+    public void Tier1_SiblingGsharpProject_TypeNavigatesToStructDeclaration()
+    {
+        // Use a real loaded CLR type so MetadataToken / Assembly.Location are real.
+        // Pretend the sibling G# project produced the assembly that hosts this type
+        // and contains a G# struct with the same Name + Namespace.
+        var target = typeof(System.Text.StringBuilder);
+        var siblingProjectName = System.IO.Path.GetFileNameWithoutExtension(target.Assembly.Location);
+
+        var workspace = new WorkspaceState();
+        var sibling = workspace.AddProject($"/test/{siblingProjectName}/{siblingProjectName}.gsproj");
+        sibling.AssemblyName = siblingProjectName;
+        sibling.UpdateFile(
+            $"/test/{siblingProjectName}/StringBuilder.gs",
+            "package System.Text\n\ntype StringBuilder class { }\n");
+
+        var resolved = CrossAssemblyDefinitionResolver.TryResolveType(workspace, target, out var location);
+
+        Assert.True(resolved, $"Expected sibling project lookup to succeed for {target.FullName}");
+        Assert.NotNull(location);
+        Assert.Contains("StringBuilder.gs", location.Uri.GetFileSystemPath());
+    }
+
+    /// <summary>
+    /// Tier 1 — Sibling G# project: a method on a sibling type navigates to
+    /// the matching G# method declaration's identifier (matched by name with
+    /// arity-based overload resolution).
+    /// </summary>
+    [Fact]
+    public void Tier1_SiblingGsharpProject_MethodNavigatesToMethodDeclaration()
+    {
+        // typeof(StringBuilder).GetMethod("Clear") — a zero-arity method we can match by name+arity.
+        var target = typeof(System.Text.StringBuilder).GetMethod(nameof(System.Text.StringBuilder.Clear));
+        Assert.NotNull(target);
+
+        var siblingProjectName = System.IO.Path.GetFileNameWithoutExtension(target.Module.Assembly.Location);
+
+        var workspace = new WorkspaceState();
+        var sibling = workspace.AddProject($"/test/{siblingProjectName}/{siblingProjectName}.gsproj");
+        sibling.AssemblyName = siblingProjectName;
+        sibling.UpdateFile(
+            $"/test/{siblingProjectName}/StringBuilder.gs",
+            "package System.Text\n\ntype StringBuilder class {\n    func Clear() { }\n}\n");
+
+        var resolved = CrossAssemblyDefinitionResolver.TryResolveMethod(workspace, target, out var location);
+
+        Assert.True(resolved);
+        Assert.NotNull(location);
+        Assert.Contains("StringBuilder.gs", location.Uri.GetFileSystemPath());
+
+        // The Identifier of the Clear() method lives on line 3 (0-based) of the source above
+        // (line 0 = "package System.Text", 1 = "", 2 = "type StringBuilder class {", 3 = "    func Clear() { }").
+        Assert.Equal(3, location.Range.Start.Line);
+    }
+
+    /// <summary>
+    /// Tier 1 — Sibling lookup: the resolver should resolve types whose CLR
+    /// namespace differs from the project's package by matching on namespace +
+    /// simple name, not by full name.
+    /// </summary>
+    [Fact]
+    public void Tier1_SiblingGsharpProject_EmptyNamespaceStructMatchesByName()
+    {
+        // System.Object has Namespace="System" — test that empty package on G# side does not match.
+        var target = typeof(object);
+        var siblingProjectName = System.IO.Path.GetFileNameWithoutExtension(target.Assembly.Location);
+
+        var workspace = new WorkspaceState();
+        var sibling = workspace.AddProject($"/test/{siblingProjectName}/{siblingProjectName}.gsproj");
+        sibling.AssemblyName = siblingProjectName;
+        // Note: no `package` statement → G# struct's PackageName is empty, won't match "System".
+        sibling.UpdateFile($"/test/{siblingProjectName}/Object.gs", "type Object class { }\n");
+
+        var resolved = CrossAssemblyDefinitionResolver.TryResolveType(workspace, target, out var location);
+
+        Assert.False(resolved);
+        Assert.Null(location);
+    }
+
+    /// <summary>
+    /// Workspace lookup: matching is by basename and case-insensitive (Windows path semantics).
+    /// </summary>
+    [Fact]
+    public void Workspace_TryGetProjectByOutputAssembly_MatchesByBasename()
+    {
+        var workspace = new WorkspaceState();
+        var lib = workspace.AddProject("/test/lib/lib.gsproj");
+        lib.AssemblyName = "MyLib";
+
+        Assert.True(workspace.TryGetProjectByOutputAssembly(
+            "/some/where/obj/Debug/net8.0/MyLib.dll",
+            out var found));
+        Assert.Same(lib, found);
+
+        Assert.True(workspace.TryGetProjectByOutputAssembly(
+            "/some/where/obj/Debug/net8.0/refint/mylib.dll",
+            out found));
+        Assert.Same(lib, found);
+    }
+
+    [Fact]
+    public void Workspace_TryGetProjectByOutputAssembly_ReturnsFalseForUnknown()
+    {
+        var workspace = new WorkspaceState();
+        var lib = workspace.AddProject("/test/lib/lib.gsproj");
+        lib.AssemblyName = "MyLib";
+
+        Assert.False(workspace.TryGetProjectByOutputAssembly(
+            "/some/where/Other.dll",
+            out var found));
+        Assert.Null(found);
+    }
+
+    [Fact]
+    public void Workspace_TryGetProjectByOutputAssembly_IgnoresProjectsWithoutAssemblyName()
+    {
+        var workspace = new WorkspaceState();
+        // Project added without an AssemblyName (typical for the implicit project
+        // or tests that don't go through discovery).
+        workspace.AddProject("/test/loose/loose.gsproj");
+
+        Assert.False(workspace.TryGetProjectByOutputAssembly("/elsewhere/Anything.dll", out _));
+    }
+
+    /// <summary>
+    /// Tier 2 — PDB-based: open a real portable PDB (the test assembly's own
+    /// sidecar) and resolve a known method token to a source file/line.
+    /// </summary>
+    [Fact]
+    public void Tier2_PdbSourceLocator_ResolvesMethodFromSidecarPdb()
+    {
+        // Pick a stable method on this very test class. The compiler emits a
+        // sequence point on its opening brace, so we can assert on file path
+        // and a reasonable line range.
+        var method = typeof(CrossProjectDefinitionTests).GetMethod(nameof(MarkerMethod), BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+
+        var assemblyPath = typeof(CrossProjectDefinitionTests).Assembly.Location;
+
+        var resolved = PdbSourceLocator.TryGetMethodSourceLocation(assemblyPath, method.MetadataToken, out var location);
+
+        Assert.True(resolved, $"Expected to read sidecar PDB next to {assemblyPath}");
+        Assert.EndsWith("CrossProjectDefinitionTests.cs", location.FilePath);
+        Assert.True(location.StartLine > 0, "Expected a 1-based source line");
+    }
+
+    [Fact]
+    public void Tier2_PdbSourceLocator_ReturnsFalseForUnknownAssembly()
+    {
+        Assert.False(PdbSourceLocator.TryGetMethodSourceLocation(
+            "/does/not/exist/Phantom.dll",
+            methodMetadataToken: 0x06000001,
+            out var location));
+        Assert.Equal(default, location);
+    }
+
+    [Fact]
+    public void Tier2_PdbSourceLocator_ResolvesTypeFromSidecarPdb()
+    {
+        var type = typeof(CrossProjectDefinitionTests);
+        var assemblyPath = type.Assembly.Location;
+
+        var resolved = PdbSourceLocator.TryGetTypeSourceLocation(assemblyPath, type.MetadataToken, out var location);
+
+        Assert.True(resolved);
+        Assert.EndsWith("CrossProjectDefinitionTests.cs", location.FilePath);
+    }
+
+    /// <summary>
+    /// CrossAssemblyDefinitionResolver — Tier 2 fallback: when no sibling
+    /// project owns the assembly the resolver should still find a Location via
+    /// the PDB.
+    /// </summary>
+    [Fact]
+    public void CrossAssemblyResolver_FallsBackToPdbWhenNoSiblingMatches()
+    {
+        var method = typeof(CrossProjectDefinitionTests).GetMethod(nameof(MarkerMethod), BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+
+        // Workspace with an unrelated sibling project — won't match by basename.
+        var workspace = new WorkspaceState();
+        var unrelated = workspace.AddProject("/test/unrelated/unrelated.gsproj");
+        unrelated.AssemblyName = "Unrelated";
+
+        var resolved = CrossAssemblyDefinitionResolver.TryResolveMethod(workspace, method, out var location);
+
+        Assert.True(resolved);
+        Assert.NotNull(location);
+        Assert.Contains("CrossProjectDefinitionTests.cs", location.Uri.GetFileSystemPath());
+    }
+
+    /// <summary>
+    /// Integration — DefinitionComputer end-to-end: a consumer file references
+    /// a struct defined in a sibling G# project. ResolveSymbol returns null for
+    /// the cross-project name (it isn't in the consumer's compilation), and
+    /// the new ImportedClrMember fallback path should kick in. Since this
+    /// scenario requires the sibling DLL to be loaded into a
+    /// MetadataLoadContext (which only happens at LSP runtime once the project
+    /// is built), the unit-test layer instead exercises the resolver directly;
+    /// the LSP pipeline is verified via the e2e projectref-e2e harness.
+    /// </summary>
+    [Fact]
+    public void DefinitionComputer_NoWorkspace_StillResolvesSameFileSymbols()
+    {
+        // Sanity: the changes did not break the original same-file Go-to-Definition path.
+        const string source = "func add(a int32, b int32) int32 { return a + b }\nlet result = add(1, 2)\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var uri = DocumentUri.From("file:///def.gs");
+
+        var location = DefinitionComputer.ComputeDefinition(uri, content, LanguageServerTestHelpers.PositionOf(source, "add", 1));
+
+        Assert.NotNull(location);
+        Assert.Equal(0, location.Range.Start.Line);
+        Assert.Equal(5, location.Range.Start.Character);
+    }
+
+    /// <summary>
+    /// End-to-end integration test for Tier 1: build a real G# Lib DLL on
+    /// disk, set up a workspace as <see cref="WorkspaceInitializer"/> would,
+    /// and drive <see cref="DefinitionComputer.ComputeDefinition"/> through the
+    /// full ResolveSymbol → ImportedClassSymbol → CrossAssemblyDefinitionResolver
+    /// pipeline. Verifies that F12 on a sibling-project type in App.gs lands
+    /// inside Lib.gs.
+    /// </summary>
+    [Fact]
+    public void DefinitionComputer_EndToEnd_NavigatesAcrossGsharpProjects()
+    {
+        var tempDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"gsharp-xprj-{System.Guid.NewGuid():N}");
+        System.IO.Directory.CreateDirectory(tempDir);
+        try
+        {
+            // 1. Compile a real Lib DLL from a real G# source file on disk.
+            var libDir = System.IO.Path.Combine(tempDir, "Lib");
+            System.IO.Directory.CreateDirectory(libDir);
+            var libSourcePath = System.IO.Path.Combine(libDir, "Greeter.gs");
+            const string LibSource =
+                "package XProjTestLib\n" +
+                "type Greeter class(Name string) {\n" +
+                "    func Greet() string {\n" +
+                "        return \"hi\"\n" +
+                "    }\n" +
+                "}\n";
+            System.IO.File.WriteAllText(libSourcePath, LibSource);
+
+            var libDllPath = System.IO.Path.Combine(libDir, "XProjTestLib.dll");
+            var libPdbPath = System.IO.Path.Combine(libDir, "XProjTestLib.pdb");
+
+            var libCompilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(
+                GSharp.Core.CodeAnalysis.Symbols.ReferenceResolver.Default(),
+                GSharp.Core.CodeAnalysis.Syntax.SyntaxTree.Parse(
+                    GSharp.Core.CodeAnalysis.Text.SourceText.From(LibSource, libSourcePath)));
+            libCompilation.DebugInformation = new GSharp.Core.CodeAnalysis.Emit.DebugInformationOptions
+            {
+                Format = GSharp.Core.CodeAnalysis.Emit.DebugInformationFormat.Portable,
+            };
+            using (var peStream = new System.IO.FileStream(libDllPath, System.IO.FileMode.Create))
+            using (var pdbStream = new System.IO.FileStream(libPdbPath, System.IO.FileMode.Create))
+            {
+                var libResult = libCompilation.Emit(peStream, pdbStream, refStream: null, assemblyName: "XProjTestLib");
+                Assert.True(libResult.Success, "Lib should compile: " + string.Join(", ", libResult.Diagnostics.Select(d => d.Message)));
+            }
+
+            // 2. App.gs source — a consumer that imports the lib and uses Greeter.
+            var appDir = System.IO.Path.Combine(tempDir, "App");
+            System.IO.Directory.CreateDirectory(appDir);
+            var appSourcePath = System.IO.Path.Combine(appDir, "Program.gs");
+            const string AppSource =
+                "package XProjTestApp\n" +
+                "import System\n" +
+                "import XProjTestLib\n" +
+                "var greeter = Greeter(\"world\")\n" +
+                "Console.WriteLine(greeter.Greet())\n";
+            System.IO.File.WriteAllText(appSourcePath, AppSource);
+
+            // 3. Workspace state — App project references Lib via the .dll path.
+            var workspace = new WorkspaceState();
+
+            var libProject = workspace.AddProject(System.IO.Path.Combine(libDir, "XProjTestLib.gsproj"));
+            libProject.AssemblyName = "XProjTestLib";
+            libProject.AddFileFromDisk(libSourcePath);
+
+            var appProject = workspace.AddProject(System.IO.Path.Combine(appDir, "XProjTestApp.gsproj"));
+            appProject.AssemblyName = "XProjTestApp";
+            appProject.References = new[] { libDllPath };
+            appProject.AddFileFromDisk(appSourcePath);
+            workspace.RegisterFile(appSourcePath, appProject);
+
+            // 4. DocumentContent for App.gs as the LSP would produce after didOpen.
+            var lineBreaks = new System.Collections.Generic.List<int>();
+            for (var i = 0; i < AppSource.Length; i++)
+            {
+                if (AppSource[i] == '\n')
+                {
+                    lineBreaks.Add(i);
+                }
+            }
+
+            var appContent = new DocumentContent(
+                appProject.GetCompilation().SyntaxTrees.First(),
+                lineBreaks,
+                appProject,
+                workspace);
+
+            // 5. Cursor on `Greeter` in `var greeter = Greeter("world")` (the call).
+            var uri = DocumentUri.FromFileSystemPath(appSourcePath);
+            var position = LanguageServerTestHelpers.PositionOf(AppSource, "Greeter", occurrence: 0);
+
+            var location = DefinitionComputer.ComputeDefinition(uri, appContent, position);
+
+            // 6. Should jump into Lib's Greeter.gs.
+            Assert.NotNull(location);
+            Assert.EndsWith("Greeter.gs", location.Uri.GetFileSystemPath());
+        }
+        finally
+        {
+            try
+            {
+                System.IO.Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup; the test runner's temp area is fine if we leak on Windows file-lock.
+            }
+        }
+    }
+
+    /// <summary>
+    /// End-to-end integration test for Tier 2: same setup as the Tier 1 test,
+    /// but the App's workspace has NO sibling project for the Lib's assembly,
+    /// so the resolver must fall through to PDB-based navigation.
+    /// </summary>
+    [Fact]
+    public void DefinitionComputer_EndToEnd_PdbFallback_NavigatesWithoutSiblingProject()
+    {
+        var tempDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"gsharp-xprj-pdb-{System.Guid.NewGuid():N}");
+        System.IO.Directory.CreateDirectory(tempDir);
+        try
+        {
+            var libDir = System.IO.Path.Combine(tempDir, "Lib");
+            System.IO.Directory.CreateDirectory(libDir);
+            var libSourcePath = System.IO.Path.Combine(libDir, "Greeter.gs");
+            const string LibSource =
+                "package XProjPdbLib\n" +
+                "type Greeter class(Name string) {\n" +
+                "    func Greet() string {\n" +
+                "        return \"hi\"\n" +
+                "    }\n" +
+                "}\n";
+            System.IO.File.WriteAllText(libSourcePath, LibSource);
+
+            var libDllPath = System.IO.Path.Combine(libDir, "XProjPdbLib.dll");
+            var libPdbPath = System.IO.Path.Combine(libDir, "XProjPdbLib.pdb");
+
+            var libCompilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(
+                GSharp.Core.CodeAnalysis.Symbols.ReferenceResolver.Default(),
+                GSharp.Core.CodeAnalysis.Syntax.SyntaxTree.Parse(
+                    GSharp.Core.CodeAnalysis.Text.SourceText.From(LibSource, libSourcePath)));
+            libCompilation.DebugInformation = new GSharp.Core.CodeAnalysis.Emit.DebugInformationOptions
+            {
+                Format = GSharp.Core.CodeAnalysis.Emit.DebugInformationFormat.Portable,
+            };
+            using (var peStream = new System.IO.FileStream(libDllPath, System.IO.FileMode.Create))
+            using (var pdbStream = new System.IO.FileStream(libPdbPath, System.IO.FileMode.Create))
+            {
+                var libResult = libCompilation.Emit(peStream, pdbStream, refStream: null, assemblyName: "XProjPdbLib");
+                Assert.True(libResult.Success);
+            }
+
+            var appDir = System.IO.Path.Combine(tempDir, "App");
+            System.IO.Directory.CreateDirectory(appDir);
+            var appSourcePath = System.IO.Path.Combine(appDir, "Program.gs");
+            const string AppSource =
+                "package XProjPdbApp\n" +
+                "import System\n" +
+                "import XProjPdbLib\n" +
+                "var greeter = Greeter(\"world\")\n" +
+                "Console.WriteLine(greeter.Greet())\n";
+            System.IO.File.WriteAllText(appSourcePath, AppSource);
+
+            // Workspace has only the App project; Lib is NOT registered as a sibling.
+            var workspace = new WorkspaceState();
+            var appProject = workspace.AddProject(System.IO.Path.Combine(appDir, "XProjPdbApp.gsproj"));
+            appProject.AssemblyName = "XProjPdbApp";
+            appProject.References = new[] { libDllPath };
+            appProject.AddFileFromDisk(appSourcePath);
+            workspace.RegisterFile(appSourcePath, appProject);
+
+            var lineBreaks = new System.Collections.Generic.List<int>();
+            for (var i = 0; i < AppSource.Length; i++)
+            {
+                if (AppSource[i] == '\n')
+                {
+                    lineBreaks.Add(i);
+                }
+            }
+
+            var appContent = new DocumentContent(
+                appProject.GetCompilation().SyntaxTrees.First(),
+                lineBreaks,
+                appProject,
+                workspace);
+
+            var uri = DocumentUri.FromFileSystemPath(appSourcePath);
+            var position = LanguageServerTestHelpers.PositionOf(AppSource, "Greeter", occurrence: 0);
+
+            var location = DefinitionComputer.ComputeDefinition(uri, appContent, position);
+
+            // PDB carries the source path from compile time → should land in Greeter.gs.
+            Assert.NotNull(location);
+            Assert.EndsWith("Greeter.gs", location.Uri.GetFileSystemPath());
+        }
+        finally
+        {
+            try
+            {
+                System.IO.Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+#pragma warning disable CA1822 // Intentionally instance method so the compiler emits a normal method body with sequence points.
+    private void MarkerMethod()
+    {
+        // PDB sequence-point anchor for Tier2_PdbSourceLocator_ResolvesMethodFromSidecarPdb.
+        System.GC.KeepAlive(this);
+    }
+#pragma warning restore CA1822
+}


### PR DESCRIPTION
## Summary

Adds two tiers of cross-assembly navigation to `textDocument/definition` so F12 / "Go to Definition" works for symbols defined in:
- **Sibling G# projects** in the same workspace (e.g. `App.gsproj` → `Lib.gsproj`).
- **C# project references** consumed from a `.gsproj` (e.g. `App.gsproj` → `MyCsharpLib.csproj`).
- **NuGet / package references** that ship a portable PDB (embedded or sidecar) — including the .NET BCL when targeting net10.0.

Previously `DefinitionComputer` returned `null` for any `Imported{Class,Type,Function}Symbol`: the switch in `FindDeclarationToken` only matched G#-source symbols, so cross-project navigation silently no-op'd.

## How it works

### Tier 1 — Sibling G# project source walk (preferred, no PDB needed)

`CrossAssemblyDefinitionResolver` checks whether the imported symbol's declaring assembly path matches a sibling `.gsproj`'s output (by AssemblyName basename), then walks that project's `Compilation.GlobalScope.{Structs,Enums,Interfaces,Delegates}` for a name + namespace match. Methods/properties/fields/events are resolved via the matching parent type's declaration. Method overloads disambiguate by arity. Even a freshly-restored project without a build resolves.

### Tier 2 — Portable-PDB navigation

`PdbSourceLocator` reads `System.Reflection.Metadata` sequence points from the assembly's sidecar `.pdb` (or its embedded PDB via `PEReader.ReadEmbeddedPortablePdbDebugDirectoryData`). Per-assembly `MetadataReader`s are cached, keyed on the assembly file's last-write time, so a successful rebuild invalidates the cache automatically. MSBuild's `obj/.../refint/{Name}.dll` ref-assembly paths transparently swap to the sibling runtime DLL alongside its PDB — because reference assemblies have no method bodies and no useful sequence points.

### Pipeline glue

- `WorkspaceState.TryGetProjectByOutputAssembly(path, out project)` — basename match (case-insensitive).
- `DiscoveredProject` / `ProjectState` carry `AssemblyName` parsed from `<AssemblyName>` (defaults to the project filename, matching the SDK's `$(TargetName)` default).
- `DocumentContent` gets a new optional `Workspace` property threaded from `LspServer` through `DocumentSyncHandler` so the per-document computers can reach sibling projects.
- `DefinitionComputer.ComputeDefinition`:
  1. Existing G#-source switch (unchanged).
  2. New: `Imported{Class,Type,Function}Symbol` → `CrossAssemblyDefinitionResolver`.
  3. Fallback when `ResolveSymbol` returns null: `ImportedClrMemberResolver.TryResolveClr{Type,Member}` (mirrors `HoverComputer.BuildImportedClrModel`) → `CrossAssemblyDefinitionResolver`. Lets F12 jump from a `Console.WriteLine` call to the BCL source (when SourceLink / embedded PDBs are available) or to any sibling member that hover already documents.

## Tests

13 new tests in `test/LanguageServer.Tests/CrossProjectDefinitionTests.cs`:
- Tier 1 sibling-project navigation for types and methods (using real CLR types so `MetadataToken` / `Assembly.Location` are real).
- `WorkspaceState.TryGetProjectByOutputAssembly` mechanics — basename / refint / unknown / no-AssemblyName.
- Tier 2 PDB resolution against the test assembly's own sidecar PDB (method, type, unknown-assembly).
- `CrossAssemblyDefinitionResolver` PDB fallback when no sibling project matches.
- **End-to-end pipeline tests** that compile a real `.gs` Lib to a DLL + PDB on disk, set up a workspace as the LSP would (lib + app projects, app references lib's DLL), and assert that `DefinitionComputer.ComputeDefinition` on a cursor over `Greeter` in `App/Program.gs` returns a `Location` pointing into `Lib/Greeter.gs` — once via the workspace (Tier 1) and once with no sibling registered (Tier 2 PDB fallback).

Full LanguageServer.Tests suite: **241 passed**, 1 pre-existing Windows-path failure unrelated to this PR (`ProjectStateTests.ProjectDirectory_DerivedFromProjectFilePath` expects POSIX paths; failure reproduces on `main`). Full solution suite green (Core 2028 / Compiler 609 / Interpreter 72 / Sdk 24).

## Future work (not in this PR)

- **NuGet packages without PDB / SourceLink** — would need a metadata-as-source decompiler (e.g. ICSharpCode.Decompiler). Currently returns `null` if neither a sibling project nor a PDB is reachable.
- **SourceLink fetch / cache** — when the PDB contains SourceLink URLs, automatically download to a temp cache so VS Code opens a real local file.
