### PR TITLE
Fix #814: T? overload disambiguation for *OrNil class/struct splits

### DIFF
--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -440,14 +440,15 @@ of that migration, not left behind as dead code.
   The G#-source port of `Gsharp.Extensions.Sequences` itself
   remains deferred: the public API surface still requires `params`
   parameters on shared-class methods (variadic is currently
-  top-level-only per ADR-0101 / GS0146), `(K, V)` value-tuple
-  return shapes on extension methods (`Indexed` / `Pairwise`), and
-  `T?` overload disambiguation for the `*OrNil` reference-vs-value
-  splits — none of which were in scope for #810. The C# escape
+  top-level-only per ADR-0101 / GS0146), ~~`(K, V)` value-tuple
+  return shapes on extension methods (`Indexed` / `Pairwise`)~~
+  (closed by issue #813), and ~~`T?` overload disambiguation for
+  the `*OrNil` reference-vs-value splits~~ (closed by issue #814)
+  — neither of the latter two were in scope for #810. The C# escape
   hatch under `src/Sdk/Gsharp.Extensions/Sequences/` stays in
-  place for that follow-up; the emit fix unblocks anyone who wants
-  to author non-variadic, non-tuple G# iterators in their own
-  projects today.
+  place for the remaining `params` follow-up; the emit fix unblocks
+  anyone who wants to author non-variadic, non-tuple G# iterators
+  in their own projects today.
 
   Issue #813 closes the value-tuple return-shape gap left by #810.
   Iterators whose element type is a tuple — `func Indexed[T]()
@@ -490,6 +491,47 @@ of that migration, not left behind as dead code.
   return shapes), and
   `test/Interpreter.Tests/Issue813TupleSequenceReturnInterpreterTests.cs`
   for tree-walking parity at the closed instantiation.
+
+  Issue #814 closes the third remaining §L5 bullet: same-name
+  overload pairs that are distinguished *only* by `[T class]` vs
+  `[T struct]` constraints (the exact shape required by
+  `Sequences.FirstOrNil` / `LastOrNil` / `SingleOrNil`) now bind,
+  emit verifier-clean IL, and execute through both the compiler and
+  the interpreter. ADR-0088 (#750) added the constraint-aware
+  filter for *imported* methods and ADR-0097 (#775) gave G# the
+  syntactic spelling, but the emit side encoded `T?` as bare
+  `!!T` (so even with `T : class` the `ldnull` → `T` shape was
+  rejected by ilverify, and with `T : struct` the `Nullable<T>`
+  semantics were lost outright). The fix encodes
+  `NullableTypeSymbol(TypeParameterSymbol)` as
+  `GENERICINST Nullable<MVAR/VAR>` whenever the underlying TP
+  carries `HasValueTypeConstraint` (driving both `EncodeTypeSymbol`
+  and `GetElementTypeToken` to land on a `Nullable<!!T>` TypeSpec),
+  threads the `nil` → `Nullable<TP>` literal conversion through the
+  same `BoundDefaultExpression` lowering used for closed
+  nullables (so `EmitDefault` materialises a `ldloca; initobj`
+  pair instead of the unverifiable `ldnull`), and synthesises a
+  TypeSpec-parented `Nullable<!!T>::.ctor(!0)` MemberRef (cached
+  per open TP) so the value-type lift of a concrete `T` value into
+  `T?` resolves correctly under instantiation. The interpreter side
+  re-routes `MethodInfo.Invoke` / `PropertyInfo.GetValue` whenever
+  the literal declaring type is unassignable from the receiver's
+  runtime type — the lowered `for v in self` loop carries the
+  symbolic `IEnumerable<object>::GetEnumerator` MethodInfo, but
+  `int[]` does not implement `IEnumerable<object>` (CLR array
+  covariance is reference-only), so the new
+  `ResolveMethodForReceiver` / `ResolvePropertyOrFieldForReceiver`
+  helpers walk the receiver's generic interface map to find the
+  matching closed `IEnumerable<int>` / `IEnumerator<int>` member.
+  Coverage:
+  `test/Core.Tests/CodeAnalysis/Binding/Issue814OrNilOverloadTests.cs`
+  for the binder + interpreter (eight tests covering both `class`
+  and `struct` resolution across all three `*OrNil` helpers,
+  diagnostic for unconstrained call sites, and end-to-end
+  tree-walking execution), and
+  `test/Compiler.Tests/Emit/Issue814OrNilOverloadEmitTests.cs`
+  for the IL-verified emit path (eight tests, all `IlVerifier.Verify`
+  clean).
 
 ## Consequences
 

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -366,9 +366,19 @@ internal sealed class ConversionClassifier
         // shares the CLR representation of `T` and is fine emitting `ldnull`,
         // so it continues through the normal BoundConversionExpression path
         // below.
+        //
+        // Issue #814 / ADR-0084 §L5: the same lowering also applies when the
+        // underlying type is an open type parameter — for `[T struct]` the
+        // representation is `Nullable<!!T>` (which requires `initobj`), and
+        // for `[T class]` an open `T` slot is verifier-strict (the C#
+        // compiler also emits `ldloca; initobj !!T` instead of `ldnull`
+        // even with a `class` constraint, since `ldnull → !!T` is rejected
+        // by ECMA-335 stack typing). Routing both constraint kinds through
+        // BoundDefaultExpression produces uniformly verifiable IL.
         if (expression.Type == TypeSymbol.Null
             && type is NullableTypeSymbol nilTargetNullable
-            && nilTargetNullable.UnderlyingType?.ClrType is { IsValueType: true })
+            && (nilTargetNullable.UnderlyingType?.ClrType is { IsValueType: true }
+                || nilTargetNullable.UnderlyingType is TypeParameterSymbol))
         {
             return new BoundDefaultExpression(null, type);
         }

--- a/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
+++ b/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
@@ -137,6 +137,17 @@ internal sealed class MetadataTokenCache
         = new Dictionary<CtorRefSymbolKey, MemberReferenceHandle>();
 
     /// <summary>
+    /// Gets the cache mapping an open type parameter <c>T</c> (constrained to
+    /// <c>struct</c>) to the <see cref="MemberReferenceHandle"/> for
+    /// <c>System.Nullable`1&lt;!!T&gt;::.ctor(!0)</c> (issue #814 / ADR-0084 §L5).
+    /// The parent TypeSpec uses the same VAR/MVAR slot as the wrapping
+    /// method's signature, so a single MemberRef per <c>T</c> serves every
+    /// instantiation of the enclosing generic method or type.
+    /// </summary>
+    public Dictionary<TypeParameterSymbol, MemberReferenceHandle> NullableOpenCtorMemberRefs { get; }
+        = new Dictionary<TypeParameterSymbol, MemberReferenceHandle>();
+
+    /// <summary>
     /// Gets the cache mapping a <see cref="FieldInfo"/> to its
     /// <see cref="MemberReferenceHandle"/>.
     /// </summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -110,6 +110,19 @@ internal sealed partial class MethodBodyEmitter
             && ReflectionMetadataEmitter.IsValueTypeNullable(toValueNullableLift)
             && from == toValueNullableLift.UnderlyingType)
         {
+            // Issue #814 / ADR-0084 §L5: open `T → Nullable<T>` where T is an
+            // open type parameter constrained to `struct`. The closed ctor
+            // is unavailable (T has no CLR type), so we emit a MemberRef
+            // parented at the TypeSpec `Nullable<!!T>` with signature
+            // `instance void .ctor(!0)`. The CLR resolves `!0` against the
+            // parent's first generic argument at call time.
+            if (toValueNullableLift.UnderlyingType is TypeParameterSymbol)
+            {
+                this.il.OpCode(ILOpCode.Newobj);
+                this.il.Token(this.outer.GetNullableCtorMemberRefForOpenTypeParameter(toValueNullableLift));
+                return;
+            }
+
             var innerClr = toValueNullableLift.UnderlyingType.ClrType
                 ?? throw new InvalidOperationException(
                     $"Nullable<{toValueNullableLift.UnderlyingType.Name}> lift has no CLR underlying type.");
@@ -644,8 +657,14 @@ internal sealed partial class MethodBodyEmitter
         // route through the slot-based `ldloca; initobj; ldloc` shape — it
         // zero-inits the storage uniformly (null for ref types, zeroed
         // bytes for value types) and IL-verifies for any instantiation.
+        // Issue #814 / ADR-0084 §L5: `T?` over an open type parameter
+        // (either `[T struct]` or `[T class]`) needs the same treatment —
+        // ldnull → !!T is unverifiable even with a `class` constraint, and
+        // for `[T struct]` the storage is `Nullable<!!T>` which requires
+        // `initobj` to materialise the missing-value sentinel.
         var typeParamLike = type is TypeParameterSymbol
-            || (type is ImportedTypeSymbol erasedGen && erasedGen.HasTypeParameterArgument);
+            || (type is ImportedTypeSymbol erasedGen && erasedGen.HasTypeParameterArgument)
+            || (type is NullableTypeSymbol nullableTp && nullableTp.UnderlyingType is TypeParameterSymbol);
 
         // Reference types: ldnull
         if (!typeParamLike && !ReflectionMetadataEmitter.IsValueTypeSymbol(type))

--- a/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
@@ -435,7 +435,17 @@ internal sealed class MethodBodyPlanner
         {
             var needsSlot = ReflectionMetadataEmitter.IsValueTypeSymbol(def.Type)
                 || def.Type is TypeParameterSymbol
-                || (def.Type is ImportedTypeSymbol erasedGen && erasedGen.HasTypeParameterArgument);
+                || (def.Type is ImportedTypeSymbol erasedGen && erasedGen.HasTypeParameterArgument)
+
+                // Issue #814 / ADR-0084 §L5: `default(T?)` over an open type
+                // parameter — either `[T struct]` (encoded as Nullable<!!T>)
+                // or `[T class]` (encoded as bare !!T) — needs the same
+                // ldloca/initobj/ldloc slot path as a closed value-type
+                // default. The type-parameter case is required because
+                // ldnull → !!T is rejected by the IL verifier even with
+                // a `class` constraint.
+                || (def.Type is NullableTypeSymbol nullableDef
+                    && nullableDef.UnderlyingType is TypeParameterSymbol);
             if (!needsSlot)
             {
                 continue;

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -4781,6 +4781,26 @@ internal sealed class ReflectionMetadataEmitter
             return this.GetTypeHandleForMember(nullableClr);
         }
 
+        // Issue #814 / ADR-0084 §L5: `T?` over an open type parameter.
+        // For `[T struct]` the storage shape is `Nullable<!!T>`, encoded
+        // as a TypeSpec naming the generic instantiation; this is the
+        // token consumed by `initobj` when zero-initialising the slot.
+        // For `[T class]` the storage shape is the bare `!!T` (a reference
+        // slot that holds `null`), so we forward to the existing
+        // TypeParameterSymbol branch by recursing on the underlying.
+        if (element is NullableTypeSymbol nullableTpElement
+            && nullableTpElement.UnderlyingType is TypeParameterSymbol nullableTpInner)
+        {
+            if (nullableTpInner.HasValueTypeConstraint)
+            {
+                var sigBlob = new BlobBuilder();
+                this.EncodeTypeSymbol(new BlobEncoder(sigBlob).TypeSpecificationSignature(), nullableTpElement);
+                return this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+            }
+
+            return this.GetElementTypeToken(nullableTpInner);
+        }
+
         if (element == TypeSymbol.Int32)
         {
             return this.GetTypeReference(this.emitCtx.CoreInt32Type);
@@ -5270,9 +5290,108 @@ internal sealed class ReflectionMetadataEmitter
             return TryUnify(fseq.ElementType, aseq.ElementType, tp, out inferred);
         }
 
+        // Issue #814 / ADR-0084 §L5: an extension method's open
+        // `sequence[T]` receiver may have a call-site actual that is a
+        // slice (`[]T`), a fixed-length array (`[N]T`), or any CLR
+        // generic type implementing `IEnumerable<T>`. The binder
+        // inserts a `BoundConversionExpression` widening to
+        // `sequence[T]`, but `StripConversion` peels it off so emit
+        // sees the pre-widening type. Without these branches the
+        // method-spec inference falls through and throws
+        // "Cannot infer type argument for 'T'" for the
+        // `arr.FirstOrNil()` / `arr.LastOrNil()` / `arr.SingleOrNil()`
+        // class/struct overload pair.
+        if (formal is SequenceTypeSymbol fseqAny)
+        {
+            if (actual is SliceTypeSymbol aSliceEnum)
+            {
+                return TryUnify(fseqAny.ElementType, aSliceEnum.ElementType, tp, out inferred);
+            }
+
+            if (actual is ArrayTypeSymbol aArrEnum)
+            {
+                return TryUnify(fseqAny.ElementType, aArrEnum.ElementType, tp, out inferred);
+            }
+
+            if (actual?.ClrType is { } actualClrSeq)
+            {
+                var openIEnumerable = typeof(System.Collections.Generic.IEnumerable<>);
+                System.Type matched = null;
+                if (actualClrSeq.IsArray)
+                {
+                    var elt = actualClrSeq.GetElementType();
+                    if (elt != null)
+                    {
+                        matched = openIEnumerable.MakeGenericType(elt);
+                    }
+                }
+                else if (actualClrSeq.IsGenericType
+                    && actualClrSeq.GetGenericTypeDefinition() == openIEnumerable)
+                {
+                    matched = actualClrSeq;
+                }
+                else
+                {
+                    foreach (var iface in actualClrSeq.GetInterfaces())
+                    {
+                        if (iface.IsGenericType
+                            && iface.GetGenericTypeDefinition() == openIEnumerable)
+                        {
+                            matched = iface;
+                            break;
+                        }
+                    }
+                }
+
+                if (matched != null)
+                {
+                    var elementSym = TypeSymbol.FromClrType(matched.GetGenericArguments()[0]);
+                    if (TryUnify(fseqAny.ElementType, elementSym, tp, out inferred))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
         if (formal is AsyncSequenceTypeSymbol faseq && actual is AsyncSequenceTypeSymbol aaseq)
         {
             return TryUnify(faseq.ElementType, aaseq.ElementType, tp, out inferred);
+        }
+
+        // Issue #814: mirror of the synchronous sequence-vs-enumerable
+        // unification above for `async sequence[T]` receivers against
+        // any CLR generic implementing `IAsyncEnumerable<T>`.
+        if (formal is AsyncSequenceTypeSymbol faseqAny && actual?.ClrType is { } actualClrAseq)
+        {
+            var openIAsync = typeof(System.Collections.Generic.IAsyncEnumerable<>);
+            System.Type matched = null;
+            if (actualClrAseq.IsGenericType
+                && actualClrAseq.GetGenericTypeDefinition() == openIAsync)
+            {
+                matched = actualClrAseq;
+            }
+            else
+            {
+                foreach (var iface in actualClrAseq.GetInterfaces())
+                {
+                    if (iface.IsGenericType
+                        && iface.GetGenericTypeDefinition() == openIAsync)
+                    {
+                        matched = iface;
+                        break;
+                    }
+                }
+            }
+
+            if (matched != null)
+            {
+                var elementSym = TypeSymbol.FromClrType(matched.GetGenericArguments()[0]);
+                if (TryUnify(faseqAny.ElementType, elementSym, tp, out inferred))
+                {
+                    return true;
+                }
+            }
         }
 
         if (formal is NullableTypeSymbol fnu && actual is NullableTypeSymbol anu)
@@ -6535,6 +6654,57 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #814 / ADR-0084 §L5: builds a <c>MemberRef</c> parented at the
+    /// <c>TypeSpec</c> for <c>System.Nullable`1&lt;!!T&gt;</c> with signature
+    /// <c>instance void .ctor(!0)</c>. The CLR substitutes <c>!0</c> against
+    /// the parent's first generic argument at call time, so a single
+    /// MemberRef serves every instantiation. Used by the
+    /// <c>T → Nullable&lt;T&gt;</c> value-type lift when <c>T</c> is an open
+    /// type parameter constrained to <c>struct</c> — the closed
+    /// <see cref="ConstructorInfo"/> we normally route through
+    /// <see cref="GetCtorReference(ConstructorInfo)"/> is unavailable because
+    /// <see cref="TypeParameterSymbol"/> has no <see cref="Type"/>.
+    /// </summary>
+    /// <param name="nullableOfTp">A <see cref="NullableTypeSymbol"/> whose underlying type is an open <see cref="TypeParameterSymbol"/>.</param>
+    /// <returns>The MemberRef handle for <c>Nullable&lt;!!T&gt;::.ctor(!0)</c>.</returns>
+    internal MemberReferenceHandle GetNullableCtorMemberRefForOpenTypeParameter(NullableTypeSymbol nullableOfTp)
+    {
+        if (nullableOfTp?.UnderlyingType is not TypeParameterSymbol tp)
+        {
+            throw new InvalidOperationException(
+                "GetNullableCtorMemberRefForOpenTypeParameter requires Nullable<TypeParameter>.");
+        }
+
+        if (this.cache.NullableOpenCtorMemberRefs.TryGetValue(tp, out var cached))
+        {
+            return cached;
+        }
+
+        var parentBlob = new BlobBuilder();
+        this.EncodeTypeSymbol(new BlobEncoder(parentBlob).TypeSpecificationSignature(), nullableOfTp);
+        var parent = this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(parentBlob));
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                parameterCount: 1,
+                returnType: r => r.Void(),
+                parameters: ps =>
+                {
+                    // `!0`: the parent TypeSpec's first generic parameter
+                    // (i.e. the inner type that Nullable<> is closed over).
+                    ps.AddParameter().Type().GenericTypeParameter(0);
+                });
+
+        var handle = this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        this.cache.NullableOpenCtorMemberRefs[tp] = handle;
+        return handle;
+    }
+
+    /// <summary>
     /// Phase 4 emit parity: get a MemberRef for a CLR field on a possibly
     /// generic declaring type (e.g. <c>KeyValuePair&lt;K, V&gt;.Key</c>).
     /// </summary>
@@ -6838,6 +7008,28 @@ internal sealed class ReflectionMetadataEmitter
                 }
 
                 this.EncodeClrType(encoder, nullableClr);
+                return;
+            }
+
+            // Issue #814 / ADR-0084 §L5: `T?` over an open type parameter
+            // constrained to `struct` must encode as `GENERICINST System.Nullable`1<MVAR/VAR>`,
+            // not as the bare `T` slot. Without this branch the struct-constrained
+            // overload of `FirstOrNil`/`LastOrNil`/`SingleOrNil` emits a return
+            // signature of `!!T` that, after instantiation with a value type,
+            // becomes plain `int32` (etc.) — but the body assigns/returns a
+            // `Nullable<T>` value, so the verifier rejects the mismatch and the
+            // runtime mis-shapes the slot.  When the constraint is `class` the
+            // CLR representation of `T?` coincides with `T` (a reference slot
+            // that can hold `null`), so we keep the existing fall-through
+            // to encode the bare type parameter.
+            if (inner is TypeParameterSymbol nullableTp && nullableTp.HasValueTypeConstraint)
+            {
+                var nullableOpen = typeof(System.Nullable<>);
+                var giNullable = encoder.GenericInstantiation(
+                    this.GetTypeReference(nullableOpen),
+                    genericArgumentCount: 1,
+                    isValueType: true);
+                this.EncodeTypeSymbol(giNullable.AddArgument(), nullableTp);
                 return;
             }
 

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -1517,12 +1517,61 @@ public sealed class Evaluator
             return fieldValue;
         }
 
-        return node.Member switch
+        // Issue #814 / ADR-0084 §L5: mirror ResolveMethodForReceiver for
+        // PropertyInfo. `IEnumerator<object>::Current` access against a
+        // value-type-element enumerator (e.g. `SZGenericArrayEnumerator<int>`
+        // from `int[].GetEnumerator()`) fails because the receiver doesn't
+        // implement `IEnumerator<object>`. Route through the matching
+        // closed-generic interface on the receiver's runtime type.
+        var member = ResolvePropertyOrFieldForReceiver(node.Member, receiver);
+
+        return member switch
         {
             System.Reflection.PropertyInfo p => p.GetValue(receiver),
             System.Reflection.FieldInfo f => f.GetValue(receiver),
             _ => throw new EvaluatorException($"Unsupported CLR member kind '{node.Member.MemberType}'.", node),
         };
+    }
+
+    private static System.Reflection.MemberInfo ResolvePropertyOrFieldForReceiver(System.Reflection.MemberInfo member, object receiver)
+    {
+        if (receiver == null || member == null)
+        {
+            return member;
+        }
+
+        var declaring = member.DeclaringType;
+        if (declaring == null || declaring.IsAssignableFrom(receiver.GetType()))
+        {
+            return member;
+        }
+
+        var receiverType = receiver.GetType();
+
+        if (declaring.IsGenericType)
+        {
+            var openDecl = declaring.GetGenericTypeDefinition();
+            foreach (var iface in receiverType.GetInterfaces())
+            {
+                if (!iface.IsGenericType || iface.GetGenericTypeDefinition() != openDecl)
+                {
+                    continue;
+                }
+
+                System.Reflection.MemberInfo candidate = member.MemberType switch
+                {
+                    System.Reflection.MemberTypes.Property => iface.GetProperty(member.Name),
+                    System.Reflection.MemberTypes.Field => iface.GetField(member.Name),
+                    _ => null,
+                };
+                if (candidate != null)
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return member;
     }
 
     // Issue #517: matches `Nullable<T>::get_Value` / `get_HasValue` against
@@ -3558,9 +3607,91 @@ public sealed class Evaluator
         var args = new object[node.Arguments.Length];
         var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args);
 
-        var result = node.Method.Invoke(receiver, args);
+        var method = ResolveMethodForReceiver(node.Method, receiver);
+
+        var result = method.Invoke(receiver, args);
         WriteBackRefSlots(refSlots, args);
         return result;
+    }
+
+    // Issue #814 / ADR-0084 §L5: when an open generic extension method is
+    // invoked through the interpreter (e.g. `arr.FirstOrNil()` against an
+    // `int[]`), the lowered `for v in self` loop carries a
+    // `System.Collections.Generic.IEnumerable<object>::GetEnumerator`
+    // MethodInfo because the binder/lowerer routes through the symbolic
+    // open shape. `MethodInfo.Invoke` against an `int[]` receiver then fails
+    // because `int[]` does not implement `IEnumerable<object>` (CLR array
+    // covariance is reference-only). Re-route through the matching closed
+    // generic interface on the receiver's runtime type when the literal
+    // declaring type is unassignable but a sibling closed instantiation is.
+    // The lookup also walks inherited interfaces (e.g. `MoveNext` lives on
+    // the non-generic `IEnumerator` even when the receiver is reached via
+    // `IEnumerator<T>`).
+    private static System.Reflection.MethodInfo ResolveMethodForReceiver(System.Reflection.MethodInfo method, object receiver)
+    {
+        if (receiver == null || method == null)
+        {
+            return method;
+        }
+
+        var declaring = method.DeclaringType;
+        if (declaring == null || declaring.IsAssignableFrom(receiver.GetType()))
+        {
+            return method;
+        }
+
+        var receiverType = receiver.GetType();
+        var paramTypes = System.Array.ConvertAll(method.GetParameters(), p => p.ParameterType);
+
+        if (declaring.IsGenericType)
+        {
+            var openDecl = declaring.GetGenericTypeDefinition();
+            foreach (var iface in receiverType.GetInterfaces())
+            {
+                if (!iface.IsGenericType || iface.GetGenericTypeDefinition() != openDecl)
+                {
+                    continue;
+                }
+
+                var candidate = iface.GetMethod(
+                    method.Name,
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public,
+                    binder: null,
+                    types: paramTypes,
+                    modifiers: null);
+                if (candidate != null)
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        // Fall-back search: the method (e.g. `MoveNext`) may live on a
+        // parent non-generic interface that the receiver also implements.
+        // Find it by name+arity across every interface and the receiver
+        // type itself; this works for `IEnumerator::MoveNext` reached via
+        // `IEnumerator<int>` and similar inheritance.
+        foreach (var iface in receiverType.GetInterfaces())
+        {
+            var candidate = iface.GetMethod(
+                method.Name,
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public,
+                binder: null,
+                types: paramTypes,
+                modifiers: null);
+            if (candidate != null)
+            {
+                return candidate;
+            }
+        }
+
+        var direct = receiverType.GetMethod(
+            method.Name,
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public,
+            binder: null,
+            types: paramTypes,
+            modifiers: null);
+        return direct ?? method;
     }
 
     // Issue #517: `GetValueOrDefault()` and `GetValueOrDefault(T)` against the

--- a/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
@@ -119,7 +119,24 @@ public static class NullableLifting
     /// <returns><see langword="true"/> when the underlying type is a CLR value type.</returns>
     internal static bool IsValueTypeNullable(NullableTypeSymbol nullable)
     {
-        return nullable?.UnderlyingType?.ClrType is { IsValueType: true };
+        if (nullable?.UnderlyingType?.ClrType is { IsValueType: true })
+        {
+            return true;
+        }
+
+        // Issue #814 / ADR-0084 §L5: `T?` over an open type parameter
+        // constrained to `struct` is a value-type `Nullable<T>` at the IL
+        // level (encoded as `GENERICINST System.Nullable`1<MVAR>`). All
+        // emit-side decisions that distinguish value-type Nullable from
+        // reference-type Nullable (slot-based default-init, newobj lift,
+        // HasValue branching in `?:`) must treat the open struct case
+        // the same as a closed value type.
+        if (nullable?.UnderlyingType is TypeParameterSymbol tp && tp.HasValueTypeConstraint)
+        {
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue814OrNilOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue814OrNilOverloadEmitTests.cs
@@ -1,0 +1,311 @@
+// <copyright file="Issue814OrNilOverloadEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #814 / ADR-0084 §L5 closing bullet — emit + IL-verify coverage
+/// for the dogfooded <c>SequenceExtensions.FirstOrNil</c> /
+/// <c>LastOrNil</c> / <c>SingleOrNil</c> shape: two extension overloads
+/// on <c>(self sequence[T])</c>, distinguished only by a
+/// <c>[T class]</c> / <c>[T struct]</c> generic-parameter constraint and
+/// a return-type representation that bottoms out in <c>T?</c>. The
+/// binder must pick the right overload; the emitter must close the open
+/// <c>T?</c> return into a reference <c>T</c> on the class side and into
+/// <c>Nullable&lt;T&gt;</c> on the struct side; the produced IL must
+/// verify under <c>ilverify</c>.
+/// </summary>
+public class Issue814OrNilOverloadEmitTests
+{
+    [Fact]
+    public void FirstOrNil_TwoOverloads_ClassReceiver_StringArray_PicksClassOverload()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            func (self sequence[T]) FirstOrNil[T class]() string { return "class" }
+            func (self sequence[T]) FirstOrNil[T struct]() string { return "struct" }
+
+            public var tag = ""
+            tag = ([]string{"a", "b"}).FirstOrNil()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal("class", GetStringField(assembly, "tag"));
+    }
+
+    [Fact]
+    public void FirstOrNil_TwoOverloads_StructReceiver_Int32Array_PicksStructOverload()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            func (self sequence[T]) FirstOrNil[T class]() string { return "class" }
+            func (self sequence[T]) FirstOrNil[T struct]() string { return "struct" }
+
+            public var tag = ""
+            tag = ([]int32{1, 2}).FirstOrNil()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal("struct", GetStringField(assembly, "tag"));
+    }
+
+    [Fact]
+    public void FirstOrNil_TQuestionReturn_ClassReceiver_StringArray_ReturnsHead()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            func (self sequence[T]) FirstOrNil[T class]() T? {
+                for v in self { return v }
+                return nil
+            }
+
+            func (self sequence[T]) FirstOrNil[T struct]() T? {
+                for v in self { return v }
+                return nil
+            }
+
+            public var head = ""
+            head = ([]string{"alpha", "beta"}).FirstOrNil() ?: "<none>"
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal("alpha", GetStringField(assembly, "head"));
+    }
+
+    [Fact]
+    public void FirstOrNil_TQuestionReturn_StructReceiver_Int32Array_ReturnsHead()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            func (self sequence[T]) FirstOrNil[T class]() T? {
+                for v in self { return v }
+                return nil
+            }
+
+            func (self sequence[T]) FirstOrNil[T struct]() T? {
+                for v in self { return v }
+                return nil
+            }
+
+            public var head = 0
+            head = ([]int32{11, 22, 33}).FirstOrNil() ?: -1
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(11, GetIntField(assembly, "head"));
+    }
+
+    [Fact]
+    public void FirstOrNil_TQuestionReturn_EmptyStringArray_ReturnsNil()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            func (self sequence[T]) FirstOrNil[T class]() T? {
+                for v in self { return v }
+                return nil
+            }
+
+            func (self sequence[T]) FirstOrNil[T struct]() T? {
+                for v in self { return v }
+                return nil
+            }
+
+            public var head = ""
+            head = ([]string{}).FirstOrNil() ?: "<none>"
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal("<none>", GetStringField(assembly, "head"));
+    }
+
+    [Fact]
+    public void FirstOrNil_TQuestionReturn_EmptyInt32Array_ReturnsNil()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            func (self sequence[T]) FirstOrNil[T class]() T? {
+                for v in self { return v }
+                return nil
+            }
+
+            func (self sequence[T]) FirstOrNil[T struct]() T? {
+                for v in self { return v }
+                return nil
+            }
+
+            public var head = 0
+            head = ([]int32{}).FirstOrNil() ?: -1
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(-1, GetIntField(assembly, "head"));
+    }
+
+    [Fact]
+    public void LastOrNil_TQuestionReturn_BothShapes_RunCorrectly()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            func (self sequence[T]) LastOrNil[T class]() T? {
+                var last T? = nil
+                for v in self { last = v }
+                return last
+            }
+
+            func (self sequence[T]) LastOrNil[T struct]() T? {
+                var last T? = nil
+                for v in self { last = v }
+                return last
+            }
+
+            public var sLast = ""
+            public var nLast = 0
+            sLast = ([]string{"a", "b", "c"}).LastOrNil() ?: "<none>"
+            nLast = ([]int32{10, 20, 30}).LastOrNil() ?: -1
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal("c", GetStringField(assembly, "sLast"));
+        Assert.Equal(30, GetIntField(assembly, "nLast"));
+    }
+
+    [Fact]
+    public void SingleOrNil_TQuestionReturn_BothShapes_RunCorrectly()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            func (self sequence[T]) SingleOrNil[T class]() T? {
+                var only T? = nil
+                var count = 0
+                for v in self {
+                    only = v
+                    count = count + 1
+                }
+                if count == 1 { return only }
+                return nil
+            }
+
+            func (self sequence[T]) SingleOrNil[T struct]() T? {
+                var only T? = nil
+                var count = 0
+                for v in self {
+                    only = v
+                    count = count + 1
+                }
+                if count == 1 { return only }
+                return nil
+            }
+
+            public var sSolo = ""
+            public var nSolo = 0
+            public var sNone = ""
+            sSolo = ([]string{"x"}).SingleOrNil() ?: "<none>"
+            nSolo = ([]int32{42}).SingleOrNil() ?: -1
+            sNone = ([]string{"a", "b"}).SingleOrNil() ?: "<none>"
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal("x", GetStringField(assembly, "sSolo"));
+        Assert.Equal(42, GetIntField(assembly, "nSolo"));
+        Assert.Equal("<none>", GetStringField(assembly, "sNone"));
+    }
+
+    #region Helpers
+
+    private static Assembly CompileAndRun(string source)
+    {
+        var outPath = CompileToFile(source, target: "exe");
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+        return assembly;
+    }
+
+    private static string CompileToFile(string source, string target)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_814_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static int GetIntField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (int)field!.GetValue(null)!;
+    }
+
+    private static string GetStringField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (string)field!.GetValue(null)!;
+    }
+
+    #endregion
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue814OrNilOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue814OrNilOverloadTests.cs
@@ -1,0 +1,230 @@
+// <copyright file="Issue814OrNilOverloadTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #814 / ADR-0084 §L5 closing bullet — disambiguation of two
+/// extension overloads that share a shape-identical receiver type
+/// (<c>(self sequence[T])</c>) and parameter list, distinguished only
+/// by a <c>class</c> / <c>struct</c> generic-parameter constraint and a
+/// return-type representation that bottoms out in <c>T?</c>. The
+/// canonical surface is <see cref="System.Linq"/>-style
+/// <c>FirstOrNil</c> / <c>LastOrNil</c> / <c>SingleOrNil</c>.
+/// </summary>
+public class Issue814OrNilOverloadTests
+{
+    [Fact]
+    public void FirstOrNil_TwoOverloadsCoexist_NoDuplicateDeclarationDiagnostic()
+    {
+        // Both overloads must declare cleanly even though their declared
+        // receiver shape (`sequence[T]`) is structurally identical — the
+        // T in each is a different TypeParameterSymbol with a disjoint
+        // constraint, so they are distinct extension entries.
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func (self sequence[T]) FirstOrNil[T class]() T? { return nil }
+func (self sequence[T]) FirstOrNil[T struct]() T? { return nil }
+";
+        Assert.Empty(GetErrorDiagnostics(source));
+    }
+
+    [Fact]
+    public void FirstOrNil_OnStringArray_ResolvesClassOverload()
+    {
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func (self sequence[T]) FirstOrNil[T class]() string { return ""class"" }
+func (self sequence[T]) FirstOrNil[T struct]() string { return ""struct"" }
+
+let arr = []string{}
+let tag = arr.FirstOrNil()
+tag
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("class", result.Value);
+    }
+
+    [Fact]
+    public void FirstOrNil_OnInt32Array_ResolvesStructOverload()
+    {
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func (self sequence[T]) FirstOrNil[T class]() string { return ""class"" }
+func (self sequence[T]) FirstOrNil[T struct]() string { return ""struct"" }
+
+let arr = []int32{}
+let tag = arr.FirstOrNil()
+tag
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("struct", result.Value);
+    }
+
+    [Fact]
+    public void FirstOrNil_ReturnTypeIsTQuestion_ResolvesClassOverloadForStrings()
+    {
+        // The actual ADR-0084 §L5 shape: return type is `T?`. The class
+        // overload returns a reference-typed `T?`; the struct overload
+        // returns a `Nullable<T>`. Pre-fix the two overloads were both
+        // declared but the binder's tie-break could not pick a winner
+        // when the only distinguishing constraint was class/struct on
+        // the receiver type-parameter.
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func (self sequence[T]) FirstOrNil[T class]() T? {
+    for v in self { return v }
+    return nil
+}
+
+func (self sequence[T]) FirstOrNil[T struct]() T? {
+    for v in self { return v }
+    return nil
+}
+
+let strs = []string{ ""alpha"", ""beta"" }
+let head = strs.FirstOrNil() ?: ""<none>""
+head
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("alpha", result.Value);
+    }
+
+    [Fact]
+    public void FirstOrNil_ReturnTypeIsTQuestion_ResolvesStructOverloadForInt32()
+    {
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func (self sequence[T]) FirstOrNil[T class]() T? {
+    for v in self { return v }
+    return nil
+}
+
+func (self sequence[T]) FirstOrNil[T struct]() T? {
+    for v in self { return v }
+    return nil
+}
+
+let nums = []int32{ 11, 22, 33 }
+let head = nums.FirstOrNil() ?: -1
+head
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(11, result.Value);
+    }
+
+    [Fact]
+    public void LastOrNil_TwoOverloadsCoexist_AndDispatchByConstraint()
+    {
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func (self sequence[T]) LastOrNil[T class]() string { return ""class"" }
+func (self sequence[T]) LastOrNil[T struct]() string { return ""struct"" }
+
+let arr1 = []string{ ""a"" }
+let arr2 = []int32{ 1 }
+arr1.LastOrNil() + arr2.LastOrNil()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("classstruct", result.Value);
+    }
+
+    [Fact]
+    public void SingleOrNil_TwoOverloadsCoexist_AndDispatchByConstraint()
+    {
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func (self sequence[T]) SingleOrNil[T class]() string { return ""class"" }
+func (self sequence[T]) SingleOrNil[T struct]() string { return ""struct"" }
+
+let arr1 = []string{ ""a"" }
+let arr2 = []int32{ 1 }
+arr1.SingleOrNil() + arr2.SingleOrNil()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("classstruct", result.Value);
+    }
+
+    [Fact]
+    public void TwoOverloads_OnlyOneMatchesConstraint_PicksUnambiguously()
+    {
+        // Only the class overload is declared; calling on an int32
+        // array must diagnose because neither candidate satisfies a
+        // struct argument.
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func (self sequence[T]) FirstOrNil[T class]() T? {
+    for v in self { return v }
+    return nil
+}
+
+let nums = []int32{ 1, 2, 3 }
+let head = nums.FirstOrNil()
+head
+";
+        // The lookup falls through; the call site should fail to resolve.
+        var diags = GetErrorDiagnostics(source);
+        Assert.NotEmpty(diags);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+
+    private static ImmutableArray<Diagnostic> GetErrorDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var program = compilation.BoundProgram;
+        return tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(program.Diagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+    }
+}


### PR DESCRIPTION
## Summary

Closes the third remaining bullet of ADR-0084 §L5: same-name overload
pairs distinguished *only* by `[T class]` vs `[T struct]` constraints
— the exact shape needed for the dogfooded G# port of
`SequenceExtensions.FirstOrNil` / `LastOrNil` / `SingleOrNil` —
now bind, emit verifier-clean IL, and execute through both the
compiler and the interpreter.

```gs
func (self sequence[T]) FirstOrNil[T class]() T?
func (self sequence[T]) FirstOrNil[T struct]() T?
```

`[]string{}.FirstOrNil()` dispatches to the `class` overload;
`[]int32{}.FirstOrNil()` dispatches to the `struct` overload, with
the value-type version producing a real `Nullable<int32>`.

## Root cause

Binder dispatch was already correct: ADR-0088 (#750) added the
constraint-aware filter for imported methods and ADR-0097 (#775)
added the G# syntactic spelling. The gaps were in **emit** and
**interpreter**:

- Emit encoded `T?` as bare `!!T`. For the `class` case the
  `nil` literal lowered to `ldnull → !!T`, which ilverify rejects
  (Roslyn itself emits `ldloca; initobj` here). For the `struct`
  case the `Nullable<T>` semantics were lost outright.
- The lowered `for v in self` loop carries the symbolic
  `IEnumerable<object>::GetEnumerator` MethodInfo, but `int[]` does
  not implement `IEnumerable<object>` — CLR array covariance is
  reference-only — so `MethodInfo.Invoke` failed in the interpreter
  for value-typed element arrays.

## Fix

**Emit:**
- Encode `NullableTypeSymbol(TypeParameterSymbol-struct)` as
  `GENERICINST Nullable<MVAR/VAR>` in both `EncodeTypeSymbol` and
  `GetElementTypeToken` (`Nullable<!!T>` TypeSpec).
- Lower `nil → Nullable<TP>` through `BoundDefaultExpression` for
  both `class` and `struct` constraints so `EmitDefault` uses the
  slot-based `ldloca; initobj` pair.
- Allocate slots for `NullableTypeSymbol(TP)` defaults in the body
  planner; recognise the shape in `EmitDefault`'s `typeParamLike`
  predicate.
- Synthesise a TypeSpec-parented `Nullable<!!T>::.ctor(!0)`
  MemberRef (cached per open TP) so the `T → T?` value-type lift
  resolves correctly under instantiation.
- Recognise `NullableTypeSymbol(TP-struct)` in `IsValueTypeNullable`
  so the conversion classifier picks the lift path.

**Interpreter:**
- New `ResolveMethodForReceiver` / `ResolvePropertyOrFieldForReceiver`
  helpers re-route `MethodInfo.Invoke` / `PropertyInfo.GetValue`
  when the literal declaring type is unassignable from the
  receiver's runtime type: walk the generic interface map for a
  closed sibling instantiation, fall back to name+arity across all
  interfaces.

## Tests

- `test/Core.Tests/.../Binding/Issue814OrNilOverloadTests.cs` —
  8 binder + interpreter tests covering both `class` and `struct`
  resolution across all three `*OrNil` helpers, the missing-
  constraint diagnostic, and end-to-end tree-walking execution.
- `test/Compiler.Tests/Emit/Issue814OrNilOverloadEmitTests.cs` —
  8 IL-verified end-to-end emit tests (every one runs
  `IlVerifier.Verify`).
- Full `dotnet test GSharp.sln` green: 5163 passed, 1 pre-existing
  skip.
- `cd website && npm ci && npm run build` clean.

## Refs

- Issue: #814
- Constraint-aware overload resolution: #750 (ADR-0088)
- G# constraint spelling: #775 (ADR-0097)
- Iterator emit / state-machine reification: #810
- SDK ↔ Extensions bootstrap: #792
- Parent epic: #706
- ADR: `docs/adr/0084-gsharp-extensions-optional-sequences.md`
  (updated to mark §L5's third remaining bullet closed)

Closes #814.
