### PR TITLE
Fix #618: audit lowering passes + capture analysis for raw-VariableSymbol gaps

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundClrIndexAssignmentExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrIndexAssignmentExpression.cs
@@ -17,6 +17,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// <c>d["key"] = 42</c> where <c>d</c> is a <c>Dictionary[string, int]</c>.
 /// Interpreter-only — the evaluator calls
 /// <c>Indexer.SetValue(target, value, args)</c>.
+/// The target is either a simple variable reference or, after closure-boxing
+/// lowering, an arbitrary expression (issue #618).
 /// </summary>
 public sealed class BoundClrIndexAssignmentExpression : BoundExpression
 {
@@ -30,7 +32,25 @@ public sealed class BoundClrIndexAssignmentExpression : BoundExpression
         Type = resultType;
     }
 
+    private BoundClrIndexAssignmentExpression(SyntaxNode syntax, BoundExpression targetExpression, PropertyInfo indexer, ImmutableArray<BoundExpression> arguments, BoundExpression value, TypeSymbol resultType)
+        : base(syntax)
+    {
+        TargetExpression = targetExpression;
+        Indexer = indexer;
+        Arguments = arguments;
+        Value = value;
+        Type = resultType;
+    }
+
     public VariableSymbol Target { get; }
+
+    /// <summary>
+    /// Gets the expression-based target, or <c>null</c> when the simple
+    /// <see cref="Target"/> variable form is used. When non-null, the emitter
+    /// evaluates this expression to produce the instance reference instead of
+    /// loading <see cref="Target"/>.
+    /// </summary>
+    public BoundExpression TargetExpression { get; }
 
     public PropertyInfo Indexer { get; }
 
@@ -41,4 +61,27 @@ public sealed class BoundClrIndexAssignmentExpression : BoundExpression
     public override TypeSymbol Type { get; }
 
     public override BoundNodeKind Kind => BoundNodeKind.ClrIndexAssignmentExpression;
+
+    /// <summary>
+    /// Creates a CLR index assignment with an expression-based target. Used
+    /// after closure-boxing lowering when the original target local has been
+    /// replaced by a field access through a box (issue #618).
+    /// </summary>
+    /// <param name="syntax">The originating syntax, or <c>null</c> for synthesized nodes.</param>
+    /// <param name="targetExpression">The expression that produces the instance reference.</param>
+    /// <param name="indexer">The CLR indexer property.</param>
+    /// <param name="arguments">The indexer argument expressions.</param>
+    /// <param name="value">The value to assign.</param>
+    /// <param name="resultType">The result type of the assignment expression.</param>
+    /// <returns>A new <see cref="BoundClrIndexAssignmentExpression"/> with an expression target.</returns>
+    public static BoundClrIndexAssignmentExpression WithExpressionTarget(
+        SyntaxNode syntax,
+        BoundExpression targetExpression,
+        PropertyInfo indexer,
+        ImmutableArray<BoundExpression> arguments,
+        BoundExpression value,
+        TypeSymbol resultType)
+    {
+        return new BoundClrIndexAssignmentExpression(syntax, targetExpression, indexer, arguments, value, resultType);
+    }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundIndexAssignmentExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundIndexAssignmentExpression.cs
@@ -8,7 +8,10 @@ using GSharp.Core.CodeAnalysis.Syntax;
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
-/// Bound indexed assignment <c>target[index] = value</c>.
+/// Bound indexed assignment <c>target[index] = value</c>. The target is either
+/// a simple variable reference or, after closure-boxing lowering, an arbitrary
+/// expression (e.g. <c>boxLocal.Value</c> for a boxed captured variable —
+/// issue #618).
 /// </summary>
 public sealed class BoundIndexAssignmentExpression : BoundExpression
 {
@@ -34,6 +37,20 @@ public sealed class BoundIndexAssignmentExpression : BoundExpression
         Type = elementType;
     }
 
+    private BoundIndexAssignmentExpression(
+        SyntaxNode syntax,
+        BoundExpression targetExpression,
+        BoundExpression index,
+        BoundExpression value,
+        TypeSymbol elementType)
+        : base(syntax)
+    {
+        TargetExpression = targetExpression;
+        Index = index;
+        Value = value;
+        Type = elementType;
+    }
+
     /// <inheritdoc/>
     public override BoundNodeKind Kind => BoundNodeKind.IndexAssignmentExpression;
 
@@ -43,9 +60,38 @@ public sealed class BoundIndexAssignmentExpression : BoundExpression
     /// <summary>Gets the target variable holding the array.</summary>
     public VariableSymbol Target { get; }
 
+    /// <summary>
+    /// Gets the expression-based target, or <c>null</c> when the simple
+    /// <see cref="Target"/> variable form is used. When non-null, the emitter
+    /// evaluates this expression to produce the array/map/slice reference
+    /// instead of loading <see cref="Target"/>.
+    /// </summary>
+    public BoundExpression TargetExpression { get; }
+
     /// <summary>Gets the index expression.</summary>
     public BoundExpression Index { get; }
 
     /// <summary>Gets the value expression.</summary>
     public BoundExpression Value { get; }
+
+    /// <summary>
+    /// Creates an index assignment with an expression-based target. Used after
+    /// closure-boxing lowering when the original target local has been replaced
+    /// by a field access through a box (issue #618).
+    /// </summary>
+    /// <param name="syntax">The originating syntax, or <c>null</c> for synthesized nodes.</param>
+    /// <param name="targetExpression">The expression that produces the array/map/slice reference.</param>
+    /// <param name="index">The index expression.</param>
+    /// <param name="value">The value to assign.</param>
+    /// <param name="elementType">The element type of the array.</param>
+    /// <returns>A new <see cref="BoundIndexAssignmentExpression"/> with an expression target.</returns>
+    public static BoundIndexAssignmentExpression WithExpressionTarget(
+        SyntaxNode syntax,
+        BoundExpression targetExpression,
+        BoundExpression index,
+        BoundExpression value,
+        TypeSymbol elementType)
+    {
+        return new BoundIndexAssignmentExpression(syntax, targetExpression, index, value, elementType);
+    }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -1010,7 +1010,15 @@ public static class BoundNodePrinter
 
     private static void WriteIndexAssignmentExpression(BoundIndexAssignmentExpression node, IndentedTextWriter writer)
     {
-        writer.WriteIdentifier(node.Target.Name);
+        if (node.TargetExpression != null)
+        {
+            node.TargetExpression.WriteTo(writer);
+        }
+        else
+        {
+            writer.WriteIdentifier(node.Target.Name);
+        }
+
         writer.WritePunctuation(SyntaxKind.OpenSquareBracketToken);
         node.Index.WriteTo(writer);
         writer.WritePunctuation(SyntaxKind.CloseSquareBracketToken);
@@ -1268,7 +1276,15 @@ public static class BoundNodePrinter
 
     private static void WriteClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node, IndentedTextWriter writer)
     {
-        writer.WriteIdentifier(node.Target.Name);
+        if (node.TargetExpression != null)
+        {
+            node.TargetExpression.WriteTo(writer);
+        }
+        else
+        {
+            writer.WriteIdentifier(node.Target.Name);
+        }
+
         writer.WritePunctuation(SyntaxKind.OpenSquareBracketToken);
         for (var i = 0; i < node.Arguments.Length; i++)
         {

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1182,11 +1182,17 @@ public abstract class BoundTreeRewriter
     /// <returns>The rewritten node.</returns>
     protected virtual BoundExpression RewriteIndexAssignmentExpression(BoundIndexAssignmentExpression node)
     {
+        var targetExpr = node.TargetExpression != null ? RewriteExpression(node.TargetExpression) : null;
         var index = RewriteExpression(node.Index);
         var value = RewriteExpression(node.Value);
-        if (index == node.Index && value == node.Value)
+        if (targetExpr == node.TargetExpression && index == node.Index && value == node.Value)
         {
             return node;
+        }
+
+        if (targetExpr != null)
+        {
+            return BoundIndexAssignmentExpression.WithExpressionTarget(null, targetExpr, index, value, node.Type);
         }
 
         return new BoundIndexAssignmentExpression(null, node.Target, index, value, node.Type);
@@ -1513,6 +1519,7 @@ public abstract class BoundTreeRewriter
     /// <returns>The rewritten node.</returns>
     protected virtual BoundExpression RewriteClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
     {
+        var targetExpr = node.TargetExpression != null ? RewriteExpression(node.TargetExpression) : null;
         ImmutableArray<BoundExpression>.Builder builder = null;
         for (var i = 0; i < node.Arguments.Length; i++)
         {
@@ -1534,12 +1541,17 @@ public abstract class BoundTreeRewriter
         }
 
         var value = RewriteExpression(node.Value);
-        if (builder == null && value == node.Value)
+        if (targetExpr == node.TargetExpression && builder == null && value == node.Value)
         {
             return node;
         }
 
         var args = builder?.ToImmutable() ?? node.Arguments;
+        if (targetExpr != null)
+        {
+            return BoundClrIndexAssignmentExpression.WithExpressionTarget(null, targetExpr, node.Indexer, args, value, node.Type);
+        }
+
         return new BoundClrIndexAssignmentExpression(null, node.Target, node.Indexer, args, value, node.Type);
     }
 

--- a/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
@@ -563,6 +563,11 @@ public abstract class BoundTreeWalker
 
     protected virtual void VisitIndexAssignmentExpression(BoundIndexAssignmentExpression node)
     {
+        if (node.TargetExpression != null)
+        {
+            VisitExpression(node.TargetExpression);
+        }
+
         VisitExpression(node.Index);
         VisitExpression(node.Value);
     }
@@ -769,6 +774,11 @@ public abstract class BoundTreeWalker
 
     protected virtual void VisitClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
     {
+        if (node.TargetExpression != null)
+        {
+            VisitExpression(node.TargetExpression);
+        }
+
         VisitList(node.Arguments);
         VisitExpression(node.Value);
     }

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -553,6 +553,32 @@ internal sealed class LambdaBinder
             return base.RewriteFieldAssignmentExpression(node);
         }
 
+        protected override BoundExpression RewriteIndexAssignmentExpression(BoundIndexAssignmentExpression node)
+        {
+            // Issue #618: BoundIndexAssignmentExpression carries its target
+            // as a raw VariableSymbol. Without this override the target
+            // variable is invisible to capture analysis when the lambda body
+            // only does index writes (e.g. `arr[i] = v`) on the variable.
+            if (node.Target != null)
+            {
+                this.RecordReference(node.Target);
+            }
+
+            return base.RewriteIndexAssignmentExpression(node);
+        }
+
+        protected override BoundExpression RewriteClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
+        {
+            // Issue #618: same as above for CLR indexer writes (e.g.
+            // `dict["key"] = v` on a Dictionary).
+            if (node.Target != null)
+            {
+                this.RecordReference(node.Target);
+            }
+
+            return base.RewriteClrIndexAssignmentExpression(node);
+        }
+
         protected override BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
         {
             // Issue #503 follow-up: a nested function literal's captures

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -275,7 +275,8 @@ internal sealed partial class MethodBodyEmitter
 
                 break;
             case BoundIndexAssignmentExpression ixa:
-                if (ixa.Target.Type is MapTypeSymbol)
+                var ixaTargetType = ixa.TargetExpression?.Type ?? ixa.Target.Type;
+                if (ixaTargetType is MapTypeSymbol)
                 {
                     this.EmitMapIndexAssignment(ixa);
                 }
@@ -287,7 +288,15 @@ internal sealed partial class MethodBodyEmitter
                     // re-evaluating the index expression (which may have side
                     // effects, e.g. a function call).
                     var tmp = this.indexAssignmentValueSlots[ixa];
-                    this.EmitLoadVariable(ixa.Target);
+                    if (ixa.TargetExpression != null)
+                    {
+                        this.EmitExpression(ixa.TargetExpression);
+                    }
+                    else
+                    {
+                        this.EmitLoadVariable(ixa.Target);
+                    }
+
                     this.EmitExpression(ixa.Index);
                     this.EmitExpression(ixa.Value);
                     this.il.OpCode(ILOpCode.Dup);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -358,14 +358,23 @@ internal sealed partial class MethodBodyEmitter
         // re-evaluation of k or a get_Item re-read. set_Item is void, so we
         // dup the value just before the call, save the dup to a scratch
         // local, then push it back as the expression result.
-        var mapType = (MapTypeSymbol)ixa.Target.Type;
+        var targetType = ixa.TargetExpression?.Type ?? ixa.Target.Type;
+        var mapType = (MapTypeSymbol)targetType;
         var dictType = mapType.ClrType;
         var setItem = dictType.GetMethod("set_Item")
             ?? throw new InvalidOperationException(
                 $"Dictionary type '{dictType.FullName}' has no set_Item method.");
 
         var tmp = this.indexAssignmentValueSlots[ixa];
-        this.EmitLoadVariable(ixa.Target);
+        if (ixa.TargetExpression != null)
+        {
+            this.EmitExpression(ixa.TargetExpression);
+        }
+        else
+        {
+            this.EmitLoadVariable(ixa.Target);
+        }
+
         this.EmitExpression(ixa.Index);
         this.EmitExpression(ixa.Value);
         this.il.OpCode(ILOpCode.Dup);
@@ -846,7 +855,7 @@ internal sealed partial class MethodBodyEmitter
             var refGetter = ixa.Indexer.GetGetMethod(nonPublic: false)
                 ?? throw new InvalidOperationException(
                     $"Indexer on '{ixa.Indexer.DeclaringType?.FullName}' has no public setter or getter.");
-            var receiver = new BoundVariableExpression(null, ixa.Target);
+            BoundExpression receiver = ixa.TargetExpression ?? new BoundVariableExpression(null, ixa.Target);
             var tmp = this.indexAssignmentValueSlots[ixa];
 
             // store: <receiver-addr> <index...> get_Item(ref T) <value> dup stloc tmp stobj/stind
@@ -876,8 +885,9 @@ internal sealed partial class MethodBodyEmitter
         // Issue #418 (P1-1): spill v to a temp before the call so the result
         // is the assigned value without a re-read via get_Item (which would
         // re-evaluate every index argument).
-        var writeReceiver = new BoundVariableExpression(null, ixa.Target);
-        var targetIsValueType = ReflectionMetadataEmitter.IsValueTypeSymbol(ixa.Target.Type);
+        BoundExpression writeReceiver = ixa.TargetExpression ?? new BoundVariableExpression(null, ixa.Target);
+        var targetType = ixa.TargetExpression?.Type ?? ixa.Target.Type;
+        var targetIsValueType = ReflectionMetadataEmitter.IsValueTypeSymbol(targetType);
         var slot = this.indexAssignmentValueSlots[ixa];
 
         this.EmitInstanceReceiver(writeReceiver);

--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -459,6 +459,81 @@ internal static class CaptureBoxingRewriter
         }
 
         /// <inheritdoc/>
+        protected override BoundExpression RewriteIndexAssignmentExpression(BoundIndexAssignmentExpression node)
+        {
+            // Issue #618: when the target of an index assignment is a boxed
+            // variable, the original target no longer has an IL slot. Rewrite
+            // to use an expression-based target: `boxLocal.Value` produces
+            // the array/slice/map reference, then the outer index assignment
+            // targets the element through that expression.
+            if (node.Target != null && this.boxInfo.TryGetValue(node.Target, out var bi))
+            {
+                var targetExpr = new BoundFieldAccessExpression(
+                    null,
+                    new BoundVariableExpression(null, bi.BoxLocal),
+                    bi.BoxClass,
+                    bi.BoxField);
+                var index = this.RewriteExpression(node.Index);
+                var value = this.RewriteExpression(node.Value);
+                return BoundIndexAssignmentExpression.WithExpressionTarget(
+                    null,
+                    targetExpr,
+                    index,
+                    value,
+                    node.Type);
+            }
+
+            return base.RewriteIndexAssignmentExpression(node);
+        }
+
+        /// <inheritdoc/>
+        protected override BoundExpression RewriteClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
+        {
+            // Issue #618: same pattern for CLR indexer writes (e.g.
+            // `dict["key"] = v` on a Dictionary). When the target is boxed,
+            // rewrite to use an expression-based target.
+            if (node.Target != null && this.boxInfo.TryGetValue(node.Target, out var bi))
+            {
+                var targetExpr = new BoundFieldAccessExpression(
+                    null,
+                    new BoundVariableExpression(null, bi.BoxLocal),
+                    bi.BoxClass,
+                    bi.BoxField);
+                ImmutableArray<BoundExpression>.Builder argBuilder = null;
+                for (var i = 0; i < node.Arguments.Length; i++)
+                {
+                    var oldArg = node.Arguments[i];
+                    var newArg = this.RewriteExpression(oldArg);
+                    if (newArg != oldArg && argBuilder == null)
+                    {
+                        argBuilder = ImmutableArray.CreateBuilder<BoundExpression>(node.Arguments.Length);
+                        for (var j = 0; j < i; j++)
+                        {
+                            argBuilder.Add(node.Arguments[j]);
+                        }
+                    }
+
+                    if (argBuilder != null)
+                    {
+                        argBuilder.Add(newArg);
+                    }
+                }
+
+                var args = argBuilder?.ToImmutable() ?? node.Arguments;
+                var value = this.RewriteExpression(node.Value);
+                return BoundClrIndexAssignmentExpression.WithExpressionTarget(
+                    null,
+                    targetExpr,
+                    node.Indexer,
+                    args,
+                    value,
+                    node.Type);
+            }
+
+            return base.RewriteClrIndexAssignmentExpression(node);
+        }
+
+        /// <inheritdoc/>
         protected override BoundStatement RewriteVariableDeclaration(BoundVariableDeclaration node)
         {
             if (this.boxInfo.TryGetValue(node.Variable, out var bi) && bi.Original == node.Variable)

--- a/test/Compiler.Tests/Emit/Issue618IndexCaptureRegressionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue618IndexCaptureRegressionTests.cs
@@ -1,0 +1,224 @@
+// <copyright file="Issue618IndexCaptureRegressionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #618 regression guard: verifies that closures capturing a variable
+/// used only as the target of an index-assignment expression (array element
+/// write, map key write, or CLR indexer write) compile correctly. Before
+/// #618 the raw <c>VariableSymbol</c> target was invisible to both
+/// <c>CapturedVariableCollector</c> and <c>BoxingRewriter</c>, causing
+/// either a missing closure field (capture analysis gap) or a stale slot
+/// reference (boxing rewrite gap).
+/// </summary>
+public class Issue618IndexCaptureRegressionTests
+{
+    /// <summary>
+    /// Lambda captures a local array and writes an element via index
+    /// assignment. The outer scope observes the mutation.
+    /// </summary>
+    [Fact]
+    public void ArrayIndexWrite_FromClosure()
+    {
+        var source = """
+            package Probe
+            import System
+
+            func Run() int32 {
+                var arr = []int32{0, 0, 0}
+                var writer = func(i int32, v int32) { arr[i] = v }
+                writer(1, 42)
+                return arr[1]
+            }
+
+            Console.WriteLine(Run())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    /// <summary>
+    /// Lambda captures a local map and writes a key via index assignment.
+    /// The outer scope observes the mutation.
+    /// </summary>
+    [Fact]
+    public void MapIndexWrite_FromClosure()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            func Run() int32 {
+                var m = map[string]int32{}
+                var put = func(k string, v int32) { m[k] = v }
+                put("hello", 7)
+                return m["hello"]
+            }
+
+            Console.WriteLine(Run())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    /// <summary>
+    /// Lambda captures a local Dictionary and writes a key via CLR indexer
+    /// assignment. The outer scope observes the mutation.
+    /// </summary>
+    [Fact]
+    public void ClrIndexerWrite_FromClosure()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            func Run() int32 {
+                var d = Dictionary[string, int32]()
+                var put = func(k string, v int32) { d[k] = v }
+                put("x", 99)
+                return d["x"]
+            }
+
+            Console.WriteLine(Run())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    /// <summary>
+    /// Lambda captures a local array inside a class method and writes
+    /// an element. Confirms the fix works in the class-method path too.
+    /// </summary>
+    [Fact]
+    public void ArrayIndexWrite_FromClosureInClassMethod()
+    {
+        var source = """
+            package Probe
+            import System
+
+            type Probe class {
+                init() {}
+                func Run() int32 {
+                    var arr = []int32{10, 20, 30}
+                    var writer = func(v int32) { arr[0] = v }
+                    writer(55)
+                    return arr[0]
+                }
+            }
+
+            var p = Probe()
+            Console.WriteLine(p.Run())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("55\n", output);
+    }
+
+    /// <summary>
+    /// Two lambdas share the same captured map and observe each other's
+    /// writes through the shared box.
+    /// </summary>
+    [Fact]
+    public void MultipleClosures_ShareCapturedMap()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            func Run() int32 {
+                var m = map[string]int32{}
+                var put = func(k string, v int32) { m[k] = v }
+                var get = func(k string) int32 { return m[k] }
+                put("a", 1)
+                put("b", 2)
+                return get("a") + get("b")
+            }
+
+            Console.WriteLine(Run())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_618_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Closes #618

## Half 1 — `program.Functions` audit

Per the #617 investigation (PR #636): lambda symbols are NOT in `program.Functions`. They exist only as `BoundFunctionLiteralExpression.Body` tree nodes. The emitter discovers them via tree-walking, not dictionary lookup. The 6.7 propagation pass (`newFunctions[lambdaSymbol] = rewrittenBody`) in `CaptureBoxingRewriter` is a defensive no-op — `ContainsKey` always returns false.

| File:Line | Site | Lambda-symbol write? | Migration needed? |
|-----------|------|---------------------|-------------------|
| `CaptureBoxingRewriter.cs:79` | `newFunctions = ImmutableDictionary.CreateBuilder<>()` | Builder init | No |
| `CaptureBoxingRewriter.cs:83` | `foreach (var pair in program.Functions)` | Iterates top-level functions only | No |
| `CaptureBoxingRewriter.cs:86` | `newFunctions[pair.Key] = newBody` | Top-level function rewrite | No |
| `CaptureBoxingRewriter.cs:115` | `if (newFunctions.ContainsKey(lambdaSymbol))` | Defensive check — always false | No |
| `CaptureBoxingRewriter.cs:117` | `newFunctions[lambdaSymbol] = rewrittenBody` | Dead code (lambda symbols never in dict) | No |
| `CaptureBoxingRewriter.cs:133` | `newFunctions.ToImmutable()` | Finalizes builder | No |
| `AsyncStateMachineRewriter.cs:45` | `foreach (var pair in program.Functions.OrderBy(...))` | Reads top-level functions | No |
| `AsyncEmitPrecheck.cs:47` | `foreach (var function in program.Functions.Keys)` | Reads top-level functions | No |
| `AsyncEmitPrecheck.cs:70` | `program.Functions.ContainsKey(entry)` | Checks entry point | No |
| `InterpolatedStringHandlerLowerer.cs:69` | `foreach (var pair in program.Functions)` | Reads top-level functions | No |
| `SideEffectSpiller.cs:90` | `foreach (var pair in program.Functions)` | Reads top-level functions | No |
| `IteratorRewriter.cs:39` | `foreach (var pair in program.Functions.OrderBy(...))` | Reads top-level functions | No |
| `AsyncIteratorRewriter.cs:47` | `foreach (var pair in program.Functions.OrderBy(...))` | Reads top-level functions | No |

**Conclusion**: Zero migrations needed. All `program.Functions` sites operate on top-level function symbols only; lambda symbols never appear as dictionary keys.

## Half 2 — raw-`VariableSymbol` property audit

Every `public VariableSymbol` property in bound nodes:

| File:Line | Property | Role | Handled? |
|-----------|----------|------|----------|
| `BoundVariableExpression.cs:52` | `Variable` | Variable read | ✅ `RewriteVariableExpression` override |
| `BoundAssignmentExpression.cs:37` | `Variable` | Variable write LHS | ✅ `RewriteAssignmentExpression` override |
| `BoundVariableDeclaration.cs:42` | `Variable` | Declaration | ✅ `RewriteVariableDeclaration` override |
| `BoundFieldAssignmentExpression.cs:39` | `Receiver` | Field write receiver | ✅ Fixed in 6.7 (#567) |
| `BoundIndexAssignmentExpression.cs:44` | `Target` | Array/map index write target | ❌→✅ **Fixed in this PR** |
| `BoundClrIndexAssignmentExpression.cs:33` | `Target` | CLR indexer write target | ❌→✅ **Fixed in this PR** |
| `BoundForEllipsisStatement.cs:47` | `Variable` | Loop variable declaration | ✅ Declares a new local (not a capture source) |
| `BoundForRangeStatement.cs:69` | `KeyVariable` | Loop variable declaration | ✅ Declares a new local |
| `BoundForRangeStatement.cs:72` | `ValueVariable` | Loop variable declaration | ✅ Declares a new local |
| `BoundAwaitForRangeStatement.cs:46` | `ValueVariable` | Loop variable declaration | ✅ Declares a new local |
| `BoundCatchClause.cs:29` | `Variable` | Exception variable declaration | ✅ Declares a new local |
| `BoundSelectCase.cs:45` | `Variable` | Select case binding declaration | ✅ Declares a new local |
| `BoundNullConditionalAccessExpression.cs:67` | `Capture` | Synthetic compiler-generated temp | ✅ Never a user variable; created by binder inline |
| `BoundNullConditionalAccessExpression.cs:77` | `ResultSlot` | Synthetic compiler-generated temp | ✅ Never a user variable; emitter-only |
| `BoundStateMachineAwaitOnCompleted.cs:42` | `AwaiterLocal` | State machine artifact | ✅ Created by async lowering, never inside lambda |
| `BoundStateMachineBuilderMoveNext.cs:33` | `ThisParameter` | State machine artifact | ✅ Created by async lowering, never inside lambda |

**Summary**: 16 raw-`VariableSymbol` properties total. 14 correctly handled (by existing overrides or by nature of being declarations/synthetic/lowering artifacts). **2 gaps found and fixed** in this PR.

## Gaps fixed

### `BoundIndexAssignmentExpression.Target`
Array/slice element write (`arr[i] = v`) and map key write (`m[k] = v`) carry the target as a raw `VariableSymbol`. Without a `CapturedVariableCollector` override, a lambda that only does index writes on a captured variable would not mark it as captured. Without a `BoxingRewriter` override, the emitter would reference the original slot (now holding the box object) instead of the boxed value.

### `BoundClrIndexAssignmentExpression.Target`
CLR indexer write (`dict["key"] = v`) carries the target as a raw `VariableSymbol`. Same class of bug — invisible to capture analysis and boxing rewrite.

## Fix pattern (mirrors #567 / `BoundFieldAssignmentExpression`)
1. Add `TargetExpression` property + `WithExpressionTarget` factory to both node types
2. Add `CapturedVariableCollector.RewriteIndexAssignmentExpression` / `RewriteClrIndexAssignmentExpression` overrides to call `RecordReference(node.Target)`
3. Add `BoxingRewriter.RewriteIndexAssignmentExpression` / `RewriteClrIndexAssignmentExpression` overrides to produce the expression-target variant when the target is boxed
4. Update the emitter to use `TargetExpression` when present
5. Update `BoundTreeRewriter`, `BoundTreeWalker`, `BoundNodePrinter` for completeness

## Regression tests
- `ArrayIndexWrite_FromClosure` — array element write through lambda
- `MapIndexWrite_FromClosure` — map key write through lambda
- `ClrIndexerWrite_FromClosure` — Dictionary CLR indexer write through lambda
- `ArrayIndexWrite_FromClosureInClassMethod` — array write inside class method lambda
- `MultipleClosures_ShareCapturedMap` — two lambdas sharing a captured map