### PR TITLE
Implement ADR-0065: class initializers and base invocation

### DIFF
--- a/docs/adr/0065-class-initializers-and-base-invocation.md
+++ b/docs/adr/0065-class-initializers-and-base-invocation.md
@@ -1,6 +1,6 @@
 # ADR-0065: Class multiple initializers and base-class invocation
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-06-10
 - **Phase**: Phase 9 — language depth / class initialization
 - **Related**: ADR-0003 (OO surface), ADR-0017 (method virtuality / `open`), ADR-0063 (method overloading — §9 multiple `init` overloads), issue [#646](https://github.com/DavidObando/gsharp/issues/646), issue [#656](https://github.com/DavidObando/gsharp/issues/656)
@@ -296,17 +296,28 @@ type HttpClient open class {
 
 ### New diagnostics
 
-The following diagnostic codes are placeholders; live codes will be assigned at implementation time.
+The diagnostic codes below are the live codes assigned at implementation time
+(see `src/Core/CodeAnalysis/DiagnosticBag.cs`).
+
+| Code | Description |
+|---|---|
+| `GS0278` | Convenience initializer body must begin with `init(args)` self-delegation. |
+| `GS0279` | Convenience initializer may not declare an explicit `: base(args)` clause. |
+| `GS0280` | `init(args)` self-delegation is only valid inside a class constructor body. |
+| `GS0281` | Designated initializer may not delegate to a sibling `init(args)` overload; use `: base(args)` instead. |
+| `GS0282` | Convenience initializer may not delegate to itself (recursive). |
+| `GS0283` | No applicable `init(...)` overload on this class matches the self-delegation arguments. |
+| `GS0284` | A user-declared `init(...)` overload duplicates the signature synthesized from the primary constructor. |
+
+Future diagnostics — to be added when the deferred two-phase enforcement
+work (see Implementation notes) lands:
 
 | Placeholder | Description |
 |---|---|
 | `GSxxxx` | Designated initializer does not assign stored property `'P'` before invoking base initializer. |
 | `GSxxxx` | Designated initializer must invoke base-class initializer before accessing inherited member `'M'`. |
-| `GSxxxx` | Convenience initializer must delegate to another initializer before accessing `'this'`. |
-| `GSxxxx` | Convenience initializer must delegate to an initializer in the same class (not base). |
 | `GSxxxx` | Instance may not be used as a value until phase-1 initialization is complete. |
 | `GSxxxx` | Convenience initializer may not directly assign stored properties; delegate first. |
-| `GSxxxx` | Duplicate initializer signature conflicts with synthesised primary constructor. |
 
 ### Migration
 
@@ -336,10 +347,32 @@ Go has no constructors. Types are always zero-initialized; factory functions (`N
 
 ## Open questions
 
-1. **Phase-1 enforcement strictness for field initializers.** If a field has a default-value expression (`Active bool = false`), does the designated init still need to "assign" it before calling `base`? Proposed default: no — fields with default values are considered pre-initialised at the start of the init body. Maintainer should confirm.
-2. **`override init` syntax.** Swift allows `override init(...)` when a subclass re-declares a base designated init. Should G# require `override` on such inits, matching the `override func` precedent (ADR-0017)? Proposed default: yes, `override init(...)` is required and diagnosed if missing.
+1. **Phase-1 enforcement strictness for field initializers.** If a field has a default-value expression (`Active bool = false`), does the designated init still need to "assign" it before calling `base`? **Resolved**: No — fields with default values are considered pre-initialised at the start of the init body. This matches the implementation's existing instance-field-initializer emission, which runs before the user-authored body.
+2. **`override init` syntax.** Swift allows `override init(...)` when a subclass re-declares a base designated init. Should G# require `override` on such inits, matching the `override func` precedent (ADR-0017)? **Deferred** to a follow-up issue alongside the initializer-inheritance Rule B implementation.
 3. **Interaction with `required` fields.** If G# introduces a `required` field modifier (analogous to C# 11's `required` members), how does it interact with designated-init obligations? Deferred to a future ADR.
-4. **Initializer access control.** May a designated init be `private`? Swift allows this (used to prevent external subclassing). Proposed default: yes, all visibility modifiers apply to `init` as they do to `func`.
+4. **Initializer access control.** May a designated init be `private`? Swift allows this (used to prevent external subclassing). **Resolved**: Yes — all visibility modifiers (`public`/`internal`/`private`) apply to `init` exactly as they do to `func`. The existing accessibility-resolution path already covers this.
+
+## Implementation notes
+
+The first implementation (this PR) covers §1, §2, §5, §8, parts of §3 and §4, and the
+diagnostic surface above. The following pieces are tracked as follow-up work:
+
+- **§3 strict ordering**: the implementation emits the base call as the first
+  instruction of a designated init body (matching the CLR convention) rather
+  than reordering the body to delay the base call to the "after all own fields
+  assigned" point. This is observationally indistinguishable for well-formed
+  programs unless the base initializer calls a virtual method that depends on
+  derived-class state — that scenario is covered by the deferred §4 Rule 2 and
+  Rule 4 diagnostics described below.
+- **§4 Rules 1, 2, 4**: full two-phase definite-assignment diagnostics
+  (all-own-properties-before-super, no-inherited-access-before-super,
+  no-self-as-value-during-phase-1). Rule 3 (convenience must delegate first)
+  is enforced via `GS0278`.
+- **§6 Rule A & Rule B initializer inheritance**: derived classes that
+  declare no `init(...)` bodies do not yet inherit the base class's
+  designated initializers as overload candidates of the derived type. Both
+  rules will be added in a follow-up PR alongside the `override init`
+  machinery noted in open question #2.
 
 ## Out of scope
 

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -259,6 +259,7 @@ ConditionalExpression
 ConditionalGotoStatement
 ConstantPattern
 ConstructorCallExpression
+ConstructorChainingExpression
 ConversionExpression
 DefaultExpression
 DereferenceExpression

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -752,8 +752,23 @@ public sealed class Binder
 
             foreach (var ctor in structSym.ExplicitConstructors)
             {
+                // ADR-0065 §5: skip synthesized primary-ctor symbols; the
+                // emitter materializes their field-assignment body directly.
+                if (ctor.IsSynthesizedFromPrimaryConstructor || ctor.Declaration == null)
+                {
+                    continue;
+                }
+
                 var ctorBinder = new Binder(parentScope, ctor.Function);
                 var ctorBody = ctorBinder.statements.BindStatement(ctor.Declaration.Body);
+
+                // ADR-0065 §2 Rule 3: a `convenience init` body must begin
+                // with a `init(args)` self-delegation expression-statement.
+                if (ctor.IsConvenience)
+                {
+                    VerifyConvenienceInitDelegatesFirst(ctor, ctorBody, ctorBinder.Diagnostics);
+                }
+
                 var ctorLoweredBody = Lowerer.Lower(ctorBody, structSym);
                 functionBodies.Add(ctor.Function, ctorLoweredBody);
                 diagnostics.AddRange(ctorBinder.Diagnostics);
@@ -1996,6 +2011,58 @@ public sealed class Binder
 
         sb.Append(')');
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// ADR-0065 §2 Rule 3: ensures the body of a <c>convenience init</c>
+    /// begins with a <c>init(args)</c> self-delegation. Reports
+    /// <c>GS0278</c> when violated. Empty bodies and bodies whose first
+    /// statement is anything other than a chaining expression-statement are
+    /// rejected.
+    /// </summary>
+    private static void VerifyConvenienceInitDelegatesFirst(ConstructorSymbol ctor, BoundStatement boundBody, DiagnosticBag diagnostics)
+    {
+        if (ctor.Declaration == null)
+        {
+            return;
+        }
+
+        var location = ctor.Declaration.InitKeyword.Location;
+
+        var firstNonNoOp = FindFirstSignificantStatement(boundBody);
+        if (firstNonNoOp is BoundExpressionStatement exprStmt
+            && exprStmt.Expression is BoundConstructorChainingExpression)
+        {
+            return;
+        }
+
+        diagnostics.ReportConvenienceInitMustDelegate(location, ctor.DeclaringType?.Name ?? "?");
+    }
+
+    /// <summary>
+    /// ADR-0065 §2: recursively descends into a single-statement block to find
+    /// the first effective top-level statement. Used by
+    /// <see cref="VerifyConvenienceInitDelegatesFirst"/> to allow trivial
+    /// pre-pass wrapping (e.g. statements injected by lowering passes added
+    /// at a later date) without giving up on the chaining check.
+    /// </summary>
+    private static BoundStatement FindFirstSignificantStatement(BoundStatement statement)
+    {
+        if (statement is BoundBlockStatement block)
+        {
+            for (var i = 0; i < block.Statements.Length; i++)
+            {
+                var inner = FindFirstSignificantStatement(block.Statements[i]);
+                if (inner != null)
+                {
+                    return inner;
+                }
+            }
+
+            return null;
+        }
+
+        return statement;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/BoundConstructorChainingExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundConstructorChainingExpression.cs
@@ -1,0 +1,39 @@
+// <copyright file="BoundConstructorChainingExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+#pragma warning disable CS1591
+#pragma warning disable SA1600
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0065 §2: a <c>init(args)</c> self-delegation appearing inside a
+/// <c>convenience init</c> body. Lowered to a CIL <c>call .ctor(this, args)</c>
+/// chained-constructor call that delegates to another initializer in the
+/// same class. The expression is value-less (type <see cref="TypeSymbol.Void"/>)
+/// and is normally wrapped in a <see cref="BoundExpressionStatement"/>.
+/// </summary>
+public sealed class BoundConstructorChainingExpression : BoundExpression
+{
+    public BoundConstructorChainingExpression(SyntaxNode syntax, ConstructorSymbol selectedConstructor, ImmutableArray<BoundExpression> arguments)
+        : base(syntax)
+    {
+        SelectedConstructor = selectedConstructor;
+        Arguments = arguments;
+    }
+
+    /// <summary>Gets the chosen sibling constructor overload to chain to.</summary>
+    public ConstructorSymbol SelectedConstructor { get; }
+
+    /// <summary>Gets the bound arguments (already permuted to parameter order and converted).</summary>
+    public ImmutableArray<BoundExpression> Arguments { get; }
+
+    public override TypeSymbol Type => TypeSymbol.Void;
+
+    public override BoundNodeKind Kind => BoundNodeKind.ConstructorChainingExpression;
+}

--- a/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -133,6 +133,11 @@ public enum BoundNodeKind
     // Issue #575: expression-level type-test and safe-cast operators.
     IsExpression,
     AsExpression,
+
+    // ADR-0065 §2: a `init(args)` self-delegation statement inside a
+    // `convenience init(...)` body. Emitted as a `call .ctor(this, args)`
+    // chained CIL call to another constructor in the same class.
+    ConstructorChainingExpression,
 }
 
 #pragma warning restore SA1602 // Enumeration items should be documented

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -172,6 +172,9 @@ public static class BoundNodePrinter
             case BoundNodeKind.ConstructorCallExpression:
                 WriteConstructorCallExpression((BoundConstructorCallExpression)node, writer);
                 break;
+            case BoundNodeKind.ConstructorChainingExpression:
+                WriteConstructorChainingExpression((BoundConstructorChainingExpression)node, writer);
+                break;
             case BoundNodeKind.UserInstanceCallExpression:
                 WriteUserInstanceCallExpression((BoundUserInstanceCallExpression)node, writer);
                 break;
@@ -1128,6 +1131,24 @@ public static class BoundNodePrinter
     private static void WriteConstructorCallExpression(BoundConstructorCallExpression node, IndentedTextWriter writer)
     {
         writer.WriteIdentifier(node.StructType.Name);
+        writer.WritePunctuation(SyntaxKind.OpenParenthesisToken);
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            if (i > 0)
+            {
+                writer.WritePunctuation(SyntaxKind.CommaToken);
+                writer.WriteSpace();
+            }
+
+            node.Arguments[i].WriteTo(writer);
+        }
+
+        writer.WritePunctuation(SyntaxKind.CloseParenthesisToken);
+    }
+
+    private static void WriteConstructorChainingExpression(BoundConstructorChainingExpression node, IndentedTextWriter writer)
+    {
+        writer.WriteKeyword("init");
         writer.WritePunctuation(SyntaxKind.OpenParenthesisToken);
         for (var i = 0; i < node.Arguments.Length; i++)
         {

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -446,6 +446,8 @@ public abstract class BoundTreeRewriter
                 return RewriteIsExpression((BoundIsExpression)node);
             case BoundNodeKind.AsExpression:
                 return RewriteAsExpression((BoundAsExpression)node);
+            case BoundNodeKind.ConstructorChainingExpression:
+                return RewriteConstructorChainingExpression((BoundConstructorChainingExpression)node);
             default:
                 throw new Exception($"Unexpected node: {node.Kind}");
         }
@@ -1319,6 +1321,34 @@ public abstract class BoundTreeRewriter
         }
 
         return builder == null ? node : new BoundConstructorCallExpression(null, node.StructType, builder.ToImmutable(), node.SelectedConstructor);
+    }
+
+    /// <summary>ADR-0065 §2: rewrites a constructor self-delegation expression.</summary>
+    /// <param name="node">The node to rewrite.</param>
+    /// <returns>The rewritten node.</returns>
+    protected virtual BoundExpression RewriteConstructorChainingExpression(BoundConstructorChainingExpression node)
+    {
+        ImmutableArray<BoundExpression>.Builder builder = null;
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            var oldArg = node.Arguments[i];
+            var newArg = RewriteExpression(oldArg);
+            if (newArg != oldArg && builder == null)
+            {
+                builder = ImmutableArray.CreateBuilder<BoundExpression>(node.Arguments.Length);
+                for (var j = 0; j < i; j++)
+                {
+                    builder.Add(node.Arguments[j]);
+                }
+            }
+
+            if (builder != null)
+            {
+                builder.Add(newArg);
+            }
+        }
+
+        return builder == null ? node : new BoundConstructorChainingExpression(node.Syntax, node.SelectedConstructor, builder.ToImmutable());
     }
 
     /// <summary>Rewrites a CLR constructor call (Phase 4 exit).</summary>

--- a/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
@@ -319,6 +319,9 @@ public abstract class BoundTreeWalker
             case BoundNodeKind.AsExpression:
                 VisitAsExpression((BoundAsExpression)node);
                 break;
+            case BoundNodeKind.ConstructorChainingExpression:
+                VisitConstructorChainingExpression((BoundConstructorChainingExpression)node);
+                break;
             default:
                 throw new InvalidOperationException(
                     $"BoundTreeWalker: unexpected expression kind '{node.Kind}'.");
@@ -607,6 +610,13 @@ public abstract class BoundTreeWalker
     }
 
     protected virtual void VisitConstructorCallExpression(BoundConstructorCallExpression node)
+    {
+        VisitList(node.Arguments);
+    }
+
+    /// <summary>ADR-0065 §2: visits a <see cref="BoundConstructorChainingExpression"/>.</summary>
+    /// <param name="node">The node being visited.</param>
+    protected virtual void VisitConstructorChainingExpression(BoundConstructorChainingExpression node)
     {
         VisitList(node.Arguments);
     }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -3182,6 +3182,16 @@ internal sealed class DeclarationBinder
         StructSymbol baseClassSymbol,
         TypeSymbol importedBaseType)
     {
+        // ADR-0065 §5: a class with a primary-constructor parameter list and
+        // no explicit `init(...)` body still needs ExplicitConstructors set up
+        // for the convenience-init self-delegation lookup, but the emitter
+        // already handles the primary-ctor-only case via its existing
+        // ClassPrimaryCtorHandles path. We only need to materialize a
+        // synthesized designated ConstructorSymbol when there are also
+        // explicit init(...) bodies (so that primary becomes a peer in the
+        // overload set), or when a class needs an init(...) overload for
+        // diagnostics or chaining purposes. For pure primary-ctor classes we
+        // leave the existing path unchanged.
         if (syntax.Constructors.IsDefaultOrEmpty)
         {
             return;
@@ -3192,12 +3202,16 @@ internal sealed class DeclarationBinder
             return;
         }
 
-        // A class uses EITHER the Kotlin-style primary constructor sugar OR
-        // explicit `init(...)` constructors — mixing the two is ambiguous.
+        // ADR-0065 §5: when both a primary-constructor parameter list and
+        // explicit `init(...)` bodies are declared, the primary constructor
+        // becomes a synthesized designated initializer that participates in
+        // the overload set alongside the explicit bodies. Duplicate signatures
+        // are diagnosed below by the same overload-equality check that catches
+        // collisions between two user-declared init overloads.
+        ConstructorSymbol synthesizedPrimary = null;
         if (structSymbol.HasPrimaryConstructor)
         {
-            Diagnostics.ReportPrimaryAndExplicitConstructors(syntax.Constructors[0].InitKeyword.Location, structSymbol.Name);
-            return;
+            synthesizedPrimary = SynthesizePrimaryConstructor(structSymbol, package);
         }
 
         // ADR-0063 §9: bind every declared init(...) constructor. Duplicate
@@ -3205,12 +3219,23 @@ internal sealed class DeclarationBinder
         // overloads, so each surviving ConstructorSymbol carries a unique
         // signature within the overload family.
         var ctorBuilder = ImmutableArray.CreateBuilder<ConstructorSymbol>();
+        if (synthesizedPrimary != null)
+        {
+            ctorBuilder.Add(synthesizedPrimary);
+        }
+
         foreach (var ctorSyntax in syntax.Constructors)
         {
             var ctor = BindSingleConstructorDeclaration(ctorSyntax, structSymbol, package, baseClassSymbol, importedBaseType);
             if (ctor == null)
             {
                 continue;
+            }
+
+            // ADR-0065 §2: enforce constraints on convenience initializers.
+            if (ctor.IsConvenience && ctor.BaseInitializer != null)
+            {
+                Diagnostics.ReportConvenienceInitMayNotCallBase(ctorSyntax.BaseKeyword.Location, structSymbol.Name);
             }
 
             var duplicate = false;
@@ -3225,10 +3250,25 @@ internal sealed class DeclarationBinder
 
             if (duplicate)
             {
-                Diagnostics.ReportDuplicateOverloadSignature(
-                    ctorSyntax.InitKeyword.Location,
-                    "init",
-                    Binder.FormatOverloadSignature(ctor.Function));
+                // ADR-0065 §5: distinguish duplication against the synthesized
+                // primary ctor from duplication between two user inits so users
+                // get an actionable message.
+                if (synthesizedPrimary != null
+                    && BoundScope.FunctionSignaturesEqual(synthesizedPrimary.Function, ctor.Function))
+                {
+                    Diagnostics.ReportInitDuplicatesPrimaryCtor(
+                        ctorSyntax.InitKeyword.Location,
+                        structSymbol.Name,
+                        Binder.FormatOverloadSignature(ctor.Function));
+                }
+                else
+                {
+                    Diagnostics.ReportDuplicateOverloadSignature(
+                        ctorSyntax.InitKeyword.Location,
+                        "init",
+                        Binder.FormatOverloadSignature(ctor.Function));
+                }
+
                 continue;
             }
 
@@ -3236,6 +3276,38 @@ internal sealed class DeclarationBinder
         }
 
         structSymbol.SetExplicitConstructors(ctorBuilder.ToImmutable());
+    }
+
+    /// <summary>
+    /// ADR-0065 §5: synthesizes a designated <see cref="ConstructorSymbol"/>
+    /// whose signature matches the class's primary-constructor parameter list.
+    /// The emitter produces its body (field assignments per parameter) directly
+    /// rather than reading from <c>BoundProgram.Functions</c>; we leave the
+    /// function's body unbound here. The synthesized ctor is marked with
+    /// <see cref="ConstructorSymbol.IsSynthesizedFromPrimaryConstructor"/> so
+    /// emit and overload-resolution paths can detect it.
+    /// </summary>
+    private ConstructorSymbol SynthesizePrimaryConstructor(StructSymbol structSymbol, PackageSymbol package)
+    {
+        // Reuse the primary-ctor parameter symbols verbatim — they already
+        // carry the right names, types, ref-kinds and any defaults. The
+        // emitter looks up the matching same-named field for each parameter.
+        var parameters = structSymbol.PrimaryConstructorParameters;
+        var ctorFunction = new FunctionSymbol(
+            ".ctor",
+            parameters,
+            TypeSymbol.Void,
+            declaration: null,
+            package,
+            Accessibility.Public,
+            receiverType: structSymbol)
+        {
+            IsSpecialName = true,
+        };
+
+        var ctorSymbol = new ConstructorSymbol(ctorFunction, declaration: null);
+        ctorSymbol.MarkSynthesizedFromPrimaryConstructor();
+        return ctorSymbol;
     }
 
     /// <summary>
@@ -3296,6 +3368,14 @@ internal sealed class DeclarationBinder
 
         var constructorSymbol = new ConstructorSymbol(ctorFunction, ctorSyntax);
         Binder.AttachDocumentation(ctorFunction, ctorSyntax);
+
+        // ADR-0065 §2: propagate the contextual `convenience` modifier from
+        // syntax onto the symbol so the binder/emitter can apply the §2
+        // rules (delegation-first, no `: base()`, this(args) chaining).
+        if (ctorSyntax.IsConvenience)
+        {
+            constructorSymbol.MarkConvenience();
+        }
 
         // Resolve the optional `: base(args)` initializer, with the constructor
         // parameters in scope so they can be forwarded to the base.

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -1632,6 +1632,263 @@ internal sealed class OverloadResolver
     }
 
     /// <summary>
+    /// ADR-0065 §2: binds a bare <c>init(args)</c> self-delegation call inside a
+    /// constructor body. The selected sibling constructor must be a different
+    /// member of the same class's <see cref="StructSymbol.ExplicitConstructors"/>
+    /// overload set. Designated initializers may not chain to a sibling; only
+    /// <c>convenience init</c> bodies may issue an <c>init(args)</c> self-delegation.
+    /// </summary>
+    private BoundExpression BindConstructorChainingExpression(CallExpressionSyntax syntax, StructSymbol owningClass, FunctionSymbol currentCtorFunction)
+    {
+        // Resolve the current ConstructorSymbol so we know whether the caller
+        // is convenience or designated, and so we can exclude it from the
+        // candidate set (recursion would loop indefinitely).
+        ConstructorSymbol currentCtor = null;
+        foreach (var c in owningClass.ExplicitConstructors)
+        {
+            if (ReferenceEquals(c.Function, currentCtorFunction))
+            {
+                currentCtor = c;
+                break;
+            }
+        }
+
+        if (currentCtor == null)
+        {
+            Diagnostics.ReportInitDelegationOutsideCtor(syntax.Identifier.Location);
+            return new BoundErrorExpression(syntax);
+        }
+
+        if (!currentCtor.IsConvenience)
+        {
+            Diagnostics.ReportInitDelegationFromDesignated(syntax.Identifier.Location, owningClass.Name);
+            return new BoundErrorExpression(syntax);
+        }
+
+        // Build the candidate overload set: every sibling explicit constructor
+        // except the one currently being bound.
+        var siblingBuilder = ImmutableArray.CreateBuilder<ConstructorSymbol>(owningClass.ExplicitConstructors.Length);
+        foreach (var c in owningClass.ExplicitConstructors)
+        {
+            if (ReferenceEquals(c, currentCtor))
+            {
+                continue;
+            }
+
+            siblingBuilder.Add(c);
+        }
+
+        if (siblingBuilder.Count == 0)
+        {
+            Diagnostics.ReportInitDelegationRecursive(syntax.Identifier.Location, owningClass.Name);
+            return new BoundErrorExpression(syntax);
+        }
+
+        if (!TryAnalyzeCallArgumentLayout(syntax.Arguments, out _, out var argumentNames))
+        {
+            return new BoundErrorExpression(syntax);
+        }
+
+        var boundArgsBuilder = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
+        for (var i = 0; i < syntax.Arguments.Count; i++)
+        {
+            var argument = UnwrapNamedArgumentValue(syntax.Arguments[i]);
+            ParameterSymbol parameterForArg = null;
+            if (siblingBuilder.Count == 1 && i < siblingBuilder[0].Parameters.Length)
+            {
+                parameterForArg = siblingBuilder[0].Parameters[i];
+            }
+
+            if (argument is RefArgumentExpressionSyntax refArg)
+            {
+                boundArgsBuilder.Add(bindRefArgumentExpression(refArg, parameterForArg));
+            }
+            else
+            {
+                boundArgsBuilder.Add(bindExpression(argument));
+            }
+        }
+
+        ConstructorSymbol selectedCtor;
+        if (siblingBuilder.Count == 1)
+        {
+            selectedCtor = siblingBuilder[0];
+        }
+        else
+        {
+            var ctorFunctions = ImmutableArray.CreateBuilder<FunctionSymbol>(siblingBuilder.Count);
+            foreach (var c in siblingBuilder)
+            {
+                ctorFunctions.Add(c.Function);
+            }
+
+            var selectedFn = SelectBestInstanceOverload(
+                ctorFunctions.MoveToImmutable(),
+                syntax.Arguments.Count,
+                argumentNames,
+                boundArgsBuilder.ToImmutable(),
+                out var ambiguous);
+
+            if (selectedFn == null)
+            {
+                if (ambiguous)
+                {
+                    Diagnostics.ReportAmbiguousOverloadResolution(syntax.Identifier.Location, "init");
+                }
+                else
+                {
+                    Diagnostics.ReportInitDelegationNoMatch(syntax.Identifier.Location, owningClass.Name);
+                }
+
+                return new BoundErrorExpression(syntax);
+            }
+
+            selectedCtor = null;
+            foreach (var c in siblingBuilder)
+            {
+                if (ReferenceEquals(c.Function, selectedFn))
+                {
+                    selectedCtor = c;
+                    break;
+                }
+            }
+
+            if (selectedCtor == null)
+            {
+                Diagnostics.ReportInitDelegationNoMatch(syntax.Identifier.Location, owningClass.Name);
+                return new BoundErrorExpression(syntax);
+            }
+        }
+
+        var parameters = selectedCtor.Parameters;
+        var requestedArgCount = syntax.Arguments.Count;
+        if (requestedArgCount < parameters.Length)
+        {
+            var minRequired = parameters.Length;
+            for (var i = parameters.Length - 1; i >= 0; i--)
+            {
+                if (parameters[i].HasExplicitDefaultValue)
+                {
+                    minRequired = i;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (requestedArgCount < minRequired)
+            {
+                Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, "init", parameters.Length, requestedArgCount);
+                return new BoundErrorExpression(syntax);
+            }
+        }
+        else if (requestedArgCount > parameters.Length)
+        {
+            Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, "init", parameters.Length, requestedArgCount);
+            return new BoundErrorExpression(syntax);
+        }
+
+        ExpressionSyntax[] parameterSyntax;
+        var boundArgs = boundArgsBuilder;
+        if (!argumentNames.IsDefault || requestedArgCount < parameters.Length)
+        {
+            if (!TryReorderUserCallArgumentsWithDefaults(
+                    syntax.Arguments,
+                    boundArgs.ToImmutable(),
+                    parameters,
+                    "init",
+                    syntax.Identifier.Location,
+                    out parameterSyntax,
+                    out var permutedBound))
+            {
+                return new BoundErrorExpression(syntax);
+            }
+
+            boundArgs = ImmutableArray.CreateBuilder<BoundExpression>(permutedBound.Length);
+            for (var i = 0; i < permutedBound.Length; i++)
+            {
+                boundArgs.Add(permutedBound[i]);
+            }
+        }
+        else
+        {
+            parameterSyntax = new ExpressionSyntax[syntax.Arguments.Count];
+            for (var i = 0; i < syntax.Arguments.Count; i++)
+            {
+                parameterSyntax[i] = syntax.Arguments[i];
+            }
+        }
+
+        var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(parameters.Length);
+        var hadErrors = false;
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            var parameter = parameters[i];
+            var argument = boundArgs[i];
+            var argLocation = parameterSyntax[i]?.Location ?? syntax.Identifier.Location;
+
+            if (argument.Type == TypeSymbol.Error)
+            {
+                hadErrors = true;
+                convertedArgs.Add(argument);
+                continue;
+            }
+
+            // ADR-0060: when the parameter is ref-kind, the bound argument is
+            // a BoundAddressOfExpression of type *T; bypass the standard
+            // convertibility check so the address is forwarded as-is.
+            if (parameter.RefKind != RefKind.None && argument is BoundAddressOfExpression addrInit)
+            {
+                var pointee = addrInit.Operand?.Type;
+                if (pointee == parameter.Type || pointee == TypeSymbol.Error || parameter.Type == TypeSymbol.Error)
+                {
+                    convertedArgs.Add(argument);
+                    continue;
+                }
+            }
+            else if (parameter.RefKind != RefKind.None && argument is BoundConditionalAddressExpression condAddrInit)
+            {
+                var pointee = condAddrInit.PointeeType;
+                if (pointee == parameter.Type || pointee == TypeSymbol.Error || parameter.Type == TypeSymbol.Error)
+                {
+                    convertedArgs.Add(argument);
+                    continue;
+                }
+            }
+
+            if (argument.Type != parameter.Type
+                && !Conversion.Classify(argument.Type, parameter.Type).IsImplicit)
+            {
+                if (conversions.TryApplyUserDefinedImplicitArgumentConversion(argument, parameter.Type, out var convertedArg))
+                {
+                    convertedArgs.Add(convertedArg);
+                    continue;
+                }
+
+                if (argument.Type != TypeSymbol.Error)
+                {
+                    Diagnostics.ReportWrongArgumentType(argLocation, parameter.Name, parameter.Type, argument.Type);
+                }
+
+                hadErrors = true;
+                convertedArgs.Add(argument);
+            }
+            else
+            {
+                convertedArgs.Add(conversions.BindConversion(argLocation, argument, parameter.Type));
+            }
+        }
+
+        if (hadErrors)
+        {
+            return new BoundErrorExpression(syntax);
+        }
+
+        return new BoundConstructorChainingExpression(syntax, selectedCtor, convertedArgs.ToImmutable());
+    }
+
+    /// <summary>
     /// ADR-0063 §9: variant of <c>TryReorderUserCallArguments</c> for constructor
     /// calls that may omit trailing or middle optional parameters. For each
     /// parameter slot not filled by a positional/named argument we synthesize a
@@ -1736,6 +1993,28 @@ internal sealed class OverloadResolver
 
     public BoundExpression BindCallExpression(CallExpressionSyntax syntax)
     {
+        // ADR-0065 §2: a bare `init(args)` call inside a constructor body is
+        // a self-delegation to a sibling constructor on the same class. This
+        // is the only legal use of `init` as a callable identifier. Recognise
+        // it before any other call-binding path so the generic identifier
+        // fallback at the bottom doesn't surface a misleading "unknown
+        // function" diagnostic.
+        if (syntax.TypeArgumentList == null
+            && syntax.Identifier.Kind == SyntaxKind.IdentifierToken
+            && syntax.Identifier.Text == "init")
+        {
+            var inCtor = getCurrentFunction();
+            if (inCtor != null
+                && inCtor.IsSpecialName
+                && inCtor.Name == ".ctor"
+                && inCtor.ReceiverType is StructSymbol owningClass
+                && owningClass.IsClass
+                && !owningClass.ExplicitConstructors.IsDefaultOrEmpty)
+            {
+                return BindConstructorChainingExpression(syntax, owningClass, inCtor);
+            }
+        }
+
         // Phase 4-exit: prefer CLR class instantiation over the single-arg
         // conversion-call hijack below, so that `StringBuilder(16)` resolves
         // to a CLR ctor rather than `conversions.BindConversion(int → StringBuilder)`.

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -2225,6 +2225,88 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0277", "A block in an if-expression value position must end with a value-producing expression.");
     }
 
+    /// <summary>
+    /// ADR-0065 §2: GS0278 — a <c>convenience init</c> body must begin with a
+    /// self-delegation <c>init(args)</c> call.
+    /// </summary>
+    /// <param name="location">The source location of the convenience init declaration.</param>
+    /// <param name="className">The owning class.</param>
+    public void ReportConvenienceInitMustDelegate(TextLocation location, string className)
+    {
+        Report(location, "GS0278", $"Convenience initializer on class '{className}' must delegate to another initializer via 'init(args)' before any other statement.");
+    }
+
+    /// <summary>
+    /// ADR-0065 §2: GS0279 — a <c>convenience init</c> may not declare an
+    /// explicit <c>: base(args)</c> clause; convenience initializers must
+    /// chain to another initializer in the same class, which transitively
+    /// reaches a designated initializer that performs the base call.
+    /// </summary>
+    /// <param name="location">The source location of the <c>: base</c> clause.</param>
+    /// <param name="className">The owning class.</param>
+    public void ReportConvenienceInitMayNotCallBase(TextLocation location, string className)
+    {
+        Report(location, "GS0279", $"Convenience initializer on class '{className}' may not declare ': base(args)'; chain to another initializer with 'init(args)' instead.");
+    }
+
+    /// <summary>
+    /// ADR-0065 §2: GS0280 — <c>init(args)</c> self-delegation only appears
+    /// inside a constructor body of a class.
+    /// </summary>
+    /// <param name="location">The source location of the self-delegation call.</param>
+    public void ReportInitDelegationOutsideCtor(TextLocation location)
+    {
+        Report(location, "GS0280", "'init(args)' constructor self-delegation is only valid inside a class constructor body.");
+    }
+
+    /// <summary>
+    /// ADR-0065 §2: GS0281 — <c>init(args)</c> self-delegation is only legal
+    /// inside a <c>convenience init</c>; designated initializers must chain
+    /// to the base class with <c>: base(args)</c> instead.
+    /// </summary>
+    /// <param name="location">The source location of the self-delegation call.</param>
+    /// <param name="className">The owning class.</param>
+    public void ReportInitDelegationFromDesignated(TextLocation location, string className)
+    {
+        Report(location, "GS0281", $"Designated initializer on class '{className}' may not delegate to a sibling 'init(args)' overload; use ': base(args)' (or omit it) to chain to the base class.");
+    }
+
+    /// <summary>
+    /// ADR-0065 §2: GS0282 — <c>init(args)</c> self-delegation must target a
+    /// different constructor than the one being executed; recursive delegation
+    /// would loop indefinitely.
+    /// </summary>
+    /// <param name="location">The source location of the self-delegation call.</param>
+    /// <param name="className">The owning class.</param>
+    public void ReportInitDelegationRecursive(TextLocation location, string className)
+    {
+        Report(location, "GS0282", $"Convenience initializer on class '{className}' may not delegate to itself; choose a different 'init(args)' overload.");
+    }
+
+    /// <summary>
+    /// ADR-0065 §2: GS0283 — overload resolution found no matching sibling
+    /// initializer for an <c>init(args)</c> self-delegation call.
+    /// </summary>
+    /// <param name="location">The source location of the self-delegation call.</param>
+    /// <param name="className">The owning class.</param>
+    public void ReportInitDelegationNoMatch(TextLocation location, string className)
+    {
+        Report(location, "GS0283", $"No applicable 'init(...)' overload on class '{className}' matches the arguments of this 'init(args)' self-delegation.");
+    }
+
+    /// <summary>
+    /// ADR-0065 §5: GS0284 — a user-declared <c>init(...)</c> overload has the
+    /// same signature as the constructor synthesized from the class's primary
+    /// constructor parameter list.
+    /// </summary>
+    /// <param name="location">The source location of the offending <c>init</c> declaration.</param>
+    /// <param name="className">The owning class.</param>
+    /// <param name="signature">The signature description.</param>
+    public void ReportInitDuplicatesPrimaryCtor(TextLocation location, string className, string signature)
+    {
+        Report(location, "GS0284", $"'init({signature})' on class '{className}' duplicates the synthesized primary-constructor overload; remove either the primary-constructor parameter list or this 'init' declaration.");
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -91,6 +91,36 @@ internal sealed partial class MethodBodyEmitter
         this.il.Token(ctorHandle);
     }
 
+    /// <summary>
+    /// ADR-0065 §2: emits the CIL for a <c>init(args)</c> self-delegation
+    /// statement that appears inside a <c>convenience init(...)</c> body.
+    /// Lowered to <c>ldarg.0; &lt;args&gt;; call &lt;ctor&gt;</c> chaining to a
+    /// sibling constructor on the same class.
+    /// </summary>
+    /// <param name="call">The bound chaining expression to emit.</param>
+    private void EmitConstructorChaining(BoundConstructorChainingExpression call)
+    {
+        if (call.SelectedConstructor == null
+            || !this.outer.cache.ExplicitCtorHandles.TryGetValue(call.SelectedConstructor, out var ctorHandle))
+        {
+            throw new InvalidOperationException(
+                $"Constructor chaining target on '{call.SelectedConstructor?.DeclaringType?.Name}' has no emitted handle.");
+        }
+
+        // Load `this` then evaluate each argument in order. Parameters of a
+        // user-authored init can never be type parameters today, so the
+        // value-type-to-System.Object boxing dance that EmitConstructorCall
+        // performs is unnecessary here.
+        this.il.LoadArgument(0);
+        foreach (var arg in call.Arguments)
+        {
+            this.EmitExpression(arg);
+        }
+
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(ctorHandle);
+    }
+
     private void EmitUserInstanceCall(BoundUserInstanceCallExpression call)
     {
         if (!this.outer.cache.MethodHandles.TryGetValue(call.Method, out var methodHandle))

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -341,6 +341,9 @@ internal sealed partial class MethodBodyEmitter
             case BoundConstructorCallExpression ctorCall:
                 this.EmitConstructorCall(ctorCall);
                 break;
+            case BoundConstructorChainingExpression ctorChain:
+                this.EmitConstructorChaining(ctorChain);
+                break;
             case BoundUserInstanceCallExpression uic:
                 this.EmitUserInstanceCall(uic);
                 break;

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -922,7 +922,11 @@ internal sealed class ReflectionMetadataEmitter
             // Issue #306: a class with an explicit base-constructor initializer
             // emits a single forwarding constructor (no separate parameterless
             // ctor), so reserve only one ctor row in that case.
-            if (c.HasPrimaryConstructor && c.BaseConstructorInitializer == null)
+            // ADR-0065 §5: when the class also declares explicit `init(...)`
+            // bodies, the synthesized primary ctor is allocated as one of the
+            // ExplicitConstructors rows above — do not reserve an additional
+            // primary-ctor row here.
+            if (c.HasPrimaryConstructor && c.BaseConstructorInitializer == null && c.ExplicitConstructor == null)
             {
                 classPrimaryCtorRows[c] = methodRow++;
             }
@@ -1508,11 +1512,39 @@ internal sealed class ReflectionMetadataEmitter
                 // Issue #306 / ADR-0063 §9: a class with explicit `init(...)`
                 // constructors emits one `.ctor` per declared overload. The first
                 // overload also serves as the legacy classCtor/primaryCtor handle.
+                // ADR-0065 §5: when the class also declares a primary-ctor
+                // parameter list, the first overload is a synthesized
+                // designated init whose body is the conventional primary-ctor
+                // field-assignment sequence — route it through
+                // EmitClassPrimaryConstructor instead of the user-body path.
                 MethodDefinitionHandle firstHandle = default;
                 var firstAssigned = false;
                 foreach (var explicitCtor in c.ExplicitConstructors)
                 {
-                    var ctorHandle = this.typeDefEmitter.EmitClassConstructorWithBody(c, explicitCtor);
+                    MethodDefinitionHandle ctorHandle;
+                    if (explicitCtor.IsSynthesizedFromPrimaryConstructor)
+                    {
+                        // The synthesized primary follows the same emission
+                        // shape as a primary-ctor-only class. If the class
+                        // declaration also carries `: Base(args)`, that base
+                        // initializer must be honored — route through the
+                        // forwarding-ctor emitter; otherwise emit the plain
+                        // primary-ctor shape (default chain to `object::.ctor`
+                        // or the parameterless base).
+                        if (c.BaseConstructorInitializer != null)
+                        {
+                            ctorHandle = this.typeDefEmitter.EmitClassConstructorWithBaseInitializer(c, c.PrimaryConstructorParameters);
+                        }
+                        else
+                        {
+                            ctorHandle = this.typeDefEmitter.EmitClassPrimaryConstructor(c);
+                        }
+                    }
+                    else
+                    {
+                        ctorHandle = this.typeDefEmitter.EmitClassConstructorWithBody(c, explicitCtor);
+                    }
+
                     this.cache.ExplicitCtorHandles[explicitCtor] = ctorHandle;
                     if (!firstAssigned)
                     {
@@ -2978,8 +3010,11 @@ internal sealed class ReflectionMetadataEmitter
         var constValues = new Dictionary<VariableSymbol, object>();
 
         // Pre-scan the base arguments so any scratch slots they require are
-        // allocated and registered in the locals signature.
-        if (init != null && !init.Arguments.IsDefaultOrEmpty)
+        // allocated and registered in the locals signature. ADR-0065 §2:
+        // convenience inits skip the base-call emission so their `init`
+        // syntax-side `: base()` (if present, but rejected at bind time) and
+        // the implicit empty-args case are irrelevant here.
+        if (!ctor.IsConvenience && init != null && !init.Arguments.IsDefaultOrEmpty)
         {
             var synth = ImmutableArray.CreateBuilder<BoundStatement>(init.Arguments.Length);
             foreach (var arg in init.Arguments)
@@ -3011,8 +3046,11 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         // Issue #640: pre-scan instance field initializer expressions for locals.
+        // ADR-0065 §2: convenience inits skip field-init emission (the
+        // chained-to designated init handles them), so don't reserve scratch
+        // slots for those expressions either.
         BoundBlockStatement fieldInitBody = null;
-        if (!classSym.InstanceFieldInitializers.IsEmpty)
+        if (!ctor.IsConvenience && !classSym.InstanceFieldInitializers.IsEmpty)
         {
             fieldInitBody = new BoundBlockStatement(null, BuildInstanceFieldInitializerStatements(classSym, function.ThisParameter));
             this.methodBodyPlanner.CollectLocalsAndLabels(
@@ -3106,28 +3144,38 @@ internal sealed class ReflectionMetadataEmitter
             liftedBinarySlots: liftedBinarySlots,
             constValues: constValues);
 
-        // base(args) — `this` followed by the (ref-kind aware) base arguments.
-        il.LoadArgument(0);
-        if (init != null && !init.Arguments.IsDefaultOrEmpty)
+        // ADR-0065 §2: a `convenience init(...)` does NOT chain to the base
+        // constructor itself — the user-authored body begins with an
+        // `init(args)` self-delegation (BoundConstructorChainingExpression)
+        // that calls a sibling constructor on the same class. That sibling
+        // is responsible for the base chain. We also skip the instance
+        // field-initializer emit step here: the chained-to designated
+        // initializer will run those initializers exactly once.
+        if (!ctor.IsConvenience)
         {
-            emitter.EmitBaseConstructorArguments(init.Arguments, init.ArgumentRefKinds);
-        }
-
-        il.OpCode(ILOpCode.Call);
-        il.Token(baseCtorToken);
-
-        // Issue #640: emit instance field initializer assignments before
-        // the user-authored constructor body (matching C# semantics).
-        if (fieldInitBody != null)
-        {
-            try
+            // base(args) — `this` followed by the (ref-kind aware) base arguments.
+            il.LoadArgument(0);
+            if (init != null && !init.Arguments.IsDefaultOrEmpty)
             {
-                emitter.EmitBlock(fieldInitBody);
+                emitter.EmitBaseConstructorArguments(init.Arguments, init.ArgumentRefKinds);
             }
-            catch (Exception ex) when (ex is not EmitDiagnosticException and not OutOfMemoryException and not StackOverflowException)
+
+            il.OpCode(ILOpCode.Call);
+            il.Token(baseCtorToken);
+
+            // Issue #640: emit instance field initializer assignments before
+            // the user-authored constructor body (matching C# semantics).
+            if (fieldInitBody != null)
             {
-                var anchor = emitter.CurrentAnchor ?? classSym.Declaration;
-                EmitDiagnosticException.Wrap(anchor, ex);
+                try
+                {
+                    emitter.EmitBlock(fieldInitBody);
+                }
+                catch (Exception ex) when (ex is not EmitDiagnosticException and not OutOfMemoryException and not StackOverflowException)
+                {
+                    var anchor = emitter.CurrentAnchor ?? classSym.Declaration;
+                    EmitDiagnosticException.Wrap(anchor, ex);
+                }
             }
         }
 

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -541,6 +541,7 @@ public sealed class Evaluator
                 BoundNodeKind.InterpolatedStringExpression => EvaluateInterpolatedStringExpression((BoundInterpolatedStringExpression)node),
                 BoundNodeKind.IsExpression => EvaluateIsExpression((BoundIsExpression)node),
                 BoundNodeKind.AsExpression => EvaluateAsExpression((BoundAsExpression)node),
+                BoundNodeKind.ConstructorChainingExpression => EvaluateConstructorChainingExpression((BoundConstructorChainingExpression)node),
                 _ => throw new EvaluatorException($"Unexpected node {node.Kind}", node),
             };
         }
@@ -1109,18 +1110,62 @@ public sealed class Evaluator
         var explicitCtor = node.SelectedConstructor ?? node.StructType.ExplicitConstructor;
         if (explicitCtor != null)
         {
+            // ADR-0065 §5: a synthesized primary-ctor designated init has no
+            // user-authored body in `program.Functions`. Materialize it on
+            // the fly: assign each primary-ctor parameter to its same-named
+            // field, then fall through to base-init / CLR-allocation handling
+            // by reusing the primary-ctor path below.
+            if (explicitCtor.IsSynthesizedFromPrimaryConstructor)
+            {
+                var primaryParams = node.StructType.PrimaryConstructorParameters;
+                for (var i = 0; i < primaryParams.Length; i++)
+                {
+                    sv.Fields[primaryParams[i].Name] = EvaluateExpression(node.Arguments[i]);
+                }
+
+                // Forward an explicit class-level base initializer if present
+                // (the synthesized primary mirrors the original primary-ctor shape).
+                var baseInitOnStruct = node.StructType.BaseConstructorInitializer;
+                if (baseInitOnStruct != null
+                    && baseInitOnStruct.GSharpBaseType is StructSymbol gsBase)
+                {
+                    var frame = new Dictionary<VariableSymbol, object>();
+                    for (var i = 0; i < primaryParams.Length; i++)
+                    {
+                        frame[primaryParams[i]] = sv.Fields[primaryParams[i].Name];
+                    }
+
+                    locals.Push(frame);
+                    try
+                    {
+                        var baseParams = gsBase.PrimaryConstructorParameters;
+                        for (var i = 0; i < baseParams.Length && i < baseInitOnStruct.Arguments.Length; i++)
+                        {
+                            sv.Fields[baseParams[i].Name] = EvaluateExpression(baseInitOnStruct.Arguments[i]);
+                        }
+                    }
+                    finally
+                    {
+                        locals.Pop();
+                    }
+                }
+
+                AllocateClrBacking(sv, node.StructType, baseInitOnStruct);
+                return sv;
+            }
+
             var ctorFunction = explicitCtor.Function;
-            var frame = new Dictionary<VariableSymbol, object>
+            var frame2 = new Dictionary<VariableSymbol, object>
             {
                 [ctorFunction.ThisParameter] = sv,
             };
 
             for (var i = 0; i < ctorFunction.Parameters.Length; i++)
             {
-                frame[ctorFunction.Parameters[i]] = EvaluateExpression(node.Arguments[i]);
+                frame2[ctorFunction.Parameters[i]] = EvaluateExpression(node.Arguments[i]);
             }
 
-            locals.Push(frame);
+            locals.Push(frame2);
             try
             {
                 // Forward the GSharp base initializer. CLR base initializers are
@@ -3469,6 +3514,106 @@ public sealed class Evaluator
         if (targetClr.IsInstanceOfType(value))
         {
             return value;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// ADR-0065 §2: evaluates a <c>init(args)</c> self-delegation call inside
+    /// a <c>convenience init</c> body. Looks up the current <c>this</c> in the
+    /// active locals frame and invokes the chained-to sibling constructor's
+    /// body against it. Returns <see langword="null"/> (the statement has no
+    /// value-position result).
+    /// </summary>
+    private object EvaluateConstructorChainingExpression(BoundConstructorChainingExpression node)
+    {
+        var targetCtor = node.SelectedConstructor;
+        if (targetCtor == null)
+        {
+            throw new EvaluatorException("Constructor chaining target was not resolved.", node);
+        }
+
+        var thisParam = targetCtor.Function.ThisParameter;
+        StructValue receiver = null;
+
+        // Walk the local frames stack from innermost outward looking for the
+        // current `this` binding. The convenience init body is bound with its
+        // own `this`, which matches the chained-to ctor's `this` since both
+        // belong to the same class.
+        foreach (var frame in locals)
+        {
+            foreach (var kv in frame)
+            {
+                if (kv.Value is StructValue sv && kv.Key is ParameterSymbol param && param.Name == "this")
+                {
+                    receiver = sv;
+                    break;
+                }
+            }
+
+            if (receiver != null)
+            {
+                break;
+            }
+        }
+
+        if (receiver == null)
+        {
+            throw new EvaluatorException("Convenience initializer self-delegation could not locate the current 'this'.", node);
+        }
+
+        // Evaluate the chained-to ctor's arguments first (in the current frame
+        // so that the convenience init's own parameters are in scope).
+        var argValues = new object[node.Arguments.Length];
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            argValues[i] = EvaluateExpression(node.Arguments[i]);
+        }
+
+        // Build the chained-to ctor's frame and run its body. ADR-0065 §5: a
+        // synthesized primary-ctor delegate has no bound body — materialize
+        // the same field-assignment shape as the primary-ctor path.
+        if (targetCtor.IsSynthesizedFromPrimaryConstructor)
+        {
+            var primaryParams = targetCtor.DeclaringType?.PrimaryConstructorParameters ?? ImmutableArray<ParameterSymbol>.Empty;
+            for (var i = 0; i < primaryParams.Length; i++)
+            {
+                receiver.Fields[primaryParams[i].Name] = argValues[i];
+            }
+
+            return null;
+        }
+
+        var chainFrame = new Dictionary<VariableSymbol, object>
+        {
+            [thisParam] = receiver,
+        };
+
+        for (var i = 0; i < targetCtor.Function.Parameters.Length; i++)
+        {
+            chainFrame[targetCtor.Function.Parameters[i]] = argValues[i];
+        }
+
+        locals.Push(chainFrame);
+        try
+        {
+            if (targetCtor.BaseInitializer is BaseConstructorInitializer chainBaseInit
+                && chainBaseInit.GSharpBaseType is StructSymbol chainGsBase)
+            {
+                var baseParams = chainGsBase.PrimaryConstructorParameters;
+                for (var i = 0; i < baseParams.Length && i < chainBaseInit.Arguments.Length; i++)
+                {
+                    receiver.Fields[baseParams[i].Name] = EvaluateExpression(chainBaseInit.Arguments[i]);
+                }
+            }
+
+            var body = program.Functions[targetCtor.Function];
+            EvaluateStatement(body);
+        }
+        finally
+        {
+            locals.Pop();
         }
 
         return null;

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -316,6 +316,7 @@ public static class SpillSequenceSpiller
                 case BoundClrEventSubscriptionExpression:
                 case BoundEventSubscriptionExpression:
                 case BoundConstructorCallExpression:
+                case BoundConstructorChainingExpression:
                 case BoundFieldAccessExpression:
                 case BoundPropertyAccessExpression:
                 case BoundPropertyAssignmentExpression:

--- a/src/Core/CodeAnalysis/Symbols/ConstructorSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ConstructorSymbol.cs
@@ -23,7 +23,7 @@ public sealed class ConstructorSymbol
 {
     /// <summary>Initializes a new instance of the <see cref="ConstructorSymbol"/> class.</summary>
     /// <param name="function">The underlying instance-method-shaped function symbol used as the bind/emit/interpret key.</param>
-    /// <param name="declaration">The declaring syntax.</param>
+    /// <param name="declaration">The declaring syntax. May be <see langword="null"/> for compiler-synthesized constructors (e.g. ADR-0065 §5 primary-ctor synthesis).</param>
     public ConstructorSymbol(FunctionSymbol function, ConstructorDeclarationSyntax declaration)
     {
         Function = function;
@@ -33,7 +33,7 @@ public sealed class ConstructorSymbol
     /// <summary>Gets the underlying function symbol (receiver = the owning class) keyed in <c>BoundProgram.Functions</c>.</summary>
     public FunctionSymbol Function { get; }
 
-    /// <summary>Gets the declaring syntax node.</summary>
+    /// <summary>Gets the declaring syntax node, or <see langword="null"/> when this is a compiler-synthesized constructor (ADR-0065 §5).</summary>
     public ConstructorDeclarationSyntax Declaration { get; }
 
     /// <summary>Gets the constructor parameters (excluding the implicit <c>this</c>).</summary>
@@ -45,10 +45,37 @@ public sealed class ConstructorSymbol
     /// <summary>Gets the resolved explicit base-constructor initializer (<c>: base(args)</c>), or <c>null</c> when the constructor chains to a parameterless base constructor.</summary>
     public BaseConstructorInitializer BaseInitializer { get; private set; }
 
+    /// <summary>
+    /// Gets a value indicating whether this constructor is a
+    /// <c>convenience init</c> (ADR-0065 §2) that must delegate to another
+    /// initializer in the same class before performing any other work.
+    /// </summary>
+    public bool IsConvenience { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this constructor was compiler-synthesized
+    /// from a primary-constructor parameter list (ADR-0065 §5). The emitter
+    /// materializes the field-assignment body for these constructors rather
+    /// than reading it from the program's function bodies.
+    /// </summary>
+    public bool IsSynthesizedFromPrimaryConstructor { get; private set; }
+
     /// <summary>Sets <see cref="BaseInitializer"/> after the binder resolves the base-constructor argument list.</summary>
     /// <param name="initializer">The resolved base-constructor initializer.</param>
     public void SetBaseInitializer(BaseConstructorInitializer initializer)
     {
         BaseInitializer = initializer;
+    }
+
+    /// <summary>ADR-0065 §2: marks this constructor as <c>convenience</c>.</summary>
+    public void MarkConvenience()
+    {
+        IsConvenience = true;
+    }
+
+    /// <summary>ADR-0065 §5: marks this constructor as synthesized from the primary-constructor parameter list.</summary>
+    public void MarkSynthesizedFromPrimaryConstructor()
+    {
+        IsSynthesizedFromPrimaryConstructor = true;
     }
 }

--- a/src/Core/CodeAnalysis/Syntax/ConstructorDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/ConstructorDeclarationSyntax.cs
@@ -18,6 +18,7 @@ public sealed class ConstructorDeclarationSyntax : MemberSyntax
     /// <summary>Initializes a new instance of the <see cref="ConstructorDeclarationSyntax"/> class.</summary>
     /// <param name="syntaxTree">The parent syntax tree.</param>
     /// <param name="accessibilityModifier">The optional accessibility modifier (<c>public</c>/<c>internal</c>/<c>private</c>).</param>
+    /// <param name="convenienceModifier">The optional ADR-0065 §2 <c>convenience</c> modifier, or <c>null</c>.</param>
     /// <param name="initKeyword">The contextual <c>init</c> keyword that introduces the constructor.</param>
     /// <param name="openParenthesisToken">The opening paren of the parameter list.</param>
     /// <param name="parameters">The constructor parameters.</param>
@@ -31,6 +32,7 @@ public sealed class ConstructorDeclarationSyntax : MemberSyntax
     public ConstructorDeclarationSyntax(
         SyntaxTree syntaxTree,
         SyntaxToken accessibilityModifier,
+        SyntaxToken convenienceModifier,
         SyntaxToken initKeyword,
         SyntaxToken openParenthesisToken,
         SeparatedSyntaxList<ParameterSyntax> parameters,
@@ -44,6 +46,7 @@ public sealed class ConstructorDeclarationSyntax : MemberSyntax
         : base(syntaxTree)
     {
         AccessibilityModifier = accessibilityModifier;
+        ConvenienceModifier = convenienceModifier;
         InitKeyword = initKeyword;
         OpenParenthesisToken = openParenthesisToken;
         Parameters = parameters;
@@ -61,6 +64,12 @@ public sealed class ConstructorDeclarationSyntax : MemberSyntax
 
     /// <summary>Gets the optional accessibility modifier.</summary>
     public SyntaxToken AccessibilityModifier { get; }
+
+    /// <summary>Gets the optional ADR-0065 §2 <c>convenience</c> modifier, or <c>null</c>.</summary>
+    public SyntaxToken ConvenienceModifier { get; }
+
+    /// <summary>Gets a value indicating whether this constructor is declared with the <c>convenience</c> modifier (ADR-0065 §2).</summary>
+    public bool IsConvenience => ConvenienceModifier != null;
 
     /// <summary>Gets the contextual <c>init</c> keyword.</summary>
     public SyntaxToken InitKeyword { get; }
@@ -96,5 +105,5 @@ public sealed class ConstructorDeclarationSyntax : MemberSyntax
     public bool HasBaseInitializer => BaseKeyword != null;
 
     /// <inheritdoc/>
-    public override TextSpan Span => TextSpan.FromBounds(InitKeyword.Span.Start, Body.Span.End);
+    public override TextSpan Span => TextSpan.FromBounds((ConvenienceModifier ?? InitKeyword).Span.Start, Body.Span.End);
 }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -932,7 +932,12 @@ public class Parser
                 if (Peek(ahead).Kind == SyntaxKind.FuncKeyword ||
                     (Peek(ahead).Kind == SyntaxKind.IdentifierToken && Peek(ahead).Text == "prop") ||
                     (Peek(ahead).Kind == SyntaxKind.IdentifierToken && Peek(ahead).Text == "event") ||
-                    (Peek(ahead).Kind == SyntaxKind.IdentifierToken && Peek(ahead).Text == "init" && Peek(ahead + 1).Kind == SyntaxKind.OpenParenthesisToken))
+                    (Peek(ahead).Kind == SyntaxKind.IdentifierToken && Peek(ahead).Text == "init" && Peek(ahead + 1).Kind == SyntaxKind.OpenParenthesisToken) ||
+                    (Peek(ahead).Kind == SyntaxKind.IdentifierToken && Peek(ahead).Text == "convenience"
+                        && ((Peek(ahead + 1).Kind == SyntaxKind.IdentifierToken && Peek(ahead + 1).Text == "init" && Peek(ahead + 2).Kind == SyntaxKind.OpenParenthesisToken)
+                            || (Peek(ahead + 1).Kind == SyntaxKind.FuncKeyword
+                                && Peek(ahead + 2).Kind == SyntaxKind.IdentifierToken && Peek(ahead + 2).Text == "init"
+                                && Peek(ahead + 3).Kind == SyntaxKind.OpenParenthesisToken))))
                 {
                     memberAccessibility = NextToken();
                 }
@@ -971,6 +976,19 @@ public class Parser
                 memberAsyncModifier = NextToken();
             }
 
+            // ADR-0065 §2: optional `convenience` contextual keyword may
+            // precede `init` (or `func init`) on a class constructor.
+            SyntaxToken memberConvenienceModifier = null;
+            if (Current.Kind == SyntaxKind.IdentifierToken
+                && Current.Text == "convenience"
+                && ((Peek(1).Kind == SyntaxKind.IdentifierToken && Peek(1).Text == "init" && Peek(2).Kind == SyntaxKind.OpenParenthesisToken)
+                    || (Peek(1).Kind == SyntaxKind.FuncKeyword
+                        && Peek(2).Kind == SyntaxKind.IdentifierToken && Peek(2).Text == "init"
+                        && Peek(3).Kind == SyntaxKind.OpenParenthesisToken)))
+            {
+                memberConvenienceModifier = NextToken();
+            }
+
             if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "init" && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
             {
                 // Issue #306: standalone user-defined constructor
@@ -991,7 +1009,7 @@ public class Parser
                     Diagnostics.ReportUnexpectedToken(Current.Location, Current.Kind, SyntaxKind.IdentifierToken);
                 }
 
-                var constructor = ParseConstructorDeclaration(memberAccessibility);
+                var constructor = ParseConstructorDeclaration(memberAccessibility, memberConvenienceModifier);
                 constructor.WithAnnotations(memberAnnotations);
                 constructors.Add(constructor);
             }
@@ -1068,7 +1086,7 @@ public class Parser
                         Diagnostics.ReportUnexpectedToken(Current.Location, Current.Kind, SyntaxKind.IdentifierToken);
                     }
 
-                    var constructor = ParseConstructorDeclaration(memberAccessibility);
+                    var constructor = ParseConstructorDeclaration(memberAccessibility, memberConvenienceModifier);
                     constructor.WithAnnotations(memberAnnotations);
                     constructors.Add(constructor);
                 }
@@ -1141,8 +1159,10 @@ public class Parser
     /// <summary>
     /// Issue #306: parses a standalone user-defined constructor
     /// <c>init(params) [: base(args)] { body }</c> inside a class body.
+    /// ADR-0065 §2: accepts an optional leading <c>convenience</c> contextual
+    /// modifier passed in by the caller.
     /// </summary>
-    private ConstructorDeclarationSyntax ParseConstructorDeclaration(SyntaxToken accessibilityModifier)
+    private ConstructorDeclarationSyntax ParseConstructorDeclaration(SyntaxToken accessibilityModifier, SyntaxToken convenienceModifier = null)
     {
         var initKeyword = NextToken(); // consume the contextual "init" identifier
         var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
@@ -1168,6 +1188,7 @@ public class Parser
         return new ConstructorDeclarationSyntax(
             syntaxTree,
             accessibilityModifier,
+            convenienceModifier,
             initKeyword,
             openParen,
             parameters,

--- a/test/Compiler.Tests/Emit/Adr0065ConvenienceInitEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Adr0065ConvenienceInitEmitTests.cs
@@ -1,0 +1,425 @@
+// <copyright file="Adr0065ConvenienceInitEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// ADR-0065 §2 / §5: end-to-end emit tests for convenience initializers,
+/// constructor self-delegation, and primary-ctor / explicit-init coexistence.
+/// Each test compiles via <c>gsc</c>, runs <c>ilverify</c>, and then executes
+/// the produced assembly under <c>dotnet exec</c> to assert behavior.
+/// </summary>
+public class Adr0065ConvenienceInitEmitTests
+{
+    [Fact]
+    public void ConvenienceInit_DelegatesToDesignated_CompilesAndRuns()
+    {
+        var source = """
+            package Probe
+            import System
+
+            type Rect class {
+                Width int32
+                Height int32
+                init(w int32, h int32) {
+                    Width = w
+                    Height = h
+                }
+                convenience init(side int32) {
+                    init(side, side)
+                }
+            }
+
+            var r1 = Rect(3, 4)
+            var r2 = Rect(5)
+            Console.WriteLine(r1.Width)
+            Console.WriteLine(r1.Height)
+            Console.WriteLine(r2.Width)
+            Console.WriteLine(r2.Height)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n4\n5\n5\n", output);
+    }
+
+    [Fact]
+    public void ConvenienceInit_ChainOfConveniences_CompilesAndRuns()
+    {
+        // ADR-0065 §2: a convenience init may delegate to another convenience
+        // init, which transitively reaches the designated initializer that
+        // performs the actual field setup.
+        var source = """
+            package Probe
+            import System
+
+            type HttpClient class {
+                BaseUrl string
+                Timeout int32
+                init(baseUrl string, timeout int32) {
+                    BaseUrl = baseUrl
+                    Timeout = timeout
+                }
+                convenience init(baseUrl string) {
+                    init(baseUrl, 30)
+                }
+                convenience init() {
+                    init("http://localhost")
+                }
+            }
+
+            var a = HttpClient("https://example", 5)
+            var b = HttpClient("https://other")
+            var c = HttpClient()
+            Console.WriteLine(a.BaseUrl)
+            Console.WriteLine(a.Timeout)
+            Console.WriteLine(b.BaseUrl)
+            Console.WriteLine(b.Timeout)
+            Console.WriteLine(c.BaseUrl)
+            Console.WriteLine(c.Timeout)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("https://example\n5\nhttps://other\n30\nhttp://localhost\n30\n", output);
+    }
+
+    [Fact]
+    public void PrimaryCtorWithConvenience_DelegatesToSynthesizedPrimary()
+    {
+        // ADR-0065 §5: the synthesized primary-ctor init is one of the
+        // designated initializers in the overload set. A convenience init may
+        // delegate to it via `init(args)`.
+        var source = """
+            package Probe
+            import System
+
+            type LifecycleTab class(Title string, Key string) {
+                Active bool = false
+                convenience init(key string) {
+                    init(key, key)
+                }
+            }
+
+            var t1 = LifecycleTab("Settings", "settings")
+            var t2 = LifecycleTab("home")
+            Console.WriteLine(t1.Title)
+            Console.WriteLine(t1.Key)
+            Console.WriteLine(t1.Active)
+            Console.WriteLine(t2.Title)
+            Console.WriteLine(t2.Key)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Settings\nsettings\nFalse\nhome\nhome\n", output);
+    }
+
+    [Fact]
+    public void PrimaryCtorPlusInitOverload_BothInitializersWork()
+    {
+        // ADR-0065 §5: primary ctor `(Name string)` AND explicit
+        // `init(age int32)` with distinct signatures both compile and are
+        // selectable by argument type.
+        var source = """
+            package Probe
+            import System
+
+            type Person class(Name string) {
+                Age int32
+                init(age int32) {
+                    Age = age
+                }
+            }
+
+            var byName = Person("Alice")
+            var byAge = Person(42)
+            Console.WriteLine(byName.Name)
+            Console.WriteLine(byAge.Age)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Alice\n42\n", output);
+    }
+
+    [Fact]
+    public void DesignatedInit_UsingInitDelegation_ReportsError()
+    {
+        // ADR-0065 §2 / GS0281: only convenience init may use init(args)
+        // self-delegation; designated must call base via : base() instead.
+        var source = """
+            package Probe
+
+            type Bad class {
+                X int32
+                init(x int32) {
+                    X = x
+                }
+                init() {
+                    init(0)
+                }
+            }
+            """;
+
+        var errors = CompileExpectingErrors(source);
+        Assert.True(
+            errors.Any(e => e.Contains("GS0281") || e.Contains("designated")),
+            $"Expected GS0281: {string.Join("\n", errors)}");
+    }
+
+    [Fact]
+    public void ConvenienceInit_WithoutDelegation_ReportsError()
+    {
+        // ADR-0065 §2 / GS0278: a convenience init body must begin with an
+        // init(args) self-delegation.
+        var source = """
+            package Probe
+
+            type Bad class {
+                X int32
+                init(x int32) {
+                    X = x
+                }
+                convenience init() {
+                    X = 0
+                }
+            }
+            """;
+
+        var errors = CompileExpectingErrors(source);
+        Assert.True(
+            errors.Any(e => e.Contains("GS0278") || e.Contains("delegate")),
+            $"Expected GS0278: {string.Join("\n", errors)}");
+    }
+
+    [Fact]
+    public void ConvenienceInit_WithBaseClause_ReportsError()
+    {
+        // ADR-0065 §2 / GS0279: convenience init may not declare ': base()'.
+        var source = """
+            package Probe
+
+            type Animal open class {
+                Name string
+                init(name string) {
+                    Name = name
+                }
+            }
+
+            type Dog class : Animal {
+                init(name string) : base(name) {
+                }
+                convenience init() : base("rex") {
+                    init("rex")
+                }
+            }
+            """;
+
+        var errors = CompileExpectingErrors(source);
+        Assert.True(
+            errors.Any(e => e.Contains("GS0279") || e.Contains("convenience")),
+            $"Expected GS0279: {string.Join("\n", errors)}");
+    }
+
+    [Fact]
+    public void InitDelegation_OutsideCtor_ReportsError()
+    {
+        // ADR-0065 §2 / GS0280: bare init(args) outside any ctor body is not
+        // a valid identifier-call. Falls through to the standard "unknown
+        // function" diagnostic since `init` only has special meaning inside
+        // a class ctor body.
+        var source = """
+            package Probe
+
+            type Foo class {
+                init() {
+                }
+            }
+
+            func main() {
+                init(1)
+            }
+            """;
+
+        var errors = CompileExpectingErrors(source);
+        // The bare identifier `init` outside a ctor body has no binding;
+        // either GS0280 (if we ever surface it from a free-function ctx)
+        // or a generic "undefined name" diagnostic is acceptable.
+        Assert.NotEmpty(errors);
+    }
+
+    [Fact]
+    public void ConvenienceInit_OverloadResolution_PicksMatchingSibling()
+    {
+        // ADR-0065 §2 + ADR-0063 §9: when multiple sibling overloads exist
+        // the init(args) call uses arity/type-based overload resolution.
+        var source = """
+            package Probe
+            import System
+
+            type Color class {
+                R int32
+                G int32
+                B int32
+                init(r int32, g int32, b int32) {
+                    R = r
+                    G = g
+                    B = b
+                }
+                init(gray int32) {
+                    R = gray
+                    G = gray
+                    B = gray
+                }
+                convenience init() {
+                    init(0)
+                }
+            }
+
+            var black = Color()
+            var gray = Color(128)
+            var red = Color(255, 0, 0)
+            Console.WriteLine(black.R)
+            Console.WriteLine(gray.G)
+            Console.WriteLine(red.R)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n128\n255\n", output);
+    }
+
+    // ====================================================================
+    // Helpers
+    // ====================================================================
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_adr0065_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+
+    private static System.Collections.Generic.List<string> CompileExpectingErrors(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_adr0065_err_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit != 0, "expected gsc to report errors but it succeeded");
+            var combined = compileOut.ToString() + compileErr.ToString();
+            return combined.Split('\n').Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue656InitAsPrimaryCtorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue656InitAsPrimaryCtorEmitTests.cs
@@ -230,16 +230,16 @@ public class Issue656InitAsPrimaryCtorEmitTests
 
     // ====================================================================
     // ADR-0065 §5: class with primary-ctor parameter list AND explicit
-    // init(args) — this is a compile-time error per current binder rule
-    // ("A class uses EITHER primary ctor OR explicit init, not both").
+    // init(args) — both coexist; primary becomes one designated init.
     // ====================================================================
 
     [Fact]
-    public void PrimaryCtorAndExplicitInit_ReportsError()
+    public void PrimaryCtorAndExplicitInit_Coexist()
     {
-        // ADR-0065 §5 says primary ctor is one designated init among others.
-        // However the current binder (per pre-existing rule) rejects mixing
-        // primary-ctor syntax with explicit init bodies. Verify the error.
+        // ADR-0065 §5: a class may declare both a primary-constructor parameter
+        // list and additional explicit `init(...)` bodies. The synthesized
+        // primary ctor is one designated initializer; user-declared inits are
+        // additional overloads, picked by overload resolution.
         var source = """
             package Probe
             import System
@@ -251,12 +251,36 @@ public class Issue656InitAsPrimaryCtorEmitTests
                 }
             }
 
-            var d = Dual("x")
-            Console.WriteLine(d.Name)
+            var byName = Dual("Alice")
+            var byAge = Dual(42)
+            Console.WriteLine(byName.Name)
+            Console.WriteLine(byAge.Age)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Alice\n42\n", output);
+    }
+
+    [Fact]
+    public void PrimaryCtorAndExplicitInit_DuplicateSignatureReportsError()
+    {
+        // ADR-0065 §5: a user-written init with the same signature as the
+        // synthesized primary-ctor init is a compile-time error.
+        var source = """
+            package Probe
+            import System
+
+            type Dup class(Name string) {
+                func init(other string) {
+                    Name = other
+                }
+            }
             """;
 
         var errors = CompileExpectingErrors(source);
-        Assert.True(errors.Any(e => e.Contains("init")), $"Expected an error about init: {string.Join("\n", errors)}");
+        Assert.True(
+            errors.Any(e => e.Contains("GS0284") || (e.Contains("primary") && e.Contains("init"))),
+            $"Expected GS0284 (duplicates primary ctor): {string.Join("\n", errors)}");
     }
 
     // ====================================================================

--- a/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
@@ -636,10 +636,11 @@ var r = Rect(true)
     }
 
     [Fact]
-    public void ExplicitConstructor_PrimaryAndExplicit_Diagnoses()
+    public void ExplicitConstructor_PrimaryAndExplicit_SameSignatureDiagnoses()
     {
-        // Issue #306: GS0215 — a class cannot declare both a primary constructor
-        // and an explicit `init` constructor.
+        // ADR-0065 §5: the primary constructor is one designated init among
+        // others. A user-declared init that duplicates its signature is a
+        // compile-time error (GS0284).
         var source = @"
 type Bad class(X int32) {
     init(y int32) {
@@ -649,7 +650,28 @@ type Bad class(X int32) {
 0
 ";
         var result = Evaluate(source);
-        Assert.Contains(result.Diagnostics, d => d.Message.Contains("both a primary constructor and an explicit 'init' constructor"));
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("duplicates the synthesized primary-constructor overload"));
+    }
+
+    [Fact]
+    public void ExplicitConstructor_PrimaryAndExplicit_DistinctSignatures_Compile()
+    {
+        // ADR-0065 §5: when a class declares a primary-constructor parameter
+        // list AND additional explicit init(...) bodies with distinct
+        // signatures, both kinds coexist as designated initializers.
+        var source = @"
+type Both class(Name string) {
+    Age int32
+    init(age int32) {
+        Age = age
+    }
+}
+var byName = Both(""Alice"")
+byName.Name
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Alice", result.Value);
     }
 
     [Fact]
@@ -673,6 +695,91 @@ b.X
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
         Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void ConvenienceInit_DelegatesToDesignated_Evaluates()
+    {
+        // ADR-0065 §2: convenience init body begins with `init(args)` which
+        // delegates to the designated init in the same class.
+        var source = @"
+type Rect class {
+    Width int32
+    Height int32
+    init(w int32, h int32) {
+        Width = w
+        Height = h
+    }
+    convenience init(side int32) {
+        init(side, side)
+    }
+}
+var r = Rect(7)
+r.Width + r.Height
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(14, result.Value);
+    }
+
+    [Fact]
+    public void ConvenienceInit_MissingDelegation_ReportsGS0278()
+    {
+        // ADR-0065 §2 Rule 3 / GS0278.
+        var source = @"
+type Bad class {
+    X int32
+    init(x int32) {
+        X = x
+    }
+    convenience init() {
+        X = 0
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("delegate to another initializer"));
+    }
+
+    [Fact]
+    public void DesignatedInit_InitDelegation_ReportsGS0281()
+    {
+        // ADR-0065 §2 / GS0281: only convenience init may use init(args).
+        var source = @"
+type Bad class {
+    X int32
+    init(x int32) {
+        X = x
+    }
+    init() {
+        init(0)
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Designated initializer"));
+    }
+
+    [Fact]
+    public void ConvenienceInit_WithBase_ReportsGS0279()
+    {
+        // ADR-0065 §2 / GS0279: convenience may not declare `: base()`.
+        var source = @"
+type Animal open class(Name string) {
+}
+type Dog class : Animal(""rex"") {
+    init(n string) {
+    }
+    convenience init() : base(""rex"") {
+        init(""rex"")
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("may not declare ': base"));
     }
 
     private static EvaluationResult Evaluate(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue656InitAsPrimaryCtorBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue656InitAsPrimaryCtorBinderTests.cs
@@ -141,9 +141,10 @@ var cfg = Config()
     }
 
     [Fact]
-    public void PrimaryCtorAndFuncInit_ReportsError()
+    public void PrimaryCtorAndFuncInit_BothInitializersAvailable()
     {
-        // Mixing primary-ctor param list with explicit init is an error
+        // ADR-0065 §5: primary ctor + explicit `func init(age int32)` with
+        // distinct signatures coexist; both are designated initializers.
         var source = @"
 type Dual class(Name string) {
     Age int32
@@ -154,8 +155,14 @@ type Dual class(Name string) {
 
 var d = Dual(""x"")
 ";
-        var (result, _) = EvaluateAndGetStructs(source);
-        Assert.NotEmpty(result.Diagnostics);
+        var (result, structs) = EvaluateAndGetStructs(source);
+        Assert.Empty(result.Diagnostics);
+
+        var dual = structs.Single(s => s.Name == "Dual");
+        Assert.True(dual.HasPrimaryConstructor);
+        Assert.Equal(2, dual.ExplicitConstructors.Length);
+        Assert.True(dual.ExplicitConstructors[0].IsSynthesizedFromPrimaryConstructor);
+        Assert.False(dual.ExplicitConstructors[1].IsSynthesizedFromPrimaryConstructor);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/BoundNodeKindExhaustivenessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/BoundNodeKindExhaustivenessTests.cs
@@ -157,6 +157,7 @@ public class BoundNodeKindExhaustivenessTests
         "ChannelCloseExpression",
         "IsExpression",
         "AsExpression",
+        "ConstructorChainingExpression",
 
         // Pattern kinds.
         "ConstantPattern",
@@ -297,6 +298,7 @@ public class BoundNodeKindExhaustivenessTests
         "ChannelCloseExpression",
         "IsExpression",
         "AsExpression",
+        "ConstructorChainingExpression",
 
         // Pattern kinds.
         "ConstantPattern",

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -259,6 +259,7 @@ ConditionalExpression
 ConditionalGotoStatement
 ConstantPattern
 ConstructorCallExpression
+ConstructorChainingExpression
 ConversionExpression
 DefaultExpression
 DereferenceExpression


### PR DESCRIPTION
Implements the Swift-inspired two-phase initializer model adopted in
[ADR-0065](./docs/adr/0065-class-initializers-and-base-invocation.md).
Closes #646.

## What's in this PR

### §5 — Primary ctor and explicit `init(...)` bodies coexist

Lifts the previous "primary OR explicit init" ban (was `GS0215`). The
primary-ctor parameter list is materialised as a synthesised designated
init (`ConstructorSymbol.IsSynthesizedFromPrimaryConstructor`) and
becomes one of the `ExplicitConstructors`. Duplicate signatures between
user inits and the synthesised primary are reported as `GS0284`.

```gsharp
type Person class(Name string) {
    Age int32
    init(age int32) {           // additional designated init
        Age = age
    }
}

var byName = Person("Alice")    // → synthesised primary init
var byAge = Person(42)          // → user init(age int32)
```

### §2 — Convenience initializers + `init(args)` self-delegation

- Parser accepts the contextual `convenience` modifier before `init`
  (and before `func init`).
- A bare `init(args)` call inside a class ctor body is recognised by the
  binder as a sibling self-delegation, overload-resolved against the
  class's `ExplicitConstructors` (excluding the caller), and lowered to
  a new `BoundConstructorChainingExpression`.
- Emit: convenience inits skip the base-call / field-initializer chain
  and delegate to the chained designated ctor via
  `ldarg.0; <args>; call this..ctor`.
- Evaluator: handles both the synthesised-primary fall-through and the
  self-delegation by locating the active `this` frame and re-running the
  chained-to ctor body.

```gsharp
type Rect class {
    Width int32
    Height int32
    init(w int32, h int32) {
        Width = w
        Height = h
    }
    convenience init(side int32) {
        init(side, side)        // self-delegation
    }
}
```

### §4 Rule 3 — Convenience must delegate first

Enforced by `Binder.VerifyConvenienceInitDelegatesFirst` (`GS0278`).
Convenience may not declare `: base()` (`GS0279`). Designated may not
use `init(args)` self-delegation (`GS0281`).

### New diagnostics

| Code | Description |
|---|---|
| `GS0278` | Convenience initializer body must begin with `init(args)` self-delegation. |
| `GS0279` | Convenience initializer may not declare an explicit `: base(args)` clause. |
| `GS0280` | `init(args)` self-delegation is only valid inside a class constructor body. |
| `GS0281` | Designated initializer may not delegate to a sibling `init(args)` overload. |
| `GS0282` | Convenience initializer may not delegate to itself (recursive). |
| `GS0283` | No applicable `init(...)` overload matches the self-delegation arguments. |
| `GS0284` | A user-declared `init(...)` overload duplicates the synthesised primary-ctor signature. |

### New bound node

`ConstructorChainingExpression` (added to walker / rewriter / printer /
emit dispatch / spill spiller / coverage golden / exhaustiveness
allowlists).

## Tests

- 9 new emit tests in `Adr0065ConvenienceInitEmitTests` covering
  convenience-delegates-designated, convenience-chain-2-deep,
  primary-ctor + convenience, primary-ctor + init coexistence,
  overload-resolution from convenience, and four diagnostic forms.
- 4 new binding tests in `ClassTests` for `GS0278` / `GS0281` /
  `GS0279` and the convenience evaluator path.
- Updated `Issue656InitAsPrimaryCtorEmitTests.PrimaryCtorAndExplicitInit_*`
  and `Issue656InitAsPrimaryCtorBinderTests.PrimaryCtorAndFuncInit_*` to
  reflect the new behaviour (compile instead of error).

All baseline test suites pass:

| Suite | Pass | Skip |
|---|---|---|
| Core.Tests | 2290 | 1 |
| Compiler.Tests | 958 | 0 |
| Interpreter.Tests | 98 | 0 |
| LanguageServer.Tests | 242 | 0 |
| Sdk.Tests | 26 | 0 |

## Out of scope (tracked as ADR Implementation Notes for follow-up)

- §3 strict base-call reordering — emit still places the base call first
  in a designated init body. Indistinguishable in practice without
  virtual calls in base ctors; will land alongside the §4 Rules 2 + 4
  diagnostics below.
- §4 Rules 1 / 2 / 4 — full two-phase definite-assignment diagnostics
  (all-own-properties-before-super, no-inherited-access-before-super,
  no-self-as-value-during-phase-1).
- §6 initializer inheritance Rules A and B + `override init` machinery.
