### PR TITLE
Fix #797: parse @Attr annotations on members inside shared { } blocks

### DIFF
--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -320,8 +320,9 @@ of that migration, not left behind as dead code.
   inside a generic shared method)~~ (closed by issue #794), ~~no
   `default(T)` expression~~ (closed by issue #795 / ADR-0100), no
   `params` parameter declaration, ~~no `==` between `(T) -> T` /
-  `sequence[T]` values and `nil`~~ (closed by issue #796), no
-  `[MethodImpl(...)]` annotation parsing inside `shared { }` blocks,
+  `sequence[T]` values and `nil`~~ (closed by issue #796), ~~no
+  `[MethodImpl(...)]` annotation parsing inside `shared { }` blocks~~
+  (closed by issue #797),
   no `yield` inside a shared-static method that returns
   `IEnumerable[T]`. Each is filed as a focused follow-up. The C#
   escape hatch under `src/Sdk/Gsharp.Extensions/Optional/` and
@@ -361,6 +362,22 @@ of that migration, not left behind as dead code.
   shape (verifier-clean for any managed reference). No new
   `BoundNodeKind` was introduced; the change is a single predicate
   extension.
+
+  Issue #797 closed the fifth follow-up bullet: the shared-block
+  member loop in `Parser.ParseSharedBlock` did not call
+  `ParseAnnotations()`, so a leading `@MethodImpl(...)` on a
+  shared-static method was reinterpreted as the start of a field
+  declaration and rejected. The fix mirrors the instance-member
+  surface in `ParseAggregateDeclaration`: each iteration now parses
+  any leading `@Foo` lead-ins (ADR-0047 §3) and forwards the
+  collected list via `.WithAnnotations(memberAnnotations)` onto the
+  resulting field / method / property / event syntax node. The
+  binder side already consumed `syntax.Annotations` on every shared
+  member (see `DeclarationBinder` shared-block paths), so the bound
+  symbols now carry the annotation and the emitter writes the
+  expected `CustomAttribute` rows on the MethodDef / FieldDef /
+  PropertyDef. Unlocks the `Sequences.Range` / `Optional.Map` port
+  hot-path marking with `[MethodImpl(AggressiveInlining)]`.
 
 ## Consequences
 

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -1926,6 +1926,12 @@ public class Parser
         {
             var startToken = Current;
 
+            // Issue #797: each shared-block member may be preceded by
+            // Kotlin-style `@Foo` annotations (ADR-0047 §3), mirroring the
+            // instance-member surface in ParseAggregateDeclaration. The default
+            // target follows the member kind (field/method/property/event).
+            var memberAnnotations = ParseAnnotations();
+
             SyntaxToken memberAccessibility = null;
             if (Current.Kind == SyntaxKind.PublicKeyword ||
                 Current.Kind == SyntaxKind.InternalKeyword ||
@@ -1965,7 +1971,9 @@ public class Parser
                     Diagnostics.ReportUnexpectedToken(sharedMemberAsyncModifier.Location, SyntaxKind.AsyncKeyword, SyntaxKind.FuncKeyword);
                 }
 
-                properties.Add(ParsePropertyDeclaration(memberAccessibility, null, null));
+                var property = ParsePropertyDeclaration(memberAccessibility, null, null);
+                property.WithAnnotations(memberAnnotations);
+                properties.Add(property);
             }
             else if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "event")
             {
@@ -1974,11 +1982,15 @@ public class Parser
                     Diagnostics.ReportUnexpectedToken(sharedMemberAsyncModifier.Location, SyntaxKind.AsyncKeyword, SyntaxKind.FuncKeyword);
                 }
 
-                events.Add(ParseEventDeclaration(memberAccessibility, null, null));
+                var eventDecl = ParseEventDeclaration(memberAccessibility, null, null);
+                eventDecl.WithAnnotations(memberAnnotations);
+                events.Add(eventDecl);
             }
             else if (Current.Kind == SyntaxKind.FuncKeyword)
             {
-                methods.Add((FunctionDeclarationSyntax)ParseFunctionDeclaration(memberAccessibility, openModifier: null, overrideModifier: null, sharedMemberAsyncModifier));
+                var method = (FunctionDeclarationSyntax)ParseFunctionDeclaration(memberAccessibility, openModifier: null, overrideModifier: null, sharedMemberAsyncModifier);
+                method.WithAnnotations(memberAnnotations);
+                methods.Add(method);
             }
             else
             {
@@ -1987,7 +1999,7 @@ public class Parser
                     Diagnostics.ReportUnexpectedToken(sharedMemberAsyncModifier.Location, SyntaxKind.AsyncKeyword, SyntaxKind.FuncKeyword);
                 }
 
-                fields.Add(ParseFieldDeclaration());
+                fields.Add(ParseFieldDeclaration().WithAnnotations(memberAnnotations));
             }
 
             if (Current == startToken)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue797SharedBlockAnnotationBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue797SharedBlockAnnotationBinderTests.cs
@@ -1,0 +1,151 @@
+// <copyright file="Issue797SharedBlockAnnotationBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #797: confirms that Kotlin-style <c>@Foo</c> annotations parsed on
+/// members of a <c>shared { … }</c> block (ADR-0053) reach the bound member
+/// symbol via <see cref="DeclarationBinder"/>. Prior to #797 the parser
+/// silently dropped the annotation by reinterpreting the leading <c>@</c>
+/// as the start of a field declaration; the binder never saw it.
+/// </summary>
+public class Issue797SharedBlockAnnotationBinderTests
+{
+    [Fact]
+    public void AnnotationOnStaticMethod_BindsToStaticMethodSymbol()
+    {
+        const string source = @"
+package P
+
+class Sample {
+    shared {
+        @Obsolete
+        func Run() {
+        }
+    }
+}
+";
+        var scope = BindSource(source);
+        Assert.Empty(scope.Diagnostics);
+
+        var sample = scope.Structs.Single(s => s.Name == "Sample");
+        var run = Assert.Single(sample.StaticMethods);
+        Assert.Equal("Run", run.Name);
+        Assert.True(run.IsStatic);
+        var attr = Assert.Single(run.Attributes);
+        Assert.Equal("System.ObsoleteAttribute", attr.AttributeType.Name);
+        Assert.Equal(AttributeTargetKind.Method, attr.Target);
+    }
+
+    [Fact]
+    public void AnnotationWithStringArgument_OnStaticMethod_BindsArgument()
+    {
+        const string source = @"
+package P
+
+class Sample {
+    shared {
+        @Obsolete(""please call NewRun instead"")
+        func Run() {
+        }
+    }
+}
+";
+        var scope = BindSource(source);
+        Assert.Empty(scope.Diagnostics);
+
+        var run = scope.Structs.Single(s => s.Name == "Sample").StaticMethods.Single();
+        var attr = Assert.Single(run.Attributes);
+        var posArg = Assert.Single(attr.PositionalArguments);
+        Assert.Equal("please call NewRun instead", posArg.Value);
+    }
+
+    [Fact]
+    public void StackedAnnotations_OnStaticMethod_AreAllBound()
+    {
+        // Mirrors `AttributeBinderTests.Binds_Multiple_Stacked_Annotations` —
+        // both attribute applications are recorded on the symbol even though
+        // the binder emits a duplicate-application diagnostic for `[Obsolete]`
+        // (AllowMultiple = false).
+        const string source = @"
+package P
+
+class Sample {
+    shared {
+        @Obsolete
+        @Obsolete(""again"")
+        func Run() {
+        }
+    }
+}
+";
+        var scope = BindSource(source);
+
+        var run = scope.Structs.Single(s => s.Name == "Sample").StaticMethods.Single();
+        Assert.Equal(2, run.Attributes.Length);
+    }
+
+    [Fact]
+    public void AnnotationOnStaticField_BindsToFieldSymbol()
+    {
+        const string source = @"
+package P
+
+class Config {
+    shared {
+        @Obsolete
+        var Threshold int32 = 0
+    }
+}
+";
+        var scope = BindSource(source);
+        Assert.Empty(scope.Diagnostics);
+
+        var config = scope.Structs.Single(s => s.Name == "Config");
+        var threshold = Assert.Single(config.StaticFields);
+        Assert.Equal("Threshold", threshold.Name);
+        Assert.True(threshold.IsStatic);
+        var attr = Assert.Single(threshold.Attributes);
+        Assert.Equal("System.ObsoleteAttribute", attr.AttributeType.Name);
+        Assert.Equal(AttributeTargetKind.Field, attr.Target);
+    }
+
+    [Fact]
+    public void AnnotationOnStaticProperty_BindsToPropertySymbol()
+    {
+        const string source = @"
+package P
+
+class Config {
+    shared {
+        @Obsolete
+        prop Name string
+    }
+}
+";
+        var scope = BindSource(source);
+        Assert.Empty(scope.Diagnostics);
+
+        var config = scope.Structs.Single(s => s.Name == "Config");
+        var name = Assert.Single(config.StaticProperties);
+        Assert.True(name.IsStatic);
+        var attr = Assert.Single(name.Attributes);
+        Assert.Equal("System.ObsoleteAttribute", attr.AttributeType.Name);
+        Assert.Equal(AttributeTargetKind.Property, attr.Target);
+    }
+
+    private static BoundGlobalScope BindSource(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue797SharedBlockAnnotationEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue797SharedBlockAnnotationEmitTests.cs
@@ -1,0 +1,72 @@
+// <copyright file="Issue797SharedBlockAnnotationEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #797: end-to-end emit verification that a Kotlin-style annotation
+/// on a static method declared inside a <c>shared { … }</c> block
+/// (ADR-0053) survives the parser → binder → emitter pipeline and lands as
+/// a real <c>CustomAttribute</c> row on the emitted MethodDef.
+/// </summary>
+public class Issue797SharedBlockAnnotationEmitTests
+{
+    [Fact]
+    public void AnnotationOnSharedStaticMethod_IsEmittedOnMethodDef()
+    {
+        const string Source = @"package Issue797.SharedAttrEmit
+
+import System
+
+class Sequences {
+    shared {
+        @Obsolete(""issue-797 marker"")
+        func Range(start int32, count int32) int32 {
+            return start + count
+        }
+    }
+}
+";
+        var asm = CompileToAssembly(Source, "Issue797.SharedAttrEmit");
+
+        var seqType = asm.GetTypes().Single(t => t.Name == "Sequences");
+        var range = seqType.GetMethod(
+            "Range",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+        Assert.NotNull(range);
+        Assert.True(range!.IsStatic, "Range should be emitted as a static method (shared { } block).");
+
+        var obsolete = range.GetCustomAttributes(typeof(ObsoleteAttribute), inherit: false)
+            .Cast<ObsoleteAttribute>()
+            .SingleOrDefault();
+        Assert.NotNull(obsolete);
+        Assert.Equal("issue-797 marker", obsolete!.Message);
+    }
+
+    private static Assembly CompileToAssembly(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: false);
+        return loadContext.LoadFromStream(peStream);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue797SharedBlockAnnotationParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue797SharedBlockAnnotationParserTests.cs
@@ -1,0 +1,180 @@
+// <copyright file="Issue797SharedBlockAnnotationParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #797: parser support for Kotlin-style <c>@Foo</c> annotations
+/// (ADR-0047 §3) on members declared inside a <c>shared { … }</c> block
+/// (ADR-0053). The top-level / instance-member surface accepts <c>@Foo</c>
+/// lead-ins on every member kind; before #797 the shared-block parser
+/// treated a leading <c>@</c> as the start of a field declaration and
+/// rejected programs like
+/// <c>shared { @MethodImpl(...) func Range(...) sequence[int32] { ... } }</c>.
+/// </summary>
+public class Issue797SharedBlockAnnotationParserTests
+{
+    [Fact]
+    public void Repro_FromIssue_ParsesCleanly()
+    {
+        // The exact source quoted in the issue body. The signature uses
+        // `sequence[int32]` so it exercises the same return-type shape the
+        // dogfooded `Sequences.Range` helper expects.
+        const string source = @"
+package P
+
+class Sequences {
+    shared {
+        @MethodImpl(MethodImplOptions.AggressiveInlining)
+        func Range(start int32, count int32) sequence[int32] {
+            return nil
+        }
+    }
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        Assert.NotNull(structDecl.SharedBlock);
+        var method = Assert.Single(structDecl.SharedBlock.Methods);
+        Assert.Equal("Range", method.Identifier.Text);
+        var annotation = Assert.Single(method.Annotations);
+        Assert.Equal("MethodImpl", annotation.GetNameText());
+        Assert.True(annotation.HasArgumentList);
+    }
+
+    [Fact]
+    public void StackedAnnotations_OnSharedMethod_AreAttached()
+    {
+        const string source = @"
+package P
+
+class Native {
+    shared {
+        @MethodImpl(MethodImplOptions.AggressiveInlining)
+        @DllImport(""libfoo"")
+        func Bar(x int32) int32 {
+            return x
+        }
+    }
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var method = tree.Root.Members
+            .OfType<StructDeclarationSyntax>().Single()
+            .SharedBlock!.Methods.Single();
+        Assert.Equal("Bar", method.Identifier.Text);
+        Assert.Equal(2, method.Annotations.Length);
+        Assert.Equal("MethodImpl", method.Annotations[0].GetNameText());
+        Assert.Equal("DllImport", method.Annotations[1].GetNameText());
+    }
+
+    [Theory]
+    [InlineData("public")]
+    [InlineData("internal")]
+    [InlineData("private")]
+    public void AnnotationFollowedByAccessibilityModifiedFunc_Parses(string accessibility)
+    {
+        // ADR-0085 / ADR-0090 / ADR-0053: visibility modifiers may precede the
+        // method in a `shared { }` block; the annotation must apply to the
+        // resulting method (not to a phantom field).
+        var source = $@"
+package P
+
+class Sample {{
+    shared {{
+        @Obsolete
+        {accessibility} func Run() {{
+        }}
+    }}
+}}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var method = tree.Root.Members
+            .OfType<StructDeclarationSyntax>().Single()
+            .SharedBlock!.Methods.Single();
+        Assert.Equal("Run", method.Identifier.Text);
+        Assert.NotNull(method.AccessibilityModifier);
+        Assert.Equal(accessibility, method.AccessibilityModifier.Text);
+        var annotation = Assert.Single(method.Annotations);
+        Assert.Equal("Obsolete", annotation.GetNameText());
+    }
+
+    [Fact]
+    public void AnnotationOnSharedField_IsAttached()
+    {
+        const string source = @"
+package P
+
+class Config {
+    shared {
+        @Obsolete
+        var Threshold int32 = 0
+    }
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var field = tree.Root.Members
+            .OfType<StructDeclarationSyntax>().Single()
+            .SharedBlock!.Fields.Single();
+        Assert.Equal("Threshold", field.Identifier.Text);
+        var annotation = Assert.Single(field.Annotations);
+        Assert.Equal("Obsolete", annotation.GetNameText());
+    }
+
+    [Fact]
+    public void AnnotationOnSharedProperty_IsAttached()
+    {
+        const string source = @"
+package P
+
+class Config {
+    shared {
+        @Obsolete
+        prop Name string
+    }
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var property = tree.Root.Members
+            .OfType<StructDeclarationSyntax>().Single()
+            .SharedBlock!.Properties.Single();
+        Assert.Equal("Name", property.Identifier.Text);
+        var annotation = Assert.Single(property.Annotations);
+        Assert.Equal("Obsolete", annotation.GetNameText());
+    }
+
+    [Fact]
+    public void AnnotationFollowedByNonMemberToken_StillReportsParserDiagnostic()
+    {
+        // Negative: after consuming `@Obsolete`, the next token (`42`) is not
+        // a legal start of any member; the field-declaration fallback must
+        // surface its usual GS0288 (missing `var`/`let`) or similar error.
+        const string source = @"
+package P
+
+class Sample {
+    shared {
+        @Obsolete
+        42
+    }
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.NotEmpty(tree.Diagnostics);
+    }
+}


### PR DESCRIPTION
## Summary

Restores the Kotlin-style `@Foo` annotation lead-in (ADR-0047 §3) on members declared inside a `shared { … }` block (ADR-0053). Discovered while porting `Gsharp.Extensions.Sequences` to G# under #792 — `@MethodImpl(MethodImplOptions.AggressiveInlining)` on `Sequences.Range` was rejected by the parser.

## Root cause

`Parser.ParseSharedBlock` did not call `ParseAnnotations()` at the start of each member iteration. The top-level / instance-member surface in `ParseAggregateDeclaration` handles annotations correctly, but the shared-block loop dropped straight into the accessibility / kind disambiguator, so a leading `@` was reinterpreted as the start of a field declaration and the program was rejected.

## Fix

Mirror the instance-member path in `ParseSharedBlock`: parse leading `@Foo` lead-ins on each iteration and forward the collected list onto the resulting field / method / property / event syntax node via `.WithAnnotations(memberAnnotations)`. The binder already consumes `syntax.Annotations` on every shared-block member (see the static-fields / static-methods / static-properties / static-events loops in `DeclarationBinder`), so the bound symbols now carry the annotation and the emitter writes the expected `CustomAttribute` rows.

No `BoundNodeKind` was added; the change is a single parser-layer extension that reuses the existing `MemberSyntax.WithAnnotations` slot.

## Tests added

| Layer | File | What it covers |
|---|---|---|
| Parser | `Issue797SharedBlockAnnotationParserTests.cs` (8 tests) | Exact issue repro; stacked `@MethodImpl; @DllImport`; `@Attr` + `public`/`internal`/`private func`; `@Attr` on shared field & property; negative `@Attr` + non-member token still diagnoses. |
| Binder | `Issue797SharedBlockAnnotationBinderTests.cs` (5 tests) | Annotation reaches `FunctionSymbol` / `FieldSymbol` / `PropertySymbol` on the bound `StructSymbol.StaticMethods` / `StaticFields` / `StaticProperties` with the right `AttributeTargetKind`. |
| Emit | `Issue797SharedBlockAnnotationEmitTests.cs` (1 test) | End-to-end: `@Obsolete("...")` on a shared-static method lands as a real `ObsoleteAttribute` CustomAttribute row on the emitted static MethodDef (verified via reflection). |

## Verification

- `dotnet build GSharp.sln`: 0 warnings, 0 errors.
- `dotnet test GSharp.sln --no-restore`: 5040 tests passed, 1 skipped (`RegenerateBaseline`), 0 failed across Core (3121), Compiler (1249), Interpreter (267), LanguageServer (264), Extensions (107), Sdk (32).
- `ilverify` clean (covered by `IlVerifier.Verify` in the existing emit-test pipeline).
- `cd website && npm run build`: succeeds, no broken links.

## Docs

ADR-0084 §L5 updated: the `[MethodImpl(...)]` bullet is marked closed and a "closed by #797" paragraph documents the root cause and fix (alongside the existing #794 / #796 closures).

Closes #797
Related #792
Parent #706