### PR TITLE
Fix #654: emit error on if statement inside lambda body

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Emit;
@@ -307,7 +308,7 @@ internal sealed class ClosureEmitter
                 $"Synthesized closure '{closureName}' captures '{rewriter.UnsupportedCapture.Name}' from a kind ('{rewriter.UnsupportedCaptureKind}') the emitter cannot currently rewrite. Run under the interpreter for now.");
         }
 
-        this.lambdaBodies[invokeMethod] = rewrittenBody;
+        this.lambdaBodies[invokeMethod] = (BoundBlockStatement)Lowerer.Lower(rewrittenBody);
         this.SynthesizedClosureClasses.Add(closureClass);
         var info = new ClosureInfo(closureClass, invokeMethod, captureFields);
         this.ClosureInvokeToInfo[invokeMethod] = info;

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1298,7 +1298,7 @@ internal sealed class ReflectionMetadataEmitter
                     continue;
                 }
 
-                this.lambdaBodies[literal.Function] = literal.Body;
+                this.lambdaBodies[literal.Function] = (BoundBlockStatement)Lowerer.Lower(literal.Body);
                 hostBucket.Add(literal.Function);
             }
         }

--- a/test/Compiler.Tests/Emit/Issue654IfInLambdaEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue654IfInLambdaEmitTests.cs
@@ -1,0 +1,191 @@
+// <copyright file="Issue654IfInLambdaEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #654: <c>if</c> statement inside a lambda body triggered GS9998
+/// ("Bound statement kind 'IfStatement' is not yet supported by the emitter")
+/// because lambda bodies (both capturing and non-capturing) were not run
+/// through the <see cref="GSharp.Core.CodeAnalysis.Lowering.Lowerer"/> before
+/// being stored in <c>lambdaBodies</c>. The Lowerer converts <c>IfStatement</c>
+/// into <c>ConditionalGotoStatement</c> + <c>LabelStatement</c> which the
+/// emitter already supports.
+/// </summary>
+public class Issue654IfInLambdaEmitTests
+{
+    #region if inside Task.Run lambda (original repro)
+
+    [Fact]
+    public void If_In_TaskRun_Lambda_Compiles_And_Runs()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Threading.Tasks
+
+            Task.Run(func() {
+                let x = 0
+                if x > 0 {
+                    return
+                }
+            }).Wait()
+            Console.Write("ok")
+            """;
+
+        var (_, stdout) = CompileRunCapture(source);
+        Assert.Equal("ok", stdout);
+    }
+
+    #endregion
+
+    #region if/else inside synchronous closure lambda (captures outer var)
+
+    [Fact]
+    public void IfElse_In_Closure_Lambda_Compiles_And_Runs()
+    {
+        var source = """
+            package Probe
+            import System
+
+            var result = ""
+            var action = func() {
+                let x = 42
+                if x > 10 {
+                    result = "big"
+                } else {
+                    result = "small"
+                }
+            }
+            action()
+            Console.Write(result)
+            """;
+
+        var (_, stdout) = CompileRunCapture(source);
+        Assert.Equal("big", stdout);
+    }
+
+    #endregion
+
+    #region nested if inside for inside lambda
+
+    [Fact]
+    public void NestedIf_In_For_In_Lambda_Compiles_And_Runs()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Threading.Tasks
+
+            var sum = 0
+            Task.Run(func() {
+                for i := 0; i < 5; i = i + 1 {
+                    if i > 2 {
+                        if i < 5 {
+                            sum = sum + i
+                        }
+                    }
+                }
+            }).Wait()
+            Console.Write(sum)
+            """;
+
+        // i=3 and i=4 satisfy both conditions → sum = 3 + 4 = 7
+        var (_, stdout) = CompileRunCapture(source);
+        Assert.Equal("7", stdout);
+    }
+
+    #endregion
+
+    #region if inside non-capturing Func lambda (non-void return)
+
+    [Fact]
+    public void If_In_Func_Lambda_Compiles_And_Runs()
+    {
+        var source = """
+            package Probe
+            import System
+
+            var compute = func(x int32) int32 {
+                if x > 3 {
+                    return x * 2
+                }
+                return x
+            }
+            Console.Write(compute(5))
+            """;
+
+        var (_, stdout) = CompileRunCapture(source);
+        Assert.Equal("10", stdout);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static (Assembly assembly, string stdout) CompileRunCapture(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_654_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+
+        var captured = new StringWriter();
+        var prevOut2 = Console.Out;
+        Console.SetOut(captured);
+        try
+        {
+            entry!.Invoke(null, null);
+        }
+        finally
+        {
+            Console.SetOut(prevOut2);
+        }
+
+        return (assembly, captured.ToString().Replace("\r\n", "\n"));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Fixes #654

## Root Cause

Lambda bodies (both non-capturing and capture-bearing closures) were stored in the `lambdaBodies` dictionary **without** being run through the `Lowerer`. The Lowerer converts high-level control-flow statements (`IfStatement`, `ForStatement`, etc.) into the primitive `ConditionalGotoStatement` + `LabelStatement` pairs that the emitter supports. Without lowering, the emitter hit its default switch case and threw GS9998.

The async lambda path in `StateMachineEmitter` already called `Lowerer.Lower()` explicitly (with a comment explaining the omission), but synchronous lambdas were missed.

## Fix

Apply `Lowerer.Lower()` to lambda bodies at the two storage sites:

1. **`ReflectionMetadataEmitter.cs`** — non-capturing lambda bodies (`literal.Body`)
2. **`ClosureEmitter.cs`** — capture-bearing lambda bodies (after `CaptureRewriter`)

Double-lowering (for the async path that lowers again) is idempotent since the Lowerer only rewrites node kinds it recognizes and passes through already-lowered primitives unchanged.

## New Tests (`Issue654IfInLambdaEmitTests.cs`)

| Test | Coverage |
|------|----------|
| `If_In_TaskRun_Lambda_Compiles_And_Runs` | Original repro: `if` in no-capture `Task.Run` lambda |
| `IfElse_In_Closure_Lambda_Compiles_And_Runs` | `if/else` in capture-bearing closure |
| `NestedIf_In_For_In_Lambda_Compiles_And_Runs` | Nested `if` inside `for` inside lambda |
| `If_In_Func_Lambda_Compiles_And_Runs` | `if` with early return in `Func<int>` lambda |

All tests include IL verification via `IlVerifier.Verify`.

## Verification

```
dotnet build GSharp.sln -nologo -clp:NoSummary          # 0 errors, 0 warnings
dotnet test test/Compiler.Tests/   --no-restore --nologo # 867 passed
dotnet test test/Core.Tests/       --no-restore --nologo # 2197 passed, 1 skipped
dotnet test test/Interpreter.Tests/--no-restore --nologo # 98 passed
dotnet test test/Sdk.Tests/        --no-restore --nologo # 26 passed
dotnet test test/LanguageServer.Tests/ --no-restore --nologo # 242 passed
```