### PR TITLE
6.6: Unified EnumOperatorTable for all enum operator groups (incl. §11.10 arithmetic gaps)

### DIFF
--- a/docs/enum-operators.md
+++ b/docs/enum-operators.md
@@ -1,0 +1,47 @@
+# Enum Operator Rules
+
+G# follows the C# §11.10 enum operator specification. All enum operator rules are centralized in [`EnumOperatorTable`](../src/Core/CodeAnalysis/Binding/EnumOperatorTable.cs) — a single declarative source that the binary binder, unary binder, and emitter all consult.
+
+## Supported operations
+
+| Syntax | Left operand | Right operand | Result type | Category |
+|--------|--------------|---------------|-------------|----------|
+| `==` `!=` `<` `<=` `>` `>=` | E | E | `bool` | Comparison |
+| `\|` `&` `^` | E | E | E | Bitwise |
+| `+` | E | U | E | Arithmetic |
+| `+` | U | E | E | Arithmetic |
+| `-` | E | U | E | Arithmetic |
+| `-` | E | E | U | Arithmetic |
+| `^` (prefix) | E | — | E | Unary (ones-complement) |
+
+Where **E** is any enum type and **U** is its CLR underlying type (one of `int8`, `uint8`, `int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`).
+
+## Intentionally excluded
+
+Per C# §11.10 these are **not** valid for enum types and G# correctly rejects them:
+
+- Shift operators (`<<`, `>>`) on enums.
+- Unary minus (`-`) on enums.
+- Multiplication, division, modulus (`*`, `/`, `%`) on enums.
+- Any binary operator between two *different* enum types.
+- Any arithmetic between an enum and a non-underlying integral type (e.g., `DayOfWeek + int64` when `DayOfWeek` is int32-backed).
+
+## Nullable lifting (§6.1 composition)
+
+All enum operators automatically compose with G#'s §6.1 lifted-nullable system:
+
+```
+var a System.DayOfWeek? = DayOfWeek.Monday
+var b int32? = int32(2)
+Console.WriteLine(a + b)  // prints "Wednesday"
+```
+
+If either operand is `nil`, the result is `nil` (the nullable-no-value representation). The binder handles both homogeneous (`E? op E?`) and heterogeneous (`E? op U?`, `E? op U`) nullable lifts.
+
+## Adding a new enum operator group
+
+To add support for a hypothetical new operator on enums:
+
+1. Add one or more `BinaryRule` entries to the `Rules` dictionary in `EnumOperatorTable.cs`, keyed by the token's `SyntaxKind`.
+2. Add corresponding test methods to `EnumOperatorTableTests.cs` (unit) and an emit-level test class.
+3. The lifted-nullable arm, the emitter's `IsUnsignedOrChar` check, and IL verification all compose automatically — no additional wiring is needed.

--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -104,49 +104,14 @@ public sealed class BoundBinaryOperator
             return new BoundBinaryOperator(syntaxKind, cmpKind, ltp, ltp, TypeSymbol.Bool);
         }
 
-        // Issue #574 (closes the "same family as #534" enum operator gap):
-        // == / != / < / <= / > / >= on same-type enum values. Both
-        // user-defined enums (EnumSymbol) and imported CLR enums
-        // (ImportedTypeSymbol whose ClrType.IsEnum) are supported via the
-        // shared IsEnumType helper — mirroring the bitwise arm below.
-        // Enums sit on the eval stack as their underlying integer so the
-        // existing Ceq / Clt / Cgt emit paths work transparently; signed
-        // vs unsigned dispatch is handled by IsUnsignedOrChar reading
-        // through to the enum's underlying type at emit time.
-        if (leftType != null && leftType == rightType && IsEnumType(leftType))
+        // Issues #534, #574, and 6.6 unification: all C# §11.10 enum
+        // operators (==, !=, <, <=, >, >=, |, &, ^, + underlying,
+        // - underlying, - enum) drive through the single EnumOperatorTable.
+        // Adding a new enum-supported operator group is a one-row change in
+        // that table — no new arm here.
+        if (EnumOperatorTable.TryBindBinary(syntaxKind, leftType, rightType, out var enumKind, out var enumResultType))
         {
-            var cmpKind = syntaxKind switch
-            {
-                SyntaxKind.EqualsEqualsToken => (BoundBinaryOperatorKind?)BoundBinaryOperatorKind.Equals,
-                SyntaxKind.BangEqualsToken => BoundBinaryOperatorKind.NotEquals,
-                SyntaxKind.LessToken => BoundBinaryOperatorKind.Less,
-                SyntaxKind.LessOrEqualsToken => BoundBinaryOperatorKind.LessOrEquals,
-                SyntaxKind.GreaterToken => BoundBinaryOperatorKind.Greater,
-                SyntaxKind.GreaterOrEqualsToken => BoundBinaryOperatorKind.GreaterOrEquals,
-                _ => null,
-            };
-            if (cmpKind != null)
-            {
-                return new BoundBinaryOperator(syntaxKind, cmpKind.Value, leftType, rightType, TypeSymbol.Bool);
-            }
-        }
-
-        // Issue #534: bitwise |, &, ^ on same-type enum values.
-        // Both user-defined (EnumSymbol) and imported CLR enum types are
-        // supported. The result type is the enum type itself (matching C#
-        // §11.10.5). The IL is the same as for the underlying integer —
-        // enums are represented as their underlying int on the eval stack.
-        if ((syntaxKind == SyntaxKind.PipeToken || syntaxKind == SyntaxKind.AmpersandToken || syntaxKind == SyntaxKind.HatToken)
-            && leftType != null && leftType == rightType
-            && IsEnumType(leftType))
-        {
-            var bitwiseKind = syntaxKind switch
-            {
-                SyntaxKind.PipeToken => BoundBinaryOperatorKind.BitwiseOr,
-                SyntaxKind.AmpersandToken => BoundBinaryOperatorKind.BitwiseAnd,
-                _ => BoundBinaryOperatorKind.BitwiseXor,
-            };
-            return new BoundBinaryOperator(syntaxKind, bitwiseKind, leftType, rightType, leftType);
+            return new BoundBinaryOperator(syntaxKind, enumKind, leftType, rightType, enumResultType);
         }
 
         // Phase 3.B.2 / ADR-0029 + ADR-0033: structural == / != on data and inline struct values.
@@ -210,6 +175,27 @@ public sealed class BoundBinaryOperator
             // (e.g. the user wrote `+` on `bool?`, which has no underlying
             // form), there is no lifted form either.
             var underlyingOp = Bind(syntaxKind, lN.UnderlyingType, rN.UnderlyingType);
+            if (underlyingOp != null && IsLiftableKind(underlyingOp.Kind))
+            {
+                TypeSymbol liftedResult = IsLiftedToBoolKind(underlyingOp.Kind)
+                    ? (TypeSymbol)TypeSymbol.Bool
+                    : NullableTypeSymbol.Get(underlyingOp.Type);
+                return new BoundBinaryOperator(syntaxKind, underlyingOp.Kind, leftType, rightType, liftedResult);
+            }
+        }
+
+        // 6.6 / §6.1: lifted binary for heterogeneous nullable operands
+        // (enum? + underlying?, underlying? + enum?, enum? - enum?→underlying?).
+        // The same-type arm above handles enum? == enum? and enum? | enum?;
+        // this arm handles the §11.10 arithmetic rules where both sides
+        // are nullable but wrap DIFFERENT underlying types.
+        if (leftType is NullableTypeSymbol lHet
+            && rightType is NullableTypeSymbol rHet
+            && lHet != rHet
+            && lHet.UnderlyingType?.ClrType is { IsValueType: true }
+            && rHet.UnderlyingType?.ClrType is { IsValueType: true })
+        {
+            var underlyingOp = Bind(syntaxKind, lHet.UnderlyingType, rHet.UnderlyingType);
             if (underlyingOp != null && IsLiftableKind(underlyingOp.Kind))
             {
                 TypeSymbol liftedResult = IsLiftedToBoolKind(underlyingOp.Kind)
@@ -366,21 +352,5 @@ public sealed class BoundBinaryOperator
         list.Add(new BoundBinaryOperator(SyntaxKind.LessOrEqualsToken, BoundBinaryOperatorKind.LessOrEquals, t, t, TypeSymbol.Bool));
         list.Add(new BoundBinaryOperator(SyntaxKind.GreaterToken, BoundBinaryOperatorKind.Greater, t, t, TypeSymbol.Bool));
         list.Add(new BoundBinaryOperator(SyntaxKind.GreaterOrEqualsToken, BoundBinaryOperatorKind.GreaterOrEquals, t, t, TypeSymbol.Bool));
-    }
-
-    /// <summary>
-    /// Returns <c>true</c> when <paramref name="type"/> represents an enum
-    /// type — either a user-defined <see cref="EnumSymbol"/> or an imported
-    /// CLR enum (<see cref="ImportedTypeSymbol"/> whose <see cref="TypeSymbol.ClrType"/>
-    /// is an enum).
-    /// </summary>
-    private static bool IsEnumType(TypeSymbol type)
-    {
-        if (type is EnumSymbol)
-        {
-            return true;
-        }
-
-        return type?.ClrType != null && type.ClrType.IsEnum;
     }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundUnaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundUnaryOperator.cs
@@ -73,11 +73,11 @@ public sealed class BoundUnaryOperator
             }
         }
 
-        // Issue #534: ^ (ones complement) on enum values (CLR or user-defined).
-        // The result type is the enum type itself (matching C# §11.10.5).
-        if (syntaxKind == SyntaxKind.HatToken && IsEnumType(operandType))
+        // Issues #534 and 6.6 unification: ^ (ones complement) on enum
+        // values drives through the EnumOperatorTable.
+        if (EnumOperatorTable.TryBindUnary(syntaxKind, operandType, out var enumKind, out var enumResultType))
         {
-            return new BoundUnaryOperator(syntaxKind, BoundUnaryOperatorKind.OnesComplement, operandType);
+            return new BoundUnaryOperator(syntaxKind, enumKind, operandType, enumResultType);
         }
 
         return null;
@@ -120,20 +120,5 @@ public sealed class BoundUnaryOperator
         }
 
         return list.ToArray();
-    }
-
-    /// <summary>
-    /// Returns <c>true</c> when <paramref name="type"/> represents an enum
-    /// type — either a user-defined <see cref="EnumSymbol"/> or an imported
-    /// CLR enum.
-    /// </summary>
-    private static bool IsEnumType(TypeSymbol type)
-    {
-        if (type is EnumSymbol)
-        {
-            return true;
-        }
-
-        return type?.ClrType != null && type.ClrType.IsEnum;
     }
 }

--- a/src/Core/CodeAnalysis/Binding/EnumOperatorTable.cs
+++ b/src/Core/CodeAnalysis/Binding/EnumOperatorTable.cs
@@ -1,0 +1,304 @@
+// <copyright file="EnumOperatorTable.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Single declarative source for every C# §11.10 enum operator rule.
+/// Adding a new operator group is a one-row change in this table — no new arm
+/// in BoundBinaryOperator.cs or BoundUnaryOperator.cs.
+/// </summary>
+/// <remarks>
+/// Issues #534 (bitwise), #574 (comparison), and bug-overview item 6.6
+/// (architectural unification + §11.10 arithmetic gaps) are all serviced
+/// through this table. The emit-side signed-vs-unsigned dispatch
+/// (<see cref="IsUnsignedEnumUnderlying"/>) is also co-located here so the
+/// connection between "binder accepted enum1 &lt; enum2" and "emitter chose
+/// clt_un" lives in one place.
+/// </remarks>
+internal static class EnumOperatorTable
+{
+    private static readonly Dictionary<SyntaxKind, BinaryRule[]> BinaryRules = new()
+    {
+        // Comparison: enum == enum → bool (post-#574)
+        [SyntaxKind.EqualsEqualsToken] = new[] { new BinaryRule(BoundBinaryOperatorKind.Equals, OperandShape.EnumEnum, ResultRule.ResultBool) },
+        [SyntaxKind.BangEqualsToken] = new[] { new BinaryRule(BoundBinaryOperatorKind.NotEquals, OperandShape.EnumEnum, ResultRule.ResultBool) },
+        [SyntaxKind.LessToken] = new[] { new BinaryRule(BoundBinaryOperatorKind.Less, OperandShape.EnumEnum, ResultRule.ResultBool) },
+        [SyntaxKind.LessOrEqualsToken] = new[] { new BinaryRule(BoundBinaryOperatorKind.LessOrEquals, OperandShape.EnumEnum, ResultRule.ResultBool) },
+        [SyntaxKind.GreaterToken] = new[] { new BinaryRule(BoundBinaryOperatorKind.Greater, OperandShape.EnumEnum, ResultRule.ResultBool) },
+        [SyntaxKind.GreaterOrEqualsToken] = new[] { new BinaryRule(BoundBinaryOperatorKind.GreaterOrEquals, OperandShape.EnumEnum, ResultRule.ResultBool) },
+
+        // Bitwise: enum op enum → enum (post-#534)
+        [SyntaxKind.PipeToken] = new[] { new BinaryRule(BoundBinaryOperatorKind.BitwiseOr, OperandShape.EnumEnum, ResultRule.ResultEnum) },
+        [SyntaxKind.AmpersandToken] = new[] { new BinaryRule(BoundBinaryOperatorKind.BitwiseAnd, OperandShape.EnumEnum, ResultRule.ResultEnum) },
+        [SyntaxKind.HatToken] = new[] { new BinaryRule(BoundBinaryOperatorKind.BitwiseXor, OperandShape.EnumEnum, ResultRule.ResultEnum) },
+
+        // Arithmetic: §11.10 enum ± underlying and enum - enum (NEW in 6.6)
+        [SyntaxKind.PlusToken] = new[]
+        {
+            new BinaryRule(BoundBinaryOperatorKind.Sum, OperandShape.EnumUnderlying, ResultRule.ResultEnum),
+            new BinaryRule(BoundBinaryOperatorKind.Sum, OperandShape.UnderlyingEnum, ResultRule.ResultEnum),
+        },
+        [SyntaxKind.MinusToken] = new[]
+        {
+            new BinaryRule(BoundBinaryOperatorKind.Difference, OperandShape.EnumUnderlying, ResultRule.ResultEnum),
+            new BinaryRule(BoundBinaryOperatorKind.Difference, OperandShape.EnumEnum, ResultRule.ResultUnderlying),
+        },
+    };
+
+    private enum OperandShape
+    {
+        /// <summary>Both operands are the SAME enum type.</summary>
+        EnumEnum,
+
+        /// <summary>Left is enum, right is the enum's CLR underlying primitive.</summary>
+        EnumUnderlying,
+
+        /// <summary>Left is the enum's CLR underlying primitive, right is enum.</summary>
+        UnderlyingEnum,
+    }
+
+    private enum ResultRule
+    {
+        /// <summary>Result type equals the enum operand's type.</summary>
+        ResultEnum,
+
+        /// <summary>Result type equals the enum's CLR underlying primitive.</summary>
+        ResultUnderlying,
+
+        /// <summary>Result type is bool.</summary>
+        ResultBool,
+    }
+
+    /// <summary>
+    /// Attempts to bind a binary operator for enum operands per C# §11.10.
+    /// </summary>
+    /// <param name="syntaxKind">The binary operator token kind.</param>
+    /// <param name="leftType">The left operand type.</param>
+    /// <param name="rightType">The right operand type.</param>
+    /// <param name="kind">The resulting bound operator kind, if matched.</param>
+    /// <param name="resultType">The resulting type symbol, if matched.</param>
+    /// <returns><c>true</c> if the table contains a matching rule.</returns>
+    public static bool TryBindBinary(
+        SyntaxKind syntaxKind,
+        TypeSymbol leftType,
+        TypeSymbol rightType,
+        out BoundBinaryOperatorKind kind,
+        out TypeSymbol resultType)
+    {
+        kind = default;
+        resultType = null;
+
+        if (leftType == null || rightType == null)
+        {
+            return false;
+        }
+
+        if (!BinaryRules.TryGetValue(syntaxKind, out var rules))
+        {
+            return false;
+        }
+
+        foreach (var rule in rules)
+        {
+            if (TryMatchBinaryShape(rule.Shape, leftType, rightType, out var enumType, out var underlyingType))
+            {
+                kind = rule.Kind;
+                resultType = rule.Result switch
+                {
+                    ResultRule.ResultBool => TypeSymbol.Bool,
+                    ResultRule.ResultEnum => enumType,
+                    ResultRule.ResultUnderlying => underlyingType,
+                    _ => throw new InvalidOperationException($"Unknown result rule: {rule.Result}"),
+                };
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to bind a unary operator for an enum operand per C# §11.10.
+    /// Currently only ones-complement (~) is supported; unary minus is
+    /// intentionally excluded per §11.10.
+    /// </summary>
+    /// <param name="syntaxKind">The unary operator token kind.</param>
+    /// <param name="operandType">The operand type.</param>
+    /// <param name="kind">The resulting bound operator kind, if matched.</param>
+    /// <param name="resultType">The resulting type symbol, if matched.</param>
+    /// <returns><c>true</c> if the table contains a matching rule.</returns>
+    public static bool TryBindUnary(
+        SyntaxKind syntaxKind,
+        TypeSymbol operandType,
+        out BoundUnaryOperatorKind kind,
+        out TypeSymbol resultType)
+    {
+        kind = default;
+        resultType = null;
+
+        if (syntaxKind == SyntaxKind.HatToken && IsEnumType(operandType))
+        {
+            kind = BoundUnaryOperatorKind.OnesComplement;
+            resultType = operandType;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the given type is an enum with an unsigned
+    /// CLR underlying type (byte, ushort, uint, ulong). Used by the emitter's
+    /// <c>IsUnsignedOrChar</c> for signed-vs-unsigned IL opcode selection.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns><c>true</c> if <paramref name="type"/> is an enum with an unsigned underlying type.</returns>
+    public static bool IsUnsignedEnumUnderlying(TypeSymbol type)
+    {
+        if (type == null)
+        {
+            return false;
+        }
+
+        if (type is EnumSymbol)
+        {
+            return false;
+        }
+
+        if (type.ClrType?.IsEnum == true)
+        {
+            var underlyingName = Enum.GetUnderlyingType(type.ClrType).FullName;
+            return underlyingName == "System.Byte"
+                || underlyingName == "System.UInt16"
+                || underlyingName == "System.UInt32"
+                || underlyingName == "System.UInt64";
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="type"/> represents an enum
+    /// type — either a user-defined <see cref="EnumSymbol"/> or an imported
+    /// CLR enum (<see cref="ImportedTypeSymbol"/> whose <see cref="TypeSymbol.ClrType"/>
+    /// is an enum). Single source of truth, replacing the duplicated private
+    /// IsEnumType in BoundBinaryOperator.cs and BoundUnaryOperator.cs.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns><c>true</c> if the type is an enum.</returns>
+    public static bool IsEnumType(TypeSymbol type)
+    {
+        if (type is NullableTypeSymbol)
+        {
+            return false;
+        }
+
+        if (type is EnumSymbol)
+        {
+            return true;
+        }
+
+        return type?.ClrType != null && type.ClrType.IsEnum;
+    }
+
+    /// <summary>
+    /// Gets the G# <see cref="TypeSymbol"/> representing the CLR underlying
+    /// primitive type for a given enum type. Returns <c>null</c> if the type
+    /// is not an enum.
+    /// </summary>
+    /// <param name="enumType">The enum type symbol.</param>
+    /// <returns>The underlying primitive type symbol, or <c>null</c>.</returns>
+    internal static TypeSymbol GetUnderlyingType(TypeSymbol enumType)
+    {
+        if (enumType is EnumSymbol es)
+        {
+            return es.UnderlyingType;
+        }
+
+        if (enumType?.ClrType?.IsEnum == true)
+        {
+            var clrUnderlying = Enum.GetUnderlyingType(enumType.ClrType);
+            return TypeSymbol.FromClrType(clrUnderlying);
+        }
+
+        return null;
+    }
+
+    private static bool TryMatchBinaryShape(
+        OperandShape shape,
+        TypeSymbol leftType,
+        TypeSymbol rightType,
+        out TypeSymbol enumType,
+        out TypeSymbol underlyingType)
+    {
+        enumType = null;
+        underlyingType = null;
+
+        switch (shape)
+        {
+            case OperandShape.EnumEnum:
+                if (leftType == rightType && IsEnumType(leftType))
+                {
+                    enumType = leftType;
+                    underlyingType = GetUnderlyingType(leftType);
+                    return underlyingType != null;
+                }
+
+                return false;
+
+            case OperandShape.EnumUnderlying:
+                if (IsEnumType(leftType))
+                {
+                    var underlying = GetUnderlyingType(leftType);
+                    if (underlying != null && underlying == rightType)
+                    {
+                        enumType = leftType;
+                        underlyingType = underlying;
+                        return true;
+                    }
+                }
+
+                return false;
+
+            case OperandShape.UnderlyingEnum:
+                if (IsEnumType(rightType))
+                {
+                    var underlying = GetUnderlyingType(rightType);
+                    if (underlying != null && underlying == leftType)
+                    {
+                        enumType = rightType;
+                        underlyingType = underlying;
+                        return true;
+                    }
+                }
+
+                return false;
+
+            default:
+                return false;
+        }
+    }
+
+    private readonly struct BinaryRule
+    {
+        public BinaryRule(BoundBinaryOperatorKind kind, OperandShape shape, ResultRule result)
+        {
+            Kind = kind;
+            Shape = shape;
+            Result = result;
+        }
+
+        public BoundBinaryOperatorKind Kind { get; }
+
+        public OperandShape Shape { get; }
+
+        public ResultRule Result { get; }
+    }
+}

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -442,6 +442,38 @@ internal sealed partial class ExpressionBinder
             }
         }
 
+        // 6.6 / §6.1: mixed-mode lift for heterogeneous nullable operands.
+        // Handles enum? + int32 → lift int32 to int32?, then re-bind as
+        // (enum?, int32?) which the heterogeneous lifted arm resolves.
+        // Also handles int32 + enum? → lift int32 to int32?.
+        if (boundOperator == null)
+        {
+            if (boundLeft.Type is NullableTypeSymbol leftN2
+                && boundRight.Type is not NullableTypeSymbol
+                && boundRight.Type?.ClrType is { IsValueType: true })
+            {
+                var rightLifted = NullableTypeSymbol.Get(boundRight.Type);
+                var lifted = BoundBinaryOperator.Bind(syntax.OperatorToken.Kind, leftN2, rightLifted);
+                if (lifted != null)
+                {
+                    boundRight = conversions.BindConversion(syntax.Right.Location, boundRight, rightLifted);
+                    boundOperator = lifted;
+                }
+            }
+            else if (boundRight.Type is NullableTypeSymbol rightN2
+                && boundLeft.Type is not NullableTypeSymbol
+                && boundLeft.Type?.ClrType is { IsValueType: true })
+            {
+                var leftLifted = NullableTypeSymbol.Get(boundLeft.Type);
+                var lifted = BoundBinaryOperator.Bind(syntax.OperatorToken.Kind, leftLifted, rightN2);
+                if (lifted != null)
+                {
+                    boundLeft = conversions.BindConversion(syntax.Left.Location, boundLeft, leftLifted);
+                    boundOperator = lifted;
+                }
+            }
+        }
+
         if (boundOperator == null)
         {
             // Stream D: try user-defined `func (a T) operator <op>(b U) R` on

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -650,10 +650,13 @@ internal sealed partial class MethodBodyEmitter
     private void EmitLiftedNullableBinary(BoundBinaryExpression b, LiftedBinarySlots slots)
     {
         var leftNullable = (NullableTypeSymbol)b.Left.Type;
-        var underlying = leftNullable.UnderlyingType;
-        var underlyingClr = underlying.ClrType
+        var rightNullable = b.Right.Type == TypeSymbol.Null ? null : (NullableTypeSymbol)b.Right.Type;
+        var leftUnderlying = leftNullable.UnderlyingType;
+        var leftUnderlyingClr = leftUnderlying.ClrType
             ?? throw new InvalidOperationException(
-                $"Lifted binary operator '{b.Op.Kind}' on Nullable<{underlying.Name}>: underlying has no CLR type.");
+                $"Lifted binary operator '{b.Op.Kind}' on Nullable<{leftUnderlying.Name}>: underlying has no CLR type.");
+        var rightUnderlying = rightNullable?.UnderlyingType;
+        var rightUnderlyingClr = rightUnderlying?.ClrType;
 
         var lhsSlot = slots.LhsSlot;
         var rhsSlot = slots.RhsSlot;
@@ -665,7 +668,7 @@ internal sealed partial class MethodBodyEmitter
         // `HasValue`.
         if (b.Right.Type == TypeSymbol.Null)
         {
-            var getHasValue = this.outer.wellKnown.GetNullableGetHasValueReference(underlyingClr);
+            var getHasValue = this.outer.wellKnown.GetNullableGetHasValueReference(leftUnderlyingClr);
 
             this.EmitExpression(b.Left);
             this.il.StoreLocal(lhsSlot);
@@ -698,13 +701,13 @@ internal sealed partial class MethodBodyEmitter
 
         if (isEquality)
         {
-            this.EmitLiftedEquality(b.Op.Kind, lhsSlot, rhsSlot, underlying, underlyingClr);
+            this.EmitLiftedEquality(b.Op.Kind, lhsSlot, rhsSlot, leftUnderlying, leftUnderlyingClr, rightUnderlyingClr);
             return;
         }
 
         if (isOrdering)
         {
-            this.EmitLiftedOrdering(b.Op.Kind, lhsSlot, rhsSlot, underlying, underlyingClr);
+            this.EmitLiftedOrdering(b.Op.Kind, lhsSlot, rhsSlot, leftUnderlying, leftUnderlyingClr, rightUnderlyingClr);
             return;
         }
 
@@ -718,7 +721,16 @@ internal sealed partial class MethodBodyEmitter
                 + "check LiftedBinaryOperatorCollector and the prepass in CollectLocalsAndLabels.");
         }
 
-        this.EmitLiftedArithmetic(b.Op.Kind, lhsSlot, rhsSlot, slots.ResultSlot, underlying, underlyingClr);
+        // For heterogeneous enum arithmetic (enum? + int32? → enum?), the
+        // result type may differ from the left underlying. Use the
+        // operator's result type to determine the Nullable<R> wrapper.
+        var resultNullable = (NullableTypeSymbol)b.Type;
+        var resultUnderlying = resultNullable.UnderlyingType;
+        var resultUnderlyingClr = resultUnderlying.ClrType
+            ?? throw new InvalidOperationException(
+                $"Lifted binary result Nullable<{resultUnderlying.Name}>: underlying has no CLR type.");
+
+        this.EmitLiftedArithmetic(b.Op.Kind, lhsSlot, rhsSlot, slots.ResultSlot, leftUnderlying, leftUnderlyingClr, rightUnderlyingClr, resultUnderlyingClr);
     }
 
     private void EmitLiftedEquality(
@@ -726,10 +738,13 @@ internal sealed partial class MethodBodyEmitter
         int lhsSlot,
         int rhsSlot,
         TypeSymbol underlying,
-        Type underlyingClr)
+        Type leftUnderlyingClr,
+        Type rightUnderlyingClr)
     {
-        var getHasValue = this.outer.wellKnown.GetNullableGetHasValueReference(underlyingClr);
-        var getValue = this.outer.wellKnown.GetNullableGetValueReference(underlyingClr);
+        var getHasValueLhs = this.outer.wellKnown.GetNullableGetHasValueReference(leftUnderlyingClr);
+        var getHasValueRhs = this.outer.wellKnown.GetNullableGetHasValueReference(rightUnderlyingClr);
+        var getValueLhs = this.outer.wellKnown.GetNullableGetValueReference(leftUnderlyingClr);
+        var getValueRhs = this.outer.wellKnown.GetNullableGetValueReference(rightUnderlyingClr);
 
         var bothEmptyLabel = this.il.DefineLabel();
         var flagsAgreeLabel = this.il.DefineLabel();
@@ -738,10 +753,10 @@ internal sealed partial class MethodBodyEmitter
         // Compare HasValue flags. If they differ, result is false.
         this.il.LoadLocalAddress(lhsSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(getHasValue);
+        this.il.Token(getHasValueLhs);
         this.il.LoadLocalAddress(rhsSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(getHasValue);
+        this.il.Token(getHasValueRhs);
         this.il.Branch(ILOpCode.Beq, flagsAgreeLabel);
 
         // Mismatched HasValue → false.
@@ -752,16 +767,16 @@ internal sealed partial class MethodBodyEmitter
         this.il.MarkLabel(flagsAgreeLabel);
         this.il.LoadLocalAddress(lhsSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(getHasValue);
+        this.il.Token(getHasValueLhs);
         this.il.Branch(ILOpCode.Brfalse, bothEmptyLabel);
 
         // Both present: load values and compare.
         this.il.LoadLocalAddress(lhsSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(getValue);
+        this.il.Token(getValueLhs);
         this.il.LoadLocalAddress(rhsSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(getValue);
+        this.il.Token(getValueRhs);
         this.EmitUnderlyingEqualityCeq(underlying);
         this.il.Branch(ILOpCode.Br, end);
 
@@ -783,10 +798,13 @@ internal sealed partial class MethodBodyEmitter
         int lhsSlot,
         int rhsSlot,
         TypeSymbol underlying,
-        Type underlyingClr)
+        Type leftUnderlyingClr,
+        Type rightUnderlyingClr)
     {
-        var getHasValue = this.outer.wellKnown.GetNullableGetHasValueReference(underlyingClr);
-        var getValue = this.outer.wellKnown.GetNullableGetValueReference(underlyingClr);
+        var getHasValueLhs = this.outer.wellKnown.GetNullableGetHasValueReference(leftUnderlyingClr);
+        var getHasValueRhs = this.outer.wellKnown.GetNullableGetHasValueReference(rightUnderlyingClr);
+        var getValueLhs = this.outer.wellKnown.GetNullableGetValueReference(leftUnderlyingClr);
+        var getValueRhs = this.outer.wellKnown.GetNullableGetValueReference(rightUnderlyingClr);
 
         var falseLabel = this.il.DefineLabel();
         var end = this.il.DefineLabel();
@@ -794,20 +812,20 @@ internal sealed partial class MethodBodyEmitter
         // (lhs.HasValue & rhs.HasValue) — if any is absent, result is false.
         this.il.LoadLocalAddress(lhsSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(getHasValue);
+        this.il.Token(getHasValueLhs);
         this.il.LoadLocalAddress(rhsSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(getHasValue);
+        this.il.Token(getHasValueRhs);
         this.il.OpCode(ILOpCode.And);
         this.il.Branch(ILOpCode.Brfalse, falseLabel);
 
         // Both present: load underlying values and compare.
         this.il.LoadLocalAddress(lhsSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(getValue);
+        this.il.Token(getValueLhs);
         this.il.LoadLocalAddress(rhsSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(getValue);
+        this.il.Token(getValueRhs);
         this.EmitUnderlyingOrdering(kind, underlying);
         this.il.Branch(ILOpCode.Br, end);
 
@@ -823,17 +841,20 @@ internal sealed partial class MethodBodyEmitter
         int rhsSlot,
         int resultSlot,
         TypeSymbol underlying,
-        Type underlyingClr)
+        Type leftUnderlyingClr,
+        Type rightUnderlyingClr,
+        Type resultUnderlyingClr)
     {
-        var getHasValue = this.outer.wellKnown.GetNullableGetHasValueReference(underlyingClr);
-        var getValue = this.outer.wellKnown.GetNullableGetValueReference(underlyingClr);
+        var getHasValueLhs = this.outer.wellKnown.GetNullableGetHasValueReference(leftUnderlyingClr);
+        var getHasValueRhs = this.outer.wellKnown.GetNullableGetHasValueReference(rightUnderlyingClr);
+        var getValueLhs = this.outer.wellKnown.GetNullableGetValueReference(leftUnderlyingClr);
+        var getValueRhs = this.outer.wellKnown.GetNullableGetValueReference(rightUnderlyingClr);
 
         // Resolve Nullable<R> ctor / type tokens for the result.
-        // R == underlying for arithmetic / bitwise.
-        if (!NullableLifting.TryConstructNullable(this.outer.emitCtx.References, underlyingClr, out var nullableClr))
+        if (!NullableLifting.TryConstructNullable(this.outer.emitCtx.References, resultUnderlyingClr, out var nullableClr))
         {
             throw new InvalidOperationException(
-                $"Cannot construct Nullable<{underlyingClr.FullName}>: System.Nullable`1 is not resolvable in the reference set.");
+                $"Cannot construct Nullable<{resultUnderlyingClr.FullName}>: System.Nullable`1 is not resolvable in the reference set.");
         }
 
         var nullableInnerArg = nullableClr.GetGenericArguments()[0];
@@ -848,20 +869,20 @@ internal sealed partial class MethodBodyEmitter
         // Both present? If yes, fall through to compute; otherwise jump to null branch.
         this.il.LoadLocalAddress(lhsSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(getHasValue);
+        this.il.Token(getHasValueLhs);
         this.il.LoadLocalAddress(rhsSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(getHasValue);
+        this.il.Token(getHasValueRhs);
         this.il.OpCode(ILOpCode.And);
         this.il.Branch(ILOpCode.Brfalse, nullBranch);
 
         // Compute underlying op and wrap as Nullable<R>.
         this.il.LoadLocalAddress(lhsSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(getValue);
+        this.il.Token(getValueLhs);
         this.il.LoadLocalAddress(rhsSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(getValue);
+        this.il.Token(getValueRhs);
         this.EmitUnderlyingArithmetic(kind, underlying);
         this.il.OpCode(ILOpCode.Newobj);
         this.il.Token(this.outer.GetCtorReference(ctor));

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -556,17 +556,13 @@ internal sealed partial class MethodBodyEmitter
             return true;
         }
 
-        // Issue #574: enum comparisons (< <= > >=) dispatch through the
-        // enum's CLR underlying type. A byte/ushort/uint/ulong-backed
-        // enum needs the unsigned IL comparison opcodes (clt_un / cgt_un);
-        // a sbyte/short/int/long-backed enum needs the signed forms.
-        if (t?.ClrType?.IsEnum == true)
+        // Issue #574 / 6.6: enum comparisons and arithmetic dispatch through
+        // the enum's CLR underlying type. Unsigned-backed enums need the
+        // unsigned IL opcodes (clt_un / cgt_un). Delegates to the single
+        // source of truth in EnumOperatorTable.
+        if (Binding.EnumOperatorTable.IsUnsignedEnumUnderlying(t))
         {
-            var underlyingName = System.Enum.GetUnderlyingType(t.ClrType).FullName;
-            return underlyingName == "System.Byte"
-                || underlyingName == "System.UInt16"
-                || underlyingName == "System.UInt32"
-                || underlyingName == "System.UInt64";
+            return true;
         }
 
         return false;

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -1101,8 +1101,19 @@ internal sealed class SlotPlanner
                     or BoundBinaryOperatorKind.NotEquals;
             }
 
-            if (node.Right.Type is not NullableTypeSymbol rightNullable
-                || (NullableTypeSymbol)node.Left.Type! != rightNullable)
+            if (node.Right.Type is not NullableTypeSymbol rightNullable)
+            {
+                return false;
+            }
+
+            // Same-type nullable (e.g. int32? + int32?, enum? | enum?) or
+            // heterogeneous nullable for §11.10 enum arithmetic (e.g.
+            // enum? + int32?, enum? - enum? → int32?). Both sides must be
+            // value-type nullable; heterogeneous pairs are allowed because
+            // the EnumOperatorTable permits different-typed operands.
+            var leftNullable = (NullableTypeSymbol)node.Left.Type!;
+            if (leftNullable != rightNullable
+                && !(rightNullable.UnderlyingType?.ClrType is { IsValueType: true }))
             {
                 return false;
             }

--- a/test/Compiler.Tests/Emit/Issue6_6EnumArithmeticEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue6_6EnumArithmeticEmitTests.cs
@@ -1,0 +1,490 @@
+// <copyright file="Issue6_6EnumArithmeticEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Bug-overview item 6.6: C# §11.10 enum arithmetic operators.
+/// Tests the four §11.10 arithmetic rules:
+///   enum + underlying → enum
+///   underlying + enum → enum
+///   enum - underlying → enum
+///   enum - enum → underlying
+/// Coverage includes both imported CLR enums and user-defined G# enums,
+/// and both signed-backed (int32) and unsigned-backed (byte) enums.
+/// </summary>
+public class Issue6_6EnumArithmeticEmitTests
+{
+    [Fact]
+    public void DayOfWeek_Plus_Int32_Produces_Enum()
+    {
+        var source = """
+            package P
+            import System
+
+            Console.WriteLine(DayOfWeek.Monday + int32(2))
+            """;
+
+        Assert.Equal("Wednesday\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Int32_Plus_DayOfWeek_Produces_Enum()
+    {
+        var source = """
+            package P
+            import System
+
+            Console.WriteLine(int32(2) + DayOfWeek.Monday)
+            """;
+
+        Assert.Equal("Wednesday\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DayOfWeek_Minus_Int32_Produces_Enum()
+    {
+        var source = """
+            package P
+            import System
+
+            Console.WriteLine(DayOfWeek.Friday - int32(1))
+            """;
+
+        Assert.Equal("Thursday\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DayOfWeek_Minus_DayOfWeek_Produces_Underlying()
+    {
+        var source = """
+            package P
+            import System
+
+            Console.WriteLine(DayOfWeek.Friday - DayOfWeek.Monday)
+            """;
+
+        Assert.Equal("4\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void UserDefinedEnum_Plus_Int32()
+    {
+        var source = """
+            package P
+            import System
+
+            type Color enum {
+                Red,
+                Green,
+                Blue,
+            }
+
+            var c = Color.Red + int32(2)
+            Console.WriteLine(c == Color.Blue)
+            """;
+
+        Assert.Equal("True\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void UserDefinedEnum_Minus_UserDefinedEnum()
+    {
+        var source = """
+            package P
+            import System
+
+            type Color enum {
+                Red,
+                Green,
+                Blue,
+            }
+
+            Console.WriteLine(Color.Blue - Color.Red)
+            """;
+
+        Assert.Equal("2\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Int32_Plus_UserDefinedEnum()
+    {
+        var source = """
+            package P
+            import System
+
+            type Color enum {
+                Red,
+                Green,
+                Blue,
+            }
+
+            var c = int32(1) + Color.Red
+            Console.WriteLine(c == Color.Green)
+            """;
+
+        Assert.Equal("True\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void UnsignedBackedEnum_Plus_Underlying()
+    {
+        var csSource = """
+            namespace TestEnums
+            {
+                public enum ByteEnum : byte
+                {
+                    Zero = 0,
+                    One = 1,
+                    Two = 2,
+                    Three = 3,
+                }
+            }
+            """;
+        var gSource = """
+            package P
+            import System
+            import TestEnums
+
+            var v = ByteEnum.One + uint8(2)
+            Console.WriteLine(v == ByteEnum.Three)
+            """;
+
+        Assert.Equal("True\n", CompileAndRunWithSiblingCs(csSource, gSource, "TestEnums"));
+    }
+
+    [Fact]
+    public void UnsignedBackedEnum_Minus_Enum()
+    {
+        var csSource = """
+            namespace TestEnums
+            {
+                public enum ByteEnum : byte
+                {
+                    Zero = 0,
+                    One = 1,
+                    Two = 2,
+                    Three = 3,
+                }
+            }
+            """;
+        var gSource = """
+            package P
+            import System
+            import TestEnums
+
+            Console.WriteLine(ByteEnum.Three - ByteEnum.One)
+            """;
+
+        Assert.Equal("2\n", CompileAndRunWithSiblingCs(csSource, gSource, "TestEnums"));
+    }
+
+    [Fact]
+    public void Negative_EnumTimesEnum_ProducesDiagnostic()
+    {
+        var source = """
+            package P
+            import System
+
+            var bad = DayOfWeek.Monday * DayOfWeek.Tuesday
+            """;
+
+        var diagnostics = CompileExpectingErrors(source);
+        Assert.Contains(diagnostics, d => d.Contains("'*'") && d.Contains("DayOfWeek"));
+    }
+
+    [Fact]
+    public void Negative_EnumShiftLeft_ProducesDiagnostic()
+    {
+        var source = """
+            package P
+            import System
+
+            var bad = DayOfWeek.Monday << int32(1)
+            """;
+
+        var diagnostics = CompileExpectingErrors(source);
+        Assert.Contains(diagnostics, d => d.Contains("'<<'"));
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue6_6_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static List<string> CompileExpectingErrors(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue6_6_neg_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit != 0, $"expected gsc to report errors but it succeeded\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            var combined = compileOut.ToString() + compileErr.ToString();
+            return combined.Split('\n').Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue6_6_sib_").FullName;
+        try
+        {
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+            foreach (var reference in BclReferences.Value)
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            File.Copy(siblingDll, Path.Combine(tempDir, Path.GetFileName(siblingDll)), overwrite: true);
+            IlVerifier.Verify(outPath, additionalReferences: new[] { siblingDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string BuildCsProject(string csDir, string siblingName)
+    {
+        RunDotnet(csDir, "restore");
+        RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+
+        var dll = Path.Combine(csDir, "bin", "Release", "net10.0", siblingName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static void RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Compiler.Tests/Emit/Issue6_6EnumLiftedNullableArithmeticEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue6_6EnumLiftedNullableArithmeticEmitTests.cs
@@ -1,0 +1,234 @@
+// <copyright file="Issue6_6EnumLiftedNullableArithmeticEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Bug-overview item 6.6: §6.1 × §11.10 composition — lifted nullable
+/// enum arithmetic. Verifies that enum arithmetic operators automatically
+/// compose with the lifted-nullable binary arm.
+/// </summary>
+public class Issue6_6EnumLiftedNullableArithmeticEmitTests
+{
+    [Fact]
+    public void EnumNullable_Plus_UnderlyingNullable_BothPresent()
+    {
+        var source = """
+            package P
+            import System
+
+            var a System.DayOfWeek? = DayOfWeek.Monday
+            var b int32? = int32(2)
+            Console.WriteLine(a + b)
+            """;
+
+        Assert.Equal("Wednesday\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EnumNullable_Plus_UnderlyingNullable_LeftNull()
+    {
+        var source = """
+            package P
+            import System
+
+            var a System.DayOfWeek? = nil
+            var b int32? = int32(2)
+            Console.WriteLine(a + b)
+            """;
+
+        Assert.Equal("\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EnumNullable_Plus_UnderlyingNullable_RightNull()
+    {
+        var source = """
+            package P
+            import System
+
+            var a System.DayOfWeek? = DayOfWeek.Monday
+            var b int32? = nil
+            Console.WriteLine(a + b)
+            """;
+
+        Assert.Equal("\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EnumNullable_Minus_EnumNullable_BothPresent()
+    {
+        var source = """
+            package P
+            import System
+
+            var a System.DayOfWeek? = DayOfWeek.Friday
+            var b System.DayOfWeek? = DayOfWeek.Monday
+            Console.WriteLine(a - b)
+            """;
+
+        Assert.Equal("4\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EnumNullable_Minus_EnumNullable_LeftNull()
+    {
+        var source = """
+            package P
+            import System
+
+            var a System.DayOfWeek? = nil
+            var b System.DayOfWeek? = DayOfWeek.Monday
+            Console.WriteLine(a - b)
+            """;
+
+        Assert.Equal("\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EnumNullable_Minus_UnderlyingNullable_BothPresent()
+    {
+        var source = """
+            package P
+            import System
+
+            var a System.DayOfWeek? = DayOfWeek.Friday
+            var b int32? = int32(1)
+            Console.WriteLine(a - b)
+            """;
+
+        Assert.Equal("Thursday\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void UnderlyingNullable_Plus_EnumNullable_BothPresent()
+    {
+        var source = """
+            package P
+            import System
+
+            var a int32? = int32(3)
+            var b System.DayOfWeek? = DayOfWeek.Monday
+            Console.WriteLine(a + b)
+            """;
+
+        Assert.Equal("Thursday\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EnumNullable_Mixed_NonNullable_Underlying()
+    {
+        var source = """
+            package P
+            import System
+
+            var a System.DayOfWeek? = DayOfWeek.Monday
+            Console.WriteLine(a + int32(4))
+            """;
+
+        Assert.Equal("Friday\n", CompileAndRun(source));
+    }
+
+    // ── Helpers (same pattern as Issue574 / Issue6_6 arithmetic) ───────
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue6_6_lifted_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/EnumOperatorTableTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/EnumOperatorTableTests.cs
@@ -1,0 +1,207 @@
+// <copyright file="EnumOperatorTableTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Unit tests for <see cref="EnumOperatorTable"/>: validates each row in
+/// the binary/unary tables, negative cases, and helper methods.
+/// </summary>
+public class EnumOperatorTableTests
+{
+    private static readonly TypeSymbol DayOfWeekType = ImportedTypeSymbol.Get(typeof(DayOfWeek));
+    private static readonly TypeSymbol ConsoleKeyType = ImportedTypeSymbol.Get(typeof(ConsoleKey));
+
+    // ── TryBindBinary: comparison operators ────────────────────────────
+
+    [Theory]
+    [InlineData(SyntaxKind.EqualsEqualsToken, BoundBinaryOperatorKind.Equals)]
+    [InlineData(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals)]
+    [InlineData(SyntaxKind.LessToken, BoundBinaryOperatorKind.Less)]
+    [InlineData(SyntaxKind.LessOrEqualsToken, BoundBinaryOperatorKind.LessOrEquals)]
+    [InlineData(SyntaxKind.GreaterToken, BoundBinaryOperatorKind.Greater)]
+    [InlineData(SyntaxKind.GreaterOrEqualsToken, BoundBinaryOperatorKind.GreaterOrEquals)]
+    public void Comparison_SameEnum_ReturnsBool(SyntaxKind syntax, BoundBinaryOperatorKind expectedKind)
+    {
+        Assert.True(EnumOperatorTable.TryBindBinary(syntax, DayOfWeekType, DayOfWeekType, out var kind, out var result));
+        Assert.Equal(expectedKind, kind);
+        Assert.Equal(TypeSymbol.Bool, result);
+    }
+
+    // ── TryBindBinary: bitwise operators ──────────────────────────────
+
+    [Theory]
+    [InlineData(SyntaxKind.PipeToken, BoundBinaryOperatorKind.BitwiseOr)]
+    [InlineData(SyntaxKind.AmpersandToken, BoundBinaryOperatorKind.BitwiseAnd)]
+    [InlineData(SyntaxKind.HatToken, BoundBinaryOperatorKind.BitwiseXor)]
+    public void Bitwise_SameEnum_ReturnsEnum(SyntaxKind syntax, BoundBinaryOperatorKind expectedKind)
+    {
+        Assert.True(EnumOperatorTable.TryBindBinary(syntax, DayOfWeekType, DayOfWeekType, out var kind, out var result));
+        Assert.Equal(expectedKind, kind);
+        Assert.Equal(DayOfWeekType, result);
+    }
+
+    // ── TryBindBinary: arithmetic operators ───────────────────────────
+
+    [Fact]
+    public void Plus_EnumUnderlying_ReturnsEnum()
+    {
+        Assert.True(EnumOperatorTable.TryBindBinary(SyntaxKind.PlusToken, DayOfWeekType, TypeSymbol.Int32, out var kind, out var result));
+        Assert.Equal(BoundBinaryOperatorKind.Sum, kind);
+        Assert.Equal(DayOfWeekType, result);
+    }
+
+    [Fact]
+    public void Plus_UnderlyingEnum_ReturnsEnum()
+    {
+        Assert.True(EnumOperatorTable.TryBindBinary(SyntaxKind.PlusToken, TypeSymbol.Int32, DayOfWeekType, out var kind, out var result));
+        Assert.Equal(BoundBinaryOperatorKind.Sum, kind);
+        Assert.Equal(DayOfWeekType, result);
+    }
+
+    [Fact]
+    public void Minus_EnumUnderlying_ReturnsEnum()
+    {
+        Assert.True(EnumOperatorTable.TryBindBinary(SyntaxKind.MinusToken, DayOfWeekType, TypeSymbol.Int32, out var kind, out var result));
+        Assert.Equal(BoundBinaryOperatorKind.Difference, kind);
+        Assert.Equal(DayOfWeekType, result);
+    }
+
+    [Fact]
+    public void Minus_EnumEnum_ReturnsUnderlying()
+    {
+        Assert.True(EnumOperatorTable.TryBindBinary(SyntaxKind.MinusToken, DayOfWeekType, DayOfWeekType, out var kind, out var result));
+        Assert.Equal(BoundBinaryOperatorKind.Difference, kind);
+        Assert.Equal(TypeSymbol.Int32, result);
+    }
+
+    // ── TryBindBinary: negative cases ─────────────────────────────────
+
+    [Fact]
+    public void Star_EnumEnum_NotSupported()
+    {
+        Assert.False(EnumOperatorTable.TryBindBinary(SyntaxKind.StarToken, DayOfWeekType, DayOfWeekType, out _, out _));
+    }
+
+    [Fact]
+    public void Slash_EnumUnderlying_NotSupported()
+    {
+        Assert.False(EnumOperatorTable.TryBindBinary(SyntaxKind.SlashToken, DayOfWeekType, TypeSymbol.Int32, out _, out _));
+    }
+
+    [Fact]
+    public void ShiftLeft_Enum_NotSupported()
+    {
+        Assert.False(EnumOperatorTable.TryBindBinary(SyntaxKind.ShiftLeftToken, DayOfWeekType, TypeSymbol.Int32, out _, out _));
+    }
+
+    [Fact]
+    public void MixedEnums_NotSupported()
+    {
+        Assert.False(EnumOperatorTable.TryBindBinary(SyntaxKind.EqualsEqualsToken, DayOfWeekType, ConsoleKeyType, out _, out _));
+    }
+
+    [Fact]
+    public void Plus_EnumWrongUnderlying_NotSupported()
+    {
+        // DayOfWeek is int-backed; int64 is not the underlying type.
+        Assert.False(EnumOperatorTable.TryBindBinary(SyntaxKind.PlusToken, DayOfWeekType, TypeSymbol.Int64, out _, out _));
+    }
+
+    [Fact]
+    public void NullTypes_NotSupported()
+    {
+        Assert.False(EnumOperatorTable.TryBindBinary(SyntaxKind.PlusToken, null, DayOfWeekType, out _, out _));
+        Assert.False(EnumOperatorTable.TryBindBinary(SyntaxKind.PlusToken, DayOfWeekType, null, out _, out _));
+    }
+
+    // ── TryBindUnary ──────────────────────────────────────────────────
+
+    [Fact]
+    public void UnaryHat_Enum_ReturnsOnesComplement()
+    {
+        Assert.True(EnumOperatorTable.TryBindUnary(SyntaxKind.HatToken, DayOfWeekType, out var kind, out var result));
+        Assert.Equal(BoundUnaryOperatorKind.OnesComplement, kind);
+        Assert.Equal(DayOfWeekType, result);
+    }
+
+    [Fact]
+    public void UnaryMinus_Enum_NotSupported()
+    {
+        Assert.False(EnumOperatorTable.TryBindUnary(SyntaxKind.MinusToken, DayOfWeekType, out _, out _));
+    }
+
+    [Fact]
+    public void UnaryHat_NonEnum_NotSupported()
+    {
+        Assert.False(EnumOperatorTable.TryBindUnary(SyntaxKind.HatToken, TypeSymbol.Int32, out _, out _));
+    }
+
+    // ── IsUnsignedEnumUnderlying ──────────────────────────────────────
+
+    [Fact]
+    public void IsUnsignedEnumUnderlying_SignedEnum_ReturnsFalse()
+    {
+        // DayOfWeek is int32-backed (signed)
+        Assert.False(EnumOperatorTable.IsUnsignedEnumUnderlying(DayOfWeekType));
+    }
+
+    [Fact]
+    public void IsUnsignedEnumUnderlying_NonEnum_ReturnsFalse()
+    {
+        Assert.False(EnumOperatorTable.IsUnsignedEnumUnderlying(TypeSymbol.Int32));
+        Assert.False(EnumOperatorTable.IsUnsignedEnumUnderlying(TypeSymbol.UInt32));
+        Assert.False(EnumOperatorTable.IsUnsignedEnumUnderlying(null));
+    }
+
+    // ── IsEnumType ────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsEnumType_ImportedEnum_ReturnsTrue()
+    {
+        Assert.True(EnumOperatorTable.IsEnumType(DayOfWeekType));
+    }
+
+    [Fact]
+    public void IsEnumType_NullableEnum_ReturnsFalse()
+    {
+        var nullable = NullableTypeSymbol.Get(DayOfWeekType);
+        Assert.False(EnumOperatorTable.IsEnumType(nullable));
+    }
+
+    [Fact]
+    public void IsEnumType_Primitive_ReturnsFalse()
+    {
+        Assert.False(EnumOperatorTable.IsEnumType(TypeSymbol.Int32));
+        Assert.False(EnumOperatorTable.IsEnumType(TypeSymbol.Bool));
+    }
+
+    [Fact]
+    public void IsEnumType_Null_ReturnsFalse()
+    {
+        Assert.False(EnumOperatorTable.IsEnumType(null));
+    }
+
+    // ── GetUnderlyingType ─────────────────────────────────────────────
+
+    [Fact]
+    public void GetUnderlyingType_ImportedEnum_ReturnsInt32()
+    {
+        // DayOfWeek is int32-backed
+        Assert.Equal(TypeSymbol.Int32, EnumOperatorTable.GetUnderlyingType(DayOfWeekType));
+    }
+
+    [Fact]
+    public void GetUnderlyingType_NonEnum_ReturnsNull()
+    {
+        Assert.Null(EnumOperatorTable.GetUnderlyingType(TypeSymbol.Int32));
+        Assert.Null(EnumOperatorTable.GetUnderlyingType(null));
+    }
+}


### PR DESCRIPTION
## Summary

Bug-overview item 6.6: refactors the per-operator-group enum handling (post-#574 comparison, post-#534 bitwise, ones-complement) into a single declarative `EnumOperatorTable`, and closes the C# §11.10 enum arithmetic gaps (`enum ± underlying`, `enum − enum → underlying`) as natural fallout. This is an architectural hardening PR — #574 is already closed; this is a post-#574 structural refactor.

## Pieces

- **New file `EnumOperatorTable.cs`**: single declarative source for every C# §11.10 enum operator rule (comparison, bitwise, arithmetic, unary ones-complement). Three operand shapes (`EnumEnum`, `EnumUnderlying`, `UnderlyingEnum`) × three result categories (`ResultBool`, `ResultEnum`, `ResultUnderlying`).
- **Collapsed binary binder**: two separate per-arm enum blocks (comparison lines 107-132, bitwise lines 134-150) → single `EnumOperatorTable.TryBindBinary` call.
- **Collapsed unary binder**: ones-complement arm → `EnumOperatorTable.TryBindUnary` call.
- **Emit-side reroute**: `IsUnsignedOrChar` enum branch delegates to `EnumOperatorTable.IsUnsignedEnumUnderlying`.
- **§6.1 lifted-nullable composition**: added heterogeneous nullable arm + heterogeneous mixed-mode lift so `enum? + int32?`, `enum? - enum?`, and `enum? + int32` all work. Fixed `NullableTypeSymbol.ClrType` leak where `DayOfWeek?.ClrType.IsEnum == true` was incorrectly matching nullable-wrapped enums.
- **Three new test classes**: `Issue6_6EnumArithmeticEmitTests` (11 tests), `Issue6_6EnumLiftedNullableArithmeticEmitTests` (8 tests), `EnumOperatorTableTests` (30 unit tests).
- **Documentation**: `docs/enum-operators.md` summarizing the unified enum operator support.

## `check-conversion-side` audit finding

On unmodified main (pre-this-PR), all four enum arithmetic patterns — `DayOfWeek.Monday + int32(2)`, `int32(2) + DayOfWeek.Monday`, `DayOfWeek.Friday - DayOfWeek.Monday`, `DayOfWeek.Monday - int32(1)` — produce binder error `GS0129: Binary operator is not defined for types`. **The new arithmetic rules are pure additions with zero regression risk** — no existing code could have been relying on enum arithmetic since it was always rejected.

## Spot-check outputs

```
$ DayOfWeek.Monday + int32(2)
Wednesday

$ DayOfWeek.Friday - DayOfWeek.Monday
4

$ var a System.DayOfWeek? = DayOfWeek.Monday; var b int32? = nil; Console.WriteLine(a + b)
(empty line — nullable-no-value)

$ DayOfWeek.Monday * DayOfWeek.Tuesday
error GS0129: Binary operator '*' is not defined for types 'System.DayOfWeek' and 'System.DayOfWeek'.
```

## Follow-up issues filed

- #613 — Binder: extend the EnumOperatorTable pattern to user-defined operator-lifted types
- #614 — Tech debt: audit BoundBinaryOperator.cs / BoundUnaryOperator.cs for other per-arm patterns
- #615 — Interpreter: enum arithmetic operator support (NarrowToResultType does not handle enum types)

## Test results

- **Core.Tests**: 2179 passed, 1 skipped (RegenerateBaseline)
- **Compiler.Tests**: all enum-related tests pass (69 tests green in targeted run including Issue534, Issue574, Issue6_6, NullableLiftedBinary, EnumEmit, ImportedEnumAttribute). Full-suite run hits pre-existing OOM (file-descriptor exhaustion in test host process when 659 tests run in a single process) — documented, not caused by this PR.

## Pre-existing OOM note

The Compiler.Tests host process crashes with "Too many open files" / "Out of memory" when all 659 tests run in a single process. This is a pre-existing issue unrelated to this PR. All tests pass individually or in targeted batches.