### PR TITLE
Fix NRE in accessor binder when parameter type is unresolvable

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -815,7 +815,7 @@ internal sealed class DeclarationBinder
                     {
                         var parameterSyntax = methodSyntax.Parameters[pIndex];
                         var parameterName = parameterSyntax.Identifier.Text;
-                        var parameterType = bindTypeClause(parameterSyntax.Type);
+                        var parameterType = bindTypeClause(parameterSyntax.Type) ?? TypeSymbol.Error;
 
                         // ADR-0101 follow-up / issue #812: variadic parameters
                         // are now accepted on class instance methods. The body
@@ -824,7 +824,7 @@ internal sealed class DeclarationBinder
                         // passes through a single `[]T` argument unchanged) —
                         // see OverloadResolver.BindUserInstanceCall.
                         var isVariadic = parameterSyntax.IsVariadic;
-                        if (isVariadic && parameterType != null && parameterType != TypeSymbol.Error)
+                        if (isVariadic && parameterType != TypeSymbol.Error)
                         {
                             parameterType = SliceTypeSymbol.Get(parameterType);
                         }
@@ -1436,7 +1436,7 @@ internal sealed class DeclarationBinder
                     foreach (var parameterSyntax in methodSyntax.Parameters)
                     {
                         var parameterName = parameterSyntax.Identifier.Text;
-                        var parameterType = bindTypeClause(parameterSyntax.Type);
+                        var parameterType = bindTypeClause(parameterSyntax.Type) ?? TypeSymbol.Error;
 
                         // ADR-0101 follow-up / issue #812: variadic parameters
                         // are now accepted on shared/static class methods. The
@@ -1444,7 +1444,7 @@ internal sealed class DeclarationBinder
                         // path goes through the same overload resolver that
                         // handles top-level variadic functions.
                         var isVariadic = parameterSyntax.IsVariadic;
-                        if (isVariadic && parameterType != null && parameterType != TypeSymbol.Error)
+                        if (isVariadic && parameterType != TypeSymbol.Error)
                         {
                             parameterType = SliceTypeSymbol.Get(parameterType);
                         }
@@ -2497,7 +2497,7 @@ internal sealed class DeclarationBinder
             foreach (var parameterSyntax in methodSyntax.Parameters)
             {
                 var parameterName = parameterSyntax.Identifier.Text;
-                var parameterType = bindTypeClause(parameterSyntax.Type);
+                var parameterType = bindTypeClause(parameterSyntax.Type) ?? TypeSymbol.Error;
 
                 // ADR-0101 follow-up / issue #812: variadic parameters are now
                 // accepted on interface methods. For abstract members the
@@ -2506,7 +2506,7 @@ internal sealed class DeclarationBinder
                 // and the emitter stamps [ParamArrayAttribute] on the MethodDef
                 // (interface method emit shares the same path as class methods).
                 var isVariadic = parameterSyntax.IsVariadic;
-                if (isVariadic && parameterType != null && parameterType != TypeSymbol.Error)
+                if (isVariadic && parameterType != TypeSymbol.Error)
                 {
                     parameterType = SliceTypeSymbol.Get(parameterType);
                 }
@@ -2896,7 +2896,7 @@ internal sealed class DeclarationBinder
             {
                 var parameterSyntax = syntax.Parameters[pIndex];
                 var parameterName = parameterSyntax.Identifier.Text;
-                var parameterType = bindTypeClause(parameterSyntax.Type);
+                var parameterType = bindTypeClause(parameterSyntax.Type) ?? TypeSymbol.Error;
                 if (!seenParameterNames.Add(parameterName))
                 {
                     Diagnostics.ReportParameterAlreadyDeclared(parameterSyntax.Location, parameterName);
@@ -2907,7 +2907,7 @@ internal sealed class DeclarationBinder
                     // and must be the last parameter. Auto-packing of trailing
                     // arguments happens at the call site.
                     var isVariadic = parameterSyntax.IsVariadic;
-                    if (isVariadic && parameterType != null && parameterType != TypeSymbol.Error)
+                    if (isVariadic && parameterType != TypeSymbol.Error)
                     {
                         parameterType = SliceTypeSymbol.Get(parameterType);
                     }
@@ -4049,7 +4049,7 @@ internal sealed class DeclarationBinder
         foreach (var parameterSyntax in ctorSyntax.Parameters)
         {
             var parameterName = parameterSyntax.Identifier.Text;
-            var parameterType = bindTypeClause(parameterSyntax.Type);
+            var parameterType = bindTypeClause(parameterSyntax.Type) ?? TypeSymbol.Error;
 
             // ADR-0101 follow-up / issue #812: variadic parameters are now
             // accepted on explicit `init(...)` constructors. The body sees
@@ -4057,7 +4057,7 @@ internal sealed class DeclarationBinder
             // `: this(...)` / `: base(...)` chaining) go through the
             // constructor overload paths that pack trailing arguments.
             var isVariadic = parameterSyntax.IsVariadic;
-            if (isVariadic && parameterType != null && parameterType != TypeSymbol.Error)
+            if (isVariadic && parameterType != TypeSymbol.Error)
             {
                 parameterType = SliceTypeSymbol.Get(parameterType);
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1470,7 +1470,7 @@ internal sealed partial class ExpressionBinder
                     Diagnostics.ReportUnableToFindMember(ne.Location, nullableMemberName);
                     return new BoundErrorExpression(null);
                 }
-                else if (receiver != null && receiver.Type is not NullableTypeSymbol && receiver.Type.ClrType != null)
+                else if (receiver != null && receiver.Type != null && receiver.Type is not NullableTypeSymbol && receiver.Type.ClrType != null)
                 {
                     // Phase 4 exit: read a public instance property or field on
                     // a CLR receiver (e.g. `lst.Count`, `sb.Length`,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue826NreOnUnresolvedParameterTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue826NreOnUnresolvedParameterTypeTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="Issue826NreOnUnresolvedParameterTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #826 — the language server crashed with a NullReferenceException
+/// when binding member access on a receiver whose type could not be resolved
+/// (e.g. parameter typed with an unknown CLR type). The binder must report
+/// diagnostics gracefully instead of throwing.
+/// </summary>
+public class Issue826NreOnUnresolvedParameterTypeTests
+{
+    [Fact]
+    public void MemberAccessOnUnresolvedParameterType_DoesNotThrow()
+    {
+        var source = @"
+type Foo class {
+    func DoStuff(x UnknownType) {
+        let y = x.SomeMember
+    }
+}
+";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var diagnostics = compilation.BoundProgram.Diagnostics;
+
+        // Must report diagnostics (unresolved type) but not throw.
+        Assert.NotEmpty(diagnostics);
+    }
+
+    [Fact]
+    public void ChainedMemberAccessOnUnresolvedParameterType_DoesNotThrow()
+    {
+        var source = @"
+type Foo class {
+    func DoStuff(x UnknownType) {
+        let y = x.A.B
+    }
+}
+";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var diagnostics = compilation.BoundProgram.Diagnostics;
+
+        Assert.NotEmpty(diagnostics);
+    }
+
+    [Fact]
+    public void MethodCallOnUnresolvedParameterType_DoesNotThrow()
+    {
+        var source = @"
+type Foo class {
+    func DoStuff(x UnknownType) {
+        let y = x.ToString().Length
+    }
+}
+";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var diagnostics = compilation.BoundProgram.Diagnostics;
+
+        Assert.NotEmpty(diagnostics);
+    }
+
+    [Fact]
+    public void FieldWithUnresolvedType_MemberAccess_DoesNotThrow()
+    {
+        // Simulates the old-syntax field declaration pattern (without var/let)
+        // where the field type cannot be resolved.
+        var source = @"
+type Bar class {
+    var x UnknownType = nil
+
+    func DoStuff() {
+        let y = x.Member
+    }
+}
+";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var diagnostics = compilation.BoundProgram.Diagnostics;
+
+        Assert.NotEmpty(diagnostics);
+    }
+}


### PR DESCRIPTION
Fixes #826

When a type clause cannot be resolved (e.g. referencing a CLR type not available in the loaded references), `BindTypeClause` returns null. This null propagated into `ParameterSymbol.Type`, causing a `NullReferenceException` at `ExpressionBinder.Access.cs:1473` when binding member access on that parameter.

**Root cause:** `DeclarationBinder` created `ParameterSymbol` instances with a null `Type` when the type clause was unresolvable. Unlike fields (which are skipped), parameters were added to the function signature with null types.

**Fix:**
- `DeclarationBinder`: fall back to `TypeSymbol.Error` when `bindTypeClause` returns null for parameter types across all method kinds (instance, static, interface, top-level, and explicit constructors).
- `ExpressionBinder.Access`: add a defensive null guard for `receiver.Type` before accessing `.ClrType`, ensuring the binder reports a diagnostic instead of crashing even if a null Type leaks through another path.

The language server now shows red squiggles for unresolvable types instead of failing the entire diagnostic pass with an NRE.