### PR TITLE
Fix #687: color-color resolution for type/field name collisions and qualified namespace static calls

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -456,7 +456,32 @@ internal sealed partial class ExpressionBinder
         if (leftPart is NameExpressionSyntax leftName)
         {
             var name = leftName.IdentifierToken.Text;
-            if (scope.TryLookupSymbol(name) is VariableSymbol variable)
+            var variableHit = scope.TryLookupSymbol(name) as VariableSymbol;
+
+            // Issue #687 (Option A — C#-style "color color"): when an identifier
+            // resolves to both a value (field/local/parameter) AND a same-named
+            // type in scope, prefer the type interpretation if the right-hand
+            // side of the accessor is a static member of that type. Fall through
+            // to the value interpretation otherwise so instance access continues
+            // to bind as today (`field.InstanceMethod()`).
+            if (variableHit != null
+                && TryResolveColorColorType(name, leftName, out var colorClassSymbol, out var colorStructSymbol, out var colorEnumSymbol)
+                && RightPartLooksLikeStaticMember(colorClassSymbol, colorStructSymbol, colorEnumSymbol, rightPart))
+            {
+                if (colorClassSymbol != null)
+                {
+                    classSymbol = colorClassSymbol;
+                }
+                else if (colorStructSymbol != null)
+                {
+                    userStructSymbol = colorStructSymbol;
+                }
+                else
+                {
+                    enumSymbol = colorEnumSymbol;
+                }
+            }
+            else if (variableHit is VariableSymbol variable)
             {
                 if (variable is ImplicitFieldVariableSymbol implicitField)
                 {
@@ -642,39 +667,254 @@ internal sealed partial class ExpressionBinder
 
     private bool TryBindImportAccessor(ImportSymbol import, ref ExpressionSyntax rightPart, out ImportedClassSymbol importedClass)
     {
-        // Handle `<importName>.<TypeName>(.<more>)*` where <importName> is either an
-        // alias or the import's path. The next segment of the chain names the type;
-        // we resolve `<import.Target>.<TypeName>` and consume that segment.
+        // Handle `<importName>.<Segment>(.<Segment>)*.<TypeName>(.<more>)*` where
+        // <importName> is either an alias or the import's path. Walks the accessor
+        // chain extending the namespace prefix until a segment resolves as a type;
+        // unresolved leading segments are treated as additional namespace levels
+        // (issue #687: e.g. `System.IO.Path.Combine(...)` with `import System.IO`
+        // peels `IO` as a namespace continuation, then resolves `System.IO.Path`).
         importedClass = null;
 
-        NameExpressionSyntax typeNameSyntax;
-        ExpressionSyntax remainder;
-
-        switch (rightPart)
+        var currentPath = import.Target;
+        var currentRight = rightPart;
+        while (true)
         {
-            case AccessorExpressionSyntax nested when nested.LeftPart is NameExpressionSyntax leftName:
-                typeNameSyntax = leftName;
-                remainder = nested.RightPart;
-                break;
+            NameExpressionSyntax typeNameSyntax;
+            ExpressionSyntax remainder;
+            bool hasMoreChain;
 
-            case NameExpressionSyntax ne:
-                typeNameSyntax = ne;
-                remainder = ne;
-                break;
+            switch (currentRight)
+            {
+                case AccessorExpressionSyntax nested when nested.LeftPart is NameExpressionSyntax leftName:
+                    typeNameSyntax = leftName;
+                    remainder = nested.RightPart;
+                    hasMoreChain = true;
+                    break;
 
-            default:
+                case NameExpressionSyntax ne:
+                    typeNameSyntax = ne;
+                    remainder = ne;
+                    hasMoreChain = false;
+                    break;
+
+                default:
+                    return false;
+            }
+
+            var fullTypeName = currentPath + "." + typeNameSyntax.IdentifierToken.Text;
+            if (scope.References.TryResolveType(fullTypeName, out var type))
+            {
+                importedClass = new ImportedClassSymbol(type, typeNameSyntax);
+                rightPart = remainder;
+                return true;
+            }
+
+            // Not a type. If there's still a chain to consume, treat this segment
+            // as another namespace level and keep walking. Otherwise, give up.
+            if (!hasMoreChain)
+            {
                 return false;
+            }
+
+            currentPath = fullTypeName;
+            currentRight = remainder;
+        }
+    }
+
+    /// <summary>
+    /// Issue #687 (Option A): when a name resolves to a value but also matches an
+    /// in-scope type with the same simple name (an imported CLR class, user-defined
+    /// struct/class, or enum), surface that type so the caller can apply the
+    /// C#-style "color color" preference when the right-hand side of the accessor
+    /// is a static member of the type.
+    /// </summary>
+    private bool TryResolveColorColorType(
+        string name,
+        NameExpressionSyntax leftName,
+        out ImportedClassSymbol importedClassSymbol,
+        out StructSymbol userStructSymbol,
+        out EnumSymbol enumSymbol)
+    {
+        importedClassSymbol = null;
+        userStructSymbol = null;
+        enumSymbol = null;
+
+        if (scope.TryLookupImportedClass(name, leftName, out var importedClass))
+        {
+            importedClassSymbol = importedClass;
+            return true;
         }
 
-        var fullTypeName = import.Target + "." + typeNameSyntax.IdentifierToken.Text;
-        if (!scope.References.TryResolveType(fullTypeName, out var type))
+        if (scope.TryLookupTypeAlias(name, out var typeAlias))
+        {
+            if (typeAlias is StructSymbol foundStruct)
+            {
+                userStructSymbol = foundStruct;
+                return true;
+            }
+
+            if (typeAlias is EnumSymbol foundEnum)
+            {
+                enumSymbol = foundEnum;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #687 (Option A): inspects the right-hand side of an accessor chain
+    /// to determine whether it would bind as a static member (field, property,
+    /// event, nested type, or method) of the supplied type. Used to decide
+    /// between the value and type interpretation when a name collides with a
+    /// same-named type in scope. When no static member matches, the binder
+    /// falls back to the value interpretation so existing instance-access
+    /// semantics continue to work unchanged.
+    /// </summary>
+    private bool RightPartLooksLikeStaticMember(
+        ImportedClassSymbol importedClassSymbol,
+        StructSymbol userStructSymbol,
+        EnumSymbol enumSymbol,
+        ExpressionSyntax rightPart)
+    {
+        if (!TryGetAccessorChainHead(rightPart, out var headName, out var isCall))
         {
             return false;
         }
 
-        importedClass = new ImportedClassSymbol(type, typeNameSyntax);
-        rightPart = remainder;
-        return true;
+        if (importedClassSymbol != null)
+        {
+            return HasStaticMember(importedClassSymbol.ClassType, headName, isCall);
+        }
+
+        if (userStructSymbol != null)
+        {
+            return HasUserTypeStaticMember(userStructSymbol, headName, isCall);
+        }
+
+        if (enumSymbol != null)
+        {
+            return !isCall && enumSymbol.TryGetMember(headName, out _);
+        }
+
+        return false;
+    }
+
+    private static bool TryGetAccessorChainHead(ExpressionSyntax rightPart, out string headName, out bool isCall)
+    {
+        switch (rightPart)
+        {
+            case CallExpressionSyntax ce when !ce.Identifier.IsMissing:
+                headName = ce.Identifier.Text;
+                isCall = true;
+                return !string.IsNullOrEmpty(headName);
+
+            case NameExpressionSyntax ne when !ne.IdentifierToken.IsMissing:
+                headName = ne.IdentifierToken.Text;
+                isCall = false;
+                return !string.IsNullOrEmpty(headName);
+
+            case AccessorExpressionSyntax acc:
+                return TryGetAccessorChainHead(acc.LeftPart, out headName, out isCall);
+
+            case IndexExpressionSyntax ix:
+                return TryGetAccessorChainHead(ix.Target, out headName, out isCall);
+
+            case ObjectCreationExpressionSyntax objCreate:
+                return TryGetAccessorChainHead(objCreate.Target, out headName, out isCall);
+
+            default:
+                headName = null;
+                isCall = false;
+                return false;
+        }
+    }
+
+    private bool HasStaticMember(System.Type clrType, string headName, bool isCall)
+    {
+        if (clrType == null)
+        {
+            return false;
+        }
+
+        if (isCall)
+        {
+            var methods = ClrTypeUtilities.SafeGetMethodsIncludingInterfaces(clrType, BindingFlags.Public | BindingFlags.Static);
+            foreach (var m in methods)
+            {
+                if (m.Name == headName)
+                {
+                    return true;
+                }
+            }
+
+            if (scope.References.TryResolveNestedType(clrType, headName, out _))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        if (ClrTypeUtilities.SafeGetField(clrType, headName, BindingFlags.Public | BindingFlags.Static) != null)
+        {
+            return true;
+        }
+
+        var prop = ClrTypeUtilities.SafeGetProperty(clrType, headName, BindingFlags.Public | BindingFlags.Static);
+        if (prop != null && prop.GetIndexParameters().Length == 0)
+        {
+            return true;
+        }
+
+        if (scope.References.TryResolveNestedType(clrType, headName, out _))
+        {
+            return true;
+        }
+
+        try
+        {
+            if (clrType.GetEvent(headName, BindingFlags.Public | BindingFlags.Static) != null)
+            {
+                return true;
+            }
+        }
+        catch (System.Exception)
+        {
+            // Defensive: some metadata-load-context types throw on event lookup;
+            // treat as "no event" so the binder falls back to instance semantics.
+        }
+
+        return false;
+    }
+
+    private static bool HasUserTypeStaticMember(StructSymbol structSym, string headName, bool isCall)
+    {
+        if (structSym == null)
+        {
+            return false;
+        }
+
+        if (isCall)
+        {
+            return structSym.TryGetStaticMethod(headName, out _);
+        }
+
+        if (structSym.TryGetStaticField(headName, out _))
+        {
+            return true;
+        }
+
+        foreach (var prop in structSym.StaticProperties)
+        {
+            if (prop.Name == headName)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private BoundExpression BindEnumAccessorStep(EnumSymbol enumSymbol, ExpressionSyntax rightPart)

--- a/test/Compiler.Tests/Emit/Issue687ColorColorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue687ColorColorEmitTests.cs
@@ -1,0 +1,159 @@
+// <copyright file="Issue687ColorColorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #687: end-to-end emit + runtime validation for the C# "color color"
+/// rule and the qualified-namespace-path escape hatch. A class with a field
+/// whose name shadows an imported type (<c>Path string</c> alongside
+/// <c>System.IO.Path</c>) must compile, the static call <c>Path.Combine</c>
+/// inside the method body must bind against <c>System.IO.Path</c>, and the
+/// fully-qualified <c>System.IO.Path.Combine(...)</c> spelling must continue
+/// to work as an escape hatch.
+/// </summary>
+public class Issue687ColorColorEmitTests
+{
+    [Fact]
+    public void ColorColor_FieldShadowsImportedType_StaticCallEmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+            import System.IO
+
+            type Entry class {
+                Path string = ""
+
+                func Build(suffix string) string {
+                    return Path.Combine(this.Path, suffix)
+                }
+            }
+
+            var e = Entry() { Path = "root" }
+            Console.WriteLine(e.Build("leaf.txt"))
+            """;
+
+        var output = CompileAndRun(source);
+        var expected = System.IO.Path.Combine("root", "leaf.txt") + "\n";
+        Assert.Equal(expected, output);
+    }
+
+    [Fact]
+    public void QualifiedNamespacePath_StaticCallEmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            Console.WriteLine(System.IO.Path.Combine("a", "b"))
+            """;
+
+        var output = CompileAndRun(source);
+        var expected = System.IO.Path.Combine("a", "b") + "\n";
+        Assert.Equal(expected, output);
+    }
+
+    [Fact]
+    public void ColorColor_InstanceMemberAccess_FallsBackToField()
+    {
+        // Field type is `string` and `Path.Length` is an instance member of the
+        // string value, not a static of System.IO.Path. The fall-back must keep
+        // the instance interpretation, returning the length of the field value
+        // ("/tmp" → 4) at runtime.
+        var source = """
+            package P
+            import System
+            import System.IO
+
+            type Probe class {
+                Path string = ""
+
+                func Len() int32 {
+                    return Path.Length
+                }
+            }
+
+            var p = Probe() { Path = "/tmp" }
+            Console.WriteLine(p.Len())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("4\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue687_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue687ColorColorTypeShadowingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue687ColorColorTypeShadowingTests.cs
@@ -1,0 +1,263 @@
+// <copyright file="Issue687ColorColorTypeShadowingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #687: a class field whose simple name shadows an imported type used to
+/// make the type unreachable from within the same class — the binder always
+/// preferred the field, and even the fully-qualified namespace path
+/// (<c>System.IO.Path.Combine(...)</c>) failed to bind. These tests cover the
+/// two-pronged fix:
+///
+/// <list type="bullet">
+/// <item><description>
+/// Option A — C# "color color" rule (ECMA-334 §12.7.4.1): when an identifier
+/// names both a value and a same-named type and the right-hand side of the
+/// accessor matches a static member of that type, prefer the type. Fall back
+/// to the instance interpretation when no static member matches.
+/// </description></item>
+/// <item><description>
+/// Option B — a fully-qualified namespace-traversal path
+/// (<c>System.IO.Path.Combine(...)</c>) binds against the type at the end of
+/// the chain whenever the leading namespace is reachable via an in-scope
+/// import (including the implicit <c>System</c> import).
+/// </description></item>
+/// </list>
+/// </summary>
+public class Issue687ColorColorTypeShadowingTests
+{
+    [Fact]
+    public void ColorColor_FieldShadowsImportedType_StaticCallBinds()
+    {
+        var source = """
+            package P
+            import System.IO
+
+            type Entry class {
+                Path string = ""
+
+                func Build(suffix string) string {
+                    return Path.Combine(this.Path, suffix)
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ColorColor_FieldShadowsType_StaticCallWithImplicitSystem_Binds()
+    {
+        // `Type` is a System.Type and the field is named the same. Calling
+        // `Type.GetType(...)` should bind against System.Type even though the
+        // field shadows the simple name.
+        var source = """
+            package P
+
+            type Holder class {
+                Type string = "System.Int32"
+
+                func Resolve() bool {
+                    return Type.GetType(this.Type) != nil
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ColorColor_FieldOnly_NotShadowed_StillBindsAsField()
+    {
+        // No matching type — `Name` is just a string field — instance member
+        // access (string.Length / no static match) must still go through the
+        // field interpretation rather than reporting GS0157.
+        var source = """
+            package P
+
+            type Person class {
+                Name string = ""
+
+                func NameLength() int32 {
+                    return Name.Length
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ColorColor_FieldShadowsType_InstanceMemberAccess_FallsBackToField()
+    {
+        // `Path` field of type string — there is a matching imported type
+        // (System.IO.Path) but the member used (`Length`) is NOT a static of
+        // System.IO.Path, so the binder must keep the instance interpretation
+        // and bind `Path.Length` against the string field.
+        var source = """
+            package P
+            import System.IO
+
+            type Probe class {
+                Path string = ""
+
+                func PathLength() int32 {
+                    return Path.Length
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ColorColor_BareFieldRead_StillBindsToField()
+    {
+        // `return Path` (no member access) must still resolve to the field
+        // value, not a type symbol. The color-color rule only kicks in for
+        // member-access positions.
+        var source = """
+            package P
+            import System.IO
+
+            type Probe class {
+                Path string = "/tmp"
+
+                func GetPath() string {
+                    return Path
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void QualifiedNamespacePath_StaticCall_Binds()
+    {
+        // Option B: `System.IO.Path.Combine(...)` is a fully qualified
+        // namespace path. With the implicit `import System` and an explicit
+        // `import System.IO` in scope, the binder must walk the namespace
+        // segments and bind the static call against System.IO.Path.
+        var source = """
+            package P
+            import System.IO
+
+            type Probe class {
+                Path string = ""
+
+                func Combine(suffix string) string {
+                    return System.IO.Path.Combine(this.Path, suffix)
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void QualifiedNamespacePath_TopLevel_StaticCall_Binds()
+    {
+        // Even outside a colliding-field context, the qualified path must
+        // resolve: a regression test for the namespace-traversal extension to
+        // `TryBindImportAccessor`.
+        var source = """
+            package P
+
+            func Run() string {
+                return System.IO.Path.Combine("a", "b")
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void QualifiedNamespacePath_StaticMemberAccess_Binds()
+    {
+        var source = """
+            package P
+
+            func Sep() string {
+                return System.IO.Path.DirectorySeparatorChar.ToString()
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void QualifiedNamespacePath_DeepChain_Binds()
+    {
+        var source = """
+            package P
+
+            func Encoded() string {
+                return System.Text.Encoding.UTF8.WebName
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ColorColor_LocalShadowsType_StaticCallBinds()
+    {
+        // The color-color rule should also work when a local variable, not a
+        // field, is what shadows the imported type.
+        var source = """
+            package P
+            import System.IO
+
+            func Build() string {
+                var Path = "/tmp"
+                return Path.Combine(Path, "file.txt")
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ColorColor_ParameterShadowsType_StaticCallBinds()
+    {
+        var source = """
+            package P
+            import System.IO
+
+            func Build(Path string, suffix string) string {
+                return Path.Combine(Path, suffix)
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        if (tree.Diagnostics.Any())
+        {
+            return tree.Diagnostics;
+        }
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+}


### PR DESCRIPTION
Fixes #687.

## Problem

When a class field's simple name shadowed an imported type (for example, a field `Path string` inside a class that imports `System.IO`), the binder always preferred the field. As a result, calling a static of the shadowed type from inside the class body (`Path.Combine(this.Path, suffix)`) failed with `GS0159` ("Cannot find function Combine"). There was no escape hatch either — `System.IO.Path.Combine(...)` failed with `GS0157` ("Cannot find type System") because the namespace-qualified type-prefix path was not recognised once the leading segment didn't resolve directly as a type.

The only workaround was to rename every shadowing field, which the issue documents as a real porting pain point.

## Approach (both options from #687)

### Option A — C# "color color" rule (ECMA-334 §12.7.4.1)

`BindAccessorExpression` (`ExpressionBinder.Access.cs`) used to take the first `VariableSymbol` lookup hit and commit to the value interpretation, never reconsidering. The new logic, when the name resolves to a value, also tries to resolve it as a same-named type in scope (imported CLR class, user-defined struct/class, enum). If it finds one **and** the right-hand side of the accessor matches a static member of that type (static field, property, event, nested type, or method), the binder routes through the type interpretation.

When the right-hand side does **not** match a static member of the type (e.g. `pathField.Length` where the field is a string), the binder falls back to the value interpretation, so existing instance-access semantics continue to work unchanged. Bare value reads at value positions (`return Path`) are also unchanged — the rule only fires inside member-access chains.

The check looks at the chain *head* (peeking through wrappers like `AccessorExpressionSyntax`, `IndexExpressionSyntax`, `ObjectCreationExpressionSyntax`) so the rule kicks in correctly for `Type.StaticMethod(...)`, `Type.StaticField`, and `Type.NestedType.X` alike.

### Option B — fully-qualified `Namespace.Type.Static(...)`

`TryBindImportAccessor` used to peel exactly one segment off the accessor right-hand side and try `<import.Target>.<segment>` as a type. If that didn't resolve (because the segment was another namespace level), the lookup gave up and the binder reported `GS0157`. The function is now iterative: when a candidate fails to resolve as a type, the segment is treated as another namespace level and the walk continues with the extended prefix. The implicit `System` import (registered by `CreateRootScope`) plus the iterative walker is what lets `System.IO.Path.Combine(...)` resolve end-to-end against `System.IO.Path` with `import System.IO` in scope.

## Binder mechanism (where the rule sits)

- `ExpressionBinder.Access.cs` → `BindAccessorExpression`: split the `TryLookupSymbol` outcome so the color-color rule can intercept *before* the variable interpretation commits.
- Two new private helpers do the work:
  - `TryResolveColorColorType` — checks `TryLookupImportedClass` and `TryLookupTypeAlias` (struct/enum) for a same-named type.
  - `RightPartLooksLikeStaticMember` (with `TryGetAccessorChainHead`, `HasStaticMember`, `HasUserTypeStaticMember`) — decides whether the right-hand side names a static member, using existing `ClrTypeUtilities.SafeGet*` helpers and `ReferenceResolver.TryResolveNestedType`.
- `TryBindImportAccessor` was rewritten as a `while` loop that extends `currentPath` segment-by-segment.

Only existing bound node kinds are reused (`BoundImportedCallExpression`, `BoundFieldAccessExpression`, `BoundPropertyAccessExpression`, …), so no `EmitExpression` switch, `BoundTreeRewriter`/`BoundTreeWalker`/`BoundNodePrinter`, `SpillSequenceSpiller`, or `BoundNodeKindExhaustivenessTests` updates are required.

## Fall-back semantics (when the field wins)

| Source                                              | Resolution                                                  |
| --------------------------------------------------- | ----------------------------------------------------------- |
| `Path.Combine(this.Path, suffix)` with field `Path` | **Type** — `System.IO.Path.Combine` (static method matches) |
| `Path.Length` with field `Path string`              | **Field** — `string.Length` (no static `Length` on `Path`)  |
| `return Path` with field `Path`                     | **Field** — bare read, no accessor                          |
| `Type.GetType("System.Int32")` with field `Type`    | **Type** — `System.Type.GetType` (static method matches)    |
| `System.IO.Path.Combine("a", "b")` at top level     | **Type** — namespace walker resolves `System.IO.Path`       |

## Tests added

`test/Core.Tests/CodeAnalysis/Binding/Issue687ColorColorTypeShadowingTests.cs` (11 binder tests):
- field that shadows `System.IO.Path` calls `Path.Combine(...)` (the exact repro from the issue),
- field that shadows `System.Type` calls `Type.GetType(...)`,
- non-shadowed field-only access still binds (regression guard),
- shadowed field but instance member access (`Path.Length`) falls back to the field,
- bare field read at a value position still binds to the field,
- qualified namespace path `System.IO.Path.Combine(...)` inside a colliding-field class,
- qualified namespace path at top level,
- qualified namespace static member access (`System.IO.Path.DirectorySeparatorChar.ToString()`),
- deep qualified chain (`System.Text.Encoding.UTF8.WebName`),
- local-variable shadowing,
- parameter shadowing.

`test/Compiler.Tests/Emit/Issue687ColorColorEmitTests.cs` (3 end-to-end emit + run tests, gated by `IlVerifier`):
- field-shadow color-color: emits, runs, and produces the expected combined path,
- qualified-namespace-path call: emits, runs, and matches `System.IO.Path.Combine("a","b")`,
- fall-back to instance interpretation: emits, runs, prints `4` for `Path.Length` of `"/tmp"`.

## Out of scope / explicitly not addressed

The third spelling sketched in the issue (`import alias = …` for re-exporting an individual type, or angle-bracketed type escape `<System.IO.Path>.X`) is a separate language feature — it isn't needed to unblock the porting cases because Option A + Option B together cover them. The existing `import alias = path` namespace-alias syntax (`ImportAliasTests`) continues to work as before.