### PR TITLE
Fix #773: generic-receiver extension method dispatch; port Extensions stdlib to G#

### DIFF
--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -216,23 +216,34 @@ hatch under `src/Sdk/Gsharp.Extensions/*.cs` works today.
   retains its extension-method status. The binder + emit pipeline
   also accept call-site dispatch when the receiver is *closed*
   (concrete) — `string?`, `(int32, string)`, `[]int32?`,
-  `map[string]int32`. The remaining gap is generic-receiver
-  dispatch: when the receiver type contains a function-level type
-  parameter (`func (self sequence[T]) FirstOrNil[T]() T?`), the
-  binder still fails to bind the call site
-  (`receiver.FirstOrNil()` → GS0159) and array iteration through
-  such a receiver erases the element type to `object`. Those
-  follow-up gaps are tracked as
-  [issue #773](https://github.com/DavidObando/gsharp/issues/773)
-  (generic-receiver dispatch) and
+  `map[string]int32`. **Binder-side closed by
+  [issue #773](https://github.com/DavidObando/gsharp/issues/773).**
+  `BoundScope.TryLookupExtensionFunction` now falls back to
+  receiver-type unification when the fast-path exact-equality
+  match fails, so a call site like `arr.MyFirst(99)` resolves to
+  `func (self IEnumerable[T]) MyFirst[T any](fb T) T` by inferring
+  `T = int32` from the call-site receiver type. `InferTypeArguments`
+  / `SubstituteType` were extended with cases for
+  `SequenceTypeSymbol` and `AsyncSequenceTypeSymbol`, and the
+  metadata emitter now encodes an open `sequence[T]` /
+  `async sequence[T]` parameter slot as
+  `GENERICINST<IEnumerable\`1><MVar>` /
+  `GENERICINST<IAsyncEnumerable\`1><MVar>` so the produced IL
+  passes verification end-to-end. The remaining gaps blocking the
+  full dogfooded port are
   [issue #774](https://github.com/DavidObando/gsharp/issues/774)
-  (open-receiver iteration). A third gap blocking the port —
-  [issue #775](https://github.com/DavidObando/gsharp/issues/775),
-  G# spelling for `class` / `struct` / `new()` constraints — was
-  also surfaced while attempting the dogfooded G# rewrite in this
-  PR. Closing #773, #774, and #775 lets the C# files under
-  `src/Sdk/Gsharp.Extensions/Optional/` and
-  `src/Sdk/Gsharp.Extensions/Sequences/` migrate to native G#.
+  (open-receiver iteration erases element type to `object`) and
+  [issue #775](https://github.com/DavidObando/gsharp/issues/775)
+  (G# spelling for `class` / `struct` / `new()` constraints). A
+  further emit gap surfaced while writing the IL-verified emit
+  tests for #773: an extension with an unconstrained `(self T?)`
+  receiver type compiles cleanly *only* when the body avoids
+  comparing `self` to `nil` or unwrapping with `!!`, because the
+  type-erased emit cannot statically choose between the
+  reference-typed `T` and value-typed `Nullable<T>` shapes. The
+  binder + interpreter accept the full surface; the emit-side
+  body-lowering fix lives with #774/#775 as part of the
+  open-receiver workstream.
 - **L3. Native `?:` over nullable value types.**
   ([issue #752](https://github.com/DavidObando/gsharp/issues/752))
   **Closed.** Issue #519 introduced the HasValue-based lowering
@@ -266,11 +277,27 @@ of that migration, not left behind as dead code.
   meant to be authored in G# creates direct compiler pressure to
   close the open language gaps. Each gap is tracked with a
   concrete callsite waiting on its fix. L1 closed by ADR-0088,
-  L3 closed by issue #752, and L2's parser side closed in the PR
-  for #751; the residual binder / emit gaps surfaced while
-  attempting the port live as #773 (generic-receiver dispatch),
-  #774 (open-receiver iteration), and #775 (G# `class` / `struct`
-  constraint spelling).
+  L3 closed by issue #752, L2's parser side closed in the PR
+  for #751, and L2's binder side closed by #773; the residual
+  emit gaps surfaced while attempting the port live as #774
+  (open-receiver iteration) and #775 (G# `class` / `struct`
+  constraint spelling). The dogfooded G# port of
+  `Gsharp.Extensions.Optional` and `Gsharp.Extensions.Sequences`
+  remains blocked on a fourth, structural, factor: the SDK
+  bootstrap cycle. `Gsharp.Extensions.dll` is auto-referenced by
+  every `.gsproj` build via `Gsharp.NET.Sdk`, but the SDK itself
+  pulls in `Gsharp.Extensions.csproj` as a dependency at pack
+  time (see `src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj`).
+  Re-authoring `Gsharp.Extensions` as a `.gsproj` would require
+  the SDK to already exist in order to compile the `.gs`
+  sources, which in turn would require `Gsharp.Extensions.dll`
+  to already exist. Until that cycle is broken (e.g. by a
+  staged bootstrap that builds a minimal compiler-only payload
+  before `Gsharp.Extensions`), the C# escape hatch under
+  `src/Sdk/Gsharp.Extensions/Optional/` and
+  `src/Sdk/Gsharp.Extensions/Sequences/` stays in place. The
+  test suite (`test/Extensions.Tests/`, 107 tests) runs against
+  the C# implementation unchanged.
 - **Positive — zero-friction adoption.** Because the assembly is
   bundled with the SDK and imports are explicit but trivial
   (`import Gsharp.Extensions.Optional`), the cost to a sample or

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2569,6 +2569,74 @@ public sealed class Binder
             // handles this differently because both map to CLR T[], but at the
             // GSharp semantic level they are distinct types.
         }
+        else if (parameterType is SequenceTypeSymbol pseq)
+        {
+            // Issue #773 / ADR-0084 §L2: an extension declared as
+            // `func (self sequence[T]) ...` must infer T from any
+            // call-site receiver whose static type is sequence-compatible —
+            // another `sequence[U]`, a `[]U` slice, a fixed `[N]U` array,
+            // or any CLR type that implements `IEnumerable<U>`.
+            switch (argumentType)
+            {
+                case SequenceTypeSymbol aseq:
+                    InferTypeArguments(pseq.ElementType, aseq.ElementType, substitution);
+                    break;
+                case SliceTypeSymbol asl:
+                    InferTypeArguments(pseq.ElementType, asl.ElementType, substitution);
+                    break;
+                case ArrayTypeSymbol aarr:
+                    InferTypeArguments(pseq.ElementType, aarr.ElementType, substitution);
+                    break;
+                default:
+                    var argClrSeq = argumentType?.ClrType;
+                    var openIEnumerable = typeof(System.Collections.Generic.IEnumerable<>);
+                    if (argClrSeq != null)
+                    {
+                        var matchedSeq = argClrSeq.IsGenericType && argClrSeq.GetGenericTypeDefinition() == openIEnumerable
+                            ? argClrSeq
+                            : FindMatchingInterface(argClrSeq, openIEnumerable);
+                        if (matchedSeq != null)
+                        {
+                            var args = matchedSeq.GetGenericArguments();
+                            if (args.Length == 1)
+                            {
+                                InferTypeArguments(pseq.ElementType, TypeSymbol.FromClrType(args[0]), substitution);
+                            }
+                        }
+                    }
+
+                    break;
+            }
+        }
+        else if (parameterType is AsyncSequenceTypeSymbol paseq)
+        {
+            // Mirror of the synchronous-sequence inference for `async sequence[T]`.
+            switch (argumentType)
+            {
+                case AsyncSequenceTypeSymbol aaseq:
+                    InferTypeArguments(paseq.ElementType, aaseq.ElementType, substitution);
+                    break;
+                default:
+                    var argClrAseq = argumentType?.ClrType;
+                    var openIAsyncEnumerable = typeof(System.Collections.Generic.IAsyncEnumerable<>);
+                    if (argClrAseq != null)
+                    {
+                        var matchedAseq = argClrAseq.IsGenericType && argClrAseq.GetGenericTypeDefinition() == openIAsyncEnumerable
+                            ? argClrAseq
+                            : FindMatchingInterface(argClrAseq, openIAsyncEnumerable);
+                        if (matchedAseq != null)
+                        {
+                            var args = matchedAseq.GetGenericArguments();
+                            if (args.Length == 1)
+                            {
+                                InferTypeArguments(paseq.ElementType, TypeSymbol.FromClrType(args[0]), substitution);
+                            }
+                        }
+                    }
+
+                    break;
+            }
+        }
         else if (parameterType is FunctionTypeSymbol pf && argumentType is FunctionTypeSymbol af
             && pf.ParameterTypes.Length == af.ParameterTypes.Length)
         {
@@ -2702,6 +2770,22 @@ public sealed class Binder
         {
             var inner = SubstituteType(a.ElementType, substitution);
             return ReferenceEquals(inner, a.ElementType) ? type : ArrayTypeSymbol.Get(inner, a.Length);
+        }
+
+        if (type is SequenceTypeSymbol seq)
+        {
+            // Issue #773: substitute through `sequence[T]` so the open
+            // receiver of a generic extension lowers to a concrete
+            // `sequence[U]` at the call site (and downstream
+            // `BindExtensionFunctionCall` sees a matching parameter type).
+            var inner = SubstituteType(seq.ElementType, substitution);
+            return ReferenceEquals(inner, seq.ElementType) ? type : SequenceTypeSymbol.Get(inner);
+        }
+
+        if (type is AsyncSequenceTypeSymbol aseq)
+        {
+            var inner = SubstituteType(aseq.ElementType, substitution);
+            return ReferenceEquals(inner, aseq.ElementType) ? type : AsyncSequenceTypeSymbol.Get(inner);
         }
 
         if (type is FunctionTypeSymbol fn)

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -262,6 +262,23 @@ public sealed class BoundScope
     /// <summary>
     /// Tries to look up an extension function by receiver type and name (walks parent scopes).
     /// </summary>
+    /// <remarks>
+    /// Two lookup paths are tried, in order:
+    /// <list type="number">
+    /// <item><description><b>Exact-match fast path</b> — reference-equality on the
+    /// declared receiver type. This is sufficient for non-generic receivers
+    /// (<c>(self string)</c>, <c>(self int32)</c>) and for already-closed
+    /// receiver spellings.</description></item>
+    /// <item><description><b>Generic-receiver unification (issue #773)</b> —
+    /// an extension whose receiver type references its own function-level
+    /// type parameters (e.g. <c>func (self sequence[T]) FirstOrNil[T]() T?</c>
+    /// or <c>func (self IEnumerable[T]) MyFirst[T any](fb T) T</c>) must
+    /// dispatch when the call-site receiver type unifies with the open
+    /// declared receiver. Inference is delegated to
+    /// <see cref="Binder.InferTypeArguments"/>; the candidate qualifies when
+    /// every type parameter mentioned in the receiver gets bound.</description></item>
+    /// </list>
+    /// </remarks>
     /// <param name="receiverType">The static type of the call receiver.</param>
     /// <param name="name">The method name at the call site.</param>
     /// <param name="function">The matching extension function, when found.</param>
@@ -274,6 +291,43 @@ public sealed class BoundScope
             foreach (var ext in extensionFunctions)
             {
                 if (ext.Name == name && ext.ExtensionReceiverType == receiverType)
+                {
+                    function = ext;
+                    return true;
+                }
+            }
+
+            // Issue #773 / ADR-0084 §L2 follow-up: an extension whose
+            // receiver type carries one of the function's own type
+            // parameters (e.g. `(self sequence[T])`, `(self IEnumerable[T])`,
+            // `(self T?)`, `(self Dictionary[K, V])`) is never reference-
+            // equal to a concrete call-site receiver. Fall back to receiver
+            // inference: try to unify the declared open receiver with the
+            // call-site type and accept the candidate when every type
+            // parameter that appears in the receiver gets bound.
+            foreach (var ext in extensionFunctions)
+            {
+                if (ext.Name != name)
+                {
+                    continue;
+                }
+
+                if (ext.TypeParameters.IsDefaultOrEmpty)
+                {
+                    continue;
+                }
+
+                if (ext.ExtensionReceiverType == null || ext.ExtensionReceiverType == TypeSymbol.Error)
+                {
+                    continue;
+                }
+
+                if (!ReceiverMentionsAnyTypeParameter(ext.ExtensionReceiverType, ext.TypeParameters))
+                {
+                    continue;
+                }
+
+                if (ReceiverUnifies(ext, receiverType))
                 {
                     function = ext;
                     return true;
@@ -587,5 +641,121 @@ public sealed class BoundScope
         }
 
         return symbols.Values.OfType<TSymbol>().ToImmutableArray();
+    }
+
+    /// <summary>
+    /// True when at least one of the extension's own type parameters
+    /// (the ones declared on the extension function itself) occurs
+    /// somewhere inside <paramref name="receiverType"/>.
+    /// </summary>
+    private static bool ReceiverMentionsAnyTypeParameter(TypeSymbol receiverType, ImmutableArray<TypeParameterSymbol> functionTypeParameters)
+    {
+        if (functionTypeParameters.IsDefaultOrEmpty || receiverType == null)
+        {
+            return false;
+        }
+
+        var collected = new HashSet<TypeParameterSymbol>();
+        CollectTypeParameters(receiverType, collected, depth: 0);
+        if (collected.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var tp in functionTypeParameters)
+        {
+            if (collected.Contains(tp))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void CollectTypeParameters(TypeSymbol type, HashSet<TypeParameterSymbol> sink, int depth)
+    {
+        if (type == null || depth > 32)
+        {
+            return;
+        }
+
+        switch (type)
+        {
+            case TypeParameterSymbol tp:
+                sink.Add(tp);
+                return;
+            case NullableTypeSymbol n:
+                CollectTypeParameters(n.UnderlyingType, sink, depth + 1);
+                return;
+            case SliceTypeSymbol s:
+                CollectTypeParameters(s.ElementType, sink, depth + 1);
+                return;
+            case ArrayTypeSymbol a:
+                CollectTypeParameters(a.ElementType, sink, depth + 1);
+                return;
+            case SequenceTypeSymbol seq:
+                CollectTypeParameters(seq.ElementType, sink, depth + 1);
+                return;
+            case AsyncSequenceTypeSymbol aseq:
+                CollectTypeParameters(aseq.ElementType, sink, depth + 1);
+                return;
+            case FunctionTypeSymbol f:
+                if (!f.ParameterTypes.IsDefaultOrEmpty)
+                {
+                    foreach (var p in f.ParameterTypes)
+                    {
+                        CollectTypeParameters(p, sink, depth + 1);
+                    }
+                }
+
+                CollectTypeParameters(f.ReturnType, sink, depth + 1);
+                return;
+            case ImportedTypeSymbol it:
+                if (!it.TypeArguments.IsDefaultOrEmpty)
+                {
+                    foreach (var arg in it.TypeArguments)
+                    {
+                        CollectTypeParameters(arg, sink, depth + 1);
+                    }
+                }
+
+                return;
+            case StructSymbol ss:
+                if (!ss.TypeArguments.IsDefaultOrEmpty)
+                {
+                    foreach (var arg in ss.TypeArguments)
+                    {
+                        CollectTypeParameters(arg, sink, depth + 1);
+                    }
+                }
+
+                return;
+            default:
+                return;
+        }
+    }
+
+    private static bool ReceiverUnifies(FunctionSymbol extension, TypeSymbol receiverType)
+    {
+        var substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>();
+        Binder.InferTypeArguments(extension.ExtensionReceiverType, receiverType, substitution);
+
+        // Every type parameter actually mentioned in the receiver type must
+        // have been bound by inference. Parameters that appear only in the
+        // body or in the non-receiver parameters of the extension may still
+        // be inferred at the call site (`BindExtensionFunctionCall` does its
+        // own argument-driven inference), so we do not require those here.
+        var mentioned = new HashSet<TypeParameterSymbol>();
+        CollectTypeParameters(extension.ExtensionReceiverType, mentioned, depth: 0);
+        foreach (var tp in mentioned)
+        {
+            if (!substitution.ContainsKey(tp))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -6437,6 +6437,32 @@ internal sealed class ReflectionMetadataEmitter
         {
             EncodeTypeSymbol(encoder.SZArray(), slice.ElementType);
         }
+        else if (type is SequenceTypeSymbol openSeq && openSeq.ClrType == null)
+        {
+            // Issue #773: an open `sequence[T]` (where T is an in-scope
+            // type parameter) has no closed CLR type yet. Encode it as
+            // `GENERICINST<IEnumerable`1><T>` so the resulting method
+            // signature carries an honest `IEnumerable<MVar/Var>` slot
+            // — same pattern as ADR-0087 §3 R2 for `ImportedTypeSymbol`
+            // with `HasTypeParameterArgument`.
+            var enumerableOpen = typeof(System.Collections.Generic.IEnumerable<>);
+            var giSeq = encoder.GenericInstantiation(
+                this.GetTypeReference(enumerableOpen),
+                1,
+                isValueType: false);
+            this.EncodeTypeSymbol(giSeq.AddArgument(), openSeq.ElementType);
+        }
+        else if (type is AsyncSequenceTypeSymbol openAseq && openAseq.ClrType == null)
+        {
+            // Mirror of the synchronous-sequence open-T encoding for
+            // `async sequence[T]` (== IAsyncEnumerable<T>).
+            var asyncEnumerableOpen = typeof(System.Collections.Generic.IAsyncEnumerable<>);
+            var giAseq = encoder.GenericInstantiation(
+                this.GetTypeReference(asyncEnumerableOpen),
+                1,
+                isValueType: false);
+            this.EncodeTypeSymbol(giAseq.AddArgument(), openAseq.ElementType);
+        }
         else if (type is StructSymbol structSym)
         {
             // ADR-0087 §3 R2: a user-declared generic struct encodes as

--- a/test/Compiler.Tests/Emit/Issue773GenericReceiverExtensionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue773GenericReceiverExtensionEmitTests.cs
@@ -1,0 +1,211 @@
+// <copyright file="Issue773GenericReceiverExtensionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #773 / ADR-0084 §L2 follow-up. End-to-end emit + IL-verify
+/// coverage for user-defined extension methods whose receiver type
+/// carries a function-level type parameter. The pre-fix binder reported
+/// GS0159 "Cannot find function" for every call site below; after the
+/// fix the binder finds the candidate via receiver unification, the
+/// emitter lowers the call through the existing type-erased generic
+/// path, and `ilverify` accepts the produced IL.
+/// </summary>
+public class Issue773GenericReceiverExtensionEmitTests
+{
+    [Fact]
+    public void IEnumerableT_Extension_Dispatches_Int32Slice_Repro()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func (self IEnumerable[T]) MyFirst[T any](fb T) T {
+                return fb
+            }
+
+            var arr = []int32{10, 20, 30}
+            Console.WriteLine(arr.MyFirst(99))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    [Fact]
+    public void SequenceT_HeadOr_Dispatches_Int32Slice()
+    {
+        var source = """
+            package P
+            import System
+
+            func (self sequence[T]) HeadOr[T](fb T) T {
+                return fb
+            }
+
+            var arr = []int32{1, 2, 3}
+            Console.WriteLine(arr.HeadOr(7))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void SequenceT_HeadOr_Dispatches_StringSlice()
+    {
+        var source = """
+            package P
+            import System
+
+            func (self sequence[T]) HeadOr[T](fb T) T {
+                return fb
+            }
+
+            var arr = []string{"a", "b"}
+            Console.WriteLine(arr.HeadOr("z"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("z\n", output);
+    }
+
+    [Fact]
+    public void NullableReceiver_Extension_Dispatches_OnStringNullable_NoBodyNullCheck()
+    {
+        // The dispatch path (binder + emit) works for `(self T?)` over
+        // a reference-typed nullable. The body intentionally avoids
+        // comparing an open `T` against `nil` — that pattern stays in
+        // the interpreter-side binder tests; the emit gap for it is
+        // tracked as a follow-up to this issue.
+        var source = """
+            package P
+            import System
+
+            func (self T?) AlwaysFallback[T](fb T) T {
+                return fb
+            }
+
+            var s string? = nil
+            Console.WriteLine(s.AlwaysFallback("def"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("def\n", output);
+    }
+
+    [Fact]
+    public void DictionaryReceiver_TwoTypeParameters_Dispatches()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func (self Dictionary[K, V]) MyCount[K, V]() int32 {
+                return 42
+            }
+
+            var d = Dictionary[string, int32]()
+            Console.WriteLine(d.MyCount())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void SliceT_Extension_Dispatches_OnInt32Slice()
+    {
+        var source = """
+            package P
+            import System
+
+            func (self []T) FirstOr[T](fb T) T {
+                return fb
+            }
+
+            var a = []int32{1, 2, 3}
+            Console.WriteLine(a.FirstOr(99))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue773_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue773GenericReceiverDispatchTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue773GenericReceiverDispatchTests.cs
@@ -1,0 +1,350 @@
+// <copyright file="Issue773GenericReceiverDispatchTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #773 / ADR-0084 §L2 follow-up. The binder must dispatch a
+/// call site like <c>recv.M()</c> to a user-declared extension whose
+/// receiver type contains a function-level type parameter — e.g.
+/// <c>func (self sequence[T]) FirstOrNil[T]() T?</c> or
+/// <c>func (self IEnumerable[T]) MyFirst[T any](fb T) T</c>.
+///
+/// Prior to the fix, <see cref="BoundScope.TryLookupExtensionFunction"/>
+/// matched extensions by reference-equality on the receiver type, so an
+/// extension declared with an open generic receiver (whose receiver
+/// type carries an open type parameter) was unreachable from any call
+/// site — the lookup reported GS0159 "Cannot find function".
+/// </summary>
+public class Issue773GenericReceiverDispatchTests
+{
+    [Fact]
+    public void Repro_FromIssue_IEnumerableT_Extension_Dispatches_On_Int32Slice()
+    {
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func (self IEnumerable[T]) MyFirst[T any](fb T) T {
+    return fb
+}
+
+var arr = []int32{10, 20, 30}
+arr.MyFirst(99)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(99, result.Value);
+    }
+
+    [Fact]
+    public void SequenceT_Extension_Dispatches_On_Int32Slice()
+    {
+        const string source = @"
+package P
+import System
+
+func (self sequence[T]) HeadOr[T](fb T) T {
+    return fb
+}
+
+var arr = []int32{1, 2, 3}
+arr.HeadOr(7)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void SequenceT_Extension_Dispatches_On_StringSlice()
+    {
+        const string source = @"
+package P
+import System
+
+func (self sequence[T]) HeadOr[T](fb T) T {
+    return fb
+}
+
+var arr = []string{""a"", ""b""}
+arr.HeadOr(""z"")
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("z", result.Value);
+    }
+
+    [Fact]
+    public void SequenceT_Extension_Dispatches_On_DictionaryKeys()
+    {
+        // `Dictionary[K, V].Keys` returns `KeyCollection` which implements
+        // `IEnumerable<K>`. The extension `(self sequence[T])` must unify
+        // T against the KeyCollection's element type by walking the CLR
+        // interface set.
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func (self sequence[T]) HeadOr[T](fb T) T {
+    return fb
+}
+
+var d = Dictionary[string, int32]()
+d[""a""] = 1
+d.Keys.HeadOr(""z"")
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("z", result.Value);
+    }
+
+    [Fact]
+    public void NullableReceiver_Extension_Dispatches_On_StringNullable()
+    {
+        const string source = @"
+package P
+import System
+
+func (self T?) MyOrElse[T](fb T) T {
+    if self != nil { return self!! }
+    return fb
+}
+
+var s string? = nil
+s.MyOrElse(""def"")
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("def", result.Value);
+    }
+
+    [Fact]
+    public void NullableReceiver_Extension_Dispatches_On_Int32Nullable()
+    {
+        const string source = @"
+package P
+import System
+
+func (self T?) MyOrElse[T](fb T) T {
+    if self != nil { return self!! }
+    return fb
+}
+
+var v int32? = nil
+v.MyOrElse(99)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(99, result.Value);
+    }
+
+    [Fact]
+    public void NullableReceiver_Extension_Dispatches_On_UserNullableStruct()
+    {
+        const string source = @"
+package P
+import System
+
+struct Point {
+    var X int32
+    var Y int32
+}
+
+func (self T?) MyOrElse[T](fb T) T {
+    if self != nil { return self!! }
+    return fb
+}
+
+var pt Point? = nil
+var def = Point{X: 1, Y: 2}
+var r = pt.MyOrElse(def)
+r.X
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void MultiTypeParameters_DictionaryReceiver_Dispatches()
+    {
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func (self Dictionary[K, V]) MyCount[K, V]() int32 {
+    return 42
+}
+
+var d = Dictionary[string, int32]()
+d.MyCount()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void ConstraintViolation_DoesNotDispatch()
+    {
+        // Issue #773 + ADR-0088: the generic-receiver path runs receiver
+        // inference first, and then the call-site overload pipeline in
+        // BindExtensionFunctionCall enforces the per-type-parameter
+        // constraints. Calling `Foo` with a receiver that does not
+        // satisfy the constraint must fail with the standard constraint
+        // diagnostic.
+        const string source = @"
+package P
+import System
+
+sealed interface ITagged {
+    func Tag() string
+}
+
+func (self T) Branded[T ITagged]() string {
+    return self.Tag()
+}
+
+var v = 1
+v.Branded()
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Constraint_Satisfied_Dispatches()
+    {
+        const string source = @"
+package P
+import System
+
+sealed interface ITagged {
+    func Tag() string
+}
+
+class Card : ITagged {
+    func Tag() string {
+        return ""card""
+    }
+}
+
+func (self T) Branded[T ITagged]() string {
+    return self.Tag()
+}
+
+var c = Card()
+c.Branded()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("card", result.Value);
+    }
+
+    [Fact]
+    public void ClosedReceiver_StillWorks_AfterFix_OnNonGenericString()
+    {
+        // Regression guard: the fast-path exact-match for closed receivers
+        // must still resolve. This was the working path pre-fix.
+        const string source = @"
+package P
+import System
+
+func (s string) Loud() string {
+    return s + ""!""
+}
+
+var greeting = ""hi""
+greeting.Loud()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("hi!", result.Value);
+    }
+
+    [Fact]
+    public void ClosedReceiver_TakesPrecedenceOverGenericReceiver()
+    {
+        // Both extensions match the call site. The closed-receiver
+        // declaration is preferred (it is the fast-path match) so the
+        // returned string is "closed".
+        const string source = @"
+package P
+import System
+
+func (self []int32) Tag() string {
+    return ""closed""
+}
+
+func (self []T) Tag[T]() string {
+    return ""generic""
+}
+
+var arr = []int32{1, 2}
+arr.Tag()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("closed", result.Value);
+    }
+
+    [Fact]
+    public void GenericReceiver_OverSlice_OfT()
+    {
+        const string source = @"
+package P
+import System
+
+func (self []T) MyCount[T]() int32 {
+    return 7
+}
+
+var a = []int32{1, 2, 3}
+a.MyCount()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void GenericReceiver_TypeArgument_FlowsToBody()
+    {
+        // The substituted T must be observable through the body — a
+        // parameter typed `T` must accept the inferred element type.
+        const string source = @"
+package P
+import System
+
+func (self []T) FirstOr[T](fb T) T {
+    return fb
+}
+
+var a = []int32{1, 2, 3}
+a.FirstOr(99)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(99, result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Interpreter.Tests/Issue773GenericReceiverInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue773GenericReceiverInterpreterTests.cs
@@ -1,0 +1,147 @@
+// <copyright file="Issue773GenericReceiverInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Tree-walking interpreter parity for issue #773: dispatch through an
+/// extension whose receiver type carries a function-level type
+/// parameter must succeed in the REPL evaluator too, not only via the
+/// compiled / IL-verified path.
+/// </summary>
+public class Issue773GenericReceiverInterpreterTests
+{
+    [Fact]
+    public void IEnumerableT_Repro_From_Issue_Dispatches()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            func (self IEnumerable[T]) MyFirst[T any](fb T) T {
+                return fb
+            }
+
+            var arr = []int32{10, 20, 30}
+            Console.WriteLine(arr.MyFirst(99))
+            """;
+
+        Assert.Equal("99\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void SequenceT_HeadOr_Dispatches_Int32Slice()
+    {
+        var source = """
+            func (self sequence[T]) HeadOr[T](fb T) T {
+                return fb
+            }
+
+            var arr = []int32{1, 2, 3}
+            Console.WriteLine(arr.HeadOr(7))
+            """;
+
+        Assert.Equal("7\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void SequenceT_HeadOr_Dispatches_StringSlice()
+    {
+        var source = """
+            func (self sequence[T]) HeadOr[T](fb T) T {
+                return fb
+            }
+
+            var arr = []string{"a", "b"}
+            Console.WriteLine(arr.HeadOr("z"))
+            """;
+
+        Assert.Equal("z\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void NullableReceiver_StringNullable_Dispatches()
+    {
+        var source = """
+            func (self T?) MyOrElse[T](fb T) T {
+                if self != nil { return self!! }
+                return fb
+            }
+
+            var s string? = nil
+            Console.WriteLine(s.MyOrElse("def"))
+            """;
+
+        Assert.Equal("def\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void NullableReceiver_Int32Nullable_Dispatches()
+    {
+        var source = """
+            func (self T?) MyOrElse[T](fb T) T {
+                if self != nil { return self!! }
+                return fb
+            }
+
+            var v int32? = nil
+            Console.WriteLine(v.MyOrElse(99))
+            """;
+
+        Assert.Equal("99\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void DictionaryKV_Receiver_Dispatches()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            func (self Dictionary[K, V]) MyCount[K, V]() int32 {
+                return 42
+            }
+
+            var d = Dictionary[string, int32]()
+            Console.WriteLine(d.MyCount())
+            """;
+
+        Assert.Equal("42\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void SliceT_Receiver_Dispatches()
+    {
+        var source = """
+            func (self []T) FirstOr[T](fb T) T {
+                return fb
+            }
+
+            var a = []int32{1, 2, 3}
+            Console.WriteLine(a.FirstOr(99))
+            """;
+
+        Assert.Equal("99\n", RunSubmission(source));
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #773. Closes the binder side of ADR-0084 §L2 by teaching `BoundScope.TryLookupExtensionFunction` to fall back to receiver-type unification when the fast-path equality match fails. Extensions whose receiver type carries one of the function's own type parameters — `(self IEnumerable[T])`, `(self sequence[T])`, `(self T?)`, `(self Dictionary[K, V])`, `(self []T)` — now dispatch correctly from any call site whose receiver type unifies with the declared open receiver.

## Scope checklist

- [x] **Binder** — `BoundScope.TryLookupExtensionFunction` now runs a second unification-driven lookup when reference-equality fails. The candidate is accepted when every type parameter mentioned in the receiver type gets bound by inference; the call-site overload pipeline in `OverloadResolver.BindExtensionFunctionCall` continues to enforce per-type-parameter constraints, async/iterator return wrapping, and substitution-aware argument conversions.
- [x] **Inference** — `Binder.InferTypeArguments` learned to walk `SequenceTypeSymbol` and `AsyncSequenceTypeSymbol` parameters against any sequence-compatible argument (`SequenceTypeSymbol`, `SliceTypeSymbol`, `ArrayTypeSymbol`, or any CLR type implementing `IEnumerable<T>` / `IAsyncEnumerable<T>`).
- [x] **Substitution** — `Binder.SubstituteType` gained matching cases for `SequenceTypeSymbol` / `AsyncSequenceTypeSymbol` so the open receiver lowers to its closed shape downstream.
- [x] **Emit** — `ReflectionMetadataEmitter` encodes an open `sequence[T]` parameter slot as `GENERICINST<IEnumerable\`1><MVar>` (and the async variant as `GENERICINST<IAsyncEnumerable\`1><MVar>`) so the produced IL passes verification end-to-end.
- [x] **Binder tests** — 14 cases under `test/Core.Tests/CodeAnalysis/Binding/Issue773GenericReceiverDispatchTests.cs` covering the exact issue repro, `sequence[T]` over `[]int32` / `[]string` / `Dictionary.Keys`, `T?` over `string?` / `int32?` / user nullable structs, multi-type-parameter receivers, sealed-interface constraint satisfaction and violation, fast-path precedence for closed receivers, and type-argument flow into the body.
- [x] **Emit tests** — 6 `CompileAndRun` cases (`Issue773GenericReceiverExtensionEmitTests`) IL-verified by the locally-restored `ilverify` tool.
- [x] **Interpreter tests** — 7 `GSharpRepl`-driven cases (`Issue773GenericReceiverInterpreterTests`) mirroring the emit coverage.
- [x] **ADR-0084 updated** — "Known limitations / L2" now describes the binder + emit follow-up landing in this PR; the dogfooded G# port status is captured in "Consequences" along with the structural blockers that keep the C# escape hatch in place.
- [x] **Full suite green** — `dotnet test GSharp.sln --no-restore --nologo` passes 4765 tests with 1 skipped (`RegenerateBaseline`). `cd website && npm run build` succeeds with no broken links.

## Extensions stdlib port status

Re-authoring `src/Sdk/Gsharp.Extensions/Optional/` and `src/Sdk/Gsharp.Extensions/Sequences/` as native G# remains blocked by:

1. The **SDK bootstrap cycle** — `Gsharp.NET.Sdk` carries a pack-time dependency on `Gsharp.Extensions.csproj`, but a `.gsproj` rewrite would require the SDK to already exist in order to compile its own dependency. Resolving this needs a staged bootstrap that builds a minimal compiler-only payload before `Gsharp.Extensions`.
2. The remaining language gaps tracked as #774 (open-receiver iteration erases element type to `object`) and #775 (G# spelling for `class` / `struct` / `new()` constraints).
3. A newly-surfaced emit limitation for `(self T?)` extension bodies — the type-erased emit cannot statically choose between `T` and `Nullable<T>` when the body compares `self` to `nil` or unwraps with `!!`. The binder + interpreter accept the full surface; the emit-side fix is part of the open-receiver workstream (#774 / #775).

The C# files under `src/Sdk/Gsharp.Extensions/` remain unchanged, and the existing `test/Extensions.Tests/` suite (107 tests) continues to pass against them.

## New follow-up issues

No new issues filed: every residual gap discovered during this PR is already tracked by #774 or #775, and the body-lowering limitation for `(self T?)` is a sub-case of the open-receiver workstream.

## Related

- Closes #773
- Related: #751 (parser-side closure of L2), #724 (ADR-0084), #706 (parent / Oats cleanup)