### PR TITLE
Fix #832: discarded open-T return no longer inserts spurious unbox.any

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -224,6 +224,24 @@ internal sealed partial class MethodBodyEmitter
 
                     this.il.OpCode(useCall ? ILOpCode.Call : ILOpCode.Callvirt);
                     this.il.Token(instCallHandle);
+
+                    // Issue #832: when the receiver is a symbolic open-generic
+                    // container (e.g. `Queue[T]` with an in-scope `T`), the
+                    // MemberRef is parented at the symbolic instantiation and
+                    // the runtime stack value after `callvirt` is the
+                    // substituted symbolic return (`!T`) — NOT the closed CLR
+                    // `object` that `instCall.Method.ReturnType` reports for
+                    // the type-erased close. Skip the erasure-widening so we
+                    // don't emit a spurious `unbox.any T` against a stack slot
+                    // that already holds `T`. The spurious unbox passed
+                    // ilverify at the source method but produced a runtime
+                    // NullReferenceException once a state-machine rewrite
+                    // (e.g. iterator MoveNext) re-inspected the IL.
+                    if (this.outer.TryGetSymbolicSubstitutedInstanceMethodReturn(receiverType, instCall.Method, out _))
+                    {
+                        break;
+                    }
+
                     this.EmitErasedObjectReturnWidening(
                         TypeSymbol.FromClrType(instCall.Method.ReturnType),
                         instCall.Type);

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -6652,6 +6652,55 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #832 (mirrors the property variant above for instance method calls):
+    /// when an instance method call's receiver is a symbolic open-generic
+    /// container (e.g. <c>Queue[T]</c> with an in-scope <c>T</c>), the call's
+    /// MemberRef parent is encoded as the symbolic generic instantiation, so
+    /// the runtime stack value after <c>callvirt</c> is the substituted
+    /// symbolic return type (<c>!T</c>) — NOT the closed CLR <c>object</c>
+    /// that <see cref="MethodInfo.ReturnType"/> reports for the type-erased
+    /// closed method. Returning that substituted return to the body emitter
+    /// lets the erasure-widening short-circuit, avoiding a verifier-breaking
+    /// (and runtime-crashing) <c>unbox.any T</c> when the result is discarded
+    /// or otherwise consumed at the open-T slot.
+    /// </summary>
+    /// <param name="receiverType">The receiver's type as seen by the body emitter.</param>
+    /// <param name="method">The closed-CLR method selected by the lowerer.</param>
+    /// <param name="substitutedReturn">The substituted symbolic return type, on success.</param>
+    /// <returns><see langword="true"/> when the receiver is a symbolic
+    /// open-generic container and the substituted return resolves to a
+    /// non-error symbolic type.</returns>
+    internal bool TryGetSymbolicSubstitutedInstanceMethodReturn(
+        TypeSymbol receiverType,
+        MethodInfo method,
+        out TypeSymbol substitutedReturn)
+    {
+        substitutedReturn = null;
+        if (method == null
+            || !TryNormalizeToSymbolicContainer(receiverType, out var openDef, out var typeArguments)
+            || typeArguments.IsDefaultOrEmpty
+            || !(typeArguments.Any(TypeSymbol.ContainsTypeParameter) || typeArguments.Any(ArgIsSymbolicUserDefined)))
+        {
+            return false;
+        }
+
+        var openMethod = ResolveMethodOnOpenDefinition(openDef, method);
+        if (openMethod == null)
+        {
+            return false;
+        }
+
+        var openReturn = openMethod.ReturnType;
+        if (openReturn == null || openReturn == typeof(void))
+        {
+            return false;
+        }
+
+        substitutedReturn = MemberLookup.MapOpenClrTypeToSymbolic(openReturn, openDef, typeArguments);
+        return substitutedReturn != null && substitutedReturn != TypeSymbol.Error;
+    }
+
+    /// <summary>
     /// Phase 4 emit parity: get a MemberRef for a CLR instance constructor.
     /// Handles both non-generic types (<c>StringBuilder()</c>) and constructed
     /// generic types (<c>List&lt;int&gt;()</c>, <c>Dictionary&lt;string, int&gt;()</c>).

--- a/src/Sdk/Gsharp.Extensions/Sequences/SequenceExtensions.gs
+++ b/src/Sdk/Gsharp.Extensions/Sequences/SequenceExtensions.gs
@@ -195,13 +195,12 @@ func (source IEnumerable[T]) ToMap[T, TKey, TValue](keyFn (T) -> TKey, valueFn (
 // ====================================================================
 
 func WindowedIterator[T](source IEnumerable[T], size int32) IEnumerable[IList[T]] {
-    var buffer = List[T](size)
+    var buffer = Queue[T](size)
     for item in source {
-        buffer.Add(item)
+        buffer.Enqueue(item)
         if buffer.Count == size {
-            let snap = List[T](buffer)
-            yield snap
-            buffer.RemoveAt(0)
+            yield List[T](buffer)
+            buffer.Dequeue()
         }
     }
 }

--- a/test/Compiler.Tests/Emit/Issue832DiscardedOpenTReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue832DiscardedOpenTReturnEmitTests.cs
@@ -1,0 +1,311 @@
+// <copyright file="Issue832DiscardedOpenTReturnEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #832 (parent #706, related #806 / ADR-0084). End-to-end emit +
+/// IL-verify coverage for instance calls on a symbolic open-generic
+/// receiver whose closed CLR shape is type-erased to <c>object</c>.
+///
+/// Pre-fix, the BoundImportedInstanceCallExpression emit path always
+/// invoked <c>EmitErasedObjectReturnWidening</c> with the closed-CLR
+/// return type (e.g. <c>Queue&lt;object&gt;::Dequeue() → object</c>).
+/// When the receiver was a symbolic container (e.g. <c>Queue[T]</c>
+/// with an in-scope <c>T</c>), the MemberRef was already parented at
+/// the symbolic instantiation, so the runtime stack value after the
+/// <c>callvirt</c> was the substituted symbolic <c>!T</c>, not the
+/// erased <c>object</c>. The widening therefore appended a spurious
+/// <c>unbox.any !T</c> against a stack slot that already held <c>T</c>.
+///
+/// The source-level method body usually escaped notice because the
+/// widening was emitted while the call's result was on the stack — the
+/// caller then either popped it (expression-statement discard) or
+/// converted/consumed it. In an iterator <c>MoveNext</c> rewrite the
+/// state machine re-loaded the receiver and a <c>callvirt</c>-then-pop
+/// shape exposed the bug: ilverify rejected the IL with
+/// <c>[StackObjRef] [found value 'T'] Expected an ObjRef on the
+/// stack</c> at the spurious unbox, and the runtime threw
+/// <c>NullReferenceException</c> from <c>MoveNext</c>.
+///
+/// The fix routes through a new helper
+/// <c>TryGetSymbolicSubstitutedInstanceMethodReturn</c> that mirrors the
+/// existing property variant: when the receiver normalises to a
+/// symbolic open-generic container, the widening is skipped because
+/// the substituted symbolic return type matches the expected bound
+/// type and no <c>object→T</c> projection is needed.
+///
+/// Each test compiles with gsc, verifies via
+/// <see cref="IlVerifier.Verify(string, System.Collections.Generic.IEnumerable{string}, System.Collections.Generic.IEnumerable{string})"/>,
+/// then runs under <c>dotnet exec</c> and asserts the captured stdout.
+/// </summary>
+public class Issue832DiscardedOpenTReturnEmitTests
+{
+    [Fact]
+    public void WindowedIteratorRepro_QueueDequeueDiscardClassT_Verifiable()
+    {
+        // Verbatim repro from issue #832: an iterator that calls
+        // `Queue[T]::Dequeue()` in expression-statement position. T is
+        // reference-typed at this call site. Pre-fix this asserted both
+        //   * ilverify: `[StackObjRef] found value 'T'` at the spurious
+        //     unbox.any in the state-machine MoveNext, and
+        //   * runtime: `System.NullReferenceException` in
+        //     <WindowedIterator>d__N.MoveNext().
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func WindowedIterator[T](source IEnumerable[T], size int32) IEnumerable[IList[T]] {
+                var buffer = Queue[T](size)
+                for item in source {
+                    buffer.Enqueue(item)
+                    if buffer.Count == size {
+                        yield List[T](buffer)
+                        buffer.Dequeue()
+                    }
+                }
+            }
+
+            var data = List[string]()
+            data.Add("a")
+            data.Add("b")
+            data.Add("c")
+            data.Add("d")
+            for w in WindowedIterator[string](data, 2) {
+                for x in w {
+                    Console.Write(x)
+                    Console.Write(" ")
+                }
+
+                Console.WriteLine("")
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("a b \nb c \nc d \n", output);
+    }
+
+    [Fact]
+    public void WindowedIteratorRepro_QueueDequeueDiscardStructT_Verifiable()
+    {
+        // Same iterator as above, but T is a value type at the call
+        // site. Pre-fix the spurious `unbox.any !T` against an open
+        // value-type T failed ilverify identically, and the JIT shape
+        // of `unbox.any` on a value-type stack slot reliably crashed
+        // before the iterator even produced its first element.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func WindowedIterator[T](source IEnumerable[T], size int32) IEnumerable[IList[T]] {
+                var buffer = Queue[T](size)
+                for item in source {
+                    buffer.Enqueue(item)
+                    if buffer.Count == size {
+                        yield List[T](buffer)
+                        buffer.Dequeue()
+                    }
+                }
+            }
+
+            var data = List[int32]()
+            data.Add(1)
+            data.Add(2)
+            data.Add(3)
+            data.Add(4)
+            for w in WindowedIterator[int32](data, 2) {
+                for x in w {
+                    Console.Write(x)
+                    Console.Write(" ")
+                }
+
+                Console.WriteLine("")
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1 2 \n2 3 \n3 4 \n", output);
+    }
+
+    [Fact]
+    public void DiscardedOpenT_DirectFunctionBody_ClassT_Verifiable()
+    {
+        // Strip the iterator state-machine rewrite from the repro so
+        // the failing emit is exercised in a plain function body. The
+        // discard is the immediate site of the spurious `unbox.any`;
+        // pre-fix ilverify rejected this DLL too — the iterator
+        // rewrite merely surfaces the failure as a runtime NRE.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func Drain[T class](buffer Queue[T]) int32 {
+                var count = 0
+                while buffer.Count > 0 {
+                    buffer.Dequeue()
+                    count = count + 1
+                }
+
+                return count
+            }
+
+            var q = Queue[string]()
+            q.Enqueue("x")
+            q.Enqueue("y")
+            q.Enqueue("z")
+            Console.WriteLine(Drain[string](q))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n", output);
+    }
+
+    [Fact]
+    public void DiscardedOpenT_DirectFunctionBody_StructT_Verifiable()
+    {
+        // Same as above, but with an open value-type T. The pre-fix
+        // failure mode for struct-T was an `unbox.any !T` against a
+        // stack slot that already held the boxed-free `!T`; both
+        // ilverify and the runtime rejected it.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func Drain[T struct](buffer Queue[T]) int32 {
+                var count = 0
+                while buffer.Count > 0 {
+                    buffer.Dequeue()
+                    count = count + 1
+                }
+
+                return count
+            }
+
+            var q = Queue[int32]()
+            q.Enqueue(10)
+            q.Enqueue(20)
+            q.Enqueue(30)
+            q.Enqueue(40)
+            Console.WriteLine(Drain[int32](q))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("4\n", output);
+    }
+
+    [Fact]
+    public void DiscardedOpenT_ListRemoveDiscard_StructT_Verifiable()
+    {
+        // Cross-check the fix isn't Queue-specific: a different
+        // BCL container method that also returns the open `!T`
+        // (`List[T].Remove(item)` returns bool, not T — pick a Stack
+        // instead so the discarded return is `T`). This proves the
+        // emit guard fires uniformly across symbolic open-generic
+        // receivers, not just `Queue[T]`.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func PopAll[T](stack Stack[T]) int32 {
+                var n = 0
+                while stack.Count > 0 {
+                    stack.Pop()
+                    n = n + 1
+                }
+
+                return n
+            }
+
+            var s = Stack[int32]()
+            s.Push(1)
+            s.Push(2)
+            s.Push(3)
+            Console.WriteLine(PopAll[int32](s))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue832_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException(
+                    "exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Interpreter.Tests/Issue832DiscardedOpenTReturnInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue832DiscardedOpenTReturnInterpreterTests.cs
@@ -1,0 +1,113 @@
+// <copyright file="Issue832DiscardedOpenTReturnInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #832 — tree-walking interpreter parity for the discarded
+/// open-T return shape. The interpreter has no emitted IL, so it
+/// never exercised the spurious <c>unbox.any</c> the emit suite
+/// guards against, but it MUST still execute the expression-statement
+/// discard of a <c>T</c>-returning call without observable effect
+/// beyond the call's side effects (here: removing an element from
+/// the receiver container).
+///
+/// Same scope split as Issue #813 / #798 — the open-T iterator path
+/// is exercised at a closed instantiation because the tree-walking
+/// interpreter has no state-machine substitution for an open generic
+/// method-type parameter. The closed shape proves the call dispatch
+/// and the discard both behave correctly.
+/// </summary>
+public class Issue832DiscardedOpenTReturnInterpreterTests
+{
+    [Fact]
+    public void DiscardedDequeue_ClosedQueueOfString_ExecutesSideEffect()
+    {
+        // `Queue[string]::Dequeue()` is called in expression-statement
+        // position. The interpreter must dispatch the call, remove
+        // the front element, and discard the returned value without
+        // surfacing a binding error or runtime exception.
+        var source = """
+            import System
+            import System.Collections.Generic
+
+            var q = Queue[string]()
+            q.Enqueue("a")
+            q.Enqueue("b")
+            q.Enqueue("c")
+            q.Dequeue()
+            Console.WriteLine(q.Count)
+            Console.WriteLine(q.Peek())
+            """;
+
+        Assert.Equal("2\nb\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void DiscardedDequeue_ClosedQueueOfInt32_ExecutesSideEffect()
+    {
+        // Same shape but with a value-type element. The emit path
+        // routes through the same `unbox.any` guard; the interpreter
+        // simply dispatches the BCL call. The discard must compose
+        // with subsequent state checks.
+        var source = """
+            import System
+            import System.Collections.Generic
+
+            var q = Queue[int32]()
+            q.Enqueue(10)
+            q.Enqueue(20)
+            q.Enqueue(30)
+            q.Dequeue()
+            q.Dequeue()
+            Console.WriteLine(q.Count)
+            Console.WriteLine(q.Peek())
+            """;
+
+        Assert.Equal("1\n30\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void DiscardedPop_ClosedStackOfInt32_ExecutesSideEffect()
+    {
+        // Cross-check the discard works for a different BCL
+        // container method (`Stack[T]::Pop()` also returns `T`).
+        var source = """
+            import System
+            import System.Collections.Generic
+
+            var s = Stack[int32]()
+            s.Push(1)
+            s.Push(2)
+            s.Push(3)
+            s.Pop()
+            Console.WriteLine(s.Count)
+            Console.WriteLine(s.Peek())
+            """;
+
+        Assert.Equal("2\n2\n", RunSubmission(source));
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary

When an instance method on a symbolic open-generic receiver (e.g. `Queue[T]` with an in-scope `T`) returned the open type parameter and the result was discarded — most visibly inside an iterator state-machine where the IL surfaces independently — the emit path appended a spurious `unbox.any !T` after the `callvirt`. ilverify caught it as `[StackObjRef] [found value 'T'] Expected an ObjRef on the stack`, and the runtime threw `NullReferenceException` from the rewritten `MoveNext`.

## Root cause

`MethodBodyEmitter.Expressions.cs` always invoked `EmitErasedObjectReturnWidening(TypeSymbol.FromClrType(instCall.Method.ReturnType), instCall.Type)` after the `callvirt`. For a symbolic open-generic receiver the call's MemberRef is parented at the symbolic instantiation (`Queue<!T>`), so the runtime stack value after the call is the substituted symbolic `!T` — **not** the closed-CLR `object` that `MethodInfo.ReturnType` reports against the type-erased `Queue<object>::Dequeue() -> object` close. The widening therefore unconditionally projected stack `object` to `T` against a slot that already held `T`.

## Fix

Add `ReflectionMetadataEmitter.TryGetSymbolicSubstitutedInstanceMethodReturn` (mirrors the existing `TryGetSymbolicSubstitutedPropertyReturn` from #774). Gate the widening in the `BoundImportedInstanceCallExpression` emit path on it: when the receiver normalises to a symbolic open-generic container and the substituted return resolves to a non-error symbolic type, skip widening — the substituted symbolic return already matches the bound expected type. No new BoundNodeKind.

Restore the original `Queue[T]` / `Dequeue` shape in `src/Sdk/Gsharp.Extensions/Sequences/SequenceExtensions.gs` `WindowedIterator[T]` now that the emit path no longer breaks it.

## Tests

- `test/Compiler.Tests/Emit/Issue832DiscardedOpenTReturnEmitTests.cs` — 5 end-to-end emit + ilverify + dotnet-exec tests:
  - The verbatim `WindowedIterator[T]` repro from the issue, with both reference-typed (`string`) and value-typed (`int32`) `T` to cover the class / struct expansion of `unbox.any`.
  - A non-iterator `while buffer.Count > 0 { buffer.Dequeue() }` discard, both class-T and struct-T.
  - A `Stack[T]::Pop()` discard to prove the fix isn't `Queue`-specific.
- `test/Interpreter.Tests/Issue832DiscardedOpenTReturnInterpreterTests.cs` — 3 tree-walking interpreter tests against closed instantiations (the interpreter has no state-machine substitution for an open generic method-type parameter, same scope split as #813 / #798): `Queue[string]`, `Queue[int32]`, `Stack[int32]` — each with a discarded `T`-returning call followed by a side-effect assertion.
- Full `dotnet test GSharp.sln --no-restore --nologo` green (1331 Compiler.Tests, 3262 Core.Tests, 299 Interpreter.Tests, 104 Extensions.Tests, 266 LanguageServer.Tests, 32 Sdk.Tests). ilverify clean on the repro DLL and on the rebuilt `Gsharp.Extensions.dll`.
- `cd website && npm run build` succeeds with no broken links.

## Links

- Closes #832
- Related: #806 (Gsharp.Extensions G# migration that surfaced the iterator-block path), ADR-0084 (open-T emit erasure model), #774 (property-side counterpart of this guard)
- Parent: #706