### PR TITLE
Fix #649: Tuple containing CLR ref type from project reference no longer triggers GS9998

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -929,25 +929,29 @@ internal sealed partial class MethodBodyEmitter
         // Phase 4.5 emit parity: `(e1, e2, ...)` lowers to
         // `newobj ValueTuple<T1, T2, ...>::.ctor(T1, T2, ...)`. The CLR
         // backing type is set by TupleTypeSymbol.BuildClrType for arities
-        // 2–7; higher arities have a null ClrType and are interpreter-only.
-        var clrType = tuple.TupleType.ClrType
-            ?? throw new NotSupportedException(
-                $"Tuple of arity {tuple.TupleType.Arity} has no CLR backing type; emit not supported.");
+        // 2–7; higher arities have a null ClrType when element types include
+        // G#-defined types (StructSymbol) that don't yet have a runtime Type.
+        var clrType = tuple.TupleType.ClrType;
+        var arity = tuple.TupleType.Arity;
 
-        ConstructorInfo ctor = null;
-        foreach (var c in clrType.GetConstructors())
+        if (clrType == null && arity >= 2 && arity <= 7)
         {
-            if (c.GetParameters().Length == tuple.Elements.Length)
+            // Issue #649: G#-defined types lack a ClrType, so we build the
+            // tuple TypeSpec and ctor MemberRef symbolically.
+            foreach (var elem in tuple.Elements)
             {
-                ctor = c;
-                break;
+                this.EmitExpression(elem);
             }
+
+            this.il.OpCode(ILOpCode.Newobj);
+            this.il.Token(this.outer.GetTupleCtorReference(tuple.TupleType));
+            return;
         }
 
-        if (ctor == null)
+        if (clrType == null)
         {
-            throw new InvalidOperationException(
-                $"ValueTuple type '{clrType.FullName}' has no constructor of arity {tuple.Elements.Length}.");
+            throw new NotSupportedException(
+                $"Tuple of arity {arity} has no CLR backing type; emit not supported.");
         }
 
         foreach (var elem in tuple.Elements)
@@ -956,7 +960,35 @@ internal sealed partial class MethodBodyEmitter
         }
 
         this.il.OpCode(ILOpCode.Newobj);
-        this.il.Token(this.outer.GetCtorReference(ctor));
+
+        // Issue #649: When a tuple's type arguments include a type loaded via
+        // MetadataLoadContext (e.g. a project-referenced CLR class), calling
+        // .GetConstructors() on the closed generic throws NotSupportedException.
+        // Resolve the ctor from the open generic type definition instead.
+        if (clrType.IsConstructedGenericType)
+        {
+            this.il.Token(this.outer.GetCtorReferenceOnConstructedGeneric(clrType, tuple.Elements.Length));
+        }
+        else
+        {
+            ConstructorInfo ctor = null;
+            foreach (var c in clrType.GetConstructors())
+            {
+                if (c.GetParameters().Length == tuple.Elements.Length)
+                {
+                    ctor = c;
+                    break;
+                }
+            }
+
+            if (ctor == null)
+            {
+                throw new InvalidOperationException(
+                    $"ValueTuple type '{clrType.FullName}' has no constructor of arity {tuple.Elements.Length}.");
+            }
+
+            this.il.Token(this.outer.GetCtorReference(ctor));
+        }
     }
 
     private void EmitTupleElementAccess(BoundTupleElementAccessExpression access)
@@ -967,18 +999,44 @@ internal sealed partial class MethodBodyEmitter
         // managed-pointer receivers are valid operands for ldfld; the
         // common cases (locals/params/temps) go through
         // EmitInstanceReceiver to prefer the address form.
-        var clrType = access.TupleType.ClrType
-            ?? throw new NotSupportedException(
-                $"Tuple of arity {access.TupleType.Arity} has no CLR backing type; emit not supported.");
-
+        var clrType = access.TupleType.ClrType;
+        var arity = access.TupleType.Arity;
         var fieldName = "Item" + (access.Index + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
-        var field = clrType.GetField(fieldName)
-            ?? throw new InvalidOperationException(
-                $"ValueTuple type '{clrType.FullName}' has no public field '{fieldName}'.");
+
+        if (clrType == null && arity >= 2 && arity <= 7)
+        {
+            // Issue #649: G#-defined types lack a ClrType, so we build the
+            // tuple TypeSpec and field MemberRef symbolically.
+            this.EmitInstanceReceiver(access.Receiver);
+            this.il.OpCode(ILOpCode.Ldfld);
+            this.il.Token(this.outer.GetTupleFieldReference(access.TupleType, fieldName));
+            return;
+        }
+
+        if (clrType == null)
+        {
+            throw new NotSupportedException(
+                $"Tuple of arity {arity} has no CLR backing type; emit not supported.");
+        }
 
         this.EmitInstanceReceiver(access.Receiver);
         this.il.OpCode(ILOpCode.Ldfld);
-        this.il.Token(this.outer.GetFieldReference(field));
+
+        // Issue #649: When a tuple's type arguments include a type loaded via
+        // MetadataLoadContext (e.g. a project-referenced CLR class), calling
+        // .GetField() on the closed generic throws NotSupportedException.
+        // Resolve the field from the open generic type definition instead.
+        if (clrType.IsConstructedGenericType)
+        {
+            this.il.Token(this.outer.GetFieldReferenceOnConstructedGeneric(clrType, fieldName));
+        }
+        else
+        {
+            var field = clrType.GetField(fieldName)
+                ?? throw new InvalidOperationException(
+                    $"ValueTuple type '{clrType.FullName}' has no public field '{fieldName}'.");
+            this.il.Token(this.outer.GetFieldReference(field));
+        }
     }
 
     /// <summary>ADR-0039: Emits address-of by dispatching on the operand shape.</summary>

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -4300,6 +4300,220 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #649: Gets a MemberRef for a field on a constructed generic type without
+    /// calling <c>.GetField()</c> on the closed generic (which throws
+    /// <see cref="NotSupportedException"/> when type arguments are MLC-loaded or
+    /// TypeBuilder-backed). Resolves the field from the open generic type definition.
+    /// </summary>
+    internal MemberReferenceHandle GetFieldReferenceOnConstructedGeneric(Type closedGenericType, string fieldName)
+    {
+        var openType = closedGenericType.GetGenericTypeDefinition();
+        var openField = openType.GetField(
+            fieldName,
+            BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                $"Open generic type '{openType.FullName}' has no field '{fieldName}'.");
+
+        var parent = this.GetTypeHandleForMember(closedGenericType);
+
+        var sigBlob = new BlobBuilder();
+        this.EncodeClrType(new BlobEncoder(sigBlob).FieldSignature(), openField.FieldType);
+
+        var handle = this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString(fieldName),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        return handle;
+    }
+
+    /// <summary>
+    /// Issue #649: Gets a MemberRef for a constructor on a constructed generic type without
+    /// calling <c>.GetConstructors()</c> on the closed generic (which throws
+    /// <see cref="NotSupportedException"/> when type arguments are MLC-loaded or
+    /// TypeBuilder-backed). Resolves the constructor from the open generic type definition.
+    /// </summary>
+    internal MemberReferenceHandle GetCtorReferenceOnConstructedGeneric(Type closedGenericType, int paramCount)
+    {
+        var openType = closedGenericType.GetGenericTypeDefinition();
+        ConstructorInfo openCtor = null;
+        foreach (var c in openType.GetConstructors())
+        {
+            if (c.GetParameters().Length == paramCount)
+            {
+                openCtor = c;
+                break;
+            }
+        }
+
+        if (openCtor == null)
+        {
+            throw new InvalidOperationException(
+                $"Open generic type '{openType.FullName}' has no constructor of arity {paramCount}.");
+        }
+
+        var parent = this.GetTypeHandleForMember(closedGenericType);
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                openCtor.GetParameters().Length,
+                returnType: r => r.Void(),
+                parameters: ps =>
+                {
+                    foreach (var p in openCtor.GetParameters())
+                    {
+                        var paramType = p.ParameterType;
+                        if (paramType.IsByRef)
+                        {
+                            this.EncodeClrType(ps.AddParameter().Type(isByRef: true), paramType.GetElementType()!);
+                        }
+                        else
+                        {
+                            this.EncodeClrType(ps.AddParameter().Type(), paramType);
+                        }
+                    }
+                });
+
+        var handle = this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        return handle;
+    }
+
+    /// <summary>
+    /// Issue #649: Gets the TypeSpec handle for a <c>ValueTuple&lt;...&gt;</c> whose element
+    /// types include G#-defined types (StructSymbol) that lack a CLR backing type.
+    /// Encodes each element type via <see cref="EncodeTypeSymbol"/> so user-defined types
+    /// are correctly referenced by their TypeDef handles.
+    /// </summary>
+    private EntityHandle GetTupleTypeSpec(TupleTypeSymbol tupleType)
+    {
+        var arity = tupleType.Arity;
+        var openType = arity switch
+        {
+            2 => typeof(ValueTuple<,>),
+            3 => typeof(ValueTuple<,,>),
+            4 => typeof(ValueTuple<,,,>),
+            5 => typeof(ValueTuple<,,,,>),
+            6 => typeof(ValueTuple<,,,,,>),
+            7 => typeof(ValueTuple<,,,,,,>),
+            _ => throw new NotSupportedException(
+                $"Symbolic tuple TypeSpec not supported for arity {arity}."),
+        };
+
+        var sigBlob = new BlobBuilder();
+        var genInst = new BlobEncoder(sigBlob).TypeSpecificationSignature()
+            .GenericInstantiation(
+                this.GetTypeReference(openType),
+                arity,
+                isValueType: true);
+        foreach (var elemType in tupleType.ElementTypes)
+        {
+            this.EncodeTypeSymbol(genInst.AddArgument(), elemType);
+        }
+
+        return this.emitCtx.Metadata.AddTypeSpecification(
+            this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+    }
+
+    /// <summary>
+    /// Issue #649: Gets a MemberRef for a tuple field (<c>Item1</c>...<c>Item7</c>) when
+    /// the tuple's <see cref="TypeSymbol.ClrType"/> is null (element types include
+    /// G#-defined types). Builds the field MemberRef against the symbolically-constructed
+    /// <c>ValueTuple</c> TypeSpec.
+    /// </summary>
+    internal MemberReferenceHandle GetTupleFieldReference(TupleTypeSymbol tupleType, string fieldName)
+    {
+        var parent = this.GetTupleTypeSpec(tupleType);
+
+        // Get the open field from the BCL ValueTuple generic definition for signature encoding.
+        var openType = tupleType.Arity switch
+        {
+            2 => typeof(ValueTuple<,>),
+            3 => typeof(ValueTuple<,,>),
+            4 => typeof(ValueTuple<,,,>),
+            5 => typeof(ValueTuple<,,,,>),
+            6 => typeof(ValueTuple<,,,,,>),
+            7 => typeof(ValueTuple<,,,,,,>),
+            _ => throw new NotSupportedException(
+                $"Symbolic tuple field ref not supported for arity {tupleType.Arity}."),
+        };
+
+        var openField = openType.GetField(
+            fieldName,
+            BindingFlags.Instance | BindingFlags.Public)
+            ?? throw new InvalidOperationException(
+                $"Open ValueTuple type has no field '{fieldName}'.");
+
+        var sigBlob = new BlobBuilder();
+        this.EncodeClrType(new BlobEncoder(sigBlob).FieldSignature(), openField.FieldType);
+
+        return this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString(fieldName),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+    }
+
+    /// <summary>
+    /// Issue #649: Gets a MemberRef for a tuple constructor when the tuple's
+    /// <see cref="TypeSymbol.ClrType"/> is null (element types include G#-defined
+    /// types). Builds the ctor MemberRef against the symbolically-constructed
+    /// <c>ValueTuple</c> TypeSpec.
+    /// </summary>
+    internal MemberReferenceHandle GetTupleCtorReference(TupleTypeSymbol tupleType)
+    {
+        var parent = this.GetTupleTypeSpec(tupleType);
+        var arity = tupleType.Arity;
+
+        var openType = arity switch
+        {
+            2 => typeof(ValueTuple<,>),
+            3 => typeof(ValueTuple<,,>),
+            4 => typeof(ValueTuple<,,,>),
+            5 => typeof(ValueTuple<,,,,>),
+            6 => typeof(ValueTuple<,,,,,>),
+            7 => typeof(ValueTuple<,,,,,,>),
+            _ => throw new NotSupportedException(
+                $"Symbolic tuple ctor ref not supported for arity {arity}."),
+        };
+
+        ConstructorInfo openCtor = null;
+        foreach (var c in openType.GetConstructors())
+        {
+            if (c.GetParameters().Length == arity)
+            {
+                openCtor = c;
+                break;
+            }
+        }
+
+        if (openCtor == null)
+        {
+            throw new InvalidOperationException(
+                $"Open ValueTuple type of arity {arity} has no matching constructor.");
+        }
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                openCtor.GetParameters().Length,
+                returnType: r => r.Void(),
+                parameters: ps =>
+                {
+                    foreach (var p in openCtor.GetParameters())
+                    {
+                        this.EncodeClrType(ps.AddParameter().Type(), p.ParameterType);
+                    }
+                });
+
+        return this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+    }
+
+    /// <summary>
     /// Issue #491 (ADR-0060 follow-up): encodes a single local-variable signature slot.
     /// A <see cref="ByRefTypeSymbol"/> entry signals a ref-aliasing local (<c>let ref</c> /
     /// <c>var ref</c>) whose slot must carry <c>ELEMENT_TYPE_BYREF</c> wrapping the pointee
@@ -4486,6 +4700,32 @@ internal sealed class ReflectionMetadataEmitter
             var elementClr = chType.ElementType.ClrType ?? typeof(object);
             var channelClr = typeof(System.Threading.Channels.Channel<>).MakeGenericType(elementClr);
             this.EncodeClrType(encoder, channelClr);
+        }
+        else if (type is TupleTypeSymbol tupleWithNullClr && tupleWithNullClr.ClrType == null
+            && tupleWithNullClr.Arity >= 2 && tupleWithNullClr.Arity <= 7)
+        {
+            // Issue #649: Tuple containing G#-defined types whose ClrType is null.
+            // Encode as ValueTuple<...> generic instantiation using EncodeTypeSymbol
+            // for each element so user-defined types reference their TypeDef handles.
+            var openType = tupleWithNullClr.Arity switch
+            {
+                2 => typeof(ValueTuple<,>),
+                3 => typeof(ValueTuple<,,>),
+                4 => typeof(ValueTuple<,,,>),
+                5 => typeof(ValueTuple<,,,,>),
+                6 => typeof(ValueTuple<,,,,,>),
+                7 => typeof(ValueTuple<,,,,,,>),
+                _ => throw new NotSupportedException("unreachable"),
+            };
+
+            var genericInst = encoder.GenericInstantiation(
+                this.GetTypeReference(openType),
+                tupleWithNullClr.Arity,
+                isValueType: true);
+            foreach (var elemType in tupleWithNullClr.ElementTypes)
+            {
+                this.EncodeTypeSymbol(genericInst.AddArgument(), elemType);
+            }
         }
         else if (type?.ClrType != null)
         {

--- a/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
@@ -47,7 +47,23 @@ public sealed class TupleTypeSymbol : TypeSymbol
         }
 
         var key = BuildName(elementTypes);
-        return Cache.GetOrAdd(key, _ => new TupleTypeSymbol(elementTypes));
+
+        // Issue #649: The cache is keyed by name alone (e.g. "(Holder, string)").
+        // Across compilations in the same process (common in tests), different
+        // TypeSymbol instances with the same name may appear (loaded from
+        // different MetadataLoadContext instances). Validate that the cached
+        // entry's element types still match by reference; if not, replace it.
+        if (Cache.TryGetValue(key, out var existing))
+        {
+            if (existing.ElementTypes.SequenceEqual(elementTypes))
+            {
+                return existing;
+            }
+        }
+
+        var result = new TupleTypeSymbol(elementTypes);
+        Cache[key] = result;
+        return result;
     }
 
     private static string BuildName(ImmutableArray<TypeSymbol> elementTypes)

--- a/test/Compiler.Tests/Emit/Issue649TupleClrRefTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue649TupleClrRefTypeEmitTests.cs
@@ -1,0 +1,417 @@
+// <copyright file="Issue649TupleClrRefTypeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #649: Any tuple containing a CLR reference type from a project
+/// reference triggered <c>GS9998: NotSupportedException: TypeBuilder generic
+/// instantiation does not support resolving members</c>. The root cause was
+/// that <c>EmitTupleElementAccess</c> called <c>.GetField()</c> and
+/// <c>EmitTupleLiteral</c> called <c>.GetConstructors()</c> on the closed
+/// <c>ValueTuple&lt;...&gt;</c> generic — which throws when any type argument
+/// is loaded via MetadataLoadContext. The fix resolves fields and constructors
+/// from the open generic type definition instead.
+/// </summary>
+public class Issue649TupleClrRefTypeEmitTests
+{
+    private const string HolderSiblingCs = """
+        namespace Probe.CSharp
+        {
+            public sealed class Holder
+            {
+                public string A { get; init; } = "";
+            }
+
+            public sealed class Holder2
+            {
+                public int X { get; init; }
+
+                public sealed class Nested
+                {
+                    public string B { get; init; } = "";
+                }
+            }
+        }
+        """;
+
+    [Fact]
+    public void Tuple2_OneClrRefType_ReturnsAndDestructures()
+    {
+        // (Holder, string) — the exact shape from the issue.
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            func make() (Holder, string) {
+                return (Holder() { A = "x" }, "b")
+            }
+
+            let (h, s) = make()
+            Console.Write(h.A)
+            Console.Write("|")
+            Console.Write(s)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(HolderSiblingCs, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("x|b", output);
+    }
+
+    [Fact]
+    public void Tuple2_TwoClrRefTypes_OneNested()
+    {
+        // (Holder, Holder2.Nested) — two CLR ref types, one nested.
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            func make() (Holder, Holder2.Nested) {
+                return (Holder() { A = "alpha" }, Holder2.Nested() { B = "beta" })
+            }
+
+            let (h, n) = make()
+            Console.Write(h.A)
+            Console.Write("|")
+            Console.Write(n.B)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(HolderSiblingCs, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("alpha|beta", output);
+    }
+
+    [Fact]
+    public void Tuple4_ClrRefTypeWithPrimitives()
+    {
+        // (Holder, int32, string, string) — 4-element tuple with CLR ref type.
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            func make() (Holder, int32, string, string) {
+                return (Holder() { A = "val" }, 42, "c", "d")
+            }
+
+            let (h, i, s1, s2) = make()
+            Console.Write(h.A)
+            Console.Write("|")
+            Console.Write(i.ToString())
+            Console.Write("|")
+            Console.Write(s1)
+            Console.Write("|")
+            Console.Write(s2)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(HolderSiblingCs, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("val|42|c|d", output);
+    }
+
+    [Fact]
+    public void Tuple_DirectItemAccess_WithoutDestructure()
+    {
+        // Use t.Item1, t.Item2 without destructure — tests the same ldfld path.
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            func make() (Holder, string) {
+                return (Holder() { A = "direct" }, "access")
+            }
+
+            let t = make()
+            Console.Write(t.Item1.A)
+            Console.Write("|")
+            Console.Write(t.Item2)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(HolderSiblingCs, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("direct|access", output);
+    }
+
+    [Fact]
+    public void Tuple_WithGSharpDefinedRefType()
+    {
+        // A tuple containing a G#-defined class (TypeBuilder-backed) alongside
+        // a CLR ref type from the sibling — tests both directions of the
+        // mixed-arg generic instantiation.
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type MyClass class {
+                Name string
+                init() {}
+            }
+
+            func make() (MyClass, Holder) {
+                return (MyClass() { Name = "gs" }, Holder() { A = "cs" })
+            }
+
+            let (mc, h) = make()
+            Console.Write(mc.Name)
+            Console.Write("|")
+            Console.Write(h.A)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(HolderSiblingCs, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("gs|cs", output);
+    }
+
+    [Fact]
+    public void Tuple_AsParameterType()
+    {
+        // Tuple containing CLR ref type passed as a function parameter.
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            func consume(t (Holder, string)) string {
+                return t.Item1.A + "|" + t.Item2
+            }
+
+            let t = (Holder() { A = "param" }, "test")
+            Console.Write(consume(t))
+            """;
+
+        var output = CompileAndRunWithSiblingCs(HolderSiblingCs, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("param|test", output);
+    }
+
+    [Fact]
+    public void Tuple_AsFieldType()
+    {
+        // Tuple containing CLR ref type stored as a field in a G# class.
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type Container class {
+                Data (Holder, int32)
+                init() {
+                    Data = (Holder() { A = "field" }, 99)
+                }
+            }
+
+            var c = Container()
+            Console.Write(c.Data.Item1.A)
+            Console.Write("|")
+            Console.Write(c.Data.Item2.ToString())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(HolderSiblingCs, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("field|99", output);
+    }
+
+    [Fact]
+    public void Tuple7_MaxWithoutRest_ClrRefType()
+    {
+        // 7-element tuple (max arity without TRest) containing a CLR ref type.
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            func make() (Holder, int32, int32, int32, int32, int32, string) {
+                return (Holder() { A = "seven" }, 1, 2, 3, 4, 5, "end")
+            }
+
+            let (h, a, b, c, d, e, s) = make()
+            Console.Write(h.A)
+            Console.Write("|")
+            Console.Write(s)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(HolderSiblingCs, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("seven|end", output);
+    }
+
+    [Fact]
+    public void Tuple_PrimitivesOnly_StillWorks()
+    {
+        // Sanity check: primitives-only tuples (which worked before) still work.
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            func make() (string, int32, string, int32) {
+                return ("a", 1, "b", 2)
+            }
+
+            let (s1, i1, s2, i2) = make()
+            Console.Write(s1)
+            Console.Write(i1.ToString())
+            Console.Write(s2)
+            Console.Write(i2.ToString())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(HolderSiblingCs, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("a1b2", output);
+    }
+
+    // --- Helpers ---
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue649_sib_").FullName;
+        try
+        {
+            // Step 1: compile the sibling C# library.
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            // Step 2: compile the G# code referencing the sibling.
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            // Place the sibling next to the produced assembly so the
+            // probing path resolves it at runtime.
+            File.Copy(siblingDll, Path.Combine(tempDir, Path.GetFileName(siblingDll)), overwrite: true);
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { siblingDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string BuildCsProject(string csDir, string siblingName)
+    {
+        RunDotnet(csDir, "restore");
+        RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+
+        var dll = Path.Combine(csDir, "bin", "Release", "net10.0", siblingName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static void RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Root Cause

The emitter's `EmitTupleElementAccess` called `.GetField()` and `EmitTupleLiteral` called `.GetConstructors()` directly on the closed generic `ValueTuple<T1, T2, ...>` type. When any type argument is loaded via `MetadataLoadContext` (which is how project-referenced assemblies are loaded), these calls throw `NotSupportedException: TypeBuilder generic instantiation does not support resolving members`, surfacing as `GS9998`.

## Fix

1. **MLC-loaded type arguments (the primary #649 fix):** For constructed generic tuples, resolve fields/constructors from the open generic type definition (`typeof(ValueTuple<,>)`) and build the `MemberRef` with the closed TypeSpec as parent. Added `GetFieldReferenceOnConstructedGeneric` and `GetCtorReferenceOnConstructedGeneric` helpers in `ReflectionMetadataEmitter`.

2. **G#-defined type arguments (bonus fix):** Tuples containing `StructSymbol` types (whose `ClrType` is null during compilation) now emit correctly. Added `GetTupleTypeSpec`, `GetTupleFieldReference`, and `GetTupleCtorReference` that build the `ValueTuple<...>` TypeSpec symbolically using `EncodeTypeSymbol` for each element. Also added a `TupleTypeSymbol` case in `EncodeTypeSymbol` for signature encoding.

3. **Cache staleness fix:** `TupleTypeSymbol.Get` now validates that a cached entry's element types match by reference, preventing stale MLC types from a previous compilation's (now-disposed) load context from being reused.

## Tests

9 new tests in `Issue649TupleClrRefTypeEmitTests.cs` covering:
- 2-element tuple with one CLR ref type (`(Holder, string)`)
- 2-element tuple with two CLR ref types, one nested (`(Holder, Holder2.Nested)`)
- 4-element tuple with CLR ref type (`(Holder, int32, string, string)`)
- 7-element tuple (max without TRest) with CLR ref type
- Tuple direct item access (`t.Item1.A`) without destructure
- Tuple with G#-defined ref type + CLR ref type
- Tuple as parameter type
- Tuple as field type in a G# class
- Primitives-only tuple (regression guard)

All tests include IL verification via `IlVerifier.Verify` and runtime execution validation.

Fixes #649