### PR TITLE
Fix #671: user types as CLR generic args in declaration position

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1349,14 +1349,22 @@ public sealed class Binder
                 if (TypeSymbol.ContainsTypeParameter(ta))
                 {
                     hasTypeParameterArg = true;
-                    clrArgs[i] = typeof(object);
+                    clrArgs[i] = scope.References.MapClrTypeToReferences(typeof(object));
                     continue;
                 }
 
+                // Issue #671: a user-defined G# type (class, struct,
+                // interface, enum, delegate) used as a type argument to a CLR
+                // generic has no ClrType at bind time — the CLR TypeDef is only
+                // produced during emit. Handle the same way as type parameters:
+                // project onto System.Object for the closed CLR shape and
+                // preserve the symbolic argument via GetConstructed so the
+                // emitter can recover the real type.
                 if (ta.ClrType == null)
                 {
-                    Diagnostics.ReportTypeNotGeneric(syntax.TypeArguments[i].Identifier?.Location ?? syntax.Identifier.Location, ta.Name);
-                    return null;
+                    hasTypeParameterArg = true;
+                    clrArgs[i] = scope.References.MapClrTypeToReferences(typeof(object));
+                    continue;
                 }
 
                 // Project host CLR type arguments onto the resolver's reference
@@ -1373,9 +1381,10 @@ public sealed class Binder
                 var closed = clrOpenType.MakeGenericType(clrArgs);
                 if (hasTypeParameterArg)
                 {
-                    // #313: keep the symbolic `[T]` arguments alongside the
-                    // type-erased closed CLR shape so call-site inference and
-                    // return-type substitution can recover the type parameter.
+                    // #313 / #671: keep the symbolic type arguments alongside
+                    // the type-erased closed CLR shape so call-site inference,
+                    // return-type substitution, and user-type emit can recover
+                    // the real type argument.
                     return ImportedTypeSymbol.GetConstructed(closed, clrOpenType, symbolicArgs.MoveToImmutable());
                 }
 
@@ -1755,14 +1764,17 @@ public sealed class Binder
             if (TypeSymbol.ContainsTypeParameter(ta))
             {
                 hasTypeParameterArg = true;
-                clrArgs[i] = typeof(object);
+                clrArgs[i] = scope.References.MapClrTypeToReferences(typeof(object));
                 continue;
             }
 
+            // Issue #671: user-defined types without a ClrType project onto
+            // System.Object (same as type parameters above).
             if (ta.ClrType == null)
             {
-                Diagnostics.ReportTypeNotGeneric(syntax.TypeArguments[i].Identifier?.Location ?? syntax.Identifier.Location, ta.Name);
-                return null;
+                hasTypeParameterArg = true;
+                clrArgs[i] = scope.References.MapClrTypeToReferences(typeof(object));
+                continue;
             }
 
             clrArgs[i] = ResolveClrTypeForGenericArg(ta) ?? scope.References.MapClrTypeToReferences(ta.ClrType);

--- a/test/Compiler.Tests/Emit/Issue671UserTypeAsClrGenericArgEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue671UserTypeAsClrGenericArgEmitTests.cs
@@ -1,0 +1,193 @@
+// <copyright file="Issue671UserTypeAsClrGenericArgEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// End-to-end emit tests for issue #671: user-defined G# class/interface used as
+/// a type argument to a CLR generic in declaration position (field type, method
+/// return type, method parameter type). Verifies that the emitted assembly loads,
+/// runs, and produces correct output.
+/// </summary>
+public class Issue671UserTypeAsClrGenericArgEmitTests
+{
+    [Fact]
+    public void Field_ListOfUserClass_Compiles_And_Runs()
+    {
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+
+            type Container class {
+                items List[MyType]
+            }
+
+            let c = Container()
+            Console.WriteLine("ok")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("ok\n", output);
+    }
+
+    [Fact]
+    public void MethodReturn_ListOfUserClass_Compiles()
+    {
+        // Verifies that a method with return type List[MyType] compiles without
+        // error. IL verification of the access pattern is a follow-up concern
+        // (the field signature is correctly emitted as List<MyType>).
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+
+            type Container class {
+                items List[MyType]
+
+                func getItems() List[MyType] {
+                    return items
+                }
+            }
+
+            let c = Container()
+            Console.WriteLine("method-return-ok")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("method-return-ok\n", output);
+    }
+
+    [Fact]
+    public void MethodParam_ListOfUserClass_Compiles()
+    {
+        // Verifies that a method with parameter type List[MyType] compiles
+        // without error and the assembly is IL-valid.
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+
+            type Container class {
+                func accept(xs List[MyType]) {
+                }
+            }
+
+            let c = Container()
+            Console.WriteLine("method-param-ok")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("method-param-ok\n", output);
+    }
+
+    [Fact]
+    public void Field_DictionaryStringAndUserClass_Compiles_And_Runs()
+    {
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+
+            type Container class {
+                lookup Dictionary[string, MyType]
+            }
+
+            let c = Container()
+            Console.WriteLine("dict-ok")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("dict-ok\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue671_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue671UserTypeAsClrGenericArgTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue671UserTypeAsClrGenericArgTests.cs
@@ -1,0 +1,369 @@
+// <copyright file="Issue671UserTypeAsClrGenericArgTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests for issue #671: user-defined G# class or interface used as a
+/// type argument to a CLR generic (<c>List[MyType]</c>, <c>Task[MyType]</c>,
+/// <c>Dictionary[string, MyType]</c>) in field-type, method return-type, or
+/// method parameter-type position must bind without error.
+/// <para>
+/// Previously the declaration-position generic-construction path rejected types
+/// whose <see cref="TypeSymbol.ClrType"/> was <c>null</c> (always the case for
+/// user-defined types before emit) by surfacing GS0149 "Type 'X' is not generic".
+/// The fix projects such types onto <c>System.Object</c> for the closed CLR shape
+/// (same as type parameters under the type-erased model) while preserving the
+/// real symbolic argument via <see cref="ImportedTypeSymbol.GetConstructed"/>.
+/// </para>
+/// </summary>
+public class Issue671UserTypeAsClrGenericArgTests
+{
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics;
+    }
+
+    private static ImmutableArray<Diagnostic> BindMultiFile(params string[] sources)
+    {
+        var trees = sources
+            .Select(s => SyntaxTree.Parse(SourceText.From(s)))
+            .ToArray();
+        var compilation = new Compilation(trees);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics;
+    }
+
+    // ─── Field type position ─────────────────────────────────────────────
+
+    [Fact]
+    public void Field_ListOfUserClass_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+
+            type Container class {
+                items List[MyType]
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Field_ListOfUserInterface_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type IMyType interface {
+                func GetName() string
+            }
+
+            type Container class {
+                items List[IMyType]
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    // ─── Method return-type position ─────────────────────────────────────
+
+    [Fact]
+    public void MethodReturn_ListOfUserClass_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+
+            type Container class {
+                items List[MyType]
+
+                func getItems() List[MyType] {
+                    return items
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    // ─── Method parameter-type position ──────────────────────────────────
+
+    [Fact]
+    public void MethodParam_ListOfUserClass_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+
+            type Container class {
+                func addAll(xs List[MyType]) {
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    // ─── IReadOnlyList / IEnumerable / Task ──────────────────────────────
+
+    [Fact]
+    public void Field_IReadOnlyListOfUserClass_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type MyType class {
+                Value int32
+            }
+
+            type Container class {
+                items IReadOnlyList[MyType]
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Field_IEnumerableOfUserClass_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type MyType class {
+                Value int32
+            }
+
+            type Container class {
+                items IEnumerable[MyType]
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Field_TaskOfUserClass_Binds()
+    {
+        var source = """
+            package App
+            import System.Threading.Tasks
+
+            type MyType class {
+                Value int32
+            }
+
+            type Container class {
+                pending Task[MyType]
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    // ─── Multi-arg generics ──────────────────────────────────────────────
+
+    [Fact]
+    public void Field_DictionaryStringAndUserClass_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+
+            type Container class {
+                items Dictionary[string, MyType]
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    // ─── Cross-file (same package) ───────────────────────────────────────
+
+    [Fact]
+    public void CrossFile_ListOfUserClass_Binds()
+    {
+        var fileA = """
+            package App
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+            """;
+
+        var fileB = """
+            package App
+            import System.Collections.Generic
+
+            type Container class {
+                items List[MyType]
+            }
+            """;
+
+        Assert.Empty(BindMultiFile(fileA, fileB));
+    }
+
+    // ─── Regression guards ───────────────────────────────────────────────
+
+    [Fact]
+    public void Regression_Field_ListOfString_StillBinds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type Container class {
+                items List[string]
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Regression_Field_DictionaryOfClrTypes_StillBinds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type Container class {
+                items Dictionary[string, int32]
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Regression_BodyPosition_ListOfUserClass_StillBinds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+
+            type Container class {
+                items List[MyType]
+            }
+
+            func main() {
+                var c = Container()
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    // ─── MLC (MetadataLoadContext) path ──────────────────────────────────
+
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+            typeof(System.Collections.Generic.Dictionary<,>).Assembly.Location,
+            typeof(System.Threading.Tasks.Task<>).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+            typeof(System.Linq.Enumerable).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    private static ImmutableArray<Diagnostic> BindWithReferences(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(
+            previous: null,
+            ImmutableArray.Create(tree),
+            MetadataLoadContextResolver());
+        var program = Binder.BindProgram(globalScope, MetadataLoadContextResolver());
+        return globalScope.Diagnostics.AddRange(program.Diagnostics);
+    }
+
+    [Fact]
+    public void MLC_Field_ListOfUserClass_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+
+            type Container class {
+                items List[MyType]
+            }
+            """;
+
+        Assert.Empty(BindWithReferences(source));
+    }
+
+    [Fact]
+    public void MLC_Field_DictionaryStringAndUserClass_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+
+            type Container class {
+                items Dictionary[string, MyType]
+            }
+            """;
+
+        Assert.Empty(BindWithReferences(source));
+    }
+}


### PR DESCRIPTION
Fixes #671

## Root cause

The declaration-position generic-construction path in `Binder.BindTypeClause` and `Binder.ConstructIfGeneric` rejected type arguments whose `ClrType` was `null` — always the case for user-defined G# classes, interfaces, enums, and delegates before emit — by reporting GS0149 `Type 'X' is not generic`.

The expression-position binder (bodies) already handled this case correctly by using `System.Object` as a placeholder (issue #320), but the declaration-position path had no such handling.

## Fix

Both sites now handle `ta.ClrType == null` the same way as type parameters under the type-erased model:
1. Project onto `scope.References.MapClrTypeToReferences(typeof(object))` for the closed CLR shape (MLC-safe)
2. Set `hasTypeParameterArg = true` to force the `ImportedTypeSymbol.GetConstructed` path
3. The symbolic type arguments are preserved so the emitter can produce correct `GenericInstantiation` signatures

Also fixes a latent MLC bug in the existing type-parameter path (#313) which used bare `typeof(object)` — incompatible with MetadataLoadContext-loaded types.

## New tests

**Binder tests** (`Issue671UserTypeAsClrGenericArgTests.cs`, 14 tests):
- Field type: `List[MyClass]`, `List[IMyIface]`, `IReadOnlyList[T]`, `IEnumerable[T]`, `Task[T]`, `Dictionary[string, T]`
- Method return type: `func get() List[MyType]`
- Method parameter type: `func add(xs List[MyType])`
- Cross-file (same package)
- MLC (MetadataLoadContext) path
- Regression guards: `List[string]`, `Dictionary[string, int32]`

**Emit tests** (`Issue671UserTypeAsClrGenericArgEmitTests.cs`, 4 tests):
- Field type compilation + IL verification + runtime
- Method return type compilation + IL verification
- Method parameter type compilation + IL verification
- Multi-arg generic (`Dictionary[string, MyType]`) compilation + IL verification + runtime

## Verification

```
dotnet test test/Core.Tests/Core.Tests.csproj         → 2264 passed
dotnet test test/Compiler.Tests/Compiler.Tests.csproj → 925 passed
dotnet test test/Interpreter.Tests/                   → 98 passed
dotnet test test/LanguageServer.Tests/                → 242 passed
```

## Known limitation (not in scope)

Member access on a generic type instantiation with user-type args (e.g. `list.Count` where `list` is `List[MyType]`) produces an IL verification mismatch when the member reference is resolved against the erased `List<object>` but the stack carries `List<MyType>`. This is a pre-existing emit concern (orthogonal to the binder fix) and is not addressed here.