### PR TITLE
Fix #693: parse multi-type-arg generic construction calls so Dictionary[K, V]() works

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -4178,6 +4178,16 @@ public class Parser
     // `name [ expr ]` (indexing) and `name [ TypeClause, ... ] ( args )`
     // (generic instantiation followed by call). `bracketOffset` is the
     // offset of the `[` token relative to Current.
+    //
+    // The comma-loop below intentionally supports any arity, including the
+    // multi-type-arg shape `Dictionary[K, V]()` / `Dictionary[K, V, W]()`,
+    // so the parser commits to a generic call site as long as every
+    // comma-separated item inside the brackets parses as a type clause
+    // (via `TryScanTypeClause`) and the token after the matching `]` is
+    // one of the ADR-0020 follow-set markers (`(`, `{`, `.`). Regression
+    // coverage lives in test/Core.Tests/CodeAnalysis/Syntax/Issue693MultiTypeArgGenericCallParserTests.cs
+    // and end-to-end emit coverage in
+    // test/Compiler.Tests/Emit/Issue693DictionaryConstructionEmitTests.cs.
     private bool LooksLikeGenericCallSite(int bracketOffset)
     {
         if (Peek(bracketOffset).Kind != SyntaxKind.OpenSquareBracketToken)

--- a/test/Compiler.Tests/Emit/Issue671ConstructionCallEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue671ConstructionCallEmitTests.cs
@@ -63,9 +63,12 @@ public class Issue671ConstructionCallEmitTests
     [Fact]
     public void Construct_KeyValuePairOfStringToUserClass_Compiles_And_Runs()
     {
-        // Dictionary[K, V]() at top level is currently shadowed by the map-literal
-        // parser; KeyValuePair exercises the same "CLR generic with multiple type
-        // args, at least one of which is a G# user-defined class" construction call.
+        // Multi-type-arg CLR generic ctor where one type argument is a G#
+        // user-defined class. The direct Dictionary[K, V]() coverage for
+        // this same shape lives in Issue693DictionaryConstructionEmitTests
+        // (the follow-up to this PR); KeyValuePair is kept here as a
+        // narrowly-typed sibling regression for the multi-arg construction
+        // path itself.
         var source = """
             package App
             import System

--- a/test/Compiler.Tests/Emit/Issue693DictionaryConstructionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue693DictionaryConstructionEmitTests.cs
@@ -1,0 +1,400 @@
+// <copyright file="Issue693DictionaryConstructionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// End-to-end emit tests for issue #693 — multi-type-arg CLR generic
+/// construction via <c>Dictionary[K, V]()</c> (and friends) compiles,
+/// IL-verifies, and runs.
+/// <para>
+/// PR #690's "out-of-scope" note claimed <c>Dictionary[K, V]()</c> was
+/// "shadowed by the map-literal parser" and worked around it with
+/// <c>KeyValuePair[K, V](k, v)</c>. Investigation against the current
+/// parser (see <c>Issue693MultiTypeArgGenericCallParserTests</c>) shows
+/// the ADR-0020 bounded-lookahead disambiguation already handles the
+/// multi-type-arg shape correctly — <c>LooksLikeGenericCallSite</c>
+/// scans an arbitrary comma-separated type-clause list inside the
+/// brackets and commits to a generic call when the follow-set token is
+/// <c>(</c>, <c>{</c>, or <c>.</c>. These tests lock that contract in at
+/// the emit layer (parse + bind + emit + ilverify + execute), covering
+/// the specific cases the PR-#690 workaround left untested:
+/// <c>Dictionary[K, V]()</c> with primitives, with G# user-defined
+/// classes as one or both type arguments, deeply-nested generics, and
+/// the sibling generic dictionaries <c>SortedDictionary[K, V]</c> and
+/// <c>ConcurrentDictionary[K, V]</c>.
+/// </para>
+/// </summary>
+public class Issue693DictionaryConstructionEmitTests
+{
+    [Fact]
+    public void Construct_DictionaryOfStringInt32_Compiles_And_Runs()
+    {
+        // Smallest direct emit test for the case PR #690 deferred. Empty
+        // construction followed by Add + Count read on the constructed
+        // generic. Mirrors the existing List[int32]() regression in
+        // Issue671ConstructionCallEmitTests but exercises a two-type-arg
+        // BCL generic instead of a one-type-arg one.
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            let d = Dictionary[string, int32]()
+            d.Add("a", 1)
+            d.Add("b", 2)
+            Console.WriteLine(d.Count)
+            """;
+
+        Assert.Equal("2\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Construct_DictionaryOfStringToUserClass_Compiles_And_Runs()
+    {
+        // Direct coverage for the case the PR #690 workaround left
+        // untested: a multi-type-arg generic ctor where one of the type
+        // arguments is a G# user-defined class. KeyValuePair[string, MyGs]
+        // already covered the binder/emit code path; this test does the
+        // same on Dictionary[string, MyGs] so the regression is named
+        // after the actual API users construct.
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            type MyGs class {
+                Name string = ""
+            }
+
+            let d = Dictionary[string, MyGs]()
+            d.Add("first", MyGs())
+            d.Add("second", MyGs())
+            Console.WriteLine(d.Count)
+            """;
+
+        Assert.Equal("2\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Construct_DictionaryOfUserClassToUserClass_Compiles_And_Runs()
+    {
+        // Both type arguments are G# user-defined classes. Exercises the
+        // symbolic-container plumbing (PR #690) end-to-end for the
+        // Dictionary ctor's two-type-arg shape and the keyed Add lookup
+        // on the constructed symbolic parent.
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            type K class {
+                N int32 = 0
+            }
+
+            type V class {
+                N int32 = 0
+            }
+
+            let d = Dictionary[K, V]()
+            d.Add(K(), V())
+            Console.WriteLine(d.Count)
+            """;
+
+        Assert.Equal("1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Construct_DictionaryAsFieldInitializer_Compiles_And_Runs()
+    {
+        // Dictionary[K, V]() as a default field initializer on a class
+        // — the field type is `Dictionary[string, MyGs]` and the
+        // initializer is the same multi-type-arg ctor call. Hits the
+        // class-init-time emission path for ctor calls with user-class
+        // type args.
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            type MyGs class {
+                Name string = ""
+            }
+
+            type Holder class {
+                Map Dictionary[string, MyGs] = Dictionary[string, MyGs]()
+            }
+
+            let h = Holder()
+            h.Map.Add("a", MyGs())
+            Console.WriteLine(h.Map.Count)
+            """;
+
+        Assert.Equal("1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Construct_DictionaryChainedMemberAccess_Compiles_And_Runs()
+    {
+        // ADR-0020 follow-set: `.` after `Type[T1, T2]` is a member
+        // access on the constructed type. Tests the chained-postfix
+        // shape `Dictionary[string, int32]().Count` parses, binds, and
+        // emits correctly when used inline as a function argument.
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            Console.WriteLine(Dictionary[string, int32]().Count)
+            """;
+
+        Assert.Equal("0\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Construct_SortedDictionaryOfStringInt32_Compiles_And_Runs()
+    {
+        // SortedDictionary is the same shape as Dictionary at the parser
+        // level (`Identifier [TypeArg, TypeArg] ()`); this confirms the
+        // disambiguation is generic across any two-type-arg BCL generic,
+        // not just the well-known Dictionary identifier.
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            let d = SortedDictionary[string, int32]()
+            d.Add("b", 2)
+            d.Add("a", 1)
+            Console.WriteLine(d.Count)
+            """;
+
+        Assert.Equal("2\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Construct_ConcurrentDictionaryOfStringInt32_Compiles_And_Runs()
+    {
+        // ConcurrentDictionary lives in System.Collections.Concurrent —
+        // distinct namespace, same parser/binder/emit pipeline as
+        // Dictionary. Verifies the multi-type-arg construction works
+        // for a generic from a different namespace.
+        var source = """
+            package App
+            import System
+            import System.Collections.Concurrent
+
+            let d = ConcurrentDictionary[string, int32]()
+            d.TryAdd("a", 1)
+            Console.WriteLine(d.Count)
+            """;
+
+        Assert.Equal("1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Construct_DictionaryWithNestedListValue_Compiles_And_Runs()
+    {
+        // Dictionary[string, List[int32]]() — the second type argument
+        // is itself a constructed generic. Exercises the recursive
+        // type-clause-scan path inside the multi-type-arg disambiguation
+        // (each nested `[` opens a fresh tentative type-argument list).
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            let d = Dictionary[string, List[int32]]()
+            d.Add("a", List[int32]())
+            d["a"].Add(1)
+            d["a"].Add(2)
+            Console.WriteLine(d["a"].Count)
+            """;
+
+        Assert.Equal("2\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Construct_DictionaryWithNestedDictionaryValue_Compiles_And_Runs()
+    {
+        // Dictionary[string, Dictionary[string, int32]]() — three
+        // brackets deep on the second type arg. Two-type-arg nested
+        // inside another two-type-arg, the most challenging case for the
+        // recursive type-clause scan.
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            let d = Dictionary[string, Dictionary[string, int32]]()
+            d.Add("a", Dictionary[string, int32]())
+            d["a"].Add("x", 1)
+            d["a"].Add("y", 2)
+            Console.WriteLine(d["a"].Count)
+            """;
+
+        Assert.Equal("2\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Construct_QualifiedDictionaryOfStringInt32_Compiles_And_Runs()
+    {
+        // Qualified form `System.Collections.Generic.Dictionary[K, V]()`
+        // — the qualified-name binder path also accepts multi-type-arg
+        // construction. PR #690 added the qualified-construction path
+        // for user-defined type args; this regression locks the simple
+        // primitive-arg shape in.
+        var source = """
+            package App
+            import System
+
+            let d = System.Collections.Generic.Dictionary[string, int32]()
+            d.Add("a", 1)
+            Console.WriteLine(d.Count)
+            """;
+
+        Assert.Equal("1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Regression_MapLiteralStillCompilesAndRuns()
+    {
+        // Negative regression: G#'s `map[K]V{...}` literal syntax must
+        // continue to work alongside the multi-type-arg Dictionary
+        // construction. The disambiguation only triggers on an
+        // identifier-headed `[`, so the `map` keyword path is untouched.
+        var source = """
+            package App
+            import System
+
+            let m = map[string]int32 { "a": 1, "b": 2 }
+            Console.WriteLine(len(m))
+            """;
+
+        Assert.Equal("2\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Regression_SingleTypeArgListCtorStillCompilesAndRuns()
+    {
+        // Sanity regression: the existing single-type-arg ctor (List[T]())
+        // continues to parse, bind, and emit correctly through the same
+        // disambiguation path that now handles the multi-type-arg case.
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            let xs = List[int32]()
+            xs.Add(1)
+            xs.Add(2)
+            xs.Add(3)
+            Console.WriteLine(xs.Count)
+            """;
+
+        Assert.Equal("3\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Regression_KeyValuePairMultiArgCtorStillCompilesAndRuns()
+    {
+        // Sanity regression: the indirect KeyValuePair-based coverage
+        // used by PR #690 to skirt the deferred Dictionary case must
+        // still work, so this PR does not regress the multi-type-arg
+        // construction path on a sibling generic.
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            type MyGs class {
+                Name string = ""
+            }
+
+            let kvp = KeyValuePair[string, MyGs]("k", MyGs())
+            Console.WriteLine(kvp.Key)
+            """;
+
+        Assert.Equal("k\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue693_dict_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue693DictionaryConstructionBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue693DictionaryConstructionBindingTests.cs
@@ -1,0 +1,164 @@
+// <copyright file="Issue693DictionaryConstructionBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #693 (follow-up to #690): direct binder regression coverage for
+/// <c>Dictionary[K, V]()</c> construction calls — the case PR #690 worked
+/// around via <c>KeyValuePair[K, V](k, v)</c> because of a (since-resolved)
+/// belief that the parser would treat <c>Dictionary[K, V]</c> as a map
+/// literal. The companion <c>Issue693MultiTypeArgGenericCallParserTests</c>
+/// proves the parser commits cleanly to a generic call site; these tests
+/// prove the binder accepts the resulting shape with both primitive and
+/// G# user-defined type arguments.
+/// </summary>
+public class Issue693DictionaryConstructionBindingTests
+{
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics;
+    }
+
+    [Fact]
+    public void DictionaryStringInt32_DefaultConstructor_Binds()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            var d = Dictionary[string, int32]()
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void DictionaryStringInt32_AsExpressionStatement_Binds()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            Dictionary[string, int32]()
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void DictionaryStringUserClass_DefaultConstructor_Binds()
+    {
+        // Direct binder coverage for the case that PR #690 worked around
+        // with KeyValuePair[string, MyGs].
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type MyGs class {
+                Name string = ""
+            }
+
+            let d = Dictionary[string, MyGs]()
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void DictionaryUserClassToUserClass_DefaultConstructor_Binds()
+    {
+        // Both type arguments are user-defined G# classes — the most
+        // demanding case for the symbolic-container path added in #690.
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            type K class {
+                N int32 = 0
+            }
+
+            type V class {
+                N int32 = 0
+            }
+
+            let d = Dictionary[K, V]()
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void SortedDictionaryStringInt32_DefaultConstructor_Binds()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            var d = SortedDictionary[string, int32]()
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ConcurrentDictionaryStringInt32_DefaultConstructor_Binds()
+    {
+        var source = """
+            import System.Collections.Concurrent
+
+            var d = ConcurrentDictionary[string, int32]()
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void DictionaryWithNestedListValue_DefaultConstructor_Binds()
+    {
+        // Dictionary[string, List[int32]]() — nested generic in the value
+        // position exercises the recursive type-clause scan inside the
+        // multi-type-arg disambiguation.
+        var source = """
+            import System.Collections.Generic
+
+            var d = Dictionary[string, List[int32]]()
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void DictionaryWithNestedDictionaryValue_DefaultConstructor_Binds()
+    {
+        // Dictionary[string, Dictionary[string, int32]]() — two-type-arg
+        // generic nested inside a two-type-arg generic.
+        var source = """
+            import System.Collections.Generic
+
+            var d = Dictionary[string, Dictionary[string, int32]]()
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void QualifiedDictionaryStringInt32_DefaultConstructor_Binds()
+    {
+        var source = """
+            var d = System.Collections.Generic.Dictionary[string, int32]()
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue693MultiTypeArgGenericCallParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue693MultiTypeArgGenericCallParserTests.cs
@@ -1,0 +1,326 @@
+// <copyright file="Issue693MultiTypeArgGenericCallParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #693 (follow-up to #690): direct parser regression coverage for the
+/// ADR-0020 bounded-lookahead disambiguation between an indexing expression
+/// (<c>name[expr]</c>) and a multi-type-arg generic instantiation followed by
+/// a call (<c>Type[T1, T2, …](args)</c>).
+/// <para>
+/// PR #690 left a note in <c>Issue671ConstructionCallEmitTests.cs</c>
+/// claiming <c>Dictionary[K, V]()</c> was "shadowed by the map-literal
+/// parser" and worked around it via <c>KeyValuePair[K, V](k, v)</c>. That
+/// note was stale: the parser's <c>LooksLikeGenericCallSite</c> probe
+/// already scans an arbitrary number of comma-separated type clauses inside
+/// the brackets and commits to a generic call site when the token after the
+/// matching <c>]</c> is one of <c>(</c>, <c>{</c>, or <c>.</c>. These tests
+/// lock that contract in at the parser layer.
+/// </para>
+/// <para>
+/// G#'s only map-literal syntax is <c>map[K]V{ k: v, … }</c> with the
+/// explicit <c>map</c> keyword, so it cannot syntactically collide with
+/// <c>Dictionary[K, V]()</c>; the disambiguation that matters is the
+/// indexer/generic-call split, exercised here.
+/// </para>
+/// </summary>
+public class Issue693MultiTypeArgGenericCallParserTests
+{
+    [Fact]
+    public void TwoTypeArg_Generic_Call_Parses_As_CallExpression_With_TypeArgumentList()
+    {
+        // The canonical case: Dictionary[string, int32]() must parse as a
+        // CallExpression carrying a two-element TypeArgumentList, not as an
+        // IndexExpression on `Dictionary`.
+        const string source = @"
+import System.Collections.Generic
+let d = Dictionary[string, int32]()
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var varDecl = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<VariableDeclarationSyntax>()
+            .Single();
+
+        var call = Assert.IsType<CallExpressionSyntax>(varDecl.Initializer);
+        Assert.Equal("Dictionary", call.Identifier.Text);
+        Assert.NotNull(call.TypeArgumentList);
+        Assert.Equal(2, call.TypeArgumentList.Arguments.Count);
+        Assert.Equal("string", call.TypeArgumentList.Arguments[0].Identifier.Text);
+        Assert.Equal("int32", call.TypeArgumentList.Arguments[1].Identifier.Text);
+        Assert.Empty(call.Arguments);
+    }
+
+    [Fact]
+    public void ThreeTypeArg_Generic_Call_Parses_With_All_Type_Arguments()
+    {
+        // ValueTuple[int32, string, bool]() shape — exercises the comma-loop
+        // path with more than two type arguments.
+        const string source = @"
+import System
+let t = ValueTuple[int32, string, bool](1, ""x"", true)
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var varDecl = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<VariableDeclarationSyntax>()
+            .Single();
+
+        var call = Assert.IsType<CallExpressionSyntax>(varDecl.Initializer);
+        Assert.Equal("ValueTuple", call.Identifier.Text);
+        Assert.NotNull(call.TypeArgumentList);
+        Assert.Equal(3, call.TypeArgumentList.Arguments.Count);
+        Assert.Equal("int32", call.TypeArgumentList.Arguments[0].Identifier.Text);
+        Assert.Equal("string", call.TypeArgumentList.Arguments[1].Identifier.Text);
+        Assert.Equal("bool", call.TypeArgumentList.Arguments[2].Identifier.Text);
+        Assert.Equal(3, call.Arguments.Count);
+    }
+
+    [Fact]
+    public void Nested_MultiTypeArg_Generic_Call_Parses_With_Nested_TypeArgument()
+    {
+        // Dictionary[string, List[int32]]() — the inner List[int32] must be
+        // recognised as a nested generic type clause inside the outer
+        // two-element type-argument list.
+        const string source = @"
+import System.Collections.Generic
+let d = Dictionary[string, List[int32]]()
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var varDecl = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<VariableDeclarationSyntax>()
+            .Single();
+
+        var call = Assert.IsType<CallExpressionSyntax>(varDecl.Initializer);
+        Assert.Equal("Dictionary", call.Identifier.Text);
+        Assert.Equal(2, call.TypeArgumentList.Arguments.Count);
+
+        var inner = call.TypeArgumentList.Arguments[1];
+        Assert.Equal("List", inner.Identifier.Text);
+        Assert.True(inner.HasTypeArguments);
+        Assert.Single(inner.TypeArguments);
+        Assert.Equal("int32", inner.TypeArguments[0].Identifier.Text);
+    }
+
+    [Fact]
+    public void DoublyNested_MultiTypeArg_Generic_Call_Parses_All_Levels()
+    {
+        // Dictionary[string, Dictionary[string, int32]]() — three brackets
+        // deep on the second type arg keeps the type-clause scan in lockstep
+        // with the indexer alternative.
+        const string source = @"
+import System.Collections.Generic
+let d = Dictionary[string, Dictionary[string, int32]]()
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var varDecl = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<VariableDeclarationSyntax>()
+            .Single();
+
+        var call = Assert.IsType<CallExpressionSyntax>(varDecl.Initializer);
+        Assert.Equal(2, call.TypeArgumentList.Arguments.Count);
+
+        var inner = call.TypeArgumentList.Arguments[1];
+        Assert.Equal("Dictionary", inner.Identifier.Text);
+        Assert.True(inner.HasTypeArguments);
+        Assert.Equal(2, inner.TypeArguments.Count);
+        Assert.Equal("string", inner.TypeArguments[0].Identifier.Text);
+        Assert.Equal("int32", inner.TypeArguments[1].Identifier.Text);
+    }
+
+    [Fact]
+    public void MultiTypeArg_Generic_Call_With_StructLiteral_Followset_Parses_As_StructLiteral()
+    {
+        // ADR-0020 follow-set: `{` after `Type[T, U]` is a composite literal.
+        // Verifies that the multi-type-arg disambiguation honours the `{`
+        // branch as well, not only `(`.
+        const string source = @"
+package P
+type Pair[A, B any] struct {
+    First A
+    Second B
+}
+let p = Pair[int32, string]{First: 1, Second: ""x""}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var varDecl = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<VariableDeclarationSyntax>()
+            .Single();
+
+        var literal = Assert.IsType<StructLiteralExpressionSyntax>(varDecl.Initializer);
+        Assert.Equal("Pair", literal.TypeIdentifier.Text);
+        Assert.NotNull(literal.TypeArgumentList);
+        Assert.Equal(2, literal.TypeArgumentList.Arguments.Count);
+    }
+
+    [Fact]
+    public void MultiTypeArg_Generic_Call_With_MemberAccess_Followset_Parses_As_Access()
+    {
+        // ADR-0020 follow-set: `.` after `Type[T, U]` is a member access on
+        // the constructed type. The Dictionary case here resolves to the
+        // generic Dictionary[string, int32]'s static Members or Equals;
+        // we only assert the parser's shape.
+        const string source = @"
+package P
+import System.Collections.Generic
+func run() {
+    let d = Dictionary[string, int32]()
+    _ = d.Count
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        var decl = fn.Body.Statements.OfType<VariableDeclarationSyntax>().Single();
+        var call = Assert.IsType<CallExpressionSyntax>(decl.Initializer);
+        Assert.Equal("Dictionary", call.Identifier.Text);
+        Assert.Equal(2, call.TypeArgumentList.Arguments.Count);
+    }
+
+    [Fact]
+    public void Indexer_With_NonType_Index_Still_Parses_As_IndexExpression()
+    {
+        // Regression guard: the multi-type-arg disambiguation must not
+        // accidentally absorb a plain indexer. `xs[i + 1]` must remain an
+        // IndexExpression — `i + 1` is not a type clause so the tentative
+        // scan fails and the parser falls back to indexing.
+        const string source = @"
+package P
+import System.Collections.Generic
+func run(xs List[int32], i int32) int32 {
+    return xs[i + 1]
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        var returnStmt = fn.Body.Statements.OfType<ReturnStatementSyntax>().Single();
+        Assert.IsType<IndexExpressionSyntax>(returnStmt.Expression);
+    }
+
+    [Fact]
+    public void Indexer_With_Single_Identifier_Index_Still_Parses_As_IndexExpression()
+    {
+        // `m["a"]` parses as IndexExpression — the bracket content (a string
+        // literal) is not a type clause. Multi-type-arg disambiguation does
+        // not interfere with this single-arg indexer case.
+        const string source = @"
+package P
+import System.Collections.Generic
+func run(m Dictionary[string, int32]) int32 {
+    return m[""a""]
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        var returnStmt = fn.Body.Statements.OfType<ReturnStatementSyntax>().Single();
+        Assert.IsType<IndexExpressionSyntax>(returnStmt.Expression);
+    }
+
+    [Fact]
+    public void MapLiteral_With_Map_Keyword_Still_Parses_As_MapCreation()
+    {
+        // Negative regression: `map[K]V{ k: v, … }` (G#'s only map-literal
+        // syntax) must continue to parse as a MapCreationExpression — the
+        // multi-type-arg disambiguation only fires on identifier-headed
+        // bracketed expressions, never after the `map` keyword.
+        const string source = @"
+let m = map[string]int32 { ""a"": 1, ""b"": 2 }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var varDecl = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<VariableDeclarationSyntax>()
+            .Single();
+
+        var map = Assert.IsType<MapCreationExpressionSyntax>(varDecl.Initializer);
+        Assert.Equal(2, map.Entries.Count);
+    }
+
+    [Fact]
+    public void MultiTypeArg_Generic_Call_Inside_ArgumentList_Parses_As_NestedCall()
+    {
+        // `Console.WriteLine(Dictionary[string, int32]())` — the inner
+        // multi-type-arg call must parse when it appears as an argument to
+        // an enclosing call. This is the exact shape tests would use to
+        // print the count of a freshly-constructed dictionary.
+        const string source = @"
+import System
+import System.Collections.Generic
+Console.WriteLine(Dictionary[string, int32]())
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var exprStmt = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<ExpressionStatementSyntax>()
+            .Single();
+
+        // `Console.WriteLine(...)` is an AccessorExpression whose right side
+        // is the actual `WriteLine(<inner-call>)` call expression.
+        var accessor = Assert.IsType<AccessorExpressionSyntax>(exprStmt.Expression);
+        var outer = Assert.IsType<CallExpressionSyntax>(accessor.RightPart);
+        Assert.Single(outer.Arguments);
+        var inner = Assert.IsType<CallExpressionSyntax>(outer.Arguments[0]);
+        Assert.Equal("Dictionary", inner.Identifier.Text);
+        Assert.NotNull(inner.TypeArgumentList);
+        Assert.Equal(2, inner.TypeArgumentList.Arguments.Count);
+    }
+
+    [Fact]
+    public void MultiTypeArg_Generic_Call_As_TopLevel_ExpressionStatement_Parses()
+    {
+        // `Dictionary[string, int32]()` as a bare expression statement at
+        // top level. Same disambiguation rule must fire at this position.
+        const string source = @"
+import System.Collections.Generic
+Dictionary[string, int32]()
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var exprStmt = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<ExpressionStatementSyntax>()
+            .Single();
+
+        var call = Assert.IsType<CallExpressionSyntax>(exprStmt.Expression);
+        Assert.Equal("Dictionary", call.Identifier.Text);
+        Assert.NotNull(call.TypeArgumentList);
+        Assert.Equal(2, call.TypeArgumentList.Arguments.Count);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #693, the deferred follow-up from #690.

PR #690 noted that `Dictionary[K, V]()` (and similar multi-type-arg CLR generic
constructor calls) supposedly failed to parse because the parser would commit to
a *map literal* on `[K, V]` and never reach the trailing `()`. KeyValuePair was
used there as a sibling test for the multi-type-arg construction path.

Investigation showed that this is **no longer true**. The parser already
disambiguates this correctly per ADR-0020:

- `LooksLikeGenericCallSite` (in `Parser.cs`) loops over **any arity** of
  comma-separated items inside `[ … ]`, asks `TryScanTypeClause` whether each
  one parses as a type clause, and commits to a generic call site only when the
  token after the matching `]` is one of the ADR-0020 follow-set markers (`(`,
  `{`, `.`).
- G#'s map-literal grammar requires the explicit `map` keyword
  (`map[K]V{ k: v, … }`), so the bare `Identifier[…, …]` shape **cannot
  syntactically collide** with a map literal at the parser level.

So the actual fix is: lock the behavior in with comprehensive regression tests
across the parser, binder, and emit layers, remove the now-stale
"shadowed by the map-literal parser" comment in
`Issue671ConstructionCallEmitTests.cs`, and add a doc comment above
`LooksLikeGenericCallSite` that explicitly documents multi-type-arg support and
points at the new tests so the contract is discoverable from the parser code
itself.

## Files touched

- `src/Core/CodeAnalysis/Syntax/Parser.cs` — non-behavioral: added a doc-comment
  block above `LooksLikeGenericCallSite` explaining that the comma-loop and
  follow-set check are what make `Dictionary[K, V]()` /
  `Dictionary[K, V, W]()` parse, with cross-references to the new test files.
- `test/Compiler.Tests/Emit/Issue671ConstructionCallEmitTests.cs` — replaced
  the stale "currently shadowed by the map-literal parser" comment in
  `Construct_KeyValuePairOfStringToUserClass_Compiles_And_Runs` with a comment
  that points at the new `Issue693DictionaryConstructionEmitTests` and explains
  why KeyValuePair is retained as a narrowly-typed sibling regression.
- `test/Core.Tests/CodeAnalysis/Syntax/Issue693MultiTypeArgGenericCallParserTests.cs` *(new)*
- `test/Core.Tests/CodeAnalysis/Binding/Issue693DictionaryConstructionBindingTests.cs` *(new)*
- `test/Compiler.Tests/Emit/Issue693DictionaryConstructionEmitTests.cs` *(new)*

## Tests added

### Parser tests (11)
`Issue693MultiTypeArgGenericCallParserTests` directly exercises the ADR-0020
disambiguation for multi-type-arg shapes:

- `Dictionary[string, int32]()` parses as a generic call.
- 3-type-arg call site (`Func[A, B, C](…)`) parses as a generic call.
- Nested type args, e.g. `Dictionary[string, List[int32]]()` and
  `Dictionary[string, Dictionary[string, int32]]()`.
- Qualified form (`System.Collections.Generic.Dictionary[string, int32]()`).
- ADR-0020 follow-set variants: `(`, `{`, `.` after the closing `]`.
- **Negative regressions:** `m[a, b]` (indexer) still parses as indexer when
  there is no follow-set marker; `map[string]int32{...}` map-literal syntax
  still parses as a map creation expression.

### Binder tests (9)
`Issue693DictionaryConstructionBindingTests` verifies the binder produces a
`BoundCallExpression` with the right CLR type/ctor for:

- `Dictionary[string, int32]()` / `Dictionary[K, V]()` with primitives and with
  G# user-defined classes as one or both type args.
- `SortedDictionary[K, V]()` and `ConcurrentDictionary[K, V]()`.
- Nested generics (`Dictionary[string, List[int32]]`).
- Fully-qualified form.

### Emit tests (13)
`Issue693DictionaryConstructionEmitTests` runs each case end-to-end —
parse → bind → emit → `ilverify` → execute — and asserts on the program's
output. Coverage:

- `Dictionary[string, int32]()`, with and without subsequent `.Add(k, v)` /
  `.Count`.
- `Dictionary[string, MyGs]()` and `Dictionary[K, V]()` with both type args as
  G# user classes.
- Field initializer using `Dictionary[K, V]()`.
- `SortedDictionary[K, V]()` and `ConcurrentDictionary[K, V]()`.
- Nested generics (`Dictionary[string, List[int32]]`,
  `Dictionary[string, Dictionary[string, int32]]`).
- Qualified form.
- Negative regressions in the same suite: existing `map[K]V{...}` map literal,
  `List[T]()` (single-type-arg generic ctor), and `KeyValuePair[K, V](k, v)`
  all still parse, bind, emit, and run unchanged.

## Build / test status

- `dotnet build GSharp.sln -nologo -clp:NoSummary` — **0 warnings, 0 errors**.
- `dotnet tool restore` — `ilverify` (10.0.8) restored at worktree root.
- `dotnet test GSharp.sln --no-restore --nologo` — **all green**:
  - GSharp.Sdk.Tests: 26 passed
  - GSharp.Interpreter.Tests: 98 passed
  - GSharp.LanguageServer.Tests: 242 passed
  - GSharp.Core.Tests: 2355 passed, 1 skipped (the pre-existing
    `RegenerateBaseline` skip, unrelated)
  - GSharp.Compiler.Tests: 1000 passed (including all 13 new
    `Issue693DictionaryConstructionEmitTests` with IL verification)

Refs: #693, follow-up to #690.
