### PR TITLE
Fix #663: user-defined CLR conversion operators + nullable type in type-fn cast

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -1749,6 +1749,14 @@ internal sealed class OverloadResolver
 
         if (syntax.Arguments.Count == 1 && lookupType(syntax.Identifier.Text) is TypeSymbol type)
         {
+            // Issue #663: when the call carries a `?` token (e.g. `string?(x)`),
+            // wrap the resolved type in NullableTypeSymbol so the conversion
+            // targets the nullable form.
+            if (syntax.NullableQuestionToken != null)
+            {
+                type = NullableTypeSymbol.Get(type);
+            }
+
             // A single-arg call to a primitive-typed name is a conversion
             // (`int(x)`, `string(x)`). Defer to BindConversion. For a class
             // or inline-struct type, treat it as a ctor call instead — even

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -259,6 +259,17 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #663: fall back to user-defined op_Implicit / op_Explicit when
+        // no built-in emit path fires. This covers types like JsonNode that
+        // expose conversion operators to string, int, bool, etc.
+        if (from?.ClrType != null && to?.ClrType != null
+            && ClrOperatorResolution.TryResolveConversion(from.ClrType, to.ClrType, allowExplicit: true, out var userConvMethod, out _))
+        {
+            this.il.OpCode(ILOpCode.Call);
+            this.il.Token(this.outer.GetMethodReference(userConvMethod));
+            return;
+        }
+
         throw new NotSupportedException(
             $"Conversion from '{from.Name}' to '{to.Name}' is not yet supported by the emitter.");
     }
@@ -632,6 +643,39 @@ internal sealed partial class MethodBodyEmitter
         this.il.OpCode(ILOpCode.Call);
         this.il.Token(this.outer.GetMethodReference(conv.Method));
         this.EmitErasedObjectReturnWidening(TypeSymbol.FromClrType(conv.Method.ReturnType), conv.Type);
+
+        // Issue #663: when the operator returns a non-nullable value type T but the
+        // target type is Nullable<T> (e.g. op_Explicit(JsonNode) → int, target int32?),
+        // lift the result into Nullable<T> via newobj.
+        if (conv.Type is NullableTypeSymbol targetNullable
+            && ReflectionMetadataEmitter.IsValueTypeNullable(targetNullable)
+            && conv.Method.ReturnType.IsValueType
+            && !IsNullableValueType(conv.Method.ReturnType))
+        {
+            var innerClr = targetNullable.UnderlyingType.ClrType
+                ?? throw new InvalidOperationException(
+                    $"Nullable<{targetNullable.UnderlyingType.Name}> lift has no CLR underlying type.");
+
+            if (!NullableLifting.TryConstructNullable(this.outer.emitCtx.References, innerClr, out var nullableClr))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot construct Nullable<{innerClr.FullName}>: System.Nullable`1 is not resolvable in the reference set.");
+            }
+
+            var nullableInnerArg = nullableClr.GetGenericArguments()[0];
+            var ctor = nullableClr.GetConstructor(new[] { nullableInnerArg })
+                ?? throw new InvalidOperationException(
+                    $"Nullable<{nullableInnerArg.FullName}> has no single-arg constructor.");
+            this.il.OpCode(ILOpCode.Newobj);
+            this.il.Token(this.outer.GetCtorReference(ctor));
+        }
+    }
+
+    private static bool IsNullableValueType(Type t)
+    {
+        return t.IsGenericType
+            && !t.IsGenericTypeDefinition
+            && string.Equals(t.GetGenericTypeDefinition().FullName, "System.Nullable`1", StringComparison.Ordinal);
     }
 
     private void EmitZeroInit(int slot, TypeSymbol gsharpType, Type clrType)

--- a/src/Core/CodeAnalysis/Syntax/CallExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/CallExpressionSyntax.cs
@@ -41,9 +41,31 @@ public sealed class CallExpressionSyntax : ExpressionSyntax
         SyntaxToken openParenthesisToken,
         SeparatedSyntaxList<ExpressionSyntax> arguments,
         SyntaxToken closeParenthesisToken)
+        : this(syntaxTree, identifier, nullableQuestionToken: null, typeArgumentList, openParenthesisToken, arguments, closeParenthesisToken)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="CallExpressionSyntax"/> class with nullable type-conversion call support (issue #663).</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="identifier">The identifier.</param>
+    /// <param name="nullableQuestionToken">Optional <c>?</c> token indicating the type-conversion
+    /// targets the nullable form of the type (e.g. <c>string?(x)</c>).</param>
+    /// <param name="typeArgumentList">Optional explicit type-argument list.</param>
+    /// <param name="openParenthesisToken">The open parenthesis token.</param>
+    /// <param name="arguments">The arguments.</param>
+    /// <param name="closeParenthesisToken">The close parenthesis token.</param>
+    public CallExpressionSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken identifier,
+        SyntaxToken nullableQuestionToken,
+        TypeArgumentListSyntax typeArgumentList,
+        SyntaxToken openParenthesisToken,
+        SeparatedSyntaxList<ExpressionSyntax> arguments,
+        SyntaxToken closeParenthesisToken)
         : base(syntaxTree)
     {
         Identifier = identifier;
+        NullableQuestionToken = nullableQuestionToken;
         TypeArgumentList = typeArgumentList;
         OpenParenthesisToken = openParenthesisToken;
         Arguments = arguments;
@@ -57,6 +79,11 @@ public sealed class CallExpressionSyntax : ExpressionSyntax
     /// Gets the identifier.
     /// </summary>
     public SyntaxToken Identifier { get; }
+
+    /// <summary>Gets the optional <c>?</c> token following the identifier, indicating
+    /// this is a nullable-type conversion call (e.g. <c>string?(x)</c>). <c>null</c>
+    /// when the call does not use the nullable form (issue #663).</summary>
+    public SyntaxToken NullableQuestionToken { get; }
 
     /// <summary>Gets the optional explicit type-argument list <c>[T1, T2]</c> attached to this call site (Phase 4.1 / ADR-0020); <c>null</c> when the call has no explicit type arguments.</summary>
     public TypeArgumentListSyntax TypeArgumentList { get; }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -4054,6 +4054,13 @@ public class Parser
             current = MaybeWrapWithObjectInitializer(current);
         }
         else if (Current.Kind == SyntaxKind.IdentifierToken
+            && Peek(1).Kind == SyntaxKind.QuestionToken
+            && Peek(2).Kind == SyntaxKind.OpenParenthesisToken)
+        {
+            // Issue #663: `string?(expr)` — nullable-type conversion call.
+            current = ParseNullableTypeCallExpression();
+        }
+        else if (Current.Kind == SyntaxKind.IdentifierToken
             && Peek(1).Kind == SyntaxKind.OpenSquareBracketToken
             && LooksLikeGenericCallSite(1))
         {
@@ -4240,6 +4247,21 @@ public class Parser
         var closeParenthesisToken = MatchToken(SyntaxKind.CloseParenthesisToken);
         arguments = MaybeAppendTrailingLambda(arguments);
         return new CallExpressionSyntax(syntaxTree, identifier, openParenthesisToken, arguments, closeParenthesisToken);
+    }
+
+    // Issue #663: `string?(expr)` — nullable-type conversion call form.
+    // Consumes `Identifier ? ( args )` and builds a CallExpressionSyntax
+    // carrying the `?` token so the binder can wrap the resolved type in
+    // NullableTypeSymbol.
+    private ExpressionSyntax ParseNullableTypeCallExpression()
+    {
+        var identifier = MatchToken(SyntaxKind.IdentifierToken);
+        var questionToken = MatchToken(SyntaxKind.QuestionToken);
+        var openParenthesisToken = MatchToken(SyntaxKind.OpenParenthesisToken);
+        var arguments = ParseArguments();
+        var closeParenthesisToken = MatchToken(SyntaxKind.CloseParenthesisToken);
+        arguments = MaybeAppendTrailingLambda(arguments);
+        return new CallExpressionSyntax(syntaxTree, identifier, questionToken, typeArgumentList: null, openParenthesisToken, arguments, closeParenthesisToken);
     }
 
     // Issue #522: when the token following a constructor call's `)` is `{`

--- a/test/Compiler.Tests/Emit/Issue663UserDefinedConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue663UserDefinedConversionEmitTests.cs
@@ -1,0 +1,247 @@
+// <copyright file="Issue663UserDefinedConversionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #663: user-defined CLR conversion operators (op_Explicit/op_Implicit)
+/// and nullable-type-as-function-call cast form (`string?(x)`).
+/// Each test compiles via in-process <c>gsc</c>, IL-verifies the PE, then runs
+/// under <c>dotnet exec</c> and asserts captured stdout.
+/// </summary>
+public class Issue663UserDefinedConversionEmitTests
+{
+    [Fact]
+    public void JsonNode_Explicit_String_Via_TypeFnCast()
+    {
+        // string(node["name"]!!) — non-nullable type-fn cast that invokes
+        // op_Explicit(JsonNode) → string.
+        var source = """
+            package Test
+            import System
+            import System.Text.Json.Nodes
+
+            let obj = JsonObject()
+            obj["name"] = JsonValue.Create("ada")
+            let name = string(obj["name"]!!)
+            Console.WriteLine(name)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("ada\n", output);
+    }
+
+    [Fact]
+    public void JsonNode_Explicit_NullableString_Via_NullableTypeFnCast()
+    {
+        // string?(node["name"]) — nullable-type-fn cast form (parser fix).
+        var source = """
+            package Test
+            import System
+            import System.Text.Json.Nodes
+
+            let obj = JsonObject()
+            obj["name"] = JsonValue.Create("ada")
+            let name = string?(obj["name"])
+            Console.WriteLine(name!!)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("ada\n", output);
+    }
+
+    [Fact]
+    public void JsonNode_Explicit_NullableString_Returns_Nil_For_Missing_Key()
+    {
+        // string?(node["absent"]) should return nil when the key is absent.
+        var source = """
+            package Test
+            import System
+            import System.Text.Json.Nodes
+
+            let obj = JsonObject()
+            obj["name"] = JsonValue.Create("ada")
+            let alias = string?(obj["absent"])
+            if alias == nil {
+                Console.WriteLine("nil")
+            } else {
+                Console.WriteLine(alias!!)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("nil\n", output);
+    }
+
+    [Fact]
+    public void JsonNode_Explicit_Int32_Via_TypeFnCast()
+    {
+        // int32(node["age"]!!) — non-nullable type-fn cast that invokes
+        // op_Explicit(JsonNode) → int32.
+        var source = """
+            package Test
+            import System
+            import System.Text.Json.Nodes
+
+            let obj = JsonObject()
+            obj["age"] = JsonValue.Create(42)
+            let age = int32(obj["age"]!!)
+            Console.WriteLine(age)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void JsonNode_Explicit_Bool_Via_TypeFnCast()
+    {
+        // bool(node["flag"]!!) — non-nullable type-fn cast that invokes
+        // op_Explicit(JsonNode) → bool.
+        var source = """
+            package Test
+            import System
+            import System.Text.Json.Nodes
+
+            let obj = JsonObject()
+            obj["flag"] = JsonValue.Create(true)
+            let flag = bool(obj["flag"]!!)
+            Console.WriteLine(flag)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void JsonNode_Explicit_NullableInt32_Via_NullableTypeFnCast()
+    {
+        // int32?(node["age"]) — nullable type-fn cast.
+        var source = """
+            package Test
+            import System
+            import System.Text.Json.Nodes
+
+            let obj = JsonObject()
+            obj["age"] = JsonValue.Create(42)
+            let age = int32?(obj["age"])
+            Console.WriteLine(age!!)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exitCode == 0,
+            $"gsc failed (exit {exitCode}):\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue663_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add("/nowarn:GS9100");
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            if (compileExit != 0)
+            {
+                return (compileExit, compileOut.ToString(), compileErr.ToString());
+            }
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+
+            if (proc.ExitCode != 0)
+            {
+                return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+            }
+
+            return (0, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #663

## Root causes fixed

### 1. Parser: `string?(expr)` rejected with GS0005

The parser only recognized `Identifier ( args )` as a call expression. When a `?` suffix appeared between the identifier and the open paren (e.g. `string?(x)`), it was not recognized.

**Fix**: Added a new parser path in `ParseNameOrCallExpression` that matches `Identifier ? (` and produces a `CallExpressionSyntax` carrying the `?` token. Extended `CallExpressionSyntax` with an optional `NullableQuestionToken` property. The binder in `OverloadResolver.BindCallExpression` wraps the resolved type in `NullableTypeSymbol` when the question token is present.

### 2. Emit: user-defined CLR conversion operators (op_Explicit/op_Implicit) not honored

When `Conversion.Classify` returned `Explicit` for a non-built-in conversion path (e.g. `JsonNode → string` via the catch-all "any CLR type → string via ToString()" rule), the emitter's `EmitConversion` could not emit IL for it and threw `NotSupportedException`.

**Fix**: Added a fallback in `EmitConversion` (before the final throw) that attempts `ClrOperatorResolution.TryResolveConversion` and emits a `call` to the resolved operator method. Also added Nullable\<T\> lifting in `EmitClrConversionCall` for the case where the operator returns a non-nullable value type T but the target is `Nullable<T>` (e.g. `op_Explicit(JsonNode) → int` targeting `int32?`).

## New tests

- `Issue663UserDefinedConversionEmitTests.cs` (6 end-to-end tests):
  - `JsonNode_Explicit_String_Via_TypeFnCast` — `string(node["name"]!!)`
  - `JsonNode_Explicit_NullableString_Via_NullableTypeFnCast` — `string?(node["name"])`
  - `JsonNode_Explicit_NullableString_Returns_Nil_For_Missing_Key` — nil path
  - `JsonNode_Explicit_Int32_Via_TypeFnCast` — `int32(node["age"]!!)`
  - `JsonNode_Explicit_Bool_Via_TypeFnCast` — `bool(node["flag"]!!)`
  - `JsonNode_Explicit_NullableInt32_Via_NullableTypeFnCast` — `int32?(node["age"])`

All tests compile, IL-verify, and execute correctly.

## Verification

```
dotnet build GSharp.sln -nologo -p:UseAppHost=false  # 0 errors
dotnet test test/Core.Tests/         # 2216 passed
dotnet test test/Compiler.Tests/     # 911 passed
dotnet test test/Interpreter.Tests/  # 98 passed
dotnet test test/LanguageServer.Tests/ # 242 passed
```