### PR TITLE
Fix #605: add await using let / IAsyncDisposable support (C# semantics)

### DIFF
--- a/docs/adr/0030-defer-and-using-block-scope.md
+++ b/docs/adr/0030-defer-and-using-block-scope.md
@@ -19,6 +19,8 @@ Deferred call arguments are evaluated eagerly when the `defer` statement execute
 
 `using` declarations share the same block cleanup lowering. `using let x = expr` binds the declaration at the point it appears, then wraps the remaining statements in the enclosing block in `try/finally` with `x.Dispose()` in the `finally`. Interleaved `defer` and `using` declarations compose as one LIFO cleanup stack.
 
+`await using let x = expr` (issue #605) is the async sibling: it probes for `DisposeAsync()` returning `ValueTask` (the `IAsyncDisposable` pattern) and lowers to `try/finally` with `await x.DisposeAsync()` in the `finally`. It requires `async func` context and follows the same scope-exit machinery. When a type implements both `IDisposable` and `IAsyncDisposable`, `await using let` calls `DisposeAsync` and plain `using let` calls `Dispose`.
+
 ## Rationale for block scope over function scope
 
 Block scope keeps the Phase 7.1 lowering small and local to block binding. It composes cleanly with `using`, `if`, `for`, `scope`, and ordinary nested blocks because each construct already has a lexical block boundary that can own cleanups. It also matches every other scope-cleanup mechanism in the language rather than introducing a second whole-function post-pass just for `defer`. If a future sample requires Go-exact semantics, GSharp can add a `defer-fn` variant or upgrade to function-scoped semantics without breaking programs that already rely on block-scoped cleanup.

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -12,12 +12,15 @@ AmpersandToken
 Annotation
 AnnotationTarget
 ArrayCreationExpression
+AsExpression
+AsKeyword
 AssignmentExpression
 AsyncKeyword
 AtToken
 AwaitExpression
 AwaitForRangeStatement
 AwaitKeyword
+AwaitUsingStatement
 BadToken
 BangBangToken
 BangEqualsToken
@@ -109,6 +112,7 @@ InterfaceKeyword
 InternalKeyword
 InterpolatedStringExpression
 InterpolatedStringToken
+IsExpression
 IsKeyword
 LeftArrowToken
 LessOrEqualsToken
@@ -175,11 +179,11 @@ SelectKeyword
 SelectStatement
 SemicolonToken
 SequenceKeyword
+SharedBlock
 ShiftLeftEqualsToken
 ShiftLeftToken
 ShiftRightEqualsToken
 ShiftRightToken
-SharedBlock
 SlashEqualsToken
 SlashToken
 StarEqualsToken
@@ -221,6 +225,7 @@ YieldStatement
 AddressOfExpression
 AppendExpression
 ArrayCreationExpression
+AsExpression
 AssignmentExpression
 Attribute
 AwaitExpression
@@ -256,6 +261,7 @@ DefaultExpression
 DereferenceExpression
 DiscardPattern
 ErrorExpression
+EventSubscriptionExpression
 ExpressionStatement
 FieldAccessExpression
 FieldAssignmentExpression
@@ -273,6 +279,7 @@ IndexExpression
 IndirectAssignmentExpression
 IndirectCallExpression
 InterpolatedStringExpression
+IsExpression
 LabelStatement
 LenExpression
 ListPattern

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -436,6 +436,13 @@ Cause/fix examples:
 |----|----------|-------------|-----------------|
 | GS0269 | Error | Unrecognised escape sequence `\X` in string literal. | `"\q"` — `\q` is not a valid escape. Use `\\` for a literal backslash. |
 
+## Async disposable diagnostics (GS0271–GS0272)
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0271 | Error | `await using let` outside an async function. | `func f() { await using let x = ... }` — `await using let` requires `async func`. |
+| GS0272 | Error | Type is not async-disposable. | `await using let x = Foo()` where `Foo` provides no public `DisposeAsync()` method returning `ValueTask`. |
+
 ## Internal compiler error diagnostics (GS9998–GS9999)
 
 | ID | Severity | Description |

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -975,6 +975,52 @@ internal sealed class ConversionClassifier
         return new BoundImportedInstanceCallExpression(null, receiver2, disposeMethod, TypeSymbol.Void, ImmutableArray<BoundExpression>.Empty);
     }
 
+    /// <summary>
+    /// Issue #605: builds a bound <c>await receiver.DisposeAsync()</c> expression.
+    /// Probes for a public parameterless <c>DisposeAsync()</c> returning
+    /// <see cref="System.Threading.Tasks.ValueTask"/> on user-defined G# classes
+    /// and CLR types (via <c>IAsyncDisposable</c>).
+    /// Reports <see cref="DiagnosticBag.ReportTypeNotAsyncDisposable"/> on failure.
+    /// </summary>
+    /// <param name="variable">The variable to async-dispose.</param>
+    /// <param name="location">The diagnostic location.</param>
+    /// <returns>A <see cref="BoundAwaitExpression"/> wrapping the DisposeAsync call, or <c>null</c> on failure.</returns>
+    public BoundExpression TryBuildDisposeAsyncCall(VariableSymbol variable, TextLocation location)
+    {
+        var valueTaskType = TypeSymbol.FromClrType(typeof(System.Threading.Tasks.ValueTask));
+
+        // User-defined G# class path: probe for DisposeAsync() returning ValueTask.
+        if (variable.Type is StructSymbol userType
+            && userType.TryGetMethodIncludingInherited("DisposeAsync", out var userDisposeAsync)
+            && userDisposeAsync.Parameters.Length == 0
+            && userDisposeAsync.Accessibility == Accessibility.Public)
+        {
+            var receiver = new BoundVariableExpression(null, variable);
+            var call = new BoundUserInstanceCallExpression(null, receiver, userDisposeAsync, ImmutableArray<BoundExpression>.Empty);
+            return new BoundAwaitExpression(null, call, TypeSymbol.Void);
+        }
+
+        // CLR-type path: walk self + transitive interfaces for DisposeAsync.
+        var clrType = variable.Type?.ClrType;
+        if (clrType == null)
+        {
+            Diagnostics.ReportTypeNotAsyncDisposable(location, variable.Type ?? TypeSymbol.Error);
+            return null;
+        }
+
+        var disposeAsyncMethod = MemberLookup.SafeGetMethodIncludingSelfAndInterfaces(clrType, "DisposeAsync", Type.EmptyTypes);
+        if (disposeAsyncMethod == null ||
+            disposeAsyncMethod.ReturnType.FullName != "System.Threading.Tasks.ValueTask")
+        {
+            Diagnostics.ReportTypeNotAsyncDisposable(location, variable.Type);
+            return null;
+        }
+
+        var receiver2 = new BoundVariableExpression(null, variable);
+        var clrCall = new BoundImportedInstanceCallExpression(null, receiver2, disposeAsyncMethod, valueTaskType, ImmutableArray<BoundExpression>.Empty);
+        return new BoundAwaitExpression(null, clrCall, TypeSymbol.Void);
+    }
+
     // ----- Private helpers (kept here because they are only used by methods in this class) -----
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -195,6 +195,8 @@ internal sealed class StatementBinder
                 return BindScopeStatement((ScopeStatementSyntax)syntax);
             case SyntaxKind.AwaitForRangeStatement:
                 return BindAwaitForRangeStatement((AwaitForRangeStatementSyntax)syntax);
+            case SyntaxKind.AwaitUsingStatement:
+                return BindAwaitUsingStatement((AwaitUsingStatementSyntax)syntax);
             case SyntaxKind.YieldStatement:
                 return BindYieldStatement((YieldStatementSyntax)syntax);
             case SyntaxKind.TupleDeconstructionStatement:
@@ -269,6 +271,28 @@ internal sealed class StatementBinder
                     var innerStatements = ImmutableArray.CreateBuilder<BoundStatement>();
                     BindBlockStatements(statementSyntaxes, i + 1, innerStatements);
                     statements.Add(BuildCleanupTryStatement(innerStatements.ToImmutable(), usingLowering.Cleanup));
+                    return;
+                }
+
+                if (statementSyntax is AwaitUsingStatementSyntax awaitUsingSyntax)
+                {
+                    var awaitUsingLowering = BindAwaitUsingStatementInBlock(awaitUsingSyntax);
+                    if (awaitUsingLowering.Declaration != null)
+                    {
+                        statements.Add(awaitUsingLowering.Declaration);
+                    }
+
+                    if (awaitUsingLowering.Cleanup == null)
+                    {
+                        statements.Add(awaitUsingLowering.ErrorStatement);
+                        InvalidateNarrowingsForAssignedVariables(statementSyntax);
+                        continue;
+                    }
+
+                    InvalidateNarrowingsForAssignedVariables(statementSyntax);
+                    var innerStatements = ImmutableArray.CreateBuilder<BoundStatement>();
+                    BindBlockStatements(statementSyntaxes, i + 1, innerStatements);
+                    statements.Add(BuildCleanupTryStatement(innerStatements.ToImmutable(), awaitUsingLowering.Cleanup));
                     return;
                 }
 
@@ -1344,6 +1368,37 @@ internal sealed class StatementBinder
         }
 
         return (declaration, disposeCall, null);
+    }
+
+    private BoundStatement BindAwaitUsingStatement(AwaitUsingStatementSyntax syntax)
+    {
+        var awaitUsingLowering = BindAwaitUsingStatementInBlock(syntax);
+        if (awaitUsingLowering.Cleanup == null)
+        {
+            return awaitUsingLowering.ErrorStatement;
+        }
+
+        var tryStmt = BuildCleanupTryStatement(ImmutableArray<BoundStatement>.Empty, awaitUsingLowering.Cleanup);
+        return new BoundBlockStatement(syntax, ImmutableArray.Create<BoundStatement>(awaitUsingLowering.Declaration, tryStmt));
+    }
+
+    private (BoundVariableDeclaration Declaration, BoundExpression Cleanup, BoundStatement ErrorStatement) BindAwaitUsingStatementInBlock(AwaitUsingStatementSyntax syntax)
+    {
+        // Gate: await using let requires an async context.
+        if (function == null || !function.IsAsync)
+        {
+            Diagnostics.ReportAwaitUsingOutsideAsyncFunction(syntax.AwaitKeyword.Location);
+            return (null, null, BindErrorStatement());
+        }
+
+        var declaration = (BoundVariableDeclaration)BindVariableDeclaration(syntax.Declaration);
+        var disposeAsyncCall = conversions.TryBuildDisposeAsyncCall(declaration.Variable, syntax.AwaitKeyword.Location);
+        if (disposeAsyncCall == null)
+        {
+            return (declaration, null, BindErrorStatement());
+        }
+
+        return (declaration, disposeAsyncCall, null);
     }
 
     private BoundStatement BindDeferStatement(DeferStatementSyntax syntax)

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -2139,6 +2139,25 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0270", $"The 'as' operator requires the target type to be a reference type or a nullable value type, but '{typeName}' is a non-nullable value type. Use 'as {typeName}?' instead.");
     }
 
+    /// <summary>
+    /// Reports that <c>await using let</c> appears outside an <c>async</c> function.
+    /// </summary>
+    /// <param name="location">The text location of the <c>await</c> keyword.</param>
+    public void ReportAwaitUsingOutsideAsyncFunction(TextLocation location)
+    {
+        Report(location, "GS0271", "'await using let' can only be used inside an 'async func'.");
+    }
+
+    /// <summary>
+    /// Reports that a type used in an <c>await using</c> declaration does not implement IAsyncDisposable.
+    /// </summary>
+    /// <param name="location">The text location of the await using keyword.</param>
+    /// <param name="type">The non-async-disposable type.</param>
+    public void ReportTypeNotAsyncDisposable(TextLocation location, TypeSymbol type)
+    {
+        Report(location, "GS0272", $"Type '{type.Name}' cannot be used in an 'await using' statement because it does not provide a public DisposeAsync() method returning ValueTask.");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Syntax/AwaitUsingStatementSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/AwaitUsingStatementSyntax.cs
@@ -1,0 +1,42 @@
+// <copyright file="AwaitUsingStatementSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents an <c>await using let name = expr</c> declaration whose
+/// bound variable is asynchronously disposed (via
+/// <c>IAsyncDisposable.DisposeAsync</c>) when the enclosing scope exits.
+/// </summary>
+public sealed class AwaitUsingStatementSyntax : StatementSyntax
+{
+    /// <summary>Initializes a new instance of the <see cref="AwaitUsingStatementSyntax"/> class.</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="awaitKeyword">The <c>await</c> keyword.</param>
+    /// <param name="usingKeyword">The <c>using</c> keyword.</param>
+    /// <param name="declaration">The wrapped variable declaration.</param>
+    public AwaitUsingStatementSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken awaitKeyword,
+        SyntaxToken usingKeyword,
+        VariableDeclarationSyntax declaration)
+        : base(syntaxTree)
+    {
+        AwaitKeyword = awaitKeyword;
+        UsingKeyword = usingKeyword;
+        Declaration = declaration;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.AwaitUsingStatement;
+
+    /// <summary>Gets the <c>await</c> keyword.</summary>
+    public SyntaxToken AwaitKeyword { get; }
+
+    /// <summary>Gets the <c>using</c> keyword.</summary>
+    public SyntaxToken UsingKeyword { get; }
+
+    /// <summary>Gets the wrapped variable declaration.</summary>
+    public VariableDeclarationSyntax Declaration { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -2323,6 +2323,11 @@ public class Parser
                     return ParseAwaitForRangeStatement();
                 }
 
+                if (Peek(1).Kind == SyntaxKind.UsingKeyword)
+                {
+                    return ParseAwaitUsingStatement();
+                }
+
                 goto default;
             default:
                 // ADR-0040: contextual `yield` keyword — parse as yield statement
@@ -3211,6 +3216,21 @@ public class Parser
 
         var decl = (VariableDeclarationSyntax)ParseVariableDeclaration();
         return new UsingStatementSyntax(syntaxTree, keyword, decl);
+    }
+
+    private StatementSyntax ParseAwaitUsingStatement()
+    {
+        var awaitKeyword = MatchToken(SyntaxKind.AwaitKeyword);
+        var usingKeyword = MatchToken(SyntaxKind.UsingKeyword);
+        if (Current.Kind != SyntaxKind.LetKeyword &&
+            Current.Kind != SyntaxKind.VarKeyword &&
+            Current.Kind != SyntaxKind.ConstKeyword)
+        {
+            MatchToken(SyntaxKind.LetKeyword);
+        }
+
+        var decl = (VariableDeclarationSyntax)ParseVariableDeclaration();
+        return new AwaitUsingStatementSyntax(syntaxTree, awaitKeyword, usingKeyword, decl);
     }
 
     private StatementSyntax ParseGoStatement()

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -223,6 +223,7 @@ public enum SyntaxKind
     SelectCase,
     ScopeStatement,
     AwaitForRangeStatement,
+    AwaitUsingStatement,
     EventSubscriptionExpression,
     YieldStatement,
 

--- a/test/Compiler.Tests/Emit/Issue605AwaitUsingLetEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue605AwaitUsingLetEmitTests.cs
@@ -1,0 +1,510 @@
+// <copyright file="Issue605AwaitUsingLetEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #605: <c>await using let</c> support for types implementing
+/// <c>IAsyncDisposable</c>. Tests cover user-defined G# classes, CLR types,
+/// mixed IDisposable + IAsyncDisposable, exception safety, return semantics,
+/// and negative diagnostics (outside async, async-only with sync using).
+/// </summary>
+public class Issue605AwaitUsingLetEmitTests
+{
+    [Fact]
+    public void AwaitUsingLet_UserClassImplementsIAsyncDisposable_DisposeAsyncCalledAtScopeExit()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Threading.Tasks
+
+            type AsyncResource class : IAsyncDisposable {
+                func DisposeAsync() ValueTask {
+                    Console.WriteLine("disposed-async")
+                    return ValueTask.CompletedTask
+                }
+            }
+
+            async func test() {
+                await using let r = AsyncResource{}
+                Console.WriteLine("inside")
+            }
+            test().GetAwaiter().GetResult()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("inside\ndisposed-async\n", output);
+    }
+
+    [Fact]
+    public void AwaitUsingLet_ClrClassImplementsIAsyncDisposable_DisposeAsyncCalledAtScopeExit()
+    {
+        // We use a sibling C# assembly that prints on DisposeAsync to confirm it's called.
+        var csHelper = """
+            using System;
+            using System.Threading.Tasks;
+
+            namespace AsyncHelpers
+            {
+                public class ClrAsyncDisp : IAsyncDisposable
+                {
+                    public ValueTask DisposeAsync()
+                    {
+                        Console.WriteLine("clr-disposed-async");
+                        return ValueTask.CompletedTask;
+                    }
+                }
+            }
+            """;
+
+        var source = """
+            package Probe
+            import System
+            import System.Threading.Tasks
+            import AsyncHelpers
+
+            async func test() {
+                await using let r = ClrAsyncDisp()
+                Console.WriteLine("inside-clr")
+            }
+            test().GetAwaiter().GetResult()
+            """;
+
+        var output = CompileAndRunWithSiblingCs(source, csHelper);
+        Assert.Equal("inside-clr\nclr-disposed-async\n", output);
+    }
+
+    [Fact]
+    public void AwaitUsingLet_TypeImplementsBothSyncAndAsync_PrefersDisposeAsync()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Threading.Tasks
+
+            type DualDisp class : IDisposable, IAsyncDisposable {
+                func Dispose() {
+                    Console.WriteLine("sync-dispose")
+                }
+                func DisposeAsync() ValueTask {
+                    Console.WriteLine("async-dispose")
+                    return ValueTask.CompletedTask
+                }
+            }
+
+            async func test() {
+                await using let d = DualDisp{}
+                Console.WriteLine("body")
+            }
+            test().GetAwaiter().GetResult()
+            """;
+
+        var output = CompileAndRun(source);
+        // await using must call DisposeAsync, NOT Dispose.
+        Assert.Equal("body\nasync-dispose\n", output);
+    }
+
+    [Fact]
+    public void AwaitUsingLet_DisposeAsyncCalledEvenOnException()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Threading.Tasks
+
+            type SafeRes class : IAsyncDisposable {
+                func DisposeAsync() ValueTask {
+                    Console.WriteLine("safe-dispose")
+                    return ValueTask.CompletedTask
+                }
+            }
+
+            async func test() {
+                try {
+                    await using let s = SafeRes{}
+                    Console.WriteLine("before-throw")
+                    throw Exception("boom")
+                } catch (ex Exception) {
+                    Console.WriteLine("caught")
+                }
+            }
+            test().GetAwaiter().GetResult()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("before-throw\nsafe-dispose\ncaught\n", output);
+    }
+
+    [Fact]
+    public void AwaitUsingLet_ReturnsValueFromScope_DisposesBeforeReturn()
+    {
+        // Tests that DisposeAsync runs when the scope completes normally
+        // and a value is returned from the function.
+        var source = """
+            package Probe
+            import System
+            import System.Threading.Tasks
+
+            type TrackRes class : IAsyncDisposable {
+                func DisposeAsync() ValueTask {
+                    Console.WriteLine("track-dispose")
+                    return ValueTask.CompletedTask
+                }
+            }
+
+            async func compute() int32 {
+                var result = 0
+                {
+                    await using let t = TrackRes{}
+                    Console.WriteLine("computing")
+                    result = 42
+                }
+                return result
+            }
+
+            let result = compute().GetAwaiter().GetResult()
+            Console.WriteLine("result=" + result.ToString())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("computing\ntrack-dispose\nresult=42\n", output);
+    }
+
+    [Fact]
+    public void AwaitUsingLet_OutsideAsyncFunction_ErrorsWithPreciseGS()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Threading.Tasks
+
+            type Res class : IAsyncDisposable {
+                func DisposeAsync() ValueTask {
+                    return ValueTask.CompletedTask
+                }
+            }
+
+            func test() {
+                await using let r = Res{}
+                Console.WriteLine("nope")
+            }
+            test()
+            """;
+
+        var errors = CompileExpectingErrors(source);
+        Assert.Contains(errors, e => e.Contains("GS0271"));
+    }
+
+    [Fact]
+    public void UsingLet_OnIAsyncDisposableOnlyType_StillErrorsBecauseNoSyncDispose()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Threading.Tasks
+
+            type AsyncOnly class : IAsyncDisposable {
+                func DisposeAsync() ValueTask {
+                    Console.WriteLine("async-only")
+                    return ValueTask.CompletedTask
+                }
+            }
+
+            func test() {
+                using let r = AsyncOnly{}
+                Console.WriteLine("nope")
+            }
+            test()
+            """;
+
+        var errors = CompileExpectingErrors(source);
+        Assert.Contains(errors, e => e.Contains("GS0119"));
+    }
+
+    [Fact]
+    public void UsingLet_OnSyncIDisposable_StillWorks()
+    {
+        // Regression: ensure the 6.4 using-let fix is unaffected.
+        var source = """
+            package Probe
+            import System
+
+            type SyncRes class : IDisposable {
+                func Dispose() {
+                    Console.WriteLine("sync-disposed")
+                }
+            }
+
+            func test() {
+                using let s = SyncRes{}
+                Console.WriteLine("sync-inside")
+            }
+            test()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("sync-inside\nsync-disposed\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue605_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRunWithSiblingCs(string gsSource, string csHelper)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue605_sibling_").FullName;
+        try
+        {
+            // Compile the C# helper into a sibling DLL.
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csHelper);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>Helper</AssemblyName>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            RunDotnet(csDir, "restore");
+            RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+
+            var csDll = Path.Combine(csDir, "bin", "Release", "net10.0", "Helper.dll");
+            Assert.True(File.Exists(csDll), $"Helper.dll not found at {csDll}");
+
+            // Now compile the G# source referencing the helper.
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gsSource);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + csDll,
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            File.Copy(csDll, Path.Combine(tempDir, "Helper.dll"), overwrite: true);
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { csDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start dotnet");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(60_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {args[0]} failed:\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+
+    private static List<string> CompileExpectingErrors(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue605_err_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit != 0, "expected gsc to report errors but it succeeded");
+            var combined = compileOut.ToString() + compileErr.ToString();
+            return combined.Split('\n').Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -20,6 +20,7 @@ AtToken
 AwaitExpression
 AwaitForRangeStatement
 AwaitKeyword
+AwaitUsingStatement
 BadToken
 BangBangToken
 BangEqualsToken


### PR DESCRIPTION
Closes #605

## Design summary

**Syntax**: `await using let r = expr` — matches C#'s `await using var` (await-first).

**Bound node**: No new `BoundNodeKind`. The cleanup expression is a `BoundAwaitExpression` wrapping the `DisposeAsync()` call. This feeds into the existing `BuildCleanupTryStatement` scope-exit machinery (try/finally with await DisposeAsync in finally).

**DisposeAsync probe** (`ConversionClassifier.TryBuildDisposeAsyncCall`):
- User-defined G# class path: probes `StructSymbol.TryGetMethodIncludingInherited("DisposeAsync")`.
- CLR-type path: `MemberLookup.SafeGetMethodIncludingSelfAndInterfaces(clrType, "DisposeAsync", Type.EmptyTypes)` with return type check (`FullName == "System.Threading.Tasks.ValueTask"`).

**Lowering**: The existing `BuildCleanupTryStatement` places the cleanup expression (now a `BoundAwaitExpression`) inside a `finally` block. The async state machine rewriter (Pattern B in `AsyncExceptionHandlerRewriter`) lifts the await out of the `finally` region, matching C# semantics.

**Diagnostics**:
- `GS0271`: `'await using let' can only be used inside an 'async func'.`
- `GS0272`: `Type 'X' cannot be used in an 'await using' statement because it does not provide a public DisposeAsync() method returning ValueTask.`

**Mixed IDisposable + IAsyncDisposable**: `await using let` calls `DisposeAsync()`; plain `using let` calls `Dispose()`. Both coexist correctly.

## Before (GS0119 on user-defined IAsyncDisposable type with `using let`)

```
error GS0119: Type 'AsyncResource' cannot be used in a 'using' statement because it does not provide a public Dispose() method.
```

## After (`await using let` compiles and runs)

```
$ gsc /out:test.dll /target:exe /targetframework:net10.0 test.gs
Wrote test.dll

$ dotnet exec test.dll
inside
disposed-async
```

## New regression tests (8)

- `AwaitUsingLet_UserClassImplementsIAsyncDisposable_DisposeAsyncCalledAtScopeExit`
- `AwaitUsingLet_ClrClassImplementsIAsyncDisposable_DisposeAsyncCalledAtScopeExit`
- `AwaitUsingLet_TypeImplementsBothSyncAndAsync_PrefersDisposeAsync`
- `AwaitUsingLet_DisposeAsyncCalledEvenOnException`
- `AwaitUsingLet_ReturnsValueFromScope_DisposesBeforeReturn`
- `AwaitUsingLet_OutsideAsyncFunction_ErrorsWithPreciseGS` (GS0271)
- `UsingLet_OnIAsyncDisposableOnlyType_StillErrorsBecauseNoSyncDispose` (GS0119)
- `UsingLet_OnSyncIDisposable_StillWorks` (regression pin)

## Follow-up issues

None — full implementation delivered.