### PR TITLE
PR-E-3: extract WellKnownReferences (BCL ref fields + lazy initializers)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -69,21 +69,21 @@ internal sealed class ReflectionMetadataEmitter
     // consume this same cache via constructor injection.
     private readonly MetadataTokenCache cache;
 
-    // ADR-0051 Phase 6: cached MemberReferenceHandle for NotImplementedException..ctor().
-    private MemberReferenceHandle? notImplementedExceptionCtorRef;
-
-    // ADR-0052: cached MemberReferenceHandles for Delegate.Combine and Delegate.Remove.
-    private MemberReferenceHandle? delegateCombineRef;
-    private MemberReferenceHandle? delegateRemoveRef;
-
-    // Issue #256: cached open MemberRef for Interlocked.CompareExchange<T>(ref T, T, T).
-    private MemberReferenceHandle? interlockedCompareExchangeOpenRef;
-
-    // Issue #420 (P3-11): cached MemberRefs for IsReadOnlyAttribute/IsByRefLikeAttribute/ObsoleteAttribute ctors,
-    // so repeated emission of these markers doesn't create duplicate MemberRef rows.
-    private MemberReferenceHandle? isReadOnlyAttributeCtorRef;
-    private MemberReferenceHandle? isByRefLikeAttributeCtorRef;
-    private MemberReferenceHandle? obsoleteAttributeStringBoolCtorRef;
+    // PR-E-3: the well-known BCL MemberRef/TypeRef fields
+    // (notImplementedExceptionCtorRef, delegateCombineRef/RemoveRef,
+    // interlockedCompareExchangeOpenRef, isReadOnly/IsByRefLike/ObsoleteAttribute
+    // ctor refs, objectTypeRef/valueTypeRef/objectCtorRef, stringConcatRef/
+    // EqualsRef/ConcatArrayRef, objectStatic/InstanceXxxRef, nullRefException
+    // CtorRef, convertToStringRef, cultureInvariantGetterRef, hashCodeTypeRef/
+    // AddOpenRef/ToHashCodeRef/CombineOpenRefs[], systemAttribute Type/CtorRef)
+    // and their paired Get* lazy initializers have moved into
+    // WellKnownReferences. The lone StandaloneSignatureHandle hashCodeLocalSig
+    // and its `GetHashCodeLocalSignature()` initializer stay on the emitter:
+    // that's a per-emit StandaloneSignature row (not a Type/MemberRef) and is
+    // squarely in PR-E-6 DataStructSynthesizer scope.
+    // Not readonly because instantiation depends on EmitContext.Core* having
+    // been resolved first — that happens during EmitCore, not the ctor.
+    private WellKnownReferences wellKnown;
 
     // Phase 4 emit parity (E1): synthesized lambda bodies (no captures).
     // Populated by a pre-pass walker over every user function/entry body.
@@ -147,28 +147,14 @@ internal sealed class ReflectionMetadataEmitter
     // coreInt32Type, coreBooleanType, coreArrayType, coreValueType,
     // coreSystemType, coreRuntimeTypeHandleType, coreEnumType,
     // coreMulticastDelegateType, coreIntPtrType) moved onto EmitContext.
-    private TypeReferenceHandle objectTypeRef;
-    private TypeReferenceHandle valueTypeRef;
-    private MemberReferenceHandle objectCtorRef;
-    private MemberReferenceHandle stringConcatRef;
-    private MemberReferenceHandle stringEqualsRef;
-    private MemberReferenceHandle objectStaticEqualsRef;
-    private MemberReferenceHandle objectInstanceToStringRef;
-    private MemberReferenceHandle objectInstanceGetHashCodeRef;
-    private MemberReferenceHandle nullRefExceptionCtorRef;
-
-    // Issue #410 / ADR-0029: cached member refs for data-struct synthesized members.
-    private MemberReferenceHandle stringConcatArrayRef;
-    private MemberReferenceHandle convertToStringRef;
-    private MemberReferenceHandle cultureInvariantGetterRef;
-    private MemberReferenceHandle hashCodeAddOpenRef;
-    private MemberReferenceHandle hashCodeToHashCodeRef;
-    private readonly MemberReferenceHandle?[] hashCodeCombineOpenRefs = new MemberReferenceHandle?[8];
-    private TypeReferenceHandle hashCodeTypeRef;
+    // PR-E-3: objectTypeRef, valueTypeRef, objectCtorRef,
+    // stringConcatRef/EqualsRef, objectStaticEqualsRef,
+    // objectInstanceToStringRef/GetHashCodeRef, nullRefExceptionCtorRef,
+    // stringConcatArrayRef, convertToStringRef, cultureInvariantGetterRef,
+    // hashCodeAddOpenRef/ToHashCodeRef, hashCodeCombineOpenRefs[],
+    // hashCodeTypeRef, systemAttributeTypeRef/CtorRef moved onto
+    // WellKnownReferences.
     private StandaloneSignatureHandle hashCodeLocalSig;
-
-    private EntityHandle? systemAttributeTypeRef;
-    private MemberReferenceHandle? systemAttributeCtorRef;
 
     private ReflectionMetadataEmitter(BoundProgram program, ReferenceResolver references, string assemblyName, bool metadataOnly)
     {
@@ -328,9 +314,14 @@ internal sealed class ReflectionMetadataEmitter
         // type for user-declared named delegate emission.
         this.emitCtx.CoreMulticastDelegateType = this.ResolveCoreType("System.MulticastDelegate", typeof(System.MulticastDelegate));
         this.emitCtx.CoreIntPtrType = this.ResolveCoreType("System.IntPtr", typeof(System.IntPtr));
-        this.objectTypeRef = this.GetTypeReference(this.emitCtx.CoreObjectType);
-        this.valueTypeRef = this.GetTypeReference(this.emitCtx.CoreValueType);
-        this.objectCtorRef = this.GetObjectDefaultCtorReference();
+
+        // PR-E-3: WellKnownReferences depends on EmitContext.Core* and on the
+        // dedup-cached GetTypeReference / GetMethodReference resolvers that
+        // still live on this emitter. Its ctor eagerly resolves the three
+        // refs the rest of EmitCore needs immediately (Object/ValueType
+        // TypeRefs, Object..ctor MemberRef); every other well-known ref is
+        // lazily materialised on first access via its paired Get* method.
+        this.wellKnown = new WellKnownReferences(this.emitCtx, this.GetTypeReference, this.GetMethodReference);
 
         // Pre-assign FieldDefinitionHandles for user struct fields. Struct
         // TypeDefs are emitted between <Module> and the per-package <Program>
@@ -1158,7 +1149,7 @@ internal sealed class ReflectionMetadataEmitter
                     | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit,
                 @namespace: this.emitCtx.Metadata.GetOrAddString(globalsHostPkg.Name),
                 name: this.emitCtx.Metadata.GetOrAddString("<Program>"),
-                baseType: this.objectTypeRef,
+                baseType: this.wellKnown.ObjectTypeRef,
                 fieldList: MetadataTokens.FieldDefinitionHandle(programFirstFieldRow),
                 methodList: MetadataTokens.MethodDefinitionHandle(packageCtorRows[globalsHostPkg]));
             programTypeDefHandles[globalsHostPkg] = programHandle;
@@ -1180,7 +1171,7 @@ internal sealed class ReflectionMetadataEmitter
                     | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit,
                 @namespace: this.emitCtx.Metadata.GetOrAddString(pkg.Name),
                 name: this.emitCtx.Metadata.GetOrAddString("<Program>"),
-                baseType: this.objectTypeRef,
+                baseType: this.wellKnown.ObjectTypeRef,
                 fieldList: MetadataTokens.FieldDefinitionHandle(fieldListRow),
                 methodList: MetadataTokens.MethodDefinitionHandle(packageCtorRows[pkg]));
             programTypeDefHandles[pkg] = programHandle;
@@ -2115,7 +2106,7 @@ internal sealed class ReflectionMetadataEmitter
             {
                 // Phase 4 of #141 / ADR-0047 §5: @Attribute sugar — base is
                 // System.Attribute, regardless of any other resolution.
-                baseType = this.GetSystemAttributeTypeRef();
+                baseType = this.wellKnown.GetSystemAttributeTypeRef();
             }
             else if (structSym.BaseClass != null && this.cache.StructTypeDefs.TryGetValue(structSym.BaseClass, out var baseHandle))
             {
@@ -2130,7 +2121,7 @@ internal sealed class ReflectionMetadataEmitter
             }
             else
             {
-                baseType = this.objectTypeRef;
+                baseType = this.wellKnown.ObjectTypeRef;
             }
         }
         else
@@ -2138,7 +2129,7 @@ internal sealed class ReflectionMetadataEmitter
             typeAttrs = TypeAttributes.SequentialLayout | TypeAttributes.Sealed
                 | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit
                 | MapTypeAccessibility(structSym.Accessibility);
-            baseType = this.valueTypeRef;
+            baseType = this.wellKnown.ValueTypeRef;
         }
 
         var handle2 = this.emitCtx.Metadata.AddTypeDefinition(
@@ -2269,7 +2260,7 @@ internal sealed class ReflectionMetadataEmitter
             {
                 // Fallback: throw new NotImplementedException().
                 var il = new InstructionEncoder(new BlobBuilder());
-                var nieCtor = this.GetNotImplementedExceptionCtor();
+                var nieCtor = this.wellKnown.GetNotImplementedExceptionCtor();
                 il.OpCode(ILOpCode.Newobj);
                 il.Token(nieCtor);
                 il.OpCode(ILOpCode.Throw);
@@ -2336,7 +2327,7 @@ internal sealed class ReflectionMetadataEmitter
             {
                 // Fallback: throw new NotImplementedException().
                 var il = new InstructionEncoder(new BlobBuilder());
-                var nieCtor = this.GetNotImplementedExceptionCtor();
+                var nieCtor = this.wellKnown.GetNotImplementedExceptionCtor();
                 il.OpCode(ILOpCode.Newobj);
                 il.Token(nieCtor);
                 il.OpCode(ILOpCode.Throw);
@@ -2485,7 +2476,7 @@ internal sealed class ReflectionMetadataEmitter
             else
             {
                 var il = new InstructionEncoder(new BlobBuilder());
-                var nieCtor = this.GetNotImplementedExceptionCtor();
+                var nieCtor = this.wellKnown.GetNotImplementedExceptionCtor();
                 il.OpCode(ILOpCode.Newobj);
                 il.Token(nieCtor);
                 il.OpCode(ILOpCode.Throw);
@@ -2534,7 +2525,7 @@ internal sealed class ReflectionMetadataEmitter
             else
             {
                 var il = new InstructionEncoder(new BlobBuilder());
-                var nieCtor = this.GetNotImplementedExceptionCtor();
+                var nieCtor = this.wellKnown.GetNotImplementedExceptionCtor();
                 il.OpCode(ILOpCode.Newobj);
                 il.Token(nieCtor);
                 il.OpCode(ILOpCode.Throw);
@@ -2662,7 +2653,7 @@ internal sealed class ReflectionMetadataEmitter
                 il.OpCode(ILOpCode.Ldloc_1);
                 il.LoadArgument(0);
                 il.OpCode(ILOpCode.Call);
-                il.Token(this.GetDelegateCombineRef());
+                il.Token(this.wellKnown.GetDelegateCombineRef());
                 il.OpCode(ILOpCode.Castclass);
                 il.Token(eventTypeHandle);
                 il.OpCode(ILOpCode.Stloc_2);
@@ -2702,7 +2693,7 @@ internal sealed class ReflectionMetadataEmitter
             else
             {
                 var il = new InstructionEncoder(new BlobBuilder());
-                var nieCtor = this.GetNotImplementedExceptionCtor();
+                var nieCtor = this.wellKnown.GetNotImplementedExceptionCtor();
                 il.OpCode(ILOpCode.Newobj);
                 il.Token(nieCtor);
                 il.OpCode(ILOpCode.Throw);
@@ -2763,7 +2754,7 @@ internal sealed class ReflectionMetadataEmitter
                 il.OpCode(ILOpCode.Ldloc_1);
                 il.LoadArgument(0);
                 il.OpCode(ILOpCode.Call);
-                il.Token(this.GetDelegateRemoveRef());
+                il.Token(this.wellKnown.GetDelegateRemoveRef());
                 il.OpCode(ILOpCode.Castclass);
                 il.Token(eventTypeHandle);
                 il.OpCode(ILOpCode.Stloc_2);
@@ -2803,7 +2794,7 @@ internal sealed class ReflectionMetadataEmitter
             else
             {
                 var il = new InstructionEncoder(new BlobBuilder());
-                var nieCtor = this.GetNotImplementedExceptionCtor();
+                var nieCtor = this.wellKnown.GetNotImplementedExceptionCtor();
                 il.OpCode(ILOpCode.Newobj);
                 il.Token(nieCtor);
                 il.OpCode(ILOpCode.Throw);
@@ -2830,26 +2821,6 @@ internal sealed class ReflectionMetadataEmitter
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob),
             bodyOffset: bodyOffset,
             parameterList: firstParamHandle);
-    }
-
-    /// <summary>Resolves a MemberReferenceHandle for System.NotImplementedException..ctor().</summary>
-    private MemberReferenceHandle GetNotImplementedExceptionCtor()
-    {
-        if (this.notImplementedExceptionCtorRef.HasValue)
-        {
-            return this.notImplementedExceptionCtorRef.Value;
-        }
-
-        var nieType = typeof(System.NotImplementedException);
-        var nieTypeRef = this.GetTypeReference(nieType);
-        var ctorSig = new BlobBuilder();
-        new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
-            .Parameters(0, r => r.Void(), _ => { });
-        this.notImplementedExceptionCtorRef = this.emitCtx.Metadata.AddMemberReference(
-            nieTypeRef,
-            this.emitCtx.Metadata.GetOrAddString(".ctor"),
-            this.emitCtx.Metadata.GetOrAddBlob(ctorSig));
-        return this.notImplementedExceptionCtorRef.Value;
     }
 
     /// <summary>
@@ -3187,7 +3158,7 @@ internal sealed class ReflectionMetadataEmitter
                 il.OpCode(ILOpCode.Ldloc_1);
                 il.LoadArgument(1);
                 il.OpCode(ILOpCode.Call);
-                il.Token(this.GetDelegateCombineRef());
+                il.Token(this.wellKnown.GetDelegateCombineRef());
                 il.OpCode(ILOpCode.Castclass);
                 il.Token(eventTypeHandle);
                 il.OpCode(ILOpCode.Stloc_2);
@@ -3230,7 +3201,7 @@ internal sealed class ReflectionMetadataEmitter
             {
                 // Fallback: throw new NotImplementedException().
                 var il = new InstructionEncoder(new BlobBuilder());
-                var nieCtor = this.GetNotImplementedExceptionCtor();
+                var nieCtor = this.wellKnown.GetNotImplementedExceptionCtor();
                 il.OpCode(ILOpCode.Newobj);
                 il.Token(nieCtor);
                 il.OpCode(ILOpCode.Throw);
@@ -3304,7 +3275,7 @@ internal sealed class ReflectionMetadataEmitter
                 il.OpCode(ILOpCode.Ldloc_1);
                 il.LoadArgument(1);
                 il.OpCode(ILOpCode.Call);
-                il.Token(this.GetDelegateRemoveRef());
+                il.Token(this.wellKnown.GetDelegateRemoveRef());
                 il.OpCode(ILOpCode.Castclass);
                 il.Token(eventTypeHandle);
                 il.OpCode(ILOpCode.Stloc_2);
@@ -3347,7 +3318,7 @@ internal sealed class ReflectionMetadataEmitter
             {
                 // Fallback: throw new NotImplementedException().
                 var il = new InstructionEncoder(new BlobBuilder());
-                var nieCtor = this.GetNotImplementedExceptionCtor();
+                var nieCtor = this.wellKnown.GetNotImplementedExceptionCtor();
                 il.OpCode(ILOpCode.Newobj);
                 il.Token(nieCtor);
                 il.OpCode(ILOpCode.Throw);
@@ -3406,7 +3377,7 @@ internal sealed class ReflectionMetadataEmitter
             {
                 // Fallback: throw new NotImplementedException().
                 var il = new InstructionEncoder(new BlobBuilder());
-                var nieCtor = this.GetNotImplementedExceptionCtor();
+                var nieCtor = this.wellKnown.GetNotImplementedExceptionCtor();
                 il.OpCode(ILOpCode.Newobj);
                 il.Token(nieCtor);
                 il.OpCode(ILOpCode.Throw);
@@ -3466,96 +3437,12 @@ internal sealed class ReflectionMetadataEmitter
             parameterList: firstParamHandle);
     }
 
-    /// <summary>ADR-0052: resolves a MemberReferenceHandle for Delegate.Combine(Delegate, Delegate).</summary>
-    private MemberReferenceHandle GetDelegateCombineRef()
-    {
-        if (this.delegateCombineRef.HasValue)
-        {
-            return this.delegateCombineRef.Value;
-        }
-
-        var delegateTypeRef = this.GetTypeReference(typeof(System.Delegate));
-        var sig = new BlobBuilder();
-        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
-            .Parameters(2,
-                r => r.Type().Type(delegateTypeRef, isValueType: false),
-                ps =>
-                {
-                    ps.AddParameter().Type().Type(delegateTypeRef, isValueType: false);
-                    ps.AddParameter().Type().Type(delegateTypeRef, isValueType: false);
-                });
-
-        this.delegateCombineRef = this.emitCtx.Metadata.AddMemberReference(
-            delegateTypeRef,
-            this.emitCtx.Metadata.GetOrAddString("Combine"),
-            this.emitCtx.Metadata.GetOrAddBlob(sig));
-        return this.delegateCombineRef.Value;
-    }
-
-    /// <summary>ADR-0052: resolves a MemberReferenceHandle for Delegate.Remove(Delegate, Delegate).</summary>
-    private MemberReferenceHandle GetDelegateRemoveRef()
-    {
-        if (this.delegateRemoveRef.HasValue)
-        {
-            return this.delegateRemoveRef.Value;
-        }
-
-        var delegateTypeRef = this.GetTypeReference(typeof(System.Delegate));
-        var sig = new BlobBuilder();
-        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
-            .Parameters(2,
-                r => r.Type().Type(delegateTypeRef, isValueType: false),
-                ps =>
-                {
-                    ps.AddParameter().Type().Type(delegateTypeRef, isValueType: false);
-                    ps.AddParameter().Type().Type(delegateTypeRef, isValueType: false);
-                });
-
-        this.delegateRemoveRef = this.emitCtx.Metadata.AddMemberReference(
-            delegateTypeRef,
-            this.emitCtx.Metadata.GetOrAddString("Remove"),
-            this.emitCtx.Metadata.GetOrAddBlob(sig));
-        return this.delegateRemoveRef.Value;
-    }
-
-    /// <summary>
-    /// Issue #256: resolves the open MemberRef for Interlocked.CompareExchange&lt;T&gt;(ref T, T, T).
-    /// </summary>
-    private MemberReferenceHandle GetInterlockedCompareExchangeOpenRef()
-    {
-        if (this.interlockedCompareExchangeOpenRef.HasValue)
-        {
-            return this.interlockedCompareExchangeOpenRef.Value;
-        }
-
-        var interlockedTypeRef = this.GetTypeReference(typeof(System.Threading.Interlocked));
-
-        // Signature: static T CompareExchange<T>(ref T, T, T) with 1 generic param.
-        // In open form, T is !!0 (method type parameter at index 0).
-        var sig = new BlobBuilder();
-        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false, genericParameterCount: 1)
-            .Parameters(3,
-                r => r.Type().GenericMethodTypeParameter(0),
-                ps =>
-                {
-                    ps.AddParameter().Type(isByRef: true).GenericMethodTypeParameter(0);
-                    ps.AddParameter().Type().GenericMethodTypeParameter(0);
-                    ps.AddParameter().Type().GenericMethodTypeParameter(0);
-                });
-
-        this.interlockedCompareExchangeOpenRef = this.emitCtx.Metadata.AddMemberReference(
-            interlockedTypeRef,
-            this.emitCtx.Metadata.GetOrAddString("CompareExchange"),
-            this.emitCtx.Metadata.GetOrAddBlob(sig));
-        return this.interlockedCompareExchangeOpenRef.Value;
-    }
-
     /// <summary>
     /// Issue #256: produces a MethodSpec for Interlocked.CompareExchange&lt;EventType&gt;.
     /// </summary>
     private EntityHandle GetInterlockedCompareExchangeSpec(TypeSymbol eventType)
     {
-        var openRef = this.GetInterlockedCompareExchangeOpenRef();
+        var openRef = this.wellKnown.GetInterlockedCompareExchangeOpenRef();
         var sigBlob = new BlobBuilder();
         var argsEncoder = new BlobEncoder(sigBlob).MethodSpecificationSignature(1);
         var typeEncoder = argsEncoder.AddArgument();
@@ -3730,7 +3617,7 @@ internal sealed class ReflectionMetadataEmitter
             }
             else
             {
-                baseType = this.objectTypeRef;
+                baseType = this.wellKnown.ObjectTypeRef;
             }
         }
         else
@@ -3738,7 +3625,7 @@ internal sealed class ReflectionMetadataEmitter
             typeAttrs = TypeAttributes.SequentialLayout | TypeAttributes.Sealed
                 | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit
                 | TypeAttributes.NestedPrivate;
-            baseType = this.valueTypeRef;
+            baseType = this.wellKnown.ValueTypeRef;
         }
 
         // Nested types have no namespace in ECMA-335 metadata.
@@ -3947,7 +3834,7 @@ internal sealed class ReflectionMetadataEmitter
     /// <param name="typeHandle">The inline struct TypeDef handle.</param>
     private void EmitIsReadOnlyAttribute(TypeDefinitionHandle typeHandle)
     {
-        var ctorRef = this.GetIsReadOnlyAttributeCtorRef();
+        var ctorRef = this.wellKnown.GetIsReadOnlyAttributeCtorRef();
 
         var valueBlob = new BlobBuilder();
         valueBlob.WriteUInt16(0x0001);
@@ -3967,7 +3854,7 @@ internal sealed class ReflectionMetadataEmitter
     /// <param name="paramHandle">The Parameter row to annotate.</param>
     private void EmitIsReadOnlyAttributeOnParameter(ParameterHandle paramHandle)
     {
-        var ctorRef = this.GetIsReadOnlyAttributeCtorRef();
+        var ctorRef = this.wellKnown.GetIsReadOnlyAttributeCtorRef();
 
         var valueBlob = new BlobBuilder();
         valueBlob.WriteUInt16(0x0001);
@@ -3977,43 +3864,6 @@ internal sealed class ReflectionMetadataEmitter
             parent: paramHandle,
             constructor: ctorRef,
             value: this.emitCtx.Metadata.GetOrAddBlob(valueBlob));
-    }
-
-    /// <summary>
-    /// ADR-0060 §6: returns the TypeRef handle for
-    /// <c>System.Runtime.CompilerServices.IsReadOnlyAttribute</c>, used as the
-    /// <c>modreq</c> on each emitted <c>in</c> parameter signature.
-    /// </summary>
-    /// <returns>The TypeRef entity handle, or <see langword="default"/> if the type can't be resolved.</returns>
-    private EntityHandle GetIsReadOnlyAttributeTypeRef()
-    {
-        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.IsReadOnlyAttribute", out var resolved)
-            ? resolved
-            : typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute);
-        return this.GetTypeReference(attrType);
-    }
-
-    private MemberReferenceHandle GetIsReadOnlyAttributeCtorRef()
-    {
-        if (this.isReadOnlyAttributeCtorRef.HasValue)
-        {
-            return this.isReadOnlyAttributeCtorRef.Value;
-        }
-
-        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.IsReadOnlyAttribute", out var resolved)
-            ? resolved
-            : typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute);
-        var attrTypeRef = this.GetTypeReference(attrType);
-
-        var ctorSig = new BlobBuilder();
-        new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
-            .Parameters(0, r => r.Void(), _ => { });
-
-        this.isReadOnlyAttributeCtorRef = this.emitCtx.Metadata.AddMemberReference(
-            attrTypeRef,
-            this.emitCtx.Metadata.GetOrAddString(".ctor"),
-            this.emitCtx.Metadata.GetOrAddBlob(ctorSig));
-        return this.isReadOnlyAttributeCtorRef.Value;
     }
 
     /// <summary>
@@ -4032,7 +3882,7 @@ internal sealed class ReflectionMetadataEmitter
     /// <param name="typeHandle">The ref-struct TypeDef handle.</param>
     private void EmitIsByRefLikeAttribute(TypeDefinitionHandle typeHandle)
     {
-        var ctorRef = this.GetIsByRefLikeAttributeCtorRef();
+        var ctorRef = this.wellKnown.GetIsByRefLikeAttributeCtorRef();
 
         var valueBlob = new BlobBuilder();
         valueBlob.WriteUInt16(0x0001);
@@ -4043,7 +3893,7 @@ internal sealed class ReflectionMetadataEmitter
             constructor: ctorRef,
             value: this.emitCtx.Metadata.GetOrAddBlob(valueBlob));
 
-        var obsoleteCtorRef = this.GetObsoleteAttributeStringBoolCtorRef();
+        var obsoleteCtorRef = this.wellKnown.GetObsoleteAttributeStringBoolCtorRef();
 
         var obsoleteBlob = new BlobBuilder();
         obsoleteBlob.WriteUInt16(0x0001);
@@ -4055,56 +3905,6 @@ internal sealed class ReflectionMetadataEmitter
             parent: typeHandle,
             constructor: obsoleteCtorRef,
             value: this.emitCtx.Metadata.GetOrAddBlob(obsoleteBlob));
-    }
-
-    private MemberReferenceHandle GetIsByRefLikeAttributeCtorRef()
-    {
-        if (this.isByRefLikeAttributeCtorRef.HasValue)
-        {
-            return this.isByRefLikeAttributeCtorRef.Value;
-        }
-
-        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.IsByRefLikeAttribute", out var resolved)
-            ? resolved
-            : typeof(System.Runtime.CompilerServices.IsByRefLikeAttribute);
-        var attrTypeRef = this.GetTypeReference(attrType);
-
-        var ctorSig = new BlobBuilder();
-        new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
-            .Parameters(0, r => r.Void(), _ => { });
-
-        this.isByRefLikeAttributeCtorRef = this.emitCtx.Metadata.AddMemberReference(
-            attrTypeRef,
-            this.emitCtx.Metadata.GetOrAddString(".ctor"),
-            this.emitCtx.Metadata.GetOrAddBlob(ctorSig));
-        return this.isByRefLikeAttributeCtorRef.Value;
-    }
-
-    private MemberReferenceHandle GetObsoleteAttributeStringBoolCtorRef()
-    {
-        if (this.obsoleteAttributeStringBoolCtorRef.HasValue)
-        {
-            return this.obsoleteAttributeStringBoolCtorRef.Value;
-        }
-
-        var obsoleteType = this.emitCtx.References.TryResolveType("System.ObsoleteAttribute", out var obsoleteResolved)
-            ? obsoleteResolved
-            : typeof(System.ObsoleteAttribute);
-        var obsoleteTypeRef = this.GetTypeReference(obsoleteType);
-
-        var obsoleteCtorSig = new BlobBuilder();
-        new BlobEncoder(obsoleteCtorSig).MethodSignature(isInstanceMethod: true)
-            .Parameters(2, r => r.Void(), p =>
-            {
-                p.AddParameter().Type().String();
-                p.AddParameter().Type().Boolean();
-            });
-
-        this.obsoleteAttributeStringBoolCtorRef = this.emitCtx.Metadata.AddMemberReference(
-            obsoleteTypeRef,
-            this.emitCtx.Metadata.GetOrAddString(".ctor"),
-            this.emitCtx.Metadata.GetOrAddBlob(obsoleteCtorSig));
-        return this.obsoleteAttributeStringBoolCtorRef.Value;
     }
 
     /// <summary>
@@ -4890,7 +4690,7 @@ internal sealed class ReflectionMetadataEmitter
                         var paramEncoder = ps.AddParameter();
                         if (p.RefKind == RefKind.In)
                         {
-                            var isReadOnlyAttrType = this.GetIsReadOnlyAttributeTypeRef();
+                            var isReadOnlyAttrType = this.wellKnown.GetIsReadOnlyAttributeTypeRef();
                             if (!isReadOnlyAttrType.IsNil)
                             {
                                 paramEncoder.CustomModifiers().AddModifier(isReadOnlyAttrType, isOptional: false);
@@ -5357,7 +5157,7 @@ internal sealed class ReflectionMetadataEmitter
             parameterList: this.NextParameterHandle());
     }
 
-    /// <summary>Resolves the <c>.ctor()</c> token a derived class's ctor should chain to: either the base class's default ctor (already emitted) or <see cref="objectCtorRef"/>.</summary>
+    /// <summary>Resolves the <c>.ctor()</c> token a derived class's ctor should chain to: either the base class's default ctor (already emitted) or <see cref="WellKnownReferences.ObjectCtorRef"/>.</summary>
     private EntityHandle GetBaseCtorToken(StructSymbol classSym)
     {
         if (classSym.BaseClass != null && this.cache.ClassCtorHandles.TryGetValue(classSym.BaseClass, out var baseCtor))
@@ -5369,7 +5169,7 @@ internal sealed class ReflectionMetadataEmitter
         {
             // Phase 4 of #141 / ADR-0047 §5: chain to System.Attribute..ctor()
             // since the base type was overridden away from System.Object.
-            return this.GetSystemAttributeCtorRef();
+            return this.wellKnown.GetSystemAttributeCtorRef();
         }
 
         if (classSym.ImportedBaseType?.ClrType is Type importedBaseClr)
@@ -5379,7 +5179,7 @@ internal sealed class ReflectionMetadataEmitter
             return this.GetImportedBaseDefaultCtorReference(importedBaseClr);
         }
 
-        return this.objectCtorRef;
+        return this.wellKnown.ObjectCtorRef;
     }
 
     /// <summary>
@@ -5422,37 +5222,6 @@ internal sealed class ReflectionMetadataEmitter
             parent: this.GetTypeReference(importedBaseClr),
             name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-    }
-
-    private EntityHandle GetSystemAttributeTypeRef()
-    {
-        if (!this.systemAttributeTypeRef.HasValue)
-        {
-            var t = this.emitCtx.References.TryResolveType("System.Attribute", out var resolved)
-                ? resolved
-                : typeof(System.Attribute);
-            this.systemAttributeTypeRef = this.GetTypeReference(t);
-        }
-
-        return this.systemAttributeTypeRef.Value;
-    }
-
-    private MemberReferenceHandle GetSystemAttributeCtorRef()
-    {
-        if (!this.systemAttributeCtorRef.HasValue)
-        {
-            var attrTypeRef = this.GetSystemAttributeTypeRef();
-            var ctorSig = new BlobBuilder();
-            new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
-                .Parameters(0, r => r.Void(), _ => { });
-
-            this.systemAttributeCtorRef = this.emitCtx.Metadata.AddMemberReference(
-                attrTypeRef,
-                this.emitCtx.Metadata.GetOrAddString(".ctor"),
-                this.emitCtx.Metadata.GetOrAddBlob(ctorSig));
-        }
-
-        return this.systemAttributeCtorRef.Value;
     }
 
     /// <summary>
@@ -5866,7 +5635,7 @@ internal sealed class ReflectionMetadataEmitter
                         var paramEncoder = ps.AddParameter();
                         if (p.RefKind == RefKind.In)
                         {
-                            var isReadOnlyAttrType = this.GetIsReadOnlyAttributeTypeRef();
+                            var isReadOnlyAttrType = this.wellKnown.GetIsReadOnlyAttributeTypeRef();
                             if (!isReadOnlyAttrType.IsNil)
                             {
                                 paramEncoder.CustomModifiers().AddModifier(isReadOnlyAttrType, isOptional: false);
@@ -6067,7 +5836,7 @@ internal sealed class ReflectionMetadataEmitter
             il.OpCode(ILOpCode.Ldfld);
             il.Token(fieldHandle);
             this.EmitBoxIfNeeded(il, field.Type);
-            il.Call(this.GetObjectStaticEqualsReference());
+            il.Call(this.wellKnown.GetObjectStaticEqualsReference());
             il.OpCode(ILOpCode.Ret);
         }
 
@@ -6101,7 +5870,7 @@ internal sealed class ReflectionMetadataEmitter
             il.OpCode(ILOpCode.Ldfld);
             il.Token(fieldHandle);
             this.EmitBoxIfNeeded(il, field.Type);
-            il.Call(this.GetObjectStaticEqualsReference());
+            il.Call(this.wellKnown.GetObjectStaticEqualsReference());
             il.OpCode(ILOpCode.Ret);
         }
 
@@ -6120,7 +5889,7 @@ internal sealed class ReflectionMetadataEmitter
             il.Token(fieldHandle);
             this.EmitBoxIfNeeded(il, field.Type);
             il.OpCode(ILOpCode.Callvirt);
-            il.Token(this.GetObjectInstanceGetHashCodeReference());
+            il.Token(this.wellKnown.GetObjectInstanceGetHashCodeReference());
             il.OpCode(ILOpCode.Ret);
         }
 
@@ -6140,10 +5909,10 @@ internal sealed class ReflectionMetadataEmitter
             il.Token(fieldHandle);
             this.EmitBoxIfNeeded(il, field.Type);
             il.OpCode(ILOpCode.Callvirt);
-            il.Token(this.GetObjectInstanceToStringReference());
-            il.Call(this.GetStringConcatReference());
+            il.Token(this.wellKnown.GetObjectInstanceToStringReference());
+            il.Call(this.wellKnown.GetStringConcatReference());
             il.LoadString(this.emitCtx.Metadata.GetOrAddUserString(")"));
-            il.Call(this.GetStringConcatReference());
+            il.Call(this.wellKnown.GetStringConcatReference());
             il.OpCode(ILOpCode.Ret);
         }
 
@@ -6175,7 +5944,7 @@ internal sealed class ReflectionMetadataEmitter
             il.OpCode(ILOpCode.Ldfld);
             il.Token(fieldHandle);
             this.EmitBoxIfNeeded(il, field.Type);
-            il.Call(this.GetObjectStaticEqualsReference());
+            il.Call(this.wellKnown.GetObjectStaticEqualsReference());
             if (isInequality)
             {
                 il.LoadConstantI4(0);
@@ -6322,7 +6091,7 @@ internal sealed class ReflectionMetadataEmitter
                 il.OpCode(ILOpCode.Ldfld);
                 il.Token(fieldHandle);
                 this.EmitBoxIfNeeded(il, field.Type);
-                il.Call(this.GetObjectStaticEqualsReference());
+                il.Call(this.wellKnown.GetObjectStaticEqualsReference());
                 il.Branch(ILOpCode.Brfalse, retFalse);
             }
 
@@ -6389,7 +6158,7 @@ internal sealed class ReflectionMetadataEmitter
                 // ldloca.s 0; initobj HashCode
                 il.LoadLocalAddress(0);
                 il.OpCode(ILOpCode.Initobj);
-                il.Token(this.GetHashCodeTypeReference());
+                il.Token(this.wellKnown.GetHashCodeTypeReference());
 
                 var addSpec = this.GetHashCodeAddObjectSpec();
                 foreach (var field in fields)
@@ -6405,7 +6174,7 @@ internal sealed class ReflectionMetadataEmitter
                 }
 
                 il.LoadLocalAddress(0);
-                il.Call(this.GetHashCodeToHashCodeReference());
+                il.Call(this.wellKnown.GetHashCodeToHashCodeReference());
                 il.OpCode(ILOpCode.Ret);
 
                 localsSignature = this.GetHashCodeLocalSignature();
@@ -6473,8 +6242,8 @@ internal sealed class ReflectionMetadataEmitter
                 il.OpCode(ILOpCode.Ldfld);
                 il.Token(fieldHandle);
                 this.EmitBoxIfNeeded(il, field.Type);
-                il.Call(this.GetCultureInvariantGetterReference());
-                il.Call(this.GetConvertToStringReference());
+                il.Call(this.wellKnown.GetCultureInvariantGetterReference());
+                il.Call(this.wellKnown.GetConvertToStringReference());
                 il.OpCode(ILOpCode.Stelem_ref);
 
                 // Piece 2*i + 2: separator (", F{i+1}=" if more fields, else ")")
@@ -6487,7 +6256,7 @@ internal sealed class ReflectionMetadataEmitter
                 il.OpCode(ILOpCode.Stelem_ref);
             }
 
-            il.Call(this.GetStringConcatArrayReference());
+            il.Call(this.wellKnown.GetStringConcatArrayReference());
             il.OpCode(ILOpCode.Ret);
         }
 
@@ -6535,7 +6304,7 @@ internal sealed class ReflectionMetadataEmitter
                 il.OpCode(ILOpCode.Ldfld);
                 il.Token(fieldHandle);
                 this.EmitBoxIfNeeded(il, field.Type);
-                il.Call(this.GetObjectStaticEqualsReference());
+                il.Call(this.wellKnown.GetObjectStaticEqualsReference());
                 il.Branch(ILOpCode.Brfalse, retFalse);
             }
 
@@ -7102,7 +6871,7 @@ internal sealed class ReflectionMetadataEmitter
         {
             var il = new InstructionEncoder(new BlobBuilder());
             il.LoadArgument(0);
-            il.Call(this.objectCtorRef);
+            il.Call(this.wellKnown.ObjectCtorRef);
             il.OpCode(ILOpCode.Ret);
             bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(il);
         }
@@ -7338,7 +7107,7 @@ internal sealed class ReflectionMetadataEmitter
                         var paramEncoder = ps.AddParameter();
                         if (p.RefKind == RefKind.In)
                         {
-                            var isReadOnlyAttrType = this.GetIsReadOnlyAttributeTypeRef();
+                            var isReadOnlyAttrType = this.wellKnown.GetIsReadOnlyAttributeTypeRef();
                             if (!isReadOnlyAttrType.IsNil)
                             {
                                 paramEncoder.CustomModifiers().AddModifier(isReadOnlyAttrType, isOptional: false);
@@ -9697,91 +9466,6 @@ internal sealed class ReflectionMetadataEmitter
         return fallback;
     }
 
-    private MemberReferenceHandle GetNullReferenceExceptionCtorRef()
-    {
-        // System.NullReferenceException::.ctor() — used to back the `!!`
-        // operator's runtime check when its operand is null.
-        if (!this.nullRefExceptionCtorRef.IsNil)
-        {
-            return this.nullRefExceptionCtorRef;
-        }
-
-        var nreType = this.ResolveCoreType("System.NullReferenceException", typeof(NullReferenceException));
-        var nreTypeRef = this.GetTypeReference(nreType);
-        var sigBlob = new BlobBuilder();
-        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
-            .Parameters(0, r => r.Void(), _ => { });
-        this.nullRefExceptionCtorRef = this.emitCtx.Metadata.AddMemberReference(
-            parent: nreTypeRef,
-            name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
-            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        return this.nullRefExceptionCtorRef;
-    }
-
-    // Issue #504: returns a callable MemberRef for `System.Nullable<T>::get_Value`
-    // closed over the supplied value-type underlying CLR type. Used by `!!` emit
-    // to unwrap a `Nullable<T>` operand (throws `InvalidOperationException` at
-    // runtime when `HasValue` is false, matching the BCL property).
-    private MemberReferenceHandle GetNullableGetValueReference(Type underlyingValueType)
-    {
-        if (underlyingValueType == null || !underlyingValueType.IsValueType)
-        {
-            throw new InvalidOperationException(
-                $"GetNullableGetValueReference: '{underlyingValueType?.FullName}' is not a value type.");
-        }
-
-        var nullableClr = typeof(System.Nullable<>).MakeGenericType(underlyingValueType);
-        var getValue = nullableClr.GetMethod("get_Value", Type.EmptyTypes)
-            ?? throw new InvalidOperationException(
-                $"System.Nullable<{underlyingValueType.FullName}>::get_Value() is not resolvable.");
-        return this.GetMethodReference(getValue);
-    }
-
-    // Issue #519: returns a callable MemberRef for `System.Nullable<T>::get_HasValue`
-    // closed over the supplied value-type underlying CLR type. Used by `?:` emit
-    // on a value-type `Nullable<T>` operand to branch on the presence flag without
-    // box/dup tricks (which are illegal on a struct stack value).
-    private MemberReferenceHandle GetNullableGetHasValueReference(Type underlyingValueType)
-    {
-        if (underlyingValueType == null || !underlyingValueType.IsValueType)
-        {
-            throw new InvalidOperationException(
-                $"GetNullableGetHasValueReference: '{underlyingValueType?.FullName}' is not a value type.");
-        }
-
-        var nullableClr = typeof(System.Nullable<>).MakeGenericType(underlyingValueType);
-        var getHasValue = nullableClr.GetMethod("get_HasValue", Type.EmptyTypes)
-            ?? throw new InvalidOperationException(
-                $"System.Nullable<{underlyingValueType.FullName}>::get_HasValue() is not resolvable.");
-        return this.GetMethodReference(getHasValue);
-    }
-
-    private MemberReferenceHandle GetStringLengthReference()
-    {
-        // System.String::get_Length() — used to implement len(string).
-        var method = this.emitCtx.CoreStringType.GetMethod("get_Length", Type.EmptyTypes)
-            ?? throw new InvalidOperationException("String.get_Length is not resolvable from the supplied references.");
-        return this.GetMethodReference(method);
-    }
-
-    private MemberReferenceHandle GetStringCharsReference()
-    {
-        // System.String::get_Chars(Int32) — used for string indexing (issue #537).
-        var method = this.emitCtx.CoreStringType.GetMethod("get_Chars", new[] { typeof(int) })
-            ?? throw new InvalidOperationException("String.get_Chars(int) is not resolvable from the supplied references.");
-        return this.GetMethodReference(method);
-    }
-
-    private MemberReferenceHandle GetTypeFromHandleReference()
-    {
-        // System.Type::GetTypeFromHandle(RuntimeTypeHandle) — backs `typeof(T)`.
-        var method = this.emitCtx.CoreSystemType.GetMethod(
-            "GetTypeFromHandle",
-            new[] { this.emitCtx.CoreRuntimeTypeHandleType })
-            ?? throw new InvalidOperationException("Type.GetTypeFromHandle(RuntimeTypeHandle) is not resolvable from the supplied references.");
-        return this.GetMethodReference(method);
-    }
-
     private EntityHandle GetTypeOfToken(TypeSymbol type)
     {
         // Issue #143: `typeof(T)` token resolution. `NullableTypeSymbol` over a
@@ -9796,16 +9480,6 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         return this.GetElementTypeToken(type);
-    }
-
-    private MemberReferenceHandle GetArrayCopyReference()
-    {
-        // System.Array::Copy(Array, Array, Int32) — used to implement append(slice, element).
-        var method = this.emitCtx.CoreArrayType.GetMethod(
-            "Copy",
-            new[] { this.emitCtx.CoreArrayType, this.emitCtx.CoreArrayType, this.emitCtx.CoreInt32Type })
-            ?? throw new InvalidOperationException("Array.Copy(Array, Array, int) is not resolvable from the supplied references.");
-        return this.GetMethodReference(method);
     }
 
     private AssemblyReferenceHandle GetAssemblyReference(Assembly assembly)
@@ -10237,197 +9911,6 @@ internal sealed class ReflectionMetadataEmitter
         return handle;
     }
 
-    private MemberReferenceHandle GetObjectDefaultCtorReference()
-    {
-        var sigBlob = new BlobBuilder();
-        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
-            .Parameters(0, r => r.Void(), _ => { });
-        return this.emitCtx.Metadata.AddMemberReference(
-            parent: this.objectTypeRef,
-            name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
-            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-    }
-
-    private MemberReferenceHandle GetStringConcatReference()
-    {
-        if (!this.stringConcatRef.IsNil)
-        {
-            return this.stringConcatRef;
-        }
-
-        var stringTypeRef = this.GetTypeReference(this.emitCtx.CoreStringType);
-        var sigBlob = new BlobBuilder();
-        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: false)
-            .Parameters(
-                2,
-                r => r.Type().String(),
-                ps =>
-                {
-                    ps.AddParameter().Type().String();
-                    ps.AddParameter().Type().String();
-                });
-        this.stringConcatRef = this.emitCtx.Metadata.AddMemberReference(
-            parent: stringTypeRef,
-            name: this.emitCtx.Metadata.GetOrAddString("Concat"),
-            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        return this.stringConcatRef;
-    }
-
-    private MemberReferenceHandle GetStringEqualsReference()
-    {
-        if (!this.stringEqualsRef.IsNil)
-        {
-            return this.stringEqualsRef;
-        }
-
-        var stringTypeRef = this.GetTypeReference(this.emitCtx.CoreStringType);
-        var sigBlob = new BlobBuilder();
-        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: false)
-            .Parameters(
-                2,
-                r => r.Type().Boolean(),
-                ps =>
-                {
-                    ps.AddParameter().Type().String();
-                    ps.AddParameter().Type().String();
-                });
-        this.stringEqualsRef = this.emitCtx.Metadata.AddMemberReference(
-            parent: stringTypeRef,
-            name: this.emitCtx.Metadata.GetOrAddString("Equals"),
-            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        return this.stringEqualsRef;
-    }
-
-    private MemberReferenceHandle GetObjectInstanceToStringReference()
-    {
-        if (!this.objectInstanceToStringRef.IsNil)
-        {
-            return this.objectInstanceToStringRef;
-        }
-
-        var sigBlob = new BlobBuilder();
-        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
-            .Parameters(0, r => r.Type().String(), _ => { });
-        this.objectInstanceToStringRef = this.emitCtx.Metadata.AddMemberReference(
-            parent: this.objectTypeRef,
-            name: this.emitCtx.Metadata.GetOrAddString("ToString"),
-            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        return this.objectInstanceToStringRef;
-    }
-
-    private MemberReferenceHandle GetObjectInstanceGetHashCodeReference()
-    {
-        if (!this.objectInstanceGetHashCodeRef.IsNil)
-        {
-            return this.objectInstanceGetHashCodeRef;
-        }
-
-        var sigBlob = new BlobBuilder();
-        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
-            .Parameters(0, r => r.Type().Int32(), _ => { });
-        this.objectInstanceGetHashCodeRef = this.emitCtx.Metadata.AddMemberReference(
-            parent: this.objectTypeRef,
-            name: this.emitCtx.Metadata.GetOrAddString("GetHashCode"),
-            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        return this.objectInstanceGetHashCodeRef;
-    }
-
-    /// <summary>
-    /// Returns a MemberRef for static <c>bool System.Object.Equals(object, object)</c>.
-    /// Used by Phase 3.B.2 data-struct <c>==</c> / <c>!=</c> lowering: we box
-    /// the operand values and call this static helper, which routes through
-    /// the virtual <c>ValueType.Equals(object)</c> override (reflection-based
-    /// field-by-field comparison) for user value types. Same observable
-    /// semantics as the interpreter's structural equality (ADR-0029); a
-    /// future iteration may replace this with a direct synthesized
-    /// <c>Equals(T)</c> method for performance.
-    /// </summary>
-    private MemberReferenceHandle GetObjectStaticEqualsReference()
-    {
-        if (!this.objectStaticEqualsRef.IsNil)
-        {
-            return this.objectStaticEqualsRef;
-        }
-
-        var sigBlob = new BlobBuilder();
-        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: false)
-            .Parameters(
-                2,
-                r => r.Type().Boolean(),
-                ps =>
-                {
-                    ps.AddParameter().Type().Object();
-                    ps.AddParameter().Type().Object();
-                });
-        this.objectStaticEqualsRef = this.emitCtx.Metadata.AddMemberReference(
-            parent: this.objectTypeRef,
-            name: this.emitCtx.Metadata.GetOrAddString("Equals"),
-            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        return this.objectStaticEqualsRef;
-    }
-
-    /// <summary>
-    /// Issue #410 / ADR-0029: returns a TypeRef for <c>System.HashCode</c>,
-    /// used by data-struct <c>GetHashCode</c> synthesis. Cached because
-    /// <see cref="GetTypeReference(Type)"/> already caches by Type, but the
-    /// data-struct helpers need a strongly-typed handle.
-    /// </summary>
-    private TypeReferenceHandle GetHashCodeTypeReference()
-    {
-        if (!this.hashCodeTypeRef.IsNil)
-        {
-            return this.hashCodeTypeRef;
-        }
-
-        this.hashCodeTypeRef = this.GetTypeReference(typeof(System.HashCode));
-        return this.hashCodeTypeRef;
-    }
-
-    /// <summary>
-    /// Issue #410 / ADR-0029: resolves an open MemberRef for the
-    /// <c>System.HashCode.Combine&lt;T1, ..., Tn&gt;</c> overload with the
-    /// given arity (1 ≤ <paramref name="arity"/> ≤ 8). Each open parameter
-    /// is encoded as a generic method parameter (<c>!!i</c>) and instantiated
-    /// to <see cref="object"/> via a MethodSpec at the call site.
-    /// </summary>
-    private MemberReferenceHandle GetHashCodeCombineOpenReference(int arity)
-    {
-        if (arity < 1 || arity > 8)
-        {
-            throw new ArgumentOutOfRangeException(nameof(arity), arity, "HashCode.Combine supports arities 1 through 8.");
-        }
-
-        var cached = this.hashCodeCombineOpenRefs[arity - 1];
-        if (cached.HasValue)
-        {
-            return cached.Value;
-        }
-
-        var hashCodeRef = this.GetHashCodeTypeReference();
-
-        // Signature: static int Combine<T1,...,Tn>(T1, ..., Tn) with `arity`
-        // generic method parameters. In open form each Ti is !!i.
-        var sig = new BlobBuilder();
-        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false, genericParameterCount: arity)
-            .Parameters(
-                arity,
-                r => r.Type().Int32(),
-                ps =>
-                {
-                    for (int i = 0; i < arity; i++)
-                    {
-                        ps.AddParameter().Type().GenericMethodTypeParameter(i);
-                    }
-                });
-
-        var openRef = this.emitCtx.Metadata.AddMemberReference(
-            hashCodeRef,
-            this.emitCtx.Metadata.GetOrAddString("Combine"),
-            this.emitCtx.Metadata.GetOrAddBlob(sig));
-        this.hashCodeCombineOpenRefs[arity - 1] = openRef;
-        return openRef;
-    }
-
     /// <summary>
     /// Issue #410 / ADR-0029: produces a MethodSpec instantiating
     /// <c>HashCode.Combine&lt;T1,...,Tn&gt;</c> with <see cref="object"/> for
@@ -10438,7 +9921,7 @@ internal sealed class ReflectionMetadataEmitter
     /// </summary>
     private EntityHandle GetHashCodeCombineObjectSpec(int arity)
     {
-        var openRef = this.GetHashCodeCombineOpenReference(arity);
+        var openRef = this.wellKnown.GetHashCodeCombineOpenReference(arity);
         var sigBlob = new BlobBuilder();
         var argsEncoder = new BlobEncoder(sigBlob).MethodSpecificationSignature(arity);
         for (int i = 0; i < arity; i++)
@@ -10450,68 +9933,16 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
-    /// Issue #410 / ADR-0029: resolves the open MemberRef for the instance
-    /// method <c>System.HashCode.Add&lt;T&gt;(T)</c>, used by the &gt;8-field
-    /// fold path for <c>GetHashCode</c>.
-    /// </summary>
-    private MemberReferenceHandle GetHashCodeAddOpenReference()
-    {
-        if (!this.hashCodeAddOpenRef.IsNil)
-        {
-            return this.hashCodeAddOpenRef;
-        }
-
-        var hashCodeRef = this.GetHashCodeTypeReference();
-
-        var sig = new BlobBuilder();
-        new BlobEncoder(sig).MethodSignature(isInstanceMethod: true, genericParameterCount: 1)
-            .Parameters(
-                1,
-                r => r.Void(),
-                ps => ps.AddParameter().Type().GenericMethodTypeParameter(0));
-
-        this.hashCodeAddOpenRef = this.emitCtx.Metadata.AddMemberReference(
-            hashCodeRef,
-            this.emitCtx.Metadata.GetOrAddString("Add"),
-            this.emitCtx.Metadata.GetOrAddBlob(sig));
-        return this.hashCodeAddOpenRef;
-    }
-
-    /// <summary>
     /// Issue #410 / ADR-0029: produces a MethodSpec for
     /// <c>HashCode.Add&lt;object&gt;(object)</c>.
     /// </summary>
     private EntityHandle GetHashCodeAddObjectSpec()
     {
-        var openRef = this.GetHashCodeAddOpenReference();
+        var openRef = this.wellKnown.GetHashCodeAddOpenReference();
         var sigBlob = new BlobBuilder();
         var argsEncoder = new BlobEncoder(sigBlob).MethodSpecificationSignature(1);
         argsEncoder.AddArgument().Object();
         return this.emitCtx.Metadata.AddMethodSpecification(openRef, this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-    }
-
-    /// <summary>
-    /// Issue #410 / ADR-0029: resolves the MemberRef for instance method
-    /// <c>System.HashCode.ToHashCode()</c>.
-    /// </summary>
-    private MemberReferenceHandle GetHashCodeToHashCodeReference()
-    {
-        if (!this.hashCodeToHashCodeRef.IsNil)
-        {
-            return this.hashCodeToHashCodeRef;
-        }
-
-        var hashCodeRef = this.GetHashCodeTypeReference();
-
-        var sig = new BlobBuilder();
-        new BlobEncoder(sig).MethodSignature(isInstanceMethod: true)
-            .Parameters(0, r => r.Type().Int32(), _ => { });
-
-        this.hashCodeToHashCodeRef = this.emitCtx.Metadata.AddMemberReference(
-            hashCodeRef,
-            this.emitCtx.Metadata.GetOrAddString("ToHashCode"),
-            this.emitCtx.Metadata.GetOrAddBlob(sig));
-        return this.hashCodeToHashCodeRef;
     }
 
     /// <summary>
@@ -10526,99 +9957,12 @@ internal sealed class ReflectionMetadataEmitter
             return this.hashCodeLocalSig;
         }
 
-        var hashCodeRef = this.GetHashCodeTypeReference();
+        var hashCodeRef = this.wellKnown.GetHashCodeTypeReference();
         var sigBlob = new BlobBuilder();
         var encoder = new BlobEncoder(sigBlob).LocalVariableSignature(1);
         encoder.AddVariable().Type().Type(hashCodeRef, isValueType: true);
         this.hashCodeLocalSig = this.emitCtx.Metadata.AddStandaloneSignature(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
         return this.hashCodeLocalSig;
-    }
-
-    /// <summary>
-    /// Issue #410 / ADR-0029: resolves the MemberRef for the static
-    /// <c>System.Convert.ToString(object, IFormatProvider)</c> overload used
-    /// by data-struct <c>ToString</c> synthesis. Handles null reference-type
-    /// fields gracefully (returns the empty string) per the ADR.
-    /// </summary>
-    private MemberReferenceHandle GetConvertToStringReference()
-    {
-        if (!this.convertToStringRef.IsNil)
-        {
-            return this.convertToStringRef;
-        }
-
-        var convertRef = this.GetTypeReference(typeof(System.Convert));
-        var ifpRef = this.GetTypeReference(typeof(System.IFormatProvider));
-
-        var sig = new BlobBuilder();
-        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
-            .Parameters(
-                2,
-                r => r.Type().String(),
-                ps =>
-                {
-                    ps.AddParameter().Type().Object();
-                    ps.AddParameter().Type().Type(ifpRef, isValueType: false);
-                });
-
-        this.convertToStringRef = this.emitCtx.Metadata.AddMemberReference(
-            convertRef,
-            this.emitCtx.Metadata.GetOrAddString("ToString"),
-            this.emitCtx.Metadata.GetOrAddBlob(sig));
-        return this.convertToStringRef;
-    }
-
-    /// <summary>
-    /// Issue #410 / ADR-0029: resolves the MemberRef for the static
-    /// property getter <c>System.Globalization.CultureInfo::get_InvariantCulture</c>,
-    /// used to thread an invariant <see cref="System.IFormatProvider"/> into
-    /// <c>Convert.ToString</c> during data-struct <c>ToString</c> synthesis.
-    /// </summary>
-    private MemberReferenceHandle GetCultureInvariantGetterReference()
-    {
-        if (!this.cultureInvariantGetterRef.IsNil)
-        {
-            return this.cultureInvariantGetterRef;
-        }
-
-        var cultureInfoRef = this.GetTypeReference(typeof(System.Globalization.CultureInfo));
-
-        var sig = new BlobBuilder();
-        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
-            .Parameters(0, r => r.Type().Type(cultureInfoRef, isValueType: false), _ => { });
-
-        this.cultureInvariantGetterRef = this.emitCtx.Metadata.AddMemberReference(
-            cultureInfoRef,
-            this.emitCtx.Metadata.GetOrAddString("get_InvariantCulture"),
-            this.emitCtx.Metadata.GetOrAddBlob(sig));
-        return this.cultureInvariantGetterRef;
-    }
-
-    /// <summary>
-    /// Issue #410 / ADR-0029: resolves the MemberRef for the static
-    /// <c>System.String.Concat(string[])</c> overload used to assemble the
-    /// data-struct <c>ToString</c> output from a per-field array of pieces.
-    /// </summary>
-    private MemberReferenceHandle GetStringConcatArrayReference()
-    {
-        if (!this.stringConcatArrayRef.IsNil)
-        {
-            return this.stringConcatArrayRef;
-        }
-
-        var stringTypeRef = this.GetTypeReference(this.emitCtx.CoreStringType);
-        var sig = new BlobBuilder();
-        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
-            .Parameters(
-                1,
-                r => r.Type().String(),
-                ps => ps.AddParameter().Type().SZArray().String());
-
-        this.stringConcatArrayRef = this.emitCtx.Metadata.AddMemberReference(
-            stringTypeRef,
-            this.emitCtx.Metadata.GetOrAddString("Concat"),
-            this.emitCtx.Metadata.GetOrAddBlob(sig));
-        return this.stringConcatArrayRef;
     }
 
     /// <summary>
@@ -12462,7 +11806,7 @@ internal sealed class ReflectionMetadataEmitter
                         // Issue #537: string indexing via get_Chars(int32).
                         this.EmitExpression(idx.Target);
                         this.EmitExpression(idx.Index);
-                        this.il.Call(this.outer.GetStringCharsReference());
+                        this.il.Call(this.outer.wellKnown.GetStringCharsReference());
                     }
                     else
                     {
@@ -13560,7 +12904,7 @@ internal sealed class ReflectionMetadataEmitter
                     this.il.StoreLocal(unwrapSlot);
                     this.il.LoadLocalAddress(unwrapSlot);
                     this.il.OpCode(ILOpCode.Call);
-                    this.il.Token(this.outer.GetNullableGetValueReference(innerClr));
+                    this.il.Token(this.outer.wellKnown.GetNullableGetValueReference(innerClr));
                     return;
                 }
 
@@ -13569,7 +12913,7 @@ internal sealed class ReflectionMetadataEmitter
                 var nonNull = this.il.DefineLabel();
                 this.il.Branch(ILOpCode.Brtrue, nonNull);
                 this.il.OpCode(ILOpCode.Pop);
-                var nreCtor = this.outer.GetNullReferenceExceptionCtorRef();
+                var nreCtor = this.outer.wellKnown.GetNullReferenceExceptionCtorRef();
                 this.il.OpCode(ILOpCode.Newobj);
                 this.il.Token(nreCtor);
                 this.il.OpCode(ILOpCode.Throw);
@@ -13642,7 +12986,7 @@ internal sealed class ReflectionMetadataEmitter
                     this.il.StoreLocal(slot);
                     this.il.LoadLocalAddress(slot);
                     this.il.OpCode(ILOpCode.Call);
-                    this.il.Token(this.outer.GetNullableGetHasValueReference(innerClr));
+                    this.il.Token(this.outer.wellKnown.GetNullableGetHasValueReference(innerClr));
                     var fallback = this.il.DefineLabel();
                     var end = this.il.DefineLabel();
                     this.il.Branch(ILOpCode.Brfalse, fallback);
@@ -13667,7 +13011,7 @@ internal sealed class ReflectionMetadataEmitter
                         // introduced in PR #541 and uses no extra slots.
                         this.il.LoadLocalAddress(slot);
                         this.il.OpCode(ILOpCode.Call);
-                        this.il.Token(this.outer.GetNullableGetValueReference(innerClr));
+                        this.il.Token(this.outer.wellKnown.GetNullableGetValueReference(innerClr));
                     }
 
                     this.il.Branch(ILOpCode.Br, end);
@@ -13712,17 +13056,17 @@ internal sealed class ReflectionMetadataEmitter
                     case BoundBinaryOperatorKind.Sum:
                         this.EmitExpression(b.Left);
                         this.EmitExpression(b.Right);
-                        this.il.Call(this.outer.GetStringConcatReference());
+                        this.il.Call(this.outer.wellKnown.GetStringConcatReference());
                         return;
                     case BoundBinaryOperatorKind.Equals:
                         this.EmitExpression(b.Left);
                         this.EmitExpression(b.Right);
-                        this.il.Call(this.outer.GetStringEqualsReference());
+                        this.il.Call(this.outer.wellKnown.GetStringEqualsReference());
                         return;
                     case BoundBinaryOperatorKind.NotEquals:
                         this.EmitExpression(b.Left);
                         this.EmitExpression(b.Right);
-                        this.il.Call(this.outer.GetStringEqualsReference());
+                        this.il.Call(this.outer.wellKnown.GetStringEqualsReference());
                         this.il.LoadConstantI4(0);
                         this.il.OpCode(ILOpCode.Ceq);
                         return;
@@ -13753,7 +13097,7 @@ internal sealed class ReflectionMetadataEmitter
                     this.il.Token(this.outer.GetElementTypeToken(field.Type));
                 }
 
-                this.il.Call(field.Type == TypeSymbol.String ? this.outer.GetStringEqualsReference() : this.outer.GetObjectStaticEqualsReference());
+                this.il.Call(field.Type == TypeSymbol.String ? this.outer.wellKnown.GetStringEqualsReference() : this.outer.wellKnown.GetObjectStaticEqualsReference());
                 if (b.Op.Kind == BoundBinaryOperatorKind.NotEquals)
                 {
                     this.il.LoadConstantI4(0);
@@ -13777,7 +13121,7 @@ internal sealed class ReflectionMetadataEmitter
                 this.EmitExpression(b.Right);
                 this.il.OpCode(ILOpCode.Box);
                 this.il.Token(structTypeDef);
-                this.il.Call(this.outer.GetObjectStaticEqualsReference());
+                this.il.Call(this.outer.wellKnown.GetObjectStaticEqualsReference());
                 if (b.Op.Kind == BoundBinaryOperatorKind.NotEquals)
                 {
                     this.il.LoadConstantI4(0);
@@ -13799,7 +13143,7 @@ internal sealed class ReflectionMetadataEmitter
             {
                 this.EmitExpression(b.Left);
                 this.EmitExpression(b.Right);
-                this.il.Call(this.outer.GetObjectStaticEqualsReference());
+                this.il.Call(this.outer.wellKnown.GetObjectStaticEqualsReference());
                 if (b.Op.Kind == BoundBinaryOperatorKind.NotEquals)
                 {
                     this.il.LoadConstantI4(0);
@@ -14846,7 +14190,7 @@ internal sealed class ReflectionMetadataEmitter
             this.EmitExpression(len.Operand);
             if (len.Operand.Type == TypeSymbol.String)
             {
-                this.il.Call(this.outer.GetStringLengthReference());
+                this.il.Call(this.outer.wellKnown.GetStringLengthReference());
             }
             else if (len.Operand.Type is MapTypeSymbol mapType)
             {
@@ -14870,7 +14214,7 @@ internal sealed class ReflectionMetadataEmitter
             // Issue #143: `typeof(T)` -> ldtoken <T> ; call Type::GetTypeFromHandle.
             this.il.OpCode(ILOpCode.Ldtoken);
             this.il.Token(this.outer.GetTypeOfToken(typeOf.OperandType));
-            this.il.Call(this.outer.GetTypeFromHandleReference());
+            this.il.Call(this.outer.wellKnown.GetTypeFromHandleReference());
         }
 
         private void EmitAppend(BoundAppendExpression app)
@@ -14909,7 +14253,7 @@ internal sealed class ReflectionMetadataEmitter
             this.il.LoadLocal(slots.Src);
             this.il.OpCode(ILOpCode.Ldlen);
             this.il.OpCode(ILOpCode.Conv_i4);
-            this.il.Call(this.outer.GetArrayCopyReference());
+            this.il.Call(this.outer.wellKnown.GetArrayCopyReference());
 
             // dst[src.Length] = element
             this.il.LoadLocal(slots.Dst);
@@ -15499,7 +14843,7 @@ internal sealed class ReflectionMetadataEmitter
             {
                 loadValue();
                 this.EmitExpression(cp.Value);
-                this.il.Call(this.outer.GetStringEqualsReference());
+                this.il.Call(this.outer.wellKnown.GetStringEqualsReference());
                 this.il.Branch(ILOpCode.Brfalse, failLabel);
                 return;
             }
@@ -16715,7 +16059,7 @@ internal sealed class ReflectionMetadataEmitter
 
             this.il.LoadConstantI4(call.Arguments.Length);
             this.il.OpCode(ILOpCode.Newarr);
-            this.il.Token(this.outer.objectTypeRef);
+            this.il.Token(this.outer.wellKnown.ObjectTypeRef);
 
             for (int i = 0; i < call.Arguments.Length; i++)
             {

--- a/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
+++ b/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
@@ -1,0 +1,827 @@
+// <copyright file="WellKnownReferences.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace GSharp.Core.CodeAnalysis.Emit;
+
+/// <summary>
+/// Owns every well-known BCL <see cref="MemberReferenceHandle"/> /
+/// <see cref="TypeReferenceHandle"/> that the
+/// <see cref="ReflectionMetadataEmitter"/> threads through code generation —
+/// <c>System.Object</c> / <c>System.ValueType</c> TypeRefs, the
+/// <c>Object..ctor()</c> MemberRef, <c>String.Concat</c>, <c>String.Equals</c>,
+/// <c>Object.Equals(object, object)</c>, <c>Object.ToString()</c>,
+/// <c>Object.GetHashCode()</c>, the <c>System.HashCode</c> family
+/// (<c>Combine</c>, <c>Add</c>, <c>ToHashCode</c>),
+/// <c>Convert.ToString(object, IFormatProvider)</c>,
+/// <c>CultureInfo.InvariantCulture</c>, <c>Delegate.Combine/Remove</c>,
+/// <c>Interlocked.CompareExchange&lt;T&gt;</c>,
+/// <c>NotImplementedException..ctor()</c>,
+/// <c>NullReferenceException..ctor()</c>,
+/// <c>System.Attribute..ctor()</c>, the
+/// <c>IsReadOnlyAttribute</c> / <c>IsByRefLikeAttribute</c> /
+/// <c>ObsoleteAttribute</c> ctors, and the stateless lookups for
+/// <c>String.get_Length</c> / <c>String.get_Chars</c> /
+/// <c>Type.GetTypeFromHandle</c> / <c>Array.Copy</c> /
+/// <c>Nullable&lt;T&gt;.get_Value</c> / <c>Nullable&lt;T&gt;.get_HasValue</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// PR-E-3 extracts this type as the third step of the
+/// <see cref="ReflectionMetadataEmitter"/> decomposition described in the
+/// repository-level decomposition plan. The class consumes
+/// <see cref="EmitContext"/> for <c>Metadata</c>/<c>References</c>/<c>Core*</c>
+/// access and small <see cref="Func{T, TResult}"/> hooks for the
+/// dedup-cached resolvers <c>GetTypeReference(Type)</c> and
+/// <c>GetMethodReference(MethodInfo)</c> that still live on
+/// <see cref="ReflectionMetadataEmitter"/> (and which themselves route
+/// through <see cref="MetadataTokenCache"/>).
+/// </para>
+/// <para>
+/// Eager refs (<see cref="ObjectTypeRef"/>, <see cref="ValueTypeRef"/>,
+/// <see cref="ObjectCtorRef"/>) are populated by the constructor — the
+/// emitter's <c>EmitCore</c> resolves the BCL <c>Core*</c> types onto
+/// <see cref="EmitContext"/> first, then instantiates
+/// <see cref="WellKnownReferences"/> exactly once. Every other ref is
+/// lazy: the corresponding <c>Get*</c> method tests the backing field for
+/// nil/HasValue and creates the row on first access. This preserves the
+/// existing single-row-per-reference dedup behavior so the emitted IL stays
+/// byte-identical with what the inline ReflectionMetadataEmitter
+/// implementation produced before this PR.
+/// </para>
+/// </remarks>
+internal sealed class WellKnownReferences
+{
+    private readonly EmitContext emitCtx;
+    private readonly Func<Type, TypeReferenceHandle> getTypeReference;
+    private readonly Func<MethodInfo, MemberReferenceHandle> getMethodReference;
+    private readonly MemberReferenceHandle?[] hashCodeCombineOpenRefs = new MemberReferenceHandle?[8];
+
+    // ADR-0051 Phase 6: cached MemberReferenceHandle for NotImplementedException..ctor().
+    private MemberReferenceHandle? notImplementedExceptionCtorRef;
+
+    // ADR-0052: cached MemberReferenceHandles for Delegate.Combine and Delegate.Remove.
+    private MemberReferenceHandle? delegateCombineRef;
+    private MemberReferenceHandle? delegateRemoveRef;
+
+    // Issue #256: cached open MemberRef for Interlocked.CompareExchange<T>(ref T, T, T).
+    private MemberReferenceHandle? interlockedCompareExchangeOpenRef;
+
+    // Issue #420 (P3-11): cached MemberRefs for IsReadOnlyAttribute/IsByRefLikeAttribute/ObsoleteAttribute ctors,
+    // so repeated emission of these markers doesn't create duplicate MemberRef rows.
+    private MemberReferenceHandle? isReadOnlyAttributeCtorRef;
+    private MemberReferenceHandle? isByRefLikeAttributeCtorRef;
+    private MemberReferenceHandle? obsoleteAttributeStringBoolCtorRef;
+
+    // Issue #410 / ADR-0029: cached member refs for data-struct synthesized members.
+    private MemberReferenceHandle stringConcatRef;
+    private MemberReferenceHandle stringEqualsRef;
+    private MemberReferenceHandle objectStaticEqualsRef;
+    private MemberReferenceHandle objectInstanceToStringRef;
+    private MemberReferenceHandle objectInstanceGetHashCodeRef;
+    private MemberReferenceHandle nullRefExceptionCtorRef;
+    private MemberReferenceHandle stringConcatArrayRef;
+    private MemberReferenceHandle convertToStringRef;
+    private MemberReferenceHandle cultureInvariantGetterRef;
+    private MemberReferenceHandle hashCodeAddOpenRef;
+    private MemberReferenceHandle hashCodeToHashCodeRef;
+    private TypeReferenceHandle hashCodeTypeRef;
+
+    private EntityHandle? systemAttributeTypeRef;
+    private MemberReferenceHandle? systemAttributeCtorRef;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WellKnownReferences"/>
+    /// class and eagerly resolves the three references the emitter needs
+    /// before any TypeDef row is written: the <c>System.Object</c> TypeRef,
+    /// the <c>System.ValueType</c> TypeRef, and the parameterless
+    /// <c>Object..ctor()</c> MemberRef used as the base-class chain target
+    /// for every synthesized default ctor.
+    /// </summary>
+    /// <param name="emitCtx">The cross-cutting emit context.</param>
+    /// <param name="getTypeReference">
+    /// Dedup-cached resolver for arbitrary CLR <see cref="Type"/> →
+    /// <see cref="TypeReferenceHandle"/>. Lives on
+    /// <see cref="ReflectionMetadataEmitter"/> because it routes through
+    /// <see cref="MetadataTokenCache.TypeRefs"/> and recursively handles
+    /// nested / coreLib-base / generic-instantiation cases.
+    /// </param>
+    /// <param name="getMethodReference">
+    /// Dedup-cached resolver for arbitrary <see cref="MethodInfo"/> →
+    /// <see cref="MemberReferenceHandle"/>. Lives on
+    /// <see cref="ReflectionMetadataEmitter"/> because it encodes open
+    /// generic method signatures using the same machinery as user-defined
+    /// method emission.
+    /// </param>
+    public WellKnownReferences(
+        EmitContext emitCtx,
+        Func<Type, TypeReferenceHandle> getTypeReference,
+        Func<MethodInfo, MemberReferenceHandle> getMethodReference)
+    {
+        this.emitCtx = emitCtx ?? throw new ArgumentNullException(nameof(emitCtx));
+        this.getTypeReference = getTypeReference ?? throw new ArgumentNullException(nameof(getTypeReference));
+        this.getMethodReference = getMethodReference ?? throw new ArgumentNullException(nameof(getMethodReference));
+
+        // Eager init: previously lived inline in ReflectionMetadataEmitter.EmitCore
+        // immediately after the Core* types were resolved onto EmitContext. Order
+        // matters — ObjectCtorRef depends on ObjectTypeRef.
+        this.ObjectTypeRef = this.getTypeReference(this.emitCtx.CoreObjectType);
+        this.ValueTypeRef = this.getTypeReference(this.emitCtx.CoreValueType);
+        this.ObjectCtorRef = this.BuildObjectDefaultCtorReference();
+    }
+
+    /// <summary>
+    /// Gets the eager-resolved TypeRef for <c>System.Object</c>. Used as the
+    /// base type for every emitted reference-type TypeDef and as the parent
+    /// of <see cref="ObjectCtorRef"/>.
+    /// </summary>
+    public TypeReferenceHandle ObjectTypeRef { get; }
+
+    /// <summary>
+    /// Gets the eager-resolved TypeRef for <c>System.ValueType</c>. Used as
+    /// the base type for every emitted value-type TypeDef (data structs,
+    /// enums, ref structs, async/iterator state-machine structs).
+    /// </summary>
+    public TypeReferenceHandle ValueTypeRef { get; }
+
+    /// <summary>
+    /// Gets the eager-resolved MemberRef for the parameterless
+    /// <c>System.Object..ctor()</c>. Used as the chain target for every
+    /// synthesized default ctor on a reference-type TypeDef whose base class
+    /// resolves to <see cref="object"/>.
+    /// </summary>
+    public MemberReferenceHandle ObjectCtorRef { get; }
+
+    /// <summary>Resolves a MemberReferenceHandle for System.NotImplementedException..ctor().</summary>
+    /// <returns>The cached <see cref="MemberReferenceHandle"/>.</returns>
+    public MemberReferenceHandle GetNotImplementedExceptionCtor()
+    {
+        if (this.notImplementedExceptionCtorRef.HasValue)
+        {
+            return this.notImplementedExceptionCtorRef.Value;
+        }
+
+        var nieType = typeof(System.NotImplementedException);
+        var nieTypeRef = this.getTypeReference(nieType);
+        var ctorSig = new BlobBuilder();
+        new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => r.Void(), _ => { });
+        this.notImplementedExceptionCtorRef = this.emitCtx.Metadata.AddMemberReference(
+            nieTypeRef,
+            this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            this.emitCtx.Metadata.GetOrAddBlob(ctorSig));
+        return this.notImplementedExceptionCtorRef.Value;
+    }
+
+    /// <summary>ADR-0052: resolves a MemberReferenceHandle for Delegate.Combine(Delegate, Delegate).</summary>
+    /// <returns>The cached <see cref="MemberReferenceHandle"/>.</returns>
+    public MemberReferenceHandle GetDelegateCombineRef()
+    {
+        if (this.delegateCombineRef.HasValue)
+        {
+            return this.delegateCombineRef.Value;
+        }
+
+        var delegateTypeRef = this.getTypeReference(typeof(System.Delegate));
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
+            .Parameters(
+                2,
+                r => r.Type().Type(delegateTypeRef, isValueType: false),
+                ps =>
+                {
+                    ps.AddParameter().Type().Type(delegateTypeRef, isValueType: false);
+                    ps.AddParameter().Type().Type(delegateTypeRef, isValueType: false);
+                });
+
+        this.delegateCombineRef = this.emitCtx.Metadata.AddMemberReference(
+            delegateTypeRef,
+            this.emitCtx.Metadata.GetOrAddString("Combine"),
+            this.emitCtx.Metadata.GetOrAddBlob(sig));
+        return this.delegateCombineRef.Value;
+    }
+
+    /// <summary>ADR-0052: resolves a MemberReferenceHandle for Delegate.Remove(Delegate, Delegate).</summary>
+    /// <returns>The cached <see cref="MemberReferenceHandle"/>.</returns>
+    public MemberReferenceHandle GetDelegateRemoveRef()
+    {
+        if (this.delegateRemoveRef.HasValue)
+        {
+            return this.delegateRemoveRef.Value;
+        }
+
+        var delegateTypeRef = this.getTypeReference(typeof(System.Delegate));
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
+            .Parameters(
+                2,
+                r => r.Type().Type(delegateTypeRef, isValueType: false),
+                ps =>
+                {
+                    ps.AddParameter().Type().Type(delegateTypeRef, isValueType: false);
+                    ps.AddParameter().Type().Type(delegateTypeRef, isValueType: false);
+                });
+
+        this.delegateRemoveRef = this.emitCtx.Metadata.AddMemberReference(
+            delegateTypeRef,
+            this.emitCtx.Metadata.GetOrAddString("Remove"),
+            this.emitCtx.Metadata.GetOrAddBlob(sig));
+        return this.delegateRemoveRef.Value;
+    }
+
+    /// <summary>
+    /// Issue #256: resolves the open MemberRef for Interlocked.CompareExchange&lt;T&gt;(ref T, T, T).
+    /// </summary>
+    /// <returns>The cached <see cref="MemberReferenceHandle"/>.</returns>
+    public MemberReferenceHandle GetInterlockedCompareExchangeOpenRef()
+    {
+        if (this.interlockedCompareExchangeOpenRef.HasValue)
+        {
+            return this.interlockedCompareExchangeOpenRef.Value;
+        }
+
+        var interlockedTypeRef = this.getTypeReference(typeof(System.Threading.Interlocked));
+
+        // Signature: static T CompareExchange<T>(ref T, T, T) with 1 generic param.
+        // In open form, T is !!0 (method type parameter at index 0).
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false, genericParameterCount: 1)
+            .Parameters(
+                3,
+                r => r.Type().GenericMethodTypeParameter(0),
+                ps =>
+                {
+                    ps.AddParameter().Type(isByRef: true).GenericMethodTypeParameter(0);
+                    ps.AddParameter().Type().GenericMethodTypeParameter(0);
+                    ps.AddParameter().Type().GenericMethodTypeParameter(0);
+                });
+
+        this.interlockedCompareExchangeOpenRef = this.emitCtx.Metadata.AddMemberReference(
+            interlockedTypeRef,
+            this.emitCtx.Metadata.GetOrAddString("CompareExchange"),
+            this.emitCtx.Metadata.GetOrAddBlob(sig));
+        return this.interlockedCompareExchangeOpenRef.Value;
+    }
+
+    /// <summary>
+    /// ADR-0060 §6: returns the TypeRef handle for
+    /// <c>System.Runtime.CompilerServices.IsReadOnlyAttribute</c>, used as the
+    /// <c>modreq</c> on each emitted <c>in</c> parameter signature.
+    /// </summary>
+    /// <returns>The cached <see cref="MemberReferenceHandle"/>.</returns>
+    /// <returns>The cached <see cref="EntityHandle"/>.</returns>
+    /// <returns>The TypeRef entity handle, or <see langword="default"/> if the type can't be resolved.</returns>
+    public EntityHandle GetIsReadOnlyAttributeTypeRef()
+    {
+        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.IsReadOnlyAttribute", out var resolved)
+            ? resolved
+            : typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute);
+        return this.getTypeReference(attrType);
+    }
+
+    public MemberReferenceHandle GetIsReadOnlyAttributeCtorRef()
+    {
+        if (this.isReadOnlyAttributeCtorRef.HasValue)
+        {
+            return this.isReadOnlyAttributeCtorRef.Value;
+        }
+
+        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.IsReadOnlyAttribute", out var resolved)
+            ? resolved
+            : typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute);
+        var attrTypeRef = this.getTypeReference(attrType);
+
+        var ctorSig = new BlobBuilder();
+        new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => r.Void(), _ => { });
+
+        this.isReadOnlyAttributeCtorRef = this.emitCtx.Metadata.AddMemberReference(
+            attrTypeRef,
+            this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            this.emitCtx.Metadata.GetOrAddBlob(ctorSig));
+        return this.isReadOnlyAttributeCtorRef.Value;
+    }
+
+    public MemberReferenceHandle GetIsByRefLikeAttributeCtorRef()
+    {
+        if (this.isByRefLikeAttributeCtorRef.HasValue)
+        {
+            return this.isByRefLikeAttributeCtorRef.Value;
+        }
+
+        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.IsByRefLikeAttribute", out var resolved)
+            ? resolved
+            : typeof(System.Runtime.CompilerServices.IsByRefLikeAttribute);
+        var attrTypeRef = this.getTypeReference(attrType);
+
+        var ctorSig = new BlobBuilder();
+        new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => r.Void(), _ => { });
+
+        this.isByRefLikeAttributeCtorRef = this.emitCtx.Metadata.AddMemberReference(
+            attrTypeRef,
+            this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            this.emitCtx.Metadata.GetOrAddBlob(ctorSig));
+        return this.isByRefLikeAttributeCtorRef.Value;
+    }
+
+    public MemberReferenceHandle GetObsoleteAttributeStringBoolCtorRef()
+    {
+        if (this.obsoleteAttributeStringBoolCtorRef.HasValue)
+        {
+            return this.obsoleteAttributeStringBoolCtorRef.Value;
+        }
+
+        var obsoleteType = this.emitCtx.References.TryResolveType("System.ObsoleteAttribute", out var obsoleteResolved)
+            ? obsoleteResolved
+            : typeof(System.ObsoleteAttribute);
+        var obsoleteTypeRef = this.getTypeReference(obsoleteType);
+
+        var obsoleteCtorSig = new BlobBuilder();
+        new BlobEncoder(obsoleteCtorSig).MethodSignature(isInstanceMethod: true)
+            .Parameters(2, r => r.Void(), p =>
+            {
+                p.AddParameter().Type().String();
+                p.AddParameter().Type().Boolean();
+            });
+
+        this.obsoleteAttributeStringBoolCtorRef = this.emitCtx.Metadata.AddMemberReference(
+            obsoleteTypeRef,
+            this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            this.emitCtx.Metadata.GetOrAddBlob(obsoleteCtorSig));
+        return this.obsoleteAttributeStringBoolCtorRef.Value;
+    }
+
+    public EntityHandle GetSystemAttributeTypeRef()
+    {
+        if (!this.systemAttributeTypeRef.HasValue)
+        {
+            var t = this.emitCtx.References.TryResolveType("System.Attribute", out var resolved)
+                ? resolved
+                : typeof(System.Attribute);
+            this.systemAttributeTypeRef = this.getTypeReference(t);
+        }
+
+        return this.systemAttributeTypeRef.Value;
+    }
+
+    public MemberReferenceHandle GetSystemAttributeCtorRef()
+    {
+        if (!this.systemAttributeCtorRef.HasValue)
+        {
+            var attrTypeRef = this.GetSystemAttributeTypeRef();
+            var ctorSig = new BlobBuilder();
+            new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
+                .Parameters(0, r => r.Void(), _ => { });
+
+            this.systemAttributeCtorRef = this.emitCtx.Metadata.AddMemberReference(
+                attrTypeRef,
+                this.emitCtx.Metadata.GetOrAddString(".ctor"),
+                this.emitCtx.Metadata.GetOrAddBlob(ctorSig));
+        }
+
+        return this.systemAttributeCtorRef.Value;
+    }
+
+    public MemberReferenceHandle GetNullReferenceExceptionCtorRef()
+    {
+        // System.NullReferenceException::.ctor() — used to back the `!!`
+        // operator's runtime check when its operand is null.
+        if (!this.nullRefExceptionCtorRef.IsNil)
+        {
+            return this.nullRefExceptionCtorRef;
+        }
+
+        var nreType = this.emitCtx.References.TryResolveType("System.NullReferenceException", out var resolved)
+            ? resolved
+            : typeof(NullReferenceException);
+        var nreTypeRef = this.getTypeReference(nreType);
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => r.Void(), _ => { });
+        this.nullRefExceptionCtorRef = this.emitCtx.Metadata.AddMemberReference(
+            parent: nreTypeRef,
+            name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        return this.nullRefExceptionCtorRef;
+    }
+
+    // Issue #504: returns a callable MemberRef for `System.Nullable<T>::get_Value`
+    // closed over the supplied value-type underlying CLR type. Used by `!!` emit
+    // to unwrap a `Nullable<T>` operand (throws `InvalidOperationException` at
+    // runtime when `HasValue` is false, matching the BCL property).
+    public MemberReferenceHandle GetNullableGetValueReference(Type underlyingValueType)
+    {
+        if (underlyingValueType == null || !underlyingValueType.IsValueType)
+        {
+            throw new InvalidOperationException(
+                $"GetNullableGetValueReference: '{underlyingValueType?.FullName}' is not a value type.");
+        }
+
+        var nullableClr = typeof(System.Nullable<>).MakeGenericType(underlyingValueType);
+        var getValue = nullableClr.GetMethod("get_Value", Type.EmptyTypes)
+            ?? throw new InvalidOperationException(
+                $"System.Nullable<{underlyingValueType.FullName}>::get_Value() is not resolvable.");
+        return this.getMethodReference(getValue);
+    }
+
+    // Issue #519: returns a callable MemberRef for `System.Nullable<T>::get_HasValue`
+    // closed over the supplied value-type underlying CLR type. Used by `?:` emit
+    // on a value-type `Nullable<T>` operand to branch on the presence flag without
+    // box/dup tricks (which are illegal on a struct stack value).
+    public MemberReferenceHandle GetNullableGetHasValueReference(Type underlyingValueType)
+    {
+        if (underlyingValueType == null || !underlyingValueType.IsValueType)
+        {
+            throw new InvalidOperationException(
+                $"GetNullableGetHasValueReference: '{underlyingValueType?.FullName}' is not a value type.");
+        }
+
+        var nullableClr = typeof(System.Nullable<>).MakeGenericType(underlyingValueType);
+        var getHasValue = nullableClr.GetMethod("get_HasValue", Type.EmptyTypes)
+            ?? throw new InvalidOperationException(
+                $"System.Nullable<{underlyingValueType.FullName}>::get_HasValue() is not resolvable.");
+        return this.getMethodReference(getHasValue);
+    }
+
+    public MemberReferenceHandle GetStringLengthReference()
+    {
+        // System.String::get_Length() — used to implement len(string).
+        var method = this.emitCtx.CoreStringType.GetMethod("get_Length", Type.EmptyTypes)
+            ?? throw new InvalidOperationException("String.get_Length is not resolvable from the supplied references.");
+        return this.getMethodReference(method);
+    }
+
+    public MemberReferenceHandle GetStringCharsReference()
+    {
+        // System.String::get_Chars(Int32) — used for string indexing (issue #537).
+        var method = this.emitCtx.CoreStringType.GetMethod("get_Chars", new[] { typeof(int) })
+            ?? throw new InvalidOperationException("String.get_Chars(int) is not resolvable from the supplied references.");
+        return this.getMethodReference(method);
+    }
+
+    public MemberReferenceHandle GetTypeFromHandleReference()
+    {
+        // System.Type::GetTypeFromHandle(RuntimeTypeHandle) — backs `typeof(T)`.
+        var method = this.emitCtx.CoreSystemType.GetMethod(
+            "GetTypeFromHandle",
+            new[] { this.emitCtx.CoreRuntimeTypeHandleType })
+            ?? throw new InvalidOperationException("Type.GetTypeFromHandle(RuntimeTypeHandle) is not resolvable from the supplied references.");
+        return this.getMethodReference(method);
+    }
+
+    public MemberReferenceHandle GetArrayCopyReference()
+    {
+        // System.Array::Copy(Array, Array, Int32) — used to implement append(slice, element).
+        var method = this.emitCtx.CoreArrayType.GetMethod(
+            "Copy",
+            new[] { this.emitCtx.CoreArrayType, this.emitCtx.CoreArrayType, this.emitCtx.CoreInt32Type })
+            ?? throw new InvalidOperationException("Array.Copy(Array, Array, int) is not resolvable from the supplied references.");
+        return this.getMethodReference(method);
+    }
+
+    public MemberReferenceHandle GetStringConcatReference()
+    {
+        if (!this.stringConcatRef.IsNil)
+        {
+            return this.stringConcatRef;
+        }
+
+        var stringTypeRef = this.getTypeReference(this.emitCtx.CoreStringType);
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: false)
+            .Parameters(
+                2,
+                r => r.Type().String(),
+                ps =>
+                {
+                    ps.AddParameter().Type().String();
+                    ps.AddParameter().Type().String();
+                });
+        this.stringConcatRef = this.emitCtx.Metadata.AddMemberReference(
+            parent: stringTypeRef,
+            name: this.emitCtx.Metadata.GetOrAddString("Concat"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        return this.stringConcatRef;
+    }
+
+    public MemberReferenceHandle GetStringEqualsReference()
+    {
+        if (!this.stringEqualsRef.IsNil)
+        {
+            return this.stringEqualsRef;
+        }
+
+        var stringTypeRef = this.getTypeReference(this.emitCtx.CoreStringType);
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: false)
+            .Parameters(
+                2,
+                r => r.Type().Boolean(),
+                ps =>
+                {
+                    ps.AddParameter().Type().String();
+                    ps.AddParameter().Type().String();
+                });
+        this.stringEqualsRef = this.emitCtx.Metadata.AddMemberReference(
+            parent: stringTypeRef,
+            name: this.emitCtx.Metadata.GetOrAddString("Equals"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        return this.stringEqualsRef;
+    }
+
+    public MemberReferenceHandle GetObjectInstanceToStringReference()
+    {
+        if (!this.objectInstanceToStringRef.IsNil)
+        {
+            return this.objectInstanceToStringRef;
+        }
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => r.Type().String(), _ => { });
+        this.objectInstanceToStringRef = this.emitCtx.Metadata.AddMemberReference(
+            parent: this.ObjectTypeRef,
+            name: this.emitCtx.Metadata.GetOrAddString("ToString"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        return this.objectInstanceToStringRef;
+    }
+
+    public MemberReferenceHandle GetObjectInstanceGetHashCodeReference()
+    {
+        if (!this.objectInstanceGetHashCodeRef.IsNil)
+        {
+            return this.objectInstanceGetHashCodeRef;
+        }
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => r.Type().Int32(), _ => { });
+        this.objectInstanceGetHashCodeRef = this.emitCtx.Metadata.AddMemberReference(
+            parent: this.ObjectTypeRef,
+            name: this.emitCtx.Metadata.GetOrAddString("GetHashCode"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        return this.objectInstanceGetHashCodeRef;
+    }
+
+    /// <summary>
+    /// Returns a MemberRef for static <c>bool System.Object.Equals(object, object)</c>.
+    /// Used by Phase 3.B.2 data-struct <c>==</c> / <c>!=</c> lowering: we box
+    /// the operand values and call this static helper, which routes through
+    /// the virtual <c>ValueType.Equals(object)</c> override (reflection-based
+    /// field-by-field comparison) for user value types. Same observable
+    /// semantics as the interpreter's structural equality (ADR-0029); a
+    /// future iteration may replace this with a direct synthesized
+    /// <c>Equals(T)</c> method for performance.
+    /// </summary>
+    /// <returns>The cached <see cref="MemberReferenceHandle"/>.</returns>
+    public MemberReferenceHandle GetObjectStaticEqualsReference()
+    {
+        if (!this.objectStaticEqualsRef.IsNil)
+        {
+            return this.objectStaticEqualsRef;
+        }
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: false)
+            .Parameters(
+                2,
+                r => r.Type().Boolean(),
+                ps =>
+                {
+                    ps.AddParameter().Type().Object();
+                    ps.AddParameter().Type().Object();
+                });
+        this.objectStaticEqualsRef = this.emitCtx.Metadata.AddMemberReference(
+            parent: this.ObjectTypeRef,
+            name: this.emitCtx.Metadata.GetOrAddString("Equals"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        return this.objectStaticEqualsRef;
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: returns a TypeRef for <c>System.HashCode</c>,
+    /// used by data-struct <c>GetHashCode</c> synthesis. Cached because the
+    /// data-struct helpers need a strongly-typed handle even though the
+    /// underlying <see cref="MetadataTokenCache.TypeRefs"/> dedups by
+    /// <see cref="Type"/>.
+    /// </summary>
+    /// <returns>The cached <see cref="TypeReferenceHandle"/>.</returns>
+    public TypeReferenceHandle GetHashCodeTypeReference()
+    {
+        if (!this.hashCodeTypeRef.IsNil)
+        {
+            return this.hashCodeTypeRef;
+        }
+
+        this.hashCodeTypeRef = this.getTypeReference(typeof(System.HashCode));
+        return this.hashCodeTypeRef;
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: resolves an open MemberRef for the
+    /// <c>System.HashCode.Combine&lt;T1, ..., Tn&gt;</c> overload with the
+    /// given arity (1 ≤ <paramref name="arity"/> ≤ 8). Each open parameter
+    /// is encoded as a generic method parameter (<c>!!i</c>) and instantiated
+    /// to <see cref="object"/> via a MethodSpec at the call site.
+    /// </summary>
+    /// <param name="arity">The number of generic parameters (1–8) on the desired <c>HashCode.Combine</c> overload.</param>
+    /// <returns>The cached <see cref="MemberReferenceHandle"/>.</returns>
+    public MemberReferenceHandle GetHashCodeCombineOpenReference(int arity)
+    {
+        if (arity < 1 || arity > 8)
+        {
+            throw new ArgumentOutOfRangeException(nameof(arity), arity, "HashCode.Combine supports arities 1 through 8.");
+        }
+
+        var cached = this.hashCodeCombineOpenRefs[arity - 1];
+        if (cached.HasValue)
+        {
+            return cached.Value;
+        }
+
+        var hashCodeRef = this.GetHashCodeTypeReference();
+
+        // Signature: static int Combine<T1,...,Tn>(T1, ..., Tn) with `arity`
+        // generic method parameters. In open form each Ti is !!i.
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false, genericParameterCount: arity)
+            .Parameters(
+                arity,
+                r => r.Type().Int32(),
+                ps =>
+                {
+                    for (int i = 0; i < arity; i++)
+                    {
+                        ps.AddParameter().Type().GenericMethodTypeParameter(i);
+                    }
+                });
+
+        var openRef = this.emitCtx.Metadata.AddMemberReference(
+            hashCodeRef,
+            this.emitCtx.Metadata.GetOrAddString("Combine"),
+            this.emitCtx.Metadata.GetOrAddBlob(sig));
+        this.hashCodeCombineOpenRefs[arity - 1] = openRef;
+        return openRef;
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: resolves the open MemberRef for the instance
+    /// method <c>System.HashCode.Add&lt;T&gt;(T)</c>, used by the &gt;8-field
+    /// fold path for <c>GetHashCode</c>.
+    /// </summary>
+    /// <returns>The cached <see cref="MemberReferenceHandle"/>.</returns>
+    public MemberReferenceHandle GetHashCodeAddOpenReference()
+    {
+        if (!this.hashCodeAddOpenRef.IsNil)
+        {
+            return this.hashCodeAddOpenRef;
+        }
+
+        var hashCodeRef = this.GetHashCodeTypeReference();
+
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: true, genericParameterCount: 1)
+            .Parameters(
+                1,
+                r => r.Void(),
+                ps => ps.AddParameter().Type().GenericMethodTypeParameter(0));
+
+        this.hashCodeAddOpenRef = this.emitCtx.Metadata.AddMemberReference(
+            hashCodeRef,
+            this.emitCtx.Metadata.GetOrAddString("Add"),
+            this.emitCtx.Metadata.GetOrAddBlob(sig));
+        return this.hashCodeAddOpenRef;
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: resolves the MemberRef for instance method
+    /// <c>System.HashCode.ToHashCode()</c>.
+    /// </summary>
+    /// <returns>The cached <see cref="MemberReferenceHandle"/>.</returns>
+    public MemberReferenceHandle GetHashCodeToHashCodeReference()
+    {
+        if (!this.hashCodeToHashCodeRef.IsNil)
+        {
+            return this.hashCodeToHashCodeRef;
+        }
+
+        var hashCodeRef = this.GetHashCodeTypeReference();
+
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => r.Type().Int32(), _ => { });
+
+        this.hashCodeToHashCodeRef = this.emitCtx.Metadata.AddMemberReference(
+            hashCodeRef,
+            this.emitCtx.Metadata.GetOrAddString("ToHashCode"),
+            this.emitCtx.Metadata.GetOrAddBlob(sig));
+        return this.hashCodeToHashCodeRef;
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: resolves the MemberRef for the static
+    /// <c>System.Convert.ToString(object, IFormatProvider)</c> overload used
+    /// by data-struct <c>ToString</c> synthesis. Handles null reference-type
+    /// fields gracefully (returns the empty string) per the ADR.
+    /// </summary>
+    /// <returns>The cached <see cref="MemberReferenceHandle"/>.</returns>
+    public MemberReferenceHandle GetConvertToStringReference()
+    {
+        if (!this.convertToStringRef.IsNil)
+        {
+            return this.convertToStringRef;
+        }
+
+        var convertRef = this.getTypeReference(typeof(System.Convert));
+        var ifpRef = this.getTypeReference(typeof(System.IFormatProvider));
+
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
+            .Parameters(
+                2,
+                r => r.Type().String(),
+                ps =>
+                {
+                    ps.AddParameter().Type().Object();
+                    ps.AddParameter().Type().Type(ifpRef, isValueType: false);
+                });
+
+        this.convertToStringRef = this.emitCtx.Metadata.AddMemberReference(
+            convertRef,
+            this.emitCtx.Metadata.GetOrAddString("ToString"),
+            this.emitCtx.Metadata.GetOrAddBlob(sig));
+        return this.convertToStringRef;
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: resolves the MemberRef for the static
+    /// property getter <c>System.Globalization.CultureInfo::get_InvariantCulture</c>,
+    /// used to thread an invariant <see cref="System.IFormatProvider"/> into
+    /// <c>Convert.ToString</c> during data-struct <c>ToString</c> synthesis.
+    /// </summary>
+    /// <returns>The cached <see cref="MemberReferenceHandle"/>.</returns>
+    public MemberReferenceHandle GetCultureInvariantGetterReference()
+    {
+        if (!this.cultureInvariantGetterRef.IsNil)
+        {
+            return this.cultureInvariantGetterRef;
+        }
+
+        var cultureInfoRef = this.getTypeReference(typeof(System.Globalization.CultureInfo));
+
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
+            .Parameters(0, r => r.Type().Type(cultureInfoRef, isValueType: false), _ => { });
+
+        this.cultureInvariantGetterRef = this.emitCtx.Metadata.AddMemberReference(
+            cultureInfoRef,
+            this.emitCtx.Metadata.GetOrAddString("get_InvariantCulture"),
+            this.emitCtx.Metadata.GetOrAddBlob(sig));
+        return this.cultureInvariantGetterRef;
+    }
+
+    /// <summary>
+    /// Issue #410 / ADR-0029: resolves the MemberRef for the static
+    /// <c>System.String.Concat(string[])</c> overload used to assemble the
+    /// data-struct <c>ToString</c> output from a per-field array of pieces.
+    /// </summary>
+    /// <returns>The cached <see cref="MemberReferenceHandle"/>.</returns>
+    public MemberReferenceHandle GetStringConcatArrayReference()
+    {
+        if (!this.stringConcatArrayRef.IsNil)
+        {
+            return this.stringConcatArrayRef;
+        }
+
+        var stringTypeRef = this.getTypeReference(this.emitCtx.CoreStringType);
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig).MethodSignature(isInstanceMethod: false)
+            .Parameters(
+                1,
+                r => r.Type().String(),
+                ps => ps.AddParameter().Type().SZArray().String());
+
+        this.stringConcatArrayRef = this.emitCtx.Metadata.AddMemberReference(
+            stringTypeRef,
+            this.emitCtx.Metadata.GetOrAddString("Concat"),
+            this.emitCtx.Metadata.GetOrAddBlob(sig));
+        return this.stringConcatArrayRef;
+    }
+
+    private MemberReferenceHandle BuildObjectDefaultCtorReference()
+    {
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => r.Void(), _ => { });
+        return this.emitCtx.Metadata.AddMemberReference(
+            parent: this.ObjectTypeRef,
+            name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+    }
+}


### PR DESCRIPTION
## Summary

Third step in the `ReflectionMetadataEmitter` decomposition (Phase 2 / E-3 of the multi-PR plan). Extracts the ~25 well-known BCL `TypeReferenceHandle` / `MemberReferenceHandle` fields and their paired `Get*` lazy initializer methods into a new `internal sealed class WellKnownReferences` at `src/Core/CodeAnalysis/Emit/WellKnownReferences.cs`. Follows PR-E-1 (`EmitContext`, #586) and PR-E-2 (`MetadataTokenCache`, #587).

## Inventory moved

**Eager refs (populated by `WellKnownReferences`'s constructor — replaces the inline `metadata.AddTypeReference` / `metadata.AddMemberReference` block in `ReflectionMetadataEmitter.EmitCore`):**
- `ObjectTypeRef` (was `objectTypeRef`)
- `ValueTypeRef` (was `valueTypeRef`)
- `ObjectCtorRef` (was `objectCtorRef`)

**Lazy `MemberReferenceHandle?` (cached on first `Get*` call):**
- `notImplementedExceptionCtorRef`
- `delegateCombineRef`, `delegateRemoveRef`
- `interlockedCompareExchangeOpenRef`
- `isReadOnlyAttributeCtorRef`, `isByRefLikeAttributeCtorRef`
- `obsoleteAttributeStringBoolCtorRef`
- `systemAttributeTypeRef`, `systemAttributeCtorRef`

**Lazy `MemberReferenceHandle` (`IsNil`-checked):**
- `stringConcatRef`, `stringEqualsRef`
- `objectStaticEqualsRef`
- `objectInstanceToStringRef`, `objectInstanceGetHashCodeRef`
- `nullRefExceptionCtorRef`
- `stringConcatArrayRef`
- `convertToStringRef`, `cultureInvariantGetterRef`
- `hashCodeAddOpenRef`, `hashCodeToHashCodeRef`
- `hashCodeTypeRef` (`TypeReferenceHandle`)

**Array-shaped cache:**
- `hashCodeCombineOpenRefs : MemberReferenceHandle?[8]`

**`Get*` methods moved (now `public` on `WellKnownReferences`, same shape as before):**
- `GetNotImplementedExceptionCtor`
- `GetDelegateCombineRef`, `GetDelegateRemoveRef`
- `GetInterlockedCompareExchangeOpenRef`
- `GetIsReadOnlyAttributeTypeRef`, `GetIsReadOnlyAttributeCtorRef`
- `GetIsByRefLikeAttributeCtorRef`
- `GetObsoleteAttributeStringBoolCtorRef`
- `GetSystemAttributeTypeRef`, `GetSystemAttributeCtorRef`
- `GetNullReferenceExceptionCtorRef`
- `GetNullableGetValueReference`, `GetNullableGetHasValueReference`
- `GetStringLengthReference`, `GetStringCharsReference`
- `GetTypeFromHandleReference`, `GetArrayCopyReference`
- `GetStringConcatReference`, `GetStringEqualsReference`
- `GetObjectInstanceToStringReference`, `GetObjectInstanceGetHashCodeReference`
- `GetObjectStaticEqualsReference`
- `GetHashCodeTypeReference`
- `GetHashCodeCombineOpenReference`, `GetHashCodeAddOpenReference`
- `GetHashCodeToHashCodeReference`
- `GetConvertToStringReference`, `GetCultureInvariantGetterReference`
- `GetStringConcatArrayReference`

## Eager-init relocation

The eager-init block that previously lived inline in `ReflectionMetadataEmitter.EmitCore` (directly calling `metadata.AddTypeReference(...)` for `ObjectTypeRef`/`ValueTypeRef` and `metadata.AddMemberReference(...)` for `ObjectCtorRef`) has been **relocated into `WellKnownReferences`'s constructor**. `EmitCore` now instantiates `new WellKnownReferences(emitCtx, getTypeRef, getMethodRef)` exactly once, after the BCL `Core*` types have been resolved onto `EmitContext`.

## Design notes

- `WellKnownReferences` depends on `EmitContext` (`Metadata` / `References` / `Core*`) plus two `Func<>` hooks (`Func<Type, TypeReferenceHandle>` and `Func<MethodInfo, MemberReferenceHandle>`) routed to the existing dedup-cached resolvers on `ReflectionMetadataEmitter`. This satisfies the constraint that `WellKnownReferences` MUST NOT depend on `ReflectionMetadataEmitter` itself.
- Eager refs are exposed as get-only properties; lazy refs are exposed as `Get*()` methods with the same signature as before — consumers move from `this.X` to `this.wellKnown.X` / `this.GetX()` to `this.wellKnown.GetX()` with no shape change.
- `GetObjectDefaultCtorReference`'s factory body becomes a private `BuildObjectDefaultCtorReference()` used once to populate `ObjectCtorRef` at construction time; consumers now read `wellKnown.ObjectCtorRef`.
- `hashCodeLocalSig` + `GetHashCodeLocalSignature` stay on the emitter (returns `StandaloneSignatureHandle`, belongs to later `DataStructSynthesizer`).
- `GetHashCodeCombineObjectSpec` / `GetHashCodeAddObjectSpec` stay on the emitter (they construct `MethodSpec`s, not `MemberRef`s); both now call into `wellKnown.GetHashCodeCombineOpenReference` / `AddOpenReference`.

## Verification

- ✅ `src/Core/CodeAnalysis/Emit/WellKnownReferences.cs` exists (827 LoC).
- ✅ `ReflectionMetadataEmitter.cs` LoC: **17873 → 17217 (−656)**.
- ✅ `RefactoringBaselineTests`: **92/92 pass with zero hash diffs**.
- ✅ `DeterministicEmitTests`: **3/3 pass**.
- ✅ `Core.Tests` suite: 2120/2120 pass.
- ✅ Full solution builds with 0 warnings, 0 errors.
- ✅ No public/internal symbol visible to `Compilation.cs` or any test was renamed.

## Next PR in the sequence

**PR-E-4: `SlotPlanner`.**
