### PR TITLE
Close #617: propagation-pass approach is the right balance

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -101,6 +101,15 @@ internal static class CaptureBoxingRewriter
         // program.Functions[lambdaSymbol] still points to the original
         // un-rewritten body. The emitter looks lambdas up by FunctionSymbol
         // key, so we must overwrite those entries here. This closes #567.
+        //
+        // Architecture note (issue #617): today lambda symbols are NOT in
+        // program.Functions (they live only as BoundFunctionLiteralExpression
+        // tree nodes, and the emitter discovers them via tree-walking). This
+        // makes the loop below a defensive no-op — the ContainsKey guard is
+        // always false. The loop is retained as a safety net: if a future
+        // refactor ever registers lambda symbols in program.Functions, this
+        // propagation ensures correctness regardless of iteration order,
+        // making topological sorting of the foreach unnecessary.
         foreach (var (lambdaSymbol, rewrittenBody) in allLambdaUpdates)
         {
             if (newFunctions.ContainsKey(lambdaSymbol))


### PR DESCRIPTION
Closes #617

## Investigation Summary

Issue #617 proposed replacing the propagation pass in `CaptureBoxingRewriter.Lower` (added in 6.7, PR #619) with a topological lowering order. This PR documents the investigation and finding that the refactor is unnecessary.

### Key Finding

Lambda symbols are **NOT** in `program.Functions`. They exist exclusively as `BoundFunctionLiteralExpression.Body` tree nodes within enclosing function bodies. The emitter discovers lambda bodies by tree-walking (`CollectFunctionLiterals` → `lambdaBodies[literal.Function] = literal.Body`), not by `program.Functions[lambdaSymbol]` lookup.

This makes:
1. The propagation loop (lines 104–111 of `CaptureBoxingRewriter.cs`) a **defensive no-op** — `newFunctions.ContainsKey(lambdaSymbol)` is always false.
2. Topological ordering of the `program.Functions` iteration **irrelevant** — there are no ordering dependencies between entries.

### Comparison Matrix

| Dimension | Topological Sort | Propagation Pass (current) |
|-----------|-----------------|---------------------------|
| **Code complexity** | Graph construction + reverse-topological iteration + handling already-rewritten bodies | Collector + post-loop overwrite (9 lines, currently no-op) |
| **Robustness** | Would need guards against re-boxing already-boxed variables if lambdas ever enter `program.Functions` | Unconditional overwrite works correctly regardless of order |
| **Performance** | O(n) graph build (unnecessary overhead for a no-op scenario) | O(n) iteration over empty `allLambdaUpdates` dict |
| **Maintainability** | Adds real complexity for no current benefit | Minimal defensive code with explanatory comment |
| **Bug surface** | If someone adds lambdas to `program.Functions`, topological sort must handle re-boxing; subtle double-boxing risk | If someone adds lambdas, propagation just works (overwrite is unconditional given ContainsKey) |

### Evidence (file:line)

- `src/Core/CodeAnalysis/Binding/Binder.cs:683–976` — `functionBodies` only contains top-level functions, class methods, constructors, property/event accessors. No lambda synthetic symbols.
- `src/Core/CodeAnalysis/Binding/LambdaBinder.cs:197–301` — `BindFunctionLiteralExpression` returns a `BoundFunctionLiteralExpression` node (tree-embedded); does NOT register in any `functionBodies` map.
- `src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs:1299` — emitter stores lambda bodies from tree: `this.lambdaBodies[literal.Function] = literal.Body`.
- `src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs:487–537` — `BoxingRewriter.RewriteFunctionLiteralExpression` rewrites lambda bodies inline during the outer's pass.

### Why No Refactor

The topological approach solves a problem that doesn't exist: there are no ordering dependencies in the `program.Functions` iteration because lambda bodies are not entries in that dictionary. The propagation pass is cheap defensive code (iterates over an empty dictionary in practice) that would automatically become active if the architecture ever changes to register lambdas in `program.Functions`. Replacing it with a topological sort would add real complexity (graph construction, re-boxing guards) for zero current benefit and marginal future benefit.

### Change

Added an architecture note (9 lines) in the propagation-pass comment explaining this finding, preventing future confusion about why topological sorting was considered unnecessary.

### Test Results

All 4 test suites green (3322 tests, 0 failures):
- Core.Tests: 2197 passed, 1 skipped
- Compiler.Tests: 785 passed
- Interpreter.Tests: 98 passed
- LanguageServer.Tests: 242 passed