### PR TITLE
Fix #794: thread generic T through generic instance-method calls in generic shared method

### DIFF
--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -315,20 +315,35 @@ of that migration, not left behind as dead code.
   **Source-port side: deferred.** While porting `Optional.gs` and
   `Sequences.gs` it became clear that the public API surface still
   hits several smaller, previously undocumented G# language gaps —
-  generic-method type-parameter threading through generic
+  ~~generic-method type-parameter threading through generic
   instance-method calls (`List[T]().ToArray()` returns `object[]`
-  inside a generic shared method), no `default(T)` expression, no
-  `params` parameter declaration, no `==` between `(T) -> T` /
-  `sequence[T]` values and `nil`, no `[MethodImpl(...)]` annotation
-  parsing inside `shared { }` blocks, no `yield` inside a
-  shared-static method that returns `IEnumerable[T]`. Each is filed
-  as a focused follow-up. The C# escape hatch under
-  `src/Sdk/Gsharp.Extensions/Optional/` and
+  inside a generic shared method)~~ (closed by issue #794), no
+  `default(T)` expression, no `params` parameter declaration, no
+  `==` between `(T) -> T` / `sequence[T]` values and `nil`, no
+  `[MethodImpl(...)]` annotation parsing inside `shared { }` blocks,
+  no `yield` inside a shared-static method that returns
+  `IEnumerable[T]`. Each is filed as a focused follow-up. The C#
+  escape hatch under `src/Sdk/Gsharp.Extensions/Optional/` and
   `src/Sdk/Gsharp.Extensions/Sequences/` remains in place; the
   Extensions test suite (107 tests) continues to run against it
   unchanged. Once those follow-ups close the actual G# port becomes
   mechanical — the bootstrap + `[Extension]` emit make it a flag
   flip rather than an infrastructure project.
+
+  Issue #794 specifically closed the first follow-up bullet: when a
+  receiver carries symbolic type arguments (`ImportedTypeSymbol`
+  with `OpenDefinition` + `TypeArguments`, the #313 / #671
+  shape), every instance call and property read on that receiver
+  now reprojects through the open declaring type's signature so the
+  result symbol carries the in-scope `T` / `K` / `V` rather than the
+  type-erased `object`. `List[T]().ToArray()` is `[]T`,
+  `Dictionary[K, V]().Keys` is `ICollection[K]`, and
+  `List[T]().Add(v)` binds when `v` is typed `T` (the binder
+  treats type-parameter args as `object` for overload resolution
+  against an erased receiver). The fix lives at the binder layer
+  only — no `BoundNodeKind` was added, and emit/IL-verify run
+  green end-to-end through the existing #765 / R5 reified-generics
+  path.
 
 ## Consequences
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1411,9 +1411,17 @@ internal sealed partial class ExpressionBinder
                         // are rare on CLR types and stay on the existing
                         // MapClrMemberType path, which preserves the
                         // ByRefTypeSymbol wrapper.
-                        var propType = prop.PropertyType.IsByRef
-                            ? MapClrMemberType(prop.PropertyType)
-                            : ClrNullability.GetPropertyTypeSymbol(prop);
+                        // Issue #794: substitute the receiver's symbolic
+                        // type arguments back through the property's open
+                        // declaring type so e.g. `Dictionary[K, V]().Keys`
+                        // surfaces as `ICollection[K]` (a generic shape
+                        // containing the in-scope `K`) instead of the
+                        // type-erased `ICollection<object>`.
+                        var receiverOverride = ResolveInstancePropertyTypeFromReceiver(receiver.Type, prop);
+                        var propType = receiverOverride
+                            ?? (prop.PropertyType.IsByRef
+                                ? MapClrMemberType(prop.PropertyType)
+                                : ClrNullability.GetPropertyTypeSymbol(prop));
                         return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrPropertyAccessExpression(null, receiver, prop, propType));
                     }
 
@@ -2029,6 +2037,63 @@ internal sealed partial class ExpressionBinder
         }
 
         return TypeSymbol.FromClrType(clrType);
+    }
+
+    /// <summary>
+    /// Issue #794: substitute the receiver's symbolic type arguments back
+    /// through a CLR property's open declaring type. The closed `clrReceiverType`
+    /// is the type-erased shape (#313 / #671), so reflection's
+    /// <see cref="PropertyInfo.PropertyType"/> reports the property's open type
+    /// closed over `object` — e.g. `Dictionary[K, V].Keys` surfaces as
+    /// `ICollection&lt;object&gt;`. Walk the open property on the receiver's
+    /// <see cref="ImportedTypeSymbol.OpenDefinition"/> and project its property
+    /// type using the receiver's <see cref="ImportedTypeSymbol.TypeArguments"/>.
+    /// Returns <see langword="null"/> when no substitution applies.
+    /// </summary>
+    private static TypeSymbol ResolveInstancePropertyTypeFromReceiver(TypeSymbol receiverType, PropertyInfo closedProperty)
+    {
+        if (receiverType is not ImportedTypeSymbol imp
+            || imp.OpenDefinition == null
+            || imp.TypeArguments.IsDefaultOrEmpty
+            || closedProperty == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            // Match by name + indexer arity to find the open counterpart.
+            // Properties on closed generic instances carry stable
+            // metadata-name overlap with their open declaration; an exact
+            // name lookup on the open type with the same instance-binding
+            // flags is sufficient for the single-name, non-indexer
+            // properties that surface real receiver-type generics.
+            var openType = closedProperty.DeclaringType != imp.ClrType && closedProperty.DeclaringType?.IsGenericType == true
+                ? imp.OpenDefinition.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == closedProperty.DeclaringType.GetGenericTypeDefinition())
+                    ?? imp.OpenDefinition
+                : imp.OpenDefinition;
+            var openProperty = ClrTypeUtilities.SafeGetProperty(
+                openType,
+                closedProperty.Name,
+                BindingFlags.Public | BindingFlags.Instance);
+            if (openProperty == null || openProperty.GetIndexParameters().Length != 0)
+            {
+                return null;
+            }
+
+            var openPropType = openProperty.PropertyType;
+            if (openPropType == null)
+            {
+                return null;
+            }
+
+            var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openPropType, imp.OpenDefinition, imp.TypeArguments);
+            return TypeSymbol.ContainsTypeParameter(mapped) ? mapped : null;
+        }
+        catch (System.Reflection.AmbiguousMatchException)
+        {
+            return null;
+        }
     }
 
     private static bool IsReadOnlyRefReturn(PropertyInfo indexer, MethodInfo getter)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -895,6 +895,85 @@ internal sealed partial class ExpressionBinder
         return null;
     }
 
+    /// <summary>
+    /// Issue #794: when an instance call is dispatched against a receiver whose
+    /// <see cref="ImportedTypeSymbol"/> carries symbolic type arguments
+    /// (e.g. <c>List[T]</c>, <c>Dictionary[K, V]</c>) — including the
+    /// open in-scope type-parameter case from #313/#671 — substitute the
+    /// open declaring type's return type using the receiver's symbolic
+    /// arguments. Without this override the call's return type comes from the
+    /// type-erased closed shape (<c>List&lt;object&gt;.ToArray()</c> →
+    /// <c>object[]</c>), losing the symbolic projection (<c>T[]</c>).
+    /// Returns <see langword="null"/> when no override is needed so callers
+    /// keep their existing return-type derivation.
+    /// </summary>
+    /// <param name="receiverType">The receiver's static type symbol.</param>
+    /// <param name="closedMethod">The closed method selected by overload resolution.</param>
+    /// <returns>The override return type symbol, or <see langword="null"/>.</returns>
+    private static TypeSymbol ResolveInstanceReturnTypeFromReceiver(TypeSymbol receiverType, System.Reflection.MethodInfo closedMethod)
+    {
+        if (receiverType is not ImportedTypeSymbol imp
+            || imp.OpenDefinition == null
+            || imp.TypeArguments.IsDefaultOrEmpty
+            || closedMethod == null)
+        {
+            return null;
+        }
+
+        var openMethod = TryGetOpenInstanceMethod(imp.OpenDefinition, closedMethod);
+        if (openMethod == null)
+        {
+            return null;
+        }
+
+        var openReturn = openMethod.ReturnType;
+        if (openReturn == null || openReturn == typeof(void))
+        {
+            return null;
+        }
+
+        var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openReturn, imp.OpenDefinition, imp.TypeArguments);
+        return TypeSymbol.ContainsTypeParameter(mapped) ? mapped : null;
+    }
+
+    /// <summary>
+    /// Locates the open-generic-definition counterpart of <paramref name="closedMethod"/>
+    /// on <paramref name="openDefinition"/>. Match is by metadata token + module,
+    /// which is stable for methods on a constructed generic type (the
+    /// reflection layer reports the open token regardless of the closing).
+    /// </summary>
+    /// <param name="openDefinition">The open generic type definition.</param>
+    /// <param name="closedMethod">The closed method to project.</param>
+    /// <returns>The open method, or <see langword="null"/> when no match.</returns>
+    private static System.Reflection.MethodInfo TryGetOpenInstanceMethod(System.Type openDefinition, System.Reflection.MethodInfo closedMethod)
+    {
+        if (openDefinition == null || closedMethod == null)
+        {
+            return null;
+        }
+
+        if (closedMethod.DeclaringType == openDefinition)
+        {
+            return closedMethod;
+        }
+
+        var token = closedMethod.MetadataToken;
+        var module = closedMethod.Module;
+        var bindingFlags = System.Reflection.BindingFlags.Public
+            | System.Reflection.BindingFlags.NonPublic
+            | System.Reflection.BindingFlags.Instance
+            | System.Reflection.BindingFlags.Static;
+        foreach (var candidate in openDefinition.GetMethods(bindingFlags))
+        {
+            if (candidate.MetadataToken == token && ReferenceEquals(candidate.Module, module))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
     private BoundExpression BindAccessorCall(BoundExpression receiver, ImportedClassSymbol classSymbol, CallExpressionSyntax ce)
     {
         var methodName = ce.Identifier.Text;
@@ -1247,7 +1326,9 @@ internal sealed partial class ExpressionBinder
                     switch (resolution.Outcome)
                     {
                         case OverloadResolution.ResolutionOutcome.Resolved:
-                            var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols) ?? MapClrMemberType(resolution.Best.ReturnType);
+                            var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols)
+                                ?? ResolveInstanceReturnTypeFromReceiver(receiver?.Type, resolution.Best)
+                                ?? MapClrMemberType(resolution.Best.ReturnType);
                             var instParameters = resolution.Best.GetParameters();
                             var instMapping = resolution.ParameterMapping;
                             var instExpandedArgs = resolution.IsExpanded
@@ -1661,7 +1742,9 @@ internal sealed partial class ExpressionBinder
         switch (resolution.Outcome)
         {
             case OverloadResolution.ResolutionOutcome.Resolved:
-                var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols) ?? TypeSymbol.FromClrType(resolution.Best.ReturnType);
+                var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols)
+                    ?? ResolveInstanceReturnTypeFromReceiver(receiver?.Type, resolution.Best)
+                    ?? TypeSymbol.FromClrType(resolution.Best.ReturnType);
                 var inheritedParameters = resolution.Best.GetParameters();
                 var inheritedMapping = resolution.ParameterMapping;
                 var inheritedExpandedArgs = resolution.IsExpanded

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -797,6 +797,25 @@ internal sealed partial class ExpressionBinder
             return clrType;
         }
 
+        // Issue #794: a generic type parameter referenced inside a generic
+        // shared method (or generic top-level func / extension) has no
+        // ClrType — it is type-erased to `System.Object` at the IL layer
+        // (ADR-0004 / #313). Surface that erasure so overload resolution
+        // against an imported instance call like `List[T]().Add(v)` picks
+        // the `Add(object)` overload instead of bailing out. The bound call
+        // re-projects the symbolic argument type back through the
+        // receiver's `TypeArguments` for emit. `T?` (nullable wrapper of a
+        // type parameter) rides through the same erasure.
+        if (typeSymbol is TypeParameterSymbol)
+        {
+            return typeof(object);
+        }
+
+        if (typeSymbol is NullableTypeSymbol { UnderlyingType: TypeParameterSymbol })
+        {
+            return typeof(object);
+        }
+
         // User-defined G# class: provide the imported base type's CLR type
         // so that overload resolution can proceed (base-class assignability
         // and the supplementary interface check handle the rest).

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -465,6 +465,38 @@ internal sealed class MemberLookup
             return TypeSymbol.FromClrType(openClr);
         }
 
+        // Issue #794: an open generic type's instance member can return an
+        // array of an open parameter (e.g. `List<T>.ToArray()` → `T[]`). The
+        // CLR `Type` reports `IsArray` for those, not `IsGenericType`. Recurse
+        // on the element type and surface a G# slice (`[]T`) so the call site
+        // sees the symbolic projection rather than the erased `object[]`.
+        if (openClr.IsArray && openClr.GetArrayRank() == 1)
+        {
+            var openElement = openClr.GetElementType();
+            var mappedElement = MapOpenClrTypeToSymbolic(openElement, openDefinition, typeArguments);
+            if (TypeSymbol.ContainsTypeParameter(mappedElement))
+            {
+                return SliceTypeSymbol.Get(mappedElement);
+            }
+
+            return TypeSymbol.FromClrType(openClr);
+        }
+
+        // Issue #794: a managed pointer return (e.g. `List<T>.this[int]` on
+        // `Span<T>`) reports `IsByRef`. Recurse on the pointee and wrap with
+        // `ByRefTypeSymbol` to mirror the open-shape's contract.
+        if (openClr.IsByRef)
+        {
+            var openPointee = openClr.GetElementType();
+            var mappedPointee = MapOpenClrTypeToSymbolic(openPointee, openDefinition, typeArguments);
+            if (TypeSymbol.ContainsTypeParameter(mappedPointee))
+            {
+                return ByRefTypeSymbol.Get(mappedPointee);
+            }
+
+            return TypeSymbol.FromClrType(openClr);
+        }
+
         if (openClr.IsGenericType && !openClr.IsGenericTypeDefinition)
         {
             var openArgs = openClr.GetGenericArguments();

--- a/test/Compiler.Tests/Emit/Issue794GenericInstanceCallReturnTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue794GenericInstanceCallReturnTypeEmitTests.cs
@@ -1,0 +1,255 @@
+// <copyright file="Issue794GenericInstanceCallReturnTypeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #794 end-to-end coverage. The binder fix re-projects the
+/// receiver's symbolic type arguments through instance calls and
+/// property reads on imported CLR generics. These tests round-trip
+/// each scenario through compile → IL-verify → run so we catch any
+/// emit-time regression in the type-erased generic dispatch path
+/// (ADR-0087 R1–R5 / #313 / #671 / #765).
+/// </summary>
+public class Issue794GenericInstanceCallReturnTypeEmitTests
+{
+    [Fact]
+    public void ListT_ToArray_From_Generic_Shared_Roundtrips_Int32()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func MakeList[T any](v T) []T {
+                        var list = List[T]()
+                        list.Add(v)
+                        list.Add(v)
+                        return list.ToArray()
+                    }
+                }
+            }
+
+            var arr = Sequences.MakeList[int32](42)
+            Console.WriteLine(arr.Length)
+            Console.WriteLine(arr[0])
+            Console.WriteLine(arr[1])
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n42\n42\n", output);
+    }
+
+    [Fact]
+    public void ListT_ToArray_From_Generic_Shared_Roundtrips_String()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func MakeList[T any](v T) []T {
+                        var list = List[T]()
+                        list.Add(v)
+                        return list.ToArray()
+                    }
+                }
+            }
+
+            var arr = Sequences.MakeList[string]("hi")
+            Console.WriteLine(arr.Length)
+            Console.WriteLine(arr[0])
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\nhi\n", output);
+    }
+
+    [Fact]
+    public void ListT_Count_From_Generic_Shared_Returns_Int32()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func CountThree[T any](v T) int32 {
+                        var list = List[T]()
+                        list.Add(v)
+                        list.Add(v)
+                        list.Add(v)
+                        return list.Count
+                    }
+                }
+            }
+
+            Console.WriteLine(Sequences.CountThree[int32](0))
+            Console.WriteLine(Sequences.CountThree[string](""))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n3\n", output);
+    }
+
+    [Fact]
+    public void ListT_Add_With_TypeParameter_Argument_Inside_Generic_TopLevel_Func()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func MakeAndCount[T any](a T, b T) int32 {
+                var list = List[T]()
+                list.Add(a)
+                list.Add(b)
+                return list.Count
+            }
+
+            Console.WriteLine(MakeAndCount[int32](1, 2))
+            Console.WriteLine(MakeAndCount[string]("x", "y"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n2\n", output);
+    }
+
+    [Fact]
+    public void DictionaryKV_Keys_Iterated_Returns_K()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Helper {
+                shared {
+                    func FirstOrFallback[K any, V any](fb K, seed V) K {
+                        var dict = Dictionary[K, V]()
+                        dict.Add(fb, seed)
+                        for k in dict.Keys {
+                            return k
+                        }
+                        return fb
+                    }
+                }
+            }
+
+            Console.WriteLine(Helper.FirstOrFallback[string, int32]("fallback", 0))
+            Console.WriteLine(Helper.FirstOrFallback[int32, string](-1, ""))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("fallback\n-1\n", output);
+    }
+
+    [Fact]
+    public void Generic_Extension_Method_With_ListT_ToArray_Roundtrip()
+    {
+        // Cross-check #773: an extension whose receiver is `[]T` calls
+        // through to `List[T]().ToArray()` and must thread the same `T`.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func (self []T) DoubleViaList[T]() []T {
+                var list = List[T]()
+                for v in self {
+                    list.Add(v)
+                    list.Add(v)
+                }
+                return list.ToArray()
+            }
+
+            var arr = []int32{1, 2}
+            var doubled = arr.DoubleViaList()
+            Console.WriteLine(doubled.Length)
+            Console.WriteLine(doubled[0])
+            Console.WriteLine(doubled[3])
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("4\n1\n2\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue794_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue794GenericInstanceCallReturnTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue794GenericInstanceCallReturnTypeTests.cs
@@ -1,0 +1,253 @@
+// <copyright file="Issue794GenericInstanceCallReturnTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #794 / ADR-0084 §L5 follow-up. When a generic method (top-level
+/// <c>func</c>, generic shared method on a class, or generic extension
+/// method) instantiates an imported CLR generic over its own in-scope
+/// type parameter (e.g. <c>List[T]()</c>), every subsequent instance
+/// call or property access on that receiver must thread the symbolic
+/// type argument back through the member's return / parameter signature:
+///
+/// <list type="bullet">
+///   <item><c>List[T]().ToArray()</c> → <c>[]T</c> (was <c>object[]</c>)</item>
+///   <item><c>List[T]().Add(v)</c> binds when <c>v</c> is typed <c>T</c></item>
+///   <item><c>List[T]().Count</c> → <c>int32</c></item>
+///   <item><c>Dictionary[K, V]().Keys</c> → <c>ICollection[K]</c></item>
+/// </list>
+///
+/// Pre-fix the binder used <see cref="System.Type"/>-driven reflection
+/// on the receiver's type-erased closed CLR shape
+/// (<c>List&lt;object&gt;</c>) and surfaced the return / property type
+/// as the erased projection, which then failed conversion to the
+/// declared <c>[]T</c> / <c>K</c> / <c>ICollection[K]</c>.
+/// </summary>
+public class Issue794GenericInstanceCallReturnTypeTests
+{
+    [Fact]
+    public void Repro_From_Issue_ListT_ToArray_Inside_Generic_Shared_Returns_SliceOfT()
+    {
+        // Verbatim issue repro (sans the `default` literal, tracked
+        // separately). Pre-fix: `GS0155: Cannot convert type
+        // 'System.Object[]' to '[]T'.`
+        const string source = @"
+package Repro
+import System
+import System.Collections.Generic
+
+class Sequences {
+    shared {
+        func MakeList[T any]() []T {
+            var list = List[T]()
+            return list.ToArray()
+        }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ListT_Count_Returns_Int32_Inside_Generic_Shared()
+    {
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+class Sequences {
+    shared {
+        func Make[T any]() int32 {
+            var list = List[T]()
+            return list.Count
+        }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ListT_Add_Accepts_TypeParameter_Argument_Inside_Generic_Shared()
+    {
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+class Sequences {
+    shared {
+        func Make[T any](v T) int32 {
+            var list = List[T]()
+            list.Add(v)
+            return list.Count
+        }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void DictionaryKV_Keys_Returns_GenericKeyCollection_Inside_Generic_Shared()
+    {
+        // The for-in iteration variable `k` must surface as the
+        // receiver's symbolic `K` (not the erased `object`) so the
+        // return-as-`K` unifies. The fix substitutes the `Keys`
+        // property type (`ICollection<TKey>`) through the receiver's
+        // TypeArguments.
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+class Sequences {
+    shared {
+        func FirstKey[K any, V any](fb K) K {
+            var dict = Dictionary[K, V]()
+            for k in dict.Keys {
+                return k
+            }
+            return fb
+        }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void Inside_TopLevel_Generic_Func_ToArray_Threads_T()
+    {
+        // Identical shape to the issue repro but inside a top-level
+        // generic `func` rather than a shared method on a class.
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func MakeList[T any]() []T {
+    var list = List[T]()
+    return list.ToArray()
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void Inside_Generic_Extension_Method_ToArray_Threads_T()
+    {
+        // Cross-check with the #773 receiver-clause fix: an extension
+        // method with a generic receiver must also thread its own type
+        // parameter through subsequent instance calls on a CLR generic.
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func (self []T) DuplicateInto[T]() []T {
+    var list = List[T]()
+    for v in self {
+        list.Add(v)
+        list.Add(v)
+    }
+    return list.ToArray()
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ListT_ToArray_Bound_Return_Type_Is_SliceOfT()
+    {
+        // Walk the bound tree to confirm the call's bound return type
+        // is `[]T` over the function's type parameter — not the erased
+        // `[]object`.
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func MakeList[T any]() []T {
+    var list = List[T]()
+    return list.ToArray()
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var fn = compilation.BoundProgram.Functions.Keys.Single(f => f.Name == "MakeList");
+        var body = compilation.BoundProgram.Functions[fn];
+        var slices = new TypeCollector<SliceTypeSymbol>();
+        slices.Visit(body);
+        Assert.Contains(slices.Collected, s => s.ElementType is TypeParameterSymbol tp && tp.Name == "T");
+    }
+
+    [Fact]
+    public void DictionaryKV_Keys_Bound_Type_Carries_Symbolic_K()
+    {
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func MakeKeys[K any, V any]() {
+    var dict = Dictionary[K, V]()
+    var keys = dict.Keys
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var fn = compilation.BoundProgram.Functions.Keys.Single(f => f.Name == "MakeKeys");
+        var body = compilation.BoundProgram.Functions[fn];
+        var imps = new TypeCollector<ImportedTypeSymbol>();
+        imps.Visit(body);
+        Assert.Contains(imps.Collected, t =>
+            !t.TypeArguments.IsDefaultOrEmpty
+            && t.TypeArguments.Any(a => a is TypeParameterSymbol tp && tp.Name == "K"));
+    }
+
+    private static IReadOnlyList<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics;
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(tree) { IsLibrary = true };
+    }
+
+    private sealed class TypeCollector<T> : BoundTreeWalker
+        where T : TypeSymbol
+    {
+        public List<T> Collected { get; } = new();
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node?.Type is T match)
+            {
+                Collected.Add(match);
+            }
+
+            base.VisitExpression(node);
+        }
+    }
+}

--- a/test/Interpreter.Tests/Issue794GenericInstanceCallReturnTypeInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue794GenericInstanceCallReturnTypeInterpreterTests.cs
@@ -1,0 +1,181 @@
+// <copyright file="Issue794GenericInstanceCallReturnTypeInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Tree-walking interpreter parity for issue #794: instance-call and
+/// property-access return-type substitution through an open generic
+/// receiver must also work in the REPL, not only in the IL-emit path.
+/// </summary>
+public class Issue794GenericInstanceCallReturnTypeInterpreterTests
+{
+    [Fact]
+    public void ListT_ToArray_From_Generic_Shared_Roundtrips_Int32()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func MakeList[T any](v T) []T {
+                        var list = List[T]()
+                        list.Add(v)
+                        list.Add(v)
+                        return list.ToArray()
+                    }
+                }
+            }
+
+            var arr = Sequences.MakeList[int32](42)
+            Console.WriteLine(arr.Length)
+            Console.WriteLine(arr[0])
+            Console.WriteLine(arr[1])
+            """;
+
+        Assert.Equal("2\n42\n42\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void ListT_ToArray_From_Generic_Shared_Roundtrips_String()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func MakeList[T any](v T) []T {
+                        var list = List[T]()
+                        list.Add(v)
+                        return list.ToArray()
+                    }
+                }
+            }
+
+            var arr = Sequences.MakeList[string]("hi")
+            Console.WriteLine(arr.Length)
+            Console.WriteLine(arr[0])
+            """;
+
+        Assert.Equal("1\nhi\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void ListT_Count_From_Generic_Shared_Returns_Int32()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func CountThree[T any](v T) int32 {
+                        var list = List[T]()
+                        list.Add(v)
+                        list.Add(v)
+                        list.Add(v)
+                        return list.Count
+                    }
+                }
+            }
+
+            Console.WriteLine(Sequences.CountThree[int32](0))
+            Console.WriteLine(Sequences.CountThree[string](""))
+            """;
+
+        Assert.Equal("3\n3\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void ListT_Add_With_TypeParameter_Argument_Inside_Generic_TopLevel_Func()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            func MakeAndCount[T any](a T, b T) int32 {
+                var list = List[T]()
+                list.Add(a)
+                list.Add(b)
+                return list.Count
+            }
+
+            Console.WriteLine(MakeAndCount[int32](1, 2))
+            Console.WriteLine(MakeAndCount[string]("x", "y"))
+            """;
+
+        Assert.Equal("2\n2\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void DictionaryKV_Keys_Iterated_Returns_K()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            class Helper {
+                shared {
+                    func FirstOrFallback[K any, V any](fb K, seed V) K {
+                        var dict = Dictionary[K, V]()
+                        dict.Add(fb, seed)
+                        for k in dict.Keys {
+                            return k
+                        }
+                        return fb
+                    }
+                }
+            }
+
+            Console.WriteLine(Helper.FirstOrFallback[string, int32]("fallback", 0))
+            Console.WriteLine(Helper.FirstOrFallback[int32, string](-1, ""))
+            """;
+
+        Assert.Equal("fallback\n-1\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void Generic_Extension_Method_With_ListT_ToArray_Roundtrip()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            func (self []T) DoubleViaList[T]() []T {
+                var list = List[T]()
+                for v in self {
+                    list.Add(v)
+                    list.Add(v)
+                }
+                return list.ToArray()
+            }
+
+            var arr = []int32{1, 2}
+            var doubled = arr.DoubleViaList()
+            Console.WriteLine(doubled.Length)
+            Console.WriteLine(doubled[0])
+            Console.WriteLine(doubled[3])
+            """;
+
+        Assert.Equal("4\n1\n2\n", RunSubmission(source));
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #794. Inside a generic shared method (or generic top-level `func` / generic extension method), instance calls and property reads on a receiver typed as an imported CLR generic over an in-scope type parameter (e.g. `List[T]()`, `Dictionary[K, V]()`) now thread the symbolic `T` / `K` / `V` back through the member's signature. `List[T]().ToArray()` is `[]T` (was `object[]` / GS0155), `Dictionary[K, V]().Keys` is `ICollection[K]`, and `List[T]().Add(v)` binds when `v` is typed `T`.

## Root cause

Three sites in `ExpressionBinder.Calls.cs` / `ExpressionBinder.Access.cs` derived the call / property result type from `MethodInfo.ReturnType` / `PropertyInfo.PropertyType` on the receiver's *closed type-erased* CLR shape (`List<object>`), never consulting the receiver's symbolic `ImportedTypeSymbol.TypeArguments`. The overload-resolution argument-type vector also bailed when a single arg's effective CLR type was null — true for any bare `TypeParameterSymbol`.

## Fix (binder-only — no new `BoundNodeKind`)

1. `MemberLookup.MapOpenClrTypeToSymbolic` now recurses through array and by-ref shapes so an open `T[]` / `T&` round-trips back to `SliceTypeSymbol([]T)` / `ByRefTypeSymbol(T)`.
2. New `ResolveInstanceReturnTypeFromReceiver` helper finds the open-definition counterpart of the closed method (matched by metadata token + module — stable for methods on a constructed generic) and projects the open return type through the receiver's `TypeArguments`. Wired into all three instance-call resolution paths.
3. Analogous `ResolveInstancePropertyTypeFromReceiver` helper for the CLR property-access path.
4. `GetEffectiveArgumentClrTypeForOverloadResolution` returns `typeof(object)` for `TypeParameterSymbol` and `Nullable<T>` of one, matching the type-erased IL surface so `List[T]().Add(v)` (and similar) picks the right overload.

ADR-0084 §L5 updated to mark the first follow-up bullet closed.

## Related

- #773 — open generic-receiver extension dispatch (sibling binder fix)
- #774 — open-receiver iteration emit gap
- #765 — ADR-0087 R5: ImportedTypeSymbol ctor rework for closed CLR generics over user types
- #792 — SDK bootstrap that surfaced this gap during the dogfooded `Gsharp.Extensions.Sequences` port
- ADR-0084 §L5 — the dogfooding driver
- parent #706

## Coverage

- `Issue794GenericInstanceCallReturnTypeTests` (8 binder cases): exact issue repro, `List[T].Count`, `List[T].Add(v)`, `Dictionary[K,V].Keys` iteration, parity inside top-level generic func, parity inside generic extension (#773 cross-check), plus two bound-tree shape assertions.
- `Issue794GenericInstanceCallReturnTypeEmitTests` (6 cases): each binder scenario re-run through `CompileAndRun` + `ilverify`.
- `Issue794GenericInstanceCallReturnTypeInterpreterTests` (6 cases): REPL parity with the emit suite.

## Verification

- `dotnet test GSharp.sln` — **4924 passed, 1 skipped, 0 failed** (8m38s for the Compiler.Tests leg).
- `cd website && npm run build` — clean, no broken links.
- `ilverify` clean on every emit-test assembly.

Closes #794
