### PR TITLE
Add #669: if as a value-producing expression

### DIFF
--- a/docs/adr/0064-if-expression-and-block-expression.md
+++ b/docs/adr/0064-if-expression-and-block-expression.md
@@ -1,0 +1,57 @@
+# ADR-0064: If-expression and block-with-trailing-expression value forms
+
+- **Status**: Accepted
+- **Date**: 2026-06-10
+- **Implemented**: 2026-06-10 (PR [#669](https://github.com/DavidObando/gsharp/issues/669))
+- **Phase**: Phase 8 — language ergonomics / expression surface
+- **Related**: ADR-0062 (generalized ternary), issue #669
+
+## Context
+
+G# has a generalized ternary (`cond ? a : b`, ADR-0062) but no way to write multi-statement conditional expressions or readable `else if` chains in value position. Users coming from Rust, Kotlin, Swift, and F# expect `if` to work as a value-producing expression.
+
+## Decision
+
+Add `if` as a value-producing expression that coexists with the ternary:
+
+```ebnf
+IfExpression := 'if' Expression Block ('else' (IfExpression | Block))?
+Block        := '{' Statement* (Expression)? '}'
+```
+
+- The block's final expression (last expression statement) is the value.
+- `if` without `else` is statement-only; using it in value position reports **GS0276**.
+- A block without a trailing expression in value position reports **GS0277**.
+- `else if` chains are right-associative (nested `IfExpressionSyntax`).
+- Common-type/branch-type-unification rules are identical to ADR-0062 ternary.
+- Lowers to the same `BoundConditionalExpression` that ternary uses (no new emit logic).
+- Multi-statement blocks lower to `BoundBlockExpression` (already exists for interpolated strings and object initializers).
+
+## Examples
+
+```gsharp
+let f = if filter != nil { filter!! } else { LibraryFilter() }
+
+let title = if user.IsAdmin {
+    log("admin route")
+    "Admin Dashboard"
+} else {
+    "Home"
+}
+
+let grade = if pct >= 90 { "A" }
+           else if pct >= 80 { "B" }
+           else { "C" }
+```
+
+## Diagnostics
+
+- **GS0276**: if-expression in value position must have an `else` branch.
+- **GS0277**: block in if-expression value position must end with a value-producing expression.
+
+## Consequences
+
+- **Positive**: multi-statement branches and `else if` chains now work in value position.
+- **Positive**: no new bound-node kinds; reuses existing `BoundConditionalExpression` and `BoundBlockExpression`.
+- **Neutral**: ternary (`?:`) continues to work unchanged (coexistence).
+- **Negative**: `if` at expression-level requires the parser to disambiguate struct-literal syntax (`name { }`) from block expressions; resolved via `suppressTrailingObjectInitializer`.

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -26,6 +26,7 @@ BangBangToken
 BangEqualsToken
 BangToken
 BinaryExpression
+BlockExpression
 BlockStatement
 BreakKeyword
 BreakStatement
@@ -100,6 +101,7 @@ GreaterToken
 HatEqualsToken
 HatToken
 IdentifierToken
+IfExpression
 IfKeyword
 IfStatement
 ImportDeclaration

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -286,7 +286,8 @@ public sealed class Binder
             resolveClrTypeForGenericArg: ResolveClrTypeForGenericArg,
             reportObsoleteUseIfApplicable: ReportObsoleteUseIfApplicable,
             isAsyncIteratorReturnType: IsAsyncIteratorReturnType,
-            getCurrentFunction: () => this.function);
+            getCurrentFunction: () => this.function,
+            bindStatement: syntax => statements.BindStatement(syntax));
 
         // statements/declarations still reference this.expressions through
         // the callbacks above; expressions is wired last so its constructor

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -233,6 +233,108 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Issue #669: binds an if-expression to a <see cref="BoundConditionalExpression"/>
+    /// (the same bound node used by the ternary operator). Multi-statement blocks
+    /// are lowered to <see cref="BoundBlockExpression"/> wrapping the final value.
+    /// </summary>
+    private BoundExpression BindIfExpression(IfExpressionSyntax syntax)
+    {
+        // An if-expression in value position must have an else branch.
+        if (syntax.ElseExpression == null)
+        {
+            Diagnostics.ReportIfExpressionMissingElse(syntax.IfKeyword.Location);
+            return new BoundErrorExpression(null);
+        }
+
+        var condition = BindExpression(syntax.Condition, TypeSymbol.Bool);
+
+        var whenTrue = BindBlockExpressionValue(syntax.ThenBlock);
+        var whenFalse = BindIfExpressionElseBranch(syntax.ElseExpression);
+
+        if (condition is BoundErrorExpression || whenTrue is BoundErrorExpression || whenFalse is BoundErrorExpression)
+        {
+            return new BoundErrorExpression(null);
+        }
+
+        var resultType = ComputeConditionalCommonType(whenTrue.Type, whenFalse.Type);
+        if (resultType == null)
+        {
+            Diagnostics.ReportConditionalNoCommonResultType(
+                syntax.Location,
+                whenTrue.Type?.Name ?? "?",
+                whenFalse.Type?.Name ?? "?");
+            return new BoundErrorExpression(null);
+        }
+
+        var convertedTrue = ConvertConditionalBranch(syntax.ThenBlock.Location, whenTrue, resultType);
+        var convertedFalse = ConvertConditionalBranch(syntax.ElseExpression.Location, whenFalse, resultType);
+        if (convertedTrue is BoundErrorExpression || convertedFalse is BoundErrorExpression)
+        {
+            return new BoundErrorExpression(null);
+        }
+
+        return new BoundConditionalExpression(null, condition, convertedTrue, convertedFalse, resultType);
+    }
+
+    /// <summary>
+    /// Binds the else branch of an if-expression: either a nested if-expression
+    /// (<c>else if</c> chain) or a block expression.
+    /// </summary>
+    private BoundExpression BindIfExpressionElseBranch(ExpressionSyntax elseSyntax)
+    {
+        if (elseSyntax is IfExpressionSyntax nestedIf)
+        {
+            return BindIfExpression(nestedIf);
+        }
+
+        if (elseSyntax is BlockExpressionSyntax block)
+        {
+            return BindBlockExpressionValue(block);
+        }
+
+        // Should not happen from well-formed parse trees.
+        return new BoundErrorExpression(null);
+    }
+
+    /// <summary>
+    /// Binds a block-with-trailing-expression in value position. If the block
+    /// has no trailing expression, reports a diagnostic. The result is either
+    /// the bound trailing expression (when there are no prefix statements), or
+    /// a <see cref="BoundBlockExpression"/> wrapping the prefix statements and
+    /// the trailing value.
+    /// </summary>
+    private BoundExpression BindBlockExpressionValue(BlockExpressionSyntax syntax)
+    {
+        if (syntax.Expression == null)
+        {
+            Diagnostics.ReportBlockExpressionMissingTrailingExpression(syntax.CloseBraceToken.Location);
+            return new BoundErrorExpression(null);
+        }
+
+        // If there are no prefix statements, just bind the expression directly.
+        if (syntax.Statements.IsDefaultOrEmpty)
+        {
+            return BindExpression(syntax.Expression);
+        }
+
+        // Bind prefix statements.
+        var boundStatements = ImmutableArray.CreateBuilder<BoundStatement>();
+        foreach (var stmt in syntax.Statements)
+        {
+            var boundStmt = bindStatement(stmt);
+            boundStatements.Add(boundStmt);
+        }
+
+        var boundExpression = BindExpression(syntax.Expression);
+        if (boundExpression is BoundErrorExpression)
+        {
+            return boundExpression;
+        }
+
+        return new BoundBlockExpression(null, boundStatements.ToImmutable(), boundExpression);
+    }
+
+    /// <summary>
     /// ADR-0062: chooses a common result type for two conditional branches
     /// using the following ordered rules (mirroring the ADR §2 common-type
     /// procedure):

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -69,6 +69,7 @@ internal sealed partial class ExpressionBinder
     private readonly Action<TextLocation, Symbol, string> reportObsoleteUseIfApplicable;
     private readonly Func<TypeSymbol, bool> isAsyncIteratorReturnType;
     private readonly Func<FunctionSymbol> getCurrentFunction;
+    private readonly Func<StatementSyntax, BoundStatement> bindStatement;
 
     public ExpressionBinder(
         BinderContext binderCtx,
@@ -82,7 +83,8 @@ internal sealed partial class ExpressionBinder
         Func<TypeSymbol, Type> resolveClrTypeForGenericArg,
         Action<TextLocation, Symbol, string> reportObsoleteUseIfApplicable,
         Func<TypeSymbol, bool> isAsyncIteratorReturnType,
-        Func<FunctionSymbol> getCurrentFunction)
+        Func<FunctionSymbol> getCurrentFunction,
+        Func<StatementSyntax, BoundStatement> bindStatement = null)
     {
         this.binderCtx = binderCtx ?? throw new ArgumentNullException(nameof(binderCtx));
         this.memberLookup = memberLookup ?? throw new ArgumentNullException(nameof(memberLookup));
@@ -96,6 +98,7 @@ internal sealed partial class ExpressionBinder
         this.reportObsoleteUseIfApplicable = reportObsoleteUseIfApplicable ?? throw new ArgumentNullException(nameof(reportObsoleteUseIfApplicable));
         this.isAsyncIteratorReturnType = isAsyncIteratorReturnType ?? throw new ArgumentNullException(nameof(isAsyncIteratorReturnType));
         this.getCurrentFunction = getCurrentFunction ?? throw new ArgumentNullException(nameof(getCurrentFunction));
+        this.bindStatement = bindStatement;
     }
 
     private DiagnosticBag Diagnostics => binderCtx.Diagnostics;
@@ -231,6 +234,8 @@ internal sealed partial class ExpressionBinder
                 // the call sites short-circuit to BindConditionalAddress
                 // before reaching this dispatch.
                 return BindConditionalExpression((ConditionalExpressionSyntax)syntax);
+            case SyntaxKind.IfExpression:
+                return BindIfExpression((IfExpressionSyntax)syntax);
             case SyntaxKind.IndirectAssignmentExpression:
                 return BindIndirectAssignmentExpression((IndirectAssignmentExpressionSyntax)syntax);
             case SyntaxKind.IsExpression:

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -2205,6 +2205,26 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
             DiagnosticSeverity.Warning);
     }
 
+    /// <summary>
+    /// GS0276: An if-expression used in value position has no <c>else</c> branch.
+    /// Without an else, the expression cannot produce a value for all code paths.
+    /// </summary>
+    /// <param name="location">The source location of the <c>if</c> keyword.</param>
+    public void ReportIfExpressionMissingElse(TextLocation location)
+    {
+        Report(location, "GS0276", "An if-expression in value position must have an 'else' branch so that all code paths produce a value.");
+    }
+
+    /// <summary>
+    /// GS0277: A block in an if-expression value position has no trailing
+    /// value-producing expression.
+    /// </summary>
+    /// <param name="location">The source location of the block's closing brace.</param>
+    public void ReportBlockExpressionMissingTrailingExpression(TextLocation location)
+    {
+        Report(location, "GS0277", "A block in an if-expression value position must end with a value-producing expression.");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Syntax/BlockExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/BlockExpressionSyntax.cs
@@ -1,0 +1,57 @@
+// <copyright file="BlockExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #669: a block-with-trailing-expression of the form
+/// <c>{ stmt1; stmt2; expr }</c>. The trailing expression (if present)
+/// is the value produced by the block. When there is no trailing expression
+/// the block is statement-only and is only legal in statement position.
+/// </summary>
+public sealed class BlockExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlockExpressionSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="openBraceToken">The opening <c>{</c> token.</param>
+    /// <param name="statements">The prefix statements (all but the trailing expression).</param>
+    /// <param name="expression">The trailing expression that yields the block's value (may be null for statement-only blocks).</param>
+    /// <param name="closeBraceToken">The closing <c>}</c> token.</param>
+    public BlockExpressionSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken openBraceToken,
+        ImmutableArray<StatementSyntax> statements,
+        ExpressionSyntax expression,
+        SyntaxToken closeBraceToken)
+        : base(syntaxTree)
+    {
+        OpenBraceToken = openBraceToken;
+        Statements = statements;
+        Expression = expression;
+        CloseBraceToken = closeBraceToken;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.BlockExpression;
+
+    /// <summary>Gets the opening <c>{</c> token.</summary>
+    public SyntaxToken OpenBraceToken { get; }
+
+    /// <summary>Gets the prefix statements.</summary>
+    public ImmutableArray<StatementSyntax> Statements { get; }
+
+    /// <summary>
+    /// Gets the trailing expression. May be null for statement-only blocks
+    /// (in which case the surrounding if-expression is only legal in statement
+    /// position, which the binder enforces).
+    /// </summary>
+    public ExpressionSyntax Expression { get; }
+
+    /// <summary>Gets the closing <c>}</c> token.</summary>
+    public SyntaxToken CloseBraceToken { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/IfExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/IfExpressionSyntax.cs
@@ -1,0 +1,62 @@
+// <copyright file="IfExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #669: an if-expression of the form
+/// <c>if cond { expr } else { expr }</c> (value-producing) or
+/// <c>if cond { expr } else if ... { expr } else { expr }</c> (chained).
+/// The else branch is either another <see cref="IfExpressionSyntax"/> (for
+/// <c>else if</c> chains) or a <see cref="BlockExpressionSyntax"/>.
+/// </summary>
+public sealed class IfExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IfExpressionSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="ifKeyword">The <c>if</c> keyword token.</param>
+    /// <param name="condition">The condition expression.</param>
+    /// <param name="thenBlock">The then-block expression.</param>
+    /// <param name="elseKeyword">The optional <c>else</c> keyword token (null when absent).</param>
+    /// <param name="elseExpression">The optional else-branch: a <see cref="BlockExpressionSyntax"/> or another <see cref="IfExpressionSyntax"/> (null when absent).</param>
+    public IfExpressionSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken ifKeyword,
+        ExpressionSyntax condition,
+        BlockExpressionSyntax thenBlock,
+        SyntaxToken elseKeyword,
+        ExpressionSyntax elseExpression)
+        : base(syntaxTree)
+    {
+        IfKeyword = ifKeyword;
+        Condition = condition;
+        ThenBlock = thenBlock;
+        ElseKeyword = elseKeyword;
+        ElseExpression = elseExpression;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.IfExpression;
+
+    /// <summary>Gets the <c>if</c> keyword token.</summary>
+    public SyntaxToken IfKeyword { get; }
+
+    /// <summary>Gets the condition expression.</summary>
+    public ExpressionSyntax Condition { get; }
+
+    /// <summary>Gets the then-block expression.</summary>
+    public BlockExpressionSyntax ThenBlock { get; }
+
+    /// <summary>Gets the optional <c>else</c> keyword token.</summary>
+    public SyntaxToken ElseKeyword { get; }
+
+    /// <summary>
+    /// Gets the else branch: a <see cref="BlockExpressionSyntax"/> for a plain else,
+    /// or another <see cref="IfExpressionSyntax"/> for an <c>else if</c> chain.
+    /// Null when no else branch is present.
+    /// </summary>
+    public ExpressionSyntax ElseExpression { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -31,6 +31,13 @@ public class Parser
     // an inner `T() { … }` still works inside `if Foo(T() { X = 1 }) { … }`.
     private int suppressTrailingObjectInitializer;
 
+    // Separate counter that suppresses `Ident {` struct-literal parsing.
+    // Only incremented by ParseIfExpression to prevent the condition from
+    // consuming the then-block's opening brace as a struct literal.
+    // For-range and other body-header contexts must NOT suppress struct
+    // literals — e.g. `for v in Numbers{} { body }` is valid.
+    private int suppressStructLiteral;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="Parser"/> class.
     /// </summary>
@@ -4072,7 +4079,7 @@ public class Parser
         }
         else if (Current.Kind == SyntaxKind.IdentifierToken
             && Peek(1).Kind == SyntaxKind.OpenBraceToken
-            && suppressTrailingObjectInitializer == 0
+            && suppressStructLiteral == 0
             && IsStructLiteralFollowingBrace(2))
         {
             current = ParseStructLiteralExpression();
@@ -4745,6 +4752,7 @@ public class Parser
     {
         var ifKeyword = MatchToken(SyntaxKind.IfKeyword);
         suppressTrailingObjectInitializer++;
+        suppressStructLiteral++;
         ExpressionSyntax condition;
         try
         {
@@ -4752,6 +4760,7 @@ public class Parser
         }
         finally
         {
+            suppressStructLiteral--;
             suppressTrailingObjectInitializer--;
         }
 

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -3709,6 +3709,9 @@ public class Parser
             case SyntaxKind.SwitchKeyword:
                 return ParsePostfixChain(ParseSwitchExpression());
 
+            case SyntaxKind.IfKeyword:
+                return ParsePostfixChain(ParseIfExpression());
+
             case SyntaxKind.IdentifierToken:
             default:
                 return ParseNameOrCallExpression();
@@ -4069,6 +4072,7 @@ public class Parser
         }
         else if (Current.Kind == SyntaxKind.IdentifierToken
             && Peek(1).Kind == SyntaxKind.OpenBraceToken
+            && suppressTrailingObjectInitializer == 0
             && IsStructLiteralFollowingBrace(2))
         {
             current = ParseStructLiteralExpression();
@@ -4732,6 +4736,115 @@ public class Parser
         }
 
         return NextToken();
+    }
+
+    // Issue #669: parse an if-expression of the form
+    // `if cond { expr }`, `if cond { expr } else { expr }`,
+    // or `if cond { expr } else if ... { expr } else { expr }`.
+    private IfExpressionSyntax ParseIfExpression()
+    {
+        var ifKeyword = MatchToken(SyntaxKind.IfKeyword);
+        suppressTrailingObjectInitializer++;
+        ExpressionSyntax condition;
+        try
+        {
+            condition = ParseExpression();
+        }
+        finally
+        {
+            suppressTrailingObjectInitializer--;
+        }
+
+        var thenBlock = ParseBlockExpression();
+
+        SyntaxToken elseKeyword = null;
+        ExpressionSyntax elseExpression = null;
+        if (Current.Kind == SyntaxKind.ElseKeyword)
+        {
+            elseKeyword = NextToken();
+            if (Current.Kind == SyntaxKind.IfKeyword)
+            {
+                elseExpression = ParseIfExpression();
+            }
+            else
+            {
+                elseExpression = ParseBlockExpression();
+            }
+        }
+
+        return new IfExpressionSyntax(syntaxTree, ifKeyword, condition, thenBlock, elseKeyword, elseExpression);
+    }
+
+    // Issue #669: parse a block expression `{ stmt*; expr? }`.
+    // The last item in the block, if it is an expression statement, becomes
+    // the trailing value-producing expression of the block.
+    private BlockExpressionSyntax ParseBlockExpression()
+    {
+        var statements = ImmutableArray.CreateBuilder<StatementSyntax>();
+        ExpressionSyntax trailingExpression = null;
+
+        var openBraceToken = MatchToken(SyntaxKind.OpenBraceToken);
+
+        while (Current.Kind != SyntaxKind.EndOfFileToken &&
+               Current.Kind != SyntaxKind.CloseBraceToken)
+        {
+            var startToken = Current;
+
+            var statement = ParseBlockExpressionItem();
+            statements.Add(statement);
+
+            if (Current == startToken)
+            {
+                NextToken();
+            }
+        }
+
+        var closeBraceToken = MatchToken(SyntaxKind.CloseBraceToken);
+
+        // If the last statement is an expression statement, treat its
+        // expression as the block's trailing value-producing expression.
+        if (statements.Count > 0 && statements[^1] is ExpressionStatementSyntax exprStmt)
+        {
+            statements.RemoveAt(statements.Count - 1);
+            trailingExpression = exprStmt.Expression;
+        }
+
+        return new BlockExpressionSyntax(syntaxTree, openBraceToken, statements.ToImmutable(), trailingExpression, closeBraceToken);
+    }
+
+    // Issue #669: parse a single item inside a block expression. This is
+    // similar to ParseStatement() but recognizes `if` as potentially
+    // an if-expression (when followed by the block-expression shape).
+    private StatementSyntax ParseBlockExpressionItem()
+    {
+        // If the current token is `if` and this could be an if-expression
+        // (value-producing), parse it as an expression statement wrapping
+        // an IfExpressionSyntax. This handles nested `if` in block position.
+        if (Current.Kind == SyntaxKind.IfKeyword && LooksLikeIfExpression())
+        {
+            var ifExpr = ParseIfExpression();
+            return new ExpressionStatementSyntax(syntaxTree, ifExpr);
+        }
+
+        return ParseStatement();
+    }
+
+    // Issue #669: lookahead to determine if an `if` at the current position
+    // looks like an if-expression rather than an if-statement. We check
+    // whether `if <expr> {` pattern is followed by a `}` at the same brace
+    // depth, and then either by `else` or by the end of the enclosing block.
+    // Simple heuristic: an if-expression body is always a brace block
+    // (not a bare statement), so `if expr {` is the if-expression shape.
+    // If-statements in G# also use `if expr {`, so we disambiguate by
+    // context: in a block expression, we always prefer the expression parse.
+    private bool LooksLikeIfExpression()
+    {
+        // In block-expression context, all `if` forms can be treated as
+        // expressions. If the if has no else (statement-only form), the binder
+        // will reject it with GS0276 when in value position; but in non-value
+        // trailing position it would just produce a null trailing expression
+        // which the binder handles. We always prefer the expression parse here.
+        return true;
     }
 
     // ADR-0060 helper for the optional `out var name T` / `out let name T` /

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -296,6 +296,11 @@ public enum SyntaxKind
     // `expr is T` → bool; `expr as T` → T (or T?).
     IsExpression,
     AsExpression,
+
+    // Issue #669: if as a value-producing expression.
+    // `if cond { a } else { b }` → value.
+    IfExpression,
+    BlockExpression,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue669IfExpressionEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue669IfExpressionEmitTests.cs
@@ -1,0 +1,310 @@
+// <copyright file="Issue669IfExpressionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #669: end-to-end emit tests for if-expressions as value-producing
+/// forms. Covers basic two-arm, else-if chains, nested if-expressions,
+/// multi-statement blocks, if-expression as argument, and type inference.
+/// </summary>
+public class Issue669IfExpressionEmitTests
+{
+    [Fact]
+    public void IfExpression_TrueArm_ReturnsCorrectValue()
+    {
+        const string Source = @"package IfExpr1
+import System
+
+var cond = true
+var x = if cond { 11 } else { 22 }
+Console.WriteLine(x)
+";
+        var output = CompileAndRun(Source, "IfExpr1");
+        Assert.Contains("11", output);
+    }
+
+    [Fact]
+    public void IfExpression_FalseArm_ReturnsCorrectValue()
+    {
+        const string Source = @"package IfExpr2
+import System
+
+var cond = false
+var x = if cond { 11 } else { 22 }
+Console.WriteLine(x)
+";
+        var output = CompileAndRun(Source, "IfExpr2");
+        Assert.Contains("22", output);
+    }
+
+    [Fact]
+    public void IfExpression_StringArms()
+    {
+        const string Source = @"package IfExprStr
+import System
+
+var pick = true
+var label = if pick { ""yes"" } else { ""no"" }
+Console.WriteLine(label)
+";
+        var output = CompileAndRun(Source, "IfExprStr");
+        Assert.Contains("yes", output);
+    }
+
+    [Fact]
+    public void IfExpression_ElseIfChain()
+    {
+        const string Source = @"package IfExprChain
+import System
+
+var score = 85
+var grade = if score >= 90 { ""A"" } else if score >= 80 { ""B"" } else if score >= 70 { ""C"" } else { ""F"" }
+Console.WriteLine(grade)
+";
+        var output = CompileAndRun(Source, "IfExprChain");
+        Assert.Contains("B", output);
+    }
+
+    [Fact]
+    public void IfExpression_ElseIfChain_LastArm()
+    {
+        const string Source = @"package IfExprChain2
+import System
+
+var score = 50
+var grade = if score >= 90 { ""A"" } else if score >= 80 { ""B"" } else if score >= 70 { ""C"" } else { ""F"" }
+Console.WriteLine(grade)
+";
+        var output = CompileAndRun(Source, "IfExprChain2");
+        Assert.Contains("F", output);
+    }
+
+    [Fact]
+    public void IfExpression_Nested()
+    {
+        const string Source = @"package IfExprNest
+import System
+
+var a = true
+var b = false
+var n = if a { if b { 1 } else { 2 } } else { 3 }
+Console.WriteLine(n)
+";
+        var output = CompileAndRun(Source, "IfExprNest");
+        Assert.Contains("2", output);
+    }
+
+    [Fact]
+    public void IfExpression_MultiStatementBlock()
+    {
+        const string Source = @"package IfExprMulti
+import System
+
+var isAdmin = true
+var title = if isAdmin {
+    Console.Write("""")
+    ""Admin""
+} else { ""Home"" }
+Console.WriteLine(title)
+";
+        var output = CompileAndRun(Source, "IfExprMulti");
+        Assert.Contains("Admin", output);
+    }
+
+    [Fact]
+    public void IfExpression_AsCallArgument()
+    {
+        const string Source = @"package IfExprArg
+import System
+
+var flag = true
+Console.WriteLine(if flag { ""on"" } else { ""off"" })
+";
+        var output = CompileAndRun(Source, "IfExprArg");
+        Assert.Contains("on", output);
+    }
+
+    [Fact]
+    public void IfExpression_TypeInference()
+    {
+        const string Source = @"package IfExprInfer
+import System
+
+var x = 10
+let result = if x > 5 { x * 2 } else { x + 1 }
+Console.WriteLine(result)
+";
+        var output = CompileAndRun(Source, "IfExprInfer");
+        Assert.Contains("20", output);
+    }
+
+    [Fact]
+    public void IfExpression_MissingElse_ReportsGS0276()
+    {
+        const string Source = @"package IfExprNoElse
+
+var cond = true
+var x = if cond { 1 }
+";
+        var diags = CompileExpectingDiagnostics(Source);
+        Assert.Contains(diags, d => d.Id == "GS0276");
+    }
+
+    [Fact]
+    public void IfExpression_EmptyBlock_ReportsGS0277()
+    {
+        const string Source = @"package IfExprEmpty
+
+var cond = true
+var x = if cond { } else { 1 }
+";
+        var diags = CompileExpectingDiagnostics(Source);
+        Assert.Contains(diags, d => d.Id == "GS0277");
+    }
+
+    [Fact]
+    public void IfExpression_NoCommonType_ReportsGS0263()
+    {
+        const string Source = @"package IfExprBadType
+
+var cond = true
+var x = if cond { true } else { ""no"" }
+";
+        var diags = CompileExpectingDiagnostics(Source);
+        Assert.Contains(diags, d => d.Id == "GS0263");
+    }
+
+    [Fact]
+    public void Ternary_StillWorks_AfterIfExpression()
+    {
+        // Regression guard: ternary continues to work
+        const string Source = @"package TernaryStill
+import System
+
+var pick = true
+var x = pick ? 11 : 22
+Console.WriteLine(x)
+";
+        var output = CompileAndRun(Source, "TernaryStill");
+        Assert.Contains("11", output);
+    }
+
+    [Fact]
+    public void IfExpression_OriginalReproFromIssue()
+    {
+        // The original repro from issue #669 (adapted to compile):
+        // `let f = if filter != nil { filter!! } else { LibraryFilter() }`
+        const string Source = @"package IfExprRepro
+import System
+
+func LibraryFilter() string {
+    return ""default""
+}
+
+var filter string? = nil
+let f = if filter != nil { filter!! } else { LibraryFilter() }
+Console.WriteLine(f)
+";
+        var output = CompileAndRun(Source, "IfExprRepro");
+        Assert.Contains("default", output);
+    }
+
+    [Fact]
+    public void IfExpression_OriginalReproWithNonNilFilter()
+    {
+        const string Source = @"package IfExprRepro2
+import System
+
+func LibraryFilter() string {
+    return ""default""
+}
+
+var filter string? = ""custom""
+let f = if filter != nil { filter!! } else { LibraryFilter() }
+Console.WriteLine(f)
+";
+        var output = CompileAndRun(Source, "IfExprRepro2");
+        Assert.Contains("custom", output);
+    }
+
+    [Fact]
+    public void IfStatement_StillWorks_Unchanged()
+    {
+        // Regression guard: if-statement unchanged
+        const string Source = @"package IfStmt
+import System
+
+var x = 0
+if true {
+    x = 42
+}
+Console.WriteLine(x)
+";
+        var output = CompileAndRun(Source, "IfStmt");
+        Assert.Contains("42", output);
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, parameters: null);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static System.Collections.Generic.IReadOnlyList<GSharp.Core.CodeAnalysis.Diagnostic> CompileExpectingDiagnostics(string source)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.False(result.Success, "compilation was expected to fail: " + string.Join("; ", result.Diagnostics.Select(d => d.Id + ":" + d.Message)));
+        return result.Diagnostics;
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -26,6 +26,7 @@ BangBangToken
 BangEqualsToken
 BangToken
 BinaryExpression
+BlockExpression
 BlockStatement
 BreakKeyword
 BreakStatement
@@ -100,6 +101,7 @@ GreaterToken
 HatEqualsToken
 HatToken
 IdentifierToken
+IfExpression
 IfKeyword
 IfStatement
 ImportDeclaration


### PR DESCRIPTION
Fixes #669

## Summary

Implements `if` as a value-producing expression that coexists with the existing ternary operator (ADR-0062). The form supports multi-statement blocks, `else if` chains, and nested if-expressions.

## Grammar

```ebnf
IfExpression := 'if' Expression Block ('else' (IfExpression | Block))?
Block        := '{' Statement* (Expression)? '}'
```

## Approach

- **Parser**: `IfExpressionSyntax` and `BlockExpressionSyntax` parse `if` in expression position (primary expression level). Block-with-trailing-expression uses the "last expression statement is the value" strategy.
- **Binder**: If-expression binds to `BoundConditionalExpression` (same as ternary), reusing all ADR-0062 common-type rules. Multi-statement blocks produce `BoundBlockExpression` (already exists).
- **Emit/lowering**: No new emitter cases — reuses existing `BoundConditionalExpression` and `BoundBlockExpression` emit paths.
- **Diagnostics**: GS0276 (if-expression in value position without `else`), GS0277 (block without trailing expression in value position).

## New tests (16 tests in `Issue669IfExpressionEmitTests.cs`)

- Basic true/false arm selection
- String arms
- `else if` chains (multiple arms)
- Nested if-expressions (`if a { if b { 1 } else { 2 } } else { 3 }`)
- Multi-statement blocks (side-effects + trailing value)
- If-expression as function call argument
- Type inference on if-expression initializer
- Missing else → GS0276
- Empty block → GS0277
- No common type → GS0263
- Ternary regression guard
- Original issue repro (nullable filter pattern)
- If-statement unchanged (regression guard)

## ADR

ADR-0064: if-expression-and-block-expression.md

## Verification

- `dotnet build GSharp.sln`: clean (0 warnings, 0 errors)
- `dotnet test Core.Tests`: 2247 passed, 3 failed (all pre-existing: ForIn pattern enumerable, snapshot golden, ForIn.gs sample)
- `dotnet test Compiler.Tests`: 920 passed, 1 failed (pre-existing ForIn.gs)
- `BoundNodeKindExhaustivenessTests`: all 14 pass
- No new BoundNodeKind added; no exhaustiveness allowlist changes needed