### PR TITLE
Implement #713: LSP completion polish for async func type clauses

### DIFF
--- a/build/gsharp.build.props
+++ b/build/gsharp.build.props
@@ -25,6 +25,10 @@
     <!-- Runtime packages-->
     <MicrosoftVisualStudioValidationPackageReference Include="Microsoft.VisualStudio.Validation" Version="17.8.8" />
     <StreamJsonRpcPackageReference Include="StreamJsonRpc" Version="2.21.10" />
+    <!-- Pin transitive MessagePack to a patched version (advisory GHSA-hv8m-jj95-wg3x).
+         StreamJsonRpc 2.21.10 brings MessagePack 2.5.187, which fails NU1903 (Warning As Error)
+         on the vscode-extension Compile step. -->
+    <MessagePackPackageReference Include="MessagePack" Version="2.5.301" />
     <!-- Design-time packages -->
     <NerdbankGitVersioningPackageReference Include="Nerdbank.GitVersioning" Version="3.6.143" PrivateAssets="All" />
     <StyleCopAnalyzersPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -26,6 +26,19 @@ public static class HoverComputer
         var compilation = content.Project?.GetCompilation() ?? new Compilation(content.SyntaxTree);
         var offset = SemanticLookup.ToOffset(content, position);
         var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
+
+        // Issue #713: when hovering a token inside an `async func(...)` (ADR-0043) or
+        // `async sequence[T]` (ADR-0042) type clause, surface the ADR-rooted prose
+        // before falling through to symbol/identifier resolution. The two type-clause
+        // spellings have no resolved symbol of their own — the binder collapses them
+        // onto FunctionTypeSymbol / AsyncSequenceTypeSymbol — so without this carve-out
+        // the user would get nothing.
+        var asyncHover = TryComputeAsyncTypeClauseHover(content.SyntaxTree, offset, token);
+        if (asyncHover != null)
+        {
+            return asyncHover;
+        }
+
         var symbol = SemanticLookup.ResolveSymbol(compilation, token);
 
         // When the token isn't directly in the semantic model (e.g. member access
@@ -84,6 +97,54 @@ public static class HoverComputer
     public static string FormatSymbol(Symbol symbol, Compilation compilation)
     {
         return SymbolDisplay.ToDisplayString(symbol, SymbolDisplayFormat.Signature, compilation);
+    }
+
+    private static Hover TryComputeAsyncTypeClauseHover(SyntaxTree tree, int offset, SyntaxToken token)
+    {
+        if (token == null || token.IsMissing)
+        {
+            return null;
+        }
+
+        // Only trigger on the three tokens that uniquely identify the two async-type
+        // spellings — anything else (identifier, operator, punctuation) falls back to
+        // the regular symbol-resolution path.
+        if (token.Kind != SyntaxKind.AsyncKeyword
+            && token.Kind != SyntaxKind.SequenceKeyword
+            && token.Kind != SyntaxKind.FuncKeyword)
+        {
+            return null;
+        }
+
+        var enclosing = TypeClauseCompletions.FindEnclosingTypeClause(tree.Root, offset);
+        if (enclosing == null)
+        {
+            return null;
+        }
+
+        string body;
+        if (enclosing.IsAsyncFunction && (token.Kind == SyntaxKind.AsyncKeyword || token.Kind == SyntaxKind.FuncKeyword))
+        {
+            body = "```gsharp\nasync func(...) R\n```\n\n" + TypeClauseCompletions.AsyncFuncDocumentation;
+        }
+        else if (enclosing.IsAsyncSequence && (token.Kind == SyntaxKind.AsyncKeyword || token.Kind == SyntaxKind.SequenceKeyword))
+        {
+            body = "```gsharp\nasync sequence[T]\n```\n\n" + TypeClauseCompletions.AsyncSequenceDocumentation;
+        }
+        else
+        {
+            return null;
+        }
+
+        return new Hover
+        {
+            Contents = new MarkedStringsOrMarkupContent(new MarkupContent
+            {
+                Kind = MarkupKind.Markdown,
+                Value = body,
+            }),
+            Range = SemanticLookup.ToRange(token),
+        };
     }
 
     private static HoverModel BuildHoverModel(Symbol symbol, Compilation compilation)
@@ -1285,6 +1346,12 @@ public static class CompletionComputer
 
         var items = new List<CompletionItem>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        // Issue #713: in a type-clause position, surface the `async func(...) R`
+        // (ADR-0043) and `async sequence[T]` (ADR-0042) snippets so the two
+        // GSharp-flavored async-type spellings are discoverable. The snippets stay
+        // out of every other completion context.
+        TypeClauseCompletions.TryAddTypeClauseSnippets(items, seen, content.SyntaxTree, offset);
 
         // Add keywords
         foreach (var keyword in GetKeywords())

--- a/src/LanguageServer/LanguageServer.csproj
+++ b/src/LanguageServer/LanguageServer.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="@(StreamJsonRpcPackageReference)" />
+    <PackageReference Include="@(MessagePackPackageReference)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LanguageServer/Protocol/Models.cs
+++ b/src/LanguageServer/Protocol/Models.cs
@@ -231,6 +231,12 @@ public enum CompletionItemKind
     TypeParameter = 25,
 }
 
+public enum InsertTextFormat
+{
+    PlainText = 1,
+    Snippet = 2,
+}
+
 public sealed class CompletionItem
 {
     [JsonPropertyName("label")]
@@ -241,6 +247,26 @@ public sealed class CompletionItem
 
     [JsonPropertyName("detail")]
     public string Detail { get; set; }
+
+    [JsonPropertyName("documentation")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public MarkupContent Documentation { get; set; }
+
+    [JsonPropertyName("insertText")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string InsertText { get; set; }
+
+    [JsonPropertyName("insertTextFormat")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public InsertTextFormat InsertTextFormat { get; set; }
+
+    [JsonPropertyName("sortText")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string SortText { get; set; }
+
+    [JsonPropertyName("filterText")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string FilterText { get; set; }
 }
 
 public sealed class CompletionList

--- a/src/LanguageServer/TypeClauseCompletions.cs
+++ b/src/LanguageServer/TypeClauseCompletions.cs
@@ -1,0 +1,297 @@
+// <copyright file="TypeClauseCompletions.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.LanguageServer.Protocol;
+
+namespace GSharp.LanguageServer;
+
+/// <summary>
+/// Issue #713 — LSP completion polish for the <c>async func(...) R</c> (ADR-0043) and
+/// <c>async sequence[T]</c> (ADR-0042) type-clause spellings.
+/// </summary>
+/// <remarks>
+/// The two forms only make sense in a type-clause position (parameter / local / field /
+/// return type / generic argument / etc.). The detector here piggy-backs on the syntax
+/// tree the parser already produced: it walks down from the root looking for the
+/// deepest <see cref="TypeClauseSyntax"/> that brackets the caret offset, plus a small
+/// set of "type-clause-bearing" parents whose type slot is currently empty (the user
+/// hasn't typed anything yet — e.g. <c>let x |</c>, <c>func foo(p |)</c>,
+/// <c>func foo() |</c>). This piggy-backs on the parser's own type-clause shapes
+/// instead of duplicating the start-of-type-clause set.
+/// </remarks>
+internal static class TypeClauseCompletions
+{
+    /// <summary>Snippet label for the <c>async func(...) R</c> form (ADR-0043).</summary>
+    public const string AsyncFuncLabel = "async func(...) R";
+
+    /// <summary>Snippet label for the <c>async sequence[T]</c> form (ADR-0042).</summary>
+    public const string AsyncSequenceLabel = "async sequence[T]";
+
+    /// <summary>
+    /// Markdown body rendered as <see cref="CompletionItem.Documentation"/> for the
+    /// <c>async func</c> snippet, and reused by <see cref="HoverComputer"/> when hovering
+    /// the <c>async</c>/<c>func</c> tokens of an async function-type clause.
+    /// </summary>
+    public const string AsyncFuncDocumentation =
+        "**`async func(P) R`** — function-type spelling for `func(P) Task[R]` (ADR-0043).\n\n" +
+        "In any type-clause position, `async func(P1, P2, ...) R` resolves to the same `FunctionTypeSymbol` as the explicit " +
+        "`func(P1, P2, ...) Task[R]` spelling — the two are freely interchangeable. " +
+        "Use this form to match the `async func foo() R` declaration shape at consumer sites (parameters, locals, fields, " +
+        "return types). The return-slot wrap mirrors the declaration-site rules of ADR-0023; writing `Task[X]` explicitly " +
+        "inside an `async func(...)` is a diagnostic (GS0189) because the modifier already implies it.\n\n" +
+        "Special-case follower: `async sequence[T]` resolves to `IAsyncEnumerable[T]` (ADR-0042).";
+
+    /// <summary>
+    /// Markdown body rendered as <see cref="CompletionItem.Documentation"/> for the
+    /// <c>async sequence</c> snippet, and reused by <see cref="HoverComputer"/> when
+    /// hovering the <c>async</c>/<c>sequence</c> tokens of an async sequence type clause.
+    /// </summary>
+    public const string AsyncSequenceDocumentation =
+        "**`async sequence[T]`** — type-clause spelling for `IAsyncEnumerable[T]` (ADR-0042).\n\n" +
+        "In any type-clause position, `async sequence[T]` resolves to `System.Collections.Generic.IAsyncEnumerable<T>` — " +
+        "the same `AsyncSequenceTypeSymbol` produced by the ADR-0041 implicit-swap in an async iterator's return slot. " +
+        "Use this form at consumer sites (parameters, locals, fields, generic arguments) to keep a GSharp-flavored spelling " +
+        "instead of dropping to the BCL `IAsyncEnumerable[T]` name.\n\n" +
+        "`async` as a type-clause prefix is only legal before `sequence[T]` (ADR-0042) or `func(...)` (ADR-0043).";
+
+    /// <summary>
+    /// Sort prefix that floats both async-type snippets above keyword and global-symbol
+    /// items in a type-clause position. LSP sorts ascending by <see cref="CompletionItem.SortText"/>;
+    /// the leading zeros keep them ahead of identifier names.
+    /// </summary>
+    private const string SortPrefix = "00";
+
+    /// <summary>
+    /// Adds the <c>async func(...) R</c> and <c>async sequence[T]</c> snippets to
+    /// <paramref name="items"/> when <paramref name="offset"/> sits in a type-clause
+    /// position inside <paramref name="tree"/>. No-op outside type-clause positions.
+    /// </summary>
+    /// <param name="items">The completion-item list being built.</param>
+    /// <param name="seen">The label-deduplication set shared with the caller.</param>
+    /// <param name="tree">The syntax tree to inspect.</param>
+    /// <param name="offset">The caret offset.</param>
+    /// <returns><c>true</c> when the caret is in a type-clause position and snippets were appended (or were already present).</returns>
+    public static bool TryAddTypeClauseSnippets(
+        List<CompletionItem> items,
+        HashSet<string> seen,
+        SyntaxTree tree,
+        int offset)
+    {
+        if (!IsInTypeClausePosition(tree, offset))
+        {
+            return false;
+        }
+
+        AddSnippet(items, seen, AsyncFuncLabel, BuildAsyncFuncSnippet(), AsyncFuncDocumentation, "01");
+        AddSnippet(items, seen, AsyncSequenceLabel, BuildAsyncSequenceSnippet(), AsyncSequenceDocumentation, "02");
+        return true;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the caret at <paramref name="offset"/> sits in a position
+    /// where the parser would parse a <see cref="TypeClauseSyntax"/>.
+    /// </summary>
+    /// <remarks>
+    /// Two cases qualify:
+    /// <list type="bullet">
+    ///   <item>the deepest syntax node containing the offset is (or is inside) a <see cref="TypeClauseSyntax"/>; OR</item>
+    ///   <item>the offset sits in the *empty* type-clause slot of a parent that expects one — between the identifier and the
+    ///         <c>=</c> of a variable declaration, between a function's <c>)</c> and its body brace, etc.</item>
+    /// </list>
+    /// </remarks>
+    /// <param name="tree">The syntax tree to inspect.</param>
+    /// <param name="offset">The caret offset.</param>
+    /// <returns><c>true</c> when the caret sits in a type-clause position.</returns>
+    public static bool IsInTypeClausePosition(SyntaxTree tree, int offset)
+    {
+        // First: deepest enclosing TypeClauseSyntax (the populated case — the user has
+        // typed something parsable into the type slot, even if it's just `async `).
+        if (FindEnclosingTypeClause(tree.Root, offset) != null)
+        {
+            return true;
+        }
+
+        // Second: empty type-slot of a known type-clause-bearing parent.
+        foreach (var node in EnumerateNodesContaining(tree.Root, offset))
+        {
+            if (IsCaretInEmptyTypeSlot(node, offset))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the deepest <see cref="TypeClauseSyntax"/> in <paramref name="root"/> whose
+    /// span brackets <paramref name="offset"/>, or <c>null</c> when the caret is not inside
+    /// a type clause. Used by hover to render ADR-rooted docs on <c>async</c> and the
+    /// following keyword token.
+    /// </summary>
+    /// <param name="root">The root node to walk.</param>
+    /// <param name="offset">The caret offset.</param>
+    /// <returns>The deepest enclosing type clause, or <c>null</c>.</returns>
+    public static TypeClauseSyntax FindEnclosingTypeClause(SyntaxNode root, int offset)
+    {
+        TypeClauseSyntax best = null;
+        foreach (var node in EnumerateAllNodes(root))
+        {
+            if (node is not TypeClauseSyntax typeClause)
+            {
+                continue;
+            }
+
+            if (typeClause.Span.Start <= offset && offset <= typeClause.Span.End)
+            {
+                if (best == null || typeClause.Span.Length < best.Span.Length)
+                {
+                    best = typeClause;
+                }
+            }
+        }
+
+        return best;
+    }
+
+    /// <summary>
+    /// Builds the LSP snippet for <c>async func(T) R</c> (ADR-0043). The snippet
+    /// expands to a syntactically-valid type clause when accepted; placeholders
+    /// <c>${1:T}</c> and <c>${2:R}</c> are tab-stops for the user.
+    /// </summary>
+    /// <returns>The snippet body.</returns>
+    public static string BuildAsyncFuncSnippet() => "async func(${1:T}) ${2:R}";
+
+    /// <summary>
+    /// Builds the LSP snippet for <c>async sequence[T]</c> (ADR-0042).
+    /// </summary>
+    /// <returns>The snippet body.</returns>
+    public static string BuildAsyncSequenceSnippet() => "async sequence[${1:T}]";
+
+    private static bool IsCaretInEmptyTypeSlot(SyntaxNode node, int offset)
+    {
+        switch (node)
+        {
+            case VariableDeclarationSyntax variable when variable.TypeClause == null:
+                // `let x |` (no type, no equals yet) or `let x | = ...`. The type slot lives
+                // between the identifier and either the equals token or the end of the decl.
+                return IsBetween(variable.Identifier?.Span.End ?? -1, GetEarliestEnd(variable.EqualsToken, variable.Initializer), offset);
+
+            case ParameterSyntax parameter when parameter.Type == null:
+                // `func foo(p |` — the type slot is between the identifier (or ellipsis) and the
+                // parameter's end.
+                var afterIdent = parameter.EllipsisToken?.Span.End ?? parameter.Identifier?.Span.End ?? -1;
+                return IsBetween(afterIdent, parameter.Span.End, offset);
+
+            case FieldDeclarationSyntax field when field.Type == null:
+                // `var name |` inside a struct/class body.
+                return IsBetween(field.Identifier?.Span.End ?? -1, GetEarliestEnd(field.EqualsToken, field.Initializer), offset);
+
+            case FunctionDeclarationSyntax func when func.Type == null:
+                // `func foo() |{ ... }` — the optional return-type slot between the parameter
+                // list's closing parenthesis and the body brace.
+                return IsBetween(func.CloseParenthesisToken?.Span.End ?? -1, func.Body?.Span.Start ?? -1, offset);
+
+            default:
+                return false;
+        }
+    }
+
+    private static int GetEarliestEnd(SyntaxToken token, SyntaxNode node)
+    {
+        if (token != null && !token.IsMissing)
+        {
+            return token.Span.Start;
+        }
+
+        if (node != null)
+        {
+            return node.Span.Start;
+        }
+
+        return int.MaxValue;
+    }
+
+    private static bool IsBetween(int startExclusiveLow, int endInclusiveHigh, int offset)
+    {
+        if (startExclusiveLow < 0 || endInclusiveHigh < 0 || endInclusiveHigh < startExclusiveLow)
+        {
+            return false;
+        }
+
+        // We allow the caret to sit at either end of the slot.
+        return startExclusiveLow <= offset && offset <= endInclusiveHigh;
+    }
+
+    private static void AddSnippet(
+        List<CompletionItem> items,
+        HashSet<string> seen,
+        string label,
+        string snippet,
+        string documentation,
+        string sortKey)
+    {
+        if (!seen.Add(label))
+        {
+            return;
+        }
+
+        items.Add(new CompletionItem
+        {
+            Label = label,
+            Kind = CompletionItemKind.Snippet,
+            Detail = "GSharp type-clause snippet",
+            InsertText = snippet,
+            InsertTextFormat = InsertTextFormat.Snippet,
+            SortText = SortPrefix + sortKey,
+            FilterText = "async",
+            Documentation = new MarkupContent
+            {
+                Kind = MarkupKind.Markdown,
+                Value = documentation,
+            },
+        });
+    }
+
+    private static IEnumerable<SyntaxNode> EnumerateAllNodes(SyntaxNode node)
+    {
+        yield return node;
+        foreach (var child in node.GetChildren())
+        {
+            if (child is SyntaxToken)
+            {
+                continue;
+            }
+
+            foreach (var descendant in EnumerateAllNodes(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+
+    private static IEnumerable<SyntaxNode> EnumerateNodesContaining(SyntaxNode node, int offset)
+    {
+        if (offset < node.Span.Start || offset > node.Span.End)
+        {
+            yield break;
+        }
+
+        yield return node;
+        foreach (var child in node.GetChildren())
+        {
+            if (child is SyntaxToken)
+            {
+                continue;
+            }
+
+            foreach (var descendant in EnumerateNodesContaining(child, offset))
+            {
+                yield return descendant;
+            }
+        }
+    }
+}

--- a/test/LanguageServer.Tests/AsyncTypeClauseCompletionTests.cs
+++ b/test/LanguageServer.Tests/AsyncTypeClauseCompletionTests.cs
@@ -1,0 +1,286 @@
+// <copyright file="AsyncTypeClauseCompletionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.LanguageServer.Protocol;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// Issue #713 — exercises the LSP completion and hover polish for the two
+/// async type-clause spellings:
+/// <list type="bullet">
+///   <item><c>async func(...) R</c> (ADR-0043) — alias for <c>func(...) Task[R]</c>.</item>
+///   <item><c>async sequence[T]</c> (ADR-0042) — alias for <c>IAsyncEnumerable[T]</c>.</item>
+/// </list>
+/// </summary>
+public class AsyncTypeClauseCompletionTests
+{
+    // ---------- Completion: snippets surface in type-clause positions ----------
+
+    [Fact]
+    public void Completion_AtStartOfEmptyParameterTypeSlot_OffersBothAsyncSnippets()
+    {
+        // Cursor right after the parameter identifier, before any type characters have been
+        // typed: `func foo(p |)`. This is the canonical "empty type-clause position".
+        const string source = "func foo(p ) { }\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, AfterMarker(source, "func foo(p "));
+
+        AssertHasAsyncFuncSnippet(items);
+        AssertHasAsyncSequenceSnippet(items);
+    }
+
+    [Fact]
+    public void Completion_AfterAsyncKeywordInParameterType_StillOffersBothAsyncSnippets()
+    {
+        // User has typed `async ` in a type-clause slot. The parser produces an incomplete
+        // async-prefixed type clause; the caret sits inside it. Both snippets should still
+        // appear so the user can pick `async func(...)` or `async sequence[T]`.
+        const string source = "func foo(p async ) { }\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, AfterMarker(source, "func foo(p async "));
+
+        AssertHasAsyncFuncSnippet(items);
+        AssertHasAsyncSequenceSnippet(items);
+
+        // The snippets must sort ahead of the keyword/global soup so they are surfaced first
+        // when the user filters by "async".
+        var asyncFuncItem = items.Single(i => i.Label == TypeClauseCompletions.AsyncFuncLabel);
+        Assert.False(string.IsNullOrEmpty(asyncFuncItem.SortText));
+        Assert.StartsWith("0", asyncFuncItem.SortText, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Completion_InsideExpressionPosition_DoesNotOfferAsyncSnippets()
+    {
+        // Caret sits inside an expression body (the `return` statement), which is NOT a
+        // type-clause position. Snippets must NOT appear or they would pollute every
+        // completion list in the file.
+        const string source = "func foo() int32 { return  }\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, AfterMarker(source, "return "));
+
+        Assert.DoesNotContain(items, i => i.Label == TypeClauseCompletions.AsyncFuncLabel);
+        Assert.DoesNotContain(items, i => i.Label == TypeClauseCompletions.AsyncSequenceLabel);
+    }
+
+    [Fact]
+    public void Completion_InsideVariableInitializerExpression_DoesNotOfferAsyncSnippets()
+    {
+        // A variable initializer expression is also NOT a type-clause position.
+        const string source = "let x int32 = 42\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, AfterMarker(source, "let x int32 = "));
+
+        Assert.DoesNotContain(items, i => i.Label == TypeClauseCompletions.AsyncFuncLabel);
+        Assert.DoesNotContain(items, i => i.Label == TypeClauseCompletions.AsyncSequenceLabel);
+    }
+
+    [Fact]
+    public void Completion_InsideFunctionReturnTypeSlot_OffersBothAsyncSnippets()
+    {
+        // `func foo() |{ ... }` — the optional return-type slot is a type-clause position.
+        const string source = "func foo() { return }\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, AfterMarker(source, "func foo() "));
+
+        AssertHasAsyncFuncSnippet(items);
+        AssertHasAsyncSequenceSnippet(items);
+    }
+
+    [Fact]
+    public void Completion_InsideLocalVariableTypeSlot_OffersBothAsyncSnippets()
+    {
+        // `let x | = ...` — the optional type-clause slot of a variable declaration.
+        const string source = "func main() { let x  = 0 }\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, AfterMarker(source, "let x "));
+
+        AssertHasAsyncFuncSnippet(items);
+        AssertHasAsyncSequenceSnippet(items);
+    }
+
+    // ---------- Snippet text: each inserted body parses cleanly as a type clause ----------
+
+    [Theory]
+    [InlineData(TypeClauseSnippetForm.AsyncFunc)]
+    [InlineData(TypeClauseSnippetForm.AsyncSequence)]
+    public void Snippet_PlaceholderExpansion_ParsesAsValidTypeClause(TypeClauseSnippetForm form)
+    {
+        var raw = form == TypeClauseSnippetForm.AsyncFunc
+            ? TypeClauseCompletions.BuildAsyncFuncSnippet()
+            : TypeClauseCompletions.BuildAsyncSequenceSnippet();
+
+        // The snippet body is in LSP placeholder format `${1:T}`; expand placeholders to their
+        // default values so the resulting text is G# syntax — the same text the editor would
+        // commit if the user accepted the snippet without retyping.
+        var expanded = ExpandPlaceholders(raw);
+        Assert.Contains("async", expanded, System.StringComparison.Ordinal);
+
+        // Embed the expanded type into a minimal program at a type-clause position, then parse
+        // and assert no parser diagnostics. `let _x EXPANDED = nil` is the most compact site;
+        // ADR-0042 / ADR-0043 both allow these spellings in a local's type slot.
+        var program = $"func host() {{ let _x {expanded} = nil }}\n";
+        var tree = SyntaxTree.Parse(program);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    // ---------- Hover: ADR-rooted documentation on async type clauses ----------
+
+    [Fact]
+    public void Hover_OnAsyncKeywordOfAsyncFuncTypeClause_RendersAdr0043Documentation()
+    {
+        const string source = "func foo(cb async func(int32) int32) { }\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "async"));
+
+        Assert.NotNull(hover);
+        var text = hover.Contents.ToString();
+        Assert.Contains("ADR-0043", text, System.StringComparison.Ordinal);
+        Assert.Contains("async func", text, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Hover_OnFuncKeywordOfAsyncFuncTypeClause_RendersAdr0043Documentation()
+    {
+        const string source = "func foo(cb async func(int32) int32) { }\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "func(int32)"));
+
+        Assert.NotNull(hover);
+        Assert.Contains("ADR-0043", hover.Contents.ToString(), System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Hover_OnAsyncKeywordOfAsyncSequenceTypeClause_RendersAdr0042Documentation()
+    {
+        const string source = "func foo(s async sequence[int32]) { }\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "async"));
+
+        Assert.NotNull(hover);
+        var text = hover.Contents.ToString();
+        Assert.Contains("ADR-0042", text, System.StringComparison.Ordinal);
+        Assert.Contains("async sequence", text, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Hover_OnSequenceKeywordOfAsyncSequenceTypeClause_RendersAdr0042Documentation()
+    {
+        const string source = "func foo(s async sequence[int32]) { }\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "sequence"));
+
+        Assert.NotNull(hover);
+        Assert.Contains("ADR-0042", hover.Contents.ToString(), System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Hover_OnPlainSequenceKeyword_DoesNotRenderAsyncHover()
+    {
+        // A non-async `sequence[T]` type clause should NOT pick up the ADR-0042 hover; the
+        // hover is reserved for the async-prefixed form. (The regular hover path may return
+        // null here — what matters is that the ADR-0042 prose does not leak out.)
+        const string source = "func foo(s sequence[int32]) { }\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "sequence"));
+
+        if (hover != null)
+        {
+            Assert.DoesNotContain("ADR-0042", hover.Contents.ToString(), System.StringComparison.Ordinal);
+            Assert.DoesNotContain("ADR-0043", hover.Contents.ToString(), System.StringComparison.Ordinal);
+        }
+    }
+
+    // ---------- Completion-item shape: snippet, markdown docs, both wired ----------
+
+    [Fact]
+    public void Completion_AsyncFuncSnippetItem_IsMarkedAsSnippetWithMarkdownDocs()
+    {
+        const string source = "func foo(p ) { }\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, AfterMarker(source, "func foo(p "));
+        var item = items.Single(i => i.Label == TypeClauseCompletions.AsyncFuncLabel);
+
+        Assert.Equal(CompletionItemKind.Snippet, item.Kind);
+        Assert.Equal(InsertTextFormat.Snippet, item.InsertTextFormat);
+        Assert.Equal(TypeClauseCompletions.BuildAsyncFuncSnippet(), item.InsertText);
+        Assert.NotNull(item.Documentation);
+        Assert.Equal(MarkupKind.Markdown, item.Documentation.Kind);
+        Assert.Contains("ADR-0043", item.Documentation.Value, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Completion_AsyncSequenceSnippetItem_IsMarkedAsSnippetWithMarkdownDocs()
+    {
+        const string source = "func foo(p ) { }\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, AfterMarker(source, "func foo(p "));
+        var item = items.Single(i => i.Label == TypeClauseCompletions.AsyncSequenceLabel);
+
+        Assert.Equal(CompletionItemKind.Snippet, item.Kind);
+        Assert.Equal(InsertTextFormat.Snippet, item.InsertTextFormat);
+        Assert.Equal(TypeClauseCompletions.BuildAsyncSequenceSnippet(), item.InsertText);
+        Assert.NotNull(item.Documentation);
+        Assert.Equal(MarkupKind.Markdown, item.Documentation.Kind);
+        Assert.Contains("ADR-0042", item.Documentation.Value, System.StringComparison.Ordinal);
+    }
+
+    private static void AssertHasAsyncFuncSnippet(System.Collections.Generic.IReadOnlyList<CompletionItem> items)
+    {
+        Assert.Contains(
+            items,
+            i => i.Label == TypeClauseCompletions.AsyncFuncLabel
+                && i.Kind == CompletionItemKind.Snippet
+                && i.InsertTextFormat == InsertTextFormat.Snippet);
+    }
+
+    private static void AssertHasAsyncSequenceSnippet(System.Collections.Generic.IReadOnlyList<CompletionItem> items)
+    {
+        Assert.Contains(
+            items,
+            i => i.Label == TypeClauseCompletions.AsyncSequenceLabel
+                && i.Kind == CompletionItemKind.Snippet
+                && i.InsertTextFormat == InsertTextFormat.Snippet);
+    }
+
+    private static Position AfterMarker(string source, string marker)
+    {
+        var start = LanguageServerTestHelpers.PositionOf(source, marker);
+        return new Position(start.Line, start.Character + marker.Length);
+    }
+
+    /// <summary>
+    /// Replaces every LSP placeholder of shape <c>${N:default}</c> with its default text.
+    /// Used to verify the committed-snippet text is a valid G# type clause.
+    /// </summary>
+    /// <param name="raw">The raw snippet body.</param>
+    /// <returns>The expanded text the editor would commit if the user pressed Enter without retyping.</returns>
+    private static string ExpandPlaceholders(string raw)
+    {
+        return System.Text.RegularExpressions.Regex.Replace(raw, @"\$\{\d+:([^}]*)\}", "$1");
+    }
+
+    public enum TypeClauseSnippetForm
+    {
+        AsyncFunc,
+        AsyncSequence,
+    }
+}

--- a/website/docs/tooling/lsp.md
+++ b/website/docs/tooling/lsp.md
@@ -52,7 +52,7 @@ The server capability factory enables the following:
 | Folding ranges | `textDocument/foldingRange`. |
 | Selection ranges | `textDocument/selectionRange`. |
 | Linked editing | `textDocument/linkedEditingRange`. |
-| Completion | `textDocument/completion`, triggered on `.`. |
+| Completion | `textDocument/completion`, triggered on `.`. In a type-clause position (parameter, local, field, return type, generic argument, etc.) the list includes ready-to-use snippets for `async func(...) R` (ADR-0043) and `async sequence[T]` (ADR-0042), with Markdown documentation rendered from the same prose hover surfaces on the corresponding tokens. |
 | Signature help | `textDocument/signatureHelp`, triggered by `(` and `,`. |
 | Rename | `textDocument/prepareRename` and `textDocument/rename`. |
 | Code actions | `textDocument/codeAction`, currently refactor/rewrite-style actions. |
@@ -70,7 +70,7 @@ During `initialize`, the server attempts best-effort workspace discovery from th
 
 ## Feature notes and limitations
 
-- Completion is scope-aware and dot-triggered, but the implementation remains much simpler than mature .NET language services.
+- Completion is scope-aware and dot-triggered, but the implementation remains much simpler than mature .NET language services. Type-clause positions additionally surface `async func(...) R` and `async sequence[T]` snippets so the two GSharp-flavored async-type spellings (ADR-0043 / ADR-0042) are discoverable without having to know they exist.
 - Formatting is a lexer-based whole-document formatter with a canonical whitespace pass; current implementation uses two-space indentation internally.
 - Rename, linked editing, references, CodeLens, implementation, and type-definition results are computed from the compiler's semantic lookup model and are strongest for symbols in the current project/document model.
 - The server serializes handlers through a single gate so edits and reads are processed in order, not incrementally in parallel.


### PR DESCRIPTION
## Summary

Adds LSP completion-list discoverability for the two GSharp-flavored async-type spellings introduced by ADR-0042 and ADR-0043. Whenever the caret sits in a type-clause position (parameter, local, field, return-type slot, generic argument, etc.), the completion list surfaces two ready-to-use snippets — *and* hover over the matching tokens now renders the same ADR-rooted prose. Tooling-only; zero language-semantics, lowering, emit, or binder changes.

Both snippets:
- `async func(${1:T}) ${2:R}` — alias for `func(T) Task[R]` (ADR-0043).
- `async sequence[${1:T}]` — alias for `IAsyncEnumerable[T]` (ADR-0042).

The detector piggy-backs on the syntax tree the parser already produced rather than adding a parallel start-of-type-clause set: the deepest enclosing `TypeClauseSyntax` that brackets the caret offset, plus the empty type-clause slot of a parent that expects one (variable decl, parameter, field, function return slot).

## Scope checklist

- [x] Completion provider — `async func(...) R` and `async sequence[T]` snippets in any type-clause position.
- [x] Snippet templates — `InsertTextFormat = Snippet`, `${1:T}` / `${2:R}` tab-stops; expansion verified to parse cleanly with zero diagnostics.
- [x] LSP `CompletionItem` model extended with `InsertText`, `InsertTextFormat`, `Documentation` (MarkupContent), `SortText`, `FilterText` — the snippet payload actually reaches the editor.
- [x] Hover — ADR-rooted Markdown docs on the `async`/`func`/`sequence` tokens of an async type clause; non-async `sequence` is unaffected.
- [x] Tests (LanguageServer.Tests/AsyncTypeClauseCompletionTests.cs, 15 cases):
  - Three trigger scenarios: empty type-clause slot (parameter, return slot, local) → both snippets; after `async ` in type-clause position → both snippets; expression / initializer / `return` body → snippets suppressed.
  - Two hover scenarios per form: `async` and the following keyword token both render ADR-rooted prose.
  - Snippet round-trip: expanded placeholder text re-parses with zero diagnostics.
- [x] Docs — `website/docs/tooling/lsp.md` capability row + feature-notes paragraph updated.
- [x] LSP perf invariants preserved — the detector reads only the syntax tree (no `Compilation.BoundProgram`, no `SemanticModel` bind, no `ProjectState` reflow); existing 3-tier cache discipline (Compilation.BoundProgram lazy, SemanticLookup ConditionalWeakTable, ProjectState.UpdateFile no-op) is untouched.

## Verification

- `dotnet build GSharp.sln -nologo -clp:NoSummary` — green.
- `dotnet test GSharp.sln --no-restore --nologo` — green; **0 failed**, 4039 passed (26 Sdk + 144 Interpreter + 257 LanguageServer + 2545 Core + 1067 Compiler), 1 skipped (pre-existing `RegenerateBaseline`).
- `cd website && npm ci && npm run build` — green.

## References

- ADR-0042: `async sequence[T]` as a type-clause spelling for `IAsyncEnumerable[T]` — `docs/adr/0042-async-sequence-type-clause.md`.
- ADR-0043: `async func(P) R` as a type-clause spelling for `func(P) Task[R]` — `docs/adr/0043-async-func-type-clause.md`.
- Issue: #713
- Parent: #706

Closes #713