### PR TITLE
PR N-1: extract NullableLifting facade (pure refactor)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2395,17 +2395,7 @@ public sealed class Binder
     /// when the symbol has no CLR type.
     /// </returns>
     private Type ResolveClrTypeForGenericArg(TypeSymbol typeSymbol)
-    {
-        if (typeSymbol is NullableTypeSymbol nullable
-            && nullable.UnderlyingType?.ClrType is { IsValueType: true } innerVt
-            && this.memberLookup.TryGetNullableConstructedType(innerVt, out var nullableClr))
-        {
-            return nullableClr;
-        }
-
-        var clr = typeSymbol?.ClrType;
-        return clr != null ? scope.References.MapClrTypeToReferences(clr) : null;
-    }
+        => NullableLifting.ResolveClrTypeForGenericArg(this.scope.References, typeSymbol);
 
     // Issue #337: build an (unresolved) CLR member method-group expression for a
     // member name that resolves to a method on an imported static type or a CLR

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -538,30 +538,7 @@ internal sealed class MemberLookup
     /// <param name="constructed">The constructed nullable CLR type, on success.</param>
     /// <returns><see langword="true"/> when construction succeeded.</returns>
     public bool TryGetNullableConstructedType(Type underlying, out Type constructed)
-    {
-        constructed = null;
-        if (underlying == null)
-        {
-            return false;
-        }
-
-        if (!this.binderCtx.References.TryResolveType("System.Nullable`1", out var nullableOpen) || nullableOpen == null)
-        {
-            return false;
-        }
-
-        try
-        {
-            var mappedUnderlying = this.binderCtx.References.MapClrTypeToReferences(underlying) ?? underlying;
-            constructed = nullableOpen.MakeGenericType(mappedUnderlying);
-            return constructed != null;
-        }
-        catch
-        {
-            constructed = null;
-            return false;
-        }
-    }
+        => NullableLifting.TryConstructNullable(this.binderCtx.References, underlying, out constructed);
 
     /// <summary>
     /// Issue #294: collects every <c>static [Extension]</c> method named

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -153,8 +153,7 @@ internal static class OverloadResolution
             var t = target.IsByRef ? target.GetElementType()! : target;
 
             // Nullable<T> (value-type nullable)
-            if (t.IsGenericType
-                && string.Equals(t.GetGenericTypeDefinition().FullName, "System.Nullable`1", StringComparison.Ordinal))
+            if (NullableLifting.IsValueTypeNullableClr(t))
             {
                 return ImplicitConversionKind.NullableWrap;
             }
@@ -1750,12 +1749,7 @@ internal static class OverloadResolution
 
     private static bool IsNullableWrap(Type source, Type target)
     {
-        if (!target.IsGenericType)
-        {
-            return false;
-        }
-
-        if (!string.Equals(target.GetGenericTypeDefinition().FullName, "System.Nullable`1", StringComparison.Ordinal))
+        if (!NullableLifting.IsValueTypeNullableClr(target))
         {
             return false;
         }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -3967,9 +3967,7 @@ internal sealed class ReflectionMetadataEmitter
     // default value, and `box Nullable<T>` for object widening — none of
     // which the reference-type path handles.
     internal static bool IsValueTypeNullable(NullableTypeSymbol nullable)
-    {
-        return nullable?.UnderlyingType?.ClrType is { IsValueType: true };
-    }
+        => NullableLifting.IsValueTypeNullable(nullable);
 
     private void EncodeClrType(SignatureTypeEncoder encoder, Type type)
     {

--- a/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
@@ -1,0 +1,140 @@
+// <copyright file="NullableLifting.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Bug-overview §6.1 / phased Nullable&lt;T&gt; unification: single seam for
+/// every <c>Nullable&lt;T&gt;</c> probe and constructor-projection helper
+/// that the binder and emitter need. PR N-1 is a pure refactor that gathers
+/// the previously scattered helpers in one place; subsequent PRs (N-2/N-3/N-4)
+/// plug their fixes into this facade rather than into N separate call sites.
+/// </summary>
+public static class NullableLifting
+{
+    /// <summary>
+    /// Issue #530: returns the effective CLR <see cref="Type"/> to use when
+    /// matching <paramref name="typeSymbol"/> as a method argument in overload
+    /// resolution. For a <see cref="NullableTypeSymbol"/> wrapping a value
+    /// type, this returns <c>Nullable&lt;T&gt;</c> rather than the underlying
+    /// <c>T</c>, because the emitter encodes the local as <c>Nullable&lt;T&gt;</c>
+    /// and the selected overload must accept that type on the evaluation stack.
+    /// For all other types the result equals <c>typeSymbol?.ClrType</c>.
+    /// </summary>
+    /// <param name="typeSymbol">The type symbol to resolve.</param>
+    /// <returns>The CLR <see cref="Type"/> to use for overload resolution, or <see langword="null"/> if <paramref name="typeSymbol"/> is <see langword="null"/>.</returns>
+    public static Type GetEffectiveClrType(TypeSymbol typeSymbol)
+    {
+        if (typeSymbol is NullableTypeSymbol nullable
+            && nullable.UnderlyingType?.ClrType is { IsValueType: true } innerVt)
+        {
+            return typeof(Nullable<>).MakeGenericType(innerVt);
+        }
+
+        return typeSymbol?.ClrType;
+    }
+
+    /// <summary>
+    /// Constructs <c>Nullable&lt;TUnderlying&gt;</c> projected onto
+    /// <paramref name="references"/>. Returns <see langword="false"/> when the
+    /// open <c>Nullable&lt;&gt;</c> is not reachable from the given reference
+    /// set, or when projecting <paramref name="underlying"/> through the
+    /// reference set fails.
+    /// </summary>
+    /// <param name="references">The reference resolver used to discover the open <c>Nullable&lt;&gt;</c> definition and to project <paramref name="underlying"/> onto.</param>
+    /// <param name="underlying">The value-type underlying type.</param>
+    /// <param name="constructed">The constructed nullable CLR type, on success.</param>
+    /// <returns><see langword="true"/> when construction succeeded.</returns>
+    public static bool TryConstructNullable(ReferenceResolver references, Type underlying, out Type constructed)
+    {
+        constructed = null;
+        if (underlying == null)
+        {
+            return false;
+        }
+
+        if (!references.TryResolveType("System.Nullable`1", out var nullableOpen) || nullableOpen == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var mappedUnderlying = references.MapClrTypeToReferences(underlying) ?? underlying;
+            constructed = nullableOpen.MakeGenericType(mappedUnderlying);
+            return constructed != null;
+        }
+        catch
+        {
+            constructed = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Issue #530: returns the CLR type to use when <paramref name="typeSymbol"/>
+    /// appears as a generic type argument (e.g. <c>Task[int32?]</c> or
+    /// <c>FromResult[string?]</c>). For a <see cref="NullableTypeSymbol"/>
+    /// wrapping a value type the result is <c>Nullable&lt;T&gt;</c>; for a
+    /// nullable reference type the result is the underlying reference type
+    /// (since CLR has no separate <c>string?</c> type).
+    /// </summary>
+    /// <param name="references">The reference resolver used to construct
+    /// <c>Nullable&lt;T&gt;</c> and to project the result onto the reference
+    /// load context.</param>
+    /// <param name="typeSymbol">The type symbol to resolve.</param>
+    /// <returns>
+    /// The CLR type projected onto the reference load context, or <c>null</c>
+    /// when the symbol has no CLR type.
+    /// </returns>
+    public static Type ResolveClrTypeForGenericArg(ReferenceResolver references, TypeSymbol typeSymbol)
+    {
+        if (typeSymbol is NullableTypeSymbol nullable
+            && nullable.UnderlyingType?.ClrType is { IsValueType: true } innerVt
+            && TryConstructNullable(references, innerVt, out var nullableClr))
+        {
+            return nullableClr;
+        }
+
+        var clr = typeSymbol?.ClrType;
+        return clr != null ? references.MapClrTypeToReferences(clr) : null;
+    }
+
+    /// <summary>
+    /// Issue #504: a <see cref="NullableTypeSymbol"/> whose underlying CLR
+    /// type is a value type maps to the CLR struct <c>System.Nullable&lt;T&gt;</c>
+    /// — a distinct CLR value type with its own layout and ctor.
+    /// <see cref="NullableTypeSymbol"/> over a reference type, by contrast,
+    /// shares the CLR representation of T (the wrapper is a binder-level
+    /// annotation; <c>ldnull</c> is a valid value for it). Emit-time conversion
+    /// logic for value-type <c>Nullable&lt;T&gt;</c> needs a
+    /// <c>newobj Nullable&lt;T&gt;::.ctor(T)</c> for the lift, an
+    /// <c>initobj</c> for the default value, and <c>box Nullable&lt;T&gt;</c>
+    /// for object widening — none of which the reference-type path handles.
+    /// </summary>
+    /// <param name="nullable">The wrapper to test.</param>
+    /// <returns><see langword="true"/> when the underlying type is a CLR value type.</returns>
+    internal static bool IsValueTypeNullable(NullableTypeSymbol nullable)
+    {
+        return nullable?.UnderlyingType?.ClrType is { IsValueType: true };
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="type"/> is a
+    /// constructed <c>System.Nullable&lt;T&gt;</c> (i.e. closed-generic over the
+    /// open <c>System.Nullable`1</c> definition). The open definition itself
+    /// and non-generic / unconstructed types return <see langword="false"/>.
+    /// </summary>
+    /// <param name="type">The CLR <see cref="Type"/> to probe.</param>
+    /// <returns><see langword="true"/> for a constructed <c>Nullable&lt;T&gt;</c>.</returns>
+    internal static bool IsValueTypeNullableClr(Type type)
+    {
+        return type != null
+            && type.IsGenericType
+            && !type.IsGenericTypeDefinition
+            && string.Equals(type.GetGenericTypeDefinition().FullName, "System.Nullable`1", StringComparison.Ordinal);
+    }
+}

--- a/src/Core/CodeAnalysis/Symbols/NullableTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullableTypeSymbol.cs
@@ -54,13 +54,5 @@ public sealed class NullableTypeSymbol : TypeSymbol
     /// <param name="typeSymbol">The type symbol to resolve.</param>
     /// <returns>The CLR <see cref="Type"/> to use for overload resolution, or <see langword="null"/> if <paramref name="typeSymbol"/> is <see langword="null"/>.</returns>
     public static Type GetEffectiveClrType(TypeSymbol typeSymbol)
-    {
-        if (typeSymbol is NullableTypeSymbol nullable
-            && nullable.UnderlyingType?.ClrType is { IsValueType: true } innerVt)
-        {
-            return typeof(Nullable<>).MakeGenericType(innerVt);
-        }
-
-        return typeSymbol?.ClrType;
-    }
+        => NullableLifting.GetEffectiveClrType(typeSymbol);
 }

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -145,14 +145,10 @@ public class TypeSymbol : Symbol
         // (`Nullable<T>` aka `T?` in C#) as a GSharp `NullableTypeSymbol`
         // wrapping the underlying. Reference-type nullability driven by
         // `[NullableAttribute]` byte arrays is a follow-up.
-        if (clrType.IsGenericType && !clrType.IsGenericTypeDefinition)
+        if (NullableLifting.IsValueTypeNullableClr(clrType))
         {
-            var def = clrType.GetGenericTypeDefinition();
-            if (def.FullName == "System.Nullable`1")
-            {
-                var inner = clrType.GetGenericArguments()[0];
-                return NullableTypeSymbol.Get(FromClrType(inner));
-            }
+            var inner = clrType.GetGenericArguments()[0];
+            return NullableTypeSymbol.Get(FromClrType(inner));
         }
 
         // Compare by FullName so types loaded from a MetadataLoadContext (carrying the

--- a/test/Core.Tests/CodeAnalysis/Symbols/NullableLiftingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/NullableLiftingTests.cs
@@ -1,0 +1,169 @@
+// <copyright file="NullableLiftingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// PR N-1 / bug-overview §6.1: the <see cref="NullableLifting"/> facade
+/// collects every <c>Nullable&lt;T&gt;</c> probe / constructor-projection
+/// helper that the binder and emitter rely on. These tests pin the
+/// behavioural contract of the facade so subsequent PRs (N-2/N-3/N-4) that
+/// plug new logic into the same seam cannot regress the pre-existing
+/// callers silently.
+/// </summary>
+public class NullableLiftingTests
+{
+    [Fact]
+    public void IsValueTypeNullable_Returns_True_For_Value_Type_Nullable()
+    {
+        var sym = NullableTypeSymbol.Get(TypeSymbol.Int32);
+        Assert.True(NullableLifting.IsValueTypeNullable(sym));
+    }
+
+    [Fact]
+    public void IsValueTypeNullable_Returns_False_For_Reference_Type_Nullable()
+    {
+        var sym = NullableTypeSymbol.Get(TypeSymbol.String);
+        Assert.False(NullableLifting.IsValueTypeNullable(sym));
+    }
+
+    [Fact]
+    public void IsValueTypeNullable_Returns_False_For_Null_Argument()
+    {
+        Assert.False(NullableLifting.IsValueTypeNullable(null!));
+    }
+
+    [Fact]
+    public void IsValueTypeNullableClr_Returns_True_For_Constructed_Nullable_Of_Int()
+    {
+        Assert.True(NullableLifting.IsValueTypeNullableClr(typeof(int?)));
+    }
+
+    [Fact]
+    public void IsValueTypeNullableClr_Returns_False_For_Open_Nullable_Definition()
+    {
+        Assert.False(NullableLifting.IsValueTypeNullableClr(typeof(Nullable<>)));
+    }
+
+    [Fact]
+    public void IsValueTypeNullableClr_Returns_False_For_Non_Generic_Type()
+    {
+        Assert.False(NullableLifting.IsValueTypeNullableClr(typeof(int)));
+        Assert.False(NullableLifting.IsValueTypeNullableClr(typeof(string)));
+    }
+
+    [Fact]
+    public void IsValueTypeNullableClr_Returns_False_For_Null_Argument()
+    {
+        Assert.False(NullableLifting.IsValueTypeNullableClr(null!));
+    }
+
+    [Fact]
+    public void GetEffectiveClrType_Returns_Nullable_For_ValueType_Wrapper()
+    {
+        var sym = NullableTypeSymbol.Get(TypeSymbol.Int32);
+        var clr = NullableLifting.GetEffectiveClrType(sym);
+        Assert.Equal(typeof(int?), clr);
+    }
+
+    [Fact]
+    public void GetEffectiveClrType_Returns_Underlying_For_ReferenceType_Wrapper()
+    {
+        var sym = NullableTypeSymbol.Get(TypeSymbol.String);
+        var clr = NullableLifting.GetEffectiveClrType(sym);
+        Assert.Equal(typeof(string), clr);
+    }
+
+    [Fact]
+    public void GetEffectiveClrType_Returns_Underlying_For_NonNullable()
+    {
+        var clr = NullableLifting.GetEffectiveClrType(TypeSymbol.Int32);
+        Assert.Equal(typeof(int), clr);
+    }
+
+    [Fact]
+    public void GetEffectiveClrType_Returns_Null_For_Null_Argument()
+    {
+        Assert.Null(NullableLifting.GetEffectiveClrType(null!));
+    }
+
+    [Fact]
+    public void TryConstructNullable_Succeeds_With_Default_References()
+    {
+        var refs = ReferenceResolver.Default();
+        var ok = NullableLifting.TryConstructNullable(refs, typeof(int), out var constructed);
+        Assert.True(ok);
+        Assert.Equal(typeof(int?), constructed);
+    }
+
+    [Fact]
+    public void TryConstructNullable_Returns_False_For_Null_Underlying()
+    {
+        var refs = ReferenceResolver.Default();
+        var ok = NullableLifting.TryConstructNullable(refs, null!, out var constructed);
+        Assert.False(ok);
+        Assert.Null(constructed);
+    }
+
+    [Fact]
+    public void TryConstructNullable_Returns_Nullable_For_TimeSpan()
+    {
+        var refs = ReferenceResolver.Default();
+        var ok = NullableLifting.TryConstructNullable(refs, typeof(TimeSpan), out var constructed);
+        Assert.True(ok);
+        Assert.Equal(typeof(TimeSpan?), constructed);
+    }
+
+    [Fact]
+    public void ResolveClrTypeForGenericArg_Returns_Nullable_For_ValueType_NullableTypeSymbol()
+    {
+        var refs = ReferenceResolver.Default();
+        var sym = NullableTypeSymbol.Get(TypeSymbol.Int32);
+        var clr = NullableLifting.ResolveClrTypeForGenericArg(refs, sym);
+        Assert.Equal(typeof(int?), clr);
+    }
+
+    [Fact]
+    public void ResolveClrTypeForGenericArg_Returns_Underlying_For_ReferenceType_NullableTypeSymbol()
+    {
+        var refs = ReferenceResolver.Default();
+        var sym = NullableTypeSymbol.Get(TypeSymbol.String);
+        var clr = NullableLifting.ResolveClrTypeForGenericArg(refs, sym);
+
+        // Reference-type nullability has no CLR counterpart: contract documented
+        // at Binder.cs:2387 says the result is the bare underlying reference type.
+        Assert.Equal(typeof(string), clr);
+    }
+
+    [Fact]
+    public void ResolveClrTypeForGenericArg_Returns_Mapped_Type_For_NonNullable_Imported_Type()
+    {
+        var refs = ReferenceResolver.Default();
+        var clr = NullableLifting.ResolveClrTypeForGenericArg(refs, TypeSymbol.Int32);
+        Assert.Equal(typeof(int), clr);
+    }
+
+    [Fact]
+    public void ResolveClrTypeForGenericArg_Returns_Null_For_TypeSymbol_With_No_ClrType()
+    {
+        var refs = ReferenceResolver.Default();
+        var userStruct = new StructSymbol(
+            "MyStruct",
+            ImmutableArray<FieldSymbol>.Empty,
+            Accessibility.Public,
+            declaration: null!,
+            packageName: "test");
+        Assert.Null(userStruct.ClrType);
+
+        var clr = NullableLifting.ResolveClrTypeForGenericArg(refs, userStruct);
+        Assert.Null(clr);
+    }
+}


### PR DESCRIPTION
First of a phased `Nullable<T>` unification (bug-overview §6.1). This PR is a **pure refactor with no behaviour change** — every existing test still passes; the diff is +318/-62 across 8 files, of which ~205 lines are the new facade itself and 92 lines are new pinning tests.

### Why

`Nullable<T>` handling is scattered across many code paths in the binder and emitter today. Subsequent PRs in this phase (N-2 fixing issue #571, N-3 fixing issue #504 reopen, N-4 lifted operators) all need to plug into the same canonical `Nullable` seam. This PR introduces that seam so the follow-ups don't have to update N independent call sites.

### What

**New facade** — `src/Core/CodeAnalysis/Symbols/NullableLifting.cs` exposes the five members the binder and emitter currently inline:

| Member | Visibility | Origin |
| --- | --- | --- |
| `IsValueTypeNullable(NullableTypeSymbol)` | `internal` | moved verbatim from `ReflectionMetadataEmitter` |
| `IsValueTypeNullableClr(Type)` | `internal` | NEW helper — consolidates the inline `System.Nullable\`1` probe |
| `GetEffectiveClrType(TypeSymbol)` | `public` | moved from `NullableTypeSymbol` |
| `TryConstructNullable(ReferenceResolver, Type, out Type)` | `public` | moved + renamed from `MemberLookup.TryGetNullableConstructedType`; takes `ReferenceResolver` directly |
| `ResolveClrTypeForGenericArg(ReferenceResolver, TypeSymbol)` | `public` | moved from `Binder`; takes `ReferenceResolver` directly |

**Forwarding only** — every existing method on `ReflectionMetadataEmitter`, `NullableTypeSymbol`, `MemberLookup`, and `Binder` keeps its original signature, visibility, and parameter names, and becomes a one-line forward to the facade. No call site elsewhere in the codebase changes.

**Inline-probe replacements** — three sites that inlined the `System.Nullable\`1` discrimination are now one-liners through `NullableLifting.IsValueTypeNullableClr`:
- `TypeSymbol.FromClrType` (Nullable detection during CLR-to-symbol lift)
- `OverloadResolution.ClassifyImplicit` (null-source / nullable-target classification)
- `OverloadResolution.IsNullableWrap` (target check for nullable-wrap conversion)

### Tests

`test/Core.Tests/CodeAnalysis/Symbols/NullableLiftingTests.cs` — 18 facade-pinning tests covering value-type vs reference-type `NullableTypeSymbol`, the open vs constructed `Nullable<>` distinction, `null` arguments, `ReferenceResolver.Default()` round-trips for `Nullable<int>` and `Nullable<TimeSpan>`, and the reference-type `NullableTypeSymbol` contract documented at `Binder.cs:2387` (returns bare underlying because CLR has no separate `string?` type).

### Verification

| | Baseline | Post-change |
| --- | ---: | ---: |
| Sdk.Tests | 24 | 24 |
| Interpreter.Tests | 72 | 72 |
| LanguageServer.Tests | 242 | 242 |
| Core.Tests | 2121 (2120 + 1 skipped) | 2139 (2138 + 1 skipped) |
| Compiler.Tests | 617 | 617 |
| **Total** | **3076** | **3094** |

Diff = +18, matching the new facade-pinning tests exactly. Zero regressions.

### Scope notes

- Does **not** close any issue — this PR fixes nothing on its own; it is the seam that lets the follow-up PRs land cleanly.
- The remaining inline `System.Nullable\`1` probes in `Evaluator`, `AsyncStateMachineTypeBuilder`, and `SymbolDocumentationIdProvider` are intentionally **left untouched** in this PR. They migrate as part of the behavioural PRs (N-2 / N-3 / N-4) that need to change their behaviour, so the migration commit and the behaviour commit are co-located in history.