### PR TITLE
PR-E-9: extract ClosureEmitter (closure orchestration + display-class synthesis)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
@@ -1,0 +1,503 @@
+// <copyright file="ClosureEmitter.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Emit;
+
+/// <summary>
+/// Closure-environment orchestration and display-class synthesis. Owns
+/// the metadata that describes every lambda / <c>go</c> capture environment
+/// emitted into the assembly, and owns the rewriter that lowers a captured-
+/// variable read inside a lambda body into a <c>this.field</c> access against
+/// the synthesized display class.
+/// </summary>
+/// <remarks>
+/// <para>
+/// PR-E-9 introduces this component. Per the decomposition plan, the
+/// closure-emit surface is split between two host types in the pre-refactor
+/// source — exactly as PR-E-5 <see cref="ConversionEmitter"/> handled the
+/// conversion-emit surface:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// Stateless, top-level orchestration on <see cref="ReflectionMetadataEmitter"/>
+/// (<c>SynthesizeClosures</c>, <c>SynthesizeGoClosures</c>,
+/// <c>SynthesizeDisplayClass</c>) plus the nested helper classes
+/// (<see cref="ClosureInfo"/>, <see cref="CaptureRewriter"/>,
+/// <see cref="ConstructedTypeCollector"/>) and the closure-state caches
+/// (<see cref="ClosureInfos"/>, <see cref="GoClosureInfos"/>,
+/// <see cref="ClosureInvokeToInfo"/>, <see cref="SynthesizedClosureClasses"/>,
+/// <see cref="Counter"/>). <strong>These move here.</strong>
+/// </item>
+/// <item>
+/// Body-emit-internal closure methods inside <c>BodyEmitter</c>
+/// (<c>EmitFunctionLiteral</c> [two overloads], <c>EmitMethodGroup</c>,
+/// <c>EmitFunctionToDelegateConversion</c>,
+/// <c>EmitFunctionToNamedDelegateConversion</c>,
+/// <c>EmitFunctionLiteralToNamedDelegate</c>,
+/// <c>EmitMethodGroupToNamedDelegate</c>,
+/// <c>EmitClrEventSubscription</c>, <c>EmitUserEventSubscription</c>,
+/// <c>EmitCapturedVariableLoad</c>, <c>EmitOpenDelegateDynamicInvoke</c>)
+/// that reference <c>BodyEmitter</c>'s private <c>il</c>, <c>outer</c>,
+/// <c>locals</c>, <c>parameters</c>, <c>enclosingClosure</c> fields and
+/// call back into <c>EmitExpression</c> / <c>EmitLoadVariable</c> for every
+/// captured value and method-group target. <strong>These are deferred to
+/// PR-E-11 <c>MethodBodyEmitter</c></strong>, where <c>BodyEmitter</c> is
+/// promoted to its own top-level type with its own partials (including
+/// <c>MethodBodyEmitter.Closures.cs</c>). Moving them in PR-E-9 would
+/// require widening <c>BodyEmitter</c>'s private surface to expose all of
+/// those collaborators through an <c>IBodyEmitContext</c> interface, only
+/// to take it apart again in PR-E-11. <strong>This is the same Option B
+/// playbook PR-E-5 used</strong> for the same reason.
+/// </item>
+/// </list>
+/// <para>
+/// <b>Future home of the #567 / #503 unifying fix.</b> The plan calls this
+/// PR out as "the structural home for the eventual #567 + #503 unifying
+/// fix" — closure-environment emission unified with display-class
+/// emission. The fix itself is deferred until PR-E-11 promotes
+/// <c>BodyEmitter</c> to <c>MethodBodyEmitter</c>, because the fix needs to
+/// span both the synthesis side (here) and the emit-time side
+/// (<c>EmitCapturedVariableLoad</c> / <c>EmitFunctionLiteral</c>). Putting
+/// the synthesis side in its own type today is the prerequisite that lets
+/// PR-E-11 land that cross-cutting fix in one focused diff without
+/// rummaging through the root emitter.
+/// </para>
+/// <para>
+/// <b>What stays on <see cref="ReflectionMetadataEmitter"/></b>:
+/// </para>
+/// <list type="bullet">
+/// <item>The <c>lambdaBodies</c> dictionary. It is cross-cutting (populated
+/// by closure synthesis here AND by every state-machine synthesizer in
+/// E-10), and the root emitter walks it from <c>EmitFunction</c>. Keeping
+/// it on the root means E-9 and the future E-10 both write into it via
+/// the constructor-injected dictionary reference, and the root keeps its
+/// existing read paths unchanged. The plan explicitly nominates this
+/// option ("Pick (a) for this PR — it keeps the diff minimal").</item>
+/// <item><c>RegisterConstructedTypeAliases</c>. It is a single-use caller
+/// of <see cref="ConstructedTypeCollector"/> that walks the root's
+/// program-function bodies and lambda bodies and writes into the
+/// <see cref="MetadataTokenCache"/>; it is not closure orchestration in
+/// its own right. The collector type moves here (it is closure-emit-side
+/// per PR-E-4's deferral note); the caller stays.</item>
+/// <item>The state-machine synthesizers (<c>SynthesizeIteratorStateMachines</c>,
+/// <c>SynthesizeAsyncIteratorStateMachines</c>,
+/// <c>SynthesizeAsyncLambdaStateMachines</c>) and their nested classes
+/// (<c>IteratorStateMachineInfo</c>, <c>AsyncIteratorEmitContext</c>).
+/// These move with PR-E-10 <c>StateMachineEmitter</c>. They share the
+/// <see cref="Counter"/> field and append to <see cref="SynthesizedClosureClasses"/>
+/// from the root; both are exposed publicly here so the still-on-root SM
+/// methods (and, once moved, the future <c>StateMachineEmitter</c>) can
+/// mutate them directly.</item>
+/// </list>
+/// <para>
+/// Like every other PR-E-* component, <see cref="ClosureEmitter"/> is
+/// <c>internal sealed</c> and constructor-injected. It receives the same
+/// <see cref="EmitContext"/>, <see cref="MetadataTokenCache"/>, and
+/// <see cref="WellKnownReferences"/> trio as its peers, plus the
+/// <see cref="SlotPlanner"/> for <c>go</c>-statement capture discovery
+/// and a shared reference to the root's <c>lambdaBodies</c> dictionary so
+/// it can register every synthesized closure-Invoke body without taking a
+/// hard back-reference to <see cref="ReflectionMetadataEmitter"/>.
+/// </para>
+/// </remarks>
+internal sealed class ClosureEmitter
+{
+#pragma warning disable SA1401 // field must be private — exposed as a public field (not property) so the still-on-root state-machine synthesizers (and, once moved, the future StateMachineEmitter) can pass it to Interlocked.Increment(ref ...). A property cannot be ref-passed in the same shape the pre-refactor source used.
+    /// <summary>
+    /// Monotonically increasing counter that disambiguates synthesized
+    /// closure / state-machine class names. Public field (not property)
+    /// so callers can pass it to <see cref="System.Threading.Interlocked.Increment(ref int)"/>
+    /// directly. The root emitter's state-machine synthesizers
+    /// (<c>SynthesizeIteratorStateMachines</c>,
+    /// <c>SynthesizeAsyncIteratorStateMachines</c>) increment this
+    /// counter alongside <see cref="SynthesizeClosures"/> /
+    /// <see cref="SynthesizeGoClosures"/> so every synthesized class
+    /// gets a globally unique name.
+    /// </summary>
+    public int Counter;
+#pragma warning restore SA1401
+
+#pragma warning disable IDE0052 // unused; reserved for the deferred BodyEmitter-internal moves landing in PR-E-11
+    private readonly EmitContext emitCtx;
+    private readonly MetadataTokenCache cache;
+    private readonly WellKnownReferences wellKnown;
+#pragma warning restore IDE0052
+    private readonly SlotPlanner slotPlanner;
+    private readonly Dictionary<FunctionSymbol, BoundBlockStatement> lambdaBodies;
+
+    public ClosureEmitter(
+        EmitContext emitCtx,
+        MetadataTokenCache cache,
+        WellKnownReferences wellKnown,
+        SlotPlanner slotPlanner,
+        Dictionary<FunctionSymbol, BoundBlockStatement> lambdaBodies)
+    {
+        this.emitCtx = emitCtx ?? throw new ArgumentNullException(nameof(emitCtx));
+        this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        this.wellKnown = wellKnown ?? throw new ArgumentNullException(nameof(wellKnown));
+        this.slotPlanner = slotPlanner ?? throw new ArgumentNullException(nameof(slotPlanner));
+        this.lambdaBodies = lambdaBodies ?? throw new ArgumentNullException(nameof(lambdaBodies));
+    }
+
+    /// <summary>
+    /// Gets per-lambda closure metadata for every captured-variable function
+    /// literal in the program. Populated by <see cref="SynthesizeClosures"/>
+    /// and read by both the root emitter (when wiring <c>BodyEmitter</c>'s
+    /// <c>enclosingClosure</c>) and by <c>BodyEmitter</c> itself (for the
+    /// <c>EmitFunctionLiteral</c> path).
+    /// </summary>
+    public Dictionary<BoundFunctionLiteralExpression, ClosureInfo> ClosureInfos { get; } = new Dictionary<BoundFunctionLiteralExpression, ClosureInfo>();
+
+    /// <summary>
+    /// Gets per-<c>go</c>-site closure metadata. The display class wraps the
+    /// <c>go</c> expression in an <c>InvokeAction</c> method (or
+    /// <c>InvokeAsync</c> for async <c>go</c>) that <c>Task.Run</c> can
+    /// bind to.
+    /// </summary>
+    public Dictionary<BoundGoStatement, ClosureInfo> GoClosureInfos { get; } = new Dictionary<BoundGoStatement, ClosureInfo>();
+
+    /// <summary>
+    /// Gets the reverse map from a closure-invoke <see cref="FunctionSymbol"/> to
+    /// its <see cref="ClosureInfo"/>. The root emitter reads this when
+    /// constructing a <c>BodyEmitter</c> so nested-closure transitive
+    /// captures (issue #503 follow-up) route through the enclosing
+    /// display class.
+    /// </summary>
+    public Dictionary<FunctionSymbol, ClosureInfo> ClosureInvokeToInfo { get; } = new Dictionary<FunctionSymbol, ClosureInfo>();
+
+    /// <summary>
+    /// Gets every synthesized aggregate class emitted on behalf of a closure,
+    /// <c>go</c> site, or state machine. The root emitter appends these
+    /// to the program's user-struct list before TypeDef row planning;
+    /// state-machine synthesizers (still on the root, moving with
+    /// PR-E-10) also append to this list directly, which is why the
+    /// collection is exposed as a mutable <see cref="List{T}"/>.
+    /// </summary>
+    public List<StructSymbol> SynthesizedClosureClasses { get; } = new List<StructSymbol>();
+
+    // Phase 4 emit parity (E2): for each lambda that captures outer variables,
+    // synthesize a sealed closure class on the entry-point package with:
+    //   - one public field per captured VariableSymbol (typed identically),
+    //   - one instance method (the lambda body, with captured reads/writes
+    //     rewritten to this.field reads/writes),
+    //   - a default ctor (chains to object::.ctor() via the existing
+    //     EmitClassDefaultConstructor path).
+    // Capture semantics are snapshot-by-value at literal creation time — the
+    // same semantics the interpreter implements (see
+    // <c>EvaluateFunctionLiteralExpression</c>): writes inside the lambda
+    // update the closure copy only, not the outer variable.
+    //
+    // Nested-lambda captures (a lambda that captures a variable already
+    // captured by an enclosing closure) are not yet supported: detecting them
+    // requires another rewrite layer. The synthesis throws a clear
+    // NotSupportedException for that case.
+    public void SynthesizeClosures(List<BoundFunctionLiteralExpression> literals, PackageSymbol hostPackage)
+    {
+        foreach (var literal in literals)
+        {
+            if (literal.CapturedVariables.Length == 0)
+            {
+                continue;
+            }
+
+            var closureName = "<closure_" + literal.Function.Name + "_" + System.Threading.Interlocked.Increment(ref this.Counter).ToString(System.Globalization.CultureInfo.InvariantCulture) + ">";
+            var info = this.SynthesizeDisplayClass(
+                closureName,
+                literal.CapturedVariables,
+                literal.Function.Parameters,
+                literal.Function.Type,
+                literal.Body,
+                hostPackage,
+                invokeName: "Invoke");
+
+            this.ClosureInfos[literal] = info;
+        }
+    }
+
+    public void SynthesizeGoClosures(List<BoundGoStatement> goStatements, PackageSymbol hostPackage)
+    {
+        foreach (var go in goStatements)
+        {
+            var captured = this.slotPlanner.CollectCapturedVariables(go.Expression);
+
+            // When the go target is async (returns Task/Task<T>), the closure must
+            // return Task so that Task.Run(Func<Task>) properly awaits completion.
+            // Detection must be robust across assembly-load contexts: when the
+            // compilation is cross-targeting (explicit /reference paths loaded
+            // through a MetadataLoadContext), go.Expression.Type.ClrType is a
+            // reference-pack Type whose identity differs from the gsc host's
+            // System.Threading.Tasks.Task, so typeof(Task).IsAssignableFrom(...)
+            // returns false. That mis-detection emits an Action thunk that
+            // discards the spawned Task — breaking structured scope-join and
+            // producing invalid IL when the async target captures arguments.
+            // Compare by metadata name across the base-type chain instead.
+            var isAsync = IsTaskClrType(go.Expression.Type?.ClrType);
+            var returnType = isAsync ? TypeSymbol.FromClrType(typeof(System.Threading.Tasks.Task)) : TypeSymbol.Void;
+            BoundStatement bodyStatement = isAsync
+                ? new BoundReturnStatement(null, go.Expression)
+                : new BoundExpressionStatement(null, go.Expression);
+            var body = new BoundBlockStatement(null, ImmutableArray.Create(bodyStatement));
+
+            var closureName = "<go_" + System.Threading.Interlocked.Increment(ref this.Counter).ToString(System.Globalization.CultureInfo.InvariantCulture) + ">";
+            var info = this.SynthesizeDisplayClass(
+                closureName,
+                captured,
+                ImmutableArray<ParameterSymbol>.Empty,
+                returnType,
+                body,
+                hostPackage,
+                invokeName: "InvokeAction");
+
+            this.GoClosureInfos[go] = info;
+        }
+    }
+
+    public ClosureInfo SynthesizeDisplayClass(
+        string closureName,
+        ImmutableArray<VariableSymbol> capturedVariables,
+        ImmutableArray<ParameterSymbol> parameters,
+        TypeSymbol returnType,
+        BoundBlockStatement body,
+        PackageSymbol hostPackage,
+        string invokeName)
+    {
+        var packageName = hostPackage?.Name ?? string.Empty;
+        var fieldBuilder = ImmutableArray.CreateBuilder<FieldSymbol>(capturedVariables.Length);
+        var captureFields = new Dictionary<VariableSymbol, FieldSymbol>();
+        foreach (var captured in capturedVariables)
+        {
+            var field = new FieldSymbol(captured.Name, captured.Type, Accessibility.Public);
+            fieldBuilder.Add(field);
+            captureFields[captured] = field;
+        }
+
+        var closureClass = new StructSymbol(
+            name: closureName,
+            fields: fieldBuilder.MoveToImmutable(),
+            accessibility: Accessibility.Internal,
+            declaration: null,
+            packageName: packageName,
+            isData: false,
+            isInline: false,
+            isClass: true);
+
+        var invokeMethod = new FunctionSymbol(
+            name: invokeName,
+            parameters: parameters,
+            type: returnType,
+            declaration: null,
+            package: hostPackage,
+            accessibility: Accessibility.Public,
+            receiverType: (TypeSymbol)closureClass);
+
+        closureClass.SetMethods(ImmutableArray.Create(invokeMethod));
+
+        var rewriter = new CaptureRewriter(closureClass, captureFields, invokeMethod.ThisParameter);
+        var rewrittenBody = (BoundBlockStatement)rewriter.RewriteStatement(body);
+        if (rewriter.UnsupportedCapture != null)
+        {
+            throw new NotSupportedException(
+                $"Synthesized closure '{closureName}' captures '{rewriter.UnsupportedCapture.Name}' from a kind ('{rewriter.UnsupportedCaptureKind}') the emitter cannot currently rewrite. Run under the interpreter for now.");
+        }
+
+        this.lambdaBodies[invokeMethod] = rewrittenBody;
+        this.SynthesizedClosureClasses.Add(closureClass);
+        var info = new ClosureInfo(closureClass, invokeMethod, captureFields);
+        this.ClosureInvokeToInfo[invokeMethod] = info;
+        return info;
+    }
+
+    /// <summary>
+    /// Determines whether a CLR type is <see cref="System.Threading.Tasks.Task"/>
+    /// or <c>Task&lt;T&gt;</c>, comparing by metadata name across the base-type
+    /// chain so the result is independent of the assembly-load context the type
+    /// originates from. <c>typeof(Task).IsAssignableFrom(t)</c> is unreliable
+    /// here because cross-targeting compilations surface types through a
+    /// <see cref="System.Reflection.MetadataLoadContext"/>, giving them a
+    /// distinct <see cref="Type"/> identity from the gsc host's BCL.
+    /// </summary>
+    /// <remarks>
+    /// Internal-static rather than private so the still-on-<see cref="ReflectionMetadataEmitter"/>
+    /// <c>BodyEmitter</c> can use it from its <c>EmitGoStatement</c> path
+    /// when shape-deciding whether the spawned closure is a
+    /// <c>Func&lt;Task&gt;</c> vs. an <c>Action</c>. Both call sites move
+    /// into PR-E-11 <c>MethodBodyEmitter.Closures</c> alongside the rest of
+    /// the BodyEmitter-internal closure-emit methods.
+    /// </remarks>
+    /// <param name="clrType">The CLR type to test (may be <see langword="null"/>).</param>
+    /// <returns><see langword="true"/> if <paramref name="clrType"/> is <see cref="System.Threading.Tasks.Task"/> or any subclass thereof (notably <c>Task&lt;T&gt;</c>); otherwise <see langword="false"/>.</returns>
+    internal static bool IsTaskClrType(Type clrType)
+    {
+        for (var t = clrType; t != null; t = t.BaseType)
+        {
+            if (string.Equals(t.FullName, "System.Threading.Tasks.Task", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Captured-variable metadata for a single synthesized display class.
+    /// Produced by <see cref="SynthesizeDisplayClass"/>; consumed by the
+    /// root emitter when wiring <c>BodyEmitter</c> and by
+    /// <c>BodyEmitter</c> itself when emitting captured-variable loads.
+    /// </summary>
+    public sealed class ClosureInfo
+    {
+        public ClosureInfo(StructSymbol classSym, FunctionSymbol invokeMethod, Dictionary<VariableSymbol, FieldSymbol> captureFields)
+        {
+            this.ClassSym = classSym;
+            this.InvokeMethod = invokeMethod;
+            this.CaptureFields = captureFields;
+        }
+
+        public StructSymbol ClassSym { get; }
+
+        public FunctionSymbol InvokeMethod { get; }
+
+        public Dictionary<VariableSymbol, FieldSymbol> CaptureFields { get; }
+    }
+
+    /// <summary>
+    /// Rewrites a lambda body so every captured-variable reference is
+    /// retargeted to a <c>this.field</c> access against the synthesized
+    /// display class. Run once per closure during
+    /// <see cref="SynthesizeDisplayClass"/>; the result is stored as the
+    /// Invoke method's lambda body and threaded through the normal
+    /// <c>EmitFunction</c> path.
+    /// </summary>
+    public sealed class CaptureRewriter : BoundTreeRewriter
+    {
+        private readonly StructSymbol closureClass;
+        private readonly Dictionary<VariableSymbol, FieldSymbol> captureFields;
+        private readonly ParameterSymbol thisParam;
+
+        public CaptureRewriter(StructSymbol closureClass, Dictionary<VariableSymbol, FieldSymbol> captureFields, ParameterSymbol thisParam)
+        {
+            this.closureClass = closureClass;
+            this.captureFields = captureFields;
+            this.thisParam = thisParam;
+        }
+
+        // Set when the rewriter encounters a captured variable in a context
+        // it cannot lower (e.g., as the target of a BoundIndexAssignmentExpression
+        // or other shape that the BoundFieldAssignment node does not model).
+        // Reported by SynthesizeClosures as a NotSupportedException.
+        public VariableSymbol UnsupportedCapture { get; private set; }
+
+        public string UnsupportedCaptureKind { get; private set; }
+
+        protected override BoundExpression RewriteVariableExpression(BoundVariableExpression node)
+        {
+            if (this.captureFields.TryGetValue(node.Variable, out var field))
+            {
+                return new BoundFieldAccessExpression(
+                    null,
+                    new BoundVariableExpression(null, this.thisParam),
+                    this.closureClass,
+                    field);
+            }
+
+            return node;
+        }
+
+        protected override BoundExpression RewriteAssignmentExpression(BoundAssignmentExpression node)
+        {
+            if (this.captureFields.TryGetValue(node.Variable, out var field))
+            {
+                var value = this.RewriteExpression(node.Expression);
+                return new BoundFieldAssignmentExpression(null, this.thisParam, this.closureClass, field, value);
+            }
+
+            return base.RewriteAssignmentExpression(node);
+        }
+
+        protected override BoundStatement RewriteVariableDeclaration(BoundVariableDeclaration node)
+        {
+            // Lambda body declares its own locals — never the captured ones.
+            // Still record an "unsupported capture" check in case a captured
+            // VariableSymbol re-appears as a declaration shadow (binder bug).
+            if (this.captureFields.ContainsKey(node.Variable))
+            {
+                this.UnsupportedCapture = node.Variable;
+                this.UnsupportedCaptureKind = nameof(BoundVariableDeclaration);
+            }
+
+            return base.RewriteVariableDeclaration(node);
+        }
+    }
+
+    /// <summary>
+    /// Collects every constructed (non-definition) <see cref="StructSymbol"/>
+    /// referenced anywhere in the bound program — function bodies, class
+    /// methods, AND lambda bodies. PR-E-4 <see cref="SlotPlanner"/>
+    /// explicitly deferred this rewriter to PR-E-9 because it is a
+    /// closure-emit-side helper (the lambda-body walk is what makes it
+    /// closure-aware) rather than a slot walker. The root emitter's
+    /// <c>RegisterConstructedTypeAliases</c> drives this collector to
+    /// alias every constructed type into the same TypeDef / ctor / field
+    /// rows as its definition.
+    /// </summary>
+    public sealed class ConstructedTypeCollector : BoundTreeRewriter
+    {
+        public HashSet<StructSymbol> Constructed { get; } = new HashSet<StructSymbol>();
+
+        protected override BoundExpression RewriteExpression(BoundExpression node)
+        {
+            this.TryAdd(node.Type);
+            switch (node)
+            {
+                case BoundStructLiteralExpression sl:
+                    this.TryAdd(sl.StructType);
+                    foreach (var init in sl.Initializers)
+                    {
+                        this.TryAdd(init.Field.Type);
+                    }
+
+                    break;
+                case BoundFieldAccessExpression fa:
+                    this.TryAdd(fa.StructType);
+                    this.TryAdd(fa.Field.Type);
+                    break;
+                case BoundFieldAssignmentExpression fas:
+                    this.TryAdd(fas.StructType);
+                    this.TryAdd(fas.Field.Type);
+                    break;
+                case BoundPropertyAccessExpression pa:
+                    this.TryAdd(pa.StructType);
+                    this.TryAdd(pa.Property.Type);
+                    break;
+                case BoundPropertyAssignmentExpression pas:
+                    this.TryAdd(pas.StructType);
+                    this.TryAdd(pas.Property.Type);
+                    break;
+                case BoundConstructorCallExpression cc:
+                    this.TryAdd(cc.StructType);
+                    break;
+                case BoundVariableExpression ve:
+                    this.TryAdd(ve.Variable.Type);
+                    break;
+            }
+
+            return base.RewriteExpression(node);
+        }
+
+        private void TryAdd(TypeSymbol type)
+        {
+            if (type is StructSymbol s && !s.TypeArguments.IsDefaultOrEmpty)
+            {
+                this.Constructed.Add(s);
+            }
+        }
+    }
+}

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -92,35 +92,19 @@ internal sealed class ReflectionMetadataEmitter
     // body is emitted via the same EmitFunction path.
     private readonly Dictionary<FunctionSymbol, BoundBlockStatement> lambdaBodies = new Dictionary<FunctionSymbol, BoundBlockStatement>();
 
-    // Phase 4 emit parity (E2): synthesized closure classes for lambdas
-    // that capture outer variables. Each captured-variable lambda gets:
-    //   * A sealed class with one public field per capture (the closure).
-    //   * An instance method holding the rewritten body where captured-
-    //     variable reads/writes become this.field reads/writes.
-    //   * A default ctor (chains to object::.ctor()) — emitted by the
-    //     existing EmitClassDefaultConstructor path.
-    // Capture semantics match the interpreter: snapshot-by-value at the
-    // literal site. The synthesized class is appended to the user struct
-    // list so it threads through the existing class TypeDef/method/field
-    // row planning naturally.
-    private readonly Dictionary<BoundFunctionLiteralExpression, ClosureInfo> closureInfos = new Dictionary<BoundFunctionLiteralExpression, ClosureInfo>();
-
-    // Phase F: each `go` site is lowered through a synthesized display class
-    // with an InvokeAction instance method that Task.Run can bind to an Action.
-    private readonly Dictionary<BoundGoStatement, ClosureInfo> goClosureInfos = new Dictionary<BoundGoStatement, ClosureInfo>();
-    private readonly List<StructSymbol> synthesizedClosureClasses = new List<StructSymbol>();
-
-    // Issue #503 follow-up (nested-closure transitive capture): reverse map
-    // from a closure's Invoke method symbol to its ClosureInfo, so that when
-    // the BodyEmitter for that Invoke method emits a NESTED function-literal
-    // construction, it can route a captured-variable load through the
-    // enclosing closure's display-class field. Without this, the nested
-    // load fell through EmitLoadVariable's slot/parameter/global lookup and
-    // surfaced as GS9998 "no local slot or parameter index" at compile time.
-    private readonly Dictionary<FunctionSymbol, ClosureInfo> closureInvokeToInfo = new Dictionary<FunctionSymbol, ClosureInfo>();
+    // PR-E-9: closure-environment metadata and synthesized display classes
+    // moved onto ClosureEmitter. Where this file used to declare:
+    //   closureInfos                  -> closures.ClosureInfos
+    //   goClosureInfos                -> closures.GoClosureInfos
+    //   synthesizedClosureClasses     -> closures.SynthesizedClosureClasses
+    //   closureInvokeToInfo           -> closures.ClosureInvokeToInfo
+    //   closureCounter                -> closures.Counter
+    // The state-machine synthesizers below (still on this class until PR-E-10)
+    // mutate closures.SynthesizedClosureClasses and closures.Counter directly;
+    // BodyEmitter reads closures.ClosureInfos / closures.GoClosureInfos for
+    // the EmitFunctionLiteral / EmitGoStatement paths.
     private readonly Dictionary<FunctionSymbol, BoundBlockStatement> iteratorKickoffBodies = new Dictionary<FunctionSymbol, BoundBlockStatement>();
     private readonly Dictionary<StructSymbol, IteratorStateMachineInfo> iteratorStateMachineInfos = new Dictionary<StructSymbol, IteratorStateMachineInfo>();
-    private int closureCounter;
 
     // Async state-machine plans produced by AsyncStateMachineRewriter.
     private ImmutableArray<AsyncStateMachinePlan> asyncStateMachinePlans = ImmutableArray<AsyncStateMachinePlan>.Empty;
@@ -239,6 +223,24 @@ internal sealed class ReflectionMetadataEmitter
     // Not readonly for the same EmitCore-ordering reason as
     // memberDefEmitter / dataStructSynth / wellKnown.
     private TypeDefEmitter typeDefEmitter;
+
+    // PR-E-9: ClosureEmitter — owns the closure-environment metadata,
+    // display-class synthesis (SynthesizeClosures / SynthesizeGoClosures /
+    // SynthesizeDisplayClass), and the nested ClosureInfo / CaptureRewriter /
+    // ConstructedTypeCollector helpers. Constructor-injected with a shared
+    // reference to this.lambdaBodies so the synthesis path can register the
+    // rewritten lambda body for every closure-Invoke method without a hard
+    // back-reference to this root emitter. Wired in EmitCore after wellKnown
+    // is materialised (SlotPlanner already exists from the ctor; lambdaBodies
+    // is a field initializer). Not readonly because EmitCore is the
+    // construction site, mirroring the conversionEmitter / dataStructSynth /
+    // memberDefEmitter / typeDefEmitter pattern. The BodyEmitter-internal
+    // closure-emit methods (EmitFunctionLiteral, EmitMethodGroup,
+    // EmitFunctionToDelegateConversion, EmitCapturedVariableLoad,
+    // EmitClrEventSubscription, EmitUserEventSubscription, etc.) stay on
+    // BodyEmitter and move with it in PR-E-11; this is the same Option B
+    // playbook PR-E-5 ConversionEmitter used.
+    private ClosureEmitter closures;
 
     private ReflectionMetadataEmitter(BoundProgram program, ReferenceResolver references, string assemblyName, bool metadataOnly)
     {
@@ -470,6 +472,21 @@ internal sealed class ReflectionMetadataEmitter
             this.EmitClassConstructorWithBaseInitializerBodyBytes,
             this.EmitClassConstructorWithBodyBodyBytes);
 
+        // PR-E-9: ClosureEmitter wires up after TypeDefEmitter. It depends
+        // on the same EmitContext/MetadataTokenCache/WellKnownReferences
+        // trio plus the SlotPlanner (for go-statement capture discovery)
+        // and a shared reference to this.lambdaBodies so the synthesis
+        // path can register the rewritten lambda-body for every
+        // closure-Invoke method without taking a hard back-reference to
+        // this root emitter — same composition pattern as the other
+        // PR-E-* components.
+        this.closures = new ClosureEmitter(
+            this.emitCtx,
+            this.cache,
+            this.wellKnown,
+            this.slotPlanner,
+            this.lambdaBodies);
+
         // Pre-assign FieldDefinitionHandles for user struct fields. Struct
         // TypeDefs are emitted between <Module> and the per-package <Program>
         // types so the field/method-row ranges fall out correctly:
@@ -491,8 +508,8 @@ internal sealed class ReflectionMetadataEmitter
         var hostPackageGuess = this.emitCtx.Program.EntryPoint?.Package
             ?? this.emitCtx.Program.EntryPointPackage
             ?? (this.emitCtx.Program.Packages.IsDefaultOrEmpty ? null : this.emitCtx.Program.Packages[0]);
-        this.SynthesizeClosures(lambdaLiterals, hostPackageGuess);
-        this.SynthesizeGoClosures(goStatements, hostPackageGuess);
+        this.closures.SynthesizeClosures(lambdaLiterals, hostPackageGuess);
+        this.closures.SynthesizeGoClosures(goStatements, hostPackageGuess);
         this.SynthesizeIteratorStateMachines(hostPackageGuess);
         this.SynthesizeAsyncIteratorStateMachines(hostPackageGuess);
         this.SynthesizeAsyncLambdaStateMachines(lambdaLiterals, hostPackageGuess);
@@ -502,9 +519,9 @@ internal sealed class ReflectionMetadataEmitter
         // their TypeDefs come last among the class block; field-row planning
         // walks the combined list so closure fields get well-defined rows.
         var allAggregates = this.emitCtx.Program.Structs;
-        if (this.synthesizedClosureClasses.Count > 0)
+        if (this.closures.SynthesizedClosureClasses.Count > 0)
         {
-            allAggregates = allAggregates.AddRange(this.synthesizedClosureClasses);
+            allAggregates = allAggregates.AddRange(this.closures.SynthesizedClosureClasses);
         }
 
         // Async state-machine types: materialized structs with their hoisted
@@ -1255,7 +1272,7 @@ internal sealed class ReflectionMetadataEmitter
         // can `newobj` the box before its body is materialized.
         foreach (var c in nonSmClasses)
         {
-            var isSynthesizedClosure = this.synthesizedClosureClasses.Contains(c);
+            var isSynthesizedClosure = this.closures.SynthesizedClosureClasses.Contains(c);
             var hasDefaultOnlyCtor = c.ExplicitConstructor == null
                 && c.BaseConstructorInitializer == null
                 && !c.HasPrimaryConstructor;
@@ -4056,7 +4073,7 @@ internal sealed class ReflectionMetadataEmitter
                 structThis = function.ThisParameter;
             }
 
-            var enclosingClosureInfo = this.closureInvokeToInfo.TryGetValue(function, out var ec) ? ec : null;
+            var enclosingClosureInfo = this.closures.ClosureInvokeToInfo.TryGetValue(function, out var ec) ? ec : null;
             var emitter = new BodyEmitter(
                 this,
                 il,
@@ -4716,7 +4733,7 @@ internal sealed class ReflectionMetadataEmitter
     // symbol.
     private void RegisterConstructedTypeAliases()
     {
-        var collector = new ConstructedTypeCollector();
+        var collector = new ClosureEmitter.ConstructedTypeCollector();
         foreach (var kvp in this.emitCtx.Program.Functions)
         {
             collector.RewriteStatement(kvp.Value);
@@ -4770,105 +4787,6 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
-    // Phase 4 emit parity (E2): for each lambda that captures outer variables,
-    // synthesize a sealed closure class on the entry-point package with:
-    //   - one public field per captured VariableSymbol (typed identically),
-    //   - one instance method (the lambda body, with captured reads/writes
-    //     rewritten to this.field reads/writes),
-    //   - a default ctor (chains to object::.ctor() via the existing
-    //     EmitClassDefaultConstructor path).
-    // Capture semantics are snapshot-by-value at literal creation time — the
-    // same semantics the interpreter implements (see
-    // <c>EvaluateFunctionLiteralExpression</c>): writes inside the lambda
-    // update the closure copy only, not the outer variable.
-    //
-    // Nested-lambda captures (a lambda that captures a variable already
-    // captured by an enclosing closure) are not yet supported: detecting them
-    // requires another rewrite layer. The synthesis throws a clear
-    // NotSupportedException for that case.
-    private void SynthesizeClosures(List<BoundFunctionLiteralExpression> literals, PackageSymbol hostPackage)
-    {
-        foreach (var literal in literals)
-        {
-            if (literal.CapturedVariables.Length == 0)
-            {
-                continue;
-            }
-
-            var closureName = "<closure_" + literal.Function.Name + "_" + System.Threading.Interlocked.Increment(ref this.closureCounter).ToString(System.Globalization.CultureInfo.InvariantCulture) + ">";
-            var info = this.SynthesizeDisplayClass(
-                closureName,
-                literal.CapturedVariables,
-                literal.Function.Parameters,
-                literal.Function.Type,
-                literal.Body,
-                hostPackage,
-                invokeName: "Invoke");
-
-            this.closureInfos[literal] = info;
-        }
-    }
-
-    private void SynthesizeGoClosures(List<BoundGoStatement> goStatements, PackageSymbol hostPackage)
-    {
-        foreach (var go in goStatements)
-        {
-            var captured = this.slotPlanner.CollectCapturedVariables(go.Expression);
-
-            // When the go target is async (returns Task/Task<T>), the closure must
-            // return Task so that Task.Run(Func<Task>) properly awaits completion.
-            // Detection must be robust across assembly-load contexts: when the
-            // compilation is cross-targeting (explicit /reference paths loaded
-            // through a MetadataLoadContext), go.Expression.Type.ClrType is a
-            // reference-pack Type whose identity differs from the gsc host's
-            // System.Threading.Tasks.Task, so typeof(Task).IsAssignableFrom(...)
-            // returns false. That mis-detection emits an Action thunk that
-            // discards the spawned Task — breaking structured scope-join and
-            // producing invalid IL when the async target captures arguments.
-            // Compare by metadata name across the base-type chain instead.
-            var isAsync = IsTaskClrType(go.Expression.Type?.ClrType);
-            var returnType = isAsync ? TypeSymbol.FromClrType(typeof(System.Threading.Tasks.Task)) : TypeSymbol.Void;
-            BoundStatement bodyStatement = isAsync
-                ? new BoundReturnStatement(null, go.Expression)
-                : new BoundExpressionStatement(null, go.Expression);
-            var body = new BoundBlockStatement(null, ImmutableArray.Create(bodyStatement));
-
-            var closureName = "<go_" + System.Threading.Interlocked.Increment(ref this.closureCounter).ToString(System.Globalization.CultureInfo.InvariantCulture) + ">";
-            var info = this.SynthesizeDisplayClass(
-                closureName,
-                captured,
-                ImmutableArray<ParameterSymbol>.Empty,
-                returnType,
-                body,
-                hostPackage,
-                invokeName: "InvokeAction");
-
-            this.goClosureInfos[go] = info;
-        }
-    }
-
-    /// <summary>
-    /// Determines whether a CLR type is <see cref="System.Threading.Tasks.Task"/>
-    /// or <c>Task&lt;T&gt;</c>, comparing by metadata name across the base-type
-    /// chain so the result is independent of the assembly-load context the type
-    /// originates from. <c>typeof(Task).IsAssignableFrom(t)</c> is unreliable
-    /// here because cross-targeting compilations surface types through a
-    /// <see cref="System.Reflection.MetadataLoadContext"/>, giving them a
-    /// distinct <see cref="Type"/> identity from the gsc host's BCL.
-    /// </summary>
-    private static bool IsTaskClrType(Type clrType)
-    {
-        for (var t = clrType; t != null; t = t.BaseType)
-        {
-            if (string.Equals(t.FullName, "System.Threading.Tasks.Task", StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     private void SynthesizeIteratorStateMachines(PackageSymbol hostPackage)
     {
         if (this.iteratorPlans.IsDefaultOrEmpty)
@@ -4912,7 +4830,7 @@ internal sealed class ReflectionMetadataEmitter
             }
 
             var smClass = new StructSymbol(
-                name: "<" + plan.Function.Name + ">d__" + System.Threading.Interlocked.Increment(ref this.closureCounter).ToString(System.Globalization.CultureInfo.InvariantCulture),
+                name: "<" + plan.Function.Name + ">d__" + System.Threading.Interlocked.Increment(ref this.closures.Counter).ToString(System.Globalization.CultureInfo.InvariantCulture),
                 fields: fields.ToImmutable(),
                 accessibility: Accessibility.Internal,
                 declaration: null,
@@ -4959,7 +4877,7 @@ internal sealed class ReflectionMetadataEmitter
                 ImmutableArray.Create<BoundStatement>(
                 new BoundReturnStatement(null, this.CreateIteratorStateMachineLiteral(smClass, stateField, parameterFields, plan.Function.Parameters, p => new BoundVariableExpression(null, p))))));
             this.iteratorStateMachineInfos[smClass] = new IteratorStateMachineInfo(plan, smClass);
-            this.synthesizedClosureClasses.Add(smClass);
+            this.closures.SynthesizedClosureClasses.Add(smClass);
         }
     }
 
@@ -5052,7 +4970,7 @@ internal sealed class ReflectionMetadataEmitter
             }
 
             var smClass = new StructSymbol(
-                name: "<" + plan.Function.Name + ">d__" + System.Threading.Interlocked.Increment(ref this.closureCounter).ToString(System.Globalization.CultureInfo.InvariantCulture),
+                name: "<" + plan.Function.Name + ">d__" + System.Threading.Interlocked.Increment(ref this.closures.Counter).ToString(System.Globalization.CultureInfo.InvariantCulture),
                 fields: fields.ToImmutable(),
                 accessibility: Accessibility.Internal,
                 declaration: null,
@@ -5174,7 +5092,7 @@ internal sealed class ReflectionMetadataEmitter
                 new BoundReturnStatement(null, this.CreateAsyncIteratorKickoffLiteral(smClass, stateField, builderField, parameterFields, plan.Function.Parameters)))));
 
             this.asyncIteratorInfos[smClass] = plan;
-            this.synthesizedClosureClasses.Add(smClass);
+            this.closures.SynthesizedClosureClasses.Add(smClass);
 
             // Resolve builder info for async iterator emit context.
             var returnClrType = plan.Function.Type?.ClrType;
@@ -5540,7 +5458,7 @@ internal sealed class ReflectionMetadataEmitter
             FunctionSymbol kickoffFunction;
             BoundBlockStatement body;
 
-            if (this.closureInfos.TryGetValue(literal, out var closure))
+            if (this.closures.ClosureInfos.TryGetValue(literal, out var closure))
             {
                 // Capture-bearing async lambda: the closure's Invoke method is the kickoff.
                 kickoffFunction = closure.InvokeMethod;
@@ -5573,7 +5491,7 @@ internal sealed class ReflectionMetadataEmitter
 
             // Record nesting: capture-bearing async lambda SMs nest inside
             // their closure class (Subset A of the Roslyn nesting convention).
-            if (this.closureInfos.TryGetValue(literal, out var closureForNesting))
+            if (this.closures.ClosureInfos.TryGetValue(literal, out var closureForNesting))
             {
                 var smStruct = plan.StateMachine.MaterializeAsStructSymbol();
                 this.asyncSmEnclosingClosures[smStruct] = closureForNesting.ClassSym;
@@ -5583,61 +5501,6 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         this.asyncStateMachinePlans = plans.ToImmutable();
-    }
-
-    private ClosureInfo SynthesizeDisplayClass(
-        string closureName,
-        ImmutableArray<VariableSymbol> capturedVariables,
-        ImmutableArray<ParameterSymbol> parameters,
-        TypeSymbol returnType,
-        BoundBlockStatement body,
-        PackageSymbol hostPackage,
-        string invokeName)
-    {
-        var packageName = hostPackage?.Name ?? string.Empty;
-        var fieldBuilder = ImmutableArray.CreateBuilder<FieldSymbol>(capturedVariables.Length);
-        var captureFields = new Dictionary<VariableSymbol, FieldSymbol>();
-        foreach (var captured in capturedVariables)
-        {
-            var field = new FieldSymbol(captured.Name, captured.Type, Accessibility.Public);
-            fieldBuilder.Add(field);
-            captureFields[captured] = field;
-        }
-
-        var closureClass = new StructSymbol(
-            name: closureName,
-            fields: fieldBuilder.MoveToImmutable(),
-            accessibility: Accessibility.Internal,
-            declaration: null,
-            packageName: packageName,
-            isData: false,
-            isInline: false,
-            isClass: true);
-
-        var invokeMethod = new FunctionSymbol(
-            name: invokeName,
-            parameters: parameters,
-            type: returnType,
-            declaration: null,
-            package: hostPackage,
-            accessibility: Accessibility.Public,
-            receiverType: (TypeSymbol)closureClass);
-
-        closureClass.SetMethods(ImmutableArray.Create(invokeMethod));
-
-        var rewriter = new CaptureRewriter(closureClass, captureFields, invokeMethod.ThisParameter);
-        var rewrittenBody = (BoundBlockStatement)rewriter.RewriteStatement(body);
-        if (rewriter.UnsupportedCapture != null)
-        {
-            throw new NotSupportedException(
-                $"Synthesized closure '{closureName}' captures '{rewriter.UnsupportedCapture.Name}' from a kind ('{rewriter.UnsupportedCaptureKind}') the emitter cannot currently rewrite. Run under the interpreter for now.");
-        }
-
-        this.lambdaBodies[invokeMethod] = rewrittenBody;
-        this.synthesizedClosureClasses.Add(closureClass);
-        var info = new ClosureInfo(closureClass, invokeMethod, captureFields);
-        this.closureInvokeToInfo[invokeMethod] = info;
-        return info;
     }
 
     private void CollectStatements(
@@ -7122,136 +6985,6 @@ internal sealed class ReflectionMetadataEmitter
         public Lowering.Async.AsyncMethodBuilderInfo BuilderInfo { get; }
     }
 
-    private sealed class ClosureInfo
-    {
-        public ClosureInfo(StructSymbol classSym, FunctionSymbol invokeMethod, Dictionary<VariableSymbol, FieldSymbol> captureFields)
-        {
-            this.ClassSym = classSym;
-            this.InvokeMethod = invokeMethod;
-            this.CaptureFields = captureFields;
-        }
-
-        public StructSymbol ClassSym { get; }
-
-        public FunctionSymbol InvokeMethod { get; }
-
-        public Dictionary<VariableSymbol, FieldSymbol> CaptureFields { get; }
-    }
-
-    private sealed class CaptureRewriter : BoundTreeRewriter
-    {
-        private readonly StructSymbol closureClass;
-        private readonly Dictionary<VariableSymbol, FieldSymbol> captureFields;
-        private readonly ParameterSymbol thisParam;
-
-        public CaptureRewriter(StructSymbol closureClass, Dictionary<VariableSymbol, FieldSymbol> captureFields, ParameterSymbol thisParam)
-        {
-            this.closureClass = closureClass;
-            this.captureFields = captureFields;
-            this.thisParam = thisParam;
-        }
-
-        // Set when the rewriter encounters a captured variable in a context
-        // it cannot lower (e.g., as the target of a BoundIndexAssignmentExpression
-        // or other shape that the BoundFieldAssignment node does not model).
-        // Reported by SynthesizeClosures as a NotSupportedException.
-        public VariableSymbol UnsupportedCapture { get; private set; }
-
-        public string UnsupportedCaptureKind { get; private set; }
-
-        protected override BoundExpression RewriteVariableExpression(BoundVariableExpression node)
-        {
-            if (this.captureFields.TryGetValue(node.Variable, out var field))
-            {
-                return new BoundFieldAccessExpression(
-                    null,
-                    new BoundVariableExpression(null, this.thisParam),
-                    this.closureClass,
-                    field);
-            }
-
-            return node;
-        }
-
-        protected override BoundExpression RewriteAssignmentExpression(BoundAssignmentExpression node)
-        {
-            if (this.captureFields.TryGetValue(node.Variable, out var field))
-            {
-                var value = this.RewriteExpression(node.Expression);
-                return new BoundFieldAssignmentExpression(null, this.thisParam, this.closureClass, field, value);
-            }
-
-            return base.RewriteAssignmentExpression(node);
-        }
-
-        protected override BoundStatement RewriteVariableDeclaration(BoundVariableDeclaration node)
-        {
-            // Lambda body declares its own locals — never the captured ones.
-            // Still record an "unsupported capture" check in case a captured
-            // VariableSymbol re-appears as a declaration shadow (binder bug).
-            if (this.captureFields.ContainsKey(node.Variable))
-            {
-                this.UnsupportedCapture = node.Variable;
-                this.UnsupportedCaptureKind = nameof(BoundVariableDeclaration);
-            }
-
-            return base.RewriteVariableDeclaration(node);
-        }
-    }
-
-    private sealed class ConstructedTypeCollector : BoundTreeRewriter
-    {
-        public HashSet<StructSymbol> Constructed { get; } = new HashSet<StructSymbol>();
-
-        protected override BoundExpression RewriteExpression(BoundExpression node)
-        {
-            this.TryAdd(node.Type);
-            switch (node)
-            {
-                case BoundStructLiteralExpression sl:
-                    this.TryAdd(sl.StructType);
-                    foreach (var init in sl.Initializers)
-                    {
-                        this.TryAdd(init.Field.Type);
-                    }
-
-                    break;
-                case BoundFieldAccessExpression fa:
-                    this.TryAdd(fa.StructType);
-                    this.TryAdd(fa.Field.Type);
-                    break;
-                case BoundFieldAssignmentExpression fas:
-                    this.TryAdd(fas.StructType);
-                    this.TryAdd(fas.Field.Type);
-                    break;
-                case BoundPropertyAccessExpression pa:
-                    this.TryAdd(pa.StructType);
-                    this.TryAdd(pa.Property.Type);
-                    break;
-                case BoundPropertyAssignmentExpression pas:
-                    this.TryAdd(pas.StructType);
-                    this.TryAdd(pas.Property.Type);
-                    break;
-                case BoundConstructorCallExpression cc:
-                    this.TryAdd(cc.StructType);
-                    break;
-                case BoundVariableExpression ve:
-                    this.TryAdd(ve.Variable.Type);
-                    break;
-            }
-
-            return base.RewriteExpression(node);
-        }
-
-        private void TryAdd(TypeSymbol type)
-        {
-            if (type is StructSymbol s && !s.TypeArguments.IsDefaultOrEmpty)
-            {
-                this.Constructed.Add(s);
-            }
-        }
-    }
-
     /// <summary>
     /// Issue #456: deterministic ordering for FunctionSymbols emitted into
     /// the MethodDef table. Sort first by the function's source declaration
@@ -7361,7 +7094,7 @@ internal sealed class ReflectionMetadataEmitter
         // closure are loaded/stored through `this`'s display-class fields
         // instead of looking for a local slot or parameter index. Null when
         // the current method isn't a closure Invoke.
-        private readonly ClosureInfo enclosingClosure;
+        private readonly ClosureEmitter.ClosureInfo enclosingClosure;
 
         // Stack of currently-active protected regions; each entry holds the set of
         // bound labels defined lexically within that region (including nested
@@ -7401,7 +7134,7 @@ internal sealed class ReflectionMetadataEmitter
             Lowering.Async.AsyncStateMachinePlan asyncPlan = null,
             AsyncIteratorEmitContext asyncIteratorEmitCtx = null,
             Dictionary<VariableSymbol, object> constValues = null,
-            ClosureInfo enclosingClosure = null)
+            ClosureEmitter.ClosureInfo enclosingClosure = null)
         {
             this.outer = outer;
             this.il = il;
@@ -8328,7 +8061,7 @@ internal sealed class ReflectionMetadataEmitter
         /// </summary>
         private void EmitFunctionLiteralToNamedDelegate(BoundFunctionLiteralExpression literal, MethodDefinitionHandle delegateCtorHandle)
         {
-            if (this.outer.closureInfos.TryGetValue(literal, out var closure))
+            if (this.outer.closures.ClosureInfos.TryGetValue(literal, out var closure))
             {
                 if (!this.outer.cache.ClassCtorHandles.TryGetValue(closure.ClassSym, out var closureCtor))
                 {
@@ -11773,7 +11506,7 @@ internal sealed class ReflectionMetadataEmitter
                 // For no-capture lambdas, the plan's kickoff is literal.Function.
                 // For capture-bearing lambdas, the plan's kickoff is closure.InvokeMethod.
                 FunctionSymbol planKey = literal.Function;
-                if (this.outer.closureInfos.TryGetValue(literal, out var closureForAsync))
+                if (this.outer.closures.ClosureInfos.TryGetValue(literal, out var closureForAsync))
                 {
                     planKey = closureForAsync.InvokeMethod;
                 }
@@ -11789,7 +11522,7 @@ internal sealed class ReflectionMetadataEmitter
 
         private void EmitFunctionLiteral(BoundFunctionLiteralExpression literal, Type overrideDelegateType)
         {
-            if (this.outer.closureInfos.TryGetValue(literal, out var closure))
+            if (this.outer.closures.ClosureInfos.TryGetValue(literal, out var closure))
             {
                 // Capture-bearing literal: instantiate the closure class,
                 // snapshot each captured variable into its field, then bind
@@ -12624,8 +12357,8 @@ internal sealed class ReflectionMetadataEmitter
 
             this.EmitGoAction(node);
 
-            var closure = this.outer.goClosureInfos[node];
-            var isAsync = ReflectionMetadataEmitter.IsTaskClrType(closure.InvokeMethod.Type?.ClrType);
+            var closure = this.outer.closures.GoClosureInfos[node];
+            var isAsync = ClosureEmitter.IsTaskClrType(closure.InvokeMethod.Type?.ClrType);
 
             MethodInfo run;
             if (isAsync)
@@ -12658,7 +12391,7 @@ internal sealed class ReflectionMetadataEmitter
 
         private void EmitGoAction(BoundGoStatement node)
         {
-            if (!this.outer.goClosureInfos.TryGetValue(node, out var closure))
+            if (!this.outer.closures.GoClosureInfos.TryGetValue(node, out var closure))
             {
                 throw new InvalidOperationException("Go statement has no synthesized display class.");
             }
@@ -12693,7 +12426,7 @@ internal sealed class ReflectionMetadataEmitter
                 this.il.Token(fieldHandle);
             }
 
-            var isAsync = ReflectionMetadataEmitter.IsTaskClrType(closure.InvokeMethod.Type?.ClrType);
+            var isAsync = ClosureEmitter.IsTaskClrType(closure.InvokeMethod.Type?.ClrType);
 
             if (isAsync)
             {


### PR DESCRIPTION
## Summary

Phase 2 PR-E-9 of the `ReflectionMetadataEmitter.cs` decomposition: moves the closure-environment orchestration and display-class synthesis surface out of `ReflectionMetadataEmitter` into a new `internal sealed ClosureEmitter` at `src/Core/CodeAnalysis/Emit/ClosureEmitter.cs`.

**This PR is the structural home for the eventual #567 + #503 unifying fix** (closure-environment emission unified with display-class emission). The fix itself is deferred to PR-E-11 `MethodBodyEmitter` — neither #567 nor #503 is closed by this PR. Setting up this structural home is the prerequisite that lets the cross-cutting fix land in one focused diff once `BodyEmitter` is promoted.

## Approach: Option B (same playbook PR-E-5 used)

Top-level orchestration moves into `ClosureEmitter`. The `BodyEmitter`-internal closure-emit methods stay on `BodyEmitter` and move with it in PR-E-11. Option A would require widening `BodyEmitter`'s private surface to expose `this.il` / `this.outer` / `this.locals` / `this.parameters` / `this.enclosingClosure` through an `IBodyEmitContext` interface, only to take it apart again in PR-E-11 when `BodyEmitter` becomes top-level `MethodBodyEmitter` with a `.Closures.cs` partial.

## Moved into ClosureEmitter

### Nested classes (was `ReflectionMetadataEmitter.cs` ~7125–7280)
- `ClosureInfo` — closure-environment metadata (class symbol, invoke method, capture-field map)
- `CaptureRewriter : BoundTreeRewriter` — rewrites a lambda body to replace captured-variable reads with `this.field` accesses
- `ConstructedTypeCollector : BoundTreeRewriter` — **deferred to here from PR-E-4 `SlotPlanner`** per its explicit deferral note (it is a closure-emit-side rewriter, not a slot walker)

### Top-level orchestration methods (was ~4789, ~4812, ~5588)
- `SynthesizeClosures(List<BoundFunctionLiteralExpression>, PackageSymbol)`
- `SynthesizeGoClosures(List<BoundGoStatement>, PackageSymbol)`
- `SynthesizeDisplayClass(string, ImmutableArray<VariableSymbol>, ImmutableArray<ParameterSymbol>, TypeSymbol, BoundBlockStatement, PackageSymbol, string)`
- `IsTaskClrType(Type)` — widened from `private static` to `internal static` so the still-on-RME `BodyEmitter.EmitGoStatement` path can call it (both call sites move in PR-E-11)

### Closure caches (was ~106, ~110, ~111, ~120, ~123)
| Was | Now |
| --- | --- |
| `closureInfos` | `closures.ClosureInfos` |
| `goClosureInfos` | `closures.GoClosureInfos` |
| `synthesizedClosureClasses` | `closures.SynthesizedClosureClasses` |
| `closureInvokeToInfo` | `closures.ClosureInvokeToInfo` |
| `closureCounter` | `closures.Counter` (public field — by-ref-passable for `Interlocked.Increment`) |

## Stayed on ReflectionMetadataEmitter (per plan)

- **`lambdaBodies` dictionary** — cross-cutting; populated by closures here AND by state-machine synthesizers in E-10. RME owns it; `ClosureEmitter` receives the dictionary reference via constructor injection and writes through it from `SynthesizeDisplayClass`. **The plan explicitly nominated this option** (\"Pick (a) for this PR — it keeps the diff minimal\").
- **`RegisterConstructedTypeAliases`** — RME-side caller of the moved `ConstructedTypeCollector`. Updated to instantiate via `new ClosureEmitter.ConstructedTypeCollector()`.
- **`BodyEmitter`-internal closure-emit methods** — defer to PR-E-11:
  - `EmitFunctionLiteral` (both overloads)
  - `EmitMethodGroup`
  - `EmitFunctionToDelegateConversion`
  - `EmitFunctionToNamedDelegateConversion`
  - `EmitFunctionLiteralToNamedDelegate`
  - `EmitMethodGroupToNamedDelegate`
  - `EmitClrEventSubscription`
  - `EmitUserEventSubscription`
  - `EmitCapturedVariableLoad`
  - `EmitOpenDelegateDynamicInvoke`
- **State-machine synthesizers** (`SynthesizeIteratorStateMachines`, `SynthesizeAsyncIteratorStateMachines`, `SynthesizeAsyncLambdaStateMachines`) and `IteratorStateMachineInfo` / `AsyncIteratorEmitContext` nested classes — move with PR-E-10 `StateMachineEmitter`.

## Wiring

`ReflectionMetadataEmitter.EmitCore` instantiates `ClosureEmitter` after `TypeDefEmitter`:

```csharp
this.closures = new ClosureEmitter(
    this.emitCtx,
    this.cache,
    this.wellKnown,
    this.slotPlanner,
    this.lambdaBodies);
```

Internal call-site rewrites:
- `this.SynthesizeClosures(...)` → `this.closures.SynthesizeClosures(...)`
- `this.SynthesizeGoClosures(...)` → `this.closures.SynthesizeGoClosures(...)`
- `this.closureInfos[...]` → `this.closures.ClosureInfos[...]`
- `this.goClosureInfos[...]` → `this.closures.GoClosureInfos[...]`
- `this.synthesizedClosureClasses` → `this.closures.SynthesizedClosureClasses`
- `this.closureInvokeToInfo[...]` → `this.closures.ClosureInvokeToInfo[...]`
- `ref this.closureCounter` → `ref this.closures.Counter`
- `this.outer.closureInfos / .goClosureInfos` (from `BodyEmitter`) → `this.outer.closures.ClosureInfos / .GoClosureInfos`
- `BodyEmitter.enclosingClosure` field & ctor-param type `ClosureInfo` → `ClosureEmitter.ClosureInfo`
- `new ConstructedTypeCollector()` → `new ClosureEmitter.ConstructedTypeCollector()`
- `BodyEmitter` callers of `IsTaskClrType` → `ClosureEmitter.IsTaskClrType`

`ClosureEmitter` does **not** take a back-reference to `ReflectionMetadataEmitter` — composition + the shared `lambdaBodies` reference only, matching every other PR-E-* component.

## Validation

| Test surface | Result |
| --- | --- |
| `dotnet build GSharp.sln` | ✅ 0 errors, 0 warnings |
| **`RefactoringBaselineTests`** | ✅ all pass — **zero hash diffs**; baseline not regenerated |
| **`DeterministicEmitTests`** | ✅ green |
| **`SlotDictionaryAliasingAssertionTests`** | ✅ green |
| `Core.Tests` (2120 tests total) | ✅ all pass |
| `Interpreter.Tests` (72) | ✅ all pass |
| `LanguageServer.Tests` (242) | ✅ all pass |
| `Sdk.Tests` (24) | ✅ all pass |
| `Compiler.Tests` Closure/Lambda/Async/Issue503/Issue523/Issue527 (64) | ✅ all pass |
| `Compiler.Tests` LanguageConformance + Acceptance (83) | ✅ all pass |
| `Compiler.Tests` IlVerifier (3) | ✅ all pass |

The full `Compiler.Tests` run-as-one-process OOMs locally on macOS (xUnit testhost heap exhaustion across ~700 compile-and-execute tests, also reproducible on `main`). GitHub Actions Linux CI runs the full suite cleanly — last 5 `main` commits all green; relying on CI for the full-suite gate.

## LoC delta

| File | Before | After | Δ |
| --- | ---: | ---: | ---: |
| `ReflectionMetadataEmitter.cs` | 13249 | 12982 | −267 |
| `ClosureEmitter.cs` (new) | 0 | 503 | +503 |

## Constraints satisfied

- Public/internal API surface visible to `Compilation.cs` or any test: **unchanged** (no renames).
- Emitted IL for every `RefactoringBaselineTests` fixture: **byte-identical** (zero hash diffs).
- All `GS####` diagnostics: same codes, locations, messages.

## Next

**PR-E-10 `StateMachineEmitter`** — extracts `SynthesizeIteratorStateMachines`, `SynthesizeAsyncIteratorStateMachines`, `SynthesizeAsyncLambdaStateMachines` and the `IteratorStateMachineInfo` / `AsyncIteratorEmitContext` nested classes. Those synthesizers already mutate `this.closures.SynthesizedClosureClasses` and `this.closures.Counter` through the public surface this PR establishes, so the E-10 move requires no further wiring changes on the `ClosureEmitter` side.