### PR TITLE
Fix #831: open-T == nil emits verifiable IL

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -70,6 +70,49 @@ internal sealed partial class MethodBodyEmitter
                 return;
             }
 
+            // Issue #831: `!!` on an open-type-parameter operand whose
+            // type is bare `T` or `T?` and where T is NOT
+            // struct-constrained. The bottom `dup; brtrue` path below
+            // is invalid IL — the verifier rejects `dup` / `brtrue`
+            // on an opaque `!!T` stack value because it cannot prove T
+            // is a reference type at the signature layer. Mirror the
+            // value-type spill: store the operand to a `T`-typed slot,
+            // probe its non-nullness via `box !!T; brtrue nonNull`,
+            // throw on the null path, and reload the slot on the
+            // non-null path. The JIT elides the box when T resolves to
+            // a reference type at runtime (ECMA-335 III.4.1). This
+            // catches both the un-narrowed `self!!` over `self T?` and
+            // the smart-cast `self!!` whose binder-typed operand has
+            // already collapsed to bare `T` after a null-check guard.
+            if (TryGetOpenTypeParameter(u.Operand.Type, out var tpOperand))
+            {
+                if (!this.receiverSpillSlots.TryGetValue(u, out var tpUnwrapSlot))
+                {
+                    throw new InvalidOperationException(
+                        "No scratch slot pre-allocated for class-constrained `T?` / open `T` '!!' operand — "
+                        + "check NullableValueTypeUnwrapCollector and the prepass in CollectLocalsAndLabels.");
+                }
+
+                var tpToken = this.outer.GetElementTypeToken(tpOperand);
+                var tpNonNull = this.il.DefineLabel();
+
+                this.EmitExpression(u.Operand);
+                this.il.StoreLocal(tpUnwrapSlot);
+                this.il.LoadLocal(tpUnwrapSlot);
+                this.il.OpCode(ILOpCode.Box);
+                this.il.Token(tpToken);
+                this.il.Branch(ILOpCode.Brtrue, tpNonNull);
+
+                var tpNreCtor = this.outer.wellKnown.GetNullReferenceExceptionCtorRef();
+                this.il.OpCode(ILOpCode.Newobj);
+                this.il.Token(tpNreCtor);
+                this.il.OpCode(ILOpCode.Throw);
+
+                this.il.MarkLabel(tpNonNull);
+                this.il.LoadLocal(tpUnwrapSlot);
+                return;
+            }
+
             this.EmitExpression(u.Operand);
             this.il.OpCode(ILOpCode.Dup);
             var nonNull = this.il.DefineLabel();
@@ -182,6 +225,52 @@ internal sealed partial class MethodBodyEmitter
 
                 // Null branch: evaluate RHS, which the binder typed to
                 // match the operator's result (either `T` or `Nullable<T>`).
+                this.il.MarkLabel(fallback);
+                this.EmitExpression(b.Right);
+                this.il.MarkLabel(end);
+                return;
+            }
+
+            // Issue #831: NullCoalesce over a class-constrained (or
+            // unconstrained) `T?` whose underlying is an open type
+            // parameter. The underlying T has no static ClrType, so
+            // neither the value-type Nullable<T> spill branch above nor
+            // the bottom `dup; brtrue` shape is verifiable IL: the
+            // verifier rejects `dup` / `brtrue` on an opaque `!!T`
+            // stack value because it cannot prove T is a reference type
+            // at the signature layer (ECMA-335 III.1.8). Mirror the
+            // value-type spill: store the LHS to a `T`-typed slot, probe
+            // its non-nullness via `box !!T; brtrue/brfalse` (which the
+            // verifier accepts because `box` always produces an object
+            // reference), and either reload the slot or evaluate RHS.
+            // The JIT elides the box at runtime when T resolves to a
+            // reference type (ECMA-335 III.4.1), so the optimized native
+            // code is no worse than the original `dup; brtrue` shape.
+            if (b.Left.Type is NullableTypeSymbol tpNullable
+                && tpNullable.UnderlyingType is TypeParameterSymbol tpUnderlying
+                && !tpUnderlying.HasValueTypeConstraint)
+            {
+                if (!this.nullableCoalesceSpillSlots.TryGetValue(b, out var tpSlot))
+                {
+                    throw new InvalidOperationException(
+                        "No scratch slot pre-allocated for class-constrained `T?` '?:' LHS — "
+                        + "check NullableValueTypeCoalesceCollector and the prepass in CollectLocalsAndLabels.");
+                }
+
+                var tpToken = this.outer.GetElementTypeToken(tpUnderlying);
+                var fallback = this.il.DefineLabel();
+                var end = this.il.DefineLabel();
+
+                this.EmitExpression(b.Left);
+                this.il.StoreLocal(tpSlot);
+                this.il.LoadLocal(tpSlot);
+                this.il.OpCode(ILOpCode.Box);
+                this.il.Token(tpToken);
+                this.il.Branch(ILOpCode.Brfalse, fallback);
+
+                this.il.LoadLocal(tpSlot);
+                this.il.Branch(ILOpCode.Br, end);
+
                 this.il.MarkLabel(fallback);
                 this.EmitExpression(b.Right);
                 this.il.MarkLabel(end);
@@ -341,6 +430,45 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #831: `T? == nil` / `T? != nil` where the underlying T
+        // is an open type parameter (class-constrained, struct-constrained
+        // or unconstrained). The concrete value-type Nullable<T> arm above
+        // (via liftedBinarySlots + EmitLiftedNullableBinary) only catches
+        // operands with a static `ClrType`, which open type parameters do
+        // NOT have — so without this guard the bottom of EmitBinary would
+        // emit `<T-value>; ldnull; ceq`. ilverify rejects that with
+        // `[StackUnexpected]: found Nullobjref ... expected value 'T'`
+        // (class/unconstrained) or `expected value 'Nullable`1<T>'`
+        // (struct-constrained), because `ceq` cannot match an opaque
+        // stack slot against a managed-null reference at the verifier
+        // layer. Box the operand first so the comparison runs against an
+        // `O` reference. The CLR's `box` opcode has the property that
+        // `box Nullable<T>` yields the managed-null reference when
+        // HasValue is false (ECMA-335 III.4.1) — so the same shape
+        // works uniformly for class-T (boxing a reference is a no-op the
+        // JIT elides) and struct-T (boxing a Nullable encodes HasValue
+        // into the reference). We use the LHS expression's full type
+        // token (the NullableTypeSymbol) so the `box` operand resolves to
+        // `!!T` for class/unconstrained-T (where T? stores as a bare
+        // reference slot) and to `Nullable<!!T>` for struct-T (where T?
+        // stores as a value-typed nullable).
+        if ((b.Op.Kind == BoundBinaryOperatorKind.Equals || b.Op.Kind == BoundBinaryOperatorKind.NotEquals)
+            && TryMatchTypeParameterNilCompare(b, out var tpNilOperand))
+        {
+            this.EmitExpression(tpNilOperand);
+            this.il.OpCode(ILOpCode.Box);
+            this.il.Token(this.outer.GetElementTypeToken(tpNilOperand.Type));
+            this.il.OpCode(ILOpCode.Ldnull);
+            this.il.OpCode(ILOpCode.Ceq);
+            if (b.Op.Kind == BoundBinaryOperatorKind.NotEquals)
+            {
+                this.il.LoadConstantI4(0);
+                this.il.OpCode(ILOpCode.Ceq);
+            }
+
+            return;
+        }
+
         // Short-circuit evaluation for logical `&&` and `||`: the right
         // operand must not be evaluated when the left operand already
         // determines the result. Emit a dup + conditional branch so the
@@ -440,6 +568,88 @@ internal sealed partial class MethodBodyEmitter
         }
 
         EmitNarrowingTruncationIfNeeded(b.Op.Kind, b.Type);
+    }
+
+    /// <summary>
+    /// Issue #831: matches `T? == nil` / `T? != nil` (and the symmetric
+    /// `nil == T?` / `nil != T?`) where the underlying T is an open
+    /// type parameter (class-constrained, struct-constrained, or
+    /// unconstrained). The concrete value-type Nullable&lt;T&gt; arm
+    /// (driven by <see cref="liftedBinarySlots"/>) only catches
+    /// operands with a static <c>ClrType</c>; open type parameters
+    /// have none, so this match fills the gap. The caller boxes the
+    /// matched operand using its full nullable type token, which
+    /// resolves to a bare reference slot for class/unconstrained T and
+    /// to <c>Nullable&lt;!!T&gt;</c> for struct T.
+    /// </summary>
+    private static bool TryMatchTypeParameterNilCompare(
+        BoundBinaryExpression node,
+        out BoundExpression operand)
+    {
+        if (node.Right.Type == TypeSymbol.Null
+            && IsOpenTypeParameterNullable(node.Left.Type))
+        {
+            operand = node.Left;
+            return true;
+        }
+
+        if (node.Left.Type == TypeSymbol.Null
+            && IsOpenTypeParameterNullable(node.Right.Type))
+        {
+            operand = node.Right;
+            return true;
+        }
+
+        operand = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #831: returns true when <paramref name="t"/> is a
+    /// <see cref="NullableTypeSymbol"/> wrapping an open type parameter
+    /// (regardless of constraint). The CLR storage of <c>T?</c> is
+    /// either a bare <c>!!T</c> reference slot (class/unconstrained T)
+    /// or a <c>Nullable&lt;!!T&gt;</c> value-typed slot (struct T) —
+    /// see <see cref="ReflectionMetadataEmitter.GetElementTypeToken"/>.
+    /// Both shapes need the same `box; ldnull; ceq` lowering for
+    /// nil-comparison to be verifier-clean: boxing a reference is a
+    /// JIT-elided no-op, while boxing <c>Nullable&lt;T&gt;</c> per
+    /// ECMA-335 III.4.1 yields a managed-null reference when
+    /// HasValue is false.
+    /// </summary>
+    private static bool IsOpenTypeParameterNullable(TypeSymbol t)
+    {
+        return t is NullableTypeSymbol nullable
+            && nullable.UnderlyingType is TypeParameterSymbol;
+    }
+
+    /// <summary>
+    /// Issue #831: returns true when <paramref name="t"/> resolves to an
+    /// open type parameter that is NOT struct-constrained, either
+    /// directly (e.g. after a smart-cast narrowing) or via a
+    /// <see cref="NullableTypeSymbol"/> wrapper. Used by the `!!`
+    /// (NullAssertion) emit path to recognise both `self T?` and the
+    /// narrowed bare-`T` operand shape produced after a preceding
+    /// nil-check guard.
+    /// </summary>
+    private static bool TryGetOpenTypeParameter(TypeSymbol t, out TypeParameterSymbol typeParameter)
+    {
+        if (t is TypeParameterSymbol bare && !bare.HasValueTypeConstraint)
+        {
+            typeParameter = bare;
+            return true;
+        }
+
+        if (t is NullableTypeSymbol nullable
+            && nullable.UnderlyingType is TypeParameterSymbol wrapped
+            && !wrapped.HasValueTypeConstraint)
+        {
+            typeParameter = wrapped;
+            return true;
+        }
+
+        typeParameter = null;
+        return false;
     }
 
     private void EmitNarrowingTruncationIfNeeded(BoundBinaryOperatorKind kind, TypeSymbol resultType)

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -991,13 +991,27 @@ internal sealed class SlotPlanner
         }
     }
 
-    // Issue #504: walks the bound tree collecting every `BoundUnaryExpression`
-    // whose operator is `NullAssertion` (`!!`) and whose operand is a
-    // value-type `Nullable<T>`. Each such site needs a `Nullable<T>`-typed
-    // temp slot so the emitter can spill the operand and call
-    // `Nullable<T>::get_Value` (which yields the underlying `T` or throws
-    // `InvalidOperationException`). The reference-type `!!` path uses the
-    // existing `dup; brtrue; throw NRE` pattern and needs no slot.
+    // Issue #504 + Issue #831: walks the bound tree collecting every
+    // `BoundUnaryExpression` whose operator is `NullAssertion` (`!!`)
+    // and whose operand requires an emit-time spill slot. Two shapes
+    // qualify:
+    //
+    //   * Value-type `Nullable<T>` operand — the emitter spills the
+    //     struct to a slot and calls `Nullable<T>::get_Value` (which
+    //     yields the underlying `T` or throws `InvalidOperationException`).
+    //
+    //   * Open-type-parameter operand whose binder-typed shape is `T?`
+    //     or bare `T` (after a smart-cast that narrowed `T?` to `T`),
+    //     where T is NOT struct-constrained. The bare `!!T` stack value
+    //     cannot be probed via `dup; brtrue` either — the verifier
+    //     rejects branching on an opaque type-parameter slot. The
+    //     emitter instead stores the operand to a `T`-typed slot,
+    //     probes its non-nullness via `box !!T; brtrue nonNull`, throws
+    //     on null, and reloads the slot on the non-null path.
+    //
+    // Reference-type `!!` over a concrete reference (string?, Func<T>?,
+    // sequence[T], ...) uses the existing `dup; brtrue; throw NRE`
+    // pattern and needs no slot.
     private sealed class NullableValueTypeUnwrapCollector : BoundTreeWalker
     {
         private readonly List<BoundUnaryExpression> sink;
@@ -1009,11 +1023,29 @@ internal sealed class SlotPlanner
 
         protected override void VisitUnaryExpression(BoundUnaryExpression node)
         {
-            if (node.Op.Kind == BoundUnaryOperatorKind.NullAssertion
-                && node.Operand.Type is NullableTypeSymbol n
-                && n.UnderlyingType?.ClrType is { IsValueType: true })
+            if (node.Op.Kind == BoundUnaryOperatorKind.NullAssertion)
             {
-                this.sink.Add(node);
+                bool needsSlot = false;
+
+                if (node.Operand.Type is NullableTypeSymbol n)
+                {
+                    needsSlot = n.UnderlyingType?.ClrType is { IsValueType: true }
+                        || (n.UnderlyingType is TypeParameterSymbol tp && !tp.HasValueTypeConstraint);
+                }
+                else if (node.Operand.Type is TypeParameterSymbol bare && !bare.HasValueTypeConstraint)
+                {
+                    // Issue #831: smart-cast may narrow `self T?` to bare
+                    // `T` after a preceding `if self == nil { return }`
+                    // guard, but the runtime value still needs the
+                    // verifiable `box; brtrue` shape rather than the
+                    // direct `dup; brtrue` over an opaque `!!T` slot.
+                    needsSlot = true;
+                }
+
+                if (needsSlot)
+                {
+                    this.sink.Add(node);
+                }
             }
 
             base.VisitUnaryExpression(node);
@@ -1021,14 +1053,25 @@ internal sealed class SlotPlanner
     }
 
     // Issue #519: walks the bound tree collecting every `BoundBinaryExpression`
-    // whose operator is `NullCoalesce` (`?:`) and whose LHS is a value-type
-    // `Nullable<T>`. Each such site needs a `Nullable<T>`-typed temp slot so
-    // the emitter can spill the LHS once, call `Nullable<T>::get_HasValue`
-    // off the slot's address, and either reload the slot (when the result
-    // type is `Nullable<T>`) or call `Nullable<T>::get_Value` off the slot's
-    // address (when the result type is the underlying `T`). The reference-
-    // type `?:` path uses the existing `dup; brtrue; pop; rhs` pattern and
-    // needs no slot.
+    // whose operator is `NullCoalesce` (`?:`) and whose LHS needs an emit-time
+    // spill slot. Two shapes qualify:
+    //
+    //   * Value-type `Nullable<T>` LHS — the emitter spills the LHS once and
+    //     calls `Nullable<T>::get_HasValue` / `get_Value` off the slot's
+    //     address (since `dup; brtrue` is invalid IL for struct stack values).
+    //
+    //   * Issue #831: open-type-parameter `T?` LHS where T is NOT
+    //     struct-constrained (class-constrained or unconstrained). The bare
+    //     `!!T` stack value cannot be probed with `dup; brtrue` either —
+    //     the verifier rejects branching on an opaque type-parameter slot
+    //     because it cannot prove T is a reference type at the signature
+    //     layer. The slot is typed as `T?` (which encodes as bare `!!T` per
+    //     `ReflectionMetadataEmitter.GetElementTypeToken`), and the emitter
+    //     probes its non-nullness via `box !!T; brfalse fallback`.
+    //
+    // Reference-type `?:` over a concrete reference type (string?, Func<T>?,
+    // sequence[T], etc.) uses the existing `dup; brtrue; pop; rhs` pattern
+    // and needs no slot.
     private sealed class NullableValueTypeCoalesceCollector : BoundTreeWalker
     {
         private readonly List<BoundBinaryExpression> sink;
@@ -1041,10 +1084,15 @@ internal sealed class SlotPlanner
         protected override void VisitBinaryExpression(BoundBinaryExpression node)
         {
             if (node.Op.Kind == BoundBinaryOperatorKind.NullCoalesce
-                && node.Left.Type is NullableTypeSymbol n
-                && n.UnderlyingType?.ClrType is { IsValueType: true })
+                && node.Left.Type is NullableTypeSymbol n)
             {
-                this.sink.Add(node);
+                bool needsSlot = n.UnderlyingType?.ClrType is { IsValueType: true }
+                    || (n.UnderlyingType is TypeParameterSymbol tp && !tp.HasValueTypeConstraint);
+
+                if (needsSlot)
+                {
+                    this.sink.Add(node);
+                }
             }
 
             base.VisitBinaryExpression(node);

--- a/test/Compiler.Tests/Emit/Issue831OpenTNilCompareEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue831OpenTNilCompareEmitTests.cs
@@ -1,0 +1,335 @@
+// <copyright file="Issue831OpenTNilCompareEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #831 / ADR-0084 follow-up. End-to-end emit + IL-verify
+/// coverage for `T? == nil` / `T? != nil` and the closely-related
+/// `self!!` / `self ?: defaultValue` patterns where `T` is an open
+/// type parameter constrained with `[T class]` (or left unconstrained).
+///
+/// Pre-fix the emitter naively produced
+///
+///   ldarg.0; ldnull; ceq            // for `== nil`
+///   ldarg.0; dup; brtrue; ...        // for `!!`
+///   ldarg.0; dup; brtrue; ...        // for `?:`
+///
+/// against an opaque `!!T` stack value — the runtime JIT tolerated it
+/// for reference-typed T but `ilverify` rejected the IL with
+/// `[StackUnexpected]: found Nullobjref ... expected value 'T'` (and
+/// related Stack errors for `dup; brtrue` on a type-parameter slot).
+/// The fix routes every site through a verifier-clean `box !!T` plus
+/// `ldnull; ceq` / `brtrue` sequence. The JIT elides the box when T
+/// resolves to a reference type, so the optimized native shape is
+/// equivalent.
+///
+/// Each test compiles the source with gsc, gates the produced PE
+/// through <see cref="IlVerifier.Verify(string, System.Collections.Generic.IEnumerable{string}, System.Collections.Generic.IEnumerable{string})"/>,
+/// then runs it under `dotnet exec` and asserts on the captured stdout.
+/// </summary>
+public class Issue831OpenTNilCompareEmitTests
+{
+    [Fact]
+    public void OpenTNilCompare_ClassConstrained_RoundTrip_Verifiable()
+    {
+        // Mirrors the Gsharp.Extensions.Optional.Map repro from issue
+        // #831 (the body in src/Sdk/Gsharp.Extensions/Optional/Optional.gs):
+        // `if self == nil { return nil }; return f(self!!)`. The
+        // pre-fix emit shape failed ilverify with
+        //   [StackUnexpected]: found Nullobjref 'NullReference'
+        //                       expected value 'T'
+        // at offset 0x16 (the `ldnull; ceq` over an opaque `!!T`
+        // operand). The smart-cast unwrap `self!!` then produced a
+        // second `dup; brtrue` failure on the same opaque slot — the
+        // fix has to clean BOTH sites for runtime success.
+        var source = """
+            package P
+            import System
+
+            func MapOrFallback[T class](self T?, f (T) -> T, fallback T) T {
+                if self == nil {
+                    return fallback
+                }
+
+                return f(self!!)
+            }
+
+            var present string? = "hello"
+            var absent string? = nil
+            Console.WriteLine(MapOrFallback(present, (s string) -> s + "!", "missing"))
+            Console.WriteLine(MapOrFallback(absent, (s string) -> s + "!", "missing"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello!\nmissing\n", output);
+    }
+
+    [Fact]
+    public void OpenTNilCompare_ClassConstrained_NotEquals_Verifiable()
+    {
+        // The `!= nil` lobe goes through the same emit guard with an
+        // appended `ldc.i4.0; ceq` for the negation. Exercise it on its
+        // own so a regression in the `!=` branch surfaces independently
+        // of the `==` lobe.
+        var source = """
+            package P
+            import System
+
+            func IsPresent[T class](self T?) bool {
+                return self != nil
+            }
+
+            var present string? = "x"
+            var absent string? = nil
+            Console.WriteLine(IsPresent(present))
+            Console.WriteLine(IsPresent(absent))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void OpenTNullCoalesce_ClassConstrained_Verifiable()
+    {
+        // Mirrors `OrElse[T class]` from Optional.gs:
+        // `func (self T?) OrElse[T class](defaultValue T) T { return self ?: defaultValue }`.
+        // Pre-fix the bottom-of-EmitBinary `dup; brtrue` emitted an
+        // invalid `dup` over an opaque `!!T` slot. The fix spills the
+        // LHS to a `!!T`-typed slot and probes via `box; brfalse`.
+        var source = """
+            package P
+            import System
+
+            func OrElse[T class](self T?, defaultValue T) T {
+                return self ?: defaultValue
+            }
+
+            var present string? = "value"
+            var absent string? = nil
+            Console.WriteLine(OrElse(present, "fallback"))
+            Console.WriteLine(OrElse(absent, "fallback"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("value\nfallback\n", output);
+    }
+
+    [Fact]
+    public void OpenTNullAssertion_ClassConstrained_NonNull_Verifiable()
+    {
+        // `!!` (NullAssertion) over an open `[T class]` operand — both
+        // the un-narrowed `T?` shape and the smart-cast `bare T` shape
+        // (when the call sits after an `if self == nil` guard) now use
+        // the verifier-clean `box; brtrue; throw NRE; load slot`
+        // sequence in place of the old `dup; brtrue; throw NRE`.
+        var source = """
+            package P
+            import System
+
+            func UnwrapOrDefault[T class](self T?, fallback T) T {
+                if self == nil {
+                    return fallback
+                }
+
+                return self!!
+            }
+
+            var present string? = "present"
+            var absent string? = nil
+            Console.WriteLine(UnwrapOrDefault(present, "fallback"))
+            Console.WriteLine(UnwrapOrDefault(absent, "fallback"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("present\nfallback\n", output);
+    }
+
+    [Fact]
+    public void OpenTNullAssertion_ClassConstrained_NullThrows_Verifiable()
+    {
+        // Belt-and-braces: when the input IS null and the guard is
+        // bypassed, the runtime must still throw NullReferenceException
+        // (preserving the pre-fix semantics). Confirms the new emit
+        // shape didn't accidentally drop the throw branch.
+        var source = """
+            package P
+            import System
+
+            func RawUnwrap[T class](self T?) T {
+                return self!!
+            }
+
+            var s string? = nil
+            try {
+                Console.WriteLine(RawUnwrap(s))
+            } catch (e NullReferenceException) {
+                Console.WriteLine("caught")
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("caught\n", output);
+    }
+
+    [Fact]
+    public void OpenTNilCompare_StructConstrained_PassesIlverify()
+    {
+        // Issue #831 originally targeted `[T class]` operands, but the
+        // same emit gap existed for `[T struct]`: the existing
+        // value-type Nullable<T> lifted-binary collector only catches
+        // operands with a static `ClrType`, which open type parameters
+        // never have. Without a guard, `Nullable<!!T> == nil` for open
+        // struct-T also fell through to the bottom of EmitBinary and
+        // produced `<Nullable<!!T>>; ldnull; ceq` — ilverify rejected
+        // with `expected value 'Nullable`1<T>'`. The fix uses the same
+        // `box; ldnull; ceq` shape for ALL open-T nullables: the CLR
+        // box of `Nullable<T>` per ECMA-335 III.4.1 yields a managed-
+        // null reference when HasValue is false, so the comparison
+        // semantically agrees with the pre-fix runtime behaviour.
+        var source = """
+            package P
+            import System
+
+            func StructIsPresent[T struct](self T?) bool {
+                if self == nil {
+                    return false
+                }
+
+                return true
+            }
+
+            var present int32? = 42
+            var absent int32? = nil
+            Console.WriteLine(StructIsPresent(present))
+            Console.WriteLine(StructIsPresent(absent))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void OpenTNilCompare_BothOverloads_DispatchedCorrectly()
+    {
+        // End-to-end check that two parallel overloads — one
+        // `[T class]`, one `[T struct]` — both compile to verifier-clean
+        // IL via the same emit path and that argument dispatch picks
+        // the right one per call site. Class-T boxes a bare `!!T`
+        // reference slot (no-op the JIT elides); struct-T boxes a
+        // `Nullable<!!T>` value-typed slot (the CLR yields a null
+        // reference when HasValue is false). The `box; ldnull; ceq`
+        // shape works uniformly.
+        var source = """
+            package P
+            import System
+
+            func ClassifyClass[T class](self T?) int32 {
+                if self == nil {
+                    return 0
+                }
+
+                return 1
+            }
+
+            func ClassifyStruct[T struct](self T?) int32 {
+                if self == nil {
+                    return 0
+                }
+
+                return 1
+            }
+
+            var refSome string? = "a"
+            var refNone string? = nil
+            var valSome int32? = 99
+            var valNone int32? = nil
+
+            Console.WriteLine(ClassifyClass(refSome))
+            Console.WriteLine(ClassifyClass(refNone))
+            Console.WriteLine(ClassifyStruct(valSome))
+            Console.WriteLine(ClassifyStruct(valNone))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n0\n1\n0\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue831_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException(
+                    "exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the emitter to produce verifier-clean IL for nil-related operations on open type-parameter operands (`T?`, bare `T` after smart-cast narrowing). Pre-fix the JIT tolerated the IL at runtime but `ilverify` rejected it — eight `Gsharp.Extensions.Optional` helpers (the SDK migration introduced by #806) tripped the gate.

## Root cause

The existing slot-allocation/emit paths for nullable-related ops (`liftedBinarySlots`, `NullableValueTypeUnwrapCollector`, `NullableValueTypeCoalesceCollector`) gated on the operand's static `ClrType`. Open type parameters have no `ClrType`, so every shape over an open T fell through to the bottom of `EmitBinary`/`EmitUnary` and produced:

- `ldarg.0; ldnull; ceq` for `self == nil` — `[StackUnexpected]: found Nullobjref ... expected value 'T'`
- `dup; brtrue` for `self ?: rhs` — `Unexpected type on the stack` for `dup` over an opaque `!!T`
- `dup; brtrue` for `self!!` — same root cause

## Fix (emit-only, no new BoundNodeKind)

`src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs`:

- For `T? == nil` / `!= nil` over any open-T constraint: emit `box <T?>; ldnull; ceq` (with `ldc.i4.0; ceq` for the `!=` lobe). Per ECMA-335 III.4.1, `box Nullable<T>` yields a managed-null reference when `HasValue` is `false`, so the same shape works uniformly for class-, struct-, and unconstrained-T. The JIT elides the box for reference-typed T.
- For `T? ?: rhs` over class/unconstrained T: spill the LHS to a `T`-typed slot, probe via `box !!T; brfalse fallback`, reload the slot on the non-null path.
- For `!!` over class/unconstrained T (both bare `T` and `T?` shapes): spill to a `T`-typed slot, probe via `box !!T; brtrue nonNull`, throw NRE on null, reload slot on non-null.

`src/Core/CodeAnalysis/Emit/SlotPlanner.cs`:

- Extend `NullableValueTypeUnwrapCollector` and `NullableValueTypeCoalesceCollector` to pre-allocate `!!T`-typed slots for the new open-T paths.

## Tests

New file `test/Compiler.Tests/Emit/Issue831OpenTNilCompareEmitTests.cs` (7 cases) — each compiles a sample with `gsc`, gates the PE through `IlVerifier.Verify`, and runs it under `dotnet exec` asserting stdout:

| Test | Shape covered |
| --- | --- |
| `OpenTNilCompare_ClassConstrained_RoundTrip_Verifiable` | Original `Optional.Map` repro |
| `OpenTNilCompare_ClassConstrained_NotEquals_Verifiable` | `!= nil` negation lobe |
| `OpenTNullCoalesce_ClassConstrained_Verifiable` | `self ?: defaultValue` (`OrElse`) |
| `OpenTNullAssertion_ClassConstrained_NonNull_Verifiable` | smart-cast `self!!` after guard |
| `OpenTNullAssertion_ClassConstrained_NullThrows_Verifiable` | NRE preserved on null inputs |
| `OpenTNilCompare_StructConstrained_PassesIlverify` | `[T struct]` open-T `Nullable<T> == nil` |
| `OpenTNilCompare_BothOverloads_DispatchedCorrectly` | dual-overload dispatch end-to-end |

## Verification

- `dotnet test GSharp.sln` — **all 5,286 tests pass** (Core 3262, Compiler 1326, Interpreter 296, LanguageServer 266, Extensions 104, Sdk 32; 1 `RegenerateBaseline` skipped).
- `ilverify` on `Gsharp.Extensions.dll` — 8 Optional-helper errors → 0. Only the pre-existing unrelated `Sequences.Empty()` error remains (out of scope for this PR).
- `cd website && npm ci && npm run build` — clean build, no broken links.

## Links

Closes #831
Related: #806 (SDK migration that surfaced the gap), ADR-0084, parent #706