### PR TITLE
Fix #652: emit error in await for over IAsyncEnumerable<T>

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -489,26 +489,54 @@ public sealed class Lowerer : BoundTreeRewriter
             return new BoundExpressionStatement(null, new BoundErrorExpression(null));
         }
 
-        var elementClr = asyncEnumerableInterface.GetGenericArguments()[0];
-        var enumeratorClr = typeof(System.Collections.Generic.IAsyncEnumerator<>).MakeGenericType(elementClr);
-        var valueTaskBoolClr = typeof(System.Threading.Tasks.ValueTask<>).MakeGenericType(typeof(bool));
+        // Issue #652: resolve all helper types from the same MetadataLoadContext
+        // as the stream type. Using typeof(...) here would yield host-runtime types
+        // that cannot be mixed with MLC-loaded types in MakeGenericType/GetMethod
+        // calls, causing ArgumentException ("Type must be a type provided by the
+        // MetadataLoadContext").  Instead, derive everything from the interface and
+        // method signatures that are already in the correct context.
 
-        var getAsyncEnumerator = asyncEnumerableInterface.GetMethod(
-            "GetAsyncEnumerator",
-            new[] { typeof(System.Threading.CancellationToken) });
-        var moveNextAsync = enumeratorClr.GetMethod("MoveNextAsync", System.Type.EmptyTypes);
-        var currentProperty = enumeratorClr.GetProperty("Current");
-        var disposeAsync = typeof(System.IAsyncDisposable).GetMethod("DisposeAsync", System.Type.EmptyTypes);
-
-        if (getAsyncEnumerator == null || moveNextAsync == null || currentProperty == null || disposeAsync == null)
+        // GetAsyncEnumerator is the sole method on IAsyncEnumerable<T>.
+        var getAsyncEnumerator = asyncEnumerableInterface.GetMethod("GetAsyncEnumerator");
+        if (getAsyncEnumerator == null)
         {
             return new BoundExpressionStatement(null, new BoundErrorExpression(null));
         }
 
-        var cancellationTokenType = TypeSymbol.FromClrType(typeof(System.Threading.CancellationToken));
+        // IAsyncEnumerator<T> — from the return type (already in MLC context).
+        var enumeratorClr = getAsyncEnumerator.ReturnType;
+        var moveNextAsync = enumeratorClr.GetMethod("MoveNextAsync");
+        var currentProperty = enumeratorClr.GetProperty("Current");
+
+        // IAsyncDisposable.DisposeAsync — find via enumerator's implemented interfaces.
+        System.Reflection.MethodInfo disposeAsync = null;
+        foreach (var iface in enumeratorClr.GetInterfaces())
+        {
+            if (iface.FullName == "System.IAsyncDisposable")
+            {
+                disposeAsync = iface.GetMethod("DisposeAsync");
+                break;
+            }
+        }
+
+        if (moveNextAsync == null || currentProperty == null || disposeAsync == null)
+        {
+            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+        }
+
+        // ValueTask<bool> — from MoveNextAsync's return type (MLC context).
+        var valueTaskBoolClr = moveNextAsync.ReturnType;
+
+        // CancellationToken — from GetAsyncEnumerator's parameter (MLC context).
+        var cancellationTokenClr = getAsyncEnumerator.GetParameters()[0].ParameterType;
+
+        // ValueTask (non-generic) — from DisposeAsync's return type (MLC context).
+        var valueTaskClr = disposeAsync.ReturnType;
+
+        var cancellationTokenType = TypeSymbol.FromClrType(cancellationTokenClr);
         var enumeratorType = TypeSymbol.FromClrType(enumeratorClr);
         var valueTaskBoolType = TypeSymbol.FromClrType(valueTaskBoolClr);
-        var valueTaskType = TypeSymbol.FromClrType(typeof(System.Threading.Tasks.ValueTask));
+        var valueTaskType = TypeSymbol.FromClrType(valueTaskClr);
         var currentType = TypeSymbol.FromClrType(currentProperty.PropertyType);
 
         var enumeratorSymbol = new LocalVariableSymbol("$awaitEnum", isReadOnly: true, type: enumeratorType);

--- a/test/Compiler.Tests/Emit/Issue652AwaitForAsyncEnumerableEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue652AwaitForAsyncEnumerableEmitTests.cs
@@ -1,0 +1,246 @@
+// <copyright file="Issue652AwaitForAsyncEnumerableEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #652: <c>await for x in y</c> over <c>IAsyncEnumerable&lt;T&gt;</c>
+/// triggered GS9998 ("Type must be a type provided by the MetadataLoadContext")
+/// because the lowering mixed runtime <c>typeof(...)</c> types with
+/// MetadataLoadContext-loaded types when constructing generic instantiations.
+/// These tests verify that the desugaring correctly derives all helper types
+/// from the same context as the stream type.
+/// </summary>
+public class Issue652AwaitForAsyncEnumerableEmitTests
+{
+    #region Free async-yield function producer
+
+    [Fact]
+    public void AwaitFor_FreeFunction_Producer_Compiles_And_Runs()
+    {
+        // Free function returning IAsyncEnumerable[int32] consumed via await for.
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Inner() IAsyncEnumerable[int32] {
+                yield 1
+                await Task.Delay(1)
+                yield 2
+            }
+
+            async func Consume() {
+                var sum = 0
+                let seq = Inner()
+                await for n in seq {
+                    sum = sum + n
+                }
+                Console.WriteLine(sum)
+            }
+
+            Consume().Wait()
+            """;
+
+        var (assembly, stdout) = CompileRunCapture(source);
+        Assert.Equal("3", stdout.Trim());
+    }
+
+    #endregion
+
+    #region Class member producer
+
+    [Fact]
+    public void AwaitFor_ClassMember_Producer_Compiles_And_Runs()
+    {
+        // Class method returning IAsyncEnumerable[int32] consumed via await for.
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            type Producer class {
+                init() {}
+
+                async func Numbers() IAsyncEnumerable[int32] {
+                    yield 10
+                    await Task.Delay(1)
+                    yield 20
+                    await Task.Delay(1)
+                    yield 30
+                }
+            }
+
+            async func Run() {
+                var sum = 0
+                let p = Producer()
+                await for n in p.Numbers() {
+                    sum = sum + n
+                }
+                Console.WriteLine(sum)
+            }
+
+            Run().Wait()
+            """;
+
+        var (assembly, stdout) = CompileRunCapture(source);
+        Assert.Equal("60", stdout.Trim());
+    }
+
+    #endregion
+
+    #region Nested await-for (await for inside await for)
+
+    [Fact]
+    public void AwaitFor_Nested_Compiles_And_Runs()
+    {
+        // Two nested await-for loops over independent async enumerables.
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Outer() IAsyncEnumerable[int32] {
+                yield 1
+                await Task.Delay(1)
+                yield 2
+            }
+
+            async func Inner(x int32) IAsyncEnumerable[int32] {
+                yield x * 10
+                await Task.Delay(1)
+                yield x * 100
+            }
+
+            async func Run() {
+                var sum = 0
+                await for a in Outer() {
+                    await for b in Inner(a) {
+                        sum = sum + b
+                    }
+                }
+                Console.WriteLine(sum)
+            }
+
+            Run().Wait()
+            """;
+
+        // Outer yields 1, 2
+        // Inner(1) yields 10, 100 → 110
+        // Inner(2) yields 20, 200 → 220
+        // Total = 330
+        var (assembly, stdout) = CompileRunCapture(source);
+        Assert.Equal("330", stdout.Trim());
+    }
+
+    #endregion
+
+    #region await for with string element type
+
+    [Fact]
+    public void AwaitFor_StringElement_Compiles_And_Runs()
+    {
+        // Ensure the fix works for reference-type element types too.
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Words() IAsyncEnumerable[string] {
+                yield "hello"
+                await Task.Delay(1)
+                yield "world"
+            }
+
+            async func Run() {
+                var result = ""
+                await for w in Words() {
+                    result = result + w + " "
+                }
+                Console.Write(result)
+            }
+
+            Run().Wait()
+            """;
+
+        var (assembly, stdout) = CompileRunCapture(source);
+        Assert.Equal("hello world ", stdout);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static (Assembly assembly, string stdout) CompileRunCapture(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_652_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        // Run the entry point and capture stdout
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+
+        var captured = new StringWriter();
+        var prevOut2 = Console.Out;
+        Console.SetOut(captured);
+        try
+        {
+            entry!.Invoke(null, null);
+        }
+        finally
+        {
+            Console.SetOut(prevOut2);
+        }
+
+        return (assembly, captured.ToString().Replace("\r\n", "\n"));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Fixes #652

## Root Cause

The `await for` lowering in `LowerAwaitForRange` (`src/Core/CodeAnalysis/Lowering/Lowerer.cs`) used `typeof(...)` to obtain open generic types (`IAsyncEnumerator<>`, `ValueTask<>`, `IAsyncDisposable`, `CancellationToken`) from the **host runtime**, then called `MakeGenericType` / `GetMethod` with type arguments from the **MetadataLoadContext**. This cross-context mixing caused `ArgumentException` ("Type must be a type provided by the MetadataLoadContext") at emit time, surfacing as GS9998.

## Fix

Derive all helper types from the interface/method signatures that are already loaded in the correct MetadataLoadContext:

| Before (runtime `typeof`) | After (MLC-consistent) |
|---|---|
| `typeof(IAsyncEnumerator<>).MakeGenericType(elementClr)` | `getAsyncEnumerator.ReturnType` |
| `typeof(ValueTask<>).MakeGenericType(typeof(bool))` | `moveNextAsync.ReturnType` |
| `typeof(CancellationToken)` | `getAsyncEnumerator.GetParameters()[0].ParameterType` |
| `typeof(IAsyncDisposable).GetMethod(...)` | Find `IAsyncDisposable` in enumerator's interfaces |
| `typeof(ValueTask)` | `disposeAsync.ReturnType` |

## New Tests

`test/Compiler.Tests/Emit/Issue652AwaitForAsyncEnumerableEmitTests.cs`:

1. **AwaitFor_FreeFunction_Producer** — free async-yield func producing `IAsyncEnumerable[int32]`
2. **AwaitFor_ClassMember_Producer** — class method producer
3. **AwaitFor_Nested** — nested `await for` inside another `await for`
4. **AwaitFor_StringElement** — reference-type (`string`) element type

All tests compile the source through `gsc`, run IL verification via `IlVerifier.Verify`, load the assembly, invoke the entry point, and assert the expected output.

## Verification

- `dotnet build GSharp.sln` — ✅ clean
- `dotnet test test/Core.Tests/` — ✅ 2197 passed, 1 skipped
- `dotnet test test/Compiler.Tests/` — ✅ 863 passed
- `dotnet test test/Interpreter.Tests/` — ✅ 98 passed
- `dotnet test test/LanguageServer.Tests/` — ✅ 242 passed
- IL verification passes for all new test assemblies (via `IlVerifier.Verify` in test harness)