### PR TITLE
Fix #537: string iteration in for-in (emit MLC parameter projection)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
+++ b/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
@@ -478,7 +478,7 @@ internal sealed class WellKnownReferences
     public MemberReferenceHandle GetStringCharsReference()
     {
         // System.String::get_Chars(Int32) — used for string indexing (issue #537).
-        var method = this.emitCtx.CoreStringType.GetMethod("get_Chars", new[] { typeof(int) })
+        var method = this.emitCtx.CoreStringType.GetMethod("get_Chars", new[] { this.emitCtx.CoreInt32Type })
             ?? throw new InvalidOperationException("String.get_Chars(int) is not resolvable from the supplied references.");
         return this.getMethodReference(method);
     }


### PR DESCRIPTION
## Root Cause

`GetStringCharsReference()` in `WellKnownReferences.cs` passed `typeof(int)` — a **runtime** `System.Type` — as the parameter-type array when calling `Type.GetMethod("get_Chars", ...)` on the MetadataLoadContext (MLC)-loaded `System.String` type. The MLC's `DefaultBinder.SelectMethod` rejects mixed runtime/MLC types with:

```
error GS9998: ArgumentException: Type must be a type provided by the MetadataLoadContext. (Parameter 'types')
```

## Fix

Replace `typeof(int)` with `this.emitCtx.CoreInt32Type` — the MLC-resolved `System.Int32` — consistent with sibling helpers like `GetArrayCopyReference()` which correctly use MLC-loaded types in their parameter arrays.

One-line change in `src/Core/CodeAnalysis/Emit/WellKnownReferences.cs` line 481.

## Audit

- `GetStringLengthReference()` uses `Type.EmptyTypes` (no parameters) — safe.
- `GetTypeFromHandleReference()` uses `this.emitCtx.CoreRuntimeTypeHandleType` — correct.
- `GetArrayCopyReference()` uses `this.emitCtx.CoreArrayType` / `CoreInt32Type` — correct.
- No other `GetMethod` call in the file passes runtime `typeof(...)` types.

## Test Coverage

All 8 existing regression tests in `Issue537ForCharInStringEmitTests.cs` now pass:
- Literal strings, string variables, empty strings
- BMP non-ASCII characters (é, €, 日)
- Surrogate pairs (emoji U+1F600)
- `ToCharArray()` regression guard
- Key+value iteration (`for i, c in str`)

Full test suite: **3327 passed**, 1 skipped, 0 failed.

Closes #537.