### PR TITLE
Fix #615: interpreter parity for enum arithmetic (NarrowToResultType + adjacent sites)

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -1795,16 +1795,23 @@ public sealed class Evaluator
     {
         var operand = EvaluateExpression(u.Operand);
 
+        // Issue #615: unwrap enum operands to underlying before arithmetic/bitwise.
+        var rawOperand = UnwrapEnumToUnderlying(operand);
+
+        object result;
         switch (u.Op.Kind)
         {
             case BoundUnaryOperatorKind.Identity:
-                return operand;
+                result = rawOperand;
+                break;
             case BoundUnaryOperatorKind.Negation:
-                return Negate(operand);
+                result = Negate(rawOperand);
+                break;
             case BoundUnaryOperatorKind.LogicalNegation:
                 return !(bool)operand;
             case BoundUnaryOperatorKind.OnesComplement:
-                return OnesComplement(operand);
+                result = OnesComplement(rawOperand);
+                break;
             case BoundUnaryOperatorKind.NullAssertion:
                 if (operand == null)
                 {
@@ -1817,6 +1824,14 @@ public sealed class Evaluator
             default:
                 throw new EvaluatorException($"Unexpected unary operator {u.Op}", u);
         }
+
+        // Issue #615: wrap result back to enum type if the operator's result is enum.
+        if (u.Type?.ClrType != null && u.Type.ClrType.IsEnum)
+        {
+            return Enum.ToObject(u.Type.ClrType, result);
+        }
+
+        return result;
     }
 
     private static object Negate(object v) => v switch
@@ -1896,6 +1911,28 @@ public sealed class Evaluator
 
     private static object EvaluateNumericBinary(BoundBinaryExpression b, object left, object right)
     {
+        // Issue #615: enum operands arrive as boxed enum values (e.g. DayOfWeek)
+        // which do not match the primitive pattern arms in NumericAdd/Sub/etc.
+        // Unwrap to the underlying integral type before arithmetic/comparison.
+        left = UnwrapEnumToUnderlying(left);
+        right = UnwrapEnumToUnderlying(right);
+
+        // §6.1 lifted nullable: if either operand is null, arithmetic/bitwise
+        // yields null and ordering yields false.
+        if (left == null || right == null)
+        {
+            switch (b.Op.Kind)
+            {
+                case BoundBinaryOperatorKind.Less:
+                case BoundBinaryOperatorKind.LessOrEquals:
+                case BoundBinaryOperatorKind.Greater:
+                case BoundBinaryOperatorKind.GreaterOrEquals:
+                    return false;
+                default:
+                    return null;
+            }
+        }
+
         var resultType = b.Type;
         switch (b.Op.Kind)
         {
@@ -2182,6 +2219,30 @@ public sealed class Evaluator
         if (resultType == TypeSymbol.Char)
         {
             return unchecked((char)Convert.ToInt32(value));
+        }
+
+        // Issue #615: when the result type is an enum, produce a properly-typed
+        // boxed enum value via Enum.ToObject. The arithmetic helpers return a
+        // raw underlying integer; this converts it back to the declared enum type.
+        if (resultType?.ClrType != null && resultType.ClrType.IsEnum)
+        {
+            return Enum.ToObject(resultType.ClrType, value);
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Issue #615: converts a boxed CLR enum value to its underlying primitive
+    /// (e.g. DayOfWeek.Monday → int 1) so that the pattern-matching arms in
+    /// NumericAdd/Sub/Compare/OnesComplement etc. can match the value. Non-enum
+    /// values pass through unchanged.
+    /// </summary>
+    private static object UnwrapEnumToUnderlying(object value)
+    {
+        if (value != null && value.GetType().IsEnum)
+        {
+            return Convert.ChangeType(value, Enum.GetUnderlyingType(value.GetType()));
         }
 
         return value;

--- a/test/Interpreter.Tests/Issue615InterpreterEnumArithmeticTests.cs
+++ b/test/Interpreter.Tests/Issue615InterpreterEnumArithmeticTests.cs
@@ -1,0 +1,342 @@
+// <copyright file="Issue615InterpreterEnumArithmeticTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #615: interpreter parity for C# §11.10 enum arithmetic.
+/// Mirrors the emit-side test cases from Issue6_6EnumArithmeticEmitTests and
+/// Issue6_6EnumLiftedNullableArithmeticEmitTests, verifying that the interpreter
+/// produces correctly-typed enum values (not raw integers) for:
+///   enum + underlying → enum
+///   underlying + enum → enum
+///   enum - underlying → enum
+///   enum - enum → underlying
+///   enum | enum → enum (bitwise)
+///   ~enum → enum (unary)
+///   enum == enum, enum &lt; enum (comparison)
+///   lifted nullable forms (§6.1)
+/// </summary>
+public class Issue615InterpreterEnumArithmeticTests
+{
+    // ───────────────────────────────────────────────────────────────────
+    // §11.10 arithmetic: enum + underlying → enum
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DayOfWeek_Plus_Int32_Produces_Enum()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "Console.WriteLine(DayOfWeek.Monday + int32(2))\n");
+        Assert.Contains("Wednesday", output);
+    }
+
+    [Fact]
+    public void Int32_Plus_DayOfWeek_Produces_Enum()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "Console.WriteLine(int32(2) + DayOfWeek.Monday)\n");
+        Assert.Contains("Wednesday", output);
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // §11.10 arithmetic: enum - underlying → enum
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DayOfWeek_Minus_Int32_Produces_Enum()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "Console.WriteLine(DayOfWeek.Friday - int32(1))\n");
+        Assert.Contains("Thursday", output);
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // §11.10 arithmetic: enum - enum → underlying
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DayOfWeek_Minus_DayOfWeek_Produces_Underlying()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "Console.WriteLine(DayOfWeek.Friday - DayOfWeek.Monday)\n");
+        Assert.Contains("4", output);
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // User-defined enum arithmetic
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void UserDefinedEnum_Plus_Int32()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "type Color enum {\n" +
+            "    Red,\n" +
+            "    Green,\n" +
+            "    Blue,\n" +
+            "}\n" +
+            "var c = Color.Red + int32(2)\n" +
+            "Console.WriteLine(c == Color.Blue)\n");
+        Assert.Contains("True", output);
+    }
+
+    [Fact]
+    public void UserDefinedEnum_Minus_UserDefinedEnum()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "type Color enum {\n" +
+            "    Red,\n" +
+            "    Green,\n" +
+            "    Blue,\n" +
+            "}\n" +
+            "Console.WriteLine(Color.Blue - Color.Red)\n");
+        Assert.Contains("2", output);
+    }
+
+    [Fact]
+    public void Int32_Plus_UserDefinedEnum()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "type Color enum {\n" +
+            "    Red,\n" +
+            "    Green,\n" +
+            "    Blue,\n" +
+            "}\n" +
+            "var c = int32(1) + Color.Red\n" +
+            "Console.WriteLine(c == Color.Green)\n");
+        Assert.Contains("True", output);
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Bitwise: enum | enum → enum
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DayOfWeek_BitwiseOr_Produces_Enum()
+    {
+        // DayOfWeek.Monday(1) | DayOfWeek.Tuesday(2) = 3 (Wednesday)
+        var output = RunSubmission(
+            "import System\n" +
+            "var result = DayOfWeek.Monday | DayOfWeek.Tuesday\n" +
+            "Console.WriteLine(result)\n");
+        Assert.Contains("Wednesday", output);
+    }
+
+    [Fact]
+    public void DayOfWeek_BitwiseAnd_Produces_Enum()
+    {
+        // DayOfWeek.Wednesday(3) & DayOfWeek.Monday(1) = 1 (Monday)
+        var output = RunSubmission(
+            "import System\n" +
+            "var result = DayOfWeek.Wednesday & DayOfWeek.Monday\n" +
+            "Console.WriteLine(result)\n");
+        Assert.Contains("Monday", output);
+    }
+
+    [Fact]
+    public void DayOfWeek_BitwiseXor_Produces_Enum()
+    {
+        // DayOfWeek.Wednesday(3) ^ DayOfWeek.Monday(1) = 2 (Tuesday)
+        var output = RunSubmission(
+            "import System\n" +
+            "var result = DayOfWeek.Wednesday ^ DayOfWeek.Monday\n" +
+            "Console.WriteLine(result)\n");
+        Assert.Contains("Tuesday", output);
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Unary: ~enum → enum
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void OnesComplement_DayOfWeek_Produces_Enum()
+    {
+        // ~DayOfWeek.Sunday(0) = all bits set = -1 as int backed enum
+        var output = RunSubmission(
+            "import System\n" +
+            "var result = ^DayOfWeek.Sunday\n" +
+            "Console.WriteLine(result)\n");
+        // -1 is not a named DayOfWeek member, so ToString() prints the numeric value
+        Assert.Contains("-1", output);
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Comparison: enum == enum, enum < enum
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DayOfWeek_Equality_Works()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "Console.WriteLine(DayOfWeek.Monday == DayOfWeek.Monday)\n" +
+            "Console.WriteLine(DayOfWeek.Monday == DayOfWeek.Friday)\n");
+        Assert.Contains("True", output);
+        Assert.Contains("False", output);
+    }
+
+    [Fact]
+    public void DayOfWeek_LessThan_Works()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "Console.WriteLine(DayOfWeek.Monday < DayOfWeek.Friday)\n" +
+            "Console.WriteLine(DayOfWeek.Friday < DayOfWeek.Monday)\n");
+        // First should be True, second should be False
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("True", lines[0].Trim());
+        Assert.Equal("False", lines[1].Trim());
+    }
+
+    [Fact]
+    public void DayOfWeek_GreaterThan_Works()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "Console.WriteLine(DayOfWeek.Friday > DayOfWeek.Monday)\n");
+        Assert.Contains("True", output);
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Lifted-nullable forms (§6.1): enum? + underlying? → enum?
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void LiftedNullable_EnumPlus_BothPresent()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "var a System.DayOfWeek? = DayOfWeek.Monday\n" +
+            "var b int32? = int32(2)\n" +
+            "Console.WriteLine(a + b)\n");
+        Assert.Contains("Wednesday", output);
+    }
+
+    [Fact]
+    public void LiftedNullable_EnumPlus_LeftNull()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "var a System.DayOfWeek? = nil\n" +
+            "var b int32? = int32(2)\n" +
+            "Console.WriteLine(a + b)\n");
+        // nil arithmetic produces nil, which prints as empty string
+        var trimmed = output.Trim();
+        Assert.Equal(string.Empty, trimmed);
+    }
+
+    [Fact]
+    public void LiftedNullable_EnumPlus_RightNull()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "var a System.DayOfWeek? = DayOfWeek.Monday\n" +
+            "var b int32? = nil\n" +
+            "Console.WriteLine(a + b)\n");
+        var trimmed = output.Trim();
+        Assert.Equal(string.Empty, trimmed);
+    }
+
+    [Fact]
+    public void LiftedNullable_EnumMinus_BothPresent()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "var a System.DayOfWeek? = DayOfWeek.Friday\n" +
+            "var b System.DayOfWeek? = DayOfWeek.Monday\n" +
+            "Console.WriteLine(a - b)\n");
+        Assert.Contains("4", output);
+    }
+
+    [Fact]
+    public void LiftedNullable_EnumMinus_LeftNull()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "var a System.DayOfWeek? = nil\n" +
+            "var b System.DayOfWeek? = DayOfWeek.Monday\n" +
+            "Console.WriteLine(a - b)\n");
+        var trimmed = output.Trim();
+        Assert.Equal(string.Empty, trimmed);
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Runtime type verification: confirm the result is actually
+    // DayOfWeek (not a raw int) for imported CLR enums.
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EnumPlusUnderlying_ResultType_IsDayOfWeek()
+    {
+        // DayOfWeek.ToString() prints the named member; an int prints a number.
+        // DayOfWeek.Monday + 2 should print "Wednesday" (not "3").
+        var output = RunSubmission(
+            "import System\n" +
+            "var result = DayOfWeek.Monday + int32(2)\n" +
+            "Console.WriteLine(result)\n");
+        Assert.Contains("Wednesday", output);
+        Assert.DoesNotContain("3", output);
+    }
+
+    [Fact]
+    public void EnumMinusUnderlying_ResultType_IsDayOfWeek()
+    {
+        var output = RunSubmission(
+            "import System\n" +
+            "var result = DayOfWeek.Friday - int32(1)\n" +
+            "Console.WriteLine(result)\n");
+        Assert.Contains("Thursday", output);
+        Assert.DoesNotContain("4", output);
+    }
+
+    [Fact]
+    public void EnumMinusEnum_ResultType_IsUnderlying()
+    {
+        // enum - enum → underlying int (not an enum member name)
+        var output = RunSubmission(
+            "import System\n" +
+            "var result = DayOfWeek.Friday - DayOfWeek.Monday\n" +
+            "Console.WriteLine(result)\n");
+        Assert.Contains("4", output);
+        Assert.DoesNotContain("Thursday", output);
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Helper
+    // ───────────────────────────────────────────────────────────────────
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        using var errWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(outWriter);
+        Console.SetError(errWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        return outWriter.ToString() + errWriter.ToString();
+    }
+}


### PR DESCRIPTION
Closes #615

## Diagnosis

`Evaluator.NarrowToResultType` only handled primitive sub-int narrowings and fell through for enum result types, leaving interpreted enum arithmetic returning a raw `int` instead of a properly-typed boxed enum. Additionally, `EvaluateNumericBinary` received boxed CLR enum operands (e.g. `DayOfWeek.Monday`) that don't match the primitive pattern-matching arms in `NumericAdd`/`NumericSub`/etc. — causing a crash. The same issue affected `EvaluateUnaryExpression` for `~enum`.

## Before (interpreter)

```
> DayOfWeek.Monday + int32(2)
// InvalidOperationException: Unsupported + on System.DayOfWeek and System.Int32
```

## After (interpreter)

```
> DayOfWeek.Monday + int32(2)
Wednesday
```

## Fix sites

1. **`NarrowToResultType`** (line ~2221): added enum result type detection — calls `Enum.ToObject(resultType.ClrType, value)` to produce a properly-typed boxed enum.
2. **`EvaluateNumericBinary`** (line ~1911): added `UnwrapEnumToUnderlying()` calls on both operands before arithmetic/comparison, plus null-propagation for §6.1 lifted nullable.
3. **`EvaluateUnaryExpression`** (line ~1794): unwrap enum operand before `OnesComplement`/`Negate`, wrap result via `Enum.ToObject` when result type is enum.
4. **New helper `UnwrapEnumToUnderlying()`**: converts boxed CLR enums to underlying integral primitives via `Convert.ChangeType` + `Enum.GetUnderlyingType`.

## Tests added

22 new tests in `Issue615InterpreterEnumArithmeticTests.cs`:
- enum + underlying → enum (CLR and user-defined)
- underlying + enum → enum
- enum - underlying → enum
- enum - enum → underlying
- enum | enum → enum (bitwise or/and/xor)
- ~enum → enum (unary ones complement)
- enum == enum, enum < enum, enum > enum (comparison)
- Lifted-nullable: enum? + int32? (both present, left null, right null)
- Lifted-nullable: enum? - enum? (both present, left null)
- Runtime type verification (ToString prints named member, not raw int)

## Test results

All 5 suites green:
- Core.Tests: 2197 passed, 1 skipped
- Compiler.Tests: 785 passed
- Interpreter.Tests: 98 passed (76 existing + 22 new)
- LanguageServer.Tests: 242 passed
- Sdk.Tests: 26 passed