### PR TITLE
Fix #666: project inferred type args for LINQ instance-syntax extension methods

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -1943,12 +1943,22 @@ internal static class OverloadResolution
             return null;
         }
 
-        for (var t = type; t != null; t = t.BaseType)
+        var openDefName = openDefinition.FullName;
+
+        try
         {
-            if (t.IsGenericType && ReferenceEquals(t.GetGenericTypeDefinition(), openDefinition))
+            for (var t = type; t != null; t = t.BaseType)
             {
-                return t;
+                if (t.IsGenericType && MatchesOpenDefinition(t.GetGenericTypeDefinition(), openDefinition, openDefName))
+                {
+                    return t;
+                }
             }
+        }
+        catch (NotSupportedException)
+        {
+            // TypeBuilderInstantiation (cross-context constructed generics) may
+            // throw on BaseType traversal; fall through to interface walk.
         }
 
         Type[] ifaces;
@@ -1960,16 +1970,56 @@ internal static class OverloadResolution
         {
             return null;
         }
+        catch (NotSupportedException)
+        {
+            // Issue #666: TypeBuilderInstantiation (produced when
+            // FunctionTypeSymbol.BuildClrType constructs a host-runtime Func<>
+            // with MetadataLoadContext type arguments) throws
+            // NotSupportedException from GetInterfaces(). Treat as "no match"
+            // and let inference continue from other parameters.
+
+            // Fallback: if the type itself is a closed generic whose open
+            // definition matches by name, return it directly. This handles
+            // Func<T,bool> / Action<T> shapes from BuildClrType.
+            if (type.IsGenericType && !type.IsGenericTypeDefinition
+                && MatchesOpenDefinition(type.GetGenericTypeDefinition(), openDefinition, openDefName))
+            {
+                return type;
+            }
+
+            return null;
+        }
 
         foreach (var iface in ifaces)
         {
-            if (iface.IsGenericType && ReferenceEquals(iface.GetGenericTypeDefinition(), openDefinition))
+            if (iface.IsGenericType && MatchesOpenDefinition(iface.GetGenericTypeDefinition(), openDefinition, openDefName))
             {
                 return iface;
             }
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Issue #666: compares a candidate open generic type definition against
+    /// <paramref name="openDefinition"/>. Uses <see cref="object.ReferenceEquals"/>
+    /// first (fast path for same-context types), then falls back to
+    /// <see cref="Type.FullName"/> comparison for cross-reflection-context
+    /// scenarios (e.g. a host-runtime <c>Func&lt;,&gt;</c> vs a
+    /// MetadataLoadContext <c>Func&lt;,&gt;</c>).
+    /// </summary>
+    private static bool MatchesOpenDefinition(Type candidateDefinition, Type openDefinition, string openDefName)
+    {
+        if (ReferenceEquals(candidateDefinition, openDefinition))
+        {
+            return true;
+        }
+
+        // Cross-context fallback: same FullName implies structural equivalence
+        // for open generic definitions.
+        return openDefName != null
+            && string.Equals(candidateDefinition.FullName, openDefName, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue666LinqExtensionInferredTypeArgEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue666LinqExtensionInferredTypeArgEmitTests.cs
@@ -1,0 +1,287 @@
+// <copyright file="Issue666LinqExtensionInferredTypeArgEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #666: LINQ extension methods called via instance syntax on
+/// <c>List&lt;T&gt;</c> / <c>IEnumerable&lt;T&gt;</c> where <c>T</c> is a CLR
+/// reference type from a project reference must compile, IL-verify, and run
+/// correctly. The sibling C# library pattern exercises the cross-
+/// <see cref="System.Reflection.MetadataLoadContext"/> inference path that
+/// previously threw <see cref="NotSupportedException"/> inside
+/// <c>FindClosedGeneric</c>.
+/// </summary>
+public class Issue666LinqExtensionInferredTypeArgEmitTests
+{
+    [Fact]
+    public void WhereSelectToArray_OnClrRefElement_CompilesRunsAndIlVerifies()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public sealed class ItemCls
+                {
+                    public string Name { get; set; } = "";
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import Probe.CSharp
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            var xs = List[ItemCls]()
+            var a = ItemCls()
+            a.Name = "alpha"
+            xs.Add(a)
+            var b = ItemCls()
+            b.Name = "beta"
+            xs.Add(b)
+            var c = ItemCls()
+            c.Name = "skip"
+            xs.Add(c)
+
+            var result = xs.Where(func(i ItemCls) bool { return i.Name != "skip" }).Select(func(i ItemCls) string { return i.Name }).ToArray()
+            Console.WriteLine(result.Length)
+            Console.WriteLine(result[0])
+            Console.WriteLine(result[1])
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("2\nalpha\nbeta\n", output);
+    }
+
+    [Fact]
+    public void FirstOrDefault_OnClrRefElement_CompilesRunsAndIlVerifies()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public sealed class ItemCls
+                {
+                    public string Name { get; set; } = "";
+                }
+            }
+            """;
+
+        // FirstOrDefault returns a nullable reference; access the result
+        // via Count() on the filtered sequence to avoid nullable member
+        // lookup (a separate binder concern).
+        var gsource = """
+            package Probe
+            import Probe.CSharp
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            var xs = List[ItemCls]()
+            var a = ItemCls()
+            a.Name = "first"
+            xs.Add(a)
+
+            var count = xs.Where(func(i ItemCls) bool { return true }).Count()
+            Console.WriteLine(count)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void AsEnumerableWhere_OnClrRefElement_CompilesRunsAndIlVerifies()
+    {
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public sealed class ItemCls
+                {
+                    public string Name { get; set; } = "";
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe
+            import Probe.CSharp
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            var xs = List[ItemCls]()
+            var a = ItemCls()
+            a.Name = "hello"
+            xs.Add(a)
+            var b = ItemCls()
+            b.Name = "world"
+            xs.Add(b)
+
+            var result = xs.AsEnumerable().Where(func(i ItemCls) bool { return i.Name == "world" }).ToArray()
+            Console.WriteLine(result.Length)
+            Console.WriteLine(result[0].Name)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("1\nworld\n", output);
+    }
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue666_").FullName;
+        try
+        {
+            // Step 1: compile the sibling C# library.
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            // Step 2: compile the G# code referencing the sibling.
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            // Place the sibling next to the produced assembly for runtime resolution.
+            File.Copy(siblingDll, Path.Combine(tempDir, Path.GetFileName(siblingDll)), overwrite: true);
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { siblingDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string BuildCsProject(string csDir, string siblingName)
+    {
+        RunDotnet(csDir, "restore");
+        RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+
+        var dll = Path.Combine(csDir, "bin", "Release", "net10.0", siblingName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static void RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue666LinqExtensionOnClrRefTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue666LinqExtensionOnClrRefTypeTests.cs
@@ -1,0 +1,217 @@
+// <copyright file="Issue666LinqExtensionOnClrRefTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #666: LINQ extension methods (Where, Select, FirstOrDefault, ToArray,
+/// AsEnumerable) called via instance syntax on IEnumerable&lt;T&gt;/List&lt;T&gt;
+/// must work when T is a CLR reference type from a project-referenced (non-BCL)
+/// assembly loaded through <see cref="System.Reflection.MetadataLoadContext"/>.
+/// </summary>
+public class Issue666LinqExtensionOnClrRefTypeTests
+{
+    [Fact]
+    public void Where_OnList_ClrRefElement_InstanceSyntax_Binds()
+    {
+        var source = @"
+package Probe
+import GSharp.Core.Tests.Fixtures
+import System.Collections.Generic
+import System.Linq
+
+var xs = List[Issue666ItemCls]()
+xs.Add(Issue666ItemCls())
+var q = xs.Where(func(i Issue666ItemCls) bool { return true })
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void Select_OnList_ClrRefElement_InstanceSyntax_Binds()
+    {
+        var source = @"
+package Probe
+import GSharp.Core.Tests.Fixtures
+import System.Collections.Generic
+import System.Linq
+
+var xs = List[Issue666ItemCls]()
+xs.Add(Issue666ItemCls())
+var q = xs.Select(func(i Issue666ItemCls) string { return i.Name })
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void FirstOrDefault_OnList_ClrRefElement_InstanceSyntax_Binds()
+    {
+        var source = @"
+package Probe
+import GSharp.Core.Tests.Fixtures
+import System.Collections.Generic
+import System.Linq
+
+var xs = List[Issue666ItemCls]()
+xs.Add(Issue666ItemCls())
+var q = xs.FirstOrDefault()
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void ToArray_OnList_ClrRefElement_InstanceSyntax_Binds()
+    {
+        var source = @"
+package Probe
+import GSharp.Core.Tests.Fixtures
+import System.Collections.Generic
+import System.Linq
+
+var xs = List[Issue666ItemCls]()
+xs.Add(Issue666ItemCls())
+var arr = xs.ToArray()
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void AsEnumerable_OnList_ClrRefElement_InstanceSyntax_Binds()
+    {
+        var source = @"
+package Probe
+import GSharp.Core.Tests.Fixtures
+import System.Collections.Generic
+import System.Linq
+
+var xs = List[Issue666ItemCls]()
+xs.Add(Issue666ItemCls())
+var q = xs.AsEnumerable()
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void WhereSelectChain_ClrRefElement_InstanceSyntax_Binds()
+    {
+        var source = @"
+package Probe
+import GSharp.Core.Tests.Fixtures
+import System.Collections.Generic
+import System.Linq
+
+var xs = List[Issue666ItemCls]()
+xs.Add(Issue666ItemCls())
+var q = xs.Where(func(i Issue666ItemCls) bool { return true }).Select(func(i Issue666ItemCls) string { return i.Name })
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void AsEnumerableWhere_ClrRefElement_InstanceSyntax_Binds()
+    {
+        var source = @"
+package Probe
+import GSharp.Core.Tests.Fixtures
+import System.Collections.Generic
+import System.Linq
+
+var xs = List[Issue666ItemCls]()
+xs.Add(Issue666ItemCls())
+var q = xs.AsEnumerable().Where(func(i Issue666ItemCls) bool { return true })
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    // --- Regression guards: BCL types (should already pass) ---
+
+    [Fact]
+    public void Where_OnList_String_InstanceSyntax_Binds()
+    {
+        var source = @"
+package Probe
+import System.Collections.Generic
+import System.Linq
+
+var xs = List[string]()
+xs.Add(""hello"")
+var q = xs.Where(func(s string) bool { return true })
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void Where_OnList_Int32_InstanceSyntax_Binds()
+    {
+        var source = @"
+package Probe
+import System.Collections.Generic
+import System.Linq
+
+var xs = List[int32]()
+xs.Add(1)
+var q = xs.Where(func(x int32) bool { return x > 0 })
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    // --- Regression guard: explicit static form (the #320 workaround) ---
+
+    [Fact]
+    public void Where_ExplicitStatic_ClrRefElement_Binds()
+    {
+        var source = @"
+package Probe
+import GSharp.Core.Tests.Fixtures
+import System.Collections.Generic
+import System.Linq
+
+var xs = List[Issue666ItemCls]()
+xs.Add(Issue666ItemCls())
+var q = Enumerable.Where[Issue666ItemCls](xs, func(i Issue666ItemCls) bool { return true })
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    private static void AssertBindsWithoutErrors(string source)
+    {
+        // Load the test assembly (which contains the Issue666ItemCls fixture)
+        // plus all BCL assemblies through a MetadataLoadContext, reproducing
+        // the cross-context configuration that triggers issue #666.
+        var fixturePath = typeof(Fixtures.Issue666ItemCls).Assembly.Location;
+        var paths = new List<string> { fixturePath };
+
+        // Include BCL assemblies so System.Linq.Enumerable is discoverable.
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (!string.IsNullOrEmpty(tpa))
+        {
+            foreach (var p in tpa.Split(Path.PathSeparator))
+            {
+                if (!string.IsNullOrWhiteSpace(p) && File.Exists(p))
+                {
+                    paths.Add(p);
+                }
+            }
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(paths);
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), resolver);
+        var program = Binder.BindProgram(globalScope, resolver);
+        var diagnostics = globalScope.Diagnostics.AddRange(program.Diagnostics);
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
+    }
+}

--- a/test/Core.Tests/Fixtures/Issue666ItemCls.cs
+++ b/test/Core.Tests/Fixtures/Issue666ItemCls.cs
@@ -1,0 +1,17 @@
+// <copyright file="Issue666ItemCls.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.Tests.Fixtures;
+
+/// <summary>
+/// Issue #666 fixture: a simple CLR reference type from a "project reference"
+/// assembly. When this assembly is supplied via <c>/reference:</c> (or loaded
+/// through <see cref="System.Reflection.MetadataLoadContext"/> in a binder
+/// test), using <c>ItemCls</c> as the element type of a generic collection
+/// and then calling LINQ extension methods with instance syntax must succeed.
+/// </summary>
+public sealed class Issue666ItemCls
+{
+    public string Name { get; set; } = string.Empty;
+}


### PR DESCRIPTION
Fixes #666

## Root cause

`FindClosedGeneric` in `OverloadResolution` used `ReferenceEquals` to compare generic type definitions when unifying argument types against method parameter types during type-argument inference. This fails when the argument type is a cross-context `TypeBuilderInstantiation` — produced by `FunctionTypeSymbol.BuildClrType` when it constructs a host-runtime `Func<,>` with MetadataLoadContext type arguments (the case when a lambda parameter's type is a CLR reference type from a project reference).

Additionally, `TypeBuilderInstantiation.GetInterfaces()` throws `NotSupportedException`, which was not caught (only `InvalidOperationException` was handled).

The net effect: `TryInferTypeArguments` crashed on the lambda argument, inference failed entirely, the extension method wasn't applicable, and the binder fell through to GS0159 "Cannot find function Where".

## Fix

Introduce a `MatchesOpenDefinition` helper that falls back to `FullName`-based comparison when `ReferenceEquals` fails (the same cross-context pattern used by `ClrTypeUtilities.AreSame`). Also catch `NotSupportedException` alongside `InvalidOperationException`, with a fallback that checks the type itself when `GetInterfaces()` is unavailable.

This mirrors the #320 fix (explicit type-argument path) for the inferred path: once `FindClosedGeneric` correctly matches the lambda's `Func` type across contexts, type inference binds `TSource`/`TResult` from both the receiver and the lambda parameter, the projection step maps inferred types via `MapClrTypeToReferences`, and `MakeGenericMethod` succeeds.

## New tests

**Binder tests** (`Issue666LinqExtensionOnClrRefTypeTests.cs`, 10 cases):
- Instance-syntax `Where`, `Select`, `FirstOrDefault`, `ToArray`, `AsEnumerable` on `List<ClrRefType>`
- Chained forms: `Where().Select()`, `AsEnumerable().Where()`
- Regression guards: `List<string>`, `List<int32>` (BCL types)
- Regression guard: explicit static `Enumerable.Where[T](xs, ...)` (the #320 path)

**Emit/end-to-end tests** (`Issue666LinqExtensionInferredTypeArgEmitTests.cs`, 3 cases):
- `Where.Select.ToArray` chain over a sibling C# library type
- `Where.Count` chain
- `AsEnumerable().Where().ToArray()` chain

All use the established sibling-C#-library pattern with `/reference:` + TPA, ILVerify, and `dotnet exec` runtime assertion.

## Verification

```
dotnet test GSharp.sln --no-restore --nologo
# Core.Tests:        2234 passed
# Compiler.Tests:     921 passed
# Interpreter.Tests:   98 passed
# LanguageServer.Tests: 242 passed
```