### PR TITLE
Fix #737: nil-guard else-branch IL for nullable references

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -178,26 +178,49 @@ public sealed class Lowerer : BoundTreeRewriter
             //
             // gotoFalse <condition> else
             // <then>
-            // goto end
+            // goto end          // omitted when <then> ends unconditionally
             // else:
             // <else>
-            // end:
+            // end:              // omitted when the `goto end` above was omitted
+            //
+            // Issue #737: the naive shape above emits a dead `goto end` and a
+            // trailing `end:` label whenever the then-arm terminates (return /
+            // throw / unconditional goto). When the if-else is the last
+            // statement of a method body AND the else-arm also terminates, the
+            // `end:` label resolves to an offset past the final `ret`. The
+            // CLR rejects any `br` to past-end-of-body with
+            // `InvalidProgramException`, so the assembly cannot JIT. Lower the
+            // then-arm first to inspect its terminator behavior, then omit
+            // both the dead `goto end` and the dangling `end:` label when the
+            // then-arm can never fall through. (The condition and else-arm
+            // are still lowered via the inner BoundBlockStatement's recursive
+            // RewriteStatement walk.)
             var elseLabel = GenerateLabel();
-            var endLabel = GenerateLabel();
-
-            var gotoFalse = new BoundConditionalGotoStatement(null, elseLabel, node.Condition, false);
-            var gotoEndStatement = new BoundGotoStatement(null, endLabel);
             var elseLabelStatement = new BoundLabelStatement(null, elseLabel);
-            var endLabelStatement = new BoundLabelStatement(null, endLabel);
-            var result = new BoundBlockStatement(
-                null,
-                ImmutableArray.Create<BoundStatement>(
-                gotoFalse,
-                node.ThenStatement,
-                gotoEndStatement,
-                elseLabelStatement,
-                node.ElseStatement,
-                endLabelStatement));
+            var gotoFalse = new BoundConditionalGotoStatement(null, elseLabel, node.Condition, false);
+
+            var loweredThen = this.RewriteStatement(node.ThenStatement);
+            var thenCanFallThrough = !EndsInUnconditionalTransfer(loweredThen);
+
+            var builder = ImmutableArray.CreateBuilder<BoundStatement>();
+            builder.Add(gotoFalse);
+            builder.Add(loweredThen);
+
+            if (thenCanFallThrough)
+            {
+                var endLabel = GenerateLabel();
+                builder.Add(new BoundGotoStatement(null, endLabel));
+                builder.Add(elseLabelStatement);
+                builder.Add(node.ElseStatement);
+                builder.Add(new BoundLabelStatement(null, endLabel));
+            }
+            else
+            {
+                builder.Add(elseLabelStatement);
+                builder.Add(node.ElseStatement);
+            }
+
+            var result = new BoundBlockStatement(null, builder.ToImmutable());
             return RewriteStatement(result);
         }
     }
@@ -1057,6 +1080,48 @@ public sealed class Lowerer : BoundTreeRewriter
             System.Reflection.FieldInfo field => TypeSymbol.FromClrType(field.FieldType),
             _ => TypeSymbol.Error,
         };
+    }
+
+    /// <summary>
+    /// Issue #737: returns <see langword="true"/> when control flow falling
+    /// off the end of <paramref name="statement"/> is unreachable because the
+    /// last (non-label) statement is an unconditional control transfer.
+    /// Conservative — only the obvious leaf shapes are recognized; a
+    /// <see langword="false"/> result is always safe (the caller emits the
+    /// trailing <c>goto end</c> + <c>end:</c> pair). The check looks past
+    /// trailing label statements because labels emit no IL of their own.
+    /// </summary>
+    /// <param name="statement">The statement to inspect.</param>
+    /// <returns><see langword="true"/> when the statement provably ends in
+    /// <c>return</c>, <c>throw</c>, or an unconditional <c>goto</c>; otherwise
+    /// <see langword="false"/>.</returns>
+    private static bool EndsInUnconditionalTransfer(BoundStatement statement)
+    {
+        switch (statement)
+        {
+            case BoundReturnStatement:
+            case BoundThrowStatement:
+            case BoundGotoStatement:
+                return true;
+            case BoundBlockStatement block:
+                {
+                    for (int i = block.Statements.Length - 1; i >= 0; i--)
+                    {
+                        var s = block.Statements[i];
+                        if (s is BoundLabelStatement)
+                        {
+                            continue;
+                        }
+
+                        return EndsInUnconditionalTransfer(s);
+                    }
+
+                    return false;
+                }
+
+            default:
+                return false;
+        }
     }
 
     private static BoundBlockStatement Flatten(BoundStatement statement)

--- a/test/Compiler.Tests/Emit/Issue712FlowNarrowingExtensionsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue712FlowNarrowingExtensionsEmitTests.cs
@@ -105,10 +105,11 @@ public class Issue712FlowNarrowingExtensionsEmitTests
     {
         // ADR-0069 + issue #712: the guard-style early-exit composes through
         // `||` so the post-if region observes both `s != nil` AND `!force`.
-        // (We use the post-if lift form instead of an `else` block because the
-        // existing nil-guard ELSE-branch IL emission has a pre-existing bug —
-        // see ADR-0069 issue #735 follow-up — and that bug is unrelated to
-        // the `||` composition exercised here.)
+        // (Originally this test had to use the post-if lift form because the
+        // else-branch form tripped pre-existing if-else lowering bug #737;
+        // that bug was fixed alongside this assertion, and the else-branch
+        // companion lives in `Issue737NilGuardElseBranchEmitTests` to keep
+        // each test scoped to one regression area.)
         var source = """
             package Test
             import System

--- a/test/Compiler.Tests/Emit/Issue737NilGuardElseBranchEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue737NilGuardElseBranchEmitTests.cs
@@ -1,0 +1,328 @@
+// <copyright file="Issue737NilGuardElseBranchEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #737 — pre-existing if-else lowering bug exposed by ADR-0069
+/// nullable-reference narrowing: when both arms of an <c>if/else</c> end
+/// in an unconditional control transfer (e.g. each arm returns), the
+/// lowerer emitted a dead <c>goto endLabel</c> after the then-arm and a
+/// trailing <c>endLabel:</c> label whose IL offset landed past the final
+/// <c>ret</c> of the method body. The CLR JIT rejected the assembly with
+/// <c>System.InvalidProgramException</c>. The original repro surfaced
+/// inside a nil-guard else-branch on a nullable reference because that is
+/// the canonical "use the narrowed value" shape, but the underlying bug
+/// is purely about the if-else terminator analysis in the lowerer and
+/// applies to every reference / value / primitive type.
+///
+/// Each test compiles via in-process <c>gsc</c>, IL-verifies the emitted
+/// PE (so the prior past-end <c>br</c> is caught here, not only at JIT
+/// time), and runs the assembly under <c>dotnet exec</c>, asserting
+/// captured stdout.
+/// </summary>
+public class Issue737NilGuardElseBranchEmitTests
+{
+    [Fact]
+    public void IfElse_BothBranchesReturn_String_ElseBranchReadsNarrowed()
+    {
+        var source = """
+            package Test
+            import System
+
+            func Length(s string?) int32 {
+                if s == nil {
+                    return -1
+                } else {
+                    return s.Length
+                }
+            }
+
+            Console.WriteLine(Length("hello"))
+            Console.WriteLine(Length(nil))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n-1\n", output);
+    }
+
+    [Fact]
+    public void IfElse_PositiveGuard_ThenBranchReadsNarrowed()
+    {
+        var source = """
+            package Test
+            import System
+
+            func Use(s string) int32 {
+                return s.Length
+            }
+
+            func Length(s string?) int32 {
+                if s != nil {
+                    return Use(s)
+                }
+                return -1
+            }
+
+            Console.WriteLine(Length("hi"))
+            Console.WriteLine(Length(nil))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n-1\n", output);
+    }
+
+    [Fact]
+    public void IfElse_BothBranchesReturn_OrComposition_ElseReadsNarrowed()
+    {
+        // Issue #712 (PR #736) had to use the post-if-lift form for the
+        // emit coverage of `||` nil-guard composition because this form
+        // tripped the pre-existing #737 bug. Now that #737 is fixed, the
+        // else-branch form is the cleaner shape and must work end-to-end.
+        var source = """
+            package Test
+            import System
+
+            func Length(s string?, force bool) int32 {
+                if s == nil || force {
+                    return -1
+                } else {
+                    return s.Length
+                }
+            }
+
+            Console.WriteLine(Length("hello", false))
+            Console.WriteLine(Length("hello", true))
+            Console.WriteLine(Length(nil, false))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n-1\n-1\n", output);
+    }
+
+    [Fact]
+    public void IfElse_BothBranchesReturn_ChainedAndGuard()
+    {
+        // Multiple-variable narrowing: `a != nil && b != nil` must narrow
+        // both `a` and `b` in the then-arm even when both arms of the
+        // outer if-else terminate.
+        var source = """
+            package Test
+            import System
+
+            func Both(a string?, b string?) int32 {
+                if a != nil && b != nil {
+                    return a.Length + b.Length
+                } else {
+                    return -1
+                }
+            }
+
+            Console.WriteLine(Both("hi", "ya"))
+            Console.WriteLine(Both("hi", nil))
+            Console.WriteLine(Both(nil, "ya"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("4\n-1\n-1\n", output);
+    }
+
+    [Fact]
+    public void IfElse_BothBranchesReturn_UserClass_ElseReadsNarrowed()
+    {
+        var source = """
+            package Test
+            import System
+
+            class Greeter {
+                var Name string
+                func Greet() string { return "hi " + Name }
+            }
+
+            func DescribeOrDefault(g Greeter?) string {
+                if g == nil {
+                    return "none"
+                } else {
+                    return g.Greet()
+                }
+            }
+
+            Console.WriteLine(DescribeOrDefault(Greeter{Name: "Alice"}))
+            Console.WriteLine(DescribeOrDefault(nil))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi Alice\nnone\n", output);
+    }
+
+    [Fact]
+    public void IfElse_BothBranchesReturn_Interface_ElseReadsNarrowed()
+    {
+        // IDisposable is a CLR-imported interface; the narrowed read
+        // observes it as a non-nullable reference and the in-else call
+        // must compile to a plain `ldarg` + `callvirt` — no Nullable<T>
+        // unwrap, no boxing.
+        var source = """
+            package Test
+            import System
+
+            class MyDisposable : IDisposable {
+                func Dispose() {
+                    Console.WriteLine("disposed")
+                }
+            }
+
+            func Read(d IDisposable?) string {
+                if d == nil {
+                    return "none"
+                } else {
+                    d.Dispose()
+                    return "ok"
+                }
+            }
+
+            var d IDisposable = MyDisposable{}
+            Console.WriteLine(Read(d))
+            Console.WriteLine(Read(nil))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("disposed\nok\nnone\n", output);
+    }
+
+    [Fact]
+    public void IfElse_BothBranchesReturn_NonNullableBaseline_NoNarrowing()
+    {
+        // The same shape on non-nullable values must also produce
+        // verifiable IL — the bug was in the lowerer's if-else
+        // terminator analysis, NOT in nullable-reference narrowing.
+        var source = """
+            package Test
+            import System
+
+            func Classify(n int32) int32 {
+                if n > 0 {
+                    return 1
+                } else {
+                    return -1
+                }
+            }
+
+            Console.WriteLine(Classify(5))
+            Console.WriteLine(Classify(-3))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n-1\n", output);
+    }
+
+    [Fact]
+    public void IfElse_BothBranchesThrow_StillEmitsValidIl()
+    {
+        // `throw` is the other unconditional control transfer; both
+        // branches throwing should not corrupt the trailing IL either.
+        var source = """
+            package Test
+            import System
+
+            func MustHave(s string?) {
+                if s == nil {
+                    throw System.InvalidOperationException("nil!")
+                } else {
+                    throw System.InvalidOperationException("got: " + s)
+                }
+            }
+
+            try {
+                MustHave("hi")
+            } catch (e Exception) {
+                Console.WriteLine(e.Message)
+            }
+            try {
+                MustHave(nil)
+            } catch (e Exception) {
+                Console.WriteLine(e.Message)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("got: hi\nnil!\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue737_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed (exit {compileExit}):\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Interpreter.Tests/Issue737NilGuardElseBranchInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue737NilGuardElseBranchInterpreterTests.cs
@@ -1,0 +1,196 @@
+// <copyright file="Issue737NilGuardElseBranchInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #737 — interpreter parity for the if-else terminator shape that
+/// the emit fix unblocked. The interpreter shares the binder with the
+/// emit pipeline (smart-cast narrowing rides on
+/// <c>BoundVariableExpression.NarrowedType</c>) so it has always handled
+/// the narrowed reads correctly; the bug was strictly in the IL emitter.
+/// These tests pin down the runtime semantics so a future emitter or
+/// lowerer change cannot diverge from the interpreter's observable
+/// behavior.
+/// </summary>
+public class Issue737NilGuardElseBranchInterpreterTests
+{
+    [Fact]
+    public void IfElse_BothBranchesReturn_String_ElseBranchReadsNarrowed()
+    {
+        var source = """
+            func Length(s string?) int32 {
+                if s == nil {
+                    return -1
+                } else {
+                    return s.Length
+                }
+            }
+
+            Console.WriteLine(Length("hello"))
+            Console.WriteLine(Length(nil))
+            """;
+
+        Assert.Equal("5\n-1\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void IfElse_PositiveGuard_ThenBranchReadsNarrowed()
+    {
+        var source = """
+            func Use(s string) int32 {
+                return s.Length
+            }
+
+            func Length(s string?) int32 {
+                if s != nil {
+                    return Use(s)
+                }
+                return -1
+            }
+
+            Console.WriteLine(Length("hi"))
+            Console.WriteLine(Length(nil))
+            """;
+
+        Assert.Equal("2\n-1\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void IfElse_BothBranchesReturn_OrComposition_ElseReadsNarrowed()
+    {
+        var source = """
+            func Length(s string?, force bool) int32 {
+                if s == nil || force {
+                    return -1
+                } else {
+                    return s.Length
+                }
+            }
+
+            Console.WriteLine(Length("hello", false))
+            Console.WriteLine(Length("hello", true))
+            Console.WriteLine(Length(nil, false))
+            """;
+
+        Assert.Equal("5\n-1\n-1\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void IfElse_BothBranchesReturn_ChainedAndGuard()
+    {
+        var source = """
+            func Both(a string?, b string?) int32 {
+                if a != nil && b != nil {
+                    return a.Length + b.Length
+                } else {
+                    return -1
+                }
+            }
+
+            Console.WriteLine(Both("hi", "ya"))
+            Console.WriteLine(Both("hi", nil))
+            Console.WriteLine(Both(nil, "ya"))
+            """;
+
+        Assert.Equal("4\n-1\n-1\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void IfElse_BothBranchesReturn_UserClass_ElseReadsNarrowed()
+    {
+        var source = """
+            class Greeter {
+                var Name string
+                func Greet() string { return "hi " + Name }
+            }
+
+            func DescribeOrDefault(g Greeter?) string {
+                if g == nil {
+                    return "none"
+                } else {
+                    return g.Greet()
+                }
+            }
+
+            Console.WriteLine(DescribeOrDefault(Greeter{Name: "Alice"}))
+            Console.WriteLine(DescribeOrDefault(nil))
+            """;
+
+        Assert.Equal("hi Alice\nnone\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void IfElse_BothBranchesReturn_Interface_ElseReadsNarrowed()
+    {
+        // A G#-declared interface (not a CLR import) so this also runs
+        // under the interpreter, whose CLR-interface implementation
+        // surface differs from the emitter's.
+        var source = """
+            interface IGreeter {
+                func Greet() string
+            }
+
+            class Hello : IGreeter {
+                var Name string
+                func Greet() string { return "hi " + Name }
+            }
+
+            func DescribeOrDefault(g IGreeter?) string {
+                if g == nil {
+                    return "none"
+                } else {
+                    return g.Greet()
+                }
+            }
+
+            var h IGreeter = Hello{Name: "Alice"}
+            Console.WriteLine(DescribeOrDefault(h))
+            Console.WriteLine(DescribeOrDefault(nil))
+            """;
+
+        Assert.Equal("hi Alice\nnone\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void IfElse_BothBranchesReturn_NonNullableBaseline_NoNarrowing()
+    {
+        var source = """
+            func Classify(n int32) int32 {
+                if n > 0 {
+                    return 1
+                } else {
+                    return -1
+                }
+            }
+
+            Console.WriteLine(Classify(5))
+            Console.WriteLine(Classify(-3))
+            """;
+
+        Assert.Equal("1\n-1\n", RunSubmission(source));
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the if-else lowering bug filed as #737. When both arms of an `if/else` ended in an unconditional control transfer (`return` / `throw` / unconditional `goto`), the lowerer emitted a dead `goto endLabel` after the then-arm plus a trailing `endLabel:` label. When the `if/else` was the last statement of a method body, the `endLabel:` resolved to an offset past the method's final `ret`, and the `br` to it became a branch to past-end-of-body — IL that the CLR JIT rejects with `System.InvalidProgramException`.

The bug was originally reported as a nullable-reference / smart-cast narrowing problem in the else-branch of a nil-guard, because that is the canonical "use the narrowed value" shape (`if s == nil { … } else { use(s) }`). But the underlying defect is purely in the if-else lowering and applies to every type — the included non-nullable baseline test proves it on `int32`.

## Root cause

`Lowerer.RewriteIfStatement` produced this shape unconditionally for if-with-else:

```
gotoFalse cond elseLabel
<then>            // may end in 'ret' / 'throw' / 'goto'
goto endLabel     // dead when <then> terminates
elseLabel:
<else>            // may end in 'ret' / 'throw' / 'goto'
endLabel:         // dangling at past-end when <else> also terminates
```

The `br endLabel` after `<then>` is unreachable, and the `endLabel:` at past-end-of-body is a verification error.

## Fix

In `Lowerer.RewriteIfStatement` (`src/Core/CodeAnalysis/Lowering/Lowerer.cs`), lower the then-arm first; when its last (non-label) statement is a `BoundReturnStatement` / `BoundThrowStatement` / `BoundGotoStatement`, omit both the trailing `goto endLabel` and the dangling `endLabel:`. The existing `gotoFalse → elseLabel:` edge alone is enough to encode all reachable control flow in that case.

`EndsInUnconditionalTransfer` is intentionally conservative: it only recognizes the three obvious leaf shapes plus a block whose last non-label statement is one of those shapes. A `false` result is always safe (the original goto/label pair is emitted).

No `BoundNode` kinds were introduced; no smart-cast / emit / interpreter code was touched.

## Tests

- **`test/Compiler.Tests/Emit/Issue737NilGuardElseBranchEmitTests.cs`** — eight end-to-end emit tests (compile + IL-verify + `dotnet exec`) covering:
  - the exact issue repro on `string?` (else-branch `return s.Length`)
  - the positive form `if s != nil { … }`
  - `||` guard composition — the shape PR #736 had to side-step using the post-if-lift form
  - `&&` chained narrowing (`a != nil && b != nil`)
  - a user class (`Greeter?`)
  - a CLR interface (`IDisposable?`)
  - a non-nullable baseline (`int32`) — proves the fix is type-agnostic
  - a "both branches throw" variant
- **`test/Interpreter.Tests/Issue737NilGuardElseBranchInterpreterTests.cs`** — REPL/evaluator parity tests for the same shapes (the interpreter has always handled the narrowed reads correctly; these pin the runtime behavior so a future change cannot diverge).
- **`test/Compiler.Tests/Emit/Issue712FlowNarrowingExtensionsEmitTests.cs`** — refreshed the comment on `Or_NilGuard_PostIfLift_NarrowsToNonNullable` now that the else-branch form works; the companion test in the new file exercises the original work-around shape directly.

## Verification

- `dotnet test GSharp.sln --no-restore --nologo` — **Failed: 0, Passed: 4,210, Skipped: 4** (all skips are pre-existing baselines / 1ES-gated tests).
- `IlVerifier.Verify(...)` is called on every emitted sample in the new emit suite — passes cleanly (the helper crashed with `IndexOutOfRangeException` on the pre-fix IL).

## Related

- Closes #737
- Parent: #706
- Related: #712 / PR #736 (the `||` composition test that had to use the post-if-lift form is now joined by an else-branch companion)