### PR TITLE
Fix #613: investigation shows existing user-operator dispatch is already centralized

### DIFF
--- a/src/Core/CodeAnalysis/Binding/EnumOperatorTable.cs
+++ b/src/Core/CodeAnalysis/Binding/EnumOperatorTable.cs
@@ -21,6 +21,23 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// (<see cref="IsUnsignedEnumUnderlying"/>) is also co-located here so the
 /// connection between "binder accepted enum1 &lt; enum2" and "emitter chose
 /// clt_un" lives in one place.
+///
+/// <para><strong>Why this pattern is NOT extended to user-defined operators
+/// (issue #613 investigation):</strong> The <c>EnumOperatorTable</c> is a
+/// closed-world static ruleset — all enums share the same §11.10 operator set,
+/// so a declarative dictionary is ideal. User-defined operators (Streams C
+/// and D) are open-world dynamic dispatch: each type declares its own operator
+/// set via CLR <c>op_*</c> methods or GSharp receiver-form <c>operator</c>
+/// declarations. They resolve through method lookup (reflection for imported
+/// CLR types in <see cref="ClrOperatorResolution"/>; symbol-table lookup for
+/// GSharp types via <c>StructSymbol.TryGetMethodIncludingInherited</c>), not
+/// through type-shape predicate matching. Both paths are already centralized
+/// at single call sites in <c>ExpressionBinder.Operators.cs</c> and produce
+/// different bound node types (<c>BoundCallExpression</c> /
+/// <c>BoundClrBinaryOperatorExpression</c>) than the built-in operators this
+/// table feeds. A shared base class or generic <c>OperatorLiftTable</c> would
+/// add abstraction without reducing duplication, since no duplication exists
+/// to consolidate.</para>
 /// </remarks>
 internal static class EnumOperatorTable
 {


### PR DESCRIPTION
Closes #613

## Investigation summary

**What `EnumOperatorTable` does:** A closed-world declarative table (`Dictionary<SyntaxKind, BinaryRule[]>`) that maps every C# §11.10 enum operator to a `BoundBinaryOperatorKind` result via type-shape predicates (`EnumEnum`, `EnumUnderlying`, `UnderlyingEnum`). Adding a new enum operator group is a one-row change — no new arm elsewhere.

**What user-defined operator code paths look like today:**

- **Stream D** (GSharp user types, ADR-0035): single dispatch site at `ExpressionBinder.Operators.cs:60` (unary) and `:479` (binary) → `OperatorNames.TryGet*Name` → `StructSymbol.TryGetMethodIncludingInherited` or extension-function lookup → lowers to `BoundCallExpression`.
- **Stream C** (imported CLR types, ADR-0034): single dispatch site at `ExpressionBinder.Operators.cs:91` (unary) and `:526` (binary) → `ClrOperatorResolution.TryResolve*` (contains its own `Dictionary<SyntaxKind, string>` name map + reflection + `OverloadResolution.Resolve`) → lowers to `BoundClrBinaryOperatorExpression` / `BoundClrUnaryOperatorExpression`.

Both streams are already centralized at single call sites with no per-operator-group duplication.

## Why no code change (Option B)

The `EnumOperatorTable` pattern and user-defined operator dispatch are structurally incompatible for three reasons:

1. **Closed-world vs. open-world:** Enums share a fixed §11.10 operator set → a static table is ideal. User types each declare their own operator methods → requires dynamic method lookup (reflection or symbol-table search).

2. **Different bound node types:** `EnumOperatorTable` feeds `BoundBinaryOperator`/`BoundUnaryOperator` (built-in semantics). User operators produce `BoundCallExpression` (Stream D) or `BoundClrBinaryOperatorExpression` (Stream C) — fundamentally different downstream emit paths.

3. **No duplication to consolidate:** Unlike the pre-6.6 enum path (which had scattered per-operator arms in `BoundBinaryOperator.cs`), user operators have exactly one unary and one binary call site each, already dispatching through dedicated centralized helpers (`ClrOperatorResolution`, `OperatorNames`).

A generic `OperatorLiftTable<TKind>` or sibling `UserOperatorTable` would add abstraction without reducing code or improving maintainability.

## Evidence

| Claim | Location |
|-------|----------|
| Stream D unary dispatch (single site) | `ExpressionBinder.Operators.cs:60-88` |
| Stream D binary dispatch (single site) | `ExpressionBinder.Operators.cs:477-523` |
| Stream C unary dispatch (single site) | `ExpressionBinder.Operators.cs:91-108` |
| Stream C binary dispatch (single site) | `ExpressionBinder.Operators.cs:526-544` |
| `ClrOperatorResolution` — already centralized | `ClrOperatorResolution.cs:22-319` |
| `OperatorNames` — already centralized | `OperatorNames.cs:14-63` |
| ADR-0035 design confirming dispatch architecture | `docs/adr/0035-user-operator-overloads.md` |

## Test results

All suites green (no behavioral change — documentation-only commit):
- Core.Tests: 2197 passed, 1 skipped
- Compiler.Tests: 785 passed
- LanguageServer.Tests: 242 passed
- Interpreter.Tests: 76 passed