### PR TITLE
Fix #752: emit valid IL for ?: (Elvis) over nullable value-type receiver

### DIFF
--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -235,13 +235,17 @@ hatch under `src/Sdk/Gsharp.Extensions/*.cs` works today.
   `src/Sdk/Gsharp.Extensions/Sequences/` migrate to native G#.
 - **L3. Native `?:` over nullable value types.**
   ([issue #752](https://github.com/DavidObando/gsharp/issues/752))
-  The current
-  emitter cannot lower the Elvis operator when the receiver is a
-  nullable struct (`Nullable<T>`) — the `dup; brtrue` pattern it
-  uses is invalid IL for boxed value-type stack slots. The
-  `OrElse` / `OrCompute` helpers exist partly to give
-  callers a safe surface today; `?:` over nullable value types is
-  tracked separately.
+  **Closed.** Issue #519 introduced the HasValue-based lowering
+  for value-type `Nullable<T>` LHS in the `?:` emit path; issue
+  #752 finished the job by switching the non-null branch's unwrap
+  from `Nullable<T>::get_Value()` to the cheaper
+  `GetValueOrDefault()` (no boxing, no callvirt, no redundant
+  throw path) and by giving the coalesce its own scratch slot
+  separate from the receiver-spill slot so `(v ?: 0).ToString()`
+  emits verifiable IL. The `Optional` and `Sequences` samples
+  now use `?:` directly on `int32?` receivers; the `OrElse` /
+  `OrCompute` helpers remain available for deferred / computed
+  fallbacks but are no longer the only safe surface.
 
 When any of these gaps closes, the corresponding helpers should
 migrate to native G# sources and the C# files under
@@ -260,12 +264,13 @@ of that migration, not left behind as dead code.
   in the tour and the standard-library reference.
 - **Positive — dogfooding pressure.** Shipping a real assembly
   meant to be authored in G# creates direct compiler pressure to
-  close L2 / L3 (L1 closed by ADR-0088). Each remaining gap is now
-  a tracked issue with a concrete callsite waiting on its fix.
-  L2's parser side closed in PR for #751; the residual binder /
-  emit gaps surfaced while attempting the port live as #773
-  (generic-receiver dispatch), #774 (open-receiver iteration),
-  and #775 (G# `class` / `struct` constraint spelling).
+  close the open language gaps. Each gap is tracked with a
+  concrete callsite waiting on its fix. L1 closed by ADR-0088,
+  L3 closed by issue #752, and L2's parser side closed in the PR
+  for #751; the residual binder / emit gaps surfaced while
+  attempting the port live as #773 (generic-receiver dispatch),
+  #774 (open-receiver iteration), and #775 (G# `class` / `struct`
+  constraint spelling).
 - **Positive — zero-friction adoption.** Because the assembly is
   bundled with the SDK and imports are explicit but trivial
   (`import Gsharp.Extensions.Optional`), the cost to a sample or

--- a/samples/GsharpExtensionsOptional.gs
+++ b/samples/GsharpExtensionsOptional.gs
@@ -6,6 +6,11 @@
 // the reference-typed surface: the G# binder honours generic constraints
 // (`where T : class` vs `where T : struct`) during overload resolution
 // and picks the correct overload based on the receiver type.
+// Issue #752 / ADR-0084 L3 also closed the last value-typed gap: the
+// Elvis (`?:`) operator now emits verifiable IL on a nullable struct
+// receiver, so `count ?: -1` is preferred over `.OrElse(-1)` in
+// idiomatic G# code (the helper remains available for lazy/computed
+// fallbacks and for receiver clauses that need a method call shape).
 // The Gsharp.Extensions.* namespaces are explicit-import only — nothing here
 // is auto-imported, even with the implicit-imports compiler option enabled.
 
@@ -57,16 +62,18 @@ Console.WriteLine(name.OrThrow("name was missing"))
 // --- Value-typed nullables (T : struct) --------------------------------------
 // ADR-0088 / issue #750: the binder picks the struct overload based on the
 // receiver's CLR shape (Nullable<T>) and the `where T : struct` constraint.
+// Issue #752 / ADR-0084 L3: `?:` is now the canonical fallback shape; the
+// `OrCompute` helper remains for the deferred-default case.
 
 let count int32? = 7
 let doubled = count.Map(func(n int32) int32 { return n * 2 })
-Console.WriteLine(doubled.OrElse(-1))
+Console.WriteLine(doubled ?: -1)
 
 let none int32? = nil
-Console.WriteLine(none.OrElse(-1))
+Console.WriteLine(none ?: -1)
 
 let positive = count.Filter(func(n int32) bool { return n > 0 })
-Console.WriteLine(positive.OrElse(-1))
+Console.WriteLine(positive ?: -1)
 
 count.IfPresent(func(n int32) {
     Console.WriteLine("count present: " + n.ToString())

--- a/samples/GsharpExtensionsSequences.gs
+++ b/samples/GsharpExtensionsSequences.gs
@@ -90,17 +90,20 @@ Console.WriteLine("SingleOrNil(many): " + (Sequences.Of("a", "b").SingleOrNil() 
 // Value-type terminals share the canonical name with the reference-typed
 // surface: ADR-0088 (issue #750) lets the binder honour generic constraints
 // so `FirstOrNil` resolves to the struct overload on int sequences.
+// Issue #752 / ADR-0084 L3: the Elvis (`?:`) operator now emits verifiable
+// IL on a nullable struct receiver, so we apply it directly to the
+// value-typed terminals instead of routing through `.OrElse(-1)`.
 let firstVal = Sequences.Of(11, 22, 33).FirstOrNil()
-Console.WriteLine("FirstOrNil(value): " + firstVal.OrElse(-1).ToString())
+Console.WriteLine("FirstOrNil(value): " + (firstVal ?: -1).ToString())
 
 let lastVal = Sequences.Of(11, 22, 33).LastOrNil()
-Console.WriteLine("LastOrNil(value): " + lastVal.OrElse(-1).ToString())
+Console.WriteLine("LastOrNil(value): " + (lastVal ?: -1).ToString())
 
 let solo = Sequences.Of(42).SingleOrNil()
-Console.WriteLine("SingleOrNil(value, one): " + solo.OrElse(-1).ToString())
+Console.WriteLine("SingleOrNil(value, one): " + (solo ?: -1).ToString())
 
 let manyVals = Sequences.Of(1, 2).SingleOrNil()
-Console.WriteLine("SingleOrNil(value, many): " + manyVals.OrElse(-1).ToString())
+Console.WriteLine("SingleOrNil(value, many): " + (manyVals ?: -1).ToString())
 
 // --- Collectors --------------------------------------------------------------
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -137,7 +137,7 @@ internal sealed partial class MethodBodyEmitter
             if (b.Left.Type is NullableTypeSymbol leftNullable
                 && leftNullable.UnderlyingType?.ClrType is { IsValueType: true } innerClr)
             {
-                if (!this.receiverSpillSlots.TryGetValue(b, out var slot))
+                if (!this.nullableCoalesceSpillSlots.TryGetValue(b, out var slot))
                 {
                     throw new InvalidOperationException(
                         "No scratch slot pre-allocated for value-type Nullable<T> '?:' LHS — "
@@ -165,15 +165,17 @@ internal sealed partial class MethodBodyEmitter
                 }
                 else
                 {
-                    // Result is the underlying `T` — call `get_Value()`
+                    // Result is the underlying `T` — call `GetValueOrDefault()`
                     // off the slot's address. `HasValue == true` was just
-                    // observed, so the call cannot throw; routing through
-                    // get_Value (rather than a field-style unwrap) keeps
-                    // the IL shape consistent with the `!!` emit path
-                    // introduced in PR #541 and uses no extra slots.
+                    // observed, so the value is present; routing through
+                    // `GetValueOrDefault` (Issue #752 / ADR-0084 L3) avoids
+                    // the BCL `get_Value` property's redundant HasValue check
+                    // and throw path, producing a strictly cheaper IL shape
+                    // with no boxing and no callvirt while still leaving the
+                    // verifier-clean `T` on the stack.
                     this.il.LoadLocalAddress(slot);
                     this.il.OpCode(ILOpCode.Call);
-                    this.il.Token(this.outer.wellKnown.GetNullableGetValueReference(innerClr));
+                    this.il.Token(this.outer.wellKnown.GetNullableGetValueOrDefaultReference(innerClr));
                 }
 
                 this.il.Branch(ILOpCode.Br, end);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -63,6 +63,7 @@ internal sealed partial class MethodBodyEmitter
     private readonly Dictionary<BoundScopeStatement, (int Tasks, int Cts, int Awaiter)> scopeFrameSlots;
     private readonly Dictionary<BoundSelectStatement, SelectSlots> selectStatementSlots;
     private readonly Dictionary<BoundExpression, int> receiverSpillSlots;
+    private readonly Dictionary<BoundBinaryExpression, int> nullableCoalesceSpillSlots;
     private readonly Dictionary<BoundExpression, int> indexAssignmentValueSlots;
     private readonly Dictionary<BoundGoStatement, BoundScopeStatement> goEnclosingScopes;
     private readonly Dictionary<BoundBinaryExpression, LiftedBinarySlots> liftedBinarySlots;
@@ -125,6 +126,7 @@ internal sealed partial class MethodBodyEmitter
         Dictionary<BoundExpression, int> indexAssignmentValueSlots,
         Dictionary<BoundGoStatement, BoundScopeStatement> goEnclosingScopes,
         Dictionary<BoundBinaryExpression, LiftedBinarySlots> liftedBinarySlots = null,
+        Dictionary<BoundBinaryExpression, int> nullableCoalesceSpillSlots = null,
         ParameterSymbol structThisParameter = null,
         Lowering.Async.AsyncStateMachineFieldMap asyncFieldMap = null,
         Lowering.Async.AsyncStateMachinePlan asyncPlan = null,
@@ -151,6 +153,7 @@ internal sealed partial class MethodBodyEmitter
         this.indexAssignmentValueSlots = indexAssignmentValueSlots;
         this.goEnclosingScopes = goEnclosingScopes;
         this.liftedBinarySlots = liftedBinarySlots ?? new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
+        this.nullableCoalesceSpillSlots = nullableCoalesceSpillSlots ?? new Dictionary<BoundBinaryExpression, int>();
         this.structThisParameter = structThisParameter;
         this.asyncFieldMap = asyncFieldMap;
         this.asyncPlan = asyncPlan;

--- a/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
@@ -336,6 +336,7 @@ internal sealed class MethodBodyPlanner
         Dictionary<BoundExpression, int> indexAssignmentValueSlots,
         Dictionary<BoundGoStatement, BoundScopeStatement> goEnclosingScopes,
         Dictionary<BoundBinaryExpression, LiftedBinarySlots> liftedBinarySlots,
+        Dictionary<BoundBinaryExpression, int> nullableCoalesceSpillSlots,
         InstructionEncoder il)
     {
         this.CollectStatements(body.Statements, function, locals, localTypes, labels, appendSlots, il, pass: 1);
@@ -512,22 +513,33 @@ internal sealed class MethodBodyPlanner
             receiverSpillSlots[unwrap] = slot;
         }
 
-        // Issue #519: `?:` whose LHS is a value-type `Nullable<T>` lowers at
-        // emit time to a HasValue/Value sequence that needs a `Nullable<T>`-
-        // typed temp slot (it cannot use `dup; brtrue`, which is invalid IL
-        // for value-type stack shapes). The slot is keyed by the binary
-        // expression node and typed as the LHS's NullableTypeSymbol so
-        // EncodeTypeSymbol emits the proper `System.Nullable<T>` token.
+        // Issue #519 / #752 / ADR-0084 L3: `?:` whose LHS is a value-type
+        // `Nullable<T>` lowers at emit time to a HasValue/GetValueOrDefault
+        // sequence that needs a `Nullable<T>`-typed temp slot (it cannot
+        // use `dup; brtrue`, which is invalid IL for value-type stack
+        // shapes). The slot is keyed by the binary expression node and
+        // typed as the LHS's NullableTypeSymbol so EncodeTypeSymbol emits
+        // the proper `System.Nullable<T>` token.
+        //
+        // The slot lives in its OWN dictionary (separate from
+        // `receiverSpillSlots`) because the same binary node may also be
+        // the receiver of an instance call — `(v ?: 0).ToString()` — in
+        // which case the receiver-spill collector independently
+        // allocates an underlying-`T`-typed slot to take `ldloca` of the
+        // call receiver. Conflating the two slots in one dictionary
+        // produced invalid IL (issue #752): the receiver slot's type
+        // overwrote the Nullable<T> spill type and the HasValue call
+        // received the wrong receiver address.
         foreach (var coalesce in this.CollectNullableValueTypeCoalesces(body))
         {
-            if (receiverSpillSlots.ContainsKey(coalesce))
+            if (nullableCoalesceSpillSlots.ContainsKey(coalesce))
             {
                 continue;
             }
 
             var slot = localTypes.Count;
             localTypes.Add(coalesce.Left.Type);
-            receiverSpillSlots[coalesce] = slot;
+            nullableCoalesceSpillSlots[coalesce] = slot;
         }
 
         // PR N-4 / §6.1 / C# §7.3.7: lifted binary operators over a value-

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -2290,6 +2290,7 @@ internal sealed class ReflectionMetadataEmitter
             var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
             var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
             var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
+            var nullableCoalesceSpillSlots = new Dictionary<BoundBinaryExpression, int>();
 
             // Issue #216: collect compile-time const bindings before slot allocation.
             var constValues = new Dictionary<VariableSymbol, object>();
@@ -2315,6 +2316,7 @@ internal sealed class ReflectionMetadataEmitter
                 indexAssignmentValueSlots,
                 goEnclosingScopes,
                 liftedBinarySlots,
+                nullableCoalesceSpillSlots,
                 il);
 
             // MoveNext is instance on the SM struct: arg0 = this.
@@ -2356,6 +2358,7 @@ internal sealed class ReflectionMetadataEmitter
                 indexAssignmentValueSlots,
                 goEnclosingScopes,
                 liftedBinarySlots: liftedBinarySlots,
+                nullableCoalesceSpillSlots: nullableCoalesceSpillSlots,
                 constValues: constValues,
                 structThisParameter: moveNextBody.ThisParameter,
                 asyncFieldMap: plan.FieldMap,
@@ -2472,6 +2475,7 @@ internal sealed class ReflectionMetadataEmitter
         var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
         var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
         var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
+        var nullableCoalesceSpillSlots = new Dictionary<BoundBinaryExpression, int>();
         var constValues = new Dictionary<VariableSymbol, object>();
 
         this.methodBodyPlanner.CollectLocalsAndLabels(
@@ -2494,6 +2498,7 @@ internal sealed class ReflectionMetadataEmitter
             indexAssignmentValueSlots,
             goEnclosingScopes,
             liftedBinarySlots,
+            nullableCoalesceSpillSlots,
             il);
 
         var parameters = new Dictionary<ParameterSymbol, int>();
@@ -2531,6 +2536,7 @@ internal sealed class ReflectionMetadataEmitter
             indexAssignmentValueSlots,
             goEnclosingScopes,
             liftedBinarySlots: liftedBinarySlots,
+            nullableCoalesceSpillSlots: nullableCoalesceSpillSlots,
             constValues: constValues);
 
         try
@@ -2580,6 +2586,7 @@ internal sealed class ReflectionMetadataEmitter
         var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
         var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
         var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
+        var nullableCoalesceSpillSlots = new Dictionary<BoundBinaryExpression, int>();
         var constValues = new Dictionary<VariableSymbol, object>();
 
         this.methodBodyPlanner.CollectLocalsAndLabels(
@@ -2602,6 +2609,7 @@ internal sealed class ReflectionMetadataEmitter
             indexAssignmentValueSlots,
             goEnclosingScopes,
             liftedBinarySlots,
+            nullableCoalesceSpillSlots,
             il);
 
         var parameters = new Dictionary<ParameterSymbol, int>
@@ -2642,6 +2650,7 @@ internal sealed class ReflectionMetadataEmitter
             indexAssignmentValueSlots,
             goEnclosingScopes,
             liftedBinarySlots: liftedBinarySlots,
+            nullableCoalesceSpillSlots: nullableCoalesceSpillSlots,
             constValues: constValues);
 
         // base()
@@ -2699,6 +2708,7 @@ internal sealed class ReflectionMetadataEmitter
         var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
         var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
         var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
+        var nullableCoalesceSpillSlots = new Dictionary<BoundBinaryExpression, int>();
         var constValues = new Dictionary<VariableSymbol, object>();
 
         this.methodBodyPlanner.CollectLocalsAndLabels(
@@ -2721,6 +2731,7 @@ internal sealed class ReflectionMetadataEmitter
             indexAssignmentValueSlots,
             goEnclosingScopes,
             liftedBinarySlots,
+            nullableCoalesceSpillSlots,
             il);
 
         var paramSlots = new Dictionary<ParameterSymbol, int>
@@ -2765,6 +2776,7 @@ internal sealed class ReflectionMetadataEmitter
             indexAssignmentValueSlots,
             goEnclosingScopes,
             liftedBinarySlots: liftedBinarySlots,
+            nullableCoalesceSpillSlots: nullableCoalesceSpillSlots,
             constValues: constValues);
 
         // base()
@@ -2861,6 +2873,7 @@ internal sealed class ReflectionMetadataEmitter
         var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
         var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
         var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
+        var nullableCoalesceSpillSlots = new Dictionary<BoundBinaryExpression, int>();
         var constValues = new Dictionary<VariableSymbol, object>();
 
         // Pre-scan the base arguments so any scratch slots they require are
@@ -2893,6 +2906,7 @@ internal sealed class ReflectionMetadataEmitter
                 indexAssignmentValueSlots,
                 goEnclosingScopes,
                 liftedBinarySlots,
+                nullableCoalesceSpillSlots,
                 il);
         }
 
@@ -2921,6 +2935,7 @@ internal sealed class ReflectionMetadataEmitter
                 indexAssignmentValueSlots,
                 goEnclosingScopes,
                 liftedBinarySlots,
+                nullableCoalesceSpillSlots,
                 il);
         }
 
@@ -2966,6 +2981,7 @@ internal sealed class ReflectionMetadataEmitter
             indexAssignmentValueSlots,
             goEnclosingScopes,
             liftedBinarySlots: liftedBinarySlots,
+            nullableCoalesceSpillSlots: nullableCoalesceSpillSlots,
             constValues: constValues);
 
         // base(args)
@@ -3055,6 +3071,7 @@ internal sealed class ReflectionMetadataEmitter
         var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
         var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
         var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
+        var nullableCoalesceSpillSlots = new Dictionary<BoundBinaryExpression, int>();
         var constValues = new Dictionary<VariableSymbol, object>();
 
         // Pre-scan the base arguments so any scratch slots they require are
@@ -3090,6 +3107,7 @@ internal sealed class ReflectionMetadataEmitter
                 indexAssignmentValueSlots,
                 goEnclosingScopes,
                 liftedBinarySlots,
+                nullableCoalesceSpillSlots,
                 il);
         }
 
@@ -3121,6 +3139,7 @@ internal sealed class ReflectionMetadataEmitter
                 indexAssignmentValueSlots,
                 goEnclosingScopes,
                 liftedBinarySlots,
+                nullableCoalesceSpillSlots,
                 il);
         }
 
@@ -3145,6 +3164,7 @@ internal sealed class ReflectionMetadataEmitter
             indexAssignmentValueSlots,
             goEnclosingScopes,
             liftedBinarySlots,
+            nullableCoalesceSpillSlots,
             il);
 
         // Slot 0 is the implicit `this`; user parameters shift up by one.
@@ -3190,6 +3210,7 @@ internal sealed class ReflectionMetadataEmitter
             indexAssignmentValueSlots,
             goEnclosingScopes,
             liftedBinarySlots: liftedBinarySlots,
+            nullableCoalesceSpillSlots: nullableCoalesceSpillSlots,
             constValues: constValues);
 
         // ADR-0065 §2: a `convenience init(...)` does NOT chain to the base
@@ -3275,6 +3296,7 @@ internal sealed class ReflectionMetadataEmitter
         var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
         var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
         var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
+        var nullableCoalesceSpillSlots = new Dictionary<BoundBinaryExpression, int>();
         var constValues = new Dictionary<VariableSymbol, object>();
 
         MethodBodyPlanner.CollectConstValues(body, constValues);
@@ -3298,6 +3320,7 @@ internal sealed class ReflectionMetadataEmitter
             indexAssignmentValueSlots,
             goEnclosingScopes,
             liftedBinarySlots,
+            nullableCoalesceSpillSlots,
             il);
 
         // Slot 0 is the implicit `this`; deinit has no user parameters.
@@ -3339,6 +3362,7 @@ internal sealed class ReflectionMetadataEmitter
             indexAssignmentValueSlots,
             goEnclosingScopes,
             liftedBinarySlots: liftedBinarySlots,
+            nullableCoalesceSpillSlots: nullableCoalesceSpillSlots,
             constValues: constValues);
 
         // Wrap the user body in try { … } finally { base.Finalize(); }.
@@ -3458,6 +3482,7 @@ internal sealed class ReflectionMetadataEmitter
                 var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
                 var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
                 var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
+                var nullableCoalesceSpillSlots = new Dictionary<BoundBinaryExpression, int>();
 
                 // Issue #216: collect compile-time const bindings before slot allocation.
                 var constValues = new Dictionary<VariableSymbol, object>();
@@ -3483,6 +3508,7 @@ internal sealed class ReflectionMetadataEmitter
                     indexAssignmentValueSlots,
                     goEnclosingScopes,
                     liftedBinarySlots,
+                    nullableCoalesceSpillSlots,
                     il);
 
                 // For instance methods, IL slot 0 is the implicit `this`, so user
@@ -3560,6 +3586,7 @@ internal sealed class ReflectionMetadataEmitter
                     indexAssignmentValueSlots,
                     goEnclosingScopes,
                     liftedBinarySlots: liftedBinarySlots,
+                    nullableCoalesceSpillSlots: nullableCoalesceSpillSlots,
                     constValues: constValues,
                     structThisParameter: structThis,
                     asyncIteratorEmitCtx: aiEmitCtx,

--- a/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
+++ b/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
@@ -446,6 +446,33 @@ internal sealed class WellKnownReferences
         return this.getMethodReference(getValue);
     }
 
+    // Issue #752 / ADR-0084 L3: returns a callable MemberRef for
+    // `System.Nullable<T>::GetValueOrDefault()` closed over the supplied value-type
+    // underlying CLR type. Used by `?:` emit on a value-type `Nullable<T>` operand
+    // on the non-null branch: since `HasValue` was just observed true, the result
+    // is the same as `get_Value()` but without the BCL's redundant HasValue check
+    // and exception path. No boxing, no callvirt.
+    public MemberReferenceHandle GetNullableGetValueOrDefaultReference(Type underlyingValueType)
+    {
+        if (underlyingValueType == null || !underlyingValueType.IsValueType)
+        {
+            throw new InvalidOperationException(
+                $"GetNullableGetValueOrDefaultReference: '{underlyingValueType?.FullName}' is not a value type.");
+        }
+
+        // Issue #571: see GetNullableGetValueReference for rationale.
+        if (!NullableLifting.TryConstructNullable(this.emitCtx.References, underlyingValueType, out var nullableClr))
+        {
+            throw new InvalidOperationException(
+                $"Cannot construct Nullable<{underlyingValueType.FullName}>: System.Nullable`1 is not resolvable in the reference set.");
+        }
+
+        var getValueOrDefault = nullableClr.GetMethod("GetValueOrDefault", Type.EmptyTypes)
+            ?? throw new InvalidOperationException(
+                $"System.Nullable<{underlyingValueType.FullName}>::GetValueOrDefault() is not resolvable.");
+        return this.getMethodReference(getValueOrDefault);
+    }
+
     // Issue #519: returns a callable MemberRef for `System.Nullable<T>::get_HasValue`
     // closed over the supplied value-type underlying CLR type. Used by `?:` emit
     // on a value-type `Nullable<T>` operand to branch on the presence flag without

--- a/test/Compiler.Tests/Emit/Issue752ElvisNullableValueTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue752ElvisNullableValueTypeEmitTests.cs
@@ -1,0 +1,287 @@
+// <copyright file="Issue752ElvisNullableValueTypeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #752 / ADR-0084 L3: the Elvis (<c>?:</c>) operator over a value-type
+/// <c>Nullable&lt;T&gt;</c> receiver. Issue #519 introduced the HasValue-based
+/// emit path; this file pins down the exact patterns enumerated in #752 and
+/// guards against regression in the cheaper <c>GetValueOrDefault()</c> shape
+/// used on the non-null branch (no boxing, no callvirt, no redundant
+/// HasValue/throw — the BCL property's predicate was just observed).
+///
+/// Each test compiles via <c>gsc</c>, runs <c>ilverify</c> against the
+/// produced PE, then executes the assembly under <c>dotnet exec</c> and
+/// asserts on the captured stdout. Invalid IL is surfaced as a verification
+/// failure rather than silently passing.
+/// </summary>
+public class Issue752ElvisNullableValueTypeEmitTests
+{
+    [Fact]
+    public void Elvis_NullableInt_LeftNil_ReturnsRightUnderlying()
+    {
+        // Canonical absent case: result type is the underlying `int32`.
+        // Non-null branch reaches `GetValueOrDefault()` against the spill
+        // slot; null branch evaluates the literal RHS.
+        var source = """
+            package P
+
+            import System
+
+            let v int32? = nil
+            let n = v ?: 0
+            Console.WriteLine(n)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n", output);
+    }
+
+    [Fact]
+    public void Elvis_NullableInt_LeftPresent_ReturnsLeftUnderlying()
+    {
+        // Mirror of the absent case: HasValue is true, so the non-null
+        // branch fires and `GetValueOrDefault()` returns 42 without the
+        // BCL `get_Value` throw path.
+        var source = """
+            package P
+
+            import System
+
+            let v int32? = 42
+            let n = v ?: 0
+            Console.WriteLine(n)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void Elvis_NullableInt_Nested_BothNullableOperands_ChainsThroughRightArm()
+    {
+        // `(a ?: b) ?: 0` — both inner operands are `int32?`. The inner
+        // expression's result is `int32?` (preserving wrapper shape per
+        // existing typing rules), and the outer's result is `int32`.
+        // Two separate spill slots are pre-allocated, one per BoundBinary.
+        var source = """
+            package P
+
+            import System
+
+            let a int32? = nil
+            let b int32? = 7
+            let n = (a ?: b) ?: 0
+            Console.WriteLine(n)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void Elvis_NullableInt_Nested_AllNil_FallsThroughToLiteral()
+    {
+        // Same shape as above but every nullable arm is absent; the final
+        // non-nullable literal must win.
+        var source = """
+            package P
+
+            import System
+
+            let a int32? = nil
+            let b int32? = nil
+            let n = (a ?: b) ?: 0
+            Console.WriteLine(n)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n", output);
+    }
+
+    [Fact]
+    public void Elvis_ReferenceTypeString_RegressionGuard()
+    {
+        // Reference-typed nullables must continue to flow through the
+        // existing `dup; brtrue; pop; rhs` short-circuit, which is legal
+        // IL for object references. The value-type HasValue branch must
+        // not capture this case (regression guard for the #752 fix).
+        var source = """
+            package P
+
+            import System
+
+            let s string? = nil
+            let r string = s ?: "missing"
+            Console.WriteLine(r)
+
+            let t string? = "hello"
+            let u string = t ?: "missing"
+            Console.WriteLine(u)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("missing\nhello\n", output);
+    }
+
+    [Fact]
+    public void Elvis_NullableInt_LeftNil_BothArmsNullable_PreservesAbsenceShape()
+    {
+        // When both arms are `int32?`, the operator result type is the
+        // wrapper. The HasValue==false path returns the RHS wrapper
+        // unchanged; observed through `!!` here to assert the inner
+        // value once the operator picked the RHS.
+        var source = """
+            package P
+
+            import System
+
+            let a int32? = nil
+            let b int32? = 99
+            let r int32? = a ?: b
+            Console.WriteLine(r!!)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    [Fact]
+    public void Elvis_NullableInt_ReceiverOfInstanceCall_TakesAddressOfUnderlyingResult()
+    {
+        // Repro at the heart of #752: when the `?:` result is the
+        // receiver of an instance call on the underlying value type
+        // (e.g. `.ToString()`), the emitter needs TWO distinct
+        // scratch slots — a `Nullable<T>`-typed slot for the HasValue
+        // spill and an underlying-`T`-typed slot for the receiver-
+        // address spill. Before the fix, both purposes shared one
+        // dictionary entry: the receiver-spill collector clobbered
+        // the coalesce slot's type, producing invalid IL that the CLR
+        // verifier rejected as `StackUnexpected` (the HasValue call's
+        // receiver address pointed at an `int32` slot, not a
+        // `Nullable<int32>` slot).
+        var source = """
+            package P
+
+            import System
+
+            let v int32? = 42
+            Console.WriteLine((v ?: -1).ToString())
+
+            let w int32? = nil
+            Console.WriteLine((w ?: -1).ToString())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n-1\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue752_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Interpreter.Tests/Issue752ElvisNullableValueTypeInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue752ElvisNullableValueTypeInterpreterTests.cs
@@ -1,0 +1,134 @@
+// <copyright file="Issue752ElvisNullableValueTypeInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #752 / ADR-0084 L3: interpreter parity for the Elvis (<c>?:</c>)
+/// operator over value-type <c>Nullable&lt;T&gt;</c> receivers. The
+/// interpreter stores nullables as their underlying boxed payload (or
+/// <c>null</c> when absent), so the existing <c>left ?? right</c> path
+/// in <c>EvaluateBinaryExpression</c> handles both reference- and
+/// value-typed nullables uniformly — these tests pin down the runtime
+/// semantics so a future evaluator change cannot silently diverge from
+/// the emitted IL behavior validated by
+/// <c>Issue752ElvisNullableValueTypeEmitTests</c>.
+/// </summary>
+public class Issue752ElvisNullableValueTypeInterpreterTests
+{
+    [Fact]
+    public void Elvis_NullableInt_LeftNil_ReturnsRightUnderlying()
+    {
+        var source = """
+            let v int32? = nil
+            let n = v ?: 0
+            Console.WriteLine(n)
+            """;
+
+        Assert.Equal("0\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void Elvis_NullableInt_LeftPresent_ReturnsLeftUnderlying()
+    {
+        var source = """
+            let v int32? = 42
+            let n = v ?: 0
+            Console.WriteLine(n)
+            """;
+
+        Assert.Equal("42\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void Elvis_NullableInt_Nested_MiddleHasValue_ChainsThroughInner()
+    {
+        var source = """
+            let a int32? = nil
+            let b int32? = 7
+            let n = (a ?: b) ?: 0
+            Console.WriteLine(n)
+            """;
+
+        Assert.Equal("7\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void Elvis_NullableInt_Nested_AllNil_FallsThroughToLiteral()
+    {
+        var source = """
+            let a int32? = nil
+            let b int32? = nil
+            let n = (a ?: b) ?: 0
+            Console.WriteLine(n)
+            """;
+
+        Assert.Equal("0\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void Elvis_NullableInt_BothArmsNullable_PreservesWrapperShape()
+    {
+        var source = """
+            let a int32? = nil
+            let b int32? = 99
+            let r int32? = a ?: b
+            Console.WriteLine(r!!)
+            """;
+
+        Assert.Equal("99\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void Elvis_ReferenceTypeString_RegressionGuard()
+    {
+        var source = """
+            let s string? = nil
+            let r string = s ?: "missing"
+            Console.WriteLine(r)
+
+            let t string? = "hello"
+            let u string = t ?: "missing"
+            Console.WriteLine(u)
+            """;
+
+        Assert.Equal("missing\nhello\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void Elvis_NullableInt_ReceiverOfInstanceCall_Interpreted()
+    {
+        var source = """
+            let v int32? = 42
+            Console.WriteLine((v ?: -1).ToString())
+
+            let w int32? = nil
+            Console.WriteLine((w ?: -1).ToString())
+            """;
+
+        Assert.Equal("42\n-1\n", RunSubmission(source));
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary

The Elvis (`?:`) operator over a value-type `Nullable<T>` receiver emits IL that the CLR verifier rejects when the coalesce result is the receiver of an instance call (`(v ?: 0).ToString()`). This PR completes the work begun in #519 by closing the last remaining gap and the corresponding §L3 entry in ADR-0084.

## Root cause

Issue #519 introduced a `HasValue`-based emit path for value-type `Nullable<T>` LHS of `?:`, but it shared the spill-slot dictionary (`receiverSpillSlots`) with the receiver-spill collector. When the same `?:` node was also used as the receiver of an instance call, the receiver-spill collector ran first and registered the slot as the underlying-`T` type (`int32`). The coalesce collector then saw the existing key and silently skipped, leaving the Nullable<T> spill to write into an int32-typed slot. The emit produced `ldloca` against an `int32` storage address and called `Nullable<int32>::get_HasValue` — ilverify flagged this as `StackUnexpected` and the JIT rejected the program with `InvalidProgramException`.

## Fix

- **Separate scratch-slot dictionary for nullable coalesce.** Introduce `nullableCoalesceSpillSlots: Dictionary<BoundBinaryExpression, int>` so the coalesce can independently allocate a `Nullable<T>`-typed slot, while the receiver-spill collector keeps its own underlying-`T` slot for taking the call receiver's address.
- **`GetValueOrDefault()` on the non-null branch.** The BCL `get_Value` property re-checks `HasValue` and throws when absent; since we just observed `HasValue == true`, that path is dead weight. Switch the unwrap to `Nullable<T>::GetValueOrDefault()` — no callvirt, no exception path, no boxing.

The fix is localized to emit. No BoundTree changes; no new BoundNodeKind. Reference-type Elvis (`string?`) continues to use the existing `dup; brtrue; pop; rhs` short-circuit (regression guard added).

## Tests

- **`test/Compiler.Tests/Emit/Issue752ElvisNullableValueTypeEmitTests.cs`** (7 tests, all IL-verified end-to-end via the local `dotnet-ilverify` tool):
  - `let v int32? = nil; let n = v ?: 0` → 0
  - `let v int32? = 42; let n = v ?: 0` → 42
  - Nested: `(a ?: b) ?: 0` (both inner operands `int32?`) — chains and falls through correctly.
  - Both arms `int32?` — preserves wrapper shape.
  - Reference-type `string?` Elvis — regression guard.
  - `(v ?: -1).ToString()` and `(w ?: -1).ToString()` — the exact two-slot repro from #752.
- **`test/Interpreter.Tests/Issue752ElvisNullableValueTypeInterpreterTests.cs`** (7 tests) — interpreter parity for the same patterns; the interpreter's `??` path handles nullables uniformly (no behavioral change needed).
- Full `dotnet test GSharp.sln` is green: 195/195 interpreter, 107/107 extensions, 257/257 language-server, 2786/2787 core (1 pre-existing skip), 1125/1128 compiler (3 pre-existing skips), 26/26 sdk.

## Samples

The `Optional` and `Sequences` samples in ADR-0084's surface previously used `.OrElse(-1)` as the safe-but-verbose workaround. They now use `?:` directly:

```gs
// Before (workaround):
Console.WriteLine(doubled.OrElse(-1))
Console.WriteLine("FirstOrNil(value): " + firstVal.OrElse(-1).ToString())

// After:
Console.WriteLine(doubled ?: -1)
Console.WriteLine("FirstOrNil(value): " + (firstVal ?: -1).ToString())
```

Both samples produce identical golden output and pass `SampleConformanceTests` (which runs ilverify against every emitted sample).

## ADR-0084 §Known Limitations

L3 (Native `?:` over nullable value types) is now **Closed**: both the historical PR #519 fix and this PR's two-slot repair are described, the cheaper `GetValueOrDefault()` shape is noted, and the consequences section is updated so it no longer references L3 as open.

## Local verification

- `dotnet build GSharp.sln` — green.
- `dotnet test GSharp.sln --no-restore --nologo` — green across all test projects.
- `dotnet tool restore` then `dotnet tool run ilverify` against the two updated samples — both report `All Classes and Methods … Verified.`.
- `cd website && npm ci && npm run build` — green, no broken links.

Closes #752. Related: #750, #751, #724 (ADR-0084). Parent: #706.