### PR TITLE
Fix #664: CLR T[] arrays are indexable

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1563,6 +1563,12 @@ internal sealed partial class ExpressionBinder
         {
             ArrayTypeSymbol arr => arr.ElementType,
             SliceTypeSymbol slice => slice.ElementType,
+
+            // Issue #664: CLR T[] arrays (e.g. result of string.Split) are indexable.
+            ImportedTypeSymbol imp when imp.ClrType is { IsArray: true } clr && clr.GetArrayRank() == 1
+                => TypeSymbol.FromClrType(clr.GetElementType()),
+            NullabilityAnnotatedTypeSymbol annot when annot.ClrType is { IsArray: true } clr && clr.GetArrayRank() == 1
+                => annot.GetTypeArgumentSymbolForClrType(clr.GetElementType()),
             _ => null,
         };
     }

--- a/test/Compiler.Tests/Emit/Issue664ClrArrayIndexerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue664ClrArrayIndexerEmitTests.cs
@@ -1,0 +1,199 @@
+// <copyright file="Issue664ClrArrayIndexerEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// End-to-end emit and execution tests for issue #664: CLR <c>T[]</c> arrays
+/// (e.g. the result of <c>string.Split</c>) must be indexable with <c>arr[i]</c>
+/// for both read and write, emitting correct <c>ldelem</c>/<c>stelem</c> opcodes.
+/// </summary>
+public class Issue664ClrArrayIndexerEmitTests
+{
+    [Fact]
+    public void StringSplit_IndexZero_ReturnsFirstElement()
+    {
+        var source = """
+            package P
+            import System
+
+            let parts = "a,b,c".Split(",")
+            Console.WriteLine(parts[0])
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("a\n", output);
+    }
+
+    [Fact]
+    public void StringArray_IndexAssignment_Works()
+    {
+        var source = """
+            package P
+            import System
+
+            var parts = "a,b,c".Split(",")
+            parts[0] = "z"
+            Console.WriteLine(parts[0])
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("z\n", output);
+    }
+
+    [Fact]
+    public void IntArray_ReadIndex_Works()
+    {
+        var source = """
+            package P
+            import System
+            import System.Linq
+
+            var arr = Enumerable.ToArray[int32](Enumerable.Range(10, 3))
+            Console.WriteLine(arr[1])
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("11\n", output);
+    }
+
+    [Fact]
+    public void IntArray_WriteIndex_Works()
+    {
+        var source = """
+            package P
+            import System
+            import System.Linq
+
+            var arr = Enumerable.ToArray[int32](Enumerable.Range(0, 3))
+            arr[0] = 99
+            Console.WriteLine(arr[0])
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    [Fact]
+    public void ObjectArray_ReadIndex_Works()
+    {
+        var source = """
+            package P
+            import System
+
+            let args = Environment.GetCommandLineArgs()
+            let first = args[0]
+            Console.WriteLine(first != "")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void CharArray_ReadIndex_Works()
+    {
+        var source = """
+            package P
+            import System
+
+            var ca = "hello".ToCharArray()
+            Console.WriteLine(int32(ca[0]))
+            Console.WriteLine(int32(ca[4]))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("104\n111\n", output);
+    }
+
+    [Fact]
+    public void CharArray_WriteIndex_Works()
+    {
+        var source = """
+            package P
+            import System
+
+            var ca = "hello".ToCharArray()
+            ca[0] = 'H'
+            Console.WriteLine(int32(ca[0]))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("72\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue664_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue664ClrArrayIndexerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue664ClrArrayIndexerTests.cs
@@ -1,0 +1,154 @@
+// <copyright file="Issue664ClrArrayIndexerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #664 — CLR <c>T[]</c> arrays (e.g. the result of <c>string.Split</c>,
+/// <c>.ToArray()</c>, or any imported method returning a CLR array) must be
+/// indexable with <c>arr[i]</c> for both read and write.
+/// </summary>
+public class Issue664ClrArrayIndexerTests
+{
+    [Fact]
+    public void ReadIndex_StringArray_FromSplit_Compiles()
+    {
+        var source = @"
+package P
+import System
+
+let parts = ""a,b,c"".Split("","")
+let first = parts[0]
+";
+        AssertCompilesWithoutErrors(source);
+    }
+
+    [Fact]
+    public void ReadIndex_IntArray_FromLinq_Compiles()
+    {
+        var source = @"
+package P
+import System
+import System.Linq
+
+let arr = Enumerable.ToArray[int32](Enumerable.Range(0, 5))
+let v = arr[2]
+";
+        AssertCompilesWithoutErrors(source);
+    }
+
+    [Fact]
+    public void ReadIndex_ObjectArray_Compiles()
+    {
+        var source = @"
+package P
+import System
+
+let arr = Environment.GetCommandLineArgs()
+let first = arr[0]
+";
+        AssertCompilesWithoutErrors(source);
+    }
+
+    [Fact]
+    public void WriteIndex_StringArray_Compiles()
+    {
+        var source = @"
+package P
+import System
+
+var parts = ""a,b,c"".Split("","")
+parts[0] = ""z""
+";
+        AssertCompilesWithoutErrors(source);
+    }
+
+    [Fact]
+    public void WriteIndex_IntArray_Compiles()
+    {
+        var source = @"
+package P
+import System
+import System.Linq
+
+var arr = Enumerable.ToArray[int32](Enumerable.Range(0, 5))
+arr[0] = 99
+";
+        AssertCompilesWithoutErrors(source);
+    }
+
+    [Fact]
+    public void GSharpSlice_StillIndexable()
+    {
+        var source = @"
+package P
+
+var xs = []int32{1, 2, 3}
+let v = xs[0]
+xs[1] = 42
+";
+        AssertCompilesWithoutErrors(source);
+    }
+
+    [Fact]
+    public void List_StillIndexable()
+    {
+        var source = @"
+package P
+import System.Collections.Generic
+
+var list = List[int32]()
+list.Add(10)
+let v = list[0]
+";
+        AssertCompilesWithoutErrors(source);
+    }
+
+    [Fact]
+    public void NonIndexableType_StillProducesGS0116()
+    {
+        var source = @"
+package P
+import System.IO
+
+var s = Stream.Null
+let v = s[0]
+";
+        var diagnostics = EmitDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.IsError && d.Message.Contains("not indexable"));
+    }
+
+    private static void AssertCompilesWithoutErrors(string source)
+    {
+        var diagnostics = EmitDiagnostics(source, out var success);
+        Assert.True(
+            success,
+            "Emit failed:\n" + string.Join("\n", diagnostics.Select(d => d.ToString())));
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
+    }
+
+    private static IReadOnlyList<Diagnostic> EmitDiagnostics(string source)
+        => EmitDiagnostics(source, out _);
+
+    private static IReadOnlyList<Diagnostic> EmitDiagnostics(string source, out bool success)
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        success = result.Success;
+        return result.Diagnostics;
+    }
+}


### PR DESCRIPTION
Fixes #664

## Root cause

`GetIndexElementType` in `ExpressionBinder.Access.cs` only recognized G#'s built-in `ArrayTypeSymbol` and `SliceTypeSymbol` as indexable. CLR `T[]` arrays (returned by `string.Split`, `.ToArray()`, etc.) appear as `ImportedTypeSymbol` with `ClrType.IsArray == true` and were not matched, producing GS0116.

## Fix

Extended `GetIndexElementType` to handle:
- `ImportedTypeSymbol` where `ClrType.IsArray && GetArrayRank() == 1` → element type via `TypeSymbol.FromClrType(clr.GetElementType())`
- `NullabilityAnnotatedTypeSymbol` wrapping a CLR array → element type via `GetTypeArgumentSymbolForClrType`

This single change enables both read (`arr[i]`) and write (`arr[i] = v`) indexing on CLR arrays, reusing the existing `BoundIndexExpression`/`BoundIndexAssignmentExpression` emit paths that already emit correct `ldelem`/`stelem` opcodes.

## New tests

### Binder tests (`test/Core.Tests/CodeAnalysis/Binding/Issue664ClrArrayIndexerTests.cs`)
- Read index on `string[]` from `Split`
- Read index on `int32[]` from LINQ
- Read index on `string[]` from `Environment.GetCommandLineArgs()`
- Write index on `string[]`
- Write index on `int32[]`
- G# slice (`[]int32`) still indexable (regression guard)
- `List[int32]` still indexable (regression guard)
- Non-indexable type (`Stream`) still produces GS0116

### Emit / end-to-end tests (`test/Compiler.Tests/Emit/Issue664ClrArrayIndexerEmitTests.cs`)
- `"a,b,c".Split(",")[0]` → `"a"`
- String array index assignment
- Int array read/write
- Object array read
- Char array read/write
- All tests include IL verification via `IlVerifier.Verify`

## Verification

- `dotnet build GSharp.sln` — clean
- `dotnet test test/Core.Tests` — 2224 passed
- `dotnet test test/Compiler.Tests` — 918 passed
- `dotnet test test/Interpreter.Tests` — 98 passed
- `dotnet test test/LanguageServer.Tests` — 242 passed
- `dotnet test test/Sdk.Tests` — 26 passed
- IL verification clean on all emit tests