### PR TITLE
Fix #638: class implementing CLR interface with Nullable<T> return type

### DIFF
--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -220,7 +220,7 @@ internal sealed class MemberLookup
             return null;
         }
 
-        if (!ClrTypeUtilities.AreSame(field.Type?.ClrType, clrProp.PropertyType))
+        if (!ClrTypeUtilities.AreSame(NullableLifting.GetEffectiveClrType(field.Type), clrProp.PropertyType))
         {
             return null;
         }
@@ -568,7 +568,7 @@ internal sealed class MemberLookup
                 continue;
             }
 
-            if (!ClrTypeUtilities.AreSame(candidate.Type?.ClrType, clrMethod.ReturnType))
+            if (!ClrTypeUtilities.AreSame(NullableLifting.GetEffectiveClrType(candidate.Type), clrMethod.ReturnType))
             {
                 continue;
             }
@@ -576,7 +576,7 @@ internal sealed class MemberLookup
             var allMatch = true;
             for (var i = 0; i < callable.Length; i++)
             {
-                if (!ClrTypeUtilities.AreSame(callable[i].Type?.ClrType, clrParams[i].ParameterType))
+                if (!ClrTypeUtilities.AreSame(NullableLifting.GetEffectiveClrType(callable[i].Type), clrParams[i].ParameterType))
                 {
                     allMatch = false;
                     break;
@@ -605,7 +605,7 @@ internal sealed class MemberLookup
         foreach (var implProp in structSymbol.Properties)
         {
             if (implProp.Name == clrProp.Name
-                && ClrTypeUtilities.AreSame(implProp.Type?.ClrType, clrProp.PropertyType))
+                && ClrTypeUtilities.AreSame(NullableLifting.GetEffectiveClrType(implProp.Type), clrProp.PropertyType))
             {
                 return implProp;
             }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -172,6 +172,36 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #638: numeric-widening + nullable wrapping: T1 → Nullable<T2>
+        // where T1 is numerically convertible to T2 (e.g., int32 → int64?).
+        // The exact-match case (T → Nullable<T>) was handled above; this
+        // covers cross-width conversions that would otherwise be mishandled
+        // by TryEmitNumericConversion below (which sees NullableTypeSymbol.ClrType
+        // as the raw underlying type and emits only the conv.* without wrapping).
+        if (to is NullableTypeSymbol toValueNullableWiden
+            && ReflectionMetadataEmitter.IsValueTypeNullable(toValueNullableWiden)
+            && from != toValueNullableWiden.UnderlyingType
+            && TryEmitNumericConversion(from, toValueNullableWiden.UnderlyingType, conv.IsChecked))
+        {
+            var widenInnerClr = toValueNullableWiden.UnderlyingType.ClrType
+                ?? throw new InvalidOperationException(
+                    $"Nullable<{toValueNullableWiden.UnderlyingType.Name}> lift has no CLR underlying type.");
+
+            if (!NullableLifting.TryConstructNullable(this.outer.emitCtx.References, widenInnerClr, out var widenNullableClr))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot construct Nullable<{widenInnerClr.FullName}>: System.Nullable`1 is not resolvable in the reference set.");
+            }
+
+            var widenNullableInnerArg = widenNullableClr.GetGenericArguments()[0];
+            var widenCtor = widenNullableClr.GetConstructor(new[] { widenNullableInnerArg })
+                ?? throw new InvalidOperationException(
+                    $"Nullable<{widenNullableInnerArg.FullName}> has no single-arg constructor.");
+            this.il.OpCode(ILOpCode.Newobj);
+            this.il.Token(this.outer.GetCtorReference(widenCtor));
+            return;
+        }
+
         // ADR-0044 numeric conversion lattice. Any pair of numeric CLR
         // primitives (sbyte/byte/short/ushort/int/uint/long/ulong/nint/
         // nuint/float/double/decimal/char) gets a typed IL conversion.

--- a/test/Compiler.Tests/Emit/Issue638NullableValueReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue638NullableValueReturnEmitTests.cs
@@ -125,10 +125,8 @@ public class Issue638NullableValueReturnEmitTests
     }
 
     [Fact]
-    public void NullableLongReturn_Interface_ReturnsNil()
+    public void NullableLongReturn_Interface_ReturnsNilAndRealValue()
     {
-        // Note: int64? return with a non-nil value exposes a pre-existing
-        // emitter limitation for int64 nullable lifting. Test nil path only.
         var sibling = """
             namespace Probe.CSharp
             {
@@ -144,18 +142,26 @@ public class Issue638NullableValueReturnEmitTests
             import System
             import Probe.CSharp
 
-            type MaybeLongImpl class : IMaybeLong {
+            type MaybeLongImplNil class : IMaybeLong {
                 func Big() int64? {
                     return nil
                 }
             }
 
-            var m IMaybeLong = MaybeLongImpl{}
-            Console.WriteLine(m.Big() == nil)
+            type MaybeLongImplValue class : IMaybeLong {
+                func Big() int64? {
+                    return 42
+                }
+            }
+
+            var n IMaybeLong = MaybeLongImplNil{}
+            Console.WriteLine(n.Big() == nil)
+            var v IMaybeLong = MaybeLongImplValue{}
+            Console.WriteLine(v.Big())
             """;
 
         var output = CompileAndRunWithSiblingCs(sibling, gsource);
-        Assert.Equal("True\n", output);
+        Assert.Equal("True\n42\n", output);
     }
 
     [Fact]
@@ -451,6 +457,170 @@ public class Issue638NullableValueReturnEmitTests
 
         var output = CompileAndRunWithSiblingCs(sibling, gsource);
         Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void NullableLongReturn_ComputedValue()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface ILongAdder
+                {
+                    long? Add(long a, long b);
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type LongAdder class : ILongAdder {
+                func Add(a int64, b int64) int64? {
+                    return a + b
+                }
+            }
+
+            var adder ILongAdder = LongAdder{}
+            Console.WriteLine(adder.Add(1000000000, 2000000000))
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("3000000000\n", output);
+    }
+
+    [Fact]
+    public void NullableULongReturn_Interface()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IMaybeULong
+                {
+                    ulong? Value();
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type MaybeULongImpl class : IMaybeULong {
+                func Value() uint64? {
+                    return uint64(1024)
+                }
+            }
+
+            var m IMaybeULong = MaybeULongImpl{}
+            var v = m.Value()
+            Console.WriteLine(v)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("1024\n", output);
+    }
+
+    [Fact]
+    public void NullableLongParam_Interface()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface ILongEcho
+                {
+                    long? Echo(long? input);
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type LongEchoer class : ILongEcho {
+                func Echo(input int64?) int64? {
+                    return input
+                }
+            }
+
+            var e ILongEcho = LongEchoer{}
+            var v = e.Echo(int64(99))
+            Console.WriteLine(v)
+            Console.WriteLine(e.Echo(nil) == nil)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("99\nTrue\n", output);
+    }
+
+    [Fact]
+    public void NullableLongProperty_Interface()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IHasNullableLongProp
+                {
+                    long? Value { get; }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type HasNullableLongProp class : IHasNullableLongProp {
+                prop Value int64? { get { return 42 } }
+            }
+
+            var p IHasNullableLongProp = HasNullableLongProp{}
+            var v = p.Value
+            Console.WriteLine(v)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void NullableDoubleReturn_NonNilRoundTrip()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IDoubleRoundTrip
+                {
+                    double? Echo(double? input);
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type DoubleRoundTrip class : IDoubleRoundTrip {
+                func Echo(input float64?) float64? {
+                    return input
+                }
+            }
+
+            var d IDoubleRoundTrip = DoubleRoundTrip{}
+            var v = d.Echo(2.718)
+            Console.WriteLine(v)
+            Console.WriteLine(d.Echo(nil) == nil)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("2.718\nTrue\n", output);
     }
 
     // ----- helpers -----

--- a/test/Compiler.Tests/Emit/Issue638NullableValueReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue638NullableValueReturnEmitTests.cs
@@ -1,0 +1,606 @@
+// <copyright file="Issue638NullableValueReturnEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #638: a G# class implementing a CLR interface method that returns
+/// <c>Nullable&lt;T&gt;</c> for a value-type <c>T</c> was rejected with
+/// GS0187 because the interface-satisfaction check compared the G# binder's
+/// <c>NullableTypeSymbol.ClrType</c> (the underlying <c>T</c>) against the
+/// interface's <c>Nullable&lt;T&gt;</c> without lifting through
+/// <c>NullableLifting.GetEffectiveClrType</c>.
+/// </summary>
+public class Issue638NullableValueReturnEmitTests
+{
+    [Fact]
+    public void NullableIntReturn_SingleMethodInterface_ReturnsNilAndRealValue()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IMaybeInt
+                {
+                    int? Try(bool give);
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type MaybeIntImpl class : IMaybeInt {
+                func Try(give bool) int32? {
+                    if give {
+                        return 42
+                    }
+                    return nil
+                }
+            }
+
+            var m IMaybeInt = MaybeIntImpl{}
+            var v = m.Try(true)
+            Console.WriteLine(v)
+            var n = m.Try(false)
+            Console.WriteLine(n == nil)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("42\nTrue\n", output);
+    }
+
+    [Fact]
+    public void NullableBoolReturn_Interface()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IMaybeBool
+                {
+                    bool? Check();
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type MaybeBoolImpl class : IMaybeBool {
+                func Check() bool? {
+                    return true
+                }
+            }
+
+            var m IMaybeBool = MaybeBoolImpl{}
+            Console.WriteLine(m.Check())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void NullableDoubleReturn_Interface()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IMaybeDouble
+                {
+                    double? Compute();
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type MaybeDoubleImpl class : IMaybeDouble {
+                func Compute() float64? {
+                    return 3.14
+                }
+            }
+
+            var m IMaybeDouble = MaybeDoubleImpl{}
+            Console.WriteLine(m.Compute())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("3.14\n", output);
+    }
+
+    [Fact]
+    public void NullableLongReturn_Interface_ReturnsNil()
+    {
+        // Note: int64? return with a non-nil value exposes a pre-existing
+        // emitter limitation for int64 nullable lifting. Test nil path only.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IMaybeLong
+                {
+                    long? Big();
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type MaybeLongImpl class : IMaybeLong {
+                func Big() int64? {
+                    return nil
+                }
+            }
+
+            var m IMaybeLong = MaybeLongImpl{}
+            Console.WriteLine(m.Big() == nil)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void NullableCharReturn_Interface()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IMaybeChar
+                {
+                    char? Letter();
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type MaybeCharImpl class : IMaybeChar {
+                func Letter() char? {
+                    return 'A'
+                }
+            }
+
+            var m IMaybeChar = MaybeCharImpl{}
+            Console.WriteLine(m.Letter())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("A\n", output);
+    }
+
+    [Fact]
+    public void NullableDateTimeReturn_CustomStruct()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IMaybeDateTime
+                {
+                    System.DateTime? When();
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type MaybeDateTimeImpl class : IMaybeDateTime {
+                func When() DateTime? {
+                    return nil
+                }
+            }
+
+            var m IMaybeDateTime = MaybeDateTimeImpl{}
+            Console.WriteLine(m.When() == nil)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void NullableIntProperty_Interface()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IHasNullableIntProp
+                {
+                    int? Value { get; }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type HasNullableIntProp class : IHasNullableIntProp {
+                prop Value int32? { get { return 7 } }
+            }
+
+            var p IHasNullableIntProp = HasNullableIntProp{}
+            Console.WriteLine(p.Value)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void MethodWithMultipleParams_AndNullableReturn()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IAdder
+                {
+                    int? Sum(int a, int b);
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type Adder class : IAdder {
+                func Sum(a int32, b int32) int32? {
+                    return a + b
+                }
+            }
+
+            var adder IAdder = Adder{}
+            Console.WriteLine(adder.Sum(3, 4))
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void NullableParamAndNullableReturn()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IEcho
+                {
+                    int? Echo(int? input);
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type Echoer class : IEcho {
+                func Echo(input int32?) int32? {
+                    return input
+                }
+            }
+
+            var e IEcho = Echoer{}
+            Console.WriteLine(e.Echo(99))
+            Console.WriteLine(e.Echo(nil) == nil)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("99\nTrue\n", output);
+    }
+
+    [Fact]
+    public void MultipleMethodsMixedReturnShapes()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IMixed
+                {
+                    int? NullableInt();
+                    string PlainString();
+                    bool? NullableBool();
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type Mixed class : IMixed {
+                func NullableInt() int32? { return 10 }
+                func PlainString() string { return "hi" }
+                func NullableBool() bool? { return nil }
+            }
+
+            var m IMixed = Mixed{}
+            Console.WriteLine(m.NullableInt())
+            Console.WriteLine(m.PlainString())
+            Console.WriteLine(m.NullableBool() == nil)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("10\nhi\nTrue\n", output);
+    }
+
+    [Fact]
+    public void NullableStringReturn_ReferenceNullable_Regression()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IMaybeString
+                {
+                    string? Try();
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type MaybeStringImpl class : IMaybeString {
+                func Try() string? {
+                    return nil
+                }
+            }
+
+            var m IMaybeString = MaybeStringImpl{}
+            Console.WriteLine(m.Try() == nil)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void InheritedInterface_NullableReturn()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IBase
+                {
+                    int? GetId();
+                }
+                public interface IDerived : IBase
+                {
+                    string Name { get; }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type Impl class : IDerived {
+                func GetId() int32? { return 123 }
+                prop Name string { get { return "test" } }
+            }
+
+            var d IDerived = Impl{}
+            Console.WriteLine(d.GetId())
+            Console.WriteLine(d.Name)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("123\ntest\n", output);
+    }
+
+    [Fact]
+    public void ConsoleKeyInfoNullableReturn_FromIssue()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IKeyReader
+                {
+                    System.ConsoleKeyInfo? ReadKey();
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type KeyReader class : IKeyReader {
+                func ReadKey() ConsoleKeyInfo? {
+                    return nil
+                }
+            }
+
+            var k IKeyReader = KeyReader{}
+            Console.WriteLine(k.ReadKey() == nil)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource);
+        Assert.Equal("True\n", output);
+    }
+
+    // ----- helpers -----
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName = "Probe.CSharp")
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue638_").FullName;
+        try
+        {
+            // Step 1: compile the sibling C# library.
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            // Step 2: compile the G# code referencing the sibling.
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            File.Copy(siblingDll, Path.Combine(tempDir, Path.GetFileName(siblingDll)), overwrite: true);
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { siblingDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string BuildCsProject(string csDir, string siblingName)
+    {
+        RunDotnet(csDir, "restore");
+        RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+
+        var dll = Path.Combine(csDir, "bin", "Release", "net10.0", siblingName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static void RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Root Cause

The interface-satisfaction logic in `MemberLookup.HasMatchingMethodForClrSignature` compared G# method/property types against CLR interface member types using raw `.ClrType`. For a `NullableTypeSymbol` wrapping a value type `T`, `.ClrType` returns the underlying `T` (e.g. `System.Int32`) rather than `Nullable<T>` (e.g. `Nullable<Int32>`). This caused a mismatch against the interface's `Nullable<T>` return type, resulting in a spurious GS0187 diagnostic.

Reference-nullable (`string?`) was unaffected because its CLR representation is the same as the non-nullable form (just an attribute annotation).

## Fix (commit 1): Interface-satisfaction check

Replace `.Type?.ClrType` with `NullableLifting.GetEffectiveClrType()` in three locations within `MemberLookup.cs`:
1. **`HasMatchingMethodForClrSignature`** — return type comparison
2. **`HasMatchingMethodForClrSignature`** — parameter type comparison
3. **`FindMatchingProperty`** — property type comparison
4. **`FindMatchingFieldForPropertyContract`** — field-satisfies-property comparison

`NullableLifting.GetEffectiveClrType` correctly projects `NullableTypeSymbol<value-type>` → `Nullable<T>` and passes through all other types unchanged. This is the same approach used for overload resolution (issue #530).

## Fix (commit 2): Numeric-widening nullable emit bug (`int64?` non-nil)

### Additional Root Cause

The emitter handled exact-match `T → Nullable<T>` wrapping (e.g., `int32 → int32?`) but NOT cross-width `T1 → Nullable<T2>` conversions (e.g., `int32 → int64?`). Because `NullableTypeSymbol.ClrType` returns the underlying type, `TryEmitNumericConversion` would see `typeof(int) → typeof(long)`, emit only `conv.i8` without the subsequent `newobj Nullable<long>::.ctor(long)`, producing ILVerify-invalid IL: `[found Long][expected Nullable<int64>]`.

### Additional Fix

Added a dedicated code path in `MethodBodyEmitter.Conversions.cs` (before the general numeric-conversion lattice) that detects value-type nullable targets requiring numeric widening. It emits the widening conversion first, then the `Nullable<T>` constructor call.

## Test Coverage

`Issue638NullableValueReturnEmitTests.cs` — 18 end-to-end tests:
- `int32?` return (nil and real value)
- `bool?`, `double?`, `char?` returns
- **`int64?` return (nil AND non-nil)** — previously deferred
- **`int64?` computed return** (`a + b`)
- **`uint64?` return** (cross-width widening)
- **`int64?` parameter pass-through** (round-trip)
- **`int64?` property via interface**
- **`double?` round-trip** (8-byte float, verifies scope)
- `DateTime?` (custom BCL struct)
- `ConsoleKeyInfo?` (from issue report)
- Nullable int property via interface
- Method with multiple params + nullable return
- Nullable param AND nullable return
- Multiple methods with mixed return shapes on one interface
- Inherited interface with nullable return
- `string?` (reference-nullable) regression test

All tests compile, pass ILVerify, and execute correctly at runtime.

## Full Suite Results

- Compiler.Tests: 816 passed
- Core.Tests: 2197 passed (1 skipped)
- Interpreter.Tests: 98 passed
- LanguageServer.Tests: 242 passed

**Total: 3353 passed, 0 failed.**

Closes #638