### PR TITLE
Fix #689: route nested field assignment LHS through this for ImplicitFieldVariableSymbol receiver

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -305,6 +305,26 @@ internal sealed partial class ExpressionBinder
             return value;
         }
 
+        // Issue #689 (follow-up to #655): when the receiver name resolves to an
+        // implicit field on `this` (e.g. `Tracker.Value = v` where Tracker is a
+        // field), the raw ImplicitFieldVariableSymbol has no local slot and the
+        // emitter throws GS9998 at EmitLoadVariable time. Synthesize an
+        // expression receiver (`this.Tracker`) so the resulting bound node
+        // carries a real BoundExpression receiver. The async/sync-iterator
+        // state-machine rewriters already recurse through BoundFieldAccess-
+        // Expression and substitute the `this` parameter with the hoisted
+        // `<>4__this` proxy field — routing through an expression receiver
+        // makes the write path symmetric with the read path fixed in #655.
+        BoundExpression implicitFieldReceiverExpr = null;
+        if (variable is ImplicitFieldVariableSymbol implicitField)
+        {
+            implicitFieldReceiverExpr = new BoundFieldAccessExpression(
+                null,
+                new BoundVariableExpression(null, implicitField.Receiver),
+                implicitField.StructType,
+                implicitField.Field);
+        }
+
         // Stream B: instance-CLR receiver → property/field write via reflection.
         if (variable.Type is not StructSymbol && variable.Type is not NullableTypeSymbol && variable.Type?.ClrType != null)
         {
@@ -331,7 +351,7 @@ internal sealed partial class ExpressionBinder
 
             _ = instWritable;
             _ = instTargetType;
-            var instReceiver = new BoundVariableExpression(null, variable);
+            var instReceiver = implicitFieldReceiverExpr ?? new BoundVariableExpression(null, variable);
             var instConverted = conversions.BindConversion(syntax.Value.Location, value, instTargetSymbol);
             return new BoundClrPropertyAssignmentExpression(null, instReceiver, instanceMember, instConverted, instTargetSymbol);
         }
@@ -354,7 +374,8 @@ internal sealed partial class ExpressionBinder
                 }
 
                 var propConverted = conversions.BindConversion(syntax.Value.Location, value, prop.Type);
-                return new BoundPropertyAssignmentExpression(null, new BoundVariableExpression(null, variable), structSymbol, prop, propConverted);
+                var propReceiver = implicitFieldReceiverExpr ?? new BoundVariableExpression(null, variable);
+                return new BoundPropertyAssignmentExpression(null, propReceiver, structSymbol, prop, propConverted);
             }
 
             // Issue #319: a GSharp class inheriting an imported CLR base exposes
@@ -381,7 +402,7 @@ internal sealed partial class ExpressionBinder
 
                     _ = inhWritable;
                     _ = inhTargetType;
-                    var inhReceiver = new BoundVariableExpression(null, variable);
+                    var inhReceiver = implicitFieldReceiverExpr ?? new BoundVariableExpression(null, variable);
                     var inhConverted = conversions.BindConversion(syntax.Value.Location, value, inhTargetSymbol);
                     return new BoundClrPropertyAssignmentExpression(null, inhReceiver, clrMember, inhConverted, inhTargetSymbol);
                 }
@@ -409,6 +430,11 @@ internal sealed partial class ExpressionBinder
             $"{structSymbol.Name}.{field.Name}");
 
         var converted = conversions.BindConversion(syntax.Value.Location, value, field.Type);
+        if (implicitFieldReceiverExpr != null)
+        {
+            return BoundFieldAssignmentExpression.WithExpressionReceiver(null, implicitFieldReceiverExpr, structSymbol, field, converted);
+        }
+
         return new BoundFieldAssignmentExpression(null, variable, structSymbol, field, converted);
     }
 

--- a/test/Compiler.Tests/Emit/Issue689AsyncIteratorNestedFieldWriteEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue689AsyncIteratorNestedFieldWriteEmitTests.cs
@@ -1,0 +1,550 @@
+// <copyright file="Issue689AsyncIteratorNestedFieldWriteEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #689 (follow-up to #655): writing to a member of a class-typed
+/// field through an unqualified field name inside an async-iterator method
+/// (<c>async func ... IAsyncEnumerable[T]</c>) on a class must not trigger
+/// GS9998 ("Variable 'X' has no local slot or parameter index").
+/// The fix routes the assignment receiver through an explicit
+/// <c>this.Field</c> bound expression so the async-iterator state-machine
+/// rewriter can substitute the hoisted <c>&lt;&gt;4__this</c> proxy field
+/// — symmetric with the read path fixed in #655.
+/// </summary>
+public class Issue689AsyncIteratorNestedFieldWriteEmitTests
+{
+    #region Exact issue repro: unqualified nested field write inside async iterator
+
+    [Fact]
+    public void AsyncIterator_UnqualifiedNestedFieldWrite_No_ICE()
+    {
+        // Exact repro from issue #689: `Tracker.Value = 7` (no `this.`)
+        // inside an async iterator on a class triggered GS9998.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading
+            import System.Threading.Tasks
+
+            type Counter class {
+                Value int32 = 0
+            }
+
+            type Executor class {
+                Tracker Counter = Counter()
+
+                async func Run(ct CancellationToken) IAsyncEnumerable[int32] {
+                    Tracker.Value = 7
+                    yield 1
+                    await Task.Delay(5, ct)
+                    yield 2
+                }
+            }
+
+            public var result = 0
+            let exec = Executor()
+            let e = exec.Run(CancellationToken.None).GetAsyncEnumerator()
+            for e.MoveNextAsync().AsTask().Result {
+                result = result + e.Current
+            }
+            result = result + exec.Tracker.Value
+            """;
+
+        var assembly = CompileAndRun(source);
+        var result = GetResult<int>(assembly);
+        // yield 1 + yield 2 + Tracker.Value(7) = 10
+        Assert.Equal(10, result);
+    }
+
+    #endregion
+
+    #region Read-modify-write through nested field, unqualified
+
+    [Fact]
+    public void AsyncIterator_NestedFieldReadModifyWrite_Unqualified()
+    {
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            type Counter class {
+                Value int32 = 0
+            }
+
+            type Probe class {
+                Tracker Counter = Counter()
+
+                async func Run() IAsyncEnumerable[int32] {
+                    Tracker.Value = Tracker.Value + 1
+                    yield Tracker.Value
+                    await Task.Delay(1)
+                    Tracker.Value = Tracker.Value + 10
+                    yield Tracker.Value
+                }
+            }
+
+            public var result = 0
+            let p = Probe()
+            let e = p.Run().GetAsyncEnumerator()
+            for e.MoveNextAsync().AsTask().Result {
+                result = result + e.Current
+            }
+            result = result + p.Tracker.Value
+            """;
+
+        var assembly = CompileAndRun(source);
+        var result = GetResult<int>(assembly);
+        // yield 1 + yield 11 + Tracker.Value(11) = 23
+        Assert.Equal(23, result);
+    }
+
+    #endregion
+
+    #region Cross-yield/await: nested field write persists across suspensions
+
+    [Fact]
+    public void AsyncIterator_NestedFieldWrite_Persists_Across_Yield_And_Await()
+    {
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            type Counter class {
+                Value int32 = 0
+            }
+
+            type Executor class {
+                Tracker Counter = Counter()
+
+                async func Run() IAsyncEnumerable[int32] {
+                    Tracker.Value = 5
+                    yield Tracker.Value
+                    await Task.Delay(1)
+                    Tracker.Value = Tracker.Value + 10
+                    yield Tracker.Value
+                    await Task.Delay(1)
+                    Tracker.Value = 99
+                    yield Tracker.Value
+                }
+            }
+
+            public var result = 0
+            let exec = Executor()
+            let e = exec.Run().GetAsyncEnumerator()
+            for e.MoveNextAsync().AsTask().Result {
+                result = result + e.Current
+            }
+            result = result + exec.Tracker.Value
+            """;
+
+        var assembly = CompileAndRun(source);
+        var result = GetResult<int>(assembly);
+        // yield 5 + yield 15 + yield 99 + Tracker.Value(99) = 218
+        Assert.Equal(218, result);
+    }
+
+    #endregion
+
+    #region Sanity: `this.` qualified write still works
+
+    [Fact]
+    public void AsyncIterator_QualifiedNestedFieldWrite_Still_Works()
+    {
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            type Counter class {
+                Value int32 = 0
+            }
+
+            type Executor class {
+                Tracker Counter = Counter()
+
+                async func Run() IAsyncEnumerable[int32] {
+                    this.Tracker.Value = 42
+                    yield this.Tracker.Value
+                    await Task.Delay(1)
+                    this.Tracker.Value = this.Tracker.Value + 1
+                    yield this.Tracker.Value
+                }
+            }
+
+            public var result = 0
+            let exec = Executor()
+            let e = exec.Run().GetAsyncEnumerator()
+            for e.MoveNextAsync().AsTask().Result {
+                result = result + e.Current
+            }
+            result = result + exec.Tracker.Value
+            """;
+
+        var assembly = CompileAndRun(source);
+        var result = GetResult<int>(assembly);
+        // yield 42 + yield 43 + Tracker.Value(43) = 128
+        Assert.Equal(128, result);
+    }
+
+    #endregion
+
+    #region Sanity: primitive field write still works (was already passing in #655)
+
+    [Fact]
+    public void AsyncIterator_PrimitiveFieldWrite_Still_Works()
+    {
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            type Executor class {
+                PlainNum int32 = 0
+
+                async func Run() IAsyncEnumerable[int32] {
+                    PlainNum = 42
+                    yield PlainNum
+                    await Task.Delay(1)
+                    PlainNum = 100
+                    yield PlainNum
+                }
+            }
+
+            public var result = 0
+            let exec = Executor()
+            let e = exec.Run().GetAsyncEnumerator()
+            for e.MoveNextAsync().AsTask().Result {
+                result = result + e.Current
+            }
+            result = result + exec.PlainNum
+            """;
+
+        var assembly = CompileAndRun(source);
+        var result = GetResult<int>(assembly);
+        // yield 42 + yield 100 + PlainNum(100) = 242
+        Assert.Equal(242, result);
+    }
+
+    #endregion
+
+    #region Sync method: same unqualified nested field write must also work
+
+    [Fact]
+    public void SyncMethod_UnqualifiedNestedFieldWrite_Works()
+    {
+        // The underlying bug was a binder issue (BindFieldAssignmentExpression
+        // emitting an ImplicitFieldVariableSymbol Receiver with no local slot).
+        // Verify the sync case is also fixed.
+        var source = """
+            package Probe
+
+            type Counter class {
+                Value int32 = 0
+            }
+
+            type Executor class {
+                Tracker Counter = Counter()
+
+                func Run() int32 {
+                    Tracker.Value = 7
+                    return Tracker.Value
+                }
+            }
+
+            public var result = Executor().Run()
+            """;
+
+        var assembly = CompileAndRun(source);
+        var result = GetResult<int>(assembly);
+        Assert.Equal(7, result);
+    }
+
+    #endregion
+
+    #region Compound-style: read-modify-write across multiple statements in sync method
+
+    [Fact]
+    public void SyncMethod_NestedFieldReadModifyWrite_Works()
+    {
+        var source = """
+            package Probe
+
+            type Counter class {
+                Value int32 = 0
+            }
+
+            type Executor class {
+                Tracker Counter = Counter()
+
+                func Run() int32 {
+                    Tracker.Value = 1
+                    Tracker.Value = Tracker.Value + 10
+                    Tracker.Value = Tracker.Value * 2
+                    return Tracker.Value
+                }
+            }
+
+            public var result = Executor().Run()
+            """;
+
+        var assembly = CompileAndRun(source);
+        var result = GetResult<int>(assembly);
+        Assert.Equal(22, result);
+    }
+
+    #endregion
+
+    #region Compound `+=` on nested field inside async iterator
+
+    [Fact]
+    public void AsyncIterator_NestedFieldCompoundPlusEquals_Works()
+    {
+        // Verify the related compound-assignment path is also unaffected.
+        // `Tracker.Value += N` is parsed as EventSubscriptionExpression and
+        // routed through TryBindChainedCompoundAssignment which already used
+        // an expression receiver — but exercise it here to lock in coverage.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            type Counter class {
+                Value int32 = 0
+            }
+
+            type Executor class {
+                Tracker Counter = Counter()
+
+                async func Run() IAsyncEnumerable[int32] {
+                    Tracker.Value += 3
+                    yield Tracker.Value
+                    await Task.Delay(1)
+                    Tracker.Value += 4
+                    yield Tracker.Value
+                }
+            }
+
+            public var result = 0
+            let exec = Executor()
+            let e = exec.Run().GetAsyncEnumerator()
+            for e.MoveNextAsync().AsTask().Result {
+                result = result + e.Current
+            }
+            result = result + exec.Tracker.Value
+            """;
+
+        var assembly = CompileAndRun(source);
+        var result = GetResult<int>(assembly);
+        // yield 3 + yield 7 + Tracker.Value(7) = 17
+        Assert.Equal(17, result);
+    }
+
+    #endregion
+
+    #region Interface-typed field: nested field write must not be over-narrow
+
+    [Fact]
+    public void AsyncIterator_NestedFieldWrite_When_FieldHasInterfaceTypedHolder()
+    {
+        // Ensure the fix isn't accidentally limited to a particular receiver
+        // type. Here the field type is a user-defined class that itself holds
+        // a nested user class, and the write targets the inner field. Also
+        // works on a struct nested in a class.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            type Counter class {
+                Value int32 = 0
+                Name string = "init"
+            }
+
+            type Holder class {
+                Inner Counter = Counter()
+            }
+
+            type Executor class {
+                H Holder = Holder()
+
+                async func Run() IAsyncEnumerable[int32] {
+                    H.Inner.Value = 5
+                    yield H.Inner.Value
+                    await Task.Delay(1)
+                    H.Inner.Value = 12
+                    yield H.Inner.Value
+                }
+            }
+
+            public var result = 0
+            let exec = Executor()
+            let e = exec.Run().GetAsyncEnumerator()
+            for e.MoveNextAsync().AsTask().Result {
+                result = result + e.Current
+            }
+            result = result + exec.H.Inner.Value
+            """;
+
+        var assembly = CompileAndRun(source);
+        var result = GetResult<int>(assembly);
+        // yield 5 + yield 12 + H.Inner.Value(12) = 29
+        Assert.Equal(29, result);
+    }
+
+    #endregion
+
+    #region Sync iterator variant (sequence[T]): same write path must work
+
+    [Fact]
+    public void SyncIterator_UnqualifiedNestedFieldWrite_Works()
+    {
+        // The sync-iterator state machine is a separate rewriter from the
+        // async one but shares the same bound-tree shape for nested field
+        // writes. Verify the fix applies symmetrically.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            type Counter class {
+                Value int32 = 0
+            }
+
+            type Executor class {
+                Tracker Counter = Counter()
+
+                func Run() sequence[int32] {
+                    Tracker.Value = 11
+                    yield Tracker.Value
+                    Tracker.Value = Tracker.Value + 4
+                    yield Tracker.Value
+                }
+            }
+
+            public var result = 0
+            let exec = Executor()
+            for x in exec.Run() {
+                result = result + x
+            }
+            result = result + exec.Tracker.Value
+            """;
+
+        var assembly = CompileAndRun(source);
+        var result = GetResult<int>(assembly);
+        // yield 11 + yield 15 + Tracker.Value(15) = 41
+        Assert.Equal(41, result);
+    }
+
+    #endregion
+
+    #region async sequence[T] variant (alternate syntax) — write path
+
+    [Fact]
+    public void AsyncIterator_AsyncSequence_UnqualifiedNestedFieldWrite_Works()
+    {
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            type Counter class {
+                Value int32 = 0
+            }
+
+            type Executor class {
+                Tracker Counter = Counter()
+
+                async func Run() async sequence[int32] {
+                    Tracker.Value = 21
+                    yield Tracker.Value
+                    await Task.Delay(1)
+                    Tracker.Value = Tracker.Value + 1
+                    yield Tracker.Value
+                }
+            }
+
+            public var result = 0
+            let exec = Executor()
+            let e = exec.Run().GetAsyncEnumerator()
+            for e.MoveNextAsync().AsTask().Result {
+                result = result + e.Current
+            }
+            result = result + exec.Tracker.Value
+            """;
+
+        var assembly = CompileAndRun(source);
+        var result = GetResult<int>(assembly);
+        // yield 21 + yield 22 + Tracker.Value(22) = 65
+        Assert.Equal(65, result);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static Assembly CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_689_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        // Run the entry point.
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        return assembly;
+    }
+
+    private static T GetResult<T>(Assembly assembly)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var resultField = program.GetField("result", BindingFlags.Public | BindingFlags.Static);
+        return (T)resultField!.GetValue(null)!;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Fixes #689. Companion to #655 (read path).

Unqualified `field.member = value` writes inside a class method bound to a `BoundFieldAssignmentExpression` whose `Receiver` was the raw `ImplicitFieldVariableSymbol` for the outer field. The emitter has no local slot for that pseudo-variable and threw `GS9998: Variable 'X' has no local slot or parameter index` at `EmitLoadVariable` time.

Inside an async-iterator state machine the failure surfaced as a partial regression of #655: the *read* path was fixed by that change (route `Tracker.Value` through the captured `<>4__this` proxy via `BoundFieldAccessExpression` recursion in the iterator rewriter), but the *assignment* LHS still bound to the slot-less `ImplicitFieldVariableSymbol`. The `this.` qualifier worked because the parser then routed the write through `MemberFieldAssignmentExpressionSyntax` and the binder produced `BoundFieldAssignmentExpression.WithExpressionReceiver` with a proper `BoundFieldAccessExpression(this, Type, Field)` receiver — which the iterator rewriter handles correctly.

## Root cause

`Tracker.Value = 7` parses as `FieldAssignmentExpressionSyntax` (the parser's `Identifier Dot Identifier =` short-form). `BindFieldAssignmentExpression` resolved `Tracker` via `BindVariableReference` to an `ImplicitFieldVariableSymbol` and then stored that variable as the `Receiver` of the `BoundFieldAssignmentExpression`. The async/sync iterator state-machine rewriters never see a `BoundVariableExpression` for the implicit field (it's a raw `VariableSymbol` reference held directly on the assignment node), so the proxy substitution never fired and the emit path hit the slot lookup throw.

The `this.` workaround masked the bug because that path parsed as `MemberFieldAssignmentExpressionSyntax` and went through `BindMemberFieldAssignmentExpression` which already produces an expression receiver.

## Fix

Single change in `src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs` (`BindFieldAssignmentExpression`): when the receiver name resolves to an `ImplicitFieldVariableSymbol`, synthesize the corresponding `BoundFieldAccessExpression(this, OwnerType, Field)` and route the resulting bound assignment through `BoundFieldAssignmentExpression.WithExpressionReceiver`. The existing iterator rewriters already recurse through `BoundFieldAccessExpression` and substitute the captured-`this` proxy correctly, so no additional rewriter changes are needed.

The same expression receiver is also propagated to the sibling property / CLR-property / inherited-CLR-member write paths inside the same binder method so a future `ImplicitFieldVariableSymbol` receiver in any of them won't reintroduce the ICE.

## Files changed

- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs` — synthesize `implicitFieldReceiverExpr` once and prefer it over `new BoundVariableExpression(null, variable)` in all four write paths (field, property, CLR property, inherited CLR), and use `WithExpressionReceiver` for the user-struct field write.

## Why other shapes were unaffected

| Shape | Why it already worked |
|---|---|
| `PlainNum = 42` (primitive field write) | Parses as `AssignmentExpressionSyntax` → `BindAssignmentExpression` which uses `implicitField.Receiver` (the `this` `ParameterSymbol`, which the emitter loads as `ldarg.0`). |
| `Tracker = Counter()` (whole-field reassign) | Same path as above. |
| `this.Tracker.Value = 7` | Parses as `MemberFieldAssignmentExpressionSyntax` → `BindMemberFieldAssignmentExpression` which already binds the receiver to a `BoundExpression` and uses `WithExpressionReceiver`. |
| `Tracker.Value` read | Bound through `ExpressionBinder.cs`'s `ImplicitFieldVariableSymbol` branch which emits `BoundFieldAccessExpression(this, ...)` — the iterator rewriter then recurses and substitutes `<>4__this`. |
| `Tracker.Value += 1` | Parses as `EventSubscriptionExpressionSyntax` → `TryBindChainedCompoundAssignment` which already uses `WithExpressionReceiver`. |
| `Tracker.Touch()` method-call receiver | Receiver is bound through the read path which already routes through `BoundFieldAccessExpression`. |

## Tests added

`test/Compiler.Tests/Emit/Issue689AsyncIteratorNestedFieldWriteEmitTests.cs` (11 tests, all emit + run + IlVerify):

- `AsyncIterator_UnqualifiedNestedFieldWrite_No_ICE` — exact issue repro
- `AsyncIterator_NestedFieldReadModifyWrite_Unqualified` — `Tracker.Value = Tracker.Value + 1`
- `AsyncIterator_NestedFieldWrite_Persists_Across_Yield_And_Await` — multi-suspend state persistence
- `AsyncIterator_QualifiedNestedFieldWrite_Still_Works` — `this.`-qualified sanity
- `AsyncIterator_PrimitiveFieldWrite_Still_Works` — primitive sanity
- `SyncMethod_UnqualifiedNestedFieldWrite_Works` — non-iterator sync sanity (the binder fix applies broadly)
- `SyncMethod_NestedFieldReadModifyWrite_Works` — three sequential writes in a sync method
- `AsyncIterator_NestedFieldCompoundPlusEquals_Works` — locks in coverage on the compound path
- `AsyncIterator_NestedFieldWrite_When_FieldHasInterfaceTypedHolder` — multi-level nesting (`H.Inner.Value`)
- `SyncIterator_UnqualifiedNestedFieldWrite_Works` — sync iterator state-machine variant
- `AsyncIterator_AsyncSequence_UnqualifiedNestedFieldWrite_Works` — alternate `async sequence[T]` syntax

## Verification

```
$ dotnet build GSharp.sln -nologo -clp:NoSummary
Build succeeded.   0 Warning(s)   0 Error(s)

$ dotnet test GSharp.sln --no-restore --nologo
Passed!  - GSharp.Sdk.Tests.dll         (26 tests)
Passed!  - GSharp.Interpreter.Tests.dll (98 tests)
Passed!  - GSharp.LanguageServer.Tests.dll (242 tests)
Passed!  - GSharp.Core.Tests.dll        (2335 passed, 1 skipped)
Passed!  - GSharp.Compiler.Tests.dll    (987 tests)
```

All ilverify gates clean.

Related: #655 (read path).