### PR TITLE
Implement #721 (ADR-0081): "did you mean nil?" diagnostic on null usage

### DIFF
--- a/docs/adr/0081-null-identifier-did-you-mean-nil.md
+++ b/docs/adr/0081-null-identifier-did-you-mean-nil.md
@@ -1,0 +1,181 @@
+# ADR-0081: "Did you mean `nil`?" diagnostic for the `null` identifier
+
+- **Status**: Accepted
+- **Date**: 2026-06-12
+- **Phase**: Phase 6 (cleanup)
+- **Related**: ADR-0001 (null model — `nil` is the canonical null
+  literal), issue #660 (initial GS0273 wiring inside attribute
+  arguments), issue #706 (Oats cleanup parent), implementing issue
+  #721.
+
+## Context
+
+G# spells the null literal `nil` (ADR-0001). The token `null` is
+**not** a keyword: it parses as an ordinary identifier and resolves
+through the usual variable / function / type lookup. Users coming
+from C#, Kotlin, Java, or TypeScript reflexively type `null` —
+historically that produced the generic GS0125 "Variable 'null'
+doesn't exist" diagnostic, which gives no hint that the language
+expects the spelling `nil`.
+
+Issue #660 introduced a small, targeted special case: when
+`ReportUndefinedVariable` was called with the name `null`, it
+re-routed to a new **GS0273** "use 'nil' instead of 'null'"
+diagnostic so that `@Obsolete(null)` produced an actionable error.
+Issue #721 widens the surface and pins the contract:
+
+- The diagnostic must fire in **every** value-expression position
+  where the user could plausibly mean nil — not just attribute
+  argument lists.
+- It must **not** fire when the identifier `null` is bound to a
+  real symbol in scope (e.g., a free function `func null() {}` or
+  a local `let null = "x"`). Identifiers named `null` in
+  declaration-like positions remain legal.
+- When the surrounding context has a target type that accepts nil
+  (a `NullableTypeSymbol`, a reference type, or a `T?` parameter
+  slot), the binder should **recover** by treating the offending
+  identifier as if the user had written `nil`. This prevents a
+  cascade of cannot-convert / type-mismatch errors from the same
+  source mistake.
+- The diagnostic wording must point at the fix: "Did you mean
+  'nil'?".
+
+## Decision
+
+Keep `null` as a plain identifier — no lexer or parser change. The
+binder owns the diagnostic and the recovery.
+
+### Wording and code
+
+GS0273 (severity **Error**) — wording:
+
+> `'null'` is not a literal in G#. Did you mean `'nil'`?
+
+The diagnostic is anchored at the `null` identifier token. It is an
+error (not a warning) because the source is unambiguously wrong:
+even with the synthesized recovery, the program as written does not
+compile under G#'s rules.
+
+### When the diagnostic fires
+
+The binder emits GS0273 whenever **all** of the following hold for
+a `NameExpressionSyntax`:
+
+1. The identifier token's text is exactly `"null"`.
+2. The token is in a **value-expression position** — i.e., the
+   parser produced a `NameExpressionSyntax`, which only happens
+   when the syntactic position calls for an expression. Names that
+   appear in declaration-like positions (function names, field
+   names, type names, parameter names) never reach this binder
+   path; they are bound as declared symbols and the binder treats
+   them as ordinary identifiers.
+3. Symbol lookup in the enclosing `BoundScope` returns no symbol
+   with that name (variable, function, type, parameter, alias —
+   nothing).
+
+When any one of those fails, GS0273 does not fire. Concretely:
+
+- `func null() { }` declares a function named `null`. A later
+  `null()` call resolves through `TryBindMethodGroup`, hits a real
+  symbol, and no diagnostic is emitted.
+- `let null = "hello"` declares a local named `null`. A later
+  `let s = null` resolves the local; no diagnostic.
+- `var null int32` (a field named `null` inside a struct) is
+  legal; member access through the field works as for any other
+  identifier.
+
+### Recovery
+
+When GS0273 fires, the binder also synthesises a `nil` literal
+(`BoundLiteralExpression(syntax, value: null)` — static type
+`TypeSymbol.Null`) and returns it from `BindNameExpression`
+instead of `BoundErrorExpression`. The synthesized node carries
+the same syntax span as the offending identifier.
+
+Downstream consumers see the same shape they would have seen had
+the user written `nil`:
+
+- In a target-type slot (e.g., the right-hand side of
+  `let x string? = null`, an argument to `Foo(null)` where `Foo`
+  takes `T?`, or the field initializer of a nullable-typed
+  property), the existing `nil → T?` conversion path applies and
+  the expression typechecks cleanly. No cascading "cannot convert"
+  diagnostic fires.
+- In a comparison (`x == null`, `null != y`), the recovered nil
+  literal flows into `BoundBinaryOperator.Bind`, which already
+  has the lifted-equality arm for `T? == nil`. No cascading
+  operator-not-defined error fires.
+- Inside a lambda body, the recovery runs through the same
+  `BindNameExpression` path; nested binding behaves identically to
+  top-level.
+- When there is no nullable target type (`let x = null` with no
+  type clause), the synthesized nil flows into the usual
+  binding-from-nil path — which today binds `x` to the nil
+  sentinel type. The user still gets GS0273 as the **first** and
+  most actionable diagnostic; whatever follow-on diagnostic the
+  binder produces about the inferred nil type stays in place for
+  the residual issue.
+
+This single recovery rule subsumes the earlier "fall through to
+the generic name-not-found diagnostic" recommendation discussed in
+the issue. We chose the recovery path uniformly because the user
+clearly intended a null literal — the recovered-as-nil program is
+strictly more informative (and often compilable) than the
+cascading "name not found" + "type cannot be inferred" pair.
+
+### Why not a soft keyword?
+
+A lexer/parser-level recognition of `null` (e.g., produce a
+synthesised `NilKeyword` token with a diagnostic) was considered
+and rejected:
+
+- It would steal the identifier `null` from any user who chose to
+  name a function, local, field, or parameter `null`. The current
+  scheme keeps that name legally usable.
+- It would shift the diagnostic out of the binder, away from the
+  scope information the rule actually depends on. The binder
+  already knows whether `null` resolves to a symbol; the lexer
+  does not.
+- The binder-level rule is purely additive: no existing well-typed
+  G# program changes shape.
+
+The binder-anchored path is therefore the contract going forward.
+
+## Consequences
+
+Positive:
+
+- Newcomers from C#/Kotlin/Java/TypeScript get a clear, actionable
+  error message — and a compiling recovery — the first time they
+  type `null`.
+- The diagnostic is precise: it fires only when the source is
+  unambiguously wrong (the identifier `null` is undefined in
+  scope), so user code that legitimately names a symbol `null`
+  is unaffected.
+- No grammar surface change. `null` remains a plain identifier;
+  existing programs that already accept the identifier `null`
+  (none in tree, but theoretically possible) keep working.
+- The recovery removes the cascade of follow-on diagnostics that
+  previously made the underlying spelling mistake harder to spot.
+
+Negative:
+
+- Slight behavior change relative to issue #660's initial GS0273:
+  the diagnostic message is reworded (the new wording matches the
+  issue acceptance criteria), and the binder now returns a nil
+  literal recovery rather than `BoundErrorExpression`. The two
+  existing Issue660 tests still assert only the diagnostic code
+  and the presence of `nil` in the message; both remain satisfied.
+
+Neutral:
+
+- No new BoundNodeKind. The recovery reuses the existing
+  `BoundLiteralExpression` node shape used by `nil`.
+- No emit, lowering, or rewriter change. The bound tree downstream
+  of the recovery is indistinguishable from the user having
+  written `nil`.
+
+## Open follow-ups
+
+None. The change is self-contained at the binder boundary; no
+parser, emit, or interpreter follow-up is needed.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -443,6 +443,14 @@ Cause/fix examples:
 | GS0271 | Error | `await using let` outside an async function. | `func f() { await using let x = ... }` — `await using let` requires `async func`. |
 | GS0272 | Error | Type is not async-disposable. | `await using let x = Foo()` where `Foo` provides no public `DisposeAsync()` method returning `ValueTask`. |
 
+## `null` identifier "did you mean nil?" diagnostic (GS0273)
+
+See [ADR-0081](adr/0081-null-identifier-did-you-mean-nil.md). `null` is not a keyword in G#; the canonical null literal is `nil` (ADR-0001). When the identifier `null` is used in a value-expression position and no symbol named `null` is in scope, the binder emits `GS0273` and recovers by synthesising a `nil` literal so target-type contexts continue to typecheck. The diagnostic is suppressed when a symbol named `null` (variable, function, field) is in scope — those declarations remain legal and identifier resolution wins over the recovery.
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0273 | Error | `'null' is not a literal in G#. Did you mean 'nil'?` | `let x string? = null` — replace `null` with `nil`. Also fires for `Foo(null)` where `Foo` takes `T?`, `x == null`, and inside lambda bodies. Does not fire when `null` resolves to a real symbol in scope. |
+
 ## If-expression diagnostics (GS0276–GS0277)
 
 See [ADR-0064](adr/0064-if-expression-and-block-expression.md). `if` used as a value-producing expression (`let x = if cond { a } else { b }`) requires both branches to produce a value of a common type. The diagnostics below guard the two binder rejection paths that are unique to the expression form; the branch-type-mismatch case reuses GS0263 (shared with the ADR-0062 ternary).

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -289,6 +289,18 @@ internal sealed partial class ExpressionBinder
                 Diagnostics.ReportNotAVariable(syntax.IdentifierToken.Location, name);
             }
 
+            // Issue #721 / ADR-0081: when the unresolved identifier is the
+            // literal text `null` and no symbol named `null` exists in scope,
+            // synthesise a `nil` literal so that target-type contexts (e.g.
+            // `let x string? = null`, `Foo(null)` where `Foo` takes `T?`,
+            // and `x == null`) continue to typecheck without cascading
+            // errors. The GS0273 "did you mean 'nil'?" diagnostic has
+            // already been emitted by ReportUndefinedVariable above.
+            if (name == "null" && scope.TryLookupSymbol(name) is null)
+            {
+                return new BoundLiteralExpression(syntax, value: null);
+            }
+
             return new BoundErrorExpression(null);
         }
 

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -381,8 +381,12 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     /// <param name="name">The name of the variable.</param>
     public void ReportUndefinedVariable(TextLocation location, string name)
     {
-        // Issue #660: when the user writes 'null' (C# spelling), produce a
-        // targeted diagnostic suggesting 'nil' instead of the generic GS0125.
+        // Issue #660 / #721: when the user writes 'null' (C# spelling) and no
+        // symbol named `null` exists in scope, surface the GS0273 "did you
+        // mean 'nil'?" diagnostic instead of the generic GS0125. The binder
+        // also synthesises a `nil` literal so that target-type contexts (such
+        // as `let x string? = null` or `Foo(null)` with a nullable parameter)
+        // continue to typecheck without cascading errors.
         if (name == "null")
         {
             ReportUseNilInsteadOfNull(location);
@@ -2288,12 +2292,12 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     /// <summary>
     /// Reports that the identifier <c>null</c> was used where the G# null
     /// literal <c>nil</c> is required. G# does not recognise <c>null</c> as
-    /// a keyword — the correct spelling is <c>nil</c>.
+    /// a keyword — the correct spelling is <c>nil</c> (ADR-0081).
     /// </summary>
     /// <param name="location">The source location of the <c>null</c> identifier.</param>
     public void ReportUseNilInsteadOfNull(TextLocation location)
     {
-        Report(location, "GS0273", "G# spells the null literal as 'nil'; 'null' is not a recognised keyword.");
+        Report(location, "GS0273", "'null' is not a literal in G#. Did you mean 'nil'?");
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue721NullIdentifierDiagnosticTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue721NullIdentifierDiagnosticTests.cs
@@ -1,0 +1,193 @@
+// <copyright file="Issue721NullIdentifierDiagnosticTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #721 / ADR-0081 — when the user writes the C# spelling
+/// <c>null</c> in a value-expression position and no symbol named
+/// <c>null</c> exists in scope, the binder emits the friendly
+/// GS0273 "did you mean 'nil'?" diagnostic and recovers by
+/// synthesising a <c>nil</c> literal so target-type contexts
+/// continue to typecheck.
+/// </summary>
+public class Issue721NullIdentifierDiagnosticTests
+{
+    [Fact]
+    public void Let_NullableString_AssignedNull_ReportsGS0273()
+    {
+        var diags = Bind("""
+            let x string? = null
+            """);
+
+        var diag = Assert.Single(diags.Where(d => d.Id == "GS0273"));
+        Assert.Contains("'null'", diag.Message);
+        Assert.Contains("'nil'", diag.Message);
+        Assert.Contains("Did you mean", diag.Message);
+
+        // The diagnostic is anchored at the 'null' token.
+        Assert.Equal("null", diag.Location.Text.ToString(diag.Location.Span));
+
+        // No cascading "cannot convert" or "name not found" diagnostic
+        // should fire — the recovery synthesises a nil literal that
+        // typechecks cleanly against `string?`.
+        Assert.DoesNotContain(diags, d => d.Id == "GS0125");
+    }
+
+    [Fact]
+    public void Call_With_NullableParameter_AssignedNull_ReportsGS0273()
+    {
+        var diags = Bind("""
+            func Foo(s string?) {
+            }
+
+            Foo(null)
+            """);
+
+        var diag = Assert.Single(diags.Where(d => d.Id == "GS0273"));
+        Assert.Contains("'nil'", diag.Message);
+        Assert.Equal("null", diag.Location.Text.ToString(diag.Location.Span));
+
+        // Recovery converts nil → string? cleanly: no other diagnostic.
+        Assert.DoesNotContain(diags, d => d.Id == "GS0125");
+        Assert.Empty(diags.Where(d => d.IsError && d.Id != "GS0273"));
+    }
+
+    [Fact]
+    public void Equality_Against_Null_ReportsGS0273()
+    {
+        var diags = Bind("""
+            let x string? = nil
+            let same = x == null
+            """);
+
+        Assert.Contains(diags, d => d.Id == "GS0273");
+
+        // Equality `x == nil` is well-formed for `string?` once the
+        // recovery treats `null` as `nil`. The same comparison must
+        // not produce a residual operator-mismatch diagnostic.
+        Assert.DoesNotContain(diags, d => d.IsError && d.Id != "GS0273");
+    }
+
+    [Fact]
+    public void Existing_Local_Named_Null_Resolves_Without_Diagnostic()
+    {
+        // A locally-declared `let null = "hi"` shadows the would-be
+        // diagnostic. Subsequent uses of `null` resolve to the local
+        // and GS0273 must not fire.
+        var diags = Bind("""
+            let null = "hi"
+            let s = null
+            """);
+
+        Assert.Empty(diags.Where(d => d.IsError));
+        Assert.DoesNotContain(diags, d => d.Id == "GS0273");
+    }
+
+    [Fact]
+    public void Existing_Function_Named_Null_Resolves_Without_Diagnostic()
+    {
+        // A free function named `null` is legal — `null` is not a
+        // keyword. Calling it must not produce GS0273.
+        var diags = Bind("""
+            func null() int32 {
+                return 42
+            }
+
+            let v = null()
+            """);
+
+        Assert.Empty(diags.Where(d => d.IsError));
+        Assert.DoesNotContain(diags, d => d.Id == "GS0273");
+    }
+
+    [Fact]
+    public void Let_Without_Target_Type_Reports_GS0273_With_Recovery()
+    {
+        // No target type is available for `let x = null`; the binder
+        // still reports GS0273 (the user clearly intended nil), and
+        // recovers by synthesising a nil literal so downstream
+        // diagnostics about nil-typed bindings are not stacked
+        // on top of a cascading "name not found" diagnostic.
+        var diags = Bind("""
+            let x = null
+            """);
+
+        Assert.Contains(diags, d => d.Id == "GS0273");
+
+        // The legacy GS0125 path is no longer reached for `null`.
+        Assert.DoesNotContain(diags, d => d.Id == "GS0125");
+    }
+
+    [Fact]
+    public void Null_Inside_Lambda_Body_Reports_GS0273_And_Typechecks()
+    {
+        // Inside a lambda body, the same BindNameExpression path
+        // applies — GS0273 fires for the inner `null` and the
+        // synthesised nil flows into the local `string?` target
+        // slot, which typechecks without cascading errors.
+        var diags = Bind("""
+            let f = () -> {
+                let v string? = null
+                return v
+            }
+            let _ = f()
+            """);
+
+        Assert.Contains(diags, d => d.Id == "GS0273");
+        Assert.DoesNotContain(diags, d => d.IsError && d.Id != "GS0273");
+    }
+
+    [Fact]
+    public void NullableInt_AssignedNull_ReportsGS0273()
+    {
+        // Nullable value-type target (`int32?` is a CLR Nullable<int>).
+        var diags = Bind("""
+            let n int32? = null
+            """);
+
+        var diag = Assert.Single(diags.Where(d => d.Id == "GS0273"));
+        Assert.Equal("null", diag.Location.Text.ToString(diag.Location.Span));
+        Assert.DoesNotContain(diags, d => d.Id == "GS0125");
+    }
+
+    [Fact]
+    public void Existing_Nil_Program_Still_Compiles_And_Runs()
+    {
+        // Sanity guard: the changes for #721 must not regress the
+        // canonical `nil` spelling.
+        var result = Evaluate("""
+            let x string? = nil
+            if x == nil { 1 } else { 0 }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/website/docs/guide/types-and-values.md
+++ b/website/docs/guide/types-and-values.md
@@ -12,6 +12,8 @@ G# combines Go-like aggregate and collection syntax with CLR type identity. Use 
 
 `nil` is the null literal. Nullable types are written with `?`, such as `string?`. A non-null value converts to its nullable form, and `nil` converts to nullable types. `null` is not a literal in G#. Use `?:` for null coalescing, `?.` for null-conditional access, and `!!` only when a failed assertion should throw immediately.
 
+If you type the C# spelling `null` in a value position and no symbol named `null` exists in scope, the binder reports `GS0273` ("`'null'` is not a literal in G#. Did you mean `'nil'`?") and recovers by treating the identifier as `nil`, so target-type contexts (`let x string? = null`, `Foo(null)` where `Foo` takes `T?`, `x == null`) continue to typecheck. The diagnostic is suppressed when `null` resolves to a real symbol (a function, local, or field named `null` is legal because `null` is not a keyword). See [ADR-0081](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0081-null-identifier-did-you-mean-nil.md).
+
 This model follows [ADR-0001](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0001-null-model.md).
 
 ## Primitive values

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -657,4 +657,32 @@ Cause/fix:
   be deferred — but note this is a one-release grace period; the `=`
   branch is removed in a later release.
 
+## `null` identifier "did you mean nil?" diagnostic (GS0273)
+
+ADR-0081 (issue #721) pins the contract for the C# spelling `null` used
+in a G# source where the canonical null literal is `nil` (ADR-0001).
+`null` is **not** a keyword in G# — it parses as an ordinary identifier
+and resolves through normal symbol lookup. When the identifier `null`
+is used in a value-expression position and no symbol named `null` is
+in scope, the binder emits `GS0273` and recovers by treating the
+identifier as `nil` so target-type contexts (e.g.
+`let x string? = null`, `Foo(null)` where `Foo` takes `T?`, or
+`x == null`) continue to typecheck without cascading errors.
+
+| ID | Severity | Message |
+|----|----------|---------|
+| GS0273 | Error | `'null' is not a literal in G#. Did you mean 'nil'?` |
+
+Cause/fix:
+
+- **GS0273** — `let x string? = null`, `Foo(null)` where `Foo` takes
+  `T?`, `x == null`. Replace `null` with `nil` (`let x string? = nil`,
+  `Foo(nil)`, `x == nil`). The diagnostic is anchored at the `null`
+  token. GS0273 does **not** fire when a symbol named `null` is in
+  scope — `let null = "hi"; let s = null` and
+  `func null() int32 { return 42 }; let v = null()` both resolve
+  normally with no diagnostic. See
+  [ADR-0081](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0081-null-identifier-did-you-mean-nil.md)
+  for the full rule, scope, and recovery rationale.
+
 

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -114,7 +114,7 @@ Malformed interpolation is reported by dedicated diagnostics: `GS0220` (non-cons
 
 ### Boolean and nil literals
 
-`true` and `false` are boolean literals. `nil` is the null literal. `null` is not a keyword or literal in G#.
+`true` and `false` are boolean literals. `nil` is the null literal. `null` is not a keyword or literal in G#. When the identifier `null` appears in a value-expression position and no symbol named `null` exists in scope, the binder reports `GS0273` ("`'null'` is not a literal in G#. Did you mean `'nil'`?") and recovers by treating the identifier as `nil`, so target-type contexts continue to typecheck (ADR-0081). Declarations may legally name a symbol `null` (e.g. `func null() { ... }` or `let null = "hi"`); identifier resolution wins over the recovery in that case.
 
 ## Constants and variables
 

--- a/website/docs/tour/types.md
+++ b/website/docs/tour/types.md
@@ -158,4 +158,8 @@ Console.WriteLine(counts["gsharp"])
 
 A composite literal with no fields uses the zero value for each field. A `var` declaration with an explicit type and no initializer also starts at the type's zero value: `0` for numeric types, `False` for `bool`, empty for `string`, and `nil` for nullable values.
 
+## A note on `nil` vs `null`
+
+The null literal in G# is spelled `nil`, not `null`. Coming from C#, Kotlin, Java, or TypeScript? Your fingers will reach for `null` — and the compiler will catch it for you. Typing `null` in a value position reports `GS0273` ("`'null'` is not a literal in G#. Did you mean `'nil'`?") and the binder treats it as `nil` so the rest of the expression still typechecks. The diagnostic only fires when nothing in scope is named `null`; the identifier itself is not a keyword, so a function or local named `null` is legal and resolves normally. See [ADR-0081](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0081-null-identifier-did-you-mean-nil.md).
+
 Next: [Tour: Control flow](/docs/tour/control-flow).


### PR DESCRIPTION
## Summary

ADR-0081 pins the contract for the C# spelling `null` written in a G# value-expression position. When no symbol named `null` exists in scope, the binder reports **GS0273** with the wording "`null` is not a literal in G#. Did you mean `nil`?" and recovers by synthesising a `nil` literal so target-type contexts (`let x string? = null`, `Foo(null)` where `Foo` takes `T?`, `x == null`, lambda bodies) continue to typecheck without cascading errors.

The recovery is suppressed when `null` resolves to a real symbol — declarations such as `func null() { ... }` or `let null = "hi"` remain legal because `null` is not a keyword.

## Scope checklist

- [x] Diagnostic code (`GS0273`), wording, and severity (Error) pinned in ADR-0081.
- [x] Binder-level recovery: `BindNameExpression` synthesises a `nil` literal when the unresolved identifier is `null` and no scope symbol shadows it. No new `BoundNodeKind` introduced.
- [x] Tests (`test/Core.Tests/.../Issue721NullIdentifierDiagnosticTests.cs`) cover:
  - `let x string? = null` → GS0273, anchored at `null`, no cascading errors.
  - `let n int32? = null` → GS0273 (nullable value-type target).
  - `Foo(null)` where `Foo` takes `T?` → GS0273, no cascading errors.
  - `x == null` for `string? x` → GS0273, no cascading operator-mismatch diagnostic.
  - `let null = "hi"; let s = null` → no diagnostic, resolves to local.
  - `func null() int32 { ... }; let v = null()` → no diagnostic, resolves to function.
  - `let x = null` with no target type → GS0273 still fires (recovery is uniform; rationale documented in ADR-0081 under "Recovery").
  - Lambda body with nested `let v string? = null` → GS0273, no cascading errors.
  - Canonical `nil` spelling still compiles and runs (regression guard).
- [x] Spec section on `nil` updated (`website/docs/ref/spec.md` §Boolean and nil literals).
- [x] Diagnostics catalogue updated in both `docs/diagnostics.md` and `website/docs/ref/diagnostics.md`.
- [x] Tour for newcomers gains a short "A note on `nil` vs `null`" section (`website/docs/tour/types.md`).
- [x] Full test suite green: 2,689 Core + 1,076 Compiler + 257 LSP + 165 Interpreter + 26 SDK = 4,213 tests passing.
- [x] Docusaurus build clean (`cd website && npm run build` succeeds with no broken links).

## ADR

- [ADR-0081](docs/adr/0081-null-identifier-did-you-mean-nil.md): `"Did you mean nil?" diagnostic for the null identifier`.

## Links

- Closes #721
- Refs #706 (parent Oats cleanup)
- Refs #660 (initial GS0273 wiring inside attribute arguments — superseded by the wider rule)