### PR TITLE
Fix #640: emit class field initializers into constructor bodies

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -426,6 +426,11 @@ internal sealed class DeclarationBinder
             primaryCtorParameters = ctorBuilder.ToImmutable();
         }
 
+        // Issue #640: collect instance-field initializer expressions alongside
+        // the field declarations so we can bind them later (after the struct
+        // symbol exists) and emit them into every constructor body.
+        var pendingInstanceInitializers = new List<(FieldSymbol Field, ExpressionSyntax InitSyntax, TypeSymbol FieldType)>();
+
         foreach (var fieldSyntax in syntax.Fields)
         {
             var fieldName = fieldSyntax.Identifier.Text;
@@ -476,6 +481,14 @@ internal sealed class DeclarationBinder
                     Binder.FieldDeclarationAllowedTargets,
                     "a field declaration",
                     System.AttributeTargets.Field));
+            }
+
+            // Issue #640: remember the initializer syntax for binding after
+            // the struct symbol is created (we need the struct in scope for
+            // type-correct binding, and the field symbol is needed for keying).
+            if (fieldSyntax.Initializer != null)
+            {
+                pendingInstanceInitializers.Add((fieldSymbol, fieldSyntax.Initializer, fieldType));
             }
 
             fields.Add(fieldSymbol);
@@ -708,6 +721,21 @@ internal sealed class DeclarationBinder
         // (`: Base(args)`). The arguments are bound in a scope that exposes the
         // primary-constructor parameters so they can be forwarded to the base.
         BindBaseConstructorInitializer(syntax, structSymbol, baseClassSymbol, importedBaseType, primaryCtorParameters);
+
+        // Issue #640: now that the struct symbol exists, bind the deferred
+        // instance-field initializer expressions and install them on the symbol.
+        if (pendingInstanceInitializers.Count > 0)
+        {
+            var instanceInitBuilder = ImmutableDictionary.CreateBuilder<FieldSymbol, BoundExpression>();
+            foreach (var (fieldSym, initSyntax, fieldType) in pendingInstanceInitializers)
+            {
+                var boundInit = bindExpression(initSyntax);
+                var convertedInit = conversions.BindConversion(initSyntax.Location, boundInit, fieldType);
+                instanceInitBuilder[fieldSym] = convertedInit;
+            }
+
+            structSymbol.SetInstanceFieldInitializers(instanceInitBuilder.ToImmutable());
+        }
 
         if (!scope.TryDeclareTypeAlias(name, structSymbol))
         {

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -531,6 +531,8 @@ internal sealed class ReflectionMetadataEmitter
             this.customAttrEncoder.EmitIsReadOnlyAttributeOnParameter,
             this.GetCtorReference,
             this.EmitStaticConstructorBodyBytes,
+            this.EmitClassDefaultConstructorBodyBytes,
+            this.EmitClassPrimaryConstructorBodyBytes,
             this.EmitClassConstructorWithBaseInitializerBodyBytes,
             this.EmitClassConstructorWithBodyBodyBytes);
 
@@ -2459,6 +2461,285 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #640: builds the IL body for a default parameterless constructor
+    /// that calls the base ctor and then evaluates instance field initializers
+    /// in declaration order. Returns the resulting body offset.
+    /// </summary>
+    private int EmitClassDefaultConstructorBodyBytes(StructSymbol classSym, EntityHandle baseCtorToken)
+    {
+        // Synthesize a `this` parameter for the field-initializer receiver.
+        var thisParam = new ParameterSymbol("this", classSym);
+
+        // Synthesize field-initializer assignment statements.
+        var statements = BuildInstanceFieldInitializerStatements(classSym, thisParam);
+        var body = new BoundBlockStatement(null, statements);
+
+        var il = new InstructionEncoder(new BlobBuilder(), new ControlFlowBuilder());
+        var locals = new Dictionary<VariableSymbol, int>();
+        var labels = new Dictionary<BoundLabel, LabelHandle>();
+        var localTypes = new List<TypeSymbol>();
+        var appendSlots = new Dictionary<BoundAppendExpression, (int Src, int Dst)>();
+        var structLiteralSlots = new Dictionary<BoundStructLiteralExpression, int>();
+        var defaultExpressionSlots = new Dictionary<BoundDefaultExpression, int>();
+        var mapIndexSlots = new Dictionary<BoundIndexExpression, int>();
+        var patternSwitchSlots = new Dictionary<BoundPatternSwitchStatement, int>();
+        var typePatternScratchSlots = new Dictionary<BoundTypePattern, int>();
+        var switchExpressionSlots = new Dictionary<BoundSwitchExpression, (int Result, int Discriminant)>();
+        var channelOpSlots = new Dictionary<BoundNode, (int VT, int TA, int Result, int Spare)>();
+        var scopeFrameSlots = new Dictionary<BoundScopeStatement, (int Tasks, int Cts, int Awaiter)>();
+        var selectStatementSlots = new Dictionary<BoundSelectStatement, SelectSlots>();
+        var receiverSpillSlots = new Dictionary<BoundExpression, int>();
+        var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
+        var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
+        var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
+        var constValues = new Dictionary<VariableSymbol, object>();
+
+        this.methodBodyPlanner.CollectLocalsAndLabels(
+            body,
+            null,
+            locals,
+            localTypes,
+            labels,
+            appendSlots,
+            structLiteralSlots,
+            defaultExpressionSlots,
+            mapIndexSlots,
+            patternSwitchSlots,
+            typePatternScratchSlots,
+            switchExpressionSlots,
+            channelOpSlots,
+            scopeFrameSlots,
+            selectStatementSlots,
+            receiverSpillSlots,
+            indexAssignmentValueSlots,
+            goEnclosingScopes,
+            liftedBinarySlots,
+            il);
+
+        var parameters = new Dictionary<ParameterSymbol, int>
+        {
+            [thisParam] = 0,
+        };
+
+        StandaloneSignatureHandle localsSignature = default;
+        if (localTypes.Count > 0)
+        {
+            var localsSigBlob = new BlobBuilder();
+            var encoder = new BlobEncoder(localsSigBlob).LocalVariableSignature(localTypes.Count);
+            foreach (var t in localTypes)
+            {
+                EncodeLocalVariableType(encoder.AddVariable(), t);
+            }
+
+            localsSignature = this.emitCtx.Metadata.AddStandaloneSignature(this.emitCtx.Metadata.GetOrAddBlob(localsSigBlob));
+        }
+
+        var emitter = new MethodBodyEmitter(
+            this,
+            il,
+            locals,
+            parameters,
+            labels,
+            appendSlots,
+            structLiteralSlots,
+            defaultExpressionSlots,
+            mapIndexSlots,
+            patternSwitchSlots,
+            typePatternScratchSlots,
+            switchExpressionSlots,
+            channelOpSlots,
+            scopeFrameSlots,
+            selectStatementSlots,
+            receiverSpillSlots,
+            indexAssignmentValueSlots,
+            goEnclosingScopes,
+            liftedBinarySlots: liftedBinarySlots,
+            constValues: constValues);
+
+        // base()
+        il.LoadArgument(0);
+        il.OpCode(ILOpCode.Call);
+        il.Token(baseCtorToken);
+
+        // Instance field initializers
+        try
+        {
+            emitter.EmitBlock(body);
+        }
+        catch (Exception ex) when (ex is not EmitDiagnosticException and not OutOfMemoryException and not StackOverflowException)
+        {
+            var anchor = emitter.CurrentAnchor ?? classSym.Declaration;
+            EmitDiagnosticException.Wrap(anchor, ex);
+        }
+
+        il.OpCode(ILOpCode.Ret);
+        return this.emitCtx.MethodBodyStream.AddMethodBody(il, localVariablesSignature: localsSignature);
+    }
+
+    /// <summary>
+    /// Issue #640: builds the IL body for a primary constructor that calls
+    /// the base ctor, assigns primary-ctor parameters into their same-named
+    /// fields, and then evaluates instance field initializers in declaration
+    /// order. Returns the resulting body offset.
+    /// </summary>
+    private int EmitClassPrimaryConstructorBodyBytes(StructSymbol classSym, EntityHandle baseCtorToken)
+    {
+        var parameters = classSym.PrimaryConstructorParameters;
+
+        // Synthesize a `this` parameter for the field-initializer receiver.
+        var thisParam = new ParameterSymbol("this", classSym);
+
+        // Synthesize field-initializer assignment statements.
+        var statements = BuildInstanceFieldInitializerStatements(classSym, thisParam);
+        var body = new BoundBlockStatement(null, statements);
+
+        var il = new InstructionEncoder(new BlobBuilder(), new ControlFlowBuilder());
+        var locals = new Dictionary<VariableSymbol, int>();
+        var labels = new Dictionary<BoundLabel, LabelHandle>();
+        var localTypes = new List<TypeSymbol>();
+        var appendSlots = new Dictionary<BoundAppendExpression, (int Src, int Dst)>();
+        var structLiteralSlots = new Dictionary<BoundStructLiteralExpression, int>();
+        var defaultExpressionSlots = new Dictionary<BoundDefaultExpression, int>();
+        var mapIndexSlots = new Dictionary<BoundIndexExpression, int>();
+        var patternSwitchSlots = new Dictionary<BoundPatternSwitchStatement, int>();
+        var typePatternScratchSlots = new Dictionary<BoundTypePattern, int>();
+        var switchExpressionSlots = new Dictionary<BoundSwitchExpression, (int Result, int Discriminant)>();
+        var channelOpSlots = new Dictionary<BoundNode, (int VT, int TA, int Result, int Spare)>();
+        var scopeFrameSlots = new Dictionary<BoundScopeStatement, (int Tasks, int Cts, int Awaiter)>();
+        var selectStatementSlots = new Dictionary<BoundSelectStatement, SelectSlots>();
+        var receiverSpillSlots = new Dictionary<BoundExpression, int>();
+        var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
+        var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
+        var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
+        var constValues = new Dictionary<VariableSymbol, object>();
+
+        this.methodBodyPlanner.CollectLocalsAndLabels(
+            body,
+            null,
+            locals,
+            localTypes,
+            labels,
+            appendSlots,
+            structLiteralSlots,
+            defaultExpressionSlots,
+            mapIndexSlots,
+            patternSwitchSlots,
+            typePatternScratchSlots,
+            switchExpressionSlots,
+            channelOpSlots,
+            scopeFrameSlots,
+            selectStatementSlots,
+            receiverSpillSlots,
+            indexAssignmentValueSlots,
+            goEnclosingScopes,
+            liftedBinarySlots,
+            il);
+
+        var paramSlots = new Dictionary<ParameterSymbol, int>
+        {
+            [thisParam] = 0,
+        };
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            paramSlots[parameters[i]] = i + 1;
+        }
+
+        StandaloneSignatureHandle localsSignature = default;
+        if (localTypes.Count > 0)
+        {
+            var localsSigBlob = new BlobBuilder();
+            var encoder = new BlobEncoder(localsSigBlob).LocalVariableSignature(localTypes.Count);
+            foreach (var t in localTypes)
+            {
+                EncodeLocalVariableType(encoder.AddVariable(), t);
+            }
+
+            localsSignature = this.emitCtx.Metadata.AddStandaloneSignature(this.emitCtx.Metadata.GetOrAddBlob(localsSigBlob));
+        }
+
+        var emitter = new MethodBodyEmitter(
+            this,
+            il,
+            locals,
+            paramSlots,
+            labels,
+            appendSlots,
+            structLiteralSlots,
+            defaultExpressionSlots,
+            mapIndexSlots,
+            patternSwitchSlots,
+            typePatternScratchSlots,
+            switchExpressionSlots,
+            channelOpSlots,
+            scopeFrameSlots,
+            selectStatementSlots,
+            receiverSpillSlots,
+            indexAssignmentValueSlots,
+            goEnclosingScopes,
+            liftedBinarySlots: liftedBinarySlots,
+            constValues: constValues);
+
+        // base()
+        il.LoadArgument(0);
+        il.OpCode(ILOpCode.Call);
+        il.Token(baseCtorToken);
+
+        // Primary ctor parameter → field assignments
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            var param = parameters[i];
+            if (!classSym.TryGetField(param.Name, out var field))
+            {
+                throw new InvalidOperationException($"Class '{classSym.Name}' has no field for primary ctor parameter '{param.Name}'.");
+            }
+
+            if (!this.cache.StructFieldDefs.TryGetValue(field, out var fieldHandle))
+            {
+                throw new InvalidOperationException($"Class field '{field.Name}' has no emitted FieldDef.");
+            }
+
+            il.LoadArgument(0);
+            il.LoadArgument(i + 1);
+            il.OpCode(ILOpCode.Stfld);
+            il.Token(fieldHandle);
+        }
+
+        // Instance field initializers
+        try
+        {
+            emitter.EmitBlock(body);
+        }
+        catch (Exception ex) when (ex is not EmitDiagnosticException and not OutOfMemoryException and not StackOverflowException)
+        {
+            var anchor = emitter.CurrentAnchor ?? classSym.Declaration;
+            EmitDiagnosticException.Wrap(anchor, ex);
+        }
+
+        il.OpCode(ILOpCode.Ret);
+        return this.emitCtx.MethodBodyStream.AddMethodBody(il, localVariablesSignature: localsSignature);
+    }
+
+    /// <summary>
+    /// Issue #640: builds the bound assignment statements for all instance
+    /// field initializers in declaration order. Used by the default, primary,
+    /// forwarding, and explicit constructor body emitters.
+    /// </summary>
+    private static ImmutableArray<BoundStatement> BuildInstanceFieldInitializerStatements(StructSymbol classSym, ParameterSymbol thisParam = null)
+    {
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        foreach (var field in classSym.Fields)
+        {
+            if (classSym.InstanceFieldInitializers.TryGetValue(field, out var initExpr))
+            {
+                var assignment = new BoundFieldAssignmentExpression(null, thisParam, classSym, field, initExpr);
+                statements.Add(new BoundExpressionStatement(null, assignment));
+            }
+        }
+
+        return statements.ToImmutable();
+    }
+
+    /// <summary>
     /// Issue #306: builds the IL body for a forwarding constructor that
     /// runs <c>base(args)</c> before assigning the primary-constructor
     /// parameters into their same-named fields. Returns the resulting
@@ -2471,6 +2752,9 @@ internal sealed class ReflectionMetadataEmitter
         EntityHandle baseCtorToken)
     {
         var il = new InstructionEncoder(new BlobBuilder(), new ControlFlowBuilder());
+
+        // Synthesize a `this` parameter for the field-initializer receiver.
+        var thisParam = new ParameterSymbol("this", classSym);
 
         var locals = new Dictionary<VariableSymbol, int>();
         var labels = new Dictionary<BoundLabel, LabelHandle>();
@@ -2524,7 +2808,38 @@ internal sealed class ReflectionMetadataEmitter
                 il);
         }
 
-        var paramSlots = new Dictionary<ParameterSymbol, int>();
+        // Issue #640: pre-scan instance field initializer expressions for locals.
+        BoundBlockStatement fieldInitBody = null;
+        if (!classSym.InstanceFieldInitializers.IsEmpty)
+        {
+            fieldInitBody = new BoundBlockStatement(null, BuildInstanceFieldInitializerStatements(classSym, thisParam));
+            this.methodBodyPlanner.CollectLocalsAndLabels(
+                fieldInitBody,
+                null,
+                locals,
+                localTypes,
+                labels,
+                appendSlots,
+                structLiteralSlots,
+                defaultExpressionSlots,
+                mapIndexSlots,
+                patternSwitchSlots,
+                typePatternScratchSlots,
+                switchExpressionSlots,
+                channelOpSlots,
+                scopeFrameSlots,
+                selectStatementSlots,
+                receiverSpillSlots,
+                indexAssignmentValueSlots,
+                goEnclosingScopes,
+                liftedBinarySlots,
+                il);
+        }
+
+        var paramSlots = new Dictionary<ParameterSymbol, int>
+        {
+            [thisParam] = 0,
+        };
         for (var i = 0; i < parameters.Length; i++)
         {
             paramSlots[parameters[i]] = i + 1;
@@ -2598,6 +2913,20 @@ internal sealed class ReflectionMetadataEmitter
             il.Token(fieldHandle);
         }
 
+        // Issue #640: emit instance field initializer assignments.
+        if (fieldInitBody != null)
+        {
+            try
+            {
+                emitter.EmitBlock(fieldInitBody);
+            }
+            catch (Exception ex) when (ex is not EmitDiagnosticException and not OutOfMemoryException and not StackOverflowException)
+            {
+                var anchor = emitter.CurrentAnchor ?? classSym.Declaration;
+                EmitDiagnosticException.Wrap(anchor, ex);
+            }
+        }
+
         il.OpCode(ILOpCode.Ret);
         return this.emitCtx.MethodBodyStream.AddMethodBody(il, localVariablesSignature: localsSignature);
     }
@@ -2652,6 +2981,34 @@ internal sealed class ReflectionMetadataEmitter
 
             this.methodBodyPlanner.CollectLocalsAndLabels(
                 new BoundBlockStatement(null, synth.ToImmutable()),
+                null,
+                locals,
+                localTypes,
+                labels,
+                appendSlots,
+                structLiteralSlots,
+                defaultExpressionSlots,
+                mapIndexSlots,
+                patternSwitchSlots,
+                typePatternScratchSlots,
+                switchExpressionSlots,
+                channelOpSlots,
+                scopeFrameSlots,
+                selectStatementSlots,
+                receiverSpillSlots,
+                indexAssignmentValueSlots,
+                goEnclosingScopes,
+                liftedBinarySlots,
+                il);
+        }
+
+        // Issue #640: pre-scan instance field initializer expressions for locals.
+        BoundBlockStatement fieldInitBody = null;
+        if (!classSym.InstanceFieldInitializers.IsEmpty)
+        {
+            fieldInitBody = new BoundBlockStatement(null, BuildInstanceFieldInitializerStatements(classSym, function.ThisParameter));
+            this.methodBodyPlanner.CollectLocalsAndLabels(
+                fieldInitBody,
                 null,
                 locals,
                 localTypes,
@@ -2750,6 +3107,21 @@ internal sealed class ReflectionMetadataEmitter
 
         il.OpCode(ILOpCode.Call);
         il.Token(baseCtorToken);
+
+        // Issue #640: emit instance field initializer assignments before
+        // the user-authored constructor body (matching C# semantics).
+        if (fieldInitBody != null)
+        {
+            try
+            {
+                emitter.EmitBlock(fieldInitBody);
+            }
+            catch (Exception ex) when (ex is not EmitDiagnosticException and not OutOfMemoryException and not StackOverflowException)
+            {
+                var anchor = emitter.CurrentAnchor ?? classSym.Declaration;
+                EmitDiagnosticException.Wrap(anchor, ex);
+            }
+        }
 
         // Run the user-authored constructor body.
         try

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -96,6 +96,8 @@ internal sealed class TypeDefEmitter
     private readonly Action<ParameterHandle> emitIsReadOnlyAttributeOnParameter;
     private readonly Func<ConstructorInfo, MemberReferenceHandle> getCtorReference;
     private readonly Func<StructSymbol, int> emitStaticConstructorBodyBytes;
+    private readonly Func<StructSymbol, EntityHandle, int> emitClassDefaultConstructorBodyBytes;
+    private readonly Func<StructSymbol, EntityHandle, int> emitClassPrimaryConstructorBodyBytes;
     private readonly Func<StructSymbol, ImmutableArray<ParameterSymbol>, BaseConstructorInitializer, EntityHandle, int> emitClassConstructorWithBaseInitializerBodyBytes;
     private readonly Func<StructSymbol, ConstructorSymbol, BaseConstructorInitializer, EntityHandle, int> emitClassConstructorWithBodyBodyBytes;
 
@@ -111,6 +113,8 @@ internal sealed class TypeDefEmitter
         Action<ParameterHandle> emitIsReadOnlyAttributeOnParameter,
         Func<ConstructorInfo, MemberReferenceHandle> getCtorReference,
         Func<StructSymbol, int> emitStaticConstructorBodyBytes,
+        Func<StructSymbol, EntityHandle, int> emitClassDefaultConstructorBodyBytes,
+        Func<StructSymbol, EntityHandle, int> emitClassPrimaryConstructorBodyBytes,
         Func<StructSymbol, ImmutableArray<ParameterSymbol>, BaseConstructorInitializer, EntityHandle, int> emitClassConstructorWithBaseInitializerBodyBytes,
         Func<StructSymbol, ConstructorSymbol, BaseConstructorInitializer, EntityHandle, int> emitClassConstructorWithBodyBodyBytes)
     {
@@ -125,6 +129,8 @@ internal sealed class TypeDefEmitter
         this.emitIsReadOnlyAttributeOnParameter = emitIsReadOnlyAttributeOnParameter ?? throw new ArgumentNullException(nameof(emitIsReadOnlyAttributeOnParameter));
         this.getCtorReference = getCtorReference ?? throw new ArgumentNullException(nameof(getCtorReference));
         this.emitStaticConstructorBodyBytes = emitStaticConstructorBodyBytes ?? throw new ArgumentNullException(nameof(emitStaticConstructorBodyBytes));
+        this.emitClassDefaultConstructorBodyBytes = emitClassDefaultConstructorBodyBytes ?? throw new ArgumentNullException(nameof(emitClassDefaultConstructorBodyBytes));
+        this.emitClassPrimaryConstructorBodyBytes = emitClassPrimaryConstructorBodyBytes ?? throw new ArgumentNullException(nameof(emitClassPrimaryConstructorBodyBytes));
         this.emitClassConstructorWithBaseInitializerBodyBytes = emitClassConstructorWithBaseInitializerBodyBytes ?? throw new ArgumentNullException(nameof(emitClassConstructorWithBaseInitializerBodyBytes));
         this.emitClassConstructorWithBodyBodyBytes = emitClassConstructorWithBodyBodyBytes ?? throw new ArgumentNullException(nameof(emitClassConstructorWithBodyBodyBytes));
     }
@@ -811,12 +817,22 @@ internal sealed class TypeDefEmitter
         int bodyOffset = -1;
         if (!this.emitCtx.MetadataOnly)
         {
-            var il = new InstructionEncoder(new BlobBuilder());
-            il.LoadArgument(0);
-            il.OpCode(ILOpCode.Call);
-            il.Token(baseCtorToken);
-            il.OpCode(ILOpCode.Ret);
-            bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(il);
+            // Issue #640: when the class declares instance field initializers,
+            // delegate to the body-emitter callback so expressions are evaluated
+            // and stored into fields after the base ctor call.
+            if (!classSym.InstanceFieldInitializers.IsEmpty)
+            {
+                bodyOffset = this.emitClassDefaultConstructorBodyBytes(classSym, baseCtorToken);
+            }
+            else
+            {
+                var il = new InstructionEncoder(new BlobBuilder());
+                il.LoadArgument(0);
+                il.OpCode(ILOpCode.Call);
+                il.Token(baseCtorToken);
+                il.OpCode(ILOpCode.Ret);
+                bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(il);
+            }
         }
 
         var ctorSig = new BlobBuilder();
@@ -877,34 +893,45 @@ internal sealed class TypeDefEmitter
         int bodyOffset = -1;
         if (!this.emitCtx.MetadataOnly)
         {
-            var il = new InstructionEncoder(new BlobBuilder());
-            il.LoadArgument(0);
-            il.OpCode(ILOpCode.Call);
-            il.Token(baseCtorToken);
-
-            // For each ctor param: this.<field> = arg; positional 1:1 with
-            // fields of the same name.
-            for (var i = 0; i < parameters.Length; i++)
+            // Issue #640: when the class declares instance field initializers,
+            // delegate to the body-emitter callback so expressions are evaluated
+            // and stored into fields after the base ctor call and primary ctor
+            // parameter assignments.
+            if (!classSym.InstanceFieldInitializers.IsEmpty)
             {
-                var param = parameters[i];
-                if (!classSym.TryGetField(param.Name, out var field))
-                {
-                    throw new InvalidOperationException($"Class '{classSym.Name}' has no field for primary ctor parameter '{param.Name}'.");
-                }
-
-                if (!this.cache.StructFieldDefs.TryGetValue(field, out var fieldHandle))
-                {
-                    throw new InvalidOperationException($"Class field '{field.Name}' has no emitted FieldDef.");
-                }
-
-                il.LoadArgument(0);
-                il.LoadArgument(i + 1);
-                il.OpCode(ILOpCode.Stfld);
-                il.Token(fieldHandle);
+                bodyOffset = this.emitClassPrimaryConstructorBodyBytes(classSym, baseCtorToken);
             }
+            else
+            {
+                var il = new InstructionEncoder(new BlobBuilder());
+                il.LoadArgument(0);
+                il.OpCode(ILOpCode.Call);
+                il.Token(baseCtorToken);
 
-            il.OpCode(ILOpCode.Ret);
-            bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(il);
+                // For each ctor param: this.<field> = arg; positional 1:1 with
+                // fields of the same name.
+                for (var i = 0; i < parameters.Length; i++)
+                {
+                    var param = parameters[i];
+                    if (!classSym.TryGetField(param.Name, out var field))
+                    {
+                        throw new InvalidOperationException($"Class '{classSym.Name}' has no field for primary ctor parameter '{param.Name}'.");
+                    }
+
+                    if (!this.cache.StructFieldDefs.TryGetValue(field, out var fieldHandle))
+                    {
+                        throw new InvalidOperationException($"Class field '{field.Name}' has no emitted FieldDef.");
+                    }
+
+                    il.LoadArgument(0);
+                    il.LoadArgument(i + 1);
+                    il.OpCode(ILOpCode.Stfld);
+                    il.Token(fieldHandle);
+                }
+
+                il.OpCode(ILOpCode.Ret);
+                bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(il);
+            }
         }
 
         var ctorSig = new BlobBuilder();

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -226,6 +226,9 @@ public sealed class StructSymbol : TypeSymbol
     /// <summary>Gets the bound initializer expressions for static fields with non-default values (Issue #262). Keyed by field symbol.</summary>
     public ImmutableDictionary<FieldSymbol, BoundExpression> StaticFieldInitializers { get; private set; } = ImmutableDictionary<FieldSymbol, BoundExpression>.Empty;
 
+    /// <summary>Gets the bound initializer expressions for instance fields with non-default values (Issue #640). Keyed by field symbol; iterated in <see cref="Fields"/> source order at emit time.</summary>
+    public ImmutableDictionary<FieldSymbol, BoundExpression> InstanceFieldInitializers { get; private set; } = ImmutableDictionary<FieldSymbol, BoundExpression>.Empty;
+
     /// <summary>Gets the type parameters when this is a generic definition (Phase 4.3 / ADR-0020). Empty for non-generic types and for constructed instances.</summary>
     public ImmutableArray<TypeParameterSymbol> TypeParameters { get; private set; } = ImmutableArray<TypeParameterSymbol>.Empty;
 
@@ -400,6 +403,13 @@ public sealed class StructSymbol : TypeSymbol
     public void SetStaticFieldInitializers(ImmutableDictionary<FieldSymbol, BoundExpression> initializers)
     {
         StaticFieldInitializers = initializers;
+    }
+
+    /// <summary>Sets <see cref="InstanceFieldInitializers"/> after binding instance-field initializers (Issue #640).</summary>
+    /// <param name="initializers">A mapping from field symbol to its bound initializer expression.</param>
+    public void SetInstanceFieldInitializers(ImmutableDictionary<FieldSymbol, BoundExpression> initializers)
+    {
+        InstanceFieldInitializers = initializers;
     }
 
     /// <summary>Tries to find a static field by name on this type (ADR-0053).</summary>

--- a/test/Compiler.Tests/Emit/Issue640FieldInitializerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue640FieldInitializerEmitTests.cs
@@ -1,0 +1,431 @@
+// <copyright file="Issue640FieldInitializerEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #640: class field initializers (<c>field T = expr</c>) must be
+/// evaluated at construction time and emitted into every constructor body.
+/// Each test compiles via <c>gsc</c>, ilverifies the produced PE, then
+/// executes the assembly under <c>dotnet exec</c> and asserts on the
+/// captured stdout.
+/// </summary>
+public class Issue640FieldInitializerEmitTests
+{
+    [Fact]
+    public void Int32_Field_Initializer()
+    {
+        var source = """
+            package P
+            import System
+
+            type Holder class {
+                n int32 = 42
+                func Get() int32 { return n }
+            }
+
+            var h = Holder()
+            Console.WriteLine(h.Get())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void Int64_Field_Initializer()
+    {
+        var source = """
+            package P
+            import System
+
+            type Holder class {
+                n int64 = 100
+                func Get() int64 { return n }
+            }
+
+            var h = Holder()
+            Console.WriteLine(h.Get())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("100\n", output);
+    }
+
+    [Fact]
+    public void Bool_Field_Initializer()
+    {
+        var source = """
+            package P
+            import System
+
+            type Holder class {
+                flag bool = true
+                func Get() bool { return flag }
+            }
+
+            var h = Holder()
+            Console.WriteLine(h.Get())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void String_Field_Initializer()
+    {
+        var source = """
+            package P
+            import System
+
+            type Holder class {
+                s string = "hello"
+                func Get() string { return s }
+            }
+
+            var h = Holder()
+            Console.WriteLine(h.Get())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello\n", output);
+    }
+
+    [Fact]
+    public void Computed_Expression_Initializer()
+    {
+        var source = """
+            package P
+            import System
+
+            type Holder class {
+                c int32 = 1 + 2 * 3
+                func Get() int32 { return c }
+            }
+
+            var h = Holder()
+            Console.WriteLine(h.Get())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void Multiple_Fields_With_Initializers()
+    {
+        var source = """
+            package P
+            import System
+
+            type Multi class {
+                a int32 = 10
+                b int32 = 20
+                c string = "abc"
+                func Show() string {
+                    return a.ToString() + "," + b.ToString() + "," + c
+                }
+            }
+
+            var m = Multi()
+            Console.WriteLine(m.Show())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("10,20,abc\n", output);
+    }
+
+    [Fact]
+    public void Initializer_Runs_With_ExplicitInit_Constructor()
+    {
+        // Field initializers run BEFORE the user-authored init body.
+        var source = """
+            package P
+            import System
+
+            type Widget class {
+                baseValue int32 = 100
+                extra int32
+
+                init(e int32) {
+                    extra = e
+                }
+
+                func Total() int32 { return baseValue + extra }
+            }
+
+            var w = Widget(5)
+            Console.WriteLine(w.Total())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("105\n", output);
+    }
+
+    [Fact]
+    public void Initializer_Runs_With_PrimaryConstructor()
+    {
+        var source = """
+            package P
+            import System
+
+            type Thing class(name string) {
+                prefix string = "Item:"
+                func Label() string { return prefix + name }
+            }
+
+            var t = Thing("foo")
+            Console.WriteLine(t.Label())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Item:foo\n", output);
+    }
+
+    [Fact]
+    public void Initializer_Runs_For_All_Constructor_Overloads()
+    {
+        // Use a single init(x int32) to confirm field initializer still runs.
+        var source = """
+            package P
+            import System
+
+            type Dual class {
+                tag string = "default"
+                n int32
+
+                init(x int32) {
+                    n = x
+                }
+
+                func Show() string { return tag + ":" + n.ToString() }
+            }
+
+            var b = Dual(7)
+            Console.WriteLine(b.Show())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("default:7\n", output);
+    }
+
+    [Fact]
+    public void Inheritance_DerivedFieldInitializers_Run()
+    {
+        var source = """
+            package P
+            import System
+
+            type Base open class {
+                baseVal int32 = 1
+                func GetBase() int32 { return baseVal }
+            }
+
+            type Derived class : Base {
+                derivedVal int32 = 2
+                func GetDerived() int32 { return derivedVal }
+            }
+
+            var d = Derived()
+            Console.WriteLine(d.GetBase())
+            Console.WriteLine(d.GetDerived())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n2\n", output);
+    }
+
+    [Fact]
+    public void Field_Without_Initializer_StillDefaultsToZero()
+    {
+        // Regression guard: fields without initializers must still default.
+        var source = """
+            package P
+            import System
+
+            type Mixed class {
+                initialized int32 = 42
+                uninitialized int32
+                func Show() string {
+                    return initialized.ToString() + "," + uninitialized.ToString()
+                }
+            }
+
+            var m = Mixed()
+            Console.WriteLine(m.Show())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42,0\n", output);
+    }
+
+    [Fact]
+    public void Double_Field_Initializer()
+    {
+        var source = """
+            package P
+            import System
+
+            type Holder class {
+                d float64 = 3.14
+                func Get() float64 { return d }
+            }
+
+            var h = Holder()
+            Console.WriteLine(h.Get())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3.14\n", output);
+    }
+
+    [Fact]
+    public void ExplicitInit_CanOverrideFieldInitializer()
+    {
+        // The user-defined init body runs AFTER field initializers,
+        // so it can override the field's initial value.
+        var source = """
+            package P
+            import System
+
+            type Override class {
+                n int32 = 10
+
+                init(value int32) {
+                    n = value
+                }
+
+                func Get() int32 { return n }
+            }
+
+            var o = Override(99)
+            Console.WriteLine(o.Get())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    // Test infrastructure — mirrors Issue524DefaultCtorEmitTests pattern.
+
+    private static string CompileAndRun(string source)
+    {
+        var (exit, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exit == 0,
+            $"exited {exit}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue640_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(
+                runtimeConfigPath,
+                """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(runtimeConfigPath);
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}


### PR DESCRIPTION
## Root cause

`DeclarationBinder` bound instance field initializer expressions but never stored them on the `StructSymbol`. The four constructor emission paths (default, primary, base-forwarding, explicit init) in `TypeDefEmitter` / `ReflectionMetadataEmitter` had no logic to emit field initializer assignments, so fields always read as their CLR default value at runtime.

## Fix

1. **StructSymbol** — Added `InstanceFieldInitializers` property (`ImmutableDictionary<FieldSymbol, BoundExpression>`) and `SetInstanceFieldInitializers()` setter.

2. **DeclarationBinder** — In `BindStructDeclarationBody`, collect pending instance field initializers during the field loop, bind them after the struct symbol is created, and call `SetInstanceFieldInitializers()`.

3. **ReflectionMetadataEmitter** — Added `BuildInstanceFieldInitializerStatements()` helper that constructs `BoundExpressionStatement(BoundFieldAssignmentExpression)` nodes with a synthesized `this` receiver (`ParameterSymbol` at slot 0). Added two new body-emission callbacks (`EmitClassDefaultConstructorBodyBytes`, `EmitClassPrimaryConstructorBodyBytes`).

4. **TypeDefEmitter** — Accepts the two new callbacks; delegates to them when `InstanceFieldInitializers` is non-empty.

5. **All 4 constructor paths** now emit field initializer statements:
   - `EmitClassDefaultConstructor` (parameterless, no user body)
   - `EmitClassPrimaryConstructor` (Kotlin-style primary ctor)
   - `EmitClassConstructorWithBaseInitializer` (forwarding to base)
   - `EmitClassConstructorWithBody` (explicit `init` with user body)

## Semantics

- Field initializers run **after** the base constructor call, **before** the user-written constructor body (matches C# semantics).
- Fields are initialized in declaration order.
- Forward references between sibling field initializers are allowed (no compile-time error) — simpler than C#'s restriction.

## Test coverage

13 new `[Fact]` tests in `Issue640FieldInitializerEmitTests.cs` covering:
- Primitives: int32, int64, bool, double
- String field initializer
- Computed expression (`1 + 2 * 3`)
- Multiple fields with initializers
- Explicit `init()` user-defined constructor
- Primary constructor syntax
- User-defined `init(args)` with field initializer
- Inheritance (base + derived field initializers)
- Mixed initialized / uninitialized fields
- Init body override (user body assignment takes precedence)
- ILVerify validation on all tests

## Full suite results

All tests pass (0 failures):
- Interpreter.Tests: 98 passed
- LanguageServer.Tests: 242 passed
- Core.Tests: 2197 passed, 1 skipped
- Compiler.Tests: 829 passed

Closes #640.