### PR TITLE
PR-E-5: extract ConversionEmitter (conversion-shaped IL emission)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ConversionEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ConversionEmitter.cs
@@ -1,0 +1,153 @@
+// <copyright file="ConversionEmitter.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Emit;
+
+/// <summary>
+/// Conversion-shaped IL emission. Pairs structurally with the binder-side
+/// <c>ConversionClassifier</c> (PR-B-3): the classifier produces a typed
+/// bound representation of every conversion path; this emitter renders
+/// those bound nodes into IL.
+/// </summary>
+/// <remarks>
+/// <para>
+/// PR-E-5 introduces this component. Per the decomposition plan, the
+/// conversion-emit surface is split between two host types in the
+/// pre-refactor source:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// Stateless, top-level helpers on <see cref="ReflectionMetadataEmitter"/>
+/// (<c>EmitBoxIfNeeded</c>, <c>EmitDefaultValue</c>) that take an
+/// <see cref="InstructionEncoder"/> as a parameter and do not depend on
+/// per-method body-emit state. <strong>These move here.</strong>
+/// </item>
+/// <item>
+/// Body-emit-internal methods inside <c>BodyEmitter</c>
+/// (<c>EmitConversion</c>, <c>EmitErasedObjectReturnWidening</c>,
+/// <c>EmitNarrowingTruncationIfNeeded</c>, <c>EmitSubI4Truncation</c>,
+/// <c>EmitDefault</c>, <c>EmitClrConversionCall</c>, <c>EmitZeroInit</c>)
+/// that reference <c>BodyEmitter</c>'s private <c>il</c>,
+/// <c>defaultExpressionSlots</c>, and call back into <c>EmitExpression</c>
+/// and the closure-emit helpers (<c>EmitFunctionToDelegateConversion</c>,
+/// <c>EmitFunctionLiteral</c>, <c>EmitMethodGroup</c>,
+/// <c>EmitCapturedVariableLoad</c>). <strong>These are deferred to PR-E-11
+/// <c>MethodBodyEmitter</c></strong>, where <c>BodyEmitter</c> is promoted
+/// to its own top-level type with its own partials (including
+/// <c>MethodBodyEmitter.Conversions.cs</c>). Moving them in PR-E-5 would
+/// require widening <c>BodyEmitter</c>'s private surface to expose all of
+/// those collaborators through an <c>IBodyEmitContext</c> interface, only
+/// to take it apart again in PR-E-11 — and the closure-conversion path
+/// itself fans out into helpers that belong with PR-E-9
+/// <c>ClosureEmitter</c>. Both methods are exercised by
+/// <c>RefactoringBaselineTests</c>; the deferral keeps the IL byte-identical
+/// gate trivially satisfied here.
+/// </item>
+/// </list>
+/// <para>
+/// Like every other PR-E-* component, <c>ConversionEmitter</c> is
+/// <c>internal sealed</c> and constructor-injected. It receives the same
+/// <see cref="EmitContext"/>, <see cref="MetadataTokenCache"/>, and
+/// <see cref="WellKnownReferences"/> as its peers, plus a
+/// <c>Func&lt;TypeSymbol, EntityHandle&gt;</c> bound to
+/// <c>ReflectionMetadataEmitter</c>'s <c>GetElementTypeToken</c>. That
+/// callback mirrors the <c>needsRvalueReceiverSpill</c> delegate that
+/// PR-E-4 <see cref="SlotPlanner"/> uses to avoid taking a hard
+/// back-reference to the root emitter.
+/// </para>
+/// </remarks>
+internal sealed class ConversionEmitter
+{
+#pragma warning disable IDE0052 // unused; reserved for the deferred BodyEmitter-internal moves landing in PR-E-11
+    private readonly EmitContext emitCtx;
+    private readonly MetadataTokenCache cache;
+    private readonly WellKnownReferences wellKnown;
+#pragma warning restore IDE0052
+    private readonly Func<TypeSymbol, EntityHandle> getElementTypeToken;
+
+    public ConversionEmitter(
+        EmitContext emitCtx,
+        MetadataTokenCache cache,
+        WellKnownReferences wellKnown,
+        Func<TypeSymbol, EntityHandle> getElementTypeToken)
+    {
+        this.emitCtx = emitCtx ?? throw new ArgumentNullException(nameof(emitCtx));
+        this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        this.wellKnown = wellKnown ?? throw new ArgumentNullException(nameof(wellKnown));
+        this.getElementTypeToken = getElementTypeToken ?? throw new ArgumentNullException(nameof(getElementTypeToken));
+    }
+
+    /// <summary>
+    /// Emits a <c>box T</c> instruction iff <paramref name="type"/> is a
+    /// value type symbol. The shape mirrors the conditions the binder
+    /// records on every boxing conversion (CLR-object widening, interface
+    /// upcast of a value type, generic argument materialization on an
+    /// erased generic).
+    /// </summary>
+    /// <param name="il">Destination instruction encoder.</param>
+    /// <param name="type">GSharp type of the value currently on the evaluation stack.</param>
+    public void EmitBoxIfNeeded(InstructionEncoder il, TypeSymbol type)
+    {
+        if (ReflectionMetadataEmitter.IsValueTypeSymbol(type))
+        {
+            il.OpCode(ILOpCode.Box);
+            il.Token(this.getElementTypeToken(type));
+        }
+    }
+
+    /// <summary>
+    /// Pushes a CLR-default value for <paramref name="type"/> onto the
+    /// evaluation stack. Sits in the conversion-shaped emit surface
+    /// alongside <see cref="EmitBoxIfNeeded"/>. The pre-refactor source had
+    /// no callers for this helper; it is preserved verbatim for parity.
+    /// </summary>
+    /// <param name="il">Destination instruction encoder.</param>
+    /// <param name="type">CLR type whose default value should be pushed.</param>
+    public void EmitDefaultValue(InstructionEncoder il, Type type)
+    {
+        if (type == typeof(int) || type == typeof(bool) || type == typeof(byte)
+            || type == typeof(short) || type == typeof(char))
+        {
+            il.LoadConstantI4(0);
+        }
+        else if (type == typeof(long))
+        {
+            il.LoadConstantI8(0);
+        }
+        else if (type == typeof(float))
+        {
+            il.OpCode(ILOpCode.Ldc_r4);
+            il.CodeBuilder.WriteSingle(0.0f);
+        }
+        else if (type == typeof(double))
+        {
+            il.OpCode(ILOpCode.Ldc_r8);
+            il.CodeBuilder.WriteDouble(0.0);
+        }
+        else if (type.IsValueType)
+        {
+            // For value types we need initobj pattern but SetResult takes the value
+            // by value, not by ref. Use a local initialized to default.
+            // Simplified: just push 0 for small structs or use ldloca + initobj.
+            // For now, use a simple approach: push ldloca on a temp, initobj, ldloc.
+            // Actually, the simplest correct approach: if it's a primitive, handled above.
+            // For struct value types, we can't easily push default without a local.
+            // Let's use ldloca on the arg slot (but we don't have one).
+            // Simplest: we won't support generic Task<CustomStruct> yet.
+            // For the common cases (Task<int>, Task<string>, Task<bool>), the above handles it.
+            // Fallback: push 0 and hope for the best (works for small value types).
+            il.LoadConstantI4(0);
+        }
+        else
+        {
+            // Reference types: default is null.
+            il.OpCode(ILOpCode.Ldnull);
+        }
+    }
+}

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -8,6 +8,7 @@
 #pragma warning disable SA1214 // readonly fields before non-readonly
 #pragma warning disable SA1515 // single-line comment preceded by blank line
 #pragma warning disable SA1201 // method should not follow a class (this file mixes private helper classes inline with methods)
+#pragma warning disable SA1202 // 'internal' members should come before 'private' members (PR-E-5: IsValueTypeSymbol was widened to internal in-place for ConversionEmitter; ordering is restored once Phase 2 decomposition finishes)
 
 using System;
 using System.Collections.Generic;
@@ -164,6 +165,25 @@ internal sealed class ReflectionMetadataEmitter
     // (the MetadataTokenCache for GlobalFieldDefs lookups, and the
     // NeedsRvalueReceiverSpill predicate) via constructor injection.
     private readonly SlotPlanner slotPlanner;
+
+    // PR-E-5: SlotPlanner's sibling — ConversionEmitter — owns conversion-
+    // shaped IL emission. In this PR it hosts the two stateless top-level
+    // helpers (EmitBoxIfNeeded, EmitDefaultValue) that take an
+    // InstructionEncoder by parameter. The BodyEmitter-internal conversion
+    // methods (EmitConversion, EmitErasedObjectReturnWidening,
+    // EmitNarrowingTruncationIfNeeded, EmitSubI4Truncation, EmitDefault,
+    // EmitClrConversionCall, EmitZeroInit) remain on BodyEmitter for now;
+    // they call back into closure-emit helpers slated for E-9
+    // ClosureEmitter, and BodyEmitter itself is promoted to a top-level
+    // type with a MethodBodyEmitter.Conversions.cs partial in E-11
+    // MethodBodyEmitter. Both motions land cleanly in E-11; bringing them
+    // forward here would require widening BodyEmitter's private surface
+    // only to take it apart again two PRs later.
+    // Not readonly because instantiation depends on EmitContext.Core* /
+    // wellKnown / GetElementTypeToken closing over fields that are only
+    // valid after EmitCore has resolved the BCL core types — mirrors the
+    // wellKnown pattern.
+    private ConversionEmitter conversionEmitter;
 
     private ReflectionMetadataEmitter(BoundProgram program, ReferenceResolver references, string assemblyName, bool metadataOnly)
     {
@@ -332,6 +352,12 @@ internal sealed class ReflectionMetadataEmitter
         // TypeRefs, Object..ctor MemberRef); every other well-known ref is
         // lazily materialised on first access via its paired Get* method.
         this.wellKnown = new WellKnownReferences(this.emitCtx, this.GetTypeReference, this.GetMethodReference);
+
+        // PR-E-5: now that wellKnown is materialised, wire ConversionEmitter.
+        // GetElementTypeToken is passed as a delegate (same pattern as
+        // SlotPlanner's needsRvalueReceiverSpill) so the new component does
+        // not need a hard back-reference to this emitter.
+        this.conversionEmitter = new ConversionEmitter(this.emitCtx, this.cache, this.wellKnown, this.GetElementTypeToken);
 
         // Pre-assign FieldDefinitionHandles for user struct fields. Struct
         // TypeDefs are emitted between <Module> and the per-package <Program>
@@ -5795,15 +5821,9 @@ internal sealed class ReflectionMetadataEmitter
             parameterList: this.NextParameterHandle());
     }
 
-    private void EmitBoxIfNeeded(InstructionEncoder il, TypeSymbol type)
-    {
-        if (IsValueTypeSymbol(type))
-        {
-            il.OpCode(ILOpCode.Box);
-            il.Token(this.GetElementTypeToken(type));
-        }
-    }
-
+    // PR-E-5: EmitBoxIfNeeded(InstructionEncoder, TypeSymbol) moved to
+    // ConversionEmitter. Internal call sites now route through
+    // this.conversionEmitter.EmitBoxIfNeeded(il, type).
     private int FinishInlineBody(InstructionEncoder il)
     {
         return this.emitCtx.MetadataOnly ? -1 : this.emitCtx.MethodBodyStream.AddMethodBody(il);
@@ -5839,13 +5859,13 @@ internal sealed class ReflectionMetadataEmitter
             il.LoadArgument(0);
             il.OpCode(ILOpCode.Ldfld);
             il.Token(fieldHandle);
-            this.EmitBoxIfNeeded(il, field.Type);
+            this.conversionEmitter.EmitBoxIfNeeded(il, field.Type);
             il.LoadArgument(1);
             il.OpCode(ILOpCode.Unbox);
             il.Token(typeDef);
             il.OpCode(ILOpCode.Ldfld);
             il.Token(fieldHandle);
-            this.EmitBoxIfNeeded(il, field.Type);
+            this.conversionEmitter.EmitBoxIfNeeded(il, field.Type);
             il.Call(this.wellKnown.GetObjectStaticEqualsReference());
             il.OpCode(ILOpCode.Ret);
         }
@@ -5875,11 +5895,11 @@ internal sealed class ReflectionMetadataEmitter
             il.LoadArgument(0);
             il.OpCode(ILOpCode.Ldfld);
             il.Token(fieldHandle);
-            this.EmitBoxIfNeeded(il, field.Type);
+            this.conversionEmitter.EmitBoxIfNeeded(il, field.Type);
             il.LoadArgumentAddress(1);
             il.OpCode(ILOpCode.Ldfld);
             il.Token(fieldHandle);
-            this.EmitBoxIfNeeded(il, field.Type);
+            this.conversionEmitter.EmitBoxIfNeeded(il, field.Type);
             il.Call(this.wellKnown.GetObjectStaticEqualsReference());
             il.OpCode(ILOpCode.Ret);
         }
@@ -5897,7 +5917,7 @@ internal sealed class ReflectionMetadataEmitter
             il.LoadArgument(0);
             il.OpCode(ILOpCode.Ldfld);
             il.Token(fieldHandle);
-            this.EmitBoxIfNeeded(il, field.Type);
+            this.conversionEmitter.EmitBoxIfNeeded(il, field.Type);
             il.OpCode(ILOpCode.Callvirt);
             il.Token(this.wellKnown.GetObjectInstanceGetHashCodeReference());
             il.OpCode(ILOpCode.Ret);
@@ -5917,7 +5937,7 @@ internal sealed class ReflectionMetadataEmitter
             il.LoadArgument(0);
             il.OpCode(ILOpCode.Ldfld);
             il.Token(fieldHandle);
-            this.EmitBoxIfNeeded(il, field.Type);
+            this.conversionEmitter.EmitBoxIfNeeded(il, field.Type);
             il.OpCode(ILOpCode.Callvirt);
             il.Token(this.wellKnown.GetObjectInstanceToStringReference());
             il.Call(this.wellKnown.GetStringConcatReference());
@@ -5949,11 +5969,11 @@ internal sealed class ReflectionMetadataEmitter
             il.LoadArgumentAddress(0);
             il.OpCode(ILOpCode.Ldfld);
             il.Token(fieldHandle);
-            this.EmitBoxIfNeeded(il, field.Type);
+            this.conversionEmitter.EmitBoxIfNeeded(il, field.Type);
             il.LoadArgumentAddress(1);
             il.OpCode(ILOpCode.Ldfld);
             il.Token(fieldHandle);
-            this.EmitBoxIfNeeded(il, field.Type);
+            this.conversionEmitter.EmitBoxIfNeeded(il, field.Type);
             il.Call(this.wellKnown.GetObjectStaticEqualsReference());
             if (isInequality)
             {
@@ -6096,11 +6116,11 @@ internal sealed class ReflectionMetadataEmitter
                 il.LoadArgument(0);
                 il.OpCode(ILOpCode.Ldfld);
                 il.Token(fieldHandle);
-                this.EmitBoxIfNeeded(il, field.Type);
+                this.conversionEmitter.EmitBoxIfNeeded(il, field.Type);
                 il.LoadArgumentAddress(1);
                 il.OpCode(ILOpCode.Ldfld);
                 il.Token(fieldHandle);
-                this.EmitBoxIfNeeded(il, field.Type);
+                this.conversionEmitter.EmitBoxIfNeeded(il, field.Type);
                 il.Call(this.wellKnown.GetObjectStaticEqualsReference());
                 il.Branch(ILOpCode.Brfalse, retFalse);
             }
@@ -6156,7 +6176,7 @@ internal sealed class ReflectionMetadataEmitter
                     il.LoadArgument(0);
                     il.OpCode(ILOpCode.Ldfld);
                     il.Token(fieldHandle);
-                    this.EmitBoxIfNeeded(il, field.Type);
+                    this.conversionEmitter.EmitBoxIfNeeded(il, field.Type);
                 }
 
                 il.OpCode(ILOpCode.Call);
@@ -6178,7 +6198,7 @@ internal sealed class ReflectionMetadataEmitter
                     il.LoadArgument(0);
                     il.OpCode(ILOpCode.Ldfld);
                     il.Token(fieldHandle);
-                    this.EmitBoxIfNeeded(il, field.Type);
+                    this.conversionEmitter.EmitBoxIfNeeded(il, field.Type);
                     il.OpCode(ILOpCode.Call);
                     il.Token(addSpec);
                 }
@@ -6251,7 +6271,7 @@ internal sealed class ReflectionMetadataEmitter
                 il.LoadArgument(0);
                 il.OpCode(ILOpCode.Ldfld);
                 il.Token(fieldHandle);
-                this.EmitBoxIfNeeded(il, field.Type);
+                this.conversionEmitter.EmitBoxIfNeeded(il, field.Type);
                 il.Call(this.wellKnown.GetCultureInvariantGetterReference());
                 il.Call(this.wellKnown.GetConvertToStringReference());
                 il.OpCode(ILOpCode.Stelem_ref);
@@ -6309,11 +6329,11 @@ internal sealed class ReflectionMetadataEmitter
                 il.LoadArgumentAddress(0);
                 il.OpCode(ILOpCode.Ldfld);
                 il.Token(fieldHandle);
-                this.EmitBoxIfNeeded(il, field.Type);
+                this.conversionEmitter.EmitBoxIfNeeded(il, field.Type);
                 il.LoadArgumentAddress(1);
                 il.OpCode(ILOpCode.Ldfld);
                 il.Token(fieldHandle);
-                this.EmitBoxIfNeeded(il, field.Type);
+                this.conversionEmitter.EmitBoxIfNeeded(il, field.Type);
                 il.Call(this.wellKnown.GetObjectStaticEqualsReference());
                 il.Branch(ILOpCode.Brfalse, retFalse);
             }
@@ -6581,50 +6601,10 @@ internal sealed class ReflectionMetadataEmitter
             parameterList: this.NextParameterHandle());
     }
 
-    /// <summary>
-    /// Emits IL for pushing the default value of a CLR type onto the stack.
-    /// </summary>
-    private void EmitDefaultValue(InstructionEncoder il, Type type)
-    {
-        if (type == typeof(int) || type == typeof(bool) || type == typeof(byte)
-            || type == typeof(short) || type == typeof(char))
-        {
-            il.LoadConstantI4(0);
-        }
-        else if (type == typeof(long))
-        {
-            il.LoadConstantI8(0);
-        }
-        else if (type == typeof(float))
-        {
-            il.OpCode(ILOpCode.Ldc_r4);
-            il.CodeBuilder.WriteSingle(0.0f);
-        }
-        else if (type == typeof(double))
-        {
-            il.OpCode(ILOpCode.Ldc_r8);
-            il.CodeBuilder.WriteDouble(0.0);
-        }
-        else if (type.IsValueType)
-        {
-            // For value types we need initobj pattern but SetResult takes the value
-            // by value, not by ref. Use a local initialized to default.
-            // Simplified: just push 0 for small structs or use ldloca + initobj.
-            // For now, use a simple approach: push ldloca on a temp, initobj, ldloc.
-            // Actually, the simplest correct approach: if it's a primitive, handled above.
-            // For struct value types, we can't easily push default without a local.
-            // Let's use ldloca on the arg slot (but we don't have one).
-            // Simplest: we won't support generic Task<CustomStruct> yet.
-            // For the common cases (Task<int>, Task<string>, Task<bool>), the above handles it.
-            // Fallback: push 0 and hope for the best (works for small value types).
-            il.LoadConstantI4(0);
-        }
-        else
-        {
-            // Reference types: default is null.
-            il.OpCode(ILOpCode.Ldnull);
-        }
-    }
+    // PR-E-5: EmitDefaultValue(InstructionEncoder, Type) moved to
+    // ConversionEmitter. The pre-refactor source had no callers for this
+    // helper — it sits in the conversion-shaped emit surface alongside
+    // EmitBoxIfNeeded and is preserved for parity / future use.
 
     /// <summary>
     /// Emits the kickoff body for an async function: creates the state-machine
@@ -9734,7 +9714,12 @@ internal sealed class ReflectionMetadataEmitter
     // Phase 4 emit parity (F1): used by call sites to decide whether a value
     // crossing the open-generic boundary needs box / unbox.any. Mirrors the
     // CLR's value-type predicate over GSharp type symbols.
-    private static bool IsValueTypeSymbol(TypeSymbol type)
+    // PR-E-5: widened from `private static` to `internal static` so the
+    // extracted ConversionEmitter (a sibling file in this assembly) can
+    // call into the canonical value-type test without taking a hard
+    // back-reference to the root emitter. The predicate itself is
+    // structurally pure and has no other dependencies.
+    internal static bool IsValueTypeSymbol(TypeSymbol type)
     {
         if (type == TypeSymbol.Int32 || type == TypeSymbol.Bool)
         {


### PR DESCRIPTION
## Summary

PR-E-5 of the `ReflectionMetadataEmitter.cs` decomposition (Phase 2). Introduces `src/Core/CodeAnalysis/Emit/ConversionEmitter.cs` as the sibling of `SlotPlanner` for conversion-shaped IL emission. Pairs structurally with the binder-side `ConversionClassifier` (PR-B-3).

## Option chosen: **B** (deferral of `BodyEmitter`-internal methods to PR-E-11)

This PR moves the two stateless top-level conversion helpers (`EmitBoxIfNeeded`, `EmitDefaultValue`) that take an `InstructionEncoder` by parameter and do not depend on per-method body-emit state. The `BodyEmitter`-internal conversion methods are deferred to PR-E-11 `MethodBodyEmitter`, where `BodyEmitter` is promoted to a top-level type with its own partials including `MethodBodyEmitter.Conversions.cs`.

### Why Option B over Option A

Option A would require widening `BodyEmitter`'s private surface with an `IBodyEmitContext` interface exposing `il`, `EmitExpression`, and ~6 closure-emit collaborators (`EmitFunctionToDelegateConversion`, `EmitFunctionLiteralToNamedDelegateConversion`, `EmitFunctionLiteral`, `EmitMethodGroup`, `EmitCapturedVariableLoad`, `TryEmitNumericConversion`, `TryEmitEnumConversion`) — only to take the seam apart again two PRs later. The closure-conversion path itself fans out into helpers that belong with PR-E-9 `ClosureEmitter`. Both motions land cleanly in E-11 once `BodyEmitter` is no longer a `private sealed` nested class.

The structural value of `ConversionEmitter` as a focused component is preserved: it now exists as a real type with its own file, constructor-injected dependencies, and the wiring (`this.conversionEmitter`) ready for the deferred moves.

## Inventory

### Moved (this PR)

| Method | Pre-refactor location |
|---|---|
| `EmitBoxIfNeeded(InstructionEncoder, TypeSymbol)` | `ReflectionMetadataEmitter.cs:5798` |
| `EmitDefaultValue(InstructionEncoder, Type)` | `ReflectionMetadataEmitter.cs:6587` (note: dead code in the pre-refactor source; preserved verbatim for parity) |

### Deferred to PR-E-11 `MethodBodyEmitter.Conversions.cs`

| Method | Pre-refactor location |
|---|---|
| `EmitConversion(BoundConversionExpression)` | `BodyEmitter` ~`:11036` |
| `EmitErasedObjectReturnWidening(TypeSymbol, TypeSymbol)` | `BodyEmitter` ~`:11218` |
| `EmitNarrowingTruncationIfNeeded(BoundBinaryOperatorKind, TypeSymbol)` | `BodyEmitter` ~`:12326` |
| `EmitSubI4Truncation(TypeSymbol)` | `BodyEmitter` ~`:12371` |
| `EmitDefault(BoundDefaultExpression)` | `BodyEmitter` ~`:12853` |
| `EmitClrConversionCall(BoundClrConversionCallExpression)` | `BodyEmitter` ~`:14591` |
| `EmitZeroInit(int, TypeSymbol, Type)` | `BodyEmitter` ~`:16264` |

## Wiring

- `ReflectionMetadataEmitter` adds a non-readonly `conversionEmitter` field (mirroring the `wellKnown` field pattern — instantiation depends on `EmitContext.Core*` having been resolved first, so it happens inside `EmitCore` after `new WellKnownReferences(...)`, not the ctor).
- Constructor injection: `new ConversionEmitter(emitCtx, cache, wellKnown, GetElementTypeToken)`. The `GetElementTypeToken` delegate matches the `needsRvalueReceiverSpill` pattern PR-E-4 `SlotPlanner` uses to avoid taking a hard back-reference to the root emitter.
- 15 internal call sites of `this.EmitBoxIfNeeded(il, …)` rewritten to `this.conversionEmitter.EmitBoxIfNeeded(il, …)`.
- `IsValueTypeSymbol` widened from `private static` to `internal static` so the sibling component can call it directly without a delegate. SA1202 file-level disable added (transient member-order artifact of the in-progress decomposition).

## Gates

- ✅ `RefactoringBaselineTests`: **zero hash diffs** across the full refactoring-baseline sample set (every fixture exercises the boxing path).
- ✅ `DeterministicEmitTests`: green.
- ✅ `SlotDictionaryAliasingAssertionTests`: green; globs all `Emit` files, so `ConversionEmitter.cs` is automatically included.
- ✅ `Core.Tests` (2120 pass), `Interpreter.Tests` (72 pass), `LanguageServer.Tests` (242 pass), `Sdk.Tests` (24 pass): all green locally.
- ⚠️ `Compiler.Tests`: green when run in isolation. The local macOS dev machine exhausts memory/file descriptors when running the full suite in a single test host process (independent of this change — same crash reproduces on `origin/main` pre-edit). Verified by running the "failing" tests individually and as small groups; CI will run the full suite.

## LoC delta

| File | Before | After | Δ |
|---|---:|---:|---:|
| `ReflectionMetadataEmitter.cs` | 16284 | 16269 | −15 |
| `ConversionEmitter.cs` | (new) | 153 | +153 |

## Surface preservation

No public or internal symbol visible to `Compilation.cs` or any test had its name or signature changed. `IsValueTypeSymbol` was widened from `private` to `internal` (additive, behavior-preserving).

## Next

PR-E-6 `DataStructSynthesizer`.
