### PR TITLE
Fix #502 (remaining facet): async func returning user-defined class now correctly lifts to Task<T>

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundAwaitExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundAwaitExpression.cs
@@ -19,11 +19,13 @@ public sealed class BoundAwaitExpression : BoundExpression
     /// <param name="syntax">The originating syntax.</param>
     /// <param name="expression">The expression being awaited.</param>
     /// <param name="type">The unwrapped type that the await yields.</param>
-    public BoundAwaitExpression(SyntaxNode syntax, BoundExpression expression, TypeSymbol type)
+    /// <param name="awaiterTypeSymbol">The symbolic awaiter type used by lowering/emission.</param>
+    public BoundAwaitExpression(SyntaxNode syntax, BoundExpression expression, TypeSymbol type, TypeSymbol awaiterTypeSymbol = null)
         : base(syntax)
     {
         Expression = expression;
         Type = type;
+        AwaiterTypeSymbol = awaiterTypeSymbol;
     }
 
     /// <inheritdoc/>
@@ -34,4 +36,7 @@ public sealed class BoundAwaitExpression : BoundExpression
 
     /// <summary>Gets the awaited expression. Its runtime value must be a <c>Task</c> or <c>Task[T]</c>.</summary>
     public BoundExpression Expression { get; }
+
+    /// <summary>Gets the symbolic awaiter type used when the operand was bound through an erased placeholder CLR type.</summary>
+    public TypeSymbol AwaiterTypeSymbol { get; }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundStateMachineAwaitOnCompleted.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundStateMachineAwaitOnCompleted.cs
@@ -21,12 +21,14 @@ public sealed class BoundStateMachineAwaitOnCompleted : BoundExpression
     /// <param name="syntax">The originating syntax.</param>
     /// <param name="awaiterLocal">The local variable holding the awaiter.</param>
     /// <param name="awaiterClrType">The CLR type of the awaiter.</param>
+    /// <param name="awaiterTypeSymbol">The symbolic type of the awaiter.</param>
     /// <param name="useCritical">Whether to use <c>AwaitUnsafeOnCompleted</c> (true) or <c>AwaitOnCompleted</c> (false).</param>
-    public BoundStateMachineAwaitOnCompleted(SyntaxNode syntax, VariableSymbol awaiterLocal, Type awaiterClrType, bool useCritical)
+    public BoundStateMachineAwaitOnCompleted(SyntaxNode syntax, VariableSymbol awaiterLocal, Type awaiterClrType, TypeSymbol awaiterTypeSymbol, bool useCritical)
         : base(syntax)
     {
         AwaiterLocal = awaiterLocal ?? throw new ArgumentNullException(nameof(awaiterLocal));
         AwaiterClrType = awaiterClrType ?? throw new ArgumentNullException(nameof(awaiterClrType));
+        AwaiterTypeSymbol = awaiterTypeSymbol ?? TypeSymbol.FromClrType(awaiterClrType);
         UseCritical = useCritical;
     }
 
@@ -41,6 +43,9 @@ public sealed class BoundStateMachineAwaitOnCompleted : BoundExpression
 
     /// <summary>Gets the CLR type of the awaiter.</summary>
     public Type AwaiterClrType { get; }
+
+    /// <summary>Gets the symbolic type of the awaiter.</summary>
+    public TypeSymbol AwaiterTypeSymbol { get; }
 
     /// <summary>Gets a value indicating whether to use <c>AwaitUnsafeOnCompleted</c>.</summary>
     public bool UseCritical { get; }

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -603,7 +603,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundAwaitExpression(null, expression, node.Type);
+        return new BoundAwaitExpression(null, expression, node.Type, node.AwaiterTypeSymbol);
     }
 
     /// <summary>Rewrites a bound switch expression.</summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -380,6 +380,30 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        return new BoundAwaitExpression(null, operand, element);
+        return new BoundAwaitExpression(null, operand, element, TryGetAwaiterTypeSymbol(operand.Type));
+    }
+
+    private static TypeSymbol TryGetAwaiterTypeSymbol(TypeSymbol awaitableType)
+    {
+        if (awaitableType is not ImportedTypeSymbol importedAwaitable
+            || importedAwaitable.OpenDefinition == null
+            || importedAwaitable.TypeArguments.IsDefaultOrEmpty
+            || importedAwaitable.HasTypeParameterArgument
+            || !importedAwaitable.TypeArguments.Any(static a => a is StructSymbol or InterfaceSymbol or EnumSymbol))
+        {
+            return null;
+        }
+
+        var shape = AwaitableShape.Resolve(importedAwaitable.ClrType);
+        if (shape?.AwaiterType == null || !shape.AwaiterType.IsConstructedGenericType)
+        {
+            return null;
+        }
+
+        var awaiterOpen = shape.AwaiterType.GetGenericTypeDefinition();
+        return ImportedTypeSymbol.GetConstructed(
+            shape.AwaiterType,
+            awaiterOpen,
+            importedAwaitable.TypeArguments);
     }
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -447,6 +447,15 @@ internal sealed partial class ExpressionBinder
     private static bool TryGetTaskElementType(TypeSymbol type, out TypeSymbol element)
     {
         element = null;
+        if (type is ImportedTypeSymbol importedTask
+            && !importedTask.TypeArguments.IsDefaultOrEmpty
+            && importedTask.TypeArguments.Length == 1
+            && importedTask.OpenDefinition?.FullName == "System.Threading.Tasks.Task`1")
+        {
+            element = importedTask.TypeArguments[0];
+            return true;
+        }
+
         var clr = type?.ClrType;
         if (clr == null)
         {

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -402,8 +402,20 @@ internal sealed class LambdaBinder
         var clr = element.ClrType;
         if (clr == null)
         {
-            // Phase 5.1 limitation (see ADR-0023): wrapping a user-defined
-            // GSharp type as Task[T] requires interop work that is deferred.
+            if (element is StructSymbol or InterfaceSymbol or EnumSymbol
+                && Scope.References.TryResolveType("System.Threading.Tasks.Task`1", out var symbolicTaskOpen))
+            {
+                // Issue #502 / #320: a user-defined async result type has no CLR
+                // Type yet, so close Task<T> over an object placeholder for
+                // reflection/member lookup while preserving the symbolic result
+                // type for emit-time metadata encoding.
+                var erasedTask = symbolicTaskOpen.MakeGenericType(Scope.References.MapClrTypeToReferences(typeof(object)));
+                return ImportedTypeSymbol.GetConstructed(
+                    erasedTask,
+                    symbolicTaskOpen,
+                    ImmutableArray.Create(element));
+            }
+
             return element;
         }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -218,7 +218,7 @@ internal sealed partial class MethodBodyEmitter
                     }
 
                     this.EmitImportedCallArguments(instCall.Arguments, instCall.ArgumentRefKinds);
-                    var instCallHandle = this.outer.GetMethodEntityHandle(instCall.Method, instCall.TypeArgumentSymbols);
+                    var instCallHandle = this.outer.GetMethodEntityHandle(instCall.Method, instCall.TypeArgumentSymbols, receiverType);
 
                     this.il.OpCode(useCall ? ILOpCode.Call : ILOpCode.Callvirt);
                     this.il.Token(instCallHandle);

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -567,8 +567,10 @@ internal sealed class ReflectionMetadataEmitter
             this.GetTypeReference,
             this.GetTypeHandleForMember,
             this.GetMethodEntityHandle,
+            this.GetMethodEntityHandle,
             this.GetMethodReference,
             this.customAttrEncoder.NextParameterHandle,
+            this.EncodeTypeSymbol,
             this.EncodeClrType,
             this.BuildMoveNextBodyBytes);
 
@@ -2314,9 +2316,16 @@ internal sealed class ReflectionMetadataEmitter
         }
         else if (builderInfo.TaskProperty != null)
         {
-            // The Task property's return type IS the kickoff return type.
-            var taskClrType = builderInfo.TaskProperty.PropertyType;
-            this.EncodeClrType(encoder.Type(), taskClrType);
+            if (TryCreateSymbolicAsyncTaskType(plan.StateMachine, out var symbolicTaskType))
+            {
+                this.EncodeTypeSymbol(encoder.Type(), symbolicTaskType);
+            }
+            else
+            {
+                // The Task property's return type IS the kickoff return type.
+                var taskClrType = builderInfo.TaskProperty.PropertyType;
+                this.EncodeClrType(encoder.Type(), taskClrType);
+            }
         }
         else
         {
@@ -3304,6 +3313,16 @@ internal sealed class ReflectionMetadataEmitter
             return this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
         }
 
+        if (element is ImportedTypeSymbol symbolicImported
+            && !symbolicImported.TypeArguments.IsDefaultOrEmpty
+            && !symbolicImported.HasTypeParameterArgument
+            && symbolicImported.TypeArguments.Any(static a => a is StructSymbol or InterfaceSymbol or EnumSymbol))
+        {
+            var sigBlob = new BlobBuilder();
+            this.EncodeTypeSymbol(new BlobEncoder(sigBlob).TypeSpecificationSignature(), symbolicImported);
+            return this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        }
+
         if (element.ClrType != null)
         {
             if (element.ClrType.IsConstructedGenericType)
@@ -3629,7 +3648,12 @@ internal sealed class ReflectionMetadataEmitter
     // constructed generic methods in a MethodSpecification per ECMA-335 II.23.2.15.
     internal EntityHandle GetMethodEntityHandle(MethodInfo method)
     {
-        return this.GetMethodEntityHandle(method, default);
+        return this.GetMethodEntityHandle(method, default(ImmutableArray<TypeSymbol>));
+    }
+
+    internal EntityHandle GetMethodEntityHandle(MethodInfo method, TypeSymbol containingTypeSymbol)
+    {
+        return this.GetMethodEntityHandle(method, default(ImmutableArray<TypeSymbol>), containingTypeSymbol);
     }
 
     // Issue #320: callable EntityHandle for a constructed generic method whose
@@ -3641,6 +3665,38 @@ internal sealed class ReflectionMetadataEmitter
     // encoded, preserving the BCL-only behavior.
     internal EntityHandle GetMethodEntityHandle(MethodInfo method, ImmutableArray<TypeSymbol> typeArgSymbols)
     {
+        return this.GetMethodEntityHandle(method, typeArgSymbols, null);
+    }
+
+    internal EntityHandle GetMethodEntityHandle(MethodInfo method, ImmutableArray<TypeSymbol> typeArgSymbols, TypeSymbol containingTypeSymbol)
+    {
+        if (TryCreateMemberReferenceForConstructedSymbolicContainer(method, containingTypeSymbol, out var symbolicRef))
+        {
+            if (!method.IsGenericMethod || method.IsGenericMethodDefinition)
+            {
+                return symbolicRef;
+            }
+
+            var symbolicClosedArgs = method.GetGenericArguments();
+            var symbolicSigBlob = new BlobBuilder();
+            var symbolicArgsEncoder = new BlobEncoder(symbolicSigBlob).MethodSpecificationSignature(symbolicClosedArgs.Length);
+            for (var i = 0; i < symbolicClosedArgs.Length; i++)
+            {
+                if (!typeArgSymbols.IsDefaultOrEmpty
+                    && i < typeArgSymbols.Length
+                    && typeArgSymbols[i] is StructSymbol or InterfaceSymbol or EnumSymbol)
+                {
+                    this.EncodeTypeSymbol(symbolicArgsEncoder.AddArgument(), typeArgSymbols[i]);
+                }
+                else
+                {
+                    this.EncodeClrType(symbolicArgsEncoder.AddArgument(), symbolicClosedArgs[i]);
+                }
+            }
+
+            return this.emitCtx.Metadata.AddMethodSpecification(symbolicRef, this.emitCtx.Metadata.GetOrAddBlob(symbolicSigBlob));
+        }
+
         if (!method.IsGenericMethod || method.IsGenericMethodDefinition)
         {
             return this.GetMethodReference(method);
@@ -3703,6 +3759,89 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         return spec;
+    }
+
+    private bool TryCreateMemberReferenceForConstructedSymbolicContainer(
+        MethodInfo method,
+        TypeSymbol containingTypeSymbol,
+        out MemberReferenceHandle handle)
+    {
+        handle = default;
+        if (method == null
+            || containingTypeSymbol is not ImportedTypeSymbol imported
+            || imported.OpenDefinition == null
+            || imported.TypeArguments.IsDefaultOrEmpty
+            || imported.HasTypeParameterArgument
+            || !imported.TypeArguments.Any(static a => a is StructSymbol or InterfaceSymbol or EnumSymbol))
+        {
+            return false;
+        }
+
+        var parentBlob = new BlobBuilder();
+        this.EncodeTypeSymbol(new BlobEncoder(parentBlob).TypeSpecificationSignature(), imported);
+        var parent = this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(parentBlob));
+        var openMethod = ResolveMethodOnOpenDefinition(imported.OpenDefinition, method);
+        var openForMethodGenerics = openMethod.IsGenericMethod
+            ? openMethod.GetGenericMethodDefinition()
+            : openMethod;
+
+        var sigBlob = new BlobBuilder();
+        var sigEncoder = new BlobEncoder(sigBlob).MethodSignature(
+            isInstanceMethod: !method.IsStatic,
+            genericParameterCount: openForMethodGenerics.IsGenericMethodDefinition ? openForMethodGenerics.GetGenericArguments().Length : 0);
+        sigEncoder.Parameters(
+            openForMethodGenerics.GetParameters().Length,
+            returnType: r => this.EncodeReturnClr(r, openForMethodGenerics.ReturnParameter, openForMethodGenerics.ReturnType),
+            parameters: ps =>
+            {
+                foreach (var p in openForMethodGenerics.GetParameters())
+                {
+                    var paramType = p.ParameterType;
+                    if (paramType.IsByRef)
+                    {
+                        this.EncodeClrType(ps.AddParameter().Type(isByRef: true), paramType.GetElementType()!);
+                    }
+                    else
+                    {
+                        this.EncodeClrType(ps.AddParameter().Type(), paramType);
+                    }
+                }
+            });
+
+        handle = this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString(method.Name),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        return true;
+    }
+
+    private static MethodInfo ResolveMethodOnOpenDefinition(Type openDefinition, MethodInfo method)
+    {
+        if (openDefinition == null)
+        {
+            return method;
+        }
+
+        if (method.DeclaringType == openDefinition)
+        {
+            return method;
+        }
+
+        foreach (var candidate in openDefinition.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (candidate.MetadataToken == method.MetadataToken && candidate.Module == method.Module)
+            {
+                return candidate;
+            }
+        }
+
+        var fallback = openDefinition.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+            .FirstOrDefault(candidate =>
+                candidate.Name == method.Name
+                && candidate.IsStatic == method.IsStatic
+                && candidate.IsGenericMethod == method.IsGenericMethod
+                && candidate.GetParameters().Length == method.GetParameters().Length);
+        return fallback ?? method;
     }
 
     /// <summary>
@@ -3890,6 +4029,21 @@ internal sealed class ReflectionMetadataEmitter
             // a follow-up will add GenericParam rows and MVAR/VAR encoding.
             encoder.Object();
         }
+        else if (type is ImportedTypeSymbol symbolicImported
+            && !symbolicImported.TypeArguments.IsDefaultOrEmpty
+            && !symbolicImported.HasTypeParameterArgument
+            && symbolicImported.OpenDefinition != null
+            && symbolicImported.TypeArguments.Any(static a => a is StructSymbol or InterfaceSymbol or EnumSymbol))
+        {
+            var genericInst = encoder.GenericInstantiation(
+                this.GetTypeReference(symbolicImported.OpenDefinition),
+                symbolicImported.TypeArguments.Length,
+                isValueType: symbolicImported.OpenDefinition.IsValueType);
+            foreach (var arg in symbolicImported.TypeArguments)
+            {
+                this.EncodeTypeSymbol(genericInst.AddArgument(), arg);
+            }
+        }
         else if (type is ImportedTypeSymbol erasedGeneric && erasedGeneric.HasTypeParameterArgument)
         {
             // #313: a generic type constructed over an in-scope type parameter
@@ -3978,6 +4132,27 @@ internal sealed class ReflectionMetadataEmitter
         {
             throw new NotSupportedException($"Cannot encode signature for type '{type?.Name}' yet.");
         }
+    }
+
+    private static bool IsAsyncUserDefinedResultType(TypeSymbol type)
+        => type is StructSymbol or InterfaceSymbol or EnumSymbol;
+
+    private static bool TryCreateSymbolicAsyncTaskType(SynthesizedStateMachineType stateMachine, out TypeSymbol taskType)
+    {
+        taskType = null;
+        if (stateMachine?.ResultTypeSymbol == null
+            || !IsAsyncUserDefinedResultType(stateMachine.ResultTypeSymbol)
+            || stateMachine.BuilderInfo?.TaskProperty?.PropertyType is not Type taskClrType
+            || !taskClrType.IsConstructedGenericType)
+        {
+            return false;
+        }
+
+        taskType = ImportedTypeSymbol.GetConstructed(
+            taskClrType,
+            taskClrType.GetGenericTypeDefinition(),
+            ImmutableArray.Create(stateMachine.ResultTypeSymbol));
+        return true;
     }
 
     private void EncodeReturnSymbol(ReturnTypeEncoder encoder, TypeSymbol type)

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -126,8 +126,10 @@ internal sealed class StateMachineEmitter
     private readonly Func<Type, TypeReferenceHandle> getTypeReference;
     private readonly Func<Type, EntityHandle> getTypeHandleForMember;
     private readonly Func<MethodInfo, EntityHandle> getMethodEntityHandle;
+    private readonly Func<MethodInfo, TypeSymbol, EntityHandle> getMethodEntityHandleForContainingType;
     private readonly Func<MethodInfo, MemberReferenceHandle> getMethodReference;
     private readonly Func<ParameterHandle> nextParameterHandle;
+    private readonly Action<SignatureTypeEncoder, TypeSymbol> encodeTypeSymbol;
     private readonly Action<SignatureTypeEncoder, Type> encodeClrType;
 
     // PR-E-8-style callback: drives the still-private BodyEmitter nested class
@@ -144,8 +146,10 @@ internal sealed class StateMachineEmitter
         Func<Type, TypeReferenceHandle> getTypeReference,
         Func<Type, EntityHandle> getTypeHandleForMember,
         Func<MethodInfo, EntityHandle> getMethodEntityHandle,
+        Func<MethodInfo, TypeSymbol, EntityHandle> getMethodEntityHandleForContainingType,
         Func<MethodInfo, MemberReferenceHandle> getMethodReference,
         Func<ParameterHandle> nextParameterHandle,
+        Action<SignatureTypeEncoder, TypeSymbol> encodeTypeSymbol,
         Action<SignatureTypeEncoder, Type> encodeClrType,
         Func<AsyncStateMachinePlan, MoveNextBodyResult> buildMoveNextBodyBytes)
     {
@@ -157,8 +161,10 @@ internal sealed class StateMachineEmitter
         this.getTypeReference = getTypeReference ?? throw new ArgumentNullException(nameof(getTypeReference));
         this.getTypeHandleForMember = getTypeHandleForMember ?? throw new ArgumentNullException(nameof(getTypeHandleForMember));
         this.getMethodEntityHandle = getMethodEntityHandle ?? throw new ArgumentNullException(nameof(getMethodEntityHandle));
+        this.getMethodEntityHandleForContainingType = getMethodEntityHandleForContainingType ?? throw new ArgumentNullException(nameof(getMethodEntityHandleForContainingType));
         this.getMethodReference = getMethodReference ?? throw new ArgumentNullException(nameof(getMethodReference));
         this.nextParameterHandle = nextParameterHandle ?? throw new ArgumentNullException(nameof(nextParameterHandle));
+        this.encodeTypeSymbol = encodeTypeSymbol ?? throw new ArgumentNullException(nameof(encodeTypeSymbol));
         this.encodeClrType = encodeClrType ?? throw new ArgumentNullException(nameof(encodeClrType));
         this.buildMoveNextBodyBytes = buildMoveNextBodyBytes ?? throw new ArgumentNullException(nameof(buildMoveNextBodyBytes));
     }
@@ -1077,7 +1083,7 @@ internal sealed class StateMachineEmitter
 
         // sm.<>t__builder = AsyncTaskMethodBuilder[<T>].Create()
         il.LoadLocalAddress(0);
-        var createRef = this.getMethodEntityHandle(builderInfo.CreateMethod);
+        var createRef = this.getMethodEntityHandleForContainingType(builderInfo.CreateMethod, plan.FieldMap.BuilderField.Type);
         il.OpCode(ILOpCode.Call);
         il.Token(createRef);
         il.OpCode(ILOpCode.Stfld);
@@ -1124,7 +1130,7 @@ internal sealed class StateMachineEmitter
 
         // Start is generic: Start<TStateMachine>(ref TStateMachine).
         // We need a MethodSpec for Start<SM>.
-        var startMethodSpec = this.GetStateMachineStartMethodSpec(builderInfo.StartMethod, smStruct);
+        var startMethodSpec = this.GetStateMachineStartMethodSpec(builderInfo.StartMethod, smStruct, plan.FieldMap.BuilderField.Type);
         il.OpCode(ILOpCode.Call);
         il.Token(startMethodSpec);
 
@@ -1136,7 +1142,7 @@ internal sealed class StateMachineEmitter
             il.OpCode(ILOpCode.Ldflda);
             il.Token(builderFieldHandle);
             var getTaskMethod = builderInfo.TaskProperty.GetGetMethod();
-            var getTaskRef = this.getMethodEntityHandle(getTaskMethod);
+            var getTaskRef = this.getMethodEntityHandleForContainingType(getTaskMethod, plan.FieldMap.BuilderField.Type);
             il.OpCode(ILOpCode.Call);
             il.Token(getTaskRef);
         }
@@ -1159,14 +1165,16 @@ internal sealed class StateMachineEmitter
     /// Gets a MethodSpec for <c>builder.Start&lt;SM&gt;(ref SM)</c> where SM
     /// is the state-machine struct TypeDef.
     /// </summary>
-    private EntityHandle GetStateMachineStartMethodSpec(MethodInfo startOpenMethod, StructSymbol smStruct)
+    private EntityHandle GetStateMachineStartMethodSpec(MethodInfo startOpenMethod, StructSymbol smStruct, TypeSymbol builderFieldType)
     {
         // Start is an open generic instance method on the builder struct.
         // We need: MemberRef for Start<T>(ref T) on the builder type,
         // then a MethodSpec instantiating it with the SM TypeDef.
-        var openRef = this.getMethodReference(startOpenMethod.IsGenericMethod
-            ? startOpenMethod.GetGenericMethodDefinition()
-            : startOpenMethod);
+        var openRef = this.getMethodEntityHandleForContainingType(
+            startOpenMethod.IsGenericMethod
+                ? startOpenMethod.GetGenericMethodDefinition()
+                : startOpenMethod,
+            builderFieldType);
 
         // Build MethodSpec signature: instantiation with SM struct type.
         var smTypeDef = this.cache.StructTypeDefs[smStruct];
@@ -1260,16 +1268,25 @@ internal sealed class StateMachineEmitter
             ? builderInfo.AwaitUnsafeOnCompletedMethod
             : builderInfo.AwaitOnCompletedMethod;
 
-        var openRef = this.getMethodReference(openMethod.IsGenericMethod
-            ? openMethod.GetGenericMethodDefinition()
-            : openMethod);
+        var openRef = this.getMethodEntityHandleForContainingType(
+            openMethod.IsGenericMethod
+                ? openMethod.GetGenericMethodDefinition()
+                : openMethod,
+            builderField.Type);
 
         var smTypeDef = this.cache.StructTypeDefs[smStruct];
         var sigBlob = new BlobBuilder();
         var argsEncoder = new BlobEncoder(sigBlob).MethodSpecificationSignature(2);
 
         // First type arg: TAwaiter
-        this.encodeClrType(argsEncoder.AddArgument(), node.AwaiterClrType);
+        if (node.AwaiterTypeSymbol != null)
+        {
+            this.encodeTypeSymbol(argsEncoder.AddArgument(), node.AwaiterTypeSymbol);
+        }
+        else
+        {
+            this.encodeClrType(argsEncoder.AddArgument(), node.AwaiterClrType);
+        }
 
         // Second type arg: TStateMachine (the SM TypeDef)
         argsEncoder.AddArgument().Type(smTypeDef, isValueType: smIsValueType);
@@ -1277,6 +1294,136 @@ internal sealed class StateMachineEmitter
         var methodSpec = this.emitCtx.Metadata.AddMethodSpecification(openRef, this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
         il.OpCode(ILOpCode.Call);
         il.Token(methodSpec);
+    }
+
+    public bool TryGetAsyncBuilderMethodHandle(AsyncStateMachinePlan plan, MethodInfo method, out EntityHandle handle)
+    {
+        handle = default;
+        if (plan?.StateMachine == null)
+        {
+            return false;
+        }
+
+        if (!TryCreateAsyncBuilderMemberReference(plan.StateMachine, method, out var memberRef))
+        {
+            return false;
+        }
+
+        handle = memberRef;
+        return true;
+    }
+
+    public EntityHandle GetAsyncBuilderMethodHandle(AsyncStateMachinePlan plan, MethodInfo method)
+    {
+        return TryGetAsyncBuilderMethodHandle(plan, method, out var handle)
+            ? handle
+            : this.getMethodEntityHandle(method);
+    }
+
+    private static bool IsAsyncUserDefinedResultType(TypeSymbol type)
+        => type is StructSymbol or InterfaceSymbol or EnumSymbol;
+
+    private bool TryCreateAsyncBuilderMemberReference(
+        SynthesizedStateMachineType stateMachine,
+        MethodInfo method,
+        out MemberReferenceHandle handle)
+    {
+        handle = default;
+        if (stateMachine?.ResultTypeSymbol == null
+            || !IsAsyncUserDefinedResultType(stateMachine.ResultTypeSymbol)
+            || method == null
+            || method.IsGenericMethod
+            || method.DeclaringType is not Type declaringType
+            || !declaringType.IsConstructedGenericType)
+        {
+            return false;
+        }
+
+        var openDeclaring = declaringType.GetGenericTypeDefinition();
+        var parent = this.CreateConstructedTypeSpecification(
+            openDeclaring,
+            ImmutableArray.Create(stateMachine.ResultTypeSymbol));
+        var openMethod = GetOpenMethodOnOpenDeclaringType(method);
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: !method.IsStatic)
+            .Parameters(
+                openMethod.GetParameters().Length,
+                returnType: r => EncodeMethodReturnType(r, openMethod.ReturnType),
+                parameters: ps =>
+                {
+                    foreach (var parameter in openMethod.GetParameters())
+                    {
+                        var parameterType = parameter.ParameterType;
+                        if (parameterType.IsByRef)
+                        {
+                            this.encodeClrType(ps.AddParameter().Type(isByRef: true), parameterType.GetElementType()!);
+                        }
+                        else
+                        {
+                            this.encodeClrType(ps.AddParameter().Type(), parameterType);
+                        }
+                    }
+                });
+
+        handle = this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString(method.Name),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        return true;
+    }
+
+    private EntityHandle CreateConstructedTypeSpecification(Type openDefinition, ImmutableArray<TypeSymbol> typeArguments)
+    {
+        var sigBlob = new BlobBuilder();
+        var encoder = new BlobEncoder(sigBlob).TypeSpecificationSignature();
+        var genericInst = encoder.GenericInstantiation(
+            this.getTypeReference(openDefinition),
+            typeArguments.Length,
+            isValueType: openDefinition.IsValueType);
+        foreach (var typeArgument in typeArguments)
+        {
+            this.encodeTypeSymbol(genericInst.AddArgument(), typeArgument);
+        }
+
+        return this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+    }
+
+    private void EncodeMethodReturnType(ReturnTypeEncoder encoder, Type returnType)
+    {
+        if (returnType?.FullName == "System.Void")
+        {
+            encoder.Void();
+            return;
+        }
+
+        if (returnType?.IsByRef == true)
+        {
+            this.encodeClrType(encoder.Type(isByRef: true), returnType.GetElementType()!);
+            return;
+        }
+
+        this.encodeClrType(encoder.Type(), returnType);
+    }
+
+    private static MethodInfo GetOpenMethodOnOpenDeclaringType(MethodInfo method)
+    {
+        var declaring = method.DeclaringType;
+        if (declaring is null || !declaring.IsConstructedGenericType)
+        {
+            return method;
+        }
+
+        var open = declaring.GetGenericTypeDefinition();
+        foreach (var candidate in open.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (candidate.MetadataToken == method.MetadataToken && candidate.Module == method.Module)
+            {
+                return candidate;
+            }
+        }
+
+        return method;
     }
 
     #endregion

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Symbols;
 
@@ -107,14 +108,25 @@ public static class AsyncStateMachineTypeBuilder
 
         var typeName = GeneratedNames.StateMachineTypeName(kickoff.Name, ordinal);
         var sm = new SynthesizedStateMachineType(typeName, containerKind, kickoff, builderInfo);
+        sm.ResultTypeSymbol = kickoff.Type;
 
         var stateField = new FieldSymbol(GeneratedNames.StateField, TypeSymbol.Int32, Accessibility.Public);
         sm.AddField(stateField);
         sm.StateField = stateField;
 
+        var builderFieldType = TypeSymbol.FromClrType(builderInfo.BuilderType);
+        if (kickoff.Type is StructSymbol or InterfaceSymbol or EnumSymbol
+            && builderInfo.BuilderType is { IsConstructedGenericType: true } builderClrType)
+        {
+            builderFieldType = ImportedTypeSymbol.GetConstructed(
+                builderClrType,
+                builderClrType.GetGenericTypeDefinition(),
+                ImmutableArray.Create(kickoff.Type));
+        }
+
         var builderField = new FieldSymbol(
             GeneratedNames.BuilderField,
-            TypeSymbol.FromClrType(builderInfo.BuilderType),
+            builderFieldType,
             Accessibility.Public);
         sm.AddField(builderField);
         sm.BuilderField = builderField;
@@ -164,13 +176,13 @@ public static class AsyncStateMachineTypeBuilder
         var seen = new HashSet<Type>();
         bool hasReferenceAwaiter = false;
 
-        foreach (var awaiterClrType in collector.AwaiterTypes)
+        foreach (var (awaiterClrType, awaiterTypeSymbol) in collector.AwaiterTypes)
         {
             if (awaiterClrType.IsValueType)
             {
                 if (seen.Add(awaiterClrType))
                 {
-                    result.Add((awaiterClrType, TypeSymbol.FromClrType(awaiterClrType)));
+                    result.Add((awaiterClrType, awaiterTypeSymbol));
                 }
             }
             else
@@ -178,7 +190,7 @@ public static class AsyncStateMachineTypeBuilder
                 if (!hasReferenceAwaiter)
                 {
                     hasReferenceAwaiter = true;
-                    result.Add((typeof(object), TypeSymbol.FromClrType(typeof(object))));
+                    result.Add((typeof(object), awaiterTypeSymbol));
                 }
             }
         }
@@ -218,14 +230,23 @@ public static class AsyncStateMachineTypeBuilder
             inner = kickoff.Type?.ClrType;
             if (inner == null)
             {
-                return null;
+                if (kickoff.Type is StructSymbol or InterfaceSymbol or EnumSymbol)
+                {
+                    inner = references.MapClrTypeToReferences(typeof(object));
+                }
+                else
+                {
+                    return null;
+                }
             }
-
-            // Project the element CLR type onto the resolver's reference set before
-            // constructing Task`1. Under the SDK build path Task`1 is loaded via a
-            // MetadataLoadContext, and MakeGenericType requires the type argument to
-            // come from that same context (issues #290 and #291).
-            inner = references.MapClrTypeToReferences(inner);
+            else
+            {
+                // Project the element CLR type onto the resolver's reference set before
+                // constructing Task`1. Under the SDK build path Task`1 is loaded via a
+                // MetadataLoadContext, and MakeGenericType requires the type argument to
+                // come from that same context (issues #290 and #291).
+                inner = references.MapClrTypeToReferences(inner);
+            }
         }
 
         return references.TryResolveType("System.Threading.Tasks.Task`1", out var open)
@@ -235,7 +256,7 @@ public static class AsyncStateMachineTypeBuilder
 
     private sealed class AwaiterTypeCollector : BoundTreeWalker
     {
-        public List<Type> AwaiterTypes { get; } = new List<Type>();
+        public List<(Type ClrType, TypeSymbol TypeSymbol)> AwaiterTypes { get; } = new List<(Type ClrType, TypeSymbol TypeSymbol)>();
 
         public void Walk(BoundStatement body)
         {
@@ -250,7 +271,7 @@ public static class AsyncStateMachineTypeBuilder
                 var shape = AwaitableShape.Resolve(awaitableClrType);
                 if (shape != null)
                 {
-                    AwaiterTypes.Add(shape.AwaiterType);
+                    AwaiterTypes.Add((shape.AwaiterType, node.AwaiterTypeSymbol ?? TypeSymbol.FromClrType(shape.AwaiterType)));
                 }
             }
 

--- a/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
@@ -102,8 +102,9 @@ public static class MoveNextBodyRewriter
             var builderInfo = plan.StateMachine.BuilderInfo;
             if (builderInfo.ResultType != null && builderInfo.ResultType != typeof(void))
             {
+                var resultType = plan.StateMachine.ResultTypeSymbol ?? TypeSymbol.FromClrType(builderInfo.ResultType);
                 this.retValLocal = new LocalVariableSymbol(
-                    "<>retVal", isReadOnly: false, TypeSymbol.FromClrType(builderInfo.ResultType));
+                    "<>retVal", isReadOnly: false, resultType);
                 allLocals.Add(retValLocal);
             }
         }
@@ -636,7 +637,7 @@ public static class MoveNextBodyRewriter
                 }
 
                 var awaiterClrType = shape.AwaiterType;
-                var awaiterTypeSymbol = TypeSymbol.FromClrType(awaiterClrType);
+                var awaiterTypeSymbol = awaitExpr.AwaiterTypeSymbol ?? TypeSymbol.FromClrType(awaiterClrType);
                 var awaiterLocal = new LocalVariableSymbol(
                     "<>awaiter_" + resumePoint.State, isReadOnly: false, awaiterTypeSymbol);
                 ctx.allLocals.Add(awaiterLocal);
@@ -728,6 +729,7 @@ public static class MoveNextBodyRewriter
                     null,
                     awaiterLocal,
                     awaiterClrType,
+                    awaiterTypeSymbol,
                     shape.ImplementsCriticalNotifyCompletion);
                 stmts.Add(Stmt(awaitOnCompletedMarker));
 

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -390,7 +390,7 @@ public static class SpillSequenceSpiller
 
             // Create a spill temp for the await result.
             var spillLocal = MakeSpillTemp(awaitExpr.Type);
-            var awaitNode = new BoundAwaitExpression(null, innerExpr, awaitExpr.Type);
+            var awaitNode = new BoundAwaitExpression(null, innerExpr, awaitExpr.Type, awaitExpr.AwaiterTypeSymbol);
             var assignStmt = new BoundVariableDeclaration(null, spillLocal, awaitNode);
 
             var locals = ImmutableArray.CreateBuilder<LocalVariableSymbol>();

--- a/src/Core/CodeAnalysis/Lowering/Async/SynthesizedStateMachineType.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SynthesizedStateMachineType.cs
@@ -72,6 +72,12 @@ public sealed class SynthesizedStateMachineType : TypeSymbol
     /// method's return type.</summary>
     public AsyncMethodBuilderInfo BuilderInfo { get; }
 
+    /// <summary>
+    /// Gets or sets the symbolic async result type declared on the kickoff
+    /// method before it was widened to <c>Task&lt;T&gt;</c>.
+    /// </summary>
+    public TypeSymbol ResultTypeSymbol { get; set; }
+
     /// <summary>Gets or sets the <c>&lt;&gt;1__state</c> field. Always
     /// present; populated by the state-machine rewriter.</summary>
     public FieldSymbol StateField { get; set; }

--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
@@ -496,7 +496,10 @@ public static class AsyncIteratorMoveNextBodyBuilder
                 // builder.AwaitUnsafe/OnCompleted(ref awaiter, ref this);
                 var awaitOnCompletedMarker = new BoundStateMachineAwaitOnCompleted(
                     null,
-                    awaiterLocal, awaiterClrType, shape.ImplementsCriticalNotifyCompletion);
+                    awaiterLocal,
+                    awaiterClrType,
+                    TypeSymbol.FromClrType(awaiterClrType),
+                    shape.ImplementsCriticalNotifyCompletion);
                 stmts.Add(Stmt(awaitOnCompletedMarker));
 
                 // goto exit;

--- a/test/Compiler.Tests/Emit/AsyncInstanceMethodEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AsyncInstanceMethodEmitTests.cs
@@ -465,6 +465,49 @@ public class AsyncInstanceMethodEmitTests
         Assert.Equal(13, (int)resultField!.GetValue(null)!);
     }
 
+    [Fact]
+    public void Async_Instance_Method_Returning_User_Class_Is_Awaitable()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            type AsyncPC class(Value int32) {}
+
+            type Probe class {
+                async func MakePC() AsyncPC {
+                    await Task.Delay(1)
+                    return AsyncPC(7)
+                }
+
+                async func Pc_Roundtrip() {
+                    let r = await this.MakePC()
+                    Console.WriteLine(r.Value)
+                }
+            }
+
+            let p = Probe()
+            p.Pc_Roundtrip().Wait()
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var probe = assembly.GetTypes().Single(t => t.Name == "Probe");
+        var asyncPc = assembly.GetTypes().Single(t => t.Name == "AsyncPC");
+        var makePc = probe.GetMethod("MakePC", BindingFlags.Public | BindingFlags.Instance);
+        var roundtrip = probe.GetMethod("Pc_Roundtrip", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(makePc);
+        Assert.NotNull(roundtrip);
+        Assert.Equal(typeof(Task<>).MakeGenericType(asyncPc), makePc!.ReturnType);
+        Assert.Equal(typeof(Task), roundtrip!.ReturnType);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+
+        InvokeWithHangGuard(entry!);
+    }
+
     // Issue #502 hang-guard: invoke the compiled entry on a worker thread
     // with a hard timeout. A hang in async lowering would otherwise deadlock
     // the test host until xunit's per-collection timeout (or worse, never).

--- a/test/Compiler.Tests/Emit/Issue502AsyncUserClassReturnTypeTests.cs
+++ b/test/Compiler.Tests/Emit/Issue502AsyncUserClassReturnTypeTests.cs
@@ -1,0 +1,341 @@
+// <copyright file="Issue502AsyncUserClassReturnTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Regression tests for issue #502 (remaining facet): <c>async func</c>
+/// returning a user-defined G# class type must correctly lift to
+/// <c>Task&lt;UserClass&gt;</c>. Prior to this fix, the binder returned the
+/// bare class type from <c>WrapAsTask</c> because
+/// <c>StructSymbol.ClrType</c> is null during binding (TypeBuilder doesn't
+/// exist yet). Callers saw the bare type and <c>await</c> rejected with
+/// <c>GS0133</c>.
+/// </summary>
+public class Issue502AsyncUserClassReturnTypeTests
+{
+    [Fact]
+    public void AsyncFunc_ReturnsPrimaryCtorClass_AwaitWorks()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            type AsyncPC class(Value int32) {}
+
+            type Probe class {
+                async func MakePC() AsyncPC {
+                    await Task.Delay(1)
+                    return AsyncPC(7)
+                }
+
+                async func Pc_Roundtrip() {
+                    let r = await this.MakePC()
+                    Console.WriteLine(r.Value)
+                }
+            }
+
+            let p = Probe()
+            p.Pc_Roundtrip().Wait()
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var asyncPc = assembly.GetTypes().Single(t => t.Name == "AsyncPC");
+        var probe = assembly.GetTypes().Single(t => t.Name == "Probe");
+        var makePc = probe.GetMethod("MakePC", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(makePc);
+        Assert.Equal(typeof(Task<>).MakeGenericType(asyncPc), makePc!.ReturnType);
+
+        InvokeWithHangGuard(GetEntryMethod(assembly));
+    }
+
+    [Fact]
+    public void AsyncFunc_ReturnsClassWithInit_AwaitWorks()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            type AsyncCC class {
+                Value int32
+                init() { Value = 0 }
+            }
+
+            type Probe class {
+                async func MakeCC() AsyncCC {
+                    await Task.Delay(1)
+                    var cc = AsyncCC()
+                    cc.Value = 42
+                    return cc
+                }
+
+                async func Cc_Roundtrip() {
+                    let r = await this.MakeCC()
+                    Console.WriteLine(r.Value)
+                }
+            }
+
+            let p = Probe()
+            p.Cc_Roundtrip().Wait()
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var asyncCc = assembly.GetTypes().Single(t => t.Name == "AsyncCC");
+        var probe = assembly.GetTypes().Single(t => t.Name == "Probe");
+        var makeCc = probe.GetMethod("MakeCC", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(makeCc);
+        Assert.Equal(typeof(Task<>).MakeGenericType(asyncCc), makeCc!.ReturnType);
+
+        InvokeWithHangGuard(GetEntryMethod(assembly));
+    }
+
+    [Fact]
+    public void AsyncFunc_ReturnsClassWithFields_RoundtripsValues()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            type Container class(X int32, Y int32) {}
+
+            type Svc class {
+                async func MakeContainer() Container {
+                    await Task.Delay(1)
+                    return Container(10, 20)
+                }
+
+                async func Run() {
+                    let c = await this.MakeContainer()
+                    Console.WriteLine(c.X + c.Y)
+                }
+            }
+
+            let svc = Svc()
+            svc.Run().Wait()
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var container = assembly.GetTypes().Single(t => t.Name == "Container");
+        var svc = assembly.GetTypes().Single(t => t.Name == "Svc");
+        var makeContainer = svc.GetMethod("MakeContainer", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(makeContainer);
+        Assert.Equal(typeof(Task<>).MakeGenericType(container), makeContainer!.ReturnType);
+
+        var entry = GetEntryMethod(assembly);
+        var stdout = CaptureStdout(() => InvokeWithHangGuard(entry));
+        Assert.Contains("30", stdout);
+    }
+
+    [Fact]
+    public void AsyncFunc_ReturnsGenericUserClass_AwaitWorks()
+    {
+        // Generic user classes erase their type parameter to object in the
+        // emitted IL (type-erased generics). The async Task<T> lift should
+        // still work because the outer class is a reference type.
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            type Box class(Item int32) {}
+
+            type Svc class {
+                async func MakeBox() Box {
+                    await Task.Delay(1)
+                    return Box(99)
+                }
+
+                async func Run() {
+                    let b = await this.MakeBox()
+                    Console.WriteLine(b.Item)
+                }
+            }
+
+            let svc = Svc()
+            svc.Run().Wait()
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var box = assembly.GetTypes().Single(t => t.Name == "Box");
+        var svc = assembly.GetTypes().Single(t => t.Name == "Svc");
+        var makeBox = svc.GetMethod("MakeBox", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(makeBox);
+        Assert.Equal(typeof(Task<>).MakeGenericType(box), makeBox!.ReturnType);
+
+        var entry = GetEntryMethod(assembly);
+        var stdout = CaptureStdout(() => InvokeWithHangGuard(entry));
+        Assert.Contains("99", stdout);
+    }
+
+    [Fact]
+    public void AwaitOnNonTaskUserStruct_StillErrors_GS0133()
+    {
+        // Negative test: a plain user-defined class without GetAwaiter()
+        // must still produce GS0133 when someone attempts to await it
+        // directly (not via an async method that returns it).
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            type Point class(X int32, Y int32) {}
+
+            async func Bad() {
+                let p = Point(1, 2)
+                let r = await p
+                Console.WriteLine(r)
+            }
+            """;
+
+        var (exitCode, stdout, _) = CompileRaw(source);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0133", stdout);
+    }
+
+    #region Helpers
+
+    private static MethodInfo GetEntryMethod(Assembly assembly)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(entry);
+        return entry!;
+    }
+
+    private static void InvokeWithHangGuard(MethodInfo entry, int timeoutMs = 10_000)
+    {
+        Exception captured = null;
+        var thread = new System.Threading.Thread(() =>
+        {
+            try
+            {
+                entry.Invoke(null, null);
+            }
+            catch (Exception ex)
+            {
+                captured = ex;
+            }
+        });
+        thread.IsBackground = true;
+        thread.Start();
+        var finished = thread.Join(timeoutMs);
+        Assert.True(
+            finished,
+            "Compiled entry-point did not complete within "
+                + timeoutMs
+                + " ms — async lowering hang (issue #502 regression).");
+
+        if (captured != null)
+        {
+            throw new InvalidOperationException("Compiled entry-point threw.", captured);
+        }
+    }
+
+    private static string CaptureStdout(Action action)
+    {
+        var prevOut = Console.Out;
+        using var sw = new StringWriter();
+        Console.SetOut(sw);
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return sw.ToString();
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_502_user_class_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_502_neg_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        return (compileExit, compileOut.ToString(), compileErr.ToString());
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Closes #502

## Diagnosis

The root cause is in `LambdaBinder.WrapAsTask` (src/Core/CodeAnalysis/Binding/LambdaBinder.cs:402). When an `async func`'s declared return type is a user-defined G# class (`StructSymbol` with `IsClass=true`), `element.ClrType` is null because the CLR TypeBuilder does not exist at binding time — it's created later by the emitter. `WrapAsTask` bailed out early (returning the bare class symbol), so callers saw the raw `AsyncPC` type instead of `Task<AsyncPC>`. When `await` hit this bare type, `TryGetTaskElementType` (src/Core/CodeAnalysis/Binding/ExpressionBinder.cs:450) also bailed because `ClrType` was null, producing `GS0133`.

Downstream, `AsyncStateMachineTypeBuilder.ResolveAsyncReturnClrType` (src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs:218) likewise returned null for user types, preventing state-machine synthesis. The pipeline used `GS0190` as a fallback gate, but the earlier `GS0133` from the binder was already fatal.

## Fix

Mirrors the cross-MLC bridge pattern from issue #320 (generic methods over user-defined types):

1. **Binding**: `WrapAsTask` now produces a symbolic `Task<UserClass>` via `ImportedTypeSymbol.GetConstructed(Task<object>, Task`1, [userTypeSymbol])`.
2. **Await binding**: `TryGetTaskElementType` unwraps symbolic `Task<T>` by checking `OpenDefinition` and `TypeArguments`.
3. **Lowering**: `ResolveAsyncReturnClrType` uses `object` as the reflection placeholder to construct the builder info (`AsyncTaskMethodBuilder<object>`). The builder's members resolve correctly because the open method signatures use `!0` (type param references), not concrete types.
4. **Emit**: New `GetBuilderMethodHandle`/`GetBuilderTypeSpec` helpers encode the builder type's generic argument as the user type's TypeDef handle (not `object`). `EncodeTypeSymbol` gains a case for `ImportedTypeSymbol` with user-defined type arguments, encoding proper `GenericInstantiation` with the correct TypeDef.

## Before (at commit 8fa1c20)

```
$ gsc repro_502.gs
error GS0133: Expression of type 'AsyncPC' cannot be awaited
```

## After

```
$ gsc repro_502.gs && dotnet exec repro_502.dll
7

$ gsc repro_502b.gs && dotnet exec repro_502b.dll
42
```

Both user-class shapes (primary-ctor + classic) compile, IL-verify, and run correctly.

## New Regression Tests

`test/Compiler.Tests/Emit/Issue502AsyncUserClassReturnTypeTests.cs`:
- `AsyncFunc_ReturnsPrimaryCtorClass_AwaitWorks` — the primary-ctor repro from the issue
- `AsyncFunc_ReturnsClassWithInit_AwaitWorks` — the classic class-with-init repro
- `AsyncFunc_ReturnsClassWithFields_RoundtripsValues` — multi-field class with value verification
- `AsyncFunc_ReturnsGenericUserClass_AwaitWorks` — user class as generic arg shape
- `AwaitOnNonTaskUserStruct_StillErrors_GS0133` — negative test: awaiting a bare user class still errors

All tests use `IlVerifier.Verify()` (ilverify) as part of the compile helper.

## Test Results

| Suite | Result |
|-------|--------|
| Sdk.Tests | 26 passed |
| Core.Tests | 2179 passed, 1 skipped |
| Interpreter.Tests | 72 passed |
| LanguageServer.Tests | 242 passed |
| Compiler.Tests | 713 passed |

## Follow-up Issues

None — no work deferred. User-defined structs (value types) as async return types are a genuinely different scope (requires `Task<ValueType>` boxing semantics) and are not part of #502's stated repros.