### PR TITLE
Fix #614: audit shows remaining per-arm patterns don't benefit from centralization

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -94,6 +94,10 @@ public sealed class BoundBinaryOperator
         // Phase 4.2 / ADR-0020: `==` / `!=` on a `comparable`-constrained type parameter.
         // Allowed only when both operands are the SAME type-parameter symbol whose
         // constraint is `Comparable`. (`any` falls through to "operator undefined".)
+        //
+        // Issue #614 audit: intentionally a single arm — only 2 operators (== / !=)
+        // gated by a narrow type-parameter predicate. No combinatorial growth risk;
+        // a table would add indirection without reducing duplication.
         if ((syntaxKind == SyntaxKind.EqualsEqualsToken || syntaxKind == SyntaxKind.BangEqualsToken)
             && leftType is TypeParameterSymbol ltp && ltp == rightType
             && ltp.Constraint == TypeParameterConstraint.Comparable)
@@ -115,6 +119,10 @@ public sealed class BoundBinaryOperator
         }
 
         // Phase 3.B.2 / ADR-0029 + ADR-0033: structural == / != on data and inline struct values.
+        //
+        // Issue #614 audit: intentionally a single arm — only 2 operators (== / !=)
+        // restricted to user-declared struct types with IsData or IsInline. The type
+        // test (`is StructSymbol`) is structural, not table-friendly.
         if (leftType is StructSymbol ls && rightType is StructSymbol rs && ls == rs && (ls.IsData || ls.IsInline))
         {
             if (syntaxKind == SyntaxKind.EqualsEqualsToken)
@@ -129,6 +137,10 @@ public sealed class BoundBinaryOperator
         }
 
         // Phase 3.C.2 / ADR-0001: == and != against nil for any nullable type.
+        //
+        // Issue #614 audit: intentionally a single arm — only 2 operators (== / !=)
+        // with a symmetric null-sentinel predicate. No growth dimension; the nil
+        // comparison semantic is fixed.
         if ((syntaxKind == SyntaxKind.EqualsEqualsToken || syntaxKind == SyntaxKind.BangEqualsToken) &&
             (IsNullCompare(leftType, rightType) || IsNullCompare(rightType, leftType)))
         {
@@ -140,6 +152,9 @@ public sealed class BoundBinaryOperator
         // non-nil, otherwise the right. Type is the underlying of the left
         // side (when the right is the same underlying or is itself nullable
         // with that underlying).
+        //
+        // Issue #614 audit: intentionally a single arm — there is only ONE
+        // null-coalescing operator token; no combinatorial dimension to tabulate.
         if (syntaxKind == SyntaxKind.QuestionColonToken)
         {
             TypeSymbol leftUnderlying = leftType is NullableTypeSymbol leftNullable ? leftNullable.UnderlyingType : leftType;
@@ -166,6 +181,12 @@ public sealed class BoundBinaryOperator
         // they take a non-matching int rhs and are rarely used on
         // nullables; falling through here leaves them as a non-fatal
         // "operator undefined" diagnostic at user-source level.
+        //
+        // Issue #614 audit: intentionally a single arm — this is a generic
+        // lifting meta-algorithm that already handles ALL liftable operator
+        // kinds uniformly via IsLiftableKind(). It delegates to the main Bind
+        // for the underlying form, so it has no per-operator duplication to
+        // tabulate.
         if (leftType is NullableTypeSymbol lN
             && rightType is NullableTypeSymbol rN
             && lN == rN
@@ -189,6 +210,9 @@ public sealed class BoundBinaryOperator
         // The same-type arm above handles enum? == enum? and enum? | enum?;
         // this arm handles the §11.10 arithmetic rules where both sides
         // are nullable but wrap DIFFERENT underlying types.
+        //
+        // Issue #614 audit: same rationale as the homogeneous nullable arm
+        // above — a generic lifting meta-algorithm, not per-operator duplication.
         if (leftType is NullableTypeSymbol lHet
             && rightType is NullableTypeSymbol rHet
             && lHet != rHet

--- a/src/Core/CodeAnalysis/Binding/BoundUnaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundUnaryOperator.cs
@@ -59,6 +59,10 @@ public sealed class BoundUnaryOperator
         // Phase 3.C.3 / ADR-0001: postfix `!!` is dynamically typed by the
         // operand: it returns the underlying type when applied to T?, and is
         // a no-op on already-non-nullable values (binder will diagnose).
+        //
+        // Issue #614 audit: intentionally a single arm — there is only ONE
+        // null-assertion operator token, and the result type is computed from
+        // the operand type at runtime. No combinatorial dimension to tabulate.
         if (syntaxKind == SyntaxKind.BangBangToken)
         {
             var underlying = operandType is NullableTypeSymbol n ? n.UnderlyingType : operandType;


### PR DESCRIPTION
Closes #614

## Audit Summary

Comprehensive audit of all per-arm patterns in `BoundBinaryOperator.Bind()` and `BoundUnaryOperator.Bind()`. **8 patterns total, 0 centralized, 6 documented-and-skipped, 2 already centralized.**

## Audit Table

| # | File:Line | Pattern | Type Family | Decision | Rationale |
|---|-----------|---------|-------------|----------|-----------|
| 1 | `BoundBinaryOperator.cs:97-108` | `==`/`!=` on `comparable`-constrained type parameter | Type-parameter operators | Document & skip | Only 2 operators, gated by narrow `TypeParameterSymbol` predicate with `Comparable` constraint. No combinatorial growth risk. |
| 2 | `BoundBinaryOperator.cs:115-118` | `EnumOperatorTable.TryBindBinary` dispatch | Enum operators | Already centralized | Extracted in 6.6 / PR #633. Single dispatch arm delegates to declarative table. |
| 3 | `BoundBinaryOperator.cs:121-135` | Structural `==`/`!=` on `data`/`inline` structs | Struct equality | Document & skip | Only 2 operators, restricted to `StructSymbol` with `IsData \|\| IsInline`. Type test is structural, not table-friendly. |
| 4 | `BoundBinaryOperator.cs:138-143` | `==`/`!=` against nil for nullable types | Nil comparison | Document & skip | Only 2 operators with symmetric null-sentinel predicate. Fixed semantic, no growth dimension. |
| 5 | `BoundBinaryOperator.cs:148-163` | Null-coalescing `?:` | Null coalescing | Document & skip | Single operator token (`QuestionColonToken`). No combinatorial axis to tabulate. |
| 6 | `BoundBinaryOperator.cs:175-194` | Lifted binary (homogeneous `T? op T?`) | Nullable lifting | Document & skip | Generic meta-algorithm handling ALL liftable operators via `IsLiftableKind()`. Already unified — delegates to main `Bind` for underlying form. |
| 7 | `BoundBinaryOperator.cs:200-215` | Lifted binary (heterogeneous `T? op U?`) | Nullable lifting | Document & skip | Same lifting meta-algorithm for different-underlying-type pairs. Same rationale as #6. |
| 8 | `BoundUnaryOperator.cs:62-69` | Null assertion `!!` | Null assertion | Document & skip | Single operator token, dynamically typed result. No combinatorial dimension. |

## Patterns NOT Present (per issue checklist)

- **String concatenation**: Already in the static `BuildSupportedOperators()` table (line 315) — no special arm needed.
- **Pointer arithmetic**: GSharp uses managed by-ref pointers (ADR-0039); no pointer arithmetic operators exist.
- **Tuple equality**: Not present in these files.
- **Delegate +/- for multicast**: Not present.
- **Conditional access result types**: Handled elsewhere (`BoundNullConditionalAccessExpression`).

## Extractions

None. No pattern exhibits the multi-operator × multi-type combinatorial explosion that made `EnumOperatorTable` valuable for enums.

## Documented-and-Skipped Patterns

All 6 non-centralized patterns now have inline `Issue #614 audit:` comments explaining why they stay as single arms. Each comment gives the next maintainer the rationale without needing to find this PR.

## Test Results

All 5 suites green:
- `GSharp.Core.Tests`: 2197 passed, 1 skipped
- `GSharp.Compiler.Tests`: 785 passed
- `GSharp.LanguageServer.Tests`: 242 passed
- `GSharp.Interpreter.Tests`: 76 passed
- Total: 3300 passed, 1 skipped, 0 failed