### PR TITLE
Fix #658: implicit user-class to CLR-interface conversion missing in ctor overload resolution

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -440,17 +440,26 @@ internal sealed partial class ExpressionBinder
         var ctors = ClrTypeUtilities.SafeGetConstructors(clrType, BindingFlags.Public | BindingFlags.Instance);
         var argTypes = new System.Type[boundArguments.Count];
         var argsAllTyped = true;
+        var hasUserClassArg = false;
         for (var i = 0; i < boundArguments.Count; i++)
         {
             // Issue #530: use GetEffectiveArgumentClrType (see instance method path).
             // Issue #533: allow null (nil literal) to flow through; overload
             // resolution now handles null source as compatible with reference
             // types and Nullable<T>.
-            var t = GetEffectiveArgumentClrType(boundArguments[i].Type);
+            // Issue #658: use the overload-resolution variant that provides a
+            // surrogate CLR type for user-defined G# classes (whose ClrType is
+            // null at bind time) so overload resolution can proceed.
+            var t = GetEffectiveArgumentClrTypeForOverloadResolution(boundArguments[i].Type);
             if (t == null && boundArguments[i].Type != TypeSymbol.Null)
             {
                 argsAllTyped = false;
                 break;
+            }
+
+            if (boundArguments[i].Type is StructSymbol { IsClass: true })
+            {
+                hasUserClassArg = true;
             }
 
             argTypes[i] = t;
@@ -461,19 +470,38 @@ internal sealed partial class ExpressionBinder
         bool ctorIsExpanded = false;
         if (argsAllTyped)
         {
-            var resolution = OverloadResolution.Resolve(ctors, argTypes, interpolatedStringArgs: ComputeInterpolatedStringArgFlags(syntax.Arguments, boundArguments.Count), argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
-            switch (resolution.Outcome)
+            // Issue #658: when any argument is a user-defined G# class, set up
+            // the supplementary interface check so ClassifyImplicit recognises
+            // the user-class → CLR-interface implicit reference conversion.
+            if (hasUserClassArg)
             {
-                case OverloadResolution.ResolutionOutcome.Resolved:
-                    bestCtor = resolution.Best;
-                    ctorMapping = resolution.ParameterMapping;
-                    ctorIsExpanded = resolution.IsExpanded;
-                    break;
-                case OverloadResolution.ResolutionOutcome.Ambiguous:
-                    Diagnostics.ReportAmbiguousOverload(syntax.Location, clrType.Name, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
-                    return false;
-                default:
-                    break;
+                OverloadResolution.SupplementaryInterfaceCheck = (source, target) =>
+                    IsUserClassAssignableToInterface(boundArguments, argTypes, source, target);
+            }
+
+            try
+            {
+                var resolution = OverloadResolution.Resolve(ctors, argTypes, interpolatedStringArgs: ComputeInterpolatedStringArgFlags(syntax.Arguments, boundArguments.Count), argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
+                switch (resolution.Outcome)
+                {
+                    case OverloadResolution.ResolutionOutcome.Resolved:
+                        bestCtor = resolution.Best;
+                        ctorMapping = resolution.ParameterMapping;
+                        ctorIsExpanded = resolution.IsExpanded;
+                        break;
+                    case OverloadResolution.ResolutionOutcome.Ambiguous:
+                        Diagnostics.ReportAmbiguousOverload(syntax.Location, clrType.Name, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
+                        return false;
+                    default:
+                        break;
+                }
+            }
+            finally
+            {
+                if (hasUserClassArg)
+                {
+                    OverloadResolution.SupplementaryInterfaceCheck = null;
+                }
             }
         }
 
@@ -975,17 +1003,24 @@ internal sealed partial class ExpressionBinder
         {
             var argTypes = new System.Type[arguments.Length];
             var argsAllTyped = true;
+            var hasUserClassArg = false;
             for (var i = 0; i < arguments.Length; i++)
             {
                 // Issue #530: use GetEffectiveArgumentClrType so that a
                 // nullable value type argument (e.g. `int32?`) is matched
                 // as `Nullable<T>` in overload resolution.
                 // Issue #533: allow null (nil literal) through.
-                var t = GetEffectiveArgumentClrType(arguments[i].Type);
+                // Issue #658: use overload-resolution variant for user classes.
+                var t = GetEffectiveArgumentClrTypeForOverloadResolution(arguments[i].Type);
                 if (t == null && arguments[i].Type != TypeSymbol.Null)
                 {
                     argsAllTyped = false;
                     break;
+                }
+
+                if (arguments[i].Type is StructSymbol { IsClass: true })
+                {
+                    hasUserClassArg = true;
                 }
 
                 argTypes[i] = t;
@@ -993,30 +1028,47 @@ internal sealed partial class ExpressionBinder
 
             if (argsAllTyped)
             {
-                var resolution = OverloadResolution.Resolve(candidates, argTypes, explicitTypeArgs, scope.References.MapClrTypeToReferences, ComputeInterpolatedStringArgFlags(ce.Arguments, arguments.Length), argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
-                switch (resolution.Outcome)
+                // Issue #658: set up supplementary interface check for user-class args.
+                if (hasUserClassArg)
                 {
-                    case OverloadResolution.ResolutionOutcome.Resolved:
-                        var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols) ?? MapClrMemberType(resolution.Best.ReturnType);
-                        var instParameters = resolution.Best.GetParameters();
-                        var instMapping = resolution.ParameterMapping;
-                        var instExpandedArgs = resolution.IsExpanded
-                            ? overloads.ExpandParamsArguments(arguments, instParameters, ce, parameterMapping: instMapping)
-                            : arguments;
-                        var instDownstreamMapping = resolution.IsExpanded ? default : instMapping;
-                        var instRebound = RebindFormattableInterpolationArguments(instExpandedArgs, ce.Arguments, instParameters, instDownstreamMapping);
-                        var instHandlerArgs = ApplyInterpolatedStringHandlers(instParameters, instRebound, receiver, ce.Location, instDownstreamMapping);
-                        var instDelegateArgs = RebindFunctionLiteralDelegateArguments(instHandlerArgs, instParameters, instDownstreamMapping);
-                        var instConvertedArgs = conversions.BindClrParameterConversions(instDelegateArgs, instParameters, ce, instDownstreamMapping);
-                        var instArguments = OverloadResolver.BuildOrderedCallArguments(instConvertedArgs, instDownstreamMapping, instParameters);
-                        var instRefKinds = ComputeArgumentRefKinds(instParameters);
-                        overloads.ValidateRefArguments(instArguments, instRefKinds, methodName, ce.Location);
-                        return ConversionClassifier.AutoDereferenceRefReturn(new BoundImportedInstanceCallExpression(null, receiver, resolution.Best, returnType, instArguments, instRefKinds, typeArgSymbols));
-                    case OverloadResolution.ResolutionOutcome.Ambiguous:
-                        Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
-                        return new BoundErrorExpression(null);
-                    default:
-                        break;
+                    OverloadResolution.SupplementaryInterfaceCheck = (source, target) =>
+                        IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target);
+                }
+
+                try
+                {
+                    var resolution = OverloadResolution.Resolve(candidates, argTypes, explicitTypeArgs, scope.References.MapClrTypeToReferences, ComputeInterpolatedStringArgFlags(ce.Arguments, arguments.Length), argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
+                    switch (resolution.Outcome)
+                    {
+                        case OverloadResolution.ResolutionOutcome.Resolved:
+                            var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols) ?? MapClrMemberType(resolution.Best.ReturnType);
+                            var instParameters = resolution.Best.GetParameters();
+                            var instMapping = resolution.ParameterMapping;
+                            var instExpandedArgs = resolution.IsExpanded
+                                ? overloads.ExpandParamsArguments(arguments, instParameters, ce, parameterMapping: instMapping)
+                                : arguments;
+                            var instDownstreamMapping = resolution.IsExpanded ? default : instMapping;
+                            var instRebound = RebindFormattableInterpolationArguments(instExpandedArgs, ce.Arguments, instParameters, instDownstreamMapping);
+                            var instHandlerArgs = ApplyInterpolatedStringHandlers(instParameters, instRebound, receiver, ce.Location, instDownstreamMapping);
+                            var instDelegateArgs = RebindFunctionLiteralDelegateArguments(instHandlerArgs, instParameters, instDownstreamMapping);
+                            var instConvertedArgs = conversions.BindClrParameterConversions(instDelegateArgs, instParameters, ce, instDownstreamMapping);
+                            var instArguments = OverloadResolver.BuildOrderedCallArguments(instConvertedArgs, instDownstreamMapping, instParameters);
+                            var instRefKinds = ComputeArgumentRefKinds(instParameters);
+                            overloads.ValidateRefArguments(instArguments, instRefKinds, methodName, ce.Location);
+                            return ConversionClassifier.AutoDereferenceRefReturn(new BoundImportedInstanceCallExpression(null, receiver, resolution.Best, returnType, instArguments, instRefKinds, typeArgSymbols));
+                        case OverloadResolution.ResolutionOutcome.Ambiguous:
+                            Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
+                            return new BoundErrorExpression(null);
+                        default:
+                            break;
+                    }
+                }
+                finally
+                {
+                    if (hasUserClassArg)
+                    {
+                        OverloadResolution.SupplementaryInterfaceCheck = null;
+                    }
                 }
             }
         }
@@ -1269,20 +1321,46 @@ internal sealed partial class ExpressionBinder
         }
 
         var argTypes = new System.Type[arguments.Length];
+        var hasUserClassArg = false;
         for (var i = 0; i < arguments.Length; i++)
         {
             // Issue #530: use GetEffectiveArgumentClrType (see instance method path).
             // Issue #533: allow null (nil literal) through.
-            var t = GetEffectiveArgumentClrType(arguments[i].Type);
+            // Issue #658: use overload-resolution variant for user classes.
+            var t = GetEffectiveArgumentClrTypeForOverloadResolution(arguments[i].Type);
             if (t == null && arguments[i].Type != TypeSymbol.Null)
             {
                 return false;
             }
 
+            if (arguments[i].Type is StructSymbol { IsClass: true })
+            {
+                hasUserClassArg = true;
+            }
+
             argTypes[i] = t;
         }
 
-        var resolution = OverloadResolution.Resolve(candidates, argTypes, explicitTypeArgs, scope.References.MapClrTypeToReferences, argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
+        // Issue #658: set up supplementary interface check for user-class args.
+        if (hasUserClassArg)
+        {
+            OverloadResolution.SupplementaryInterfaceCheck = (source, target) =>
+                IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target);
+        }
+
+        OverloadResolution.Result<MethodInfo> resolution;
+        try
+        {
+            resolution = OverloadResolution.Resolve(candidates, argTypes, explicitTypeArgs, scope.References.MapClrTypeToReferences, argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
+        }
+        finally
+        {
+            if (hasUserClassArg)
+            {
+                OverloadResolution.SupplementaryInterfaceCheck = null;
+            }
+        }
+
         switch (resolution.Outcome)
         {
             case OverloadResolution.ResolutionOutcome.Resolved:
@@ -1379,14 +1457,21 @@ internal sealed partial class ExpressionBinder
         // resolution (including generic inference) can run.
         var argTypes = new Type[arguments.Length + 1];
         argTypes[0] = receiverClrType;
+        var hasUserClassArg = false;
         for (var i = 0; i < arguments.Length; i++)
         {
             // Issue #530: use GetEffectiveArgumentClrType (see instance method path).
             // Issue #533: allow null (nil literal) through.
-            var t = GetEffectiveArgumentClrType(arguments[i].Type);
+            // Issue #658: use overload-resolution variant for user classes.
+            var t = GetEffectiveArgumentClrTypeForOverloadResolution(arguments[i].Type);
             if (t == null && arguments[i].Type != TypeSymbol.Null)
             {
                 return false;
+            }
+
+            if (arguments[i].Type is StructSymbol { IsClass: true })
+            {
+                hasUserClassArg = true;
             }
 
             argTypes[i + 1] = t;
@@ -1419,7 +1504,26 @@ internal sealed partial class ExpressionBinder
         // when the call site supplied explicit type arguments (e.g.
         // services.AddSingleton[IService, Service]()), those are used to close
         // the generic method instead of inference.
-        var resolution = OverloadResolution.Resolve(candidates, argTypes, explicitTypeArgs, scope.References.MapClrTypeToReferences, argumentNames: extensionArgumentNames);
+        // Issue #658: set up supplementary interface check for user-class args.
+        if (hasUserClassArg)
+        {
+            OverloadResolution.SupplementaryInterfaceCheck = (source, target) =>
+                IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target);
+        }
+
+        OverloadResolution.Result<MethodInfo> resolution;
+        try
+        {
+            resolution = OverloadResolution.Resolve(candidates, argTypes, explicitTypeArgs, scope.References.MapClrTypeToReferences, argumentNames: extensionArgumentNames);
+        }
+        finally
+        {
+            if (hasUserClassArg)
+            {
+                OverloadResolution.SupplementaryInterfaceCheck = null;
+            }
+        }
+
         switch (resolution.Outcome)
         {
             case OverloadResolution.ResolutionOutcome.Resolved:
@@ -1536,5 +1640,107 @@ internal sealed partial class ExpressionBinder
         }
 
         return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Issue #658: determines whether a user-defined G# class argument (identified
+    /// by its surrogate CLR type in <paramref name="argTypes"/>) implements the
+    /// specified CLR <paramref name="target"/> interface. Used as the
+    /// <see cref="OverloadResolution.SupplementaryInterfaceCheck"/> callback during
+    /// overload resolution for calls that include user-class arguments.
+    /// </summary>
+    private static bool IsUserClassAssignableToInterface(
+        ImmutableArray<BoundExpression>.Builder boundArguments,
+        System.Type[] argTypes,
+        System.Type source,
+        System.Type target)
+    {
+        for (var i = 0; i < boundArguments.Count; i++)
+        {
+            if (!ReferenceEquals(argTypes[i], source))
+            {
+                continue;
+            }
+
+            if (boundArguments[i].Type is StructSymbol { IsClass: true } ss)
+            {
+                if (UserClassImplementsInterface(ss, target))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #658: checks whether a user-defined G# class (or any of its base
+    /// classes) declares implementation of the specified CLR interface.
+    /// </summary>
+    private static bool UserClassImplementsInterface(StructSymbol ss, System.Type target)
+    {
+        for (var current = ss; current != null; current = current.BaseClass)
+        {
+            foreach (var iface in current.ImplementedClrInterfaces)
+            {
+                if (iface.ClrType == null)
+                {
+                    continue;
+                }
+
+                // Direct match: the implemented interface IS the target.
+                if (ClrTypeUtilities.AreSame(iface.ClrType, target))
+                {
+                    return true;
+                }
+
+                // The implemented interface itself inherits from the target.
+                if (ClrTypeUtilities.ImplementsInterfaceByName(iface.ClrType, target))
+                {
+                    return true;
+                }
+            }
+        }
+
+        // Also check the imported CLR base type (if any) — it may implement
+        // the target interface.
+        if (ss.ImportedBaseType?.ClrType != null
+            && ClrTypeUtilities.ImplementsInterfaceByName(ss.ImportedBaseType.ClrType, target))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #658: variant of <see cref="IsUserClassAssignableToInterface"/> that
+    /// works with <see cref="ImmutableArray{T}"/> arguments (used by instance
+    /// method call paths).
+    /// </summary>
+    private static bool IsUserClassAssignableToInterfaceFromArgs(
+        ImmutableArray<BoundExpression> boundArguments,
+        System.Type[] argTypes,
+        System.Type source,
+        System.Type target)
+    {
+        for (var i = 0; i < boundArguments.Length; i++)
+        {
+            if (!ReferenceEquals(argTypes[i], source))
+            {
+                continue;
+            }
+
+            if (boundArguments[i].Type is StructSymbol { IsClass: true } ss)
+            {
+                if (UserClassImplementsInterface(ss, target))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -612,6 +612,33 @@ internal sealed partial class ExpressionBinder
         return NullableTypeSymbol.GetEffectiveClrType(typeSymbol);
     }
 
+    /// <summary>
+    /// Issue #658: returns a CLR <see cref="Type"/> suitable for overload
+    /// resolution even for user-defined G# class types (whose
+    /// <see cref="TypeSymbol.ClrType"/> is null at bind time). For such types
+    /// the imported base type's CLR type is returned (or <c>typeof(object)</c>
+    /// if none). Regular types delegate to
+    /// <see cref="GetEffectiveArgumentClrType"/>.
+    /// </summary>
+    internal Type GetEffectiveArgumentClrTypeForOverloadResolution(TypeSymbol typeSymbol)
+    {
+        var clrType = GetEffectiveArgumentClrType(typeSymbol);
+        if (clrType != null)
+        {
+            return clrType;
+        }
+
+        // User-defined G# class: provide the imported base type's CLR type
+        // so that overload resolution can proceed (base-class assignability
+        // and the supplementary interface check handle the rest).
+        if (typeSymbol is StructSymbol { IsClass: true } ss)
+        {
+            return ss.ImportedBaseType?.ClrType ?? typeof(object);
+        }
+
+        return null;
+    }
+
     private bool TryBindClrMethodGroup(BoundExpression receiver, Type declaringType, bool wantStatic, string name, out BoundExpression methodGroup)
     {
         methodGroup = null;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -128,6 +128,22 @@ internal static class OverloadResolution
     public static Func<Type, Type, bool> UserDefinedImplicitConversionLookup { get; set; }
 
     /// <summary>
+    /// Issue #658: per-call supplementary interface check for user-defined G#
+    /// classes whose CLR type does not exist at bind time. When set (non-null),
+    /// <see cref="ClassifyImplicit"/> invokes this callback as a final
+    /// reference-conversion check before falling through to
+    /// <see cref="UserDefinedImplicitConversionLookup"/>. The binder sets this
+    /// before calling <see cref="Resolve{T}"/> for calls that include user-
+    /// class arguments and clears it immediately after.
+    /// </summary>
+    [ThreadStatic]
+#pragma warning disable SA1401 // Field should be private
+#pragma warning disable SA1201 // Elements should appear in the correct order
+    internal static Func<Type, Type, bool> SupplementaryInterfaceCheck;
+#pragma warning restore SA1201
+#pragma warning restore SA1401
+
+    /// <summary>
     /// Classifies the implicit conversion from <paramref name="source"/> to
     /// <paramref name="target"/>. Designed to work across reflection contexts
     /// (MetadataLoadContext vs. live runtime) by falling back to FullName
@@ -263,6 +279,17 @@ internal static class OverloadResolution
                     return ImplicitConversionKind.Reference;
                 }
             }
+        }
+
+        // Issue #658: supplementary interface check for user-defined G# classes.
+        // When the binder is resolving a call that includes a user-class argument
+        // whose CLR type is a surrogate (e.g. System.Object), the built-in checks
+        // above won't recognise that the user class implements the target interface.
+        // This callback lets the binder inject that knowledge.
+        var sic = SupplementaryInterfaceCheck;
+        if (sic != null && target.IsInterface && sic(source, target))
+        {
+            return ImplicitConversionKind.Reference;
         }
 
         var udi = UserDefinedImplicitConversionLookup;

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -163,6 +163,7 @@ public sealed class ImportedClassSymbol : Symbol
         }
 
         var argTypes = new Type[arguments.Length];
+        var hasUserClassArg = false;
         for (var i = 0; i < arguments.Length; i++)
         {
             // Issue #530: use effective CLR type so nullable value types
@@ -170,16 +171,44 @@ public sealed class ImportedClassSymbol : Symbol
             // Issue #533: allow null (nil literal) through; overload resolution
             // now classifies null source as compatible with reference types and
             // Nullable<T>.
+            // Issue #658: provide surrogate type for user-defined G# classes.
             var t = NullableTypeSymbol.GetEffectiveClrType(arguments[i].Type);
             if (t == null && arguments[i].Type != TypeSymbol.Null)
             {
-                return false;
+                if (arguments[i].Type is StructSymbol { IsClass: true } ss)
+                {
+                    t = ss.ImportedBaseType?.ClrType ?? typeof(object);
+                    hasUserClassArg = true;
+                }
+                else
+                {
+                    return false;
+                }
             }
 
             argTypes[i] = t;
         }
 
-        var result = OverloadResolution.Resolve(nameMatches, argTypes, explicitTypeArgs, projectTypeArgument, ComputeInterpolatedStringArgFlags(callExpression, arguments.Length), argumentNames);
+        // Issue #658: set up supplementary interface check for user-class args.
+        if (hasUserClassArg)
+        {
+            OverloadResolution.SupplementaryInterfaceCheck = (source, target) =>
+                IsUserClassAssignableToInterface(arguments, argTypes, source, target);
+        }
+
+        OverloadResolution.Result<MethodInfo> result;
+        try
+        {
+            result = OverloadResolution.Resolve(nameMatches, argTypes, explicitTypeArgs, projectTypeArgument, ComputeInterpolatedStringArgFlags(callExpression, arguments.Length), argumentNames);
+        }
+        finally
+        {
+            if (hasUserClassArg)
+            {
+                OverloadResolution.SupplementaryInterfaceCheck = null;
+            }
+        }
+
         switch (result.Outcome)
         {
             case OverloadResolution.ResolutionOutcome.Resolved:
@@ -264,5 +293,48 @@ public sealed class ImportedClassSymbol : Symbol
         }
 
         return flags;
+    }
+
+    /// <summary>
+    /// Issue #658: checks whether a user-defined G# class argument implements
+    /// the specified CLR target interface.
+    /// </summary>
+    private static bool IsUserClassAssignableToInterface(
+        ImmutableArray<BoundExpression> boundArguments,
+        Type[] argTypes,
+        Type source,
+        Type target)
+    {
+        for (var i = 0; i < boundArguments.Length; i++)
+        {
+            if (!ReferenceEquals(argTypes[i], source))
+            {
+                continue;
+            }
+
+            if (boundArguments[i].Type is StructSymbol { IsClass: true } ss)
+            {
+                for (var current = ss; current != null; current = current.BaseClass)
+                {
+                    foreach (var iface in current.ImplementedClrInterfaces)
+                    {
+                        if (iface.ClrType != null
+                            && (ClrTypeUtilities.AreSame(iface.ClrType, target)
+                                || ClrTypeUtilities.ImplementsInterfaceByName(iface.ClrType, target)))
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                if (ss.ImportedBaseType?.ClrType != null
+                    && ClrTypeUtilities.ImplementsInterfaceByName(ss.ImportedBaseType.ClrType, target))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/test/Compiler.Tests/Emit/Issue658CtorClrInterfaceParamEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue658CtorClrInterfaceParamEmitTests.cs
@@ -1,0 +1,403 @@
+// <copyright file="Issue658CtorClrInterfaceParamEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #658: a G# class implementing a CLR interface must be passable
+/// directly to a constructor or method parameter typed as that interface,
+/// without requiring an explicit upcast or interface-typed local. Covers the
+/// interaction with default-valued parameters (synthesized overload arity).
+/// </summary>
+public class Issue658CtorClrInterfaceParamEmitTests
+{
+    [Fact]
+    public void CtorWithInterfaceParam_MultiArg_CompilesAndRuns()
+    {
+        // Exact repro from issue body: JobScheduler(IExecutor, int = 3).
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IExecutor { void Run(); }
+                public sealed class JobScheduler
+                {
+                    private readonly IExecutor _executor;
+                    private readonly int _retries;
+                    public JobScheduler(IExecutor executor, int retries = 3)
+                    {
+                        _executor = executor;
+                        _retries = retries;
+                    }
+                    public void Execute()
+                    {
+                        System.Console.WriteLine("retries=" + _retries);
+                        _executor.Run();
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type ProbeExecutor class : IExecutor {
+                func Run() {
+                    Console.WriteLine("executed")
+                }
+            }
+
+            let e = ProbeExecutor{}
+            let s = JobScheduler(e, 5)
+            s.Execute()
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("retries=5\nexecuted\n", output);
+    }
+
+    [Fact]
+    public void CtorWithInterfaceParam_SingleArg_DefaultUsed()
+    {
+        // Single-argument call relying on default value.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IExecutor { void Run(); }
+                public sealed class JobScheduler
+                {
+                    private readonly int _retries;
+                    public JobScheduler(IExecutor executor, int retries = 3)
+                    {
+                        _retries = retries;
+                        executor.Run();
+                    }
+                    public int Retries => _retries;
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type ProbeExecutor class : IExecutor {
+                func Run() {
+                    Console.WriteLine("ran")
+                }
+            }
+
+            let e = ProbeExecutor{}
+            let s = JobScheduler(e)
+            Console.WriteLine(s.Retries)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("ran\n3\n", output);
+    }
+
+    [Fact]
+    public void WorkaroundExplicitTypeAnnotation_StillWorks()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IExecutor { void Run(); }
+                public sealed class JobScheduler
+                {
+                    public JobScheduler(IExecutor executor, int retries = 3)
+                    {
+                        executor.Run();
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type ProbeExecutor class : IExecutor {
+                func Run() {
+                    Console.WriteLine("annotated")
+                }
+            }
+
+            let exe IExecutor = ProbeExecutor{}
+            let s = JobScheduler(exe, 5)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("annotated\n", output);
+    }
+
+    [Fact]
+    public void WorkaroundAsExpression_StillWorks()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IExecutor { void Run(); }
+                public sealed class JobScheduler
+                {
+                    public JobScheduler(IExecutor executor, int retries = 3)
+                    {
+                        executor.Run();
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type ProbeExecutor class : IExecutor {
+                func Run() {
+                    Console.WriteLine("as-cast")
+                }
+            }
+
+            let exe = ProbeExecutor{} as IExecutor
+            let s = JobScheduler(exe, 5)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("as-cast\n", output);
+    }
+
+    [Fact]
+    public void MethodCallWithInterfaceParam_CompilesAndRuns()
+    {
+        // Verify the same fix applies to regular method calls (not just ctors).
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IExecutor { void Run(); }
+                public static class Runner
+                {
+                    public static void Launch(IExecutor executor, int times = 1)
+                    {
+                        for (int i = 0; i < times; i++)
+                            executor.Run();
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type ProbeExecutor class : IExecutor {
+                func Run() {
+                    Console.WriteLine("go")
+                }
+            }
+
+            let e = ProbeExecutor{}
+            Runner.Launch(e, 2)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("go\ngo\n", output);
+    }
+
+    [Fact]
+    public void MethodCallWithInterfaceParam_SingleArg_DefaultUsed()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public interface IExecutor { void Run(); }
+                public static class Runner
+                {
+                    public static void Launch(IExecutor executor, int times = 1)
+                    {
+                        for (int i = 0; i < times; i++)
+                            executor.Run();
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import System
+            import Probe.CSharp
+
+            type ProbeExecutor class : IExecutor {
+                func Run() {
+                    Console.WriteLine("single")
+                }
+            }
+
+            let e = ProbeExecutor{}
+            Runner.Launch(e)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("single\n", output);
+    }
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue658_sib_").FullName;
+        try
+        {
+            // Step 1: compile the sibling C# library.
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            // Step 2: compile the G# code referencing the sibling.
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            File.Copy(siblingDll, Path.Combine(tempDir, Path.GetFileName(siblingDll)), overwrite: true);
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { siblingDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string BuildCsProject(string csDir, string siblingName)
+    {
+        RunDotnet(csDir, "restore");
+        RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+        var dll = Path.Combine(csDir, "bin", "Release", "net10.0", siblingName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static void RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #658

## Root Cause

When a G# user-defined class (`StructSymbol` with `IsClass=true`) was passed as an argument to a CLR constructor or static method expecting an interface parameter, the binder's overload resolution skipped the call entirely. This happened because `GetEffectiveArgumentClrType` returned `null` for user-defined types (whose `ClrType` is only populated during emit), causing the `argsAllTyped` guard to bail out before `OverloadResolution.Resolve` was ever invoked.

The workaround (explicit type annotation, `as` cast, or type-function cast) worked because it gave the variable an interface-typed `TypeSymbol` with a valid `ClrType`, bypassing the issue at the call site.

## Fix

Three-pronged approach:

1. **`GetEffectiveArgumentClrTypeForOverloadResolution`** (new method on `ExpressionBinder`): returns the imported base type's CLR type (or `typeof(object)`) as a surrogate for user-defined G# classes, allowing overload resolution to proceed rather than bailing out.

2. **`OverloadResolution.SupplementaryInterfaceCheck`** (new `[ThreadStatic]` callback): invoked by `ClassifyImplicit` when the built-in interface checks fail for the surrogate type. The binder sets this before calling `Resolve()`; the callback walks the `StructSymbol`'s `ImplementedClrInterfaces` (and base class hierarchy) to confirm the user class satisfies the target interface parameter.

3. **Applied consistently** across all call paths: CLR constructors (`TryBindClrConstructorFromType`), imported class static methods (`ImportedClassSymbol.TryLookupFunction`), instance methods on CLR receivers, inherited CLR instance methods, and imported extension methods.

## Tests

6 new end-to-end emit tests in `Issue658CtorClrInterfaceParamEmitTests.cs`:
- Multi-arg ctor: `JobScheduler(ProbeExecutor{}, 5)`
- Single-arg ctor with default: `JobScheduler(ProbeExecutor{})`
- Workaround regressions: explicit type annotation, `as` cast
- Static method multi-arg: `Runner.Launch(ProbeExecutor{}, 2)`
- Static method single-arg with default: `Runner.Launch(ProbeExecutor{})`

All tests IL-verified via `IlVerifier.Verify`.

## Verification

```
dotnet build GSharp.sln -nologo -clp:NoSummary         # ✅ 0 errors
dotnet test test/Core.Tests/ --no-restore --nologo      # ✅ 2197 passed
dotnet test test/Compiler.Tests/ --no-restore --nologo  # ✅ 881 passed
dotnet test test/Interpreter.Tests/ --no-restore        # ✅ 98 passed
dotnet test test/LanguageServer.Tests/ --no-restore     # ✅ 242 passed
dotnet test test/Sdk.Tests/ --no-restore                # ✅ 26 passed
```

No deferred work.