### PR TITLE
Fix #572: resolve default interface methods on concrete CLR class receivers

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -434,11 +434,13 @@ internal static class ClrTypeUtilities
         => SafeGetMember(type, name, flags, (t, f) => t.GetEvent(name, f), SafeGetEvents);
 
     /// <summary>
-    /// Issue #529: looks up a property by name, walking the transitive
-    /// interface hierarchy when <paramref name="type"/> is an interface.
+    /// Issues #529 / #572: looks up a property by name, walking the transitive
+    /// interface hierarchy. For interface types this surfaces inherited
+    /// interface members; for concrete classes this surfaces default
+    /// interface properties (DIMs) that the class does not override.
     /// CLR reflection does not include inherited interface members in
-    /// <see cref="Type.GetProperties(BindingFlags)"/> for interface types,
-    /// so this helper explicitly walks <see cref="Type.GetInterfaces()"/>.
+    /// <see cref="Type.GetProperties(BindingFlags)"/>, so this helper
+    /// explicitly walks <see cref="Type.GetInterfaces()"/>.
     /// </summary>
     /// <param name="type">The type to search.</param>
     /// <param name="name">The property name.</param>
@@ -452,7 +454,7 @@ internal static class ClrTypeUtilities
             return direct;
         }
 
-        if (type is null || !type.IsInterface)
+        if (type is null)
         {
             return null;
         }
@@ -503,12 +505,13 @@ internal static class ClrTypeUtilities
     }
 
     /// <summary>
-    /// Issue #529: enumerates methods including those declared on
-    /// transitive base interfaces when <paramref name="type"/> is an
-    /// interface. For non-interface types, this is equivalent to
-    /// <see cref="SafeGetMethods"/>. Methods from base interfaces that
-    /// are hidden by a same-name-and-parameter-types method on a
-    /// more-derived interface are excluded (mirrors C# hiding rules).
+    /// Issues #529 / #572: enumerates methods including those declared on
+    /// transitive base interfaces. For interface types this surfaces
+    /// inherited interface members; for concrete classes this surfaces
+    /// default interface methods (DIMs) that the class does not override.
+    /// Methods from interfaces that are hidden by a same-name-and-parameter-types
+    /// method already present (on the class or a more-derived interface) are
+    /// excluded (mirrors C# hiding rules).
     /// </summary>
     /// <param name="type">The type to enumerate.</param>
     /// <param name="flags">The binding flags controlling visibility.</param>
@@ -516,13 +519,19 @@ internal static class ClrTypeUtilities
     public static MethodInfo[] SafeGetMethodsIncludingInterfaces(Type type, BindingFlags flags)
     {
         var direct = SafeGetMethods(type, flags);
-        if (type is null || !type.IsInterface)
+        if (type is null)
+        {
+            return direct;
+        }
+
+        var interfaces = SafeGetInterfaces(type);
+        if (interfaces.Length == 0)
         {
             return direct;
         }
 
         var all = new List<MethodInfo>(direct);
-        foreach (var iface in SafeGetInterfaces(type))
+        foreach (var iface in interfaces)
         {
             foreach (var m in SafeGetMethods(iface, flags))
             {

--- a/test/Compiler.Tests/Emit/Issue572DimDispatchOnConcreteTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue572DimDispatchOnConcreteTypeEmitTests.cs
@@ -14,14 +14,56 @@ namespace GSharp.Compiler.Tests.Emit;
 /// <summary>
 /// Issue #572: calling a default interface method (DIM) on a concrete CLR
 /// class that does not override the DIM was rejected with GS0159 because
-/// <c>ExpressionBinder.TryBindInheritedClrInstanceCall</c> used
-/// <c>Type.GetMethods()</c> which does not surface DIMs from interfaces.
-/// The fix routes through <c>MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces</c>.
+/// <c>ClrTypeUtilities.SafeGetMethodsIncludingInterfaces</c> only walked
+/// interfaces when the receiver was itself an interface type. The fix
+/// removes the <c>!type.IsInterface</c> guard so interface methods (DIMs)
+/// are surfaced on concrete class receivers as well.
 /// </summary>
 public class Issue572DimDispatchOnConcreteTypeEmitTests
 {
+    // ---------------------------------------------------------------
+    // Core DIM resolution on concrete type
+    // ---------------------------------------------------------------
+
     [Fact]
-    public void DimDispatch_ConcreteType_ReturnsExpectedValue()
+    public void DimDispatch_ConcreteType_NoArgMethod()
+    {
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface IWithDIM
+                {
+                    string Name { get; }
+                    string Greeting() => "Hello, " + Name + "!";
+                }
+
+                public class WithDIMImpl : IWithDIM
+                {
+                    public string Name { get; }
+                    public WithDIMImpl(string name) { Name = name; }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            var obj = WithDIMImpl("world")
+            Console.WriteLine(obj.Greeting())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Equal("Hello, world!\n", output);
+    }
+
+    // ---------------------------------------------------------------
+    // Regression: through-interface still works
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void DimDispatch_ThroughInterface_StillWorks()
     {
         var sibling = """
             namespace ProbeRef
@@ -53,6 +95,76 @@ public class Issue572DimDispatchOnConcreteTypeEmitTests
         var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
         Assert.Equal("Hello, world!\n", output);
     }
+
+    // ---------------------------------------------------------------
+    // DIM with parameters
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void DimDispatch_WithParameters()
+    {
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface IGreeter
+                {
+                    string Greet(string name, int times) => name + "x" + times.ToString();
+                }
+
+                public class SimpleGreeter : IGreeter { }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            var g = SimpleGreeter()
+            Console.WriteLine(g.Greet("hi", 3))
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Equal("hix3\n", output);
+    }
+
+    // ---------------------------------------------------------------
+    // DIM with overloads: M() and M(int)
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void DimDispatch_Overloaded()
+    {
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface IOverloaded
+                {
+                    string M() => "noarg";
+                    string M(int n) => "arg:" + n.ToString();
+                }
+
+                public class OverloadedImpl : IOverloaded { }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            var o = OverloadedImpl()
+            Console.WriteLine(o.M())
+            Console.WriteLine(o.M(42))
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Equal("noarg\narg:42\n", output);
+    }
+
+    // ---------------------------------------------------------------
+    // Class explicitly overrides DIM — class version wins
+    // ---------------------------------------------------------------
 
     [Fact]
     public void DimDispatch_OverriddenDim_PrefersConcrete()
@@ -86,6 +198,175 @@ public class Issue572DimDispatchOnConcreteTypeEmitTests
 
         var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
         Assert.Equal("Overridden: world\n", output);
+    }
+
+    // ---------------------------------------------------------------
+    // DIM inherited from grandparent interface (I3 : I2, I2 : I1, DIM on I1)
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void DimDispatch_TransitiveInheritance()
+    {
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface IGrandparent
+                {
+                    string Deep() => "deep-dim";
+                }
+
+                public interface IParent : IGrandparent { }
+                public interface IChild : IParent { }
+
+                public class DeepImpl : IChild { }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            var d = DeepImpl()
+            Console.WriteLine(d.Deep())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Equal("deep-dim\n", output);
+    }
+
+    // ---------------------------------------------------------------
+    // DIM on a sealed class
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void DimDispatch_SealedClass()
+    {
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface ISealable
+                {
+                    string Tag() => "sealed-dim";
+                }
+
+                public sealed class SealedImpl : ISealable { }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            var s = SealedImpl()
+            Console.WriteLine(s.Tag())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Equal("sealed-dim\n", output);
+    }
+
+    // ---------------------------------------------------------------
+    // DIM property (default interface property with body)
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void DimDispatch_Property()
+    {
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface IHasDefaultProp
+                {
+                    string Label => "default-label";
+                }
+
+                public class PropImpl : IHasDefaultProp { }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            var p = PropImpl()
+            Console.WriteLine(p.Label)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Equal("default-label\n", output);
+    }
+
+    // ---------------------------------------------------------------
+    // Multiple interfaces each with a DIM — both resolvable
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void DimDispatch_MultipleInterfaces()
+    {
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface IFoo
+                {
+                    string Foo() => "foo-dim";
+                }
+
+                public interface IBar
+                {
+                    string Bar() => "bar-dim";
+                }
+
+                public class MultImpl : IFoo, IBar { }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            var m = MultImpl()
+            Console.WriteLine(m.Foo())
+            Console.WriteLine(m.Bar())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Equal("foo-dim\nbar-dim\n", output);
+    }
+
+    // ---------------------------------------------------------------
+    // Generic interface with DIM
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void DimDispatch_GenericInterface()
+    {
+        var sibling = """
+            namespace ProbeRef
+            {
+                public interface IGen<T>
+                {
+                    string Describe() => typeof(T).Name;
+                }
+
+                public class GenImpl : IGen<int> { }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import ProbeRef
+
+            var g = GenImpl()
+            Console.WriteLine(g.Describe())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "ProbeRef");
+        Assert.Equal("Int32\n", output);
     }
 
     private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)


### PR DESCRIPTION
## Root cause

`ClrTypeUtilities.SafeGetMethodsIncludingInterfaces` and `SafeGetPropertyIncludingInterfaces` (introduced for #529) had a guard `!type.IsInterface` that short-circuited interface walking for concrete (non-interface) types. This meant Default Interface Methods (DIMs — interface instance methods with a default body) were never surfaced when the receiver was a concrete class. The binder would report GS0159 ("Cannot find function") for a DIM call on a concrete class, even though C# dispatches it correctly via the interface vtable.

## Fix

Remove the `!type.IsInterface` guard in both methods so interface methods and properties are always walked regardless of whether the receiver type is a concrete class or an interface. The existing `IsHiddenByExisting` logic ensures class-declared methods/properties take precedence over DIMs with the same signature — matching C# semantics where the class override wins.

**Files changed:**
- `src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs` — the two-line fix (remove early-return guards)
- `test/Compiler.Tests/Emit/Issue572DimDispatchOnConcreteTypeEmitTests.cs` — comprehensive test coverage

## Test coverage (10 tests)

| Test | What it verifies |
|------|-----------------|
| `DimDispatch_ConcreteType_NoArgMethod` | Core repro: DIM method called directly on concrete class |
| `DimDispatch_ThroughInterface_StillWorks` | Regression: through-interface dispatch unchanged |
| `DimDispatch_WithParameters` | DIM with multiple parameters |
| `DimDispatch_Overloaded` | Overloaded DIMs (`M()` and `M(int)`) |
| `DimDispatch_OverriddenDim_PrefersConcrete` | Class override takes precedence over DIM |
| `DimDispatch_TransitiveInheritance` | DIM on grandparent interface (I3:I2:I1) |
| `DimDispatch_SealedClass` | DIM on sealed class |
| `DimDispatch_Property` | DIM property (default interface property with body) |
| `DimDispatch_MultipleInterfaces` | Multiple interfaces each with distinct DIMs |
| `DimDispatch_GenericInterface` | Generic interface with DIM |

## Full suite results

All tests pass (0 failures):
- Compiler.Tests: 798 passed
- Core.Tests: 2197 passed, 1 skipped
- Interpreter.Tests: 98 passed
- LanguageServer.Tests: 242 passed
- Sdk.Tests: 26 passed

Closes #572.