### PR TITLE
Fix #569: construct nested CLR types via Outer.Inner() (unify name resolution with type-clause path)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -241,6 +241,140 @@ internal sealed partial class ExpressionBinder
             }
         }
 
+        // Issue #569: the dotted prefix may name an outer type (not a namespace),
+        // with the terminal identifier being a nested type. Try resolving the
+        // prefix as a type and then walking the terminal name as a nested type.
+        // This covers `Outer.Inner()`, `Ns.Outer.Inner()`, and deeply-nested
+        // chains like `Outer.Middle.Inner()` where the prefix segments include
+        // both namespace and outer-type components.
+        if (TryResolveAsNestedTypeChain(namespacePrefix, typeSimpleName, arity, terminalCall, out clrType))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #569: resolves a dotted prefix + terminal name as an outer type
+    /// containing a nested type. The prefix is split at each dot position to
+    /// find the outer type, then remaining segments and the terminal name are
+    /// walked as nested types via <see cref="ReferenceResolver.TryResolveNestedType"/>.
+    /// </summary>
+    private bool TryResolveAsNestedTypeChain(string namespacePrefix, string typeSimpleName, int arity, CallExpressionSyntax terminalCall, out System.Type clrType)
+    {
+        clrType = null;
+        if (string.IsNullOrEmpty(namespacePrefix))
+        {
+            return false;
+        }
+
+        var prefixSegments = namespacePrefix.Split('.');
+
+        // Try each split point: first N segments are a type name, remaining
+        // segments + terminal name are nested types. Start from the longest
+        // outer prefix (most specific) first.
+        for (var outerLen = prefixSegments.Length; outerLen >= 1; outerLen--)
+        {
+            var outerName = string.Join(".", prefixSegments, 0, outerLen);
+            System.Type outerType = null;
+
+            // Try resolving the outer name directly.
+            if (!scope.References.TryResolveType(outerName, out outerType))
+            {
+                // Try with each import prefix.
+                foreach (var import in scope.GetDeclaredImports())
+                {
+                    var qualified = import.Target + "." + outerName;
+                    if (scope.References.TryResolveType(qualified, out outerType))
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (outerType == null)
+            {
+                continue;
+            }
+
+            // Walk remaining prefix segments as nested types.
+            var current = outerType;
+            var walkFailed = false;
+            for (var i = outerLen; i < prefixSegments.Length; i++)
+            {
+                if (!scope.References.TryResolveNestedType(current, prefixSegments[i], out var next))
+                {
+                    walkFailed = true;
+                    break;
+                }
+
+                current = next;
+            }
+
+            if (walkFailed)
+            {
+                continue;
+            }
+
+            // Now resolve the terminal name as a nested type of `current`.
+            System.Type nestedType = null;
+            if (arity > 0)
+            {
+                scope.References.TryResolveNestedType(current, typeSimpleName + "`" + arity, out nestedType);
+            }
+
+            if (nestedType == null)
+            {
+                scope.References.TryResolveNestedType(current, typeSimpleName, out nestedType);
+            }
+
+            if (nestedType == null)
+            {
+                continue;
+            }
+
+            // Close the generic if type arguments are supplied.
+            if (arity > 0 && nestedType.IsGenericTypeDefinition)
+            {
+                var clrArgs = new System.Type[arity];
+                var argsResolved = true;
+                for (var i = 0; i < arity; i++)
+                {
+                    var ta = bindTypeClause(terminalCall.TypeArgumentList.Arguments[i]);
+                    if (ta?.ClrType == null)
+                    {
+                        argsResolved = false;
+                        break;
+                    }
+
+                    clrArgs[i] = scope.References.MapClrTypeToReferences(ta.ClrType);
+                }
+
+                if (!argsResolved)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    clrType = nestedType.MakeGenericType(clrArgs);
+                    return true;
+                }
+                catch (System.ArgumentException)
+                {
+                    continue;
+                }
+            }
+            else if (nestedType.IsGenericTypeDefinition)
+            {
+                continue;
+            }
+
+            clrType = nestedType;
+            return true;
+        }
+
         return false;
     }
 
@@ -745,6 +879,22 @@ internal sealed partial class ExpressionBinder
 
             case CallExpressionSyntax ce:
                 return BindAccessorCall(receiver, classSymbol, ce);
+
+            // Issue #569: an object-initializer suffix on a nested-type
+            // constructor (`Outer.Inner() { Prop = val }`) parses as
+            // ObjectCreationExpressionSyntax wrapping the call. Bind the
+            // inner call through the accessor path (which resolves the
+            // nested type constructor), then apply the initializer
+            // assignments against the constructed instance.
+            case ObjectCreationExpressionSyntax objCreate
+                when objCreate.Target is CallExpressionSyntax innerCall:
+                var ctorResult = BindAccessorCall(receiver, classSymbol, innerCall);
+                if (ctorResult is BoundErrorExpression)
+                {
+                    return ctorResult;
+                }
+
+                return BindObjectInitializerSuffix(objCreate, ctorResult);
 
             // Issue #507 follow-up: support indexer reads through a member chain
             // (`obj.Member[k]`, `obj.A.B[k]`, `obj?.Member[k]`). ParsePostfixChain

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -91,10 +91,19 @@ internal sealed partial class ExpressionBinder
     private BoundExpression BindObjectCreationExpression(ObjectCreationExpressionSyntax syntax)
     {
         var target = BindExpression(syntax.Target);
+        return BindObjectInitializerSuffix(syntax, target);
+    }
+
+    /// <summary>
+    /// Issue #569: applies the object-initializer suffix to an already-bound
+    /// constructor call. Shared by <see cref="BindObjectCreationExpression"/>
+    /// (general path) and the accessor-step path for nested-type constructors
+    /// with initializer suffixes (<c>Outer.Inner() { Prop = val }</c>).
+    /// </summary>
+    private BoundExpression BindObjectInitializerSuffix(ObjectCreationExpressionSyntax syntax, BoundExpression target)
+    {
         if (target.Type == TypeSymbol.Error || target.Type == null)
         {
-            // Still drain the initializer values so they report their own
-            // diagnostics (e.g. unresolved names inside the RHS expressions).
             foreach (var init in syntax.Initializers)
             {
                 _ = BindExpression(init.Value);
@@ -541,6 +550,78 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Issue #569: resolves a nested type constructor call when the call
+    /// identifier names a nested type within a containing CLR type.
+    /// For example, <c>Outer.Inner()</c> where <c>Inner</c> is a nested class
+    /// inside <c>Outer</c>. Supports generic nested types via
+    /// <c>Outer.Inner[T]()</c> and deeply-nested types via recursive accessor
+    /// chains (<c>Outer.Middle.Inner()</c> is handled by the accessor step
+    /// resolving <c>Outer.Middle</c> as a nested type that becomes the new
+    /// classSymbol for the terminal call). This unifies the call-expression
+    /// path with the type-clause resolution that #526 added.
+    /// </summary>
+    /// <param name="containingType">The CLR type of the outer class (e.g. <c>Outer</c>).</param>
+    /// <param name="syntax">The call expression (identifier = nested type name, args = ctor args).</param>
+    /// <param name="result">The bound constructor call on success.</param>
+    /// <returns>Whether a nested type was found and a constructor was bound.</returns>
+    private bool TryBindNestedTypeConstructorCall(System.Type containingType, CallExpressionSyntax syntax, out BoundExpression result)
+    {
+        result = null;
+        var nestedName = syntax.Identifier.Text;
+        var arity = syntax.TypeArgumentList?.Arguments.Count ?? 0;
+
+        System.Type nestedType = null;
+
+        // Try arity-mangled name first for generic nested types (e.g. Inner`1).
+        if (arity > 0)
+        {
+            scope.References.TryResolveNestedType(containingType, nestedName + "`" + arity, out nestedType);
+        }
+
+        if (nestedType == null)
+        {
+            scope.References.TryResolveNestedType(containingType, nestedName, out nestedType);
+        }
+
+        if (nestedType == null)
+        {
+            return false;
+        }
+
+        // Close generic nested type if type arguments were provided.
+        if (arity > 0 && nestedType.IsGenericTypeDefinition)
+        {
+            var clrArgs = new System.Type[arity];
+            for (var i = 0; i < arity; i++)
+            {
+                var ta = bindTypeClause(syntax.TypeArgumentList.Arguments[i]);
+                if (ta?.ClrType == null)
+                {
+                    return false;
+                }
+
+                clrArgs[i] = scope.References.MapClrTypeToReferences(ta.ClrType);
+            }
+
+            try
+            {
+                nestedType = nestedType.MakeGenericType(clrArgs);
+            }
+            catch (System.ArgumentException)
+            {
+                return false;
+            }
+        }
+        else if (nestedType.IsGenericTypeDefinition)
+        {
+            // Nested type is generic but no type arguments supplied — cannot construct.
+            return false;
+        }
+
+        return TryBindClrConstructorFromType(nestedType, syntax, out result);
+    }
+
+    /// <summary>
     /// Issue #311: resolves the explicit <c>[T1, T2]</c> type-argument list on a
     /// generic-method call site into CLR types projected onto the reference load
     /// context, ready for <see cref="System.Reflection.MethodInfo.MakeGenericMethod"/>.
@@ -720,6 +801,15 @@ internal sealed partial class ExpressionBinder
             if (!argumentNames.IsDefault && overloads.TryReportUnknownNamedArgumentForClr(classSymbol.ClassType, methodName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public, ce, argumentNames))
             {
                 return new BoundErrorExpression(null);
+            }
+
+            // Issue #569: when no static/instance method matches, check whether
+            // the call identifier names a nested type of the outer class. If so,
+            // bind as a constructor invocation — this unifies the call-expression
+            // path with the type-clause path that #526 already fixed.
+            if (TryBindNestedTypeConstructorCall(classSymbol.ClassType, ce, out var nestedCtorResult))
+            {
+                return nestedCtorResult;
             }
 
             Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);

--- a/test/Compiler.Tests/Emit/Issue569NestedTypeConstructionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue569NestedTypeConstructionTests.cs
@@ -1,0 +1,463 @@
+// <copyright file="Issue569NestedTypeConstructionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #569: nested CLR types must be constructible via <c>Outer.Inner()</c>
+/// in call/construction-expression position. The binder must unify the
+/// call-expression resolution path with the type-clause path that #526 fixed,
+/// so that <c>Outer.Inner(args)</c> binds as a constructor invocation when
+/// <c>Inner</c> is a nested type of <c>Outer</c>.
+/// </summary>
+public class Issue569NestedTypeConstructionTests
+{
+    private const string InstanceOuterSiblingCs = """
+        namespace Probe.CSharp
+        {
+            public class InstanceOuter
+            {
+                public class NestedFactory
+                {
+                    public int Value { get; set; }
+                    public NestedFactory() { Value = 42; }
+                    public NestedFactory(int v) { Value = v; }
+                    public override string ToString() => $"NestedFactory({Value})";
+                }
+            }
+        }
+        """;
+
+    private const string StaticOuterSiblingCs = """
+        namespace Probe.CSharp
+        {
+            public static class StaticOuter
+            {
+                public class NestedFactory
+                {
+                    public int Value { get; set; }
+                    public NestedFactory() { Value = 99; }
+                    public NestedFactory(int v) { Value = v; }
+                    public override string ToString() => $"NestedFactory({Value})";
+                }
+            }
+        }
+        """;
+
+    private const string DeeplyNestedSiblingCs = """
+        namespace Probe.CSharp
+        {
+            public class Outer
+            {
+                public class Middle
+                {
+                    public class Inner
+                    {
+                        public int N { get; }
+                        public Inner() { N = 7; }
+                        public Inner(int n) { N = n; }
+                        public override string ToString() => $"Inner({N})";
+                    }
+                }
+            }
+        }
+        """;
+
+    [Fact]
+    public void NestedType_InInstanceOuter_Constructs_CompilesAndRuns()
+    {
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            let f = InstanceOuter.NestedFactory()
+            Console.WriteLine(f.Value)
+            let g = InstanceOuter.NestedFactory(7)
+            Console.WriteLine(g.Value)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(InstanceOuterSiblingCs, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("42\n7\n", output);
+    }
+
+    [Fact]
+    public void NestedType_InStaticOuter_Constructs_CompilesAndRuns()
+    {
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            let f = StaticOuter.NestedFactory()
+            Console.WriteLine(f.Value)
+            let g = StaticOuter.NestedFactory(5)
+            Console.WriteLine(g.Value)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(StaticOuterSiblingCs, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("99\n5\n", output);
+    }
+
+    [Fact]
+    public void NestedType_Deeply_OuterMiddleInner_Constructs_CompilesAndRuns()
+    {
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            let a = Outer.Middle.Inner()
+            Console.WriteLine(a.N)
+            let b = Outer.Middle.Inner(123)
+            Console.WriteLine(b.N)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(DeeplyNestedSiblingCs, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("7\n123\n", output);
+    }
+
+    [Fact]
+    public void NestedType_WithObjectInitializer_ConstructsAndSetsFields()
+    {
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            let f = InstanceOuter.NestedFactory() { Value = 55 }
+            Console.WriteLine(f.Value)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(InstanceOuterSiblingCs, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("55\n", output);
+    }
+
+    [Fact]
+    public void NestedType_PassedAsArgumentToCtor_CompilesAndRuns()
+    {
+        // Construct a nested type and pass it directly as an argument
+        // to another function — exercises the bound expression flowing
+        // through the call-argument position.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public class Container
+                {
+                    public class Payload
+                    {
+                        public int X { get; }
+                        public Payload(int x) { X = x; }
+                    }
+
+                    public static int Extract(Payload p) => p.X;
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            let result = Container.Extract(Container.Payload(42))
+            Console.WriteLine(result)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void NestedType_NonExistentInner_StillErrors_GS0159()
+    {
+        // A typo'd nested type name must still error (not silently pass).
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            let f = InstanceOuter.Bogus()
+            """;
+
+        var diagnostics = CompileExpectingErrorsWithSiblingCs(InstanceOuterSiblingCs, gsource, siblingName: "Probe.CSharp");
+        Assert.Contains(diagnostics, d => d.Contains("GS0159") || d.Contains("Cannot find function"));
+    }
+
+    [Fact]
+    public void NestedType_AsTypeClause_StillWorks()
+    {
+        // Pin the #526 fix: nested type in type-clause position must
+        // still resolve correctly.
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            var f InstanceOuter.NestedFactory = InstanceOuter.NestedFactory(10)
+            Console.WriteLine(f.Value)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(InstanceOuterSiblingCs, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("10\n", output);
+    }
+
+    [Fact]
+    public void NestedType_AsBaseType_StillWorks()
+    {
+        // Pin the #526 fix: nested interface as base type must still work.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public class Outer
+                {
+                    public interface INested
+                    {
+                        int Compute();
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            type Impl class : Outer.INested {
+                func Compute() int32 { return 77 }
+            }
+
+            var i Outer.INested = Impl{}
+            Console.WriteLine(i.Compute())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("77\n", output);
+    }
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue569_sib_").FullName;
+        try
+        {
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            File.Copy(siblingDll, Path.Combine(tempDir, Path.GetFileName(siblingDll)), overwrite: true);
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { siblingDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static List<string> CompileExpectingErrorsWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue569_err_").FullName;
+        try
+        {
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit != 0, "expected gsc to report errors but it succeeded");
+
+            var combined = compileOut.ToString() + compileErr.ToString();
+            return combined.Split('\n').Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string BuildCsProject(string csDir, string siblingName)
+    {
+        RunDotnet(csDir, "restore");
+        RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+
+        var dll = Path.Combine(csDir, "bin", "Release", "net10.0", siblingName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static string RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #569

## Diagnosis

The binder's call-expression path (`BindAccessorCall` in `ExpressionBinder.Calls.cs:686-727`) only searched for static/instance methods when a `classSymbol` was set. When `InstanceOuter.NestedFactory()` was written, the binder resolved `InstanceOuter` as an `ImportedClassSymbol` (line 356-358 of `ExpressionBinder.Access.cs`), then tried `classSymbol.TryLookupFunction("NestedFactory", ...)` looking for a **method** — but `NestedFactory` is a **nested type**, not a method. The type-clause and base-type resolution paths (#526 fix in PR #552) already walked nested types via `Type.GetNestedType`, but this resolution was never applied to the call/construction-expression path — exactly the gap §3.3 of the bug overview identified.

The qualified-constructor path (`TryResolveQualifiedClrType` in `ExpressionBinder.Access.cs:154-245`) also failed because it resolved type names by full dotted name (`TryResolveType`), while CLR nested types use `+` as the separator in their full name (`Namespace.Outer+Inner`), not `.`.

## Fix

1. **`TryBindNestedTypeConstructorCall`** (ExpressionBinder.Calls.cs) — after method lookup fails in the `classSymbol != null` branch, checks whether the call identifier names a nested type of `classSymbol.ClassType` via `ReferenceResolver.TryResolveNestedType`, then delegates to the shared `TryBindClrConstructorFromType` helper.

2. **`TryResolveAsNestedTypeChain`** (ExpressionBinder.Access.cs) — extends the qualified-constructor path to try resolving dotted prefixes as outer types with nested type chains, handling deeply-nested constructions like `Outer.Middle.Inner()`.

3. **`ObjectCreationExpressionSyntax` case in `BindAccessorStep`** — handles `Outer.Inner() { Prop = val }` (object-initializer suffix on a nested-type constructor).

4. **Refactored `BindObjectCreationExpression`** to reuse the new `BindObjectInitializerSuffix` helper, eliminating code duplication.

## Before (GS0159)

```
$ echo 'package T; import Probe.CSharp; let f = InstanceOuter.NestedFactory()' | gsc
error GS0159: Cannot find function NestedFactory.

$ echo 'package T; import Probe.CSharp; let g = StaticOuter.NestedFactory()' | gsc
error GS0159: Cannot find function NestedFactory.
```

## After (compiles and runs)

```
$ echo 'package T; import System; import Probe.CSharp; let f = InstanceOuter.NestedFactory(); Console.WriteLine(f.Value)' | gsc && dotnet exec test.dll
42

$ echo 'package T; import System; import Probe.CSharp; let g = StaticOuter.NestedFactory(); Console.WriteLine(g.Value)' | gsc && dotnet exec test.dll
99
```

## Regression tests

New file: `test/Compiler.Tests/Emit/Issue569NestedTypeConstructionTests.cs`

| Test | Shape |
|------|-------|
| `NestedType_InInstanceOuter_Constructs_CompilesAndRuns` | Issue body shape 1 |
| `NestedType_InStaticOuter_Constructs_CompilesAndRuns` | Issue body shape 2 |
| `NestedType_Deeply_OuterMiddleInner_Constructs_CompilesAndRuns` | Deeply-nested `Outer.Middle.Inner()` |
| `NestedType_WithObjectInitializer_ConstructsAndSetsFields` | Object initializer on nested ctor |
| `NestedType_PassedAsArgumentToCtor_CompilesAndRuns` | Nested ctor as call argument |
| `NestedType_NonExistentInner_StillErrors_GS0159` | Negative: typo still errors |
| `NestedType_AsTypeClause_StillWorks` | Regression guard for #526 |
| `NestedType_AsBaseType_StillWorks` | Regression guard for #526 |

## Test results

All 5 suites green:
- Sdk.Tests: 26 passed
- Core.Tests: 2179 passed, 1 skipped
- Interpreter.Tests: 72 passed
- LanguageServer.Tests: 242 passed
- Compiler.Tests: 736 passed

## Follow-up issues

None — all adjacent shapes (deep nesting, object initializer, passed-as-argument) are handled in this PR.