### PR TITLE
Fix #660: nil-friendly @InlineData and clearer diagnostics for null/nil misuse

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -950,6 +950,7 @@ internal sealed class DeclarationBinder
                             "a method declaration",
                             System.AttributeTargets.Method);
                         methodSymbol.SetAttributes(methodAttributes);
+                        ValidateInlineDataNilArguments(methodAttributes, methodSymbol.Parameters);
                     }
 
                     // ADR-0063 §11: detect duplicate-signature within the class.
@@ -1461,6 +1462,7 @@ internal sealed class DeclarationBinder
                             "a method declaration",
                             System.AttributeTargets.Method);
                         methodSymbol.SetAttributes(methodAttributes);
+                        ValidateInlineDataNilArguments(methodAttributes, methodSymbol.Parameters);
                     }
 
                     Binder.AttachDocumentation(methodSymbol, methodSyntax);
@@ -2575,6 +2577,7 @@ internal sealed class DeclarationBinder
                 function.ReturnRefKind = returnRefKind;
                 Binder.AttachDocumentation(function, syntax);
                 function.SetAttributes(functionAttributes);
+                ValidateInlineDataNilArguments(functionAttributes, function.Parameters);
 
                 // ADR-0063 §11: detect duplicate-signature against existing methods on the receiver.
                 foreach (var existingMethod in methodReceiverStruct.Methods)
@@ -2599,6 +2602,7 @@ internal sealed class DeclarationBinder
             function.ReturnRefKind = returnRefKind;
             Binder.AttachDocumentation(function, syntax);
             function.SetAttributes(functionAttributes);
+            ValidateInlineDataNilArguments(functionAttributes, function.Parameters);
 
             if (syntax.IsExtension)
             {
@@ -3881,6 +3885,61 @@ internal sealed class DeclarationBinder
         value = result;
         type = bound.Type;
         return true;
+    }
+
+    /// <summary>
+    /// Issue #660: for test-data attributes like xUnit's <c>@InlineData</c>,
+    /// cross-validates nil (null) positional arguments against the owning
+    /// method's parameter types. If a nil is supplied for a non-nullable
+    /// parameter, reports GS0274.
+    /// </summary>
+    internal void ValidateInlineDataNilArguments(
+        ImmutableArray<BoundAttribute> attributes,
+        ImmutableArray<ParameterSymbol> parameters)
+    {
+        foreach (var attr in attributes)
+        {
+            if (attr == null)
+            {
+                continue;
+            }
+
+            // Match the InlineDataAttribute by CLR type name (handles any xunit version).
+            var clrType = attr.AttributeType?.ClrType;
+            if (clrType == null || !clrType.FullName.EndsWith("InlineDataAttribute", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var positional = attr.PositionalArguments;
+            var annotation = attr.Syntax;
+            if (annotation == null || positional.IsDefaultOrEmpty || parameters.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            // InlineData's positional arguments are expanded into the params
+            // object[] — each positional arg[i] corresponds to method parameter[i].
+            var argExpressions = annotation.Arguments;
+            for (int i = 0; i < positional.Length && i < parameters.Length; i++)
+            {
+                if (positional[i].Value == null && positional[i].Type == TypeSymbol.Null)
+                {
+                    var paramType = parameters[i].Type;
+                    if (paramType != null && !(paramType is NullableTypeSymbol))
+                    {
+                        // Get the source location of the nil literal in the argument list.
+                        var argLocation = i < argExpressions.Count
+                            ? argExpressions[i].Location
+                            : annotation.Location;
+                        Diagnostics.ReportNilNotAssignableToNonNullableParameter(
+                            argLocation,
+                            parameters[i].Name,
+                            paramType.Name);
+                    }
+                }
+            }
+        }
     }
 
     private static object CoerceAttributeElement(object value, Type elementType)

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -381,6 +381,14 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     /// <param name="name">The name of the variable.</param>
     public void ReportUndefinedVariable(TextLocation location, string name)
     {
+        // Issue #660: when the user writes 'null' (C# spelling), produce a
+        // targeted diagnostic suggesting 'nil' instead of the generic GS0125.
+        if (name == "null")
+        {
+            ReportUseNilInsteadOfNull(location);
+            return;
+        }
+
         var message = $"Variable '{name}' doesn't exist.";
         Report(location, "GS0125", message);
     }
@@ -2156,6 +2164,31 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     public void ReportTypeNotAsyncDisposable(TextLocation location, TypeSymbol type)
     {
         Report(location, "GS0272", $"Type '{type.Name}' cannot be used in an 'await using' statement because it does not provide a public DisposeAsync() method returning ValueTask.");
+    }
+
+    /// <summary>
+    /// Reports that the identifier <c>null</c> was used where the G# null
+    /// literal <c>nil</c> is required. G# does not recognise <c>null</c> as
+    /// a keyword — the correct spelling is <c>nil</c>.
+    /// </summary>
+    /// <param name="location">The source location of the <c>null</c> identifier.</param>
+    public void ReportUseNilInsteadOfNull(TextLocation location)
+    {
+        Report(location, "GS0273", "G# spells the null literal as 'nil'; 'null' is not a recognised keyword.");
+    }
+
+    /// <summary>
+    /// Reports that <c>nil</c> was supplied as an attribute argument for a
+    /// parameter whose type is not nullable. The user should make the
+    /// corresponding parameter nullable (e.g. <c>string?</c> instead of
+    /// <c>string</c>).
+    /// </summary>
+    /// <param name="location">The source location of the <c>nil</c> literal.</param>
+    /// <param name="parameterName">The name of the target method parameter.</param>
+    /// <param name="typeName">The non-nullable type name.</param>
+    public void ReportNilNotAssignableToNonNullableParameter(TextLocation location, string parameterName, string typeName)
+    {
+        Report(location, "GS0274", $"'nil' cannot be assigned to parameter '{parameterName}' of non-nullable type '{typeName}'; consider changing the parameter type to '{typeName}?'.");
     }
 
     private static string FormatMissingNames(IEnumerable<string> missingNames)

--- a/test/Compiler.Tests/Emit/Issue660InlineDataNilEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue660InlineDataNilEmitTests.cs
@@ -1,0 +1,177 @@
+// <copyright file="Issue660InlineDataNilEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #660: verifies that <c>nil</c> in <c>@InlineData</c> compiles
+/// correctly when the corresponding method parameter is a nullable
+/// reference type, and that the attribute blob contains the expected
+/// null reference.
+/// </summary>
+public class Issue660InlineDataNilEmitTests
+{
+    [Fact]
+    public void NilInInlineData_WithNullableParam_Compiles_And_EmitsNull()
+    {
+        // Case 1: @InlineData(nil, ...) with string? parameter → success
+        var source = """
+            package Probe.Tests
+            import Xunit
+
+            type Tests class {
+                @Theory
+                @InlineData(nil, "abc", false)
+                @InlineData("abc", "abc", true)
+                func Equal_Compare(a string?, b string, expected bool) {
+                    Assert.Equal(expected, a == b)
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var testsType = assembly.GetTypes().Single(t => t.Name == "Tests");
+        var method = testsType.GetMethod("Equal_Compare", BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        // Verify InlineData attributes are emitted
+        var inlineDataAttrs = method.GetCustomAttributesData()
+            .Where(d => d.AttributeType.Name == "InlineDataAttribute")
+            .ToList();
+        Assert.Equal(2, inlineDataAttrs.Count);
+
+        // The first InlineData should have null as first element in the object[] blob
+        var firstArgs = inlineDataAttrs[0].ConstructorArguments;
+        Assert.Single(firstArgs);
+        var firstArray = firstArgs[0].Value as System.Collections.ObjectModel.ReadOnlyCollection<CustomAttributeTypedArgument>;
+        Assert.NotNull(firstArray);
+        Assert.Equal(3, firstArray.Count);
+        Assert.Null(firstArray[0].Value); // nil → null in the blob
+        Assert.Equal("abc", firstArray[1].Value);
+    }
+
+    [Fact]
+    public void NilInInlineData_WithNonNullableParam_Reports_GS0274()
+    {
+        // Case 2: @InlineData(nil, ...) with non-nullable string → GS0274
+        var source = """
+            package Probe.Tests
+            import Xunit
+
+            type Tests class {
+                @Theory
+                @InlineData(nil, "abc", false)
+                func Equal_Compare(a string, b string, expected bool) {
+                    Assert.Equal(expected, a == b)
+                }
+            }
+            """;
+
+        var (exitCode, stdout, stderr) = CompileRaw(source);
+        var output = stdout + stderr;
+        Assert.Contains("GS0274", output);
+        Assert.Contains("nil", output);
+        Assert.Contains("string?", output);
+    }
+
+    [Fact]
+    public void NullIdentifier_InInlineData_Reports_GS0273()
+    {
+        // Case 3: @InlineData(null, ...) → GS0273 suggesting nil
+        var source = """
+            package Probe.Tests
+            import Xunit
+
+            type Tests class {
+                @Theory
+                @InlineData(null, "abc", false)
+                func Equal_Compare(a string?, b string, expected bool) {
+                    Assert.Equal(expected, a == b)
+                }
+            }
+            """;
+
+        var (exitCode, stdout, stderr) = CompileRaw(source);
+        var output = stdout + stderr;
+        Assert.Contains("GS0273", output);
+        Assert.Contains("nil", output);
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue660_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue660_diag_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        return (compileExit, compileOut.ToString(), compileErr.ToString());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue660NilAttributeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue660NilAttributeTests.cs
@@ -1,0 +1,93 @@
+// <copyright file="Issue660NilAttributeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #660: tests for nil/null behaviour in attribute arguments.
+/// </summary>
+public class Issue660NilAttributeTests
+{
+    [Fact]
+    public void Nil_In_Obsolete_Attribute_Succeeds()
+    {
+        // nil as a string argument to @Obsolete should work since string accepts null.
+        var source = """
+            import System
+
+            @Obsolete(nil)
+            func Helper() {
+            }
+            """;
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        Assert.Empty(globalScope.Diagnostics);
+    }
+
+    [Fact]
+    public void Null_Identifier_Reports_GS0273_Instead_Of_GS0125()
+    {
+        // Using C# spelling 'null' should produce GS0273 (friendly "use nil" message)
+        // instead of the generic GS0125 "Variable 'null' doesn't exist".
+        var source = """
+            import System
+
+            @Obsolete(null)
+            func Helper() {
+            }
+            """;
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        var diags = globalScope.Diagnostics.ToList();
+        Assert.Contains(diags, d => d.Id == "GS0273");
+        Assert.DoesNotContain(diags, d => d.Id == "GS0125");
+    }
+
+    [Fact]
+    public void Null_Identifier_Message_Suggests_Nil()
+    {
+        var source = """
+            import System
+
+            @Obsolete(null)
+            func Helper() {
+            }
+            """;
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        var diag = globalScope.Diagnostics.First(d => d.Id == "GS0273");
+        Assert.Contains("nil", diag.Message);
+    }
+
+    [Fact]
+    public void Nil_In_Attribute_ParamsArray_Succeeds()
+    {
+        // nil in a params string[] attribute arg (like @MemberNotNull)
+        var source = """
+            import System.Diagnostics.CodeAnalysis
+
+            type Box class {
+                @MemberNotNull(nil)
+                func Setup() {
+                }
+            }
+            """;
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        Assert.Empty(globalScope.Diagnostics);
+    }
+
+    private static BoundGlobalScope BindSource(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+}


### PR DESCRIPTION
Fixes #660

## Root cause

1. `nil` in attribute arguments already compiled correctly (the literal-expression path in `TryBindAttributeArgument` binds `nil` to a null value with `TypeSymbol.Null`). However, there was no cross-validation against the method's parameter types for `@InlineData`-style attributes, so `nil` on a non-nullable parameter silently compiled and would only fail at xunit runtime.

2. `null` (the C# keyword) is not a G# keyword — it gets parsed as a `NameExpressionSyntax`, leading to the unhelpful `GS0125: Variable 'null' doesn't exist` diagnostic.

## Fixed cases

| Scenario | Before | After |
|----------|--------|-------|
| `@InlineData(nil, ...)` with `string?` param | ✅ (already worked) | ✅ Compiles, emits null in attribute blob |
| `@InlineData(nil, ...)` with `string` param | Silent (runtime xunit failure) | **GS0274**: 'nil' cannot be assigned to parameter 'a' of non-nullable type 'string'; consider changing the parameter type to 'string?' |
| `@InlineData(null, ...)` | GS0125 + GS0202 (confusing) | **GS0273**: G# spells the null literal as 'nil'; 'null' is not a recognised keyword |

## Changes

- **`DiagnosticBag.cs`**: Added `GS0273` (use `nil` instead of `null`) and `GS0274` (nil not assignable to non-nullable parameter). `ReportUndefinedVariable` now intercepts the name `"null"` and emits GS0273 instead of GS0125.
- **`DeclarationBinder.cs`**: Added `ValidateInlineDataNilArguments` which cross-validates InlineData positional args against method parameter nullability. Called from all 4 method/function attribute-binding sites.

## New tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue660NilAttributeTests.cs` — 4 binding-level tests
- `test/Compiler.Tests/Emit/Issue660InlineDataNilEmitTests.cs` — 3 end-to-end emit tests (compile + attribute blob verification + diagnostic checks)

## Verification

```
dotnet build GSharp.sln       # 0 errors, 0 warnings
dotnet test Core.Tests        # 2201 passed
dotnet test Interpreter.Tests # 98 passed
dotnet test LanguageServer.Tests # 242 passed
dotnet test Compiler.Tests --filter Emit     # 761 passed (includes new tests)
dotnet test Compiler.Tests --filter Program  # 42 passed
dotnet test Compiler.Tests --filter Async    # 51 passed
dotnet test Compiler.Tests --filter Acceptance # 4 passed
```