### PR TITLE
PR N-4: close #574 (CLR enum ==/!=/comparisons) + add lifted Nullable<T> binary operators (§6.1 / C# §7.3.7)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -104,14 +104,31 @@ public sealed class BoundBinaryOperator
             return new BoundBinaryOperator(syntaxKind, cmpKind, ltp, ltp, TypeSymbol.Bool);
         }
 
-        // Phase 6.8: enum equality compares the underlying int values.
-        if ((syntaxKind == SyntaxKind.EqualsEqualsToken || syntaxKind == SyntaxKind.BangEqualsToken)
-            && leftType is EnumSymbol le && rightType is EnumSymbol re && le == re)
+        // Issue #574 (closes the "same family as #534" enum operator gap):
+        // == / != / < / <= / > / >= on same-type enum values. Both
+        // user-defined enums (EnumSymbol) and imported CLR enums
+        // (ImportedTypeSymbol whose ClrType.IsEnum) are supported via the
+        // shared IsEnumType helper — mirroring the bitwise arm below.
+        // Enums sit on the eval stack as their underlying integer so the
+        // existing Ceq / Clt / Cgt emit paths work transparently; signed
+        // vs unsigned dispatch is handled by IsUnsignedOrChar reading
+        // through to the enum's underlying type at emit time.
+        if (leftType != null && leftType == rightType && IsEnumType(leftType))
         {
-            var enumKind = syntaxKind == SyntaxKind.EqualsEqualsToken
-                ? BoundBinaryOperatorKind.Equals
-                : BoundBinaryOperatorKind.NotEquals;
-            return new BoundBinaryOperator(syntaxKind, enumKind, leftType, rightType, TypeSymbol.Bool);
+            var cmpKind = syntaxKind switch
+            {
+                SyntaxKind.EqualsEqualsToken => (BoundBinaryOperatorKind?)BoundBinaryOperatorKind.Equals,
+                SyntaxKind.BangEqualsToken => BoundBinaryOperatorKind.NotEquals,
+                SyntaxKind.LessToken => BoundBinaryOperatorKind.Less,
+                SyntaxKind.LessOrEqualsToken => BoundBinaryOperatorKind.LessOrEquals,
+                SyntaxKind.GreaterToken => BoundBinaryOperatorKind.Greater,
+                SyntaxKind.GreaterOrEqualsToken => BoundBinaryOperatorKind.GreaterOrEquals,
+                _ => null,
+            };
+            if (cmpKind != null)
+            {
+                return new BoundBinaryOperator(syntaxKind, cmpKind.Value, leftType, rightType, TypeSymbol.Bool);
+            }
         }
 
         // Issue #534: bitwise |, &, ^ on same-type enum values.
@@ -174,7 +191,90 @@ public sealed class BoundBinaryOperator
             }
         }
 
+        // PR N-4 / §6.1 / C# §7.3.7: lifted binary operators over a
+        // value-type Nullable<T>. Triggered when both operands are
+        // NullableTypeSymbol wrapping the SAME value-type underlying.
+        // (Mixed `T? op T` is handled in BindBinaryExpression by lifting
+        // the non-nullable side to T? via an implicit conversion before
+        // re-binding.) Arithmetic / bitwise lift to T?; equality and
+        // ordering lift to bool. Shifts are intentionally excluded —
+        // they take a non-matching int rhs and are rarely used on
+        // nullables; falling through here leaves them as a non-fatal
+        // "operator undefined" diagnostic at user-source level.
+        if (leftType is NullableTypeSymbol lN
+            && rightType is NullableTypeSymbol rN
+            && lN == rN
+            && lN.UnderlyingType?.ClrType is { IsValueType: true })
+        {
+            // Look up the underlying-form operator. If it does not exist
+            // (e.g. the user wrote `+` on `bool?`, which has no underlying
+            // form), there is no lifted form either.
+            var underlyingOp = Bind(syntaxKind, lN.UnderlyingType, rN.UnderlyingType);
+            if (underlyingOp != null && IsLiftableKind(underlyingOp.Kind))
+            {
+                TypeSymbol liftedResult = IsLiftedToBoolKind(underlyingOp.Kind)
+                    ? (TypeSymbol)TypeSymbol.Bool
+                    : NullableTypeSymbol.Get(underlyingOp.Type);
+                return new BoundBinaryOperator(syntaxKind, underlyingOp.Kind, leftType, rightType, liftedResult);
+            }
+        }
+
         return null;
+    }
+
+    /// <summary>
+    /// PR N-4: returns true for operator kinds that have a lifted
+    /// counterpart per C# §7.3.7 — arithmetic, bitwise, equality, and
+    /// ordering. Logical short-circuit (&amp;&amp;, ||), null-coalesce, and
+    /// shift operators are excluded; the former two require the user-
+    /// defined `true`/`false` operator surface, null-coalesce is itself
+    /// the way to consume a nullable, and shifts are bound on a non-
+    /// matching int rhs which the simple matching arm cannot lift.
+    /// </summary>
+    private static bool IsLiftableKind(BoundBinaryOperatorKind kind)
+    {
+        switch (kind)
+        {
+            case BoundBinaryOperatorKind.Sum:
+            case BoundBinaryOperatorKind.Difference:
+            case BoundBinaryOperatorKind.Product:
+            case BoundBinaryOperatorKind.Quotient:
+            case BoundBinaryOperatorKind.Remainder:
+            case BoundBinaryOperatorKind.BitwiseAnd:
+            case BoundBinaryOperatorKind.BitwiseOr:
+            case BoundBinaryOperatorKind.BitwiseXor:
+            case BoundBinaryOperatorKind.BitClear:
+            case BoundBinaryOperatorKind.Equals:
+            case BoundBinaryOperatorKind.NotEquals:
+            case BoundBinaryOperatorKind.Less:
+            case BoundBinaryOperatorKind.LessOrEquals:
+            case BoundBinaryOperatorKind.Greater:
+            case BoundBinaryOperatorKind.GreaterOrEquals:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// PR N-4: returns true for operator kinds whose lifted form has
+    /// result type <c>bool</c> rather than <c>Nullable&lt;R&gt;</c>
+    /// (equality and ordering, per C# §7.3.7).
+    /// </summary>
+    private static bool IsLiftedToBoolKind(BoundBinaryOperatorKind kind)
+    {
+        switch (kind)
+        {
+            case BoundBinaryOperatorKind.Equals:
+            case BoundBinaryOperatorKind.NotEquals:
+            case BoundBinaryOperatorKind.Less:
+            case BoundBinaryOperatorKind.LessOrEquals:
+            case BoundBinaryOperatorKind.Greater:
+            case BoundBinaryOperatorKind.GreaterOrEquals:
+                return true;
+            default:
+                return false;
+        }
     }
 
     private static bool IsNullCompare(TypeSymbol nullableOrUnderlying, TypeSymbol nullCandidate)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -409,6 +409,39 @@ internal sealed partial class ExpressionBinder
 
         var boundOperator = BoundBinaryOperator.Bind(syntax.OperatorToken.Kind, boundLeft.Type, boundRight.Type);
 
+        // PR N-4 / §6.1 / C# §7.3.7: mixed-mode lift. When one operand is
+        // a value-type Nullable<T> and the other is its underlying T, lift
+        // T to T? via the existing implicit conversion and re-bind. The
+        // re-bound operator hits the lifted arm in BoundBinaryOperator.Bind
+        // which returns a (T?, T?) operator; the converted operands then
+        // match its declared operand types so emit can rely on both sides
+        // being Nullable<T> at the operator site.
+        if (boundOperator == null)
+        {
+            if (boundLeft.Type is NullableTypeSymbol leftNullable
+                && leftNullable.UnderlyingType?.ClrType is { IsValueType: true }
+                && boundRight.Type == leftNullable.UnderlyingType)
+            {
+                var lifted = BoundBinaryOperator.Bind(syntax.OperatorToken.Kind, leftNullable, leftNullable);
+                if (lifted != null)
+                {
+                    boundRight = conversions.BindConversion(syntax.Right.Location, boundRight, leftNullable);
+                    boundOperator = lifted;
+                }
+            }
+            else if (boundRight.Type is NullableTypeSymbol rightNullable
+                && rightNullable.UnderlyingType?.ClrType is { IsValueType: true }
+                && boundLeft.Type == rightNullable.UnderlyingType)
+            {
+                var lifted = BoundBinaryOperator.Bind(syntax.OperatorToken.Kind, rightNullable, rightNullable);
+                if (lifted != null)
+                {
+                    boundLeft = conversions.BindConversion(syntax.Left.Location, boundLeft, rightNullable);
+                    boundOperator = lifted;
+                }
+            }
+        }
+
         if (boundOperator == null)
         {
             // Stream D: try user-defined `func (a T) operator <op>(b U) R` on

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -210,6 +210,22 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // PR N-4 / §6.1 / C# §7.3.7: lifted binary operators over a
+        // value-type Nullable<T>. The collector pre-allocates LHS / RHS
+        // (Nullable<T>) and optional result (Nullable<R>) slots; the
+        // emitted IL spills both operands once, branches on their
+        // HasValue flags, and then either calls get_Value to compute the
+        // underlying op (wrapping the scalar result as a fresh
+        // Nullable<R> for arithmetic / bitwise) or yields the relevant
+        // bool for equality / ordering. Must precede the bottom of this
+        // method, whose `add/clt/...` opcodes would otherwise see two
+        // struct values on the stack and produce invalid IL.
+        if (this.liftedBinarySlots.TryGetValue(b, out var liftedSlots))
+        {
+            this.EmitLiftedNullableBinary(b, liftedSlots);
+            return;
+        }
+
         // String concatenation / equality go through BCL helpers.
         if (b.Left.Type == TypeSymbol.String && b.Right.Type == TypeSymbol.String)
         {
@@ -608,6 +624,372 @@ internal sealed partial class MethodBodyEmitter
 
         this.il.Call(this.outer.GetMethodEntityHandle(op));
         return true;
+    }
+
+    // PR N-4 / §6.1 / C# §7.3.7: emits a lifted binary operator over a
+    // value-type Nullable<T>. The pre-allocated slot bundle gives the
+    // emitter two Nullable<T>-typed operand slots and, for arithmetic /
+    // bitwise operators that produce Nullable<R>, one result slot.
+    //
+    // The emit shape varies by result type:
+    //
+    //   * Lifted equality (== / !=) on Nullable<T>:
+    //       spill x and y; compare HasValue flags;
+    //         - if HasValue differs → false
+    //         - if both have no value → true
+    //         - otherwise → underlying op (x.Value == y.Value)
+    //       Followed by `ldc.i4.0; ceq` for !=.
+    //
+    //   * Lifted ordering (< <= > >=) on Nullable<T>:
+    //       spill x and y; if either lacks value → false;
+    //         otherwise → underlying compare on x.Value / y.Value.
+    //
+    //   * Lifted arithmetic / bitwise on Nullable<T>:
+    //       spill x and y; if either lacks value → default(Nullable<R>);
+    //         otherwise → newobj Nullable<R>::.ctor(x.Value op y.Value).
+    private void EmitLiftedNullableBinary(BoundBinaryExpression b, LiftedBinarySlots slots)
+    {
+        var leftNullable = (NullableTypeSymbol)b.Left.Type;
+        var underlying = leftNullable.UnderlyingType;
+        var underlyingClr = underlying.ClrType
+            ?? throw new InvalidOperationException(
+                $"Lifted binary operator '{b.Op.Kind}' on Nullable<{underlying.Name}>: underlying has no CLR type.");
+
+        var lhsSlot = slots.LhsSlot;
+        var rhsSlot = slots.RhsSlot;
+
+        // Form 2: `x? == nil` / `x? != nil`. The IsNullCompare arm binds
+        // this with right-operand type Null; the slot bundle has no RHS
+        // and no result slot. Spill the LHS once and consult HasValue.
+        // For `== nil` the result is `!HasValue`; for `!= nil` it is
+        // `HasValue`.
+        if (b.Right.Type == TypeSymbol.Null)
+        {
+            var getHasValue = this.outer.wellKnown.GetNullableGetHasValueReference(underlyingClr);
+
+            this.EmitExpression(b.Left);
+            this.il.StoreLocal(lhsSlot);
+            this.il.LoadLocalAddress(lhsSlot);
+            this.il.OpCode(ILOpCode.Call);
+            this.il.Token(getHasValue);
+
+            if (b.Op.Kind == BoundBinaryOperatorKind.Equals)
+            {
+                // !HasValue
+                this.il.LoadConstantI4(0);
+                this.il.OpCode(ILOpCode.Ceq);
+            }
+
+            return;
+        }
+
+        // Spill both operands.
+        this.EmitExpression(b.Left);
+        this.il.StoreLocal(lhsSlot);
+        this.EmitExpression(b.Right);
+        this.il.StoreLocal(rhsSlot);
+
+        bool isEquality = b.Op.Kind == BoundBinaryOperatorKind.Equals
+            || b.Op.Kind == BoundBinaryOperatorKind.NotEquals;
+        bool isOrdering = b.Op.Kind == BoundBinaryOperatorKind.Less
+            || b.Op.Kind == BoundBinaryOperatorKind.LessOrEquals
+            || b.Op.Kind == BoundBinaryOperatorKind.Greater
+            || b.Op.Kind == BoundBinaryOperatorKind.GreaterOrEquals;
+
+        if (isEquality)
+        {
+            this.EmitLiftedEquality(b.Op.Kind, lhsSlot, rhsSlot, underlying, underlyingClr);
+            return;
+        }
+
+        if (isOrdering)
+        {
+            this.EmitLiftedOrdering(b.Op.Kind, lhsSlot, rhsSlot, underlying, underlyingClr);
+            return;
+        }
+
+        // Arithmetic / bitwise: produces Nullable<R>. Result slot is
+        // populated by the planner so the null branch can `initobj` a
+        // default Nullable<R> and `ldloc` it as a value.
+        if (slots.ResultSlot < 0)
+        {
+            throw new InvalidOperationException(
+                $"Lifted binary operator '{b.Op.Kind}' produces Nullable<R> but no result slot was pre-allocated; "
+                + "check LiftedBinaryOperatorCollector and the prepass in CollectLocalsAndLabels.");
+        }
+
+        this.EmitLiftedArithmetic(b.Op.Kind, lhsSlot, rhsSlot, slots.ResultSlot, underlying, underlyingClr);
+    }
+
+    private void EmitLiftedEquality(
+        BoundBinaryOperatorKind kind,
+        int lhsSlot,
+        int rhsSlot,
+        TypeSymbol underlying,
+        Type underlyingClr)
+    {
+        var getHasValue = this.outer.wellKnown.GetNullableGetHasValueReference(underlyingClr);
+        var getValue = this.outer.wellKnown.GetNullableGetValueReference(underlyingClr);
+
+        var bothEmptyLabel = this.il.DefineLabel();
+        var flagsAgreeLabel = this.il.DefineLabel();
+        var end = this.il.DefineLabel();
+
+        // Compare HasValue flags. If they differ, result is false.
+        this.il.LoadLocalAddress(lhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getHasValue);
+        this.il.LoadLocalAddress(rhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getHasValue);
+        this.il.Branch(ILOpCode.Beq, flagsAgreeLabel);
+
+        // Mismatched HasValue → false.
+        this.il.LoadConstantI4(0);
+        this.il.Branch(ILOpCode.Br, end);
+
+        // Agreed: either both empty (→ true) or both present (→ underlying ceq).
+        this.il.MarkLabel(flagsAgreeLabel);
+        this.il.LoadLocalAddress(lhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getHasValue);
+        this.il.Branch(ILOpCode.Brfalse, bothEmptyLabel);
+
+        // Both present: load values and compare.
+        this.il.LoadLocalAddress(lhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getValue);
+        this.il.LoadLocalAddress(rhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getValue);
+        this.EmitUnderlyingEqualityCeq(underlying);
+        this.il.Branch(ILOpCode.Br, end);
+
+        this.il.MarkLabel(bothEmptyLabel);
+        this.il.LoadConstantI4(1);
+
+        this.il.MarkLabel(end);
+
+        // For !=, append `ldc.i4.0; ceq` to negate.
+        if (kind == BoundBinaryOperatorKind.NotEquals)
+        {
+            this.il.LoadConstantI4(0);
+            this.il.OpCode(ILOpCode.Ceq);
+        }
+    }
+
+    private void EmitLiftedOrdering(
+        BoundBinaryOperatorKind kind,
+        int lhsSlot,
+        int rhsSlot,
+        TypeSymbol underlying,
+        Type underlyingClr)
+    {
+        var getHasValue = this.outer.wellKnown.GetNullableGetHasValueReference(underlyingClr);
+        var getValue = this.outer.wellKnown.GetNullableGetValueReference(underlyingClr);
+
+        var falseLabel = this.il.DefineLabel();
+        var end = this.il.DefineLabel();
+
+        // (lhs.HasValue & rhs.HasValue) — if any is absent, result is false.
+        this.il.LoadLocalAddress(lhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getHasValue);
+        this.il.LoadLocalAddress(rhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getHasValue);
+        this.il.OpCode(ILOpCode.And);
+        this.il.Branch(ILOpCode.Brfalse, falseLabel);
+
+        // Both present: load underlying values and compare.
+        this.il.LoadLocalAddress(lhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getValue);
+        this.il.LoadLocalAddress(rhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getValue);
+        this.EmitUnderlyingOrdering(kind, underlying);
+        this.il.Branch(ILOpCode.Br, end);
+
+        this.il.MarkLabel(falseLabel);
+        this.il.LoadConstantI4(0);
+
+        this.il.MarkLabel(end);
+    }
+
+    private void EmitLiftedArithmetic(
+        BoundBinaryOperatorKind kind,
+        int lhsSlot,
+        int rhsSlot,
+        int resultSlot,
+        TypeSymbol underlying,
+        Type underlyingClr)
+    {
+        var getHasValue = this.outer.wellKnown.GetNullableGetHasValueReference(underlyingClr);
+        var getValue = this.outer.wellKnown.GetNullableGetValueReference(underlyingClr);
+
+        // Resolve Nullable<R> ctor / type tokens for the result.
+        // R == underlying for arithmetic / bitwise.
+        if (!NullableLifting.TryConstructNullable(this.outer.emitCtx.References, underlyingClr, out var nullableClr))
+        {
+            throw new InvalidOperationException(
+                $"Cannot construct Nullable<{underlyingClr.FullName}>: System.Nullable`1 is not resolvable in the reference set.");
+        }
+
+        var nullableInnerArg = nullableClr.GetGenericArguments()[0];
+        var ctor = nullableClr.GetConstructor(new[] { nullableInnerArg })
+            ?? throw new InvalidOperationException(
+                $"Nullable<{nullableInnerArg.FullName}> has no single-arg constructor.");
+        var nullableToken = this.outer.GetTypeHandleForMember(nullableClr);
+
+        var nullBranch = this.il.DefineLabel();
+        var end = this.il.DefineLabel();
+
+        // Both present? If yes, fall through to compute; otherwise jump to null branch.
+        this.il.LoadLocalAddress(lhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getHasValue);
+        this.il.LoadLocalAddress(rhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getHasValue);
+        this.il.OpCode(ILOpCode.And);
+        this.il.Branch(ILOpCode.Brfalse, nullBranch);
+
+        // Compute underlying op and wrap as Nullable<R>.
+        this.il.LoadLocalAddress(lhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getValue);
+        this.il.LoadLocalAddress(rhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getValue);
+        this.EmitUnderlyingArithmetic(kind, underlying);
+        this.il.OpCode(ILOpCode.Newobj);
+        this.il.Token(this.outer.GetCtorReference(ctor));
+        this.il.Branch(ILOpCode.Br, end);
+
+        // Null branch: default(Nullable<R>) via initobj + ldloc.
+        this.il.MarkLabel(nullBranch);
+        this.il.LoadLocalAddress(resultSlot);
+        this.il.OpCode(ILOpCode.Initobj);
+        this.il.Token(nullableToken);
+        this.il.LoadLocal(resultSlot);
+
+        this.il.MarkLabel(end);
+    }
+
+    // Emits the IL for equality comparison on two values of `underlying`
+    // already on the stack. Decimal routes through the static
+    // op_Equality method; everything else uses `ceq`.
+    private void EmitUnderlyingEqualityCeq(TypeSymbol underlying)
+    {
+        if (underlying == TypeSymbol.Decimal)
+        {
+            if (!this.TryEmitDecimalBinary(BoundBinaryOperatorKind.Equals))
+            {
+                throw new InvalidOperationException("Lifted decimal equality emit failed: decimal op_Equality is not resolvable.");
+            }
+
+            return;
+        }
+
+        this.il.OpCode(ILOpCode.Ceq);
+    }
+
+    // Emits the IL for an ordering comparison on two values of
+    // `underlying` already on the stack. Mirrors the dispatch in
+    // EmitBinary's bottom switch for less / less-or-equals / greater /
+    // greater-or-equals: unsigned-or-char chooses the un-suffixed
+    // variant, and a (clt/cgt) + (ldc.i4.0; ceq) negation is used for
+    // <= and >=.
+    private void EmitUnderlyingOrdering(BoundBinaryOperatorKind kind, TypeSymbol underlying)
+    {
+        if (underlying == TypeSymbol.Decimal)
+        {
+            if (!this.TryEmitDecimalBinary(kind))
+            {
+                throw new InvalidOperationException($"Lifted decimal '{kind}' emit failed.");
+            }
+
+            return;
+        }
+
+        bool isUnsigned = IsUnsignedOrChar(underlying);
+        switch (kind)
+        {
+            case BoundBinaryOperatorKind.Less:
+                this.il.OpCode(isUnsigned ? ILOpCode.Clt_un : ILOpCode.Clt);
+                break;
+            case BoundBinaryOperatorKind.LessOrEquals:
+                this.il.OpCode(isUnsigned ? ILOpCode.Cgt_un : ILOpCode.Cgt);
+                this.il.LoadConstantI4(0);
+                this.il.OpCode(ILOpCode.Ceq);
+                break;
+            case BoundBinaryOperatorKind.Greater:
+                this.il.OpCode(isUnsigned ? ILOpCode.Cgt_un : ILOpCode.Cgt);
+                break;
+            case BoundBinaryOperatorKind.GreaterOrEquals:
+                this.il.OpCode(isUnsigned ? ILOpCode.Clt_un : ILOpCode.Clt);
+                this.il.LoadConstantI4(0);
+                this.il.OpCode(ILOpCode.Ceq);
+                break;
+            default:
+                throw new NotSupportedException($"EmitUnderlyingOrdering: unexpected kind '{kind}'.");
+        }
+    }
+
+    // Emits the IL for an arithmetic or bitwise op on two values of
+    // `underlying` already on the stack. Decimal routes through static
+    // op_* methods; primitive types map to the matching opcode and then
+    // apply sub-i4 truncation when the underlying is byte / sbyte /
+    // short / ushort / char.
+    private void EmitUnderlyingArithmetic(BoundBinaryOperatorKind kind, TypeSymbol underlying)
+    {
+        if (underlying == TypeSymbol.Decimal)
+        {
+            if (!this.TryEmitDecimalBinary(kind))
+            {
+                throw new NotSupportedException($"Lifted decimal '{kind}' emit failed.");
+            }
+
+            return;
+        }
+
+        bool isUnsigned = IsUnsignedOrChar(underlying);
+        switch (kind)
+        {
+            case BoundBinaryOperatorKind.Sum:
+                this.il.OpCode(ILOpCode.Add);
+                break;
+            case BoundBinaryOperatorKind.Difference:
+                this.il.OpCode(ILOpCode.Sub);
+                break;
+            case BoundBinaryOperatorKind.Product:
+                this.il.OpCode(ILOpCode.Mul);
+                break;
+            case BoundBinaryOperatorKind.Quotient:
+                this.il.OpCode(isUnsigned ? ILOpCode.Div_un : ILOpCode.Div);
+                break;
+            case BoundBinaryOperatorKind.Remainder:
+                this.il.OpCode(isUnsigned ? ILOpCode.Rem_un : ILOpCode.Rem);
+                break;
+            case BoundBinaryOperatorKind.BitwiseAnd:
+                this.il.OpCode(ILOpCode.And);
+                break;
+            case BoundBinaryOperatorKind.BitwiseOr:
+                this.il.OpCode(ILOpCode.Or);
+                break;
+            case BoundBinaryOperatorKind.BitwiseXor:
+                this.il.OpCode(ILOpCode.Xor);
+                break;
+            case BoundBinaryOperatorKind.BitClear:
+                this.il.OpCode(ILOpCode.Not);
+                this.il.OpCode(ILOpCode.And);
+                break;
+            default:
+                throw new NotSupportedException($"EmitUnderlyingArithmetic: unexpected kind '{kind}'.");
+        }
+
+        EmitNarrowingTruncationIfNeeded(kind, underlying);
     }
 
     private void EmitClrBinaryOperator(BoundClrBinaryOperatorExpression op)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -65,6 +65,7 @@ internal sealed partial class MethodBodyEmitter
     private readonly Dictionary<BoundExpression, int> receiverSpillSlots;
     private readonly Dictionary<BoundExpression, int> indexAssignmentValueSlots;
     private readonly Dictionary<BoundGoStatement, BoundScopeStatement> goEnclosingScopes;
+    private readonly Dictionary<BoundBinaryExpression, LiftedBinarySlots> liftedBinarySlots;
     private readonly ParameterSymbol structThisParameter;
     private readonly Lowering.Async.AsyncStateMachineFieldMap asyncFieldMap;
     private readonly Lowering.Async.AsyncStateMachinePlan asyncPlan;
@@ -111,6 +112,7 @@ internal sealed partial class MethodBodyEmitter
         Dictionary<BoundExpression, int> receiverSpillSlots,
         Dictionary<BoundExpression, int> indexAssignmentValueSlots,
         Dictionary<BoundGoStatement, BoundScopeStatement> goEnclosingScopes,
+        Dictionary<BoundBinaryExpression, LiftedBinarySlots> liftedBinarySlots = null,
         ParameterSymbol structThisParameter = null,
         Lowering.Async.AsyncStateMachineFieldMap asyncFieldMap = null,
         Lowering.Async.AsyncStateMachinePlan asyncPlan = null,
@@ -136,6 +138,7 @@ internal sealed partial class MethodBodyEmitter
         this.receiverSpillSlots = receiverSpillSlots;
         this.indexAssignmentValueSlots = indexAssignmentValueSlots;
         this.goEnclosingScopes = goEnclosingScopes;
+        this.liftedBinarySlots = liftedBinarySlots ?? new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
         this.structThisParameter = structThisParameter;
         this.asyncFieldMap = asyncFieldMap;
         this.asyncPlan = asyncPlan;
@@ -510,12 +513,30 @@ internal sealed partial class MethodBodyEmitter
 
     private static bool IsUnsignedOrChar(TypeSymbol t)
     {
-        return t == TypeSymbol.UInt8
+        if (t == TypeSymbol.UInt8
             || t == TypeSymbol.UInt16
             || t == TypeSymbol.UInt32
             || t == TypeSymbol.UInt64
             || t == TypeSymbol.NUInt
-            || t == TypeSymbol.Char;
+            || t == TypeSymbol.Char)
+        {
+            return true;
+        }
+
+        // Issue #574: enum comparisons (< <= > >=) dispatch through the
+        // enum's CLR underlying type. A byte/ushort/uint/ulong-backed
+        // enum needs the unsigned IL comparison opcodes (clt_un / cgt_un);
+        // a sbyte/short/int/long-backed enum needs the signed forms.
+        if (t?.ClrType?.IsEnum == true)
+        {
+            var underlyingName = System.Enum.GetUnderlyingType(t.ClrType).FullName;
+            return underlyingName == "System.Byte"
+                || underlyingName == "System.UInt16"
+                || underlyingName == "System.UInt32"
+                || underlyingName == "System.UInt64";
+        }
+
+        return false;
     }
 
     // Issue #520: the EmitLoad/StoreElement helpers need to distinguish

--- a/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
@@ -310,6 +310,7 @@ internal sealed class MethodBodyPlanner
         Dictionary<BoundExpression, int> receiverSpillSlots,
         Dictionary<BoundExpression, int> indexAssignmentValueSlots,
         Dictionary<BoundGoStatement, BoundScopeStatement> goEnclosingScopes,
+        Dictionary<BoundBinaryExpression, LiftedBinarySlots> liftedBinarySlots,
         InstructionEncoder il)
     {
         this.CollectStatements(body.Statements, function, locals, localTypes, labels, appendSlots, il, pass: 1);
@@ -502,6 +503,48 @@ internal sealed class MethodBodyPlanner
             var slot = localTypes.Count;
             localTypes.Add(coalesce.Left.Type);
             receiverSpillSlots[coalesce] = slot;
+        }
+
+        // PR N-4 / §6.1 / C# §7.3.7: lifted binary operators over a value-
+        // type Nullable<T>. Each call site needs two Nullable<T>-typed
+        // operand slots (LHS, RHS) so the emitter can take their addresses
+        // for `call get_HasValue` / `call get_Value`. Arithmetic / bitwise
+        // operators additionally need a Nullable<R>-typed result slot for
+        // the null-branch `ldloca; initobj Nullable<R>; ldloc` shape;
+        // equality / ordering operators return bool and need no result
+        // slot. The slot bundle is keyed by the BoundBinaryExpression
+        // node and stored in liftedBinarySlots so the emitter can look it
+        // up at lowering time. Skip nodes already owned by other
+        // collectors (NullCoalesce uses receiverSpillSlots) to avoid
+        // double allocation.
+        foreach (var lifted in this.CollectLiftedBinaryOperators(body))
+        {
+            if (liftedBinarySlots.ContainsKey(lifted))
+            {
+                continue;
+            }
+
+            var lhsSlot = localTypes.Count;
+            localTypes.Add(lifted.Left.Type);
+
+            // `value-type Nullable<T> == nil` / `!= nil` only needs an
+            // LHS spill slot; the RHS is the `nil` literal (no temp
+            // required) and the result is bool (no result slot).
+            int rhsSlot = -1;
+            int resultSlot = -1;
+            if (lifted.Right.Type != TypeSymbol.Null)
+            {
+                rhsSlot = localTypes.Count;
+                localTypes.Add(lifted.Right.Type);
+
+                if (lifted.Type is NullableTypeSymbol)
+                {
+                    resultSlot = localTypes.Count;
+                    localTypes.Add(lifted.Type);
+                }
+            }
+
+            liftedBinarySlots[lifted] = new LiftedBinarySlots(lhsSlot, rhsSlot, resultSlot);
         }
     }
 
@@ -942,6 +985,19 @@ internal sealed class MethodBodyPlanner
     {
         var sink = new List<BoundBinaryExpression>();
         this.slotPlanner.CollectNullableValueTypeCoalesces((BoundStatement)root, sink);
+        return sink;
+    }
+
+    // PR N-4 / §6.1 / C# §7.3.7: each lifted binary operator over a
+    // value-type Nullable<T> lowers at emit time to a HasValue / get_Value
+    // sequence that needs two Nullable<T>-typed temp slots (one per
+    // operand). Arithmetic / bitwise forms additionally need a
+    // Nullable<R>-typed result slot so the null branch can initobj a
+    // default Nullable<R> and load it as a value.
+    internal IEnumerable<BoundBinaryExpression> CollectLiftedBinaryOperators(BoundNode root)
+    {
+        var sink = new List<BoundBinaryExpression>();
+        this.slotPlanner.CollectLiftedBinaryOperators((BoundStatement)root, sink);
         return sink;
     }
 

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -2197,6 +2197,7 @@ internal sealed class ReflectionMetadataEmitter
             var receiverSpillSlots = new Dictionary<BoundExpression, int>();
             var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
             var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
+            var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
 
             // Issue #216: collect compile-time const bindings before slot allocation.
             var constValues = new Dictionary<VariableSymbol, object>();
@@ -2221,6 +2222,7 @@ internal sealed class ReflectionMetadataEmitter
                 receiverSpillSlots,
                 indexAssignmentValueSlots,
                 goEnclosingScopes,
+                liftedBinarySlots,
                 il);
 
             // MoveNext is instance on the SM struct: arg0 = this.
@@ -2261,6 +2263,7 @@ internal sealed class ReflectionMetadataEmitter
                 receiverSpillSlots,
                 indexAssignmentValueSlots,
                 goEnclosingScopes,
+                liftedBinarySlots: liftedBinarySlots,
                 constValues: constValues,
                 structThisParameter: moveNextBody.ThisParameter,
                 asyncFieldMap: plan.FieldMap,
@@ -2360,6 +2363,7 @@ internal sealed class ReflectionMetadataEmitter
         var receiverSpillSlots = new Dictionary<BoundExpression, int>();
         var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
         var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
+        var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
         var constValues = new Dictionary<VariableSymbol, object>();
 
         this.methodBodyPlanner.CollectLocalsAndLabels(
@@ -2381,6 +2385,7 @@ internal sealed class ReflectionMetadataEmitter
             receiverSpillSlots,
             indexAssignmentValueSlots,
             goEnclosingScopes,
+            liftedBinarySlots,
             il);
 
         var parameters = new Dictionary<ParameterSymbol, int>();
@@ -2417,6 +2422,7 @@ internal sealed class ReflectionMetadataEmitter
             receiverSpillSlots,
             indexAssignmentValueSlots,
             goEnclosingScopes,
+            liftedBinarySlots: liftedBinarySlots,
             constValues: constValues);
         emitter.EmitBlock(body);
         il.OpCode(ILOpCode.Ret);
@@ -2454,6 +2460,7 @@ internal sealed class ReflectionMetadataEmitter
         var receiverSpillSlots = new Dictionary<BoundExpression, int>();
         var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
         var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
+        var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
         var constValues = new Dictionary<VariableSymbol, object>();
 
         // Pre-scan the base arguments so any scratch slots they require are
@@ -2485,6 +2492,7 @@ internal sealed class ReflectionMetadataEmitter
                 receiverSpillSlots,
                 indexAssignmentValueSlots,
                 goEnclosingScopes,
+                liftedBinarySlots,
                 il);
         }
 
@@ -2526,6 +2534,7 @@ internal sealed class ReflectionMetadataEmitter
             receiverSpillSlots,
             indexAssignmentValueSlots,
             goEnclosingScopes,
+            liftedBinarySlots: liftedBinarySlots,
             constValues: constValues);
 
         // base(args)
@@ -2600,6 +2609,7 @@ internal sealed class ReflectionMetadataEmitter
         var receiverSpillSlots = new Dictionary<BoundExpression, int>();
         var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
         var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
+        var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
         var constValues = new Dictionary<VariableSymbol, object>();
 
         // Pre-scan the base arguments so any scratch slots they require are
@@ -2631,6 +2641,7 @@ internal sealed class ReflectionMetadataEmitter
                 receiverSpillSlots,
                 indexAssignmentValueSlots,
                 goEnclosingScopes,
+                liftedBinarySlots,
                 il);
         }
 
@@ -2654,6 +2665,7 @@ internal sealed class ReflectionMetadataEmitter
             receiverSpillSlots,
             indexAssignmentValueSlots,
             goEnclosingScopes,
+            liftedBinarySlots,
             il);
 
         // Slot 0 is the implicit `this`; user parameters shift up by one.
@@ -2698,6 +2710,7 @@ internal sealed class ReflectionMetadataEmitter
             receiverSpillSlots,
             indexAssignmentValueSlots,
             goEnclosingScopes,
+            liftedBinarySlots: liftedBinarySlots,
             constValues: constValues);
 
         // base(args) — `this` followed by the (ref-kind aware) base arguments.
@@ -2779,6 +2792,7 @@ internal sealed class ReflectionMetadataEmitter
                 var receiverSpillSlots = new Dictionary<BoundExpression, int>();
                 var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
                 var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
+                var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
 
                 // Issue #216: collect compile-time const bindings before slot allocation.
                 var constValues = new Dictionary<VariableSymbol, object>();
@@ -2803,6 +2817,7 @@ internal sealed class ReflectionMetadataEmitter
                     receiverSpillSlots,
                     indexAssignmentValueSlots,
                     goEnclosingScopes,
+                    liftedBinarySlots,
                     il);
 
                 // For instance methods, IL slot 0 is the implicit `this`, so user
@@ -2879,6 +2894,7 @@ internal sealed class ReflectionMetadataEmitter
                     receiverSpillSlots,
                     indexAssignmentValueSlots,
                     goEnclosingScopes,
+                    liftedBinarySlots: liftedBinarySlots,
                     constValues: constValues,
                     structThisParameter: structThis,
                     asyncIteratorEmitCtx: aiEmitCtx,

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -152,6 +152,9 @@ internal sealed class SlotPlanner
     public void CollectNullableValueTypeCoalesces(BoundStatement root, List<BoundBinaryExpression> sink)
         => new NullableValueTypeCoalesceCollector(sink).Visit(root);
 
+    public void CollectLiftedBinaryOperators(BoundStatement root, List<BoundBinaryExpression> sink)
+        => new LiftedBinaryOperatorCollector(sink).Visit(root);
+
     public void RunPatternSwitchAllocator(
         BoundNode node,
         Dictionary<VariableSymbol, int> locals,
@@ -1036,6 +1039,129 @@ internal sealed class SlotPlanner
             base.VisitBinaryExpression(node);
         }
     }
+
+    // PR N-4 / §6.1 / C# §7.3.7: walks the bound tree collecting every
+    // BoundBinaryExpression that is a lifted operator over a value-type
+    // Nullable<T>. The emitter needs a fixed set of scratch slots per
+    // lifted operator site:
+    //   * one Nullable<T>-typed slot for the LHS spill (so the emitter can
+    //     take its address for call get_HasValue / get_Value),
+    //   * one Nullable<T>-typed slot for the RHS spill (same reason),
+    //   * one Nullable<R>-typed slot for the result when the operator
+    //     produces Nullable<R> (arithmetic / bitwise). The slot is used to
+    //     initobj a default Nullable<R> on the "null" branch and then load
+    //     it as a value. The slot is NOT allocated for lifted equality /
+    //     ordering, whose result is bool.
+    // Mirrors NullableValueTypeCoalesceCollector but yields a richer
+    // per-node slot bundle.
+    private sealed class LiftedBinaryOperatorCollector : BoundTreeWalker
+    {
+        private readonly List<BoundBinaryExpression> sink;
+
+        public LiftedBinaryOperatorCollector(List<BoundBinaryExpression> sink)
+        {
+            this.sink = sink;
+        }
+
+        protected override void VisitBinaryExpression(BoundBinaryExpression node)
+        {
+            if (IsLiftedValueTypeBinary(node))
+            {
+                this.sink.Add(node);
+            }
+
+            base.VisitBinaryExpression(node);
+        }
+
+        private static bool IsLiftedValueTypeBinary(BoundBinaryExpression node)
+        {
+            // Form 1: classic lifted form — both LHS and RHS are
+            // value-type Nullable<T> wrapping the same underlying. The
+            // lifted binder arm enforces this; the mixed-mode binder
+            // lift inserts an implicit `T -> T?` conversion for the
+            // non-nullable side before binding the operator.
+            //
+            // Form 2: `value-type Nullable<T> == nil` / `!= nil` — bound
+            // by the IsNullCompare arm with left=Nullable<T>, right=Null.
+            // Without slot allocation the bottom of EmitBinary would
+            // load the LHS as a struct value and the RHS as `ldnull`
+            // and then emit `ceq` — an `InvalidProgramException` at
+            // runtime. Treating this as a lifted form lets the emitter
+            // spill the LHS once and consult `HasValue`.
+            bool leftIsValueNullable = node.Left.Type is NullableTypeSymbol left
+                && left.UnderlyingType?.ClrType is { IsValueType: true };
+            if (!leftIsValueNullable)
+            {
+                return false;
+            }
+
+            if (node.Right.Type == TypeSymbol.Null)
+            {
+                return node.Op.Kind is BoundBinaryOperatorKind.Equals
+                    or BoundBinaryOperatorKind.NotEquals;
+            }
+
+            if (node.Right.Type is not NullableTypeSymbol rightNullable
+                || (NullableTypeSymbol)node.Left.Type! != rightNullable)
+            {
+                return false;
+            }
+
+            // Exclude operators whose value-type Nullable<T> emit is already
+            // owned by dedicated collectors (NullCoalesce, NullAssertion).
+            switch (node.Op.Kind)
+            {
+                case BoundBinaryOperatorKind.Sum:
+                case BoundBinaryOperatorKind.Difference:
+                case BoundBinaryOperatorKind.Product:
+                case BoundBinaryOperatorKind.Quotient:
+                case BoundBinaryOperatorKind.Remainder:
+                case BoundBinaryOperatorKind.BitwiseAnd:
+                case BoundBinaryOperatorKind.BitwiseOr:
+                case BoundBinaryOperatorKind.BitwiseXor:
+                case BoundBinaryOperatorKind.BitClear:
+                case BoundBinaryOperatorKind.Equals:
+                case BoundBinaryOperatorKind.NotEquals:
+                case BoundBinaryOperatorKind.Less:
+                case BoundBinaryOperatorKind.LessOrEquals:
+                case BoundBinaryOperatorKind.Greater:
+                case BoundBinaryOperatorKind.GreaterOrEquals:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}
+
+/// <summary>
+/// PR N-4 / §6.1 / C# §7.3.7: per-<see cref="BoundBinaryExpression"/>
+/// bundle of pre-allocated local slot indices that the body emitter
+/// consumes when lowering a lifted binary operator over a value-type
+/// <c>Nullable&lt;T&gt;</c>. Pre-allocated by <see cref="SlotPlanner"/>'s
+/// lifted-binary walker and stored in the per-method
+/// <c>liftedBinarySlots</c> dictionary.
+/// </summary>
+internal sealed class LiftedBinarySlots
+{
+    public LiftedBinarySlots(int lhsSlot, int rhsSlot, int resultSlot)
+    {
+        this.LhsSlot = lhsSlot;
+        this.RhsSlot = rhsSlot;
+        this.ResultSlot = resultSlot;
+    }
+
+    /// <summary>Gets the slot holding the spilled LHS <c>Nullable&lt;T&gt;</c>.</summary>
+    public int LhsSlot { get; }
+
+    /// <summary>Gets the slot holding the spilled RHS <c>Nullable&lt;T&gt;</c>.</summary>
+    public int RhsSlot { get; }
+
+    /// <summary>
+    /// Gets the slot holding the result <c>Nullable&lt;R&gt;</c>, or <c>-1</c>
+    /// when the lifted operator returns <c>bool</c> (equality / ordering).
+    /// </summary>
+    public int ResultSlot { get; }
 }
 
 /// <summary>

--- a/test/Compiler.Tests/Emit/Issue574EnumComparisonEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue574EnumComparisonEmitTests.cs
@@ -1,0 +1,528 @@
+// <copyright file="Issue574EnumComparisonEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #574 ("same family as #534"): the equality (== / !=) and ordering
+/// (&lt; / &lt;= / &gt; / &gt;=) operators must be defined for CLR enum
+/// types, mirroring the bitwise lowering shipped in PR #562. Previously
+/// the binder only matched user-defined <c>EnumSymbol == EnumSymbol</c>;
+/// imported BCL enums (which surface as <c>ImportedTypeSymbol</c> whose
+/// <c>ClrType.IsEnum</c>) tripped <c>GS0129 Binary operator '==' is not
+/// defined …</c>.
+///
+/// These tests pin the new behaviour:
+/// <list type="bullet">
+///   <item><c>==</c> / <c>!=</c> on imported BCL enums
+///   (<c>ConsoleKey</c>, <c>FileShare</c>) and on a user-defined C# probe
+///   enum.</item>
+///   <item><c>&lt;</c> / <c>&lt;=</c> / <c>&gt;</c> / <c>&gt;=</c> on
+///   signed-backed (int32) and unsigned-backed (byte) enums, the latter
+///   exercising the <c>clt_un</c> / <c>cgt_un</c> dispatch path.</item>
+///   <item>Regression: the user-defined <c>EnumSymbol == EnumSymbol</c> arm
+///   still works (it now flows through the same generalized <c>IsEnumType</c>
+///   helper).</item>
+///   <item>Negative: mixed-enum <c>==</c> and enum + int <c>==</c> still
+///   produce diagnostics.</item>
+/// </list>
+/// Each test compiles via <c>gsc</c>, runs <c>ilverify</c> against the
+/// produced PE, then executes the assembly under <c>dotnet exec</c> and
+/// asserts on the captured stdout.
+/// </summary>
+public class Issue574EnumComparisonEmitTests
+{
+    // ── Positive: imported BCL enum equality ────────────────────────────
+
+    [Fact]
+    public void ConsoleKey_Equality_True()
+    {
+        var source = """
+            package P
+            import System
+
+            var k = ConsoleKey.L
+            Console.WriteLine(k == ConsoleKey.L)
+            Console.WriteLine(k != ConsoleKey.L)
+            """;
+
+        Assert.Equal("True\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ConsoleKey_Equality_False()
+    {
+        var source = """
+            package P
+            import System
+
+            var k = ConsoleKey.L
+            Console.WriteLine(k == ConsoleKey.A)
+            Console.WriteLine(k != ConsoleKey.A)
+            """;
+
+        Assert.Equal("False\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void FileShare_Equality_RoundTrips()
+    {
+        var source = """
+            package P
+            import System
+            import System.IO
+
+            var a = FileShare.Read
+            var b = FileShare.Read
+            var c = FileShare.Write
+            Console.WriteLine(a == b)
+            Console.WriteLine(a == c)
+            Console.WriteLine(a != c)
+            """;
+
+        Assert.Equal("True\nFalse\nTrue\n", CompileAndRun(source));
+    }
+
+    // ── Positive: ordering on signed-backed (int) CLR enum ─────────────
+
+    [Fact]
+    public void ConsoleKey_Ordering_Less()
+    {
+        var source = """
+            package P
+            import System
+
+            var a = ConsoleKey.A
+            var b = ConsoleKey.B
+            Console.WriteLine(a < b)
+            Console.WriteLine(b < a)
+            Console.WriteLine(a <= a)
+            """;
+
+        Assert.Equal("True\nFalse\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ConsoleKey_Ordering_Greater()
+    {
+        var source = """
+            package P
+            import System
+
+            var a = ConsoleKey.A
+            var b = ConsoleKey.B
+            Console.WriteLine(b > a)
+            Console.WriteLine(a > b)
+            Console.WriteLine(b >= b)
+            """;
+
+        Assert.Equal("True\nFalse\nTrue\n", CompileAndRun(source));
+    }
+
+    // ── Positive: ordering on unsigned-backed (byte) enum — exercises clt_un / cgt_un ──
+
+    [Fact]
+    public void ByteBackedEnum_Ordering_UnsignedSemantics()
+    {
+        var csSource = """
+            using System;
+
+            namespace Probe574
+            {
+                public enum SmallEnum : byte
+                {
+                    A = 1,
+                    B = 200,
+                }
+            }
+            """;
+
+        var gsSource = """
+            package P
+            import System
+            import Probe574
+
+            var a = SmallEnum.A
+            var b = SmallEnum.B
+            Console.WriteLine(a < b)
+            Console.WriteLine(b > a)
+            Console.WriteLine(a <= a)
+            Console.WriteLine(b >= b)
+            Console.WriteLine(b == SmallEnum.B)
+            Console.WriteLine(b != a)
+            """;
+
+        Assert.Equal(
+            "True\nTrue\nTrue\nTrue\nTrue\nTrue\n",
+            CompileAndRunWithSiblingCs(csSource, gsSource, "Probe574"));
+    }
+
+    // ── Positive: user-defined G# enum equality (regression) ─────────────
+
+    [Fact]
+    public void UserDefinedGSharpEnum_EqualityStillWorks()
+    {
+        var source = """
+            package P
+            import System
+
+            type Color enum {
+                Red,
+                Green,
+                Blue,
+            }
+
+            var c = Color.Green
+            Console.WriteLine(c == Color.Green)
+            Console.WriteLine(c == Color.Red)
+            Console.WriteLine(c != Color.Red)
+            """;
+
+        Assert.Equal("True\nFalse\nTrue\n", CompileAndRun(source));
+    }
+
+    // ── Positive: user-defined G# enum ordering ─────────────────────────
+
+    [Fact]
+    public void UserDefinedGSharpEnum_Ordering()
+    {
+        var source = """
+            package P
+            import System
+
+            type Color enum {
+                Red,
+                Green,
+                Blue,
+            }
+
+            var r = Color.Red
+            var g = Color.Green
+            var b = Color.Blue
+            Console.WriteLine(r < g)
+            Console.WriteLine(g < b)
+            Console.WriteLine(b > r)
+            Console.WriteLine(g >= g)
+            Console.WriteLine(r <= g)
+            """;
+
+        Assert.Equal("True\nTrue\nTrue\nTrue\nTrue\n", CompileAndRun(source));
+    }
+
+    // ── Negative: mixed-enum equality is still rejected ─────────────────
+
+    [Fact]
+    public void MixedEnumTypes_Equality_ProducesDiagnostic()
+    {
+        var source = """
+            package P
+            import System
+            import System.IO
+
+            var bad = FileShare.Read == FileAccess.Read
+            """;
+
+        var diagnostics = CompileExpectingErrors(source);
+        Assert.Contains(diagnostics, d => d.Contains("'=='") && d.Contains("FileShare") && d.Contains("FileAccess"));
+    }
+
+    // ── Negative: enum + integer equality is still rejected ─────────────
+
+    [Fact]
+    public void EnumAndInt_Equality_ProducesDiagnostic()
+    {
+        var source = """
+            package P
+            import System
+            import System.IO
+
+            var bad = FileShare.Read == 1
+            """;
+
+        var diagnostics = CompileExpectingErrors(source);
+        Assert.Contains(diagnostics, d => d.Contains("'=='") && d.Contains("FileShare"));
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue574_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static List<string> CompileExpectingErrors(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue574_neg_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit != 0, $"expected gsc to report errors but it succeeded\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            var combined = compileOut.ToString() + compileErr.ToString();
+            return combined.Split('\n').Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue574_sib_").FullName;
+        try
+        {
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+
+            foreach (var reference in BclReferences.Value)
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            File.Copy(siblingDll, Path.Combine(tempDir, Path.GetFileName(siblingDll)), overwrite: true);
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { siblingDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string BuildCsProject(string csDir, string siblingName)
+    {
+        RunDotnet(csDir, "restore");
+        RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+
+        var dll = Path.Combine(csDir, "bin", "Release", "net10.0", siblingName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static void RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Compiler.Tests/Emit/NullableLiftedBinaryOperatorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/NullableLiftedBinaryOperatorEmitTests.cs
@@ -1,0 +1,528 @@
+// <copyright file="NullableLiftedBinaryOperatorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// PR N-4 / §6.1 / C# §7.3.7: lifted binary operators over a value-type
+/// <c>Nullable&lt;T&gt;</c>. Adds arithmetic / bitwise / equality /
+/// ordering operators on <c>T?</c> using the same HasValue / get_Value
+/// emit shape established by PR #541 (<c>!!</c>) and PR #544 (<c>?:</c>).
+///
+/// These tests pin down the new behaviour:
+/// <list type="bullet">
+///   <item>Lifted equality (<c>==</c> / <c>!=</c>): both null → true,
+///   one null → false, both present → underlying equality.</item>
+///   <item>Lifted ordering (<c>&lt;</c> / <c>&lt;=</c> / <c>&gt;</c> /
+///   <c>&gt;=</c>): any null operand → false, otherwise underlying
+///   compare.</item>
+///   <item>Lifted arithmetic (<c>+ - * / %</c>): any null operand → nil
+///   result of type <c>R?</c>, otherwise wrap <c>x.Value op y.Value</c>
+///   in a new <c>Nullable&lt;R&gt;</c>.</item>
+///   <item>Lifted bitwise (<c>&amp; | ^</c>): same null-propagation
+///   shape, integer underlying.</item>
+///   <item>Mixed-mode (<c>T? op T</c> / <c>T op T?</c>): the binder
+///   implicitly lifts the non-nullable side to <c>T?</c> and re-binds
+///   to the lifted operator.</item>
+///   <item>Existing <c>x? == nil</c> / <c>x? != nil</c> arm is not
+///   regressed (still handled by the dedicated <c>IsNullCompare</c>
+///   path; not the lifted arm).</item>
+/// </list>
+/// Each test compiles via <c>gsc</c>, runs <c>ilverify</c> against the
+/// produced PE, then executes the assembly under <c>dotnet exec</c> and
+/// asserts on the captured stdout (so any invalid IL surfaces as a
+/// verification failure rather than silently passing).
+/// </summary>
+public class NullableLiftedBinaryOperatorEmitTests
+{
+    // ─────────────────────────── Equality ───────────────────────────
+
+    [Fact]
+    public void LiftedEquals_BothPresent_SameUnderlying_IsTrue()
+    {
+        var source = """
+            package P
+            import System
+
+            var a int32? = 7
+            var b int32? = 7
+            Console.WriteLine(a == b)
+            Console.WriteLine(a != b)
+            """;
+
+        Assert.Equal("True\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LiftedEquals_BothPresent_DifferentUnderlying_IsFalse()
+    {
+        var source = """
+            package P
+            import System
+
+            var a int32? = 7
+            var b int32? = 9
+            Console.WriteLine(a == b)
+            Console.WriteLine(a != b)
+            """;
+
+        Assert.Equal("False\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LiftedEquals_BothNull_IsTrue()
+    {
+        var source = """
+            package P
+            import System
+
+            var a int32? = nil
+            var b int32? = nil
+            Console.WriteLine(a == b)
+            Console.WriteLine(a != b)
+            """;
+
+        Assert.Equal("True\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LiftedEquals_OneNull_IsFalse()
+    {
+        var source = """
+            package P
+            import System
+
+            var a int32? = 7
+            var b int32? = nil
+            Console.WriteLine(a == b)
+            Console.WriteLine(b == a)
+            Console.WriteLine(a != b)
+            Console.WriteLine(b != a)
+            """;
+
+        Assert.Equal("False\nFalse\nTrue\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LiftedEquals_BoolNullable_FullMatrix()
+    {
+        var source = """
+            package P
+            import System
+
+            var t bool? = true
+            var f bool? = false
+            var n bool? = nil
+            Console.WriteLine(t == t)
+            Console.WriteLine(t == f)
+            Console.WriteLine(t == n)
+            Console.WriteLine(n == n)
+            Console.WriteLine(t != t)
+            Console.WriteLine(n != f)
+            """;
+
+        Assert.Equal("True\nFalse\nFalse\nTrue\nFalse\nTrue\n", CompileAndRun(source));
+    }
+
+    // ─────────────────────────── Ordering ───────────────────────────
+
+    [Fact]
+    public void LiftedLess_BothPresent_UnderlyingCompare()
+    {
+        var source = """
+            package P
+            import System
+
+            var a int32? = 3
+            var b int32? = 5
+            Console.WriteLine(a < b)
+            Console.WriteLine(b < a)
+            Console.WriteLine(a < a)
+            Console.WriteLine(a <= a)
+            """;
+
+        Assert.Equal("True\nFalse\nFalse\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LiftedGreater_BothPresent_UnderlyingCompare()
+    {
+        var source = """
+            package P
+            import System
+
+            var a int32? = 3
+            var b int32? = 5
+            Console.WriteLine(b > a)
+            Console.WriteLine(a > b)
+            Console.WriteLine(b >= b)
+            Console.WriteLine(a >= b)
+            """;
+
+        Assert.Equal("True\nFalse\nTrue\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LiftedOrdering_AnyNull_IsFalse()
+    {
+        var source = """
+            package P
+            import System
+
+            var a int32? = 3
+            var n int32? = nil
+            Console.WriteLine(a < n)
+            Console.WriteLine(n < a)
+            Console.WriteLine(n < n)
+            Console.WriteLine(a > n)
+            Console.WriteLine(a <= n)
+            Console.WriteLine(a >= n)
+            """;
+
+        Assert.Equal("False\nFalse\nFalse\nFalse\nFalse\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LiftedOrdering_UnsignedUnderlying_UsesUnsignedCompare()
+    {
+        var source = """
+            package P
+            import System
+
+            var a uint32? = uint32(1)
+            var b uint32? = uint32(4000000000u)
+            Console.WriteLine(a < b)
+            Console.WriteLine(b > a)
+            """;
+
+        Assert.Equal("True\nTrue\n", CompileAndRun(source));
+    }
+
+    // ─────────────────────────── Arithmetic ─────────────────────────
+
+    [Fact]
+    public void LiftedSum_BothPresent_WrapsInNullable()
+    {
+        var source = """
+            package P
+            import System
+
+            var a int32? = 3
+            var b int32? = 5
+            var s = a + b
+            Console.WriteLine(s ?: -1)
+            """;
+
+        Assert.Equal("8\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LiftedSum_AnyNull_ProducesNullableNil()
+    {
+        var source = """
+            package P
+            import System
+
+            var a int32? = 3
+            var n int32? = nil
+            var s1 = a + n
+            var s2 = n + a
+            var s3 = n + n
+            Console.WriteLine(s1 ?: -1)
+            Console.WriteLine(s2 ?: -1)
+            Console.WriteLine(s3 ?: -1)
+            """;
+
+        Assert.Equal("-1\n-1\n-1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LiftedSubtractAndMultiply_BothPresent()
+    {
+        var source = """
+            package P
+            import System
+
+            var a int32? = 10
+            var b int32? = 4
+            var diff = a - b
+            var prod = a * b
+            Console.WriteLine(diff ?: 0)
+            Console.WriteLine(prod ?: 0)
+            """;
+
+        Assert.Equal("6\n40\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LiftedDivisionAndRemainder_BothPresent()
+    {
+        var source = """
+            package P
+            import System
+
+            var a int32? = 17
+            var b int32? = 5
+            var q = a / b
+            var r = a % b
+            Console.WriteLine(q ?: -1)
+            Console.WriteLine(r ?: -1)
+            """;
+
+        Assert.Equal("3\n2\n", CompileAndRun(source));
+    }
+
+    // ─────────────────────────── Bitwise ────────────────────────────
+
+    [Fact]
+    public void LiftedBitwise_BothPresent_IntegerSemantics()
+    {
+        var source = """
+            package P
+            import System
+
+            var a int32? = 6
+            var b int32? = 3
+            var orV  = a | b
+            var andV = a & b
+            var xorV = a ^ b
+            Console.WriteLine(orV  ?: -1)
+            Console.WriteLine(andV ?: -1)
+            Console.WriteLine(xorV ?: -1)
+            """;
+
+        Assert.Equal("7\n2\n5\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LiftedBitwise_NullPropagates()
+    {
+        var source = """
+            package P
+            import System
+
+            var a int32? = 6
+            var n int32? = nil
+            var orV  = a | n
+            var andV = n & a
+            var xorV = n ^ n
+            Console.WriteLine(orV  ?: -1)
+            Console.WriteLine(andV ?: -1)
+            Console.WriteLine(xorV ?: -1)
+            """;
+
+        Assert.Equal("-1\n-1\n-1\n", CompileAndRun(source));
+    }
+
+    // ─────────────────────────── Mixed-mode lift ────────────────────
+
+    [Fact]
+    public void MixedMode_NullableAndUnderlying_LiftsImplicitly()
+    {
+        // The binder lifts the non-nullable underlying to T? via the
+        // existing implicit T -> T? conversion, then re-binds to the
+        // lifted operator.
+        var source = """
+            package P
+            import System
+
+            var a int32? = 7
+            var s = a + 3
+            Console.WriteLine(s ?: -1)
+
+            var t = 3 + a
+            Console.WriteLine(t ?: -1)
+
+            Console.WriteLine(a == 7)
+            Console.WriteLine(7 == a)
+            Console.WriteLine(a < 9)
+            Console.WriteLine(3 < a)
+            """;
+
+        Assert.Equal("10\n10\nTrue\nTrue\nTrue\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void MixedMode_NullableNullAndUnderlying_PropagatesAndIsFalse()
+    {
+        var source = """
+            package P
+            import System
+
+            var n int32? = nil
+            var s = n + 3
+            Console.WriteLine(s ?: -1)
+            Console.WriteLine(n == 7)
+            Console.WriteLine(7 != n)
+            Console.WriteLine(n < 9)
+            """;
+
+        Assert.Equal("-1\nFalse\nTrue\nFalse\n", CompileAndRun(source));
+    }
+
+    // ─────────────────────────── Regression guards ─────────────────
+
+    [Fact]
+    public void NullableCompareAgainstNil_StillUsesNullCompareArm()
+    {
+        // Regression: the existing IsNullCompare arm handles `x? == nil`
+        // and must continue to do so (it predates the lifted arm).
+        var source = """
+            package P
+            import System
+
+            var a int32? = 7
+            var n int32? = nil
+            Console.WriteLine(a == nil)
+            Console.WriteLine(a != nil)
+            Console.WriteLine(n == nil)
+            Console.WriteLine(n != nil)
+            """;
+
+        Assert.Equal("False\nTrue\nTrue\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NonLiftedIntegerArithmetic_StillWorks()
+    {
+        // Regression: the non-lifted path (int32 + int32 -> int32) must
+        // remain green. The lifted arm is only reachable when at least
+        // one side is value-type Nullable<T>.
+        var source = """
+            package P
+            import System
+
+            var a int32 = 7
+            var b int32 = 3
+            Console.WriteLine(a + b)
+            Console.WriteLine(a == b)
+            Console.WriteLine(a > b)
+            """;
+
+        Assert.Equal("10\nFalse\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableCoalesce_StillWorksAfterLift()
+    {
+        // Regression: PR #544's `?:` lowering must still own value-type
+        // Nullable<T> NullCoalesce — it is excluded from the lifted
+        // collector and stays in receiverSpillSlots.
+        var source = """
+            package P
+            import System
+
+            var a int32? = 7
+            var n int32? = nil
+            Console.WriteLine(a ?: 99)
+            Console.WriteLine(n ?: 99)
+            """;
+
+        Assert.Equal("7\n99\n", CompileAndRun(source));
+    }
+
+    // ─────────────────────────── Helpers ───────────────────────────
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_nullable_lifted_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}


### PR DESCRIPTION
## Summary

Final PR of the §6.1 "Unify `Nullable<T>` handling" plan (builds on PR N-1 #599, PR N-2 #600, PR N-3 #601). Two coordinated changes:

### Part 1 — Close #574 (CLR enum equality + comparisons)

Generalized the binder's enum-equality arm in `BoundBinaryOperator.Bind` to handle **CLR-imported** enums via the existing `IsEnumType` helper (matching the shape of the bitwise arm at lines 122-133). Added `<`, `<=`, `>`, `>=` for enums. Extended `IsUnsignedOrChar` to consult `Enum.GetUnderlyingType`, so unsigned-backed CLR enums correctly select `clt_un` / `cgt_un` opcodes. The IL path is unchanged because enums live on the eval stack as their underlying primitive — only the binder gate needed to open.

### Part 2 — C# §7.3.7 lifted `Nullable<T>` binary operators

Added a lifted-binary arm in `BoundBinaryOperator.Bind` for `(T?, T?)` plus mixed-mode `(T?, T)` / `(T, T?)` lifting in `ExpressionBinder.Operators`. A new `LiftedBinarySlots` bundle is pre-allocated by `MethodBodyPlanner` / `SlotPlanner` and consumed by the new `EmitLiftedNullableBinary` + helpers in `MethodBodyEmitter.Operators`, which emit the textbook C# pattern:

```
if (a.HasValue && b.HasValue) result = new T?(a.GetValueOrDefault() ⊕ b.GetValueOrDefault())
else                          result = default(T?)     // arithmetic/bitwise/shift
```

```
a.HasValue == b.HasValue && (!a.HasValue || a.GetValueOrDefault() ⊕ b.GetValueOrDefault())
                                                                                  // comparison
```

Every `Nullable<>` construction goes through `NullableLifting.TryConstructNullable` (PR N-1 facade), so the cross-context MLC issues fixed in N-2 / N-3 don't regress.

### Drive-by fix

A pre-existing bug where `x? == nil` (value-type nullable compared to the nil literal) produced `InvalidProgramException` at runtime: the existing collector did not spill the LHS to a typed slot, so emit fell through to `dup; brtrue` on a struct value. Now the LHS is spilled once and the comparison lowers to `get_HasValue [+ ceq 0]`. Surfaced naturally during Part 2 instrumentation.

## Tests

| Test class | Count |
| --- | --- |
| `Issue574EnumComparisonEmitTests` | 10 |
| `NullableLiftedBinaryOperatorEmitTests` | 20 |
| **Total new** | **30** |

All new tests green. Existing nullable / emit suites green: Core (2138), Interpreter (72), LanguageServer (242), Sdk (24). `Compiler.Tests` pass per batch; the pre-existing test-host OOM on a single full-suite invocation also reproduces on baseline.

## Verification

- `dotnet build GSharp.sln -nologo -clp:NoSummary` clean
- `ilverify` clean on emitted samples for both lifted-binary and enum-comparison paths

## Related

- PR N-1 (#599): extract `NullableLifting` facade
- PR N-2 (#600): route emit-side `Nullable<>` through MLC
- PR N-3 (#601): structural `AreSame` for cross-context constructed generics
- Closes #574
