### PR TITLE
Fix #662: warn when calling GetAwaiter().GetResult() directly on ValueTask

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -878,7 +878,9 @@ internal sealed partial class ExpressionBinder
                 return BindAccessorStep(head, null, nested.RightPart);
 
             case CallExpressionSyntax ce:
-                return BindAccessorCall(receiver, classSymbol, ce);
+                var callResult = BindAccessorCall(receiver, classSymbol, ce);
+                CheckValueTaskGetAwaiterGetResult(callResult, ce);
+                return callResult;
 
             // Issue #569: an object-initializer suffix on a nested-type
             // constructor (`Outer.Inner() { Prop = val }`) parses as
@@ -1563,5 +1565,57 @@ internal sealed partial class ExpressionBinder
             SliceTypeSymbol slice => slice.ElementType,
             _ => null,
         };
+    }
+
+    /// <summary>
+    /// Issue #662: detect the pattern <c>valueTask.GetAwaiter().GetResult()</c> and
+    /// emit warning GS0275. The pattern is unsafe due to ValueTask's single-await
+    /// semantics. The safe form is <c>valueTask.AsTask().GetAwaiter().GetResult()</c>.
+    /// </summary>
+    private void CheckValueTaskGetAwaiterGetResult(BoundExpression boundCall, CallExpressionSyntax callSyntax)
+    {
+        // The outermost call must be GetResult() with 0 args on a CLR instance.
+        if (boundCall is not BoundImportedInstanceCallExpression getResultCall)
+        {
+            return;
+        }
+
+        if (getResultCall.Method.Name != "GetResult" || getResultCall.Arguments.Length != 0)
+        {
+            return;
+        }
+
+        // Its receiver must be a CLR instance call to GetAwaiter() with 0 args.
+        if (getResultCall.Receiver is not BoundImportedInstanceCallExpression getAwaiterCall)
+        {
+            return;
+        }
+
+        if (getAwaiterCall.Method.Name != "GetAwaiter" || getAwaiterCall.Arguments.Length != 0)
+        {
+            return;
+        }
+
+        // The receiver of GetAwaiter() must have a ValueTask or ValueTask<T> type.
+        var awaiterReceiverType = getAwaiterCall.Receiver?.Type?.ClrType;
+        if (awaiterReceiverType == null)
+        {
+            return;
+        }
+
+        string fullName;
+        if (awaiterReceiverType.IsGenericType && !awaiterReceiverType.IsGenericTypeDefinition)
+        {
+            fullName = awaiterReceiverType.GetGenericTypeDefinition()?.FullName;
+        }
+        else
+        {
+            fullName = awaiterReceiverType.FullName;
+        }
+
+        if (fullName == "System.Threading.Tasks.ValueTask" || fullName == "System.Threading.Tasks.ValueTask`1")
+        {
+            Diagnostics.ReportValueTaskDirectGetResult(callSyntax.Identifier.Location);
+        }
     }
 }

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -2191,6 +2191,20 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0274", $"'nil' cannot be assigned to parameter '{parameterName}' of non-nullable type '{typeName}'; consider changing the parameter type to '{typeName}?'.");
     }
 
+    /// <summary>
+    /// GS0275: Calling <c>.GetAwaiter().GetResult()</c> directly on a <c>ValueTask</c>/<c>ValueTask&lt;T&gt;</c>
+    /// is unsafe due to its single-await semantics.
+    /// </summary>
+    /// <param name="location">The source location of the <c>.GetResult()</c> call.</param>
+    public void ReportValueTaskDirectGetResult(TextLocation location)
+    {
+        Report(
+            location,
+            "GS0275",
+            "Calling '.GetAwaiter().GetResult()' directly on a ValueTask/ValueTask<T> is unsafe due to its single-await semantics. Convert to Task first via '.AsTask()' (e.g. 'v.AsTask().GetAwaiter().GetResult()').",
+            DiagnosticSeverity.Warning);
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/test/Compiler.Tests/Emit/Issue662ValueTaskGetResultWarningEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue662ValueTaskGetResultWarningEmitTests.cs
@@ -1,0 +1,234 @@
+// <copyright file="Issue662ValueTaskGetResultWarningEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #662: end-to-end emit test asserting that the compiler produces
+/// warning GS0275 when <c>.GetAwaiter().GetResult()</c> is called directly
+/// on a <c>ValueTask</c>/<c>ValueTask&lt;T&gt;</c>.
+/// </summary>
+public class Issue662ValueTaskGetResultWarningEmitTests
+{
+    [Fact]
+    public void Compiler_Emits_GS0275_Warning_For_ValueTask_GetResult()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            let vt = ValueTask[bool](true)
+            let r = vt.GetAwaiter().GetResult()
+            Console.WriteLine(r)
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(exitCode == 0, $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        Assert.Equal("True\n", stdout);
+    }
+
+    [Fact]
+    public void Compiler_Output_Contains_GS0275_Warning_Text()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            let vt = ValueTask[bool](true)
+            let r = vt.GetAwaiter().GetResult()
+            Console.WriteLine(r)
+            """;
+
+        var compilerOutput = CompileOnly(source);
+        Assert.Contains("GS0275", compilerOutput);
+        Assert.Contains("warning", compilerOutput);
+        Assert.Contains("AsTask", compilerOutput);
+    }
+
+    [Fact]
+    public void Compiler_Does_Not_Emit_GS0275_For_AsTask_Pattern()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            let vt = ValueTask[bool](true)
+            let r = vt.AsTask().GetAwaiter().GetResult()
+            Console.WriteLine(r)
+            """;
+
+        var compilerOutput = CompileOnly(source);
+        Assert.DoesNotContain("GS0275", compilerOutput);
+    }
+
+    [Fact]
+    public void Compiler_Does_Not_Emit_GS0275_For_Task_GetResult()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            let t = Task.FromResult(42)
+            let r = t.GetAwaiter().GetResult()
+            Console.WriteLine(r)
+            """;
+
+        var compilerOutput = CompileOnly(source);
+        Assert.DoesNotContain("GS0275", compilerOutput);
+    }
+
+    /// <summary>
+    /// Compiles and runs the given source; returns exit code + output.
+    /// </summary>
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_662_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = BuildCompilerArgs(outPath, srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            // GS0275 is a warning, so compilation should succeed.
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Compiles only (no run), captures compiler stdout which includes diagnostics.
+    /// </summary>
+    private static string CompileOnly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_662c_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = BuildCompilerArgs(outPath, srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            try
+            {
+                Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            return compileOut.ToString();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static List<string> BuildCompilerArgs(string outPath, string srcPath)
+    {
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+
+        foreach (var bcl in BclReferences.Value)
+        {
+            args.Add("/r:" + bcl);
+        }
+
+        args.Add(srcPath);
+        return args;
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue662ValueTaskGetResultWarningTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue662ValueTaskGetResultWarningTests.cs
@@ -1,0 +1,142 @@
+// <copyright file="Issue662ValueTaskGetResultWarningTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #662: warn when calling .GetAwaiter().GetResult() directly on a
+/// ValueTask or ValueTask&lt;T&gt;.
+/// </summary>
+public class Issue662ValueTaskGetResultWarningTests
+{
+    [Fact]
+    public void GetAwaiter_GetResult_On_ValueTask_Of_Bool_Warns_GS0275()
+    {
+        var source = """
+            import System.Threading.Tasks
+
+            let vt = ValueTask[bool](true)
+            let r = vt.GetAwaiter().GetResult()
+            """;
+
+        var diags = BindAndGetDiagnostics(source);
+        Assert.Contains(diags, d => d.Id == "GS0275");
+    }
+
+    [Fact]
+    public void GetAwaiter_GetResult_On_NonGeneric_ValueTask_Warns_GS0275()
+    {
+        var source = """
+            import System.Threading.Tasks
+
+            let vt = ValueTask(Task.CompletedTask)
+            vt.GetAwaiter().GetResult()
+            """;
+
+        var diags = BindAndGetDiagnostics(source);
+        Assert.Contains(diags, d => d.Id == "GS0275");
+    }
+
+    [Fact]
+    public void AsTask_GetAwaiter_GetResult_On_ValueTask_Does_Not_Warn()
+    {
+        var source = """
+            import System.Threading.Tasks
+
+            let vt = ValueTask[bool](true)
+            let r = vt.AsTask().GetAwaiter().GetResult()
+            """;
+
+        var diags = BindAndGetDiagnostics(source);
+        Assert.DoesNotContain(diags, d => d.Id == "GS0275");
+    }
+
+    [Fact]
+    public void GetAwaiter_GetResult_On_Task_Of_T_Does_Not_Warn()
+    {
+        var source = """
+            import System.Threading.Tasks
+
+            let t = Task.FromResult(42)
+            let r = t.GetAwaiter().GetResult()
+            """;
+
+        var diags = BindAndGetDiagnostics(source);
+        Assert.DoesNotContain(diags, d => d.Id == "GS0275");
+    }
+
+    [Fact]
+    public void GetAwaiter_GetResult_On_Task_Does_Not_Warn()
+    {
+        var source = """
+            import System.Threading.Tasks
+
+            let t = Task.CompletedTask
+            t.GetAwaiter().GetResult()
+            """;
+
+        var diags = BindAndGetDiagnostics(source);
+        Assert.DoesNotContain(diags, d => d.Id == "GS0275");
+    }
+
+    [Fact]
+    public void ValueTask_Captured_In_Local_Then_GetAwaiter_GetResult_Warns()
+    {
+        var source = """
+            import System.Threading.Tasks
+
+            let vt ValueTask[bool] = ValueTask[bool](true)
+            let r = vt.GetAwaiter().GetResult()
+            """;
+
+        var diags = BindAndGetDiagnostics(source);
+        Assert.Contains(diags, d => d.Id == "GS0275");
+    }
+
+    [Fact]
+    public void Await_On_ValueTask_Does_Not_Warn()
+    {
+        var source = """
+            import System.Threading.Tasks
+
+            async func doWork() bool {
+                let vt = ValueTask[bool](true)
+                let r = await vt
+                return r
+            }
+            """;
+
+        var diags = BindAndGetDiagnostics(source);
+        Assert.DoesNotContain(diags, d => d.Id == "GS0275");
+    }
+
+    [Fact]
+    public void Warning_Message_Mentions_AsTask()
+    {
+        var source = """
+            import System.Threading.Tasks
+
+            let vt = ValueTask[bool](true)
+            let r = vt.GetAwaiter().GetResult()
+            """;
+
+        var diags = BindAndGetDiagnostics(source);
+        var warning = diags.First(d => d.Id == "GS0275");
+        Assert.Contains("AsTask", warning.Message);
+    }
+
+    private static System.Collections.Generic.List<GSharp.Core.CodeAnalysis.Diagnostic> BindAndGetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        return globalScope.Diagnostics.ToList();
+    }
+}


### PR DESCRIPTION
Fixes #662

## Root Cause

Calling `.GetAwaiter().GetResult()` directly on a `ValueTask` or `ValueTask<T>` violates the single-await contract: a `ValueTask` may only be awaited/consumed once, and the runtime enforces this by intermittently throwing `InvalidOperationException`. The safe pattern is `.AsTask().GetAwaiter().GetResult()`, which converts to a `Task` first.

G# had no diagnostic for this dangerous pattern, so users writing the equivalent of C#'s generated code by hand could hit runtime failures silently.

## Fix

Added **warning GS0275** that fires when the binder sees the pattern:

```
<expr of type ValueTask or ValueTask<T>>.GetAwaiter().GetResult()
```

The detection is:
- Receiver of `GetResult()` is a CLR instance call to `GetAwaiter()` (arity 0)
- Receiver of that `GetAwaiter()` has CLR type `System.Threading.Tasks.ValueTask` or `System.Threading.Tasks.ValueTask`1`
- Does **not** fire for the safe `.AsTask().GetAwaiter().GetResult()` pattern (since `.AsTask()` returns a `Task`/`Task<T>`)

Message:
> Calling '.GetAwaiter().GetResult()' directly on a ValueTask/ValueTask<T> is unsafe due to its single-await semantics. Convert to Task first via '.AsTask()' (e.g. 'v.AsTask().GetAwaiter().GetResult()').

## New Tests

### Binder tests (`test/Core.Tests/CodeAnalysis/Binding/Issue662ValueTaskGetResultWarningTests.cs`)
- `GetAwaiter_GetResult_On_ValueTask_Of_Bool_Warns_GS0275` — fires on `ValueTask<bool>`
- `GetAwaiter_GetResult_On_NonGeneric_ValueTask_Warns_GS0275` — fires on `ValueTask`
- `AsTask_GetAwaiter_GetResult_On_ValueTask_Does_Not_Warn` — safe pattern silent
- `GetAwaiter_GetResult_On_Task_Of_T_Does_Not_Warn` — `Task<T>` is safe
- `GetAwaiter_GetResult_On_Task_Does_Not_Warn` — `Task` is safe
- `ValueTask_Captured_In_Local_Then_GetAwaiter_GetResult_Warns` — fires through local
- `Await_On_ValueTask_Does_Not_Warn` — `await` is fine
- `Warning_Message_Mentions_AsTask` — message quality check

### Emit tests (`test/Compiler.Tests/Emit/Issue662ValueTaskGetResultWarningEmitTests.cs`)
- `Compiler_Emits_GS0275_Warning_For_ValueTask_GetResult` — compiles, runs, produces correct output
- `Compiler_Output_Contains_GS0275_Warning_Text` — warning text in compiler stdout
- `Compiler_Does_Not_Emit_GS0275_For_AsTask_Pattern` — no false positive
- `Compiler_Does_Not_Emit_GS0275_For_Task_GetResult` — no false positive on Task

## Verification

```bash
dotnet build GSharp.sln -nologo -clp:NoSummary  # 0 warnings, 0 errors
dotnet test GSharp.sln --no-restore --nologo     # All pass (3487 total, 1 pre-existing skip)
```

IL verification clean via the existing `IlVerifier.Verify` harness (called in emit tests).