### PR TITLE
Fix #821: []T to IEnumerable[T] at static-call argument slots

### DIFF
--- a/samples/TupleSequenceIterators.gs
+++ b/samples/TupleSequenceIterators.gs
@@ -14,7 +14,7 @@ import System.Collections.Generic
 class Sequences {
     shared {
         // `(int32, T)` element type — the issue's `Indexed` spelling.
-        func Indexed[T](source sequence[T]) sequence[(int32, T)] {
+        func Indexed[T](source IEnumerable[T]) sequence[(int32, T)] {
             var index = 0
             for v in source {
                 yield (index, v)
@@ -23,7 +23,7 @@ class Sequences {
         }
 
         // `(T, T)` element type — the issue's `Pairwise` spelling.
-        func Pairwise[T](source sequence[T]) sequence[(T, T)] {
+        func Pairwise[T](source IEnumerable[T]) sequence[(T, T)] {
             var first = true
             var prev T = default(T)
             for v in source {

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -462,7 +462,7 @@ public sealed class Conversion
         if (from is SliceTypeSymbol sliceForIface && to?.ClrType != null && to.ClrType.IsInterface)
         {
             if (sliceForIface.ClrType != null
-                && ClrTypeUtilities.ImplementsInterfaceByName(sliceForIface.ClrType, to.ClrType))
+                && SliceImplementsInterface(sliceForIface, to))
             {
                 return Conversion.Implicit;
             }
@@ -729,6 +729,88 @@ public sealed class Conversion
         if (b is TupleTypeSymbol tb && a is not TupleTypeSymbol)
         {
             return tb.ClrType != null && a.ClrType != null && tb.ClrType == a.ClrType;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #821: cross-context-safe slice-to-interface check. When the
+    /// target is a constructed <see cref="ImportedTypeSymbol"/> whose
+    /// <c>ClrType</c> is the type-erased open-definition form (because
+    /// <see cref="Type.MakeGenericType(Type[])"/> could not be closed at
+    /// substitution time — typically because the open definition lives in a
+    /// <see cref="System.Reflection.MetadataLoadContext"/> while the
+    /// substituted argument types live in the live runtime) the symbolic
+    /// <see cref="ImportedTypeSymbol.TypeArguments"/> carry the real
+    /// substituted G# types. Match against those, not the erased CLR
+    /// arguments, so the slice still classifies as implicitly convertible to
+    /// the constructed interface.
+    /// </summary>
+    /// <param name="slice">The source slice type.</param>
+    /// <param name="targetInterface">The constructed interface target.</param>
+    /// <returns><see langword="true"/> when the slice's backing array
+    /// implements the target interface.</returns>
+    private static bool SliceImplementsInterface(SliceTypeSymbol slice, TypeSymbol targetInterface)
+    {
+        // Cheap path: the target's CLR generic arguments are already the
+        // properly substituted closed form. Defer to the existing
+        // by-name interface walk.
+        if (ClrTypeUtilities.ImplementsInterfaceByName(slice.ClrType, targetInterface.ClrType))
+        {
+            return true;
+        }
+
+        if (targetInterface is not ImportedTypeSymbol imported
+            || imported.OpenDefinition is null
+            || imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        // Cross-context fallback: walk the slice's backing CLR array
+        // interfaces and match each generic argument against the symbolic
+        // TypeArguments by ClrType FullName, which is assembly-qualifier
+        // free for leaf types (System.Int32, System.String, …) and so
+        // compares correctly across reflection contexts.
+        var openDef = imported.OpenDefinition;
+        foreach (var iface in slice.ClrType.GetInterfaces())
+        {
+            if (!iface.IsGenericType)
+            {
+                continue;
+            }
+
+            if (!string.Equals(
+                    iface.GetGenericTypeDefinition().FullName,
+                    openDef.FullName,
+                    StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var ifaceArgs = iface.GetGenericArguments();
+            if (ifaceArgs.Length != imported.TypeArguments.Length)
+            {
+                continue;
+            }
+
+            var allMatch = true;
+            for (var i = 0; i < ifaceArgs.Length; i++)
+            {
+                var symbolic = imported.TypeArguments[i];
+                if (symbolic?.ClrType is null
+                    || !string.Equals(ifaceArgs[i].FullName, symbolic.ClrType.FullName, StringComparison.Ordinal))
+                {
+                    allMatch = false;
+                    break;
+                }
+            }
+
+            if (allMatch)
+            {
+                return true;
+            }
         }
 
         return false;

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -532,6 +532,58 @@ internal sealed partial class MethodBodyEmitter
             return true;
         }
 
+        // Issue #821: cross-context slice-to-constructed-interface widening
+        // where the target is an <see cref="ImportedTypeSymbol"/> whose
+        // <c>ClrType</c> is the type-erased open-definition form (because
+        // <c>MakeGenericType</c> at substitution time could not produce a
+        // closed CLR type — the open def lives in a MetadataLoadContext while
+        // the arguments live in the host runtime). Match the slice's backing
+        // <c>T[]</c> interfaces against the open definition's full name and
+        // the symbolic <c>TypeArguments</c> by leaf-FullName so the CLR
+        // no-op upcast classifies correctly. Mirrors the binder fallback in
+        // <see cref="Conversion.SliceImplementsInterface"/>.
+        if (a is SliceTypeSymbol aSlice
+            && aSlice.ClrType != null
+            && b is ImportedTypeSymbol bImported
+            && bImported.OpenDefinition is { } bOpenDef
+            && !bImported.TypeArguments.IsDefaultOrEmpty)
+        {
+            foreach (var iface in aSlice.ClrType.GetInterfaces())
+            {
+                if (!iface.IsGenericType
+                    || !string.Equals(
+                        iface.GetGenericTypeDefinition().FullName,
+                        bOpenDef.FullName,
+                        StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var ifaceArgs = iface.GetGenericArguments();
+                if (ifaceArgs.Length != bImported.TypeArguments.Length)
+                {
+                    continue;
+                }
+
+                var allMatch = true;
+                for (var i = 0; i < ifaceArgs.Length; i++)
+                {
+                    var symbolic = bImported.TypeArguments[i];
+                    if (symbolic?.ClrType is null
+                        || !string.Equals(ifaceArgs[i].FullName, symbolic.ClrType.FullName, StringComparison.Ordinal))
+                    {
+                        allMatch = false;
+                        break;
+                    }
+                }
+
+                if (allMatch)
+                {
+                    return true;
+                }
+            }
+        }
+
         return false;
     }
 

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -5445,6 +5445,59 @@ internal sealed class ReflectionMetadataEmitter
             }
         }
 
+        // Issue #821: when the formal is a constructed CLR generic
+        // interface that the actual's backing array satisfies — e.g.
+        // `IEnumerable[T]` / `IList[T]` / `ICollection[T]` /
+        // `IReadOnlyList[T]` (any interface implemented by `T[]`) — and
+        // the actual is a `[]T` slice or `[N]T` fixed-length array,
+        // bridge their generic arguments by locating the matching
+        // interface instantiation on the actual's backing CLR `T[]` and
+        // recursing into the element-type slot. Mirrors the binder's
+        // slice-to-interface classifier (#570) and the
+        // `sequence[T]`-vs-slice/array arm above (#774/#814) at the
+        // static-method / free-function argument-slot inference path so
+        // generic-method-spec construction can recover `T` from a
+        // slice argument when the type parameter only appears in an
+        // interface-typed formal parameter (no `T` in the return).
+        if (formal is ImportedTypeSymbol formalImported
+            && formalImported.ClrType is { IsInterface: true, IsGenericType: true } formalIface
+            && !formalImported.TypeArguments.IsDefaultOrEmpty
+            && (actual is SliceTypeSymbol || actual is ArrayTypeSymbol)
+            && actual?.ClrType is { IsArray: true } actualClrArray)
+        {
+            Type matched = null;
+            foreach (var iface in actualClrArray.GetInterfaces())
+            {
+                if (iface.IsGenericType
+                    && ClrTypeUtilities.AreSame(
+                        iface.GetGenericTypeDefinition(),
+                        formalIface.GetGenericTypeDefinition()))
+                {
+                    matched = iface;
+                    break;
+                }
+            }
+
+            if (matched != null)
+            {
+                var matchedArgs = matched.GetGenericArguments();
+                if (formalImported.TypeArguments.Length == matchedArgs.Length)
+                {
+                    for (int i = 0; i < formalImported.TypeArguments.Length; i++)
+                    {
+                        if (TryUnify(
+                                formalImported.TypeArguments[i],
+                                TypeSymbol.FromClrType(matchedArgs[i]),
+                                tp,
+                                out inferred))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
         var formalArgs = GetGenericTypeArguments(formal);
         var actualArgs = GetGenericTypeArguments(actual);
         if (!formalArgs.IsDefaultOrEmpty && !actualArgs.IsDefaultOrEmpty
@@ -6274,7 +6327,7 @@ internal sealed class ReflectionMetadataEmitter
         // null ClrType (issue #774), or an AsyncSequenceTypeSymbol with
         // null ClrType.
         var symbolicView = ImportedTypeSymbol.GetConstructed(
-            openDefinition.MakeGenericType(GetErasedObjectArgs(openDefinition)),
+            openDefinition.MakeGenericType(this.GetErasedObjectArgs(openDefinition)),
             openDefinition,
             typeArguments);
 
@@ -6380,16 +6433,37 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
-    private static Type[] GetErasedObjectArgs(Type openDefinition)
+    // Issue #821: choose the right erased `object` for an open generic
+    // definition's MakeGenericType call. The open def may live in a
+    // MetadataLoadContext (reference-pack assemblies); passing a live
+    // `typeof(object)` to its MakeGenericType raises ArgumentException with
+    // "type was not loaded by the MetadataLoadContext that loaded the
+    // generic type or method." Use `emitCtx.CoreObjectType`, which is the
+    // System.Object resolved through the active reference context, when the
+    // open def lives outside the host runtime.
+    private Type[] GetErasedObjectArgs(Type openDefinition)
     {
         var parameters = openDefinition.GetGenericArguments();
         var result = new Type[parameters.Length];
+        var coreObject = ChooseErasedObjectType(openDefinition);
         for (var i = 0; i < parameters.Length; i++)
         {
-            result[i] = typeof(object);
+            result[i] = coreObject;
         }
 
         return result;
+    }
+
+    private Type ChooseErasedObjectType(Type openDefinition)
+    {
+        // Same context as the open def → cheap path.
+        var hostObject = typeof(object);
+        if (openDefinition?.Assembly == hostObject.Assembly)
+        {
+            return hostObject;
+        }
+
+        return this.emitCtx.CoreObjectType ?? hostObject;
     }
 
     private static MethodInfo ResolveMethodOnOpenDefinition(Type openDefinition, MethodInfo method)

--- a/test/Compiler.Tests/Emit/Issue821SliceToInterfaceAtArgumentSlotEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue821SliceToInterfaceAtArgumentSlotEmitTests.cs
@@ -1,0 +1,282 @@
+// <copyright file="Issue821SliceToInterfaceAtArgumentSlotEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #821: end-to-end emit + IL-verify coverage for the slice-to-interface
+/// implicit conversion applied at ordinary argument slots (static-method
+/// and free-function call sites). Mirrors the binder coverage in
+/// <c>Issue821SliceToInterfaceAtArgumentSlotBindingTests</c> and complements
+/// the receiver-call coverage that #570/#774 already pinned.
+/// </summary>
+/// <remarks>
+/// These cases close the gap noted while shipping #813 — the sample's
+/// <c>Sequences.Indexed[T](source IEnumerable[T])</c> shape now binds, emits
+/// verifier-clean IL, and produces the expected runtime values when a
+/// <c>[]int32</c> or <c>[]string</c> slice is passed at the static-call
+/// argument slot.
+/// </remarks>
+public class Issue821SliceToInterfaceAtArgumentSlotEmitTests
+{
+    [Fact]
+    public void StaticGeneric_IEnumerableOfT_AcceptsSliceLiteral_RunsForInt32()
+    {
+        // The literal issue repro: `Sequences.Indexed[int32](ints)`
+        // with `Indexed` declared as `func Indexed[T](source IEnumerable[T])`.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func Indexed[T](source IEnumerable[T]) sequence[(int32, T)] {
+                        var index = 0
+                        for v in source {
+                            yield (index, v)
+                            index = index + 1
+                        }
+                    }
+                }
+            }
+
+            public var sumIdx = 0
+            public var sumVal = 0
+            let ints = []int32{10, 20, 30}
+            for p in Sequences.Indexed[int32](ints) {
+                sumIdx = sumIdx + p.Item1
+                sumVal = sumVal + p.Item2
+            }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(3, GetIntField(assembly, "sumIdx"));
+        Assert.Equal(60, GetIntField(assembly, "sumVal"));
+    }
+
+    [Fact]
+    public void StaticGeneric_IEnumerableOfT_AcceptsSliceLiteral_RunsForString()
+    {
+        // String-typed closure of the same shape — confirms the runtime
+        // representation is identical for value-type and reference-type
+        // element types.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func Indexed[T](source IEnumerable[T]) sequence[(int32, T)] {
+                        var index = 0
+                        for v in source {
+                            yield (index, v)
+                            index = index + 1
+                        }
+                    }
+                }
+            }
+
+            public var sumIdx = 0
+            public var concat = ""
+            for p in Sequences.Indexed[string]([]string{"a", "b", "c"}) {
+                sumIdx = sumIdx + p.Item1
+                concat = concat + p.Item2
+            }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(3, GetIntField(assembly, "sumIdx"));
+        Assert.Equal("abc", GetStringField(assembly, "concat"));
+    }
+
+    [Fact]
+    public void FreeFunctionArgSlot_IEnumerableOfT_AcceptsSliceLiteral_Runs()
+    {
+        // Free-function call slot variant.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            func Count[T](source IEnumerable[T]) int32 {
+                var n = 0
+                for _ in source {
+                    n = n + 1
+                }
+                return n
+            }
+
+            public var n = Count[int32]([]int32{10, 20, 30})
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(3, GetIntField(assembly, "n"));
+    }
+
+    [Fact]
+    public void StaticGeneric_IListOfT_AcceptsSliceLiteral_Runs()
+    {
+        // `IList[T]` interface — slice satisfies it via the backing CLR array.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Sink {
+                shared {
+                    func Take[T](source IList[T]) int32 { return source.Count }
+                }
+            }
+
+            public var n = Sink.Take[int32]([]int32{1, 2, 3})
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(3, GetIntField(assembly, "n"));
+    }
+
+    [Fact]
+    public void StaticGeneric_ICollectionOfT_AcceptsSliceLiteral_Runs()
+    {
+        // `ICollection[T]` — slice satisfies it via the backing CLR array.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Sink {
+                shared {
+                    func Take[T](source ICollection[T]) int32 { return source.Count }
+                }
+            }
+
+            public var n = Sink.Take[int32]([]int32{1, 2, 3, 4})
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(4, GetIntField(assembly, "n"));
+    }
+
+    [Fact]
+    public void StaticGeneric_IReadOnlyListOfT_AcceptsSliceLiteral_Runs()
+    {
+        // `IReadOnlyList[T]` — slice satisfies it via the backing CLR
+        // array. Returns `int32` (not an open `T`) to keep coverage on
+        // the argument-slot conversion the issue is about and avoid the
+        // unrelated indexer-on-open-generic emit shape.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Sink {
+                shared {
+                    func Take[T](source IReadOnlyList[T]) int32 { return source.Count }
+                }
+            }
+
+            public var n = Sink.Take[int32]([]int32{7, 8, 9})
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(3, GetIntField(assembly, "n"));
+    }
+
+    [Fact]
+    public void StaticGeneric_IEnumerableOfT_AcceptsSliceFromLocal_Runs()
+    {
+        // Slice held in a local variable (not just a literal) flowed into
+        // an `IEnumerable[T]` static-method argument slot.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func Sum(source IEnumerable[int32]) int32 {
+                        var s = 0
+                        for v in source {
+                            s = s + v
+                        }
+                        return s
+                    }
+                }
+            }
+
+            let ints = []int32{10, 20, 30}
+            public var total = Sequences.Sum(ints)
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(60, GetIntField(assembly, "total"));
+    }
+
+    private static Assembly CompileAndRun(string source)
+    {
+        var outPath = CompileToFile(source);
+
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        return assembly;
+    }
+
+    private static string CompileToFile(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_821_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static int GetIntField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (int)field!.GetValue(null)!;
+    }
+
+    private static string GetStringField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (string)field!.GetValue(null)!;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue821SliceToInterfaceAtArgumentSlotBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue821SliceToInterfaceAtArgumentSlotBindingTests.cs
@@ -1,0 +1,261 @@
+// <copyright file="Issue821SliceToInterfaceAtArgumentSlotBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #821: a G# slice <c>[]T</c> must implicitly convert to every
+/// interface implemented by its backing CLR array <c>T[]</c>
+/// (<c>IEnumerable&lt;T&gt;</c>, <c>IReadOnlyList&lt;T&gt;</c>,
+/// <c>IList&lt;T&gt;</c>, <c>ICollection&lt;T&gt;</c>, the non-generic
+/// counterparts, etc.) at every ordinary argument slot — including
+/// static-method (shared) call sites and free-function call sites — not
+/// just at receiver positions on extension/instance dispatch
+/// (closed by #774's open-generic receiver fix).
+/// </summary>
+/// <remarks>
+/// The conversion is classified by
+/// <see cref="GSharp.Core.CodeAnalysis.Binding.Conversion.Classify(Symbols.TypeSymbol, Symbols.TypeSymbol)"/>
+/// via the slice-to-interface arm (originally landed for issue #570). The
+/// substitution path in <c>Binder.SubstituteType</c> rebuilds an
+/// <c>IEnumerable[T]</c> parameter into a closed CLR
+/// <see cref="System.Collections.Generic.IEnumerable{T}"/> at the call site,
+/// so the slice-to-interface classifier sees the correctly-shaped target
+/// and admits the implicit, no-op conversion. These tests pin that
+/// behaviour at all the argument slots the issue body enumerates.
+/// </remarks>
+public class Issue821SliceToInterfaceAtArgumentSlotBindingTests
+{
+    [Fact]
+    public void IssueRepro_StaticGenericIndexed_IEnumerableOfT_FromSliceOfT_Binds()
+    {
+        // The literal repro from the issue body: `Sequences.Indexed[int32](ints)`
+        // where `ints` is a `[]int32` slice and the parameter is `IEnumerable[T]`.
+        const string source = @"
+package P
+import System.Collections.Generic
+
+class Sequences {
+    shared {
+        func Indexed[T](source IEnumerable[T]) sequence[(int32, T)] {
+            var index = 0
+            for v in source {
+                yield (index, v)
+                index = index + 1
+            }
+        }
+    }
+}
+
+let ints = []int32{10, 20, 30}
+for p in Sequences.Indexed[int32](ints) {
+    let _x = p.Item1
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void StaticMethodArgSlot_SliceOfInt_To_IEnumerableOfInt_Binds()
+    {
+        // Non-generic shared method taking `IEnumerable[int32]` directly.
+        // The argument is a `[]int32` slice literal.
+        const string source = @"
+package P
+import System.Collections.Generic
+
+class Sink {
+    shared {
+        func Take(source IEnumerable[int32]) int32 { return 0 }
+    }
+}
+
+let _ = Sink.Take([]int32{1, 2, 3})
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void FreeFunctionArgSlot_SliceOfString_To_IEnumerableOfString_Binds()
+    {
+        // Free-function call slot: `[]string` argument flows into a
+        // top-level function parameter typed as `IEnumerable[string]`.
+        const string source = @"
+package P
+import System.Collections.Generic
+
+func Take(source IEnumerable[string]) int32 { return 0 }
+
+let _ = Take([]string{""a"", ""b""})
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void FreeFunctionArgSlot_GenericIndexed_SliceOfInt_To_IEnumerableOfT_Binds()
+    {
+        // Free-function generic method with an `IEnumerable[T]` parameter
+        // — confirms the substitution path (`Binder.SubstituteType`)
+        // rebuilds the closed `IEnumerable<int32>` before classification.
+        const string source = @"
+package P
+import System.Collections.Generic
+
+func Indexed[T](source IEnumerable[T]) int32 { return 0 }
+
+let _ = Indexed[int32]([]int32{10, 20, 30})
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void StaticMethodArgSlot_SliceOfInt_To_IListOfInt_Binds()
+    {
+        // `IList[T]` is implemented by `T[]` — slice must convert.
+        const string source = @"
+package P
+import System.Collections.Generic
+
+class Sink {
+    shared {
+        func Take[T](source IList[T]) int32 { return source.Count }
+    }
+}
+
+let _ = Sink.Take[int32]([]int32{1, 2, 3})
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void StaticMethodArgSlot_SliceOfInt_To_ICollectionOfInt_Binds()
+    {
+        // `ICollection[T]` is implemented by `T[]` — slice must convert.
+        const string source = @"
+package P
+import System.Collections.Generic
+
+class Sink {
+    shared {
+        func Take[T](source ICollection[T]) int32 { return source.Count }
+    }
+}
+
+let _ = Sink.Take[int32]([]int32{1, 2, 3})
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void StaticMethodArgSlot_SliceOfInt_To_IReadOnlyListOfInt_Binds()
+    {
+        // `IReadOnlyList[T]` is implemented by `T[]` — slice must convert.
+        const string source = @"
+package P
+import System.Collections.Generic
+
+class Sink {
+    shared {
+        func Take[T](source IReadOnlyList[T]) int32 { return source.Count }
+    }
+}
+
+let _ = Sink.Take[int32]([]int32{1, 2, 3})
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void Negative_SliceOfInt_To_IEnumerableOfString_Rejected()
+    {
+        // G# slices are invariant: `[]int32` must NOT convert to
+        // `IEnumerable[string]`. The binder rejects with GS0154
+        // ("Parameter requires …") — the standard overload-resolution
+        // argument-type mismatch diagnostic.
+        const string source = @"
+package P
+import System.Collections.Generic
+
+func Take(source IEnumerable[string]) int32 { return 0 }
+
+let _ = Take([]int32{1, 2, 3})
+";
+        var diags = GetDiagnostics(source);
+        Assert.NotEmpty(diags);
+        Assert.Contains(diags, d => d.Id == "GS0154" || d.Id == "GS0155");
+    }
+
+    [Fact]
+    public void Negative_SliceOfString_To_IEnumerableOfObject_Rejected()
+    {
+        // Variance regression guard mirroring #570's invariance arm:
+        // `[]string` does NOT convert to `IEnumerable[object]` even
+        // though the CLR allows array reference covariance.
+        const string source = @"
+package P
+import System.Collections.Generic
+
+func Take(source IEnumerable[object]) int32 { return 0 }
+
+let _ = Take([]string{""a"", ""b""})
+";
+        var diags = GetDiagnostics(source);
+        Assert.NotEmpty(diags);
+        Assert.Contains(diags, d => d.Id == "GS0154" || d.Id == "GS0155");
+    }
+
+    private static ImmutableArrayOfDiagnostic GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var parseDiagnostics = tree.Diagnostics;
+        var bindDiagnostics = compilation.GlobalScope.Diagnostics;
+        var programDiagnostics = compilation.BoundProgram.Diagnostics;
+        var all = parseDiagnostics
+            .Concat(bindDiagnostics)
+            .Concat(programDiagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+        return new ImmutableArrayOfDiagnostic(all);
+    }
+
+    /// <summary>
+    /// Thin wrapper used so the test cases can call <c>Assert.Empty</c>
+    /// against a <see cref="ImmutableArray{T}"/> without exposing the
+    /// GSharp diagnostic surface to xUnit's enumerable inference.
+    /// </summary>
+    private readonly struct ImmutableArrayOfDiagnostic : IReadOnlyCollection<Diagnostic>
+    {
+        private readonly ImmutableArray<Diagnostic> diagnostics;
+
+        public ImmutableArrayOfDiagnostic(ImmutableArray<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        public int Count => this.diagnostics.Length;
+
+        public IEnumerator<Diagnostic> GetEnumerator()
+        {
+            foreach (var diagnostic in this.diagnostics)
+            {
+                yield return diagnostic;
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/test/Interpreter.Tests/Issue821SliceToInterfaceAtArgumentSlotInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue821SliceToInterfaceAtArgumentSlotInterpreterTests.cs
@@ -1,0 +1,182 @@
+// <copyright file="Issue821SliceToInterfaceAtArgumentSlotInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #821 — tree-walking interpreter parity for the slice-to-interface
+/// implicit conversion applied at ordinary argument slots. Mirrors the
+/// emit suite (<c>Issue821SliceToInterfaceAtArgumentSlotEmitTests</c>)
+/// at the closed instantiation level; covers static-method (shared) and
+/// free-function call sites where the parameter is typed as
+/// <c>IEnumerable[T]</c>, <c>IList[T]</c>, <c>ICollection[T]</c>, or
+/// <c>IReadOnlyList[T]</c>.
+/// </summary>
+public class Issue821SliceToInterfaceAtArgumentSlotInterpreterTests
+{
+    [Fact]
+    public void StaticGeneric_IEnumerableOfT_AcceptsSliceLiteral_Int32()
+    {
+        // The literal issue repro at the static-call argument slot.
+        var source = """
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func Indexed[T](source IEnumerable[T]) sequence[(int32, T)] {
+                        var index = 0
+                        for v in source {
+                            yield (index, v)
+                            index = index + 1
+                        }
+                    }
+                }
+            }
+
+            var sumIdx = 0
+            var sumVal = 0
+            for p in Sequences.Indexed[int32]([]int32{10, 20, 30}) {
+                sumIdx = sumIdx + p.Item1
+                sumVal = sumVal + p.Item2
+            }
+            Console.WriteLine(sumIdx)
+            Console.WriteLine(sumVal)
+            """;
+
+        Assert.Equal("3\n60\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void StaticGeneric_IEnumerableOfT_AcceptsSliceLiteral_String()
+    {
+        // String closure of the same shape.
+        var source = """
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func Indexed[T](source IEnumerable[T]) sequence[(int32, T)] {
+                        var index = 0
+                        for v in source {
+                            yield (index, v)
+                            index = index + 1
+                        }
+                    }
+                }
+            }
+
+            var sumIdx = 0
+            var concat = ""
+            for p in Sequences.Indexed[string]([]string{"a", "b", "c"}) {
+                sumIdx = sumIdx + p.Item1
+                concat = concat + p.Item2
+            }
+            Console.WriteLine(sumIdx)
+            Console.WriteLine(concat)
+            """;
+
+        Assert.Equal("3\nabc\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void FreeFunctionArgSlot_IEnumerableOfT_AcceptsSliceLiteral()
+    {
+        // Free-function call slot.
+        var source = """
+            import System.Collections.Generic
+
+            func Count[T](source IEnumerable[T]) int32 {
+                var n = 0
+                for _ in source {
+                    n = n + 1
+                }
+                return n
+            }
+
+            Console.WriteLine(Count[int32]([]int32{10, 20, 30}))
+            """;
+
+        Assert.Equal("3\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void StaticGeneric_IListOfT_AcceptsSliceLiteral()
+    {
+        // `IList[T]` parameter — slice satisfies via backing CLR array.
+        var source = """
+            import System.Collections.Generic
+
+            class Sink {
+                shared {
+                    func Take[T](source IList[T]) int32 { return source.Count }
+                }
+            }
+
+            Console.WriteLine(Sink.Take[int32]([]int32{1, 2, 3}))
+            """;
+
+        Assert.Equal("3\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void StaticGeneric_ICollectionOfT_AcceptsSliceLiteral()
+    {
+        // `ICollection[T]` parameter.
+        var source = """
+            import System.Collections.Generic
+
+            class Sink {
+                shared {
+                    func Take[T](source ICollection[T]) int32 { return source.Count }
+                }
+            }
+
+            Console.WriteLine(Sink.Take[int32]([]int32{1, 2, 3, 4}))
+            """;
+
+        Assert.Equal("4\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void StaticGeneric_IReadOnlyListOfT_AcceptsSliceLiteral()
+    {
+        // `IReadOnlyList[T]` parameter — slice satisfies via backing CLR
+        // array. Returns `int32` to stay on the conversion path.
+        var source = """
+            import System.Collections.Generic
+
+            class Sink {
+                shared {
+                    func Take[T](source IReadOnlyList[T]) int32 { return source.Count }
+                }
+            }
+
+            Console.WriteLine(Sink.Take[int32]([]int32{7, 8, 9}))
+            """;
+
+        Assert.Equal("3\n", RunSubmission(source));
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary
`[]T` now implicitly converts to `IEnumerable[T]` (and any interface
implemented by `T[]` — `IList[T]`, `ICollection[T]`, `IReadOnlyList[T]`,
…) at every ordinary argument slot, including static-method and
free-function call sites. The repro from #821 now binds, emits
verifier-clean IL, and runs end-to-end.

## Root cause
Three coordinated gaps along the call-site spine, all surfacing only
when the constructed-interface target's CLR backing lives in a
`MetadataLoadContext` while the substituted argument types live in the
host runtime (as soon as any `/r:` reference is in play):

- **Binder** — `Conversion.cs` slice-to-interface arm read
  `to.ClrType.GetGenericArguments()` (which on an
  `ImportedTypeSymbol.GetConstructed` instance can still be the erased
  open-definition form, with `System.Object` args) instead of the real
  substituted `ImportedTypeSymbol.TypeArguments`. Result: GS0155.
- **Emitter — reference compat** — `MethodBodyEmitter.IsReferenceCompatible`
  walked `ImplementsInterfaceByName` against the same erased target,
  failing the same way. Result: GS9998 (`NotSupportedException` from
  `EmitConversion`).
- **Emitter — TypeSpec synthesis** — `GetErasedObjectArgs` always used
  the live `typeof(object)`; calling `MakeGenericType` on an MLC open
  definition with a live `System.Object` arg raised
  `ArgumentException: This type 'System.Object' was not loaded by the
  MetadataLoadContext that loaded the generic type or method.`

## Fix
- `Conversion.SliceImplementsInterface` falls back to the target's
  `OpenDefinition` + symbolic `TypeArguments`, comparing slice-array
  interface arguments by leaf `FullName` (cross-context safe), and
  keeps the slice-invariance guarantee from #570.
- `MethodBodyEmitter.IsReferenceCompatible` mirrors the binder fallback
  so the upcast is emitted as a no-op.
- `ReflectionMetadataEmitter.GetErasedObjectArgs` picks
  `emitCtx.CoreObjectType` when the open def lives outside the host
  runtime; the cheap host-only path is preserved.

The original `IEnumerable[T]` signatures on
`Sequences.Indexed` / `Sequences.Pairwise` in
`samples/TupleSequenceIterators.gs` are restored (the `sequence[T]`
shape was the #813 workaround for this exact gap).

## Tests
- **Binder** (9 tests in `Issue821SliceToInterfaceAtArgumentSlotBindingTests`):
  literal issue repro, `[]T` → `IEnumerable[T]` / `IList[T]` /
  `ICollection[T]` / `IReadOnlyList[T]` at static-method and
  free-function argument slots, negative variance guards
  (`[]int32` does not convert to `IEnumerable[string]`).
- **Emit** (7 tests in `Issue821SliceToInterfaceAtArgumentSlotEmitTests`):
  CompileAndRun + `IlVerifier` for each shape above; both `int32` and
  `string` closures.
- **Interpreter** (6 tests in
  `Issue821SliceToInterfaceAtArgumentSlotInterpreterTests`): mirrors
  the emit suite at closed instantiations through `GSharpRepl`.
- Full `dotnet test GSharp.sln` green: **5,253 passed**, 1 skipped
  (`RegenerateBaseline`).
- ilverify clean (every new emit test runs `IlVerifier.Verify`).
- `cd website && npm run build` succeeds.

## Related
Related: #774, #813. Parent series: #706.

Closes #821.
