### PR TITLE
6.7: Fix #567 closure regression (capture reference-type local + field access)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundFieldAssignmentExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundFieldAssignmentExpression.cs
@@ -12,8 +12,9 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
 /// Writes a field on a struct held in a variable: <c>variable.Field = value</c>
-/// (Phase 3.B.1). For Phase 3.B.1 the receiver must be a simple variable
-/// reference (no nested field paths yet).
+/// (Phase 3.B.1). The receiver is either a simple variable reference or, after
+/// closure-boxing lowering, an arbitrary expression (e.g. <c>boxLocal.Value</c>
+/// for a boxed reference-type captured variable — issue #567).
 /// </summary>
 public sealed class BoundFieldAssignmentExpression : BoundExpression
 {
@@ -26,7 +27,24 @@ public sealed class BoundFieldAssignmentExpression : BoundExpression
         Value = value;
     }
 
+    private BoundFieldAssignmentExpression(SyntaxNode syntax, BoundExpression receiverExpression, StructSymbol structType, FieldSymbol field, BoundExpression value)
+        : base(syntax)
+    {
+        ReceiverExpression = receiverExpression;
+        StructType = structType;
+        Field = field;
+        Value = value;
+    }
+
     public VariableSymbol Receiver { get; }
+
+    /// <summary>
+    /// Gets the expression-based receiver, or <c>null</c> when the simple
+    /// <see cref="Receiver"/> variable form is used. When non-null, the
+    /// emitter evaluates this expression to produce the instance reference
+    /// instead of loading <see cref="Receiver"/>.
+    /// </summary>
+    public BoundExpression ReceiverExpression { get; }
 
     public StructSymbol StructType { get; }
 
@@ -37,4 +55,25 @@ public sealed class BoundFieldAssignmentExpression : BoundExpression
     public override TypeSymbol Type => Field.Type;
 
     public override BoundNodeKind Kind => BoundNodeKind.FieldAssignmentExpression;
+
+    /// <summary>
+    /// Creates a field assignment with an expression-based receiver. Used
+    /// after closure-boxing lowering when the original receiver local has
+    /// been replaced by a field access through a box (issue #567).
+    /// </summary>
+    /// <param name="syntax">The originating syntax, or <c>null</c> for synthesized nodes.</param>
+    /// <param name="receiverExpression">The expression that produces the instance reference.</param>
+    /// <param name="structType">The declaring struct/class type.</param>
+    /// <param name="field">The field to write.</param>
+    /// <param name="value">The value to assign.</param>
+    /// <returns>A new <see cref="BoundFieldAssignmentExpression"/> with an expression receiver.</returns>
+    public static BoundFieldAssignmentExpression WithExpressionReceiver(
+        SyntaxNode syntax,
+        BoundExpression receiverExpression,
+        StructSymbol structType,
+        FieldSymbol field,
+        BoundExpression value)
+    {
+        return new BoundFieldAssignmentExpression(syntax, receiverExpression, structType, field, value);
+    }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1602,6 +1602,17 @@ public abstract class BoundTreeRewriter
     protected virtual BoundExpression RewriteFieldAssignmentExpression(BoundFieldAssignmentExpression node)
     {
         var value = RewriteExpression(node.Value);
+        if (node.ReceiverExpression != null)
+        {
+            var receiverExpr = RewriteExpression(node.ReceiverExpression);
+            if (ReferenceEquals(value, node.Value) && ReferenceEquals(receiverExpr, node.ReceiverExpression))
+            {
+                return node;
+            }
+
+            return BoundFieldAssignmentExpression.WithExpressionReceiver(null, receiverExpr, node.StructType, node.Field, value);
+        }
+
         return value == node.Value ? node : new BoundFieldAssignmentExpression(null, node.Receiver, node.StructType, node.Field, value);
     }
 

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -526,6 +526,21 @@ internal sealed class LambdaBinder
             return node;
         }
 
+        protected override BoundExpression RewriteFieldAssignmentExpression(BoundFieldAssignmentExpression node)
+        {
+            // Issue #567: BoundFieldAssignmentExpression carries its receiver
+            // as a raw VariableSymbol, not as a BoundVariableExpression. Without
+            // this override the receiver variable is invisible to capture
+            // analysis when the lambda body only does field writes (not reads)
+            // on the variable.
+            if (node.Receiver != null)
+            {
+                this.RecordReference(node.Receiver);
+            }
+
+            return base.RewriteFieldAssignmentExpression(node);
+        }
+
         protected override BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
         {
             // Issue #503 follow-up: a nested function literal's captures

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -466,7 +466,7 @@ internal sealed partial class MethodBodyEmitter
         }
 
         // ADR-0053: static field assignment — no receiver, use stsfld/ldsfld.
-        if (fas.Receiver == null)
+        if (fas.Receiver == null && fas.ReceiverExpression == null)
         {
             this.EmitExpression(fas.Value);
             this.il.OpCode(ILOpCode.Stsfld);
@@ -474,6 +474,24 @@ internal sealed partial class MethodBodyEmitter
 
             // Leave the assigned value on the stack as the expression result.
             this.il.OpCode(ILOpCode.Ldsfld);
+            this.il.Token(fieldHandle);
+            return;
+        }
+
+        // Issue #567: expression-based receiver (closure boxing lowered
+        // `variable.Field = value` to `boxLocal.Value.Field = value`).
+        // The receiver is an arbitrary BoundExpression that produces the
+        // instance reference on the stack.
+        if (fas.ReceiverExpression != null)
+        {
+            this.EmitExpression(fas.ReceiverExpression);
+            this.EmitExpression(fas.Value);
+            this.il.OpCode(ILOpCode.Stfld);
+            this.il.Token(fieldHandle);
+
+            // Leave the assigned value on the stack as the expression result.
+            this.EmitExpression(fas.ReceiverExpression);
+            this.il.OpCode(ILOpCode.Ldfld);
             this.il.Token(fieldHandle);
             return;
         }

--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -58,6 +58,18 @@ internal static class CaptureBoxingRewriter
     /// outer scope. Returns the original instance unchanged when no
     /// function body required boxing.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Invariant (issue #567):</b> every lambda whose body is rewritten
+    /// inside an outer function's tree must also have its
+    /// <c>program.Functions[lambdaSymbol]</c> entry updated. The emitter
+    /// looks lambdas up by <see cref="FunctionSymbol"/> key; if the entry
+    /// still points to the original un-rewritten body, the emitter trips on
+    /// unresolved variable references. The propagation pass after the main
+    /// foreach loop closes this gap by overwriting stale entries with the
+    /// rewritten lambda bodies collected during the outer function's rewrite.
+    /// </para>
+    /// </remarks>
     /// <param name="program">The bound program to lower.</param>
     /// <returns>The lowered program (or the original when nothing changed).</returns>
     public static BoundProgram Lower(BoundProgram program)
@@ -66,13 +78,34 @@ internal static class CaptureBoxingRewriter
         var newStructs = new List<StructSymbol>();
         var newFunctions = ImmutableDictionary.CreateBuilder<FunctionSymbol, BoundBlockStatement>();
         var changed = false;
+        var allLambdaUpdates = new Dictionary<FunctionSymbol, BoundBlockStatement>();
 
         foreach (var pair in program.Functions)
         {
-            var newBody = RewriteFunctionBody(pair.Key, pair.Value, program, newStructs, ref counter);
+            var (newBody, lambdaUpdates) = RewriteFunctionBody(pair.Key, pair.Value, program, newStructs, ref counter);
             newFunctions[pair.Key] = newBody;
             if (!ReferenceEquals(newBody, pair.Value))
             {
+                changed = true;
+            }
+
+            foreach (var kv in lambdaUpdates)
+            {
+                allLambdaUpdates[kv.Key] = kv.Value;
+            }
+        }
+
+        // Propagate rewritten lambda bodies to the per-symbol Functions map.
+        // When the outer function's body is rewritten, nested lambdas inside
+        // its tree are rewritten inline (through BoxingRewriter), but
+        // program.Functions[lambdaSymbol] still points to the original
+        // un-rewritten body. The emitter looks lambdas up by FunctionSymbol
+        // key, so we must overwrite those entries here. This closes #567.
+        foreach (var (lambdaSymbol, rewrittenBody) in allLambdaUpdates)
+        {
+            if (newFunctions.ContainsKey(lambdaSymbol))
+            {
+                newFunctions[lambdaSymbol] = rewrittenBody;
                 changed = true;
             }
         }
@@ -103,13 +136,16 @@ internal static class CaptureBoxingRewriter
         return result;
     }
 
-    private static BoundBlockStatement RewriteFunctionBody(
+    private static (BoundBlockStatement Body, Dictionary<FunctionSymbol, BoundBlockStatement> LambdaUpdates)
+        RewriteFunctionBody(
         FunctionSymbol function,
         BoundBlockStatement body,
         BoundProgram program,
         List<StructSymbol> newStructs,
         ref int counter)
     {
+        var emptyUpdates = new Dictionary<FunctionSymbol, BoundBlockStatement>();
+
         // Step 1: collect every captured variable touched by any function
         // literal in this body (transitively). This is the union over all
         // BoundFunctionLiteralExpression.CapturedVariables reachable from
@@ -120,7 +156,7 @@ internal static class CaptureBoxingRewriter
 
         if (capturedSet.Count == 0)
         {
-            return body;
+            return (body, emptyUpdates);
         }
 
         // Step 2: classify each captured variable.
@@ -170,7 +206,7 @@ internal static class CaptureBoxingRewriter
 
         if (boxInfo.Count == 0 && dropFromCapture.Count == 0)
         {
-            return body;
+            return (body, emptyUpdates);
         }
 
         // Step 3: rewrite the body — locals, reads, writes, and lambdas.
@@ -217,7 +253,7 @@ internal static class CaptureBoxingRewriter
             rewritten = new BoundBlockStatement(null, prologue.ToImmutable());
         }
 
-        return rewritten;
+        return (rewritten, rewriter.RewrittenLambdaBodies);
     }
 
     private static bool IsBoxable(VariableSymbol variable, FunctionSymbol function)
@@ -345,6 +381,15 @@ internal static class CaptureBoxingRewriter
             this.dropFromCapture = dropFromCapture;
         }
 
+        /// <summary>
+        /// Gets the lambda bodies rewritten during this pass. When the outer function's
+        /// body is rewritten, any nested <see cref="BoundFunctionLiteralExpression"/>
+        /// whose body changes is recorded here so <see cref="Lower"/> can propagate
+        /// the rewritten body back to <c>program.Functions[lambdaSymbol]</c>.
+        /// </summary>
+        public Dictionary<FunctionSymbol, BoundBlockStatement> RewrittenLambdaBodies { get; }
+            = new Dictionary<FunctionSymbol, BoundBlockStatement>();
+
         /// <inheritdoc/>
         protected override BoundExpression RewriteVariableExpression(BoundVariableExpression node)
         {
@@ -375,6 +420,33 @@ internal static class CaptureBoxingRewriter
             }
 
             return base.RewriteAssignmentExpression(node);
+        }
+
+        /// <inheritdoc/>
+        protected override BoundExpression RewriteFieldAssignmentExpression(BoundFieldAssignmentExpression node)
+        {
+            // Issue #567: when the receiver of a field assignment is a boxed
+            // variable, the original receiver no longer has an IL slot. Rewrite
+            // to use an expression-based receiver: `boxLocal.Value` produces
+            // the reference to the original object, then the outer field
+            // assignment targets the object's field through that expression.
+            if (node.Receiver != null && this.boxInfo.TryGetValue(node.Receiver, out var bi))
+            {
+                var receiverExpr = new BoundFieldAccessExpression(
+                    null,
+                    new BoundVariableExpression(null, bi.BoxLocal),
+                    bi.BoxClass,
+                    bi.BoxField);
+                var value = this.RewriteExpression(node.Value);
+                return BoundFieldAssignmentExpression.WithExpressionReceiver(
+                    null,
+                    receiverExpr,
+                    node.StructType,
+                    node.Field,
+                    value);
+            }
+
+            return base.RewriteFieldAssignmentExpression(node);
         }
 
         /// <inheritdoc/>
@@ -447,6 +519,13 @@ internal static class CaptureBoxingRewriter
             if (ReferenceEquals(newBody, node.Body) && !anyCaptureChange)
             {
                 return node;
+            }
+
+            // Track the rewritten body so Lower can propagate it to
+            // program.Functions[lambdaSymbol], closing #567.
+            if (!ReferenceEquals(newBody, node.Body))
+            {
+                this.RewrittenLambdaBodies[node.Function] = newBody;
             }
 
             return new BoundFunctionLiteralExpression(

--- a/test/Compiler.Tests/Emit/Issue567ClockHolderRegressionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue567ClockHolderRegressionTests.cs
@@ -1,0 +1,367 @@
+// <copyright file="Issue567ClockHolderRegressionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Regression coverage for issue #567: capturing a reference-type local in a
+/// closure inside a class method, then reading or writing a field on that
+/// local, must compile correctly and emit valid IL. The underlying bug was a
+/// stale <c>program.Functions[lambdaSymbol]</c> entry after the outer
+/// function's body was rewritten by <c>CaptureBoxingRewriter</c>, combined
+/// with a missing <c>BoundFieldAssignmentExpression</c> rewrite for boxed
+/// receivers. Each test compiles end-to-end, verifies with <c>ilverify</c>,
+/// and asserts on runtime stdout.
+/// </summary>
+public class Issue567ClockHolderRegressionTests
+{
+    /// <summary>
+    /// The exact repro from issue #567: capture a reference-type local in a
+    /// class method, set a field on it, then read that field from a closure.
+    /// </summary>
+    [Fact]
+    public void ClockHolder_FieldRead_FromClosureInClassMethod()
+    {
+        var source = """
+            package Probe
+            import System
+
+            type ClockHolder class {
+                Value int32
+                init() {}
+            }
+
+            type GS9998_Probe class {
+                init() {}
+                func Run() int32 {
+                    var clock = ClockHolder()
+                    clock.Value = 42
+                    var getter = func() int32 { return clock.Value }
+                    let v = getter()
+                    return v
+                }
+            }
+
+            var p = GS9998_Probe()
+            Console.WriteLine(p.Run())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    /// <summary>
+    /// Closure mutates a field on the captured reference-type local; the
+    /// outer scope observes the mutation.
+    /// </summary>
+    [Fact]
+    public void ClockHolder_FieldWrite_FromClosureInClassMethod()
+    {
+        var source = """
+            package Probe
+            import System
+
+            type ClockHolder class {
+                Value int32
+                init() {}
+            }
+
+            type Probe2 class {
+                init() {}
+                func Run() int32 {
+                    var clock = ClockHolder()
+                    clock.Value = 10
+                    var setter = func(x int32) { clock.Value = x }
+                    setter(99)
+                    return clock.Value
+                }
+            }
+
+            var p = Probe2()
+            Console.WriteLine(p.Run())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    /// <summary>
+    /// Closure adds to a captured list; outer scope observes the addition.
+    /// </summary>
+    [Fact]
+    public void ListMutation_FromClosureInClassMethod()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            type ListProbe class {
+                init() {}
+                func Run() int32 {
+                    var items = List[int32]()
+                    var adder = func(x int32) { items.Add(x) }
+                    adder(1)
+                    adder(2)
+                    adder(3)
+                    return items.Count
+                }
+            }
+
+            var p = ListProbe()
+            Console.WriteLine(p.Run())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n", output);
+    }
+
+    /// <summary>
+    /// Closure adds to a captured dictionary; outer scope reads the count.
+    /// </summary>
+    [Fact]
+    public void DictionaryMutation_FromClosureInClassMethod()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            type DictProbe class {
+                init() {}
+                func Run() int32 {
+                    var d = Dictionary[string, int32]()
+                    var put = func(k string, v int32) { d.Add(k, v) }
+                    put("a", 1)
+                    put("b", 2)
+                    return d.Count
+                }
+            }
+
+            var p = DictProbe()
+            Console.WriteLine(p.Run())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    /// <summary>
+    /// Two lambdas in the same scope both capture the same reference-type
+    /// local and observe each other's field writes through the shared box.
+    /// </summary>
+    [Fact]
+    public void MultipleClosures_ShareCapturedReferenceLocal()
+    {
+        var source = """
+            package Probe
+            import System
+
+            type Counter class {
+                N int32
+                init() {}
+            }
+
+            type MultiProbe class {
+                init() {}
+                func Run() int32 {
+                    var c = Counter()
+                    var inc = func() { c.N = c.N + 1 }
+                    var read = func() int32 { return c.N }
+                    inc()
+                    inc()
+                    inc()
+                    return read()
+                }
+            }
+
+            var p = MultiProbe()
+            Console.WriteLine(p.Run())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n", output);
+    }
+
+    /// <summary>
+    /// Nested closure: outer lambda captures a reference-type local; inner
+    /// lambda (declared inside outer's body) also reads a field on it.
+    /// </summary>
+    [Fact]
+    public void NestedClosure_CapturesCapturedReferenceLocal()
+    {
+        var source = """
+            package Probe
+            import System
+
+            type Holder class {
+                Val int32
+                init() {}
+            }
+
+            type NestProbe class {
+                init() {}
+                func Run() int32 {
+                    var h = Holder()
+                    h.Val = 7
+                    var outer = func() func() int32 {
+                        var inner = func() int32 { return h.Val }
+                        return inner
+                    }
+                    var f = outer()
+                    return f()
+                }
+            }
+
+            var p = NestProbe()
+            Console.WriteLine(p.Run())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    /// <summary>
+    /// Top-level function variant: closure captures a reference-type local
+    /// in a package-level function (not inside a class), confirming the fix
+    /// doesn't regress the simpler non-class-method path.
+    /// </summary>
+    [Fact]
+    public void ClosureInsideClassMethod_OnStatic()
+    {
+        var source = """
+            package Probe
+            import System
+
+            type Box class {
+                X int32
+                init() {}
+            }
+
+            func Go() int32 {
+                var b = Box()
+                b.X = 55
+                var read = func() int32 { return b.X }
+                return read()
+            }
+
+            Console.WriteLine(Go())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("55\n", output);
+    }
+
+    /// <summary>
+    /// Oahu-inspired shape: a class with a mutable state field, a method
+    /// that captures it in a closure and mutates through the closure, then
+    /// observes the mutation from the outer scope.
+    /// </summary>
+    [Fact]
+    public void OahuRepro_CtrlCStateShape()
+    {
+        var source = """
+            package Probe
+            import System
+
+            type State class {
+                Running bool
+                init() {}
+            }
+
+            type Controller class {
+                init() {}
+                func Execute() string {
+                    var state = State()
+                    state.Running = true
+                    var stop = func() { state.Running = false }
+                    stop()
+                    if state.Running {
+                        return "still running"
+                    }
+                    return "stopped"
+                }
+            }
+
+            var c = Controller()
+            Console.WriteLine(c.Execute())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("stopped\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_567_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Bug-overview item 6.7

Closes #567

## Root cause

`CaptureBoxingRewriter.Lower` iterates `program.Functions` by `FunctionSymbol`. When processing the outer function (e.g. `Run()`), the boxing rewriter descends into nested lambda bodies via `BoxingRewriter.RewriteFunctionLiteralExpression` and rewrites variable references to go through the synthesized box class. However, `program.Functions[lambdaSymbol]` — the per-symbol entry the emitter looks up via `program.Functions[function]` at emit time — was **not** updated with the rewritten body. The emitter saw the original un-rewritten lambda body and tripped on unresolved `BoundVariableExpression(clock)`.

Additionally, `CapturedVariableCollector` (in `LambdaBinder.cs`) only tracked variable references through `BoundVariableExpression` and `BoundAssignmentExpression`. It did **not** recognize `BoundFieldAssignmentExpression.Receiver` (a raw `VariableSymbol`, not a `BoundExpression` node) as a variable use. This meant that when a lambda body only wrote to a field on a captured variable (`clock.Value = x`) without reading the variable itself, the variable was never added to `CapturedVariables` — so boxing was never triggered and the emitter failed.

Finally, `BoxingRewriter` itself lacked a `RewriteFieldAssignmentExpression` override. After boxing replaces a local with a box class, any `BoundFieldAssignmentExpression` referencing the original local as its receiver must be rewritten to use an expression-based receiver (`boxLocal.Value.Field = value`). Without this, the outer function's body would also fail at emit time.

## Changes

- **Collector**: `CapturedVariableCollector.RewriteFieldAssignmentExpression` now records the receiver variable, ensuring field-assignment-only captures are detected.
- **Rewriter**: `BoxingRewriter.RewriteFieldAssignmentExpression` rewrites boxed receivers to expression-based form via `BoundFieldAssignmentExpression.WithExpressionReceiver`.
- **Emitter**: `MethodBodyEmitter.EmitFieldAssignment` handles the new `ReceiverExpression` path, emitting the receiver expression instead of `EmitLoadVariable`.
- **Propagation pass**: After the main foreach in `Lower`, a second pass overwrites `newFunctions[lambdaSymbol]` with rewritten bodies collected during the outer function's rewrite.
- **Invariant docstring**: Added remarks above `Lower()` documenting the `program.Functions` propagation requirement.
- **8-case regression test class**: `Issue567ClockHolderRegressionTests` with one `[Fact]` per shape.

## Follow-up issues

- #617 — Tech debt: consider topological lowering order for nested functions
- #618 — Tech debt: audit other lowering passes for stale program.Functions entries
- Interpreter issue: **not filed** — all 72 interpreter tests pass; the interpreter's scope model handles closures correctly without boxing.

## Spot-check stdout captures

### Spot check 1: Exact #567 issue-body repro
```
$ gsc /out:spot1.dll /target:exe spot1.gs
Wrote spot1.dll
$ dotnet exec spot1.dll
42
```

### Spot check 2: Mutating shape (closure writes clock.Value = 99)
```
$ gsc /out:spot2.dll /target:exe spot2.gs
Wrote spot2.dll
$ dotnet exec spot2.dll
99
```

### Spot check 3: Negative case (unresolved type, should still fail)
```
$ gsc /out:spot3.dll /target:exe spot3.gs
spot3.gs(5,13,5,23): error GS0130: Function 'NoSuchType' doesn't exist.
```

## Test results

- **Core.Tests**: 2179 passed, 1 skipped, 0 failed
- **Interpreter.Tests**: 72 passed, 0 failed
- **Compiler.Tests** (closure-focused): 33 passed, 0 failed (Issue523 + Issue503 + Issue567 suites)
- **Compiler.Tests** (full): pre-existing OOM/fd-exhaustion aborts the host process when all 578+ emit tests run in a single process — documented, not a regression
- **Sdk.Tests**: 26 passed, 0 failed
- **LanguageServer.Tests**: 242 passed, 0 failed