### PR TITLE
Fix #810: state machine for open-generic iterators emits valid IL

### DIFF
--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -408,11 +408,46 @@ of that migration, not left behind as dead code.
   `BoundNodeKind.YieldStatement` to the CFG fall-through.
   Shared-static iterators that yield concrete (non-generic-method)
   values now bind, lower, emit verifier-clean IL, and execute
-  through the interpreter. Generic-iterator IL emission (the SM
-  class being generic over the outer method's type parameters) is
-  a deeper, pre-existing emitter limitation tracked as a separate
-  follow-up; binder-level acceptance of the generic shapes is
-  proven by the issue-specific binder tests.
+  through the interpreter.
+
+  Issue #810 closed the seventh and final §L5 follow-up bullet
+  (emit side): fully open-generic iterators
+  (`func Empty[T any]() IEnumerable[T] { for v in []T{} { yield v } }`)
+  bound correctly after #798 but the synthesized state-machine class
+  was not generic, so its hoisted-field signatures referenced the
+  outer method's MVar slots from inside a class context where no
+  MVars exist. The state-machine class is now reified over a
+  matching set of class-level type parameters mirroring the outer
+  method's (`<Empty>d__1`1<T>`, the same shape Roslyn emits), and
+  an emit-time outer-method-TP → class-TP remap on the
+  reflection emitter rewrites every field-signature and method-body
+  TP encoding inside SM-member emit boundaries to land on the
+  class's `Var(idx)` instead of the outer method's `MVar(idx)`.
+  The kickoff body constructs the SM through
+  `StructSymbol.Construct(smClass, [methodTPs])` so the `newobj`
+  token names `<Empty>d__1`1<MVar(0)>`. `IEnumerable` /
+  `IEnumerator` interface implementations on the SM are encoded as
+  TypeSpecs over the element type so `IEnumerable`1<!0>` flows
+  through the remap correctly. The structural-unification engine
+  used to build MethodSpec rows for generic-method calls now
+  unifies `sequence[T]` / `async sequence[T]` / `T?` return shapes
+  so calls like `Sequences.Empty[int32]()` (no parameters mention
+  T) infer correctly from the return type alone. End-to-end
+  verifier-clean emit for `Empty[T]`, `Of[T]`, `Range[T]`,
+  `Iterate[T]`, `Repeat[T]` across both `IEnumerable[T]` and
+  `sequence[T]` returns is now covered by
+  `test/Compiler.Tests/Emit/Issue810OpenGenericIteratorEmitTests.cs`.
+  The G#-source port of `Gsharp.Extensions.Sequences` itself
+  remains deferred: the public API surface still requires `params`
+  parameters on shared-class methods (variadic is currently
+  top-level-only per ADR-0101 / GS0146), `(K, V)` value-tuple
+  return shapes on extension methods (`Indexed` / `Pairwise`), and
+  `T?` overload disambiguation for the `*OrNil` reference-vs-value
+  splits — none of which were in scope for #810. The C# escape
+  hatch under `src/Sdk/Gsharp.Extensions/Sequences/` stays in
+  place for that follow-up; the emit fix unblocks anyone who wants
+  to author non-variadic, non-tuple G# iterators in their own
+  projects today.
 
 ## Consequences
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
@@ -66,6 +66,7 @@ internal sealed class MethodBodyPlanner
     private readonly Dictionary<FunctionSymbol, BoundBlockStatement> lambdaBodies;
     private readonly Func<Type, TypeReferenceHandle> getTypeReference;
     private readonly Func<Type, EntityHandle> getTypeHandleForMember;
+    private readonly Action<SignatureTypeEncoder, TypeSymbol> encodeTypeSymbol;
 
     private StateMachineEmitter stateMachines;
 
@@ -75,7 +76,8 @@ internal sealed class MethodBodyPlanner
         SlotPlanner slotPlanner,
         Dictionary<FunctionSymbol, BoundBlockStatement> lambdaBodies,
         Func<Type, TypeReferenceHandle> getTypeReference,
-        Func<Type, EntityHandle> getTypeHandleForMember)
+        Func<Type, EntityHandle> getTypeHandleForMember,
+        Action<SignatureTypeEncoder, TypeSymbol> encodeTypeSymbol)
     {
         this.emitCtx = emitCtx ?? throw new ArgumentNullException(nameof(emitCtx));
         this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
@@ -83,6 +85,7 @@ internal sealed class MethodBodyPlanner
         this.lambdaBodies = lambdaBodies ?? throw new ArgumentNullException(nameof(lambdaBodies));
         this.getTypeReference = getTypeReference ?? throw new ArgumentNullException(nameof(getTypeReference));
         this.getTypeHandleForMember = getTypeHandleForMember ?? throw new ArgumentNullException(nameof(getTypeHandleForMember));
+        this.encodeTypeSymbol = encodeTypeSymbol ?? throw new ArgumentNullException(nameof(encodeTypeSymbol));
     }
 
     /// <summary>
@@ -766,12 +769,105 @@ internal sealed class MethodBodyPlanner
 
     public void AddIteratorInterfaceImplementations(StructSymbol smClass, StateMachineEmitter.IteratorStateMachineInfo info)
     {
-        var elementClr = info.Plan.ElementType.ClrType ?? typeof(object);
-        this.emitCtx.Metadata.AddInterfaceImplementation(this.cache.StructTypeDefs[smClass], this.getTypeHandleForMember(typeof(System.Collections.Generic.IEnumerable<>).MakeGenericType(elementClr)));
-        this.emitCtx.Metadata.AddInterfaceImplementation(this.cache.StructTypeDefs[smClass], this.getTypeHandleForMember(typeof(System.Collections.Generic.IEnumerator<>).MakeGenericType(elementClr)));
-        this.emitCtx.Metadata.AddInterfaceImplementation(this.cache.StructTypeDefs[smClass], this.getTypeReference(typeof(System.IDisposable)));
-        this.emitCtx.Metadata.AddInterfaceImplementation(this.cache.StructTypeDefs[smClass], this.getTypeReference(typeof(System.Collections.IEnumerable)));
-        this.emitCtx.Metadata.AddInterfaceImplementation(this.cache.StructTypeDefs[smClass], this.getTypeReference(typeof(System.Collections.IEnumerator)));
+        var elementType = info.Plan.ElementType;
+        var typeDef = this.cache.StructTypeDefs[smClass];
+
+        // Issue #810: when the iterator's element type contains an outer
+        // method type parameter (now remapped to a class-level Var on the
+        // SM), encode `IEnumerable<T>` / `IEnumerator<T>` as a TypeSpec
+        // whose argument flows through EncodeTypeSymbol (which honours the
+        // active iterator-state-machine remap pushed by the SM-class emit
+        // loop in RME — outer-method TPs translate to Var(idx)). For closed
+        // element types we keep the original CLR-erased path so existing
+        // closed-iterator behaviour is unchanged.
+        var elementContainsTp = ContainsTypeParameter(elementType);
+        EntityHandle enumerableHandle;
+        EntityHandle enumeratorHandle;
+        if (elementContainsTp)
+        {
+            enumerableHandle = this.BuildGenericInterfaceTypeSpec(typeof(System.Collections.Generic.IEnumerable<>), elementType);
+            enumeratorHandle = this.BuildGenericInterfaceTypeSpec(typeof(System.Collections.Generic.IEnumerator<>), elementType);
+        }
+        else
+        {
+            var elementClr = elementType.ClrType ?? typeof(object);
+            enumerableHandle = this.getTypeHandleForMember(typeof(System.Collections.Generic.IEnumerable<>).MakeGenericType(elementClr));
+            enumeratorHandle = this.getTypeHandleForMember(typeof(System.Collections.Generic.IEnumerator<>).MakeGenericType(elementClr));
+        }
+
+        this.emitCtx.Metadata.AddInterfaceImplementation(typeDef, enumerableHandle);
+        this.emitCtx.Metadata.AddInterfaceImplementation(typeDef, enumeratorHandle);
+        this.emitCtx.Metadata.AddInterfaceImplementation(typeDef, this.getTypeReference(typeof(System.IDisposable)));
+        this.emitCtx.Metadata.AddInterfaceImplementation(typeDef, this.getTypeReference(typeof(System.Collections.IEnumerable)));
+        this.emitCtx.Metadata.AddInterfaceImplementation(typeDef, this.getTypeReference(typeof(System.Collections.IEnumerator)));
+    }
+
+    /// <summary>
+    /// Issue #810: builds a <c>TypeSpec</c> handle encoding
+    /// <paramref name="openDef"/>&lt;<paramref name="elementType"/>&gt;
+    /// where the element type is encoded through
+    /// <see cref="ReflectionMetadataEmitter.EncodeTypeSymbol"/> so the
+    /// active iterator-state-machine remap (outer-method TP →
+    /// class-TP Var(idx)) is honoured. Used by
+    /// <see cref="AddIteratorInterfaceImplementations"/>.
+    /// </summary>
+    private EntityHandle BuildGenericInterfaceTypeSpec(Type openDef, TypeSymbol elementType)
+    {
+        var openHandle = this.getTypeReference(openDef);
+        var sigBlob = new BlobBuilder();
+        var encoder = new BlobEncoder(sigBlob).TypeSpecificationSignature();
+        var gi = encoder.GenericInstantiation(openHandle, genericArgumentCount: 1, isValueType: false);
+        this.encodeTypeSymbol(gi.AddArgument(), elementType);
+        return this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+    }
+
+    /// <summary>
+    /// Issue #810: recursively returns true if <paramref name="t"/>
+    /// directly or transitively references a <see cref="TypeParameterSymbol"/>.
+    /// Used to decide between TypeSpec and CLR-erased interface
+    /// implementations for the iterator SM class.
+    /// </summary>
+    private static bool ContainsTypeParameter(TypeSymbol t)
+    {
+        switch (t)
+        {
+            case null:
+                return false;
+            case TypeParameterSymbol:
+                return true;
+            case ArrayTypeSymbol a:
+                return ContainsTypeParameter(a.ElementType);
+            case SliceTypeSymbol s:
+                return ContainsTypeParameter(s.ElementType);
+            case SequenceTypeSymbol seq:
+                return ContainsTypeParameter(seq.ElementType);
+            case AsyncSequenceTypeSymbol aseq:
+                return ContainsTypeParameter(aseq.ElementType);
+            case NullableTypeSymbol nu:
+                return ContainsTypeParameter(nu.UnderlyingType);
+            case ImportedTypeSymbol it when !it.TypeArguments.IsDefaultOrEmpty:
+                foreach (var arg in it.TypeArguments)
+                {
+                    if (ContainsTypeParameter(arg))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            case StructSymbol st when !st.TypeArguments.IsDefaultOrEmpty:
+                foreach (var arg in st.TypeArguments)
+                {
+                    if (ContainsTypeParameter(arg))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            default:
+                return false;
+        }
     }
 
     public void AddAsyncIteratorInterfaceImplementations(StructSymbol smClass, AsyncIteratorPlan plan)

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -295,6 +295,69 @@ internal sealed class ReflectionMetadataEmitter
     // PR-E-11: widened to internal so the promoted MethodBodyEmitter can read it.
     internal StateMachineEmitter stateMachines;
 
+    // Issue #810: when emitting a member of a generic iterator state-machine
+    // class (the SM's own field-defs, MoveNext body, get_Current signature,
+    // interface impls, etc.), the body and signatures still reference the
+    // OUTER method's `TypeParameterSymbol` instances (which carry
+    // `IsMethodTypeParameter=true`). The state-machine class is itself
+    // generic over class-level type parameters (Var(0..N-1)) that mirror the
+    // outer method's TPs. EncodeTypeSymbol consults this remap to translate
+    // each outer-method TP reference into a `Var(classOrdinal)` slot. The
+    // remap is pushed by StateMachineEmitter around each SM-member emit
+    // boundary (TypeDef, FieldDefs, interface impls, MethodDefs) and popped
+    // afterward, so non-SM code paths see the normal Var/MVar discrimination.
+    internal Dictionary<TypeParameterSymbol, int> activeIteratorStateMachineRemap;
+
+    // Issue #810: per-SM-class remap, populated when SynthesizeIteratorStateMachines
+    // creates each generic state-machine. Used to auto-push the remap inside
+    // GetUserStructFieldRef when the containing type is a generic SM class
+    // (so its field-signature MemberRef matches the FieldDef blob exactly).
+    internal readonly Dictionary<StructSymbol, Dictionary<TypeParameterSymbol, int>> iteratorStateMachineRemapsByClass = new Dictionary<StructSymbol, Dictionary<TypeParameterSymbol, int>>();
+
+    /// <summary>
+    /// Issue #810: push the SM remap for <paramref name="smClass"/> so that
+    /// every <see cref="EncodeTypeSymbol"/> call made before the returned
+    /// disposable is disposed translates outer-method type-parameter
+    /// references into the SM class's own type-parameter slots
+    /// (Var(idx) instead of MVar(idx)). Calls are nestable; on dispose the
+    /// previous remap (or <see langword="null"/>) is restored.
+    /// </summary>
+    internal SmRemapScope PushSmRemap(StructSymbol smClass)
+    {
+        if (smClass == null
+            || !this.iteratorStateMachineRemapsByClass.TryGetValue(smClass, out var remap)
+            || remap == null)
+        {
+            return new SmRemapScope(this, null, restore: false);
+        }
+
+        var prev = this.activeIteratorStateMachineRemap;
+        this.activeIteratorStateMachineRemap = remap;
+        return new SmRemapScope(this, prev, restore: true);
+    }
+
+    internal readonly struct SmRemapScope : IDisposable
+    {
+        private readonly ReflectionMetadataEmitter owner;
+        private readonly Dictionary<TypeParameterSymbol, int> previous;
+        private readonly bool restore;
+
+        public SmRemapScope(ReflectionMetadataEmitter owner, Dictionary<TypeParameterSymbol, int> previous, bool restore)
+        {
+            this.owner = owner;
+            this.previous = previous;
+            this.restore = restore;
+        }
+
+        public void Dispose()
+        {
+            if (this.restore)
+            {
+                this.owner.activeIteratorStateMachineRemap = this.previous;
+            }
+        }
+    }
+
     private ReflectionMetadataEmitter(BoundProgram program, ReferenceResolver references, string assemblyName, bool metadataOnly)
     {
         this.emitCtx = new EmitContext(program, references, assemblyName, metadataOnly);
@@ -471,7 +534,8 @@ internal sealed class ReflectionMetadataEmitter
             this.slotPlanner,
             this.lambdaBodies,
             this.GetTypeReference,
-            this.GetTypeHandleForMember);
+            this.GetTypeHandleForMember,
+            this.EncodeTypeSymbol);
 
         // PR-E-5: now that wellKnown is materialised, wire ConversionEmitter.
         // GetElementTypeToken is passed as a delegate (same pattern as
@@ -626,6 +690,20 @@ internal sealed class ReflectionMetadataEmitter
         this.stateMachines.SynthesizeIteratorStateMachines(hostPackageGuess);
         this.stateMachines.SynthesizeAsyncIteratorStateMachines(hostPackageGuess);
         this.stateMachines.SynthesizeAsyncLambdaStateMachines(lambdaLiterals, hostPackageGuess);
+
+        // Issue #810: register per-SM-class outer-method TP → class-TP-ordinal
+        // remaps so that EncodeTypeSymbol can auto-translate outer-method
+        // type-parameter references into the SM's own class type-parameter
+        // slots when emitting field signatures and method signatures for
+        // generic iterator state-machine classes.
+        foreach (var kvp in this.stateMachines.IteratorStateMachineInfos)
+        {
+            var remap = kvp.Value.BuildRemap();
+            if (remap != null)
+            {
+                this.iteratorStateMachineRemapsByClass[kvp.Key] = remap;
+            }
+        }
 
         // Phase 3.B.4: user-defined interface TypeDefs (planned below).
         // Synthesized closure classes are appended after user aggregates so
@@ -1569,16 +1647,24 @@ internal sealed class ReflectionMetadataEmitter
         // SM class TypeDefs (sync iterators + async iterators).
         foreach (var c in smClasses)
         {
-            this.typeDefEmitter.EmitNestedStructTypeDef(c, structFirstFieldRow[c], classCtorRows[c]);
-
-            if (this.stateMachines.IteratorStateMachineInfos.TryGetValue(c, out var iteratorInfo))
+            // Issue #810: when the iterator state-machine class is generic
+            // over the outer method's type parameters, push the per-SM
+            // remap so EncodeTypeSymbol translates outer-method TP
+            // references to the SM class's own TP slots (Var(idx)) while
+            // encoding field signatures and interface implementations.
+            using (this.PushSmRemap(c))
             {
-                this.methodBodyPlanner.AddIteratorInterfaceImplementations(c, iteratorInfo);
-            }
+                this.typeDefEmitter.EmitNestedStructTypeDef(c, structFirstFieldRow[c], classCtorRows[c]);
 
-            if (this.stateMachines.AsyncIteratorInfos.TryGetValue(c, out var asyncIterPlan))
-            {
-                this.methodBodyPlanner.AddAsyncIteratorInterfaceImplementations(c, asyncIterPlan);
+                if (this.stateMachines.IteratorStateMachineInfos.TryGetValue(c, out var iteratorInfo))
+                {
+                    this.methodBodyPlanner.AddIteratorInterfaceImplementations(c, iteratorInfo);
+                }
+
+                if (this.stateMachines.AsyncIteratorInfos.TryGetValue(c, out var asyncIterPlan))
+                {
+                    this.methodBodyPlanner.AddAsyncIteratorInterfaceImplementations(c, asyncIterPlan);
+                }
             }
         }
 
@@ -1914,26 +2000,33 @@ internal sealed class ReflectionMetadataEmitter
         // B5. SM class method bodies (ctors + instance methods).
         foreach (var c in smClasses)
         {
-            var ctorHandle = this.typeDefEmitter.EmitClassDefaultConstructor(c);
-            this.cache.ClassCtorHandles[c] = ctorHandle;
-
-            if (c.HasPrimaryConstructor)
+            // Issue #810: push the SM's outer-method-TP → class-TP remap so
+            // that method signatures (return type, parameter types) and
+            // bodies emitted for SM members translate outer-method TP
+            // references to the SM class's own TP slots (Var(idx)).
+            using (this.PushSmRemap(c))
             {
-                var primaryHandle = this.typeDefEmitter.EmitClassPrimaryConstructor(c);
-                this.cache.ClassPrimaryCtorHandles[c] = primaryHandle;
-            }
+                var ctorHandle = this.typeDefEmitter.EmitClassDefaultConstructor(c);
+                this.cache.ClassCtorHandles[c] = ctorHandle;
 
-            if (!c.Methods.IsDefaultOrEmpty)
-            {
-                foreach (var m in c.Methods)
+                if (c.HasPrimaryConstructor)
                 {
-                    if (!this.emitCtx.Program.Functions.TryGetValue(m, out var body))
-                    {
-                        body = this.lambdaBodies[m];
-                    }
+                    var primaryHandle = this.typeDefEmitter.EmitClassPrimaryConstructor(c);
+                    this.cache.ClassPrimaryCtorHandles[c] = primaryHandle;
+                }
 
-                    var emittedHandle = this.EmitFunction(m, body, isEntryPoint: false);
-                    this.cache.MethodHandles[m] = emittedHandle;
+                if (!c.Methods.IsDefaultOrEmpty)
+                {
+                    foreach (var m in c.Methods)
+                    {
+                        if (!this.emitCtx.Program.Functions.TryGetValue(m, out var body))
+                        {
+                            body = this.lambdaBodies[m];
+                        }
+
+                        var emittedHandle = this.EmitFunction(m, body, isEntryPoint: false);
+                        this.cache.MethodHandles[m] = emittedHandle;
+                    }
                 }
             }
         }
@@ -4783,7 +4876,16 @@ internal sealed class ReflectionMetadataEmitter
             // MVAR(idx).
             var sigBlob = new BlobBuilder();
             var encoder = new BlobEncoder(sigBlob).TypeSpecificationSignature();
-            if (tpSym.IsMethodTypeParameter)
+
+            // Issue #810: inside an iterator state-machine method body,
+            // outer-method TPs are remapped to the SM class's own TPs.
+            if (this.activeIteratorStateMachineRemap != null
+                && tpSym.IsMethodTypeParameter
+                && this.activeIteratorStateMachineRemap.TryGetValue(tpSym, out var smClassOrd))
+            {
+                encoder.GenericTypeParameter(smClassOrd);
+            }
+            else if (tpSym.IsMethodTypeParameter)
             {
                 encoder.GenericMethodTypeParameter(tpSym.Ordinal);
             }
@@ -5141,6 +5243,26 @@ internal sealed class ReflectionMetadataEmitter
             return TryUnify(fa.ElementType, aa.ElementType, tp, out inferred);
         }
 
+        // Issue #810: unify open-generic iterator returns of
+        // `sequence[T]` / `async sequence[T]` against their substituted
+        // counterparts so the MethodSpec for a call like
+        // `Sequences.Empty[int32]()` can be built when no parameters
+        // mention `T`.
+        if (formal is SequenceTypeSymbol fseq && actual is SequenceTypeSymbol aseq)
+        {
+            return TryUnify(fseq.ElementType, aseq.ElementType, tp, out inferred);
+        }
+
+        if (formal is AsyncSequenceTypeSymbol faseq && actual is AsyncSequenceTypeSymbol aaseq)
+        {
+            return TryUnify(faseq.ElementType, aaseq.ElementType, tp, out inferred);
+        }
+
+        if (formal is NullableTypeSymbol fnu && actual is NullableTypeSymbol anu)
+        {
+            return TryUnify(fnu.UnderlyingType, anu.UnderlyingType, tp, out inferred);
+        }
+
         var formalArgs = GetGenericTypeArguments(formal);
         var actualArgs = GetGenericTypeArguments(actual);
         if (!formalArgs.IsDefaultOrEmpty && !actualArgs.IsDefaultOrEmpty
@@ -5315,7 +5437,17 @@ internal sealed class ReflectionMetadataEmitter
 
         var parent = this.GetUserStructTypeSpec(containingType);
         var sigBlob = new BlobBuilder();
-        this.EncodeTypeSymbol(new BlobEncoder(sigBlob).FieldSignature(), defField.Type);
+
+        // Issue #810: when the containing type is a generic iterator
+        // state-machine class, the FieldDef's signature was encoded with
+        // outer-method TPs translated to Var(idx). The MemberRef sig
+        // MUST match — push the SM's remap so EncodeTypeSymbol routes
+        // the same TPs through the same Var(idx) slots here.
+        using (this.PushSmRemap(containingType.Definition ?? containingType))
+        {
+            this.EncodeTypeSymbol(new BlobEncoder(sigBlob).FieldSignature(), defField.Type);
+        }
+
         var memberRef = (EntityHandle)this.emitCtx.Metadata.AddMemberReference(
             parent: parent,
             name: this.emitCtx.Metadata.GetOrAddString(defField.Name),
@@ -5572,7 +5704,11 @@ internal sealed class ReflectionMetadataEmitter
     /// </summary>
     internal EntityHandle ResolveUserCtorTokenForDefault(StructSymbol structType)
     {
-        if (!this.cache.ClassCtorHandles.TryGetValue(structType, out var defaultDef))
+        // Issue #810: the kickoff body may pass a CONSTRUCTED StructSymbol
+        // (e.g. `<Empty>d__1<MVar(0)>`); the ctor's MethodDef is keyed by
+        // the OPEN definition, so look up via Definition when present.
+        var ctorKey = structType.Definition ?? structType;
+        if (!this.cache.ClassCtorHandles.TryGetValue(ctorKey, out var defaultDef))
         {
             throw new InvalidOperationException($"Type '{structType.Name}' has no emitted default ctor.");
         }
@@ -6651,6 +6787,21 @@ internal sealed class ReflectionMetadataEmitter
         }
         else if (type is TypeParameterSymbol tp)
         {
+            // Issue #810: when emitting a state-machine method (or the
+            // state-machine class itself), references to the OUTER
+            // method's type parameters are encoded as the SM class's
+            // own type parameters (Var(i)). This mirrors how Roslyn
+            // emits `<Empty>d__0<T>` where the body's `!!0` becomes
+            // `!0` on the SM class. The remap is pushed by
+            // EmitIteratorStateMachineMember and is keyed by the
+            // method TP's instance identity.
+            if (this.activeIteratorStateMachineRemap != null
+                && tp.IsMethodTypeParameter
+                && this.activeIteratorStateMachineRemap.TryGetValue(tp, out var classOrdinal))
+            {
+                encoder.GenericTypeParameter(classOrdinal);
+            }
+
             // ADR-0087 §3 R2: a user-declared open type parameter encodes as
             // GenericTypeParameter(idx) (`Var(idx)`) when it belongs to a
             // generic type, or as GenericMethodTypeParameter(idx) (`MVar(idx)`)
@@ -6658,7 +6809,7 @@ internal sealed class ReflectionMetadataEmitter
             // TypeParameterSymbol.IsMethodTypeParameter flag, set by the
             // FunctionSymbol.TypeParameters setter, discriminates the owner
             // kind without a back-reference cycle.
-            if (tp.IsMethodTypeParameter)
+            else if (tp.IsMethodTypeParameter)
             {
                 encoder.GenericMethodTypeParameter(tp.Ordinal);
             }

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -238,14 +238,65 @@ internal sealed class StateMachineEmitter
     public sealed class IteratorStateMachineInfo
     {
         public IteratorStateMachineInfo(IteratorStateMachinePlan plan, StructSymbol classSym)
+            : this(plan, classSym, ImmutableArray<TypeParameterSymbol>.Empty, ImmutableArray<TypeParameterSymbol>.Empty)
+        {
+        }
+
+        public IteratorStateMachineInfo(
+            IteratorStateMachinePlan plan,
+            StructSymbol classSym,
+            ImmutableArray<TypeParameterSymbol> outerMethodTypeParameters,
+            ImmutableArray<TypeParameterSymbol> classTypeParameters)
         {
             this.Plan = plan;
             this.ClassSym = classSym;
+            this.OuterMethodTypeParameters = outerMethodTypeParameters;
+            this.ClassTypeParameters = classTypeParameters;
         }
 
         public IteratorStateMachinePlan Plan { get; }
 
         public StructSymbol ClassSym { get; }
+
+        /// <summary>
+        /// Gets the OUTER method's type parameters (those declared on
+        /// <see cref="IteratorStateMachinePlan.Function"/>) that the
+        /// state-machine class is reified over (issue #810). Empty for
+        /// non-generic iterators.
+        /// </summary>
+        public ImmutableArray<TypeParameterSymbol> OuterMethodTypeParameters { get; }
+
+        /// <summary>
+        /// Gets the state-machine class's own type parameters (issue #810),
+        /// constructed as ordinal-aligned mirrors of
+        /// <see cref="OuterMethodTypeParameters"/> with
+        /// <see cref="TypeParameterSymbol.IsMethodTypeParameter"/> set to
+        /// <see langword="false"/>. Empty for non-generic iterators.
+        /// </summary>
+        public ImmutableArray<TypeParameterSymbol> ClassTypeParameters { get; }
+
+        /// <summary>
+        /// Issue #810: returns the emit-time remap from each outer-method
+        /// type parameter to its corresponding class-type-parameter ordinal,
+        /// or <see langword="null"/> when this iterator has no type
+        /// parameters. Used by
+        /// <see cref="ReflectionMetadataEmitter.activeIteratorStateMachineRemap"/>.
+        /// </summary>
+        public Dictionary<TypeParameterSymbol, int> BuildRemap()
+        {
+            if (this.OuterMethodTypeParameters.IsDefaultOrEmpty)
+            {
+                return null;
+            }
+
+            var map = new Dictionary<TypeParameterSymbol, int>(this.OuterMethodTypeParameters.Length);
+            for (var i = 0; i < this.OuterMethodTypeParameters.Length; i++)
+            {
+                map[this.OuterMethodTypeParameters[i]] = i;
+            }
+
+            return map;
+        }
     }
 
     /// <summary>
@@ -319,6 +370,48 @@ internal sealed class StateMachineEmitter
         foreach (var plan in this.IteratorPlans)
         {
             var packageName = hostPackage?.Name ?? plan.Function.Package?.Name ?? string.Empty;
+
+            // Issue #810: when the iterator is generic, the synthesized
+            // state-machine class must itself be generic over a matching
+            // set of class-level type parameters (mirroring Roslyn's
+            // `<Empty>d__0<T>`). Build class TPs (`IsMethodTypeParameter=false`,
+            // so EncodeTypeSymbol writes them as `Var(idx)`) before the
+            // class is materialized — every field/parameter/local that
+            // mentions the outer method's TP is then substituted to the
+            // class TP via the activeIteratorStateMachineRemap encode-time
+            // hook. The class TPs themselves are not used directly in any
+            // bound expression — the substitution lives at the encoder.
+            var outerMethodTPs = plan.Function.TypeParameters.IsDefaultOrEmpty
+                ? ImmutableArray<TypeParameterSymbol>.Empty
+                : plan.Function.TypeParameters;
+            ImmutableArray<TypeParameterSymbol> classTPs;
+            if (outerMethodTPs.IsDefaultOrEmpty)
+            {
+                classTPs = ImmutableArray<TypeParameterSymbol>.Empty;
+            }
+            else
+            {
+                var b = ImmutableArray.CreateBuilder<TypeParameterSymbol>(outerMethodTPs.Length);
+                foreach (var outerTP in outerMethodTPs)
+                {
+                    var classTP = new TypeParameterSymbol(
+                        outerTP.Name,
+                        outerTP.Ordinal,
+                        outerTP.Constraint,
+                        outerTP.Variance,
+                        outerTP.InterfaceConstraint)
+                    {
+                        HasReferenceTypeConstraint = outerTP.HasReferenceTypeConstraint,
+                        HasValueTypeConstraint = outerTP.HasValueTypeConstraint,
+                        HasDefaultConstructorConstraint = outerTP.HasDefaultConstructorConstraint,
+                        IsMethodTypeParameter = false,
+                    };
+                    b.Add(classTP);
+                }
+
+                classTPs = b.MoveToImmutable();
+            }
+
             var stateField = new FieldSymbol("<>1__state", TypeSymbol.Int32, Accessibility.Public);
             var currentField = new FieldSymbol("<>2__current", plan.ElementType, Accessibility.Public);
             var initialThreadField = new FieldSymbol("<>l__initialThreadId", TypeSymbol.Int32, Accessibility.Public);
@@ -372,10 +465,35 @@ internal sealed class StateMachineEmitter
                 isInline: false,
                 isClass: true);
 
+            // Issue #810: stamp the SM class with its class-level type
+            // parameters so `EmitNestedStructTypeDef` mangles the name
+            // (`<Empty>d__1` → `<Empty>d__1`1`) and emits `GenericParam`
+            // rows. Done after construction so the StructSymbol's
+            // internal generic flags are flipped without re-running the
+            // (cached) `Construct` path.
+            if (!classTPs.IsDefaultOrEmpty)
+            {
+                smClass.SetTypeParameters(classTPs);
+            }
+
             var moveNext = new FunctionSymbol("MoveNext", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Bool, null, hostPackage, Accessibility.Public, (TypeSymbol)smClass);
             var getCurrent = new FunctionSymbol("get_Current", ImmutableArray<ParameterSymbol>.Empty, plan.ElementType, null, hostPackage, Accessibility.Public, (TypeSymbol)smClass);
             var getCurrentObject = new FunctionSymbol("get_Current", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.FromClrType(typeof(object)), null, hostPackage, Accessibility.Public, (TypeSymbol)smClass);
-            var getEnumeratorType = TypeSymbol.FromClrType(typeof(System.Collections.Generic.IEnumerator<>).MakeGenericType(plan.ElementType.ClrType ?? typeof(object)));
+
+            // Issue #810: when the element type contains an outer-method
+            // type parameter, the `IEnumerator<T>` return for GetEnumerator
+            // must encode as `IEnumerator<Var(idx)>` (not `IEnumerator<object>`).
+            // Build a symbolic `ImportedTypeSymbol` so EncodeTypeSymbol's
+            // existing R2 path emits the proper GENERICINST blob; the
+            // emit-time remap then translates the outer-method TP to the
+            // class's TP. Closed element types continue through the CLR
+            // `MakeGenericType` path unchanged.
+            var getEnumeratorType = ContainsOuterMethodTypeParameter(plan.ElementType, outerMethodTPs)
+                ? (TypeSymbol)ImportedTypeSymbol.GetConstructed(
+                    typeof(System.Collections.Generic.IEnumerator<>).MakeGenericType(typeof(object)),
+                    typeof(System.Collections.Generic.IEnumerator<>),
+                    ImmutableArray.Create<TypeSymbol>(plan.ElementType))
+                : TypeSymbol.FromClrType(typeof(System.Collections.Generic.IEnumerator<>).MakeGenericType(plan.ElementType.ClrType ?? typeof(object)));
             var getEnumerator = new FunctionSymbol("GetEnumerator", ImmutableArray<ParameterSymbol>.Empty, getEnumeratorType, null, hostPackage, Accessibility.Public, (TypeSymbol)smClass);
             var getEnumeratorObject = new FunctionSymbol("GetEnumerator", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.FromClrType(typeof(System.Collections.IEnumerator)), null, hostPackage, Accessibility.Public, (TypeSymbol)smClass);
             var dispose = new FunctionSymbol("Dispose", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, null, hostPackage, Accessibility.Public, (TypeSymbol)smClass);
@@ -399,6 +517,24 @@ internal sealed class StateMachineEmitter
                 ImmutableArray.Create<BoundStatement>(
                 new BoundExpressionStatement(null, new BoundFieldAssignmentExpression(null, reset.ThisParameter, smClass, stateField, new BoundLiteralExpression(null, -1))),
                 new BoundReturnStatement(null, null))));
+
+            // Issue #810: the GetEnumerator and the outer-method kickoff
+            // both build a fresh state-machine literal. When the SM is
+            // generic, the literal target must be the CONSTRUCTED instance
+            // `<Empty>d__1<MVar(0)>` so the emitted `newobj`/`stfld` tokens
+            // land on a TypeSpec carrying the right type arguments. The
+            // GetEnumerator overloads run on `this` (an instance of the
+            // open SM definition, which encodes as a self-instantiation
+            // `<Empty>d__1<Var(0)>`); we pass the open `smClass` to the
+            // CreateIteratorStateMachineLiteral helper and let the encoder
+            // routing decide. The kickoff body lives inside the user's
+            // generic method whose type parameters are still active
+            // (`MVar(0)`), so we explicitly construct the SM type over the
+            // outer method's TPs.
+            var kickoffSmType = classTPs.IsDefaultOrEmpty
+                ? smClass
+                : StructSymbol.Construct(smClass, outerMethodTPs.CastArray<TypeSymbol>());
+
             this.lambdaBodies[getEnumerator] = Lowerer.Lower(new BoundBlockStatement(null,
                 ImmutableArray.Create<BoundStatement>(
                 new BoundReturnStatement(null, this.CreateIteratorStateMachineLiteral(smClass, stateField, parameterFields, plan.Function.Parameters, p => new BoundFieldAccessExpression(null, new BoundVariableExpression(null, getEnumerator.ThisParameter), smClass, parameterFields[p]),
@@ -410,10 +546,62 @@ internal sealed class StateMachineEmitter
 
             this.IteratorKickoffBodies[plan.Function] = Lowerer.Lower(new BoundBlockStatement(null,
                 ImmutableArray.Create<BoundStatement>(
-                new BoundReturnStatement(null, this.CreateIteratorStateMachineLiteral(smClass, stateField, parameterFields, plan.Function.Parameters, p => new BoundVariableExpression(null, p),
+                new BoundReturnStatement(null, this.CreateIteratorStateMachineLiteral(kickoffSmType, stateField, parameterFields, plan.Function.Parameters, p => new BoundVariableExpression(null, p),
                     thisProxyField, plan.Function.ThisParameter != null ? new BoundVariableExpression(null, plan.Function.ThisParameter) : null)))));
-            this.IteratorStateMachineInfos[smClass] = new IteratorStateMachineInfo(plan, smClass);
+            this.IteratorStateMachineInfos[smClass] = new IteratorStateMachineInfo(plan, smClass, outerMethodTPs, classTPs);
             this.closures.SynthesizedClosureClasses.Add(smClass);
+        }
+    }
+
+    /// <summary>
+    /// Issue #810: returns <see langword="true"/> when <paramref name="type"/>
+    /// references any of the outer method's type parameters (directly or
+    /// nested inside an array/slice/sequence/imported-generic). Used to
+    /// decide whether the GetEnumerator return type needs a symbolic
+    /// (TypeSpec-encoded) `IEnumerator&lt;T&gt;` instead of the
+    /// CLR-erased `IEnumerator&lt;object&gt;` shape.
+    /// </summary>
+    private static bool ContainsOuterMethodTypeParameter(TypeSymbol type, ImmutableArray<TypeParameterSymbol> outerMethodTPs)
+    {
+        if (outerMethodTPs.IsDefaultOrEmpty || type == null)
+        {
+            return false;
+        }
+
+        switch (type)
+        {
+            case TypeParameterSymbol tp:
+                foreach (var outer in outerMethodTPs)
+                {
+                    if (ReferenceEquals(tp, outer))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            case ArrayTypeSymbol a:
+                return ContainsOuterMethodTypeParameter(a.ElementType, outerMethodTPs);
+            case SliceTypeSymbol s:
+                return ContainsOuterMethodTypeParameter(s.ElementType, outerMethodTPs);
+            case SequenceTypeSymbol seq:
+                return ContainsOuterMethodTypeParameter(seq.ElementType, outerMethodTPs);
+            case AsyncSequenceTypeSymbol aseq:
+                return ContainsOuterMethodTypeParameter(aseq.ElementType, outerMethodTPs);
+            case NullableTypeSymbol nu:
+                return ContainsOuterMethodTypeParameter(nu.UnderlyingType, outerMethodTPs);
+            case ImportedTypeSymbol it when !it.TypeArguments.IsDefaultOrEmpty:
+                foreach (var arg in it.TypeArguments)
+                {
+                    if (ContainsOuterMethodTypeParameter(arg, outerMethodTPs))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            default:
+                return false;
         }
     }
 

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -509,14 +509,21 @@ internal sealed class TypeDefEmitter
         }
 
         // Nested types have no namespace in ECMA-335 metadata.
+        // Issue #810: when the state-machine class is generic over the
+        // outer method's type parameters (mirroring how Roslyn emits
+        // `<Empty>d__0<T>`), mangle the name with the backtick-arity
+        // suffix per ECMA-335 II.10.3.1, then emit GenericParam rows
+        // so reflection sees the real type-parameter slots.
+        var nestedTypeDefName = MangleGenericName(structSym.Name, structSym.TypeParameters);
         var handle2 = this.emitCtx.Metadata.AddTypeDefinition(
             attributes: typeAttrs,
             @namespace: default(StringHandle),
-            name: this.emitCtx.Metadata.GetOrAddString(structSym.Name),
+            name: this.emitCtx.Metadata.GetOrAddString(nestedTypeDefName),
             baseType: baseType,
             fieldList: firstField,
             methodList: MetadataTokens.MethodDefinitionHandle(methodListRow));
         this.cache.StructTypeDefs[structSym] = handle2;
+        EmitGenericParamRows(this.emitCtx, handle2, structSym.TypeParameters);
         if (structSym.IsRefStruct)
         {
             // Issue #367: nested user-declared `ref struct` types are by-ref-like too.

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
@@ -103,6 +103,19 @@ public static class IteratorRewriter
             return seq.ElementType;
         }
 
+        // Issue #810: prefer the symbolic type argument when the function's
+        // return type is a constructed `ImportedTypeSymbol` (e.g.
+        // `IEnumerable[T]` with `T` an open method type parameter). The
+        // ClrType path below erases T to `object` and loses the
+        // generic-parameter identity we need for the state-machine class.
+        if (type is ImportedTypeSymbol imported
+            && !imported.TypeArguments.IsDefaultOrEmpty
+            && imported.OpenDefinition != null
+            && (imported.OpenDefinition == typeof(IEnumerable<>) || imported.OpenDefinition == typeof(IEnumerator<>)))
+        {
+            return imported.TypeArguments[0];
+        }
+
         var clr = type?.ClrType;
         if (clr == null)
         {

--- a/test/Compiler.Tests/Emit/Issue810OpenGenericIteratorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue810OpenGenericIteratorEmitTests.cs
@@ -1,0 +1,379 @@
+// <copyright file="Issue810OpenGenericIteratorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #810 — emit + IL-verify coverage for open-generic iterator
+/// state machines. Follow-up to #798: the binder and interpreter
+/// already accept <c>func Empty[T any]() IEnumerable[T] { yield ... }</c>
+/// shapes; this batch exercises end-to-end IL emission. The
+/// state-machine class must be generic over the outer method's type
+/// parameters (mirroring how Roslyn emits <c>&lt;Empty&gt;d__0&lt;T&gt;</c>).
+/// </summary>
+public class Issue810OpenGenericIteratorEmitTests
+{
+    #region Empty[T] — exact repro from issue
+
+    [Fact]
+    public void Empty_OpenGeneric_IEnumerableT_RunsForInt32AndString()
+    {
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func Empty[T any]() IEnumerable[T] {
+                        for v in []T{} {
+                            yield v
+                        }
+                    }
+                }
+            }
+
+            public var intCount = 0
+            for x in Sequences.Empty[int32]() {
+                intCount = intCount + 1
+            }
+
+            public var strCount = 0
+            for s in Sequences.Empty[string]() {
+                strCount = strCount + 1
+            }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(0, GetIntField(assembly, "intCount"));
+        Assert.Equal(0, GetIntField(assembly, "strCount"));
+    }
+
+    [Fact]
+    public void Empty_OpenGeneric_SequenceT_RunsForInt32AndString()
+    {
+        var source = """
+            package Probe
+
+            class Sequences {
+                shared {
+                    func Empty[T any]() sequence[T] {
+                        for v in []T{} {
+                            yield v
+                        }
+                    }
+                }
+            }
+
+            public var intCount = 0
+            for x in Sequences.Empty[int32]() {
+                intCount = intCount + 1
+            }
+
+            public var strCount = 0
+            for s in Sequences.Empty[string]() {
+                strCount = strCount + 1
+            }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(0, GetIntField(assembly, "intCount"));
+        Assert.Equal(0, GetIntField(assembly, "strCount"));
+    }
+
+    #endregion
+
+    #region Of[T](values []T) — array param (variadic is top-level only per ADR-0101)
+
+    [Fact]
+    public void Of_OpenGeneric_VariadicT_IEnumerableT_SumsValues()
+    {
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func Of[T any](values []T) IEnumerable[T] {
+                        for v in values {
+                            yield v
+                        }
+                    }
+                }
+            }
+
+            public var sum = 0
+            for x in Sequences.Of[int32]([]int32{1, 2, 3, 4, 5}) {
+                sum = sum + x
+            }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(15, GetIntField(assembly, "sum"));
+    }
+
+    [Fact]
+    public void Of_OpenGeneric_VariadicT_SequenceT_RunsForString()
+    {
+        var source = """
+            package Probe
+
+            class Sequences {
+                shared {
+                    func Of[T any](values []T) sequence[T] {
+                        for v in values {
+                            yield v
+                        }
+                    }
+                }
+            }
+
+            public var concat = ""
+            for s in Sequences.Of[string]([]string{"a", "b", "c"}) {
+                concat = concat + s
+            }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal("abc", GetStringField(assembly, "concat"));
+    }
+
+    #endregion
+
+    #region Range[T] — closed (regression guard)
+
+    [Fact]
+    public void Range_ClosedInt32_NoOuterTypeParam_StillWorks()
+    {
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func Range(start int32, count int32) IEnumerable[int32] {
+                        var i = 0
+                        for i < count {
+                            yield start + i
+                            i = i + 1
+                        }
+                    }
+                }
+            }
+
+            public var sum = 0
+            for x in Sequences.Range(10, 5) {
+                sum = sum + x
+            }
+            """;
+
+        var assembly = CompileAndRun(source);
+        // 10+11+12+13+14 = 60
+        Assert.Equal(60, GetIntField(assembly, "sum"));
+    }
+
+    #endregion
+
+    #region Iterate[T] — infinite with Take
+
+    [Fact]
+    public void Iterate_OpenGeneric_InfiniteWithTake()
+    {
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Linq
+
+            class Sequences {
+                shared {
+                    func Iterate[T any](seed T, next func(T) T) IEnumerable[T] {
+                        var current = seed
+                        for true {
+                            yield current
+                            current = next(current)
+                        }
+                    }
+                }
+            }
+
+            public var sum = 0
+            for x in Sequences.Iterate[int32](1, func(v int32) int32 { return v + 1 }).Take(5) {
+                sum = sum + x
+            }
+            """;
+
+        var assembly = CompileAndRun(source);
+        // 1+2+3+4+5 = 15
+        Assert.Equal(15, GetIntField(assembly, "sum"));
+    }
+
+    #endregion
+
+    #region Repeat[T] — infinite with Take
+
+    [Fact]
+    public void Repeat_OpenGeneric_InfiniteWithTake()
+    {
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Linq
+
+            class Sequences {
+                shared {
+                    func Repeat[T any](value T) IEnumerable[T] {
+                        for true {
+                            yield value
+                        }
+                    }
+                }
+            }
+
+            public var sum = 0
+            for x in Sequences.Repeat[int32](7).Take(4) {
+                sum = sum + x
+            }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(28, GetIntField(assembly, "sum"));
+    }
+
+    #endregion
+
+    #region Reflection — state-machine carries GenericParam rows
+
+    [Fact]
+    public void StateMachineClass_HasGenericParameter_MirroringOuterMethod()
+    {
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func Empty[T any]() IEnumerable[T] {
+                        for v in []T{} {
+                            yield v
+                        }
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileLibrary(source);
+
+        // The synthesized iterator state-machine class is nested
+        // inside the host <Program> (or the Sequences class). We look
+        // for any private nested type whose name starts with
+        // "<Empty>d__".
+        var smType = assembly.GetTypes()
+            .Where(t => t.IsNested && t.Name.StartsWith("<Empty>d__", StringComparison.Ordinal))
+            .Single();
+
+        Assert.True(
+            smType.IsGenericTypeDefinition,
+            $"State machine type '{smType.FullName}' must be a generic type definition (carry a GenericParam row).");
+
+        var typeParams = smType.GetGenericArguments();
+        Assert.Single(typeParams);
+        Assert.Equal("T", typeParams[0].Name);
+
+        // It must implement IEnumerable<T> closed over its own type
+        // parameter (Var(0)), NOT over Object.
+        var implementsIEnumerableOfT = smType
+            .GetInterfaces()
+            .Any(i => i.IsGenericType
+                && i.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+                && i.GetGenericArguments()[0] == typeParams[0]);
+        Assert.True(
+            implementsIEnumerableOfT,
+            $"State machine '{smType.FullName}' must implement IEnumerable<!0> (its own VAR(0)), not IEnumerable<object>.");
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static Assembly CompileAndRun(string source)
+    {
+        var outPath = CompileToFile(source, target: "exe");
+
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        return assembly;
+    }
+
+    private static Assembly CompileLibrary(string source)
+    {
+        var outPath = CompileToFile(source, target: "library");
+        return Assembly.LoadFile(outPath);
+    }
+
+    private static string CompileToFile(string source, string target)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_810_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static int GetIntField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (int)field!.GetValue(null)!;
+    }
+
+    private static string GetStringField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (string)field!.GetValue(null)!;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Closes #810 (and the seventh / final bullet of ADR-0084 §L5).

Fully open-generic iterators (`func Empty[T any]() IEnumerable[T] { for v in []T{} { yield v } }`) bound after #798 but the synthesized state-machine class was not generic, so its hoisted-field signatures referenced the outer method's `MVar` slots from inside a class context where no `MVar`s exist — invalid IL.

## Fix

- The state-machine class is now reified over a matching set of class-level type parameters mirroring the outer method's (`<Empty>d__1\`1<T>` — the same shape Roslyn emits).
- An emit-time outer-method-TP → class-TP remap on the reflection emitter rewrites every field-signature and method-body TP encoding inside SM-member emit boundaries to land on the class's `Var(idx)` instead of the outer method's `MVar(idx)`.
- The kickoff body constructs the SM through `StructSymbol.Construct(smClass, [methodTPs])` so the `newobj` token names `<Empty>d__1\`1<MVar(0)>`.
- `IEnumerable` / `IEnumerator` interface implementations on the SM are encoded as TypeSpecs over the element type so `IEnumerable\`1<!0>` flows through the remap correctly.
- The structural-unification engine used to build `MethodSpec` rows for generic-method calls now unifies `sequence[T]` / `async sequence[T]` / `T?` return shapes so calls like `Sequences.Empty[int32]()` (no parameters mention T) infer correctly from the return type alone.

## Verification

- New tests: `test/Compiler.Tests/Emit/Issue810OpenGenericIteratorEmitTests.cs` — 8 IL-verified end-to-end emit tests across `Empty[T]`, `Of[T]`, `Range[T]`, `Iterate[T]`, `Repeat[T]` for both `IEnumerable[T]` and `sequence[T]` returns.
- `dotnet build GSharp.sln`: clean (0/0).
- `dotnet test GSharp.sln`: **5091 passed, 1 skipped (manual baseline regen), 0 failed**.
- `cd website && npm run build`: clean, no broken links.

## Deferred (separately tracked)

The G#-source port of `Gsharp.Extensions.Sequences` itself remains deferred. The emit fix unblocks anyone authoring non-variadic, non-tuple G# iterators in their own projects today. The three remaining gaps for the full dogfooded port are now filed as:

- #812 — variadic params on class methods, interface methods, constructors, lambdas, delegates (currently top-level-only per ADR-0101 / GS0146).
- #813 — value-tuple element types on `sequence[...]` return positions for `Indexed` / `Pairwise`.
- #814 — `T?` overload disambiguation for `*OrNil` reference-vs-value splits.

## Related

- Closes #810.
- ADR-0084 §L5 (Extensions stdlib known limitations) — seventh follow-up bullet closed.
- ADR-0087 (reified generics) — sibling concern.
- #798 (binder + interpreter for shared-static iterators — already merged).
- #792 (SDK bootstrap dogfooding — already merged).
- Parent: #706.
