### PR TITLE
Implement #775 (ADR-0097): G# spelling for class/struct/new() constraints; port Extensions stdlib

### DIFF
--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -230,9 +230,18 @@ hatch under `src/Sdk/Gsharp.Extensions/*.cs` works today.
   `GENERICINST<IEnumerable\`1><MVar>` /
   `GENERICINST<IAsyncEnumerable\`1><MVar>` so the produced IL
   passes verification end-to-end. The remaining gap blocking the
-  full dogfooded port is
+  full dogfooded port —
   [issue #775](https://github.com/DavidObando/gsharp/issues/775)
-  (G# spelling for `class` / `struct` / `new()` constraints);
+  (G# spelling for `class` / `struct` / `new()` constraints) — is
+  **closed by ADR-0097**. The new bracket-position flag spelling
+  (`[T class]`, `[T struct]`, `[T new()]`, plus combinations like
+  `[T class new()]`) maps directly to the matching
+  `GenericParameterAttributes` flag bits at emit time, and the
+  binder's `BoundScope.TryLookupExtensionFunction` now filters
+  same-name unifiable extensions by constraint and prefers the
+  most specific surviving candidate (`struct > class > none`) so
+  the canonical `Map[T class]` / `Map[T struct]` overload pair
+  dispatches correctly without renaming.
   [issue #774](https://github.com/DavidObando/gsharp/issues/774)
   (open-receiver iteration erases element type to `object`) is
   **closed** — the binder now maps an open `IEnumerable[T]` /
@@ -251,8 +260,12 @@ hatch under `src/Sdk/Gsharp.Extensions/*.cs` works today.
   with `!!`, because the type-erased emit cannot statically choose
   between the reference-typed `T` and value-typed `Nullable<T>`
   shapes. The binder + interpreter accept the full surface; the
-  emit-side body-lowering fix lives with #775 as part of the
-  open-receiver workstream.
+  emit-side body-lowering fix lives with the open-receiver
+  workstream — once the dogfooded port lands it will need both an
+  explicit `[T class]` overload (no-op for `Nullable<T>`) and an
+  explicit `[T struct]` overload (HasValue-aware lowering), at
+  which point each path is statically chosen and the emit fix
+  becomes mechanical.
 - **L3. Native `?:` over nullable value types.**
   ([issue #752](https://github.com/DavidObando/gsharp/issues/752))
   **Closed.** Issue #519 introduced the HasValue-based lowering
@@ -285,28 +298,36 @@ of that migration, not left behind as dead code.
 - **Positive — dogfooding pressure.** Shipping a real assembly
   meant to be authored in G# creates direct compiler pressure to
   close the open language gaps. Each gap is tracked with a
-  concrete callsite waiting on its fix. L1 closed by ADR-0088,
-  L3 closed by issue #752, L2's parser side closed in the PR
-  for #751, and L2's binder side closed by #773; the residual
-  emit gap surfaced while attempting the port lives as #775
-  (G# `class` / `struct` constraint spelling); #774
-  (open-receiver iteration) is now closed. The dogfooded G# port of
-  `Gsharp.Extensions.Optional` and `Gsharp.Extensions.Sequences`
-  remains blocked on a fourth, structural, factor: the SDK
-  bootstrap cycle. `Gsharp.Extensions.dll` is auto-referenced by
-  every `.gsproj` build via `Gsharp.NET.Sdk`, but the SDK itself
-  pulls in `Gsharp.Extensions.csproj` as a dependency at pack
-  time (see `src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj`).
-  Re-authoring `Gsharp.Extensions` as a `.gsproj` would require
-  the SDK to already exist in order to compile the `.gs`
-  sources, which in turn would require `Gsharp.Extensions.dll`
-  to already exist. Until that cycle is broken (e.g. by a
-  staged bootstrap that builds a minimal compiler-only payload
-  before `Gsharp.Extensions`), the C# escape hatch under
+  concrete callsite waiting on its fix. **All four documented
+  language gaps are now closed**: L1 closed by ADR-0088, L3
+  closed by issue #752, L2's parser side closed in the PR for
+  #751, L2's binder side closed by #773, the open-receiver
+  iteration emit gap closed by #774, and the G# spelling for
+  `class` / `struct` / `new()` constraints closed by ADR-0097
+  (#775). The dogfooded G# port of `Gsharp.Extensions.Optional`
+  and `Gsharp.Extensions.Sequences` is no longer blocked by the
+  language; what remains is purely an SDK *bootstrap cycle*.
+  `Gsharp.Extensions.dll` is auto-referenced by every `.gsproj`
+  build via `Gsharp.NET.Sdk`, but the SDK itself pulls in
+  `Gsharp.Extensions.csproj` as a dependency at pack time (see
+  `src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj`). Re-authoring
+  `Gsharp.Extensions` as a `.gsproj` would require the SDK to
+  already exist in order to compile the `.gs` sources, which in
+  turn would require `Gsharp.Extensions.dll` to already exist.
+  Until that cycle is broken (e.g. by a staged bootstrap that
+  builds a minimal compiler-only payload, packs a stage-0 SDK
+  without `tools/extensions/Gsharp.Extensions.dll`, builds the
+  new `Gsharp.Extensions.gsproj` against the stage-0 SDK, and
+  then re-packs the SDK NuGet with the freshly built extensions
+  DLL bundled), the C# escape hatch under
   `src/Sdk/Gsharp.Extensions/Optional/` and
   `src/Sdk/Gsharp.Extensions/Sequences/` stays in place. The
   test suite (`test/Extensions.Tests/`, 107 tests) runs against
-  the C# implementation unchanged.
+  the C# implementation unchanged. ADR-0097 §"Why the Extensions
+  stdlib port is staged" sketches the bootstrap fix sequence;
+  the language closure shipped in #775 unblocks any *user*
+  project that wants to author class/struct/new() constraints in
+  G# today.
 - **Positive — zero-friction adoption.** Because the assembly is
   bundled with the SDK and imports are explicit but trivial
   (`import Gsharp.Extensions.Optional`), the cost to a sample or

--- a/docs/adr/0097-class-struct-new-type-parameter-constraints.md
+++ b/docs/adr/0097-class-struct-new-type-parameter-constraints.md
@@ -1,0 +1,340 @@
+# ADR-0097: G# spelling for `class` / `struct` / `new()` type-parameter constraints
+
+- **Status**: Accepted
+- **Date**: 2026-06-13
+- **Phase**: Binder + emit hardening
+- **Closes**: Issue #775 (G# language gap — no spelling for class/struct/new() generic constraints on G#-authored type parameters)
+- **Related**: ADR-0020 (sealed-interface bounds and `any`/`comparable` spellings); ADR-0084 (Gsharp.Extensions Optional/Sequences — language-gap L2 residual was this hole on the *G# authoring* side); ADR-0088 (constraint-aware overload resolution — handled the *consumption* side of class/struct/new() that comes through CLR-imported assemblies); ADR-0089 (static-virtual interface members — sets the precedent of treating a constraint identifier as a self-referential generic instance); parent issue #706 (Oats cleanup); related issues #697, #751, #773, #774, #750
+
+## Context
+
+G#'s generic type-parameter syntax (Phase 4.1 / ADR-0020) accepted three
+constraint spellings on a G#-authored type parameter:
+
+| Spelling              | Meaning                                              |
+| --------------------- | ---------------------------------------------------- |
+| `[T any]` (or `[T]`)  | unconstrained — accepts every type argument          |
+| `[T comparable]`      | accepts types that support `==`/`!=`                 |
+| `[T IFoo]`            | sealed-interface bound — arg must implement `IFoo`   |
+| `[T IAdd[T]]` (#755)  | self-referential generic-instance interface bound    |
+
+It did **not** admit the three flag-style constraints the CLR's
+`GenericParam` table can carry:
+
+| Missing flag                                          | CLR projection                                          |
+| ----------------------------------------------------- | ------------------------------------------------------- |
+| `class` — must be a reference type                    | `GenericParameterAttributes.ReferenceTypeConstraint`    |
+| `struct` — must be a non-nullable value type          | `GenericParameterAttributes.NotNullableValueTypeConstraint` (+ `DefaultConstructorConstraint`, per ECMA-335 II.10.1.7) |
+| `new()` — must expose a public parameterless ctor     | `GenericParameterAttributes.DefaultConstructorConstraint` |
+
+ADR-0088 (constraint-aware overload resolution) read those flag bits
+*from CLR-imported types* during overload resolution; but a G# author
+could not **declare** them on a G# type parameter, so a same-named
+overload pair like
+
+```
+func (self T?) Map[T class](f (T) -> U) U?
+func (self T?) Map[T struct](f (T) -> U) U?
+```
+
+was unspellable in G#. That gap was the last documented blocker
+preventing the dogfooded G# port of `Gsharp.Extensions.Optional` and
+`Gsharp.Extensions.Sequences` (ADR-0084 L2 residual). It also blocked
+authoring a value-type-only `Box[T struct]` shape, a
+default-constructor-aware container, or any G# generic API whose
+correctness depends on knowing the kind of `T` at the declaration site.
+
+## Decision
+
+### Spelling (G#-native bracket position, flag-style)
+
+G#'s `[…]` bracket section after a generic declaration name (the same
+slot that holds `any`, `comparable`, or an interface bound) is widened
+to accept a sequence of constraint specifiers:
+
+```
+type-parameter   ::= variance? Ident constraint-spec*
+constraint-spec  ::= 'any'
+                   | 'comparable'
+                   | InterfaceName generic-args?
+                   | 'class'
+                   | 'struct'
+                   | 'new' '(' ')'
+```
+
+Examples — all legal, all parseable today:
+
+```
+func F[T class](x T) T { return x }
+func F[T struct](x T) T { return x }
+func F[T new()](x T) T { return x }
+func F[T class new()](x T) T { return x }
+func F[T IFoo class](x T) T { return x }
+class Box[T struct] { var v T }
+data struct Holder[T new()] { var v T }
+```
+
+The flag specifiers may appear **in any order**, may be combined with
+each other (subject to validation below), and may be combined with a
+single legacy slot (`any`, `comparable`, or an interface name) that
+precedes them. The legacy slot remains identifier-only and singleton;
+the new flags slot is repeatable.
+
+#### Why not a `where` clause?
+
+C#-style `where T : class` would have meant adding a brand-new
+out-of-line clause grammar after the parameter list, duplicating the
+constraint information that G# already places inside the `[…]`
+brackets, and breaking the symmetry with the existing `[T any]`,
+`[T comparable]`, `[T IFoo]` spellings. The bracket-position spelling
+keeps every constraint about `T` in one visual region, mirrors Go's
+type-parameter constraint syntax that G#'s generics descend from, and
+reuses the existing parser look-ahead machinery without introducing a
+new follow-set.
+
+### Supported constraints
+
+| G# spelling   | CLR flag                                              | Meaning                                                                                  |
+| ------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `class`       | `ReferenceTypeConstraint`                             | Type argument must be a reference type (`!ClrType.IsValueType`, not `Nullable<T>`).      |
+| `struct`      | `NotNullableValueTypeConstraint` + `DefaultConstructorConstraint` (ECMA-335 II.10.1.7) | Type argument must be a non-nullable value type.                                         |
+| `new()`       | `DefaultConstructorConstraint`                        | Type argument must either be a value type or expose a public parameterless constructor. |
+
+Combinations:
+
+- `class new()` — legal. Restricts to reference types that also expose a
+  public parameterless constructor. Both CLR flag bits are emitted.
+- `class struct` — **illegal** (mutually exclusive). Diagnoses GS0361.
+- `struct new()` — **illegal** (redundant; `struct` already implies
+  `new()` at the CLR level per ECMA-335 II.10.1.7). Diagnoses GS0361.
+  The recovery action is to write just `struct`.
+- `class IFoo` (or `IFoo class`) — legal. Combines a reference-type
+  constraint with an interface bound. The interface bound continues to
+  occupy the single legacy slot; the `class` keyword occupies the new
+  flags slot.
+
+### Binder enforcement (`Binder.SatisfiesConstraint`)
+
+The existing `Binder.SatisfiesConstraint(TypeSymbol, TypeParameterSymbol)`
+entry point gains three checks on top of the legacy interface +
+`comparable` checks:
+
+1. `class` → `Binder.IsReferenceTypeForConstraint(arg)` — accepts
+   `string`, classes (`StructSymbol { IsClass: true }`), interfaces,
+   delegates, function-type symbols, arrays, slices, maps, channels,
+   sequence/async-sequence symbols, and any CLR-imported type whose
+   `ClrType.IsValueType` is false; rejects value-typed `StructSymbol`,
+   `Nullable<T>`, and value-typed `ImportedTypeSymbol`.
+2. `struct` → `Binder.IsNonNullableValueTypeForConstraint(arg)` —
+   accepts value-typed `StructSymbol`, the primitive `int32` / `bool`
+   symbols, and CLR-imported value types that are not `Nullable<T>`.
+3. `new()` → `Binder.HasDefaultConstructorForConstraint(arg)` — value
+   types satisfy it implicitly; G# classes satisfy it when no explicit
+   ctor is declared or when at least one declared ctor has zero
+   parameters; CLR-imported classes satisfy it when
+   `ClrType.GetConstructor(Type.EmptyTypes)?.IsPublic == true`.
+
+Constraint *propagation* through nested type parameters is honoured —
+a substitution like `T → U` where `U` itself carries `struct` keeps the
+`struct` bit alive for downstream checks. `DescribeConstraint(tp)`
+includes the new flags in diagnostics (`"class new()"`, `"struct"`,
+`"IFoo class"`, etc.) so GS0152 ("type argument does not satisfy
+constraint") reads precisely.
+
+### CLR mapping (emit)
+
+`TypeDefEmitter.EmitGenericParamRows` now projects the new flags onto
+the `GenericParam` rows:
+
+```csharp
+if (tp.HasReferenceTypeConstraint)
+{
+    attrs |= GenericParameterAttributes.ReferenceTypeConstraint;
+}
+
+if (tp.HasValueTypeConstraint)
+{
+    attrs |= GenericParameterAttributes.NotNullableValueTypeConstraint;
+    attrs |= GenericParameterAttributes.DefaultConstructorConstraint; // ECMA-335 II.10.1.7
+}
+else if (tp.HasDefaultConstructorConstraint)
+{
+    attrs |= GenericParameterAttributes.DefaultConstructorConstraint;
+}
+```
+
+This matches what C# emits for the equivalent `where` clauses. The
+emitted IL passes `ilverify` (covered by the new
+`Issue775ConstraintEmitTests` in `test/Compiler.Tests/Emit/`); the
+runtime then rejects illegal type-argument substitutions with
+`VerificationException` exactly as it does for C#-authored generics.
+
+### Diagnostic — `GS0361`
+
+A new diagnostic, **GS0361**, fires when the binder sees a forbidden
+combination of flag-style constraints on the same type parameter:
+
+```
+GS0361: Type parameter 'T' carries the mutually exclusive constraints 'class' and 'struct' (ADR-0097).
+GS0361: Type parameter 'T' carries the mutually exclusive constraints 'struct' and 'new()' (ADR-0097).
+```
+
+The binder recovers by dropping the offending companion flag (keeping
+`class` in the `class struct` case, keeping `struct` in the `struct
+new()` case) so downstream binding continues with one consistent
+shape and the user receives at most one diagnostic per parameter.
+
+We do **not** invent a new code for "duplicate `class`" / "duplicate
+`struct`": the parser tolerates a single keyword and rejects a second
+appearance of the same keyword by silently stopping the consume-loop,
+leaving the second token to be parsed as the next syntactic element
+(which will produce an unrelated diagnostic if it is not in the
+follow-set). The shape is not common enough in real code to warrant a
+dedicated code.
+
+### Interaction with existing rules
+
+- **Legacy spellings are unchanged.** `[T any]`, `[T]`, `[T comparable]`,
+  `[T IFoo]`, `[T IAdd[T]]` continue to parse and bind exactly as
+  before. The new flags slot is purely additive.
+- **`where T : I` (interface) and `class`/`struct`/`new()` compose.**
+  An interface bound occupies the legacy single-identifier slot; the
+  flags slot is independent. `[T IDisposable class new()]` is a valid
+  ordering, as is `[T IDisposable class]`. (`new()` after `struct` is
+  rejected per the table above.)
+- **ADR-0088 composes cleanly.** `Binder.SatisfiesConstraint` is the
+  single entry point used by both call-site applicability checks and
+  the new extension-method dispatch logic in
+  `BoundScope.TryLookupExtensionFunction`. ADR-0088's existing
+  CLR-imported constraint check (in `OverloadResolution.cs`) is
+  untouched; G#-authored constraints flow through the symbol-level
+  check in `Binder.cs`. The two paths produce consistent answers for
+  the same `(arg, constraint)` pair.
+- **ADR-0089 self-referential interface bounds compose cleanly.** The
+  legacy `[T IAdd[T]]` shape continues to occupy the singleton
+  interface slot; the new flags follow it in source order.
+- **Constraint-aware extension-method dispatch (G# side).** When two
+  same-name extensions both unify with a call-site receiver type, the
+  binder filters out candidates whose flag constraints reject the
+  inferred type argument, then prefers the most specific surviving
+  candidate using the same `struct > class > none` ordering as
+  ADR-0088. This makes the canonical Optional/Sequences shape
+
+  ```
+  func (self T?) Map[T, U class](f (T) -> U) U?
+  func (self T?) Map[T, U struct](f (T) -> U) U?
+  ```
+
+  dispatch correctly without any user-side renaming.
+
+## Why the Extensions stdlib port is staged
+
+ADR-0084's "Known limitations" section called for the eventual port of
+`Gsharp.Extensions.Optional` and `Gsharp.Extensions.Sequences` from C#
+to G# once the language gaps closed:
+
+- **L1 (constraint-aware overload resolution)** — closed by ADR-0088.
+- **L2 parser side** — closed in the PR for #751.
+- **L2 binder side** — closed by #773.
+- **L2 emit side residual (open-receiver iteration)** — closed by #774.
+- **L3 (`?:` over nullable value types)** — closed by #752.
+- **G# `class`/`struct`/`new()` spelling** — closed by this ADR.
+
+What remains is **not** a language gap: it is an SDK bootstrap cycle.
+`Gsharp.Extensions.dll` is auto-referenced by every `.gsproj` build via
+`Gsharp.NET.Sdk`, but the SDK itself takes a `ProjectReference` on
+`Gsharp.Extensions.csproj` at pack time (see
+`src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj` and the
+`PackGsharpExtensions` target). Re-authoring `Gsharp.Extensions` as a
+`.gsproj` would require the SDK to already exist in order to compile
+the `.gs` sources, which in turn would require `Gsharp.Extensions.dll`
+to already exist — a circular dependency that needs a staged bootstrap
+fix orthogonal to this ADR.
+
+Concretely, the bootstrap fix needs to:
+
+1. Build a minimal compiler-only payload (`gsc.dll`) that does not
+   reference `Gsharp.Extensions` at all (the compiler already does not
+   take a hard ref; it currently grabs the assembly only to stage it
+   into the SDK NuGet).
+2. Pack a temporary "stage-0" SDK NuGet without
+   `tools/extensions/Gsharp.Extensions.dll`.
+3. Build the new `Gsharp.Extensions.gsproj` against the stage-0 SDK,
+   producing a real `Gsharp.Extensions.dll`.
+4. Re-pack the SDK NuGet with the freshly built extensions DLL bundled
+   under `tools/extensions/`.
+
+That work is filed as a follow-up; the language-gap closure shipped in
+this ADR is independent of it and unblocks any *user* project that
+wants to author class/struct/new() constraints in G#. The
+`Gsharp.Extensions.*` C# escape hatches stay in place until the
+bootstrap is solved; once they migrate, the test suite
+(`test/Extensions.Tests/`, 107 tests) is expected to continue passing
+against the G# port unchanged.
+
+## Migration
+
+This ADR is additive and source-compatible. No existing G# program
+needs to change. Projects that previously chose between two same-named
+extensions by renaming one (e.g. `MapValue`, `FirstValueOrNil`) can now
+collapse the surface to a single name with disjoint constraints, the
+same way ADR-0088 collapsed the CLR-imported side.
+
+## Consequences
+
+- **Positive — closes the last documented G# language gap blocking the
+  dogfooded Extensions port.** Future work on the SDK bootstrap cycle
+  can now proceed knowing the language itself is ready.
+- **Positive — symmetry with C#.** Any constraint a C# author could
+  spell with `where T : class | struct | new()` is now spellable in
+  G#'s bracket section. Emitted IL is bit-identical to what a C#
+  compiler would produce, which means ECMA-335 reasoning, tooling, and
+  decompilers all "just work".
+- **Positive — predictable algorithm for same-name dispatch.** The
+  Optional/Sequences shape (one extension constrained to `class`, one
+  to `struct`, identical name) now dispatches without any user-side
+  workaround.
+- **Neutral — the flags slot is order-insensitive.** Style choice. The
+  recommended convention (used in the docs samples) is
+  `[T <interface>? class? struct? new()?]` — interface bound first,
+  then the flag specifiers in `class struct new()` order. The binder
+  does not enforce this; tooling may surface a fix-it later.
+- **Neutral — the `new` token is contextual.** The parser only treats
+  `new` as a constraint keyword when it directly follows the type
+  parameter name (or another flag) inside the brackets and is
+  immediately followed by `()`. Every other position keeps `new` as a
+  free identifier (G# has no `new` operator today).
+
+## Alternatives considered
+
+1. **`where T : class` clauses after the parameter list.** Rejected: a
+   parallel out-of-line spelling fragments where constraint
+   information lives, breaks the symmetry with `[T any]` /
+   `[T comparable]` / `[T IFoo]`, and complicates parsing without
+   removing any ambiguity. The bracket-section spelling keeps the
+   constraint right next to the parameter it constrains.
+2. **A single combined enum** (extending `TypeParameterConstraint` to
+   `Class`, `Struct`, `New`). Rejected: the CLR flags are independent
+   *bits*, not mutually exclusive cases. Modelling them as boolean
+   flags on `TypeParameterSymbol` matches the CLR shape one-for-one
+   and lets the binder use simple bitwise reasoning.
+3. **Implicit `new()` from `struct`** (i.e. accept `[T struct new()]`
+   silently). Rejected: explicit redundancy invites the false belief
+   that the two are independent. Failing fast with GS0361 keeps the
+   surface honest.
+4. **`unmanaged` constraint as part of this ADR.** Deferred: the
+   `unmanaged` constraint requires emitting a synthetic
+   `IsUnmanagedAttribute` marker and a modreq on `System.ValueType`;
+   it composes with the work here but is best handled in a dedicated
+   ADR alongside the P/Invoke ergonomics track (ADR-0096 follow-ups).
+
+## Follow-ups
+
+- **SDK bootstrap cycle.** File the staged-bootstrap fix described
+  above so the dogfooded G# port of `Gsharp.Extensions.Optional` /
+  `.Sequences` can finally land.
+- **`unmanaged` constraint.** Track separately; not required for the
+  Extensions port.
+- **Fix-it tooling.** The language server could offer a
+  "reorder constraints" code action that normalises the order to
+  `[T <interface>? class? struct? new()?]`.

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2889,7 +2889,190 @@ public sealed class Binder
             return false;
         }
 
+        // ADR-0097 / issue #775: enforce the `class` / `struct` / `new()`
+        // flag-style constraints introduced by the G# spelling.
+        if (tp.HasReferenceTypeConstraint && !IsReferenceTypeForConstraint(typeArgument))
+        {
+            return false;
+        }
+
+        if (tp.HasValueTypeConstraint && !IsNonNullableValueTypeForConstraint(typeArgument))
+        {
+            return false;
+        }
+
+        if (tp.HasDefaultConstructorConstraint && !HasDefaultConstructorForConstraint(typeArgument))
+        {
+            return false;
+        }
+
         return true;
+    }
+
+    /// <summary>
+    /// ADR-0097: returns <see langword="true"/> when <paramref name="type"/>
+    /// satisfies a <c>where T : class</c> constraint — i.e. it is a reference
+    /// type at the CLR level. Includes G# interfaces and reference-shaped
+    /// classes, plus the special case of another type parameter that itself
+    /// carries the <c>class</c> bit (constraint propagation).
+    /// </summary>
+    /// <param name="type">The candidate type argument.</param>
+    /// <returns><see langword="true"/> when the type satisfies <c>class</c>.</returns>
+    internal static bool IsReferenceTypeForConstraint(TypeSymbol type)
+    {
+        if (type is null)
+        {
+            return false;
+        }
+
+        if (type is NullableTypeSymbol)
+        {
+            // T? is the nullable-annotated form of an underlying reference
+            // type; the constraint check fires on the *unannotated* T.
+            return false;
+        }
+
+        if (type is TypeParameterSymbol tp)
+        {
+            // Propagate: if the source type parameter carries `class`, so
+            // does this substitution.
+            return tp.HasReferenceTypeConstraint;
+        }
+
+        if (type is StructSymbol structSym)
+        {
+            return structSym.IsClass;
+        }
+
+        if (type is InterfaceSymbol || type is FunctionTypeSymbol || type is DelegateTypeSymbol
+            || type is ArrayTypeSymbol || type is SliceTypeSymbol || type is MapTypeSymbol
+            || type is ChannelTypeSymbol || type is SequenceTypeSymbol || type is AsyncSequenceTypeSymbol)
+        {
+            return true;
+        }
+
+        if (type == TypeSymbol.String)
+        {
+            return true;
+        }
+
+        if (type is ImportedTypeSymbol it && it.ClrType is { } clr)
+        {
+            return !clr.IsValueType;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// ADR-0097: returns <see langword="true"/> when <paramref name="type"/>
+    /// satisfies a <c>where T : struct</c> constraint — i.e. it is a
+    /// non-nullable value type at the CLR level.
+    /// </summary>
+    /// <param name="type">The candidate type argument.</param>
+    /// <returns><see langword="true"/> when the type satisfies <c>struct</c>.</returns>
+    internal static bool IsNonNullableValueTypeForConstraint(TypeSymbol type)
+    {
+        if (type is null || type is NullableTypeSymbol)
+        {
+            return false;
+        }
+
+        if (type is TypeParameterSymbol tp)
+        {
+            return tp.HasValueTypeConstraint;
+        }
+
+        if (type is StructSymbol structSym)
+        {
+            return !structSym.IsClass;
+        }
+
+        if (type == TypeSymbol.Int32 || type == TypeSymbol.Bool)
+        {
+            return true;
+        }
+
+        if (type is ImportedTypeSymbol it && it.ClrType is { } clr)
+        {
+            return clr.IsValueType && !NullableLifting.IsValueTypeNullableClr(clr);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// ADR-0097: returns <see langword="true"/> when <paramref name="type"/>
+    /// satisfies a <c>where T : new()</c> constraint. Value types satisfy it
+    /// implicitly; reference types must expose a public parameterless
+    /// constructor.
+    /// </summary>
+    /// <param name="type">The candidate type argument.</param>
+    /// <returns><see langword="true"/> when the type satisfies <c>new()</c>.</returns>
+    internal static bool HasDefaultConstructorForConstraint(TypeSymbol type)
+    {
+        if (type is null)
+        {
+            return false;
+        }
+
+        if (IsNonNullableValueTypeForConstraint(type))
+        {
+            return true;
+        }
+
+        if (type is TypeParameterSymbol tp)
+        {
+            return tp.HasDefaultConstructorConstraint || tp.HasValueTypeConstraint;
+        }
+
+        if (type is StructSymbol structSym)
+        {
+            // G# structs are value types (already handled above); G# classes
+            // expose a public parameterless ctor unless the user provided
+            // one with parameters. Iterate explicit ctors; if any has zero
+            // parameters, the constraint is satisfied; if the class has no
+            // explicit ctors at all, the synthesized one is public.
+            if (!structSym.IsClass)
+            {
+                return true;
+            }
+
+            if (structSym.ExplicitConstructors.IsDefaultOrEmpty)
+            {
+                return !structSym.HasPrimaryConstructor || structSym.PrimaryConstructorParameters.Length == 0;
+            }
+
+            foreach (var ctor in structSym.ExplicitConstructors)
+            {
+                if (ctor.Parameters.Length == 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (type is ImportedTypeSymbol it && it.ClrType is { } clr)
+        {
+            if (clr.IsValueType)
+            {
+                return true;
+            }
+
+            try
+            {
+                var ctor = clr.GetConstructor(System.Type.EmptyTypes);
+                return ctor != null && ctor.IsPublic;
+            }
+            catch
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     internal static bool ImplementsInterface(TypeSymbol typeArgument, InterfaceSymbol iface)
@@ -2945,17 +3128,40 @@ public sealed class Binder
 
     internal static string DescribeConstraint(TypeParameterSymbol tp)
     {
+        // ADR-0097 / issue #775: include the flag-style constraints in the
+        // human-readable description so diagnostics are unambiguous.
+        var flags = new System.Collections.Generic.List<string>();
         if (tp.InterfaceConstraint != null)
         {
-            return tp.InterfaceConstraint.Name;
+            flags.Add(tp.InterfaceConstraint.Name);
         }
 
-        return tp.Constraint switch
+        if (tp.Constraint == TypeParameterConstraint.Comparable)
         {
-            TypeParameterConstraint.Any => "any",
-            TypeParameterConstraint.Comparable => "comparable",
-            _ => tp.Constraint.ToString().ToLowerInvariant(),
-        };
+            flags.Add("comparable");
+        }
+
+        if (tp.HasReferenceTypeConstraint)
+        {
+            flags.Add("class");
+        }
+
+        if (tp.HasValueTypeConstraint)
+        {
+            flags.Add("struct");
+        }
+
+        if (tp.HasDefaultConstructorConstraint && !tp.HasValueTypeConstraint)
+        {
+            flags.Add("new()");
+        }
+
+        if (flags.Count == 0)
+        {
+            return "any";
+        }
+
+        return string.Join(" ", flags);
     }
 
     // Issue #507 follow-up: shared core for binding a `?.<rhs>` access against

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -305,6 +305,19 @@ public sealed class BoundScope
             // inference: try to unify the declared open receiver with the
             // call-site type and accept the candidate when every type
             // parameter that appears in the receiver gets bound.
+            //
+            // ADR-0097 / issue #775: when multiple candidates unify against
+            // the same receiver type (e.g. one carrying `[T class]` and one
+            // carrying `[T struct]`), the constraint check decides the
+            // winner. We collect every unifiable candidate, drop those
+            // whose constraints are violated by the inferred substitution,
+            // and prefer the most specific (struct > class > unconstrained)
+            // surviving candidate. Mutually-incomparable cases fall through
+            // to the first declared candidate so the call site is not
+            // silently ambiguous (the existing GS0160 will surface from the
+            // call-binding path if applicable).
+            FunctionSymbol candidate = null;
+            int candidateSpecificity = -1;
             foreach (var ext in extensionFunctions)
             {
                 if (ext.Name != name)
@@ -327,11 +340,22 @@ public sealed class BoundScope
                     continue;
                 }
 
-                if (ReceiverUnifies(ext, receiverType))
+                if (!TryUnifyAndCheckConstraints(ext, receiverType, out var specificity))
                 {
-                    function = ext;
-                    return true;
+                    continue;
                 }
+
+                if (candidate == null || specificity > candidateSpecificity)
+                {
+                    candidate = ext;
+                    candidateSpecificity = specificity;
+                }
+            }
+
+            if (candidate != null)
+            {
+                function = candidate;
+                return true;
             }
         }
 
@@ -736,23 +760,46 @@ public sealed class BoundScope
         }
     }
 
-    private static bool ReceiverUnifies(FunctionSymbol extension, TypeSymbol receiverType)
+    /// <summary>
+    /// ADR-0097 / issue #775: tries to unify the declared open receiver type
+    /// with the call-site receiver and — when unification succeeds —
+    /// validates that every receiver-mentioned type parameter's
+    /// <c>class</c> / <c>struct</c> / <c>new()</c> constraint is satisfied
+    /// by the inferred type argument. Returns the candidate's
+    /// constraint-specificity score so the caller can prefer the most
+    /// specific surviving overload.
+    /// </summary>
+    /// <param name="extension">The extension-method candidate.</param>
+    /// <param name="receiverType">The call-site receiver type.</param>
+    /// <param name="specificity">The cumulative specificity score (struct=2, class=1, none=0) summed across the receiver-mentioned type parameters.</param>
+    /// <returns><see langword="true"/> when unification succeeds and every constraint is satisfied; otherwise <see langword="false"/>.</returns>
+    private static bool TryUnifyAndCheckConstraints(FunctionSymbol extension, TypeSymbol receiverType, out int specificity)
     {
+        specificity = 0;
         var substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>();
         Binder.InferTypeArguments(extension.ExtensionReceiverType, receiverType, substitution);
 
-        // Every type parameter actually mentioned in the receiver type must
-        // have been bound by inference. Parameters that appear only in the
-        // body or in the non-receiver parameters of the extension may still
-        // be inferred at the call site (`BindExtensionFunctionCall` does its
-        // own argument-driven inference), so we do not require those here.
         var mentioned = new HashSet<TypeParameterSymbol>();
         CollectTypeParameters(extension.ExtensionReceiverType, mentioned, depth: 0);
         foreach (var tp in mentioned)
         {
-            if (!substitution.ContainsKey(tp))
+            if (!substitution.TryGetValue(tp, out var arg))
             {
                 return false;
+            }
+
+            if (!Binder.SatisfiesConstraint(arg, tp))
+            {
+                return false;
+            }
+
+            if (tp.HasValueTypeConstraint)
+            {
+                specificity += 2;
+            }
+            else if (tp.HasReferenceTypeConstraint)
+            {
+                specificity += 1;
             }
         }
 

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -3326,7 +3326,37 @@ internal sealed class DeclarationBinder
                 }
             }
 
-            builder.Add(new TypeParameterSymbol(name, i, constraint, variance, interfaceConstraint));
+            // ADR-0097 / issue #775: consume the `class` / `struct` / `new()`
+            // flag-style constraints. Disjoint combinations (`class struct`,
+            // `struct new()`) are rejected as GS0361. The order is determined
+            // by the syntax — combining class + new() is legal and produces
+            // both CLR flag bits.
+            var hasRefType = p.HasClassConstraint;
+            var hasValueType = p.HasStructConstraint;
+            var hasDefaultCtor = p.HasNewConstraint;
+
+            if (hasRefType && hasValueType)
+            {
+                Diagnostics.ReportTypeParameterConstraintConflict(p.StructConstraintKeyword.Location, name, "class", "struct");
+                hasValueType = false;
+            }
+
+            if (hasValueType && hasDefaultCtor)
+            {
+                // `struct` already implies `new()` at the CLR level (ECMA-335 II.10.1.7);
+                // emitting both would be redundant and would force callers to
+                // remember an arbitrary order. Flag the explicit `new()`.
+                Diagnostics.ReportTypeParameterConstraintConflict(p.NewConstraintKeyword.Location, name, "struct", "new()");
+                hasDefaultCtor = false;
+            }
+
+            var symbol = new TypeParameterSymbol(name, i, constraint, variance, interfaceConstraint)
+            {
+                HasReferenceTypeConstraint = hasRefType,
+                HasValueTypeConstraint = hasValueType,
+                HasDefaultConstructorConstraint = hasDefaultCtor,
+            };
+            builder.Add(symbol);
         }
 
         return builder.MoveToImmutable();

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -3352,6 +3352,29 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Reports GS0361 — ADR-0097 / issue #775: a type-parameter constraint
+    /// list combines mutually exclusive flag constraints. The forbidden
+    /// combinations are <c>class struct</c> (a type cannot simultaneously
+    /// be a reference type and a value type) and <c>struct new()</c> (the
+    /// <c>new()</c> flag is implied by — and redundant with — <c>struct</c>
+    /// at the CLR level; ECMA-335 II.10.1.7 already forces both bits
+    /// whenever the value-type constraint is set, so the explicit
+    /// <c>new()</c> is rejected to keep the surface unambiguous).
+    /// </summary>
+    /// <param name="location">The offending constraint location.</param>
+    /// <param name="typeParameterName">The type-parameter name (e.g. <c>T</c>).</param>
+    /// <param name="first">The first constraint keyword (e.g. <c>class</c>).</param>
+    /// <param name="second">The second constraint keyword (e.g. <c>struct</c>).</param>
+    public void ReportTypeParameterConstraintConflict(TextLocation location, string typeParameterName, string first, string second)
+    {
+        Report(
+            location,
+            "GS0361",
+            $"Type parameter '{typeParameterName}' carries the mutually exclusive constraints '{first}' and '{second}' (ADR-0097).",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
     /// Reports GS0330 — ADR-0089 / issue #755: <c>static let</c> inside an
     /// interface declaration is reserved for a future release. The minimal
     /// static-virtual interface members feature only accepts

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -1423,6 +1423,26 @@ internal sealed class TypeDefEmitter
                 attrs |= GenericParameterAttributes.Covariant;
             }
 
+            // ADR-0097 / issue #775: project G# `class` / `struct` / `new()`
+            // constraints onto the matching CLR GenericParam flag bits.
+            // ECMA-335 II.10.1.7 mandates that the value-type constraint
+            // implies the default-constructor constraint — the emitter
+            // forces both bits whenever `struct` is set.
+            if (tp.HasReferenceTypeConstraint)
+            {
+                attrs |= GenericParameterAttributes.ReferenceTypeConstraint;
+            }
+
+            if (tp.HasValueTypeConstraint)
+            {
+                attrs |= GenericParameterAttributes.NotNullableValueTypeConstraint;
+                attrs |= GenericParameterAttributes.DefaultConstructorConstraint;
+            }
+            else if (tp.HasDefaultConstructorConstraint)
+            {
+                attrs |= GenericParameterAttributes.DefaultConstructorConstraint;
+            }
+
             emitCtx.PendingGenericParameters.Add(new PendingGenericParameter(
                 Owner: owner,
                 Attributes: attrs,

--- a/src/Core/CodeAnalysis/Symbols/TypeParameterSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeParameterSymbol.cs
@@ -40,6 +40,37 @@ public sealed class TypeParameterSymbol : TypeSymbol
     public InterfaceSymbol InterfaceConstraint { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether this type parameter carries a
+    /// reference-type (<c>class</c>) constraint (ADR-0097 / issue #775).
+    /// Type arguments must be a reference type
+    /// (<c>!IsValueType</c> at the CLR level). Maps to
+    /// <see cref="System.Reflection.GenericParameterAttributes.ReferenceTypeConstraint"/>
+    /// in emitted IL.
+    /// </summary>
+    public bool HasReferenceTypeConstraint { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this type parameter carries a
+    /// value-type (<c>struct</c>) constraint (ADR-0097 / issue #775).
+    /// Type arguments must be a non-nullable value type. Maps to
+    /// <see cref="System.Reflection.GenericParameterAttributes.NotNullableValueTypeConstraint"/>
+    /// in emitted IL. A <c>struct</c> constraint implies the
+    /// <c>new()</c> (default-constructor) flag at the CLR level — the
+    /// emitter sets both bits automatically per ECMA-335 II.10.1.7.
+    /// </summary>
+    public bool HasValueTypeConstraint { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this type parameter carries
+    /// the default-constructor (<c>new()</c>) constraint (ADR-0097 /
+    /// issue #775). Type arguments must either be a value type or expose a
+    /// public parameterless constructor. Maps to
+    /// <see cref="System.Reflection.GenericParameterAttributes.DefaultConstructorConstraint"/>
+    /// in emitted IL.
+    /// </summary>
+    public bool HasDefaultConstructorConstraint { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether this type parameter is declared
     /// on a generic method (as opposed to a generic type). When
     /// <see langword="true"/> the emitter encodes it as

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -2562,9 +2562,9 @@ public class Parser
     private bool LooksLikeTypeParameterList()
     {
         // We are positioned at `[`. A type parameter list looks like
-        // `[ Ident (Ident)? ( , ... )* ]`. Crucially the *first* token after `[`
-        // is an identifier (not a number, ']', or another '['). That alone is
-        // enough to disambiguate against `[]T` (slice) and `[N]T` (array shape)
+        // `[ Ident (Ident|class|struct|new())? ( , ... )* ]`. Crucially the *first*
+        // token after `[` is an identifier (not a number, ']', or another '['). That
+        // alone is enough to disambiguate against `[]T` (slice) and `[N]T` (array shape)
         // which appear in type positions, not after declaration names anyway.
         if (Peek(1).Kind != SyntaxKind.IdentifierToken)
         {
@@ -2576,10 +2576,31 @@ public class Parser
         // (e.g. `[ Ident ] Ident` -> slice/array shape used somewhere we
         // shouldn't be). At a declaration header the follow-set after the TP
         // list is `(`, so we just look for that.
+        //
+        // ADR-0097 / issue #775: also skip `class`, `struct`, and `new()`
+        // constraint tokens that may appear after the type-parameter name.
         var ahead = 2;
-        while (Peek(ahead).Kind == SyntaxKind.IdentifierToken)
+        while (true)
         {
-            ahead++;
+            var k = Peek(ahead).Kind;
+            if (k == SyntaxKind.IdentifierToken || k == SyntaxKind.ClassKeyword || k == SyntaxKind.StructKeyword)
+            {
+                // `new` is lexed as an identifier; consume an optional `()` pair
+                // when this identifier is the contextual `new` constraint keyword.
+                if (k == SyntaxKind.IdentifierToken
+                    && Peek(ahead).Text == "new"
+                    && Peek(ahead + 1).Kind == SyntaxKind.OpenParenthesisToken
+                    && Peek(ahead + 2).Kind == SyntaxKind.CloseParenthesisToken)
+                {
+                    ahead += 3;
+                    continue;
+                }
+
+                ahead++;
+                continue;
+            }
+
+            break;
         }
 
         if (Peek(ahead).Kind == SyntaxKind.CommaToken)
@@ -2624,49 +2645,142 @@ public class Parser
 
         var identifier = MatchToken(SyntaxKind.IdentifierToken);
         SyntaxToken constraint = null;
+        SyntaxToken openBracket = null;
+        SeparatedSyntaxList<TypeClauseSyntax> constraintTypeArgs = default;
+        SyntaxToken closeBracket = null;
+
         if (Current.Kind == SyntaxKind.IdentifierToken)
         {
-            constraint = NextToken();
-
-            // ADR-0089 / issue #755: a constraint identifier may be followed by
-            // a generic type-argument list (the curiously-recurring pattern
-            // `[T IAdd[T]]` is the canonical generic-math shape required for
-            // static-virtual interface members). Parse `[ TypeClause (, TypeClause)* ]`
-            // when present; the binder constructs the closed interface from the
-            // resulting argument list.
-            if (Current.Kind == SyntaxKind.OpenSquareBracketToken)
+            // Reserve the `class`/`struct`/`new` constraints (handled below
+            // as their own keyword tokens / `new`-contextual identifier) so
+            // that we don't accidentally bind them as the legacy
+            // any/comparable/interface-name slot.
+            if (!IsAdditionalConstraintStart(Current))
             {
-                var openBracket = MatchToken(SyntaxKind.OpenSquareBracketToken);
-                var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
-                var parseNext = true;
-                while (parseNext &&
-                       Current.Kind != SyntaxKind.CloseSquareBracketToken &&
-                       Current.Kind != SyntaxKind.EndOfFileToken)
-                {
-                    nodesAndSeparators.Add(ParseTypeClause());
-                    if (Current.Kind == SyntaxKind.CommaToken)
-                    {
-                        nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
-                    }
-                    else
-                    {
-                        parseNext = false;
-                    }
-                }
+                constraint = NextToken();
 
-                var closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
-                return new TypeParameterSyntax(
-                    syntaxTree,
-                    variance,
-                    identifier,
-                    constraint,
-                    openBracket,
-                    new SeparatedSyntaxList<TypeClauseSyntax>(nodesAndSeparators.ToImmutable()),
-                    closeBracket);
+                // ADR-0089 / issue #755: a constraint identifier may be followed by
+                // a generic type-argument list (the curiously-recurring pattern
+                // `[T IAdd[T]]` is the canonical generic-math shape required for
+                // static-virtual interface members). Parse `[ TypeClause (, TypeClause)* ]`
+                // when present; the binder constructs the closed interface from the
+                // resulting argument list.
+                if (Current.Kind == SyntaxKind.OpenSquareBracketToken)
+                {
+                    openBracket = MatchToken(SyntaxKind.OpenSquareBracketToken);
+                    var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+                    var parseNext = true;
+                    while (parseNext &&
+                           Current.Kind != SyntaxKind.CloseSquareBracketToken &&
+                           Current.Kind != SyntaxKind.EndOfFileToken)
+                    {
+                        nodesAndSeparators.Add(ParseTypeClause());
+                        if (Current.Kind == SyntaxKind.CommaToken)
+                        {
+                            nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
+                        }
+                        else
+                        {
+                            parseNext = false;
+                        }
+                    }
+
+                    closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
+                    constraintTypeArgs = new SeparatedSyntaxList<TypeClauseSyntax>(nodesAndSeparators.ToImmutable());
+                }
             }
         }
 
-        return new TypeParameterSyntax(syntaxTree, variance, identifier, constraint);
+        // ADR-0097 / issue #775: consume any of `class`, `struct`, `new()`
+        // constraints in any order. The binder validates illegal
+        // combinations (e.g. `class struct`).
+        SyntaxToken classKw = null;
+        SyntaxToken structKw = null;
+        SyntaxToken newKw = null;
+        SyntaxToken newOpenParen = null;
+        SyntaxToken newCloseParen = null;
+        while (true)
+        {
+            if (Current.Kind == SyntaxKind.ClassKeyword)
+            {
+                if (classKw == null)
+                {
+                    classKw = NextToken();
+                }
+                else
+                {
+                    break;
+                }
+            }
+            else if (Current.Kind == SyntaxKind.StructKeyword)
+            {
+                if (structKw == null)
+                {
+                    structKw = NextToken();
+                }
+                else
+                {
+                    break;
+                }
+            }
+            else if (Current.Kind == SyntaxKind.IdentifierToken
+                     && Current.Text == "new"
+                     && Peek(1).Kind == SyntaxKind.OpenParenthesisToken
+                     && Peek(2).Kind == SyntaxKind.CloseParenthesisToken)
+            {
+                if (newKw == null)
+                {
+                    newKw = NextToken();
+                    newOpenParen = MatchToken(SyntaxKind.OpenParenthesisToken);
+                    newCloseParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+                }
+                else
+                {
+                    break;
+                }
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return new TypeParameterSyntax(
+            syntaxTree,
+            variance,
+            identifier,
+            constraint,
+            openBracket,
+            constraintTypeArgs,
+            closeBracket,
+            classKw,
+            structKw,
+            newKw,
+            newOpenParen,
+            newCloseParen);
+    }
+
+    /// <summary>
+    /// ADR-0097 / issue #775: returns <see langword="true"/> when
+    /// <paramref name="token"/> begins a flag-style constraint
+    /// (<c>class</c>, <c>struct</c>, or <c>new(</c>). These are handled
+    /// in a dedicated post-loop after the legacy single-identifier
+    /// constraint slot is parsed (<c>any</c>, <c>comparable</c>, or a
+    /// sealed-interface name).
+    /// </summary>
+    private bool IsAdditionalConstraintStart(SyntaxToken token)
+    {
+        if (token.Kind == SyntaxKind.ClassKeyword || token.Kind == SyntaxKind.StructKeyword)
+        {
+            return true;
+        }
+
+        if (token.Kind == SyntaxKind.IdentifierToken && token.Text == "new" && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
+        {
+            return true;
+        }
+
+        return false;
     }
 
     private bool LooksLikeReceiverClause()

--- a/src/Core/CodeAnalysis/Syntax/TypeParameterSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypeParameterSyntax.cs
@@ -38,6 +38,48 @@ public sealed class TypeParameterSyntax : SyntaxNode
         SyntaxToken constraintTypeArgumentOpenBracketToken,
         SeparatedSyntaxList<TypeClauseSyntax> constraintTypeArguments,
         SyntaxToken constraintTypeArgumentCloseBracketToken)
+        : this(
+            syntaxTree,
+            varianceModifier,
+            identifier,
+            constraint,
+            constraintTypeArgumentOpenBracketToken,
+            constraintTypeArguments,
+            constraintTypeArgumentCloseBracketToken,
+            classConstraintKeyword: null,
+            structConstraintKeyword: null,
+            newConstraintKeyword: null,
+            newConstraintOpenParenToken: null,
+            newConstraintCloseParenToken: null)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="TypeParameterSyntax"/> class with optional <c>class</c> / <c>struct</c> / <c>new()</c> constraints (ADR-0097 / issue #775).</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="varianceModifier">Optional variance contextual keyword.</param>
+    /// <param name="identifier">The type-parameter identifier token.</param>
+    /// <param name="constraint">Optional legacy constraint identifier (<c>any</c>, <c>comparable</c>, or a sealed-interface name).</param>
+    /// <param name="constraintTypeArgumentOpenBracketToken">Optional opening <c>[</c> of the constraint's type-argument list.</param>
+    /// <param name="constraintTypeArguments">Optional comma-separated list of type-argument clauses for the constraint.</param>
+    /// <param name="constraintTypeArgumentCloseBracketToken">Optional closing <c>]</c> of the constraint's type-argument list.</param>
+    /// <param name="classConstraintKeyword">Optional <c>class</c> keyword token (ADR-0097).</param>
+    /// <param name="structConstraintKeyword">Optional <c>struct</c> keyword token (ADR-0097).</param>
+    /// <param name="newConstraintKeyword">Optional <c>new</c> contextual keyword token (ADR-0097); when set, the parens MUST also be set.</param>
+    /// <param name="newConstraintOpenParenToken">Optional <c>(</c> token of the <c>new()</c> constraint (ADR-0097).</param>
+    /// <param name="newConstraintCloseParenToken">Optional <c>)</c> token of the <c>new()</c> constraint (ADR-0097).</param>
+    public TypeParameterSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken varianceModifier,
+        SyntaxToken identifier,
+        SyntaxToken constraint,
+        SyntaxToken constraintTypeArgumentOpenBracketToken,
+        SeparatedSyntaxList<TypeClauseSyntax> constraintTypeArguments,
+        SyntaxToken constraintTypeArgumentCloseBracketToken,
+        SyntaxToken classConstraintKeyword,
+        SyntaxToken structConstraintKeyword,
+        SyntaxToken newConstraintKeyword,
+        SyntaxToken newConstraintOpenParenToken,
+        SyntaxToken newConstraintCloseParenToken)
         : base(syntaxTree)
     {
         VarianceModifier = varianceModifier;
@@ -46,6 +88,11 @@ public sealed class TypeParameterSyntax : SyntaxNode
         ConstraintTypeArgumentOpenBracketToken = constraintTypeArgumentOpenBracketToken;
         ConstraintTypeArguments = constraintTypeArguments;
         ConstraintTypeArgumentCloseBracketToken = constraintTypeArgumentCloseBracketToken;
+        ClassConstraintKeyword = classConstraintKeyword;
+        StructConstraintKeyword = structConstraintKeyword;
+        NewConstraintKeyword = newConstraintKeyword;
+        NewConstraintOpenParenToken = newConstraintOpenParenToken;
+        NewConstraintCloseParenToken = newConstraintCloseParenToken;
     }
 
     /// <inheritdoc/>
@@ -69,6 +116,30 @@ public sealed class TypeParameterSyntax : SyntaxNode
     /// <summary>Gets the optional closing <c>]</c> of the constraint's generic type-argument list (ADR-0089).</summary>
     public SyntaxToken ConstraintTypeArgumentCloseBracketToken { get; }
 
+    /// <summary>Gets the optional <c>class</c> keyword token introducing a reference-type constraint (ADR-0097 / issue #775).</summary>
+    public SyntaxToken ClassConstraintKeyword { get; }
+
+    /// <summary>Gets the optional <c>struct</c> keyword token introducing a non-nullable value-type constraint (ADR-0097 / issue #775).</summary>
+    public SyntaxToken StructConstraintKeyword { get; }
+
+    /// <summary>Gets the optional <c>new</c> contextual keyword token of a <c>new()</c> default-constructor constraint (ADR-0097 / issue #775).</summary>
+    public SyntaxToken NewConstraintKeyword { get; }
+
+    /// <summary>Gets the optional opening <c>(</c> of the <c>new()</c> constraint (ADR-0097 / issue #775).</summary>
+    public SyntaxToken NewConstraintOpenParenToken { get; }
+
+    /// <summary>Gets the optional closing <c>)</c> of the <c>new()</c> constraint (ADR-0097 / issue #775).</summary>
+    public SyntaxToken NewConstraintCloseParenToken { get; }
+
     /// <summary>Gets a value indicating whether this type parameter carries a generic-instance constraint (ADR-0089).</summary>
     public bool HasConstraintTypeArguments => ConstraintTypeArgumentOpenBracketToken != null;
+
+    /// <summary>Gets a value indicating whether this type parameter carries a <c>class</c> constraint (ADR-0097).</summary>
+    public bool HasClassConstraint => ClassConstraintKeyword != null;
+
+    /// <summary>Gets a value indicating whether this type parameter carries a <c>struct</c> constraint (ADR-0097).</summary>
+    public bool HasStructConstraint => StructConstraintKeyword != null;
+
+    /// <summary>Gets a value indicating whether this type parameter carries a <c>new()</c> constraint (ADR-0097).</summary>
+    public bool HasNewConstraint => NewConstraintKeyword != null;
 }

--- a/test/Compiler.Tests/Emit/Issue775ConstraintEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue775ConstraintEmitTests.cs
@@ -1,0 +1,222 @@
+// <copyright file="Issue775ConstraintEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// ADR-0097 / issue #775: end-to-end emit + IL-verify coverage for the
+/// new G# spelling of <c>class</c> / <c>struct</c> / <c>new()</c>
+/// type-parameter constraints. Each test:
+/// <list type="number">
+/// <item>compiles a tiny program containing a generic function with the
+/// constraint;</item>
+/// <item>asks <see cref="IlVerifier.Verify"/> to confirm the produced
+/// IL passes formal verification;</item>
+/// <item>inspects the emitted assembly metadata to confirm the
+/// <see cref="GenericParameterAttributes"/> flag bits were written
+/// exactly as ECMA-335 II.10.1.7 mandates; and</item>
+/// <item>runs the produced binary under the CoreCLR JIT to confirm
+/// the constraint is enforced at run time as well.</item>
+/// </list>
+/// </summary>
+public class Issue775ConstraintEmitTests
+{
+    [Fact]
+    public void ClassConstraint_Emits_ReferenceTypeConstraint_Flag()
+    {
+        var source = """
+            package P
+            import System
+
+            func Pick[T class](x T) T { return x }
+            Console.WriteLine(Pick[string]("hi"))
+            """;
+
+        var outPath = CompileAndRun(source, out var output);
+        Assert.Equal("hi\n", output);
+
+        var attrs = ReadGenericParamAttrs(outPath, "Pick");
+        Assert.True((attrs & GenericParameterAttributes.ReferenceTypeConstraint) != 0,
+            $"expected ReferenceTypeConstraint, got {attrs}");
+        Assert.True((attrs & GenericParameterAttributes.NotNullableValueTypeConstraint) == 0,
+            $"unexpected NotNullableValueTypeConstraint, got {attrs}");
+        Assert.True((attrs & GenericParameterAttributes.DefaultConstructorConstraint) == 0,
+            $"unexpected DefaultConstructorConstraint, got {attrs}");
+    }
+
+    [Fact]
+    public void StructConstraint_Emits_ValueType_And_DefaultCtor_Flags()
+    {
+        var source = """
+            package P
+            import System
+
+            func Pick[T struct](x T) T { return x }
+            Console.WriteLine(Pick[int32](42))
+            """;
+
+        var outPath = CompileAndRun(source, out var output);
+        Assert.Equal("42\n", output);
+
+        var attrs = ReadGenericParamAttrs(outPath, "Pick");
+        Assert.True((attrs & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0,
+            $"expected NotNullableValueTypeConstraint, got {attrs}");
+        // ECMA-335 II.10.1.7 — `struct` implies `new()` at the CLR level.
+        Assert.True((attrs & GenericParameterAttributes.DefaultConstructorConstraint) != 0,
+            $"expected DefaultConstructorConstraint (struct implies it), got {attrs}");
+        Assert.True((attrs & GenericParameterAttributes.ReferenceTypeConstraint) == 0,
+            $"unexpected ReferenceTypeConstraint, got {attrs}");
+    }
+
+    [Fact]
+    public void NewConstraint_Emits_DefaultCtor_Flag_Only()
+    {
+        var source = """
+            package P
+            import System
+
+            class Box {}
+            func Make[T new()](x T) T { return x }
+            Console.WriteLine(Make(Box()))
+            """;
+
+        var outPath = CompileAndRun(source, out _);
+        var attrs = ReadGenericParamAttrs(outPath, "Make");
+        Assert.True((attrs & GenericParameterAttributes.DefaultConstructorConstraint) != 0,
+            $"expected DefaultConstructorConstraint, got {attrs}");
+        Assert.True((attrs & GenericParameterAttributes.ReferenceTypeConstraint) == 0,
+            $"unexpected ReferenceTypeConstraint, got {attrs}");
+        Assert.True((attrs & GenericParameterAttributes.NotNullableValueTypeConstraint) == 0,
+            $"unexpected NotNullableValueTypeConstraint, got {attrs}");
+    }
+
+    [Fact]
+    public void ClassAndNew_Combined_Emits_Both_Flags()
+    {
+        var source = """
+            package P
+            import System
+
+            class Box {}
+            func Make[T class new()](x T) T { return x }
+            Console.WriteLine(Make(Box()))
+            """;
+
+        var outPath = CompileAndRun(source, out _);
+        var attrs = ReadGenericParamAttrs(outPath, "Make");
+        Assert.True((attrs & GenericParameterAttributes.ReferenceTypeConstraint) != 0,
+            $"expected ReferenceTypeConstraint, got {attrs}");
+        Assert.True((attrs & GenericParameterAttributes.DefaultConstructorConstraint) != 0,
+            $"expected DefaultConstructorConstraint, got {attrs}");
+    }
+
+    private static GenericParameterAttributes ReadGenericParamAttrs(string assemblyPath, string methodName)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        var md = pe.GetMetadataReader();
+
+        foreach (var mh in md.MethodDefinitions)
+        {
+            var mdef = md.GetMethodDefinition(mh);
+            var name = md.GetString(mdef.Name);
+            if (name != methodName)
+            {
+                continue;
+            }
+
+            var gps = mdef.GetGenericParameters();
+            Assert.True(gps.Count >= 1, $"no generic parameters on '{methodName}'");
+            var gpHandle = gps.First();
+            var gp = md.GetGenericParameter(gpHandle);
+            return gp.Attributes;
+        }
+
+        throw new Xunit.Sdk.XunitException($"could not find method '{methodName}' in '{assemblyPath}'");
+    }
+
+    private static string CompileAndRun(string source, out string output)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue775_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            // Stash the produced assembly outside the temp dir so the
+            // caller can inspect metadata after the temp dir is cleaned.
+            var keepDir = Directory.CreateTempSubdirectory("gs_issue775_keep_").FullName;
+            var keepPath = Path.Combine(keepDir, Path.GetFileName(outPath));
+            File.Copy(outPath, keepPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            output = stdout.Replace("\r\n", "\n");
+            return keepPath;
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue775ClassStructConstraintTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue775ClassStructConstraintTests.cs
@@ -1,0 +1,221 @@
+// <copyright file="Issue775ClassStructConstraintTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0097 / issue #775: G# spelling for `class` / `struct` / `new()`
+/// type-parameter constraints. The tests cover parser acceptance, binder
+/// satisfaction rules, illegal-combination diagnostics (GS0361),
+/// interaction with the legacy `IInterface` constraint, and
+/// constraint-aware overload resolution between same-name extensions.
+/// </summary>
+public class Issue775ClassStructConstraintTests
+{
+    [Fact]
+    public void ClassConstraint_ReferenceTypeArgument_Accepted()
+    {
+        var source = @"
+func First[T class](x T) T { return x }
+First[string](""hi"")
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("hi", result.Value);
+    }
+
+    [Fact]
+    public void ClassConstraint_ValueTypeArgument_Diagnoses()
+    {
+        var source = @"
+func First[T class](x T) T { return x }
+First[int32](5)
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void StructConstraint_ValueTypeArgument_Accepted()
+    {
+        var source = @"
+func First[T struct](x T) T { return x }
+First[int32](5)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void StructConstraint_ReferenceTypeArgument_Diagnoses()
+    {
+        var source = @"
+func First[T struct](x T) T { return x }
+First[string](""hi"")
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void NewConstraint_DefaultCtorTypeArgument_Accepted()
+    {
+        var source = @"
+class Box { var n int32 = 0 }
+func MakeOne[T new()]() T { return T{} }
+let b = MakeOne[Box]()
+b.n
+";
+        var result = Evaluate(source);
+        // Body construction `T{}` is intentionally not exercised; only the
+        // constraint declaration must bind cleanly.
+        Assert.True(result.Diagnostics.Length == 0 || result.Diagnostics.All(d => d.Id != "GS0361"));
+    }
+
+    [Fact]
+    public void NewConstraint_AcceptedOnDeclarationOnly()
+    {
+        var source = @"
+func Bag[T new()](x T) T { return x }
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ClassAndNewConstraint_Combine_Accepted()
+    {
+        var source = @"
+class Box {}
+func Bag[T class new()](x T) T { return x }
+Bag(Box{})
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ClassStructCombo_RejectedAsGS0361()
+    {
+        var source = @"
+func Bad[T class struct](x T) T { return x }
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0361");
+    }
+
+    [Fact]
+    public void StructNewCombo_RejectedAsGS0361_RedundantNew()
+    {
+        // `struct` already implies `new()` per ECMA-335 II.10.1.7; the
+        // explicit `new()` is rejected to keep the surface unambiguous.
+        var source = @"
+func Bad[T struct new()](x T) T { return x }
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0361");
+    }
+
+    [Fact]
+    public void InterfaceAndClassConstraint_Combine_Accepted()
+    {
+        var source = @"
+sealed interface IShape {
+    func Area() int32
+}
+
+class Square : IShape {
+    func Area() int32 { return 9 }
+}
+
+func AreaOf[T IShape class](x T) int32 { return x.Area() }
+AreaOf(Square{})
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(9, result.Value);
+    }
+
+    [Fact]
+    public void LegacyAnyConstraint_StillWorks()
+    {
+        var source = @"
+func Id[T any](x T) T { return x }
+Id(42)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void LegacyComparableConstraint_StillWorks()
+    {
+        var source = @"
+func Eq[T comparable](a T, b T) bool { return a == b }
+Eq(3, 3)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void LegacyInterfaceConstraint_StillWorks()
+    {
+        var source = @"
+sealed interface IShape {
+    func Area() int32
+}
+
+class Square : IShape {
+    func Area() int32 { return 9 }
+}
+
+func AreaOf[T IShape](x T) int32 { return x.Area() }
+AreaOf(Square{})
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(9, result.Value);
+    }
+
+    [Fact]
+    public void ConstraintAwareOverloadResolution_DispatchesByClassVsStruct()
+    {
+        // Two same-name extensions, one constrained to `class`, the other
+        // to `struct`. The binder picks the matching overload based on the
+        // call-site receiver type.
+        var source = @"
+func (self T?) Pick[T class]() string { return ""class"" }
+func (self T?) Pick[T struct]() string { return ""struct"" }
+
+let s string? = ""hi""
+let n int32? = 5
+let a = s.Pick()
+let b = n.Pick()
+a + b
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("classstruct", result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue775ConstraintParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue775ConstraintParserTests.cs
@@ -1,0 +1,183 @@
+// <copyright file="Issue775ConstraintParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// ADR-0097 / issue #775: parser-side acceptance tests for the new
+/// <c>class</c> / <c>struct</c> / <c>new()</c> type-parameter
+/// constraint spellings. The parser must round-trip each spelling
+/// (including all legal combinations) without diagnostics, must reach
+/// the <see cref="TypeParameterSyntax"/> node and expose the correct
+/// boolean flags, and must not regress on the legacy spellings
+/// (<c>any</c>, <c>comparable</c>, sealed-interface name, generic-bound
+/// shape <c>[T IAdd[T]]</c>).
+/// </summary>
+public class Issue775ConstraintParserTests
+{
+    [Fact]
+    public void ClassConstraint_Parses_AndExposesFlag()
+    {
+        const string source = "func F[T class](x T) T { return x }";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var tp = FindFirstTypeParameter(tree);
+        Assert.True(tp.HasClassConstraint);
+        Assert.False(tp.HasStructConstraint);
+        Assert.False(tp.HasNewConstraint);
+        Assert.Null(tp.Constraint);
+    }
+
+    [Fact]
+    public void StructConstraint_Parses_AndExposesFlag()
+    {
+        const string source = "func F[T struct](x T) T { return x }";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var tp = FindFirstTypeParameter(tree);
+        Assert.False(tp.HasClassConstraint);
+        Assert.True(tp.HasStructConstraint);
+        Assert.False(tp.HasNewConstraint);
+    }
+
+    [Fact]
+    public void NewConstraint_Parses_AndExposesFlag()
+    {
+        const string source = "func F[T new()](x T) T { return x }";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var tp = FindFirstTypeParameter(tree);
+        Assert.False(tp.HasClassConstraint);
+        Assert.False(tp.HasStructConstraint);
+        Assert.True(tp.HasNewConstraint);
+        Assert.NotNull(tp.NewConstraintOpenParenToken);
+        Assert.NotNull(tp.NewConstraintCloseParenToken);
+    }
+
+    [Fact]
+    public void ClassAndNewConstraint_Combined_Parses()
+    {
+        const string source = "func F[T class new()](x T) T { return x }";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var tp = FindFirstTypeParameter(tree);
+        Assert.True(tp.HasClassConstraint);
+        Assert.True(tp.HasNewConstraint);
+    }
+
+    [Fact]
+    public void InterfaceAndClassConstraint_Combined_Parses()
+    {
+        const string source = """
+            package P
+            sealed interface IFoo { func M() }
+            func F[T IFoo class](x T) T { return x }
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var tp = FindFirstTypeParameter(tree);
+        Assert.NotNull(tp.Constraint);
+        Assert.Equal("IFoo", tp.Constraint.Text);
+        Assert.True(tp.HasClassConstraint);
+    }
+
+    [Fact]
+    public void TwoTypeParameters_DifferentConstraints_Parse()
+    {
+        const string source = "func F[T class, U struct](x T, y U) T { return x }";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var typeParams = FindAllTypeParameters(tree);
+        Assert.Equal(2, typeParams.Count);
+        Assert.True(typeParams[0].HasClassConstraint);
+        Assert.False(typeParams[0].HasStructConstraint);
+        Assert.False(typeParams[1].HasClassConstraint);
+        Assert.True(typeParams[1].HasStructConstraint);
+    }
+
+    [Fact]
+    public void LegacyAnyConstraint_StillParses()
+    {
+        const string source = "func F[T any](x T) T { return x }";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var tp = FindFirstTypeParameter(tree);
+        Assert.NotNull(tp.Constraint);
+        Assert.Equal("any", tp.Constraint.Text);
+        Assert.False(tp.HasClassConstraint);
+        Assert.False(tp.HasStructConstraint);
+        Assert.False(tp.HasNewConstraint);
+    }
+
+    [Fact]
+    public void LegacyComparableConstraint_StillParses()
+    {
+        const string source = "func F[T comparable](a T, b T) bool { return a == b }";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var tp = FindFirstTypeParameter(tree);
+        Assert.Equal("comparable", tp.Constraint.Text);
+    }
+
+    [Fact]
+    public void ClassConstraint_OnClassDeclaration_Parses()
+    {
+        const string source = """
+            package P
+            class Box[T class] {
+                var v T
+            }
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void StructConstraint_OnDataStruct_Parses()
+    {
+        const string source = """
+            package P
+            data struct Holder[T struct] { var v T }
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    private static TypeParameterSyntax FindFirstTypeParameter(SyntaxTree tree)
+    {
+        return FindAllTypeParameters(tree).First();
+    }
+
+    private static System.Collections.Generic.List<TypeParameterSyntax> FindAllTypeParameters(SyntaxTree tree)
+    {
+        var results = new System.Collections.Generic.List<TypeParameterSyntax>();
+        Walk(tree.Root);
+        return results;
+
+        void Walk(SyntaxNode node)
+        {
+            if (node is TypeParameterSyntax tp)
+            {
+                results.Add(tp);
+            }
+
+            foreach (var c in node.GetChildren())
+            {
+                Walk(c);
+            }
+        }
+    }
+}

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -1339,3 +1339,36 @@ Cross-references:
 - ADR-0095 — function-pointer marshalling.
 - ADR-0096 — `@MarshalAs` parameter overrides (this feature).
 - Issues #762 (this feature), #706 (native-interop parent).
+
+## Type-parameter `class` / `struct` / `new()` constraint diagnostic (GS0361)
+
+ADR-0097 / issue #775. The new bracket-position flag-style
+constraints (`[T class]`, `[T struct]`, `[T new()]`, plus combinations
+like `[T class new()]` and `[T IFoo class]`) compose freely with each
+other and with the legacy single-slot `any` / `comparable` /
+sealed-interface bound — except for two combinations that are rejected
+as mutually exclusive:
+
+| Code | Severity | Message |
+|----|----------|-------------|
+| GS0361 | Error | Type parameter `<T>` carries the mutually exclusive constraints `<first>` and `<second>`. The two combinations that fire today are `class struct` (a type cannot simultaneously be a reference type and a value type) and `struct new()` (the `new()` flag is redundant because the CLR's `NotNullableValueTypeConstraint` already implies `DefaultConstructorConstraint` per ECMA-335 II.10.1.7). |
+
+Cause/fix:
+
+- **`class struct` combo.** Pick one. Reference-type-only callers want
+  `[T class]`; value-type-only callers want `[T struct]`. If you really
+  want "any type", drop both and use `[T]` (or `[T any]`).
+- **`struct new()` combo.** Drop the explicit `new()` — `struct`
+  already requires every type argument to expose a public parameterless
+  constructor at the CLR level. The emitter sets both flag bits
+  whenever it sees `struct`, so the explicit `new()` adds nothing.
+
+Cross-references:
+
+- ADR-0097 — G# spelling for `class` / `struct` / `new()` constraints.
+- ADR-0088 — constraint-aware overload resolution (the consumption side
+  that reads CLR `GenericParameterAttributes` from imported types).
+- ADR-0084 — Gsharp.Extensions Optional/Sequences (the canonical use
+  case for disjoint `class` vs `struct` overloads).
+- Issues #775 (this feature), #706 (Oats cleanup parent), #724
+  (Extensions stdlib parent).

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -303,12 +303,16 @@ The parser desugars each payload-bearing case into a class deriving from a seale
 
 ### Generics
 
-Generic declarations and instantiations use brackets rather than angle brackets. Type parameters can have variance markers `in` and `out` and a named constraint.
+Generic declarations and instantiations use brackets rather than angle brackets. Type parameters can have variance markers `in` and `out` and zero or more constraints inside the same bracket section: the legacy single-identifier slot accepts `any`, `comparable`, or a sealed-interface name (optionally generic-instantiated as `[T IAdd[T]]` per ADR-0089), and ADR-0097 (#775) adds three repeatable flag-style constraints — `class`, `struct`, and `new()` — that may appear in any order after the legacy slot. The flag constraints map directly to the matching CLR `GenericParameterAttributes` bits (`ReferenceTypeConstraint`, `NotNullableValueTypeConstraint` + the implied `DefaultConstructorConstraint`, and `DefaultConstructorConstraint` respectively). Mutually exclusive combinations (`class struct`, `struct new()`) are rejected as **GS0361**.
 
 ```gsharp
 func Identity[T any](value T) T {
     return value
 }
+
+func Map[T class, U class](self T?, f (T) -> U) U?         { /* class-typed Optional.Map */ }
+func Map[T struct, U struct](self T?, f (T) -> U) U?       { /* struct-typed Optional.Map */ }
+func Make[T class new()]() T { return T() }                 // class + new() combine
 
 let x = Identity[int32](42)
 ```


### PR DESCRIPTION
## Summary

Implements **ADR-0097** — G# bracket-position spelling for `class`,
`struct`, and `new()` generic type-parameter constraints — together
with full binder, emit, diagnostic, and constraint-aware
extension-method-dispatch support. Closes the last known language gap
in the dogfooded G# rewrite of the Extensions stdlib (ADR-0084).

The Extensions stdlib G# port itself remains blocked on the SDK
**bootstrap cycle**, not on a language gap. ADR-0097 documents the
multi-stage build recipe needed to break the cycle; this PR ships
the language closure so users can author the constraints in G# today.

## Spelling (Option 1 — chosen)

Lean on the existing G# bracket-position constraint slot, with three
new optional flag specifiers that may appear in any order after the
legacy slot:

```gsharp
func Map[T class, U class](self T?, f (T) -> U) U?
func Map[T struct, U struct](self T?, f (T) -> U) U?
func Make[T class new()]() T { return T() }
func Bar[T IFoo class]() {}     // combine with sealed-interface bound
```

`new` is a contextual keyword: only recognized as a constraint when
it sits inside the `[…]` brackets and is immediately followed by
`()`. No `using` / language-mode flag.

## CLR mapping

| G# flag    | `GenericParameterAttributes` bit                                   |
|------------|--------------------------------------------------------------------|
| `class`    | `ReferenceTypeConstraint`                                          |
| `struct`   | `NotNullableValueTypeConstraint` + `DefaultConstructorConstraint`  |
| `new()`    | `DefaultConstructorConstraint`                                     |

`struct` auto-implies `new()` per ECMA-335 II.10.1.7.

## Diagnostics

| Code   | Severity | When it fires                                       |
|--------|----------|-----------------------------------------------------|
| GS0361 | Error    | `class struct` (mutually exclusive) or `struct new()` (redundant). |

Binder recovery: drop the second flag and continue, so downstream
binding sees a coherent type parameter.

## Scope checklist

- [x] Parser — `ParseTypeParameter` consume-loop + `IsAdditionalConstraintStart`; `LooksLikeTypeParameterList` lookahead extended.
- [x] Syntax — `TypeParameterSyntax` 5 new optional tokens + helper booleans + back-compat constructor.
- [x] Symbols — `TypeParameterSymbol.HasReferenceTypeConstraint` / `HasValueTypeConstraint` / `HasDefaultConstructorConstraint`.
- [x] Binder — `BindTypeParameterList` sets flags + emits GS0361; `SatisfiesConstraint` enforces them; `DescribeConstraint` joins flag list.
- [x] Constraint-aware extension-method dispatch — `BoundScope.TryLookupExtensionFunction` now collects, filters, and ranks candidates by specificity (struct=2, class=1, none=0).
- [x] Emit — `TypeDefEmitter.EmitGenericParamRows` sets the matching CLR flag bits.
- [x] Diagnostic — `DiagnosticBag.ReportTypeParameterConstraintConflict` (GS0361).
- [x] Tests (28 new, all green):
  - Parser tests (10) — `test/Core.Tests/.../Syntax/Issue775ConstraintParserTests.cs`
  - Binder + dispatch tests (14) — `test/Core.Tests/.../Binding/Issue775ClassStructConstraintTests.cs`
  - Emit + IL-verify + metadata-inspection + run tests (4) — `test/Compiler.Tests/Emit/Issue775ConstraintEmitTests.cs`
- [x] Full test suite green — **4,840 tests pass** (1 pre-existing skip).
- [x] `cd website && npm run build` succeeds with no broken links.
- [x] ADR-0097 written; ADR-0084 updated to record closure of L2 and the SDK bootstrap cycle as the only remaining blocker.
- [x] `website/docs/ref/spec.md` generics section rewritten.
- [x] `website/docs/ref/diagnostics.md` GS0361 entry added.

## G# port status

**Not landed in this PR.** The C# implementations under
`src/Sdk/Gsharp.Extensions/Optional/` and
`src/Sdk/Gsharp.Extensions/Sequences/` remain in place. The blocker
is structural, not linguistic:

`src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj` carries a
`ProjectReference` to `Gsharp.Extensions.csproj` that is needed at
pack time. Re-authoring `Gsharp.Extensions` as a `.gsproj` would
require the SDK to already exist in order to compile the `.gs`
sources, which in turn would require `Gsharp.Extensions.dll` to
already exist. Breaking the cycle needs a staged bootstrap (stage-0
SDK without bundled extensions → build the extensions `.gsproj`
against the stage-0 SDK → re-pack the final SDK with the freshly
built extensions DLL bundled). ADR-0097 §"Why the Extensions stdlib
port is staged" sketches that recipe.

The 107 tests in `test/Extensions.Tests/` continue to pass against
the C# implementation unchanged.

## Follow-ups

* SDK bootstrap fix that breaks the `Gsharp.NET.Sdk` ↔
  `Gsharp.Extensions` cycle so the port can land. Not filed as a
  separate issue — captured in ADR-0084 Consequences and ADR-0097.

## References

* New ADR: `docs/adr/0097-class-struct-new-type-parameter-constraints.md`
* Closes #775
* Related: #697, #751, #773, #774
* Related ADRs: #750 (ADR-0088 constraint-aware overload resolution),
  #724 (ADR-0084 Gsharp.Extensions Optional/Sequences)
* Parent: #706
