### PR TITLE
PR-B-2: extract MemberLookup (binder-facing facade over ClrTypeUtilities)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -85,6 +85,12 @@ public sealed class Binder
     // diff in this PR; subsequent extractions will switch to `binderCtx.RootScope`.
     private readonly BinderContext binderCtx;
 
+    // PR-B-2: the pure "given a type T and a name N, return the candidates"
+    // facade. Consumes the BinderContext for the reference resolver / scope
+    // and delegates low-level CLR member walks to ClrTypeUtilities. Composed,
+    // not inherited; MemberLookup never back-references Binder.
+    private readonly MemberLookup memberLookup;
+
     private FunctionSymbol function;
 
     // SA1202 exempt: static initializer placement matches Binder's design.
@@ -110,6 +116,7 @@ public sealed class Binder
     public Binder(BoundScope parent, FunctionSymbol function)
     {
         binderCtx = new BinderContext(parent);
+        memberLookup = new MemberLookup(binderCtx);
         this.function = function;
 
         if (function != null)
@@ -1830,7 +1837,7 @@ public sealed class Binder
                 PropertySymbol overriddenProperty = null;
                 if (isOverride)
                 {
-                    if (structSymbol.BaseClass == null || !TryGetPropertyIncludingInherited(structSymbol.BaseClass, propName, out var baseProp))
+                    if (structSymbol.BaseClass == null || !MemberLookup.TryGetPropertyIncludingInherited(structSymbol.BaseClass, propName, out var baseProp))
                     {
                         Diagnostics.ReportNoBaseMethodToOverride(propSyntax.Identifier.Location, propName);
                     }
@@ -2711,7 +2718,7 @@ public sealed class Binder
                     continue;
                 }
 
-                if (HasMatchingMethodForClrSignature(structSymbol, clrMethod))
+                if (MemberLookup.HasMatchingMethodForClrSignature(structSymbol, clrMethod))
                 {
                     continue;
                 }
@@ -2726,7 +2733,7 @@ public sealed class Binder
             // Properties.
             foreach (var clrProp in clrIface.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
             {
-                var implProp = FindMatchingProperty(structSymbol, clrProp);
+                var implProp = MemberLookup.FindMatchingProperty(structSymbol, clrProp);
                 if (implProp == null)
                 {
                     Diagnostics.ReportInterfaceMethodNotImplemented(
@@ -2756,55 +2763,6 @@ public sealed class Binder
                 }
             }
         }
-    }
-
-    private static bool HasMatchingMethodForClrSignature(StructSymbol structSymbol, System.Reflection.MethodInfo clrMethod)
-    {
-        var clrParams = clrMethod.GetParameters();
-        foreach (var candidate in structSymbol.GetMethodsIncludingInherited(clrMethod.Name))
-        {
-            var callable = GetCallableParameters(candidate);
-            if (callable.Length != clrParams.Length)
-            {
-                continue;
-            }
-
-            if (!ClrTypesEquivalent(candidate.Type?.ClrType, clrMethod.ReturnType))
-            {
-                continue;
-            }
-
-            var allMatch = true;
-            for (var i = 0; i < callable.Length; i++)
-            {
-                if (!ClrTypesEquivalent(callable[i].Type?.ClrType, clrParams[i].ParameterType))
-                {
-                    allMatch = false;
-                    break;
-                }
-            }
-
-            if (allMatch)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static PropertySymbol FindMatchingProperty(StructSymbol structSymbol, System.Reflection.PropertyInfo clrProp)
-    {
-        foreach (var implProp in structSymbol.Properties)
-        {
-            if (implProp.Name == clrProp.Name
-                && ClrTypesEquivalent(implProp.Type?.ClrType, clrProp.PropertyType))
-            {
-                return implProp;
-            }
-        }
-
-        return null;
     }
 
     private static bool ClrTypesEquivalent(System.Type a, System.Type b)
@@ -2847,27 +2805,6 @@ public sealed class Binder
         }
 
         return $"{dotted}[{string.Join(", ", args)}]";
-    }
-
-    private static bool TryGetPropertyIncludingInherited(StructSymbol type, string name, out PropertySymbol property)
-    {
-        var current = type;
-        while (current != null)
-        {
-            foreach (var p in current.Properties)
-            {
-                if (p.Name == name)
-                {
-                    property = p;
-                    return true;
-                }
-            }
-
-            current = current.BaseClass;
-        }
-
-        property = null;
-        return false;
     }
 
     private InterfaceSymbol DeclareInterfaceSymbol(InterfaceDeclarationSyntax syntax, PackageSymbol package)
@@ -6208,7 +6145,7 @@ public sealed class Binder
             return new BoundExpressionStatement(syntax, stream);
         }
 
-        if (!TryGetAsyncEnumerableElementType(stream.Type, out var elementType))
+        if (!MemberLookup.TryGetAsyncEnumerableElementType(stream.Type, out var elementType))
         {
             Diagnostics.ReportTypeIsNotAsyncEnumerable(syntax.Stream.Location, stream.Type);
             return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
@@ -6388,38 +6325,6 @@ public sealed class Binder
         return TypeSymbol.FromClrType(typeof(object));
     }
 
-    private static bool TryGetAsyncEnumerableElementType(TypeSymbol type, out TypeSymbol elementType)
-    {
-        elementType = null;
-        var clr = type?.ClrType;
-        if (clr == null)
-        {
-            return false;
-        }
-
-        foreach (var iface in EnumerateSelfAndInterfaces(clr))
-        {
-            if (iface.IsGenericType &&
-                !iface.IsGenericTypeDefinition &&
-                iface.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IAsyncEnumerable`1")
-            {
-                elementType = TypeSymbol.FromClrType(iface.GetGenericArguments()[0]);
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static System.Collections.Generic.IEnumerable<System.Type> EnumerateSelfAndInterfaces(System.Type t)
-    {
-        yield return t;
-        foreach (var i in t.GetInterfaces())
-        {
-            yield return i;
-        }
-    }
-
     private TypeSymbol ResolveExceptionType()
     {
         if (scope.References.TryResolveType("System.Exception", out var t))
@@ -6496,19 +6401,19 @@ public sealed class Binder
                     keyType = TypeSymbol.Int32;
                     valueType = annotated.GetTypeArgumentSymbolForClrType(annotated.ClrType.GetElementType());
                 }
-                else if (TryGetClrDictionaryTypes(annotated.ClrType, out var aDKey, out var aDVal))
+                else if (MemberLookup.TryGetClrDictionaryTypes(annotated.ClrType, out var aDKey, out var aDVal))
                 {
                     iterationKind = ForRangeKind.Dictionary;
                     keyType = annotated.GetTypeArgumentSymbolForClrType(aDKey);
                     valueType = annotated.GetTypeArgumentSymbolForClrType(aDVal);
                 }
-                else if (TryGetClrEnumerableElementType(annotated.ClrType, out var aElemType))
+                else if (MemberLookup.TryGetClrEnumerableElementType(annotated.ClrType, out var aElemType))
                 {
                     iterationKind = ForRangeKind.Enumerable;
                     keyType = TypeSymbol.Int32;
                     valueType = annotated.GetTypeArgumentSymbolForClrType(aElemType);
                 }
-                else if (TryGetClrPatternEnumerableElementType(annotated.ClrType, out var aPatternElemType))
+                else if (MemberLookup.TryGetClrPatternEnumerableElementType(annotated.ClrType, out var aPatternElemType))
                 {
                     iterationKind = ForRangeKind.PatternEnumerator;
                     keyType = TypeSymbol.Int32;
@@ -6532,19 +6437,19 @@ public sealed class Binder
                     keyType = TypeSymbol.Int32;
                     valueType = TypeSymbol.FromClrType(imp.ClrType.GetElementType());
                 }
-                else if (TryGetClrDictionaryTypes(imp.ClrType, out var dKey, out var dVal))
+                else if (MemberLookup.TryGetClrDictionaryTypes(imp.ClrType, out var dKey, out var dVal))
                 {
                     iterationKind = ForRangeKind.Dictionary;
                     keyType = TypeSymbol.FromClrType(dKey);
                     valueType = TypeSymbol.FromClrType(dVal);
                 }
-                else if (TryGetClrEnumerableElementType(imp.ClrType, out var elemType))
+                else if (MemberLookup.TryGetClrEnumerableElementType(imp.ClrType, out var elemType))
                 {
                     iterationKind = ForRangeKind.Enumerable;
                     keyType = TypeSymbol.Int32;
                     valueType = TypeSymbol.FromClrType(elemType);
                 }
-                else if (TryGetClrPatternEnumerableElementType(imp.ClrType, out var patternElemType))
+                else if (MemberLookup.TryGetClrPatternEnumerableElementType(imp.ClrType, out var patternElemType))
                 {
                     iterationKind = ForRangeKind.PatternEnumerator;
                     keyType = TypeSymbol.Int32;
@@ -6557,7 +6462,7 @@ public sealed class Binder
                 }
 
                 break;
-            case StructSymbol userType when TryGetUserPatternEnumerableElementType(userType, out var userElemType):
+            case StructSymbol userType when MemberLookup.TryGetUserPatternEnumerableElementType(userType, out var userElemType):
                 iterationKind = ForRangeKind.PatternEnumerator;
                 keyType = TypeSymbol.Int32;
                 valueType = userElemType;
@@ -6608,120 +6513,6 @@ public sealed class Binder
         scope = scope.Parent;
 
         return new BoundForRangeStatement(syntax, keyVariable, valueVariable, collection, iterationKind, body, breakLabel, continueLabel);
-    }
-
-    private static bool TryGetClrDictionaryTypes(System.Type clrType, out System.Type keyType, out System.Type valueType)
-    {
-        foreach (var iface in EnumerateSelfAndInterfaces(clrType))
-        {
-            if (iface.IsGenericType && iface.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IDictionary`2")
-            {
-                var args = iface.GetGenericArguments();
-                keyType = args[0];
-                valueType = args[1];
-                return true;
-            }
-        }
-
-        keyType = null;
-        valueType = null;
-        return false;
-    }
-
-    private static bool TryGetClrEnumerableElementType(System.Type clrType, out System.Type elementType)
-    {
-        foreach (var iface in EnumerateSelfAndInterfaces(clrType))
-        {
-            if (iface.IsGenericType && iface.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IEnumerable`1")
-            {
-                elementType = iface.GetGenericArguments()[0];
-                return true;
-            }
-        }
-
-        // Non-generic IEnumerable falls back to object.
-        if (typeof(System.Collections.IEnumerable).IsAssignableFrom(clrType))
-        {
-            elementType = typeof(object);
-            return true;
-        }
-
-        elementType = null;
-        return false;
-    }
-
-    private static bool TryGetClrPatternEnumerableElementType(System.Type clrType, out System.Type elementType)
-    {
-        var getEnumerator = clrType.GetMethod(
-            "GetEnumerator",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public,
-            binder: null,
-            types: System.Type.EmptyTypes,
-            modifiers: null);
-        if (getEnumerator == null)
-        {
-            elementType = null;
-            return false;
-        }
-
-        var enumeratorType = getEnumerator.ReturnType;
-        var moveNext = enumeratorType.GetMethod(
-            "MoveNext",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public,
-            binder: null,
-            types: System.Type.EmptyTypes,
-            modifiers: null);
-        if (moveNext?.ReturnType != typeof(bool))
-        {
-            elementType = null;
-            return false;
-        }
-
-        if (TryGetClrCurrentMemberType(enumeratorType, out elementType))
-        {
-            return true;
-        }
-
-        elementType = null;
-        return false;
-    }
-
-    private static bool TryGetClrCurrentMemberType(System.Type enumeratorType, out System.Type elementType)
-    {
-        var currentProperty = ClrTypeUtilities.SafeGetProperty(enumeratorType, "Current", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
-        if (currentProperty != null)
-        {
-            elementType = currentProperty.PropertyType;
-            return true;
-        }
-
-        var currentField = ClrTypeUtilities.SafeGetField(enumeratorType, "Current", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
-        if (currentField != null)
-        {
-            elementType = currentField.FieldType;
-            return true;
-        }
-
-        elementType = null;
-        return false;
-    }
-
-    private static bool TryGetUserPatternEnumerableElementType(StructSymbol type, out TypeSymbol elementType)
-    {
-        if (type.TryGetMethodIncludingInherited("GetEnumerator", out var getEnumerator) &&
-            getEnumerator.Parameters.Length == 0 &&
-            getEnumerator.Type is StructSymbol enumeratorType &&
-            enumeratorType.TryGetMethodIncludingInherited("MoveNext", out var moveNext) &&
-            moveNext.Parameters.Length == 0 &&
-            moveNext.Type == TypeSymbol.Bool &&
-            enumeratorType.TryGetField("Current", out var currentField))
-        {
-            elementType = currentField.Type;
-            return true;
-        }
-
-        elementType = null;
-        return false;
     }
 
     private BoundStatement BindForConditionStatement(ForConditionStatementSyntax syntax)
@@ -7858,7 +7649,7 @@ public sealed class Binder
                 return new BoundFieldAssignmentExpression(initSyntax, receiverLocal, structSymbol, field, converted);
             }
 
-            if (TryGetPropertyIncludingInherited(structSymbol, propertyName, out var prop))
+            if (MemberLookup.TryGetPropertyIncludingInherited(structSymbol, propertyName, out var prop))
             {
                 if (!prop.HasSetter)
                 {
@@ -8305,7 +8096,7 @@ public sealed class Binder
         if (!structSymbol.TryGetFieldIncludingInherited(syntax.FieldIdentifier.Text, out var field, out _))
         {
             // ADR-0051: check if it's a property.
-            if (TryGetPropertyIncludingInherited(structSymbol, syntax.FieldIdentifier.Text, out var prop))
+            if (MemberLookup.TryGetPropertyIncludingInherited(structSymbol, syntax.FieldIdentifier.Text, out var prop))
             {
                 if (!prop.HasSetter)
                 {
@@ -10920,7 +10711,7 @@ public sealed class Binder
                 continue;
             }
 
-            knownNames ??= CollectClrParameterNames(receiverClrType, methodName, bindingFlags);
+            knownNames ??= MemberLookup.CollectClrParameterNames(receiverClrType, methodName, bindingFlags);
             if (!knownNames.Contains(name))
             {
                 var location = ce.Arguments[i] is NamedArgumentExpressionSyntax named ? named.NameToken.Location : ce.Arguments[i].Location;
@@ -10930,38 +10721,6 @@ public sealed class Binder
         }
 
         return false;
-    }
-
-    private static HashSet<string> CollectClrParameterNames(System.Type receiverClrType, string methodName, System.Reflection.BindingFlags bindingFlags)
-    {
-        var names = new HashSet<string>(StringComparer.Ordinal);
-        System.Reflection.MethodInfo[] methods;
-        try
-        {
-            methods = receiverClrType.GetMethods(bindingFlags);
-        }
-        catch
-        {
-            return names;
-        }
-
-        foreach (var method in methods)
-        {
-            if (!string.Equals(method.Name, methodName, StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            foreach (var parameter in method.GetParameters())
-            {
-                if (parameter.Name != null)
-                {
-                    names.Add(parameter.Name);
-                }
-            }
-        }
-
-        return names;
     }
 
     /// <summary>
@@ -10989,7 +10748,7 @@ public sealed class Binder
                 continue;
             }
 
-            knownNames ??= CollectClrConstructorParameterNames(clrType);
+            knownNames ??= MemberLookup.CollectClrConstructorParameterNames(clrType);
             if (!knownNames.Contains(name))
             {
                 var location = ce.Arguments[i] is NamedArgumentExpressionSyntax named ? named.NameToken.Location : ce.Arguments[i].Location;
@@ -10999,33 +10758,6 @@ public sealed class Binder
         }
 
         return false;
-    }
-
-    private static HashSet<string> CollectClrConstructorParameterNames(System.Type clrType)
-    {
-        var names = new HashSet<string>(StringComparer.Ordinal);
-        System.Reflection.ConstructorInfo[] ctors;
-        try
-        {
-            ctors = ClrTypeUtilities.SafeGetConstructors(clrType, BindingFlags.Public | BindingFlags.Instance);
-        }
-        catch
-        {
-            return names;
-        }
-
-        foreach (var ctor in ctors)
-        {
-            foreach (var parameter in ctor.GetParameters())
-            {
-                if (parameter.Name != null)
-                {
-                    names.Add(parameter.Name);
-                }
-            }
-        }
-
-        return names;
     }
 
     private ImmutableArray<BoundExpression> ValidateRefArguments(
@@ -13930,7 +13662,7 @@ public sealed class Binder
                     }
 
                     // ADR-0051: check properties before reporting "unable to find member".
-                    if (TryGetPropertyIncludingInherited(structSym, ne.IdentifierToken.Text, out var prop))
+                    if (MemberLookup.TryGetPropertyIncludingInherited(structSym, ne.IdentifierToken.Text, out var prop))
                     {
                         if (!prop.HasGetter)
                         {
@@ -13978,7 +13710,7 @@ public sealed class Binder
                 }
                 else if (receiver != null && receiver.Type is NullableTypeSymbol nullableSym
                     && nullableSym.UnderlyingType?.ClrType is { IsValueType: true } nullableInnerClr
-                    && TryGetNullableConstructedType(nullableInnerClr, out var nullableClr))
+                    && this.memberLookup.TryGetNullableConstructedType(nullableInnerClr, out var nullableClr))
                 {
                     // Issue #517: a value-type `T?` lowers to `System.Nullable<T>`
                     // at the CLR layer (see `EncodeTypeSymbol`). Resolve `.Value`,
@@ -14394,7 +14126,7 @@ public sealed class Binder
         // actually carries those members.
         var clrType = receiver.Type is NullableTypeSymbol nullableRecv
             && nullableRecv.UnderlyingType?.ClrType is { IsValueType: true } nullableInnerVt
-            && TryGetNullableConstructedType(nullableInnerVt, out var nullableConstructed)
+            && this.memberLookup.TryGetNullableConstructedType(nullableInnerVt, out var nullableConstructed)
             ? nullableConstructed
             : receiver.Type.ClrType;
 
@@ -14549,7 +14281,7 @@ public sealed class Binder
         }
         else if (matchedField.Type?.ClrType is System.Type fieldClrType
             && ClrTypeUtilities.IsDelegateType(fieldClrType)
-            && TryGetDelegateFunctionType(fieldClrType, out var clrFn))
+            && MemberLookup.TryGetDelegateFunctionType(fieldClrType, out var clrFn))
         {
             functionType = clrFn;
         }
@@ -14995,7 +14727,7 @@ public sealed class Binder
             extensionArgumentNames = withReceiver;
         }
 
-        var candidates = CollectImportedExtensionMethods(methodName);
+        var candidates = this.memberLookup.CollectImportedExtensionMethods(methodName);
         if (candidates.Count == 0)
         {
             return false;
@@ -15080,163 +14812,6 @@ public sealed class Binder
         ValidateRefArguments(bound, refKinds, methodName, ce.Location);
         result = new BoundImportedCallExpression(null, function, bound, refKinds, typeArgSymbols);
         return true;
-    }
-
-    /// <summary>
-    /// Issue #294: collects imported CLR static <c>[Extension]</c> methods with
-    /// the given name whose declaring static class lives in an imported
-    /// namespace. Candidates may be open generic method definitions; generic
-    /// inference happens later in overload resolution.
-    /// </summary>
-    /// <param name="methodName">The method name at the call site.</param>
-    /// <returns>The matching candidate methods (possibly empty).</returns>
-    private List<MethodInfo> CollectImportedExtensionMethods(string methodName)
-    {
-        var result = new List<MethodInfo>();
-        foreach (var type in GetImportedExtensionClasses())
-        {
-            MethodInfo[] methods;
-            try
-            {
-                methods = type.GetMethods(BindingFlags.Public | BindingFlags.Static);
-            }
-            catch
-            {
-                continue;
-            }
-
-            foreach (var method in methods)
-            {
-                if (!string.Equals(method.Name, methodName, StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                if (!HasExtensionAttribute(method))
-                {
-                    continue;
-                }
-
-                if (method.GetParameters().Length == 0)
-                {
-                    continue;
-                }
-
-                result.Add(method);
-            }
-        }
-
-        return result;
-    }
-
-    /// <summary>
-    /// Issue #294: enumerates static classes declared in the currently imported
-    /// namespaces that carry <c>[Extension]</c> (i.e. host extension methods).
-    /// The result is cached per binder; the import count acts as a cheap
-    /// invalidation key because imports only grow during binding.
-    /// </summary>
-    /// <returns>The imported static extension-holding classes.</returns>
-    private List<Type> GetImportedExtensionClasses()
-    {
-        var imports = scope.GetDeclaredImports();
-        var importCount = imports.IsDefault ? 0 : imports.Length;
-        if (binderCtx.CachedImportedExtensionClasses != null && binderCtx.CachedImportedExtensionImportCount == importCount)
-        {
-            return binderCtx.CachedImportedExtensionClasses;
-        }
-
-        var namespaces = new HashSet<string>(StringComparer.Ordinal);
-        if (!imports.IsDefault)
-        {
-            foreach (var import in imports)
-            {
-                if (!string.IsNullOrEmpty(import.Target))
-                {
-                    namespaces.Add(import.Target);
-                }
-            }
-        }
-
-        var classes = new List<Type>();
-        if (namespaces.Count > 0)
-        {
-            foreach (var assembly in scope.References.Assemblies)
-            {
-                IEnumerable<Type> types;
-                try
-                {
-                    types = assembly.GetTypes();
-                }
-                catch (ReflectionTypeLoadException ex)
-                {
-                    types = ex.Types.Where(t => t != null);
-                }
-                catch
-                {
-                    continue;
-                }
-
-                foreach (var type in types)
-                {
-                    if (type == null || type.Namespace == null || !namespaces.Contains(type.Namespace))
-                    {
-                        continue;
-                    }
-
-                    if (!IsStaticClass(type) || !HasExtensionAttribute(type))
-                    {
-                        continue;
-                    }
-
-                    classes.Add(type);
-                }
-            }
-        }
-
-        binderCtx.CachedImportedExtensionClasses = classes;
-        binderCtx.CachedImportedExtensionImportCount = importCount;
-        return classes;
-    }
-
-    /// <summary>
-    /// A C# static class is a sealed abstract class. Detected structurally so
-    /// it works under <see cref="System.Reflection.MetadataLoadContext"/>.
-    /// </summary>
-    /// <param name="type">The candidate type.</param>
-    /// <returns>Whether the type is a static class.</returns>
-    private static bool IsStaticClass(Type type)
-        => type.IsClass && type.IsAbstract && type.IsSealed;
-
-    /// <summary>
-    /// Robustly detects <c>[System.Runtime.CompilerServices.ExtensionAttribute]</c>
-    /// via <see cref="CustomAttributeData"/> (never runtime
-    /// <c>GetCustomAttribute</c>, which throws under
-    /// <see cref="System.Reflection.MetadataLoadContext"/>).
-    /// </summary>
-    /// <param name="member">The type or method to inspect.</param>
-    /// <returns>Whether the member carries the extension attribute.</returns>
-    private static bool HasExtensionAttribute(MemberInfo member)
-    {
-        try
-        {
-            foreach (var attribute in member.GetCustomAttributesData())
-            {
-                if (string.Equals(
-                    attribute.AttributeType?.FullName,
-                    "System.Runtime.CompilerServices.ExtensionAttribute",
-                    StringComparison.Ordinal))
-                {
-                    return true;
-                }
-            }
-        }
-        catch
-        {
-            // MetadataLoadContext may throw resolving the attribute type; treat
-            // as "not an extension" rather than failing the whole binding.
-        }
-
-        return false;
     }
 
     private BoundExpression BindUserInstanceCall(BoundExpression receiver, FunctionSymbol method, ImmutableArray<BoundExpression> arguments, CallExpressionSyntax ce, ImmutableArray<string> argumentNames = default)
@@ -15376,7 +14951,7 @@ public sealed class Binder
                     continue;
                 }
 
-                if (TryGetDelegateFunctionType(paramType.ClrType ?? expectedType.ClrType, out var targetDelegateFunctionType)
+                if (MemberLookup.TryGetDelegateFunctionType(paramType.ClrType ?? expectedType.ClrType, out var targetDelegateFunctionType)
                     && functionLiteralArgument.FunctionType != targetDelegateFunctionType)
                 {
                     convertedArgs.Add(CreateErasedFunctionLiteralAdapter(functionLiteralArgument, targetDelegateFunctionType));
@@ -15547,16 +15122,23 @@ public sealed class Binder
         // matches the single argument by assignability).
         // Issue #209: when the target carries inner-position nullable flags,
         // use them to type the element correctly (e.g., `list[0]` on `List<string?>` → `string?`).
-        if (target.Type is NullabilityAnnotatedTypeSymbol annotIdx && annotIdx.ClrType is System.Type clrAnnotIdx && TryResolveClrIndexer(clrAnnotIdx, new[] { indexSyntax }, out var idxPropAnnot, out var idxArgsAnnot))
+        if (target.Type is NullabilityAnnotatedTypeSymbol annotIdx && annotIdx.ClrType is System.Type clrAnnotIdx)
         {
-            var elemTypeAnnot = annotIdx.GetTypeArgumentSymbolForClrType(idxPropAnnot.PropertyType);
-            return AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxPropAnnot, idxArgsAnnot, elemTypeAnnot));
+            var idxArgsAnnot = ImmutableArray.Create(BindExpression(indexSyntax));
+            if (this.memberLookup.TryResolveClrIndexer(clrAnnotIdx, idxArgsAnnot, out var idxPropAnnot))
+            {
+                var elemTypeAnnot = annotIdx.GetTypeArgumentSymbolForClrType(idxPropAnnot.PropertyType);
+                return AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxPropAnnot, idxArgsAnnot, elemTypeAnnot));
+            }
         }
-
-        if (target.Type is ImportedTypeSymbol && target.Type.ClrType is System.Type clrTarget && TryResolveClrIndexer(clrTarget, new[] { indexSyntax }, out var idxProp, out var idxArgs))
+        else if (target.Type is ImportedTypeSymbol && target.Type.ClrType is System.Type clrTarget)
         {
-            var elementType = MapErasedIndexerElementType((ImportedTypeSymbol)target.Type, idxProp);
-            return AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxProp, idxArgs, elementType));
+            var idxArgs = ImmutableArray.Create(BindExpression(indexSyntax));
+            if (this.memberLookup.TryResolveClrIndexer(clrTarget, idxArgs, out var idxProp))
+            {
+                var elementType = MapErasedIndexerElementType((ImportedTypeSymbol)target.Type, idxProp);
+                return AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxProp, idxArgs, elementType));
+            }
         }
 
         if (target.Type != TypeSymbol.Error)
@@ -15909,49 +15491,56 @@ public sealed class Binder
         // Phase 4 exit: CLR indexer write on an imported reference type
         // (e.g. `d["k"] = 1` on Dictionary[string, int]).
         // Issue #209: honour inner-position nullable flags when present.
-        if (variable.Type is NullabilityAnnotatedTypeSymbol annotWr && variable.Type.ClrType is System.Type clrAnnotWr && TryResolveClrIndexer(clrAnnotWr, new[] { indexSyntax }, out var idxPropAnnotWr, out var idxArgsAnnotWr))
+        if (variable.Type is NullabilityAnnotatedTypeSymbol annotWr && variable.Type.ClrType is System.Type clrAnnotWr)
         {
-            if (!idxPropAnnotWr.CanWrite)
+            var idxArgsAnnotWr = ImmutableArray.Create(BindExpression(indexSyntax));
+            if (this.memberLookup.TryResolveClrIndexer(clrAnnotWr, idxArgsAnnotWr, out var idxPropAnnotWr))
             {
-                Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
-                return new BoundErrorExpression(null);
-            }
-
-            var valueTypeAnnotWr = annotWr.GetTypeArgumentSymbolForClrType(idxPropAnnotWr.PropertyType);
-            var boundValueAnnotWr = BindValue(valueTypeAnnotWr);
-            return new BoundClrIndexAssignmentExpression(null, variable, idxPropAnnotWr, idxArgsAnnotWr, boundValueAnnotWr, valueTypeAnnotWr);
-        }
-
-        if (variable.Type is ImportedTypeSymbol && variable.Type.ClrType is System.Type clrTarget && TryResolveClrIndexer(clrTarget, new[] { indexSyntax }, out var idxProp, out var idxArgs))
-        {
-            // ADR-0056 §2: span element write. `Span[T]` has no `set_Item`; its
-            // indexer is a `ref T`-returning getter and writes go through that
-            // managed pointer. Detect the ref-returning getter and store through
-            // it. A `ReadOnlySpan[T]` getter is `ref readonly T` — writing is a
-            // hard error (GS0226).
-            if (!idxProp.CanWrite)
-            {
-                var refGetter = idxProp.GetGetMethod(nonPublic: false);
-                if (refGetter != null && refGetter.ReturnType.IsByRef)
+                if (!idxPropAnnotWr.CanWrite)
                 {
-                    if (IsReadOnlyRefReturn(idxProp, refGetter))
-                    {
-                        Diagnostics.ReportCannotAssignReadOnlySpanElement(diagnosticLocation, variable.Type);
-                        return new BoundErrorExpression(null);
-                    }
-
-                    var pointeeType = TypeSymbol.FromClrType(refGetter.ReturnType.GetElementType()!);
-                    var refValue = BindValue(pointeeType);
-                    return new BoundClrIndexAssignmentExpression(null, variable, idxProp, idxArgs, refValue, pointeeType);
+                    Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
+                    return new BoundErrorExpression(null);
                 }
 
-                Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
-                return new BoundErrorExpression(null);
+                var valueTypeAnnotWr = annotWr.GetTypeArgumentSymbolForClrType(idxPropAnnotWr.PropertyType);
+                var boundValueAnnotWr = BindValue(valueTypeAnnotWr);
+                return new BoundClrIndexAssignmentExpression(null, variable, idxPropAnnotWr, idxArgsAnnotWr, boundValueAnnotWr, valueTypeAnnotWr);
             }
+        }
+        else if (variable.Type is ImportedTypeSymbol && variable.Type.ClrType is System.Type clrTarget)
+        {
+            var idxArgs = ImmutableArray.Create(BindExpression(indexSyntax));
+            if (this.memberLookup.TryResolveClrIndexer(clrTarget, idxArgs, out var idxProp))
+            {
+                // ADR-0056 §2: span element write. `Span[T]` has no `set_Item`; its
+                // indexer is a `ref T`-returning getter and writes go through that
+                // managed pointer. Detect the ref-returning getter and store through
+                // it. A `ReadOnlySpan[T]` getter is `ref readonly T` — writing is a
+                // hard error (GS0226).
+                if (!idxProp.CanWrite)
+                {
+                    var refGetter = idxProp.GetGetMethod(nonPublic: false);
+                    if (refGetter != null && refGetter.ReturnType.IsByRef)
+                    {
+                        if (IsReadOnlyRefReturn(idxProp, refGetter))
+                        {
+                            Diagnostics.ReportCannotAssignReadOnlySpanElement(diagnosticLocation, variable.Type);
+                            return new BoundErrorExpression(null);
+                        }
 
-            var valueType = TypeSymbol.FromClrType(idxProp.PropertyType);
-            var boundValue = BindValue(valueType);
-            return new BoundClrIndexAssignmentExpression(null, variable, idxProp, idxArgs, boundValue, valueType);
+                        var pointeeType = TypeSymbol.FromClrType(refGetter.ReturnType.GetElementType()!);
+                        var refValue = BindValue(pointeeType);
+                        return new BoundClrIndexAssignmentExpression(null, variable, idxProp, idxArgs, refValue, pointeeType);
+                    }
+
+                    Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
+                    return new BoundErrorExpression(null);
+                }
+
+                var valueType = TypeSymbol.FromClrType(idxProp.PropertyType);
+                var boundValue = BindValue(valueType);
+                return new BoundClrIndexAssignmentExpression(null, variable, idxProp, idxArgs, boundValue, valueType);
+            }
         }
 
         if (variable.Type != TypeSymbol.Error)
@@ -16187,47 +15776,6 @@ public sealed class Binder
         }
     }
 
-    private bool TryResolveClrIndexer(System.Type clrTarget, IReadOnlyList<ExpressionSyntax> argSyntaxes, out PropertyInfo indexer, out ImmutableArray<BoundExpression> boundArguments)
-    {
-        indexer = null;
-        boundArguments = ImmutableArray<BoundExpression>.Empty;
-
-        var bound = ImmutableArray.CreateBuilder<BoundExpression>(argSyntaxes.Count);
-        for (var i = 0; i < argSyntaxes.Count; i++)
-        {
-            bound.Add(BindExpression(argSyntaxes[i]));
-        }
-
-        foreach (var prop in ClrTypeUtilities.SafeGetProperties(clrTarget, BindingFlags.Public | BindingFlags.Instance))
-        {
-            var ps = prop.GetIndexParameters();
-            if (ps.Length != bound.Count)
-            {
-                continue;
-            }
-
-            var ok = true;
-            for (var i = 0; i < ps.Length; i++)
-            {
-                var argClr = bound[i].Type?.ClrType;
-                if (argClr == null || !ClrTypeUtilities.IsAssignableByName(ps[i].ParameterType, argClr))
-                {
-                    ok = false;
-                    break;
-                }
-            }
-
-            if (ok)
-            {
-                indexer = prop;
-                boundArguments = bound.ToImmutable();
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     private static TypeSymbol GetIndexElementType(TypeSymbol type)
     {
         return type switch
@@ -16410,7 +15958,7 @@ public sealed class Binder
             var rebound = argument;
             if (paramIndex < parameters.Length
                 && TryGetFunctionLiteral(argument, out var literal)
-                && TryGetDelegateFunctionType(parameters[paramIndex].ParameterType, out var targetFunctionType)
+                && MemberLookup.TryGetDelegateFunctionType(parameters[paramIndex].ParameterType, out var targetFunctionType)
                 && literal.FunctionType != targetFunctionType)
             {
                 rebound = CreateErasedFunctionLiteralAdapter(literal, targetFunctionType);
@@ -16535,41 +16083,6 @@ public sealed class Binder
         }
 
         return from.ClrType != targetParameterType;
-    }
-
-    private static bool TryGetDelegateFunctionType(Type delegateType, out FunctionTypeSymbol functionType)
-    {
-        functionType = null;
-        if (!ClrTypeUtilities.IsDelegateType(delegateType)
-            && !string.Equals(delegateType?.BaseType?.FullName, "System.MulticastDelegate", StringComparison.Ordinal)
-            && !(delegateType?.FullName?.StartsWith("System.Func`", StringComparison.Ordinal) == true)
-            && !(delegateType?.FullName?.StartsWith("System.Action`", StringComparison.Ordinal) == true))
-        {
-            return false;
-        }
-
-        var invoke = delegateType.GetMethod("Invoke");
-        if (invoke == null)
-        {
-            return false;
-        }
-
-        var parameters = invoke.GetParameters();
-        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(parameters.Length);
-        foreach (var parameter in parameters)
-        {
-            parameterTypes.Add(parameter.ParameterType.ContainsGenericParameters
-                ? TypeSymbol.Object
-                : TypeSymbol.FromClrType(parameter.ParameterType));
-        }
-
-        var returnType = invoke.ReturnType == typeof(void)
-            ? TypeSymbol.Void
-            : invoke.ReturnType.ContainsGenericParameters
-                ? TypeSymbol.Object
-                : TypeSymbol.FromClrType(invoke.ReturnType);
-        functionType = FunctionTypeSymbol.Get(parameterTypes.ToImmutable(), returnType);
-        return true;
     }
 
     private static bool TryGetFunctionLiteral(BoundExpression expression, out BoundFunctionLiteralExpression literal)
@@ -16751,45 +16264,6 @@ public sealed class Binder
         return true;
     }
 
-    // Issue #337: build an (unresolved) CLR member method-group expression for a
-    // member name that resolves to a method on an imported static type or a CLR
-    // instance receiver. Collects every accessible name-matching overload of the
-    // requested static-ness; overload selection happens later in BindConversion
-    // once the target delegate signature is known. Returns false when the type
-    // exposes no method of that name (so the caller surfaces the member
-    // diagnostic).
-    // Issue #517: build the constructed `System.Nullable<T>` type that lives
-    // in the SAME assembly context (live runtime vs MetadataLoadContext) as
-    // <paramref name="underlying"/>. Mixing contexts — e.g. live `Nullable<>`
-    // with an MLC `DateTime` — yields a `TypeBuilderInstantiation` that
-    // throws on `GetMethods` / `GetProperty`. Returns false when the open
-    // `Nullable<>` cannot be resolved against the references in scope.
-    private bool TryGetNullableConstructedType(Type underlying, out Type constructed)
-    {
-        constructed = null;
-        if (underlying == null)
-        {
-            return false;
-        }
-
-        if (!scope.References.TryResolveType("System.Nullable`1", out var nullableOpen) || nullableOpen == null)
-        {
-            return false;
-        }
-
-        try
-        {
-            var mappedUnderlying = scope.References.MapClrTypeToReferences(underlying) ?? underlying;
-            constructed = nullableOpen.MakeGenericType(mappedUnderlying);
-            return constructed != null;
-        }
-        catch
-        {
-            constructed = null;
-            return false;
-        }
-    }
-
     /// <summary>
     /// Issue #530: returns the CLR type to use when <paramref name="typeSymbol"/>
     /// appears as a generic type argument (e.g. <c>Task[int32?]</c> or
@@ -16807,7 +16281,7 @@ public sealed class Binder
     {
         if (typeSymbol is NullableTypeSymbol nullable
             && nullable.UnderlyingType?.ClrType is { IsValueType: true } innerVt
-            && TryGetNullableConstructedType(innerVt, out var nullableClr))
+            && this.memberLookup.TryGetNullableConstructedType(innerVt, out var nullableClr))
         {
             return nullableClr;
         }
@@ -16826,6 +16300,13 @@ public sealed class Binder
         return NullableTypeSymbol.GetEffectiveClrType(typeSymbol);
     }
 
+    // Issue #337: build an (unresolved) CLR member method-group expression for a
+    // member name that resolves to a method on an imported static type or a CLR
+    // instance receiver. Collects every accessible name-matching overload of the
+    // requested static-ness; overload selection happens later in BindConversion
+    // once the target delegate signature is known. Returns false when the type
+    // exposes no method of that name (so the caller surfaces the member
+    // diagnostic).
     private bool TryBindClrMethodGroup(BoundExpression receiver, Type declaringType, bool wantStatic, string name, out BoundExpression methodGroup)
     {
         methodGroup = null;

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1,0 +1,736 @@
+// <copyright file="MemberLookup.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// PR-B-2: the binder-facing facade for "given a type T and a member name N,
+/// return the candidates". Delegates low-level CLR member walks (including
+/// inherited interfaces) to <see cref="ClrTypeUtilities"/> and user-symbol
+/// scope lookups to <see cref="BoundScope"/> via <see cref="BinderContext"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This type is deliberately <em>pure</em>: it does not emit diagnostics,
+/// it does not construct <c>BoundExpression</c> values, and it does not
+/// mutate <see cref="BinderContext.NarrowedVariables"/> or
+/// <see cref="BinderContext.LoopStack"/>. The cache fields on
+/// <see cref="BinderContext"/> for imported <c>[Extension]</c> classes
+/// (<see cref="BinderContext.CachedImportedExtensionClasses"/> and
+/// <see cref="BinderContext.CachedImportedExtensionImportCount"/>) are
+/// intentionally written by <see cref="GetImportedExtensionClasses"/> —
+/// those fields exist on the context precisely so this facade can populate
+/// them.
+/// </para>
+/// <para>
+/// All decisions about "what to do with no candidate" — diagnostic emission
+/// (e.g. <c>GS0159</c>, <c>GS0125</c>, <c>GS0187</c>), error-recovery
+/// <c>BoundErrorExpression</c> construction, narrowing-state updates — live
+/// on the caller in <see cref="Binder"/>.
+/// </para>
+/// </remarks>
+internal sealed class MemberLookup
+{
+    private readonly BinderContext binderCtx;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MemberLookup"/> class.
+    /// </summary>
+    /// <param name="binderCtx">The shared binder context that exposes the
+    /// reference resolver, the root <see cref="BoundScope"/>, and the
+    /// imported-extension cache fields.</param>
+    public MemberLookup(BinderContext binderCtx)
+    {
+        this.binderCtx = binderCtx ?? throw new ArgumentNullException(nameof(binderCtx));
+    }
+
+    // ----- CLR-side type walks -----
+
+    /// <summary>
+    /// Enumerates <paramref name="t"/> followed by every interface it
+    /// implements (direct and inherited). The common building block used by
+    /// the dictionary/enumerable shape probes below — kept here so future
+    /// fixes for #568/#572/#573 (which all need the same interface walk) can
+    /// reuse one helper.
+    /// </summary>
+    /// <param name="t">The starting CLR type.</param>
+    /// <returns>The type and its interfaces in walk order.</returns>
+    public static IEnumerable<Type> EnumerateSelfAndInterfaces(Type t)
+    {
+        yield return t;
+        foreach (var i in t.GetInterfaces())
+        {
+            yield return i;
+        }
+    }
+
+    /// <summary>
+    /// Probes <paramref name="type"/> for an
+    /// <c>IAsyncEnumerable&lt;T&gt;</c> implementation and returns its
+    /// element type when present.
+    /// </summary>
+    /// <param name="type">The <see cref="TypeSymbol"/> to probe.</param>
+    /// <param name="elementType">The bound element type symbol, on success.</param>
+    /// <returns><see langword="true"/> when the type implements
+    /// <c>IAsyncEnumerable&lt;T&gt;</c>.</returns>
+    public static bool TryGetAsyncEnumerableElementType(TypeSymbol type, out TypeSymbol elementType)
+    {
+        elementType = null;
+        var clr = type?.ClrType;
+        if (clr == null)
+        {
+            return false;
+        }
+
+        foreach (var iface in EnumerateSelfAndInterfaces(clr))
+        {
+            if (iface.IsGenericType &&
+                !iface.IsGenericTypeDefinition &&
+                iface.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IAsyncEnumerable`1")
+            {
+                elementType = TypeSymbol.FromClrType(iface.GetGenericArguments()[0]);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Probes <paramref name="clrType"/> for an
+    /// <c>IDictionary&lt;TKey, TValue&gt;</c> implementation and returns the
+    /// key/value type arguments when present.
+    /// </summary>
+    /// <param name="clrType">The CLR type to probe.</param>
+    /// <param name="keyType">The dictionary's key type, on success.</param>
+    /// <param name="valueType">The dictionary's value type, on success.</param>
+    /// <returns><see langword="true"/> when the type implements
+    /// <c>IDictionary&lt;,&gt;</c>.</returns>
+    public static bool TryGetClrDictionaryTypes(Type clrType, out Type keyType, out Type valueType)
+    {
+        foreach (var iface in EnumerateSelfAndInterfaces(clrType))
+        {
+            if (iface.IsGenericType && iface.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IDictionary`2")
+            {
+                var args = iface.GetGenericArguments();
+                keyType = args[0];
+                valueType = args[1];
+                return true;
+            }
+        }
+
+        keyType = null;
+        valueType = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Probes <paramref name="clrType"/> for an
+    /// <c>IEnumerable&lt;T&gt;</c> implementation (preferred) or a
+    /// non-generic <see cref="System.Collections.IEnumerable"/> (fallback
+    /// with element type <see cref="object"/>).
+    /// </summary>
+    /// <param name="clrType">The CLR type to probe.</param>
+    /// <param name="elementType">The element CLR type, on success.</param>
+    /// <returns><see langword="true"/> when the type is enumerable.</returns>
+    public static bool TryGetClrEnumerableElementType(Type clrType, out Type elementType)
+    {
+        foreach (var iface in EnumerateSelfAndInterfaces(clrType))
+        {
+            if (iface.IsGenericType && iface.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IEnumerable`1")
+            {
+                elementType = iface.GetGenericArguments()[0];
+                return true;
+            }
+        }
+
+        // Non-generic IEnumerable falls back to object.
+        if (typeof(System.Collections.IEnumerable).IsAssignableFrom(clrType))
+        {
+            elementType = typeof(object);
+            return true;
+        }
+
+        elementType = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Probes <paramref name="clrType"/> for the C#-style "duck-typed"
+    /// enumerable shape: a public instance <c>GetEnumerator()</c> returning
+    /// a type that exposes a <c>bool MoveNext()</c> and a <c>Current</c>
+    /// property/field.
+    /// </summary>
+    /// <param name="clrType">The CLR type to probe.</param>
+    /// <param name="elementType">The element CLR type, on success.</param>
+    /// <returns><see langword="true"/> when the duck-typed shape matches.</returns>
+    public static bool TryGetClrPatternEnumerableElementType(Type clrType, out Type elementType)
+    {
+        var getEnumerator = clrType.GetMethod(
+            "GetEnumerator",
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            types: Type.EmptyTypes,
+            modifiers: null);
+        if (getEnumerator == null)
+        {
+            elementType = null;
+            return false;
+        }
+
+        var enumeratorType = getEnumerator.ReturnType;
+        var moveNext = enumeratorType.GetMethod(
+            "MoveNext",
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            types: Type.EmptyTypes,
+            modifiers: null);
+        if (moveNext?.ReturnType != typeof(bool))
+        {
+            elementType = null;
+            return false;
+        }
+
+        if (TryGetClrCurrentMemberType(enumeratorType, out elementType))
+        {
+            return true;
+        }
+
+        elementType = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Looks up the <c>Current</c> member on a duck-typed CLR enumerator —
+    /// preferring a property over a field, matching the canonical pattern.
+    /// </summary>
+    /// <param name="enumeratorType">The duck-typed enumerator type.</param>
+    /// <param name="elementType">The <c>Current</c> member's CLR type, on success.</param>
+    /// <returns><see langword="true"/> when a <c>Current</c> member exists.</returns>
+    public static bool TryGetClrCurrentMemberType(Type enumeratorType, out Type elementType)
+    {
+        var currentProperty = ClrTypeUtilities.SafeGetProperty(enumeratorType, "Current", BindingFlags.Instance | BindingFlags.Public);
+        if (currentProperty != null)
+        {
+            elementType = currentProperty.PropertyType;
+            return true;
+        }
+
+        var currentField = ClrTypeUtilities.SafeGetField(enumeratorType, "Current", BindingFlags.Instance | BindingFlags.Public);
+        if (currentField != null)
+        {
+            elementType = currentField.FieldType;
+            return true;
+        }
+
+        elementType = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Probes a user-defined <see cref="StructSymbol"/> for the
+    /// duck-typed enumerable shape (<c>GetEnumerator() → MoveNext() / Current</c>).
+    /// </summary>
+    /// <param name="type">The user struct symbol to probe.</param>
+    /// <param name="elementType">The element <see cref="TypeSymbol"/>, on success.</param>
+    /// <returns><see langword="true"/> when the duck-typed shape matches.</returns>
+    public static bool TryGetUserPatternEnumerableElementType(StructSymbol type, out TypeSymbol elementType)
+    {
+        if (type.TryGetMethodIncludingInherited("GetEnumerator", out var getEnumerator) &&
+            getEnumerator.Parameters.Length == 0 &&
+            getEnumerator.Type is StructSymbol enumeratorType &&
+            enumeratorType.TryGetMethodIncludingInherited("MoveNext", out var moveNext) &&
+            moveNext.Parameters.Length == 0 &&
+            moveNext.Type == TypeSymbol.Bool &&
+            enumeratorType.TryGetField("Current", out var currentField))
+        {
+            elementType = currentField.Type;
+            return true;
+        }
+
+        elementType = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Probes <paramref name="delegateType"/> for the canonical delegate
+    /// shape (<see cref="System.MulticastDelegate"/>-derived, or
+    /// <c>System.Func`N</c>/<c>System.Action`N</c>) and exposes the
+    /// corresponding <see cref="FunctionTypeSymbol"/>.
+    /// </summary>
+    /// <param name="delegateType">The candidate delegate CLR type.</param>
+    /// <param name="functionType">The matching function-type symbol, on success.</param>
+    /// <returns><see langword="true"/> when the type is a delegate shape.</returns>
+    public static bool TryGetDelegateFunctionType(Type delegateType, out FunctionTypeSymbol functionType)
+    {
+        functionType = null;
+        if (!ClrTypeUtilities.IsDelegateType(delegateType)
+            && !string.Equals(delegateType?.BaseType?.FullName, "System.MulticastDelegate", StringComparison.Ordinal)
+            && !(delegateType?.FullName?.StartsWith("System.Func`", StringComparison.Ordinal) == true)
+            && !(delegateType?.FullName?.StartsWith("System.Action`", StringComparison.Ordinal) == true))
+        {
+            return false;
+        }
+
+        var invoke = delegateType.GetMethod("Invoke");
+        if (invoke == null)
+        {
+            return false;
+        }
+
+        var parameters = invoke.GetParameters();
+        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(parameters.Length);
+        foreach (var parameter in parameters)
+        {
+            parameterTypes.Add(parameter.ParameterType.ContainsGenericParameters
+                ? TypeSymbol.Object
+                : TypeSymbol.FromClrType(parameter.ParameterType));
+        }
+
+        var returnType = invoke.ReturnType == typeof(void)
+            ? TypeSymbol.Void
+            : invoke.ReturnType.ContainsGenericParameters
+                ? TypeSymbol.Object
+                : TypeSymbol.FromClrType(invoke.ReturnType);
+        functionType = FunctionTypeSymbol.Get(parameterTypes.ToImmutable(), returnType);
+        return true;
+    }
+
+    /// <summary>
+    /// Collects the parameter-name set of every overload of
+    /// <paramref name="methodName"/> on <paramref name="receiverClrType"/>.
+    /// Used to surface "did you mean X" diagnostics for unknown named
+    /// arguments; this helper itself does not emit diagnostics.
+    /// </summary>
+    /// <param name="receiverClrType">The receiver CLR type.</param>
+    /// <param name="methodName">The method simple name.</param>
+    /// <param name="bindingFlags">The binding flags to use for the
+    /// reflection probe.</param>
+    /// <returns>The union of parameter names across matching overloads.
+    /// Empty when reflection failed.</returns>
+    public static HashSet<string> CollectClrParameterNames(Type receiverClrType, string methodName, BindingFlags bindingFlags)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        MethodInfo[] methods;
+        try
+        {
+            methods = receiverClrType.GetMethods(bindingFlags);
+        }
+        catch
+        {
+            return names;
+        }
+
+        foreach (var method in methods)
+        {
+            if (!string.Equals(method.Name, methodName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (var parameter in method.GetParameters())
+            {
+                if (parameter.Name != null)
+                {
+                    names.Add(parameter.Name);
+                }
+            }
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    /// Collects the parameter-name set across every public instance
+    /// constructor of <paramref name="clrType"/>. Used in the same way as
+    /// <see cref="CollectClrParameterNames"/>, for constructor call sites.
+    /// </summary>
+    /// <param name="clrType">The CLR type whose constructors to inspect.</param>
+    /// <returns>The union of parameter names across matching constructors.
+    /// Empty when reflection failed.</returns>
+    public static HashSet<string> CollectClrConstructorParameterNames(Type clrType)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        ConstructorInfo[] ctors;
+        try
+        {
+            ctors = ClrTypeUtilities.SafeGetConstructors(clrType, BindingFlags.Public | BindingFlags.Instance);
+        }
+        catch
+        {
+            return names;
+        }
+
+        foreach (var ctor in ctors)
+        {
+            foreach (var parameter in ctor.GetParameters())
+            {
+                if (parameter.Name != null)
+                {
+                    names.Add(parameter.Name);
+                }
+            }
+        }
+
+        return names;
+    }
+
+    // ----- User-symbol member walks -----
+
+    /// <summary>
+    /// Walks <paramref name="structSymbol"/> and its base-class chain looking
+    /// for an instance method overload whose CLR-projected signature matches
+    /// <paramref name="clrMethod"/>. Used by the interface-implementation
+    /// check to decide whether the user struct supplies a given CLR contract
+    /// member.
+    /// </summary>
+    /// <param name="structSymbol">The user struct symbol to inspect.</param>
+    /// <param name="clrMethod">The CLR method whose signature to match.</param>
+    /// <returns><see langword="true"/> when a matching overload exists.</returns>
+    public static bool HasMatchingMethodForClrSignature(StructSymbol structSymbol, MethodInfo clrMethod)
+    {
+        var clrParams = clrMethod.GetParameters();
+        foreach (var candidate in structSymbol.GetMethodsIncludingInherited(clrMethod.Name))
+        {
+            var callable = GetCallableParameters(candidate);
+            if (callable.Length != clrParams.Length)
+            {
+                continue;
+            }
+
+            if (!ClrTypeUtilities.AreSame(candidate.Type?.ClrType, clrMethod.ReturnType))
+            {
+                continue;
+            }
+
+            var allMatch = true;
+            for (var i = 0; i < callable.Length; i++)
+            {
+                if (!ClrTypeUtilities.AreSame(callable[i].Type?.ClrType, clrParams[i].ParameterType))
+                {
+                    allMatch = false;
+                    break;
+                }
+            }
+
+            if (allMatch)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Looks up a user-declared property on <paramref name="structSymbol"/>
+    /// whose name and CLR-projected type match <paramref name="clrProp"/>.
+    /// </summary>
+    /// <param name="structSymbol">The user struct symbol to inspect.</param>
+    /// <param name="clrProp">The CLR property to match.</param>
+    /// <returns>The matching <see cref="PropertySymbol"/>, or
+    /// <see langword="null"/> when no match exists.</returns>
+    public static PropertySymbol FindMatchingProperty(StructSymbol structSymbol, PropertyInfo clrProp)
+    {
+        foreach (var implProp in structSymbol.Properties)
+        {
+            if (implProp.Name == clrProp.Name
+                && ClrTypeUtilities.AreSame(implProp.Type?.ClrType, clrProp.PropertyType))
+            {
+                return implProp;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Walks <paramref name="type"/> and its base-class chain looking for a
+    /// user-declared property with the given <paramref name="name"/>.
+    /// </summary>
+    /// <param name="type">The starting user struct symbol.</param>
+    /// <param name="name">The property name to find.</param>
+    /// <param name="property">The matching property symbol, on success.</param>
+    /// <returns><see langword="true"/> when a property is found.</returns>
+    public static bool TryGetPropertyIncludingInherited(StructSymbol type, string name, out PropertySymbol property)
+    {
+        var current = type;
+        while (current != null)
+        {
+            foreach (var p in current.Properties)
+            {
+                if (p.Name == name)
+                {
+                    property = p;
+                    return true;
+                }
+            }
+
+            current = current.BaseClass;
+        }
+
+        property = null;
+        return false;
+    }
+
+    // ----- Indexer / Nullable<> / extension-method probes (instance helpers) -----
+
+    /// <summary>
+    /// Looks up a public instance indexer on <paramref name="clrTarget"/>
+    /// whose <c>GetIndexParameters()</c> matches <paramref name="boundArguments"/>
+    /// by name-based assignability. The caller is expected to have already
+    /// bound the index argument expressions — keeping
+    /// <see cref="MemberLookup"/> free of <c>BindExpression</c> side effects.
+    /// </summary>
+    /// <param name="clrTarget">The CLR receiver type whose indexers to probe.</param>
+    /// <param name="boundArguments">The pre-bound index argument expressions.</param>
+    /// <param name="indexer">The matching <see cref="PropertyInfo"/>, on success.</param>
+    /// <returns><see langword="true"/> when a matching indexer is found.</returns>
+    public bool TryResolveClrIndexer(Type clrTarget, ImmutableArray<BoundExpression> boundArguments, out PropertyInfo indexer)
+    {
+        indexer = null;
+
+        foreach (var prop in ClrTypeUtilities.SafeGetProperties(clrTarget, BindingFlags.Public | BindingFlags.Instance))
+        {
+            var ps = prop.GetIndexParameters();
+            if (ps.Length != boundArguments.Length)
+            {
+                continue;
+            }
+
+            var ok = true;
+            for (var i = 0; i < ps.Length; i++)
+            {
+                var argClr = boundArguments[i].Type?.ClrType;
+                if (argClr == null || !ClrTypeUtilities.IsAssignableByName(ps[i].ParameterType, argClr))
+                {
+                    ok = false;
+                    break;
+                }
+            }
+
+            if (ok)
+            {
+                indexer = prop;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Constructs <c>Nullable&lt;TUnderlying&gt;</c> projected onto the
+    /// binder's <see cref="ReferenceResolver"/>. Returns false when the
+    /// open <c>Nullable&lt;&gt;</c> is not reachable from the references in
+    /// scope, or when projecting <paramref name="underlying"/> through the
+    /// reference set fails.
+    /// </summary>
+    /// <param name="underlying">The value-type underlying type.</param>
+    /// <param name="constructed">The constructed nullable CLR type, on success.</param>
+    /// <returns><see langword="true"/> when construction succeeded.</returns>
+    public bool TryGetNullableConstructedType(Type underlying, out Type constructed)
+    {
+        constructed = null;
+        if (underlying == null)
+        {
+            return false;
+        }
+
+        if (!this.binderCtx.References.TryResolveType("System.Nullable`1", out var nullableOpen) || nullableOpen == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var mappedUnderlying = this.binderCtx.References.MapClrTypeToReferences(underlying) ?? underlying;
+            constructed = nullableOpen.MakeGenericType(mappedUnderlying);
+            return constructed != null;
+        }
+        catch
+        {
+            constructed = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Issue #294: collects every <c>static [Extension]</c> method named
+    /// <paramref name="methodName"/> across the imported extension-holding
+    /// classes (see <see cref="GetImportedExtensionClasses"/>).
+    /// </summary>
+    /// <param name="methodName">The extension method's simple name.</param>
+    /// <returns>The list of candidate <see cref="MethodInfo"/> overloads.</returns>
+    public List<MethodInfo> CollectImportedExtensionMethods(string methodName)
+    {
+        var result = new List<MethodInfo>();
+        foreach (var type in this.GetImportedExtensionClasses())
+        {
+            MethodInfo[] methods;
+            try
+            {
+                methods = type.GetMethods(BindingFlags.Public | BindingFlags.Static);
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var method in methods)
+            {
+                if (!string.Equals(method.Name, methodName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (!HasExtensionAttribute(method))
+                {
+                    continue;
+                }
+
+                if (method.GetParameters().Length == 0)
+                {
+                    continue;
+                }
+
+                result.Add(method);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Issue #294: enumerates static classes declared in the currently
+    /// imported namespaces that carry <c>[Extension]</c> (i.e. host
+    /// extension methods). The result is cached on the
+    /// <see cref="BinderContext"/> — the import count acts as a cheap
+    /// invalidation key because imports only grow during binding.
+    /// </summary>
+    /// <returns>The imported static extension-holding classes.</returns>
+    public List<Type> GetImportedExtensionClasses()
+    {
+        var imports = this.binderCtx.RootScope.GetDeclaredImports();
+        var importCount = imports.IsDefault ? 0 : imports.Length;
+        if (this.binderCtx.CachedImportedExtensionClasses != null && this.binderCtx.CachedImportedExtensionImportCount == importCount)
+        {
+            return this.binderCtx.CachedImportedExtensionClasses;
+        }
+
+        var namespaces = new HashSet<string>(StringComparer.Ordinal);
+        if (!imports.IsDefault)
+        {
+            foreach (var import in imports)
+            {
+                if (!string.IsNullOrEmpty(import.Target))
+                {
+                    namespaces.Add(import.Target);
+                }
+            }
+        }
+
+        var classes = new List<Type>();
+        if (namespaces.Count > 0)
+        {
+            foreach (var assembly in this.binderCtx.References.Assemblies)
+            {
+                IEnumerable<Type> types;
+                try
+                {
+                    types = assembly.GetTypes();
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    types = ex.Types.Where(t => t != null);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                foreach (var type in types)
+                {
+                    if (type == null || type.Namespace == null || !namespaces.Contains(type.Namespace))
+                    {
+                        continue;
+                    }
+
+                    if (!IsStaticClass(type) || !HasExtensionAttribute(type))
+                    {
+                        continue;
+                    }
+
+                    classes.Add(type);
+                }
+            }
+        }
+
+        this.binderCtx.CachedImportedExtensionClasses = classes;
+        this.binderCtx.CachedImportedExtensionImportCount = importCount;
+        return classes;
+    }
+
+    /// <summary>
+    /// A C# static class is a sealed abstract class. Detected structurally
+    /// so it works under <see cref="System.Reflection.MetadataLoadContext"/>.
+    /// </summary>
+    /// <param name="type">The candidate type.</param>
+    /// <returns><see langword="true"/> when the type is a static class.</returns>
+    public static bool IsStaticClass(Type type)
+        => type.IsClass && type.IsAbstract && type.IsSealed;
+
+    /// <summary>
+    /// Robustly detects <c>[System.Runtime.CompilerServices.ExtensionAttribute]</c>
+    /// via <see cref="CustomAttributeData"/> (never runtime
+    /// <c>GetCustomAttribute</c>, which throws under
+    /// <see cref="System.Reflection.MetadataLoadContext"/>).
+    /// </summary>
+    /// <param name="member">The type or method to inspect.</param>
+    /// <returns><see langword="true"/> when the member carries the
+    /// extension attribute.</returns>
+    public static bool HasExtensionAttribute(MemberInfo member)
+    {
+        try
+        {
+            foreach (var attribute in member.GetCustomAttributesData())
+            {
+                if (string.Equals(
+                    attribute.AttributeType?.FullName,
+                    "System.Runtime.CompilerServices.ExtensionAttribute",
+                    StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+        catch
+        {
+            // Reflection failures (notably in MLC) — treat as "no attribute".
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the callable parameter slice of <paramref name="method"/> —
+    /// dropping the synthetic receiver slot used by extension methods so
+    /// signature-matching against a CLR contract sees only the
+    /// explicitly-declared parameters. Mirrors
+    /// <c>Binder.GetCallableParameters</c> byte-for-byte (kept duplicated
+    /// rather than widening the binder's helper to <c>internal</c>; the
+    /// implementation is a one-liner).
+    /// </summary>
+    /// <param name="method">The user function symbol.</param>
+    /// <returns>The parameters visible to a non-extension caller.</returns>
+    private static ImmutableArray<ParameterSymbol> GetCallableParameters(FunctionSymbol method)
+        => method.ExplicitReceiverParameter == null ? method.Parameters : method.Parameters.RemoveAt(0);
+}


### PR DESCRIPTION
## Summary

Phase 1, **PR-B-2** of the Binder decomposition plan. Extracts the pure ‘given a type T and a name N, return the candidates’ helpers from `Binder.cs` into a new `internal sealed class MemberLookup` at `src/Core/CodeAnalysis/Binding/MemberLookup.cs`.

`MemberLookup` is the **binder-facing facade** that:
- Delegates raw CLR member walks (incl. inherited interfaces) to the existing `ClrTypeUtilities` (not absorbed — kept as the low-level reflection layer).
- Consumes `BinderContext` (PR-B-1, #577) via constructor injection — same pattern, no duplicated state.
- Returns candidates only. **No diagnostics, no `BoundExpression` construction, no `NarrowedVariables` / `LoopStack` mutation.** Callers in `Binder.cs` decide what to do with no-candidate / multi-candidate results.

## Methods moved into `MemberLookup`

Inventory taken via `grep` + `lsp documentSymbol` over `Binder.cs`; line refs are from pre-extraction `Binder.cs` (`main` at 339d330):

| Method | Prev. `Binder.cs` line | Static / instance |
| --- | --- | --- |
| `HasMatchingMethodForClrSignature` | 2761 | static |
| `FindMatchingProperty` | 2796 | static |
| `TryGetPropertyIncludingInherited` | 2852 | static |
| `TryGetAsyncEnumerableElementType` | 6391 | static |
| `EnumerateSelfAndInterfaces` | 6414 | static |
| `TryGetClrDictionaryTypes` | 6613 | static |
| `TryGetClrEnumerableElementType` | 6631 | static |
| `TryGetClrPatternEnumerableElementType` | 6653 | static |
| `TryGetClrCurrentMemberType` | 6689 | static |
| `TryGetUserPatternEnumerableElementType` | 6709 | static |
| `CollectClrParameterNames` | 10935 | static |
| `CollectClrConstructorParameterNames` | 11004 | static |
| `CollectImportedExtensionMethods` | 15093 | instance (walks `BinderContext.References`) |
| `GetImportedExtensionClasses` | 15139 | instance (populates BinderContext caches — by design) |
| `IsStaticClass` | 15207 | static |
| `HasExtensionAttribute` | 15218 | static |
| `TryGetDelegateFunctionType` | 16540 | static |
| `TryGetNullableConstructedType` | 16767 | instance (uses `BinderContext.References`) |
| `TryResolveClrIndexer` | 16190 | **refactored** — see below |

`EnumerateSelfAndInterfaces` and `TryGetPropertyIncludingInherited` are the building blocks the bug overview (§3.5) calls out for the eventual #568/#572/#573 fixes; surfacing them here is the structural point of this PR.

### `TryResolveClrIndexer` signature change

The previous `Binder` method took `IReadOnlyList<ExpressionSyntax>` and internally called `BindExpression` for each argument, returning the bound list as a second `out` parameter. That violates the facade's purity rule (it constructs `BoundExpression`).

New signature:
```csharp
public bool TryResolveClrIndexer(Type clrTarget, ImmutableArray<BoundExpression> boundArguments, out PropertyInfo indexer)
```

Callers now pre-bind the index expression(s) once at the call site and pass the bound list in. The four call sites (`BindIndexedRead` × 2 patterns, `BindIndexAssignmentExpression` × 2 patterns) were restructured from `if (pattern && lookup) { … }` into `if (pattern) { bind; if (lookup) … }` so that `BindExpression` is invoked the same number of times, in the same order, with the same diagnostic surface as before. The two type patterns (`NullabilityAnnotatedTypeSymbol` vs `ImportedTypeSymbol`) are disjoint sealed classes, so the inner-`if` restructure preserves exact control flow / fall-through to `ReportTypeNotIndexable`.

## Deliberately left on `Binder`

These helpers superficially look like lookup but fail the purity rule, so they stay (and migrate later):

- **`BindAccessor*` family** (`BindAccessorExpression`, `BindAccessorStep`, `BindAccessorCall`, `BindMemberIndexAssignmentExpression`, …) — emit diagnostics, construct `BoundExpression`, run narrowing. → **B-9 ExpressionBinder**.
- **`BindClrMethodGroupConversion`** and other `BindClr*Conversion` — conversion classification, not lookup. → **B-3 ConversionClassifier**.
- **`BindCallExpression` / `BindUserInstanceCall` / `TryReorderArguments` / `TryReportAmbiguous*`** — overload-resolution glue, emits diagnostics. → **B-4 OverloadResolver**.
- **`TryBuildDisposeCall` / `TryApplyUserDefinedImplicitArgumentConversion`** — construct `BoundExpression`. → **B-3 / B-9**.
- **`TryResolveScope` / `TryResolveUserMember`** and other `TryResolve*` name-resolution helpers — bind symbols through `BoundScope`, a different facet from CLR member lookup. May fold into MemberLookup later if symmetry helps; out of scope here.
- The static `BindGlobalScope` path and `TryInferExpressionType` — would require plumbing a `MemberLookup` instance into static contexts. Per the task instructions, instance-binder is the priority and these were left untouched.

## Purity confirmation

`MemberLookup` (the new file):
- Has no reference to `Binder`.
- Has no call to anything on `BinderContext.Diagnostics`.
- Constructs no `Bound*` node.
- Does not mutate `NarrowedVariables` or `LoopStack`.
- The only state it writes is the two imported-extension cache fields on `BinderContext` (`CachedImportedExtensionClasses`, `CachedImportedExtensionImportCount`) — those exist on `BinderContext` specifically so this facade can populate them.

## Validation

- Build: clean (0 warnings / 0 errors).
- `Core.Tests`: **2120 passed / 1 skipped / 0 failed** — matches `main` baseline.
- **`RefactoringBaselineTests`**: **92 passed / 1 skipped** (the `RegenerateBaseline` gate, always skipped). **Zero IL hash diffs** — the PR-0 (#576) byte-identical gate accepts the refactoring.
- `Interpreter.Tests`: 72/72 green.
- `LanguageServer.Tests`: 242/242 green.
- `Sdk.Tests`: 24/24 green.
- `Compiler.Tests`: not runnable locally (known macOS file-descriptor / OOM exhaustion on this machine, unrelated to this change — the one test that crashes the host passes in isolation). Relying on CI.

## LoC delta

| File | Before | After | Δ |
| --- | --- | --- | --- |
| `src/Core/CodeAnalysis/Binding/Binder.cs` | 18,546 | 18,027 | **−519** |
| `src/Core/CodeAnalysis/Binding/MemberLookup.cs` | 0 | 736 | **+736** |

The net `+217` is the file scaffolding (copyright header, namespace, usings, two private one-line static helpers copied from `Binder` to keep `Binder`'s internal visibility unchanged — `GetCallableParameters`).

## Next in sequence

**PR-B-3 `ConversionClassifier`** — extracts `BindClr*Conversion` and conversion-classification helpers.