### PR TITLE
fix(lsp): degrade gracefully on handler exceptions (#816); grammar refresh (#822)

### DIFF
--- a/src/LanguageServer/DocumentContentService.cs
+++ b/src/LanguageServer/DocumentContentService.cs
@@ -37,7 +37,7 @@ public class DocumentContentService
     /// <param name="content">Document content.</param>
     /// <returns>Whether or not the operation succeeded.</returns>
     /// <seealso cref="DocumentContent"/>
-    public bool TryGet(string key, out DocumentContent content)
+    public virtual bool TryGet(string key, out DocumentContent content)
     {
         return this.documentContents.TryGetValue(key, out content);
     }

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -206,7 +206,25 @@ public sealed class LspServer
         }
 
         cancellationToken.ThrowIfCancellationRequested();
-        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding: false, project, filePath, this.workspaceState);
+
+        DiagnosticComputationResult result;
+        try
+        {
+            result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding: false, project, filePath, this.workspaceState);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Issue #816: a binder/parser crash on partially valid input used to surface as a
+            // per-file "Object reference not set to an instance of an object" popup, blocking
+            // every other LSP feature for the file. Degrade to "no diagnostics" instead.
+            LogHandlerException(nameof(DocumentDiagnosticAsync), ex);
+            return new FullDocumentDiagnosticReport { Items = Array.Empty<Diagnostic>() };
+        }
+
         cancellationToken.ThrowIfCancellationRequested();
 
         var resultId = ComputeResultId(result.Diagnostics);
@@ -414,16 +432,48 @@ public sealed class LspServer
     public Task<LinkedEditingRanges> LinkedEditingRangeAsync(LinkedEditingRangeParams request)
         => this.GuardAsync(() => this.ComputeLinkedEditingRanges(request));
 
-    private async Task<T> GuardAsync<T>(Func<T> body)
+    private async Task<T> GuardAsync<T>(Func<T> body, [System.Runtime.CompilerServices.CallerMemberName] string caller = null)
     {
         await this.gate.WaitAsync().ConfigureAwait(false);
         try
         {
-            return body();
+            try
+            {
+                return body();
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Issue #816: handler crashes (e.g., NRE deep in symbol resolution when
+                // editing a file whose syntax outpaces the bundled LS) used to surface as
+                // a per-request "Object reference not set to an instance of an object"
+                // popup for every diagnostic / inlayHint / codeLens / semanticTokens pull
+                // until the user restarted the editor. Swallow the exception, log it to
+                // stderr for diagnosis, and return a safe default (null for reference
+                // types — LSP clients treat that as "no result" rather than an error).
+                LogHandlerException(caller, ex);
+                return default;
+            }
         }
         finally
         {
             this.gate.Release();
+        }
+    }
+
+    private static void LogHandlerException(string handler, Exception ex)
+    {
+        try
+        {
+            Console.Error.WriteLine($"[gsharp-lsp] {handler ?? "handler"} failed: {ex.GetType().FullName}: {ex.Message}");
+            Console.Error.WriteLine(ex.StackTrace);
+        }
+        catch
+        {
+            // Logging is best-effort; never let a stderr write tear down the server.
         }
     }
 

--- a/src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json
+++ b/src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json
@@ -8,6 +8,7 @@
     { "include": "#characters" },
     { "include": "#numbers" },
     { "include": "#annotations" },
+    { "include": "#declarations" },
     { "include": "#keywords" },
     { "include": "#types" },
     { "include": "#constants" },
@@ -157,6 +158,34 @@
         }
       ]
     },
+    "declarations": {
+      "patterns": [
+        {
+          "comment": "Aggregate declarations per ADR-0078: `class|struct|enum|interface Name`",
+          "match": "\\b(class|struct|enum|interface)\\s+([A-Za-z_][A-Za-z0-9_]*)",
+          "captures": {
+            "1": { "name": "keyword.declaration.gsharp" },
+            "2": { "name": "entity.name.type.gsharp" }
+          }
+        },
+        {
+          "comment": "Delegate type alias per ADR-0078: `type Name = delegate ...`",
+          "match": "\\b(type)\\s+([A-Za-z_][A-Za-z0-9_]*)",
+          "captures": {
+            "1": { "name": "keyword.declaration.gsharp" },
+            "2": { "name": "entity.name.type.gsharp" }
+          }
+        },
+        {
+          "comment": "Function/sequence declaration: `func Name(...)` or `sequence Name(...)`",
+          "match": "\\b(func|sequence)\\s+([A-Za-z_][A-Za-z0-9_]*)",
+          "captures": {
+            "1": { "name": "keyword.declaration.gsharp" },
+            "2": { "name": "entity.name.function.gsharp" }
+          }
+        }
+      ]
+    },
     "keywords": {
       "patterns": [
         {
@@ -173,7 +202,7 @@
         },
         {
           "name": "keyword.declaration.gsharp",
-          "match": "\\b(func|class|struct|enum|interface|type|operator|sequence|record|delegate|event|prop|init)\\b"
+          "match": "\\b(func|class|struct|enum|interface|type|operator|sequence|delegate|event|prop|init)\\b"
         },
         {
           "name": "storage.modifier.gsharp",
@@ -197,7 +226,7 @@
       "patterns": [
         {
           "name": "support.type.primitive.gsharp",
-          "match": "\\b(bool|uint8|int8|int16|uint16|int32|uint32|int64|uint64|nint|nuint|float32|float64|decimal|char|string|object|void|byte|sbyte|ushort|short|uint|long|ulong|float|double)\\b"
+          "match": "\\b(bool|uint8|int8|int16|uint16|int32|uint32|int64|uint64|nint|nuint|float32|float64|decimal|char|string|object|void|byte|sbyte|short|ushort|int|uint|long|ulong|float|double)\\b"
         }
       ]
     },
@@ -228,16 +257,12 @@
           "match": "\\.\\.\\."
         },
         {
-          "name": "keyword.operator.short-declaration.gsharp",
-          "match": ":="
-        },
-        {
           "name": "keyword.operator.null-coalescing.gsharp",
           "match": "\\?\\?=|\\?\\?"
         },
         {
           "name": "keyword.operator.null-conditional.gsharp",
-          "match": "\\?\\."
+          "match": "\\?\\.|\\?\\["
         },
         {
           "name": "keyword.operator.null-forgiving.gsharp",

--- a/test/LanguageServer.Tests/Issue816HandlerExceptionTests.cs
+++ b/test/LanguageServer.Tests/Issue816HandlerExceptionTests.cs
@@ -1,0 +1,193 @@
+// <copyright file="Issue816HandlerExceptionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GSharp.LanguageServer.Protocol;
+using GSharp.LanguageServer.Server;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// Issue #816: opening a real-world file in the bundled extension surfaced a
+/// "Object reference not set to an instance of an object" popup for every
+/// pull-based LSP request (diagnostic, inlayHint, codeLens, semanticTokens).
+/// The handlers must degrade to "no result" on internal exceptions rather
+/// than propagating the failure to the client.
+///
+/// The repro source uses pre-ADR-0078 syntax (<c>type Name class : I</c>)
+/// the way users hit it in the wild — i.e. a file whose grammar is partly
+/// understood by the LS. The contract under test is "no exception escapes";
+/// the actual content of the returned report/list is best-effort.
+/// </summary>
+public class Issue816HandlerExceptionTests
+{
+    private const string PreAdr0078Source = @"
+package Oahu.Cli.Tests.Experiment.Tui
+
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+import Xunit
+
+type AppShellTests class : IDisposable {
+    init() { Theme.Reset() }
+    func Dispose() { Theme.Reset() }
+
+    func MakeConsole() IAnsiConsole {
+        return AnsiConsole.Create(AnsiConsoleSettings())
+    }
+
+    func NewShell() AppShell {
+        return AppShell(MakeConsole(), AppShellOptions())
+    }
+
+    func NewShellWithBuffer(buf LogRingBuffer) AppShell {
+        return AppShell(MakeConsole(), AppShellOptions() { LogBuffer = buf })
+    }
+
+    func NewShellWithTabs(tabs List[ITabScreen]) AppShell {
+        let roTabs IReadOnlyList[ITabScreen] = tabs
+        return AppShell(MakeConsole(), AppShellOptions() { Tabs = roTabs })
+    }
+
+    func K(ch char, key ConsoleKey, shift bool, alt bool, ctrl bool) ConsoleKeyInfo {
+        return ConsoleKeyInfo(ch, key, shift, alt, ctrl)
+    }
+
+    @Fact
+    func Number_Keys_Switch_Tabs() {
+        var shell = NewShell()
+        Assert.Equal(0, shell.ActiveTab)
+        shell.Dispatch(K('3', ConsoleKey.D3, false, false, false))
+        Assert.Equal(2, shell.ActiveTab)
+    }
+}
+
+type ScreenImpl class : ITabScreen {
+    TabTitle string = ""Test""
+    TabNumberKey char = '1'
+    Capturing bool = false
+
+    prop Title string { get { return TabTitle } }
+    prop NumberKey char { get { return TabNumberKey } }
+    prop Hints IEnumerable[KeyValuePair[string, string?]] {
+        get {
+            var list = List[KeyValuePair[string, string?]]()
+            return list
+        }
+    }
+
+    func HandleKey(key ConsoleKeyInfo) bool {
+        return Capturing
+    }
+}
+";
+
+    [Fact]
+    public async Task AllPullHandlers_DegradeGracefully_OnPartiallyValidSource()
+    {
+        // Mirror the user-reported layout (project plus an under-edit .gs file). The
+        // project intentionally references siblings that do not exist on disk; the LS
+        // must not crash when discovery turns up cross-references it can't follow.
+        var rootDir = Path.Combine(Path.GetTempPath(), "gsrepro816_" + Guid.NewGuid().ToString("N"));
+        var projDir = Path.Combine(rootDir, "tests", "Oahu.Cli.Tests.Experiment");
+        var tuiDir = Path.Combine(projDir, "Tui");
+        Directory.CreateDirectory(tuiDir);
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(projDir, "Oahu.Cli.Tests.Experiment.gsproj"),
+                "<Project Sdk=\"Gsharp.NET.Sdk\">\n"
+                + "  <PropertyGroup><OutputType>Library</OutputType><TargetFramework>net10.0</TargetFramework><AssemblyName>Oahu.Cli.Tests.Experiment</AssemblyName></PropertyGroup>\n"
+                + "  <ItemGroup>\n"
+                + "    <ProjectReference Include=\"..\\..\\src\\Oahu.Cli\\Oahu.Cli.csproj\" />\n"
+                + "    <ProjectReference Include=\"..\\..\\src\\Oahu.Cli.App.Experiment\\Oahu.Cli.App.Experiment.gsproj\" />\n"
+                + "  </ItemGroup>\n"
+                + "</Project>\n");
+            var gsPath = Path.Combine(tuiDir, "AppShellTests.gs");
+            File.WriteAllText(gsPath, PreAdr0078Source);
+
+            var workspace = new WorkspaceState();
+            WorkspaceInitializer.Initialize(workspace, rootDir);
+
+            var server = new LspServer(new DocumentContentService(), workspace);
+            var uri = DocumentUri.FromFileSystemPath(gsPath);
+
+            await server.DidOpenAsync(new DidOpenTextDocumentParams
+            {
+                TextDocument = new TextDocumentItem { Uri = uri, Text = PreAdr0078Source },
+            });
+
+            var id = new TextDocumentIdentifier { Uri = uri };
+
+            // Each call must complete without throwing. The contract is "no exception
+            // escapes"; the returned values are best-effort.
+            var diagnostic = await server.DocumentDiagnosticAsync(
+                new DocumentDiagnosticParams { TextDocument = id },
+                CancellationToken.None);
+            Assert.NotNull(diagnostic);
+
+            _ = await server.InlayHintAsync(new InlayHintParams { TextDocument = id });
+            _ = await server.CodeLensAsync(new CodeLensParams { TextDocument = id });
+            _ = await server.SemanticTokensFullAsync(new SemanticTokensParams { TextDocument = id });
+            _ = await server.SemanticTokensRangeAsync(new SemanticTokensRangeParams { TextDocument = id });
+            _ = await server.HoverAsync(new HoverParams { TextDocument = id, Position = new Position(0, 0) });
+            _ = await server.DocumentSymbolAsync(new DocumentSymbolParams { TextDocument = id });
+            _ = await server.FoldingRangeAsync(new FoldingRangeParams { TextDocument = id });
+            _ = await server.CompletionAsync(new CompletionParams { TextDocument = id, Position = new Position(0, 0) });
+        }
+        finally
+        {
+            try { Directory.Delete(rootDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task GuardAsync_SwallowsHandlerException_ReturnsDefault()
+    {
+        // Direct contract test for the defensive try/catch added in LspServer.GuardAsync.
+        // The throwing-content service forces a handler body to NRE on the very first
+        // access to DocumentContent.SyntaxTree; without the catch the JSON-RPC layer
+        // would surface a "-32000 Object reference not set to an instance of an object"
+        // error popup for every request the editor pulls.
+        var contentService = new ThrowingDocumentContentService();
+        var server = new LspServer(contentService, new WorkspaceState());
+        var uri = DocumentUri.From("file:///throw-test.gs");
+
+        // Populate the service with a sentinel entry whose SyntaxTree access throws.
+        contentService.InstallThrowingEntry(uri.ToString());
+
+        var id = new TextDocumentIdentifier { Uri = uri };
+
+        // Each of these handler types would historically tear down with NRE.
+        Assert.Null(await server.HoverAsync(new HoverParams { TextDocument = id, Position = new Position(0, 0) }));
+        Assert.Empty(await server.InlayHintAsync(new InlayHintParams { TextDocument = id }) ?? Array.Empty<InlayHint>());
+        Assert.Empty(await server.CodeLensAsync(new CodeLensParams { TextDocument = id }) ?? Array.Empty<CodeLens>());
+
+        var tokens = await server.SemanticTokensFullAsync(new SemanticTokensParams { TextDocument = id });
+        Assert.True(tokens == null || tokens.Data.IsDefaultOrEmpty);
+    }
+
+    private sealed class ThrowingDocumentContentService : DocumentContentService
+    {
+        private readonly System.Collections.Concurrent.ConcurrentDictionary<string, bool> throwingKeys = new();
+
+        public void InstallThrowingEntry(string key) => this.throwingKeys[key] = true;
+
+        public override bool TryGet(string key, out DocumentContent content)
+        {
+            if (this.throwingKeys.ContainsKey(key))
+            {
+                throw new NullReferenceException("Simulated #816 NRE inside content lookup.");
+            }
+
+            return base.TryGet(key, out content);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #816, closes #822.

### #816 — LSP no longer surfaces "Object reference not set to an instance of an object" popups

When a user opened a real-world G# file in the bundled VSCode extension, every pull-based LSP request (`textDocument/diagnostic`, `inlayHint`, `codeLens`, `semanticTokens`) would surface a `-32000` error popup. Each new keystroke triggered another cascade. The same source opened cleanly against an up-to-date `main` LS, so the latent bug was simple: an unexpected exception in any handler tore through GuardAsync into the JSON-RPC layer instead of being treated as "no result".

The fix is small and defensive:

- `LspServer.GuardAsync<T>` now wraps the body in an inner try/catch. `OperationCanceledException` flows through unchanged. Anything else is logged to stderr (with the originating handler captured via `CallerMemberName`) and the call returns `default(T)`. All pull-based handler returns are reference types, so the client sees an LSP-spec-compliant "no result" instead of a crash popup.
- `DocumentDiagnosticAsync` doesn't go through `GuardAsync` (it releases its gate before the expensive compute), so it got the same try/catch around `ComputeDiagnostics` — failure returns an empty `FullDocumentDiagnosticReport` instead of throwing.
- `DocumentContentService.TryGet` is now `virtual` so the test can plant a throwing content service and prove the catch fires.

#### Regression test

`test/LanguageServer.Tests/Issue816HandlerExceptionTests.cs` adds two cases:

1. `AllPullHandlers_DegradeGracefully_OnPartiallyValidSource` — builds a realistic temp project (pre-ADR-0078 syntax, project references that don't resolve on disk) and pulls diagnostic / inlayHint / codeLens / semanticTokens (full + range) / hover / documentSymbol / foldingRange / completion. The contract under test is "no exception escapes".
2. `GuardAsync_SwallowsHandlerException_ReturnsDefault` — installs a `ThrowingDocumentContentService` whose `TryGet` throws and verifies hover/inlayHint/codeLens/semanticTokens all return safe defaults instead of propagating the exception.

### #822 — TextMate grammar refresh

`src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json`:
- Add `int` to the primitive-type alternation (ADR-0098 friendly numeric aliases — `int` was the only alias missing).
- Remove obsolete `record` declaration keyword (ADR-0078 deletes `record`; the parser now diagnoses it via `ReportRecordKeywordRemoved`).
- Remove obsolete `:=` short-declaration operator (ADR-0077).
- Extend the null-conditional operator match to include `?[` indexer (ADR-0073).
- Add a new `declarations` repository pattern so the identifier that follows `class | struct | enum | interface | type` gets `entity.name.type.gsharp` highlighting, and the identifier after `func | sequence` gets `entity.name.function.gsharp`.

The bundled `.server/` artifacts are gitignored and regenerated by `src/vscode-gsharp/esbuild.js` at publish time, so this PR doesn't ship binaries; once it lands and the next extension build runs, the new LS code and grammar both flow into the .vsix.

## Verification

- `dotnet build GSharp.sln -nologo -clp:NoSummary` — clean, no warnings.
- `dotnet test GSharp.sln --no-restore --nologo` — 5165 tests, 0 failures (LanguageServer.Tests: 266 ✓ incl. the 2 new ones; Core.Tests: 3183 ✓; Compiler.Tests: 1294 ✓; Interpreter.Tests: 283 ✓; Extensions.Tests: 107 ✓; Sdk.Tests: 32 ✓).
- Grammar JSON validated with `python3 -c "import json; json.load(open(...))"."
