### PR TITLE
Fix #796: allow == / != between function/sequence values and nil

### DIFF
--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -317,9 +317,10 @@ of that migration, not left behind as dead code.
   hits several smaller, previously undocumented G# language gaps —
   ~~generic-method type-parameter threading through generic
   instance-method calls (`List[T]().ToArray()` returns `object[]`
-  inside a generic shared method)~~ (closed by issue #794), no
-  `default(T)` expression, no `params` parameter declaration, no
-  `==` between `(T) -> T` / `sequence[T]` values and `nil`, no
+  inside a generic shared method)~~ (closed by issue #794), ~~no
+  `default(T)` expression~~ (closed by issue #795 / ADR-0100), no
+  `params` parameter declaration, ~~no `==` between `(T) -> T` /
+  `sequence[T]` values and `nil`~~ (closed by issue #796), no
   `[MethodImpl(...)]` annotation parsing inside `shared { }` blocks,
   no `yield` inside a shared-static method that returns
   `IEnumerable[T]`. Each is filed as a focused follow-up. The C#
@@ -344,6 +345,22 @@ of that migration, not left behind as dead code.
   only — no `BoundNodeKind` was added, and emit/IL-verify run
   green end-to-end through the existing #765 / R5 reified-generics
   path.
+
+  Issue #796 closed the fourth follow-up bullet: the binder's
+  `IsNullCompare` arm (in `BoundBinaryOperator.cs`) previously
+  accepted `== nil` / `!= nil` only when the non-null side was a
+  `NullableTypeSymbol` (`T?` wrapper). Function-typed
+  (`(T) -> R` / legacy `func(T) U` / `DelegateTypeSymbol`) and
+  sequence-typed (`sequence[T]` / `asyncSequence[T]`) values are
+  managed references at the CLR layer but have no `T?` spelling in
+  the language, so the guard rejected the only legal way to spell
+  "is this delegate / iterable nil?". The arm now accepts
+  `FunctionTypeSymbol`, `DelegateTypeSymbol`,
+  `SequenceTypeSymbol`, and `AsyncSequenceTypeSymbol` on the
+  non-null side; emit falls through to the generic `ldnull; ceq`
+  shape (verifier-clean for any managed reference). No new
+  `BoundNodeKind` was introduced; the change is a single predicate
+  extension.
 
 ## Consequences
 

--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -289,7 +289,32 @@ public sealed class BoundBinaryOperator
 
     private static bool IsNullCompare(TypeSymbol nullableOrUnderlying, TypeSymbol nullCandidate)
     {
-        return nullCandidate == TypeSymbol.Null && (nullableOrUnderlying is NullableTypeSymbol || nullableOrUnderlying == TypeSymbol.Null);
+        if (nullCandidate != TypeSymbol.Null)
+        {
+            return false;
+        }
+
+        if (nullableOrUnderlying == TypeSymbol.Null || nullableOrUnderlying is NullableTypeSymbol)
+        {
+            return true;
+        }
+
+        // Issue #796: extend `== nil` / `!= nil` to reference-shaped types
+        // whose CLR representation is a managed reference. The binder
+        // already accepts `T? == nil` for any nullable wrapper; the
+        // language has no `T?` spelling for these structural shapes,
+        // so allow the comparison directly. Emit falls through to the
+        // generic `ldnull; ceq` path (verifier-clean for any reference).
+        //
+        // Covered shapes (all reference-typed at the CLR level):
+        //   * `(T) -> R` / `func(T) U` — FunctionTypeSymbol, lowered to a
+        //     System.MulticastDelegate-derived closure.
+        //   * Named delegate types declared with `delegate` — DelegateTypeSymbol.
+        //   * `sequence[T]` / `asyncSequence[T]` — IEnumerable<T> / IAsyncEnumerable<T>.
+        return nullableOrUnderlying is FunctionTypeSymbol
+            || nullableOrUnderlying is DelegateTypeSymbol
+            || nullableOrUnderlying is SequenceTypeSymbol
+            || nullableOrUnderlying is AsyncSequenceTypeSymbol;
     }
 
     private static BoundBinaryOperator[] BuildSupportedOperators()

--- a/test/Compiler.Tests/Emit/Issue796FunctionAndSequenceNilCompareEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue796FunctionAndSequenceNilCompareEmitTests.cs
@@ -1,0 +1,373 @@
+// <copyright file="Issue796FunctionAndSequenceNilCompareEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #796 / ADR-0084 §L5 follow-up — end-to-end emit coverage for
+/// <c>== nil</c> / <c>!= nil</c> on function-typed and sequence-typed
+/// values. The binder change extends
+/// <see cref="GSharp.Core.CodeAnalysis.Binding.BoundBinaryOperator"/>'s
+/// <c>IsNullCompare</c> arm; emit falls through to the generic
+/// <c>ldnull; ceq</c> path because both shapes are managed references at
+/// the CLR layer (delegate / <c>IEnumerable&lt;T&gt;</c>).
+///
+/// Each test compiles via in-process <c>gsc</c>, IL-verifies the emitted
+/// PE (so any bad emit shape is caught here rather than only at JIT
+/// time), and runs the assembly under <c>dotnet exec</c> asserting
+/// captured stdout. The IL-pattern tests additionally walk the emitted
+/// bytes to confirm a <c>ldnull; ceq</c> sequence is present in the
+/// guard method body.
+/// </summary>
+public class Issue796FunctionAndSequenceNilCompareEmitTests
+{
+    [Fact]
+    public void FunctionParameter_EqualsNil_GuardsAndRuns()
+    {
+        var source = """
+            package Test
+            import System
+
+            func Guard(f () -> int32) string {
+                if f == nil {
+                    return "nil"
+                }
+                return "bound"
+            }
+
+            var nilFn () -> int32 = default(() -> int32)
+            Console.WriteLine(Guard(() -> 42))
+            Console.WriteLine(Guard(nilFn))
+            """;
+
+        var (output, ilBytes) = CompileRunAndCaptureMethodIl(source, methodName: "Guard");
+        Assert.Equal("bound\nnil\n", output);
+        Assert.True(
+            ContainsSequence(ilBytes, ILOpCode.Ldnull, ILOpCode.Ceq),
+            "Expected `ldnull; ceq` pattern in the Guard method body for a function-typed `== nil` comparison.");
+    }
+
+    [Fact]
+    public void FunctionParameter_NotEqualNil_GuardsAndRuns()
+    {
+        var source = """
+            package Test
+            import System
+
+            func IsBound(f () -> int32) bool {
+                return f != nil
+            }
+
+            var nilFn () -> int32 = default(() -> int32)
+            Console.WriteLine(IsBound(() -> 1))
+            Console.WriteLine(IsBound(nilFn))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void ConcreteArrowFunction_EqualsNil_GuardsAndRuns()
+    {
+        // Concrete `(int32) -> int32` parameter — the binder must
+        // bind `f == nil` through the FunctionTypeSymbol shape and
+        // emit must produce verifiable IL. (The open-generic
+        // `(T) -> R` shape is covered by the binder tests; element-
+        // type inference through arrow shapes is tracked separately.)
+        var source = """
+            package Test
+            import System
+
+            func Apply(x int32, f (int32) -> int32) bool {
+                return f == nil
+            }
+
+            var nilFn (int32) -> int32 = default((int32) -> int32)
+            Console.WriteLine(Apply(1, nilFn))
+            Console.WriteLine(Apply(1, (n int32) -> n + 1))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void SequenceInt32_EqualsNil_GuardsAndRuns()
+    {
+        var source = """
+            package Test
+            import System
+
+            func Sum(xs sequence[int32]) int32 {
+                if xs == nil {
+                    return -1
+                }
+                var total = 0
+                for x in xs {
+                    total = total + x
+                }
+                return total
+            }
+
+            var nilSeq sequence[int32] = default(sequence[int32])
+            Console.WriteLine(Sum([]int32{1, 2, 3}))
+            Console.WriteLine(Sum(nilSeq))
+            """;
+
+        var (output, ilBytes) = CompileRunAndCaptureMethodIl(source, methodName: "Sum");
+        Assert.Equal("6\n-1\n", output);
+        Assert.True(
+            ContainsSequence(ilBytes, ILOpCode.Ldnull, ILOpCode.Ceq),
+            "Expected `ldnull; ceq` pattern in the Sum method body for a sequence-typed `== nil` comparison.");
+    }
+
+    [Fact]
+    public void GenericSequence_NotEqualNil_GuardsAndRuns()
+    {
+        // Element-typed sequence: `sequence[int32] != nil` over a
+        // concrete element type. The generic-T form is covered by the
+        // binder tests; element-level inference through `sequence[T]`
+        // is a separate language gap tracked outside this issue.
+        var source = """
+            package Test
+            import System
+
+            func HasAny(xs sequence[int32]) bool {
+                return xs != nil
+            }
+
+            var nilSeq sequence[int32] = default(sequence[int32])
+            Console.WriteLine(HasAny([]int32{}))
+            Console.WriteLine(HasAny(nilSeq))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void NamedDelegateType_EqualsNil_GuardsAndRuns()
+    {
+        // ADR-0059 named delegate. Reference-typed at the CLR level
+        // (sealed class deriving MulticastDelegate); must compile and
+        // verify identically to the structural FunctionTypeSymbol path.
+        var source = """
+            package Test
+            import System
+
+            type Reducer = delegate func(a int32, b int32) int32
+
+            func Apply(seed int32, f Reducer) int32 {
+                if f == nil {
+                    return -1
+                }
+                return f.Invoke(seed, 10)
+            }
+
+            var add Reducer = func(a int32, b int32) int32 { return a + b }
+            var nilReducer Reducer = default(Reducer)
+            Console.WriteLine(Apply(5, add))
+            Console.WriteLine(Apply(5, nilReducer))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("15\n-1\n", output);
+    }
+
+    [Fact]
+    public void LegacyFuncForm_EqualsNil_GuardsAndRuns()
+    {
+        // The legacy `func(int32) int32` spelling lowers to the same
+        // FunctionTypeSymbol as the arrow form. Cover both spellings.
+        var source = """
+            package Test
+            import System
+
+            func Guard(f func(int32) int32) string {
+                if f == nil {
+                    return "nil"
+                }
+                return "bound"
+            }
+
+            var nilFn func(int32) int32 = default(func(int32) int32)
+            Console.WriteLine(Guard((x int32) -> x * 2))
+            Console.WriteLine(Guard(nilFn))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("bound\nnil\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (output, _) = CompileRunAndCaptureMethodIl(source, methodName: null);
+        return output;
+    }
+
+    private static (string Output, byte[] MethodIl) CompileRunAndCaptureMethodIl(string source, string methodName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue796_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed (exit {compileExit}):\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            byte[] methodIl = methodName != null ? ReadMethodIl(outPath, methodName) : Array.Empty<byte>();
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return (stdout.Replace("\r\n", "\n"), methodIl);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static byte[] ReadMethodIl(string assemblyPath, string methodName)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        var md = peReader.GetMetadataReader();
+        foreach (var methodHandle in md.MethodDefinitions)
+        {
+            var method = md.GetMethodDefinition(methodHandle);
+            if (md.GetString(method.Name) != methodName)
+            {
+                continue;
+            }
+
+            if (method.RelativeVirtualAddress == 0)
+            {
+                continue;
+            }
+
+            var body = peReader.GetMethodBody(method.RelativeVirtualAddress);
+            return body.GetILBytes() ?? Array.Empty<byte>();
+        }
+
+        throw new InvalidOperationException(
+            $"Method '{methodName}' not found in '{assemblyPath}'.");
+    }
+
+    // Lightweight opcode-sequence scan: walks the IL byte stream looking
+    // for the requested 1- or 2-byte opcodes appearing back-to-back
+    // (mirroring ECMA-335 §III.1.2.1 prefix rules: a 0xFE byte
+    // introduces a 2-byte opcode; otherwise a single byte is the
+    // opcode). Operands of intervening opcodes are skipped at a coarse
+    // level — both `ldnull` (1 byte, no operand) and `ceq` (2 bytes,
+    // 0xFE 0x01, no operand) have no operand bytes so the contiguity
+    // test is straightforward.
+    private static bool ContainsSequence(byte[] il, ILOpCode first, ILOpCode second)
+    {
+        var firstCode = (ushort)first;
+        var secondCode = (ushort)second;
+        int i = 0;
+        while (i < il.Length)
+        {
+            int firstSize;
+            ushort firstHere;
+            if (il[i] == 0xFE && i + 1 < il.Length)
+            {
+                firstHere = (ushort)(0xFE00 | il[i + 1]);
+                firstSize = 2;
+            }
+            else
+            {
+                firstHere = il[i];
+                firstSize = 1;
+            }
+
+            if (firstHere == firstCode)
+            {
+                int j = i + firstSize;
+                if (j < il.Length)
+                {
+                    ushort secondHere;
+                    if (il[j] == 0xFE && j + 1 < il.Length)
+                    {
+                        secondHere = (ushort)(0xFE00 | il[j + 1]);
+                    }
+                    else
+                    {
+                        secondHere = il[j];
+                    }
+
+                    if (secondHere == secondCode)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            i += firstSize;
+        }
+
+        return false;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue796FunctionAndSequenceNilCompareBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue796FunctionAndSequenceNilCompareBinderTests.cs
@@ -1,0 +1,280 @@
+// <copyright file="Issue796FunctionAndSequenceNilCompareBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #796 / ADR-0084 §L5 follow-up. The binder rejected
+/// <c>== nil</c> / <c>!= nil</c> for function-typed and sequence-typed
+/// values with <c>GS0129</c> even though both shapes are managed
+/// references at the CLR layer (delegate / IEnumerable&lt;T&gt;).
+///
+/// Extensions stdlib helpers (<c>OrCompute</c>, <c>Windowed</c>, etc.)
+/// need to guard against nil delegate / sequence arguments at the head
+/// of the method body — the C# escape hatch under
+/// <c>src/Sdk/Gsharp.Extensions/</c> already does exactly this. With
+/// the binder fix in place a G# source-port can do the same.
+///
+/// The fix lives in <see cref="BoundBinaryOperator.IsNullCompare"/>:
+/// the predicate now accepts <see cref="FunctionTypeSymbol"/>,
+/// <see cref="DelegateTypeSymbol"/>, <see cref="SequenceTypeSymbol"/>,
+/// and <see cref="AsyncSequenceTypeSymbol"/> on the non-null side.
+/// No new <c>BoundNodeKind</c> was introduced.
+/// </summary>
+public class Issue796FunctionAndSequenceNilCompareBinderTests
+{
+    [Fact]
+    public void Repro_OrCompute_FunctionParameter_Compared_To_Nil_Binds()
+    {
+        // Verbatim shape from the issue body — the `factory == nil`
+        // guard previously reported `GS0129: Binary operator '==' is
+        // not defined for types '(T) -> T' and 'nil'`.
+        const string source = @"
+package P
+import System
+
+func (self T?) OrCompute[T class](factory () -> T) T {
+    if factory == nil {
+        throw ArgumentNullException(""factory"")
+    }
+    return self ?: factory()
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void Repro_Windowed_SequenceReceiver_Compared_To_Nil_Binds()
+    {
+        // Second repro from the issue body — `self == nil` on a
+        // `sequence[T]` receiver previously reported
+        // `GS0129: Binary operator '==' is not defined for types 'sequence[T]' and 'nil'`.
+        const string source = @"
+package P
+import System
+
+func (self sequence[T]) Windowed[T](size int32) sequence[T] {
+    if self == nil {
+        throw ArgumentNullException(""source"")
+    }
+    return self
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void GenericArrowFunction_Vs_Nil_Equality_Binds()
+    {
+        // `(T) -> R` over a free type parameter — the binder must
+        // route through the FunctionTypeSymbol arm independent of any
+        // concrete element type.
+        const string source = @"
+package P
+
+func Guard[T, R](f (T) -> R) bool {
+    return f == nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void NoArgArrowFunction_Vs_Nil_Equality_Binds()
+    {
+        const string source = @"
+package P
+
+func Guard(f () -> int32) bool {
+    return f == nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void NoArgArrowFunction_Vs_Nil_Inequality_Binds()
+    {
+        const string source = @"
+package P
+
+func IsBound(f () -> int32) bool {
+    return f != nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void GenericSequence_Vs_Nil_Equality_Binds()
+    {
+        const string source = @"
+package P
+
+func IsEmpty[T](xs sequence[T]) bool {
+    return xs == nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void Int32Sequence_Vs_Nil_Equality_Binds()
+    {
+        const string source = @"
+package P
+
+func IsEmpty(xs sequence[int32]) bool {
+    return xs == nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void Int32Sequence_Vs_Nil_Inequality_Binds()
+    {
+        const string source = @"
+package P
+
+func HasAny(xs sequence[int32]) bool {
+    return xs != nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void Nil_Vs_FunctionParameter_Symmetric_Binds()
+    {
+        // The IsNullCompare arm is symmetric — `nil == f` must bind
+        // the same as `f == nil`.
+        const string source = @"
+package P
+
+func Guard(f () -> int32) bool {
+    return nil == f
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void NamedDelegateType_Vs_Nil_Equality_Binds()
+    {
+        // ADR-0059 named delegate values are reference-typed (sealed
+        // class deriving MulticastDelegate); the binder must treat
+        // them the same as the structural FunctionTypeSymbol shape.
+        const string source = @"
+package P
+
+type Reducer = delegate func(a int32, b int32) int32
+
+func Guard(f Reducer) bool {
+    return f == nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void NamedDelegateType_Vs_Nil_Inequality_Binds()
+    {
+        const string source = @"
+package P
+
+type Reducer = delegate func(a int32, b int32) int32
+
+func IsBound(f Reducer) bool {
+    return f != nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void LegacyFuncForm_Vs_Nil_Equality_Binds()
+    {
+        // The legacy `func(T) U` spelling (predates the arrow form)
+        // binds to the same FunctionTypeSymbol shape. The fix must
+        // cover both spellings.
+        const string source = @"
+package P
+
+func Guard(f func(int32) int32) bool {
+    return f == nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void LegacyFuncForm_Vs_Nil_Inequality_Binds()
+    {
+        const string source = @"
+package P
+
+func IsBound(f func(int32) int32) bool {
+    return f != nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void AsyncSequence_Vs_Nil_Equality_Binds()
+    {
+        // `sequence[T]` inside an `async func` aliases
+        // IAsyncEnumerable<T> per ADR-0041. The fix extends to the
+        // AsyncSequenceTypeSymbol shape as well.
+        const string source = @"
+package P
+
+async func Drain(xs sequence[int32]) bool {
+    return xs == nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void LocalFunctionVariable_Vs_Nil_Equality_Binds()
+    {
+        // Local typed as `() -> int32` — the receiver isn't a
+        // parameter but the same binder path applies.
+        const string source = @"
+package P
+
+func Run() bool {
+    var f () -> int32 = default(() -> int32)
+    return f == nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    private static ImmutableArray<Diagnostic> GetErrors(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree) { IsLibrary = true };
+        var parseDiagnostics = tree.Diagnostics;
+        var bindDiagnostics = compilation.GlobalScope.Diagnostics;
+        var programDiagnostics = compilation.BoundProgram.Diagnostics;
+        return parseDiagnostics
+            .Concat(bindDiagnostics)
+            .Concat(programDiagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+    }
+}

--- a/test/Interpreter.Tests/Issue796FunctionAndSequenceNilCompareInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue796FunctionAndSequenceNilCompareInterpreterTests.cs
@@ -1,0 +1,182 @@
+// <copyright file="Issue796FunctionAndSequenceNilCompareInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #796 / ADR-0084 §L5 follow-up — interpreter parity for
+/// <c>== nil</c> / <c>!= nil</c> on function-typed and sequence-typed
+/// values. The fix is in the binder
+/// (<see cref="GSharp.Core.CodeAnalysis.Binding.BoundBinaryOperator"/>'s
+/// <c>IsNullCompare</c> arm); the interpreter rides on the same bound
+/// tree, so these tests pin the runtime semantics observable via the
+/// REPL so a future emitter or evaluator change cannot diverge from
+/// the e2e-emit coverage in
+/// <c>Issue796FunctionAndSequenceNilCompareEmitTests</c>.
+/// </summary>
+public class Issue796FunctionAndSequenceNilCompareInterpreterTests
+{
+    [Fact]
+    public void FunctionParameter_EqualsNil_BindsAndEvaluates()
+    {
+        var source = """
+            func Guard(f () -> int32) string {
+                if f == nil {
+                    return "nil"
+                }
+                return "bound"
+            }
+
+            var nilFn () -> int32 = default(() -> int32)
+            Console.WriteLine(Guard(() -> 42))
+            Console.WriteLine(Guard(nilFn))
+            """;
+
+        Assert.Equal("bound\nnil\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void FunctionParameter_NotEqualNil_BindsAndEvaluates()
+    {
+        var source = """
+            func IsBound(f () -> int32) bool {
+                return f != nil
+            }
+
+            var nilFn () -> int32 = default(() -> int32)
+            Console.WriteLine(IsBound(() -> 1))
+            Console.WriteLine(IsBound(nilFn))
+            """;
+
+        Assert.Equal("True\nFalse\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void ConcreteArrowFunction_EqualsNil_BindsAndEvaluates()
+    {
+        var source = """
+            func Apply(x int32, f (int32) -> int32) bool {
+                return f == nil
+            }
+
+            var nilFn (int32) -> int32 = default((int32) -> int32)
+            Console.WriteLine(Apply(1, nilFn))
+            Console.WriteLine(Apply(1, (n int32) -> n + 1))
+            """;
+
+        Assert.Equal("True\nFalse\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void SequenceInt32_EqualsNil_BindsAndEvaluates()
+    {
+        var source = """
+            func Sum(xs sequence[int32]) int32 {
+                if xs == nil {
+                    return -1
+                }
+                var total = 0
+                for x in xs {
+                    total = total + x
+                }
+                return total
+            }
+
+            var nilSeq sequence[int32] = default(sequence[int32])
+            Console.WriteLine(Sum([]int32{1, 2, 3}))
+            Console.WriteLine(Sum(nilSeq))
+            """;
+
+        Assert.Equal("6\n-1\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void SequenceInt32_NotEqualNil_BindsAndEvaluates()
+    {
+        var source = """
+            func HasAny(xs sequence[int32]) bool {
+                return xs != nil
+            }
+
+            var nilSeq sequence[int32] = default(sequence[int32])
+            Console.WriteLine(HasAny([]int32{}))
+            Console.WriteLine(HasAny(nilSeq))
+            """;
+
+        Assert.Equal("True\nFalse\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void NamedDelegateType_EqualsNil_BindsAndEvaluates()
+    {
+        // ADR-0059 named delegate. The interpreter does not currently
+        // evaluate named-delegate constructions (`var x T = func(...)`
+        // for `T` a named delegate type bombs with `GS9999: Unexpected
+        // type` — a separate gap), so this test focuses strictly on
+        // the binder shape via a nil-typed local: the named-delegate
+        // value never has to materialise.
+        var source = """
+            type Reducer = delegate func(a int32, b int32) int32
+
+            func IsBound(f Reducer) string {
+                if f == nil {
+                    return "nil"
+                }
+                return "bound"
+            }
+
+            var nilReducer Reducer = default(Reducer)
+            Console.WriteLine(IsBound(nilReducer))
+            """;
+
+        var output = RunSubmission(source);
+        Assert.Contains("nil\n", output);
+    }
+
+    [Fact]
+    public void LegacyFuncForm_EqualsNil_BindsAndEvaluates()
+    {
+        // ADR-0075 deprecates the legacy `func(T) U` type-clause form
+        // (GS0303 warning). The interpreter still binds and runs the
+        // shape — assert the program output is correct and the
+        // warning is the only extra noise.
+        var source = """
+            func Guard(f func(int32) int32) string {
+                if f == nil {
+                    return "nil"
+                }
+                return "bound"
+            }
+
+            var nilFn func(int32) int32 = default(func(int32) int32)
+            Console.WriteLine(Guard((x int32) -> x * 2))
+            Console.WriteLine(Guard(nilFn))
+            """;
+
+        var output = RunSubmission(source);
+        Assert.Contains("bound\nnil\n", output);
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary
Allow `==` / `!=` between function-typed values (`(T) -> R`, legacy `func(T) U`, and named `delegate func(...)` types) **or** sequence-typed values (`sequence[T]`, `asyncSequence[T]`) and `nil`. Previously these surfaced `GS0129: Binary operator '==' is not defined for types ... and 'nil'.` even though the underlying CLR shape is a managed reference and the user has no `T?` spelling available.

## Root cause
`BoundBinaryOperator.IsNullCompare` only treated the non-null side as eligible when it was a `NullableTypeSymbol` (`T?` wrapper) or `TypeSymbol.Null`. Function and sequence symbols never satisfied that guard, so the only legal way to spell *"is this delegate / iterable nil?"* was rejected at bind time. This blocked the source port of `Gsharp.Extensions.Optional` / `.Sequences` (`OrCompute`, `Windowed`, ...) tracked under #792.

## Fix
Extend `IsNullCompare` to additionally accept `FunctionTypeSymbol`, `DelegateTypeSymbol`, `SequenceTypeSymbol`, and `AsyncSequenceTypeSymbol`. Emit falls through to the existing generic `ldnull; ceq` path: these shapes are all managed references at the CLR layer, so reference-equality lowering is already verifier-clean. No new `BoundNodeKind` was introduced, and the lifted-slot allocator continues to key on `leftIsValueNullable`, so value-type `Nullable<T>` keeps its dedicated spill path.

## Test coverage
- **Binder** (`test/Core.Tests/.../Issue796FunctionAndSequenceNilCompareBinderTests.cs`, 15 tests):
  - Verbatim repros from the issue (`OrCompute`, `Windowed`).
  - `(T) -> R`, `() -> int32`, `sequence[T]`, `sequence[int32]`, async-sequence.
  - Named delegate types (`type Reducer = delegate func(int32, int32) int32`).
  - Legacy `func(int32) int32` form (with the expected `GS0303` deprecation warning).
  - Symmetric `nil == f`.
  - Both `==` and `!=`.
- **Emit** (`test/Compiler.Tests/Emit/Issue796FunctionAndSequenceNilCompareEmitTests.cs`, 7 tests):
  - End-to-end `CompileAndRun` + `IlVerifier` round trip.
  - Two tests inspect the emitted method body via `PEReader.GetMethodBody().GetILBytes()` and assert the `ldnull; ceq` pattern is present, matching reference-type equality.
- **Interpreter** (`test/Interpreter.Tests/Issue796FunctionAndSequenceNilCompareInterpreterTests.cs`, 7 tests):
  - Mirrors the emit coverage through `GSharpRepl.EvaluateSubmission` so REPL semantics cannot diverge.

Full suite (`dotnet test GSharp.sln --no-restore --nologo`) green: 3107 Core, 1249 Compiler, 267 Interpreter, 264 LanguageServer, 107 Extensions tests. `ilverify` passes (restored via `dotnet tool restore`). `cd website && npm run build` passes with no broken links.

## Docs
- ADR-0084 §L5 updated: the *"no `==` between `(T) -> T` / `sequence[T]` values and `nil`"* follow-up bullet is now marked closed, with a paragraph describing the binder-layer fix.

## Links
- Closes #796
- Related: #792 (Optional / Sequences port that surfaced this gap)
- ADR: [docs/adr/0084-gsharp-extensions-optional-sequences.md](../blob/main/docs/adr/0084-gsharp-extensions-optional-sequences.md)
- Parent: #706
