### PR TITLE
6.4: Centralize CLR member lookup; close #568 #572 #573

### DIFF
--- a/docs/adr/0034-imported-clr-interop.md
+++ b/docs/adr/0034-imported-clr-interop.md
@@ -34,6 +34,20 @@ Ship a single coordinated change covering five concerns, in this order, in one P
 
 GSharp-side `operator` keyword (declaring `operator +` on a user type) is **explicitly out of scope** for this PR. It is tracked separately — see ADR-0026 and the Stream-D follow-up note in `docs/coverage-matrix.md`.
 
+## Centralized CLR member lookup (6.4 — closes #568, #572, #573)
+
+`MemberLookup` now exposes a family of helpers that walk a concrete CLR type *plus* its transitive implemented interfaces in a single pass: `SafeGetMethodIncludingSelfAndInterfaces`, `SafeGetMethodsIncludingSelfAndInterfaces`, and `SafeGetPropertyIncludingSelfAndInterfaces`. These are the concrete-receiver companions to the post-#529 `*IncludingInterfaces` helpers in `ClrTypeUtilities` (which only walk interfaces when the receiver type is itself an interface). Three binder call-sites that previously asked "does this type provide member M?" with independent (incomplete) walks are now routed through the centralized helpers.
+
+Additionally, `FindMatchingFieldForGetterOnlyProperty` enables a public field on a G# class to satisfy a getter-only CLR interface property contract. When a class declares `Name string` and implements an interface requiring `string Name { get; }`, the binder synthesizes a `PropertySymbol` at binding time with `BackingField` pointing to the existing field. The emit machinery handles it via the existing auto-property path — no duplicate backing field is emitted. Fields only satisfy getter-only contracts; a `{ get; set; }` interface property still requires an explicit property declaration. Example:
+
+```
+type Impl class : IHasName {
+    Name string
+}
+```
+
+where `IHasName` declares `string Name { get; }` — this now compiles and dispatches correctly through the interface.
+
 ## Consequences
 
 - Programs that previously diagnosed "operator is not defined for types" against imported types now bind cleanly — `TimeSpan + TimeSpan`, `DateTime - TimeSpan`, `Guid == Guid`, `BigInteger * BigInteger`, etc. The interpreter and the emitter both honor the resolved `op_*` method.

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -941,6 +941,21 @@ internal sealed class ConversionClassifier
     /// failure.</returns>
     public BoundExpression TryBuildDisposeCall(VariableSymbol variable, TextLocation location)
     {
+        // #568 primary path: if the variable's type is a user-defined class
+        // that declares a public parameterless Dispose() (including via
+        // IDisposable implementation), route through user-instance-call.
+        if (variable.Type is StructSymbol userType
+            && userType.TryGetMethodIncludingInherited("Dispose", out var userDispose)
+            && userDispose.Parameters.Length == 0
+            && (userDispose.Type == TypeSymbol.Void || userDispose.Type == null)
+            && userDispose.Accessibility == Accessibility.Public)
+        {
+            var receiver = new BoundVariableExpression(null, variable);
+            return new BoundUserInstanceCallExpression(null, receiver, userDispose, ImmutableArray<BoundExpression>.Empty);
+        }
+
+        // Extended CLR-type path: walk self + transitive interfaces so a
+        // CLR class inheriting Dispose solely through IDisposable is found.
         var clrType = variable.Type?.ClrType;
         if (clrType == null)
         {
@@ -948,15 +963,15 @@ internal sealed class ConversionClassifier
             return null;
         }
 
-        var disposeMethod = clrType.GetMethod("Dispose", BindingFlags.Public | BindingFlags.Instance, binder: null, types: Type.EmptyTypes, modifiers: null);
+        var disposeMethod = MemberLookup.SafeGetMethodIncludingSelfAndInterfaces(clrType, "Dispose", Type.EmptyTypes);
         if (disposeMethod == null)
         {
             Diagnostics.ReportTypeNotDisposable(location, variable.Type);
             return null;
         }
 
-        var receiver = new BoundVariableExpression(null, variable);
-        return new BoundImportedInstanceCallExpression(null, receiver, disposeMethod, TypeSymbol.Void, ImmutableArray<BoundExpression>.Empty);
+        var receiver2 = new BoundVariableExpression(null, variable);
+        return new BoundImportedInstanceCallExpression(null, receiver2, disposeMethod, TypeSymbol.Void, ImmutableArray<BoundExpression>.Empty);
     }
 
     // ----- Private helpers (kept here because they are only used by methods in this class) -----

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -1925,6 +1925,26 @@ internal sealed class DeclarationBinder
                 var implProp = MemberLookup.FindMatchingProperty(structSymbol, clrProp);
                 if (implProp == null)
                 {
+                    // #573: check whether a public field satisfies a getter-only contract.
+                    var matchingField = MemberLookup.FindMatchingFieldForGetterOnlyProperty(structSymbol, clrProp);
+                    if (matchingField != null)
+                    {
+                        // Synthesize a PropertySymbol backed by the field so the emit
+                        // path handles it via the existing auto-property machinery.
+                        var synthesized = new PropertySymbol(
+                            name: clrProp.Name,
+                            type: matchingField.Type,
+                            accessibility: Accessibility.Public,
+                            hasGetter: true,
+                            hasSetter: false,
+                            isAutoProperty: true,
+                            isVirtual: true,
+                            isOverride: false);
+                        synthesized.BackingField = matchingField;
+                        structSymbol.SetProperties(structSymbol.Properties.Add(synthesized));
+                        continue;
+                    }
+
                     Diagnostics.ReportInterfaceMethodNotImplemented(
                         syntax.Identifier.Location,
                         structSymbol.Name,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1172,10 +1172,7 @@ internal sealed partial class ExpressionBinder
     {
         result = null;
 
-        var candidates = importedBaseClr
-            .GetMethods(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public)
-            .Where(m => m.Name == methodName)
-            .ToList();
+        var candidates = MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(importedBaseClr, methodName);
         if (candidates.Count == 0)
         {
             return false;

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -73,6 +73,167 @@ internal sealed class MemberLookup
     }
 
     /// <summary>
+    /// Walks <paramref name="clrType"/> and its transitive implemented interfaces
+    /// looking for a public instance method whose name matches <paramref name="name"/>.
+    /// Closes the post-#529 gap for *concrete* receivers — <c>*IncludingInterfaces</c>
+    /// in <see cref="ClrTypeUtilities"/> only walks interfaces when the receiver is itself
+    /// an interface; this helper extends the walk to concrete classes for the
+    /// #568 / #572 family.
+    /// </summary>
+    /// <param name="clrType">The CLR type (concrete class or interface) to probe.</param>
+    /// <param name="name">The method name to match.</param>
+    /// <param name="parameterTypes">Optional parameter types for exact-match filtering.
+    /// Pass <c>null</c> to match by name only (first hit).</param>
+    /// <returns>The matching <see cref="MethodInfo"/>, or <c>null</c> when none is found.</returns>
+    public static MethodInfo SafeGetMethodIncludingSelfAndInterfaces(Type clrType, string name, Type[] parameterTypes = null)
+    {
+        if (clrType == null)
+        {
+            return null;
+        }
+
+        foreach (var type in EnumerateSelfAndInterfaces(clrType))
+        {
+            MethodInfo method;
+            try
+            {
+                method = parameterTypes != null
+                    ? type.GetMethod(name, BindingFlags.Public | BindingFlags.Instance, binder: null, types: parameterTypes, modifiers: null)
+                    : type.GetMethod(name, BindingFlags.Public | BindingFlags.Instance);
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (method != null)
+            {
+                return method;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Enumerates every public instance method on <paramref name="clrType"/>
+    /// and its transitive implemented interfaces with the given <paramref name="name"/>.
+    /// The overload-resolution-facing variant, used by call sites that need to
+    /// pass a candidate set into <see cref="OverloadResolution.Resolve"/>.
+    /// Hides base-method-with-same-signature shadowing the same way C# does
+    /// (via the existing <c>IsHiddenByExisting</c> helper in <see cref="ClrTypeUtilities"/>).
+    /// </summary>
+    /// <param name="clrType">The CLR type (concrete class or interface) to probe.</param>
+    /// <param name="name">The method name to match.</param>
+    /// <returns>The candidate list with self-slot methods first.</returns>
+    public static IReadOnlyList<MethodInfo> SafeGetMethodsIncludingSelfAndInterfaces(Type clrType, string name)
+    {
+        if (clrType == null)
+        {
+            return Array.Empty<MethodInfo>();
+        }
+
+        var selfMethods = ClrTypeUtilities.SafeGetMethods(clrType, BindingFlags.Public | BindingFlags.Instance);
+        var result = new List<MethodInfo>();
+        foreach (var m in selfMethods)
+        {
+            if (string.Equals(m.Name, name, StringComparison.Ordinal))
+            {
+                result.Add(m);
+            }
+        }
+
+        // Walk transitive interfaces for DIMs not surfaced by the concrete type.
+        foreach (var iface in ClrTypeUtilities.SafeGetInterfaces(clrType))
+        {
+            foreach (var m in ClrTypeUtilities.SafeGetMethods(iface, BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (!string.Equals(m.Name, name, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (!IsMethodHiddenByExisting(result, m))
+                {
+                    result.Add(m);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Walks <paramref name="clrType"/> and its transitive implemented interfaces
+    /// looking for a public instance property whose name matches <paramref name="name"/>.
+    /// The concrete-receiver companion to <see cref="ClrTypeUtilities.SafeGetPropertyIncludingInterfaces"/>
+    /// (which only walks interfaces when the receiver is itself an interface).
+    /// </summary>
+    /// <param name="clrType">The CLR type to probe.</param>
+    /// <param name="name">The property name to match.</param>
+    /// <returns>The matching <see cref="PropertyInfo"/>, or <c>null</c> when none is found.</returns>
+    public static PropertyInfo SafeGetPropertyIncludingSelfAndInterfaces(Type clrType, string name)
+    {
+        if (clrType == null)
+        {
+            return null;
+        }
+
+        var direct = ClrTypeUtilities.SafeGetProperty(clrType, name, BindingFlags.Public | BindingFlags.Instance);
+        if (direct != null)
+        {
+            return direct;
+        }
+
+        foreach (var iface in ClrTypeUtilities.SafeGetInterfaces(clrType))
+        {
+            var prop = ClrTypeUtilities.SafeGetProperty(iface, name, BindingFlags.Public | BindingFlags.Instance);
+            if (prop != null)
+            {
+                return prop;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the G# field on <paramref name="structSymbol"/> that satisfies
+    /// the getter-only contract of <paramref name="clrProp"/>: same name, the
+    /// field's type's CLR projection matches the property's PropertyType, and
+    /// the field is publicly accessible. Returns <c>null</c> when no such
+    /// field exists or when the contract requires a setter.
+    /// </summary>
+    /// <param name="structSymbol">The user struct symbol to inspect.</param>
+    /// <param name="clrProp">The CLR property whose contract to check.</param>
+    /// <returns>The matching <see cref="FieldSymbol"/>, or <c>null</c>.</returns>
+    public static FieldSymbol FindMatchingFieldForGetterOnlyProperty(StructSymbol structSymbol, PropertyInfo clrProp)
+    {
+        // Only getter-only contracts are satisfied by fields in this PR.
+        if (clrProp.SetMethod != null)
+        {
+            return null;
+        }
+
+        if (!structSymbol.TryGetField(clrProp.Name, out var field))
+        {
+            return null;
+        }
+
+        if (field.Accessibility != Accessibility.Public)
+        {
+            return null;
+        }
+
+        if (!ClrTypeUtilities.AreSame(field.Type?.ClrType, clrProp.PropertyType))
+        {
+            return null;
+        }
+
+        return field;
+    }
+
+    /// <summary>
     /// Probes <paramref name="type"/> for an
     /// <c>IAsyncEnumerable&lt;T&gt;</c> implementation and returns its
     /// element type when present.
@@ -710,4 +871,44 @@ internal sealed class MemberLookup
     /// <returns>The parameters visible to a non-extension caller.</returns>
     private static ImmutableArray<ParameterSymbol> GetCallableParameters(FunctionSymbol method)
         => method.ExplicitReceiverParameter == null ? method.Parameters : method.Parameters.RemoveAt(0);
+
+    /// <summary>
+    /// Returns whether <paramref name="candidate"/> is hidden by any method
+    /// already in <paramref name="existing"/>. Same-name-and-parameter-types
+    /// hiding mirrors C# semantics.
+    /// </summary>
+    private static bool IsMethodHiddenByExisting(List<MethodInfo> existing, MethodInfo candidate)
+    {
+        foreach (var m in existing)
+        {
+            if (!string.Equals(m.Name, candidate.Name, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var existingParams = m.GetParameters();
+            var candidateParams = candidate.GetParameters();
+            if (existingParams.Length != candidateParams.Length)
+            {
+                continue;
+            }
+
+            var match = true;
+            for (var i = 0; i < existingParams.Length; i++)
+            {
+                if (!ClrTypeUtilities.AreSame(existingParams[i].ParameterType, candidateParams[i].ParameterType))
+                {
+                    match = false;
+                    break;
+                }
+            }
+
+            if (match)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -713,7 +713,7 @@ internal sealed class ReflectionMetadataEmitter
             // ADR-0051 Phase 6: backing fields for auto-properties.
             foreach (var p in s.Properties)
             {
-                if (p.IsAutoProperty && p.BackingField != null)
+                if (p.IsAutoProperty && p.BackingField != null && !s.Fields.Contains(p.BackingField))
                 {
                     nextFieldRow++;
                 }
@@ -760,7 +760,7 @@ internal sealed class ReflectionMetadataEmitter
             // ADR-0051 Phase 6: backing fields for auto-properties.
             foreach (var p in s.Properties)
             {
-                if (p.IsAutoProperty && p.BackingField != null)
+                if (p.IsAutoProperty && p.BackingField != null && !s.Fields.Contains(p.BackingField))
                 {
                     nextFieldRow++;
                 }

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -196,6 +196,14 @@ internal sealed class TypeDefEmitter
                 continue;
             }
 
+            // #573: when a field-backed synthesized property reuses an existing
+            // user field (which was already emitted above), skip creating a
+            // duplicate backing FieldDef — the mapping already exists.
+            if (this.cache.StructFieldDefs.ContainsKey(prop.BackingField))
+            {
+                continue;
+            }
+
             var sigBlob = new BlobBuilder();
             this.encodeTypeSymbol(new BlobEncoder(sigBlob).FieldSignature(), prop.Type);
             var backingHandle = this.emitCtx.Metadata.AddFieldDefinition(

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -485,6 +485,29 @@ internal static class ClrTypeUtilities
         return all.ToArray();
     }
 
+    /// <summary>
+    /// Issue #529: tolerantly retrieves the transitive interface set
+    /// for a type, guarding against metadata-load failures.
+    /// </summary>
+    /// <param name="type">The type whose interfaces to retrieve.</param>
+    /// <returns>The transitive interface set, or empty on failure.</returns>
+    internal static Type[] SafeGetInterfaces(Type type)
+    {
+        if (type is null)
+        {
+            return Array.Empty<Type>();
+        }
+
+        try
+        {
+            return type.GetInterfaces();
+        }
+        catch (Exception ex) when (IsMetadataLoadFailure(ex))
+        {
+            return Array.Empty<Type>();
+        }
+    }
+
     private static TMember[] SafeEnumerate<TMember>(Type type, Func<Type, TMember[]> getAll)
         where TMember : MemberInfo
     {
@@ -547,29 +570,6 @@ internal static class ClrTypeUtilities
             }
 
             return null;
-        }
-    }
-
-    /// <summary>
-    /// Issue #529: tolerantly retrieves the transitive interface set
-    /// for a type, guarding against metadata-load failures.
-    /// </summary>
-    /// <param name="type">The type whose interfaces to retrieve.</param>
-    /// <returns>The transitive interface set, or empty on failure.</returns>
-    private static Type[] SafeGetInterfaces(Type type)
-    {
-        if (type is null)
-        {
-            return Array.Empty<Type>();
-        }
-
-        try
-        {
-            return type.GetInterfaces();
-        }
-        catch (Exception ex) when (IsMetadataLoadFailure(ex))
-        {
-            return Array.Empty<Type>();
         }
     }
 

--- a/test/Compiler.Tests/Emit/Issue568UsingLetUserIDisposableTests.cs
+++ b/test/Compiler.Tests/Emit/Issue568UsingLetUserIDisposableTests.cs
@@ -1,0 +1,202 @@
+// <copyright file="Issue568UsingLetUserIDisposableTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #568: <c>using let</c> on a G# class that implements
+/// <c>IDisposable</c> was rejected with GS0119 because
+/// <c>ConversionClassifier.TryBuildDisposeCall</c> could not find the
+/// <c>Dispose()</c> method — the user class had no CLR type yet. The fix
+/// adds a user-type path that probes <c>StructSymbol.TryGetMethodIncludingInherited</c>.
+/// </summary>
+public class Issue568UsingLetUserIDisposableTests
+{
+    [Fact]
+    public void UsingLet_GSharpClassImplementingIDisposable_CallsDispose()
+    {
+        var source = """
+            package Probe
+            import System
+
+            type Fixture class : IDisposable {
+                func Dispose() {
+                    Console.WriteLine("disposed")
+                }
+            }
+
+            func test() {
+                using let f = Fixture{}
+                Console.WriteLine("inside")
+            }
+            test()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("inside\ndisposed\n", output);
+    }
+
+    [Fact]
+    public void UsingLet_GSharpClassInheritsDispose_FromBaseClass()
+    {
+        // A G# class whose base class provides Dispose should also work.
+        var source = """
+            package Probe
+            import System
+
+            type BaseDisp open class : IDisposable {
+                func Dispose() {
+                    Console.WriteLine("base-dispose")
+                }
+            }
+
+            type Child class : BaseDisp {
+            }
+
+            func test() {
+                using let c = Child{}
+                Console.WriteLine("used")
+            }
+            test()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("used\nbase-dispose\n", output);
+    }
+
+    [Fact]
+    public void UsingLet_NonDisposableType_StillReportsGS0119()
+    {
+        var source = """
+            package Probe
+            import System
+
+            using let x = 42
+            Console.WriteLine(x)
+            """;
+
+        var errors = CompileExpectingErrors(source);
+        Assert.Contains(errors, e => e.Contains("GS0119"));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue568_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static List<string> CompileExpectingErrors(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue568_err_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit != 0, "expected gsc to report errors but it succeeded");
+            var combined = compileOut.ToString() + compileErr.ToString();
+            return combined.Split('\n').Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue572DimDispatchOnConcreteTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue572DimDispatchOnConcreteTypeEmitTests.cs
@@ -1,0 +1,234 @@
+// <copyright file="Issue572DimDispatchOnConcreteTypeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #572: calling a default interface method (DIM) on a concrete CLR
+/// class that does not override the DIM was rejected with GS0159 because
+/// <c>ExpressionBinder.TryBindInheritedClrInstanceCall</c> used
+/// <c>Type.GetMethods()</c> which does not surface DIMs from interfaces.
+/// The fix routes through <c>MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces</c>.
+/// </summary>
+public class Issue572DimDispatchOnConcreteTypeEmitTests
+{
+    [Fact]
+    public void DimDispatch_ConcreteType_ReturnsExpectedValue()
+    {
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface IWithDIM
+                {
+                    string Name { get; }
+                    string Greeting() => "Hello, " + Name + "!";
+                }
+
+                public class WithDIMImpl : IWithDIM
+                {
+                    public string Name { get; }
+                    public WithDIMImpl(string name) { Name = name; }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            var obj = WithDIMImpl("world")
+            var iface IWithDIM = obj
+            Console.WriteLine(iface.Greeting())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Equal("Hello, world!\n", output);
+    }
+
+    [Fact]
+    public void DimDispatch_OverriddenDim_PrefersConcrete()
+    {
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface IWithDIM
+                {
+                    string Name { get; }
+                    string Greeting() => "Hello, " + Name + "!";
+                }
+
+                public class WithOverride : IWithDIM
+                {
+                    public string Name { get; }
+                    public WithOverride(string name) { Name = name; }
+                    public string Greeting() => "Overridden: " + Name;
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            var obj = WithOverride("world")
+            Console.WriteLine(obj.Greeting())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Equal("Overridden: world\n", output);
+    }
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue572_sib_").FullName;
+        try
+        {
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            File.Copy(siblingDll, Path.Combine(tempDir, Path.GetFileName(siblingDll)), overwrite: true);
+            IlVerifier.Verify(outPath, additionalReferences: new[] { siblingDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string BuildCsProject(string csDir, string siblingName)
+    {
+        RunDotnet(csDir, "restore");
+        RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+        var dll = Path.Combine(csDir, "bin", "Release", "net10.0", siblingName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static void RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue573FieldSatisfiesGetterPropertyContractTests.cs
+++ b/test/Compiler.Tests/Emit/Issue573FieldSatisfiesGetterPropertyContractTests.cs
@@ -1,0 +1,381 @@
+// <copyright file="Issue573FieldSatisfiesGetterPropertyContractTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #573: a G# class with a public field whose name and type match a
+/// getter-only CLR interface property should satisfy the interface contract.
+/// Previously rejected with GS0187. The fix synthesizes a PropertySymbol
+/// backed by the field at binding time.
+/// </summary>
+public class Issue573FieldSatisfiesGetterPropertyContractTests
+{
+    [Fact]
+    public void FieldSatisfiesGetterOnlyProperty_BindsAndRuns()
+    {
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface IHasName
+                {
+                    string Name { get; }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            type Impl1 class : IHasName {
+                Name string
+            }
+
+            var impl = Impl1{Name: "hello"}
+            var iface IHasName = impl
+            Console.WriteLine(iface.Name)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Equal("hello\n", output);
+    }
+
+    [Fact]
+    public void FieldMutation_VisibleThroughInterfaceProperty()
+    {
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface IHasName
+                {
+                    string Name { get; }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            type Impl1 class : IHasName {
+                Name string
+            }
+
+            var impl = Impl1{Name: "hello"}
+            impl.Name = "world"
+            var iface IHasName = impl
+            Console.WriteLine(iface.Name)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Equal("world\n", output);
+    }
+
+    [Fact]
+    public void ExplicitPropertyAccessor_StillWorks()
+    {
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface IHasName
+                {
+                    string Name { get; }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            type Impl2 class : IHasName {
+                prop Name string { get { return "accessor" } }
+            }
+
+            var impl = Impl2{}
+            var iface IHasName = impl
+            Console.WriteLine(iface.Name)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Equal("accessor\n", output);
+    }
+
+    [Fact]
+    public void FieldDoesNotSatisfyGetSetProperty_StillReportsGS0187()
+    {
+        // A field should NOT satisfy a { get; set; } interface property in this PR.
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface IReadWrite
+                {
+                    string Value { get; set; }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            type BadImpl class : IReadWrite {
+                Value string
+            }
+            """;
+
+        var errors = CompileExpectingErrorsWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Contains(errors, e => e.Contains("GS0187"));
+    }
+
+    [Fact]
+    public void ClassOmittingPropertyEntirely_StillReportsGS0187()
+    {
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface IHasName
+                {
+                    string Name { get; }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            type NoImpl class : IHasName {
+            }
+            """;
+
+        var errors = CompileExpectingErrorsWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Contains(errors, e => e.Contains("GS0187"));
+    }
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue573_sib_").FullName;
+        try
+        {
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            File.Copy(siblingDll, Path.Combine(tempDir, Path.GetFileName(siblingDll)), overwrite: true);
+            IlVerifier.Verify(outPath, additionalReferences: new[] { siblingDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static List<string> CompileExpectingErrorsWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue573_err_").FullName;
+        try
+        {
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit != 0, "expected gsc to report errors but it succeeded");
+            var combined = compileOut.ToString() + compileErr.ToString();
+            return combined.Split('\n').Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string BuildCsProject(string csDir, string siblingName)
+    {
+        RunDotnet(csDir, "restore");
+        RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+        var dll = Path.Combine(csDir, "bin", "Release", "net10.0", siblingName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static void RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug-overview item 6.4: Centralize CLR member lookup behind one method that walks `Type.GetInterfaces()` once

Closes #568
Closes #572
Closes #573

Three open bugs are all surfaces of the same architectural gap: multiple call-sites each ask "does this type provide member M?" with independent (incomplete) walks. This PR routes all three through centralized helpers in `MemberLookup`.

### Concentric pieces

- **Lookup helpers** — `SafeGetMethodIncludingSelfAndInterfaces`, `SafeGetMethodsIncludingSelfAndInterfaces`, `SafeGetPropertyIncludingSelfAndInterfaces`, and `FindMatchingFieldForGetterOnlyProperty` in `MemberLookup.cs`. These extend the post-#529 interface walk to concrete receivers.
- **Wire `using let` + DIM dispatch** — `ConversionClassifier.TryBuildDisposeCall` now probes user-type methods first (primary #568 fix) then falls back to the CLR-type walk. `ExpressionBinder.TryBindInheritedClrInstanceCall` uses the new plural helper to surface DIMs (#572).
- **Field satisfies getter-only property contract** — `DeclarationBinder.VerifyClrInterfaceImplementations` consults `FindMatchingFieldForGetterOnlyProperty` and synthesizes a `PropertySymbol` backed by the field at binding time (#573). The emit path reuses the existing auto-property machinery.

### Follow-up issues filed

- #605 — Language: support `await using let` / IAsyncDisposable
- #606 — Binder: extend field-satisfies-property contract to read-write properties
- #607 — Tech debt: audit and migrate other CLR member-walk sites through centralized helpers
- #608 — Interpreter: verify DIM dispatch and field-satisfies-property paths (interpreter-side parity of #572/#573)

### Interpreter parity check

- #568: ✅ Interpreter handles correctly — `Dispose()` is called at scope exit.
- #572: Cannot be verified in basic interpreter mode (requires external CLR DLL with DIMs) — tracked in #608.
- #573: Cannot be verified in basic interpreter mode (requires external CLR property interface) — tracked in #608.

### Negative-diagnostic spot-check

```
_neg1.gs(3,1,3,6): error GS0119: Type 'int32' cannot be used in a 'using' statement because it does not provide a public Dispose() method.
_neg2.gs(4,3,4,22): error GS0159: Cannot find function NonExistentMethod.
_neg3.gs(8,6,8,12): error GS0187: Class 'NoImpl' does not implement interface method 'IHasX.GetX'.
```

### Test results

- Core.Tests: 2149 passed, 1 skipped
- Interpreter.Tests: 72 passed
- LanguageServer.Tests: 242 passed
- Compiler.Tests: 292 passed (pre-existing OOM abort observed during host process — does not affect results)
- BoundNodeKindExhaustivenessTests (post-6.3): 5 passed