### PR TITLE
Implement #805 (ADR-0104): map[K,V] G#-flavored spelling

### DIFF
--- a/docs/adr/0040-sequence-type-and-yield.md
+++ b/docs/adr/0040-sequence-type-and-yield.md
@@ -17,7 +17,7 @@ Async iterators (`IAsyncEnumerable[T]`) are aspirational but blocked until sync 
 
 ### 1. Introduce `sequence[T]` as a type alias for `IEnumerable[T]`
 
-By analogy with `map[K]V` aliasing `Dictionary[K, V]` (Phase 3.A.4), `sequence[T]` is the GSharp-flavored spelling of `System.Collections.Generic.IEnumerable<T>`. Both forms are interchangeable in declarations, parameter types, return types, and assignments. At the CLR metadata level they are the same type — no wrapper, no indirection.
+By analogy with `map[K,V]` aliasing `Dictionary[K, V]` (Phase 3.A.4), `sequence[T]` is the GSharp-flavored spelling of `System.Collections.Generic.IEnumerable<T>`. Both forms are interchangeable in declarations, parameter types, return types, and assignments. At the CLR metadata level they are the same type — no wrapper, no indirection.
 
 The `sequence` keyword is contextual: it is recognized only in type-annotation position (before `[`), and remains a valid identifier elsewhere.
 
@@ -43,7 +43,7 @@ This slice does not implement `yield break`. The GSharp answer for early termina
 
 ### `sequence[T]` type
 
-Parses identically to `map[K]V`: the contextual keyword `sequence` followed by `[`, a type clause, and `]`. Example:
+Parses identically to `map[K,V]`: the contextual keyword `sequence` followed by `[`, a type clause, and `]`. Example:
 
 ```gsharp
 func fib(max: int) sequence[int] {

--- a/docs/adr/0042-async-sequence-type-clause.md
+++ b/docs/adr/0042-async-sequence-type-clause.md
@@ -48,7 +48,7 @@ let factory func() async sequence[int] = gen
 
 // Pointer pointee, map value, chan element, nullable wrap
 let opt async sequence[int]? = nil
-let m map[string]async sequence[int]
+let m map[string,async sequence[int]]
 ```
 
 All of the above resolve to the same `AsyncSequenceTypeSymbol` and therefore the same CLR type as the explicit `IAsyncEnumerable[T]` spelling and the ADR-0041 implicit-swap form.
@@ -67,7 +67,7 @@ All three produce identical IL and identical symbols. The implicit swap remains 
 
 ### Restriction: `async` is only valid before `sequence` in type-clause position
 
-`async` as a type-clause prefix is reserved for the iterator alias. `async map[K]V`, `async chan T`, `async []T`, `async *T`, etc. are explicitly rejected with a diagnostic. Generalizing the modifier to function-type clauses (`async func(P) R` ≡ `func(P) Task[R]`) is the subject of ADR-0043; this ADR leaves the door open without committing.
+`async` as a type-clause prefix is reserved for the iterator alias. `async map[K,V]`, `async chan T`, `async []T`, `async *T`, etc. are explicitly rejected with a diagnostic. Generalizing the modifier to function-type clauses (`async func(P) R` ≡ `func(P) Task[R]`) is the subject of ADR-0043; this ADR leaves the door open without committing.
 
 ## Consequences
 
@@ -80,7 +80,7 @@ Positive:
 
 Negative:
 
-- Introduces a *two-token* type-clause shape (`async sequence[T]`) — a small departure from GSharp's existing single-prefix type forms (`*T`, `[]T`, `chan T`, `sequence[T]`, `map[K]V`). Mitigation: the parallel with `async func` makes the shape immediately recognizable.
+- Introduces a *two-token* type-clause shape (`async sequence[T]`) — a small departure from GSharp's existing single-prefix type forms (`*T`, `[]T`, `chan T`, `sequence[T]`, `map[K,V]`). Mitigation: the parallel with `async func` makes the shape immediately recognizable.
 - Three legal spellings exist for the same async-iterator return type. Style guidance picks one canonical form; the language remains permissive.
 
 Neutral:
@@ -102,7 +102,7 @@ Rejected: the grammar change (single parser branch) is the same regardless of ho
 
 The status quo after ADR-0041. Rejected: the parameter/local/field asymmetry is visible in every consumer-side declaration and the implementation cost is small.
 
-### D. Generalize `async` to all type-clause prefixes in this ADR (`async map[K]V`, `async chan T`, etc.)
+### D. Generalize `async` to all type-clause prefixes in this ADR (`async map[K,V]`, `async chan T`, etc.)
 
 Rejected as overreach. None of the other forms have an existing BCL counterpart, and conflating the modifier across unrelated shapes would erode its meaning. Function-type clauses (`async func(P) R`) are tracked separately in ADR-0043.
 

--- a/docs/adr/0043-async-func-type-clause.md
+++ b/docs/adr/0043-async-func-type-clause.md
@@ -69,7 +69,7 @@ The `async` type-clause prefix now has exactly two legal successors:
 - `async sequence[T]` (ADR-0042) → `IAsyncEnumerable[T]`
 - `async func(...) R`  (this ADR) → `func(...) Task[R]` (with carve-outs above)
 
-Any other follower (`async int`, `async map[K]V`, `async chan T`, `async []T`, `async *T`, etc.) is rejected by the parser with diagnostic **GS0135** ("the `async` modifier in a type clause is only valid before `sequence[T]` or `func(...)`").
+Any other follower (`async int`, `async map[K,V]`, `async chan T`, `async []T`, `async *T`, etc.) is rejected by the parser with diagnostic **GS0135** ("the `async` modifier in a type clause is only valid before `sequence[T]` or `func(...)`").
 
 ## Consequences
 
@@ -98,7 +98,7 @@ The status quo. Rejected because the asymmetry is visible at every function-type
 
 Rejected. Silent double-wrap (`Task[Task[X]]`) is almost never what the user means and creates a subtle trap. Silently no-opping (treating `Task[X]` as already-wrapped) hides intent and makes the modifier meaningless. The diagnostic forces the user to pick a single spelling.
 
-### C. Generalise the modifier to all type-clause prefixes (`async map[K]V`, `async chan T`, etc.)
+### C. Generalise the modifier to all type-clause prefixes (`async map[K,V]`, `async chan T`, etc.)
 
 Rejected as overreach, for the same reasons as ADR-0042 §Alternatives D. None of the other shapes have an established BCL-side Task or AsyncEnumerable counterpart, and the modifier would lose its meaning.
 

--- a/docs/adr/0073-null-conditional-indexing.md
+++ b/docs/adr/0073-null-conditional-indexing.md
@@ -59,7 +59,7 @@ Add `a?[i]` as a **read-only** postfix operator with these semantics:
 5. **Applies to every indexable shape.**
    - G# arrays (`[N]T`).
    - G# slices (`[]T`).
-   - G# maps (`map[K]V`).
+   - G# maps (`map[K,V]`).
    - CLR indexers on imported reference types (e.g. `Dictionary[K, V]`).
    - User-defined struct/class indexers (via the same CLR indexer path).
 6. **Assignment LHS is rejected.** `a?[i] = v`, `a?[i] += v`, and

--- a/docs/adr/0074-arrow-lambda-and-colon-switch-arms.md
+++ b/docs/adr/0074-arrow-lambda-and-colon-switch-arms.md
@@ -218,7 +218,7 @@ Positive:
   per-pass changes.
 - Switch-expression arms now read like every other C-family case
   label: `case Pattern: value`.
-- `:` is consistent with G#'s existing uses (`map[K]V{k: v}`, named
+- `:` is consistent with G#'s existing uses (`map[K,V]{k: v}`, named
   arguments, label statements, `if let x: T?`) — programmers do not
   have to learn a new separator.
 - The deprecation window is observable through `GS0302`, so existing

--- a/docs/adr/0083-gsharp-extensions-go-builtins.md
+++ b/docs/adr/0083-gsharp-extensions-go-builtins.md
@@ -32,7 +32,7 @@ The remaining built-ins are Go-style, not Go-only:
 - `append(s, e)` grows-and-copies a slice.
 - `delete(m, k)` removes a key from a map.
 - `make(T)` / `make(T, n)` / `make(T, n, m)` is the constructor
-  for `chan T`, `map[K]V`, and `[]T` (only the `chan T` shape is
+  for `chan T`, `map[K,V]`, and `[]T` (only the `chan T` shape is
   currently implemented in the parser — see "Scope" below).
 - `close(ch)` marks a channel-writer complete. ADR-0082 already
   gates `close`.
@@ -95,7 +95,7 @@ built-ins in the same cluster. See "Deconfliction with `close`"
 below.
 
 The other shapes of `make` (`make([]T, n)` for slices and
-`make(map[K]V)` for maps) are not currently supported by the
+`make(map[K,V])` for maps) are not currently supported by the
 parser (see ADR-0020 §"Open questions"). When they are added,
 they will reuse the gate site established here — the binder
 helper `ReportIfGoBuiltinImportMissing` already exists and the

--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -132,8 +132,8 @@ G#-shaped collectors:
 
 ```
 func [T]       (self sequence[T])       ToSlice() []T
-func [K, V]    (self sequence[(K, V)])  ToMap() map[K]V
-func [T, K, V] (self sequence[T])       ToMap(keyFn (T) -> K, valueFn (T) -> V) map[K]V
+func [K, V]    (self sequence[(K, V)])  ToMap() map[K,V]
+func [T, K, V] (self sequence[T])       ToMap(keyFn (T) -> K, valueFn (T) -> V) map[K,V]
 ```
 
 ### Performance — `AggressiveInlining`
@@ -211,12 +211,12 @@ hatch under `src/Sdk/Gsharp.Extensions/*.cs` works today.
   only accepted an identifier or an `[N]T` / `[]T` receiver type;
   the scanner now reads any balanced bracket region as the
   candidate type clause, so `(self T?)`, `(self sequence[T])`,
-  `(self map[K]V)`, `(self (int32, string)?)`, and arbitrary
+  `(self map[K,V])`, `(self (int32, string)?)`, and arbitrary
   combinations are recognised by the parser and the function
   retains its extension-method status. The binder + emit pipeline
   also accept call-site dispatch when the receiver is *closed*
   (concrete) — `string?`, `(int32, string)`, `[]int32?`,
-  `map[string]int32`. **Binder-side closed by
+  `map[string,int32]`. **Binder-side closed by
   [issue #773](https://github.com/DavidObando/gsharp/issues/773).**
   `BoundScope.TryLookupExtensionFunction` now falls back to
   receiver-type unification when the fast-path exact-equality
@@ -539,7 +539,7 @@ of that migration, not left behind as dead code.
   reach for `Enumerable.Range`, `FirstOrDefault`, or hand-rolled
   null-check chains now have a single Extensions surface that
   matches the rest of the language. The collectors (`ToSlice`,
-  `ToMap`) project to G#'s native `[]T` and `map[K]V` instead of
+  `ToMap`) project to G#'s native `[]T` and `map[K,V]` instead of
   to BCL `T[]` and `Dictionary<K, V>`, removing a friction point
   in the tour and the standard-library reference.
 - **Positive — dogfooding pressure.** Shipping a real assembly

--- a/docs/adr/0104-map-type-clause-spelling.md
+++ b/docs/adr/0104-map-type-clause-spelling.md
@@ -1,0 +1,264 @@
+# ADR-0104: Map type clause — canonical spelling `map[K,V]`
+
+- **Status**: Accepted
+- **Date**: 2026-06-13
+- **Phase**: v0.2 — breaking-change sweep
+- **Related**: ADR-0020 (Generic type-parameter brackets — Go-style `[T]`), ADR-0040 (`sequence[T]` type alias), ADR-0042 (`async sequence[T]` type clause), ADR-0043 (`async func(...) R` type clause), ADR-0073 (null-conditional indexing), ADR-0074 (arrow-lambda and colon switch arms), ADR-0083 (G# extensions — Go built-ins gate), ADR-0084 (G# extensions — optional sequence APIs)
+- **Issue**: [#805](https://github.com/DavidObando/gsharp/issues/805)
+- **Supersedes**: the legacy Go-flavored `map[K]V` type-clause shape originally introduced in Phase 3.A.4 (no dedicated ADR — informally documented in ADR-0040 by analogy)
+
+## Context
+
+G# inherited the Go-flavored map type-clause spelling `map[K]V` from its
+"mini-Go for the .NET CLR" origins. Over the v0.1 cycle the language has
+evolved into a fully-fledged modern programming language and the rest of
+the type grammar has converged on a uniform shape: **a contextual
+keyword (`sequence`, `func`, `chan`, `map`, …) followed by its
+type arguments inside a single bracket / parenthesis pair**, e.g.
+`sequence[T]`, `func(P) R`, `chan T`, `Foo[T1, T2]`. The map shape was
+the only remaining outlier — its key was bracketed but its value floated
+outside the brackets, requiring a bespoke parsing path and a
+special-case mental model.
+
+Specifically, the legacy shape causes the following friction:
+
+1. **Grammar inconsistency.** Every other type clause that takes multiple
+   type arguments lists them inside a single bracket pair separated by
+   commas (`Dictionary[K, V]`, `Foo[T1, T2]`, `func(P1, P2) R`,
+   `(K, V)` tuple). `map[K]V` is the lone exception, leaking the closing
+   `]` between the key and the value.
+2. **Parser composability with prefixed type clauses.** The trailing
+   value type that lives *outside* the brackets requires the
+   type-clause parser to greedily accept a *second* adjacent
+   type-clause whenever it sees `map[K]`. That breaks composability
+   with nullable suffixes, receiver-clause boundaries, and the slice
+   element-type slot.
+3. **Reader-side cognitive load.** Newcomers from any modern language
+   (C#, Kotlin, Rust, Swift, TypeScript, F#, Scala, …) read
+   `Dictionary[K, V]`, `Map<K, V>`, or `HashMap<K, V>` — *both type
+   arguments together inside the type-argument list*. The G# spelling is
+   uniquely surprising and gives no offsetting payoff.
+4. **Source-of-truth for the type symbol.** `MapTypeSymbol`'s `Name`
+   property already wants to read as a single bracketed pair when shown
+   in diagnostics; the source-text form should match.
+
+We are landing this change in v0.2 alongside the rest of the
+v0.2-window breaking sweep. There is **no deprecation window** for
+`map[K]V`: it is rejected outright with a clear migration diagnostic.
+
+## Decision
+
+### 1. Canonical spelling
+
+The one and only G# map type clause is
+
+```text
+map[K , V] ?
+```
+
+i.e. the `map` contextual keyword, followed by `[`, the **key** type
+clause, a `,`, the **value** type clause, `]`, with an optional
+trailing `?` nullability marker. Whitespace around the `,` and the
+brackets is permissive, identical to other comma-separated type
+argument lists.
+
+Example uses:
+
+```gsharp
+var m1 = map[string,int32]{"a": 1, "b": 2}
+func makeIndex() map[string,Person] { … }
+func [K, V] (self map[K,V]) CountKeys() int32 { … }
+let cache map[string,async sequence[int32]] = …
+let optionalScores map[string,int32]? = nil
+```
+
+The literal form is unchanged in shape — only the type-clause spelling
+in front of the `{` is updated:
+
+```gsharp
+let counts = map[string,int32]{"a": 1, "b": 2}
+```
+
+### 2. Hard removal of `map[K]V`
+
+The legacy Go-flavored `map[K]V` shape (key inside the brackets, value
+outside) is **rejected** by the parser. There is no deprecation warning
+window — the parser produces an error diagnostic and the program does
+not compile.
+
+This is a breaking change for v0.2. Existing source must be migrated
+mechanically:
+
+```diff
+- var m = map[string]int32{"a": 1}
++ var m = map[string,int32]{"a": 1}
+```
+
+The migration is purely syntactic; symbol identity, binding, lowering,
+and emit are unaffected. `MapTypeSymbol` continues to canonicalize per
+`(K, V)` pair, and the runtime backing type remains
+`System.Collections.Generic.Dictionary<K, V>`.
+
+### 3. Diagnostic
+
+The parser continues to **recognize** the legacy shape long enough to
+emit a span-accurate diagnostic that suggests the migration:
+
+- **Code**: `GS0366`
+- **Severity**: Error
+- **Message**: `The 'map[K]V' type-clause spelling has been removed; use 'map[{key},{value}]' instead (ADR-0104).`
+  - `{key}` is the verbatim source text of the offending key type clause.
+  - `{value}` is the verbatim source text of the offending value type clause.
+- **Span**: covers the entire shape, from the `map` keyword through the
+  end of the value type clause, so editor tooling and IDE quick-fixes
+  can replace the whole construct in one edit.
+
+The diagnostic fires once per offending occurrence. Mixed-form files
+(some legacy, some canonical) produce one diagnostic per legacy
+spelling with **no cascade errors** — the parser still binds the
+recovered shape to the correct `MapTypeSymbol` so downstream binding
+proceeds as if the canonical form had been written.
+
+### 4. Lexer / parser strategy
+
+The lexer is **unchanged** — `map` remains a contextual keyword,
+`OpenSquareBracketToken`, `CommaToken`, and `CloseSquareBracketToken`
+all exist already. The change is local to `ParseMapTypeClause`:
+
+```text
+map          (MapKeyword)
+[            (MapOpenBracketToken)
+<type>       (MapKeyType)
+,            (MapCommaToken)         ← new, canonical
+<type>       (MapValueType)
+]            (MapCloseBracketToken)
+?            (QuestionToken, optional)
+```
+
+Recovery path for the legacy shape (`map[K]V`):
+
+1. After consuming `map`, `[`, and the key type clause, peek the next
+   token.
+2. If it is `,`, take the canonical path: consume the comma, parse the
+   value type, consume the closing `]`, return.
+3. Otherwise it must be `]` (the legacy shape): consume the `]`, parse
+   the value type, compute the legacy span (`map` … end-of-value), and
+   report `GS0366` at that span. Build the `TypeClauseSyntax` with
+   `MapCommaToken = null`; downstream code only cares about
+   `MapKeyType` and `MapValueType` and is therefore unaffected.
+
+`TypeClauseSyntax` gains a new `MapCommaToken` property; the existing
+`MapOpenBracketToken` now denotes the opening `[` of the *whole*
+key/value pair and `MapCloseBracketToken` now denotes the closing `]`
+of the whole pair (rather than only the key). No new
+`BoundNodeKind` is introduced — the bound tree is unaffected.
+
+### 5. Symbol display name
+
+`MapTypeSymbol.Name` now renders as `map[K,V]` (with the comma) so
+binder diagnostics and IDE hover info match the new source spelling.
+
+## Surface syntax — coverage matrix
+
+The canonical form `map[K,V]` must work in **every** type-clause slot,
+identical to the slots the legacy form occupied:
+
+| Slot                                              | Example                                              |
+| ------------------------------------------------- | ---------------------------------------------------- |
+| `var` / `let` field & local declaration           | `var m map[string,int32] = …`                        |
+| Inferred local from map literal                   | `var m = map[string,int32]{"a": 1}`                  |
+| Function return type                              | `func makeIndex() map[string,Person] { … }`          |
+| Function parameter type                           | `func sum(m map[string,int32]) int32 { … }`          |
+| Lambda parameter & return                         | `(m map[string,int32]) -> int32 { … }`               |
+| Type argument to a generic instantiation          | `Box[map[string,int32]]`                             |
+| Tuple element                                     | `(string, map[string,int32])`                        |
+| Slice / array element                             | (matching the existing parser limitation — `[]<keyword>T` slices accept identifier element types only and are out of scope for this ADR) |
+| Nullable wrap                                     | `map[string,int32]?`                                 |
+| Receiver clause                                   | `func (self map[K,V]) CountKeys() int32 { … }`       |
+| Type alias (e.g. inside `sequence[T]` element)    | `sequence[map[string,int32]]`                        |
+| Pointer pointee                                   | `*map[string,int32]`                                 |
+| `async sequence[T]` element                       | `async sequence[map[string,int32]]`                  |
+| Map literal type prefix                           | `map[string,int32]{"a": 1, "b": 2}`                  |
+
+The map literal itself (`{k: v, …}` with `:` between key and value and
+`,` between entries) is unchanged.
+
+## Migration cost
+
+A one-time mechanical sweep replaces every legacy occurrence in this
+repository (samples, tests, docs, ADRs, website). The migration is
+purely textual and trivially scriptable. Downstream consumers can run
+the same pattern:
+
+```text
+map\[<key-type>\]<value-type>    →    map[<key-type>,<value-type>]
+```
+
+## Consequences
+
+- **Pros**
+  - Uniformly modern type grammar — all multi-argument type clauses are
+    bracketed comma-separated lists.
+  - Eliminates the bespoke "type clause whose tail floats outside the
+    brackets" parsing path and the composability edge cases that come
+    with it (array of map, slice of map, receiver-clause boundary).
+  - Reader cognitive load drops for anyone arriving from any modern
+    typed language.
+  - `MapTypeSymbol.Name` now matches its source spelling, simplifying
+    diagnostic and IDE hover text.
+
+- **Cons / mitigations**
+  - Hard break for any v0.1 source that uses `map[K]V`. **Mitigated** by
+    `GS0366`, which fires once per occurrence with the exact
+    canonical-form replacement in the message (IDE quick-fix candidate).
+  - One last Go-flavored holdover is gone — readers fluent in Go must
+    learn `map[K,V]`. **Mitigated** by the fact that every other modern
+    typed language they may be coming from already spells it this way.
+
+## Alternatives considered
+
+### A. Deprecation window — accept both forms with a warning for one release
+
+Rejected. The v0.2 release is already the place where breaking-change
+sweeps land; adding a deprecation window would carry a parsing-path
+fork into a future release with no offsetting benefit. `GS0366` already
+gives users the exact migration target on the offending line.
+
+### B. Pick a different bracket style (`Map[K,V]`, `Map<K,V>`, `map<K,V>`)
+
+Rejected.
+
+- `Map[K,V]` would shadow user-facing identifiers and abandon the
+  contextual-keyword precedent set by `sequence[T]`, `chan T`, etc.
+- `Map<K,V>` / `map<K,V>` would resurrect the C#/Java angle-bracket
+  shape which G# has consciously rejected since ADR-0020 — there is no
+  appetite to reintroduce angle brackets as a type-argument delimiter
+  for one type and one type only.
+
+### C. Keep `map[K]V` indefinitely
+
+Rejected. The shape was always a heritage item; v0.2 is the moment to
+land breaking grammar cleanups. Issue #805 is explicit that this is a
+hard removal.
+
+## Implementation notes
+
+- `ParseMapTypeClause` updated as described in *4. Lexer / parser
+  strategy* above. The legacy-shape recovery still produces a
+  well-formed `TypeClauseSyntax` so the binder and downstream stages
+  see the same surface they always did — just with a single error
+  diagnostic attached.
+- `TypeClauseSyntax` gains `MapCommaToken` (nullable when recovering
+  from the legacy shape). The reflection-based
+  `SyntaxNode.GetChildren` enumeration picks the new token up without
+  changes.
+- `MapTypeSymbol.Name` updated to render `map[K,V]`.
+- `DiagnosticBag.ReportLegacyMapTypeClauseSyntax` reports `GS0366`.
+- No new `BoundNodeKind`. Bound tree exhaustiveness gold files are
+  unaffected.
+- Every legacy occurrence under `samples/`, `test/`, `docs/`,
+  `website/docs/`, and the top-level `README.md` is rewritten to the
+  canonical form.
+- Documentation updated: spec (Built-in types / Collections), tour,
+  bridges (Go-developers guide), tutorials (data and types). New
+  diagnostic added to `website/docs/ref/diagnostics.md`.

--- a/samples/GoBuiltinsGated.gs
+++ b/samples/GoBuiltinsGated.gs
@@ -34,7 +34,7 @@ Console.WriteLine(xs[3])
 Console.WriteLine(len("hello"))
 
 // len / delete on a map.
-var m = map[string]int32{"a": 1, "b": 2, "c": 3}
+var m = map[string,int32]{"a": 1, "b": 2, "c": 3}
 Console.WriteLine(len(m))
 delete(m, "b")
 Console.WriteLine(len(m))

--- a/samples/GsharpExtensionsMixed.gs
+++ b/samples/GsharpExtensionsMixed.gs
@@ -20,7 +20,7 @@ func sumOf(values []int32) int32 {
     return total
 }
 
-func tryLookup(dict map[string]string, key string) string? {
+func tryLookup(dict map[string,string], key string) string? {
     if dict.ContainsKey(key) {
         return dict[key]
     }

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1756,7 +1756,7 @@ public sealed class Binder
 
         if (syntax.IsMap)
         {
-            // Phase 3.A.4: map type clause `map[K]V`.
+            // ADR-0104: map type clause `map[K,V]`.
             var keyType = BindTypeClause(syntax.MapKeyType);
             var valueType = BindTypeClause(syntax.MapValueType);
             if (keyType == null || valueType == null)

--- a/src/Core/CodeAnalysis/Binding/BoundMapLiteralExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundMapLiteralExpression.cs
@@ -10,7 +10,7 @@ using GSharp.Core.CodeAnalysis.Syntax;
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
-/// Bound map literal expression — <c>map[K]V{k1: v1, k2: v2, …}</c>
+/// Bound map literal expression — <c>map[K,V]{k1: v1, k2: v2, …}</c>
 /// (Phase 3.A.4).
 /// </summary>
 public sealed class BoundMapLiteralExpression : BoundExpression

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -854,7 +854,7 @@ internal sealed partial class ExpressionBinder
 
     private BoundExpression BindMapCreationExpression(MapCreationExpressionSyntax syntax)
     {
-        // Phase 3.A.4: bind `map[K]V{k1: v1, k2: v2, …}`.
+        // ADR-0104: bind `map[K,V]{k1: v1, k2: v2, …}`.
         var mapType = bindTypeClause(syntax.TypeClause);
         if (mapType == null)
         {

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -3448,6 +3448,25 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Reports GS0366 — ADR-0104 / issue #805: the legacy Go-flavored
+    /// <c>map[K]V</c> type-clause spelling has been removed in v0.2. Maps
+    /// are now spelled <c>map[K,V]</c> with both type arguments inside the
+    /// brackets.
+    /// </summary>
+    /// <param name="location">The source location spanning the offending
+    /// <c>map[K]V</c> shape (from <c>map</c> through the value type).</param>
+    /// <param name="keyTypeText">The source text of the key type clause.</param>
+    /// <param name="valueTypeText">The source text of the value type clause.</param>
+    public void ReportLegacyMapTypeClauseSyntax(TextLocation location, string keyTypeText, string valueTypeText)
+    {
+        Report(
+            location,
+            "GS0366",
+            $"The 'map[K]V' type-clause spelling has been removed; use 'map[{keyTypeText},{valueTypeText}]' instead (ADR-0104).",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
     /// Reports GS0330 — ADR-0089 / issue #755: <c>static let</c> inside an
     /// interface declaration is reserved for a future release. The minimal
     /// static-virtual interface members feature only accepts

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -699,7 +699,7 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitMapLiteral(BoundMapLiteralExpression literal)
     {
-        // Phase 3.A.4 emit: `map[K]V{k1: v1, ...}` lowers to
+        // ADR-0104 emit: `map[K,V]{k1: v1, ...}` lowers to
         // `newobj Dictionary<K,V>::.ctor()` then a (dup; key; value; callvirt set_Item)
         // sequence per entry. Using set_Item rather than Add so duplicate keys
         // overwrite (matching Go semantics; ParseMapEntries does not dedup).

--- a/src/Core/CodeAnalysis/Symbols/MapTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/MapTypeSymbol.cs
@@ -9,12 +9,13 @@ using System.Collections.Generic;
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
 /// <summary>
-/// Represents a Go-style map type <c>map[K]V</c>.
+/// Represents a G# map type <c>map[K,V]</c>.
 /// </summary>
 /// <remarks>
-/// Phase 3.A.4 — backing representation is the CLR
+/// ADR-0104 (supersedes Phase 3.A.4 Go-flavored <c>map[K]V</c>) — backing
+/// representation is the CLR
 /// <c>System.Collections.Generic.Dictionary&lt;K, V&gt;</c>. The literal
-/// form <c>map[K]V{k: v, …}</c> populates a freshly allocated dictionary;
+/// form <c>map[K,V]{k: v, …}</c> populates a freshly allocated dictionary;
 /// <c>m[k]</c> indexes it; the <c>delete(m, k)</c> built-in removes a
 /// key; <c>len(m)</c> returns <c>Count</c>. Instances are cached per
 /// <c>(K, V)</c> pair so identical map types compare by reference.
@@ -24,7 +25,7 @@ public sealed class MapTypeSymbol : TypeSymbol
     private static readonly ConcurrentDictionary<(TypeSymbol, TypeSymbol), MapTypeSymbol> Cache = new();
 
     private MapTypeSymbol(TypeSymbol keyType, TypeSymbol valueType)
-        : base($"map[{keyType.Name}]{valueType.Name}", MakeClrType(keyType, valueType))
+        : base($"map[{keyType.Name},{valueType.Name}]", MakeClrType(keyType, valueType))
     {
         KeyType = keyType;
         ValueType = valueType;

--- a/src/Core/CodeAnalysis/Syntax/MapCreationExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/MapCreationExpressionSyntax.cs
@@ -5,8 +5,8 @@
 namespace GSharp.Core.CodeAnalysis.Syntax;
 
 /// <summary>
-/// Represents a map creation expression <c>map[K]V{k1: v1, k2: v2, …}</c>
-/// (Phase 3.A.4).
+/// Represents a map creation expression <c>map[K,V]{k1: v1, k2: v2, …}</c>
+/// (ADR-0104).
 /// </summary>
 public sealed class MapCreationExpressionSyntax : ExpressionSyntax
 {
@@ -14,7 +14,7 @@ public sealed class MapCreationExpressionSyntax : ExpressionSyntax
     /// Initializes a new instance of the <see cref="MapCreationExpressionSyntax"/> class.
     /// </summary>
     /// <param name="syntaxTree">The parent syntax tree.</param>
-    /// <param name="typeClause">The leading <c>map[K]V</c> type clause.</param>
+    /// <param name="typeClause">The leading <c>map[K,V]</c> type clause.</param>
     /// <param name="openBraceToken">The opening <c>{</c> token.</param>
     /// <param name="entries">The comma-separated key/value entries.</param>
     /// <param name="closeBraceToken">The closing <c>}</c> token.</param>
@@ -35,7 +35,7 @@ public sealed class MapCreationExpressionSyntax : ExpressionSyntax
     /// <inheritdoc/>
     public override SyntaxKind Kind => SyntaxKind.MapCreationExpression;
 
-    /// <summary>Gets the <c>map[K]V</c> type clause.</summary>
+    /// <summary>Gets the <c>map[K,V]</c> type clause.</summary>
     public TypeClauseSyntax TypeClause { get; }
 
     /// <summary>Gets the opening <c>{</c> token.</summary>

--- a/src/Core/CodeAnalysis/Syntax/MapEntrySyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/MapEntrySyntax.cs
@@ -6,7 +6,7 @@ namespace GSharp.Core.CodeAnalysis.Syntax;
 
 /// <summary>
 /// Represents a single <c>key: value</c> entry inside a map literal
-/// <c>map[K]V{ … }</c> (Phase 3.A.4).
+/// <c>map[K,V]{ … }</c> (ADR-0104).
 /// </summary>
 public sealed class MapEntrySyntax : SyntaxNode
 {

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -2801,7 +2801,7 @@ public class Parser
         //   '(' ident <type-clause> ')' (ident | operator) ( '(' | '[' )
         // The original implementation hard-coded a tiny subset of type-clause
         // spellings (bare identifier, `[N]T` / `[]T`). That excluded common
-        // shapes like `T?`, `sequence[T]`, `map[K]V`, `(int, T)`, and
+        // shapes like `T?`, `sequence[T]`, `map[K,V]`, `(int, T)`, and
         // combinations thereof, silently demoting an extension-method
         // declaration to a malformed regular function. Rather than mirror
         // the entire type grammar here we scan the candidate receiver as a
@@ -3208,14 +3208,49 @@ public class Parser
 
     private TypeClauseSyntax ParseMapTypeClause()
     {
-        // Phase 3.A.4: map type clause `map[K]V` with optional trailing `?`.
+        // ADR-0104 / issue #805: canonical map type clause `map[K,V]` with optional trailing `?`.
+        // For one release we still *recognize* the legacy Go-flavored shape
+        // `map[K]V` so we can emit GS0366 with a span-accurate "did you mean
+        // 'map[K,V]'?" diagnostic, then bind it as if the new spelling had
+        // been written. No deprecation window — this is the breaking change
+        // for v0.2 called out in ADR-0104.
         var mapKeyword = MatchToken(SyntaxKind.MapKeyword);
         var openBracket = MatchToken(SyntaxKind.OpenSquareBracketToken);
         var keyType = ParseTypeClause();
-        var closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
-        var valueType = ParseTypeClause();
+
+        SyntaxToken commaToken = null;
+        SyntaxToken closeBracket;
+        TypeClauseSyntax valueType;
+        if (Current.Kind == SyntaxKind.CommaToken)
+        {
+            commaToken = MatchToken(SyntaxKind.CommaToken);
+            valueType = ParseTypeClause();
+            closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
+        }
+        else
+        {
+            // Legacy `map[K]V` shape: consume the close-bracket, then the
+            // value type that follows, then point GS0366 at the whole span.
+            closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
+            valueType = ParseTypeClause();
+
+            var legacySpan = TextSpan.FromBounds(mapKeyword.Span.Start, valueType.Span.End);
+            var legacyLocation = new TextLocation(syntaxTree.Text, legacySpan);
+            var keyText = syntaxTree.Text.ToString(keyType.Span);
+            var valueText = syntaxTree.Text.ToString(valueType.Span);
+            Diagnostics.ReportLegacyMapTypeClauseSyntax(legacyLocation, keyText, valueText);
+        }
+
         var question = Current.Kind == SyntaxKind.QuestionToken ? MatchToken(SyntaxKind.QuestionToken) : null;
-        return new TypeClauseSyntax(syntaxTree, mapKeyword, openBracket, keyType, closeBracket, valueType, question);
+        return new TypeClauseSyntax(
+            syntaxTree,
+            mapKeyword,
+            openBracket,
+            keyType,
+            commaToken,
+            valueType,
+            closeBracket,
+            question);
     }
 
     private TypeClauseSyntax ParseChanTypeClause()
@@ -4252,7 +4287,7 @@ public class Parser
     {
         // A binding clause is always followed by `=`; if we see `=` directly
         // there is no type annotation. Otherwise reuse the regular optional
-        // type-clause parser (which already handles `[]T`, `map[K]V`, `T?`,
+        // type-clause parser (which already handles `[]T`, `map[K,V]`, `T?`,
         // `chan T`, etc.).
         if (Current.Kind == SyntaxKind.EqualsToken)
         {
@@ -6080,7 +6115,7 @@ public class Parser
 
     private ExpressionSyntax ParseMapCreationExpression()
     {
-        // Phase 3.A.4: map literal `map[K]V{k1: v1, k2: v2, …}`.
+        // ADR-0104: map literal `map[K,V]{k1: v1, k2: v2, …}`.
         var typeClause = ParseMapTypeClause();
         var openBrace = MatchToken(SyntaxKind.OpenBraceToken);
         var entries = ParseMapEntries();

--- a/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
@@ -150,29 +150,32 @@ public sealed class TypeClauseSyntax : SyntaxNode
         QuestionToken = questionToken;
     }
 
-    /// <summary>Initializes a new instance of the <see cref="TypeClauseSyntax"/> class for a map type <c>map[K]V?</c> (Phase 3.A.4).</summary>
+    /// <summary>Initializes a new instance of the <see cref="TypeClauseSyntax"/> class for a map type <c>map[K,V]?</c> (ADR-0104, supersedes the Phase 3.A.4 Go-flavored <c>map[K]V</c> shape).</summary>
     /// <param name="syntaxTree">The parent syntax tree.</param>
     /// <param name="mapKeyword">The <c>map</c> keyword.</param>
-    /// <param name="mapOpenBracketToken">The <c>[</c> introducing the key type.</param>
+    /// <param name="mapOpenBracketToken">The <c>[</c> introducing the key/value type pair.</param>
     /// <param name="mapKeyType">The key type clause.</param>
-    /// <param name="mapCloseBracketToken">The <c>]</c> closing the key type.</param>
+    /// <param name="mapCommaToken">The <c>,</c> separating the key type from the value type. May be <see langword="null"/> when the parser recovered from a legacy <c>map[K]V</c> shape (see GS0366).</param>
     /// <param name="mapValueType">The value type clause.</param>
+    /// <param name="mapCloseBracketToken">The <c>]</c> closing the map type-argument list.</param>
     /// <param name="questionToken">The optional trailing <c>?</c> nullability marker.</param>
     public TypeClauseSyntax(
         SyntaxTree syntaxTree,
         SyntaxToken mapKeyword,
         SyntaxToken mapOpenBracketToken,
         TypeClauseSyntax mapKeyType,
-        SyntaxToken mapCloseBracketToken,
+        SyntaxToken mapCommaToken,
         TypeClauseSyntax mapValueType,
+        SyntaxToken mapCloseBracketToken,
         SyntaxToken questionToken)
         : base(syntaxTree)
     {
         MapKeyword = mapKeyword;
         MapOpenBracketToken = mapOpenBracketToken;
         MapKeyType = mapKeyType;
-        MapCloseBracketToken = mapCloseBracketToken;
+        MapCommaToken = mapCommaToken;
         MapValueType = mapValueType;
+        MapCloseBracketToken = mapCloseBracketToken;
         QuestionToken = questionToken;
     }
 
@@ -505,19 +508,22 @@ public sealed class TypeClauseSyntax : SyntaxNode
     /// <summary>Gets the <c>map</c> keyword for map types, or <c>null</c>.</summary>
     public SyntaxToken MapKeyword { get; }
 
-    /// <summary>Gets the <c>[</c> opening the map key type, or <c>null</c>.</summary>
+    /// <summary>Gets the <c>[</c> opening the map key/value type-argument list (ADR-0104), or <c>null</c>.</summary>
     public SyntaxToken MapOpenBracketToken { get; }
 
     /// <summary>Gets the map key type clause, or <c>null</c>.</summary>
     public TypeClauseSyntax MapKeyType { get; }
 
-    /// <summary>Gets the <c>]</c> closing the map key type, or <c>null</c>.</summary>
+    /// <summary>Gets the <c>,</c> separating the map key type from the map value type (ADR-0104), or <c>null</c> when absent (e.g. parser recovered from a legacy <c>map[K]V</c> shape under GS0366).</summary>
+    public SyntaxToken MapCommaToken { get; }
+
+    /// <summary>Gets the <c>]</c> closing the map key/value type-argument list (ADR-0104), or <c>null</c>.</summary>
     public SyntaxToken MapCloseBracketToken { get; }
 
     /// <summary>Gets the map value type clause, or <c>null</c>.</summary>
     public TypeClauseSyntax MapValueType { get; }
 
-    /// <summary>Gets a value indicating whether this clause denotes a map type <c>map[K]V</c> (Phase 3.A.4).</summary>
+    /// <summary>Gets a value indicating whether this clause denotes a map type <c>map[K,V]</c> (ADR-0104).</summary>
     public bool IsMap => MapKeyword != null;
 
     /// <summary>Gets the <c>chan</c> keyword for channel types, or <c>null</c>.</summary>

--- a/src/Sdk/Gsharp.Extensions/Sequences/SequenceExtensions.cs
+++ b/src/Sdk/Gsharp.Extensions/Sequences/SequenceExtensions.cs
@@ -264,7 +264,7 @@ public static class SequenceExtensions
 
     /// <summary>
     /// Collects a sequence of <c>(K, V)</c> tuples into a
-    /// <c>map[K]V</c>. The tuple shape is the G# spelling
+    /// <c>map[K,V]</c>. The tuple shape is the G# spelling
     /// <c>sequence[(K, V)]</c>; duplicate keys throw, matching
     /// <see cref="Enumerable.ToDictionary{T, K}(IEnumerable{T}, Func{T, K})"/>.
     /// </summary>
@@ -292,7 +292,7 @@ public static class SequenceExtensions
     }
 
     /// <summary>
-    /// Collects an arbitrary sequence into a <c>map[K]V</c> using
+    /// Collects an arbitrary sequence into a <c>map[K,V]</c> using
     /// caller-supplied key and value selectors.
     /// </summary>
     /// <typeparam name="T">Element type.</typeparam>

--- a/test/Compiler.Tests/Emit/Issue618IndexCaptureRegressionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue618IndexCaptureRegressionTests.cs
@@ -58,7 +58,7 @@ public class Issue618IndexCaptureRegressionTests
             import System.Collections.Generic
 
             func Run() int32 {
-                var m = map[string]int32{}
+                var m = map[string,int32]{}
                 var put = func(k string, v int32) { m[k] = v }
                 put("hello", 7)
                 return m["hello"]
@@ -139,7 +139,7 @@ public class Issue618IndexCaptureRegressionTests
             import System.Collections.Generic
 
             func Run() int32 {
-                var m = map[string]int32{}
+                var m = map[string,int32]{}
                 var put = func(k string, v int32) { m[k] = v }
                 var get = func(k string) int32 { return m[k] }
                 put("a", 1)

--- a/test/Compiler.Tests/Emit/Issue693DictionaryConstructionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue693DictionaryConstructionEmitTests.cs
@@ -265,7 +265,7 @@ public class Issue693DictionaryConstructionEmitTests
     [Fact]
     public void Regression_MapLiteralStillCompilesAndRuns()
     {
-        // Negative regression: G#'s `map[K]V{...}` literal syntax must
+        // Negative regression: G#'s `map[K,V]{...}` literal syntax must
         // continue to work alongside the multi-type-arg Dictionary
         // construction. The disambiguation only triggers on an
         // identifier-headed `[`, so the `map` keyword path is untouched.
@@ -274,7 +274,7 @@ public class Issue693DictionaryConstructionEmitTests
             import System
             import Gsharp.Extensions.Go
 
-            let m = map[string]int32 { "a": 1, "b": 2 }
+            let m = map[string,int32] { "a": 1, "b": 2 }
             Console.WriteLine(len(m))
             """;
 

--- a/test/Compiler.Tests/Emit/Issue709NullCoalescingAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue709NullCoalescingAssignmentEmitTests.cs
@@ -118,7 +118,7 @@ public class Issue709NullCoalescingAssignmentEmitTests
             import System
 
             func main() {
-                var m = map[string]string?{}
+                var m = map[string,string?]{}
                 m["k"] = nil
                 m["k"] ??= "v"
                 Console.WriteLine(m["k"])

--- a/test/Compiler.Tests/Emit/Issue751RichReceiverEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue751RichReceiverEmitTests.cs
@@ -13,7 +13,7 @@ namespace GSharp.Compiler.Tests.Emit;
 /// <summary>
 /// End-to-end emit + run coverage for issue #751 / ADR-0084 §L2: the
 /// receiver clause now accepts rich type spellings (nullable, generic
-/// application, tuple, nullable array, map[K]V). Each test compiles a
+/// application, tuple, nullable array, map[K,V]). Each test compiles a
 /// G# program containing an extension method declaration whose receiver
 /// previously rejected at parse time, IL-verifies the output, and
 /// executes it under <c>dotnet exec</c> to prove the dispatched call
@@ -95,11 +95,11 @@ public class Issue751RichReceiverEmitTests
             package P
             import System
 
-            func (self map[string]int32) CountKeys() int32 {
+            func (self map[string,int32]) CountKeys() int32 {
                 return self.Count
             }
 
-            var m = map[string]int32{"a": 1, "b": 2, "c": 3}
+            var m = map[string,int32]{"a": 1, "b": 2, "c": 3}
             Console.WriteLine(m.CountKeys())
             """;
 

--- a/test/Compiler.Tests/Emit/Issue805MapTypeClauseSpellingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue805MapTypeClauseSpellingEmitTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="MapEmitTests.cs" company="GSharp">
+// <copyright file="Issue805MapTypeClauseSpellingEmitTests.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -10,30 +10,39 @@ using Xunit;
 namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>
-/// Phase 3.A.4 emit-parity tests for <c>map[K,V]</c>. The backing CLR type is
-/// <c>System.Collections.Generic.Dictionary&lt;K, V&gt;</c>:
-/// <list type="bullet">
-/// <item><description>Map literal <c>map[K,V]{k: v, ...}</c> →
-/// <c>newobj Dictionary&lt;K,V&gt;..ctor()</c> + <c>callvirt set_Item</c> per entry.</description></item>
-/// <item><description>Indexing read <c>m[k]</c> →
-/// <c>callvirt TryGetValue(k, out tmp)</c>; pop bool; load tmp — yields the
-/// Go zero value when the key is missing, matching the interpreter.</description></item>
-/// <item><description>Indexed assignment <c>m[k] = v</c> →
-/// <c>callvirt set_Item(k, v)</c>.</description></item>
-/// <item><description><c>len(m)</c> → <c>callvirt get_Count</c>.</description></item>
-/// <item><description><c>delete(m, k)</c> → <c>callvirt Remove(k)</c>; pop bool.</description></item>
-/// </list>
+/// Issue #805 / ADR-0104 — end-to-end emit + ilverify coverage for the
+/// canonical <c>map[K,V]</c> spelling. These tests are intentionally
+/// minimal: the symbol-level emit path is unaffected by the
+/// surface-syntax change, so what we are pinning down is that the
+/// parser change has not broken IL emission or verifiability for the
+/// canonical literal form across every type-clause slot the issue
+/// names.
 /// </summary>
-public class MapEmitTests
+public class Issue805MapTypeClauseSpellingEmitTests
 {
     [Fact]
-    public void MapLiteral_AndIndexRead()
+    public void CanonicalSpelling_InferredLocal_EmitsAndRuns()
     {
         var source = """
             package P
             import System
 
-            var m = map[string,int32]{"a": 1, "b": 2}
+            var m = map[string,int32]{"a": 1}
+            Console.WriteLine(m["a"])
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void CanonicalSpelling_ExplicitTypedLocal_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            var m map[string,int32] = map[string,int32]{"a": 1, "b": 2}
             Console.WriteLine(m["a"])
             Console.WriteLine(m["b"])
             """;
@@ -43,110 +52,47 @@ public class MapEmitTests
     }
 
     [Fact]
-    public void MapIndex_MissingKey_ReturnsZeroValue()
+    public void CanonicalSpelling_FunctionReturnType_EmitsAndRuns()
     {
         var source = """
             package P
             import System
 
-            var m = map[string,int32]{"a": 1}
-            Console.WriteLine(m["missing"])
-            """;
+            func makeIndex() map[string,int32] {
+                return map[string,int32]{"a": 1, "b": 2}
+            }
 
-        var output = CompileAndRun(source);
-        Assert.Equal("0\n", output);
-    }
-
-    [Fact]
-    public void MapIndexAssignment_AddAndUpdate()
-    {
-        var source = """
-            package P
-            import System
-
-            var m = map[string,int32]{}
-            m["a"] = 1
-            m["b"] = 2
-            m["a"] = 99
+            var m = makeIndex()
             Console.WriteLine(m["a"])
             Console.WriteLine(m["b"])
             """;
 
         var output = CompileAndRun(source);
-        Assert.Equal("99\n2\n", output);
+        Assert.Equal("1\n2\n", output);
     }
 
     [Fact]
-    public void Len_OnMap_ReturnsCount()
-    {
-        var source = """
-            package P
-            import System
-            import Gsharp.Extensions.Go
-
-            var m = map[string,int32]{"a": 1, "b": 2, "c": 3}
-            Console.WriteLine(len(m))
-            """;
-
-        var output = CompileAndRun(source);
-        Assert.Equal("3\n", output);
-    }
-
-    [Fact]
-    public void Delete_RemovesKey_AndDecreasesLen()
-    {
-        var source = """
-            package P
-            import System
-            import Gsharp.Extensions.Go
-
-            var m = map[string,int32]{"a": 1, "b": 2}
-            delete(m, "a")
-            Console.WriteLine(len(m))
-            Console.WriteLine(m["a"])
-            Console.WriteLine(m["b"])
-            """;
-
-        var output = CompileAndRun(source);
-        Assert.Equal("1\n0\n2\n", output);
-    }
-
-    [Fact]
-    public void EmptyMapLiteral_LenIsZero()
-    {
-        var source = """
-            package P
-            import System
-            import Gsharp.Extensions.Go
-
-            var m = map[int32,string]{}
-            Console.WriteLine(len(m))
-            """;
-
-        var output = CompileAndRun(source);
-        Assert.Equal("0\n", output);
-    }
-
-    [Fact]
-    public void Map_IntKey_StringValue_RoundTrip()
+    public void CanonicalSpelling_FunctionParameterType_EmitsAndRuns()
     {
         var source = """
             package P
             import System
 
-            var m = map[int32,string]{1: "one", 2: "two"}
-            Console.WriteLine(m[1])
-            Console.WriteLine(m[2])
-            Console.WriteLine(m[42])
+            func first(m map[string,int32]) int32 {
+                return m["a"]
+            }
+
+            var m = map[string,int32]{"a": 42}
+            Console.WriteLine(first(m))
             """;
 
         var output = CompileAndRun(source);
-        Assert.Equal("one\ntwo\n\n", output);
+        Assert.Equal("42\n", output);
     }
 
     private static string CompileAndRun(string source)
     {
-        var tempDir = Directory.CreateTempSubdirectory("gs_map_emit_").FullName;
+        var tempDir = Directory.CreateTempSubdirectory("gs_map805_emit_").FullName;
         try
         {
             var srcPath = Path.Combine(tempDir, "test.gs");

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue709NullCoalescingAssignmentBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue709NullCoalescingAssignmentBindingTests.cs
@@ -142,7 +142,7 @@ public class Issue709NullCoalescingAssignmentBindingTests
         var diagnostics = Bind("""
             package P
             func F() {
-                var m = map[string]string?{}
+                var m = map[string,string?]{}
                 m["k"] = nil
                 m["k"] ??= "v"
             }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue723GoBuiltinsImportGateTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue723GoBuiltinsImportGateTests.cs
@@ -68,7 +68,7 @@ let n = len(""hello"")
     public void Len_Map_WithoutImport_ReportsGS0317_SuggestsCount()
     {
         var diags = Bind(@"
-let m = map[string]int32{""a"": 1}
+let m = map[string,int32]{""a"": 1}
 let n = len(m)
 ");
 
@@ -157,7 +157,7 @@ xs = append(xs, 2)
     public void Delete_WithoutImport_ReportsGS0317_SuggestsRemove()
     {
         var diags = Bind(@"
-var m = map[string]int32{""a"": 1}
+var m = map[string,int32]{""a"": 1}
 delete(m, ""a"")
 ");
 
@@ -171,7 +171,7 @@ delete(m, ""a"")
     public void Delete_WithImport_DoesNotReportGS0317()
     {
         var diags = Bind(GoImport + @"
-var m = map[string]int32{""a"": 1}
+var m = map[string,int32]{""a"": 1}
 delete(m, ""a"")
 ");
         AssertNoBuiltinGateDiagnostic(diags);
@@ -226,7 +226,7 @@ var xs = []int32{1, 2}
 let n = len(xs)
 let c = cap(xs)
 xs = append(xs, 3)
-let m = map[string]int32{""a"": 1}
+let m = map[string,int32]{""a"": 1}
 delete(m, ""a"")
 let q = len(m)
 ");
@@ -316,7 +316,7 @@ len(xs)
     public void EndToEnd_Delete_Evaluates_WithImport()
     {
         var result = Evaluate(GoImport + @"
-var m = map[string]int32{""a"": 1, ""b"": 2}
+var m = map[string,int32]{""a"": 1, ""b"": 2}
 delete(m, ""a"")
 len(m)
 ");

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue751RichReceiverBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue751RichReceiverBinderTests.cs
@@ -16,7 +16,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// <summary>
 /// Binder + tree-walking interpreter coverage for issue #751 / ADR-0084 §L2.
 /// Verifies that each rich receiver shape accepted by the parser fix
-/// (nullable, generic application, tuple, array-of-nullable, map[K]V)
+/// (nullable, generic application, tuple, array-of-nullable, map[K,V])
 /// binds as an extension method and is dispatched via the dot-syntax
 /// call site. Only concrete (non-type-parameter) receiver shapes are
 /// covered here — receivers that close over a function-level type
@@ -105,11 +105,11 @@ present.FirstOrZero() + absent.FirstOrZero()
     public void Map_Receiver_Dispatches_Via_DotSyntax()
     {
         var source = @"
-func (self map[string]int32) CountKeys() int32 {
+func (self map[string,int32]) CountKeys() int32 {
     return self.Count
 }
 
-var m = map[string]int32{""a"": 1, ""b"": 2, ""c"": 3}
+var m = map[string,int32]{""a"": 1, ""b"": 2, ""c"": 3}
 m.CountKeys()
 ";
         var result = Evaluate(source);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue805MapTypeClauseSpellingBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue805MapTypeClauseSpellingBinderTests.cs
@@ -1,0 +1,123 @@
+// <copyright file="Issue805MapTypeClauseSpellingBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #805 / ADR-0104 — both the canonical <c>map[K,V]</c> spelling
+/// and the parser-recovered legacy <c>map[K]V</c> shape must bind to
+/// the same cached <see cref="MapTypeSymbol"/> instance, and the
+/// symbol's display <c>Name</c> must render with the new comma form.
+/// </summary>
+public class Issue805MapTypeClauseSpellingBinderTests
+{
+    [Fact]
+    public void CanonicalSpelling_BindsAsMapTypeSymbol_WithExpectedName()
+    {
+        var (result, compilation) = Compile("""
+            var m map[string,int32] = map[string,int32]{"a": 1}
+            """);
+
+        Assert.Empty(result.Diagnostics);
+
+        var variable = LookupGlobalVariable(compilation, "m");
+        Assert.NotNull(variable);
+        var mapType = Assert.IsType<MapTypeSymbol>(variable.Type);
+        Assert.Equal("map[string,int32]", mapType.Name);
+        Assert.Equal(TypeSymbol.String, mapType.KeyType);
+        Assert.Equal(TypeSymbol.Int32, mapType.ValueType);
+    }
+
+    [Fact]
+    public void LegacyAndCanonical_ResolveToSameMapTypeSymbolInstance()
+    {
+        // The legacy shape still parses (with GS0366) and binds to the
+        // exact same cached MapTypeSymbol instance — the comma is purely
+        // a surface-syntax change.
+        var (legacyResult, legacy) = Compile("""
+            var m map[string]int32 = map[string,int32]{"a": 1}
+            """);
+
+        // GS0366 fires once per legacy occurrence; no cascade.
+        Assert.Contains(legacyResult.Diagnostics, d => d.Id == "GS0366");
+        Assert.All(
+            legacyResult.Diagnostics,
+            d => Assert.Equal("GS0366", d.Id));
+
+        var (canonicalResult, canonical) = Compile("""
+            var m map[string,int32] = map[string,int32]{"a": 1}
+            """);
+        Assert.Empty(canonicalResult.Diagnostics);
+
+        var legacyVar = LookupGlobalVariable(legacy, "m");
+        var canonicalVar = LookupGlobalVariable(canonical, "m");
+        Assert.NotNull(legacyVar);
+        Assert.NotNull(canonicalVar);
+
+        // MapTypeSymbol is cached per (K, V) pair across compilations, so
+        // reference equality holds across the two compilation units.
+        Assert.Same(legacyVar.Type, canonicalVar.Type);
+        Assert.Equal("map[string,int32]", legacyVar.Type.Name);
+    }
+
+    [Fact]
+    public void CanonicalSpelling_NullableMap_BindsAsNullableMapTypeSymbol()
+    {
+        var (result, compilation) = Compile("""
+            var m map[string,int32]? = nil
+            """);
+
+        Assert.Empty(result.Diagnostics);
+
+        var variable = LookupGlobalVariable(compilation, "m");
+        Assert.NotNull(variable);
+        var nullable = Assert.IsType<NullableTypeSymbol>(variable.Type);
+        var mapType = Assert.IsType<MapTypeSymbol>(nullable.UnderlyingType);
+        Assert.Equal("map[string,int32]", mapType.Name);
+    }
+
+    [Fact]
+    public void CanonicalSpelling_NestedInsideSequence_BindsAsSequenceOfMap()
+    {
+        // Use a function-parameter slot so we exercise the type clause
+        // without having to invent a constructible expression of type
+        // `sequence[map[K,V]]`.
+        var (result, compilation) = Compile("""
+            func receive(s sequence[map[string,int32]]) int32 {
+                return 0
+            }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+
+        var function = compilation.GlobalScope.Functions.FirstOrDefault(f => f.Name == "receive");
+        Assert.NotNull(function);
+        var paramType = function.Parameters[0].Type;
+        var seq = Assert.IsType<SequenceTypeSymbol>(paramType);
+        var mapType = Assert.IsType<MapTypeSymbol>(seq.ElementType);
+        Assert.Equal("map[string,int32]", mapType.Name);
+    }
+
+    private static VariableSymbol LookupGlobalVariable(Compilation compilation, string name)
+        => compilation.GlobalScope.Variables.FirstOrDefault(v => v.Name == name);
+
+    private static (EvaluationResult Result, Compilation Compilation) Compile(string source)
+    {
+        // Prepend the Go-extensions import so map ops bind without
+        // tripping ADR-0083's GS0317 import gate.
+        var syntaxTree = SyntaxTree.Parse(SourceText.From("import Gsharp.Extensions.Go\n" + source));
+        var compilation = new Compilation(syntaxTree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return (result, compilation);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/MapTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/MapTypeTests.cs
@@ -14,7 +14,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>
 /// Phase 3.A.4 binding and interpretation tests for the
-/// <c>map[K]V</c> type, literal, indexing, <c>len</c>, and
+/// <c>map[K,V]</c> type, literal, indexing, <c>len</c>, and
 /// <c>delete</c>.
 /// </summary>
 public class MapTypeTests
@@ -23,7 +23,7 @@ public class MapTypeTests
     public void MapLiteral_StringInt_FieldAccessReturnsValue()
     {
         var source = @"
-let m = map[string]int32{""a"": 1, ""b"": 2}
+let m = map[string,int32]{""a"": 1, ""b"": 2}
 m[""b""]
 ";
         var result = Evaluate(source);
@@ -35,7 +35,7 @@ m[""b""]
     public void MapLiteral_IntString_LenReturnsCount()
     {
         var source = @"
-let m = map[int32]string{1: ""one"", 2: ""two"", 3: ""three""}
+let m = map[int32,string]{1: ""one"", 2: ""two"", 3: ""three""}
 len(m)
 ";
         var result = Evaluate(source);
@@ -47,7 +47,7 @@ len(m)
     public void MapIndex_MissingKey_ReturnsValueTypeZero()
     {
         var source = @"
-let m = map[string]int32{""a"": 1}
+let m = map[string,int32]{""a"": 1}
 m[""missing""]
 ";
         var result = Evaluate(source);
@@ -59,7 +59,7 @@ m[""missing""]
     public void MapIndexAssignment_AddsOrUpdatesKey()
     {
         var source = @"
-var m = map[string]int32{""a"": 1}
+var m = map[string,int32]{""a"": 1}
 m[""b""] = 2
 m[""a""] = 9
 m[""a""] + m[""b""]
@@ -73,7 +73,7 @@ m[""a""] + m[""b""]
     public void MapDelete_RemovesKey_LenDecreases()
     {
         var source = @"
-var m = map[string]int32{""a"": 1, ""b"": 2}
+var m = map[string,int32]{""a"": 1, ""b"": 2}
 delete(m, ""a"")
 len(m)
 ";
@@ -86,7 +86,7 @@ len(m)
     public void MapDelete_MissingKey_NoOp()
     {
         var source = @"
-var m = map[string]int32{""a"": 1}
+var m = map[string,int32]{""a"": 1}
 delete(m, ""never_there"")
 len(m)
 ";
@@ -99,7 +99,7 @@ len(m)
     public void MapLiteral_Empty_IsAllocated()
     {
         var source = @"
-let m = map[string]int32{}
+let m = map[string,int32]{}
 len(m)
 ";
         var result = Evaluate(source);
@@ -122,7 +122,7 @@ delete(s, 0)
     public void Delete_WrongArgCount_Diagnoses()
     {
         var source = @"
-let m = map[string]int32{""a"": 1}
+let m = map[string,int32]{""a"": 1}
 delete(m)
 ";
         var result = Evaluate(source);
@@ -133,7 +133,7 @@ delete(m)
     public void MapType_TypeClause_BindsAsMapTypeSymbol()
     {
         var source = @"
-var m map[string]int32 = map[string]int32{""a"": 1}
+var m map[string,int32] = map[string,int32]{""a"": 1}
 len(m)
 ";
         var result = Evaluate(source);

--- a/test/Core.Tests/CodeAnalysis/Emit/IndexAssignmentSideEffectTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/IndexAssignmentSideEffectTests.cs
@@ -72,7 +72,7 @@ func key() string {
     calls = calls + 1
     return ""k""
 }
-var m = map[string]int32{}
+var m = map[string,int32]{}
 m[key()] = 7
 Console.WriteLine(calls)
 Console.WriteLine(m[""k""])
@@ -87,7 +87,7 @@ Console.WriteLine(m[""k""])
     {
         const string Source = @"package main
 import System
-var m = map[string]int32{}
+var m = map[string,int32]{}
 var v = (m[""x""] = 99)
 Console.WriteLine(v)
 Console.WriteLine(m[""x""])

--- a/test/Core.Tests/CodeAnalysis/Emit/SlotDictionaryAliasingAssertionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/SlotDictionaryAliasingAssertionTests.cs
@@ -53,7 +53,7 @@ func makePoint() Point {
 
 var p = makePoint()
 var z Point
-var m = map[string]int32{}
+var m = map[string,int32]{}
 m[""hello""] = 7
 var v = m[""hello""]
 var miss = m[""nope""]

--- a/test/Core.Tests/CodeAnalysis/Lowering/SideEffectSpillerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/SideEffectSpillerTests.cs
@@ -159,7 +159,7 @@ func nextKey() string {
     keyCalls = keyCalls + 1
     return ""k""
 }
-var m = map[string]int32{}
+var m = map[string,int32]{}
 m[nextKey()] = 7
 Console.WriteLine(keyCalls)
 Console.WriteLine(m[""k""])

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue693MultiTypeArgGenericCallParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue693MultiTypeArgGenericCallParserTests.cs
@@ -24,7 +24,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
 /// lock that contract in at the parser layer.
 /// </para>
 /// <para>
-/// G#'s only map-literal syntax is <c>map[K]V{ k: v, … }</c> with the
+/// G#'s only map-literal syntax is <c>map[K,V]{ k: v, … }</c> with the
 /// explicit <c>map</c> keyword, so it cannot syntactically collide with
 /// <c>Dictionary[K, V]()</c>; the disambiguation that matters is the
 /// indexer/generic-call split, exercised here.
@@ -248,12 +248,12 @@ func run(m Dictionary[string, int32]) int32 {
     [Fact]
     public void MapLiteral_With_Map_Keyword_Still_Parses_As_MapCreation()
     {
-        // Negative regression: `map[K]V{ k: v, … }` (G#'s only map-literal
+        // Negative regression: `map[K,V]{ k: v, … }` (G#'s only map-literal
         // syntax) must continue to parse as a MapCreationExpression — the
         // multi-type-arg disambiguation only fires on identifier-headed
         // bracketed expressions, never after the `map` keyword.
         const string source = @"
-let m = map[string]int32 { ""a"": 1, ""b"": 2 }
+let m = map[string,int32] { ""a"": 1, ""b"": 2 }
 ";
         var tree = SyntaxTree.Parse(source);
         Assert.Empty(tree.Diagnostics);

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue709NullCoalescingAssignmentParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue709NullCoalescingAssignmentParserTests.cs
@@ -78,7 +78,7 @@ public class Issue709NullCoalescingAssignmentParserTests
             package P
             import System
             func main() {
-                var m = map[string]string?{}
+                var m = map[string,string?]{}
                 m["k"] ??= "v"
             }
             main()

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue751ReceiverClauseParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue751ReceiverClauseParserTests.cs
@@ -12,7 +12,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
 /// Parser-level coverage for issue #751 / ADR-0084 §L2: the receiver
 /// clause `func (recv RecvType) Name(...)` must accept the full type
 /// grammar — nullable spellings (`T?`), generic applications
-/// (`sequence[T]`, `map[K]V`), array+nullable combinations (`[]T?`),
+/// (`sequence[T]`, `map[K,V]`), array+nullable combinations (`[]T?`),
 /// tuple types (`(int32, T)`), and arbitrary nesting (`sequence[T]?`).
 /// Prior to the fix, <c>LooksLikeReceiverClause</c> only matched a
 /// bare identifier or `[N]T` / `[]T` and silently demoted the rest to
@@ -25,7 +25,7 @@ public class Issue751ReceiverClauseParserTests
     [InlineData("func (self sequence[T]) M[T]() { }", "M")]
     [InlineData("func (self sequence[T]?) M[T]() { }", "M")]
     [InlineData("func (self []T?) M[T]() { }", "M")]
-    [InlineData("func (self map[K]V) M[K, V]() { }", "M")]
+    [InlineData("func (self map[K,V]) M[K, V]() { }", "M")]
     [InlineData("func (self []T) M[T]() { }", "M")]
     [InlineData("func (self [3]int32) M() { }", "M")]
     [InlineData("func (self int32) M() { }", "M")]

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue805MapTypeClauseSpellingParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue805MapTypeClauseSpellingParserTests.cs
@@ -1,0 +1,242 @@
+// <copyright file="Issue805MapTypeClauseSpellingParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #805 / ADR-0104 — the legacy Go-flavored map type-clause
+/// spelling <c>map[K]V</c> has been removed. The canonical G# spelling
+/// is <c>map[K,V]</c> with both type arguments inside the brackets,
+/// separated by a comma. The parser still recognizes the legacy shape
+/// long enough to emit a span-accurate <see cref="DiagnosticId"/>
+/// diagnostic ("did you mean <c>map[K,V]</c>?") so the file does not
+/// cascade into a thicket of follow-on parse errors.
+/// </summary>
+public class Issue805MapTypeClauseSpellingParserTests
+{
+    private const string DiagnosticId = "GS0366";
+
+    private static Diagnostic[] LegacyMapDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(source);
+        return tree.Diagnostics.Where(d => d.Id == DiagnosticId).ToArray();
+    }
+
+    private static Diagnostic[] AllParserDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(source);
+        return tree.Diagnostics.ToArray();
+    }
+
+    // --- canonical `map[K,V]` is accepted in every type-clause slot ---
+
+    [Theory]
+    [InlineData("var m map[string,int32] = map[string,int32]{\"a\": 1}")]
+    [InlineData("let m = map[string,int32]{\"a\": 1}")]
+    [InlineData("let m = map[int32,string]{1: \"one\"}")]
+    [InlineData("let m = map[string,string?]{}")]
+    [InlineData("let m map[string,int32]? = nil")]
+    [InlineData("let m sequence[map[string,int32]] = nil")]
+    [InlineData("let m = map[string,async sequence[int32]]{}")]
+    public void CanonicalSpelling_IsAcceptedInAllTypeClauseSlots(string statement)
+    {
+        var source = $$"""
+            package P
+            func main() {
+                {{statement}}
+            }
+            """;
+        var diagnostics = AllParserDiagnostics(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void CanonicalSpelling_InFunctionSignatures_NoDiagnostics()
+    {
+        const string source = """
+            package P
+
+            func makeIndex() map[string,int32] {
+                return map[string,int32]{"a": 1}
+            }
+
+            func sum(m map[string,int32]) int32 {
+                return 0
+            }
+            """;
+        Assert.Empty(AllParserDiagnostics(source));
+    }
+
+    [Fact]
+    public void CanonicalSpelling_InReceiverClause_NoDiagnostics()
+    {
+        const string source = """
+            package P
+
+            func (self map[K,V]) CountKeys[K, V]() int32 {
+                return 0
+            }
+            """;
+        Assert.Empty(AllParserDiagnostics(source));
+    }
+
+    // --- legacy `map[K]V` is rejected with GS0366 ---
+
+    [Fact]
+    public void LegacySpelling_InLocalDeclaration_ReportsGS0366()
+    {
+        const string source = """
+            package P
+            func main() {
+                var m = map[string]int32{"a": 1}
+            }
+            """;
+        var diagnostics = LegacyMapDiagnostics(source);
+        var d = Assert.Single(diagnostics);
+        Assert.Contains("'map[K]V' type-clause spelling has been removed", d.Message);
+        Assert.Contains("map[string,int32]", d.Message);
+        Assert.Contains("ADR-0104", d.Message);
+    }
+
+    [Fact]
+    public void LegacySpelling_DiagnosticSpan_CoversWholeShape()
+    {
+        // `map[string]int32` is the full offending shape; the diagnostic
+        // span must run from `map` through the value type so an IDE
+        // quick-fix can replace the whole construct in one edit.
+        const string source = """
+            package P
+            func main() {
+                var m = map[string]int32{"a": 1}
+            }
+            """;
+        var d = Assert.Single(LegacyMapDiagnostics(source));
+        var spanText = d.Location.Text.ToString(d.Location.Span);
+        Assert.Equal("map[string]int32", spanText);
+    }
+
+    [Fact]
+    public void LegacySpelling_InReturnType_ReportsGS0366()
+    {
+        const string source = """
+            package P
+            func makeIndex() map[string]int32 {
+                return map[string,int32]{}
+            }
+            """;
+        var diagnostics = LegacyMapDiagnostics(source);
+        var d = Assert.Single(diagnostics);
+        Assert.Contains("map[string,int32]", d.Message);
+    }
+
+    [Fact]
+    public void LegacySpelling_InParameterType_ReportsGS0366()
+    {
+        const string source = """
+            package P
+            func sum(m map[string]int32) int32 {
+                return 0
+            }
+            """;
+        var d = Assert.Single(LegacyMapDiagnostics(source));
+        Assert.Contains("map[string,int32]", d.Message);
+    }
+
+    [Fact]
+    public void LegacySpelling_InReceiverClause_ReportsGS0366()
+    {
+        const string source = """
+            package P
+            func (self map[K]V) CountKeys[K, V]() int32 {
+                return 0
+            }
+            """;
+        var d = Assert.Single(LegacyMapDiagnostics(source));
+        Assert.Contains("map[K,V]", d.Message);
+    }
+
+    [Fact]
+    public void LegacySpelling_InFieldDeclaration_ReportsGS0366()
+    {
+        const string source = """
+            package P
+            class Counter {
+                var bins map[string]int32 = map[string,int32]{}
+            }
+            """;
+        var d = Assert.Single(LegacyMapDiagnostics(source));
+        Assert.Contains("map[string,int32]", d.Message);
+    }
+
+    [Fact]
+    public void LegacySpelling_InNestedTypeClause_ReportsGS0366()
+    {
+        const string source = """
+            package P
+            func main() {
+                let m sequence[map[string]int32] = nil
+            }
+            """;
+        var d = Assert.Single(LegacyMapDiagnostics(source));
+        Assert.Contains("map[string,int32]", d.Message);
+    }
+
+    // --- mixed forms in same file: multiple diagnostics, no cascades ---
+
+    [Fact]
+    public void MixedForms_EmitOneDiagnosticPerLegacySite_NoCascade()
+    {
+        const string source = """
+            package P
+
+            func legacyReturn() map[string]int32 {
+                return map[string,int32]{}
+            }
+
+            func legacyParam(m map[string]int32) int32 {
+                return 0
+            }
+
+            func main() {
+                var a = map[string,int32]{"a": 1}
+                var b = map[int32]string{1: "one"}
+                var c = map[string,string]{}
+                var d = map[string]string?{}
+            }
+            """;
+        var diagnostics = LegacyMapDiagnostics(source);
+
+        // Four legacy occurrences: legacyReturn return type, legacyParam
+        // parameter type, the `map[int32]string` literal, and the
+        // `map[string]string?` literal.
+        Assert.Equal(4, diagnostics.Length);
+
+        // No cascade: the parser recovers each legacy shape into the
+        // canonical bound form, so no other parser diagnostics fire.
+        var tree = SyntaxTree.Parse(source);
+        var nonGS0366 = tree.Diagnostics.Where(d => d.Id != DiagnosticId).ToArray();
+        Assert.Empty(nonGS0366);
+    }
+
+    [Fact]
+    public void MixedForms_EveryDiagnosticCarriesItsOwnReplacement()
+    {
+        const string source = """
+            package P
+            func main() {
+                var a = map[string]int32{"a": 1}
+                var b = map[K]V{}
+            }
+            """;
+        var diagnostics = LegacyMapDiagnostics(source);
+        Assert.Equal(2, diagnostics.Length);
+        Assert.Contains(diagnostics, d => d.Message.Contains("map[string,int32]"));
+        Assert.Contains(diagnostics, d => d.Message.Contains("map[K,V]"));
+    }
+}

--- a/test/Interpreter.Tests/Issue709NullCoalescingAssignmentInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue709NullCoalescingAssignmentInterpreterTests.cs
@@ -94,7 +94,7 @@ public class Issue709NullCoalescingAssignmentInterpreterTests
     {
         var source = """
             func main() {
-                var m = map[string]string?{}
+                var m = map[string,string?]{}
                 m["k"] = nil
                 m["k"] ??= "v"
                 Console.WriteLine(m["k"])

--- a/test/Interpreter.Tests/Issue751RichReceiverInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue751RichReceiverInterpreterTests.cs
@@ -11,7 +11,7 @@ namespace GSharp.Interpreter.Tests;
 /// <summary>
 /// Tree-walking interpreter parity for issue #751 / ADR-0084 §L2: the
 /// receiver clause now accepts rich type spellings (nullable, tuple,
-/// nullable array, map[K]V). Each test exercises the same shape covered
+/// nullable array, map[K,V]). Each test exercises the same shape covered
 /// by the emit and binder suites but through the REPL evaluator, which
 /// shares the binder with the compiler.
 /// </summary>
@@ -76,11 +76,11 @@ public class Issue751RichReceiverInterpreterTests
     public void Map_Receiver_Dispatches()
     {
         var source = """
-            func (self map[string]int32) CountKeys() int32 {
+            func (self map[string,int32]) CountKeys() int32 {
                 return self.Count
             }
 
-            var m = map[string]int32{"a": 1, "b": 2, "c": 3}
+            var m = map[string,int32]{"a": 1, "b": 2, "c": 3}
             Console.WriteLine(m.CountKeys())
             """;
 

--- a/test/Interpreter.Tests/Issue805MapTypeClauseSpellingInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue805MapTypeClauseSpellingInterpreterTests.cs
@@ -1,0 +1,76 @@
+// <copyright file="Issue805MapTypeClauseSpellingInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #805 / ADR-0104 — interpreter parity for the canonical
+/// <c>map[K,V]</c> spelling. Mirrors the emit-side coverage so the two
+/// execution backends behave identically against the migrated surface
+/// syntax.
+/// </summary>
+public class Issue805MapTypeClauseSpellingInterpreterTests
+{
+    [Fact]
+    public void CanonicalSpelling_InferredLocal_RunsInRepl()
+    {
+        var source = """
+            var m = map[string,int32]{"a": 1}
+            Console.WriteLine(m["a"])
+            """;
+        var output = RunSubmission(source);
+        Assert.Contains("1", output);
+    }
+
+    [Fact]
+    public void CanonicalSpelling_ExplicitTypedLocal_RunsInRepl()
+    {
+        var source = """
+            var m map[string,int32] = map[string,int32]{"a": 1, "b": 2}
+            Console.WriteLine(m["a"])
+            Console.WriteLine(m["b"])
+            """;
+        var output = RunSubmission(source);
+        Assert.Contains("1", output);
+        Assert.Contains("2", output);
+    }
+
+    [Fact]
+    public void CanonicalSpelling_FunctionReturnAndParameter_RunsInRepl()
+    {
+        var source = """
+            func makeIndex() map[string,int32] {
+                return map[string,int32]{"a": 1, "b": 2}
+            }
+            func first(m map[string,int32]) int32 {
+                return m["a"]
+            }
+            Console.WriteLine(first(makeIndex()))
+            """;
+        var output = RunSubmission(source);
+        Assert.Contains("1", output);
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString();
+    }
+}

--- a/website/docs/bridges/gsharp-for-go-developers.md
+++ b/website/docs/bridges/gsharp-for-go-developers.md
@@ -20,7 +20,7 @@ G# is a Go-inspired language for .NET. You will recognize packages, `func`, `def
 | `:=` | `let x = …` or `var x = …` | G# removed the Go-style `:=` short declaration ([ADR-0077](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0077-drop-colon-equals-short-variable-declaration.md)); every binding site requires `let` (immutable) or `var` (mutable). For ranges, write `for i in lo ... hi` and `for v in xs`. |
 | `[]T` | `[]T` | Slices are backed by CLR arrays and support `len`, `cap`, and `append`. |
 | `[3]T` | `[3]T` | Fixed arrays carry the length in the type. |
-| `map[K]V` | `map[K]V` or `Dictionary[K, V]` | CLR generic syntax uses brackets. |
+| `map[K,V]` | `map[K,V]` or `Dictionary[K, V]` | CLR generic syntax uses brackets. |
 | `struct` | `struct`, `data struct`, `record`, or `class` | G# also has CLR classes and structural data structs. |
 | exported by `Name` | `public Name` | Visibility is explicit: `public`, `private`, or `internal`. |
 | goroutine `go f()` | `go f()` | Scoped `go` joins through `scope`. |

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -87,7 +87,7 @@ G# uses CLR-style exceptions with `try`, `catch`, `finally`, and `throw`. That c
 
 ## Are slices, maps, and sequences built in?
 
-Yes. Fixed arrays use `[N]T`, slices use `[]T`, maps use `map[K]V`, and sequences use `sequence[T]`. Slices are backed by CLR arrays, maps by dictionary-like storage, and sequences map to .NET enumerable shapes, with iterator functions using `yield`.
+Yes. Fixed arrays use `[N]T`, slices use `[]T`, maps use `map[K,V]`, and sequences use `sequence[T]`. Slices are backed by CLR arrays, maps by dictionary-like storage, and sequences map to .NET enumerable shapes, with iterator functions using `yield`.
 
 ## What editor and debugging support exists?
 

--- a/website/docs/guide/types-and-values.md
+++ b/website/docs/guide/types-and-values.md
@@ -24,12 +24,12 @@ Numeric operators are defined for matching primitive types; G# does not silently
 
 ## Arrays, slices, and maps
 
-Arrays have fixed length and are written `[N]T`. Slices are written `[]T` and are backed by CLR arrays in the current implementation. `append` returns a new array-backed value after copying. Maps are written `map[K]V` and are backed by `Dictionary<K,V>`.
+Arrays have fixed length and are written `[N]T`. Slices are written `[]T` and are backed by CLR arrays in the current implementation. `append` returns a new array-backed value after copying. Maps are written `map[K,V]` and are backed by `Dictionary<K,V>`.
 
 ```gsharp
 let numbers = []int32{1, 2, 3}
 let fixed = [3]int32{1, 2, 3}
-let names = map[int32]string{1: "one", 2: "two"}
+let names = map[int32,string]{1: "one", 2: "two"}
 ```
 
 Slice design rationale is in [ADR-0016](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0016-slice-storage.md).

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -1436,3 +1436,55 @@ Cross-references:
 - Issues #799 (this feature), #792 (dogfooded `Optional`/`Sequences` port), #706 (parent tracker).
 
 
+## Map type-clause spelling removal (GS0366)
+
+ADR-0104 / issue #805. The legacy Go-flavored map type-clause spelling
+`map[K]V` (key inside the brackets, value outside) has been **removed**
+in v0.2. The canonical G# spelling is `map[K,V]` with both type
+arguments inside the brackets, separated by a comma — the same
+single-bracket / comma-separated shape every other multi-argument type
+clause already uses (`Foo[T1, T2]`, `Dictionary[K, V]`,
+`func(P1, P2) R`, `(K, V)` tuple). There is no deprecation window;
+the parser emits `GS0366` and the program does not compile.
+
+| Code | Severity | Message |
+|----|----------|-------------|
+| GS0366 | Error | The `map[K]V` type-clause spelling has been removed; use `map[{key},{value}]` instead (ADR-0104). |
+
+Cause/fix:
+
+- Replace every type-clause occurrence of `map[K]V` with `map[K,V]`.
+  The migration is purely syntactic — symbol identity, binding,
+  lowering, and emit are unaffected, and the runtime backing type
+  remains `System.Collections.Generic.Dictionary<K, V>`.
+
+```diff
+- var m = map[string]int32{"a": 1}
++ var m = map[string,int32]{"a": 1}
+
+- func makeIndex() map[string]Person { … }
++ func makeIndex() map[string,Person] { … }
+
+- func (self map[K]V) CountKeys() int32 { … }
++ func (self map[K,V]) CountKeys() int32 { … }
+```
+
+Map index/use sites are unchanged — only the **type-clause** spelling
+moves. `m["a"]`, `len(m)`, `delete(m, k)`, and the map literal entry
+form `{k: v, …}` are all unaffected.
+
+The parser still recognises the legacy shape long enough to emit a
+span-accurate diagnostic that quotes the exact replacement, so IDE
+quick-fixes can patch the whole construct in one edit. Mixed-form
+files produce one `GS0366` per legacy occurrence with **no cascade
+errors** — the parser binds the recovered shape to the same
+`MapTypeSymbol` so downstream binding proceeds unchanged.
+
+Cross-references:
+
+- ADR-0104 — map type clause canonical spelling.
+- ADR-0020 — Go-style `[T]` generic type-parameter brackets.
+- ADR-0040 — `sequence[T]` (the other contextual-keyword type clause).
+- Issues #805 (this change), #706 (parent tracker).
+
+

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -172,10 +172,10 @@ Slices are backed by CLR arrays. `len` and `cap` observe array length, and `appe
 
 ### Maps
 
-Maps are written `map[K]V` and are backed by `Dictionary<K,V>` in the implementation. Map literals use key-value entries, indexing reads values, and indexed assignment updates entries.
+Maps are written `map[K,V]` and are backed by `Dictionary<K,V>` in the implementation. Map literals use key-value entries, indexing reads values, and indexed assignment updates entries.
 
 ```gsharp
-let counts = map[string]int32{"g": 1, "sharp": 2}
+let counts = map[string,int32]{"g": 1, "sharp": 2}
 ```
 
 ### Sequences
@@ -497,7 +497,7 @@ Member access and indexing chain after primaries. `a.b`, `a?.b`, `a[i]`, `a?[i]`
 
 ### Composite literals
 
-Struct literals use `TypeName{Field: value}`. Data structs also support copy/update with `expr with { Field = value }`. Array and slice literals use `[N]T{...}` or `[]T{...}`. Map literals use `map[K]V{key: value}`.
+Struct literals use `TypeName{Field: value}`. Data structs also support copy/update with `expr with { Field = value }`. Array and slice literals use `[N]T{...}` or `[]T{...}`. Map literals use `map[K,V]{key: value}`.
 
 ### Switch expressions and patterns
 

--- a/website/docs/ref/standard-library.md
+++ b/website/docs/ref/standard-library.md
@@ -47,7 +47,7 @@ These names are recognized specially by the binder. They are language intrinsics
 | `len` | `len(x)` | arrays, slices, strings, maps | `int32` length/count | `Gsharp.Extensions.Go` (ADR-0083) |
 | `cap` | `cap(x)` | arrays, slices | `int32` capacity | `Gsharp.Extensions.Go` (ADR-0083) |
 | `append` | `append(slice, value)` | first argument must be `[]T`; second converts to `T` | new `[]T` containing the appended value | `Gsharp.Extensions.Go` (ADR-0083) |
-| `delete` | `delete(map, key)` | first argument must be `map[K]V`; key converts to `K` | no value; removes the key if present | `Gsharp.Extensions.Go` (ADR-0083) |
+| `delete` | `delete(map, key)` | first argument must be `map[K,V]`; key converts to `K` | no value; removes the key if present | `Gsharp.Extensions.Go` (ADR-0083) |
 | `close` | `close(ch)` | `chan T` | no value; completes the channel writer | `Gsharp.Extensions.Go` (ADR-0082) |
 | `make` | `make(chan T)` or `make(chan T, capacity)` | channel creation only | `chan T` | `Gsharp.Extensions.Go` (ADR-0082, via the inner `chan` clause) |
 | receive | `<-ch` | `chan T` | next `T` value, or the closed-channel default value | `Gsharp.Extensions.Go` (ADR-0082) |
@@ -84,12 +84,12 @@ Arrays and slices support indexing, index assignment when mutable, `len`, and `c
 
 ## Maps
 
-Map types are written `map[K]V` and are backed by `Dictionary<K,V>`. Map literals use key/value entries, indexing reads values, index assignment writes values, `delete` removes a key, and `len` returns the current count. Both `delete` and `len` require `import Gsharp.Extensions.Go` (ADR-0083); the .NET-idiomatic equivalents are `counts.Remove("missing")` and `counts.Count`.
+Map types are written `map[K,V]` and are backed by `Dictionary<K,V>`. Map literals use key/value entries, indexing reads values, index assignment writes values, `delete` removes a key, and `len` returns the current count. Both `delete` and `len` require `import Gsharp.Extensions.Go` (ADR-0083); the .NET-idiomatic equivalents are `counts.Remove("missing")` and `counts.Count`.
 
 ```gsharp
 import Gsharp.Extensions.Go
 
-var counts = map[string]int32{"gsharp": 1}
+var counts = map[string,int32]{"gsharp": 1}
 counts["gsharp"] = counts["gsharp"] + 1
 delete(counts, "missing")
 Console.WriteLine(len(counts))
@@ -163,8 +163,8 @@ G#-shaped collectors:
 | Symbol | Form | One-line description |
 | --- | --- | --- |
 | `ToSlice` | `func [T] (self sequence[T]) ToSlice() []T` | Materialise the sequence into a G# slice (`T[]` under the hood). |
-| `ToMap` (tuple form) | `func [K, V] (self sequence[(K, V)]) ToMap() map[K]V` | Build a map from a sequence of key/value tuples. Throws on duplicate keys. |
-| `ToMap` (selector form) | `func [T, K, V] (self sequence[T]) ToMap(keyFn (T) -> K, valueFn (T) -> V) map[K]V` | Project each element to a `(K, V)` pair, then build the map. |
+| `ToMap` (tuple form) | `func [K, V] (self sequence[(K, V)]) ToMap() map[K,V]` | Build a map from a sequence of key/value tuples. Throws on duplicate keys. |
+| `ToMap` (selector form) | `func [T, K, V] (self sequence[T]) ToMap(keyFn (T) -> K, valueFn (T) -> V) map[K,V]` | Project each element to a `(K, V)` pair, then build the map. |
 
 `FirstOrNil` / `LastOrNil` / `SingleOrNil` (plus the `*ValueOrNil` companions), `Indexed`, `Of`, and `Empty` carry `[MethodImpl(MethodImplOptions.AggressiveInlining)]`. The iterator-block transformers (`Windowed`, `Chunked`, `Pairwise`, `Interleave`, `Range`, `RangeStep`, `Iterate`, `Repeat`) are intentionally **not** inlined — their bodies are compiler-generated state machines that the JIT does not inline.
 

--- a/website/docs/tour/types.md
+++ b/website/docs/tour/types.md
@@ -143,14 +143,14 @@ Console.WriteLine(nums[3])
 40
 ```
 
-Maps use `map[K]V` for G# map literals, and CLR collections such as `Dictionary[string, int32]` are available through imports.
+Maps use `map[K,V]` for G# map literals, and CLR collections such as `Dictionary[string, int32]` are available through imports.
 
 ```gsharp
 package Tour.Types
 
 import System
 
-var counts = map[string]int32{"gsharp": 1}
+var counts = map[string,int32]{"gsharp": 1}
 counts["gsharp"] = counts["gsharp"] + 1
 Console.WriteLine(counts["gsharp"])
 ```

--- a/website/docs/tutorials/data-and-types.md
+++ b/website/docs/tutorials/data-and-types.md
@@ -397,7 +397,7 @@ beta
 139
 ```
 
-For maps, use `map[K]V` for the G# map type or import `System.Collections.Generic` and use CLR `Dictionary[K, V]`, as shown in [Projects and packages](./project-and-packages).
+For maps, use `map[K,V]` for the G# map type or import `System.Collections.Generic` and use CLR `Dictionary[K, V]`, as shown in [Projects and packages](./project-and-packages).
 
 ## What you learned
 


### PR DESCRIPTION
Implements [ADR-0104](docs/adr/0104-map-type-clause-spelling.md). The legacy Go-flavored map type-clause spelling `map[K]V` has been removed in v0.2; the canonical G# spelling is `map[K,V]`, putting both type arguments inside the brackets separated by a comma — the same single-bracket / comma-separated shape every other multi-argument type clause already uses.

**Breaking change for v0.2.** No deprecation window.

## Scope checklist

- [x] **ADR-0104** authored — canonical `map[K,V]`, hard removal of `map[K]V`, diagnostic GS0366, lexer/parser strategy, and supersedes-notes on the pre-ADR Phase 3.A.4 origin (informally documented in ADR-0040).
- [x] **Parser** — `ParseMapTypeClause` accepts `map[K,V]?` and recovers the legacy `map[K]V` shape long enough to emit a span-accurate GS0366 diagnostic, then binds it to the same `MapTypeSymbol` so downstream binding does not cascade.
- [x] **TypeClauseSyntax** — adds `MapCommaToken`; `MapCloseBracketToken` now denotes the closing `]` of the *whole* key/value pair rather than only the key. No new `BoundNodeKind`.
- [x] **Symbol display** — `MapTypeSymbol.Name` renders as `map[K,V]` so diagnostics and IDE hover info match the source spelling.
- [x] **New diagnostic GS0366** (Error): `The 'map[K]V' type-clause spelling has been removed; use 'map[{key},{value}]' instead (ADR-0104).`
- [x] **Sweep** — every legacy `map[K]V` type-clause occurrence under `samples/`, `test/`, `docs/` (including ADRs), and `website/docs/` migrated to the canonical form. `website/versioned_docs/version-0.1` left untouched as a frozen v0.1 snapshot.
- [x] **Tests** — 29 new tests across parser, binder, emit (ilverified), and interpreter, exercising the every-slot accept matrix, span-accurate rejection of the legacy form, and the mixed-form no-cascade property.
- [x] **Docs** — spec, tour, tutorials, bridges (Go-developers guide), standard library, and FAQ all updated. New GS0366 entry added to `website/docs/ref/diagnostics.md`.
- [x] **Builds clean** — full `dotnet test GSharp.sln` green, website `npm run build` succeeds, ilverify clean.

## Test summary

```
Sdk.Tests:           32 passed
Extensions.Tests:    107 passed
Interpreter.Tests:   296 passed (+3 new)
LanguageServer.Tests: 266 passed
Core.Tests:          3262 passed, 1 skipped (+22 new)
Compiler.Tests:      1319 passed (+4 new)
TOTAL:               5282 passed, 1 skipped, 0 failed
```

## Migration count

| Area              | Files | Substitutions |
|-------------------|-------|---------------|
| samples           | 2     | 2             |
| test              | 17    | 51            |
| docs (ADRs)       | 7     | 17            |
| website/docs      | 7     | 16            |
| src (doc-comments)| 5     | 4             |
| **Total**         | **38**| **90**        |

(Plus 1 new ADR, 4 new test files, and the new GS0366 entry in `website/docs/ref/diagnostics.md`.)

## Links

- New ADR: [`docs/adr/0104-map-type-clause-spelling.md`](docs/adr/0104-map-type-clause-spelling.md)
- Issue: #805
- Parent tracker: #706

Closes #805