### PR TITLE
Fix #833: open-T generic-method call returns symbolic type

### DIFF
--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -582,13 +582,17 @@ of that migration, not left behind as dead code.
   reference-class TPs in `Optional.Map` / `FlatMap` (`ldnull` vs
   `T` ilverify mismatch), open-T `Queue<T>.Dequeue()` discard
   spuriously inserting `unbox.any !T`, and
-  `Enumerable.Empty[T]()` returning `Object[]` for open T — were
-  routed around in the G# source (use `List[T]` over `Queue[T]`,
-  retain the `class`/`struct` constraint split that maps each helper
-  to the right lowering, suppress the consumer-side `CS8602` with a
-  pragma) so the runtime behaviour matches the C# baseline; ilverify
-  is dirty on those eight methods only. The bootstrap is no longer
-  hypothetical: it builds the stdlib it ships.
+  `Enumerable.Empty[T]()` returning `Object[]` for open T (now
+  **closed by #833** — open-T generic-method calls preserve the
+  symbolic return type; `Empty[T]` in `Sequences.gs` has been
+  restored to the inlined `return Enumerable.Empty[T]()` shape) —
+  were routed around in the G# source (use `List[T]` over
+  `Queue[T]`, retain the `class`/`struct` constraint split that
+  maps each helper to the right lowering, suppress the
+  consumer-side `CS8602` with a pragma) so the runtime behaviour
+  matches the C# baseline; ilverify is dirty on those remaining
+  methods only. The bootstrap is no longer hypothetical: it
+  builds the stdlib it ships.
 
 ## Consequences
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1326,7 +1326,11 @@ internal sealed partial class ExpressionBinder
                     switch (resolution.Outcome)
                     {
                         case OverloadResolution.ResolutionOutcome.Resolved:
+                            var instSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(receiver?.Type, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
+                            var instSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(resolution.Best, typeArgSymbols, instSymbolicArgs);
+                            var instTypeArgSymbolsForCall = !instSymbolicTypeArgs.IsDefault ? instSymbolicTypeArgs : typeArgSymbols;
                             var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols)
+                                ?? MemberLookup.ResolveCallReturnTypeFromSymbolicTypeArgs(resolution.Best, instSymbolicTypeArgs, receiver?.Type)
                                 ?? ResolveInstanceReturnTypeFromReceiver(receiver?.Type, resolution.Best)
                                 ?? MapClrMemberType(resolution.Best.ReturnType);
                             var instParameters = resolution.Best.GetParameters();
@@ -1342,7 +1346,7 @@ internal sealed partial class ExpressionBinder
                             var instArguments = OverloadResolver.BuildOrderedCallArguments(instConvertedArgs, instDownstreamMapping, instParameters);
                             var instRefKinds = ComputeArgumentRefKinds(instParameters);
                             overloads.ValidateRefArguments(instArguments, instRefKinds, methodName, ce.Location);
-                            BoundExpression instCall = ConversionClassifier.AutoDereferenceRefReturn(new BoundImportedInstanceCallExpression(null, instUpdatedReceiver ?? receiver, resolution.Best, returnType, instArguments, instRefKinds, typeArgSymbols));
+                            BoundExpression instCall = ConversionClassifier.AutoDereferenceRefReturn(new BoundImportedInstanceCallExpression(null, instUpdatedReceiver ?? receiver, resolution.Best, returnType, instArguments, instRefKinds, instTypeArgSymbolsForCall));
                             return WrapWithHandlerPrelude(instCall, instHandlerPrelude, ce);
                         case OverloadResolution.ResolutionOutcome.Ambiguous:
                             Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
@@ -1782,7 +1786,11 @@ internal sealed partial class ExpressionBinder
         switch (resolution.Outcome)
         {
             case OverloadResolution.ResolutionOutcome.Resolved:
+                var inheritedSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(receiver?.Type, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
+                var inheritedSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(resolution.Best, typeArgSymbols, inheritedSymbolicArgs);
+                var inheritedTypeArgSymbolsForCall = !inheritedSymbolicTypeArgs.IsDefault ? inheritedSymbolicTypeArgs : typeArgSymbols;
                 var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols)
+                    ?? MemberLookup.ResolveCallReturnTypeFromSymbolicTypeArgs(resolution.Best, inheritedSymbolicTypeArgs, receiver?.Type)
                     ?? ResolveInstanceReturnTypeFromReceiver(receiver?.Type, resolution.Best)
                     ?? TypeSymbol.FromClrType(resolution.Best.ReturnType);
                 var inheritedParameters = resolution.Best.GetParameters();
@@ -1797,7 +1805,7 @@ internal sealed partial class ExpressionBinder
                 var inheritedArguments = OverloadResolver.BuildOrderedCallArguments(inheritedConvertedArgs, inheritedDownstreamMapping, inheritedParameters);
                 var refKinds = ComputeArgumentRefKinds(inheritedParameters);
                 overloads.ValidateRefArguments(inheritedArguments, refKinds, methodName, ce.Location);
-                BoundExpression inheritedCall = new BoundImportedInstanceCallExpression(null, inheritedUpdatedReceiver ?? receiver, resolution.Best, returnType, inheritedArguments, refKinds, typeArgSymbols);
+                BoundExpression inheritedCall = new BoundImportedInstanceCallExpression(null, inheritedUpdatedReceiver ?? receiver, resolution.Best, returnType, inheritedArguments, refKinds, inheritedTypeArgSymbolsForCall);
                 result = WrapWithHandlerPrelude(inheritedCall, inheritedHandlerPrelude, ce);
                 return true;
             case OverloadResolution.ResolutionOutcome.Ambiguous:
@@ -1912,7 +1920,15 @@ internal sealed partial class ExpressionBinder
         var receiverClrType = receiver?.Type?.ClrType;
         if (receiverClrType == null)
         {
-            return false;
+            // Issue #833: a slice/sequence of an open method type parameter
+            // (e.g. `[]T{}.ToArray()` inside `func F[T]()`) has no CLR
+            // backing on the receiver. Project it to an erased shape so
+            // overload resolution can run; symbolic recovery happens via
+            // BuildSymbolicMethodTypeArgs + ResolveCallReturnTypeFromSymbolicTypeArgs.
+            if (receiver?.Type == null || !MemberLookup.TryProjectErasedClrType(receiver.Type, out receiverClrType))
+            {
+                return false;
+            }
         }
 
         // Build the argument-type vector as the extension method sees it: the
@@ -1930,7 +1946,12 @@ internal sealed partial class ExpressionBinder
             var t = GetEffectiveArgumentClrTypeForOverloadResolution(arguments[i].Type);
             if (t == null && arguments[i].Type != TypeSymbol.Null)
             {
-                return false;
+                // Issue #833: argument may carry an open TP (e.g. `T`,
+                // `[]T`). Project to an erased shape so resolution can run.
+                if (!MemberLookup.TryProjectErasedClrType(arguments[i].Type, out t))
+                {
+                    return false;
+                }
             }
 
             if (arguments[i].Type is StructSymbol { IsClass: true })
@@ -2008,7 +2029,18 @@ internal sealed partial class ExpressionBinder
         }
 
         var importedClass = new ImportedClassSymbol(declaringType, ce);
-        var returnOverride = ResolveImportedGenericReturnType(best, typeArgSymbols);
+
+        // Issue #833: for an extension call the symbolic-argument vector
+        // includes the receiver as slot 0 to mirror the static-dispatch
+        // shape (`Class.Method(this receiver, args…)`). The inferred
+        // method-type-args may then surface a symbolic return like
+        // `[]T` from `[]T{}.ToArray()` instead of the erased
+        // `object[]`.
+        var extensionSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(receiver?.Type, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
+        var extensionSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(best, typeArgSymbols, extensionSymbolicArgs);
+        var extensionTypeArgSymbolsForCall = !extensionSymbolicTypeArgs.IsDefault ? extensionSymbolicTypeArgs : typeArgSymbols;
+        var returnOverride = ResolveImportedGenericReturnType(best, typeArgSymbols)
+            ?? MemberLookup.ResolveCallReturnTypeFromSymbolicTypeArgs(best, extensionSymbolicTypeArgs, receiver?.Type);
         var function = new ImportedFunctionSymbol(methodName, importedClass, best, ce, returnOverride);
 
         var allArguments = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length + 1);
@@ -2058,7 +2090,7 @@ internal sealed partial class ExpressionBinder
 
         var refKinds = ComputeArgumentRefKinds(parameters);
         overloads.ValidateRefArguments(bound, refKinds, methodName, ce.Location);
-        result = new BoundImportedCallExpression(null, function, bound, refKinds, typeArgSymbols);
+        result = new BoundImportedCallExpression(null, function, bound, refKinds, extensionTypeArgSymbolsForCall);
         return true;
     }
 

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -440,6 +440,31 @@ internal sealed class MemberLookup
     /// <param name="typeArguments">The symbolic arguments at the same ordinals as <paramref name="openDefinition"/>'s generic parameters.</param>
     /// <returns>The symbolic <see cref="TypeSymbol"/> projection.</returns>
     public static TypeSymbol MapOpenClrTypeToSymbolic(Type openClr, Type openDefinition, ImmutableArray<TypeSymbol> typeArguments)
+        => MapOpenClrTypeToSymbolic(openClr, openDefinition, typeArguments, openMethodDefinition: null, methodTypeArguments: default);
+
+    /// <summary>
+    /// Issue #833: extended mapping entry point that also substitutes
+    /// <em>method</em> generic parameters (<c>MVar(idx)</c>) using the
+    /// symbolic arguments at the corresponding ordinals on
+    /// <paramref name="openMethodDefinition"/>. This is the call-site
+    /// sibling of the open-receiver substitution from #794: it allows
+    /// <c>Enumerable.Empty[T]()</c> to surface its open <c>IEnumerable&lt;TResult&gt;</c>
+    /// return as the symbolic <c>IEnumerable[T]</c> (rather than the
+    /// type-erased <c>IEnumerable&lt;object&gt;</c>) and <c>[]T{}.ToArray()</c>
+    /// to surface its open <c>TSource[]</c> return as <c>[]T</c>.
+    /// </summary>
+    /// <param name="openClr">The open CLR type to map.</param>
+    /// <param name="openDefinition">The open generic <em>type</em> definition the parameters of <paramref name="openClr"/> may bind against. May be <see langword="null"/>.</param>
+    /// <param name="typeArguments">The symbolic arguments at the same ordinals as <paramref name="openDefinition"/>'s generic parameters; may be default/empty.</param>
+    /// <param name="openMethodDefinition">The open generic <em>method</em> definition the parameters of <paramref name="openClr"/> may bind against. May be <see langword="null"/>.</param>
+    /// <param name="methodTypeArguments">The symbolic arguments at the same ordinals as <paramref name="openMethodDefinition"/>'s generic parameters; may be default/empty.</param>
+    /// <returns>The symbolic <see cref="TypeSymbol"/> projection.</returns>
+    public static TypeSymbol MapOpenClrTypeToSymbolic(
+        Type openClr,
+        Type openDefinition,
+        ImmutableArray<TypeSymbol> typeArguments,
+        MethodInfo openMethodDefinition,
+        ImmutableArray<TypeSymbol> methodTypeArguments)
     {
         if (openClr == null)
         {
@@ -448,6 +473,8 @@ internal sealed class MemberLookup
 
         if (openClr.IsGenericParameter)
         {
+            // Type-level parameter (declared on a generic type): map through
+            // the receiver/container's symbolic TypeArguments.
             var declaring = openClr.DeclaringType;
             if (declaring != null && openDefinition != null && !typeArguments.IsDefaultOrEmpty)
             {
@@ -462,6 +489,27 @@ internal sealed class MemberLookup
                 }
             }
 
+            // Issue #833: method-level parameter (declared on a generic method).
+            // The CLR reports DeclaringMethod != null and DeclaringType == null
+            // for these; substitute via the parallel method-type-args slot.
+            if (openClr.DeclaringMethod != null && !methodTypeArguments.IsDefaultOrEmpty)
+            {
+                if (openMethodDefinition == null
+                    || ReferenceEquals(openClr.DeclaringMethod, openMethodDefinition)
+                    || openClr.DeclaringMethod.MetadataToken == openMethodDefinition.MetadataToken)
+                {
+                    var pos = openClr.GenericParameterPosition;
+                    if ((uint)pos < (uint)methodTypeArguments.Length)
+                    {
+                        var mapped = methodTypeArguments[pos];
+                        if (mapped != null)
+                        {
+                            return mapped;
+                        }
+                    }
+                }
+            }
+
             return TypeSymbol.FromClrType(openClr);
         }
 
@@ -470,10 +518,12 @@ internal sealed class MemberLookup
         // CLR `Type` reports `IsArray` for those, not `IsGenericType`. Recurse
         // on the element type and surface a G# slice (`[]T`) so the call site
         // sees the symbolic projection rather than the erased `object[]`.
+        // Issue #833 extends the recursion to method-level parameters so
+        // `Enumerable.ToArray[T](IEnumerable[T]) → T[]` surfaces as `[]T`.
         if (openClr.IsArray && openClr.GetArrayRank() == 1)
         {
             var openElement = openClr.GetElementType();
-            var mappedElement = MapOpenClrTypeToSymbolic(openElement, openDefinition, typeArguments);
+            var mappedElement = MapOpenClrTypeToSymbolic(openElement, openDefinition, typeArguments, openMethodDefinition, methodTypeArguments);
             if (TypeSymbol.ContainsTypeParameter(mappedElement))
             {
                 return SliceTypeSymbol.Get(mappedElement);
@@ -488,7 +538,7 @@ internal sealed class MemberLookup
         if (openClr.IsByRef)
         {
             var openPointee = openClr.GetElementType();
-            var mappedPointee = MapOpenClrTypeToSymbolic(openPointee, openDefinition, typeArguments);
+            var mappedPointee = MapOpenClrTypeToSymbolic(openPointee, openDefinition, typeArguments, openMethodDefinition, methodTypeArguments);
             if (TypeSymbol.ContainsTypeParameter(mappedPointee))
             {
                 return ByRefTypeSymbol.Get(mappedPointee);
@@ -504,7 +554,7 @@ internal sealed class MemberLookup
             var anyParam = false;
             foreach (var a in openArgs)
             {
-                var mapped = MapOpenClrTypeToSymbolic(a, openDefinition, typeArguments);
+                var mapped = MapOpenClrTypeToSymbolic(a, openDefinition, typeArguments, openMethodDefinition, methodTypeArguments);
                 symbolic.Add(mapped);
                 if (TypeSymbol.ContainsTypeParameter(mapped))
                 {
@@ -549,6 +599,245 @@ internal sealed class MemberLookup
         }
 
         return TypeSymbol.FromClrType(openClr);
+    }
+
+    /// <summary>
+    /// Issue #833: structural unification that recovers the symbolic
+    /// type-argument vector for an open generic CLR method when the call
+    /// site did <em>not</em> supply an explicit <c>[T1, T2]</c> list.
+    /// Walks every <c>(openParameter, symbolicArgument)</c> pair in
+    /// parallel and records the symbolic shape sitting at each
+    /// <c>MVar(idx)</c> slot, then returns the per-ordinal vector. When
+    /// some slot is still missing the corresponding entry is <see langword="null"/>
+    /// — callers must treat <see langword="null"/> as "no symbolic
+    /// override; fall back to the closed-CLR projection".
+    /// </summary>
+    /// <param name="openMethod">The open generic method definition.</param>
+    /// <param name="symbolicArgTypes">Symbolic argument types in call order (receiver included as slot 0 for extension methods).</param>
+    /// <returns>An array sized to the open method's generic-parameter arity, with one entry per ordinal (<see langword="null"/> when unrecovered).</returns>
+    public static TypeSymbol[] InferSymbolicMethodTypeArguments(
+        MethodInfo openMethod,
+        ImmutableArray<TypeSymbol> symbolicArgTypes)
+    {
+        if (openMethod == null || !openMethod.IsGenericMethodDefinition)
+        {
+            return Array.Empty<TypeSymbol>();
+        }
+
+        var arity = openMethod.GetGenericArguments().Length;
+        var result = new TypeSymbol[arity];
+
+        var openParams = openMethod.GetParameters();
+        var pairs = Math.Min(openParams.Length, symbolicArgTypes.IsDefault ? 0 : symbolicArgTypes.Length);
+        for (int i = 0; i < pairs; i++)
+        {
+            UnifyForMethodTypeArgs(openParams[i].ParameterType, symbolicArgTypes[i], openMethod, result);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Issue #833 (sibling to #794 on the call-site argument side): when the
+    /// imported generic method's open return type <em>contains</em> a method
+    /// type parameter that maps to an in-scope G# type parameter, substitute
+    /// the open return with the symbolic projection so the call site surfaces
+    /// e.g. <c>IEnumerable[T]</c> rather than the type-erased
+    /// <c>IEnumerable&lt;object&gt;</c>. <paramref name="symbolicMethodTypeArgs"/>
+    /// carries the resolved symbolic arguments at MVar ordinals (explicit-list
+    /// or inferred via <see cref="InferSymbolicMethodTypeArguments"/>).
+    /// Returns <see langword="null"/> when no symbolic substitution applies, so
+    /// callers keep their existing return-type derivation.
+    /// </summary>
+    /// <param name="closed">The closed generic method selected by overload resolution.</param>
+    /// <param name="symbolicMethodTypeArgs">Per-MVar symbolic type arguments; entries may be <see langword="null"/>.</param>
+    /// <param name="receiverType">The receiver's static type symbol (for type-level Var substitution); may be <see langword="null"/>.</param>
+    /// <returns>The override return type symbol, or <see langword="null"/>.</returns>
+    public static TypeSymbol ResolveCallReturnTypeFromSymbolicTypeArgs(
+        MethodInfo closed,
+        ImmutableArray<TypeSymbol> symbolicMethodTypeArgs,
+        TypeSymbol receiverType)
+    {
+        if (closed == null || !closed.IsGenericMethod)
+        {
+            return null;
+        }
+
+        if (symbolicMethodTypeArgs.IsDefaultOrEmpty || !symbolicMethodTypeArgs.Any(s => s != null))
+        {
+            return null;
+        }
+
+        var openMethod = closed.IsGenericMethodDefinition ? closed : closed.GetGenericMethodDefinition();
+        var openReturn = openMethod.ReturnType;
+        if (openReturn == null || openReturn == typeof(void))
+        {
+            return null;
+        }
+
+        Type receiverOpenDef = null;
+        ImmutableArray<TypeSymbol> receiverTypeArgs = default;
+        if (receiverType is ImportedTypeSymbol imp && imp.OpenDefinition != null && !imp.TypeArguments.IsDefaultOrEmpty)
+        {
+            receiverOpenDef = imp.OpenDefinition;
+            receiverTypeArgs = imp.TypeArguments;
+        }
+
+        var mapped = MapOpenClrTypeToSymbolic(openReturn, receiverOpenDef, receiverTypeArgs, openMethod, symbolicMethodTypeArgs);
+        return TypeSymbol.ContainsTypeParameter(mapped) ? mapped : null;
+    }
+
+    /// <summary>
+    /// Issue #833: build the per-MVar symbolic type-argument vector for an
+    /// imported generic-method call. When the call site supplied an explicit
+    /// <c>[T1, T2]</c> list (<paramref name="explicitTypeArgSymbols"/> is
+    /// non-default), those symbols are used directly. Otherwise the vector
+    /// is inferred from the call's symbolic argument types
+    /// (<paramref name="symbolicArgTypes"/>) via structural unification.
+    /// Returns <see langword="default"/> when the method is not generic or
+    /// no symbolic information can be recovered.
+    /// </summary>
+    /// <param name="closed">The closed generic method selected by overload resolution.</param>
+    /// <param name="explicitTypeArgSymbols">The explicit symbols, or default when none were supplied.</param>
+    /// <param name="symbolicArgTypes">Symbolic argument types in call order (receiver first when applicable).</param>
+    /// <returns>The per-MVar vector (length == open arity), or default when nothing recoverable.</returns>
+    public static ImmutableArray<TypeSymbol> BuildSymbolicMethodTypeArgs(
+        MethodInfo closed,
+        ImmutableArray<TypeSymbol> explicitTypeArgSymbols,
+        ImmutableArray<TypeSymbol> symbolicArgTypes)
+    {
+        if (closed == null || !closed.IsGenericMethod)
+        {
+            return default;
+        }
+
+        var openMethod = closed.IsGenericMethodDefinition ? closed : closed.GetGenericMethodDefinition();
+        var arity = openMethod.GetGenericArguments().Length;
+        if (arity == 0)
+        {
+            return default;
+        }
+
+        var inferred = !symbolicArgTypes.IsDefault && symbolicArgTypes.Length > 0
+            ? InferSymbolicMethodTypeArguments(openMethod, symbolicArgTypes)
+            : new TypeSymbol[arity];
+
+        // Explicit list takes precedence at each slot when present.
+        if (!explicitTypeArgSymbols.IsDefaultOrEmpty)
+        {
+            for (int i = 0; i < arity && i < explicitTypeArgSymbols.Length; i++)
+            {
+                if (explicitTypeArgSymbols[i] != null)
+                {
+                    inferred[i] = explicitTypeArgSymbols[i];
+                }
+            }
+        }
+
+        var anySymbolic = false;
+        for (int i = 0; i < inferred.Length; i++)
+        {
+            if (inferred[i] != null && TypeSymbol.ContainsTypeParameter(inferred[i]))
+            {
+                anySymbolic = true;
+                break;
+            }
+        }
+
+        if (!anySymbolic)
+        {
+            return default;
+        }
+
+        return ImmutableArray.Create(inferred);
+    }
+
+    /// <summary>
+    /// Issue #833: convenience helper that builds the
+    /// (receiver, arguments) → symbolic-type vector consumed by
+    /// <see cref="InferSymbolicMethodTypeArguments"/>.
+    /// </summary>
+    /// <param name="receiverType">The receiver's symbolic type (for instance/extension calls); may be <see langword="null"/> for static calls.</param>
+    /// <param name="argumentTypes">The bound arguments' symbolic types.</param>
+    /// <returns>An immutable array with receiver-first ordering when present.</returns>
+    public static ImmutableArray<TypeSymbol> BuildSymbolicArgTypeVector(TypeSymbol receiverType, ImmutableArray<TypeSymbol> argumentTypes)
+    {
+        var argCount = argumentTypes.IsDefault ? 0 : argumentTypes.Length;
+        var count = (receiverType != null ? 1 : 0) + argCount;
+        if (count == 0)
+        {
+            return ImmutableArray<TypeSymbol>.Empty;
+        }
+
+        var b = ImmutableArray.CreateBuilder<TypeSymbol>(count);
+        if (receiverType != null)
+        {
+            b.Add(receiverType);
+        }
+
+        if (argCount > 0)
+        {
+            foreach (var a in argumentTypes)
+            {
+                b.Add(a);
+            }
+        }
+
+        return b.MoveToImmutable();
+    }
+
+    /// <summary>
+    /// Issue #833: projects a <see cref="TypeSymbol"/> that may contain
+    /// open type/method parameters to a CLR <see cref="System.Type"/>
+    /// using <c>object</c> as the erasure placeholder. This lets
+    /// overload resolution match the open generic candidate (the real
+    /// symbolic substitution is recovered downstream via
+    /// <see cref="BuildSymbolicMethodTypeArgs"/> +
+    /// <see cref="ResolveCallReturnTypeFromSymbolicTypeArgs"/>).
+    /// </summary>
+    /// <param name="t">The argument's bound type.</param>
+    /// <param name="erased">On success, an erased CLR projection.</param>
+    /// <returns><see langword="true"/> when an erasure projection exists.</returns>
+    public static bool TryProjectErasedClrType(TypeSymbol t, out Type erased)
+    {
+        erased = null;
+        if (t == null)
+        {
+            return false;
+        }
+
+        if (t.ClrType != null)
+        {
+            erased = t.ClrType;
+            return true;
+        }
+
+        switch (t)
+        {
+            case TypeParameterSymbol:
+                erased = typeof(object);
+                return true;
+            case SliceTypeSymbol slice:
+                if (TryProjectErasedClrType(slice.ElementType, out var sliceElement))
+                {
+                    erased = sliceElement.MakeArrayType();
+                    return true;
+                }
+
+                return false;
+            case ArrayTypeSymbol array:
+                if (TryProjectErasedClrType(array.ElementType, out var arrayElement))
+                {
+                    erased = arrayElement.MakeArrayType();
+                    return true;
+                }
+
+                return false;
+            case NullableTypeSymbol nullable when nullable.UnderlyingType != null:
+                return TryProjectErasedClrType(nullable.UnderlyingType, out erased);
+            default:
+                return false;
+        }
     }
 
     /// <summary>
@@ -1108,5 +1397,174 @@ internal sealed class MemberLookup
         }
 
         return false;
+    }
+
+    private static void UnifyForMethodTypeArgs(Type openClr, TypeSymbol actual, MethodInfo openMethod, TypeSymbol[] result)
+    {
+        if (openClr == null || actual == null)
+        {
+            return;
+        }
+
+        // Open MVar(i) → record the actual symbolic shape (first wins).
+        if (openClr.IsGenericParameter && openClr.DeclaringMethod != null)
+        {
+            if (ReferenceEquals(openClr.DeclaringMethod, openMethod)
+                || openClr.DeclaringMethod.MetadataToken == openMethod.MetadataToken)
+            {
+                var pos = openClr.GenericParameterPosition;
+                if ((uint)pos < (uint)result.Length && result[pos] == null)
+                {
+                    result[pos] = StripNullability(actual);
+                }
+            }
+
+            return;
+        }
+
+        // T[] / []T (open array element).
+        if (openClr.IsArray && openClr.GetArrayRank() == 1)
+        {
+            var openElement = openClr.GetElementType();
+            var actualElement = TryGetElementType(actual);
+            if (actualElement != null)
+            {
+                UnifyForMethodTypeArgs(openElement, actualElement, openMethod, result);
+            }
+
+            return;
+        }
+
+        if (openClr.IsByRef)
+        {
+            var openPointee = openClr.GetElementType();
+            if (actual is ByRefTypeSymbol bf)
+            {
+                UnifyForMethodTypeArgs(openPointee, bf.PointeeType, openMethod, result);
+            }
+            else
+            {
+                UnifyForMethodTypeArgs(openPointee, actual, openMethod, result);
+            }
+
+            return;
+        }
+
+        if (openClr.IsGenericType && !openClr.IsGenericTypeDefinition)
+        {
+            var openDef = openClr.GetGenericTypeDefinition();
+            var openArgs = openClr.GetGenericArguments();
+
+            // Pattern A: actual is an ImportedTypeSymbol whose OpenDefinition matches exactly.
+            if (actual is ImportedTypeSymbol imp
+                && imp.OpenDefinition != null
+                && imp.OpenDefinition == openDef
+                && !imp.TypeArguments.IsDefaultOrEmpty
+                && imp.TypeArguments.Length == openArgs.Length)
+            {
+                for (int j = 0; j < openArgs.Length; j++)
+                {
+                    UnifyForMethodTypeArgs(openArgs[j], imp.TypeArguments[j], openMethod, result);
+                }
+
+                return;
+            }
+
+            // Pattern B: open formal is IEnumerable<T> / IEnumerable<...> and
+            // actual is a slice/array/sequence — the element type lifts as the
+            // single substitution.
+            if (openArgs.Length == 1)
+            {
+                var actualElement = TryGetElementType(actual);
+                if (actualElement != null)
+                {
+                    UnifyForMethodTypeArgs(openArgs[0], actualElement, openMethod, result);
+                    return;
+                }
+            }
+
+            // Pattern C: actual is an ImportedTypeSymbol whose OpenDefinition is
+            // a derived/implementing shape (e.g. List<T> formal-matched against
+            // IEnumerable<TSource>). Walk the actual's interfaces/base.
+            if (actual is ImportedTypeSymbol imp2 && imp2.OpenDefinition != null && !imp2.TypeArguments.IsDefaultOrEmpty)
+            {
+                if (TryMapThroughImplemented(imp2, openDef, out var liftedArgs))
+                {
+                    for (int j = 0; j < openArgs.Length && j < liftedArgs.Length; j++)
+                    {
+                        UnifyForMethodTypeArgs(openArgs[j], liftedArgs[j], openMethod, result);
+                    }
+                }
+            }
+        }
+    }
+
+    private static TypeSymbol StripNullability(TypeSymbol t)
+    {
+        if (t is NullableTypeSymbol nn && nn.UnderlyingType != null)
+        {
+            return nn.UnderlyingType;
+        }
+
+        return t;
+    }
+
+    private static TypeSymbol TryGetElementType(TypeSymbol t)
+    {
+        return t switch
+        {
+            SliceTypeSymbol s => s.ElementType,
+            ArrayTypeSymbol a => a.ElementType,
+            SequenceTypeSymbol seq => seq.ElementType,
+            AsyncSequenceTypeSymbol aseq => aseq.ElementType,
+            _ => null,
+        };
+    }
+
+    private static bool TryMapThroughImplemented(ImportedTypeSymbol imp, Type targetOpenDef, out ImmutableArray<TypeSymbol> liftedArgs)
+    {
+        liftedArgs = default;
+        if (imp.OpenDefinition == null)
+        {
+            return false;
+        }
+
+        // Walk the open definition's interfaces/base for an instantiation of
+        // targetOpenDef, then substitute the symbolic args back through.
+        foreach (var iface in EnumerateOpenInterfacesAndBases(imp.OpenDefinition))
+        {
+            if (!iface.IsGenericType || iface.GetGenericTypeDefinition() != targetOpenDef)
+            {
+                continue;
+            }
+
+            var openArgs = iface.GetGenericArguments();
+            var lifted = ImmutableArray.CreateBuilder<TypeSymbol>(openArgs.Length);
+            foreach (var oa in openArgs)
+            {
+                lifted.Add(MapOpenClrTypeToSymbolic(oa, imp.OpenDefinition, imp.TypeArguments));
+            }
+
+            liftedArgs = lifted.MoveToImmutable();
+            return true;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<Type> EnumerateOpenInterfacesAndBases(Type openDef)
+    {
+        yield return openDef;
+        foreach (var iface in openDef.GetInterfaces())
+        {
+            yield return iface;
+        }
+
+        var baseType = openDef.BaseType;
+        while (baseType != null && baseType != typeof(object))
+        {
+            yield return baseType;
+            baseType = baseType.BaseType;
+        }
     }
 }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -7712,6 +7712,16 @@ internal sealed class ReflectionMetadataEmitter
             return true;
         }
 
+        // Issue #833: an in-scope generic type parameter (MVar/Var) carried
+        // through as a call-site type argument must drive the symbolic
+        // encoding path so the resulting MethodSpec references `MVar(idx)`
+        // / `Var(idx)` instead of the type-erased `System.Object`
+        // placeholder.
+        if (arg is TypeParameterSymbol)
+        {
+            return true;
+        }
+
         if (arg is ImportedTypeSymbol nested
             && nested.OpenDefinition != null
             && !nested.TypeArguments.IsDefaultOrEmpty

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -190,6 +190,19 @@ public sealed class ImportedClassSymbol : Symbol
                     // Issue #661: Nullable<UserEnum> — map to Nullable<int>.
                     t = typeof(int?);
                 }
+                else if (MemberLookup.TryProjectErasedClrType(arguments[i].Type, out var erased))
+                {
+                    // Issue #833: argument carries an open method/type
+                    // parameter (e.g. `T`, `[]T`, `IEnumerable[T]`). The
+                    // overload-resolution layer needs *some* CLR type to
+                    // unify against the candidate's open generic parameter,
+                    // so project the TP positions to `object` (and slices
+                    // to `object[]`). Symbolic recovery for the return
+                    // type and MethodSpec args happens via
+                    // BuildSymbolicMethodTypeArgs +
+                    // ResolveCallReturnTypeFromSymbolicTypeArgs below.
+                    t = erased;
+                }
                 else
                 {
                     return false;
@@ -233,6 +246,20 @@ public sealed class ImportedClassSymbol : Symbol
                     && position < typeArgSymbols.Length)
                 {
                     returnOverride = typeArgSymbols[position];
+                }
+
+                // Issue #833: when the open return type *contains* (but is not
+                // exactly) a method type parameter that aligns with an in-scope
+                // G# type parameter (e.g. `Enumerable.Empty[T]() IEnumerable[T]`),
+                // recover the symbolic projection so the call site doesn't keep
+                // the type-erased `IEnumerable<object>`.
+                if (returnOverride == null)
+                {
+                    var symbolicArgVector = MemberLookup.BuildSymbolicArgTypeVector(
+                        receiverType: null,
+                        ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
+                    var symbolicMethodTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(result.Best, typeArgSymbols, symbolicArgVector);
+                    returnOverride = MemberLookup.ResolveCallReturnTypeFromSymbolicTypeArgs(result.Best, symbolicMethodTypeArgs, receiverType: null);
                 }
 
                 function = new ImportedFunctionSymbol(text, this, result.Best, callExpression, returnOverride);

--- a/src/Sdk/Gsharp.Extensions/Sequences/Sequences.gs
+++ b/src/Sdk/Gsharp.Extensions/Sequences/Sequences.gs
@@ -26,16 +26,20 @@ package Gsharp.Extensions.Sequences
 
 import System
 import System.Collections.Generic
+import System.Linq
 import System.Runtime.CompilerServices
 
 class Sequences {
     shared {
         // ---- Empty: zero-allocation empty sequence -----------------------
-        // Delegates to `Array.Empty[T]()` so each call returns the cached
-        // singleton — never a per-call allocation.
+        // Issue #833 (lifted): now that open-T generic-method calls
+        // preserve the symbolic return type, delegate to the BCL's own
+        // cached singleton instead of `Array.Empty[T]()`. Both surface
+        // the same shared instance under `IEnumerable[T]`; this matches
+        // the inlined shape ADR-0084 §L5 originally specified.
         @MethodImpl(MethodImplOptions.AggressiveInlining)
         func Empty[T]() IEnumerable[T] {
-            return Array.Empty[T]()
+            return Enumerable.Empty[T]()
         }
 
         // ---- Of: inline literal sequence ---------------------------------

--- a/test/Compiler.Tests/Emit/Issue833OpenTGenericMethodCallReturnTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue833OpenTGenericMethodCallReturnTypeEmitTests.cs
@@ -1,0 +1,239 @@
+// <copyright file="Issue833OpenTGenericMethodCallReturnTypeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #833 end-to-end coverage. The binder + emitter fix re-projects
+/// open method type parameters (MVar) through the return type of
+/// imported generic-method calls (e.g. <c>Enumerable.Empty[T]()</c>,
+/// <c>Array.Empty[T]()</c>, <c>[]T{}.ToArray()</c>). These tests
+/// round-trip each scenario through compile → IL-verify → run so we
+/// catch any emit-time regression in the MethodSpec encoding (ADR-0087
+/// F1 / parent #706).
+/// </summary>
+public class Issue833OpenTGenericMethodCallReturnTypeEmitTests
+{
+    [Fact]
+    public void EnumerableEmpty_With_OpenT_Roundtrips_Int32()
+    {
+        var source = """
+            package P
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func Empty[T]() IEnumerable[T] {
+                        return Enumerable.Empty[T]()
+                    }
+                }
+            }
+
+            var seq = Sequences.Empty[int32]()
+            var count = 0
+            for v in seq {
+                count = count + 1
+            }
+            Console.WriteLine(count)
+            Console.WriteLine("done")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\ndone\n", output);
+    }
+
+    [Fact]
+    public void EnumerableEmpty_With_OpenT_Roundtrips_String()
+    {
+        var source = """
+            package P
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            func Empty[T]() IEnumerable[T] {
+                return Enumerable.Empty[T]()
+            }
+
+            var seq = Empty[string]()
+            var count = 0
+            for v in seq {
+                count = count + 1
+            }
+            Console.WriteLine(count)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n", output);
+    }
+
+    [Fact]
+    public void ArrayEmpty_With_OpenT_Returns_SliceOfT_Roundtrips_Int32()
+    {
+        var source = """
+            package P
+            import System
+
+            class Sequences {
+                shared {
+                    func Empty[T]() []T {
+                        return Array.Empty[T]()
+                    }
+                }
+            }
+
+            var arr = Sequences.Empty[int32]()
+            Console.WriteLine(arr.Length)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n", output);
+    }
+
+    [Fact]
+    public void ToArray_On_OpenT_Slice_Returns_SliceOfT_Roundtrips()
+    {
+        var source = """
+            package P
+            import System
+            import System.Linq
+
+            func MakeEmpty[T]() []T {
+                return []T{}.ToArray()
+            }
+
+            var arr = MakeEmpty[int32]()
+            Console.WriteLine(arr.Length)
+            var arrS = MakeEmpty[string]()
+            Console.WriteLine(arrS.Length)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n0\n", output);
+    }
+
+    [Fact]
+    public void EnumerableRepeat_With_OpenT_Roundtrips_Value()
+    {
+        var source = """
+            package P
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            func Repeat[T](v T, n int32) IEnumerable[T] {
+                return Enumerable.Repeat[T](v, n)
+            }
+
+            var seq = Repeat[int32](42, 3)
+            for v in seq {
+                Console.WriteLine(v)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n42\n42\n", output);
+    }
+
+    [Fact]
+    public void EnumerableEmpty_Inside_Generic_Extension_Method_Roundtrips()
+    {
+        var source = """
+            package P
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            func (self []T) ReplaceWithEmpty[T]() IEnumerable[T] {
+                return Enumerable.Empty[T]()
+            }
+
+            var arr = []int32{1, 2, 3}
+            var seq = arr.ReplaceWithEmpty()
+            var count = 0
+            for v in seq {
+                count = count + 1
+            }
+            Console.WriteLine(count)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue833_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue833OpenTGenericMethodCallReturnTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue833OpenTGenericMethodCallReturnTypeTests.cs
@@ -1,0 +1,250 @@
+// <copyright file="Issue833OpenTGenericMethodCallReturnTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #833 (sibling to #794). When a generic method (top-level
+/// <c>func</c>, generic shared method on a class, or generic extension
+/// method) calls an imported CLR generic method whose type argument
+/// is the in-scope method's own type parameter (e.g.
+/// <c>Enumerable.Empty[T]()</c>, <c>[]T{}.ToArray()</c>,
+/// <c>Array.Empty[T]()</c>), the call's bound return type must
+/// preserve the symbolic <c>T</c> — not the CLR-erased <c>object</c>.
+///
+/// <list type="bullet">
+///   <item><c>Enumerable.Empty[T]()</c> → <c>IEnumerable[T]</c> (was <c>IEnumerable[object]</c>)</item>
+///   <item><c>Array.Empty[T]()</c> → <c>[]T</c> (was <c>[]object</c>)</item>
+///   <item><c>[]T{}.ToArray()</c> → <c>[]T</c> (was <c>[]object</c>)</item>
+///   <item><c>Enumerable.Repeat[T](v, n)</c> → <c>IEnumerable[T]</c></item>
+/// </list>
+///
+/// Pre-fix the binder closed the static generic method against
+/// <c>object</c> (because <c>T</c> has no reference-context CLR type),
+/// so <see cref="System.Reflection.MethodInfo.ReturnType"/> surfaced as
+/// the erased projection. That then failed conversion to the declared
+/// <c>IEnumerable[T]</c> / <c>[]T</c>.
+/// </summary>
+public class Issue833OpenTGenericMethodCallReturnTypeTests
+{
+    [Fact]
+    public void EnumerableEmpty_With_OpenT_Returns_SymbolicIEnumerableT()
+    {
+        const string source = @"
+package Repro
+import System
+import System.Linq
+import System.Collections.Generic
+
+class Sequences {
+    shared {
+        func Empty[T]() IEnumerable[T] {
+            return Enumerable.Empty[T]()
+        }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ArrayEmpty_With_OpenT_Returns_SymbolicSliceT()
+    {
+        const string source = @"
+package P
+import System
+
+class Sequences {
+    shared {
+        func Empty[T]() []T {
+            return Array.Empty[T]()
+        }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ToArray_On_OpenT_Slice_Returns_SymbolicSliceT()
+    {
+        const string source = @"
+package P
+import System
+import System.Linq
+
+class Sequences {
+    shared {
+        func MakeEmpty[T]() []T {
+            return []T{}.ToArray()
+        }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void EnumerableRepeat_With_OpenT_Returns_SymbolicIEnumerableT()
+    {
+        const string source = @"
+package P
+import System
+import System.Linq
+import System.Collections.Generic
+
+class Sequences {
+    shared {
+        func Three[T](v T) IEnumerable[T] {
+            return Enumerable.Repeat[T](v, 3)
+        }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void Inside_TopLevel_Generic_Func_EnumerableEmpty_Threads_T()
+    {
+        const string source = @"
+package P
+import System
+import System.Linq
+import System.Collections.Generic
+
+func Empty[T]() IEnumerable[T] {
+    return Enumerable.Empty[T]()
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void Inside_Generic_Extension_Method_ToArray_Threads_T()
+    {
+        const string source = @"
+package P
+import System
+import System.Linq
+import System.Collections.Generic
+
+func (self []T) MakeEmptyLike[T]() []T {
+    return Array.Empty[T]()
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void EnumerableEmpty_Bound_Return_Type_Is_SymbolicIEnumerableT()
+    {
+        // Walk the bound tree to confirm the call's bound return type
+        // is `IEnumerable[T]` over the function's type parameter — not
+        // the erased `IEnumerable[object]`.
+        const string source = @"
+package P
+import System
+import System.Linq
+import System.Collections.Generic
+
+func Empty[T]() IEnumerable[T] {
+    return Enumerable.Empty[T]()
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var fn = compilation.BoundProgram.Functions.Keys.Single(f => f.Name == "Empty");
+        var body = compilation.BoundProgram.Functions[fn];
+        var imps = new TypeCollector<ImportedTypeSymbol>();
+        imps.Visit(body);
+        Assert.Contains(imps.Collected, t =>
+            !t.TypeArguments.IsDefaultOrEmpty
+            && t.TypeArguments.Any(a => a is TypeParameterSymbol tp && tp.Name == "T"));
+    }
+
+    [Fact]
+    public void ArrayEmpty_Bound_Return_Type_Is_SliceOfT()
+    {
+        const string source = @"
+package P
+import System
+
+func Empty[T]() []T {
+    return Array.Empty[T]()
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var fn = compilation.BoundProgram.Functions.Keys.Single(f => f.Name == "Empty");
+        var body = compilation.BoundProgram.Functions[fn];
+        var slices = new TypeCollector<SliceTypeSymbol>();
+        slices.Visit(body);
+        Assert.Contains(slices.Collected, s => s.ElementType is TypeParameterSymbol tp && tp.Name == "T");
+    }
+
+    [Fact]
+    public void ToArray_On_SliceOfT_Bound_Return_Type_Is_SliceOfT()
+    {
+        const string source = @"
+package P
+import System
+import System.Linq
+
+func MakeEmpty[T]() []T {
+    return []T{}.ToArray()
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var fn = compilation.BoundProgram.Functions.Keys.Single(f => f.Name == "MakeEmpty");
+        var body = compilation.BoundProgram.Functions[fn];
+        var slices = new TypeCollector<SliceTypeSymbol>();
+        slices.Visit(body);
+        Assert.Contains(slices.Collected, s => s.ElementType is TypeParameterSymbol tp && tp.Name == "T");
+    }
+
+    private static IReadOnlyList<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics;
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(tree) { IsLibrary = true };
+    }
+
+    private sealed class TypeCollector<T> : BoundTreeWalker
+        where T : TypeSymbol
+    {
+        public List<T> Collected { get; } = new();
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node?.Type is T match)
+            {
+                Collected.Add(match);
+            }
+
+            base.VisitExpression(node);
+        }
+    }
+}

--- a/test/Interpreter.Tests/Issue833OpenTGenericMethodCallReturnTypeInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue833OpenTGenericMethodCallReturnTypeInterpreterTests.cs
@@ -1,0 +1,166 @@
+// <copyright file="Issue833OpenTGenericMethodCallReturnTypeInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Tree-walking interpreter parity for issue #833: open-T generic
+/// method calls (e.g. <c>Enumerable.Empty[T]()</c>,
+/// <c>Array.Empty[T]()</c>, <c>[]T{}.ToArray()</c>) must also bind
+/// and execute correctly in the REPL, not only in the IL-emit path.
+/// </summary>
+public class Issue833OpenTGenericMethodCallReturnTypeInterpreterTests
+{
+    [Fact]
+    public void EnumerableEmpty_With_OpenT_Roundtrips_Int32()
+    {
+        var source = """
+            import System.Linq
+            import System.Collections.Generic
+
+            class Sequences {
+                shared {
+                    func Empty[T]() IEnumerable[T] {
+                        return Enumerable.Empty[T]()
+                    }
+                }
+            }
+
+            var seq = Sequences.Empty[int32]()
+            var count = 0
+            for v in seq {
+                count = count + 1
+            }
+            Console.WriteLine(count)
+            Console.WriteLine("done")
+            """;
+
+        Assert.Equal("0\ndone\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void EnumerableEmpty_With_OpenT_TopLevelFunc_Roundtrips_String()
+    {
+        var source = """
+            import System.Linq
+            import System.Collections.Generic
+
+            func Empty[T]() IEnumerable[T] {
+                return Enumerable.Empty[T]()
+            }
+
+            var seq = Empty[string]()
+            var count = 0
+            for v in seq {
+                count = count + 1
+            }
+            Console.WriteLine(count)
+            """;
+
+        Assert.Equal("0\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void ArrayEmpty_With_OpenT_Returns_SliceOfT()
+    {
+        var source = """
+            class Sequences {
+                shared {
+                    func Empty[T]() []T {
+                        return Array.Empty[T]()
+                    }
+                }
+            }
+
+            var arr = Sequences.Empty[int32]()
+            Console.WriteLine(arr.Length)
+            """;
+
+        Assert.Equal("0\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void ToArray_On_OpenT_Slice_Returns_SliceOfT()
+    {
+        var source = """
+            import System.Linq
+
+            func MakeEmpty[T]() []T {
+                return []T{}.ToArray()
+            }
+
+            var arr = MakeEmpty[int32]()
+            Console.WriteLine(arr.Length)
+            var arrS = MakeEmpty[string]()
+            Console.WriteLine(arrS.Length)
+            """;
+
+        Assert.Equal("0\n0\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void EnumerableRepeat_With_OpenT_Roundtrips_Value()
+    {
+        var source = """
+            import System.Linq
+            import System.Collections.Generic
+
+            func Repeat[T](v T, n int32) IEnumerable[T] {
+                return Enumerable.Repeat[T](v, n)
+            }
+
+            var seq = Repeat[int32](42, 3)
+            for v in seq {
+                Console.WriteLine(v)
+            }
+            """;
+
+        Assert.Equal("42\n42\n42\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void EnumerableEmpty_Inside_Generic_Extension_Method_Roundtrips()
+    {
+        var source = """
+            import System.Linq
+            import System.Collections.Generic
+
+            func (self []T) ReplaceWithEmpty[T]() IEnumerable[T] {
+                return Enumerable.Empty[T]()
+            }
+
+            var arr = []int32{1, 2, 3}
+            var seq = arr.ReplaceWithEmpty()
+            var count = 0
+            for v in seq {
+                count = count + 1
+            }
+            Console.WriteLine(count)
+            """;
+
+        Assert.Equal("0\n", RunSubmission(source));
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary

Sibling to #794. When a generic G# method calls an imported CLR generic
method (`Enumerable.Empty[T]()`, `Array.Empty[T]()`, `[]T{}.ToArray()`,
`Enumerable.Repeat[T](v, n)`) where the type argument is the in-scope
method's own type parameter, the call's bound return type and the
emitted MethodSpec now preserve the symbolic `T` (`MVar(idx)`) instead
of the CLR-erased `object` placeholder.

Closes #833.

## Root cause

For static generic methods like `Enumerable.Empty[T]()`, the binder
closed the method with the `object` placeholder (because `T` has no
reference-context CLR `Type`), so `MethodInfo.ReturnType` surfaced as
`IEnumerable<object>` instead of `IEnumerable<T>`. The pre-existing
`ResolveImportedGenericReturnType` (#320) only handled the case where
the *whole* open return is a bare `MVar` (`T GetService<T>()`), not
composite shapes (`IEnumerable<T>`, `T[]`).

In the emitter, `ArgIsSymbolicUserDefined` did not classify
`TypeParameterSymbol` as user-defined, so even when the symbolic
type-arg vector reached `GetMethodEntityHandle`, the MethodSpec was
encoded against `object` rather than `MVar(idx)`.

ilverify reported:

```
[StackUnexpected]: Sequences.Sequences::Empty()
  [offset 0x00000005][found ref 'object[]'][expected ref 'IEnumerable`1<T0>']
```

## Fix

- **`MemberLookup`** — public helpers `InferSymbolicMethodTypeArguments`,
  `BuildSymbolicMethodTypeArgs`, `BuildSymbolicArgTypeVector`,
  `ResolveCallReturnTypeFromSymbolicTypeArgs`, and
  `TryProjectErasedClrType`. Extends the open-CLR → symbolic mapper
  to substitute method-TPs.
- **`ImportedClassSymbol`** — projects open-T arg types to erased CLR
  shapes (`T`→`object`, `[]T`→`object[]`, etc.) so overload
  resolution runs; recovers symbolic method type args + return type as
  a `#833` fallback after the `#320` single-TP override.
- **`ExpressionBinder.Calls.cs`** — threads symbolic method type args
  + return type for the BCL-instance, inherited-instance, and
  extension call paths. Permits extension-call receivers/args with
  open TPs.
- **`ReflectionMetadataEmitter`** — classifies `TypeParameterSymbol`
  as symbolic so MethodSpec args encode as `MVar(idx)` / `Var(idx)`
  (`EncodeTypeSymbol` already handled the symbol; the gate was closed
  in `ArgIsSymbolicUserDefined`).
- **`Gsharp.Extensions.Sequences.Empty[T]`** — restored the inlined
  `return Enumerable.Empty[T]()` shape per ADR-0084 §L5; the
  `Array.Empty[T]()` workaround landed during the #806 port is no
  longer needed.
- **ADR-0084 §L5** — notes that the open-T `Enumerable.Empty[T]()` gap
  is closed by #833.

No new `BoundNodeKind`; the existing `returnOverride` plumbing on
`ImportedFunctionSymbol` carries the recovered symbolic return.

## Tests

- `Core.Tests/CodeAnalysis/Binding/Issue833…Tests` (9): binder
  diagnostics + bound-tree symbol assertions for `Enumerable.Empty[T]()`,
  `Array.Empty[T]()`, `[]T{}.ToArray()`, `Enumerable.Repeat[T](v, n)`
  inside top-level generic funcs, generic shared methods, and generic
  extension methods.
- `Compiler.Tests/Emit/Issue833…EmitTests` (6): compile → IL-verify →
  run round-trip for the same shapes.
- `Interpreter.Tests/Issue833…InterpreterTests` (6): tree-walking
  parity.

**Full suite:** 5315 passed / 0 failed (≈9 min Compiler.Tests, ≈19 s
Core.Tests). **ilverify:** clean on all new emit scenarios and on the
restored `Gsharp.Extensions.Sequences` build. **Website docs:** `npm
run build` succeeds with no broken links.

## References

- Issue #833
- Related: #794 (open-receiver instance-method return-type erasure),
  #806 (G#-authored Sequences port), parent #706
- ADR-0084 (Sequences as Extensions, §L5 closure), ADR-0087 (reified
  generics emit audit, F1 category)