### PR TITLE
Fix #751: parser accepts nullable/generic receiver types; port Extensions stdlib to G#

### DIFF
--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -207,12 +207,32 @@ hatch under `src/Sdk/Gsharp.Extensions/*.cs` works today.
   name surface listed above.
 - **L2. Receiver clauses on generic / nullable receiver types.**
   ([issue #751](https://github.com/DavidObando/gsharp/issues/751))
-  `LooksLikeReceiverClause()` in the parser only accepts an
-  identifier or an `[N]T` / `[]T` receiver type. It rejects
-  `(self T?)`, `(self sequence[T])`, and similar — which means
-  every helper in this ADR has to be authored in C# (where the
-  receiver shape is unconstrained). When the parser accepts these
-  shapes, the helpers can migrate to native G# `.gs` sources.
+  **Parser-side closed.** `LooksLikeReceiverClause()` previously
+  only accepted an identifier or an `[N]T` / `[]T` receiver type;
+  the scanner now reads any balanced bracket region as the
+  candidate type clause, so `(self T?)`, `(self sequence[T])`,
+  `(self map[K]V)`, `(self (int32, string)?)`, and arbitrary
+  combinations are recognised by the parser and the function
+  retains its extension-method status. The binder + emit pipeline
+  also accept call-site dispatch when the receiver is *closed*
+  (concrete) — `string?`, `(int32, string)`, `[]int32?`,
+  `map[string]int32`. The remaining gap is generic-receiver
+  dispatch: when the receiver type contains a function-level type
+  parameter (`func (self sequence[T]) FirstOrNil[T]() T?`), the
+  binder still fails to bind the call site
+  (`receiver.FirstOrNil()` → GS0159) and array iteration through
+  such a receiver erases the element type to `object`. Those
+  follow-up gaps are tracked as
+  [issue #773](https://github.com/DavidObando/gsharp/issues/773)
+  (generic-receiver dispatch) and
+  [issue #774](https://github.com/DavidObando/gsharp/issues/774)
+  (open-receiver iteration). A third gap blocking the port —
+  [issue #775](https://github.com/DavidObando/gsharp/issues/775),
+  G# spelling for `class` / `struct` / `new()` constraints — was
+  also surfaced while attempting the dogfooded G# rewrite in this
+  PR. Closing #773, #774, and #775 lets the C# files under
+  `src/Sdk/Gsharp.Extensions/Optional/` and
+  `src/Sdk/Gsharp.Extensions/Sequences/` migrate to native G#.
 - **L3. Native `?:` over nullable value types.**
   ([issue #752](https://github.com/DavidObando/gsharp/issues/752))
   The current
@@ -242,6 +262,10 @@ of that migration, not left behind as dead code.
   meant to be authored in G# creates direct compiler pressure to
   close L2 / L3 (L1 closed by ADR-0088). Each remaining gap is now
   a tracked issue with a concrete callsite waiting on its fix.
+  L2's parser side closed in PR for #751; the residual binder /
+  emit gaps surfaced while attempting the port live as #773
+  (generic-receiver dispatch), #774 (open-receiver iteration),
+  and #775 (G# `class` / `struct` constraint spelling).
 - **Positive — zero-friction adoption.** Because the assembly is
   bundled with the SDK and imports are explicit but trivial
   (`import Gsharp.Extensions.Optional`), the cost to a sample or

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -2542,8 +2542,22 @@ public class Parser
 
     private bool LooksLikeReceiverClause()
     {
-        // Expecting: '(' ident <type-clause> ')' ident '('
-        // type-clause is either a single identifier or '[' [number] ']' ident.
+        // Issue #751 (ADR-0084 L2): a receiver clause has the shape
+        //   '(' ident <type-clause> ')' (ident | operator) ( '(' | '[' )
+        // The original implementation hard-coded a tiny subset of type-clause
+        // spellings (bare identifier, `[N]T` / `[]T`). That excluded common
+        // shapes like `T?`, `sequence[T]`, `map[K]V`, `(int, T)`, and
+        // combinations thereof, silently demoting an extension-method
+        // declaration to a malformed regular function. Rather than mirror
+        // the entire type grammar here we scan the candidate receiver as a
+        // balanced bracket region: find the matching `)` of the outer
+        // parenthesis (bailing on a top-level `,` which would mean a
+        // multi-parameter regular parameter list, never a receiver), and
+        // then verify the trailing-token shape that distinguishes a
+        // receiver clause from a regular parameter list. The actual type
+        // grammar is validated when the receiver is parsed for real by
+        // `ParseParameter` → `ParseTypeClause` — keeping the type grammar
+        // in one place.
         if (Peek(0).Kind != SyntaxKind.OpenParenthesisToken)
         {
             return false;
@@ -2554,63 +2568,84 @@ public class Parser
             return false;
         }
 
+        var parenDepth = 1;
+        var bracketDepth = 0;
         var ahead = 2;
-        if (Peek(ahead).Kind == SyntaxKind.OpenSquareBracketToken)
+        var closeParenAhead = -1;
+        while (true)
         {
-            ahead++;
-            if (Peek(ahead).Kind == SyntaxKind.NumberToken)
-            {
-                ahead++;
-            }
-
-            if (Peek(ahead).Kind != SyntaxKind.CloseSquareBracketToken)
+            var kind = Peek(ahead).Kind;
+            if (kind == SyntaxKind.EndOfFileToken)
             {
                 return false;
             }
 
-            ahead++;
-            if (Peek(ahead).Kind != SyntaxKind.IdentifierToken)
+            // A top-level `,` means we have a multi-parameter regular
+            // parameter list, not a single-parameter receiver clause.
+            // Brackets (`[...]`) and inner parens nest freely; only
+            // commas at the outer level disqualify.
+            if (parenDepth == 1 && bracketDepth == 0 && kind == SyntaxKind.CommaToken)
             {
                 return false;
             }
 
+            switch (kind)
+            {
+                case SyntaxKind.OpenParenthesisToken:
+                    parenDepth++;
+                    break;
+                case SyntaxKind.CloseParenthesisToken:
+                    parenDepth--;
+                    if (parenDepth == 0)
+                    {
+                        closeParenAhead = ahead;
+                    }
+
+                    break;
+                case SyntaxKind.OpenSquareBracketToken:
+                    bracketDepth++;
+                    break;
+                case SyntaxKind.CloseSquareBracketToken:
+                    bracketDepth--;
+                    if (bracketDepth < 0)
+                    {
+                        return false;
+                    }
+
+                    break;
+            }
+
+            if (closeParenAhead >= 0)
+            {
+                break;
+            }
+
             ahead++;
         }
-        else if (Peek(ahead).Kind == SyntaxKind.IdentifierToken)
-        {
-            ahead++;
-        }
-        else
+
+        // After the closing `)` we must see a function name (identifier or
+        // the contextual `operator` keyword for operator-overload streams).
+        ahead = closeParenAhead + 1;
+        var afterCloseKind = Peek(ahead).Kind;
+        if (afterCloseKind != SyntaxKind.IdentifierToken && afterCloseKind != SyntaxKind.OperatorKeyword)
         {
             return false;
         }
-
-        if (Peek(ahead).Kind != SyntaxKind.CloseParenthesisToken)
-        {
-            return false;
-        }
-
-        ahead++;
-        if (Peek(ahead).Kind != SyntaxKind.IdentifierToken && Peek(ahead).Kind != SyntaxKind.OperatorKeyword)
-        {
-            return false;
-        }
-
-        ahead++;
 
         // Stream D: `operator <op>(` follows the receiver clause for operator
-        // overloads. Accept any non-`(`/non-EOF token after `operator` here —
-        // the operator-token validation happens in MatchOperatorOrIdentifier.
-        if (Peek(ahead - 1).Kind == SyntaxKind.OperatorKeyword)
+        // overloads. Accept any non-EOF token after `operator` here — the
+        // operator-token validation happens in MatchOperatorOrIdentifier.
+        if (afterCloseKind == SyntaxKind.OperatorKeyword)
         {
-            return Peek(ahead).Kind != SyntaxKind.EndOfFileToken
-                && Peek(ahead + 1).Kind == SyntaxKind.OpenParenthesisToken;
+            return Peek(ahead + 1).Kind != SyntaxKind.EndOfFileToken
+                && Peek(ahead + 2).Kind == SyntaxKind.OpenParenthesisToken;
         }
 
         // The parameter list opens with `(`, or — for a generic extension
         // function — a type-parameter list `[T]` precedes it (Phase 4.1).
-        return Peek(ahead).Kind == SyntaxKind.OpenParenthesisToken
-            || Peek(ahead).Kind == SyntaxKind.OpenSquareBracketToken;
+        var afterNameKind = Peek(ahead + 1).Kind;
+        return afterNameKind == SyntaxKind.OpenParenthesisToken
+            || afterNameKind == SyntaxKind.OpenSquareBracketToken;
     }
 
     private SeparatedSyntaxList<ParameterSyntax> ParseParameterList()

--- a/test/Compiler.Tests/Emit/Issue751RichReceiverEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue751RichReceiverEmitTests.cs
@@ -1,0 +1,196 @@
+// <copyright file="Issue751RichReceiverEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// End-to-end emit + run coverage for issue #751 / ADR-0084 §L2: the
+/// receiver clause now accepts rich type spellings (nullable, generic
+/// application, tuple, nullable array, map[K]V). Each test compiles a
+/// G# program containing an extension method declaration whose receiver
+/// previously rejected at parse time, IL-verifies the output, and
+/// executes it under <c>dotnet exec</c> to prove the dispatched call
+/// reaches the extension body.
+/// </summary>
+public class Issue751RichReceiverEmitTests
+{
+    [Fact]
+    public void NullableString_Receiver_RoundTrips()
+    {
+        var source = """
+            package P
+            import System
+
+            func (self string?) OrElse(fb string) string {
+                return self ?: fb
+            }
+
+            var present string? = "hi"
+            var absent string? = nil
+            Console.WriteLine(present.OrElse("nope"))
+            Console.WriteLine(absent.OrElse("nope"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi\nnope\n", output);
+    }
+
+    [Fact]
+    public void Tuple_Receiver_RoundTrips()
+    {
+        var source = """
+            package P
+            import System
+
+            func (self (int32, string)) Show() string {
+                return self.Item1.ToString() + ":" + self.Item2
+            }
+
+            var p = (42, "hi")
+            Console.WriteLine(p.Show())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42:hi\n", output);
+    }
+
+    [Fact]
+    public void NullableArray_Receiver_RoundTrips()
+    {
+        var source = """
+            package P
+            import System
+
+            func (self []int32?) FirstOrZero() int32 {
+                if self == nil {
+                    return 0
+                }
+                if self.Length == 0 {
+                    return 0
+                }
+                return self[0]
+            }
+
+            var present []int32? = []int32{10, 20}
+            var absent []int32? = nil
+            Console.WriteLine(present.FirstOrZero())
+            Console.WriteLine(absent.FirstOrZero())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("10\n0\n", output);
+    }
+
+    [Fact]
+    public void Map_Receiver_RoundTrips()
+    {
+        var source = """
+            package P
+            import System
+
+            func (self map[string]int32) CountKeys() int32 {
+                return self.Count
+            }
+
+            var m = map[string]int32{"a": 1, "b": 2, "c": 3}
+            Console.WriteLine(m.CountKeys())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue751_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed (exit {compileExit}):\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            if (!File.Exists(runtimeConfigPath))
+            {
+                File.WriteAllText(runtimeConfigPath, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(runtimeConfigPath);
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue751RichReceiverBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue751RichReceiverBinderTests.cs
@@ -1,0 +1,132 @@
+// <copyright file="Issue751RichReceiverBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Binder + tree-walking interpreter coverage for issue #751 / ADR-0084 §L2.
+/// Verifies that each rich receiver shape accepted by the parser fix
+/// (nullable, generic application, tuple, array-of-nullable, map[K]V)
+/// binds as an extension method and is dispatched via the dot-syntax
+/// call site. Only concrete (non-type-parameter) receiver shapes are
+/// covered here — receivers that close over a function-level type
+/// parameter (e.g. <c>sequence[T]</c>, <c>T?</c>) hit a separate binder
+/// gap tracked in a follow-up issue.
+/// </summary>
+public class Issue751RichReceiverBinderTests
+{
+    [Fact]
+    public void NullableString_Receiver_Dispatches_Via_DotSyntax()
+    {
+        var source = @"
+func (self string?) OrElse(fb string) string {
+    return self ?: fb
+}
+
+var x string? = ""hi""
+var y string? = nil
+x.OrElse(""nope"") + "":"" + y.OrElse(""nope"")
+";
+        var result = Evaluate(source);
+        AssertNoErrors(result);
+        Assert.Equal("hi:nope", result.Value);
+    }
+
+    [Fact]
+    public void TupleTyped_Receiver_Dispatches_Via_DotSyntax()
+    {
+        var source = @"
+func (self (int32, string)) Show() string {
+    return self.Item1.ToString() + "":"" + self.Item2
+}
+
+var p = (42, ""hi"")
+p.Show()
+";
+        var result = Evaluate(source);
+        AssertNoErrors(result);
+        Assert.Equal("42:hi", result.Value);
+    }
+
+    [Fact]
+    public void NullableTuple_Receiver_Dispatches_Via_DotSyntax()
+    {
+        var source = @"
+func (self (int32, string)?) Tag() string {
+    if self == nil {
+        return ""nil""
+    }
+    return self!!.Item2
+}
+
+var p (int32, string)? = (7, ""seven"")
+var q (int32, string)? = nil
+p.Tag() + ""|"" + q.Tag()
+";
+        var result = Evaluate(source);
+        AssertNoErrors(result);
+        Assert.Equal("seven|nil", result.Value);
+    }
+
+    [Fact]
+    public void NullableArray_Receiver_Dispatches_Via_DotSyntax()
+    {
+        var source = @"
+func (self []int32?) FirstOrZero() int32 {
+    if self == nil {
+        return 0
+    }
+    if self.Length == 0 {
+        return 0
+    }
+    return self[0]
+}
+
+var present []int32? = []int32{10, 20}
+var absent []int32? = nil
+present.FirstOrZero() + absent.FirstOrZero()
+";
+        var result = Evaluate(source);
+        AssertNoErrors(result);
+        Assert.Equal(10, result.Value);
+    }
+
+    [Fact]
+    public void Map_Receiver_Dispatches_Via_DotSyntax()
+    {
+        var source = @"
+func (self map[string]int32) CountKeys() int32 {
+    return self.Count
+}
+
+var m = map[string]int32{""a"": 1, ""b"": 2, ""c"": 3}
+m.CountKeys()
+";
+        var result = Evaluate(source);
+        AssertNoErrors(result);
+        Assert.Equal(3, result.Value);
+    }
+
+    private static void AssertNoErrors(EvaluationResult result)
+    {
+        var errors = result.Diagnostics.Where(d => d.IsError).ToList();
+        Assert.True(errors.Count == 0, "Unexpected errors:\n" + string.Join("\n", errors.Select(d => d.ToString())));
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue751ReceiverClauseParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue751ReceiverClauseParserTests.cs
@@ -1,0 +1,119 @@
+// <copyright file="Issue751ReceiverClauseParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Parser-level coverage for issue #751 / ADR-0084 §L2: the receiver
+/// clause `func (recv RecvType) Name(...)` must accept the full type
+/// grammar — nullable spellings (`T?`), generic applications
+/// (`sequence[T]`, `map[K]V`), array+nullable combinations (`[]T?`),
+/// tuple types (`(int32, T)`), and arbitrary nesting (`sequence[T]?`).
+/// Prior to the fix, <c>LooksLikeReceiverClause</c> only matched a
+/// bare identifier or `[N]T` / `[]T` and silently demoted the rest to
+/// a regular parameter list, losing the extension-method status.
+/// </summary>
+public class Issue751ReceiverClauseParserTests
+{
+    [Theory]
+    [InlineData("func (self T?) M[T]() { }", "M")]
+    [InlineData("func (self sequence[T]) M[T]() { }", "M")]
+    [InlineData("func (self sequence[T]?) M[T]() { }", "M")]
+    [InlineData("func (self []T?) M[T]() { }", "M")]
+    [InlineData("func (self map[K]V) M[K, V]() { }", "M")]
+    [InlineData("func (self []T) M[T]() { }", "M")]
+    [InlineData("func (self [3]int32) M() { }", "M")]
+    [InlineData("func (self int32) M() { }", "M")]
+    [InlineData("func (self sequence[(int32, T)]) M[T]() { }", "M")]
+    [InlineData("func (self (int32, string)) M() { }", "M")]
+    [InlineData("func (self (int32, string)?) M() { }", "M")]
+    public void ReceiverClause_With_RichTypeSpelling_IsRecognizedAsExtension(string declaration, string expectedName)
+    {
+        var source = "package P\n" + declaration + "\n";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        Assert.True(fn.IsExtension, "Expected extension method; receiver clause was not recognised.");
+        Assert.NotNull(fn.Receiver);
+        Assert.NotNull(fn.ReceiverOpenParenthesisToken);
+        Assert.NotNull(fn.ReceiverCloseParenthesisToken);
+        Assert.Equal(expectedName, fn.Identifier.Text);
+    }
+
+    [Fact]
+    public void RegularFunction_With_GenericReturnType_IsNotMistakenForReceiverClause()
+    {
+        // Regression guard: the fix must not classify `func Foo(a int) Bar[int]
+        // { ... }` as an extension method. The function name comes BEFORE the
+        // parameter list so `LooksLikeReceiverClause` is never invoked for
+        // this shape — but we cover it explicitly because the generic-return
+        // case is the closest non-receiver token sequence.
+        const string source = @"
+package P
+
+func Foo(a int32) int32 {
+    return a
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        Assert.False(fn.IsExtension);
+    }
+
+    [Fact]
+    public void Regular_MultiParameter_Function_Without_Name_Is_Not_Receiver_Clause()
+    {
+        // Defence in depth: a multi-parameter list `(a int32, b int32)` should
+        // not match the receiver shape — the scanner bails on the top-level
+        // comma. If a developer writes `func (a int32, b int32) name()` we
+        // want it routed through the regular parameter-list parser so the
+        // diagnostics are coherent.
+        const string source = @"
+package P
+
+func name() int32 {
+    return 0
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        Assert.False(fn.IsExtension);
+    }
+
+    [Fact]
+    public void Repro_From_Issue751_Parses_Without_Diagnostics()
+    {
+        // The exact spellings from the issue body. Each one was rejected by
+        // the prior parser; all three must parse cleanly and be classified
+        // as extension methods.
+        const string source = @"
+package P
+
+func (self T?) Map[T, U](f (T) -> U) U? {
+    return nil
+}
+
+func (self sequence[T]) FirstOrNil[T]() T? {
+    return nil
+}
+
+func (self sequence[T]) Indexed[T]() sequence[(int32, T)] {
+    return nil
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fns = tree.Root.Members.OfType<FunctionDeclarationSyntax>().ToList();
+        Assert.Equal(3, fns.Count);
+        Assert.All(fns, fn => Assert.True(fn.IsExtension, $"{fn.Identifier.Text} was not recognised as extension."));
+        Assert.Equal(new[] { "Map", "FirstOrNil", "Indexed" }, fns.Select(f => f.Identifier.Text));
+    }
+}

--- a/test/Interpreter.Tests/Issue751RichReceiverInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue751RichReceiverInterpreterTests.cs
@@ -1,0 +1,107 @@
+// <copyright file="Issue751RichReceiverInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Tree-walking interpreter parity for issue #751 / ADR-0084 §L2: the
+/// receiver clause now accepts rich type spellings (nullable, tuple,
+/// nullable array, map[K]V). Each test exercises the same shape covered
+/// by the emit and binder suites but through the REPL evaluator, which
+/// shares the binder with the compiler.
+/// </summary>
+public class Issue751RichReceiverInterpreterTests
+{
+    [Fact]
+    public void NullableString_Receiver_Dispatches()
+    {
+        var source = """
+            func (self string?) OrElse(fb string) string {
+                return self ?: fb
+            }
+
+            var present string? = "hi"
+            var absent string? = nil
+            Console.WriteLine(present.OrElse("nope"))
+            Console.WriteLine(absent.OrElse("nope"))
+            """;
+
+        Assert.Equal("hi\nnope\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void Tuple_Receiver_Dispatches()
+    {
+        var source = """
+            func (self (int32, string)) Show() string {
+                return self.Item1.ToString() + ":" + self.Item2
+            }
+
+            var p = (42, "hi")
+            Console.WriteLine(p.Show())
+            """;
+
+        Assert.Equal("42:hi\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void NullableArray_Receiver_Dispatches()
+    {
+        var source = """
+            func (self []int32?) FirstOrZero() int32 {
+                if self == nil {
+                    return 0
+                }
+                if self.Length == 0 {
+                    return 0
+                }
+                return self[0]
+            }
+
+            var present []int32? = []int32{10, 20}
+            var absent []int32? = nil
+            Console.WriteLine(present.FirstOrZero())
+            Console.WriteLine(absent.FirstOrZero())
+            """;
+
+        Assert.Equal("10\n0\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void Map_Receiver_Dispatches()
+    {
+        var source = """
+            func (self map[string]int32) CountKeys() int32 {
+                return self.Count
+            }
+
+            var m = map[string]int32{"a": 1, "b": 2, "c": 3}
+            Console.WriteLine(m.CountKeys())
+            """;
+
+        Assert.Equal("3\n", RunSubmission(source));
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary
`LooksLikeReceiverClause()` only recognised a bare-identifier or array (`[N]T` / `[]T`) receiver type. Anything richer — `T?`, `sequence[T]`, `map[K]V`, tuples, or any combination thereof — was silently demoted to a malformed regular parameter list and the function lost its extension-method status (the exact symptom called out in ADR-0084 §L2).

## What changed

### Parser fix
`src/Core/CodeAnalysis/Syntax/Parser.cs` — `LooksLikeReceiverClause` now scans the candidate receiver as a balanced-bracket region: it walks forward tracking `(`/`)` and `[`/`]` depth, bails on a top-level `,` (which would mean a multi-parameter regular list), and at the matching outer `)` verifies the trailing-token shape that distinguishes a receiver clause from a regular parameter list (function name followed by `(` or `[`, or the contextual `operator` keyword). The actual type grammar stays owned by `ParseTypeClause` when `ParseParameter` binds the receiver — no duplication.

### Test coverage
- **Parser (14 tests)**: `Issue751ReceiverClauseParserTests` pins the eight rich shapes (`T?`, `sequence[T]`, `sequence[T]?`, `[]T?`, `map[K, V]`, `(int32, string)`, `(int32, string)?`, `sequence[(int32, T)]`) plus the exact repro from the issue. Also adds regression guards confirming generic-return-typed functions and multi-parameter regular lists are not misclassified.
- **Binder (5 tests)**: `Issue751RichReceiverBinderTests` evaluates each closed-receiver shape and asserts dot-syntax dispatch reaches the body.
- **Emit (4 tests)**: `Issue751RichReceiverEmitTests` round-trips each shape through `gsc` → IL verifier → `dotnet exec`.
- **Interpreter (4 tests)**: `Issue751RichReceiverInterpreterTests` mirrors the same shapes through the REPL evaluator.

### ADR-0084 update
Marks L2 *parser-side closed* and records the three residual binder/emit gaps surfaced while attempting the dogfooded G# rewrite of `Gsharp.Extensions`. They are filed as separate issues and link from the ADR (#773, #774, #775).

## What did not land

The full G# port of `src/Sdk/Gsharp.Extensions/Optional/` and `.../Sequences/` is **deferred** until the follow-up gaps close:

- **#773** — generic-receiver dispatch (call site can't find the extension when the receiver type contains a function-level type parameter; e.g. `arr.FirstOrFb(0)` against `func (self IEnumerable[T]) FirstOrFb[T any](fb T) T`).
- **#774** — open-receiver iteration (`for v in self` over `IEnumerable[T]` infers `v` as `object` instead of `T`).
- **#775** — no G# spelling yet for `class` / `struct` / `new()` generic constraints, needed to fold the single-name reference/value-typed `Optional` surface that ADR-0088 settled on.

I attempted to port at least the concrete-type `Sequences` builders, but every meaningful helper in the surface either depends on a generic receiver, on `IEnumerable[T]` projection (#774), or on `class`/`struct` disambiguation (#775). Landing a partial port would have either regressed the public surface ADR-0084 settled on (changing names) or required wholesale rework of the build to wire `Gsharp.NET.Sdk` through `Gsharp.Extensions.csproj` for the handful of helpers that *can* be expressed today. The honest decision is to keep the C# escape hatch in place until the three blockers close, then migrate the whole namespace in one move — captured in the ADR.

## Verification
- `dotnet test GSharp.sln --no-restore --nologo` — **green** (Core 2786 / Compiler 1118 / Interpreter 188 / LanguageServer 257 / Extensions 107 / Sdk 26).
- `IlVerifier.Verify` runs inside the emit suite — clean for every generated assembly.
- `cd website && npm run build` — clean, no broken links.

## Links
- Closes #751
- ADR-0084 (Extensions stdlib, issue #724) — §L2 closed parser-side here
- ADR-0088 (constraint-aware overload resolution, issue #750) — sibling that closed L1
- Parent issue #706
- Follow-ups filed in this PR: #773, #774, #775
