### PR TITLE
6.3: Make EmitExpression/SpillExpression switches exhaustive over BoundNodeKind

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Emit;
 using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Lowering.Async;
@@ -102,9 +103,30 @@ public static class SpillSequenceSpiller
                     builder.Add(rewritten);
                     return rewritten != nested;
 
-                default:
+                // Statements that are await-free leaves at this point in the pipeline.
+                // Each is either structurally unable to contain a BoundExpression child,
+                // or its expressions have been pre-spilled / lowered away by an earlier pass
+                // (AsyncExceptionHandlerRewriter, Lowerer, iterator rewriter).
+                case BoundLabelStatement:
+                case BoundGotoStatement:
+                case BoundConditionalGotoStatement:
+                case BoundThrowStatement:
+                case BoundTryStatement:
+                case BoundScopeStatement:
+                case BoundChannelSendStatement:
+                case BoundGoStatement:
+                case BoundSelectStatement:
+                case BoundPatternSwitchStatement:
+                case BoundAwaitSequencePoint:
+                case BoundYieldStatement:
                     builder.Add(statement);
                     return false;
+
+                default:
+                    EmitDiagnosticException.Throw(
+                        statement.Syntax,
+                        $"SpillSequenceSpiller: unhandled BoundStatement kind '{statement.Kind}'.");
+                    return false; // unreachable
             }
         }
 
@@ -262,9 +284,68 @@ public static class SpillSequenceSpiller
                 case BoundBlockExpression block:
                     return SpillBlockExpression(block);
 
-                default:
-                    // No await in this expression — return trivially.
+                // Expression kinds that are trivial for spilling — they are either
+                // leaf nodes (no BoundExpression children that could contain an await)
+                // or their children are structurally unable to hold an await at this
+                // point in the pipeline. If HasAwait(expression) returned true at the
+                // caller but control reaches here, a spiller blind spot exists for
+                // this kind. The throw in the default arm surfaces it as a GS9998
+                // instead of silently producing invalid IL.
+                case BoundLiteralExpression:
+                case BoundVariableExpression:
+                case BoundDefaultExpression:
+                case BoundTypeOfExpression:
+                case BoundMethodGroupExpression:
+                case BoundClrMethodGroupExpression:
+                case BoundFunctionLiteralExpression:
+                case BoundErrorExpression:
+                case BoundAddressOfExpression:
+                case BoundDereferenceExpression:
+                case BoundIndirectAssignmentExpression:
+                case BoundConditionalAddressExpression:
+                case BoundConditionalExpression:
+                case BoundClrStaticCallExpression:
+                case BoundClrConstructorCallExpression:
+                case BoundClrPropertyAccessExpression:
+                case BoundClrPropertyAssignmentExpression:
+                case BoundClrBinaryOperatorExpression:
+                case BoundClrUnaryOperatorExpression:
+                case BoundClrConversionCallExpression:
+                case BoundClrIndexExpression:
+                case BoundClrIndexAssignmentExpression:
+                case BoundClrEventSubscriptionExpression:
+                case BoundEventSubscriptionExpression:
+                case BoundConstructorCallExpression:
+                case BoundFieldAccessExpression:
+                case BoundPropertyAccessExpression:
+                case BoundPropertyAssignmentExpression:
+                case BoundNullConditionalAccessExpression:
+                case BoundTupleLiteralExpression:
+                case BoundTupleElementAccessExpression:
+                case BoundIndirectCallExpression:
+                case BoundInterpolatedStringExpression:
+                case BoundIndexExpression:
+                case BoundArrayCreationExpression:
+                case BoundLenExpression:
+                case BoundCapExpression:
+                case BoundAppendExpression:
+                case BoundStructLiteralExpression:
+                case BoundSwitchExpression:
+                case BoundMakeChannelExpression:
+                case BoundChannelReceiveExpression:
+                case BoundChannelCloseExpression:
+                case BoundMapLiteralExpression:
+                case BoundMapDeleteExpression:
+                case BoundSpillSequenceExpression:
+                case BoundStateMachineAwaitOnCompleted:
+                case BoundStateMachineBuilderMoveNext:
                     return Trivial(expression);
+
+                default:
+                    EmitDiagnosticException.Throw(
+                        expression.Syntax,
+                        $"SpillSequenceSpiller: unhandled BoundExpression kind '{expression.Kind}'.");
+                    return null; // unreachable
             }
         }
 

--- a/src/Core/CodeAnalysis/Lowering/Async/TryDispatchPlanner.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/TryDispatchPlanner.cs
@@ -26,6 +26,14 @@ namespace GSharp.Core.CodeAnalysis.Lowering.Async;
 /// <para>For nested user trys, dispatch chains through each level: outer
 /// dispatch → outermost try's entry → outermost try's internal dispatch →
 /// next-deeper try's entry → ... → resume label.</para>
+///
+/// <para>Implementation note (6.3): the traversal subclasses
+/// <see cref="BoundTreeWalker"/> instead of using a bespoke switch.
+/// The walker's recurse-by-default behavior means every node kind —
+/// including kinds added in the future — is automatically traversed.
+/// Only <see cref="BoundAwaitExpression"/> and <see cref="BoundTryStatement"/>
+/// need custom handling; everything else inherits the walker's depth-first
+/// walk. This eliminates the silent-default-drops-unknown-nodes bug class.</para>
 /// </remarks>
 internal static class TryDispatchPlanner
 {
@@ -39,12 +47,17 @@ internal static class TryDispatchPlanner
         BoundStatement body,
         IReadOnlyDictionary<BoundAwaitExpression, AwaitResumePoint> awaitResumeMap)
     {
-        var walker = new Walker(awaitResumeMap);
-        walker.Walk(body);
-        return walker.Build();
+        var visitor = new WalkVisitor(awaitResumeMap);
+        visitor.Visit(body);
+        return visitor.Build();
     }
 
-    private sealed class Walker
+    /// <summary>
+    /// <see cref="BoundTreeWalker"/> subclass that records await-to-try
+    /// nesting during a depth-first walk. All node kinds not overridden
+    /// here are traversed automatically by the walker's base implementation.
+    /// </summary>
+    private sealed class WalkVisitor : BoundTreeWalker
     {
         private readonly IReadOnlyDictionary<BoundAwaitExpression, AwaitResumePoint> awaitResumeMap;
         private readonly Stack<BoundTryStatement> tryStack = new Stack<BoundTryStatement>();
@@ -53,7 +66,7 @@ internal static class TryDispatchPlanner
         private readonly Dictionary<BoundTryStatement, List<TryDispatchEntry>> internalDispatch = new Dictionary<BoundTryStatement, List<TryDispatchEntry>>();
         private int entryOrdinal;
 
-        public Walker(IReadOnlyDictionary<BoundAwaitExpression, AwaitResumePoint> awaitResumeMap)
+        public WalkVisitor(IReadOnlyDictionary<BoundAwaitExpression, AwaitResumePoint> awaitResumeMap)
         {
             this.awaitResumeMap = awaitResumeMap;
         }
@@ -68,111 +81,36 @@ internal static class TryDispatchPlanner
                     kv => kv.Value.ToImmutableArray()));
         }
 
-        public void Walk(BoundNode node)
+        protected override void VisitAwaitExpression(BoundAwaitExpression node)
         {
-            switch (node)
+            if (awaitResumeMap.TryGetValue(node, out var rp))
             {
-                case null:
-                    return;
-                case BoundAwaitExpression aw:
-                    if (awaitResumeMap.TryGetValue(aw, out var rp))
-                    {
-                        RecordAwait(rp);
-                    }
-
-                    if (aw.Expression != null)
-                    {
-                        Walk(aw.Expression);
-                    }
-
-                    return;
-                case BoundTryStatement t:
-                    tryStack.Push(t);
-                    Walk(t.TryBlock);
-                    foreach (var c in t.CatchClauses)
-                    {
-                        // Catches and finallies should not contain awaits at
-                        // this point (AsyncExceptionHandlerRewriter lifts them
-                        // out). Walk for safety but do not record those awaits
-                        // as needing entry routing for this try.
-                        Walk(c.Body);
-                    }
-
-                    if (t.FinallyBlock != null)
-                    {
-                        Walk(t.FinallyBlock);
-                    }
-
-                    tryStack.Pop();
-                    return;
-                case BoundBlockStatement block:
-                    foreach (var s in block.Statements)
-                    {
-                        Walk(s);
-                    }
-
-                    return;
-                case BoundExpressionStatement es:
-                    Walk(es.Expression);
-                    return;
-                case BoundVariableDeclaration vd:
-                    Walk(vd.Initializer);
-                    return;
-                case BoundReturnStatement ret:
-                    Walk(ret.Expression);
-                    return;
-                case BoundIfStatement ifs:
-                    Walk(ifs.Condition);
-                    Walk(ifs.ThenStatement);
-                    Walk(ifs.ElseStatement);
-                    return;
-                case BoundConditionalGotoStatement cg:
-                    Walk(cg.Condition);
-                    return;
-                case BoundThrowStatement th:
-                    Walk(th.Expression);
-                    return;
-                case BoundScopeStatement sc:
-                    Walk(sc.Body);
-                    return;
-                case BoundAssignmentExpression a:
-                    Walk(a.Expression);
-                    return;
-                case BoundBinaryExpression b:
-                    Walk(b.Left);
-                    Walk(b.Right);
-                    return;
-                case BoundUnaryExpression u:
-                    Walk(u.Operand);
-                    return;
-                case BoundConversionExpression cv:
-                    Walk(cv.Expression);
-                    return;
-                case BoundCallExpression call:
-                    foreach (var arg in call.Arguments)
-                    {
-                        Walk(arg);
-                    }
-
-                    return;
-                case BoundImportedCallExpression ic:
-                    foreach (var arg in ic.Arguments)
-                    {
-                        Walk(arg);
-                    }
-
-                    return;
-                case BoundImportedInstanceCallExpression iic:
-                    Walk(iic.Receiver);
-                    foreach (var arg in iic.Arguments)
-                    {
-                        Walk(arg);
-                    }
-
-                    return;
-                default:
-                    return;
+                RecordAwait(rp);
             }
+
+            // Recurse into the awaited expression (e.g. a nested await).
+            base.VisitAwaitExpression(node);
+        }
+
+        protected override void VisitTryStatement(BoundTryStatement node)
+        {
+            tryStack.Push(node);
+            VisitStatement(node.TryBlock);
+            foreach (var c in node.CatchClauses)
+            {
+                // Catches and finallies should not contain awaits at
+                // this point (AsyncExceptionHandlerRewriter lifts them
+                // out). Walk for safety but do not record those awaits
+                // as needing entry routing for this try.
+                VisitStatement(c.Body);
+            }
+
+            if (node.FinallyBlock != null)
+            {
+                VisitStatement(node.FinallyBlock);
+            }
+
+            tryStack.Pop();
         }
 
         private void RecordAwait(AwaitResumePoint rp)

--- a/test/Core.Tests/CodeAnalysis/BoundNodeKindExhaustivenessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/BoundNodeKindExhaustivenessTests.cs
@@ -1,0 +1,560 @@
+// <copyright file="BoundNodeKindExhaustivenessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using GSharp.Core.CodeAnalysis.Binding;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Validates that every <see cref="BoundNodeKind"/> value is explicitly
+/// handled (or intentionally allowlisted) in each of the four emit/lowering
+/// dispatch switches. A missing case surfaces as a test failure naming the
+/// kind, so adding a new <see cref="BoundNodeKind"/> without updating the
+/// consuming switches is impossible without a red test.
+/// </summary>
+public class BoundNodeKindExhaustivenessTests
+{
+    /// <summary>
+    /// Map from <see cref="BoundNodeKind"/> enum-value name to the C# class
+    /// name(s) used in <c>case</c> patterns. Most map 1:1 by prepending
+    /// "Bound"; a few share a CLR class (e.g. <c>AwaitYieldPoint</c> and
+    /// <c>AwaitResumePoint</c> both map to <c>BoundAwaitSequencePoint</c>).
+    /// </summary>
+    private static readonly Dictionary<string, string[]> KindToClassNames = BuildKindToClassMap();
+
+    // Source paths relative to the repo root.
+    private const string EmitExpressionsPath = "src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs";
+    private const string EmitStatementsPath = "src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs";
+    private const string SpillSequenceSpillerPath = "src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs";
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Allowlists: kinds that legitimately never appear in a given switch.
+    //  Each entry documents the reason (lowered away, wrong category, etc.).
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Kinds the EmitExpression switch never sees — patterns, statements,
+    /// and expression kinds lowered away before emit.
+    /// </summary>
+    private static readonly HashSet<string> EmitExpressionAllowlist = new(new[]
+    {
+        // Pattern kinds — matched inside EmitPatternSwitchStatement, not EmitExpression.
+        "ConstantPattern",
+        "DiscardPattern",
+        "TypePattern",
+        "PropertyPattern",
+        "PropertyPatternField",
+        "RelationalPattern",
+        "ListPattern",
+
+        // Statement kinds — dispatched via EmitStatement, not EmitExpression.
+        "BlockStatement",
+        "VariableDeclaration",
+        "IfStatement",
+        "ForInfiniteStatement",
+        "ForEllipsisStatement",
+        "ForRangeStatement",
+        "LabelStatement",
+        "GotoStatement",
+        "ConditionalGotoStatement",
+        "ReturnStatement",
+        "ExpressionStatement",
+        "TryStatement",
+        "ThrowStatement",
+        "PatternSwitchStatement",
+        "GoStatement",
+        "ChannelSendStatement",
+        "SelectStatement",
+        "ScopeStatement",
+        "AwaitForRangeStatement",
+        "YieldStatement",
+
+        // Helper / annotation kinds that are not expressions.
+        "PatternSwitchArm",
+        "SwitchExpressionArm",
+        "Attribute",
+
+        // Lowered-away expression kinds: always removed by earlier passes.
+        "AwaitExpression",              // lowered by async rewriter
+        "SpillSequenceExpression",      // removed by SpillSequenceSpiller
+        "AwaitYieldPoint",              // synthetic async markers (statement-like)
+        "AwaitResumePoint",             // synthetic async markers (statement-like)
+        "InterpolatedStringExpression", // lowered to BoundBlockExpression by InterpolatedStringHandlerLowerer
+    });
+
+    /// <summary>
+    /// Kinds the EmitStatement switch never sees.
+    /// </summary>
+    private static readonly HashSet<string> EmitStatementAllowlist = new(new[]
+    {
+        // Expression kinds — dispatched via EmitExpression.
+        "ErrorExpression",
+        "LiteralExpression",
+        "VariableExpression",
+        "AssignmentExpression",
+        "UnaryExpression",
+        "BinaryExpression",
+        "CallExpression",
+        "ConversionExpression",
+        "ImportedCallExpression",
+        "ImportedInstanceCallExpression",
+        "ArrayCreationExpression",
+        "MapLiteralExpression",
+        "MapDeleteExpression",
+        "IndexExpression",
+        "IndexAssignmentExpression",
+        "LenExpression",
+        "CapExpression",
+        "AppendExpression",
+        "StructLiteralExpression",
+        "ConstructorCallExpression",
+        "UserInstanceCallExpression",
+        "FieldAccessExpression",
+        "FieldAssignmentExpression",
+        "PropertyAccessExpression",
+        "PropertyAssignmentExpression",
+        "NullConditionalAccessExpression",
+        "TupleLiteralExpression",
+        "TupleElementAccessExpression",
+        "FunctionLiteralExpression",
+        "MethodGroupExpression",
+        "ClrMethodGroupExpression",
+        "IndirectCallExpression",
+        "InterpolatedStringExpression",
+        "ClrConstructorCallExpression",
+        "ClrPropertyAccessExpression",
+        "ClrPropertyAssignmentExpression",
+        "ClrBinaryOperatorExpression",
+        "ClrUnaryOperatorExpression",
+        "ClrConversionCallExpression",
+        "ClrIndexExpression",
+        "ClrIndexAssignmentExpression",
+        "ClrEventSubscriptionExpression",
+        "EventSubscriptionExpression",
+        "AwaitExpression",
+        "SwitchExpression",
+        "BlockExpression",
+        "AddressOfExpression",
+        "DereferenceExpression",
+        "StateMachineAwaitOnCompleted",
+        "StateMachineBuilderMoveNext",
+        "SpillSequenceExpression",
+        "DefaultExpression",
+        "ClrStaticCallExpression",
+        "ConditionalAddressExpression",
+        "ConditionalExpression",
+        "IndirectAssignmentExpression",
+        "TypeOfExpression",
+        "MakeChannelExpression",
+        "ChannelReceiveExpression",
+        "ChannelCloseExpression",
+
+        // Pattern kinds.
+        "ConstantPattern",
+        "DiscardPattern",
+        "TypePattern",
+        "PropertyPattern",
+        "PropertyPatternField",
+        "RelationalPattern",
+        "ListPattern",
+
+        // Helper / annotation kinds.
+        "PatternSwitchArm",
+        "SwitchExpressionArm",
+        "Attribute",
+
+        // Lowered-away statement kinds (lowered to gotos by Lowerer).
+        "IfStatement",
+        "ForInfiniteStatement",
+        "ForEllipsisStatement",
+        "ForRangeStatement",
+        "AwaitForRangeStatement",
+    });
+
+    /// <summary>
+    /// Kinds the SpillExpression switch never sees — statement kinds, pattern kinds,
+    /// and annotation kinds.
+    /// </summary>
+    private static readonly HashSet<string> SpillExpressionAllowlist = new(new[]
+    {
+        // Statement kinds — not expressions.
+        "BlockStatement",
+        "VariableDeclaration",
+        "IfStatement",
+        "ForInfiniteStatement",
+        "ForEllipsisStatement",
+        "ForRangeStatement",
+        "LabelStatement",
+        "GotoStatement",
+        "ConditionalGotoStatement",
+        "ReturnStatement",
+        "ExpressionStatement",
+        "TryStatement",
+        "ThrowStatement",
+        "PatternSwitchStatement",
+        "GoStatement",
+        "ChannelSendStatement",
+        "SelectStatement",
+        "ScopeStatement",
+        "AwaitForRangeStatement",
+        "YieldStatement",
+
+        // Pattern kinds.
+        "ConstantPattern",
+        "DiscardPattern",
+        "TypePattern",
+        "PropertyPattern",
+        "PropertyPatternField",
+        "RelationalPattern",
+        "ListPattern",
+
+        // Helper / annotation kinds.
+        "PatternSwitchArm",
+        "SwitchExpressionArm",
+        "Attribute",
+
+        // Synthetic async markers (statement-like).
+        "AwaitYieldPoint",
+        "AwaitResumePoint",
+    });
+
+    /// <summary>
+    /// Kinds the RewriteStatementToList switch never sees — expression kinds,
+    /// pattern kinds, annotation kinds, and statement kinds that are lowered
+    /// away before the async spill pass.
+    /// </summary>
+    private static readonly HashSet<string> RewriteStatementAllowlist = new(new[]
+    {
+        // Expression kinds — not statements.
+        "ErrorExpression",
+        "LiteralExpression",
+        "VariableExpression",
+        "AssignmentExpression",
+        "UnaryExpression",
+        "BinaryExpression",
+        "CallExpression",
+        "ConversionExpression",
+        "ImportedCallExpression",
+        "ImportedInstanceCallExpression",
+        "ArrayCreationExpression",
+        "MapLiteralExpression",
+        "MapDeleteExpression",
+        "IndexExpression",
+        "IndexAssignmentExpression",
+        "LenExpression",
+        "CapExpression",
+        "AppendExpression",
+        "StructLiteralExpression",
+        "ConstructorCallExpression",
+        "UserInstanceCallExpression",
+        "FieldAccessExpression",
+        "FieldAssignmentExpression",
+        "PropertyAccessExpression",
+        "PropertyAssignmentExpression",
+        "NullConditionalAccessExpression",
+        "TupleLiteralExpression",
+        "TupleElementAccessExpression",
+        "FunctionLiteralExpression",
+        "MethodGroupExpression",
+        "ClrMethodGroupExpression",
+        "IndirectCallExpression",
+        "InterpolatedStringExpression",
+        "ClrConstructorCallExpression",
+        "ClrPropertyAccessExpression",
+        "ClrPropertyAssignmentExpression",
+        "ClrBinaryOperatorExpression",
+        "ClrUnaryOperatorExpression",
+        "ClrConversionCallExpression",
+        "ClrIndexExpression",
+        "ClrIndexAssignmentExpression",
+        "ClrEventSubscriptionExpression",
+        "EventSubscriptionExpression",
+        "AwaitExpression",
+        "SwitchExpression",
+        "BlockExpression",
+        "AddressOfExpression",
+        "DereferenceExpression",
+        "StateMachineAwaitOnCompleted",
+        "StateMachineBuilderMoveNext",
+        "SpillSequenceExpression",
+        "DefaultExpression",
+        "ClrStaticCallExpression",
+        "ConditionalAddressExpression",
+        "ConditionalExpression",
+        "IndirectAssignmentExpression",
+        "TypeOfExpression",
+        "MakeChannelExpression",
+        "ChannelReceiveExpression",
+        "ChannelCloseExpression",
+
+        // Pattern kinds.
+        "ConstantPattern",
+        "DiscardPattern",
+        "TypePattern",
+        "PropertyPattern",
+        "PropertyPatternField",
+        "RelationalPattern",
+        "ListPattern",
+
+        // Helper / annotation kinds.
+        "PatternSwitchArm",
+        "SwitchExpressionArm",
+        "Attribute",
+
+        // Lowered-away statement kinds (lowered to gotos by Lowerer before async pass).
+        "ForInfiniteStatement",
+        "ForEllipsisStatement",
+        "ForRangeStatement",
+        "AwaitForRangeStatement",
+    });
+
+    [Fact]
+    public void EmitExpression_HandlesAllBoundNodeKinds()
+    {
+        var allKinds = GetAllBoundNodeKindNames();
+        var source = ReadSourceFile(EmitExpressionsPath);
+        var handledKinds = ExtractHandledKinds(source, "private void EmitExpression(BoundExpression expression)");
+        AssertExhaustive(allKinds, handledKinds, EmitExpressionAllowlist, "EmitExpression");
+    }
+
+    [Fact]
+    public void EmitStatement_HandlesAllBoundNodeKinds()
+    {
+        var allKinds = GetAllBoundNodeKindNames();
+        var source = ReadSourceFile(EmitStatementsPath);
+        var handledKinds = ExtractHandledKinds(source, "private void EmitStatement(BoundStatement statement)");
+        AssertExhaustive(allKinds, handledKinds, EmitStatementAllowlist, "EmitStatement");
+    }
+
+    [Fact]
+    public void SpillExpression_HandlesAllBoundNodeKinds()
+    {
+        var allKinds = GetAllBoundNodeKindNames();
+        var source = ReadSourceFile(SpillSequenceSpillerPath);
+        var handledKinds = ExtractHandledKinds(source, "private BoundSpillSequenceExpression SpillExpression(BoundExpression expression)");
+        AssertExhaustive(allKinds, handledKinds, SpillExpressionAllowlist, "SpillExpression");
+    }
+
+    [Fact]
+    public void RewriteStatementToList_HandlesAllBoundNodeKinds()
+    {
+        var allKinds = GetAllBoundNodeKindNames();
+        var source = ReadSourceFile(SpillSequenceSpillerPath);
+        var handledKinds = ExtractHandledKinds(source, "private bool RewriteStatementToList(BoundStatement statement");
+        AssertExhaustive(allKinds, handledKinds, RewriteStatementAllowlist, "RewriteStatementToList");
+    }
+
+    [Fact]
+    public void SelfTest_SyntheticKindDetected()
+    {
+        // Guard against the test silently passing because its regex broke or
+        // its allowlists swallow everything. Inject a synthetic kind and
+        // assert the helper fails with a message naming it.
+        var allKinds = GetAllBoundNodeKindNames();
+        allKinds.Add("SyntheticTestKind");
+
+        var source = ReadSourceFile(EmitExpressionsPath);
+        var handledKinds = ExtractHandledKinds(source, "private void EmitExpression(BoundExpression expression)");
+
+        var missing = GetMissingKinds(allKinds, handledKinds, EmitExpressionAllowlist);
+        Assert.Contains("SyntheticTestKind", missing);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    internal static HashSet<string> GetAllBoundNodeKindNames()
+    {
+        return new HashSet<string>(Enum.GetNames(typeof(BoundNodeKind)));
+    }
+
+    private static string ReadSourceFile(string relativePath)
+    {
+        var repoRoot = FindRepoRoot();
+        var fullPath = Path.Combine(repoRoot, relativePath);
+        Assert.True(File.Exists(fullPath), $"Source file not found: {fullPath}");
+        return File.ReadAllText(fullPath);
+    }
+
+    /// <summary>
+    /// Extracts the set of <see cref="BoundNodeKind"/> names handled by a
+    /// switch statement inside the named method. Recognizes two patterns:
+    /// <list type="bullet">
+    /// <item><c>case BoundXyzExpression …:</c> (type-pattern arms)</item>
+    /// <item><c>case BoundNodeKind.Xyz:</c> (enum-value arms)</item>
+    /// </list>
+    /// </summary>
+    internal static HashSet<string> ExtractHandledKinds(string source, string methodSignature)
+    {
+        // Find the method body start.
+        var sigIndex = source.IndexOf(methodSignature, StringComparison.Ordinal);
+        Assert.True(sigIndex >= 0, $"Method signature not found: {methodSignature}");
+
+        // Find the opening brace of the method.
+        var bodyStart = source.IndexOf('{', sigIndex);
+        Assert.True(bodyStart >= 0, "Opening brace not found after method signature.");
+
+        // Walk braces to find the matching close brace.
+        var bodyEnd = FindMatchingBrace(source, bodyStart);
+        var methodBody = source.Substring(bodyStart, bodyEnd - bodyStart + 1);
+
+        var handled = new HashSet<string>();
+
+        // Pattern 1: `case BoundXyzExpression …:` or `case BoundXyzStatement …:`
+        // or `case BoundXyz:` (any Bound-prefixed type).
+        var typePatternRegex = new Regex(
+            @"case\s+(Bound\w+)\b",
+            RegexOptions.Multiline);
+
+        foreach (Match m in typePatternRegex.Matches(methodBody))
+        {
+            var className = m.Groups[1].Value;
+            var kinds = MapClassNameToKinds(className);
+            foreach (var kind in kinds)
+            {
+                handled.Add(kind);
+            }
+        }
+
+        // Pattern 2: `case BoundNodeKind.Xyz:`
+        var enumPatternRegex = new Regex(
+            @"case\s+BoundNodeKind\.(\w+)\s*:",
+            RegexOptions.Multiline);
+
+        foreach (Match m in enumPatternRegex.Matches(methodBody))
+        {
+            handled.Add(m.Groups[1].Value);
+        }
+
+        return handled;
+    }
+
+    internal static List<string> GetMissingKinds(
+        HashSet<string> allKinds,
+        HashSet<string> handledKinds,
+        HashSet<string> allowlist)
+    {
+        return allKinds
+            .Where(k => !handledKinds.Contains(k) && !allowlist.Contains(k))
+            .OrderBy(k => k)
+            .ToList();
+    }
+
+    private static void AssertExhaustive(
+        HashSet<string> allKinds,
+        HashSet<string> handledKinds,
+        HashSet<string> allowlist,
+        string switchName)
+    {
+        var missing = GetMissingKinds(allKinds, handledKinds, allowlist);
+        Assert.True(
+            missing.Count == 0,
+            $"{switchName} is missing case arms for the following BoundNodeKind values: {string.Join(", ", missing)}");
+    }
+
+    private static int FindMatchingBrace(string source, int openBraceIndex)
+    {
+        var depth = 0;
+        for (var i = openBraceIndex; i < source.Length; i++)
+        {
+            if (source[i] == '{')
+            {
+                depth++;
+            }
+            else if (source[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return i;
+                }
+            }
+        }
+
+        throw new InvalidOperationException("Unmatched opening brace.");
+    }
+
+    /// <summary>
+    /// Maps a C# class name (e.g. <c>BoundAwaitSequencePoint</c>) to the
+    /// <see cref="BoundNodeKind"/> values it represents.
+    /// </summary>
+    private static string[] MapClassNameToKinds(string className)
+    {
+        // Collect all kinds that map to this class name (handles multi-kind
+        // classes like BoundAwaitSequencePoint → AwaitYieldPoint + AwaitResumePoint).
+        var results = new List<string>();
+        foreach (var kvp in KindToClassNames)
+        {
+            foreach (var cn in kvp.Value)
+            {
+                if (cn == className)
+                {
+                    results.Add(kvp.Key);
+                }
+            }
+        }
+
+        if (results.Count > 0)
+        {
+            return results.ToArray();
+        }
+
+        // Fallback: strip "Bound" prefix and return.
+        if (className.StartsWith("Bound", StringComparison.Ordinal))
+        {
+            var kindName = className.Substring("Bound".Length);
+            return new[] { kindName };
+        }
+
+        return Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// Builds the map from <see cref="BoundNodeKind"/> name to CLR class name(s).
+    /// Most entries follow the convention <c>Xyz</c> → <c>BoundXyz</c>. Only
+    /// exceptions are listed explicitly.
+    /// </summary>
+    private static Dictionary<string, string[]> BuildKindToClassMap()
+    {
+        var map = new Dictionary<string, string[]>();
+        foreach (var name in Enum.GetNames(typeof(BoundNodeKind)))
+        {
+            // Default convention.
+            map[name] = new[] { "Bound" + name };
+        }
+
+        // Overrides for non-standard mappings.
+        // BoundAwaitSequencePoint uses AwaitYieldPoint / AwaitResumePoint kinds.
+        map["AwaitYieldPoint"] = new[] { "BoundAwaitSequencePoint" };
+        map["AwaitResumePoint"] = new[] { "BoundAwaitSequencePoint" };
+
+        // BoundAttribute uses the Attribute kind.
+        map["Attribute"] = new[] { "BoundAttribute" };
+
+        return map;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = Path.GetDirectoryName(typeof(BoundNodeKindExhaustivenessTests).Assembly.Location);
+        while (!string.IsNullOrEmpty(dir))
+        {
+            if (File.Exists(Path.Combine(dir, ".config", "dotnet-tools.json")))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        return Environment.CurrentDirectory;
+    }
+}


### PR DESCRIPTION
## Summary

Item 6.3 of the G# bug-overview: structurally hardens against the bug class of #418 / #538 by making all emit/lowering dispatch switches exhaustive over `BoundNodeKind`. Adding a new `BoundNodeKind` value without updating every consuming switch now breaks a specific unit test with a precise message naming the missing case — never a silent runtime invalid program.

## Changes

- **Layer A (explicit defaults):** Convert the silent `default:` arms in `SpillSequenceSpiller.RewriteStatementToList` and `SpillSequenceSpiller.SpillExpression` to throw `EmitDiagnosticException` on unhandled kinds. Explicitly enumerate all statement/expression kinds that are legitimate await-free leaves.

- **Layer B (walker migration):** Replace the bespoke `Walk(BoundNode)` switch in `TryDispatchPlanner` with a `BoundTreeWalker` subclass (`WalkVisitor`). The walker's recurse-by-default behavior automatically traverses every node kind, including kinds added in the future. Only `VisitAwaitExpression` and `VisitTryStatement` need custom handling; the silent-default-drops-unknown-nodes bug class is structurally eliminated.

- **Layer C (exhaustiveness test):** Add `BoundNodeKindExhaustivenessTests` in `Core.Tests` with one `[Fact]` per target switch (`EmitExpression`, `EmitStatement`, `SpillExpression`, `RewriteStatementToList`) plus a self-test `[Fact]` that injects a synthetic kind and asserts the helper catches it.

## Spot-check A: synthetic `BoundNodeKind` value

Temporarily adding a `Synthetic` value to the end of `BoundNodeKind` causes all four `[Fact]` tests to fail with:

- `EmitExpression is missing case arms for the following BoundNodeKind values: Synthetic`
- `EmitStatement is missing case arms for the following BoundNodeKind values: Synthetic`
- `SpillExpression is missing case arms for the following BoundNodeKind values: Synthetic`
- `RewriteStatementToList is missing case arms for the following BoundNodeKind values: Synthetic`

## Spot-check B: runtime GS9998 from 6.2

Temporarily removing `case BoundLiteralExpression literal:` from `EmitExpression` and compiling a simple program produces:

```
spotcheck.gs(1,1,1,1): error GS9998: EmitDiagnosticException: Bound expression kind 'LiteralExpression' is not yet supported by the emitter.
```

Note: the `(1,1,1,1)` fallback is expected — `BoundLiteralExpression` nodes in this codebase never carry a `Syntax` reference (the binder passes `null`), so the 6.2 anchor falls back to the first syntax tree root. The GS9998 diagnostic still fires correctly.