### PR TITLE
Fix #672: CLR nested type access (Outer.Inner.Member)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -858,6 +858,25 @@ internal sealed partial class ExpressionBinder
         switch (rightPart)
         {
             case AccessorExpressionSyntax nested:
+                // Issue #672: when the LHS is a CLR type symbol, check whether
+                // the left segment of the nested accessor names a nested type
+                // (e.g. `Environment.SpecialFolder.ApplicationData` — here
+                // `SpecialFolder` is a nested enum inside `Environment`). If so,
+                // create a new ImportedClassSymbol for the nested type and bind
+                // the right segment against it, enabling chained static/enum
+                // member access on nested types.
+                if (classSymbol != null && TryResolveNestedTypeFromAccessorLeft(classSymbol, nested.LeftPart, out var nestedClassSymbol))
+                {
+                    if (nested.IsNullConditional)
+                    {
+                        // Null-conditional on a type is semantically meaningless
+                        // but fall through to avoid a crash.
+                        return new BoundErrorExpression(null);
+                    }
+
+                    return BindAccessorStep(null, nestedClassSymbol, nested.RightPart);
+                }
+
                 var head = BindAccessorStep(receiver, classSymbol, nested.LeftPart);
                 if (head is BoundErrorExpression)
                 {
@@ -1108,6 +1127,68 @@ internal sealed partial class ExpressionBinder
             default:
                 return new BoundErrorExpression(null);
         }
+    }
+
+    /// <summary>
+    /// Issue #672: resolves a nested CLR type from the left part of an
+    /// accessor expression when the enclosing type is already known (i.e.
+    /// <paramref name="classSymbol"/> is non-null). Supports single-level
+    /// nesting (left part is a <see cref="NameExpressionSyntax"/>) and
+    /// multi-level nesting (left part is an <see cref="AccessorExpressionSyntax"/>
+    /// whose segments form a chain of nested types).
+    /// </summary>
+    private bool TryResolveNestedTypeFromAccessorLeft(ImportedClassSymbol classSymbol, ExpressionSyntax leftPart, out ImportedClassSymbol nestedClassSymbol)
+    {
+        nestedClassSymbol = null;
+
+        if (leftPart is NameExpressionSyntax nameExpr)
+        {
+            var name = nameExpr.IdentifierToken.Text;
+
+            // Only resolve as a nested type when the name is NOT a static
+            // field/property or method group — those take precedence.
+            if (classSymbol.TryLookupMember(name, nameExpr, out _))
+            {
+                return false;
+            }
+
+            if (TryBindClrMethodGroup(receiver: null, classSymbol.ClassType, wantStatic: true, name, out _))
+            {
+                return false;
+            }
+
+            if (scope.References.TryResolveNestedType(classSymbol.ClassType, name, out var nestedType))
+            {
+                nestedClassSymbol = new ImportedClassSymbol(nestedType, nameExpr);
+                return true;
+            }
+
+            return false;
+        }
+
+        if (leftPart is AccessorExpressionSyntax accessor)
+        {
+            // Multi-level nesting: recursively resolve the left side first,
+            // then resolve the right side as a nested type of that.
+            if (!TryResolveNestedTypeFromAccessorLeft(classSymbol, accessor.LeftPart, out var intermediateSymbol))
+            {
+                return false;
+            }
+
+            if (accessor.RightPart is NameExpressionSyntax innerName)
+            {
+                var innerNameText = innerName.IdentifierToken.Text;
+                if (scope.References.TryResolveNestedType(intermediateSymbol.ClassType, innerNameText, out var deepNested))
+                {
+                    nestedClassSymbol = new ImportedClassSymbol(deepNested, innerName);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return false;
     }
 
     private BoundExpression BindIndexExpression(IndexExpressionSyntax syntax)

--- a/test/Compiler.Tests/Emit/Issue672ClrNestedTypeAccessEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue672ClrNestedTypeAccessEmitTests.cs
@@ -1,0 +1,428 @@
+// <copyright file="Issue672ClrNestedTypeAccessEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #672: CLR nested type access in expression position must compile,
+/// IL-verify, and execute correctly. Covers nested enum value access,
+/// nested class static member access, nested struct usage, and multi-level
+/// nesting.
+/// </summary>
+public class Issue672ClrNestedTypeAccessEmitTests
+{
+    [Fact]
+    public void NestedEnum_GetFolderPath_CompilesAndRuns()
+    {
+        // The issue repro: Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
+        // must compile and produce a non-null result at runtime.
+        var source = """
+            package Probe
+            import System
+
+            var path = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
+            Console.WriteLine(path != "")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void NestedEnum_DirectValue_CompilesAndRuns()
+    {
+        // Storing a nested enum value and printing its int representation.
+        var source = """
+            package Probe
+            import System
+
+            var sf = Environment.SpecialFolder.Desktop
+            Console.WriteLine(sf)
+            """;
+
+        var output = CompileAndRun(source);
+        // Environment.SpecialFolder.Desktop prints its enum name via ToString().
+        Assert.Equal("Desktop\n", output);
+    }
+
+    [Fact]
+    public void NestedClass_StaticMember_CompilesAndRuns()
+    {
+        // A sibling C# library defines a nested class with a static property;
+        // G# accesses it via `Outer.Inner.Value`.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public sealed class Outer
+                {
+                    public sealed class Inner
+                    {
+                        public static string Value => "nested-value";
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            var v = Outer.Inner.Value
+            Console.WriteLine(v)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("nested-value\n", output);
+    }
+
+    [Fact]
+    public void NestedStruct_StaticField_CompilesAndRuns()
+    {
+        // A sibling C# library defines a nested struct with a static field.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public sealed class Container
+                {
+                    public struct Inner
+                    {
+                        public static int DefaultValue = 77;
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            var v = Container.Inner.DefaultValue
+            Console.WriteLine(v)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("77\n", output);
+    }
+
+    [Fact]
+    public void MultiLevelNesting_StaticMember_CompilesAndRuns()
+    {
+        // Three-level nesting: `Outer.Middle.Inner.Value`.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public sealed class Outer
+                {
+                    public sealed class Middle
+                    {
+                        public sealed class Inner
+                        {
+                            public static string Value => "deep";
+                        }
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            var v = Outer.Middle.Inner.Value
+            Console.WriteLine(v)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("deep\n", output);
+    }
+
+    [Fact]
+    public void NestedEnum_InSiblingLibrary_CompilesAndRuns()
+    {
+        // A nested enum in a sibling library must be accessible.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public sealed class Config
+                {
+                    public enum Mode
+                    {
+                        Fast = 1,
+                        Slow = 2,
+                        Auto = 3,
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            var m = Config.Mode.Auto
+            Console.WriteLine(m)
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("Auto\n", output);
+    }
+
+    [Fact]
+    public void NestedType_ConstructorCall_StillWorks_Regression()
+    {
+        // Issue #569 regression guard: constructing a nested type must still work.
+        var sibling = """
+            namespace Probe.CSharp
+            {
+                public sealed class Factory
+                {
+                    public sealed class Widget
+                    {
+                        public override string ToString() => "widget-ok";
+                    }
+                }
+            }
+            """;
+
+        var gsource = """
+            package Probe.Tests
+            import System
+            import Probe.CSharp
+
+            var w = Factory.Widget()
+            Console.WriteLine(w.ToString())
+            """;
+
+        var output = CompileAndRunWithSiblingCs(sibling, gsource, siblingName: "Probe.CSharp");
+        Assert.Equal("widget-ok\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue672_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue672_sib_").FullName;
+        try
+        {
+            var csDir = Path.Combine(tempDir, "csref");
+            Directory.CreateDirectory(csDir);
+            File.WriteAllText(Path.Combine(csDir, "Lib.cs"), csSource);
+            File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Library</OutputType>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <AssemblyName>{siblingName}</AssemblyName>
+                    <RootNamespace>{siblingName}</RootNamespace>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var siblingDll = BuildCsProject(csDir, siblingName);
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, gSource);
+
+            var gscArgs = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + siblingDll,
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                gscArgs.Add("/reference:" + reference);
+            }
+
+            gscArgs.Add("/nowarn:GS9100");
+            gscArgs.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(gscArgs.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            File.Copy(siblingDll, Path.Combine(tempDir, Path.GetFileName(siblingDll)), overwrite: true);
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { siblingDll });
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string BuildCsProject(string csDir, string siblingName)
+    {
+        RunDotnet(csDir, "restore");
+        RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore");
+
+        var dll = Path.Combine(csDir, "bin", "Release", "net10.0", siblingName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static string RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"dotnet {string.Join(" ", args)} failed (exit {proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/ClrNestedTypeAccessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClrNestedTypeAccessTests.cs
@@ -1,0 +1,133 @@
+// <copyright file="ClrNestedTypeAccessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #672: CLR nested type access in expression position. Verifies
+/// that `Outer.Nested.Member` resolves when `Nested` is a nested enum,
+/// class, or struct defined inside an imported CLR type.
+/// </summary>
+public class ClrNestedTypeAccessTests
+{
+    [Fact]
+    public void NestedEnum_MemberAccess_Binds()
+    {
+        // Environment.SpecialFolder.ApplicationData — the original repro.
+        var source = @"
+import System
+
+var sf = Environment.SpecialFolder.ApplicationData
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void NestedEnum_PassedToMethod_Binds()
+    {
+        // Pass nested enum value to a method that accepts it.
+        var source = @"
+import System
+
+var path = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void TopLevelEnum_ContinuesToWork_Regression()
+    {
+        // StringComparison.OrdinalIgnoreCase is a top-level enum and must
+        // continue to work.
+        var source = @"
+import System
+
+var cmp = StringComparison.OrdinalIgnoreCase
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void StaticMethod_OnImportedClass_ContinuesToWork_Regression()
+    {
+        // Environment.GetEnvironmentVariable must still resolve (regression guard).
+        var source = @"
+import System
+
+var x = Environment.GetEnvironmentVariable(""PATH"")
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void NestedEnum_MultipleValues_Bind()
+    {
+        // Access multiple values from the same nested enum.
+        var source = @"
+import System
+
+var a = Environment.SpecialFolder.ApplicationData
+var b = Environment.SpecialFolder.Desktop
+var c = Environment.SpecialFolder.UserProfile
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void NestedEnum_InvalidMember_ReportsError()
+    {
+        // A non-existent member on the nested enum should still report an error.
+        var source = @"
+import System
+
+var sf = Environment.SpecialFolder.ThisDoesNotExist
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void NestedType_StaticPropertyAccess_Binds()
+    {
+        // System.Text.Encoding has a nested class UTF8Encoding, but a
+        // more accessible static pattern: access nested type static members.
+        // Use System.IO.Path.DirectorySeparatorChar as a non-nested reference
+        // test, and use TypeCode which is nested in various patterns.
+        // Actually, let's use System.Environment.SpecialFolder which is the
+        // core issue, and verify a different nested-enum pattern:
+        // System.Globalization.UnicodeCategory — wait, that's top-level.
+        // Use System.AttributeTargets which is a flags enum.
+        // Actually AttributeTargets is top-level too.
+        // The critical test is Environment.SpecialFolder which is the only
+        // commonly-used BCL nested enum.
+        var source = @"
+import System
+
+var sf = Environment.SpecialFolder.CommonApplicationData
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #672

## Root cause

When the binder resolved a member access on an imported CLR type symbol (e.g. `Environment.SpecialFolder`), it only searched for **static fields, properties, and method groups**. If none matched, it immediately reported GS0158 ("Cannot find member"). It never checked whether the member name referred to a **nested type** (enum, class, or struct) defined inside the outer type.

## Fix

In `ExpressionBinder.Access.cs`, added a `TryResolveNestedTypeFromAccessorLeft` helper that uses the existing `ReferenceResolver.TryResolveNestedType` infrastructure to detect nested types. When the left side of an `AccessorExpressionSyntax` names a nested type of the current CLR class symbol, the binder creates a new `ImportedClassSymbol` for the nested type and continues binding the right side against it. This enables:

- Nested enum value access: `Environment.SpecialFolder.ApplicationData`
- Nested class static member access: `Outer.Inner.Value`
- Nested struct static field access: `Container.Inner.DefaultValue`
- Multi-level nesting: `Outer.Middle.Inner.Value`
- Passing nested enum values to methods: `Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)`

The fix respects the existing resolution priority: static fields/properties and method groups are checked first; nested type lookup only fires when those fail. This ensures no regressions for code that accesses static members sharing a name with a nested type.

## New tests

### Binding tests (`ClrNestedTypeAccessTests.cs`)
- `NestedEnum_MemberAccess_Binds` — the original repro
- `NestedEnum_PassedToMethod_Binds` — enum value passed to `GetFolderPath`
- `TopLevelEnum_ContinuesToWork_Regression` — `StringComparison.OrdinalIgnoreCase`
- `StaticMethod_OnImportedClass_ContinuesToWork_Regression` — `Environment.GetEnvironmentVariable`
- `NestedEnum_MultipleValues_Bind` — multiple nested enum values
- `NestedEnum_InvalidMember_ReportsError` — GS0158 still fires for non-existent members
- `NestedType_StaticPropertyAccess_Binds` — `CommonApplicationData` value

### Emit/E2E tests (`Issue672ClrNestedTypeAccessEmitTests.cs`)
- `NestedEnum_GetFolderPath_CompilesAndRuns` — full end-to-end with IL verification
- `NestedEnum_DirectValue_CompilesAndRuns` — stores enum value, prints it
- `NestedClass_StaticMember_CompilesAndRuns` — sibling C# library nested class
- `NestedStruct_StaticField_CompilesAndRuns` — sibling C# library nested struct
- `MultiLevelNesting_StaticMember_CompilesAndRuns` — `Outer.Middle.Inner.Value`
- `NestedEnum_InSiblingLibrary_CompilesAndRuns` — sibling C# library nested enum
- `NestedType_ConstructorCall_StillWorks_Regression` — issue #569 regression guard

## Verification

```
dotnet build GSharp.sln -nologo -clp:NoSummary        # 0 warnings, 0 errors
dotnet test test/Core.Tests/Core.Tests.csproj          # 2271 passed
dotnet test test/Compiler.Tests/Compiler.Tests.csproj  # 932 passed
dotnet test test/Interpreter.Tests/                    # 98 passed
dotnet test test/LanguageServer.Tests/                 # 242 passed
dotnet test test/Sdk.Tests/                            # 26 passed
```

All IL verification passes via the existing `IlVerifier.Verify` harness.