### PR TITLE
Implement #694 (ADR-0067): require var/let on type field declarations

### DIFF
--- a/docs/adr/0019-extension-functions.md
+++ b/docs/adr/0019-extension-functions.md
@@ -53,8 +53,8 @@ func (s string) Shout() string {
 package Geometry
 
 type Point struct {
-    X int
-    Y int
+    var X int
+    var Y int
 }
 
 // Same syntax, but the receiver is declared in this package, so this

--- a/docs/adr/0034-imported-clr-interop.md
+++ b/docs/adr/0034-imported-clr-interop.md
@@ -42,7 +42,7 @@ Additionally, `FindMatchingFieldForGetterOnlyProperty` enables a public field on
 
 ```
 type Impl class : IHasName {
-    Name string
+    var Name string
 }
 ```
 

--- a/docs/adr/0035-user-operator-overloads.md
+++ b/docs/adr/0035-user-operator-overloads.md
@@ -19,8 +19,8 @@ Ship receiver-form binary and unary `operator` overloads on GSharp `struct` / `d
 
 ```gsharp
 type Vector2 struct {
-    X int
-    Y int
+    var X int
+    var Y int
 }
 
 // receiver-form binary operator

--- a/docs/adr/0051-property-declarations.md
+++ b/docs/adr/0051-property-declarations.md
@@ -59,8 +59,8 @@ type Person class {
     prop FullName string {
         get { return this.first + " " + this.last }
     }
-    private first string
-    private last string
+    private var first string
+    private var last string
 }
 ```
 
@@ -78,7 +78,7 @@ type Clamped class {
             else { this._value = v }
         }
     }
-    private _value int32
+    private var _value int32
 }
 ```
 
@@ -134,7 +134,7 @@ type Derived class : Base {
         get { return "custom: " + this._label }
         set(v) { this._label = v }
     }
-    private _label string
+    private var _label string
 }
 ```
 
@@ -157,8 +157,8 @@ Data struct fields remain fields:
 
 ```gs
 type Point data struct {
-    X int32    // field — unchanged
-    Y int32    // field — unchanged
+    var X int32    // field — unchanged
+    var Y int32    // field — unchanged
 }
 ```
 
@@ -166,10 +166,10 @@ A `data struct` may additionally declare `prop` members for computed values:
 
 ```gs
 type Rect data struct {
-    X int32
-    Y int32
-    Width int32
-    Height int32
+    var X int32
+    var Y int32
+    var Width int32
+    var Height int32
     prop Area int32 { get { return this.Width * this.Height } }
 }
 ```

--- a/docs/adr/0065-class-initializers-and-base-invocation.md
+++ b/docs/adr/0065-class-initializers-and-base-invocation.md
@@ -36,9 +36,9 @@ Syntax — an `init` member without a `convenience` modifier:
 
 ```gsharp
 type Rect class {
-    Width int32
-    Height int32
-    Area int32
+    var Width int32
+    var Height int32
+    var Area int32
 
     init(w int32, h int32) {
         Width = w
@@ -58,9 +58,9 @@ Syntax — the contextual modifier `convenience` precedes `init`:
 
 ```gsharp
 type Rect class {
-    Width int32
-    Height int32
-    Area int32
+    var Width int32
+    var Height int32
+    var Area int32
 
     init(w int32, h int32) {
         Width = w
@@ -86,7 +86,7 @@ type Animal open class(Name string) {
 }
 
 type Dog class : Animal {
-    Tricks int32
+    var Tricks int32
 
     init(name string, tricks int32) : base(name) {
         Tricks = tricks
@@ -162,7 +162,7 @@ import Probe.CSharp
 import System.Collections.Generic
 
 type FakeJobService class : IJobService {
-    Active List[JobSnapshot]
+    var Active List[JobSnapshot]
 
     init() {
         Active = List[JobSnapshot]()
@@ -180,7 +180,7 @@ type FakeJobService class : IJobService {
 
 ```gsharp
 type LifecycleTab class(Title string, Key string) {
-    Active bool = false
+    var Active bool = false
 
     convenience init(key string) {
         init(key, key)   // delegates to synthesised designated init(Title, Key)
@@ -197,9 +197,9 @@ The primary ctor synthesises `init(Title string, Key string)` as designated. The
 
 ```gsharp
 type Color class {
-    R float64
-    G float64
-    B float64
+    var R float64
+    var G float64
+    var B float64
 
     init(r float64, g float64, b float64) {
         R = r
@@ -227,7 +227,7 @@ var black = Color()
 
 ```gsharp
 type Vehicle open class {
-    Wheels int32
+    var Wheels int32
 
     init(wheels int32) {
         Wheels = wheels
@@ -235,7 +235,7 @@ type Vehicle open class {
 }
 
 type Car class : Vehicle {
-    Brand string
+    var Brand string
 
     init(brand string, wheels int32) : base(wheels) {
         // Phase 1: assign own stored properties BEFORE base runs
@@ -257,8 +257,8 @@ If the programmer tried to read `Wheels` **before** assigning `Brand`, the compi
 
 ```gsharp
 type HttpClient open class {
-    BaseUrl string
-    Timeout int32
+    var BaseUrl string
+    var Timeout int32
 
     init(baseUrl string, timeout int32) {
         BaseUrl = baseUrl

--- a/docs/adr/0067-fields-require-var-keyword.md
+++ b/docs/adr/0067-fields-require-var-keyword.md
@@ -1,0 +1,113 @@
+# ADR-0067: Field declarations require `var` or `let`
+
+- **Status**: Accepted
+- **Date**: 2026-06-11
+- **Phase**: Phase 9 — language depth / type surface consistency
+- **Related**: ADR-0008 (variable bindings — `var`/`let` for locals), ADR-0029 (struct surface), ADR-0033 (inline struct), ADR-0051 (property declarations — `prop` keyword), ADR-0052 (event declarations — `event` keyword), ADR-0053 (static members — `shared { … }` block), ADR-0065 (class initializers and base invocation), issue [#694](https://github.com/DavidObando/gsharp/issues/694)
+
+## Context
+
+G# `struct` and `class` bodies began life as bare field-only structures, in the Go tradition: a member line was an identifier followed by a type clause, with no leading keyword. Over the lifetime of the language the type body picked up several richer member shapes that *do* carry an introducer keyword: `func` for methods (ADR-0017), `prop` for properties (ADR-0051), `event` for events (ADR-0052), `init` for user-defined constructors (ADR-0065), `shared { … }` for static members (ADR-0053), and so on. The result is a member surface where every member kind except fields announces itself with a keyword:
+
+```gs
+type Counter class {
+    Value int32 = 0              // field — bare; the odd one out
+    prop Name string             // property — `prop` keyword
+    event Changed Action         // event — `event` keyword
+    func Touch() { … }           // method — `func` keyword
+    init(seed int32) { … }       // constructor — `init` keyword
+}
+```
+
+This inconsistency has been called out repeatedly during reviews. It hurts readability (the eye scans the leading keyword to classify each member), it confuses the editor lookahead (where the parser today has to *guess* "is this a field, a method header missing `func`, or an annotation typo?"), and it makes the read-only intent invisible — there is no surface marking that distinguishes "this field is mutable" from "this field is set once at construction time".
+
+ADR-0008 already established `var` and `let` as the binding keywords for local variables (`var x = …` for mutable, `let x = …` for immutable runtime bindings). Lifting the same pair into the type body — Swift's exact convention — fixes all three issues with one change: every type-body member now leads with a single contextual keyword, the parser dispatch becomes unambiguous, and read-only fields gain a one-token surface marker that drives `FieldAttributes.InitOnly` in emit.
+
+## Decision
+
+Field declarations inside `struct`, `class`, `data struct`, `inline struct`, and `shared { … }` bodies **must** be introduced by a `var` (mutable) or `let` (read-only) keyword. The keyword sits immediately after the optional accessibility modifier and before the field name:
+
+```ebnf
+field_declaration = annotations? accessibility_modifier? ("var" | "let") identifier type_clause ("=" expression)?
+```
+
+### Examples
+
+```gs
+type Counter class {
+    var Value int32 = 0          // mutable instance field
+    let Origin int32 = 0         // read-only instance field — set only at init time
+    prop Name string             // property — unchanged
+    func Touch() { … }           // method — unchanged
+}
+
+type Point struct {
+    var X int32
+    var Y int32
+}
+
+type Defaults class {
+    shared {
+        var Counter int32 = 0    // mutable static field
+        let Pi float64 = 3.14159 // read-only static field
+    }
+}
+```
+
+### Semantics
+
+- `var <Name> <Type> [= initializer]` — mutable field. Identical to today's behaviour. The initializer is optional; when absent the field takes the type's default (zero) value, per ADR-0008.
+- `let <Name> <Type> [= initializer]` — read-only field. The binder rejects assignments to the field outside of construction (primary constructor, struct literal, `init(...)` body, or the field's own declaration-site initializer). The emitter sets `FieldAttributes.InitOnly` so the CLR honors the constraint at runtime and so consumers see a `readonly` field through reflection. C# and other CLR consumers experience this as a normal `public readonly int Origin`.
+- The keyword is mandatory: omitting it is a binder-time error (GS0288). The parser still attempts recovery so the rest of the type body can be checked.
+
+### What is **not** affected by this ADR
+
+- **Property declarations** (`prop`, ADR-0051) — already carry their own introducer keyword; their grammar is unchanged.
+- **Event declarations** (`event`, ADR-0052) — unchanged.
+- **Method / function declarations** (`func`, ADR-0017) — unchanged.
+- **Constructor declarations** (`init`, ADR-0065) — unchanged.
+- **Primary-constructor parameter lists** — `type Person class(Name string, Age int32) { … }` continues to parse as before. Primary-constructor parameters are *parameters*, not field declarations; the binder still synthesises a public read-only field for each parameter automatically (this is a separate language affordance, not a field-declaration shape).
+- **`inline struct` value parameter** — `type UserId inline struct(value string)` continues to declare its single value through the parenthesised parameter list, identical to the primary-constructor parameter path above.
+- **`const` declarations at top level / inside packages** — unchanged. ADR-0067 is scoped to type-body fields.
+
+### Diagnostic
+
+A new diagnostic is allocated:
+
+- **GS0288** — `"Field declarations require a 'var' (mutable) or 'let' (read-only) keyword."` Reported at the offending token's location (the would-be field identifier, or whatever the parser sees where it expected `var`/`let`). The parser then recovers by treating the next identifier as the field name so subsequent fields and members are still checked.
+
+## Considered alternatives
+
+- **Status quo (no keyword)** — rejected: directly contradicts the issue request and leaves the inconsistency described above unresolved. Even if we kept the bare form as a transitional convenience, the lack of a surface marker for read-only fields would force a separate decoration (an attribute, a contextual keyword, or per-member `readonly`) that is strictly more work for users than `let`.
+- **Single keyword (`var` only)** — rejected: the issue explicitly asks for "Swift language style" and Swift uses both `var` and `let`. Adopting only `var` would leave read-only fields with no syntactic marker, forcing users back to attributes or trusting convention. Since ADR-0008 already supports `let` for locals, lifting the same pair into type bodies is the cheaper, more uniform change.
+- **`field` keyword (C# 13 style)** — rejected: `field` is already proposed in the C# / Roslyn world as a *contextual* identifier inside property accessors (the backing-field shorthand). Reusing it as a field-declaration introducer would collide with the natural future direction of property accessors and would not give us the var/let mutability split.
+- **`val` instead of `let`** — rejected for the same reason ADR-0008 rejected it for locals: user preference is `let`, and consistency with the local-binding pair matters more than alignment with Kotlin.
+- **Keep `prop`/`event`/`func` but make fields opt-in via `field`** — rejected: produces *four* member keywords (`field`/`prop`/`event`/`func`) and still gives us nothing for read-only intent.
+- **Allow `const <Name> <Type> = <constexpr>`** as a third form — out of scope. Compile-time constants on instance types are a separate design question (ADR-0008 already covers `const` for locals); we can revisit once we have a concrete static-constant proposal.
+
+## Migration impact
+
+This is a **breaking** language change. Every existing `.gs` source that declares a bare field inside a `struct`, `class`, `data struct`, or `shared { … }` body must be updated to prepend `var` or `let`. The PR that implements this ADR migrates:
+
+- Every G# sample under `samples/` (101 files; ~30 carry field declarations).
+- Every `.gs` test fixture under `test/` (~140 files contain type declarations; ~70 declare fields).
+- Every doc snippet that shows the old syntax. The ADRs that describe field shapes (this ADR; ADR-0029, ADR-0051) are updated alongside.
+
+The rule of thumb for the mechanical migration is: bare fields that are mutated after construction become `var`; bare fields that are only ever read after construction become `let`. When in doubt the migration defaults to `var` — that preserves today's behaviour exactly and never introduces a new diagnostic. Read-only conversion (`var` → `let`) is a follow-up that callers can do at their convenience as a one-character no-risk change.
+
+## Backward compatibility
+
+Intentionally **not** backward compatible. The parser surfaces GS0288 with a precise, actionable message at the first bare-field site, which is enough information for the user to make the one-character correction. No deprecation period is offered: keeping a fallback "accept bare fields" path would defeat the consistency goal of this ADR and bifurcate the parser dispatch.
+
+## Implementation notes
+
+- **Syntax**: `FieldDeclarationSyntax` gains a `VarOrLetKeyword` token and an `IsReadOnly` convenience property (`true` iff the keyword is `let`). The constructor signature picks up the new token between `AccessibilityModifier` and `Identifier`.
+- **Parser**: `Parser.ParseFieldDeclaration` consumes the keyword after the optional accessibility modifier. A missing keyword reports GS0288 and continues; the parser does not consume tokens for recovery beyond the diagnostic.
+- **Binder**: `DeclarationBinder` reads `fieldSyntax.IsReadOnly` and ORs it into the `isReadOnly` argument of `FieldSymbol`, so the existing `IsInline` path (which already forces read-only on `inline struct` fields) continues to compose. Static fields inside `shared { … }` blocks pick up `IsReadOnly` directly from the field syntax.
+- **Emit**: no change required. `TypeDefEmitter` already maps `FieldSymbol.IsReadOnly` to `FieldAttributes.InitOnly` on both instance and static field definitions, so `let` fields automatically emit as CLR `initonly` fields.
+- **Bound tree**: no new node kind is needed. The mutability decision is recorded on the `FieldSymbol` itself (`IsReadOnly`), which is already consulted by every assignment-binding path that can target a field — `BindFieldAssignmentExpression`, `BindMemberFieldAssignmentExpression`, `BindStructLiteralExpression` (init-only enforcement), the `ImplicitFieldVariableSymbol` and `ImplicitStaticFieldVariableSymbol` accessors, and so on.
+- **Diagnostics**: a single new diagnostic, GS0288, with the message text above.
+
+## Status
+
+Accepted; implemented in the same PR as this ADR.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -221,8 +221,8 @@ G# can also **declare** its own by-ref-like value types with a `ref` modifier on
 
 ```gsharp
 type Window ref struct {
-    Items ReadOnlySpan[int32]   // a ref struct may hold by-ref-like fields
-    Label string
+    var Items ReadOnlySpan[int32]   // a ref struct may hold by-ref-like fields
+    var Label string
 }
 ```
 

--- a/samples/Class.gs
+++ b/samples/Class.gs
@@ -9,8 +9,8 @@ package GSharp.Example.Class
 import System
 
 type Point class {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 var p = Point{X: 3, Y: 4}
@@ -61,7 +61,7 @@ Console.WriteLine(pt.Sum())
 // primary ctors to base ctors; the sample uses composite literals to
 // initialize inherited fields directly.
 type Animal open class {
-    Kind string
+    var Kind string
     open func Speak() string {
         return "..."
     }

--- a/samples/DataStruct.gs
+++ b/samples/DataStruct.gs
@@ -11,8 +11,8 @@ package GSharp.Example.DataStruct
 import System
 
 type Point data struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 var p = Point{X: 3, Y: 4}

--- a/samples/DataStructErgonomics.gs
+++ b/samples/DataStructErgonomics.gs
@@ -6,8 +6,8 @@ package GSharp.Example.DataStructErgonomics
 import System
 
 type Point data struct {
-    x int32
-    y int32
+    var x int32
+    var y int32
 }
 
 let p = Point{x: 3, y: 4}

--- a/samples/ExplicitConstructor.gs
+++ b/samples/ExplicitConstructor.gs
@@ -20,9 +20,9 @@ import System
 // A class whose explicit constructor runs arbitrary statements: it assigns the
 // `Width`/`Height` fields and computes the derived `Area` field.
 type Rect class {
-    Width int32
-    Height int32
-    Area int32
+    var Width int32
+    var Height int32
+    var Area int32
 
     init(w int32, h int32) {
         Width = w
@@ -38,7 +38,7 @@ Console.WriteLine(r.Area)
 
 // The constructor body may contain control flow.
 type Clamped class {
-    Value int32
+    var Value int32
 
     init(v int32) {
         if v < 0 {
@@ -61,7 +61,7 @@ type Animal open class(Name string) {
 }
 
 type Dog class : Animal {
-    Tricks int32
+    var Tricks int32
 
     init(name string, tricks int32) : base(name) {
         Tricks = tricks
@@ -76,7 +76,7 @@ Console.WriteLine(d.Tricks)
 // An `init` constructor can chain to a CLR base (System.Exception) whose
 // constructors all require arguments, then run its own body.
 type MyError class : Exception {
-    Code int32
+    var Code int32
 
     init(message string, code int32) : base(message) {
         Code = code

--- a/samples/ExpressionEval.gs
+++ b/samples/ExpressionEval.gs
@@ -16,17 +16,17 @@ type Expr sealed interface {
 }
 
 type Lit class : Expr {
-    Value int32
+    var Value int32
 }
 
 type Add class : Expr {
-    Left Expr
-    Right Expr
+    var Left Expr
+    var Right Expr
 }
 
 type Mul class : Expr {
-    Left Expr
-    Right Expr
+    var Left Expr
+    var Right Expr
 }
 
 func eval(e Expr) int32 {

--- a/samples/GenericMethodDelegates.gs
+++ b/samples/GenericMethodDelegates.gs
@@ -13,7 +13,7 @@ import System
 // A generic class whose generic method takes a delegate parameterized by both
 // the class's type parameter (`TItem`) and the method's own (`TResult`).
 type Box[TItem] class {
-    Value TItem
+    var Value TItem
 
     func Map[TResult](f func(TItem) TResult) TResult {
         return f(this.Value)

--- a/samples/GenericMethodUserTypeArg.gs
+++ b/samples/GenericMethodUserTypeArg.gs
@@ -11,7 +11,7 @@ package GSharp.Example.GenericMethodUserTypeArg
 import System
 
 type Clock class {
-    Ticks int32
+    var Ticks int32
     func Read() int32 {
         return Ticks
     }

--- a/samples/GenericMethods.gs
+++ b/samples/GenericMethods.gs
@@ -24,7 +24,7 @@ type Box class {
 // A generic method declared on a generic class: `Echo` uses the class's `T`
 // while `GetOr` introduces its own method-level type parameter `U`.
 type Container[T] class {
-    Value T
+    var Value T
 
     func Echo(x T) T {
         return x

--- a/samples/MethodsWithReceivers.gs
+++ b/samples/MethodsWithReceivers.gs
@@ -9,8 +9,8 @@ package GSharp.Samples.MethodsWithReceivers
 import System
 
 type Point struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 func (p Point) Distance() int32 {

--- a/samples/Operators.gs
+++ b/samples/Operators.gs
@@ -7,8 +7,8 @@ package GSharp.Sample.Operators
 import System
 
 type Vector2 class {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 func (a Vector2) operator +(b Vector2) Vector2 {

--- a/samples/PatternSwitch.gs
+++ b/samples/PatternSwitch.gs
@@ -8,9 +8,9 @@ package GSharp.Samples.PatternSwitch
 
 import System
 
-type Animal open class { Name string }
-type Dog class : Animal { Bark int32 }
-type Cat class : Animal { Purr int32 }
+type Animal open class { var Name string }
+type Dog class : Animal { var Bark int32 }
+type Cat class : Animal { var Purr int32 }
 
 func describe(n int32) {
   switch n {
@@ -37,7 +37,7 @@ func shape(xs []int32) {
   }
 }
 
-type Point data struct { X int32 Y int32 }
+type Point data struct { var X int32 var Y int32 }
 
 func origin(p Point) {
   switch p {

--- a/samples/Records.gs
+++ b/samples/Records.gs
@@ -8,8 +8,8 @@ package GSharp.Example.Records
 import System
 
 type Point record {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 var p = Point{X: 3, Y: 4}

--- a/samples/RefStructGenericField.gs
+++ b/samples/RefStructGenericField.gs
@@ -18,7 +18,7 @@ package GSharp.Samples.RefStructGenericField
 import System
 
 type Window ref struct {
-    data ReadOnlySpan[int32]
+    var data ReadOnlySpan[int32]
 }
 
 func firstLen(w Window) int32 {

--- a/samples/Struct.gs
+++ b/samples/Struct.gs
@@ -7,8 +7,8 @@ package GSharp.Example.Struct
 import System
 
 type Point struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 var p = Point{X: 3, Y: 4}

--- a/samples/SwitchExpression.gs
+++ b/samples/SwitchExpression.gs
@@ -8,9 +8,9 @@ package GSharp.Samples.SwitchExpression
 
 import System
 
-type Shape open class { Name string }
-type Circle class : Shape { Radius int32 }
-type Square class : Shape { Side int32 }
+type Shape open class { var Name string }
+type Circle class : Shape { var Radius int32 }
+type Square class : Shape { var Side int32 }
 
 let nums = []int32{-3, 0, 1, 5, 101}
 for n in nums {
@@ -41,7 +41,7 @@ let listLabel = switch xs {
 }
 Console.WriteLine(listLabel)
 
-type Pair data struct { A int32 B int32 }
+type Pair data struct { var A int32 var B int32 }
 let p = Pair{A: 7, B: 7}
 let pairLabel = switch p {
   case { A: 0, B: 0 } -> "origin"

--- a/samples/UserRefStruct.gs
+++ b/samples/UserRefStruct.gs
@@ -17,7 +17,7 @@ import System
 
 // A by-ref-like accumulator with a plain field, used as a stack-confined value.
 type Accumulator ref struct {
-    Total int32
+    var Total int32
 }
 
 func add(acc Accumulator, n int32) Accumulator {
@@ -34,8 +34,8 @@ func runningTotal() int32 {
 // A by-ref-like aggregate that legally embeds another `ref struct` as a field —
 // only permitted because the containing type is itself a `ref struct`.
 type LabeledAccumulator ref struct {
-    Inner Accumulator
-    Label string
+    var Inner Accumulator
+    var Label string
 }
 
 func describe(item LabeledAccumulator) string {

--- a/samples/refactoring-baseline/AwaitInFieldAssignment.gs
+++ b/samples/refactoring-baseline/AwaitInFieldAssignment.gs
@@ -8,7 +8,7 @@ import System
 import System.Threading.Tasks
 
 type Holder class {
-    Value int32
+    var Value int32
 }
 
 async func one() int32 {

--- a/samples/refactoring-baseline/ClosureCaptureRefTypeField.gs
+++ b/samples/refactoring-baseline/ClosureCaptureRefTypeField.gs
@@ -8,7 +8,7 @@ package GSharp.Refactoring.ClosureCaptureRefTypeField
 import System
 
 type Holder class {
-    Value int32
+    var Value int32
     init() {}
 }
 

--- a/samples/refactoring-baseline/GenericMethodSpec.gs
+++ b/samples/refactoring-baseline/GenericMethodSpec.gs
@@ -8,7 +8,7 @@ package GSharp.Refactoring.GenericMethodSpec
 import System
 
 type Tag class {
-    Name string
+    var Name string
 }
 
 var empties = Array.Empty[Tag]()

--- a/samples/refactoring-baseline/RefStructByRefLike.gs
+++ b/samples/refactoring-baseline/RefStructByRefLike.gs
@@ -7,7 +7,7 @@ package GSharp.Refactoring.RefStructByRefLike
 import System
 
 type Acc ref struct {
-    Total int32
+    var Total int32
 }
 
 func bump(a Acc, n int32) Acc {

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -465,7 +465,7 @@ internal sealed class DeclarationBinder
             }
 
             var fieldAccessibility = resolveAccessibility(fieldSyntax.AccessibilityModifier);
-            var fieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: syntax.IsInline);
+            var fieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: syntax.IsInline || fieldSyntax.IsReadOnly);
             Binder.AttachDocumentation(fieldSymbol, fieldSyntax);
 
             // Issue #186 / ADR-0047 §3: bind any `@Foo` annotations attached
@@ -1330,7 +1330,7 @@ internal sealed class DeclarationBinder
                 }
 
                 var fieldAccessibility = resolveAccessibility(fieldSyntax.AccessibilityModifier);
-                var fieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: false, isStatic: true);
+                var fieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: fieldSyntax.IsReadOnly, isStatic: true);
 
                 if (!fieldSyntax.Annotations.IsDefaultOrEmpty)
                 {

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -908,6 +908,21 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// ADR-0067: reports that a field declaration inside a <c>struct</c>,
+    /// <c>class</c>, or <c>shared</c> block was written without a leading
+    /// <c>var</c> or <c>let</c> keyword. Field declarations now require
+    /// one of these binding keywords to distinguish mutable (<c>var</c>)
+    /// from read-only (<c>let</c>) storage and to keep type bodies
+    /// visually consistent with property, event, and method members.
+    /// </summary>
+    /// <param name="location">The location of the offending token.</param>
+    public void ReportFieldDeclarationRequiresVarOrLet(TextLocation location)
+    {
+        var message = "Field declarations require a 'var' (mutable) or 'let' (read-only) keyword.";
+        Report(location, "GS0288", message);
+    }
+
+    /// <summary>
     /// Reports that top-level statements within a single source file are not
     /// contiguous — they are split into two or more blocks separated by a
     /// type or function declaration (ADR-0066 deferred decision D5). Emitted

--- a/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
+++ b/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
@@ -335,6 +335,8 @@ public static class SymbolDisplay
                     builder.Space();
                 }
 
+                builder.Keyword(aggregate.Fields[i].IsReadOnly ? "let" : "var");
+                builder.Space();
                 builder.Add(SymbolDisplayPartKind.FieldName, aggregate.Fields[i].Name);
                 builder.Space();
                 builder.Type(FormatType(aggregate.Fields[i].Type));

--- a/src/Core/CodeAnalysis/Syntax/FieldDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/FieldDeclarationSyntax.cs
@@ -16,6 +16,7 @@ public sealed class FieldDeclarationSyntax : SyntaxNode
     /// </summary>
     /// <param name="syntaxTree">The parent syntax tree.</param>
     /// <param name="accessibilityModifier">The optional accessibility modifier.</param>
+    /// <param name="varOrLetKeyword">The required <c>var</c> or <c>let</c> binding keyword (ADR-0067). May be <c>null</c> only for parser error-recovery sites where the keyword was omitted; the parser also emits a diagnostic in that case.</param>
     /// <param name="identifier">The field identifier.</param>
     /// <param name="type">The field type clause.</param>
     /// <param name="equalsToken">The optional <c>=</c> token preceding the initializer.</param>
@@ -23,6 +24,7 @@ public sealed class FieldDeclarationSyntax : SyntaxNode
     public FieldDeclarationSyntax(
         SyntaxTree syntaxTree,
         SyntaxToken accessibilityModifier,
+        SyntaxToken varOrLetKeyword,
         SyntaxToken identifier,
         TypeClauseSyntax type,
         SyntaxToken equalsToken = null,
@@ -31,6 +33,7 @@ public sealed class FieldDeclarationSyntax : SyntaxNode
     {
         Annotations = ImmutableArray<AnnotationSyntax>.Empty;
         AccessibilityModifier = accessibilityModifier;
+        VarOrLetKeyword = varOrLetKeyword;
         Identifier = identifier;
         Type = type;
         EqualsToken = equalsToken;
@@ -53,6 +56,21 @@ public sealed class FieldDeclarationSyntax : SyntaxNode
 
     /// <summary>Gets the optional accessibility modifier token.</summary>
     public SyntaxToken AccessibilityModifier { get; }
+
+    /// <summary>
+    /// Gets the required <c>var</c> or <c>let</c> binding keyword (ADR-0067).
+    /// A <c>let</c> keyword marks the field as read-only (CLR <c>initonly</c>); a
+    /// <c>var</c> keyword marks it as mutable. May be <c>null</c> only when the
+    /// parser is recovering from a missing keyword and has already reported a
+    /// diagnostic at the field's position.
+    /// </summary>
+    public SyntaxToken VarOrLetKeyword { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this field was declared with the
+    /// <c>let</c> keyword and is therefore read-only (ADR-0067).
+    /// </summary>
+    public bool IsReadOnly => VarOrLetKeyword != null && VarOrLetKeyword.Kind == SyntaxKind.LetKeyword;
 
     /// <summary>Gets the field identifier.</summary>
     public SyntaxToken Identifier { get; }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -1613,6 +1613,21 @@ public class Parser
             fieldAccessibility = NextToken();
         }
 
+        // ADR-0067: field declarations must be introduced with `var` (mutable)
+        // or `let` (read-only). The keyword is captured on the syntax node so
+        // the binder can set FieldSymbol.IsReadOnly accordingly. If the user
+        // omits the keyword, surface a precise diagnostic and try to recover
+        // by treating the next identifier as the field name.
+        SyntaxToken varOrLetKeyword = null;
+        if (Current.Kind == SyntaxKind.VarKeyword || Current.Kind == SyntaxKind.LetKeyword)
+        {
+            varOrLetKeyword = NextToken();
+        }
+        else
+        {
+            Diagnostics.ReportFieldDeclarationRequiresVarOrLet(Current.Location);
+        }
+
         var fieldIdentifier = MatchToken(SyntaxKind.IdentifierToken);
         var fieldType = ParseTypeClause();
 
@@ -1625,7 +1640,7 @@ public class Parser
             initializer = ParseExpression();
         }
 
-        return new FieldDeclarationSyntax(syntaxTree, fieldAccessibility, fieldIdentifier, fieldType, equalsToken, initializer);
+        return new FieldDeclarationSyntax(syntaxTree, fieldAccessibility, varOrLetKeyword, fieldIdentifier, fieldType, equalsToken, initializer);
     }
 
     private MemberSyntax ParseFunctionDeclaration(SyntaxToken accessibilityModifier)
@@ -2303,7 +2318,27 @@ public class Parser
             return null;
         }
 
+        // ADR-0067 / issue #694: when an identifier in return-type position is a
+        // contextual member-position keyword (`event`, `prop`, `init`,
+        // `convenience`, `shared`), it actually starts the NEXT member of the
+        // enclosing type body — not a return type for the current `func(...)`
+        // clause. Bail out so the enclosing struct/class parser can dispatch on
+        // the contextual keyword.
+        if (Current.Kind == SyntaxKind.IdentifierToken && IsContextualMemberKeyword(Current.Text))
+        {
+            return null;
+        }
+
         return ParseTypeClause();
+    }
+
+    private static bool IsContextualMemberKeyword(string text)
+    {
+        return text == "event"
+            || text == "prop"
+            || text == "init"
+            || text == "convenience"
+            || text == "shared";
     }
 
     private BlockStatementSyntax ParseBlockStatement()

--- a/test/Compiler.Tests/Emit/Adr0065ConvenienceInitEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Adr0065ConvenienceInitEmitTests.cs
@@ -26,8 +26,8 @@ public class Adr0065ConvenienceInitEmitTests
             import System
 
             type Rect class {
-                Width int32
-                Height int32
+                var Width int32
+                var Height int32
                 init(w int32, h int32) {
                     Width = w
                     Height = h
@@ -60,8 +60,8 @@ public class Adr0065ConvenienceInitEmitTests
             import System
 
             type HttpClient class {
-                BaseUrl string
-                Timeout int32
+                var BaseUrl string
+                var Timeout int32
                 init(baseUrl string, timeout int32) {
                     BaseUrl = baseUrl
                     Timeout = timeout
@@ -100,7 +100,7 @@ public class Adr0065ConvenienceInitEmitTests
             import System
 
             type LifecycleTab class(Title string, Key string) {
-                Active bool = false
+                var Active bool = false
                 convenience init(key string) {
                     init(key, key)
                 }
@@ -130,7 +130,7 @@ public class Adr0065ConvenienceInitEmitTests
             import System
 
             type Person class(Name string) {
-                Age int32
+                var Age int32
                 init(age int32) {
                     Age = age
                 }
@@ -155,7 +155,7 @@ public class Adr0065ConvenienceInitEmitTests
             package Probe
 
             type Bad class {
-                X int32
+                var X int32
                 init(x int32) {
                     X = x
                 }
@@ -180,7 +180,7 @@ public class Adr0065ConvenienceInitEmitTests
             package Probe
 
             type Bad class {
-                X int32
+                var X int32
                 init(x int32) {
                     X = x
                 }
@@ -204,7 +204,7 @@ public class Adr0065ConvenienceInitEmitTests
             package Probe
 
             type Animal open class {
-                Name string
+                var Name string
                 init(name string) {
                     Name = name
                 }
@@ -262,9 +262,9 @@ public class Adr0065ConvenienceInitEmitTests
             import System
 
             type Color class {
-                R int32
-                G int32
-                B int32
+                var R int32
+                var G int32
+                var B int32
                 init(r int32, g int32, b int32) {
                     R = r
                     G = g

--- a/test/Compiler.Tests/Emit/AttributeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AttributeEmitTests.cs
@@ -69,8 +69,8 @@ public class AttributeEmitTests
 
             @Obsolete("legacy")
             type Point data struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
             """;
 
@@ -112,7 +112,7 @@ public class AttributeEmitTests
 
             @DebuggerTypeProxy(typeof(int32))
             type Box data struct {
-                Value int32
+                var Value int32
             }
             """;
 
@@ -148,7 +148,7 @@ public class AttributeEmitTests
 
             @DebuggerDisplay("{Value}", Target = typeof(string))
             type Holder data struct {
-                Value int32
+                var Value int32
             }
             """;
 
@@ -182,7 +182,7 @@ public class AttributeEmitTests
 
             @DefaultValue(42)
             type Counter data struct {
-                Value int32
+                var Value int32
             }
             """;
 
@@ -207,7 +207,7 @@ public class AttributeEmitTests
 
             @DefaultValue("hello")
             type Greeter data struct {
-                Value int32
+                var Value int32
             }
             """;
 
@@ -233,8 +233,8 @@ public class AttributeEmitTests
 
             @TupleElementNames([]string{"first", "second"})
             type Pair data struct {
-                A int32
-                B int32
+                var A int32
+                var B int32
             }
             """;
 
@@ -262,7 +262,7 @@ public class AttributeEmitTests
 
             @DefaultValue(typeof(int32))
             type Holder data struct {
-                Value int32
+                var Value int32
             }
             """;
 
@@ -363,8 +363,8 @@ public class AttributeEmitTests
 
             type Point data struct {
                 @Obsolete("use NewX")
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
             """;
 
@@ -396,7 +396,7 @@ public class AttributeEmitTests
 
             type Box class {
                 @Obsolete("retired")
-                Value int32
+                var Value int32
             }
             """;
 

--- a/test/Compiler.Tests/Emit/DataStructInteropTests.cs
+++ b/test/Compiler.Tests/Emit/DataStructInteropTests.cs
@@ -26,8 +26,8 @@ public class DataStructInteropTests
             import System
 
             type Point data struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
             """;
 
@@ -55,8 +55,8 @@ public class DataStructInteropTests
             import System
 
             type Point data struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
             """;
 
@@ -85,8 +85,8 @@ public class DataStructInteropTests
             import System
 
             type Point data struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
 
             type UserId inline struct(value int32)
@@ -114,15 +114,15 @@ public class DataStructInteropTests
             import System
 
             type Point data struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
 
             type UserId inline struct(value int32)
 
             type Foo class {
-                Name string
-                Count int32
+                var Name string
+                var Count int32
             }
             """;
 

--- a/test/Compiler.Tests/Emit/DataStructSynthesizedMembersTests.cs
+++ b/test/Compiler.Tests/Emit/DataStructSynthesizedMembersTests.cs
@@ -28,8 +28,8 @@ public class DataStructSynthesizedMembersTests
             import System
 
             type Point data struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
             """;
 
@@ -53,8 +53,8 @@ public class DataStructSynthesizedMembersTests
             import System
 
             type Point data struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
             """;
 
@@ -79,8 +79,8 @@ public class DataStructSynthesizedMembersTests
             import System
 
             type Point data struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
             """;
 
@@ -105,8 +105,8 @@ public class DataStructSynthesizedMembersTests
             import System
 
             type Point data struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
             """;
 
@@ -134,8 +134,8 @@ public class DataStructSynthesizedMembersTests
             import System
 
             type Point data struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
             """;
 
@@ -157,8 +157,8 @@ public class DataStructSynthesizedMembersTests
             import System
 
             type Pair data struct {
-                Name string
-                Count int32
+                var Name string
+                var Count int32
             }
             """;
 
@@ -182,8 +182,8 @@ public class DataStructSynthesizedMembersTests
             import System
 
             type Point data struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
             """;
 
@@ -213,8 +213,8 @@ public class DataStructSynthesizedMembersTests
             import System
 
             type Point data struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
             """;
 
@@ -239,8 +239,8 @@ public class DataStructSynthesizedMembersTests
             import System
 
             type Pair data struct {
-                Name string
-                Count int32
+                var Name string
+                var Count int32
             }
             """;
 
@@ -269,15 +269,15 @@ public class DataStructSynthesizedMembersTests
             import System
 
             type Big data struct {
-                A int32
-                B int32
-                C int32
-                D int32
-                E int32
-                F int32
-                G int32
-                H int32
-                I int32
+                var A int32
+                var B int32
+                var C int32
+                var D int32
+                var E int32
+                var F int32
+                var G int32
+                var H int32
+                var I int32
             }
             """;
 
@@ -317,8 +317,8 @@ public class DataStructSynthesizedMembersTests
             import System
 
             type Pair data struct {
-                Name string
-                Count int32
+                var Name string
+                var Count int32
             }
             """;
 
@@ -359,8 +359,8 @@ public class DataStructSynthesizedMembersTests
             import System
 
             type Point data struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
             """;
 
@@ -379,7 +379,7 @@ public class DataStructSynthesizedMembersTests
             import System
 
             type Box[T any] data struct {
-                Value T
+                var Value T
             }
             """;
 

--- a/test/Compiler.Tests/Emit/EnumEmitTests.cs
+++ b/test/Compiler.Tests/Emit/EnumEmitTests.cs
@@ -167,16 +167,16 @@ public class EnumEmitTests
             import System
 
             type S1 data struct {
-                A int32
-                B int32
+                var A int32
+                var B int32
             }
             type S2 data struct {
-                X int32
-                Y int32
-                Z int32
+                var X int32
+                var Y int32
+                var Z int32
             }
             type S3 data struct {
-                N int32
+                var N int32
             }
 
             type Color enum { Red, Green, Blue }

--- a/test/Compiler.Tests/Emit/EventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/EventEmitTests.cs
@@ -351,7 +351,7 @@ public class EventEmitTests
             import System
 
             type Counter class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
                 func Increment() { Value = Value + 1 }
             }
@@ -362,8 +362,8 @@ public class EventEmitTests
             }
 
             type Probe class {
-                Counter Counter
-                Src Source
+                var Counter Counter
+                var Src Source
                 init() {
                     Counter = Counter()
                     Src = Source()
@@ -413,7 +413,7 @@ public class EventEmitTests
             }
 
             type Probe class {
-                N Notifier
+                var N Notifier
                 init() {
                     N = Notifier()
                     N.Fired += func(sender object, e EventArgs) {
@@ -449,7 +449,7 @@ public class EventEmitTests
             import System
 
             type Counter class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
                 func Bump() { Value = Value + 1 }
             }
@@ -460,8 +460,8 @@ public class EventEmitTests
             }
 
             type Probe class {
-                Counter Counter
-                Src Source
+                var Counter Counter
+                var Src Source
                 init() {
                     Counter = Counter()
                     Src = Source()
@@ -534,7 +534,7 @@ public class EventEmitTests
             import System
 
             type Counter class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
                 func Bump() { Value = Value + 1 }
             }
@@ -545,13 +545,13 @@ public class EventEmitTests
             }
 
             type Outer class {
-                Inner Inner
+                var Inner Inner
                 init() { Inner = Inner() }
             }
 
             type Probe class {
-                Counter Counter
-                O Outer
+                var Counter Counter
+                var O Outer
                 init() {
                     Counter = Counter()
                     O = Outer()
@@ -596,12 +596,12 @@ public class EventEmitTests
             }
 
             type Outer class {
-                Inner Inner
+                var Inner Inner
                 init() { Inner = Inner() }
             }
 
             type Probe class {
-                O Outer
+                var O Outer
                 init() {
                     O = Outer()
                     O.Inner.Fired += func(s object, e EventArgs) {
@@ -637,7 +637,7 @@ public class EventEmitTests
             import System
 
             type Counter class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
                 func Bump() { Value = Value + 1 }
             }
@@ -648,14 +648,14 @@ public class EventEmitTests
             }
 
             type Outer class {
-                Inner Inner
+                var Inner Inner
                 init() { Inner = Inner() }
             }
 
             type Probe class {
-                Counter Counter
-                O Outer
-                Handler EventHandler
+                var Counter Counter
+                var O Outer
+                var Handler EventHandler
                 init() {
                     Counter = Counter()
                     O = Outer()
@@ -713,8 +713,8 @@ public class EventEmitTests
             }
 
             type Probe class {
-                Src Source
-                Hits int32
+                var Src Source
+                var Hits int32
                 init() {
                     Src = Source()
                     Hits = 0
@@ -762,8 +762,8 @@ public class EventEmitTests
             }
 
             type Probe class {
-                Src Source
-                Hits int32
+                var Src Source
+                var Hits int32
                 init() {
                     Src = Source()
                     Hits = 0
@@ -808,8 +808,8 @@ public class EventEmitTests
             }
 
             type Probe class {
-                Src Source
-                Hits int32
+                var Src Source
+                var Hits int32
                 init() {
                     Src = Source()
                     Hits = 0

--- a/test/Compiler.Tests/Emit/FieldAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/FieldAssignmentEmitTests.cs
@@ -33,8 +33,8 @@ public class FieldAssignmentEmitTests
             import System
 
             type Point struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
 
             var p = Point{X: 1, Y: 2}
@@ -54,8 +54,8 @@ public class FieldAssignmentEmitTests
             import System
 
             type Point struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
 
             var p = Point{X: 1, Y: 2}
@@ -76,7 +76,7 @@ public class FieldAssignmentEmitTests
             import System
 
             type Box class {
-                Value int32
+                var Value int32
             }
 
             var b = Box{Value: 1}
@@ -94,7 +94,7 @@ public class FieldAssignmentEmitTests
             import System
 
             type Box class {
-                Value int32
+                var Value int32
             }
 
             var b = Box{Value: 1}
@@ -117,8 +117,8 @@ public class FieldAssignmentEmitTests
             import System
 
             type Point struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
 
             var p = Point{X: 10, Y: 0}

--- a/test/Compiler.Tests/Emit/GenericTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/GenericTypeEmitTests.cs
@@ -30,7 +30,7 @@ public class GenericTypeEmitTests
             import System
 
             type Box[T any] data struct {
-                Value T
+                var Value T
             }
 
             let b = Box[int32]{Value: 42}
@@ -49,7 +49,7 @@ public class GenericTypeEmitTests
             import System
 
             type Box[T any] data struct {
-                Value T
+                var Value T
             }
 
             let b = Box[string]{Value: "hi"}
@@ -104,8 +104,8 @@ public class GenericTypeEmitTests
             import System
 
             type Pair[A any, B any] data struct {
-                First A
-                Second B
+                var First A
+                var Second B
             }
 
             let p = Pair[int32, string]{First: 3, Second: "x"}
@@ -127,7 +127,7 @@ public class GenericTypeEmitTests
             import System
 
             type Box[T any] data struct {
-                Value T
+                var Value T
             }
 
             let b = Box[int32]{Value: 20}

--- a/test/Compiler.Tests/Emit/Issue454ReceiverPredicateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue454ReceiverPredicateEmitTests.cs
@@ -48,7 +48,7 @@ public class Issue454ReceiverPredicateEmitTests
             import System.Text
 
             type Box struct {
-                sb StringBuilder
+                var sb StringBuilder
             }
 
             let b = Box{sb: StringBuilder("hello")}
@@ -151,8 +151,8 @@ public class Issue454ReceiverPredicateEmitTests
             import System
 
             type Point struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
                 prop Sum int32 {
                     get { return this.X + this.Y }
                 }

--- a/test/Compiler.Tests/Emit/Issue502AsyncUserClassReturnTypeTests.cs
+++ b/test/Compiler.Tests/Emit/Issue502AsyncUserClassReturnTypeTests.cs
@@ -69,7 +69,7 @@ public class Issue502AsyncUserClassReturnTypeTests
             import System.Threading.Tasks
 
             type AsyncCC class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
             }
 

--- a/test/Compiler.Tests/Emit/Issue503ClosureCaptureRegressionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue503ClosureCaptureRegressionTests.cs
@@ -37,14 +37,14 @@ public class Issue503ClosureCaptureRegressionTests
             }
 
             type Counter class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
                 func Increment() { Value = Value + 1 }
             }
 
             type Probe class {
-                Src Source
-                Cnt Counter
+                var Src Source
+                var Cnt Counter
                 init() {
                     Src = Source()
                     Cnt = Counter()
@@ -87,14 +87,14 @@ public class Issue503ClosureCaptureRegressionTests
             }
 
             type Counter class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
                 func Increment() { Value = Value + 1 }
             }
 
             type Probe class {
-                Src Source
-                Cnt Counter
+                var Src Source
+                var Cnt Counter
                 init() {
                     Src = Source()
                     Cnt = Counter()
@@ -136,14 +136,14 @@ public class Issue503ClosureCaptureRegressionTests
             }
 
             type Counter class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
                 func Increment() { Value = Value + 1 }
             }
 
             type Probe class {
-                Src Source
-                Cnt Counter
+                var Src Source
+                var Cnt Counter
                 init() {
                     Src = Source()
                     Cnt = Counter()
@@ -180,8 +180,8 @@ public class Issue503ClosureCaptureRegressionTests
             }
 
             type Probe class {
-                Src Source
-                Hits int32
+                var Src Source
+                var Hits int32
                 init() {
                     Src = Source()
                     Hits = 0
@@ -213,7 +213,7 @@ public class Issue503ClosureCaptureRegressionTests
             import System
 
             type Counter class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
                 func Add(n int32) { Value = Value + n }
             }
@@ -224,9 +224,9 @@ public class Issue503ClosureCaptureRegressionTests
             }
 
             type Probe class {
-                Src Source
-                A Counter
-                B Counter
+                var Src Source
+                var A Counter
+                var B Counter
                 init() {
                     Src = Source()
                     A = Counter()
@@ -269,7 +269,7 @@ public class Issue503ClosureCaptureRegressionTests
             import System
 
             type Counter class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
                 func Increment() { Value = Value + 1 }
             }
@@ -298,7 +298,7 @@ public class Issue503ClosureCaptureRegressionTests
             import System
 
             type Counter class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
                 func Increment() { Value = Value + 1 }
             }
@@ -335,7 +335,7 @@ public class Issue503ClosureCaptureRegressionTests
             }
 
             type Counter class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
                 func Increment() { Value = Value + 1 }
             }
@@ -365,7 +365,7 @@ public class Issue503ClosureCaptureRegressionTests
             import System
 
             type Counter class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
                 func Increment() { Value = Value + 1 }
             }
@@ -376,9 +376,9 @@ public class Issue503ClosureCaptureRegressionTests
             }
 
             type Probe class {
-                Src Source
-                Original Counter
-                Replacement Counter
+                var Src Source
+                var Original Counter
+                var Replacement Counter
                 init() {
                     Src = Source()
                     var c = Counter()
@@ -431,13 +431,13 @@ public class Issue503ClosureCaptureRegressionTests
             import System
 
             type Counter class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
                 func Increment() { Value = Value + 1 }
             }
 
             type Probe class {
-                Cnt Counter
+                var Cnt Counter
                 init() {
                     Cnt = Counter()
                     var counter = Cnt
@@ -469,7 +469,7 @@ public class Issue503ClosureCaptureRegressionTests
             import System
 
             type Counter class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
                 func Increment() { Value = Value + 1 }
             }
@@ -480,8 +480,8 @@ public class Issue503ClosureCaptureRegressionTests
             }
 
             type Probe class {
-                Src Source
-                Cnt Counter
+                var Src Source
+                var Cnt Counter
                 init() {
                     Src = Source()
                     Cnt = Counter()
@@ -743,7 +743,7 @@ public class Issue503ClosureCaptureRegressionTests
             import System
 
             type Counter class {
-                Value int32
+                var Value int32
                 init() { Value = 0 }
                 func Increment() { Value = Value + 1 }
             }

--- a/test/Compiler.Tests/Emit/Issue507MemberIndexAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue507MemberIndexAssignmentEmitTests.cs
@@ -41,7 +41,7 @@ public class Issue507MemberIndexAssignmentEmitTests
             import System.Collections.Generic
 
             type Holder struct {
-                Map Dictionary[string, int32]
+                var Map Dictionary[string, int32]
             }
 
             func MakeHolder() Holder {
@@ -72,11 +72,11 @@ public class Issue507MemberIndexAssignmentEmitTests
             import System.Collections.Generic
 
             type Inner struct {
-                Map Dictionary[string, int32]
+                var Map Dictionary[string, int32]
             }
 
             type Outer struct {
-                InnerObj Inner
+                var InnerObj Inner
             }
 
             func MakeOuter() Outer {
@@ -131,7 +131,7 @@ public class Issue507MemberIndexAssignmentEmitTests
             import System
 
             type Holder struct {
-                Value int32
+                var Value int32
             }
 
             func (h Holder) Pick[T](v T) int32 {
@@ -157,7 +157,7 @@ public class Issue507MemberIndexAssignmentEmitTests
             import System.Collections.Generic
 
             type Holder struct {
-                Map Dictionary[string, int32]
+                var Map Dictionary[string, int32]
             }
 
             let h = Holder{Map: Dictionary[string, int32]()}
@@ -205,7 +205,7 @@ public class Issue507MemberIndexAssignmentEmitTests
             import System.Collections.Generic
 
             type Holder struct {
-                Map Dictionary[string, int32]
+                var Map Dictionary[string, int32]
             }
 
             let h = Holder{Map: Dictionary[string, int32]()}
@@ -229,7 +229,7 @@ public class Issue507MemberIndexAssignmentEmitTests
             import System.Collections.Generic
 
             type Holder struct {
-                Map Dictionary[string, int32]
+                var Map Dictionary[string, int32]
             }
 
             let h = Holder{Map: Dictionary[string, int32]()}
@@ -252,7 +252,7 @@ public class Issue507MemberIndexAssignmentEmitTests
             import System.Collections.Generic
 
             type Holder struct {
-                Map Dictionary[string, int32]
+                var Map Dictionary[string, int32]
             }
 
             let h = Holder{Map: Dictionary[string, int32]()}
@@ -300,11 +300,11 @@ public class Issue507MemberIndexAssignmentEmitTests
             import System.Collections.Generic
 
             type Inner struct {
-                Map Dictionary[string, int32]
+                var Map Dictionary[string, int32]
             }
 
             type Outer struct {
-                InnerObj Inner
+                var InnerObj Inner
             }
 
             let o = Outer{InnerObj: Inner{Map: Dictionary[string, int32]()}}
@@ -331,7 +331,7 @@ public class Issue507MemberIndexAssignmentEmitTests
             import System.Collections.Generic
 
             type Bag struct {
-                Map Dictionary[string, int32]
+                var Map Dictionary[string, int32]
             }
 
             public var calls = 0

--- a/test/Compiler.Tests/Emit/Issue523ClosureCaptureByRefTests.cs
+++ b/test/Compiler.Tests/Emit/Issue523ClosureCaptureByRefTests.cs
@@ -215,8 +215,8 @@ public class Issue523ClosureCaptureByRefTests
             import System
 
             type Holder class {
-                public First func() int32
-                public Second func() int32
+                public var First func() int32
+                public var Second func() int32
                 init() {}
             }
 

--- a/test/Compiler.Tests/Emit/Issue524DefaultCtorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue524DefaultCtorEmitTests.cs
@@ -39,9 +39,9 @@ public class Issue524DefaultCtorEmitTests
             import System
 
             type Holder class {
-                Value int32
-                Name  string
-                Flag  bool
+                var Value int32
+                var Name  string
+                var Flag  bool
             }
 
             var h = Holder()
@@ -67,7 +67,7 @@ public class Issue524DefaultCtorEmitTests
             import System
 
             type Counter class {
-                Count int32
+                var Count int32
 
                 func Get() int32 {
                     return this.Count
@@ -118,8 +118,8 @@ public class Issue524DefaultCtorEmitTests
             import System
 
             type Point class {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
 
                 init(x int32, y int32) {
                     X = x
@@ -166,7 +166,7 @@ public class Issue524DefaultCtorEmitTests
             package P
             import System
 
-            type Holder class { Value int32 }
+            type Holder class { var Value int32 }
 
             var h = Holder(1)
             Console.WriteLine(h.Value)
@@ -280,7 +280,7 @@ public class Issue524DefaultCtorEmitTests
             import System
 
             type Box[T] class {
-                Value T
+                var Value T
             }
 
             var bs = Box[string]()

--- a/test/Compiler.Tests/Emit/Issue527StructDelegateFieldEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue527StructDelegateFieldEmitTests.cs
@@ -236,7 +236,7 @@ public class Issue527StructDelegateFieldEmitTests
             import System
 
             type CallbackBag struct {
-                OnAsk func() string
+                var OnAsk func() string
             }
 
             var bag = CallbackBag{ OnAsk: func() string { return "hi" } }

--- a/test/Compiler.Tests/Emit/Issue533NullToNullableParameterEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue533NullToNullableParameterEmitTests.cs
@@ -110,7 +110,7 @@ public class Issue533NullToNullableParameterEmitTests
             import System
 
             type Box class {
-                Value int32?
+                var Value int32?
 
                 init(v int32?) {
                     Value = v
@@ -135,7 +135,7 @@ public class Issue533NullToNullableParameterEmitTests
             import System
 
             type Wrapper class {
-                Text string?
+                var Text string?
 
                 init(t string?) {
                     Text = t

--- a/test/Compiler.Tests/Emit/Issue567ClockHolderRegressionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue567ClockHolderRegressionTests.cs
@@ -33,7 +33,7 @@ public class Issue567ClockHolderRegressionTests
             import System
 
             type ClockHolder class {
-                Value int32
+                var Value int32
                 init() {}
             }
 
@@ -68,7 +68,7 @@ public class Issue567ClockHolderRegressionTests
             import System
 
             type ClockHolder class {
-                Value int32
+                var Value int32
                 init() {}
             }
 
@@ -164,7 +164,7 @@ public class Issue567ClockHolderRegressionTests
             import System
 
             type Counter class {
-                N int32
+                var N int32
                 init() {}
             }
 
@@ -201,7 +201,7 @@ public class Issue567ClockHolderRegressionTests
             import System
 
             type Holder class {
-                Val int32
+                var Val int32
                 init() {}
             }
 
@@ -240,7 +240,7 @@ public class Issue567ClockHolderRegressionTests
             import System
 
             type Box class {
-                X int32
+                var X int32
                 init() {}
             }
 
@@ -271,7 +271,7 @@ public class Issue567ClockHolderRegressionTests
             import System
 
             type State class {
-                Running bool
+                var Running bool
                 init() {}
             }
 

--- a/test/Compiler.Tests/Emit/Issue573FieldSatisfiesGetterPropertyContractTests.cs
+++ b/test/Compiler.Tests/Emit/Issue573FieldSatisfiesGetterPropertyContractTests.cs
@@ -38,7 +38,7 @@ public class Issue573FieldSatisfiesGetterPropertyContractTests
             import ProbeRef
 
             type Impl1 class : IHasName {
-                Name string
+                var Name string
             }
 
             var impl = Impl1{Name: "hello"}
@@ -69,7 +69,7 @@ public class Issue573FieldSatisfiesGetterPropertyContractTests
             import ProbeRef
 
             type Impl1 class : IHasName {
-                Name string
+                var Name string
             }
 
             var impl = Impl1{Name: "hello"}
@@ -133,7 +133,7 @@ public class Issue573FieldSatisfiesGetterPropertyContractTests
             import ProbeRef
 
             type RWImpl class : IReadWrite {
-                Value string
+                var Value string
             }
 
             var impl = RWImpl{Value: "initial"}

--- a/test/Compiler.Tests/Emit/Issue606FieldRwPropertyTests.cs
+++ b/test/Compiler.Tests/Emit/Issue606FieldRwPropertyTests.cs
@@ -37,7 +37,7 @@ public class Issue606FieldRwPropertyTests
             import ProbeRef606
 
             type Impl class : IReadWrite {
-                Value string
+                var Value string
             }
 
             var impl = Impl{Value: "hello"}
@@ -70,7 +70,7 @@ public class Issue606FieldRwPropertyTests
             import ProbeRef606
 
             type Counter class : ICounter {
-                Count int32
+                var Count int32
             }
 
             var c = Counter{Count: 0}
@@ -102,7 +102,7 @@ public class Issue606FieldRwPropertyTests
             import ProbeRef606
 
             type Named class : IReadWrite {
-                Name string
+                var Name string
             }
 
             var n = Named{Name: "initial"}
@@ -135,7 +135,7 @@ public class Issue606FieldRwPropertyTests
             import ProbeRef606
 
             type GetImpl class : IGetOnly {
-                Name string
+                var Name string
             }
 
             var impl = GetImpl{Name: "getter-only"}
@@ -167,7 +167,7 @@ public class Issue606FieldRwPropertyTests
             import ProbeRef606
 
             type BadImpl class : IReadWrite {
-                private Value string
+                private var Value string
             }
             """;
 
@@ -195,7 +195,7 @@ public class Issue606FieldRwPropertyTests
             import ProbeRef606
 
             type BadImpl class : IReadWrite {
-                Value int32
+                var Value int32
             }
             """;
 

--- a/test/Compiler.Tests/Emit/Issue640FieldInitializerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue640FieldInitializerEmitTests.cs
@@ -28,7 +28,7 @@ public class Issue640FieldInitializerEmitTests
             import System
 
             type Holder class {
-                n int32 = 42
+                var n int32 = 42
                 func Get() int32 { return n }
             }
 
@@ -48,7 +48,7 @@ public class Issue640FieldInitializerEmitTests
             import System
 
             type Holder class {
-                n int64 = 100
+                var n int64 = 100
                 func Get() int64 { return n }
             }
 
@@ -68,7 +68,7 @@ public class Issue640FieldInitializerEmitTests
             import System
 
             type Holder class {
-                flag bool = true
+                var flag bool = true
                 func Get() bool { return flag }
             }
 
@@ -88,7 +88,7 @@ public class Issue640FieldInitializerEmitTests
             import System
 
             type Holder class {
-                s string = "hello"
+                var s string = "hello"
                 func Get() string { return s }
             }
 
@@ -108,7 +108,7 @@ public class Issue640FieldInitializerEmitTests
             import System
 
             type Holder class {
-                c int32 = 1 + 2 * 3
+                var c int32 = 1 + 2 * 3
                 func Get() int32 { return c }
             }
 
@@ -128,9 +128,9 @@ public class Issue640FieldInitializerEmitTests
             import System
 
             type Multi class {
-                a int32 = 10
-                b int32 = 20
-                c string = "abc"
+                var a int32 = 10
+                var b int32 = 20
+                var c string = "abc"
                 func Show() string {
                     return a.ToString() + "," + b.ToString() + "," + c
                 }
@@ -153,8 +153,8 @@ public class Issue640FieldInitializerEmitTests
             import System
 
             type Widget class {
-                baseValue int32 = 100
-                extra int32
+                var baseValue int32 = 100
+                var extra int32
 
                 init(e int32) {
                     extra = e
@@ -179,7 +179,7 @@ public class Issue640FieldInitializerEmitTests
             import System
 
             type Thing class(name string) {
-                prefix string = "Item:"
+                var prefix string = "Item:"
                 func Label() string { return prefix + name }
             }
 
@@ -200,8 +200,8 @@ public class Issue640FieldInitializerEmitTests
             import System
 
             type Dual class {
-                tag string = "default"
-                n int32
+                var tag string = "default"
+                var n int32
 
                 init(x int32) {
                     n = x
@@ -226,12 +226,12 @@ public class Issue640FieldInitializerEmitTests
             import System
 
             type Base open class {
-                baseVal int32 = 1
+                var baseVal int32 = 1
                 func GetBase() int32 { return baseVal }
             }
 
             type Derived class : Base {
-                derivedVal int32 = 2
+                var derivedVal int32 = 2
                 func GetDerived() int32 { return derivedVal }
             }
 
@@ -253,8 +253,8 @@ public class Issue640FieldInitializerEmitTests
             import System
 
             type Mixed class {
-                initialized int32 = 42
-                uninitialized int32
+                var initialized int32 = 42
+                var uninitialized int32
                 func Show() string {
                     return initialized.ToString() + "," + uninitialized.ToString()
                 }
@@ -276,7 +276,7 @@ public class Issue640FieldInitializerEmitTests
             import System
 
             type Holder class {
-                d float64 = 3.14
+                var d float64 = 3.14
                 func Get() float64 { return d }
             }
 
@@ -298,7 +298,7 @@ public class Issue640FieldInitializerEmitTests
             import System
 
             type Override class {
-                n int32 = 10
+                var n int32 = 10
 
                 init(value int32) {
                     n = value

--- a/test/Compiler.Tests/Emit/Issue641AsyncIteratorClassMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue641AsyncIteratorClassMemberEmitTests.cs
@@ -108,7 +108,7 @@ public class Issue641AsyncIteratorClassMemberEmitTests
             import System.Threading.Tasks
 
             type CapturingExecutor class {
-                Calls int32
+                var Calls int32
                 init() {}
 
                 async func ProduceAsync() async sequence[int32] {

--- a/test/Compiler.Tests/Emit/Issue648ChainedMemberAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue648ChainedMemberAssignmentEmitTests.cs
@@ -34,12 +34,12 @@ public class Issue648ChainedMemberAssignmentEmitTests
             import System
 
             type Inner class {
-                Value int32
+                var Value int32
                 init() {}
             }
 
             type Outer class {
-                Inner Inner
+                var Inner Inner
                 init() { Inner = Inner() }
             }
 
@@ -65,7 +65,7 @@ public class Issue648ChainedMemberAssignmentEmitTests
             }
 
             type Outer class {
-                Inner Inner
+                var Inner Inner
                 init() { Inner = Inner() }
             }
 
@@ -86,17 +86,17 @@ public class Issue648ChainedMemberAssignmentEmitTests
             import System
 
             type Leaf class {
-                Val int32
+                var Val int32
                 init() {}
             }
 
             type Mid class {
-                Leaf Leaf
+                var Leaf Leaf
                 init() { Leaf = Leaf() }
             }
 
             type Root class {
-                Mid Mid
+                var Mid Mid
                 init() { Mid = Mid() }
             }
 
@@ -117,12 +117,12 @@ public class Issue648ChainedMemberAssignmentEmitTests
             import System
 
             type Inner class {
-                Value int32
+                var Value int32
                 init() {}
             }
 
             type Outer class {
-                _inner Inner
+                var _inner Inner
                 init() { _inner = Inner() }
                 func GetInner() Inner { return _inner }
             }
@@ -144,12 +144,12 @@ public class Issue648ChainedMemberAssignmentEmitTests
             import System
 
             type Inner class {
-                Value int32
+                var Value int32
                 init() {}
             }
 
             type Outer class {
-                Inner Inner
+                var Inner Inner
                 init() { Inner = Inner() }
             }
 
@@ -171,12 +171,12 @@ public class Issue648ChainedMemberAssignmentEmitTests
             import System
 
             type Inner class {
-                Value int32
+                var Value int32
                 init() {}
             }
 
             type Outer class {
-                Inner Inner
+                var Inner Inner
                 init() { Inner = Inner() }
             }
 
@@ -198,7 +198,7 @@ public class Issue648ChainedMemberAssignmentEmitTests
             import System
 
             type Box class {
-                Value int32
+                var Value int32
                 init() {}
             }
 
@@ -232,7 +232,7 @@ public class Issue648ChainedMemberAssignmentEmitTests
             }
 
             type Outer class {
-                _inner Inner
+                var _inner Inner
                 prop Inner Inner {
                     get { return _inner }
                     set { _inner = value }

--- a/test/Compiler.Tests/Emit/Issue649TupleClrRefTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue649TupleClrRefTypeEmitTests.cs
@@ -152,7 +152,7 @@ public class Issue649TupleClrRefTypeEmitTests
             import Probe.CSharp
 
             type MyClass class {
-                Name string
+                var Name string
                 init() {}
             }
 
@@ -201,7 +201,7 @@ public class Issue649TupleClrRefTypeEmitTests
             import Probe.CSharp
 
             type Container class {
-                Data (Holder, int32)
+                var Data (Holder, int32)
                 init() {
                     Data = (Holder() { A = "field" }, 99)
                 }

--- a/test/Compiler.Tests/Emit/Issue655AsyncIteratorFieldAccessEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue655AsyncIteratorFieldAccessEmitTests.cs
@@ -33,12 +33,12 @@ public class Issue655AsyncIteratorFieldAccessEmitTests
             import System.Threading.Tasks
 
             type Counter class {
-                Value int32
+                var Value int32
                 func Enter() { Value++ }
             }
 
             type Probe class {
-                Counter Counter = Counter()
+                var Counter Counter = Counter()
 
                 async func GetAsync() IAsyncEnumerable[int32] {
                     Counter.Enter()
@@ -79,7 +79,7 @@ public class Issue655AsyncIteratorFieldAccessEmitTests
             import System.Threading.Tasks
 
             type Sensor class {
-                Reading int32
+                var Reading int32
 
                 async func Measure() IAsyncEnumerable[int32] {
                     Reading = 10
@@ -120,7 +120,7 @@ public class Issue655AsyncIteratorFieldAccessEmitTests
             import System.Threading.Tasks
 
             type Tracker class {
-                Writes int32
+                var Writes int32
 
                 async func Track() IAsyncEnumerable[int32] {
                     Writes = 1
@@ -165,12 +165,12 @@ public class Issue655AsyncIteratorFieldAccessEmitTests
             import System.Threading.Tasks
 
             type Accumulator class {
-                Total int32
+                var Total int32
                 func Add(n int32) { Total = Total + n }
             }
 
             type Worker class {
-                Acc Accumulator = Accumulator()
+                var Acc Accumulator = Accumulator()
 
                 async func Process() IAsyncEnumerable[int32] {
                     Acc.Add(10)
@@ -211,7 +211,7 @@ public class Issue655AsyncIteratorFieldAccessEmitTests
             import System.Threading.Tasks
 
             type Sequencer class {
-                Step int32
+                var Step int32
 
                 async func Generate() IAsyncEnumerable[int32] {
                     Step++
@@ -251,8 +251,8 @@ public class Issue655AsyncIteratorFieldAccessEmitTests
             import System.Threading.Tasks
 
             type State class {
-                A int32
-                B int32
+                var A int32
+                var B int32
 
                 async func Compute() IAsyncEnumerable[int32] {
                     A = 1
@@ -294,7 +294,7 @@ public class Issue655AsyncIteratorFieldAccessEmitTests
             import System.Threading.Tasks
 
             type Config class {
-                Scale int32
+                var Scale int32
 
                 init(s int32) {
                     Scale = s
@@ -336,12 +336,12 @@ public class Issue655AsyncIteratorFieldAccessEmitTests
             import System.Threading.Tasks
 
             type Counter class {
-                Value int32
+                var Value int32
                 func Enter() { Value++ }
             }
 
             type Probe class {
-                Counter Counter = Counter()
+                var Counter Counter = Counter()
 
                 async func GetAsync() async sequence[int32] {
                     Counter.Enter()

--- a/test/Compiler.Tests/Emit/Issue656InitAsPrimaryCtorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue656InitAsPrimaryCtorEmitTests.cs
@@ -54,7 +54,7 @@ public class Issue656InitAsPrimaryCtorEmitTests
             import System
 
             type FakeJobService class : IJobService {
-                Active List[JobSnapshot]
+                var Active List[JobSnapshot]
                 func init() {
                     Active = List[JobSnapshot]()
                 }
@@ -98,7 +98,7 @@ public class Issue656InitAsPrimaryCtorEmitTests
             import System
 
             type FakeJobService class : IJobService {
-                Active List[JobSnapshot]
+                var Active List[JobSnapshot]
                 init() {
                     Active = List[JobSnapshot]()
                 }
@@ -129,9 +129,9 @@ public class Issue656InitAsPrimaryCtorEmitTests
             import System
 
             type LifecycleTab class {
-                Title string
-                Key string
-                Active bool = false
+                var Title string
+                var Key string
+                var Active bool = false
                 func init(title string, key string) {
                     Title = title
                     Key = key
@@ -160,7 +160,7 @@ public class Issue656InitAsPrimaryCtorEmitTests
             import System
 
             type Counter class {
-                Value int32
+                var Value int32
                 func init() {
                     Value = 42
                 }
@@ -186,7 +186,7 @@ public class Issue656InitAsPrimaryCtorEmitTests
             import System
 
             type Greeting class {
-                Message string
+                var Message string
                 func init(name string) {
                     Message = "Hello, " + name + "!"
                 }
@@ -212,8 +212,8 @@ public class Issue656InitAsPrimaryCtorEmitTests
             import System
 
             type Config class {
-                Name string = "default"
-                Count int32
+                var Name string = "default"
+                var Count int32
                 func init() {
                     Count = 7
                 }
@@ -245,7 +245,7 @@ public class Issue656InitAsPrimaryCtorEmitTests
             import System
 
             type Dual class(Name string) {
-                Age int32
+                var Age int32
                 func init(age int32) {
                     Age = age
                 }
@@ -295,9 +295,9 @@ public class Issue656InitAsPrimaryCtorEmitTests
             import System
 
             type Color class {
-                R int32
-                G int32
-                B int32
+                var R int32
+                var G int32
+                var B int32
                 init(r int32, g int32, b int32) {
                     R = r
                     G = g
@@ -344,8 +344,8 @@ public class Issue656InitAsPrimaryCtorEmitTests
             import System
 
             type TextRenderer class : IRenderer {
-                Prefix string
-                Suffix string
+                var Prefix string
+                var Suffix string
                 func init() {
                     Prefix = "["
                     Suffix = "]"

--- a/test/Compiler.Tests/Emit/Issue671ConstructionCallEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue671ConstructionCallEmitTests.cs
@@ -27,7 +27,7 @@ public class Issue671ConstructionCallEmitTests
             import System.Collections.Generic
 
             type MyGs class {
-                Name string = ""
+                var Name string = ""
             }
 
             let xs = List[MyGs]()
@@ -75,7 +75,7 @@ public class Issue671ConstructionCallEmitTests
             import System.Collections.Generic
 
             type MyGs class {
-                Name string = ""
+                var Name string = ""
             }
 
             let kvp = KeyValuePair[string, MyGs]("k", MyGs())
@@ -95,7 +95,7 @@ public class Issue671ConstructionCallEmitTests
             import System.Collections.Generic
 
             type MyGs class {
-                Name string = ""
+                var Name string = ""
             }
 
             let outer = List[List[MyGs]]()
@@ -117,7 +117,7 @@ public class Issue671ConstructionCallEmitTests
             import System
 
             type MyGs class {
-                Name string = ""
+                var Name string = ""
             }
 
             let xs = System.Collections.Generic.List[MyGs]()

--- a/test/Compiler.Tests/Emit/Issue671UserTypeAsClrGenericArgEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue671UserTypeAsClrGenericArgEmitTests.cs
@@ -26,11 +26,11 @@ public class Issue671UserTypeAsClrGenericArgEmitTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             type Container class {
-                items List[MyType]
+                var items List[MyType]
             }
 
             let c = Container()
@@ -53,11 +53,11 @@ public class Issue671UserTypeAsClrGenericArgEmitTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             type Container class {
-                items List[MyType]
+                var items List[MyType]
 
                 func getItems() List[MyType] {
                     return items
@@ -83,7 +83,7 @@ public class Issue671UserTypeAsClrGenericArgEmitTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             type Container class {
@@ -108,11 +108,11 @@ public class Issue671UserTypeAsClrGenericArgEmitTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             type Container class {
-                lookup Dictionary[string, MyType]
+                var lookup Dictionary[string, MyType]
             }
 
             let c = Container()

--- a/test/Compiler.Tests/Emit/Issue674FieldIndexerAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue674FieldIndexerAssignmentEmitTests.cs
@@ -34,7 +34,7 @@ public class Issue674FieldIndexerAssignmentEmitTests
             import System.Collections.Generic
 
             type Bag class {
-                items List[int32] = List[int32]()
+                var items List[int32] = List[int32]()
 
                 func Add(v int32) {
                     items.Add(v)
@@ -75,7 +75,7 @@ public class Issue674FieldIndexerAssignmentEmitTests
             import System.Collections.Generic
 
             type Cache class {
-                data Dictionary[string, int32] = Dictionary[string, int32]()
+                var data Dictionary[string, int32] = Dictionary[string, int32]()
 
                 func Set(key string, value int32) {
                     data[key] = value
@@ -106,7 +106,7 @@ public class Issue674FieldIndexerAssignmentEmitTests
             import System
 
             type Container class {
-                arr []int32 = []int32{0, 0, 0, 0, 0}
+                var arr []int32 = []int32{0, 0, 0, 0, 0}
 
                 func Set(i int32, v int32) {
                     arr[i] = v
@@ -138,7 +138,7 @@ public class Issue674FieldIndexerAssignmentEmitTests
             import System.Collections.Generic
 
             type Holder class {
-                items List[int32] = List[int32]()
+                var items List[int32] = List[int32]()
 
                 init() {
                     items.Add(0)
@@ -171,8 +171,8 @@ public class Issue674FieldIndexerAssignmentEmitTests
             import System.Collections.Generic
 
             type Multi class {
-                names List[string] = List[string]()
-                scores List[int32] = List[int32]()
+                var names List[string] = List[string]()
+                var scores List[int32] = List[int32]()
 
                 init() {
                     names.Add("a")
@@ -216,7 +216,7 @@ public class Issue674FieldIndexerAssignmentEmitTests
             import System.Collections.Generic
 
             type Acc class {
-                vals List[int32] = List[int32]()
+                var vals List[int32] = List[int32]()
 
                 init() {
                     vals.Add(10)
@@ -253,7 +253,7 @@ public class Issue674FieldIndexerAssignmentEmitTests
             import System.Collections.Generic
 
             type Counter class {
-                counts List[int32] = List[int32]()
+                var counts List[int32] = List[int32]()
 
                 init() {
                     counts.Add(0)

--- a/test/Compiler.Tests/Emit/Issue687ColorColorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue687ColorColorEmitTests.cs
@@ -30,7 +30,7 @@ public class Issue687ColorColorEmitTests
             import System.IO
 
             type Entry class {
-                Path string = ""
+                var Path string = ""
 
                 func Build(suffix string) string {
                     return Path.Combine(this.Path, suffix)
@@ -74,7 +74,7 @@ public class Issue687ColorColorEmitTests
             import System.IO
 
             type Probe class {
-                Path string = ""
+                var Path string = ""
 
                 func Len() int32 {
                     return Path.Length

--- a/test/Compiler.Tests/Emit/Issue689AsyncIteratorNestedFieldWriteEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue689AsyncIteratorNestedFieldWriteEmitTests.cs
@@ -36,11 +36,11 @@ public class Issue689AsyncIteratorNestedFieldWriteEmitTests
             import System.Threading.Tasks
 
             type Counter class {
-                Value int32 = 0
+                var Value int32 = 0
             }
 
             type Executor class {
-                Tracker Counter = Counter()
+                var Tracker Counter = Counter()
 
                 async func Run(ct CancellationToken) IAsyncEnumerable[int32] {
                     Tracker.Value = 7
@@ -78,11 +78,11 @@ public class Issue689AsyncIteratorNestedFieldWriteEmitTests
             import System.Threading.Tasks
 
             type Counter class {
-                Value int32 = 0
+                var Value int32 = 0
             }
 
             type Probe class {
-                Tracker Counter = Counter()
+                var Tracker Counter = Counter()
 
                 async func Run() IAsyncEnumerable[int32] {
                     Tracker.Value = Tracker.Value + 1
@@ -121,11 +121,11 @@ public class Issue689AsyncIteratorNestedFieldWriteEmitTests
             import System.Threading.Tasks
 
             type Counter class {
-                Value int32 = 0
+                var Value int32 = 0
             }
 
             type Executor class {
-                Tracker Counter = Counter()
+                var Tracker Counter = Counter()
 
                 async func Run() IAsyncEnumerable[int32] {
                     Tracker.Value = 5
@@ -167,11 +167,11 @@ public class Issue689AsyncIteratorNestedFieldWriteEmitTests
             import System.Threading.Tasks
 
             type Counter class {
-                Value int32 = 0
+                var Value int32 = 0
             }
 
             type Executor class {
-                Tracker Counter = Counter()
+                var Tracker Counter = Counter()
 
                 async func Run() IAsyncEnumerable[int32] {
                     this.Tracker.Value = 42
@@ -210,7 +210,7 @@ public class Issue689AsyncIteratorNestedFieldWriteEmitTests
             import System.Threading.Tasks
 
             type Executor class {
-                PlainNum int32 = 0
+                var PlainNum int32 = 0
 
                 async func Run() IAsyncEnumerable[int32] {
                     PlainNum = 42
@@ -250,11 +250,11 @@ public class Issue689AsyncIteratorNestedFieldWriteEmitTests
             package Probe
 
             type Counter class {
-                Value int32 = 0
+                var Value int32 = 0
             }
 
             type Executor class {
-                Tracker Counter = Counter()
+                var Tracker Counter = Counter()
 
                 func Run() int32 {
                     Tracker.Value = 7
@@ -281,11 +281,11 @@ public class Issue689AsyncIteratorNestedFieldWriteEmitTests
             package Probe
 
             type Counter class {
-                Value int32 = 0
+                var Value int32 = 0
             }
 
             type Executor class {
-                Tracker Counter = Counter()
+                var Tracker Counter = Counter()
 
                 func Run() int32 {
                     Tracker.Value = 1
@@ -320,11 +320,11 @@ public class Issue689AsyncIteratorNestedFieldWriteEmitTests
             import System.Threading.Tasks
 
             type Counter class {
-                Value int32 = 0
+                var Value int32 = 0
             }
 
             type Executor class {
-                Tracker Counter = Counter()
+                var Tracker Counter = Counter()
 
                 async func Run() IAsyncEnumerable[int32] {
                     Tracker.Value += 3
@@ -367,16 +367,16 @@ public class Issue689AsyncIteratorNestedFieldWriteEmitTests
             import System.Threading.Tasks
 
             type Counter class {
-                Value int32 = 0
-                Name string = "init"
+                var Value int32 = 0
+                var Name string = "init"
             }
 
             type Holder class {
-                Inner Counter = Counter()
+                var Inner Counter = Counter()
             }
 
             type Executor class {
-                H Holder = Holder()
+                var H Holder = Holder()
 
                 async func Run() IAsyncEnumerable[int32] {
                     H.Inner.Value = 5
@@ -417,11 +417,11 @@ public class Issue689AsyncIteratorNestedFieldWriteEmitTests
             import System.Collections.Generic
 
             type Counter class {
-                Value int32 = 0
+                var Value int32 = 0
             }
 
             type Executor class {
-                Tracker Counter = Counter()
+                var Tracker Counter = Counter()
 
                 func Run() sequence[int32] {
                     Tracker.Value = 11
@@ -458,11 +458,11 @@ public class Issue689AsyncIteratorNestedFieldWriteEmitTests
             import System.Threading.Tasks
 
             type Counter class {
-                Value int32 = 0
+                var Value int32 = 0
             }
 
             type Executor class {
-                Tracker Counter = Counter()
+                var Tracker Counter = Counter()
 
                 async func Run() async sequence[int32] {
                     Tracker.Value = 21

--- a/test/Compiler.Tests/Emit/Issue693DictionaryConstructionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue693DictionaryConstructionEmitTests.cs
@@ -70,7 +70,7 @@ public class Issue693DictionaryConstructionEmitTests
             import System.Collections.Generic
 
             type MyGs class {
-                Name string = ""
+                var Name string = ""
             }
 
             let d = Dictionary[string, MyGs]()
@@ -95,11 +95,11 @@ public class Issue693DictionaryConstructionEmitTests
             import System.Collections.Generic
 
             type K class {
-                N int32 = 0
+                var N int32 = 0
             }
 
             type V class {
-                N int32 = 0
+                var N int32 = 0
             }
 
             let d = Dictionary[K, V]()
@@ -124,11 +124,11 @@ public class Issue693DictionaryConstructionEmitTests
             import System.Collections.Generic
 
             type MyGs class {
-                Name string = ""
+                var Name string = ""
             }
 
             type Holder class {
-                Map Dictionary[string, MyGs] = Dictionary[string, MyGs]()
+                var Map Dictionary[string, MyGs] = Dictionary[string, MyGs]()
             }
 
             let h = Holder()
@@ -314,7 +314,7 @@ public class Issue693DictionaryConstructionEmitTests
             import System.Collections.Generic
 
             type MyGs class {
-                Name string = ""
+                var Name string = ""
             }
 
             let kvp = KeyValuePair[string, MyGs]("k", MyGs())

--- a/test/Compiler.Tests/Emit/LetFieldEmitTests.cs
+++ b/test/Compiler.Tests/Emit/LetFieldEmitTests.cs
@@ -1,0 +1,101 @@
+// <copyright file="LetFieldEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// ADR-0067 / issue #694: emit tests for `let` fields on user-declared types.
+/// A `let` field maps to a CLR <c>initonly</c> field, mirroring how
+/// <c>readonly</c> fields behave in C#.
+/// </summary>
+public class LetFieldEmitTests
+{
+    [Fact]
+    public void LetField_OnClass_EmitsAsInitOnly()
+    {
+        var source = """
+            package P
+            import System
+
+            type Holder class {
+                public let Name string = "x"
+                init() {}
+            }
+            """;
+
+        var assembly = CompileToAssembly(source, target: "library");
+        var holder = assembly.GetTypes().Single(t => t.Name == "Holder");
+        var field = holder.GetField("Name", BindingFlags.Public | BindingFlags.Instance);
+
+        Assert.NotNull(field);
+        Assert.Equal(typeof(string), field.FieldType);
+        Assert.True(field.IsInitOnly, "`let` field should emit as CLR initonly.");
+    }
+
+    [Fact]
+    public void VarField_OnClass_IsNotInitOnly()
+    {
+        var source = """
+            package P
+            import System
+
+            type Holder class {
+                public var Name string = "x"
+                init() {}
+            }
+            """;
+
+        var assembly = CompileToAssembly(source, target: "library");
+        var holder = assembly.GetTypes().Single(t => t.Name == "Holder");
+        var field = holder.GetField("Name", BindingFlags.Public | BindingFlags.Instance);
+
+        Assert.NotNull(field);
+        Assert.False(field.IsInitOnly, "`var` field should NOT be initonly.");
+    }
+
+    private static Assembly CompileToAssembly(string source, string target)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_let_field_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}

--- a/test/Compiler.Tests/Emit/MethodSpecCacheUserTypeArgsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/MethodSpecCacheUserTypeArgsEmitTests.cs
@@ -30,7 +30,7 @@ public class MethodSpecCacheUserTypeArgsEmitTests
             import System
 
             type Clock class {
-                Ticks int32
+                var Ticks int32
             }
 
             var a = Array.Empty[Clock]()
@@ -59,11 +59,11 @@ public class MethodSpecCacheUserTypeArgsEmitTests
             import System
 
             type ClockA class {
-                Ticks int32
+                var Ticks int32
             }
 
             type ClockB class {
-                Ticks int32
+                var Ticks int32
             }
 
             var a = Array.Empty[ClockA]()

--- a/test/Compiler.Tests/Emit/NullableInstanceMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/NullableInstanceMemberEmitTests.cs
@@ -210,7 +210,7 @@ public class NullableInstanceMemberEmitTests
             import System
 
             type Holder class {
-                Flag bool?
+                var Flag bool?
 
                 init() {
                     Flag = nil

--- a/test/Compiler.Tests/Emit/PropertyInteropTests.cs
+++ b/test/Compiler.Tests/Emit/PropertyInteropTests.cs
@@ -340,8 +340,8 @@ public class PropertyInteropTests
             import System
 
             type Vec2 data struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
                 prop LengthSquared int32 {
                     get { return this.X * this.X + this.Y * this.Y }
                 }

--- a/test/Compiler.Tests/Emit/UserStructMethodEmitTests.cs
+++ b/test/Compiler.Tests/Emit/UserStructMethodEmitTests.cs
@@ -33,7 +33,7 @@ public class UserStructMethodEmitTests
             package P
 
             type Point struct {
-                X int32
+                var X int32
             }
 
             func (p Point) Foo() int32 {
@@ -86,8 +86,8 @@ public class UserStructMethodEmitTests
             import System
 
             type Point struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
 
             func (p Point) Distance() int32 {
@@ -121,8 +121,8 @@ public class UserStructMethodEmitTests
             import System
 
             type Point struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
 
             func (p Point) Sum() int32 {
@@ -156,7 +156,7 @@ public class UserStructMethodEmitTests
             import System
 
             type Wrap ref struct {
-                V int32
+                var V int32
             }
 
             func (w Wrap) Show() int32 {
@@ -218,8 +218,8 @@ public class UserStructMethodEmitTests
             import System
 
             type Point struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
 
             func (p Point) Sum() int32 {
@@ -254,11 +254,11 @@ public class UserStructMethodEmitTests
             import System
 
             type Inner struct {
-                V int32
+                var V int32
             }
 
             type Outer struct {
-                I Inner
+                var I Inner
             }
 
             func (i Inner) Triple() int32 {
@@ -291,11 +291,11 @@ public class UserStructMethodEmitTests
             import System
 
             type Inner struct {
-                V int32
+                var V int32
             }
 
             type Outer struct {
-                I Inner
+                var I Inner
             }
 
             func (i Inner) Triple() int32 {
@@ -331,8 +331,8 @@ public class UserStructMethodEmitTests
             import System
 
             type Point struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
 
             func (p Point) Sum() int32 {
@@ -370,8 +370,8 @@ public class UserStructMethodEmitTests
             import System
 
             type Point struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
 
             func (p Point) Sum() int32 {

--- a/test/Compiler.Tests/Emit/UserStructPropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/UserStructPropertyEmitTests.cs
@@ -32,8 +32,8 @@ public class UserStructPropertyEmitTests
             import System
 
             type Point struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
                 prop Sum int32 {
                     get { return this.X + this.Y }
                 }
@@ -57,8 +57,8 @@ public class UserStructPropertyEmitTests
             import System
 
             type Point struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
                 prop Sum int32 {
                     get { return this.X + this.Y }
                 }
@@ -84,14 +84,14 @@ public class UserStructPropertyEmitTests
             import System
 
             type Inner struct {
-                V int32
+                var V int32
                 prop Triple int32 {
                     get { return this.V * 3 }
                 }
             }
 
             type Outer struct {
-                Inner Inner
+                var Inner Inner
             }
 
             func makeOuter(v int32) Outer {
@@ -113,8 +113,8 @@ public class UserStructPropertyEmitTests
             import System
 
             type Point struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
                 prop Sum int32 {
                     get { return this.X + this.Y }
                 }
@@ -138,16 +138,16 @@ public class UserStructPropertyEmitTests
             import System
 
             type Point struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
                 prop Sum int32 {
                     get { return this.X + this.Y }
                 }
             }
 
             type Pair struct {
-                A int32
-                B int32
+                var A int32
+                var B int32
             }
 
             func makePoint(x int32, y int32) Point {

--- a/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
@@ -103,8 +103,8 @@ public class AttributeBinderTests
         var source = @"
 @Obsolete
 type Point struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 ";
         var globalScope = BindSource(source);
@@ -120,7 +120,7 @@ type Point struct {
         var source = @"
 @method:Obsolete
 type Point struct {
-    X int32
+    var X int32
 }
 ";
         var globalScope = BindSource(source);
@@ -339,8 +339,8 @@ type Point struct {
         var source = """
             @Obsolete
             type Point data struct {
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
 
             func Main() {
@@ -365,7 +365,7 @@ type Point struct {
         var source = """
             @Obsolete("legacy")
             type Old data struct {
-                Value int32
+                var Value int32
             }
 
             func Consume(o Old) {
@@ -650,8 +650,8 @@ type Point struct {
         var source = """
             type Point data struct {
                 @Obsolete("retired")
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
             """;
 
@@ -676,8 +676,8 @@ type Point struct {
         var source = """
             type Point data struct {
                 @Obsolete("use NewX")
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
 
             func Main() {
@@ -701,7 +701,7 @@ type Point struct {
         var source = """
             type Point struct {
                 @Obsolete("use NewX")
-                X int32
+                var X int32
             }
 
             func Main() {
@@ -724,8 +724,8 @@ type Point struct {
         var source = """
             type Point data struct {
                 @Obsolete("gone", true)
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
 
             func Main() {
@@ -746,8 +746,8 @@ type Point struct {
         var source = """
             type Point data struct {
                 @method:Obsolete
-                X int32
-                Y int32
+                var X int32
+                var Y int32
             }
             """;
 
@@ -763,7 +763,7 @@ type Point struct {
         var source = """
             type Box class {
                 @Obsolete("use NewValue")
-                Value int32
+                var Value int32
 
                 public func Get() int32 {
                     return Value
@@ -945,7 +945,7 @@ type Point struct {
 
             type Box class {
                 @MethodOnly
-                Value int32
+                var Value int32
             }
             """;
 

--- a/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
@@ -26,8 +26,8 @@ public class ClassTests
     {
         var source = @"
 type Box class {
-    Width int32
-    Height int32
+    var Width int32
+    var Height int32
 }
 
 var b = Box{Width: 3, Height: 4}
@@ -43,7 +43,7 @@ b.Width + b.Height
     {
         var source = @"
 type Box class {
-    Width int32
+    var Width int32
 }
 
 var b = Box{Width: 1}
@@ -61,7 +61,7 @@ b.Width
     {
         var source = @"
 type Box class {
-    Width int32
+    var Width int32
 }
 
 var b = Box{Width: 5}
@@ -79,7 +79,7 @@ b.Width
         // Regression: 3.B.3's IsClass dispatch must not regress struct value-copy.
         var source = @"
 type Point struct {
-    X int32
+    var X int32
 }
 
 var p = Point{X: 1}
@@ -97,8 +97,8 @@ p.X
     {
         var source = @"
 type Box class {
-    Width int32
-    Height int32
+    var Width int32
+    var Height int32
 }
 
 var b = Box{}
@@ -116,7 +116,7 @@ b.Width + b.Height
         // `data` to `struct`); diagnose at parse time.
         var source = @"
 type Foo data class {
-    X int32
+    var X int32
 }
 0
 ";
@@ -148,7 +148,7 @@ p.X + p.Y
         // Body fields not listed in the primary ctor are zero-initialized.
         var source = @"
 type Counter class(initial int32) {
-    Count int32
+    var Count int32
 }
 
 var c = Counter(10)
@@ -192,7 +192,7 @@ var p = Point(3, true)
     {
         var source = @"
 type Point class(X int32, Y int32) {
-    X int32
+    var X int32
 }
 0
 ";
@@ -311,7 +311,7 @@ type Pt class(X int32) {
         // Methods are class-only in 3.B.3 sub-step 2b.
         var source = @"
 type Pt struct {
-    X int32
+    var X int32
 
     func Sum() int32 {
         return X
@@ -329,8 +329,8 @@ type Pt struct {
     public void Inheritance_BaseMustBeOpen_Diagnoses()
     {
         var source = @"
-type A class { X int32 }
-type B class : A { Y int32 }
+type A class { var X int32 }
+type B class : A { var Y int32 }
 0
 ";
         var result = Evaluate(source);
@@ -341,8 +341,8 @@ type B class : A { Y int32 }
     public void Inheritance_OpenClass_Subclass_Works()
     {
         var source = @"
-type A open class { X int32 }
-type B class : A { Y int32 }
+type A open class { var X int32 }
+type B class : A { var Y int32 }
 var b = B{X: 1, Y: 2}
 b.X + b.Y
 ";
@@ -436,7 +436,7 @@ type B class : A {
     {
         var source = @"
 type A open class {
-    X int32
+    var X int32
     func GetX() int32 { return X }
 }
 type B class : A {}
@@ -518,9 +518,9 @@ type Square class(Side int32) : IShape(Side) {
         // with `this`, its parameters, and the class fields in scope.
         var source = @"
 type Rect class {
-    Width int32
-    Height int32
-    Area int32
+    var Width int32
+    var Height int32
+    var Area int32
     init(w int32, h int32) {
         Width = w
         Height = h
@@ -541,7 +541,7 @@ r.Area
         // The constructor body may contain control flow.
         var source = @"
 type Clamped class {
-    Value int32
+    var Value int32
     init(v int32) {
         if v < 0 {
             Value = 0
@@ -567,7 +567,7 @@ type Animal open class(Name string) {
     func Speak() string { return Name }
 }
 type Dog class : Animal {
-    Tricks int32
+    var Tricks int32
     init(name string, tricks int32) : base(name) {
         Tricks = tricks
     }
@@ -588,7 +588,7 @@ type Animal open class(Name string) {
     func Speak() string { return Name }
 }
 type Dog class : Animal {
-    Tricks int32
+    var Tricks int32
     init(name string, tricks int32) : base(name) {
         Tricks = tricks
     }
@@ -606,7 +606,7 @@ d.Tricks
     {
         var source = @"
 type Rect class {
-    Width int32
+    var Width int32
     init(w int32, h int32) {
         Width = w
     }
@@ -623,7 +623,7 @@ var r = Rect(3)
     {
         var source = @"
 type Rect class {
-    Width int32
+    var Width int32
     init(w int32) {
         Width = w
     }
@@ -661,7 +661,7 @@ type Bad class(X int32) {
         // signatures, both kinds coexist as designated initializers.
         var source = @"
 type Both class(Name string) {
-    Age int32
+    var Age int32
     init(age int32) {
         Age = age
     }
@@ -681,7 +681,7 @@ byName.Name
         // call site selects the best match by argument arity/type.
         var source = @"
 type Bag class {
-    X int32
+    var X int32
     init(a int32) {
         X = a
     }
@@ -704,8 +704,8 @@ b.X
         // delegates to the designated init in the same class.
         var source = @"
 type Rect class {
-    Width int32
-    Height int32
+    var Width int32
+    var Height int32
     init(w int32, h int32) {
         Width = w
         Height = h
@@ -728,7 +728,7 @@ r.Width + r.Height
         // ADR-0065 §2 Rule 3 / GS0278.
         var source = @"
 type Bad class {
-    X int32
+    var X int32
     init(x int32) {
         X = x
     }
@@ -748,7 +748,7 @@ type Bad class {
         // ADR-0065 §2 / GS0281: only convenience init may use init(args).
         var source = @"
 type Bad class {
-    X int32
+    var X int32
     init(x int32) {
         X = x
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/DataStructErgonomicsTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/DataStructErgonomicsTests.cs
@@ -71,8 +71,8 @@ q == r
     {
         var result = Evaluate(@"
 type Point struct {
-    x int32
-    y int32
+    var x int32
+    var y int32
 }
 let p = Point{x: 1, y: 2}
 p with { x = 10 }
@@ -85,8 +85,8 @@ p with { x = 10 }
     {
         var result = Evaluate(@"
 type Point struct {
-    x int32
-    y int32
+    var x int32
+    var y int32
 }
 let p = Point{x: 1, y: 2}
 p.copy(x = 10)
@@ -200,8 +200,8 @@ hits
 
     private const string PointPrelude = @"
 type Point data struct {
-    x int32
-    y int32
+    var x int32
+    var y int32
 }
 ";
 

--- a/test/Core.Tests/CodeAnalysis/Binding/DataStructTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/DataStructTests.cs
@@ -26,8 +26,8 @@ public class DataStructTests
     {
         var source = @"
 type Point data struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 var p = Point{X: 1, Y: 2}
@@ -44,8 +44,8 @@ p == q
     {
         var source = @"
 type Point data struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 var p = Point{X: 1, Y: 2}
@@ -62,8 +62,8 @@ p != q
     {
         var source = @"
 type Point data struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 var p = Point{X: 5, Y: 7}
@@ -81,8 +81,8 @@ p == q
     {
         var source = @"
 type Point struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 var p = Point{X: 1, Y: 2}
@@ -98,10 +98,10 @@ p == q
     {
         var source = @"
 type A data struct {
-    V int32
+    var V int32
 }
 type B data struct {
-    V int32
+    var V int32
 }
 
 var a = A{V: 1}
@@ -129,8 +129,8 @@ type Empty data struct {
     {
         var source = @"
 type Point data struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 var p = Point{X: 3, Y: 4}
@@ -167,8 +167,8 @@ p
         // predictable.
         var source = @"
 type Point data struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 func (p Point) Equals(other any) bool {
@@ -185,8 +185,8 @@ func (p Point) Equals(other any) bool {
     {
         var source = @"
 type Point data struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 func (p Point) GetHashCode() int32 {
@@ -203,8 +203,8 @@ func (p Point) GetHashCode() int32 {
     {
         var source = @"
 type Point data struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 func (p Point) Deconstruct() {
@@ -219,8 +219,8 @@ func (p Point) Deconstruct() {
     {
         var source = @"
 type Point data struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 0
 ";

--- a/test/Core.Tests/CodeAnalysis/Binding/ExtensionFunctionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ExtensionFunctionTests.cs
@@ -25,8 +25,8 @@ public class ExtensionFunctionTests
         var typeTree = SyntaxTree.Parse(SourceText.From(@"
 package Geometry
 public type Point struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 "));
         var extensionTree = SyntaxTree.Parse(SourceText.From(@"

--- a/test/Core.Tests/CodeAnalysis/Binding/GenericMethodDelegateTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/GenericMethodDelegateTests.cs
@@ -27,7 +27,7 @@ public class GenericMethodDelegateTests
     {
         var source = @"
 type Box[TItem] class {
-    Value TItem
+    var Value TItem
     func Map[TResult](f func(TItem) TResult) TResult {
         return f(this.Value)
     }
@@ -42,7 +42,7 @@ type Box[TItem] class {
     {
         var source = @"
 type Box[TItem] class {
-    Value TItem
+    var Value TItem
     func Map[TResult](f func(TItem) TResult) TResult {
         return f(this.Value)
     }
@@ -60,7 +60,7 @@ b.Map[int32](func(x int32) int32 { return x + x })
     {
         var source = @"
 type Box[TItem] class {
-    Value TItem
+    var Value TItem
     func Map[TResult](f func(TItem) TResult) TResult {
         return f(this.Value)
     }
@@ -78,7 +78,7 @@ b.Map[string](func(x int32) string { return ""mapped"" })
     {
         var source = @"
 type Box[TItem] class {
-    Value TItem
+    var Value TItem
     func Fold[TAcc](seed TAcc, f func(TAcc, TItem) TAcc) TAcc {
         return f(seed, this.Value)
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/GenericMethodOnTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/GenericMethodOnTypeTests.cs
@@ -162,7 +162,7 @@ Util.Identity(3)
     {
         var source = @"
 type Container[T] class {
-    Value T
+    var Value T
     func GetOr[U](other U) U { return other }
 }
 var c = Container[int32]{Value: 1}
@@ -178,7 +178,7 @@ c.GetOr(""x"")
     {
         var source = @"
 type Container[T] class {
-    Value T
+    var Value T
     func Echo(x T) T { return x }
 }
 var c = Container[int32]{Value: 1}

--- a/test/Core.Tests/CodeAnalysis/Binding/GenericMethodUserTypeArgUnderReferencesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/GenericMethodUserTypeArgUnderReferencesTests.cs
@@ -89,7 +89,7 @@ public class GenericMethodUserTypeArgUnderReferencesTests
             import System
 
             type Clock class {
-                Ticks int32
+                var Ticks int32
                 func Read() int32 {
                     return Ticks
                 }

--- a/test/Core.Tests/CodeAnalysis/Binding/GenericTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/GenericTypeTests.cs
@@ -24,8 +24,8 @@ public class GenericTypeTests
     {
         var source = @"
 type Result[T any, E any] data struct {
-    Ok T
-    Err E
+    var Ok T
+    var Err E
 }
 let r = Result[int32, string]{Ok: 5, Err: ""oops""}
 r.Ok
@@ -40,7 +40,7 @@ r.Ok
     {
         var source = @"
 type Box[T any] data struct {
-    Value T
+    var Value T
 }
 let b = Box{Value: 42}
 b.Value
@@ -55,8 +55,8 @@ b.Value
     {
         var source = @"
 type Pair[A any, B any] data struct {
-    First A
-    Second B
+    var First A
+    var Second B
 }
 let p1 = Pair[int32, string]{First: 1, Second: ""x""}
 let p2 = Pair[int32, string]{First: 1, Second: ""x""}
@@ -72,8 +72,8 @@ p1 == p2
     {
         var source = @"
 type Result[T any, E any] data struct {
-    Ok T
-    Err E
+    var Ok T
+    var Err E
 }
 let r = Result[int32]{Ok: 5, Err: ""oops""}
 ";

--- a/test/Core.Tests/CodeAnalysis/Binding/InlineStructTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/InlineStructTests.cs
@@ -49,7 +49,7 @@ a
     [Theory]
     [InlineData("type Bad inline struct(a string, b string) {}")]
     [InlineData("type Bad inline struct {}")]
-    [InlineData("type Bad inline struct(a string) { b string }")]
+    [InlineData("type Bad inline struct(a string) { var b string }")]
     [InlineData("type Bad data inline struct(value string) {}")]
     [InlineData("type Bad inline data struct(value string) {}")]
     [InlineData("type Bad open inline struct(value string) {}")]

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue319ClrBaseInterpreterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue319ClrBaseInterpreterTests.cs
@@ -32,7 +32,7 @@ public class Issue319ClrBaseInterpreterTests
         var source = @"
 import System
 type MyErr class : Exception {
-    Code int32
+    var Code int32
     init(message string, code int32) : base(message) {
         Code = code
     }
@@ -54,7 +54,7 @@ e.Message
         var source = @"
 import System
 type MyErr class : Exception {
-    Code int32
+    var Code int32
     init(message string, code int32) : base(message) {
         Code = code
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue524DefaultCtorBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue524DefaultCtorBinderTests.cs
@@ -31,7 +31,7 @@ public class Issue524DefaultCtorBinderTests
     {
         var source = @"
 type Holder class {
-    Value int32
+    var Value int32
 }
 
 var h = Holder()
@@ -48,7 +48,7 @@ var h = Holder()
         // missing function or a failing conversion.
         var source = @"
 type Holder class {
-    Value int32
+    var Value int32
 }
 
 var h = Holder(7)
@@ -83,8 +83,8 @@ var e = Empty()
         // must continue to bind against that constructor's parameter list.
         var source = @"
 type Point class {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 
     init(x int32, y int32) {
         X = x

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue656InitAsPrimaryCtorBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue656InitAsPrimaryCtorBinderTests.cs
@@ -26,7 +26,7 @@ public class Issue656InitAsPrimaryCtorBinderTests
     {
         var source = @"
 type Counter class {
-    Value int32
+    var Value int32
     init() {
         Value = 0
     }
@@ -48,7 +48,7 @@ var c = Counter()
         // `func init()` should be treated identically to bare `init()`
         var source = @"
 type Counter class {
-    Value int32
+    var Value int32
     func init() {
         Value = 0
     }
@@ -69,7 +69,7 @@ var c = Counter()
     {
         var source = @"
 type Greeting class {
-    Message string
+    var Message string
     func init(name string) {
         Message = name
     }
@@ -91,9 +91,9 @@ var g = Greeting(""hi"")
     {
         var source = @"
 type Color class {
-    R int32
-    G int32
-    B int32
+    var R int32
+    var G int32
+    var B int32
     init(r int32, g int32, b int32) {
         R = r
         G = g
@@ -123,8 +123,8 @@ var c = Color(1, 2, 3)
     {
         var source = @"
 type Config class {
-    Name string = ""default""
-    Count int32
+    var Name string = ""default""
+    var Count int32
     func init() {
         Count = 7
     }
@@ -147,7 +147,7 @@ var cfg = Config()
         // distinct signatures coexist; both are designated initializers.
         var source = @"
 type Dual class(Name string) {
-    Age int32
+    var Age int32
     func init(age int32) {
         Age = age
     }
@@ -170,7 +170,7 @@ var d = Dual(""x"")
     {
         var source = @"
 type Plain class {
-    Value int32
+    var Value int32
 }
 
 var p = Plain()

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue671UserTypeAsClrGenericArgTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue671UserTypeAsClrGenericArgTests.cs
@@ -60,11 +60,11 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             type Container class {
-                items List[MyType]
+                var items List[MyType]
             }
             """;
 
@@ -83,7 +83,7 @@ public class Issue671UserTypeAsClrGenericArgTests
             }
 
             type Container class {
-                items List[IMyType]
+                var items List[IMyType]
             }
             """;
 
@@ -100,11 +100,11 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             type Container class {
-                items List[MyType]
+                var items List[MyType]
 
                 func getItems() List[MyType] {
                     return items
@@ -125,7 +125,7 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             type Container class {
@@ -147,11 +147,11 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type MyType class {
-                Value int32
+                var Value int32
             }
 
             type Container class {
-                items IReadOnlyList[MyType]
+                var items IReadOnlyList[MyType]
             }
             """;
 
@@ -166,11 +166,11 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type MyType class {
-                Value int32
+                var Value int32
             }
 
             type Container class {
-                items IEnumerable[MyType]
+                var items IEnumerable[MyType]
             }
             """;
 
@@ -185,11 +185,11 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Threading.Tasks
 
             type MyType class {
-                Value int32
+                var Value int32
             }
 
             type Container class {
-                pending Task[MyType]
+                var pending Task[MyType]
             }
             """;
 
@@ -206,11 +206,11 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             type Container class {
-                items Dictionary[string, MyType]
+                var items Dictionary[string, MyType]
             }
             """;
 
@@ -227,7 +227,7 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
             """;
 
@@ -236,7 +236,7 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type Container class {
-                items List[MyType]
+                var items List[MyType]
             }
             """;
 
@@ -253,7 +253,7 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type Container class {
-                items List[string]
+                var items List[string]
             }
             """;
 
@@ -268,7 +268,7 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type Container class {
-                items Dictionary[string, int32]
+                var items Dictionary[string, int32]
             }
             """;
 
@@ -283,11 +283,11 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             type Container class {
-                items List[MyType]
+                var items List[MyType]
             }
 
             func main() {
@@ -337,11 +337,11 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             type Container class {
-                items List[MyType]
+                var items List[MyType]
             }
             """;
 
@@ -356,11 +356,11 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             type Container class {
-                items Dictionary[string, MyType]
+                var items Dictionary[string, MyType]
             }
             """;
 
@@ -382,7 +382,7 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             func main() {
@@ -440,7 +440,7 @@ public class Issue671UserTypeAsClrGenericArgTests
             package App
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             func main() {
@@ -460,7 +460,7 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             func main() {
@@ -481,7 +481,7 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             func main() {
@@ -519,7 +519,7 @@ public class Issue671UserTypeAsClrGenericArgTests
             import System.Collections.Generic
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             func main() {
@@ -538,7 +538,7 @@ public class Issue671UserTypeAsClrGenericArgTests
             package App
 
             type MyType class {
-                Name string = ""
+                var Name string = ""
             }
 
             func main() {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue674FieldIndexAssignmentBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue674FieldIndexAssignmentBindingTests.cs
@@ -32,7 +32,7 @@ public class Issue674FieldIndexAssignmentBindingTests
             import System.Collections.Generic
 
             type Bag class {
-                items List[int32] = List[int32]()
+                var items List[int32] = List[int32]()
 
                 func Swap(i int32, j int32) {
                     var a = items[i]
@@ -54,7 +54,7 @@ public class Issue674FieldIndexAssignmentBindingTests
             import System.Collections.Generic
 
             type Cache class {
-                data Dictionary[string, int32] = Dictionary[string, int32]()
+                var data Dictionary[string, int32] = Dictionary[string, int32]()
 
                 func Set(key string, value int32) {
                     data[key] = value
@@ -72,7 +72,7 @@ public class Issue674FieldIndexAssignmentBindingTests
             package P
 
             type Container class {
-                arr []int32 = []int32{0, 0, 0}
+                var arr []int32 = []int32{0, 0, 0}
 
                 func Set(i int32, v int32) {
                     arr[i] = v
@@ -91,7 +91,7 @@ public class Issue674FieldIndexAssignmentBindingTests
             import System.Collections.Generic
 
             type Holder class {
-                items List[int32] = List[int32]()
+                var items List[int32] = List[int32]()
 
                 init() {
                     items.Add(0)
@@ -111,7 +111,7 @@ public class Issue674FieldIndexAssignmentBindingTests
             import System.Collections.Generic
 
             type Counter class {
-                counts List[int32] = List[int32]()
+                var counts List[int32] = List[int32]()
 
                 init() {
                     counts.Add(0)
@@ -134,8 +134,8 @@ public class Issue674FieldIndexAssignmentBindingTests
             import System.Collections.Generic
 
             type Multi class {
-                names List[string] = List[string]()
-                scores List[int32] = List[int32]()
+                var names List[string] = List[string]()
+                var scores List[int32] = List[int32]()
 
                 func Update(i int32, name string, score int32) {
                     names[i] = name

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue687ColorColorTypeShadowingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue687ColorColorTypeShadowingTests.cs
@@ -44,7 +44,7 @@ public class Issue687ColorColorTypeShadowingTests
             import System.IO
 
             type Entry class {
-                Path string = ""
+                var Path string = ""
 
                 func Build(suffix string) string {
                     return Path.Combine(this.Path, suffix)
@@ -65,7 +65,7 @@ public class Issue687ColorColorTypeShadowingTests
             package P
 
             type Holder class {
-                Type string = "System.Int32"
+                var Type string = "System.Int32"
 
                 func Resolve() bool {
                     return Type.GetType(this.Type) != nil
@@ -86,7 +86,7 @@ public class Issue687ColorColorTypeShadowingTests
             package P
 
             type Person class {
-                Name string = ""
+                var Name string = ""
 
                 func NameLength() int32 {
                     return Name.Length
@@ -109,7 +109,7 @@ public class Issue687ColorColorTypeShadowingTests
             import System.IO
 
             type Probe class {
-                Path string = ""
+                var Path string = ""
 
                 func PathLength() int32 {
                     return Path.Length
@@ -131,7 +131,7 @@ public class Issue687ColorColorTypeShadowingTests
             import System.IO
 
             type Probe class {
-                Path string = "/tmp"
+                var Path string = "/tmp"
 
                 func GetPath() string {
                     return Path
@@ -154,7 +154,7 @@ public class Issue687ColorColorTypeShadowingTests
             import System.IO
 
             type Probe class {
-                Path string = ""
+                var Path string = ""
 
                 func Combine(suffix string) string {
                     return System.IO.Path.Combine(this.Path, suffix)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue693DictionaryConstructionBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue693DictionaryConstructionBindingTests.cs
@@ -67,7 +67,7 @@ public class Issue693DictionaryConstructionBindingTests
             import System.Collections.Generic
 
             type MyGs class {
-                Name string = ""
+                var Name string = ""
             }
 
             let d = Dictionary[string, MyGs]()
@@ -86,11 +86,11 @@ public class Issue693DictionaryConstructionBindingTests
             import System.Collections.Generic
 
             type K class {
-                N int32 = 0
+                var N int32 = 0
             }
 
             type V class {
-                N int32 = 0
+                var N int32 = 0
             }
 
             let d = Dictionary[K, V]()

--- a/test/Core.Tests/CodeAnalysis/Binding/LetFieldBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/LetFieldBindingTests.cs
@@ -1,0 +1,45 @@
+// <copyright file="LetFieldBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0067 / issue #694: binder tests for `let` (read-only) fields on
+/// user-declared types.
+/// </summary>
+public class LetFieldBindingTests
+{
+    [Fact]
+    public void LetField_ReassignmentReportsCannotAssign()
+    {
+        const string source = "package P\ntype Counter class {\n  let Value int32 = 0\n  init() {}\n}\nvar c = Counter()\nc.Value = 1\n";
+        var diagnostics = GetDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void VarField_ReassignmentAllowed()
+    {
+        const string source = "package P\ntype Counter class {\n  var Value int32 = 0\n  init() {}\n}\nvar c = Counter()\nc.Value = 1\n";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0127");
+    }
+
+    private static System.Collections.Generic.IEnumerable<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(source);
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics;
+    }
+}
+

--- a/test/Core.Tests/CodeAnalysis/Binding/MethodWithReceiverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/MethodWithReceiverTests.cs
@@ -23,8 +23,8 @@ public class MethodWithReceiverTests
     {
         var source = @"
 type Point struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 func (p Point) Distance() int32 {
@@ -44,8 +44,8 @@ p.Distance()
     {
         var source = @"
 type Point class {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 func (p Point) Distance() int32 {
@@ -65,8 +65,8 @@ p.Distance()
     {
         var source = @"
 type Point struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 func (p Point) Sum() int32 { return p.X + p.Y }
@@ -86,7 +86,7 @@ p.DoubleSum()
         var definingTree = SyntaxTree.Parse(SourceText.From(@"
 package Geometry
 public type Point struct {
-    X int32
+    var X int32
 }
 "));
         var extensionTree = SyntaxTree.Parse(SourceText.From(@"
@@ -150,7 +150,7 @@ func (c Count) G() int32 { return c + 1 }
     {
         var source = @"
 type Counter struct {
-    Value int32
+    var Value int32
 }
 
 func (c Counter) Inc() int32 {

--- a/test/Core.Tests/CodeAnalysis/Binding/NamedArgumentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NamedArgumentTests.cs
@@ -112,7 +112,7 @@ let r = sub(1, x: 2)
     {
         var source = @"
 type Calc data struct {
-    Bias int32
+    var Bias int32
 }
 
 func (c Calc) Combine(a int32, b int32) int32 {
@@ -159,7 +159,7 @@ let p = Point(1, X: 9)
     public void UserExtensionFunction_NamedArguments_BindAndEvaluate()
     {
         var source = @"
-type Box data struct { N int32 }
+type Box data struct { var N int32 }
 
 func (b Box) Mix(low int32, high int32) int32 {
     return b.N + low * 100 + high

--- a/test/Core.Tests/CodeAnalysis/Binding/NullableFlowAnalysisTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NullableFlowAnalysisTests.cs
@@ -367,7 +367,7 @@ if !dict.TryGetValue(""key"", &value) {
 import System.Diagnostics.CodeAnalysis
 
 type Box class {
-    _name string?
+    var _name string?
 
     func EnsureInit() {
         _name = ""default""
@@ -401,7 +401,7 @@ b.Run()
 import System.Diagnostics.CodeAnalysis
 
 type Box class {
-    _name string?
+    var _name string?
 
     @MemberNotNull(""_name"")
     func EnsureInit() {
@@ -429,7 +429,7 @@ b.Run()
 import System.Diagnostics.CodeAnalysis
 
 type Box class {
-    _name string?
+    var _name string?
 
     @MemberNotNull(""_name"")
     func EnsureInit() {
@@ -459,7 +459,7 @@ b.Run()
 import System.Diagnostics.CodeAnalysis
 
 type Box class {
-    _name string?
+    var _name string?
 
     @MemberNotNullWhen(true, ""_name"")
     func TryGet() bool {
@@ -492,7 +492,7 @@ b.Run()
 import System.Diagnostics.CodeAnalysis
 
 type Box class {
-    _name string?
+    var _name string?
 
     @MemberNotNullWhen(true, ""_name"")
     func TryGet() bool {
@@ -524,7 +524,7 @@ b.Run()
 import System.Diagnostics.CodeAnalysis
 
 type Box class {
-    _name string?
+    var _name string?
 
     @MemberNotNullWhen(true, ""_name"")
     func TryGet() bool {
@@ -557,8 +557,8 @@ b.Run()
 import System.Diagnostics.CodeAnalysis
 
 type Pair class {
-    _a string?
-    _b string?
+    var _a string?
+    var _b string?
 
     @MemberNotNull(""_a"", ""_b"")
     func Init() {

--- a/test/Core.Tests/CodeAnalysis/Binding/NullableInstanceMemberBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NullableInstanceMemberBindingTests.cs
@@ -135,7 +135,7 @@ var r = describe(5)
     {
         var source = @"
 type Holder class {
-    Flag bool?
+    var Flag bool?
 
     init() {
         Flag = nil

--- a/test/Core.Tests/CodeAnalysis/Binding/NullableTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NullableTypeTests.cs
@@ -53,7 +53,7 @@ x
         // The parser must accept `[3]int?` as a type clause (questioned element type).
         var source = @"
 type X struct {
-    Items [3]int32?
+    var Items [3]int32?
 }
 ";
         var result = Evaluate(source);

--- a/test/Core.Tests/CodeAnalysis/Binding/ObjectInitializerBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ObjectInitializerBinderTests.cs
@@ -29,8 +29,8 @@ public class ObjectInitializerBinderTests
     {
         var source = @"
 type Box class {
-    Width int32
-    Height int32
+    var Width int32
+    var Height int32
     init() { }
 }
 
@@ -65,7 +65,7 @@ b.Width + b.Height
     {
         var source = @"
 type Box class {
-    Width int32
+    var Width int32
     init() { }
 }
 
@@ -82,7 +82,7 @@ b.Width
     {
         var source = @"
 type Box class {
-    Width int32
+    var Width int32
     init() { }
 }
 
@@ -98,7 +98,7 @@ var b = Box() { Unknown = 1 }
     {
         var source = @"
 type Box class {
-    Width int32
+    var Width int32
     init() { }
 }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadAndOptionalParameterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadAndOptionalParameterTests.cs
@@ -201,7 +201,7 @@ p.Y
         // ADR-0063 §9: multiple init(...) overloads, overload-resolved at call site.
         var source = @"
 type Box class {
-    X int32
+    var X int32
     init(a int32) { X = a }
     init(a int32, b int32) { X = a * b }
 }
@@ -218,7 +218,7 @@ b.X
     {
         var source = @"
 type Box class {
-    X int32
+    var X int32
     init(a int32) { X = a }
     init(a int32) { X = a + 1 }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/PatternEvaluationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/PatternEvaluationTests.cs
@@ -38,7 +38,7 @@ x
     public void SwitchExpression_TypePattern_EvaluatesAndBindsVariable()
     {
         AssertEvaluates(@"
-type User class { Name string }
+type User class { var Name string }
 let u = User{Name: ""x""}
 let x = switch u { case v is User -> v.Name default -> ""n"" }
 x
@@ -49,7 +49,7 @@ x
     public void SwitchExpression_PropertyPattern_Evaluates()
     {
         AssertEvaluates(@"
-type User class { Name string Age int32 }
+type User class { var Name string var Age int32 }
 let u = User{Name: ""x"", Age: 1}
 let x = switch u { case { Name: ""x"", Age: > 0 } -> ""hit"" default -> ""miss"" }
 x

--- a/test/Core.Tests/CodeAnalysis/Binding/PatternTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/PatternTests.cs
@@ -19,7 +19,7 @@ public class PatternTests
     public void TypePattern_BindsVariableOnlyInArmScope()
     {
         var diagnostics = Bind(@"
-type User class { Name string }
+type User class { var Name string }
 let u = User{Name: ""x""}
 let a = switch u { case v is User -> v.Name default -> ""n"" }
 let b = v.Name
@@ -39,7 +39,7 @@ let b = v.Name
     public void PropertyPattern_MissingField_Diagnoses()
     {
         var diagnostics = Bind(@"
-type User class { Name string }
+type User class { var Name string }
 let u = User{Name: ""x""}
 let x = switch u { case { Missing: 1 } -> 1 default -> 0 }
 ");
@@ -64,7 +64,7 @@ let x = switch u { case { Missing: 1 } -> 1 default -> 0 }
     public void DiscardPattern_AcceptsAnyDiscriminantType()
     {
         var diagnostics = Bind(@"
-type User class { Name string }
+type User class { var Name string }
 let u = User{Name: ""x""}
 let x = switch u { case _ -> 1 }
 ");

--- a/test/Core.Tests/CodeAnalysis/Binding/RecordAliasTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RecordAliasTests.cs
@@ -23,15 +23,15 @@ public class RecordAliasTests
     {
         var record = BuildStruct(@"
 type Point record {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 0
 ");
         var dataStruct = BuildStruct(@"
 type Point data struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 0
 ");
@@ -48,8 +48,8 @@ type Point data struct {
     {
         var result = Evaluate(@"
 type Point record {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 Point{X: 1, Y: 2} == Point{X: 1, Y: 2}
 ");
@@ -63,8 +63,8 @@ Point{X: 1, Y: 2} == Point{X: 1, Y: 2}
     {
         var result = Evaluate(@"
 type Pair[A any, B any] record {
-    First A
-    Second B
+    var First A
+    var Second B
 }
 let p = Pair[int32, string]{First: 1, Second: ""x""}
 p.Second
@@ -91,7 +91,7 @@ record
     {
         var result = Evaluate(@"
 type X struct {
-    record int32
+    var record int32
 }
 let x = X{record: 5}
 x.record
@@ -106,7 +106,7 @@ x.record
     {
         var result = Evaluate(@"
 type Foo open record {
-    Value int32
+    var Value int32
 }
 0
 ");
@@ -120,7 +120,7 @@ type Foo open record {
     {
         var result = Evaluate(@"
 type Foo data record {
-    Value int32
+    var Value int32
 }
 0
 ");
@@ -134,7 +134,7 @@ type Foo data record {
     {
         var result = Evaluate(@"
 type Foo sealed record {
-    Value int32
+    var Value int32
 }
 0
 ");
@@ -148,7 +148,7 @@ type Foo sealed record {
     {
         var result = Evaluate(@"
 func Use(r record) int32 {
-    return 0
+    var return 0
 }
 0
 ");

--- a/test/Core.Tests/CodeAnalysis/Binding/RefKindParameterSitesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefKindParameterSitesTests.cs
@@ -29,7 +29,7 @@ public class RefKindParameterSitesTests
         // type body are class-only as of ADR-0017.
         var source = @"
 type Counter struct {
-    Value int32
+    var Value int32
 }
 
 func (c Counter) Add(ref delta int32) {
@@ -78,7 +78,7 @@ type IParser interface {
     {
         var source = @"
 type Box class {
-    Value int32
+    var Value int32
 
     init(seed int32, ref delta int32) {
         delta = delta + 1

--- a/test/Core.Tests/CodeAnalysis/Binding/RefLocalAliasingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefLocalAliasingTests.cs
@@ -43,7 +43,7 @@ tweak()
     {
         var source = @"
 type Counter struct {
-    Value int32
+    var Value int32
 }
 
 func tweak() {

--- a/test/Core.Tests/CodeAnalysis/Binding/RefSafeEscapeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefSafeEscapeTests.cs
@@ -112,7 +112,7 @@ func test() {
         var source = @"
 package P
 type S struct {
-    Ptr *int32
+    var Ptr *int32
 }
 ";
         var diagnostics = Bind(source);
@@ -138,7 +138,7 @@ type C class {
         var source = @"
 package P
 type S struct {
-    Value int32
+    var Value int32
 }
 ";
         var diagnostics = Bind(source);
@@ -285,7 +285,7 @@ func f(scoped x int32) int32 {
         var source = @"
 package P
 type Acc ref struct {
-    Total int32
+    var Total int32
 }
 func bad(scoped a Acc) Acc {
     return a
@@ -301,7 +301,7 @@ func bad(scoped a Acc) Acc {
         var source = @"
 package P
 type Acc ref struct {
-    Total int32
+    var Total int32
 }
 func passThrough(a Acc) Acc {
     return a
@@ -429,7 +429,7 @@ func bad(scoped s ReadOnlySpan[int32]) ReadOnlySpan[int32] {
         var source = @"
 package P
 type MySpan ref struct {
-    Value int32
+    var Value int32
 }
 func (s MySpan) getSelf() MySpan {
     return s
@@ -446,7 +446,7 @@ func (s MySpan) getSelf() MySpan {
         var source = @"
 package P
 type MySpan ref struct {
-    Value int32
+    var Value int32
 }
 func (s MySpan) getValue() int32 {
     return Value
@@ -463,7 +463,7 @@ func (s MySpan) getValue() int32 {
         var source = @"
 package P
 type MySpan ref struct {
-    Value int32
+    var Value int32
 }
 @UnscopedRef
 func (s MySpan) getSelf() MySpan {
@@ -481,7 +481,7 @@ func (s MySpan) getSelf() MySpan {
         var source = @"
 package P
 type Builder struct {
-    Count int32
+    var Count int32
 }
 func (b Builder) copy() Builder {
     return b

--- a/test/Core.Tests/CodeAnalysis/Binding/RefStructTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefStructTests.cs
@@ -112,7 +112,7 @@ func box(arr []int32) object {
         var source = @"
 import System
 type Holder class {
-    s ReadOnlySpan[int32]
+    var s ReadOnlySpan[int32]
 }
 ";
         var result = Evaluate(source);
@@ -196,7 +196,7 @@ func f() {
         var source = @"
 package P
 type Window ref struct {
-    Total int32
+    var Total int32
 }
 ";
         var tree = SyntaxTree.Parse(SourceText.From(source));
@@ -212,7 +212,7 @@ type Window ref struct {
         var source = @"
 package P
 type Plain struct {
-    Total int32
+    var Total int32
 }
 ";
         var tree = SyntaxTree.Parse(SourceText.From(source));
@@ -228,7 +228,7 @@ type Plain struct {
         var source = @"
 package P
 type Acc ref struct {
-    Total int32
+    var Total int32
 }
 func use() int32 {
     var a Acc = Acc{Total: 5}
@@ -245,7 +245,7 @@ func use() int32 {
         var source = @"
 package P
 type Acc ref struct {
-    Total int32
+    var Total int32
 }
 func box() object {
     var a Acc = Acc{Total: 5}
@@ -263,10 +263,10 @@ func box() object {
         var source = @"
 package P
 type Acc ref struct {
-    Total int32
+    var Total int32
 }
 type Holder struct {
-    a Acc
+    var a Acc
 }
 ";
         var diagnostics = Bind(source);
@@ -279,10 +279,10 @@ type Holder struct {
         var source = @"
 package P
 type Inner ref struct {
-    V int32
+    var V int32
 }
 type Outer ref struct {
-    Slot Inner
+    var Slot Inner
 }
 ";
         var diagnostics = Bind(source);
@@ -295,7 +295,7 @@ type Outer ref struct {
         var source = @"
 package P
 type Acc ref struct {
-    Total int32
+    var Total int32
 }
 func f() {
     var a Acc = Acc{Total: 5}
@@ -314,7 +314,7 @@ func f() {
 package P
 import System.Collections.Generic
 type Acc ref struct {
-    Total int32
+    var Total int32
 }
 func f() {
     var l List[Acc]
@@ -339,7 +339,7 @@ var s ReadOnlySpan[int32] = []int32{1, 2, 3}
         var user = @"
 package P
 type Acc ref struct {
-    Total int32
+    var Total int32
 }
 var a Acc = Acc{Total: 1}
 ";

--- a/test/Core.Tests/CodeAnalysis/Binding/StructTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/StructTests.cs
@@ -24,8 +24,8 @@ public class StructTests
     {
         var source = @"
 type Point struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 var p = Point{X: 3, Y: 4}
@@ -41,8 +41,8 @@ p.X + p.Y
     {
         var source = @"
 type Point struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 var p = Point{X: 5}
@@ -58,8 +58,8 @@ p.Y
     {
         var source = @"
 type Point struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 var p = Point{}
@@ -75,8 +75,8 @@ p.X + p.Y
     {
         var source = @"
 type Point struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 var p = Point{X: 1, Y: 2}
@@ -93,8 +93,8 @@ p.X
     {
         var source = @"
 type Point struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 var p = Point{X: 1, Y: 2}
@@ -112,7 +112,7 @@ p.X
     {
         var source = @"
 type Point struct {
-    X int32
+    var X int32
 }
 
 var p = Point{X: 1}
@@ -127,8 +127,8 @@ p.Z
     {
         var source = @"
 type Point struct {
-    X int32
-    X int32
+    var X int32
+    var X int32
 }
 0
 ";
@@ -141,10 +141,10 @@ type Point struct {
     {
         var source = @"
 type Point struct {
-    X int32
+    var X int32
 }
 type Point struct {
-    Y int32
+    var Y int32
 }
 0
 ";

--- a/test/Core.Tests/CodeAnalysis/Binding/UserOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/UserOperatorTests.cs
@@ -23,8 +23,8 @@ public class UserOperatorTests
     {
         var source = @"
 type Vector2 struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 func (a Vector2) operator +(b Vector2) Vector2 {
@@ -46,8 +46,8 @@ var first = r.X
     {
         var source = @"
 type Vector2 struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 func (a Vector2) operator -() Vector2 {
@@ -70,8 +70,8 @@ var negX = r.X
         // user-defined op_Equality even when individual fields differ.
         var source = @"
 type Vector2 struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 func (a Vector2) operator ==(b Vector2) bool {

--- a/test/Core.Tests/CodeAnalysis/Documentation/DocumentationFileEmitterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Documentation/DocumentationFileEmitterTests.cs
@@ -47,9 +47,9 @@ func Add(a int32, b int32) int32 {
 /// Represents a 2D point.
 type Point data struct {
     /// The X coordinate.
-    X float64
+    var X float64
     /// The Y coordinate.
-    Y float64
+    var Y float64
 }
 ";
         var xml = EmitDocXml(source, "Shapes");

--- a/test/Core.Tests/CodeAnalysis/Documentation/SymbolDocumentationIdProviderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Documentation/SymbolDocumentationIdProviderTests.cs
@@ -49,7 +49,7 @@ public class SymbolDocumentationIdProviderTests
     [Fact]
     public void StructType_GeneratesTPrefix()
     {
-        var tree = SyntaxTree.Parse("package Lib\ntype Point data struct { X int32, Y int32 }");
+        var tree = SyntaxTree.Parse("package Lib\ntype Point data struct { var X int32, Y int32 }");
         var compilation = new Compilation(tree);
         var type = compilation.GlobalScope.Structs.First(s => s.Name == "Point");
         var id = SymbolDocumentationIdProvider.GetDocumentationId(type);
@@ -59,7 +59,7 @@ public class SymbolDocumentationIdProviderTests
     [Fact]
     public void StructField_GeneratesFPrefix()
     {
-        var tree = SyntaxTree.Parse("package Lib\ntype Point data struct { X int32, Y int32 }");
+        var tree = SyntaxTree.Parse("package Lib\ntype Point data struct { var X int32, Y int32 }");
         var compilation = new Compilation(tree);
         var type = compilation.GlobalScope.Structs.First(s => s.Name == "Point");
         var field = type.Fields[0];

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncSpillEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncSpillEmitTests.cs
@@ -256,7 +256,7 @@ import System
 import System.Threading.Tasks
 
 type Box struct {
-    Value int32
+    var Value int32
 }
 
 async func compute() int32 { return await Task.FromResult(99) }

--- a/test/Core.Tests/CodeAnalysis/Emit/AttributeMemberRefCacheTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AttributeMemberRefCacheTests.cs
@@ -44,9 +44,9 @@ func Main() {}
     public void MultipleRefStructs_ProduceSingleIsByRefLikeAndObsoleteAttributeCtorMemberRef()
     {
         const string source = @"package RefStructCache
-type A ref struct { x int32 }
-type B ref struct { y int32 }
-type C ref struct { z int32 }
+type A ref struct { var x int32 }
+type B ref struct { var y int32 }
+type C ref struct { var z int32 }
 func Main() {}
 ";
         using var pe = Compile(source);

--- a/test/Core.Tests/CodeAnalysis/Emit/DeterministicEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/DeterministicEmitTests.cs
@@ -50,7 +50,7 @@ type Color enum {
 }
 
 type Counter data struct {
-    N int32
+    var N int32
 }
 
 func add(a int32, b int32) int32 {

--- a/test/Core.Tests/CodeAnalysis/Emit/RefKindParameterEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/RefKindParameterEmitTests.cs
@@ -231,7 +231,7 @@ Console.WriteLine(cOut)
 import System
 
 type Counter struct {
-    Value int32
+    var Value int32
 }
 
 func (c Counter) Bump(ref delta int32) {
@@ -328,7 +328,7 @@ Console.WriteLine(Helper.DoubleIt(in n))
 import System
 
 type Box class {
-    Value int32
+    var Value int32
 
     init(ref delta int32) {
         delta = delta + 1

--- a/test/Core.Tests/CodeAnalysis/Emit/RefLocalAliasingEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/RefLocalAliasingEmitTests.cs
@@ -72,7 +72,7 @@ tweak()
 import System
 
 type Counter struct {
-    Value int32
+    var Value int32
 }
 
 func tweak() {

--- a/test/Core.Tests/CodeAnalysis/Emit/RefReturnEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/RefReturnEmitTests.cs
@@ -74,7 +74,7 @@ func pick(ref a int32) ref int32 {
 import System
 
 type Box class {
-    Value int32
+    var Value int32
     func GetRef(ref x int32) ref int32 {
         return ref x
     }
@@ -100,8 +100,8 @@ Console.WriteLine(b.Value)
 import System
 
 type Pair struct {
-    A int32
-    B int32
+    var A int32
+    var B int32
 }
 
 func (p Pair) PickA(ref x int32) ref int32 {

--- a/test/Core.Tests/CodeAnalysis/Emit/RefStructGenericFieldEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/RefStructGenericFieldEmitTests.cs
@@ -38,7 +38,7 @@ public class RefStructGenericFieldEmitTests
     private const string WindowSource = @"package RefStructGenericField
 import System
 type Window ref struct {
-    data ReadOnlySpan[int32]
+    var data ReadOnlySpan[int32]
 }
 func firstLen(w Window) int32 {
     return w.data.Length

--- a/test/Core.Tests/CodeAnalysis/Emit/SlotDictionaryAliasingAssertionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/SlotDictionaryAliasingAssertionTests.cs
@@ -43,8 +43,8 @@ package SlotComboTest
 import System
 
 type Point struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 
 func makePoint() Point {

--- a/test/Core.Tests/CodeAnalysis/Emit/WalkerPrePassEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/WalkerPrePassEmitTests.cs
@@ -35,8 +35,8 @@ public class WalkerPrePassEmitTests
         const string Source = @"package P
 import System
 type Point data struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 func makeX() int32 {
     var p = Point{X: 11, Y: 22}
@@ -63,8 +63,8 @@ Console.WriteLine(t.Item2)
         const string Source = @"package P
 import System
 type Point data struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 var flag = true
 var p Point
@@ -87,8 +87,8 @@ Console.WriteLine(p.Y)
         const string Source = @"package P
 import System
 type Point data struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 var pts = []Point{Point{X: 1, Y: 2}, Point{X: 3, Y: 4}}
 Console.WriteLine(pts[0].X)
@@ -146,8 +146,8 @@ Console.WriteLine(xs[2])
         const string Source = @"package P
 import System
 type Point data struct {
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 func makeZero() Point {
     var p Point
@@ -171,7 +171,7 @@ Console.WriteLine(t.Item2)
         const string Source = @"package P
 import System
 type Box data struct {
-    Value int32
+    var Value int32
 }
 var b Box
 var nums = [3]int32{0, 1, 2}
@@ -215,8 +215,8 @@ Console.WriteLine(nine())
         const string Source = @"package P
 import System
 type Pair data struct {
-    A int32
-    B int32
+    var A int32
+    var B int32
 }
 var make = func() Pair {
     var p Pair

--- a/test/Core.Tests/CodeAnalysis/SharedBlockTests.cs
+++ b/test/Core.Tests/CodeAnalysis/SharedBlockTests.cs
@@ -36,7 +36,7 @@ public class SharedBlockTests
         var source = @"
 type Counter class {
     shared {
-        count int32
+        var count int32
     }
 }
 ";
@@ -50,7 +50,7 @@ type Counter class {
         var source = @"
 type Counter struct {
     shared {
-        count int32
+        var count int32
     }
 }
 ";
@@ -80,10 +80,10 @@ type Factory struct {
         var source = @"
 type Counter struct {
     shared {
-        x int32
+        var x int32
     }
     shared {
-        y int32
+        var y int32
     }
 }
 ";
@@ -102,7 +102,7 @@ type Counter struct {
         var source = @"
 type Counter struct {
     shared {
-        count int32
+        var count int32
     }
 }
 
@@ -136,7 +136,7 @@ var x = Factory.create()
         var source = @"
 type Counter struct {
     shared {
-        count int32
+        var count int32
     }
 }
 
@@ -156,7 +156,7 @@ Counter.count = 5
         var source = @"
 type Counter struct {
     shared {
-        count int32
+        var count int32
     }
 }
 
@@ -193,7 +193,7 @@ var result = Factory.create()
         var source = @"
 type Counter struct {
     shared {
-        count int32
+        var count int32
     }
 }
 
@@ -218,7 +218,7 @@ import System
 
 type Counter struct {
     shared {
-        count int32
+        var count int32
     }
 }
 
@@ -259,7 +259,7 @@ Console.WriteLine(Factory.create())
         var source = @"
 type Counter struct {
     shared {
-        count int32 = 42
+        var count int32 = 42
     }
 }
 ";
@@ -275,7 +275,7 @@ import System
 
 type Counter struct {
     shared {
-        count int32 = 42
+        var count int32 = 42
     }
 }
 
@@ -293,9 +293,9 @@ import System
 
 type Config struct {
     shared {
-        x int32 = 10
-        y int32 = 20
-        name string = ""hello""
+        var x int32 = 10
+        var y int32 = 20
+        var name string = ""hello""
     }
 }
 
@@ -318,8 +318,8 @@ import System
 
 type Counter struct {
     shared {
-        count int32 = 0
-        active int32 = 5
+        var count int32 = 0
+        var active int32 = 5
     }
 }
 
@@ -339,7 +339,7 @@ import System
 
 type Service class {
     shared {
-        instanceCount int32 = 100
+        var instanceCount int32 = 100
     }
 }
 
@@ -417,7 +417,7 @@ Console.WriteLine(Service.instanceCount)
         var source = @"
 type Foo class {
     shared {
-        x int32
+        var x int32
         func bar() int32 {
             return x
         }
@@ -438,7 +438,7 @@ var result = Foo.bar()
         var source = @"
 type Foo class {
     shared {
-        x int32
+        var x int32
         func setX(val int32) {
             x = val
         }
@@ -459,7 +459,7 @@ var result = Foo.x
         var source = @"
 type Counter class {
     shared {
-        count int32
+        var count int32
         func increment() int32 {
             count = count + 1
             return count
@@ -481,7 +481,7 @@ var result = Counter.increment()
         var source = @"
 type Holder class {
     shared {
-        name string
+        var name string
         func getLen() int32 {
             return len(name)
         }
@@ -502,7 +502,7 @@ var result = Holder.getLen()
         var source = @"
 type Foo class {
     shared {
-        x int32
+        var x int32
         func bar(x int32) int32 {
             return x
         }
@@ -545,7 +545,7 @@ var result = Config.name
         var source = @"
 type Counter class {
     shared {
-        count int32
+        var count int32
         prop doubled int32 {
             get { return count * 2 }
         }
@@ -566,7 +566,7 @@ var result = Counter.doubled
         var source = @"
 type Config class {
     shared {
-        _value int32
+        var _value int32
         prop value int32 {
             get { return _value }
             set(v) { _value = v }
@@ -609,7 +609,7 @@ import System
 
 type Counter class {
     shared {
-        count int32
+        var count int32
         prop doubled int32 {
             get { return count * 2 }
         }
@@ -631,7 +631,7 @@ import System
 
 type Config class {
     shared {
-        _value int32
+        var _value int32
         prop value int32 {
             get { return _value }
             set(v) { _value = v }
@@ -783,7 +783,7 @@ type Mixed class {
     {
         var source = @"
 type Counter class {
-    shared { count int32 }
+    shared { var count int32 }
     func get() int32 { return count }
 }
 
@@ -801,7 +801,7 @@ var r = c.get()
     {
         var source = @"
 type Counter class {
-    shared { count int32 }
+    shared { var count int32 }
     func set(v int32) { count = v }
 }
 
@@ -819,7 +819,7 @@ var r = Counter.count
     {
         var source = @"
 type Counter class {
-    shared { count int32 }
+    shared { var count int32 }
     func bump() int32 {
         count += 1
         return count
@@ -939,7 +939,7 @@ var r = Counter.bump()
         var source = @"
 type Counter class {
     shared {
-        count int32
+        var count int32
         func bump() int32 {
             count += 2
             return count
@@ -960,7 +960,7 @@ var r = Counter.bump()
     {
         var source = @"
 type Counter class {
-    shared { count int32 }
+    shared { var count int32 }
 }
 
 Counter.count = 4
@@ -994,7 +994,7 @@ var r = Counter.count
     {
         var source = @"
 type Counter class {
-    shared { count int32 }
+    shared { var count int32 }
 }
 
 Counter.count = 20
@@ -1014,7 +1014,7 @@ var r = Counter.count
         // instance-method seeding must do the same.
         var source = @"
 type Foo class {
-    shared { count int32 }
+    shared { var count int32 }
     func echo(count int32) int32 { return count }
 }
 
@@ -1034,7 +1034,7 @@ var r = f.echo(99)
         // after refactor that splits static-event vs static-field branches).
         var source = @"
 type Counter class {
-    shared { count int32 }
+    shared { var count int32 }
     func get() int32 { return Counter.count }
 }
 
@@ -1062,7 +1062,7 @@ import System
 type Bus class {
     shared {
         event Tick Action
-        count int32
+        var count int32
     }
 }
 
@@ -1086,7 +1086,7 @@ Console.WriteLine(Bus.count)
         var source = @"
 type Foo class {
     shared {
-        _v int32
+        var _v int32
         prop value int32 { get { return _v } }
         func bump() { value += 1 }
     }
@@ -1105,7 +1105,7 @@ type Foo class {
         var source = @"
 type Foo class {
     shared {
-        _v int32
+        var _v int32
         prop value int32 { set(v) { _v = v } }
         func bump() { value += 1 }
     }
@@ -1121,7 +1121,7 @@ type Foo class {
         var source = @"
 type Foo class {
     shared {
-        _v int32
+        var _v int32
         prop value int32 { get { return _v } }
     }
 }
@@ -1143,8 +1143,8 @@ Foo.value += 1
         // must still resolve.
         var source = @"
 type Container[T] class {
-    shared { count int32 }
-    Value T
+    shared { var count int32 }
+    var Value T
     func bump() int32 {
         count += 1
         return count
@@ -1170,7 +1170,7 @@ r
 import System
 
 type Bus class {
-    shared { count int32 }
+    shared { var count int32 }
     func bump() int32 {
         count += 1
         return count

--- a/test/Core.Tests/CodeAnalysis/Syntax/AnnotationParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/AnnotationParserTests.cs
@@ -399,8 +399,8 @@ package P
 
 type Point data struct {
     @Obsolete(""retired"")
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 ";
         var tree = SyntaxTree.Parse(source);
@@ -426,8 +426,8 @@ package P
 type Point struct {
     @Obsolete
     @Serializable
-    X int32
-    Y int32
+    var X int32
+    var Y int32
 }
 ";
         var tree = SyntaxTree.Parse(source);
@@ -452,8 +452,8 @@ package P
 
 type Box class {
     @Obsolete
-    public Value int32
-    public Other int32
+    public var Value int32
+    public var Other int32
 }
 ";
         var tree = SyntaxTree.Parse(source);

--- a/test/Core.Tests/CodeAnalysis/Syntax/FieldDeclarationParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/FieldDeclarationParserTests.cs
@@ -1,0 +1,137 @@
+// <copyright file="FieldDeclarationParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// ADR-0067 / issue #694: parser tests for the `var`/`let` requirement on
+/// field declarations inside type bodies.
+/// </summary>
+public class FieldDeclarationParserTests
+{
+    [Fact]
+    public void ParsesVarField()
+    {
+        const string source = "package P\ntype Counter class {\n  var Value int32\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var field = Assert.Single(structDecl.Fields);
+        Assert.Equal("Value", field.Identifier.Text);
+        Assert.False(field.IsReadOnly);
+        Assert.NotNull(field.VarOrLetKeyword);
+        Assert.Equal(SyntaxKind.VarKeyword, field.VarOrLetKeyword.Kind);
+    }
+
+    [Fact]
+    public void ParsesVarField_WithInitializer()
+    {
+        const string source = "package P\ntype Counter class {\n  var Value int32 = 0\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var field = Assert.Single(structDecl.Fields);
+        Assert.False(field.IsReadOnly);
+        Assert.NotNull(field.Initializer);
+    }
+
+    [Fact]
+    public void ParsesLetField()
+    {
+        const string source = "package P\ntype Counter class {\n  let Name string\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var field = Assert.Single(structDecl.Fields);
+        Assert.Equal("Name", field.Identifier.Text);
+        Assert.True(field.IsReadOnly);
+        Assert.Equal(SyntaxKind.LetKeyword, field.VarOrLetKeyword.Kind);
+    }
+
+    [Fact]
+    public void ParsesLetField_WithInitializer()
+    {
+        const string source = "package P\ntype Counter class {\n  let Name string = \"x\"\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var field = Assert.Single(structDecl.Fields);
+        Assert.True(field.IsReadOnly);
+        Assert.NotNull(field.Initializer);
+    }
+
+    [Fact]
+    public void ParsesVarField_WithAccessibility()
+    {
+        const string source = "package P\ntype Counter class {\n  public var Value int32\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var field = Assert.Single(structDecl.Fields);
+        Assert.NotNull(field.AccessibilityModifier);
+        Assert.Equal("public", field.AccessibilityModifier.Text);
+        Assert.False(field.IsReadOnly);
+    }
+
+    [Fact]
+    public void BareField_ReportsGS0288()
+    {
+        const string source = "package P\ntype Counter class {\n  Value int32\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        var diagnostic = Assert.Single(tree.Diagnostics);
+        Assert.Equal("GS0288", diagnostic.Id);
+        Assert.Contains("var", diagnostic.Message);
+        Assert.Contains("let", diagnostic.Message);
+    }
+
+    [Fact]
+    public void BareField_WithAccessibility_ReportsGS0288()
+    {
+        const string source = "package P\ntype Counter class {\n  public Value int32\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        var diagnostic = Assert.Single(tree.Diagnostics);
+        Assert.Equal("GS0288", diagnostic.Id);
+    }
+
+    [Fact]
+    public void ParsesMixedVarAndLetFields()
+    {
+        const string source = "package P\ntype Counter class {\n  var Mutable int32\n  let Constant string = \"x\"\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        Assert.Equal(2, structDecl.Fields.Length);
+        Assert.False(structDecl.Fields[0].IsReadOnly);
+        Assert.True(structDecl.Fields[1].IsReadOnly);
+    }
+
+    [Fact]
+    public void ParsesVarField_InStruct()
+    {
+        const string source = "package P\ntype Point struct {\n  var X int32\n  var Y int32\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        Assert.Equal(2, structDecl.Fields.Length);
+    }
+
+    [Fact]
+    public void ParsesVarField_InSharedBlock()
+    {
+        const string source = "package P\ntype Counter class {\n  shared {\n    var Instances int32 = 0\n  }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue693MultiTypeArgGenericCallParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue693MultiTypeArgGenericCallParserTests.cs
@@ -157,8 +157,8 @@ let d = Dictionary[string, Dictionary[string, int32]]()
         const string source = @"
 package P
 type Pair[A, B any] struct {
-    First A
-    Second B
+    var First A
+    var Second B
 }
 let p = Pair[int32, string]{First: 1, Second: ""x""}
 ";

--- a/test/Core.Tests/CodeAnalysis/Syntax/PropertyParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/PropertyParserTests.cs
@@ -98,7 +98,7 @@ public class PropertyParserTests
     public void AutoPropertyInDataStruct_ParsesButBinderReportsGS0189()
     {
         // The parser accepts prop in data struct; the binder reports GS0189.
-        const string source = "package P\ntype P data struct {\n  X int32\n  prop Y int32\n}\n";
+        const string source = "package P\ntype P data struct {\n  var X int32\n  prop Y int32\n}\n";
         var tree = SyntaxTree.Parse(source);
 
         // Parser should not fail — diagnostic comes from binder.

--- a/test/Interpreter.Tests/AttributeInterpreterTests.cs
+++ b/test/Interpreter.Tests/AttributeInterpreterTests.cs
@@ -72,7 +72,7 @@ public class AttributeInterpreterTests
     {
         // Issue #186: reading an `@Obsolete` field surfaces GS0204 at the
         // use site; the value still evaluates and prints.
-        var source = "type Point data struct {\n  @Obsolete(\"use NewX\")\n  X int32\n  Y int32\n}\nlet p = Point{ X: 1, Y: 2 }\np.X";
+        var source = "type Point data struct {\n  @Obsolete(\"use NewX\")\n  var X int32\n  var Y int32\n}\nlet p = Point{ X: 1, Y: 2 }\np.X";
         var output = RunSubmission(source);
         Assert.Contains("warning GS0204", output);
         Assert.Contains("Point.X", output);

--- a/test/Interpreter.Tests/Issue608InterpreterCLRDispatchTests.cs
+++ b/test/Interpreter.Tests/Issue608InterpreterCLRDispatchTests.cs
@@ -49,7 +49,7 @@ public class Issue608InterpreterCLRDispatchTests
             import GSharp.Interpreter.Tests.ProbeRef
             import System
             type Impl1 class : IHasName {
-                Name string
+                var Name string
             }
             var impl = Impl1{Name: "hello"}
             var iface IHasName = impl
@@ -72,7 +72,7 @@ public class Issue608InterpreterCLRDispatchTests
             import GSharp.Interpreter.Tests.ProbeRef
             import System
             type RWImpl class : IReadWrite {
-                Value string
+                var Value string
             }
             var impl = RWImpl{Value: "initial"}
             var iface IReadWrite = impl

--- a/test/Interpreter.Tests/PropertyInterpreterTests.cs
+++ b/test/Interpreter.Tests/PropertyInterpreterTests.cs
@@ -109,7 +109,7 @@ public class PropertyInterpreterTests
     [Fact]
     public void AutoPropertyInDataStruct_ReportsGS0189()
     {
-        var source = "type P data struct {\n  X int32\n  prop Y int32\n}\n";
+        var source = "type P data struct {\n  var X int32\n  prop Y int32\n}\n";
         var output = RunSubmission(source);
         Assert.Contains("GS0189", output);
     }

--- a/test/Interpreter.Tests/RefLocalAliasingInterpreterTests.cs
+++ b/test/Interpreter.Tests/RefLocalAliasingInterpreterTests.cs
@@ -70,7 +70,7 @@ tweak()
     {
         var output = RunSubmission(@"
 type Counter struct {
-    Value int32
+    var Value int32
 }
 
 func tweak() {

--- a/test/LanguageServer.Tests/CodeLensHandlerTests.cs
+++ b/test/LanguageServer.Tests/CodeLensHandlerTests.cs
@@ -79,7 +79,7 @@ public class CodeLensHandlerTests
     [Fact]
     public void ComputeLenses_StructFields()
     {
-        const string source = "type Point struct {\n    X int32\n    Y int32\n}\nvar p = Point{X: 1, Y: 2}\nvar q = p.X\n";
+        const string source = "type Point struct {\n    var X int32\n    var Y int32\n}\nvar p = Point{X: 1, Y: 2}\nvar q = p.X\n";
         var content = LanguageServerTestHelpers.Content(source);
 
         var lenses = CodeLensComputer.ComputeLenses(content);
@@ -121,7 +121,7 @@ public class CodeLensHandlerTests
     [Fact]
     public void ComputeLenses_ClassBodyMethods()
     {
-        const string source = "type Counter class {\n    Value int32\n    func Increment() {\n        Value = Value + 1\n    }\n}\nvar c = Counter{Value: 0}\nc.Increment()\nc.Increment()\n";
+        const string source = "type Counter class {\n    var Value int32\n    func Increment() {\n        Value = Value + 1\n    }\n}\nvar c = Counter{Value: 0}\nc.Increment()\nc.Increment()\n";
         var content = LanguageServerTestHelpers.Content(source);
 
         var lenses = CodeLensComputer.ComputeLenses(content);
@@ -171,7 +171,7 @@ public class CodeLensHandlerTests
     [Fact]
     public void ComputeLenses_SharedBlockMembers()
     {
-        const string source = "type Config class {\n    Name string\n    shared {\n        Default string\n    }\n}\n";
+        const string source = "type Config class {\n    var Name string\n    shared {\n        var Default string\n    }\n}\n";
         var content = LanguageServerTestHelpers.Content(source);
 
         var lenses = CodeLensComputer.ComputeLenses(content);

--- a/test/LanguageServer.Tests/CompletionHandlerTests.cs
+++ b/test/LanguageServer.Tests/CompletionHandlerTests.cs
@@ -74,7 +74,7 @@ public class CompletionHandlerTests
     [Fact]
     public void ComputeCompletions_IncludesStructTypes()
     {
-        const string source = "type Point struct {\nX int32\nY int32\n}\n";
+        const string source = "type Point struct {\nvar X int32\nvar Y int32\n}\n";
         var content = LanguageServerTestHelpers.Content(source);
 
         var items = CompletionComputer.ComputeCompletions(content, new GSharp.LanguageServer.Protocol.Position(0, 0));
@@ -114,7 +114,7 @@ public class CompletionHandlerTests
     [Fact]
     public void ComputeCompletions_AfterDotOnStructValue_OffersInstanceFields()
     {
-        const string source = "type Point struct {\nX int32\nY int32\n}\nfunc use(p Point) {\np.\n}\n";
+        const string source = "type Point struct {\nvar X int32\nvar Y int32\n}\nfunc use(p Point) {\np.\n}\n";
         var content = LanguageServerTestHelpers.Content(source);
 
         var items = CompletionComputer.ComputeCompletions(content, After(source, "p."));
@@ -190,7 +190,7 @@ public class CompletionHandlerTests
     [Fact]
     public void ComputeCompletions_AfterChainedMemberAccess_OffersMembers()
     {
-        const string source = "type Point struct {\nX int32\nY int32\n}\nfunc use(p Point) {\np.X.\n}\n";
+        const string source = "type Point struct {\nvar X int32\nvar Y int32\n}\nfunc use(p Point) {\np.X.\n}\n";
         var content = LanguageServerTestHelpers.Content(source);
 
         var items = CompletionComputer.ComputeCompletions(content, After(source, "p.X."));

--- a/test/LanguageServer.Tests/DefinitionHandlerTests.cs
+++ b/test/LanguageServer.Tests/DefinitionHandlerTests.cs
@@ -43,7 +43,7 @@ public class DefinitionHandlerTests
     [Fact]
     public void ComputeDefinition_StructNameGoesToDeclaration()
     {
-        const string source = "type Point struct {\nX int32\nY int32\n}\n";
+        const string source = "type Point struct {\nvar X int32\nvar Y int32\n}\n";
         var content = LanguageServerTestHelpers.Content(source);
         var uri = DocumentUri.From("file:///def.gs");
 

--- a/test/LanguageServer.Tests/DocumentSymbolHandlerTests.cs
+++ b/test/LanguageServer.Tests/DocumentSymbolHandlerTests.cs
@@ -28,7 +28,7 @@ public class DocumentSymbolHandlerTests
     [Fact]
     public void ComputeDocumentSymbols_ReturnsStructWithFields()
     {
-        const string source = "type Point struct {\nX int32\nY int32\n}\n";
+        const string source = "type Point struct {\nvar X int32\nvar Y int32\n}\n";
         var content = LanguageServerTestHelpers.Content(source);
 
         var symbols = DocumentSymbolComputer.ComputeDocumentSymbols(content);

--- a/test/LanguageServer.Tests/HoverHandlerTests.cs
+++ b/test/LanguageServer.Tests/HoverHandlerTests.cs
@@ -18,7 +18,7 @@ public class HoverHandlerTests
     [InlineData("var count = 0\n", "count", "var count int32")]
     [InlineData("func add(a int32, b int32) int32 { return a + b }\n", "add", "func add(a int32, b int32) int32")]
     [InlineData("func greet(name string) { }\n", "name", "name string")]
-    [InlineData("type Point struct {\nX int32\nY int32\n}\n", "Point", "type Point struct { X int32; Y int32 }")]
+    [InlineData("type Point struct {\nvar X int32\nvar Y int32\n}\n", "Point", "type Point struct { var X int32; var Y int32 }")]
     [InlineData("type Color enum { Red, Green }\n", "Color", "enum Color { Red, Green }")]
     [InlineData("import System\nfunc main() {\nConsole.WriteLine(\"hi\")\n}\n", "Console", "type System.Console class")]
     public void ComputeHover_ReturnsMarkdownSignature(string source, string token, string expected)
@@ -90,7 +90,7 @@ public class HoverHandlerTests
     [Fact]
     public void ComputeHover_ResolvesFieldOnUserDefinedStruct()
     {
-        const string source = "package P\ntype Point struct {\n    /// X coordinate\n    X int32\n    Y int32\n}\nfunc Main() {\n    var p = Point{}\n    var x = p.X\n}\n";
+        const string source = "package P\ntype Point struct {\n    /// X coordinate\n    var X int32\n    var Y int32\n}\nfunc Main() {\n    var p = Point{}\n    var x = p.X\n}\n";
         var content = LanguageServerTestHelpers.Content(source);
         var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "X", 1));
 

--- a/test/LanguageServer.Tests/NavigationHandlerTests.cs
+++ b/test/LanguageServer.Tests/NavigationHandlerTests.cs
@@ -45,7 +45,7 @@ public class NavigationHandlerTests
     [Fact]
     public void Implementation_FindsStructImplementingInterface()
     {
-        const string source = "type Shape interface { area() float64 }\ntype Circle struct { radius float64 }\nfunc (c Circle) area() float64 { return c.radius }\n";
+        const string source = "type Shape interface { area() float64 }\ntype Circle struct { var radius float64 }\nfunc (c Circle) area() float64 { return c.radius }\n";
         var content = LanguageServerTestHelpers.Content(source);
         var compilation = new Compilation(content.SyntaxTree);
         var position = LanguageServerTestHelpers.PositionOf(source, "Shape");

--- a/test/LanguageServer.Tests/SemanticLookupImplicitThisTests.cs
+++ b/test/LanguageServer.Tests/SemanticLookupImplicitThisTests.cs
@@ -47,7 +47,7 @@ public class SemanticLookupImplicitThisTests
     public void BareField_InsideMethodBody_ResolvesToField()
     {
         var sym = ResolveBareName(
-            "type Counter class {\n    Value int32\n    func Read() int32 { return Value }\n}\n",
+            "type Counter class {\n    var Value int32\n    func Read() int32 { return Value }\n}\n",
             tokenText: "Value",
             useOffsetOfNthOccurrence: 2);
 

--- a/test/LanguageServer.Tests/SemanticLookupMemberAccessTests.cs
+++ b/test/LanguageServer.Tests/SemanticLookupMemberAccessTests.cs
@@ -126,7 +126,7 @@ public class SemanticLookupMemberAccessTests
     [Fact]
     public void FieldAssignment_FieldIdentifier_Resolves()
     {
-        const string source = "type Counter class {\n    Value int32\n}\nfunc Main() {\n    var c = Counter{}\n    c.Value = 1\n}\n";
+        const string source = "type Counter class {\n    var Value int32\n}\nfunc Main() {\n    var c = Counter{}\n    c.Value = 1\n}\n";
         var (compilation, tree) = Compile(source);
 
         var valueInAssignment = IdentifierAt(tree, "Value", occurrence: 2);

--- a/test/LanguageServer.Tests/SemanticTokensHandlerTests.cs
+++ b/test/LanguageServer.Tests/SemanticTokensHandlerTests.cs
@@ -105,7 +105,7 @@ public class SemanticTokensHandlerTests
     [Fact]
     public void Tokenize_ClassifiesStructDeclaration()
     {
-        const string source = "type Point struct {\n    X int32\n    Y int32\n}\n";
+        const string source = "type Point struct {\n    var X int32\n    var Y int32\n}\n";
         var content = LanguageServerTestHelpers.Content(source);
         var tokens = GetTokens(content);
 

--- a/test/LanguageServer.Tests/WorkspaceSymbolHandlerTests.cs
+++ b/test/LanguageServer.Tests/WorkspaceSymbolHandlerTests.cs
@@ -29,7 +29,7 @@ public class WorkspaceSymbolHandlerTests
     [Fact]
     public void CollectSymbols_FindsStructsAndFields()
     {
-        const string source = "type Point struct {\nX int32\nY int32\n}\n";
+        const string source = "type Point struct {\nvar X int32\nvar Y int32\n}\n";
         var content = LanguageServerTestHelpers.Content(source);
         var results = new List<WorkspaceSymbol>();
 


### PR DESCRIPTION
Implements [#694](https://github.com/DavidObando/gsharp/issues/694).

## User request (verbatim)

> The G# language has allowed types to declare fields in structures/classes to be declared without a var, for simplicity. Later on, types added support for properties, methods (functions), events, etc. leaving fields looking a little bare.
>
> This has led me to re-think how to declare fields, and have landed on a Swift language style. Please create an ADR for this and implement it end-to-end. Given this is a language change, we expect a lot of tests to fail until they get updated so include the test updates in the scope.

## Decision

Adopt Swift-style `var` (mutable) / `let` (read-only) prefixes on every field declaration inside a type body — see [ADR-0067 `docs/adr/0067-fields-require-var-keyword.md`](./docs/adr/0067-fields-require-var-keyword.md). After ADR-0051 (properties), ADR-0052 (events), and ADR-0065 (initializers), bare fields were the only member shape in a type body without a leading keyword; the new syntax matches the keyword scheme G# already uses for local bindings in ADR-0008 and removes the visual ambiguity between fields and properties/events/methods.

## Syntax change

Before:

```gsharp
type Counter class {
    Value int32 = 0
    Name string
    func Touch() { ... }
}
```

After:

```gsharp
type Counter class {
    var Value int32 = 0
    let Name string = "x"
    func Touch() { ... }
}
```

* `let` fields emit as CLR `initonly` (mirrors `readonly` in C#).
* Reassignment of a `let` field outside an initializer/constructor reports the existing `GS0127 — Variable '...' is read-only and cannot be assigned to.`
* Property syntax (`Name Type { get; set }`) and event syntax (`event Name func(...)`) are unchanged — they already carry their own keywords or brace-bearing shape.
* Primary-constructor parameter lists (`type X class(a int32, b string)`) are unchanged — parameters are not fields.

## Compiler changes

* **Parser** — `ParseFieldDeclaration` now consumes a required `var`/`let` token after any optional accessibility modifier; missing keyword reports the new `GS0288 — Field declarations require a 'var' (mutable) or 'let' (read-only) keyword.`
* **Parser fix** — `ParseOptionalTypeClause` now refuses to consume a contextual member-position keyword (`event`/`prop`/`init`/`convenience`/`shared`) as a `func(...)` return type. This had been a latent ambiguity (silently eating the next member's lead-in identifier); GS0288 surfaced it and the fix unblocks multi-event / multi-property type bodies.
* **Syntax** — `FieldDeclarationSyntax` gains a `VarOrLetKeyword` token and an `IsReadOnly` convenience (`true` iff the keyword is `let`).
* **Binder** — `DeclarationBinder` ORs `fieldSyntax.IsReadOnly` into the existing `FieldSymbol.IsReadOnly` flag for both instance and `shared` static fields. No new bound-node kind; downstream binding and emit logic carry the flag through unchanged.
* **Symbols** — `SymbolDisplay` (hover / signature help) now renders the `var`/`let` prefix in struct / class signatures.

## Bound-tree change

Just an `IsReadOnly: bool` flag on the already-existing `FieldSymbol`. No new bound-node kinds, no `BoundTreeRewriter`/`BoundTreeWalker`/`BoundNodePrinter`/`SpillSequenceSpiller` updates required.

## Migration impact

All bare field declarations across the codebase were mechanically updated to `var <Name> <Type>` (read-only conversions to `let` are intentional follow-ups so the surface migration stays conservative).

* All `samples/**.gs` files
* All G# source fixtures embedded as C# string literals across `test/Core.Tests`, `test/Compiler.Tests`, `test/Interpreter.Tests`, `test/LanguageServer.Tests`
* Doc snippets in `docs/adr/0019`, `0034`, `0035`, `0051`, `0065`, and `docs/diagnostics.md`

## Tests added

* `test/Core.Tests/CodeAnalysis/Syntax/FieldDeclarationParserTests.cs` — 10 tests: parses `var`/`let`, accessibility + `var`, initializers, mixed `var`+`let`, struct fields, shared-block fields, plus two negative tests asserting GS0288 on bare-field declarations (with and without accessibility).
* `test/Core.Tests/CodeAnalysis/Binding/LetFieldBindingTests.cs` — `let` field assignment reports GS0127; `var` field assignment is allowed.
* `test/Compiler.Tests/Emit/LetFieldEmitTests.cs` — reflection round-trip: `let` field → `FieldInfo.IsInitOnly == true`, `var` field → `false`.

## Build & test status

* `dotnet build GSharp.sln -nologo -clp:NoSummary` — **clean** (0 errors, 0 warnings).
* `dotnet test GSharp.sln --no-restore --nologo` — **all green**:
  * Core: **2375** passed, 1 skipped, 0 failed
  * Compiler: **1002** passed, 0 failed
  * Interpreter: **98** passed, 0 failed
  * LanguageServer: **242** passed, 0 failed
  * Sdk: **26** passed, 0 failed
  * **Total: 3743 passed, 1 skipped, 0 failed**

## Files changed

133 files: 1 new ADR, 3 new test files, 4 production source files modified (parser, syntax node, diagnostics, binder, symbol display), and mechanical migration across samples, tests, and docs.

Closes #694.
