### PR TITLE
6.5: Slice conversions = array conversions; close #570 (and #537 as bookkeeping)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -435,6 +435,17 @@ public sealed class Conversion
             return Conversion.Implicit;
         }
 
+        // Slice invariance guard: if the source is a slice and the target
+        // is an interface that the #570 arm above did NOT match (e.g.
+        // IEnumerable<object> when the slice is []string), do NOT fall
+        // through to the general #521 upcast — that path would incorrectly
+        // accept it via CLR array covariance (IsAssignableFrom returns true
+        // across covariant interfaces). G# slices are invariant per spec.
+        if (from is SliceTypeSymbol && to?.ClrType != null && to.ClrType.IsInterface)
+        {
+            return Conversion.None;
+        }
+
         // Issue #521: standard CLR identity / reference upcast — a
         // reference-typed expression of CLR type `from` widens implicitly
         // to any base class or implemented interface `to`. The CLR

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -403,6 +403,38 @@ public sealed class Conversion
             return Conversion.Implicit;
         }
 
+        // Issue #570: a G# slice `[]T` is backed by a CLR `T[]` at runtime
+        // (the #528 rule above accepts `[]T → T[]`). Extend the slice → CLR-array
+        // reference-conversion family to every interface a CLR `T[]` implements:
+        // IEnumerable<T>, ICollection<T>, IList<T>, IReadOnlyCollection<T>,
+        // IReadOnlyList<T>, plus the non-generic IEnumerable/ICollection/IList,
+        // and the platform interfaces ICloneable/IStructuralComparable/
+        // IStructuralEquatable that arrays implement.
+        //
+        // The general #521 upcast below in principle subsumes this rule, but
+        // `ClrTypeUtilities.IsAssignableByName`'s "same-context fast path"
+        // silently returns false when the target interface is loaded through
+        // the MetadataLoadContext and the slice's `T[]` is constructed from
+        // the live runtime (or vice versa) — the two land in different
+        // `Type.Assembly` instances and `Type.IsAssignableFrom` throws
+        // `InvalidOperationException` across the context boundary. The
+        // dedicated arm here uses the cross-context `ImplementsInterfaceByName`
+        // walk so the rule fires regardless of which side the interface and the
+        // array were loaded from.
+        //
+        // Slice invariance: `[]string` does NOT convert to `IEnumerable<object>`
+        // even though CLR arrays are reference-covariant in the element type.
+        // `ImplementsInterfaceByName` compares generic arguments by name, so
+        // `string`'s element-type-arg only matches `string`-typed interfaces.
+        // This mirrors the explicit invariance note on the #528 rule above.
+        if (from is SliceTypeSymbol sliceForIface
+            && to?.ClrType != null && to.ClrType.IsInterface
+            && sliceForIface.ClrType != null
+            && ClrTypeUtilities.ImplementsInterfaceByName(sliceForIface.ClrType, to.ClrType))
+        {
+            return Conversion.Implicit;
+        }
+
         // Issue #521: standard CLR identity / reference upcast — a
         // reference-typed expression of CLR type `from` widens implicitly
         // to any base class or implemented interface `to`. The CLR

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -42,12 +42,13 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// <see cref="Binder"/>.
 /// </para>
 /// <para>
-/// The lifted <c>T → T?</c> conversion (#571), the slice-conversion-
-/// set-equals-array-conversion-set rule (#570), and the related Wave-3
+/// The slice-conversion-set-equals-array-conversion-set rule (#570) landed
+/// in <c>Conversion.Classify</c> (PR 6.5) via a dedicated arm and the
+/// <c>ClrTypeUtilities.ImplementsInterfaceByName</c> cross-context helper.
+/// The lifted <c>T → T?</c> conversion (#571) and the related Wave-3
 /// architectural fixes from <c>~/gsharp-bug-overview.md</c> will land
 /// in this class in a follow-up PR after the full Binder decomposition
-/// is complete. This PR only sets up the structural home for those
-/// fixes; it makes no behavior change.
+/// is complete.
 /// </para>
 /// </remarks>
 internal sealed class ConversionClassifier

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -220,13 +220,40 @@ internal static class OverloadResolution
             {
                 if (target.IsAssignableFrom(source))
                 {
-                    return ImplicitConversionKind.Reference;
+                    // Issue #570: G# slices are invariant. When the source
+                    // is an array type being passed to a generic interface,
+                    // CLR's IsAssignableFrom accepts covariant cases (e.g.
+                    // string[] → IEnumerable<object>). Guard against this
+                    // by cross-checking with ImplementsInterfaceByName which
+                    // matches generic args by name (invariantly).
+                    if (source.IsArray && target.IsInterface && target.IsGenericType
+                        && !ClrTypeUtilities.ImplementsInterfaceByName(source, target))
+                    {
+                        // Covariant match rejected — fall through.
+                    }
+                    else
+                    {
+                        return ImplicitConversionKind.Reference;
+                    }
                 }
             }
             catch (InvalidOperationException)
             {
                 // MLC cross-context paths throw; fall through to user-defined lookup.
             }
+        }
+
+        // Issue #570: cross-context interface implementation check. When
+        // `source` is an array type (e.g. the CLR backing type of a G# slice)
+        // and `target` is an interface, the same-context fast path above fails
+        // because the two types reside in different Type.Assembly instances.
+        // Use the cross-context `ImplementsInterfaceByName` walker to bridge
+        // live-runtime and MetadataLoadContext types. This enables overload
+        // resolution to find methods taking interface parameters (IEnumerable<T>,
+        // IReadOnlyList<T>, etc.) when passed a slice argument.
+        if (target.IsInterface && ClrTypeUtilities.ImplementsInterfaceByName(source, target))
+        {
+            return ImplicitConversionKind.Reference;
         }
 
         var udi = UserDefinedImplicitConversionLookup;

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -516,6 +516,19 @@ internal sealed partial class MethodBodyEmitter
             return true;
         }
 
+        // Issue #570: cross-context interface implementation check for the
+        // emitter's reference-compatibility decision. When `a` is a slice
+        // type (backed by T[]) and `b` is an interface, the same-context
+        // IsAssignableByName path above fails because the two types live in
+        // different Type.Assembly instances. Use ImplementsInterfaceByName
+        // to recognise the no-op widening.
+        if (a?.ClrType != null && b?.ClrType != null
+            && b.ClrType.IsInterface
+            && ClrTypeUtilities.ImplementsInterfaceByName(a.ClrType, b.ClrType))
+        {
+            return true;
+        }
+
         return false;
     }
 

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -157,6 +157,37 @@ internal static class ClrTypeUtilities
     }
 
     /// <summary>
+    /// Returns whether <paramref name="concrete"/> implements an interface
+    /// equivalent to <paramref name="targetInterface"/> by name and generic-
+    /// argument-name. Generalizes the cross-context (live-runtime vs.
+    /// MetadataLoadContext) interface walk that <see cref="IsAssignableByName"/>'s
+    /// same-context fast path cannot resolve. Used by #570's slice-conversions-
+    /// equal-array-conversions rule and reusable for any future cross-context
+    /// "does X implement Y?" probe.
+    /// </summary>
+    /// <param name="concrete">The candidate concrete type whose interfaces to walk.</param>
+    /// <param name="targetInterface">The interface type to match (live or MLC).</param>
+    /// <returns><see langword="true"/> when the concrete type implements an
+    /// interface whose full-name and generic argument full-names equal the target.</returns>
+    public static bool ImplementsInterfaceByName(Type concrete, Type targetInterface)
+    {
+        if (concrete is null || targetInterface is null)
+        {
+            return false;
+        }
+
+        foreach (var iface in SafeGetInterfaces(concrete))
+        {
+            if (InterfaceMatchesByName(iface, targetInterface))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Returns whether <paramref name="type"/> is a CLR delegate type, i.e. it
     /// (transitively) derives from <c>System.MulticastDelegate</c> /
     /// <c>System.Delegate</c>. Walks the base-type chain by name so it is safe
@@ -506,6 +537,48 @@ internal static class ClrTypeUtilities
         {
             return Array.Empty<Type>();
         }
+    }
+
+    private static bool InterfaceMatchesByName(Type candidate, Type target)
+    {
+        // Non-generic interfaces: direct FullName comparison.
+        if (!target.IsGenericType)
+        {
+            return string.Equals(candidate.FullName, target.FullName, StringComparison.Ordinal);
+        }
+
+        // Generic interfaces: compare the open definition's FullName (e.g.
+        // `System.Collections.Generic.IEnumerable`1`) then match each
+        // generic argument structurally via AreSame.
+        if (!candidate.IsGenericType)
+        {
+            return false;
+        }
+
+        if (!string.Equals(
+                candidate.GetGenericTypeDefinition().FullName,
+                target.GetGenericTypeDefinition().FullName,
+                StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var candidateArgs = candidate.GetGenericArguments();
+        var targetArgs = target.GetGenericArguments();
+        if (candidateArgs.Length != targetArgs.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < candidateArgs.Length; i++)
+        {
+            if (!AreSame(candidateArgs[i], targetArgs[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static TMember[] SafeEnumerate<TMember>(Type type, Func<Type, TMember[]> getAll)

--- a/test/Compiler.Tests/Emit/Issue570SliceToInterfaceConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue570SliceToInterfaceConversionEmitTests.cs
@@ -1,0 +1,567 @@
+// <copyright file="Issue570SliceToInterfaceConversionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #570: a G# slice value <c>[]T</c> did not implicitly convert to the
+/// interfaces implemented by its backing CLR array <c>T[]</c>, such as
+/// <c>IEnumerable&lt;T&gt;</c>, <c>IReadOnlyList&lt;T&gt;</c>,
+/// <c>IList&lt;T&gt;</c>, etc. The binder rejected the assignment with
+/// <c>GS0154: Parameter '…' requires a value of type 'IEnumerable&lt;string&gt;'
+/// but was given a value of type '[]string'.</c> The spec states that "slices
+/// are backed by CLR arrays", so every interface a CLR <c>T[]</c> implements
+/// must be reachable from a <c>[]T</c> via an implicit, no-op conversion. The
+/// fix adds a dedicated arm in <c>Conversion.Classify</c> that walks the
+/// array's interface set by name (cross-MLC safe via
+/// <c>ClrTypeUtilities.ImplementsInterfaceByName</c>).
+/// </summary>
+public class Issue570SliceToInterfaceConversionEmitTests
+{
+    [Fact]
+    public void SliceLiteral_PassedAs_IEnumerableOfT()
+    {
+        // The issue body's primary repro: a []string slice literal is
+        // passed to a C# method taking IEnumerable<string>.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public static class Sink
+                {
+                    public static int Count(System.Collections.Generic.IEnumerable<string> items)
+                    {
+                        int n = 0;
+                        foreach (var _ in items) n++;
+                        return n;
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            var n = Sink.Count([]string{"a", "b"})
+            Console.WriteLine(n)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void SliceLiteral_PassedAs_IReadOnlyListOfT()
+    {
+        // IReadOnlyList<T> — the most commonly-requested interface target
+        // from the issue discussion.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public static class Sink
+                {
+                    public static int CountViaRoList(System.Collections.Generic.IReadOnlyList<string> items)
+                    {
+                        return items.Count;
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            var n = Sink.CountViaRoList([]string{"x", "y"})
+            Console.WriteLine(n)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void SliceLiteral_PassedAs_IListOfT()
+    {
+        // IList<T> — confirms the slice can satisfy a mutable-list interface.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public static class Sink
+                {
+                    public static string ReadFirst(System.Collections.Generic.IList<string> items)
+                    {
+                        return items[0];
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            Console.WriteLine(Sink.ReadFirst([]string{"hello", "world"}))
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("hello\n", output);
+    }
+
+    [Fact]
+    public void SliceLiteral_PassedAs_ICollectionOfT()
+    {
+        // ICollection<T>.Count property.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public static class Sink
+                {
+                    public static int CountViaCollection(System.Collections.Generic.ICollection<string> items)
+                    {
+                        return items.Count;
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            Console.WriteLine(Sink.CountViaCollection([]string{"a", "b", "c"}))
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("3\n", output);
+    }
+
+    [Fact]
+    public void SliceLiteral_PassedAs_IReadOnlyCollectionOfT()
+    {
+        // IReadOnlyCollection<T>.Count property.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public static class Sink
+                {
+                    public static int CountViaRoCollection(System.Collections.Generic.IReadOnlyCollection<string> items)
+                    {
+                        return items.Count;
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            Console.WriteLine(Sink.CountViaRoCollection([]string{"a", "b", "c", "d"}))
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("4\n", output);
+    }
+
+    [Fact]
+    public void SliceLiteral_PassedAs_NonGenericIEnumerable()
+    {
+        // Non-generic IEnumerable — arrays implement it too.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public static class Sink
+                {
+                    public static int CountViaPlainEnumerable(System.Collections.IEnumerable items)
+                    {
+                        int n = 0;
+                        foreach (var _ in items) n++;
+                        return n;
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            Console.WriteLine(Sink.CountViaPlainEnumerable([]string{"a", "b", "c"}))
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("3\n", output);
+    }
+
+    [Fact]
+    public void SliceLiteral_PassedAs_SystemObject_SmokeTest()
+    {
+        // Slice → System.Object already worked via the line-282 rule;
+        // smoke test that the new arm doesn't conflict.
+        var gsource = """
+            package Probe.Tests
+            import System
+
+            func takeObj(o object) string { return o.ToString() }
+            Console.WriteLine(takeObj([]int32{1, 2, 3}).StartsWith("System.Int32"))
+            """;
+
+        var output = CompileAndRun(gsource);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void SliceLiteral_AssignedToProperty_TypedIReadOnlyListOfT()
+    {
+        // Same as the #528 property-assignment test but for an interface target.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public sealed class Container
+                {
+                    public System.Collections.Generic.IReadOnlyList<string> Items { get; set; }
+                        = System.Array.Empty<string>();
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            var c = Container()
+            c.Items = []string{"alpha", "beta"}
+            Console.WriteLine(c.Items.Count)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void SliceInvariance_StringToIEnumerableOfObject_StillRejected()
+    {
+        // Variance regression guard: G# slices are invariant.
+        // []string must NOT convert to IEnumerable<object> even though
+        // the CLR allows array reference covariance.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public static class Sink
+                {
+                    public static int CountObjects(System.Collections.Generic.IEnumerable<object> items)
+                    {
+                        int n = 0;
+                        foreach (var _ in items) n++;
+                        return n;
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import Probe.CSharp
+
+            Sink.CountObjects([]string{"a"})
+            """;
+
+        var diags = CompileAndCollectDiagnosticsWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        // Rejected either as GS0154 (wrong argument type) or GS0159
+        // (cannot find function — overload resolution rejects the candidate
+        // because the invariant generic-arg check blocks array covariance).
+        Assert.True(
+            diags.Contains("GS0154") || diags.Contains("GS0159"),
+            $"Expected GS0154 or GS0159 but got:\n{diags}");
+    }
+
+    [Fact]
+    public void SliceLiteral_PassedAs_IReadOnlyListOfString_ViaGSharpFunc()
+    {
+        // Real-world repro shape: a G# function taking IReadOnlyList<string>
+        // receives a []string literal (mirrors System.CommandLine.Command.Parse
+        // scenario from issue body).
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public static class Parser
+                {
+                    public static string ParseFirst(System.Collections.Generic.IReadOnlyList<string> args)
+                    {
+                        return args.Count > 0 ? args[0] : "<empty>";
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            Console.WriteLine(Parser.ParseFirst([]string{"--help", "--verbose"}))
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("--help\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue570_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var (exit, stdout, stderr, outPath, tempDir, siblingDll) =
+            CompileWithSiblingCs(csSource, gSource, siblingName);
+
+        try
+        {
+            Assert.True(
+                exit == 0,
+                $"gsc failed:\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { siblingDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var runOut = proc.StandardOutput.ReadToEnd();
+            var runErr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{runOut}\nstderr:\n{runErr}");
+
+            return runOut.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndCollectDiagnosticsWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var (_, stdout, stderr, _, tempDir, _) = CompileWithSiblingCs(csSource, gSource, siblingName);
+        try
+        {
+            return stdout + "\n" + stderr;
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static (int Exit, string Stdout, string Stderr, string OutPath, string TempDir, string SiblingDll)
+        CompileWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue570_sib_").FullName;
+        var csDir = Path.Combine(tempDir, "csref");
+        Directory.CreateDirectory(csDir);
+        File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+        File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Library</OutputType>
+                <TargetFramework>net10.0</TargetFramework>
+                <AssemblyName>{siblingName}</AssemblyName>
+                <RootNamespace>{siblingName}</RootNamespace>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var siblingDll = BuildCsProject(csDir, siblingName);
+
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, gSource);
+
+        var gscArgs = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            "/reference:" + siblingDll,
+        };
+
+        foreach (var reference in TrustedPlatformAssemblies())
+        {
+            gscArgs.Add("/reference:" + reference);
+        }
+
+        gscArgs.Add("/nowarn:GS9100");
+        gscArgs.Add(srcPath);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(gscArgs.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        if (compileExit == 0)
+        {
+            File.Copy(siblingDll, Path.Combine(tempDir, Path.GetFileName(siblingDll)), overwrite: true);
+        }
+
+        return (compileExit, compileOut.ToString(), compileErr.ToString(), outPath, tempDir, siblingDll);
+    }
+
+    private static string BuildCsProject(string csDir, string siblingName)
+    {
+        RunDotnet(csDir, "restore");
+
+        var stdout = RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+        _ = stdout;
+
+        var dll = Path.Combine(csDir, "bin", "Release", "net10.0", siblingName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static string RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug-overview §6, item 5: "Add a slice conversions = array conversions rule"

Closes #570

Closes #537 (already implemented; closed independently with citation — see [comment](https://github.com/DavidObando/gsharp/issues/537#issuecomment-4655372146))

### Summary

A G# slice `[]T` is backed by a CLR `T[]` at runtime, so it should expose every implicit reference conversion that a CLR array exposes to its implemented interfaces. Before this PR, passing a `[]string` to a method expecting `IEnumerable<string>`, `IReadOnlyList<string>`, etc. was rejected with GS0154 because the cross-context (live-runtime vs MetadataLoadContext) type-assembly mismatch defeated `IsAssignableByName`'s same-context fast path. This PR fixes that with a dedicated, invariance-preserving conversion arm.

### Pieces

- **`ClrTypeUtilities.ImplementsInterfaceByName` helper** — cross-context interface-walk matching by FullName + generic-arg structural equality (`AreSame`).
- **`Conversion.Classify` arm** — dedicated `SliceTypeSymbol → interface` arm after the #528 slice→array rule. Returns `Conversion.Implicit` when the backing array implements the target interface by name. Invariance guard: if the #570 arm rejects it (generic args differ), blocks fallthrough to the #521 upcast.
- **`OverloadResolution.ClassifyImplicit`** — adds `ImplementsInterfaceByName` fallback for cross-context cases and guards the same-context `IsAssignableFrom` path against CLR array covariance (preserving slice invariance).
- **`MethodBodyEmitter.IsReferenceCompatible`** — adds `ImplementsInterfaceByName` check so the emitter recognizes slice→interface as a no-op widening (zero IL).
- **10 regression tests** (`Issue570SliceToInterfaceConversionEmitTests.cs`) covering IEnumerable\<T\>, IReadOnlyList\<T\>, IList\<T\>, ICollection\<T\>, IReadOnlyCollection\<T\>, non-generic IEnumerable, System.Object smoke, property assignment, invariance negative, and real-world repro shape.
- **#537 bookkeeping** — closed with a citation comment; no code change (already implemented in `StatementBinder.cs:1796-1805`).
- **ConversionClassifier.cs comment** — updated to past tense reflecting the #570 rule has landed.

### Follow-up issues filed

- #610 — Binder: generalize cross-context reference upcast (promote `ImplementsInterfaceByName` into the general #521 arm)
- #611 — Tech debt: audit other slice-vs-array surface gaps

### Emit-side verification

No IL change was required for the conversion itself — the slice's runtime representation IS `T[]`, so the widening to any interface implemented by `T[]` is a reference-level no-op. The emitter's `IsReferenceCompatible` needed the same `ImplementsInterfaceByName` cross-context bridge to recognize it as a no-op (otherwise it threw `NotSupportedException`).

### Spot-checks

**Positive** — `func f(items IReadOnlyList[string]) int32 { return items.Count }; f([]string{"a","b"})`:
```
2
```

**Negative** — `func f(items IEnumerable[object]) int32 { return 0 }; f([]string{"a"})`:
```
error GS0154: Parameter 'items' requires a value of type 'System.Collections.Generic.IEnumerable`1[[System.Object, ...]]' but was given a value of type '[]string'.
```

### Pre-existing OOM note

The pre-existing OOM in `Compiler.Tests` host process (discovered during 6.2/6.3) still surfaces when all ~420+ tests run in a single process. All tests pass individually; the OOM is a test-host memory pressure issue, not a regression from this PR.