### PR TITLE
Fix #738: interpreter return inside switch arm exits the enclosing function

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -32,6 +32,19 @@ public sealed class Evaluator
 
     private object lastValue;
 
+    // Issue #738: control-transfer state for nested blocks (switch arms,
+    // try/catch/finally bodies, scope bodies, select cases, await-for-range
+    // bodies). Those constructs are kept as nested BoundBlockStatements after
+    // lowering, so a `return` or a `break`/`continue` (lowered to a labeled
+    // `goto` whose target lives in the enclosing function block) inside one
+    // of them used to be swallowed by the inner EvaluateStatement loop. The
+    // fields below let an inner loop signal an in-flight control transfer to
+    // outer loops, which propagate it until it either resolves at the right
+    // label or unwinds to a function boundary (where `EvaluateFunctionBody`
+    // consumes it).
+    private bool isReturning;
+    private BoundLabel pendingGotoLabel;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="Evaluator"/> class.
     /// </summary>
@@ -50,7 +63,7 @@ public sealed class Evaluator
     /// <returns>The evaluation result.</returns>
     public object Evaluate()
     {
-        return EvaluateStatement(program.Statement);
+        return EvaluateFunctionBody(program.Statement);
     }
 
     private object EvaluateStatement(BoundBlockStatement body)
@@ -69,6 +82,30 @@ public sealed class Evaluator
 
         while (index < body.Statements.Length)
         {
+            // Issue #738: a pending return or an in-flight goto (set by a
+            // nested EvaluateStatement on behalf of a switch arm / scope /
+            // try / select / await-for body) must either resolve in this
+            // block or be propagated to the enclosing one. We check before
+            // every statement so that returns/gotos triggered by the
+            // *previous* iteration's nested call are honored before any new
+            // statement runs.
+            if (isReturning)
+            {
+                return lastValue;
+            }
+
+            if (pendingGotoLabel != null)
+            {
+                if (labelToIndex.TryGetValue(pendingGotoLabel, out var pendIdx))
+                {
+                    pendingGotoLabel = null;
+                    index = pendIdx;
+                    continue;
+                }
+
+                return lastValue;
+            }
+
             var s = body.Statements[index];
 
             switch (s.Kind)
@@ -83,14 +120,37 @@ public sealed class Evaluator
                     break;
                 case BoundNodeKind.GotoStatement:
                     var gs = (BoundGotoStatement)s;
-                    index = labelToIndex[gs.Label];
+                    if (labelToIndex.TryGetValue(gs.Label, out var gsIdx))
+                    {
+                        index = gsIdx;
+                    }
+                    else
+                    {
+                        // Issue #738: target label lives in an enclosing
+                        // block (e.g. a `break`/`continue` lowered to
+                        // `goto loop_break`/`goto loop_continue` emitted
+                        // inside a switch arm body). Park the label and
+                        // bail; the outer EvaluateStatement will pick it
+                        // up via the top-of-loop check above.
+                        pendingGotoLabel = gs.Label;
+                        return lastValue;
+                    }
+
                     break;
                 case BoundNodeKind.ConditionalGotoStatement:
                     var cgs = (BoundConditionalGotoStatement)s;
                     var condition = (bool)EvaluateExpression(cgs.Condition);
                     if (condition == cgs.JumpIfTrue)
                     {
-                        index = labelToIndex[cgs.Label];
+                        if (labelToIndex.TryGetValue(cgs.Label, out var cgsIdx))
+                        {
+                            index = cgsIdx;
+                        }
+                        else
+                        {
+                            pendingGotoLabel = cgs.Label;
+                            return lastValue;
+                        }
                     }
                     else
                     {
@@ -104,6 +164,7 @@ public sealed class Evaluator
                 case BoundNodeKind.ReturnStatement:
                     var rs = (BoundReturnStatement)s;
                     lastValue = rs.Expression == null ? null : EvaluateExpression(rs.Expression);
+                    isReturning = true;
                     return lastValue;
                 case BoundNodeKind.TryStatement:
                     EvaluateTryStatement((BoundTryStatement)s);
@@ -146,6 +207,23 @@ public sealed class Evaluator
         }
 
         return lastValue;
+    }
+
+    /// <summary>
+    /// Issue #738: function-call boundary. Runs <paramref name="body"/> and
+    /// then drains any in-flight control-transfer state (a pending return
+    /// or a parked goto) so it cannot leak across the call boundary. A
+    /// parked goto reaching the boundary would mean a `break`/`continue`
+    /// escaped a function body, which the binder rejects — but we clear
+    /// defensively so a stale flag from a partially-evaluated previous
+    /// call cannot corrupt the next invocation on this evaluator.
+    /// </summary>
+    private object EvaluateFunctionBody(BoundBlockStatement body)
+    {
+        var result = EvaluateStatement(body);
+        isReturning = false;
+        pendingGotoLabel = null;
+        return result;
     }
 
     private void EvaluateVariableDeclaration(BoundVariableDeclaration node)
@@ -360,6 +438,14 @@ public sealed class Evaluator
                 var current = currentProperty.GetValue(enumerator);
                 Assign(node.ValueVariable, current);
                 EvaluateStatement((BoundBlockStatement)node.Body);
+
+                // Issue #738: honor in-arm returns / labeled gotos that
+                // escape the loop body. Without this check the iterator
+                // would keep dispatching MoveNextAsync past the transfer.
+                if (isReturning || pendingGotoLabel != null)
+                {
+                    break;
+                }
             }
         }
         finally
@@ -430,7 +516,24 @@ public sealed class Evaluator
         {
             if (node.FinallyBlock != null)
             {
+                // Issue #738: CIL semantics — finally always executes,
+                // even if try/catch left a pending return or goto. Stash
+                // the in-flight control transfer, run finally with a
+                // cleared state, then either keep the finally's own new
+                // transfer (it supersedes per ECMA-335 III.1.7.5) or
+                // restore the original.
+                var savedReturning = isReturning;
+                var savedGoto = pendingGotoLabel;
+                isReturning = false;
+                pendingGotoLabel = null;
+
                 EvaluateStatement((BoundBlockStatement)node.FinallyBlock);
+
+                if (!isReturning && pendingGotoLabel == null)
+                {
+                    isReturning = savedReturning;
+                    pendingGotoLabel = savedGoto;
+                }
             }
         }
     }
@@ -1095,7 +1198,7 @@ public sealed class Evaluator
         }
 
         this.locals.Push(frame);
-        var result = EvaluateStatement(closure.Body);
+        var result = EvaluateFunctionBody(closure.Body);
         this.locals.Pop();
         return result;
     }
@@ -1217,7 +1320,7 @@ public sealed class Evaluator
                 AllocateClrBacking(sv, node.StructType, explicitCtor.BaseInitializer);
 
                 var body = program.Functions[ctorFunction];
-                EvaluateStatement(body);
+                EvaluateFunctionBody(body);
             }
             finally
             {
@@ -1567,7 +1670,7 @@ public sealed class Evaluator
                 }
 
                 locals.Push(frame);
-                EvaluateStatement(body);
+                EvaluateFunctionBody(body);
                 locals.Pop();
             }
 
@@ -1722,7 +1825,7 @@ public sealed class Evaluator
                 // Issue #263: computed static property getter — no 'this' parameter.
                 var frame = new Dictionary<Symbols.VariableSymbol, object>();
                 locals.Push(frame);
-                var result = EvaluateStatement(staticGetterBody);
+                var result = EvaluateFunctionBody(staticGetterBody);
                 locals.Pop();
                 return result;
             }
@@ -1751,7 +1854,7 @@ public sealed class Evaluator
                 [node.Property.GetterSymbol.ThisParameter] = receiverValue,
             };
             locals.Push(frame);
-            var result = EvaluateStatement(getterBody);
+            var result = EvaluateFunctionBody(getterBody);
             locals.Pop();
             return result;
         }
@@ -1777,7 +1880,7 @@ public sealed class Evaluator
                     [node.Property.SetterSymbol.Parameters[0]] = value,
                 };
                 locals.Push(frame);
-                EvaluateStatement(staticSetterBody);
+                EvaluateFunctionBody(staticSetterBody);
                 locals.Pop();
             }
 
@@ -1825,7 +1928,7 @@ public sealed class Evaluator
                 [node.Property.SetterSymbol.Parameters[0]] = value,
             };
             locals.Push(frame);
-            EvaluateStatement(setterBody);
+            EvaluateFunctionBody(setterBody);
             locals.Pop();
             return value;
         }
@@ -2400,7 +2503,7 @@ public sealed class Evaluator
                 return iteratorResult;
             }
 
-            var result = EvaluateStatement(statement);
+            var result = EvaluateFunctionBody(statement);
 
             // ADR-0060 item #7: write the final parameter slot value back to
             // the caller's lvalue for every 'ref'/'out' parameter.
@@ -2467,7 +2570,7 @@ public sealed class Evaluator
         iteratorSinks.Push(list);
         try
         {
-            EvaluateStatement(body);
+            EvaluateFunctionBody(body);
         }
         finally
         {
@@ -3111,7 +3214,7 @@ public sealed class Evaluator
 
         locals.Push(frame);
         var statement = program.Functions[method];
-        var result = EvaluateStatement(statement);
+        var result = EvaluateFunctionBody(statement);
         locals.Pop();
 
         return result;
@@ -3675,7 +3778,7 @@ public sealed class Evaluator
             }
 
             var body = program.Functions[targetCtor.Function];
-            EvaluateStatement(body);
+            EvaluateFunctionBody(body);
         }
         finally
         {

--- a/test/Interpreter.Tests/Issue712FlowNarrowingExtensionsInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue712FlowNarrowingExtensionsInterpreterTests.cs
@@ -139,6 +139,12 @@ public class Issue712FlowNarrowingExtensionsInterpreterTests
         // enclosing scope: after the switch, `a` is narrowed to `Dog`
         // because the Cat and default arms exit and the Dog arm falls
         // through with `{a → Dog}` — so `a.Bark()` resolves directly.
+        //
+        // Issue #738: previously the Cat / default arms could not be
+        // exercised on the interpreter path because `return` inside a
+        // switch arm fell through to the post-switch statements. That
+        // bug is fixed, so this test mirrors the emit counterpart and
+        // runs both a Dog and a Cat input through the same function.
         var source = AnimalHierarchy + """
 
             func Run(a Animal) {
@@ -159,9 +165,10 @@ public class Issue712FlowNarrowingExtensionsInterpreterTests
             }
 
             Run(Dog{Name: "Rex"})
+            Run(Cat{Name: "Whiskers"})
             """;
 
-        Assert.Equal("matched dog\nRex:woof\n", RunSubmission(source));
+        Assert.Equal("matched dog\nRex:woof\nmatched cat\n", RunSubmission(source));
     }
 
     private static string RunSubmission(string text)

--- a/test/Interpreter.Tests/Issue738SwitchArmFlowInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue738SwitchArmFlowInterpreterTests.cs
@@ -1,0 +1,268 @@
+// <copyright file="Issue738SwitchArmFlowInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #738 — interpreter parity for control-transfer statements that
+/// appear inside a <c>switch</c>-statement arm body. The arm body is a
+/// nested <c>BoundBlockStatement</c> in the lowered tree, so the evaluator
+/// must propagate <c>return</c> out of the function, exceptions past the
+/// switch, and labeled gotos (the lowered form of <c>break</c> /
+/// <c>continue</c>) to whichever enclosing block owns the target label.
+/// Mirrors the emit-backend behavior exercised by
+/// <c>Issue712FlowNarrowingExtensionsEmitTests</c>.
+/// </summary>
+public class Issue738SwitchArmFlowInterpreterTests
+{
+    [Fact]
+    public void Return_InsideCaseArm_ExitsEnclosingFunction()
+    {
+        // Exact repro from issue #738: the interpreter previously fell
+        // through to the post-switch `return "unreached"` instead of
+        // honoring the in-arm return.
+        var source = """
+            func classify(x object) string {
+                switch x {
+                    case s is string {
+                        return "string"
+                    }
+                    default {
+                        return "other"
+                    }
+                }
+                return "unreached"
+            }
+
+            Console.WriteLine(classify("hi"))
+            Console.WriteLine(classify(42))
+            """;
+
+        Assert.Equal("string\nother\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void Return_InsideDefaultArm_ExitsEnclosingFunction()
+    {
+        var source = """
+            func classify(x int32) string {
+                switch x {
+                    case 1 {
+                        return "one"
+                    }
+                    default {
+                        return "default"
+                    }
+                }
+                return "unreached"
+            }
+
+            Console.WriteLine(classify(1))
+            Console.WriteLine(classify(2))
+            """;
+
+        Assert.Equal("one\ndefault\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void Return_FromCaseArm_DoesNotEvaluatePostSwitchStatements()
+    {
+        // After the matching arm returns, no subsequent statement in the
+        // function body should execute — confirms we don't fall through.
+        var source = """
+            func describe(x int32) string {
+                switch x {
+                    case 1 {
+                        return "one"
+                    }
+                    case 2 {
+                        return "two"
+                    }
+                    default {
+                    }
+                }
+                Console.WriteLine("post-switch (default)")
+                return "other"
+            }
+
+            Console.WriteLine(describe(1))
+            Console.WriteLine(describe(3))
+            """;
+
+        Assert.Equal("one\npost-switch (default)\nother\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void Throw_InsideCaseArm_PropagatesPastSwitch()
+    {
+        var source = """
+            func classify(x int32) string {
+                try {
+                    switch x {
+                        case 1 {
+                            throw Exception("boom")
+                        }
+                        default {
+                        }
+                    }
+                    return "after-switch"
+                } catch (e Exception) {
+                    return "caught"
+                }
+            }
+
+            Console.WriteLine(classify(1))
+            Console.WriteLine(classify(2))
+            """;
+
+        Assert.Equal("caught\nafter-switch\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void Break_InsideCaseArm_ExitsEnclosingLoopOnly()
+    {
+        // ADR-0070: an unlabeled `break` inside a switch arm targets the
+        // innermost enclosing loop's break label (switch statements are
+        // not break targets in G#). The result must reflect that the
+        // loop terminated as soon as we hit `stop`.
+        var source = """
+            func first(stop int32) int32 {
+                var values = []int32{0, 1, 2, 3}
+                var result = -1
+                for v in values {
+                    switch v {
+                        case 0 {
+                        }
+                        default {
+                            if v == stop {
+                                result = v
+                                break
+                            }
+                        }
+                    }
+                }
+                return result
+            }
+
+            Console.WriteLine(first(2))
+            Console.WriteLine(first(9))
+            """;
+
+        Assert.Equal("2\n-1\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void Continue_InsideCaseArm_ContinuesEnclosingLoop()
+    {
+        var source = """
+            func sumOdd() int32 {
+                var values = []int32{1, 2, 3, 4, 5}
+                var total = 0
+                for v in values {
+                    switch v % 2 {
+                        case 0 {
+                            continue
+                        }
+                        default {
+                        }
+                    }
+                    total = total + v
+                }
+                return total
+            }
+
+            Console.WriteLine(sumOdd())
+            """;
+
+        Assert.Equal("9\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void LabeledBreak_InsideCaseArm_TargetsOuterLoop()
+    {
+        // ADR-0070: labeled `break outer` from inside a switch arm jumps
+        // out of the labeled loop, not the innermost loop.
+        var source = """
+            func find(needle int32) int32 {
+                var hits = 0
+                outer: for var i = 0; i < 3; i = i + 1 {
+                    for var j = 0; j < 3; j = j + 1 {
+                        switch j {
+                            case 0 {
+                            }
+                            default {
+                                if i == 1 && j == needle {
+                                    break outer
+                                }
+                                hits = hits + 1
+                            }
+                        }
+                    }
+                }
+                return hits
+            }
+
+            Console.WriteLine(find(2))
+            """;
+
+        // i=0: j=0 (skip), j=1 (default, hits=1), j=2 (default, hits=2)
+        // i=1: j=0 (skip), j=1 (default, hits=3), j=2 → break outer.
+        // Outer terminates → 3.
+        Assert.Equal("3\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void LabeledContinue_InsideCaseArm_TargetsOuterLoop()
+    {
+        var source = """
+            func count(sentinel int32) int32 {
+                var hits = 0
+                outer: for var i = 0; i < 3; i = i + 1 {
+                    for var j = 0; j < 3; j = j + 1 {
+                        switch j {
+                            case 0 {
+                            }
+                            default {
+                                if j == sentinel {
+                                    continue outer
+                                }
+                                hits = hits + 1
+                            }
+                        }
+                    }
+                    hits = hits + 100
+                }
+                return hits
+            }
+
+            Console.WriteLine(count(2))
+            """;
+
+        // Each outer i (3 of them): j=0 (skip), j=1 (hits++), j=2 → continue outer (skip +100).
+        // Hits across 3 outer iterations: 3 increments only → 3.
+        Assert.Equal("3\n", RunSubmission(source));
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #738 — the interpreter previously fell through past a switch when a `return` (or labeled `break`/`continue`) appeared inside a switch arm body. The fix generalizes to all nested-block constructs the lowerer keeps as nested `BoundBlockStatement`s (switch arms, try / catch / finally, scope, select cases, await-for-range body).

## Root cause

The interpreter evaluates a function body's lowered `BoundBlockStatement` with a flat goto/label loop. After lowering, however, switch arms / try blocks / scope blocks / select cases / await-for-range bodies remain **nested** `BoundBlockStatement`s. The inner `EvaluateStatement` loop handled `return` by returning a value to its caller, but the caller (e.g. `EvaluatePatternSwitchStatement`) discarded it — the outer loop then ran `index++` and kept going. Likewise, `break` / `continue` lower to a labeled `goto` whose target lives in the enclosing function block; from inside an arm body the inner loop crashed with a `KeyNotFoundException` on its arm-local `labelToIndex` map.

## Fix

Track an in-flight control-transfer state on the evaluator:
- `isReturning` — set when a `return` was executed and is pending consumption at a function boundary.
- `pendingGotoLabel` — set when a goto could not be resolved in the current block.

The `EvaluateStatement` loop now checks both at the top of every iteration. A pending return propagates up to the function boundary; a parked goto either resolves at the current block (the enclosing function body holds the loop break/continue label) or bubbles further up.

A new `EvaluateFunctionBody` helper wraps every function-call boundary and drains the state so it cannot leak across calls. `EvaluateTryStatement` saves / restores the in-flight transfer across the `finally` block (CIL III.1.7.5: finally always runs and may itself supersede). `EvaluateAwaitForRangeStatement` breaks its iteration loop when the body sets either flag.

## Tests

- New `test/Interpreter.Tests/Issue738SwitchArmFlowInterpreterTests.cs` covers `return` (case + default), the exact issue repro, throw, unlabeled break / continue, and labeled break / continue from inside a switch arm.
- The `#712` interpreter test `Switch_PostSwitch_LiftsCommonNarrowing` had been shrunk to only exercise the Dog case because the Cat `return` tripped this bug. With the fix it now runs both inputs and asserts the same output as the emit backend.

Full `dotnet test GSharp.sln` is green (≈4 200 tests across all suites).

## References

- Closes #738
- Parent: #706 (control-flow polish)
- Related: #712 / PR #736 (flow narrowing — the bug was discovered while writing tests for that work)
- ADR-0070 (loops + labels)
- ADR-0074 (`->` lambdas, `:` switch-expression arms — switch-statement arm shape is unchanged)

## Out of scope

- No new bound-node kinds.
- No spec / sample / docs changes — this is a pure interpreter bug fix; the emit backend was already correct.