### PR TITLE
Fix #671: bind G# user-defined types as type arguments to CLR generics in construction calls

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -131,12 +131,12 @@ internal sealed partial class ExpressionBinder
         var typeSimpleName = terminalCall.Identifier.Text;
         var namespacePrefix = string.Join(".", segments);
 
-        if (!TryResolveQualifiedClrType(namespacePrefix, typeSimpleName, terminalCall, out var clrType))
+        if (!TryResolveQualifiedClrType(namespacePrefix, typeSimpleName, terminalCall, out var clrType, out var openGenericDef, out var symbolicArgs))
         {
             return false;
         }
 
-        return TryBindClrConstructorFromType(clrType, terminalCall, out result);
+        return TryBindClrConstructorFromType(clrType, terminalCall, out result, openGenericDef, symbolicArgs);
     }
 
     /// <summary>
@@ -150,10 +150,29 @@ internal sealed partial class ExpressionBinder
     /// <param name="typeSimpleName">The simple type name (the constructor call identifier).</param>
     /// <param name="terminalCall">The terminal call, used for generic arity/arguments.</param>
     /// <param name="clrType">The resolved closed CLR type on success.</param>
+    /// <param name="openGenericDefinition">
+    /// Issue #671: when one or more type arguments are G# user-defined types
+    /// (no CLR type at bind time), the closed CLR shape is type-erased to
+    /// <see cref="object"/> placeholders and this is set to the open generic
+    /// definition so the emitter can recover the symbolic form.
+    /// <see langword="null"/> otherwise.
+    /// </param>
+    /// <param name="symbolicTypeArgs">
+    /// Issue #671: the original symbolic type arguments in source order when
+    /// any user-defined type substitution is in effect; default otherwise.
+    /// </param>
     /// <returns>Whether a type was resolved.</returns>
-    private bool TryResolveQualifiedClrType(string namespacePrefix, string typeSimpleName, CallExpressionSyntax terminalCall, out System.Type clrType)
+    private bool TryResolveQualifiedClrType(
+        string namespacePrefix,
+        string typeSimpleName,
+        CallExpressionSyntax terminalCall,
+        out System.Type clrType,
+        out System.Type openGenericDefinition,
+        out ImmutableArray<TypeSymbol> symbolicTypeArgs)
     {
         clrType = null;
+        openGenericDefinition = null;
+        symbolicTypeArgs = default;
 
         var arity = terminalCall.TypeArgumentList?.Arguments.Count ?? 0;
 
@@ -195,14 +214,29 @@ internal sealed partial class ExpressionBinder
                 if (scope.References.TryResolveType(mangled, out var openType))
                 {
                     var clrArgs = new System.Type[arity];
+                    var symbolic = ImmutableArray.CreateBuilder<TypeSymbol>(arity);
                     var argsResolved = true;
+                    var hasSymbolicArg = false;
                     for (var i = 0; i < arity; i++)
                     {
                         var ta = bindTypeClause(terminalCall.TypeArgumentList.Arguments[i]);
-                        if (ta?.ClrType == null)
+                        if (ta == null)
                         {
                             argsResolved = false;
                             break;
+                        }
+
+                        symbolic.Add(ta);
+
+                        if (ta.ClrType == null)
+                        {
+                            // Issue #313 / #671: in-scope type parameter or
+                            // user-defined G# type argument — close with a
+                            // System.Object placeholder and preserve the
+                            // symbolic argument for the emitter to recover.
+                            hasSymbolicArg = true;
+                            clrArgs[i] = scope.References.GetCoreType("System.Object");
+                            continue;
                         }
 
                         // Type arguments resolve to gsc-host CLR types (e.g.
@@ -222,6 +256,12 @@ internal sealed partial class ExpressionBinder
                     try
                     {
                         clrType = openType.MakeGenericType(clrArgs);
+                        if (hasSymbolicArg)
+                        {
+                            openGenericDefinition = openType;
+                            symbolicTypeArgs = symbolic.MoveToImmutable();
+                        }
+
                         return true;
                     }
                     catch (System.ArgumentException)
@@ -1559,9 +1599,22 @@ internal sealed partial class ExpressionBinder
 
     private static TypeSymbol MapErasedIndexerElementType(ImportedTypeSymbol target, PropertyInfo closedIndexer)
     {
-        if (target.HasTypeParameterArgument
-            && target.OpenDefinition is System.Type openDefinition
-            && !target.TypeArguments.IsDefaultOrEmpty)
+        // Issue #313 (HasTypeParameterArgument): substitute the open indexer's
+        // generic-parameter result back through the target's symbolic type
+        // arguments so `list[i]` on `List[T]` is typed as `T`.
+        // Issue #671: also substitute when the target is a constructed
+        // generic with G# user-defined or nested-symbolic type arguments
+        // (e.g. `outer[0]` on `List[List[MyGs]]` -> `List[MyGs]`); without
+        // this the element would type-erase to `List<object>` and downstream
+        // member access on the result would emit against the wrong parent.
+        var hasSubstitutableArgs = !target.TypeArguments.IsDefaultOrEmpty
+            && (target.HasTypeParameterArgument
+                || target.TypeArguments.Any(static a => a.ClrType == null
+                    || (a is ImportedTypeSymbol nested
+                        && nested.OpenDefinition != null
+                        && !nested.TypeArguments.IsDefaultOrEmpty)));
+        if (hasSubstitutableArgs
+            && target.OpenDefinition is System.Type openDefinition)
         {
             try
             {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -345,6 +345,8 @@ internal sealed partial class ExpressionBinder
         var name = syntax.Identifier.Text;
 
         System.Type clrType = null;
+        System.Type openGenericDefinition = null;
+        ImmutableArray<TypeSymbol> symbolicTypeArgs = default;
         if (syntax.TypeArgumentList != null)
         {
             // `List[int]()`, `Dictionary[string, int]()`, etc. Resolve the open
@@ -355,20 +357,9 @@ internal sealed partial class ExpressionBinder
                 return false;
             }
 
-            var clrArgs = new System.Type[syntax.TypeArgumentList.Arguments.Count];
-            for (var i = 0; i < syntax.TypeArgumentList.Arguments.Count; i++)
+            if (!TryResolveClrConstructionTypeArgs(syntax.TypeArgumentList, out var clrArgs, out symbolicTypeArgs, out var hasSymbolicArg))
             {
-                var ta = bindTypeClause(syntax.TypeArgumentList.Arguments[i]);
-                if (ta?.ClrType == null)
-                {
-                    return false;
-                }
-
-                // Project host CLR type arguments onto the resolver's reference
-                // set so they share openType's load context (its
-                // MetadataLoadContext when references are supplied via /r:),
-                // which MakeGenericType requires.
-                clrArgs[i] = scope.References.MapClrTypeToReferences(ta.ClrType);
+                return false;
             }
 
             try
@@ -378,6 +369,21 @@ internal sealed partial class ExpressionBinder
             catch (System.ArgumentException)
             {
                 return false;
+            }
+
+            // Issue #671: when one or more type arguments is a G# user-defined
+            // type (its ClrType is null because the TypeDef is only produced
+            // during emit), the closed CLR shape was type-erased to
+            // `Open<object,...>`. Keep the openGenericDefinition + the real
+            // symbolic args so the emitter can later re-emit the parent
+            // TypeSpec using the user-defined TypeDef tokens.
+            if (!hasSymbolicArg)
+            {
+                symbolicTypeArgs = default;
+            }
+            else
+            {
+                openGenericDefinition = openType;
             }
         }
         else
@@ -396,7 +402,88 @@ internal sealed partial class ExpressionBinder
             clrType = importedClass.ClassType;
         }
 
-        return TryBindClrConstructorFromType(clrType, syntax, out result);
+        return TryBindClrConstructorFromType(clrType, syntax, out result, openGenericDefinition, symbolicTypeArgs);
+    }
+
+    /// <summary>
+    /// Issue #671: resolves the type arguments on a CLR generic construction
+    /// call (<c>List[MyGs]()</c>, <c>Dictionary[string, MyGs]()</c>) into
+    /// MakeGenericType-ready CLR types alongside their original symbolic
+    /// TypeSymbol forms. A G# user-defined type argument has no
+    /// reference-context CLR type (its TypeDef is produced at emit), so it is
+    /// closed with a <see cref="object"/> placeholder; the symbolic argument
+    /// is preserved so the emitter can re-emit it as its own TypeDef token in
+    /// the parent TypeSpec of the resulting MemberRef. Mirrors the
+    /// construction-side handling in <see cref="Binder.ConstructIfGeneric"/>
+    /// and the generic-method side in
+    /// <see cref="TryResolveExplicitMethodTypeArgs"/>.
+    /// </summary>
+    /// <param name="typeArgumentList">The call's <c>[T1, T2]</c> list.</param>
+    /// <param name="clrArgs">On success, the resolved (mapped) CLR type arguments ready for MakeGenericType.</param>
+    /// <param name="symbolicArgs">On success, the symbolic type arguments in source order.</param>
+    /// <param name="hasSymbolicArg">On success, whether any argument is a G# user-defined type or in-scope type parameter.</param>
+    /// <returns>Whether all type arguments resolved.</returns>
+    private bool TryResolveClrConstructionTypeArgs(
+        TypeArgumentListSyntax typeArgumentList,
+        out System.Type[] clrArgs,
+        out ImmutableArray<TypeSymbol> symbolicArgs,
+        out bool hasSymbolicArg)
+    {
+        clrArgs = new System.Type[typeArgumentList.Arguments.Count];
+        var symbolic = ImmutableArray.CreateBuilder<TypeSymbol>(typeArgumentList.Arguments.Count);
+        hasSymbolicArg = false;
+        for (var i = 0; i < typeArgumentList.Arguments.Count; i++)
+        {
+            var ta = bindTypeClause(typeArgumentList.Arguments[i]);
+            if (ta == null)
+            {
+                symbolicArgs = default;
+                return false;
+            }
+
+            symbolic.Add(ta);
+
+            if (ta.ClrType == null)
+            {
+                // Issue #313: in-scope type parameter, or issue #671: G#
+                // user-defined type whose ClrType is null at bind time.
+                // Both project onto System.Object under the type-erased
+                // model; the real symbolic argument is preserved separately.
+                hasSymbolicArg = true;
+                clrArgs[i] = scope.References.GetCoreType("System.Object");
+                continue;
+            }
+
+            // Issue #671: a nested constructed generic that itself carries
+            // symbolic user-defined arguments (e.g. `List[MyGs]` used as an
+            // argument to `List[...]`) has a (type-erased) ClrType, but the
+            // outer construction must still preserve the symbolic shape so
+            // the emitter can recover the user-defined TypeDef tokens at the
+            // inner position. Flag the outer as symbolic so the symbolic args
+            // are retained, but keep the placeholder CLR type for
+            // MakeGenericType (the closed CLR shape erases to
+            // `Open<...,object,...>` at the outer level, and the emitter
+            // descends through the symbolic args to encode the real shape).
+            if (ta is ImportedTypeSymbol nested
+                && nested.OpenDefinition != null
+                && !nested.TypeArguments.IsDefaultOrEmpty
+                && nested.TypeArguments.Any(static a => a.ClrType == null
+                    || (a is ImportedTypeSymbol n && n.OpenDefinition != null && !n.TypeArguments.IsDefaultOrEmpty)))
+            {
+                hasSymbolicArg = true;
+            }
+
+            // Project host CLR type arguments onto the resolver's reference
+            // set so they share openType's load context (its
+            // MetadataLoadContext when references are supplied via /r:),
+            // which MakeGenericType requires.
+            // Issue #530: use ResolveClrTypeForGenericArg so that `int32?`
+            // resolves to `Nullable<int>` (not bare `int`).
+            clrArgs[i] = resolveClrTypeForGenericArg(ta) ?? scope.References.MapClrTypeToReferences(ta.ClrType);
+        }
+
+        symbolicArgs = symbolic.MoveToImmutable();
+        return true;
     }
 
     /// <summary>
@@ -410,8 +497,27 @@ internal sealed partial class ExpressionBinder
     /// <param name="clrType">The closed CLR type to construct.</param>
     /// <param name="syntax">The call syntax carrying the arguments and location.</param>
     /// <param name="result">The bound constructor call on success.</param>
+    /// <param name="openGenericDefinition">
+    /// Issue #671: when <paramref name="clrType"/> was closed with a
+    /// <see cref="object"/> placeholder for one or more G# user-defined type
+    /// arguments, the open generic definition (e.g. <c>List&lt;&gt;</c>) used to
+    /// build the closed shape. Combined with <paramref name="symbolicTypeArgs"/>
+    /// it lets the emitter re-emit the parent TypeSpec using the user-defined
+    /// TypeDef tokens. <see langword="null"/> when no symbolic substitution is
+    /// in effect.
+    /// </param>
+    /// <param name="symbolicTypeArgs">
+    /// Issue #671: the original symbolic type arguments in source order, used
+    /// alongside <paramref name="openGenericDefinition"/>. Default when no
+    /// symbolic substitution is in effect.
+    /// </param>
     /// <returns>Whether a constructor was resolved and bound.</returns>
-    private bool TryBindClrConstructorFromType(System.Type clrType, CallExpressionSyntax syntax, out BoundExpression result)
+    private bool TryBindClrConstructorFromType(
+        System.Type clrType,
+        CallExpressionSyntax syntax,
+        out BoundExpression result,
+        System.Type openGenericDefinition = null,
+        ImmutableArray<TypeSymbol> symbolicTypeArgs = default)
     {
         result = null;
 
@@ -567,12 +673,28 @@ internal sealed partial class ExpressionBinder
             overloads.ValidateRefArguments(ctorArgs, ctorRefKinds, clrType.Name, syntax.Location);
         }
 
+        // Issue #671: when the closed CLR shape was type-erased to fit a G#
+        // user-defined type argument, surface the result type as a constructed
+        // ImportedTypeSymbol carrying the real symbolic arguments. The emitter
+        // uses this to re-emit the parent TypeSpec of the ctor MemberRef with
+        // the user-defined TypeDef tokens (so the NEWOBJ targets, e.g.,
+        // `List<MyGs>` rather than the erased `List<object>`).
+        TypeSymbol resultType;
+        if (openGenericDefinition != null && !symbolicTypeArgs.IsDefaultOrEmpty)
+        {
+            resultType = ImportedTypeSymbol.GetConstructed(clrType, openGenericDefinition, symbolicTypeArgs);
+        }
+        else
+        {
+            resultType = TypeSymbol.FromClrType(clrType);
+        }
+
         result = new BoundClrConstructorCallExpression(
             syntax,
             clrType,
             bestCtor,
             ctorArgs,
-            TypeSymbol.FromClrType(clrType),
+            resultType,
             ctorRefKinds);
         return true;
     }

--- a/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
+++ b/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
@@ -126,6 +126,17 @@ internal sealed class MetadataTokenCache
         = new Dictionary<ConstructorInfo, MemberReferenceHandle>();
 
     /// <summary>
+    /// Gets the cache for ctor MemberRef rows whose parent TypeSpec is
+    /// encoded against G# user-defined symbolic type arguments (issue #671).
+    /// The placeholder-closed <see cref="ConstructorInfo"/> is identical
+    /// across distinct user-type closures (all closed to <c>object</c> at the
+    /// CLR level), so the key must include the symbol argument list with
+    /// structural equality, mirroring <see cref="MethodSpecsWithSymbolArgs"/>.
+    /// </summary>
+    public Dictionary<CtorRefSymbolKey, MemberReferenceHandle> CtorRefsWithSymbolArgs { get; }
+        = new Dictionary<CtorRefSymbolKey, MemberReferenceHandle>();
+
+    /// <summary>
     /// Gets the cache mapping a <see cref="FieldInfo"/> to its
     /// <see cref="MemberReferenceHandle"/>.
     /// </summary>
@@ -338,6 +349,59 @@ internal sealed class MetadataTokenCache
         public override int GetHashCode()
         {
             var hash = RuntimeHelpers.GetHashCode(this.method);
+            for (var i = 0; i < this.typeArgs.Length; i++)
+            {
+                hash = unchecked((hash * 31) + RuntimeHelpers.GetHashCode(this.typeArgs[i]));
+            }
+
+            return hash;
+        }
+    }
+
+    /// <summary>
+    /// Issue #671: structural cache key for ctor MemberRef rows whose parent
+    /// TypeSpec carries G# user-defined symbolic type arguments. Counterpart
+    /// to <see cref="MethodSpecSymbolKey"/>.
+    /// </summary>
+    internal readonly struct CtorRefSymbolKey : IEquatable<CtorRefSymbolKey>
+    {
+        private readonly ConstructorInfo ctor;
+        private readonly ImmutableArray<TypeSymbol> typeArgs;
+
+        public CtorRefSymbolKey(ConstructorInfo ctor, ImmutableArray<TypeSymbol> typeArgs)
+        {
+            this.ctor = ctor;
+            this.typeArgs = typeArgs.IsDefault ? ImmutableArray<TypeSymbol>.Empty : typeArgs;
+        }
+
+        public bool Equals(CtorRefSymbolKey other)
+        {
+            if (!ReferenceEquals(this.ctor, other.ctor))
+            {
+                return false;
+            }
+
+            if (this.typeArgs.Length != other.typeArgs.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < this.typeArgs.Length; i++)
+            {
+                if (!ReferenceEquals(this.typeArgs[i], other.typeArgs[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override bool Equals(object obj) => obj is CtorRefSymbolKey other && this.Equals(other);
+
+        public override int GetHashCode()
+        {
+            var hash = RuntimeHelpers.GetHashCode(this.ctor);
             for (var i = 0; i < this.typeArgs.Length; i++)
             {
                 hash = unchecked((hash * 31) + RuntimeHelpers.GetHashCode(this.typeArgs[i]));

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -178,7 +178,14 @@ internal sealed partial class MethodBodyEmitter
             }
         }
 
-        var ctorRef = this.outer.GetCtorReference(ctorCall.Constructor);
+        // Issue #671: when the ctor target's containing type carries G#
+        // user-defined symbolic type arguments (closed with System.Object at
+        // the CLR layer because the user type's TypeDef is only produced
+        // during emit), build the MemberRef against a parent TypeSpec encoded
+        // with the symbolic args. Without this the `newobj` would target the
+        // type-erased `Open<object,…>::.ctor`, which fails IL verification
+        // against the locally-typed `Open<MyGs,…>` slot.
+        var ctorRef = this.outer.GetCtorReference(ctorCall.Constructor, ctorCall.Type);
         this.il.OpCode(ILOpCode.Newobj);
         this.il.Token(ctorRef);
     }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -703,7 +703,16 @@ internal sealed partial class MethodBodyEmitter
                 var getter = property.GetGetMethod(nonPublic: false)
                     ?? throw new InvalidOperationException(
                         $"Property '{property.DeclaringType?.FullName}.{property.Name}' has no public getter.");
-                var getterRef = this.outer.GetMethodReference(getter);
+                // Issue #671: when the receiver is a symbolic constructed
+                // generic (e.g. List[MyGs] with a user-defined type arg),
+                // route the getter through the receiver-aware overload so
+                // the MemberRef parent is the constructed type with the
+                // real user-type tokens instead of the type-erased
+                // List<object>. Static getters and CLR receivers fall back
+                // to the plain MemberRef path inside the overload.
+                var getterRef = isStatic
+                    ? (EntityHandle)this.outer.GetMethodReference(getter)
+                    : this.outer.GetMethodEntityHandle(getter, access.Receiver.Type);
                 this.il.OpCode(isStatic || receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
                 this.il.Token(getterRef);
                 this.EmitErasedObjectReturnWidening(
@@ -755,7 +764,12 @@ internal sealed partial class MethodBodyEmitter
                     ?? throw new InvalidOperationException(
                         $"Property '{property.DeclaringType?.FullName}.{property.Name}' has no public setter.");
                 this.il.OpCode(isStatic || receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
-                this.il.Token(this.outer.GetMethodReference(setter));
+                // Issue #671: route through the receiver-aware overload so the
+                // setter MemberRef parent is the constructed symbolic type when
+                // applicable. Falls back to the plain MemberRef path otherwise.
+                this.il.Token(isStatic
+                    ? (EntityHandle)this.outer.GetMethodReference(setter)
+                    : this.outer.GetMethodEntityHandle(setter, assn.Receiver.Type));
                 break;
             case FieldInfo field:
                 this.il.OpCode(isStatic ? ILOpCode.Stsfld : ILOpCode.Stfld);
@@ -836,7 +850,10 @@ internal sealed partial class MethodBodyEmitter
                 $"Indexer on '{idx.Indexer.DeclaringType?.FullName}' has no public getter.");
         var receiverIsValueType = ReflectionMetadataEmitter.IsValueTypeSymbol(idx.Target.Type);
         this.il.OpCode(receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
-        this.il.Token(this.outer.GetMethodReference(getter));
+        // Issue #671: route through the receiver-aware overload so the indexer
+        // getter MemberRef parent is the constructed symbolic type when the
+        // target is a generic with G# user-defined type arguments.
+        this.il.Token(this.outer.GetMethodEntityHandle(getter, idx.Target.Type));
         this.EmitErasedObjectReturnWidening(TypeSymbol.FromClrType(getter.ReturnType), idx.Type);
     }
 
@@ -866,7 +883,8 @@ internal sealed partial class MethodBodyEmitter
             }
 
             this.il.OpCode(ILOpCode.Call);
-            this.il.Token(this.outer.GetMethodReference(refGetter));
+            // Issue #671: receiver-aware MemberRef for symbolic constructed generics.
+            this.il.Token(this.outer.GetMethodEntityHandle(refGetter, receiver.Type));
             this.EmitExpression(ixa.Value);
             this.il.OpCode(ILOpCode.Dup);
             this.il.StoreLocal(tmp);
@@ -900,7 +918,8 @@ internal sealed partial class MethodBodyEmitter
         this.il.OpCode(ILOpCode.Dup);
         this.il.StoreLocal(slot);
         this.il.OpCode(targetIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
-        this.il.Token(this.outer.GetMethodReference(setter));
+        // Issue #671: receiver-aware MemberRef for symbolic constructed generics.
+        this.il.Token(this.outer.GetMethodEntityHandle(setter, targetType));
         this.il.LoadLocal(slot);
     }
 

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -3744,7 +3744,7 @@ internal sealed class ReflectionMetadataEmitter
         if (element is ImportedTypeSymbol symbolicImported
             && !symbolicImported.TypeArguments.IsDefaultOrEmpty
             && !symbolicImported.HasTypeParameterArgument
-            && symbolicImported.TypeArguments.Any(static a => a is StructSymbol or InterfaceSymbol or EnumSymbol))
+            && symbolicImported.TypeArguments.Any(ArgIsSymbolicUserDefined))
         {
             var sigBlob = new BlobBuilder();
             this.EncodeTypeSymbol(new BlobEncoder(sigBlob).TypeSpecificationSignature(), symbolicImported);
@@ -4112,7 +4112,7 @@ internal sealed class ReflectionMetadataEmitter
             {
                 if (!typeArgSymbols.IsDefaultOrEmpty
                     && i < typeArgSymbols.Length
-                    && typeArgSymbols[i] is StructSymbol or InterfaceSymbol or EnumSymbol)
+                    && ArgIsSymbolicUserDefined(typeArgSymbols[i]))
                 {
                     this.EncodeTypeSymbol(symbolicArgsEncoder.AddArgument(), typeArgSymbols[i]);
                 }
@@ -4137,7 +4137,7 @@ internal sealed class ReflectionMetadataEmitter
         // the same generic method was referenced multiple times with the same
         // user-type generic args.
         var hasSymbolArgs = !typeArgSymbols.IsDefaultOrEmpty
-            && typeArgSymbols.Any(s => s is StructSymbol or InterfaceSymbol or EnumSymbol);
+            && typeArgSymbols.Any(ArgIsSymbolicUserDefined);
         if (!hasSymbolArgs)
         {
             if (this.cache.MethodSpecs.TryGetValue(method, out var existing))
@@ -4164,9 +4164,12 @@ internal sealed class ReflectionMetadataEmitter
         {
             // Issue #320: encode a user-defined type argument via its symbol so it
             // resolves to the emitted TypeDef; BCL arguments use the closed CLR type.
+            // Issue #671: also recurse through nested constructed generics so a
+            // `MyGeneric<List<MyGs>>` argument is encoded symbolically rather than
+            // collapsing to System.Object at the placeholder.
             if (!typeArgSymbols.IsDefaultOrEmpty
                 && i < typeArgSymbols.Length
-                && typeArgSymbols[i] is StructSymbol or InterfaceSymbol or EnumSymbol)
+                && ArgIsSymbolicUserDefined(typeArgSymbols[i]))
             {
                 this.EncodeTypeSymbol(argsEncoder.AddArgument(), typeArgSymbols[i]);
             }
@@ -4200,7 +4203,7 @@ internal sealed class ReflectionMetadataEmitter
             || imported.OpenDefinition == null
             || imported.TypeArguments.IsDefaultOrEmpty
             || imported.HasTypeParameterArgument
-            || !imported.TypeArguments.Any(static a => a is StructSymbol or InterfaceSymbol or EnumSymbol))
+            || !imported.TypeArguments.Any(ArgIsSymbolicUserDefined))
         {
             return false;
         }
@@ -4278,7 +4281,32 @@ internal sealed class ReflectionMetadataEmitter
     /// generic types (<c>List&lt;int&gt;()</c>, <c>Dictionary&lt;string, int&gt;()</c>).
     /// </summary>
     internal MemberReferenceHandle GetCtorReference(ConstructorInfo ctor)
+        => this.GetCtorReference(ctor, containingTypeSymbol: null);
+
+    /// <summary>
+    /// Phase 4 emit parity: get a MemberRef for a CLR instance constructor on a
+    /// possibly type-erased generic declaring type. When
+    /// <paramref name="containingTypeSymbol"/> is an
+    /// <see cref="ImportedTypeSymbol"/> whose <see cref="ImportedTypeSymbol.TypeArguments"/>
+    /// contain one or more G# user-defined types (issue #671), the parent
+    /// TypeSpec is encoded against those symbolic arguments (resolving to the
+    /// real user-defined TypeDef tokens) instead of the type-erased
+    /// <c>Open&lt;object,…&gt;</c> shape carried by <paramref name="ctor"/>.
+    /// </summary>
+    /// <param name="ctor">The (possibly type-erased) constructor selected by overload resolution.</param>
+    /// <param name="containingTypeSymbol">The bound result type of the construction expression. May be <see langword="null"/>.</param>
+    /// <returns>A MemberRef handle for the constructor on the correctly-typed parent.</returns>
+    internal MemberReferenceHandle GetCtorReference(ConstructorInfo ctor, TypeSymbol containingTypeSymbol)
     {
+        // Issue #671: when the containing type carries symbolic user-type
+        // arguments, the cache key needs to discriminate per symbol set
+        // (multiple distinct user-type closures share a single type-erased
+        // ConstructorInfo).
+        if (TryCreateCtorMemberReferenceForConstructedSymbolicContainer(ctor, containingTypeSymbol, out var symbolicHandle))
+        {
+            return symbolicHandle;
+        }
+
         if (this.cache.CtorRefs.TryGetValue(ctor, out var existing))
         {
             return existing;
@@ -4319,6 +4347,100 @@ internal sealed class ReflectionMetadataEmitter
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
         this.cache.CtorRefs[ctor] = handle;
         return handle;
+    }
+
+    /// <summary>
+    /// Issue #671: builds a constructor MemberRef whose parent TypeSpec is
+    /// encoded from the original symbolic type arguments (resolving to G#
+    /// user-defined TypeDef tokens) rather than the type-erased
+    /// <c>Open&lt;object,…&gt;</c> shape baked into the constructor's
+    /// <see cref="MemberInfo.DeclaringType"/>. Mirrors the method
+    /// counterpart in <see cref="TryCreateMemberReferenceForConstructedSymbolicContainer"/>.
+    /// </summary>
+    /// <param name="ctor">The (type-erased) constructor.</param>
+    /// <param name="containingTypeSymbol">The bound type of the call's result; expected to be an <see cref="ImportedTypeSymbol"/> carrying user-defined type args.</param>
+    /// <param name="handle">On success, the new MemberRef handle.</param>
+    /// <returns>Whether a symbolic-container MemberRef was produced.</returns>
+    private bool TryCreateCtorMemberReferenceForConstructedSymbolicContainer(
+        ConstructorInfo ctor,
+        TypeSymbol containingTypeSymbol,
+        out MemberReferenceHandle handle)
+    {
+        handle = default;
+        if (ctor == null
+            || containingTypeSymbol is not ImportedTypeSymbol imported
+            || imported.OpenDefinition == null
+            || imported.TypeArguments.IsDefaultOrEmpty
+            || imported.HasTypeParameterArgument
+            || !imported.TypeArguments.Any(ArgIsSymbolicUserDefined))
+        {
+            return false;
+        }
+
+        var cacheKey = new MetadataTokenCache.CtorRefSymbolKey(ctor, imported.TypeArguments);
+        if (this.cache.CtorRefsWithSymbolArgs.TryGetValue(cacheKey, out var cached))
+        {
+            handle = cached;
+            return true;
+        }
+
+        var parentBlob = new BlobBuilder();
+        this.EncodeTypeSymbol(new BlobEncoder(parentBlob).TypeSpecificationSignature(), imported);
+        var parent = this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(parentBlob));
+        var openCtor = ResolveCtorOnOpenDefinition(imported.OpenDefinition, ctor);
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                openCtor.GetParameters().Length,
+                returnType: r => r.Void(),
+                parameters: ps =>
+                {
+                    foreach (var p in openCtor.GetParameters())
+                    {
+                        var paramType = p.ParameterType;
+                        if (paramType.IsByRef)
+                        {
+                            this.EncodeClrType(ps.AddParameter().Type(isByRef: true), paramType.GetElementType()!);
+                        }
+                        else
+                        {
+                            this.EncodeClrType(ps.AddParameter().Type(), paramType);
+                        }
+                    }
+                });
+
+        handle = this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        this.cache.CtorRefsWithSymbolArgs[cacheKey] = handle;
+        return true;
+    }
+
+    private static ConstructorInfo ResolveCtorOnOpenDefinition(Type openDefinition, ConstructorInfo ctor)
+    {
+        if (openDefinition == null)
+        {
+            return ctor;
+        }
+
+        if (ctor.DeclaringType == openDefinition)
+        {
+            return ctor;
+        }
+
+        foreach (var candidate in openDefinition.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (candidate.MetadataToken == ctor.MetadataToken && candidate.Module == ctor.Module)
+            {
+                return candidate;
+            }
+        }
+
+        var fallback = openDefinition.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .FirstOrDefault(candidate => candidate.GetParameters().Length == ctor.GetParameters().Length);
+        return fallback ?? ctor;
     }
 
     /// <summary>
@@ -4675,7 +4797,7 @@ internal sealed class ReflectionMetadataEmitter
             && !symbolicImported.TypeArguments.IsDefaultOrEmpty
             && !symbolicImported.HasTypeParameterArgument
             && symbolicImported.OpenDefinition != null
-            && symbolicImported.TypeArguments.Any(static a => a is StructSymbol or InterfaceSymbol or EnumSymbol))
+            && symbolicImported.TypeArguments.Any(ArgIsSymbolicUserDefined))
         {
             var genericInst = encoder.GenericInstantiation(
                 this.GetTypeReference(symbolicImported.OpenDefinition),
@@ -4875,6 +4997,48 @@ internal sealed class ReflectionMetadataEmitter
         if (type?.ClrType != null && type.ClrType.IsValueType)
         {
             return true;
+        }
+
+        return false;
+    }
+
+    // Issue #671 (construction-call follow-up): a generic type-argument
+    // position carries a "user-defined" symbol when it is itself a
+    // user-declared type (Struct/Class/Interface/Enum/Delegate) — its
+    // ClrType is only produced during emit — or when it is a nested
+    // constructed generic whose own arguments transitively carry one.
+    // This predicate gates the symbolic-container emit paths so a
+    // <c>List[List[MyGs]]</c> receiver is recognised even though its
+    // outer argument is an <see cref="ImportedTypeSymbol"/> rather than a
+    // direct user-defined symbol.
+    private static bool ArgIsSymbolicUserDefined(TypeSymbol arg)
+    {
+        if (arg is StructSymbol or InterfaceSymbol or EnumSymbol or DelegateTypeSymbol)
+        {
+            return true;
+        }
+
+        if (arg is ImportedTypeSymbol nested
+            && nested.OpenDefinition != null
+            && !nested.TypeArguments.IsDefaultOrEmpty
+            && nested.TypeArguments.Any(ArgIsSymbolicUserDefined))
+        {
+            return true;
+        }
+
+        if (arg is ArrayTypeSymbol arr)
+        {
+            return ArgIsSymbolicUserDefined(arr.ElementType);
+        }
+
+        if (arg is SliceTypeSymbol slice)
+        {
+            return ArgIsSymbolicUserDefined(slice.ElementType);
+        }
+
+        if (arg is NullableTypeSymbol nullable && nullable.UnderlyingType != null)
+        {
+            return ArgIsSymbolicUserDefined(nullable.UnderlyingType);
         }
 
         return false;

--- a/test/Compiler.Tests/Emit/Issue671ConstructionCallEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue671ConstructionCallEmitTests.cs
@@ -1,0 +1,235 @@
+// <copyright file="Issue671ConstructionCallEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// End-to-end emit tests for the construction-call follow-up of issue #671:
+/// a CLR generic invoked as a constructor with one or more G# user-defined
+/// type arguments (e.g. <c>List[MyGs]()</c>, <c>Dictionary[string, MyGs]()</c>,
+/// nested generics, fully-qualified type names) compiles, IL-verifies, and
+/// runs.
+/// </summary>
+public class Issue671ConstructionCallEmitTests
+{
+    [Fact]
+    public void Construct_ListOfUserClass_Compiles_And_Runs()
+    {
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            type MyGs class {
+                Name string = ""
+            }
+
+            let xs = List[MyGs]()
+            xs.Add(MyGs())
+            xs.Add(MyGs())
+            Console.WriteLine(xs.Count)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void Construct_ListOfUserInterface_Compiles_And_Runs()
+    {
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            type IMyGs interface {
+                func GetName() string
+            }
+
+            let xs = List[IMyGs]()
+            Console.WriteLine(xs.Count)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n", output);
+    }
+
+    [Fact]
+    public void Construct_KeyValuePairOfStringToUserClass_Compiles_And_Runs()
+    {
+        // Dictionary[K, V]() at top level is currently shadowed by the map-literal
+        // parser; KeyValuePair exercises the same "CLR generic with multiple type
+        // args, at least one of which is a G# user-defined class" construction call.
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            type MyGs class {
+                Name string = ""
+            }
+
+            let kvp = KeyValuePair[string, MyGs]("k", MyGs())
+            Console.WriteLine(kvp.Key)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("k\n", output);
+    }
+
+    [Fact]
+    public void Construct_NestedListOfListOfUserClass_Compiles_And_Runs()
+    {
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            type MyGs class {
+                Name string = ""
+            }
+
+            let outer = List[List[MyGs]]()
+            outer.Add(List[MyGs]())
+            outer[0].Add(MyGs())
+            Console.WriteLine(outer.Count)
+            Console.WriteLine(outer[0].Count)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n1\n", output);
+    }
+
+    [Fact]
+    public void Construct_QualifiedListOfUserClass_Compiles_And_Runs()
+    {
+        var source = """
+            package App
+            import System
+
+            type MyGs class {
+                Name string = ""
+            }
+
+            let xs = System.Collections.Generic.List[MyGs]()
+            xs.Add(MyGs())
+            Console.WriteLine(xs.Count)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void Construct_ListOfClrType_Regression_StillWorks()
+    {
+        // Regression guard: a CLR-only type argument (no symbolic substitution)
+        // must continue to bind and emit through the existing happy path.
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            let xs = List[int32]()
+            xs.Add(1)
+            xs.Add(2)
+            xs.Add(3)
+            Console.WriteLine(xs.Count)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n", output);
+    }
+
+    [Fact]
+    public void Construct_ListOfString_Regression_StillWorks()
+    {
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            let xs = List[string]()
+            xs.Add("a")
+            xs.Add("b")
+            Console.WriteLine(xs.Count)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue671_ctor_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue671UserTypeAsClrGenericArgTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue671UserTypeAsClrGenericArgTests.cs
@@ -366,4 +366,186 @@ public class Issue671UserTypeAsClrGenericArgTests
 
         Assert.Empty(BindWithReferences(source));
     }
+
+    // ─── Construction-call position (issue #671 reopen) ──────────────────
+    //
+    // The original fix made user types legal in *type-clause* position. The
+    // call-site path `Type[args](...)` was a separate code path that still
+    // rejected the same shape; these tests guard that the construction call
+    // also binds and preserves the symbolic type arguments end-to-end.
+
+    [Fact]
+    public void Construct_ListOfUserClass_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+
+            func main() {
+                let xs = List[MyType]()
+                xs.Add(MyType())
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Construct_ListOfUserInterface_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type IMyType interface {
+                func GetName() string
+            }
+
+            func main() {
+                let xs = List[IMyType]()
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Construct_ListOfUserEnum_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type Color enum {
+                Red, Green, Blue
+            }
+
+            func main() {
+                let xs = List[Color]()
+                xs.Add(Color.Red)
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Construct_QualifiedListOfUserClass_Binds()
+    {
+        var source = """
+            package App
+
+            type MyType class {
+                Name string = ""
+            }
+
+            func main() {
+                let xs = System.Collections.Generic.List[MyType]()
+                xs.Add(MyType())
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Construct_NestedListOfListOfUserClass_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+
+            func main() {
+                let outer = List[List[MyType]]()
+                let inner = List[MyType]()
+                outer.Add(inner)
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Construct_KeyValuePairWithUserClass_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+
+            func main() {
+                let kvp = KeyValuePair[string, MyType]("k", MyType())
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Construct_ListOfClrType_StillBinds_Regression()
+    {
+        // Pure-CLR regression: a non-user type argument must still bind cleanly.
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            func main() {
+                let xs = List[int32]()
+                xs.Add(1)
+                let ys = List[string]()
+                ys.Add("a")
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void MLC_Construct_ListOfUserClass_Binds()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type MyType class {
+                Name string = ""
+            }
+
+            func main() {
+                let xs = List[MyType]()
+                xs.Add(MyType())
+            }
+            """;
+
+        Assert.Empty(BindWithReferences(source));
+    }
+
+    [Fact]
+    public void MLC_Construct_QualifiedListOfUserClass_Binds()
+    {
+        var source = """
+            package App
+
+            type MyType class {
+                Name string = ""
+            }
+
+            func main() {
+                let xs = System.Collections.Generic.List[MyType]()
+            }
+            """;
+
+        Assert.Empty(BindWithReferences(source));
+    }
 }


### PR DESCRIPTION
Closes the remaining piece of #671 — the construction-call follow-up reopened by @DavidObando on 2026-06-10.

The first part of the bug (declaration position, e.g. `items List[MyGs]` as a field type) was fixed in #681. That commit made user types legal in *type-clause* position by projecting them onto `System.Object` for the closed CLR shape and preserving the symbolic arguments via `ImportedTypeSymbol.GetConstructed`. The call-site path `Type[args](...)` was a separate code path that still rejected the same shape with GS0130 / GS0149, and the emitter had no symbolic-container support for constructors or for property/indexer accessors.

## Repro (now passes)

```gsharp
package Probe.Tests
import System.Collections.Generic
import Xunit

type MyGs class {
    Name string = ""
}

type Probe class {
    @Fact
    func Construct_List_Of_GsClass() {
        let xs = List[MyGs]()      // ← used to fail with GS0130
        xs.Add(MyGs())             // ← used to verify-fail with mismatched parent type
        Assert.Equal(1, xs.Count)
    }
}
```

## Root cause

Three related gaps end-to-end:

1. **Binder — call-site construction.** `TryBindClrConstructorCall` (and the qualified counterpart `TryBindQualifiedClrConstructorCall` / `TryResolveQualifiedClrType`) rejected any type argument whose `ClrType` was `null`, instead of mirroring the declaration-position fix that projects user types onto `System.Object` while preserving the symbolic argument list.
2. **Binder — nested generics.** Even where a binder helper accepted the inner argument, an outer construction like `List[List[MyGs]]()` didn't propagate the symbolic shape because the inner `List[MyGs]` *had* a (type-erased) `ClrType` and was therefore treated as a plain CLR argument. The outer ImportedTypeSymbol then ended up with a sibling `List<object>` arg instead of the symbolic `List<MyGs>` arg, so the field/local signature collapsed to `List<List<object>>`.
3. **Emitter — symbolic-container plumbing.**
   - Constructors had no symbolic-container path: `newobj` always went through `GetCtorReference(ctor)` with no `containingType` knowledge.
   - Property getters/setters and indexer getters/setters always emitted against the type-erased `<object>` parent because they called `GetMethodReference(getter)` with no receiver context, never reaching the symbolic path that already existed for instance method calls.
   - The symbolic-container gate (`is StructSymbol or InterfaceSymbol or EnumSymbol`) was non-recursive, so even with the new binder, a receiver of type `List[List[MyGs]]` did not look symbolic to the emitter (its outer arg is an `ImportedTypeSymbol`, not a direct user-defined symbol).
   - `MapErasedIndexerElementType` only substituted when the target had a type *parameter*, so `outer[0]` on `List[List[MyGs]]` typed the result as the erased `List<object>`, defeating any downstream receiver-aware emit.

## Fix

### Binder
- **`ExpressionBinder.Calls.cs`** — `TryBindClrConstructorCall` now accepts `null`-`ClrType` args (project onto `System.Object`, track `openGenericDefinition` + `symbolicTypeArgs`). A new helper `TryResolveClrConstructionTypeArgs` centralizes the resolution and also flags nested constructed generics that themselves carry symbolic args. `TryBindClrConstructorFromType` returns a `BoundClrConstructorCallExpression` whose `Type` is the symbolic `ImportedTypeSymbol.GetConstructed(erasedClosed, openDef, symbolicArgs)`, so the symbolic shape survives through the rest of the bound tree (locals, fields, downstream member access).
- **`ExpressionBinder.Access.cs`** — `TryBindQualifiedClrConstructorCall` / `TryResolveQualifiedClrType` get the same treatment for `System.Collections.Generic.List[MyGs]()`.
- **`ExpressionBinder.Access.cs`** — `MapErasedIndexerElementType` now substitutes the indexer return type through the target's symbolic args even when the target is a constructed generic with user-defined or nested-symbolic args, not just when it carries an in-scope type parameter. This lets chained access like `outer[0].Add(MyGs())` see the symbolic `List[MyGs]` element type and emit the Add MemberRef against the correct parent.

### Emitter
- **`ReflectionMetadataEmitter.cs`** — new `ArgIsSymbolicUserDefined` predicate recognizes both direct user-defined symbols (`StructSymbol` including classes via `IsClass`, `InterfaceSymbol`, `EnumSymbol`, `DelegateTypeSymbol`) and nested `ImportedTypeSymbol` containers transitively carrying one. Every `is StructSymbol or InterfaceSymbol or EnumSymbol` gate in the symbolic-emit paths (method-spec, GenericInstantiation encoder, the new ctor-side helper) now uses this predicate so nested generics like `List<List<MyGs>>` survive end-to-end.
- **`ReflectionMetadataEmitter.cs`** — new `GetCtorReference(ctor, containingTypeSymbol)` overload + `TryCreateCtorMemberReferenceForConstructedSymbolicContainer` + `ResolveCtorOnOpenDefinition` mirror the existing method-side helpers so `newobj` builds a MemberRef whose parent TypeSpec uses the real user-defined TypeDef tokens.
- **`MetadataTokenCache.cs`** — new `CtorRefsWithSymbolArgs` dictionary keyed on the structural `CtorRefSymbolKey` (mirroring `MethodSpecSymbolKey`) so the placeholder-closed `ConstructorInfo` doesn't conflate distinct user-type closures.
- **`MethodBodyEmitter.Calls.cs`** — `EmitClrConstructorCall` routes through `GetCtorReference(ctor, ctorCall.Type)`.
- **`MethodBodyEmitter.MemberAccess.cs`** — CLR property getter/setter and indexer getter/setter sites route through the receiver-aware `GetMethodEntityHandle(method, receiver.Type)` overload (already present for instance method calls) so `xs.Count`, `map[k] = v`, etc. on a symbolic-typed receiver emit against the constructed symbolic parent instead of the type-erased `<object>` shape.

## Tests

### New — emit (`test/Compiler.Tests/Emit/Issue671ConstructionCallEmitTests.cs`)
End-to-end compile-+-ilverify-+-run for:
- `List[MyGs]()` (G# class)
- `List[IMyGs]()` (G# interface)
- `KeyValuePair[string, MyGs](...)` (multi-type-arg with user class)
- `List[List[MyGs]]()` (nested generic)
- `System.Collections.Generic.List[MyGs]()` (qualified)
- `List[int32]()` and `List[string]()` (CLR-arg regressions)

### Extended — binder (`test/Core.Tests/CodeAnalysis/Binding/Issue671UserTypeAsClrGenericArgTests.cs`)
Nine new tests covering simple-name + qualified construction with class, interface, enum, nested generic, KeyValuePair, the CLR-arg regression, and MLC (MetadataLoadContext) variants for the class case.

## Verification
- `dotnet build GSharp.sln -nologo -clp:NoSummary` — succeeds with 0 warnings, 0 errors.
- `dotnet test GSharp.sln --no-restore --nologo` — all green:
  - Core.Tests: 2324 passed, 1 skipped, 0 failed
  - Compiler.Tests: 973 passed, 0 failed (includes the new emit tests; ilverify ran on every emitted assembly)
  - Interpreter.Tests: 98 passed
  - LanguageServer.Tests: 242 passed
  - Sdk.Tests: 26 passed

## Out-of-scope note
The pre-existing parser ambiguity around `Dictionary[K, V]()` (where the parser begins a map literal and never reaches the `()` invocation) is unrelated to this fix. The Dictionary case is covered indirectly via `KeyValuePair[K, V](...)` which exercises the same multi-type-arg construction code path.