### PR TITLE
Fix #835: replace typeof(X) reference-identity compares with FullName-based checks

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2679,7 +2679,7 @@ public sealed class Binder
                     var openIEnumerable = typeof(System.Collections.Generic.IEnumerable<>);
                     if (argClrSeq != null)
                     {
-                        var matchedSeq = argClrSeq.IsGenericType && argClrSeq.GetGenericTypeDefinition() == openIEnumerable
+                        var matchedSeq = argClrSeq.IsGenericType && argClrSeq.GetGenericTypeDefinition().IsSameAs(openIEnumerable)
                             ? argClrSeq
                             : FindMatchingInterface(argClrSeq, openIEnumerable);
                         if (matchedSeq != null)
@@ -2708,7 +2708,7 @@ public sealed class Binder
                     var openIAsyncEnumerable = typeof(System.Collections.Generic.IAsyncEnumerable<>);
                     if (argClrAseq != null)
                     {
-                        var matchedAseq = argClrAseq.IsGenericType && argClrAseq.GetGenericTypeDefinition() == openIAsyncEnumerable
+                        var matchedAseq = argClrAseq.IsGenericType && argClrAseq.GetGenericTypeDefinition().IsSameAs(openIAsyncEnumerable)
                             ? argClrAseq
                             : FindMatchingInterface(argClrAseq, openIAsyncEnumerable);
                         if (matchedAseq != null)
@@ -2820,7 +2820,7 @@ public sealed class Binder
         {
             foreach (var iface in clrType.GetInterfaces())
             {
-                if (iface.IsGenericType && iface.GetGenericTypeDefinition() == openDefinition)
+                if (iface.IsGenericType && iface.GetGenericTypeDefinition().IsSameAs(openDefinition))
                 {
                     return iface;
                 }

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -322,19 +322,19 @@ public sealed class Conversion
         // ADR-0045: every value-type primitive (and every user struct)
         // boxes implicitly to `object`. Reference types convert to
         // `object` as a plain reference widening.
-        if (to?.ClrType == typeof(object) && from?.ClrType != null)
+        if (to?.ClrType.IsSameAs(typeof(object)) == true && from?.ClrType != null)
         {
             return Conversion.Implicit;
         }
 
         // Boxing conversion for user value types to System.Object.
-        if (from is StructSymbol fromStruct && !fromStruct.IsClass && to?.ClrType == typeof(object))
+        if (from is StructSymbol fromStruct && !fromStruct.IsClass && to?.ClrType.IsSameAs(typeof(object)) == true)
         {
             return Conversion.Implicit;
         }
 
         // ADR-0045 explicit unbox: `(T)objectValue` for any value-type T.
-        if (from?.ClrType == typeof(object) && to?.ClrType != null && to.ClrType.IsValueType)
+        if (from?.ClrType.IsSameAs(typeof(object)) == true && to?.ClrType != null && to.ClrType.IsValueType)
         {
             return Conversion.Explicit;
         }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -3036,7 +3036,7 @@ internal sealed class DeclarationBinder
                     var ecAttr = KnownAttributes.FindEnumeratorCancellation(paramAttrs);
                     if (ecAttr != null)
                     {
-                        if (parameterSymbol.Type?.ClrType != typeof(System.Threading.CancellationToken))
+                        if (parameterSymbol.Type?.ClrType.IsSameAs(typeof(System.Threading.CancellationToken)) != true)
                         {
                             Diagnostics.ReportEnumeratorCancellationWrongType(
                                 parameterSyntax.Location,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -927,7 +927,7 @@ internal sealed partial class ExpressionBinder
         }
 
         var openReturn = openMethod.ReturnType;
-        if (openReturn == null || openReturn == typeof(void))
+        if (openReturn == null || openReturn.IsSameAs(typeof(void)))
         {
             return null;
         }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -648,7 +648,7 @@ internal sealed partial class ExpressionBinder
         }
 
         var resultClrType = shape.ResultType;
-        if (resultClrType == typeof(void))
+        if (resultClrType.IsSameAs(typeof(void)))
         {
             element = TypeSymbol.Void;
         }

--- a/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
+++ b/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
@@ -18,15 +18,27 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// than a string name, so renaming an attribute type or shadowing it in
 /// user code never breaks compiler semantics.
 /// </summary>
+/// <remarks>
+/// Issue #835 / ADR-0084 §L5: every recogniser below compares by
+/// <see cref="Type.FullName"/> (via <see cref="ClrTypeUtilities.IsSameAs"/>)
+/// rather than CLR reference identity (<c>clrType.IsSameAs(typeof(X))</c>). The
+/// reference-identity form silently regresses on the BuildTask path, where
+/// imported attribute types are materialised through a
+/// <see cref="System.Reflection.MetadataLoadContext"/> and therefore are
+/// never reference-equal to the gsc host process's <c>typeof()</c> instances.
+/// </remarks>
 internal static class KnownAttributes
 {
-    private static readonly HashSet<Type> ReservedForCompilerSet = new()
+    // FullName strings instead of typeof(...) so MetadataLoadContext-loaded
+    // attribute types match against the reserved set just like host-process
+    // ones do (issue #835).
+    private static readonly HashSet<string> ReservedForCompilerNames = new(StringComparer.Ordinal)
     {
-        typeof(System.Runtime.CompilerServices.ExtensionAttribute),
-        typeof(System.Runtime.CompilerServices.AsyncStateMachineAttribute),
-        typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute),
-        typeof(System.Runtime.CompilerServices.NullableAttribute),
-        typeof(System.Runtime.CompilerServices.NullableContextAttribute),
+        "System.Runtime.CompilerServices.ExtensionAttribute",
+        "System.Runtime.CompilerServices.AsyncStateMachineAttribute",
+        "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
+        "System.Runtime.CompilerServices.NullableAttribute",
+        "System.Runtime.CompilerServices.NullableContextAttribute",
     };
 
     /// <summary>
@@ -38,7 +50,7 @@ internal static class KnownAttributes
     /// <returns><c>true</c> if the attribute is reserved for the compiler.</returns>
     public static bool IsReservedForCompiler(Type clrType)
     {
-        return clrType != null && ReservedForCompilerSet.Contains(clrType);
+        return clrType?.FullName != null && ReservedForCompilerNames.Contains(clrType.FullName);
     }
 
     /// <summary>
@@ -49,7 +61,7 @@ internal static class KnownAttributes
     /// <returns><c>true</c> when the attribute is <c>[Obsolete]</c>.</returns>
     public static bool IsObsolete(BoundAttribute attribute)
     {
-        return attribute?.AttributeType?.ClrType == typeof(System.ObsoleteAttribute);
+        return attribute?.AttributeType?.ClrType.IsSameAs(typeof(System.ObsoleteAttribute)) == true;
     }
 
     /// <summary>
@@ -65,7 +77,7 @@ internal static class KnownAttributes
     /// <returns><c>true</c> when the attribute is <c>[DllImport]</c>.</returns>
     public static bool IsDllImport(Type clrType)
     {
-        return clrType == typeof(System.Runtime.InteropServices.DllImportAttribute);
+        return clrType.IsSameAs(typeof(System.Runtime.InteropServices.DllImportAttribute));
     }
 
     /// <summary>
@@ -90,7 +102,7 @@ internal static class KnownAttributes
     /// <returns><c>true</c> when the attribute is <c>[NotNullWhen]</c>.</returns>
     public static bool IsNotNullWhen(Type clrType)
     {
-        return clrType == typeof(System.Diagnostics.CodeAnalysis.NotNullWhenAttribute);
+        return clrType.IsSameAs(typeof(System.Diagnostics.CodeAnalysis.NotNullWhenAttribute));
     }
 
     /// <summary>
@@ -112,7 +124,7 @@ internal static class KnownAttributes
     /// <returns><c>true</c> when the attribute is <c>[MaybeNullWhen]</c>.</returns>
     public static bool IsMaybeNullWhen(Type clrType)
     {
-        return clrType == typeof(System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute);
+        return clrType.IsSameAs(typeof(System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute));
     }
 
     /// <summary>
@@ -136,7 +148,7 @@ internal static class KnownAttributes
     /// <returns><c>true</c> when the attribute is <c>[MemberNotNull]</c>.</returns>
     public static bool IsMemberNotNull(Type clrType)
     {
-        return clrType == typeof(System.Diagnostics.CodeAnalysis.MemberNotNullAttribute);
+        return clrType.IsSameAs(typeof(System.Diagnostics.CodeAnalysis.MemberNotNullAttribute));
     }
 
     /// <summary>
@@ -158,7 +170,7 @@ internal static class KnownAttributes
     /// <returns><c>true</c> when the attribute is <c>[MemberNotNullWhen]</c>.</returns>
     public static bool IsMemberNotNullWhen(Type clrType)
     {
-        return clrType == typeof(System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute);
+        return clrType.IsSameAs(typeof(System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute));
     }
 
     /// <summary>
@@ -299,7 +311,7 @@ internal static class KnownAttributes
     /// <returns><c>true</c> when the attribute is <c>[EnumeratorCancellation]</c>.</returns>
     public static bool IsEnumeratorCancellation(Type clrType)
     {
-        return clrType == typeof(System.Runtime.CompilerServices.EnumeratorCancellationAttribute);
+        return clrType.IsSameAs(typeof(System.Runtime.CompilerServices.EnumeratorCancellationAttribute));
     }
 
     /// <summary>
@@ -350,7 +362,7 @@ internal static class KnownAttributes
     /// <returns><c>true</c> when the attribute is <c>[Conditional]</c>.</returns>
     public static bool IsConditional(Type clrType)
     {
-        return clrType == typeof(System.Diagnostics.ConditionalAttribute);
+        return clrType.IsSameAs(typeof(System.Diagnostics.ConditionalAttribute));
     }
 
     /// <summary>
@@ -542,7 +554,7 @@ internal static class KnownAttributes
 
         var current = clr;
         var isSelf = true;
-        while (current != null && current != typeof(object))
+        while (current != null && !current.IsSameAs(typeof(object)))
         {
             IList<System.Reflection.CustomAttributeData> data;
             try
@@ -623,7 +635,7 @@ internal static class KnownAttributes
 
         foreach (var attr in attributes)
         {
-            if (attr?.AttributeType?.ClrType != typeof(AttributeUsageAttribute))
+            if (attr?.AttributeType?.ClrType.IsSameAs(typeof(AttributeUsageAttribute)) != true)
             {
                 continue;
             }
@@ -768,7 +780,7 @@ internal static class KnownAttributes
     /// <returns><c>true</c> when the attribute is <c>[LibraryImport]</c>.</returns>
     public static bool IsLibraryImport(Type clrType)
     {
-        return clrType == typeof(System.Runtime.InteropServices.LibraryImportAttribute);
+        return clrType.IsSameAs(typeof(System.Runtime.InteropServices.LibraryImportAttribute));
     }
 
     /// <summary>
@@ -818,7 +830,7 @@ internal static class KnownAttributes
     /// <returns><c>true</c> when the attribute is <c>[UnmanagedFunctionPointer]</c>.</returns>
     public static bool IsUnmanagedFunctionPointer(Type clrType)
     {
-        return clrType == typeof(System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute);
+        return clrType.IsSameAs(typeof(System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute));
     }
 
     /// <summary>
@@ -870,7 +882,7 @@ internal static class KnownAttributes
     /// <returns><c>true</c> when the attribute is <c>[StructLayout]</c>.</returns>
     public static bool IsStructLayout(Type clrType)
     {
-        return clrType == typeof(System.Runtime.InteropServices.StructLayoutAttribute);
+        return clrType.IsSameAs(typeof(System.Runtime.InteropServices.StructLayoutAttribute));
     }
 
     /// <summary>
@@ -921,7 +933,7 @@ internal static class KnownAttributes
     /// <returns><c>true</c> when the attribute is <c>[FieldOffset]</c>.</returns>
     public static bool IsFieldOffset(Type clrType)
     {
-        return clrType == typeof(System.Runtime.InteropServices.FieldOffsetAttribute);
+        return clrType.IsSameAs(typeof(System.Runtime.InteropServices.FieldOffsetAttribute));
     }
 
     /// <summary>
@@ -1084,7 +1096,7 @@ internal static class KnownAttributes
     /// <returns><c>true</c> when the attribute is <c>[MarshalAs]</c>.</returns>
     public static bool IsMarshalAs(Type clrType)
     {
-        return clrType == typeof(System.Runtime.InteropServices.MarshalAsAttribute);
+        return clrType.IsSameAs(typeof(System.Runtime.InteropServices.MarshalAsAttribute));
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -979,12 +979,12 @@ internal sealed class LambdaBinder
         }
 
         var clr = returnType.ClrType;
-        if (clr == typeof(System.Threading.Tasks.Task))
+        if (clr.IsSameAs(typeof(System.Threading.Tasks.Task)))
         {
             return TypeSymbol.Void;
         }
 
-        if (clr.IsGenericType && clr.GetGenericTypeDefinition() == typeof(System.Threading.Tasks.Task<>))
+        if (clr.IsGenericType && clr.GetGenericTypeDefinition().IsSameAs(typeof(System.Threading.Tasks.Task<>)))
         {
             // The unwrapped awaited type lives in the generic argument slot.
             return TypeSymbol.FromClrType(clr.GetGenericArguments()[0]);

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -355,7 +355,7 @@ internal sealed class MemberLookup
             binder: null,
             types: Type.EmptyTypes,
             modifiers: null);
-        if (moveNext?.ReturnType != typeof(bool))
+        if (moveNext?.ReturnType.IsSameAs(typeof(bool)) != true)
         {
             elementType = null;
             return false;
@@ -670,7 +670,7 @@ internal sealed class MemberLookup
 
         var openMethod = closed.IsGenericMethodDefinition ? closed : closed.GetGenericMethodDefinition();
         var openReturn = openMethod.ReturnType;
-        if (openReturn == null || openReturn == typeof(void))
+        if (openReturn == null || openReturn.IsSameAs(typeof(void)))
         {
             return null;
         }
@@ -911,7 +911,7 @@ internal sealed class MemberLookup
             anyVariadic |= paramArray;
         }
 
-        var returnType = invoke.ReturnType == typeof(void)
+        var returnType = invoke.ReturnType.IsSameAs(typeof(void))
             ? TypeSymbol.Void
             : invoke.ReturnType.ContainsGenericParameters
                 ? TypeSymbol.Object
@@ -1561,7 +1561,7 @@ internal sealed class MemberLookup
         }
 
         var baseType = openDef.BaseType;
-        while (baseType != null && baseType != typeof(object))
+        while (baseType != null && !baseType.IsSameAs(typeof(object)))
         {
             yield return baseType;
             baseType = baseType.BaseType;

--- a/src/Core/CodeAnalysis/BuiltinFunctions.cs
+++ b/src/Core/CodeAnalysis/BuiltinFunctions.cs
@@ -45,6 +45,6 @@ public static class BuiltinFunctions
     /// <returns>An <see cref="IEnumerable{FunctionSymbol}"/>.</returns>
     public static IEnumerable<FunctionSymbol> GetAll()
         => typeof(BuiltinFunctions).GetFields(BindingFlags.Public | BindingFlags.Static)
-                                   .Where(f => f.FieldType == typeof(FunctionSymbol))
+                                   .Where(f => f.FieldType.IsSameAs(typeof(FunctionSymbol)))
                                    .Select(f => (FunctionSymbol)f.GetValue(null));
 }

--- a/src/Core/CodeAnalysis/Emit/ConversionEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ConversionEmitter.cs
@@ -125,21 +125,21 @@ internal sealed class ConversionEmitter
     /// <param name="type">CLR type whose default value should be pushed.</param>
     public void EmitDefaultValue(InstructionEncoder il, Type type)
     {
-        if (type == typeof(int) || type == typeof(bool) || type == typeof(byte)
-            || type == typeof(short) || type == typeof(char))
+        if (type.IsSameAs(typeof(int)) || type.IsSameAs(typeof(bool)) || type.IsSameAs(typeof(byte))
+            || type.IsSameAs(typeof(short)) || type.IsSameAs(typeof(char)))
         {
             il.LoadConstantI4(0);
         }
-        else if (type == typeof(long))
+        else if (type.IsSameAs(typeof(long)))
         {
             il.LoadConstantI8(0);
         }
-        else if (type == typeof(float))
+        else if (type.IsSameAs(typeof(float)))
         {
             il.OpCode(ILOpCode.Ldc_r4);
             il.CodeBuilder.WriteSingle(0.0f);
         }
-        else if (type == typeof(double))
+        else if (type.IsSameAs(typeof(double)))
         {
             il.OpCode(ILOpCode.Ldc_r8);
             il.CodeBuilder.WriteDouble(0.0);

--- a/src/Core/CodeAnalysis/Emit/CustomAttributeEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/CustomAttributeEncoder.cs
@@ -595,59 +595,59 @@ internal sealed class CustomAttributeEncoder
 
     private void EncodeClrTypeForCtorSig(SignatureTypeEncoder enc, Type t)
     {
-        if (t == typeof(bool))
+        if (t.IsSameAs(typeof(bool)))
         {
             enc.Boolean();
         }
-        else if (t == typeof(char))
+        else if (t.IsSameAs(typeof(char)))
         {
             enc.Char();
         }
-        else if (t == typeof(sbyte))
+        else if (t.IsSameAs(typeof(sbyte)))
         {
             enc.SByte();
         }
-        else if (t == typeof(byte))
+        else if (t.IsSameAs(typeof(byte)))
         {
             enc.Byte();
         }
-        else if (t == typeof(short))
+        else if (t.IsSameAs(typeof(short)))
         {
             enc.Int16();
         }
-        else if (t == typeof(ushort))
+        else if (t.IsSameAs(typeof(ushort)))
         {
             enc.UInt16();
         }
-        else if (t == typeof(int))
+        else if (t.IsSameAs(typeof(int)))
         {
             enc.Int32();
         }
-        else if (t == typeof(uint))
+        else if (t.IsSameAs(typeof(uint)))
         {
             enc.UInt32();
         }
-        else if (t == typeof(long))
+        else if (t.IsSameAs(typeof(long)))
         {
             enc.Int64();
         }
-        else if (t == typeof(ulong))
+        else if (t.IsSameAs(typeof(ulong)))
         {
             enc.UInt64();
         }
-        else if (t == typeof(float))
+        else if (t.IsSameAs(typeof(float)))
         {
             enc.Single();
         }
-        else if (t == typeof(double))
+        else if (t.IsSameAs(typeof(double)))
         {
             enc.Double();
         }
-        else if (t == typeof(string))
+        else if (t.IsSameAs(typeof(string)))
         {
             enc.String();
         }
-        else if (t == typeof(object))
+        else if (t.IsSameAs(typeof(object)))
         {
             enc.Object();
         }
@@ -680,55 +680,55 @@ internal sealed class CustomAttributeEncoder
             return;
         }
 
-        if (paramType == typeof(bool))
+        if (paramType.IsSameAs(typeof(bool)))
         {
             bb.WriteBoolean((bool)value);
         }
-        else if (paramType == typeof(char))
+        else if (paramType.IsSameAs(typeof(char)))
         {
             bb.WriteUInt16((char)value);
         }
-        else if (paramType == typeof(sbyte))
+        else if (paramType.IsSameAs(typeof(sbyte)))
         {
             bb.WriteSByte(Convert.ToSByte(value));
         }
-        else if (paramType == typeof(byte))
+        else if (paramType.IsSameAs(typeof(byte)))
         {
             bb.WriteByte(Convert.ToByte(value));
         }
-        else if (paramType == typeof(short))
+        else if (paramType.IsSameAs(typeof(short)))
         {
             bb.WriteInt16(Convert.ToInt16(value));
         }
-        else if (paramType == typeof(ushort))
+        else if (paramType.IsSameAs(typeof(ushort)))
         {
             bb.WriteUInt16(Convert.ToUInt16(value));
         }
-        else if (paramType == typeof(int))
+        else if (paramType.IsSameAs(typeof(int)))
         {
             bb.WriteInt32(Convert.ToInt32(value));
         }
-        else if (paramType == typeof(uint))
+        else if (paramType.IsSameAs(typeof(uint)))
         {
             bb.WriteUInt32(Convert.ToUInt32(value));
         }
-        else if (paramType == typeof(long))
+        else if (paramType.IsSameAs(typeof(long)))
         {
             bb.WriteInt64(Convert.ToInt64(value));
         }
-        else if (paramType == typeof(ulong))
+        else if (paramType.IsSameAs(typeof(ulong)))
         {
             bb.WriteUInt64(Convert.ToUInt64(value));
         }
-        else if (paramType == typeof(float))
+        else if (paramType.IsSameAs(typeof(float)))
         {
             bb.WriteSingle(Convert.ToSingle(value));
         }
-        else if (paramType == typeof(double))
+        else if (paramType.IsSameAs(typeof(double)))
         {
             bb.WriteDouble(Convert.ToDouble(value));
         }
-        else if (paramType == typeof(string))
+        else if (paramType.IsSameAs(typeof(string)))
         {
             bb.WriteSerializedString((string)value);
         }
@@ -743,7 +743,7 @@ internal sealed class CustomAttributeEncoder
         {
             WriteCustomAttributeArrayArg(bb, paramType.GetElementType()!, value);
         }
-        else if (paramType == typeof(object))
+        else if (paramType.IsSameAs(typeof(object)))
         {
             // ECMA-335 II.23.3: boxed object argument carries the
             // FieldOrPropType tag of the runtime type then the value.
@@ -860,55 +860,55 @@ internal sealed class CustomAttributeEncoder
     private static void WriteCustomAttributeFieldOrPropertyType(BlobBuilder bb, Type t)
     {
         // ECMA-335 II.23.3 — element-type byte for a FIELD/PROPERTY tag.
-        if (t == typeof(bool))
+        if (t.IsSameAs(typeof(bool)))
         {
             bb.WriteByte(0x02);
         }
-        else if (t == typeof(char))
+        else if (t.IsSameAs(typeof(char)))
         {
             bb.WriteByte(0x03);
         }
-        else if (t == typeof(sbyte))
+        else if (t.IsSameAs(typeof(sbyte)))
         {
             bb.WriteByte(0x04);
         }
-        else if (t == typeof(byte))
+        else if (t.IsSameAs(typeof(byte)))
         {
             bb.WriteByte(0x05);
         }
-        else if (t == typeof(short))
+        else if (t.IsSameAs(typeof(short)))
         {
             bb.WriteByte(0x06);
         }
-        else if (t == typeof(ushort))
+        else if (t.IsSameAs(typeof(ushort)))
         {
             bb.WriteByte(0x07);
         }
-        else if (t == typeof(int))
+        else if (t.IsSameAs(typeof(int)))
         {
             bb.WriteByte(0x08);
         }
-        else if (t == typeof(uint))
+        else if (t.IsSameAs(typeof(uint)))
         {
             bb.WriteByte(0x09);
         }
-        else if (t == typeof(long))
+        else if (t.IsSameAs(typeof(long)))
         {
             bb.WriteByte(0x0A);
         }
-        else if (t == typeof(ulong))
+        else if (t.IsSameAs(typeof(ulong)))
         {
             bb.WriteByte(0x0B);
         }
-        else if (t == typeof(float))
+        else if (t.IsSameAs(typeof(float)))
         {
             bb.WriteByte(0x0C);
         }
-        else if (t == typeof(double))
+        else if (t.IsSameAs(typeof(double)))
         {
             bb.WriteByte(0x0D);
         }
-        else if (t == typeof(string))
+        else if (t.IsSameAs(typeof(string)))
         {
             bb.WriteByte(0x0E);
         }
@@ -917,7 +917,7 @@ internal sealed class CustomAttributeEncoder
             // 0x50 — System.Type (no payload byte; the FixedArg holds the SerString).
             bb.WriteByte(0x50);
         }
-        else if (t == typeof(object))
+        else if (t.IsSameAs(typeof(object)))
         {
             // 0x51 — boxed object. The FixedArg writer prefixes the runtime
             // type tag and value when emitting the argument body.

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -423,7 +423,7 @@ internal sealed partial class MethodBodyEmitter
             .First(m => m.Name == nameof(System.Threading.Channels.Channel.CreateBounded)
                 && m.IsGenericMethodDefinition
                 && m.GetParameters().Length == 1
-                && m.GetParameters()[0].ParameterType == typeof(System.Threading.Channels.BoundedChannelOptions));
+                && m.GetParameters()[0].ParameterType.IsSameAs(typeof(System.Threading.Channels.BoundedChannelOptions)));
         var bounded = openBounded.MakeGenericMethod(elementClr);
         this.il.Call(this.outer.GetMethodEntityHandle(bounded));
     }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -234,7 +234,7 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
-        if ((to?.ClrType == typeof(object) || IsInterfaceTargetType(to)) && ReflectionMetadataEmitter.IsValueTypeSymbol(from))
+        if ((to?.ClrType.IsSameAs(typeof(object)) == true || IsInterfaceTargetType(to)) && ReflectionMetadataEmitter.IsValueTypeSymbol(from))
         {
             this.il.OpCode(ILOpCode.Box);
             this.il.Token(this.outer.GetElementTypeToken(from));
@@ -249,7 +249,7 @@ internal sealed partial class MethodBodyEmitter
         // reference boxed slot. The JIT elides the box when T resolves to a
         // reference type at runtime, so no perf regression.
         if (from is TypeParameterSymbol fromTp
-            && (to?.ClrType == typeof(object) || IsInterfaceTargetType(to)))
+            && (to?.ClrType.IsSameAs(typeof(object)) == true || IsInterfaceTargetType(to)))
         {
             this.il.OpCode(ILOpCode.Box);
             this.il.Token(this.outer.GetElementTypeToken(fromTp));
@@ -261,7 +261,7 @@ internal sealed partial class MethodBodyEmitter
         // reference (user-declared `InterfaceSymbol` or any CLR
         // interface), since a boxed value type held in an interface
         // slot needs `unbox.any` to surface as its native value type.
-        if ((from?.ClrType == typeof(object) || IsInterfaceSourceType(from))
+        if ((from?.ClrType.IsSameAs(typeof(object)) == true || IsInterfaceSourceType(from))
             && to?.ClrType != null && to.ClrType.IsValueType)
         {
             this.il.OpCode(ILOpCode.Unbox_any);
@@ -269,8 +269,8 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
-        if (from?.ClrType == typeof(object)
-            && to?.ClrType != typeof(object)
+        if (from?.ClrType.IsSameAs(typeof(object)) == true
+            && to?.ClrType.IsSameAs(typeof(object)) == false
             && to is not TypeParameterSymbol
             && !ReflectionMetadataEmitter.IsValueTypeSymbol(to))
         {
@@ -308,7 +308,7 @@ internal sealed partial class MethodBodyEmitter
             || expectedType == null
             || expectedType == TypeSymbol.Void
             || expectedType == TypeSymbol.Error
-            || expectedType?.ClrType == typeof(object))
+            || expectedType?.ClrType.IsSameAs(typeof(object)) == true)
         {
             return;
         }
@@ -367,7 +367,7 @@ internal sealed partial class MethodBodyEmitter
         // decimal is a value type with no `conv.*` opcode; route through
         // the BCL's operator methods. `op_Implicit` for widening sources
         // (every integral type → decimal) and `op_Explicit` otherwise.
-        if (to == typeof(decimal) || from == typeof(decimal))
+        if (to.IsSameAs(typeof(decimal)) || from.IsSameAs(typeof(decimal)))
         {
             return TryEmitDecimalConversion(from, to);
         }
@@ -383,23 +383,23 @@ internal sealed partial class MethodBodyEmitter
         // or r8. We pick the conv opcode that matches the *target*
         // representation.
         ILOpCode? op = null;
-        if (to == typeof(sbyte))
+        if (to.IsSameAs(typeof(sbyte)))
         {
             op = ILOpCode.Conv_i1;
         }
-        else if (to == typeof(byte))
+        else if (to.IsSameAs(typeof(byte)))
         {
             op = ILOpCode.Conv_u1;
         }
-        else if (to == typeof(short))
+        else if (to.IsSameAs(typeof(short)))
         {
             op = ILOpCode.Conv_i2;
         }
-        else if (to == typeof(ushort) || to == typeof(char))
+        else if (to.IsSameAs(typeof(ushort)) || to.IsSameAs(typeof(char)))
         {
             op = ILOpCode.Conv_u2;
         }
-        else if (to == typeof(int))
+        else if (to.IsSameAs(typeof(int)))
         {
             // From an i4-sized source the value is already i4. From i8,
             // r4, r8, nint, nuint we must narrow to i4.
@@ -410,7 +410,7 @@ internal sealed partial class MethodBodyEmitter
 
             op = ILOpCode.Conv_i4;
         }
-        else if (to == typeof(uint))
+        else if (to.IsSameAs(typeof(uint)))
         {
             if (Is32BitOrSmaller(from))
             {
@@ -419,27 +419,27 @@ internal sealed partial class MethodBodyEmitter
 
             op = ILOpCode.Conv_u4;
         }
-        else if (to == typeof(long))
+        else if (to.IsSameAs(typeof(long)))
         {
             op = ILOpCode.Conv_i8;
         }
-        else if (to == typeof(ulong))
+        else if (to.IsSameAs(typeof(ulong)))
         {
             op = ILOpCode.Conv_u8;
         }
-        else if (to == typeof(nint))
+        else if (to.IsSameAs(typeof(nint)))
         {
             op = ILOpCode.Conv_i;
         }
-        else if (to == typeof(nuint))
+        else if (to.IsSameAs(typeof(nuint)))
         {
             op = ILOpCode.Conv_u;
         }
-        else if (to == typeof(float))
+        else if (to.IsSameAs(typeof(float)))
         {
             op = ILOpCode.Conv_r4;
         }
-        else if (to == typeof(double))
+        else if (to.IsSameAs(typeof(double)))
         {
             op = ILOpCode.Conv_r8;
         }
@@ -457,7 +457,7 @@ internal sealed partial class MethodBodyEmitter
     {
         // To decimal: every numeric source has either an `op_Implicit`
         // (integrals, char) or an `op_Explicit` (float, double).
-        if (to == typeof(decimal))
+        if (to.IsSameAs(typeof(decimal)))
         {
             var op = typeof(decimal).GetMethod("op_Implicit", new[] { from })
                 ?? typeof(decimal).GetMethod("op_Explicit", new[] { from });
@@ -471,7 +471,7 @@ internal sealed partial class MethodBodyEmitter
         }
 
         // From decimal: every numeric target has an `op_Explicit`.
-        if (from == typeof(decimal))
+        if (from.IsSameAs(typeof(decimal)))
         {
             var op = typeof(decimal).GetMethod("op_Explicit", new[] { typeof(decimal) });
             // GetMethod by name+params resolves the conversion that
@@ -482,7 +482,7 @@ internal sealed partial class MethodBodyEmitter
                 if (m.Name == "op_Explicit"
                     && m.ReturnType == to
                     && m.GetParameters().Length == 1
-                    && m.GetParameters()[0].ParameterType == typeof(decimal))
+                    && m.GetParameters()[0].ParameterType.IsSameAs(typeof(decimal)))
                 {
                     op = m;
                     break;
@@ -517,44 +517,44 @@ internal sealed partial class MethodBodyEmitter
         var sourceUnsigned = IsUnsignedClrType(from);
         ILOpCode? op = null;
 
-        if (to == typeof(sbyte))
+        if (to.IsSameAs(typeof(sbyte)))
         {
             op = sourceUnsigned ? ILOpCode.Conv_ovf_i1_un : ILOpCode.Conv_ovf_i1;
         }
-        else if (to == typeof(byte))
+        else if (to.IsSameAs(typeof(byte)))
         {
             op = sourceUnsigned ? ILOpCode.Conv_ovf_u1_un : ILOpCode.Conv_ovf_u1;
         }
-        else if (to == typeof(short))
+        else if (to.IsSameAs(typeof(short)))
         {
             op = sourceUnsigned ? ILOpCode.Conv_ovf_i2_un : ILOpCode.Conv_ovf_i2;
         }
-        else if (to == typeof(ushort) || to == typeof(char))
+        else if (to.IsSameAs(typeof(ushort)) || to.IsSameAs(typeof(char)))
         {
             op = sourceUnsigned ? ILOpCode.Conv_ovf_u2_un : ILOpCode.Conv_ovf_u2;
         }
-        else if (to == typeof(int))
+        else if (to.IsSameAs(typeof(int)))
         {
             // From a same-size signed source the value already fits, but
             // from a same-size unsigned source we still need the check
             // (`uint` → `int` traps for values > Int32.MaxValue).
-            if (from == typeof(int))
+            if (from.IsSameAs(typeof(int)))
             {
                 return true;
             }
 
             op = sourceUnsigned ? ILOpCode.Conv_ovf_i4_un : ILOpCode.Conv_ovf_i4;
         }
-        else if (to == typeof(uint))
+        else if (to.IsSameAs(typeof(uint)))
         {
-            if (from == typeof(uint))
+            if (from.IsSameAs(typeof(uint)))
             {
                 return true;
             }
 
             op = sourceUnsigned ? ILOpCode.Conv_ovf_u4_un : ILOpCode.Conv_ovf_u4;
         }
-        else if (to == typeof(long))
+        else if (to.IsSameAs(typeof(long)))
         {
             // A signed widening (i1/i2/i4 → i8) needs `conv.i8` (not
             // `conv.ovf.i8`) because it can't overflow; the same holds
@@ -562,7 +562,7 @@ internal sealed partial class MethodBodyEmitter
             // long uses `conv.ovf.i8.un` to trap on the >Int64.MaxValue
             // boundary; an unsigned same-size widening (uint → long) is
             // safe but the `_un` variant still trivially succeeds.
-            if (from == typeof(long))
+            if (from.IsSameAs(typeof(long)))
             {
                 return true;
             }
@@ -571,7 +571,7 @@ internal sealed partial class MethodBodyEmitter
             {
                 op = ILOpCode.Conv_ovf_i8_un;
             }
-            else if (from == typeof(float) || from == typeof(double))
+            else if (from.IsSameAs(typeof(float)) || from.IsSameAs(typeof(double)))
             {
                 op = ILOpCode.Conv_ovf_i8;
             }
@@ -582,28 +582,28 @@ internal sealed partial class MethodBodyEmitter
                 op = ILOpCode.Conv_i8;
             }
         }
-        else if (to == typeof(ulong))
+        else if (to.IsSameAs(typeof(ulong)))
         {
-            if (from == typeof(ulong))
+            if (from.IsSameAs(typeof(ulong)))
             {
                 return true;
             }
 
             op = sourceUnsigned ? ILOpCode.Conv_ovf_u8_un : ILOpCode.Conv_ovf_u8;
         }
-        else if (to == typeof(nint))
+        else if (to.IsSameAs(typeof(nint)))
         {
             op = sourceUnsigned ? ILOpCode.Conv_ovf_i_un : ILOpCode.Conv_ovf_i;
         }
-        else if (to == typeof(nuint))
+        else if (to.IsSameAs(typeof(nuint)))
         {
             op = sourceUnsigned ? ILOpCode.Conv_ovf_u_un : ILOpCode.Conv_ovf_u;
         }
-        else if (to == typeof(float))
+        else if (to.IsSameAs(typeof(float)))
         {
             op = ILOpCode.Conv_r4;
         }
-        else if (to == typeof(double))
+        else if (to.IsSameAs(typeof(double)))
         {
             op = ILOpCode.Conv_r8;
         }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -1170,27 +1170,27 @@ internal sealed partial class MethodBodyEmitter
     private void EmitLoadIndirect(TypeSymbol pointeeType)
     {
         var clrType = pointeeType?.ClrType;
-        if (clrType == typeof(int) || clrType == typeof(uint))
+        if (clrType.IsSameAs(typeof(int)) || clrType.IsSameAs(typeof(uint)))
         {
             this.il.OpCode(ILOpCode.Ldind_i4);
         }
-        else if (clrType == typeof(long) || clrType == typeof(ulong))
+        else if (clrType.IsSameAs(typeof(long)) || clrType.IsSameAs(typeof(ulong)))
         {
             this.il.OpCode(ILOpCode.Ldind_i8);
         }
-        else if (clrType == typeof(float))
+        else if (clrType.IsSameAs(typeof(float)))
         {
             this.il.OpCode(ILOpCode.Ldind_r4);
         }
-        else if (clrType == typeof(double))
+        else if (clrType.IsSameAs(typeof(double)))
         {
             this.il.OpCode(ILOpCode.Ldind_r8);
         }
-        else if (clrType == typeof(short) || clrType == typeof(ushort) || clrType == typeof(char))
+        else if (clrType.IsSameAs(typeof(short)) || clrType.IsSameAs(typeof(ushort)) || clrType.IsSameAs(typeof(char)))
         {
             this.il.OpCode(ILOpCode.Ldind_i2);
         }
-        else if (clrType == typeof(byte) || clrType == typeof(sbyte) || clrType == typeof(bool))
+        else if (clrType.IsSameAs(typeof(byte)) || clrType.IsSameAs(typeof(sbyte)) || clrType.IsSameAs(typeof(bool)))
         {
             this.il.OpCode(ILOpCode.Ldind_i1);
         }
@@ -1209,27 +1209,27 @@ internal sealed partial class MethodBodyEmitter
     private void EmitStoreIndirect(TypeSymbol pointeeType)
     {
         var clrType = pointeeType?.ClrType;
-        if (clrType == typeof(int) || clrType == typeof(uint))
+        if (clrType.IsSameAs(typeof(int)) || clrType.IsSameAs(typeof(uint)))
         {
             this.il.OpCode(ILOpCode.Stind_i4);
         }
-        else if (clrType == typeof(long) || clrType == typeof(ulong))
+        else if (clrType.IsSameAs(typeof(long)) || clrType.IsSameAs(typeof(ulong)))
         {
             this.il.OpCode(ILOpCode.Stind_i8);
         }
-        else if (clrType == typeof(float))
+        else if (clrType.IsSameAs(typeof(float)))
         {
             this.il.OpCode(ILOpCode.Stind_r4);
         }
-        else if (clrType == typeof(double))
+        else if (clrType.IsSameAs(typeof(double)))
         {
             this.il.OpCode(ILOpCode.Stind_r8);
         }
-        else if (clrType == typeof(short) || clrType == typeof(ushort) || clrType == typeof(char))
+        else if (clrType.IsSameAs(typeof(short)) || clrType.IsSameAs(typeof(ushort)) || clrType.IsSameAs(typeof(char)))
         {
             this.il.OpCode(ILOpCode.Stind_i2);
         }
-        else if (clrType == typeof(byte) || clrType == typeof(sbyte) || clrType == typeof(bool))
+        else if (clrType.IsSameAs(typeof(byte)) || clrType.IsSameAs(typeof(sbyte)) || clrType.IsSameAs(typeof(bool)))
         {
             this.il.OpCode(ILOpCode.Stind_i1);
         }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
@@ -265,7 +265,7 @@ internal sealed partial class MethodBodyEmitter
             this.il.OpCode(ILOpCode.Unbox_any);
             this.il.Token(this.outer.GetElementTypeToken(tp.TargetType));
         }
-        else if (tp.TargetType?.ClrType != typeof(object))
+        else if (tp.TargetType?.ClrType.IsSameAs(typeof(object)) != true)
         {
             this.il.OpCode(ILOpCode.Castclass);
             this.il.Token(this.outer.GetElementTypeToken(tp.TargetType));

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -361,7 +361,7 @@ internal sealed partial class MethodBodyEmitter
 
     private static bool IsObjectStackType(TypeSymbol type)
     {
-        if (type == TypeSymbol.Object || type?.ClrType == typeof(object))
+        if (type == TypeSymbol.Object || type?.ClrType.IsSameAs(typeof(object)) == true)
         {
             return true;
         }
@@ -412,23 +412,23 @@ internal sealed partial class MethodBodyEmitter
     }
 
     private static bool IsUnsignedClrType(Type t)
-        => t == typeof(byte) || t == typeof(ushort) || t == typeof(uint)
-            || t == typeof(ulong) || t == typeof(nuint) || t == typeof(char);
+        => t.IsSameAs(typeof(byte)) || t.IsSameAs(typeof(ushort)) || t.IsSameAs(typeof(uint))
+            || t.IsSameAs(typeof(ulong)) || t.IsSameAs(typeof(nuint)) || t.IsSameAs(typeof(char));
 
     private static bool IsNumericClrType(Type t)
-        => t == typeof(sbyte) || t == typeof(byte)
-            || t == typeof(short) || t == typeof(ushort)
-            || t == typeof(int) || t == typeof(uint)
-            || t == typeof(long) || t == typeof(ulong)
-            || t == typeof(nint) || t == typeof(nuint)
-            || t == typeof(float) || t == typeof(double)
-            || t == typeof(decimal) || t == typeof(char);
+        => t.IsSameAs(typeof(sbyte)) || t.IsSameAs(typeof(byte))
+            || t.IsSameAs(typeof(short)) || t.IsSameAs(typeof(ushort))
+            || t.IsSameAs(typeof(int)) || t.IsSameAs(typeof(uint))
+            || t.IsSameAs(typeof(long)) || t.IsSameAs(typeof(ulong))
+            || t.IsSameAs(typeof(nint)) || t.IsSameAs(typeof(nuint))
+            || t.IsSameAs(typeof(float)) || t.IsSameAs(typeof(double))
+            || t.IsSameAs(typeof(decimal)) || t.IsSameAs(typeof(char));
 
     private static bool Is32BitOrSmaller(Type t)
-        => t == typeof(sbyte) || t == typeof(byte)
-            || t == typeof(short) || t == typeof(ushort)
-            || t == typeof(int) || t == typeof(uint)
-            || t == typeof(char) || t == typeof(bool);
+        => t.IsSameAs(typeof(sbyte)) || t.IsSameAs(typeof(byte))
+            || t.IsSameAs(typeof(short)) || t.IsSameAs(typeof(ushort))
+            || t.IsSameAs(typeof(int)) || t.IsSameAs(typeof(uint))
+            || t.IsSameAs(typeof(char)) || t.IsSameAs(typeof(bool));
 
     private static bool IsReferenceCompatible(TypeSymbol a, TypeSymbol b)
     {
@@ -439,7 +439,7 @@ internal sealed partial class MethodBodyEmitter
 
         // ADR-0045: any reference type widens to `object` at the IL
         // level as a no-op; the slot already holds the reference.
-        if (b?.ClrType == typeof(object) && a?.ClrType != null && !a.ClrType.IsValueType)
+        if (b?.ClrType.IsSameAs(typeof(object)) == true && a?.ClrType != null && !a.ClrType.IsValueType)
         {
             return true;
         }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -5782,14 +5782,14 @@ internal sealed class ReflectionMetadataEmitter
             return false;
         }
 
-        return openDef == typeof(ValueTuple<>)
-            || openDef == typeof(ValueTuple<,>)
-            || openDef == typeof(ValueTuple<,,>)
-            || openDef == typeof(ValueTuple<,,,>)
-            || openDef == typeof(ValueTuple<,,,,>)
-            || openDef == typeof(ValueTuple<,,,,,>)
-            || openDef == typeof(ValueTuple<,,,,,,>)
-            || openDef == typeof(ValueTuple<,,,,,,,>);
+        return openDef.IsSameAs(typeof(ValueTuple<>))
+            || openDef.IsSameAs(typeof(ValueTuple<,>))
+            || openDef.IsSameAs(typeof(ValueTuple<,,>))
+            || openDef.IsSameAs(typeof(ValueTuple<,,,>))
+            || openDef.IsSameAs(typeof(ValueTuple<,,,,>))
+            || openDef.IsSameAs(typeof(ValueTuple<,,,,,>))
+            || openDef.IsSameAs(typeof(ValueTuple<,,,,,,>))
+            || openDef.IsSameAs(typeof(ValueTuple<,,,,,,,>));
     }
 
     private readonly Dictionary<StructSymbol, EntityHandle> userStructTypeSpecCache = new(ReferenceEqualityComparer.Instance);
@@ -6850,7 +6850,7 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         var openReturn = openMethod.ReturnType;
-        if (openReturn == null || openReturn == typeof(void))
+        if (openReturn == null || openReturn.IsSameAs(typeof(void)))
         {
             return false;
         }

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -1025,7 +1025,7 @@ internal sealed class StateMachineEmitter
                     continue;
                 }
 
-                if (userParam.Type?.ClrType != typeof(System.Threading.CancellationToken))
+                if (userParam.Type?.ClrType.IsSameAs(typeof(System.Threading.CancellationToken)) != true)
                 {
                     // Binder already reported GS0207; skip emit-time threading.
                     continue;

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -822,13 +822,13 @@ public sealed class Evaluator
             var idx = 1;
             if (wantAlign)
             {
-                ok = ps[idx].ParameterType == typeof(int);
+                ok = ps[idx].ParameterType.IsSameAs(typeof(int));
                 idx++;
             }
 
             if (ok && wantFormat)
             {
-                ok = ps[idx].ParameterType == typeof(string);
+                ok = ps[idx].ParameterType.IsSameAs(typeof(string));
             }
 
             if (ok)
@@ -2989,7 +2989,7 @@ public sealed class Evaluator
             .First(m => m.Name == nameof(Channel.CreateBounded)
                 && m.IsGenericMethodDefinition
                 && m.GetParameters().Length == 1
-                && m.GetParameters()[0].ParameterType == typeof(BoundedChannelOptions));
+                && m.GetParameters()[0].ParameterType.IsSameAs(typeof(BoundedChannelOptions)));
         return bounded.MakeGenericMethod(elementClr).Invoke(null, new object[] { options });
     }
 
@@ -3483,13 +3483,13 @@ public sealed class Evaluator
 
     private static bool IsSupportedNumericClrType(Type t)
     {
-        return t == typeof(sbyte) || t == typeof(byte)
-            || t == typeof(short) || t == typeof(ushort)
-            || t == typeof(int) || t == typeof(uint)
-            || t == typeof(long) || t == typeof(ulong)
-            || t == typeof(nint) || t == typeof(nuint)
-            || t == typeof(float) || t == typeof(double)
-            || t == typeof(decimal) || t == typeof(char);
+        return t.IsSameAs(typeof(sbyte)) || t.IsSameAs(typeof(byte))
+            || t.IsSameAs(typeof(short)) || t.IsSameAs(typeof(ushort))
+            || t.IsSameAs(typeof(int)) || t.IsSameAs(typeof(uint))
+            || t.IsSameAs(typeof(long)) || t.IsSameAs(typeof(ulong))
+            || t.IsSameAs(typeof(nint)) || t.IsSameAs(typeof(nuint))
+            || t.IsSameAs(typeof(float)) || t.IsSameAs(typeof(double))
+            || t.IsSameAs(typeof(decimal)) || t.IsSameAs(typeof(char));
     }
 
     private static object UncheckedNumericConvert(object value, Type to)
@@ -3500,12 +3500,12 @@ public sealed class Evaluator
         {
             // decimal → primitive is checked at the BCL level even for
             // unchecked casts; route through (long) first when applicable.
-            if (to == typeof(float))
+            if (to.IsSameAs(typeof(float)))
             {
                 return (float)dv;
             }
 
-            if (to == typeof(double))
+            if (to.IsSameAs(typeof(double)))
             {
                 return (double)dv;
             }
@@ -3513,7 +3513,7 @@ public sealed class Evaluator
             return UncheckedNumericConvert((long)dv, to);
         }
 
-        if (to == typeof(decimal))
+        if (to.IsSameAs(typeof(decimal)))
         {
             return Convert.ToDecimal(value, System.Globalization.CultureInfo.InvariantCulture);
         }
@@ -3526,12 +3526,12 @@ public sealed class Evaluator
 
         if (value is double dbv)
         {
-            if (to == typeof(float))
+            if (to.IsSameAs(typeof(float)))
             {
                 return (float)dbv;
             }
 
-            if (to == typeof(double))
+            if (to.IsSameAs(typeof(double)))
             {
                 return dbv;
             }
@@ -3559,19 +3559,19 @@ public sealed class Evaluator
 
         return to switch
         {
-            Type t when t == typeof(sbyte) => unchecked((sbyte)asLong),
-            Type t when t == typeof(byte) => unchecked((byte)asLong),
-            Type t when t == typeof(short) => unchecked((short)asLong),
-            Type t when t == typeof(ushort) => unchecked((ushort)asLong),
-            Type t when t == typeof(int) => unchecked((int)asLong),
-            Type t when t == typeof(uint) => unchecked((uint)asLong),
-            Type t when t == typeof(long) => asLong,
-            Type t when t == typeof(ulong) => unchecked((ulong)asLong),
-            Type t when t == typeof(nint) => (nint)asLong,
-            Type t when t == typeof(nuint) => unchecked((nuint)(ulong)asLong),
-            Type t when t == typeof(float) => (float)asLong,
-            Type t when t == typeof(double) => (double)asLong,
-            Type t when t == typeof(char) => unchecked((char)asLong),
+            Type t when t.IsSameAs(typeof(sbyte)) => unchecked((sbyte)asLong),
+            Type t when t.IsSameAs(typeof(byte)) => unchecked((byte)asLong),
+            Type t when t.IsSameAs(typeof(short)) => unchecked((short)asLong),
+            Type t when t.IsSameAs(typeof(ushort)) => unchecked((ushort)asLong),
+            Type t when t.IsSameAs(typeof(int)) => unchecked((int)asLong),
+            Type t when t.IsSameAs(typeof(uint)) => unchecked((uint)asLong),
+            Type t when t.IsSameAs(typeof(long)) => asLong,
+            Type t when t.IsSameAs(typeof(ulong)) => unchecked((ulong)asLong),
+            Type t when t.IsSameAs(typeof(nint)) => (nint)asLong,
+            Type t when t.IsSameAs(typeof(nuint)) => unchecked((nuint)(ulong)asLong),
+            Type t when t.IsSameAs(typeof(float)) => (float)asLong,
+            Type t when t.IsSameAs(typeof(double)) => (double)asLong,
+            Type t when t.IsSameAs(typeof(char)) => unchecked((char)asLong),
             _ => Convert.ChangeType(value, to, System.Globalization.CultureInfo.InvariantCulture),
         };
     }

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncMethodBuilderInfo.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncMethodBuilderInfo.cs
@@ -212,7 +212,7 @@ public sealed class AsyncMethodBuilderInfo
 
         // 2. async void / async Task / async Task<T> / async ValueTask*
         //    / async IAsyncEnumerable<T> / async IAsyncEnumerator<T>.
-        if (kickoffReturnClrType == typeof(void) || kickoffReturnClrType.FullName == "System.Void")
+        if (kickoffReturnClrType.IsSameAs(typeof(void)))
         {
             var builder = CoreType("System.Runtime.CompilerServices.AsyncVoidMethodBuilder");
             return (AsyncMethodBuilderKind.Void, builder, typeof(void));
@@ -240,7 +240,7 @@ public sealed class AsyncMethodBuilderInfo
         // 3. Custom task-like via [AsyncMethodBuilder] on the return type.
         // ADR-0047 §6: recognised by type identity, not string name.
         var attributeType = kickoffReturnClrType.GetCustomAttributesData()
-            .FirstOrDefault(a => a.AttributeType == typeof(System.Runtime.CompilerServices.AsyncMethodBuilderAttribute));
+            .FirstOrDefault(a => a.AttributeType.IsSameAs(typeof(System.Runtime.CompilerServices.AsyncMethodBuilderAttribute)));
         if (attributeType != null && attributeType.ConstructorArguments.Count == 1)
         {
             var customBuilder = attributeType.ConstructorArguments[0].Value as Type;
@@ -264,7 +264,7 @@ public sealed class AsyncMethodBuilderInfo
 
         if (openOrClosed.IsGenericTypeDefinition)
         {
-            if (resultType == null || resultType == typeof(void))
+            if (resultType == null || resultType.IsSameAs(typeof(void)))
             {
                 return null;
             }
@@ -410,7 +410,7 @@ public sealed class AsyncMethodBuilderInfo
         // SetResult: no-arg for void / Task, single-arg for generic.
         MethodInfo setResult;
         if (kind == AsyncMethodBuilderKind.GenericTask
-            || (kind == AsyncMethodBuilderKind.Custom && resultType != null && resultType != typeof(void)))
+            || (kind == AsyncMethodBuilderKind.Custom && resultType != null && !resultType.IsSameAs(typeof(void))))
         {
             setResult = MemberLookup.SafeGetMethodIncludingSelfAndInterfaces(
                 builderType, "SetResult", new[] { resultType });

--- a/src/Core/CodeAnalysis/Lowering/Async/AwaitableShape.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AwaitableShape.cs
@@ -6,6 +6,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Lowering.Async;
 
@@ -93,7 +94,7 @@ public sealed class AwaitableShape
             "GetAwaiter",
             Type.EmptyTypes);
 
-        if (getAwaiter == null || getAwaiter.ReturnType == null || getAwaiter.ReturnType == typeof(void))
+        if (getAwaiter == null || getAwaiter.ReturnType == null || getAwaiter.ReturnType.IsSameAs(typeof(void)))
         {
             return null;
         }

--- a/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
@@ -100,7 +100,7 @@ public static class MoveNextBodyRewriter
             allLocals.Add(cachedStateLocal);
 
             var builderInfo = plan.StateMachine.BuilderInfo;
-            if (builderInfo.ResultType != null && builderInfo.ResultType != typeof(void))
+            if (builderInfo.ResultType != null && !builderInfo.ResultType.IsSameAs(typeof(void)))
             {
                 var resultType = plan.StateMachine.ResultTypeSymbol ?? TypeSymbol.FromClrType(builderInfo.ResultType);
                 this.retValLocal = new LocalVariableSymbol(
@@ -785,7 +785,7 @@ public static class MoveNextBodyRewriter
                     resultType,
                     ImmutableArray<BoundExpression>.Empty);
 
-                bool hasResult = resultType != TypeSymbol.Void && resultType.ClrType != typeof(void);
+                bool hasResult = resultType != TypeSymbol.Void && !resultType.ClrType.IsSameAs(typeof(void));
 
                 if (resultTarget != null && hasResult)
                 {

--- a/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
@@ -467,7 +467,7 @@ internal sealed class InterpolatedStringHandlerLowerer : BoundTreeRewriter
         LocalVariableSymbol continueLocal,
         ImmutableArray<BoundStatement> holeLeading = default)
     {
-        var returnsBool = appendCall.Type?.ClrType == typeof(bool);
+        var returnsBool = appendCall.Type?.ClrType.IsSameAs(typeof(bool)) == true;
         var leading = holeLeading.IsDefault ? ImmutableArray<BoundStatement>.Empty : holeLeading;
 
         if (continueLocal == null)
@@ -550,13 +550,13 @@ internal sealed class InterpolatedStringHandlerLowerer : BoundTreeRewriter
             var idx = 1;
             if (wantAlign)
             {
-                ok = ps[idx].ParameterType == typeof(int);
+                ok = ps[idx].ParameterType.IsSameAs(typeof(int));
                 idx++;
             }
 
             if (ok && wantFormat)
             {
-                ok = ps[idx].ParameterType == typeof(string);
+                ok = ps[idx].ParameterType.IsSameAs(typeof(string));
             }
 
             if (ok)
@@ -682,14 +682,14 @@ internal sealed class InterpolatedStringHandlerLowerer : BoundTreeRewriter
 
     private static bool AppendsReturnBool(System.Type handlerType, MethodInfo appendLiteral)
     {
-        if (appendLiteral.ReturnType == typeof(bool))
+        if (appendLiteral.ReturnType.IsSameAs(typeof(bool)))
         {
             return true;
         }
 
         foreach (var method in handlerType.GetMethods(BindingFlags.Public | BindingFlags.Instance))
         {
-            if (method.Name == "AppendFormatted" && method.ReturnType == typeof(bool))
+            if (method.Name == "AppendFormatted" && method.ReturnType.IsSameAs(typeof(bool)))
             {
                 return true;
             }

--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
@@ -598,7 +598,7 @@ public static class AsyncIteratorMoveNextBodyBuilder
                     resultType,
                     ImmutableArray<BoundExpression>.Empty);
 
-                bool hasResult = resultType != TypeSymbol.Void && resultType.ClrType != typeof(void);
+                bool hasResult = resultType != TypeSymbol.Void && !resultType.ClrType.IsSameAs(typeof(void));
 
                 if (resultTarget != null && hasResult)
                 {

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -877,7 +877,7 @@ public sealed class Lowerer : BoundTreeRewriter
                 binder: null,
                 types: System.Type.EmptyTypes,
                 modifiers: null);
-            if (ownDispose != null && ownDispose.ReturnType == typeof(void))
+            if (ownDispose != null && ownDispose.ReturnType.IsSameAs(typeof(void)))
             {
                 disposeMethod = ownDispose;
             }

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -44,14 +44,30 @@ internal static class ClrTypeUtilities
     /// <param name="a">First type.</param>
     /// <param name="b">Second type.</param>
     /// <returns><c>true</c> when both types are non-null and denote the same logical CLR type.</returns>
-    public static bool AreSame(Type a, Type b)
+    public static bool AreSame(Type a, Type b) => IsSameAs(a, b);
+
+    /// <summary>
+    /// Extension-method companion to <see cref="AreSame(Type, Type)"/>. Reads more
+    /// naturally at call sites that historically used
+    /// <c>clrType == typeof(SomeType)</c> reference-identity comparisons —
+    /// issue #835 — and prevents the silent feature drops that occur when the
+    /// left-hand <see cref="Type"/> was materialised through a
+    /// <see cref="System.Reflection.MetadataLoadContext"/> rather than the host
+    /// process's <c>typeof()</c>.
+    /// </summary>
+    /// <param name="self">The candidate type, typically a CLR type extracted
+    /// from imported metadata. May be <c>null</c>.</param>
+    /// <param name="other">The expected canonical type, typically a host
+    /// <c>typeof(...)</c> literal.</param>
+    /// <returns><c>true</c> when both types denote the same logical CLR type.</returns>
+    public static bool IsSameAs(this Type self, Type other)
     {
-        if (a is null || b is null)
+        if (self is null || other is null)
         {
             return false;
         }
 
-        if (ReferenceEquals(a, b))
+        if (ReferenceEquals(self, other))
         {
             return true;
         }
@@ -60,20 +76,20 @@ internal static class ClrTypeUtilities
         // embeds the element's assembly-qualified name when the element is
         // itself a constructed generic, so arrays of cross-context generics
         // require structural comparison.
-        if (a.IsArray && b.IsArray)
+        if (self.IsArray && other.IsArray)
         {
-            return a.GetArrayRank() == b.GetArrayRank()
-                && AreSame(a.GetElementType(), b.GetElementType());
+            return self.GetArrayRank() == other.GetArrayRank()
+                && IsSameAs(self.GetElementType(), other.GetElementType());
         }
 
-        if (a.IsByRef && b.IsByRef)
+        if (self.IsByRef && other.IsByRef)
         {
-            return AreSame(a.GetElementType(), b.GetElementType());
+            return IsSameAs(self.GetElementType(), other.GetElementType());
         }
 
-        if (a.IsPointer && b.IsPointer)
+        if (self.IsPointer && other.IsPointer)
         {
-            return AreSame(a.GetElementType(), b.GetElementType());
+            return IsSameAs(self.GetElementType(), other.GetElementType());
         }
 
         // Constructed (closed) generics: compare the open definition's
@@ -82,19 +98,19 @@ internal static class ClrTypeUtilities
         // is the cross-reflection-context fix that closes issue #504-reopen
         // for `Nullable<T>` and applies equally to any other constructed
         // generic with a leaf-FullName-matchable type argument.
-        if (a.IsGenericType && b.IsGenericType
-            && !a.IsGenericTypeDefinition && !b.IsGenericTypeDefinition)
+        if (self.IsGenericType && other.IsGenericType
+            && !self.IsGenericTypeDefinition && !other.IsGenericTypeDefinition)
         {
             if (!string.Equals(
-                    a.GetGenericTypeDefinition().FullName,
-                    b.GetGenericTypeDefinition().FullName,
+                    self.GetGenericTypeDefinition().FullName,
+                    other.GetGenericTypeDefinition().FullName,
                     StringComparison.Ordinal))
             {
                 return false;
             }
 
-            var aArgs = a.GetGenericArguments();
-            var bArgs = b.GetGenericArguments();
+            var aArgs = self.GetGenericArguments();
+            var bArgs = other.GetGenericArguments();
             if (aArgs.Length != bArgs.Length)
             {
                 return false;
@@ -102,7 +118,7 @@ internal static class ClrTypeUtilities
 
             for (var i = 0; i < aArgs.Length; i++)
             {
-                if (!AreSame(aArgs[i], bArgs[i]))
+                if (!IsSameAs(aArgs[i], bArgs[i]))
                 {
                     return false;
                 }
@@ -111,7 +127,7 @@ internal static class ClrTypeUtilities
             return true;
         }
 
-        return string.Equals(a.FullName, b.FullName, StringComparison.Ordinal);
+        return string.Equals(self.FullName, other.FullName, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
+++ b/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
@@ -551,7 +551,7 @@ public static class SymbolDisplay
 
         builder.Punctuation(")");
 
-        if (method.ReturnType != typeof(void))
+        if (!method.ReturnType.IsSameAs(typeof(void)))
         {
             builder.Space();
             builder.Type(FormatClrTypeName(method.ReturnType, format.QualifyNames));
@@ -586,7 +586,7 @@ public static class SymbolDisplay
             return "void";
         }
 
-        if (clrType == typeof(void))
+        if (clrType.IsSameAs(typeof(void)))
         {
             return "void";
         }
@@ -636,103 +636,103 @@ public static class SymbolDisplay
 
     private static bool TryGetGSharpPrimitiveName(Type clrType, out string name)
     {
-        if (clrType == typeof(bool))
+        if (clrType.IsSameAs(typeof(bool)))
         {
             name = "bool";
             return true;
         }
 
-        if (clrType == typeof(byte))
+        if (clrType.IsSameAs(typeof(byte)))
         {
             name = "uint8";
             return true;
         }
 
-        if (clrType == typeof(sbyte))
+        if (clrType.IsSameAs(typeof(sbyte)))
         {
             name = "int8";
             return true;
         }
 
-        if (clrType == typeof(short))
+        if (clrType.IsSameAs(typeof(short)))
         {
             name = "int16";
             return true;
         }
 
-        if (clrType == typeof(ushort))
+        if (clrType.IsSameAs(typeof(ushort)))
         {
             name = "uint16";
             return true;
         }
 
-        if (clrType == typeof(int))
+        if (clrType.IsSameAs(typeof(int)))
         {
             name = "int32";
             return true;
         }
 
-        if (clrType == typeof(uint))
+        if (clrType.IsSameAs(typeof(uint)))
         {
             name = "uint32";
             return true;
         }
 
-        if (clrType == typeof(long))
+        if (clrType.IsSameAs(typeof(long)))
         {
             name = "int64";
             return true;
         }
 
-        if (clrType == typeof(ulong))
+        if (clrType.IsSameAs(typeof(ulong)))
         {
             name = "uint64";
             return true;
         }
 
-        if (clrType == typeof(nint))
+        if (clrType.IsSameAs(typeof(nint)))
         {
             name = "nint";
             return true;
         }
 
-        if (clrType == typeof(nuint))
+        if (clrType.IsSameAs(typeof(nuint)))
         {
             name = "nuint";
             return true;
         }
 
-        if (clrType == typeof(float))
+        if (clrType.IsSameAs(typeof(float)))
         {
             name = "float32";
             return true;
         }
 
-        if (clrType == typeof(double))
+        if (clrType.IsSameAs(typeof(double)))
         {
             name = "float64";
             return true;
         }
 
-        if (clrType == typeof(decimal))
+        if (clrType.IsSameAs(typeof(decimal)))
         {
             name = "decimal";
             return true;
         }
 
-        if (clrType == typeof(char))
+        if (clrType.IsSameAs(typeof(char)))
         {
             name = "char";
             return true;
         }
 
-        if (clrType == typeof(string))
+        if (clrType.IsSameAs(typeof(string)))
         {
             name = "string";
             return true;
         }
 
-        if (clrType == typeof(object))
+        if (clrType.IsSameAs(typeof(object)))
         {
             name = "object";
             return true;

--- a/src/LanguageServer/SemanticLookup.cs
+++ b/src/LanguageServer/SemanticLookup.cs
@@ -756,7 +756,7 @@ public static class SemanticLookup
     private static bool IsDefaultImmutableArray(object value)
     {
         var type = value.GetType();
-        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(System.Collections.Immutable.ImmutableArray<>))
+        if (type.IsGenericType && type.GetGenericTypeDefinition().IsSameAs(typeof(System.Collections.Immutable.ImmutableArray<>)))
         {
             var isDefault = type.GetProperty("IsDefault");
             return isDefault != null && (bool)isDefault.GetValue(value)!;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue835MlcAttributeRecognitionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue835MlcAttributeRecognitionTests.cs
@@ -1,0 +1,177 @@
+// <copyright file="Issue835MlcAttributeRecognitionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests for issue #835: when the BuildTask drives gsc, well-known
+/// attribute types (Obsolete, DllImport, StructLayout, …) flow through a
+/// <see cref="System.Reflection.MetadataLoadContext"/>. The MLC's
+/// <see cref="System.Type"/> instances are <em>not</em> reference-equal to the
+/// host process's <c>typeof()</c> literals, so any recogniser that used
+/// <c>clrType == typeof(X)</c> would silently report <c>false</c> and silently
+/// drop the attribute on the BuildTask path. The recognisers must compare by
+/// <see cref="System.Type.FullName"/> instead (via
+/// <see cref="ClrTypeUtilities.IsSameAs"/>).
+/// </summary>
+public class Issue835MlcAttributeRecognitionTests
+{
+    /// <summary>
+    /// Build a <see cref="ReferenceResolver"/> rooted at the BCL reference
+    /// assemblies. Supplying explicit paths forces gsc into the
+    /// <see cref="System.Reflection.MetadataLoadContext"/> resolution path,
+    /// reproducing the BuildTask scenario inside the unit-test process.
+    /// </summary>
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+            typeof(System.Runtime.InteropServices.DllImportAttribute).Assembly.Location,
+            typeof(System.Runtime.InteropServices.StructLayoutAttribute).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+            typeof(System.Linq.Enumerable).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    private static BoundGlobalScope BindWithMlc(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), MetadataLoadContextResolver());
+    }
+
+    [Fact]
+    public void Obsolete_From_Mlc_Is_Recognised()
+    {
+        var source = """
+            package P
+            import System
+
+            @Obsolete("use Bar instead")
+            func Helper() {
+            }
+            """;
+
+        var globalScope = BindWithMlc(source);
+        var helper = globalScope.Functions.Single(f => f.Name == "Helper");
+        var attr = Assert.Single(helper.Attributes);
+
+        // ClrType must come from the MLC (different reflection context than
+        // typeof(System.ObsoleteAttribute) in the test host).
+        Assert.NotNull(attr.AttributeType?.ClrType);
+        Assert.NotSame(typeof(System.ObsoleteAttribute), attr.AttributeType.ClrType);
+        Assert.Equal("System.ObsoleteAttribute", attr.AttributeType.ClrType.FullName);
+
+        // The whole point of #835: the recogniser must return true regardless
+        // of which reflection context produced the Type instance.
+        Assert.True(KnownAttributes.IsObsolete(attr));
+        Assert.True(KnownAttributes.TryGetObsolete(helper.Attributes, out var message, out var isError));
+        Assert.Equal("use Bar instead", message);
+        Assert.False(isError);
+    }
+
+    [Fact]
+    public void DllImport_From_Mlc_Is_Recognised()
+    {
+        var source = """
+            package P
+            import System.Runtime.InteropServices
+
+            @DllImport("kernel32.dll")
+            func GetTickCount() uint32;
+            """;
+
+        var globalScope = BindWithMlc(source);
+        var fn = globalScope.Functions.Single(f => f.Name == "GetTickCount");
+        var attr = Assert.Single(fn.Attributes);
+
+        Assert.NotNull(attr.AttributeType?.ClrType);
+        Assert.NotSame(typeof(System.Runtime.InteropServices.DllImportAttribute), attr.AttributeType.ClrType);
+        Assert.Equal(
+            "System.Runtime.InteropServices.DllImportAttribute",
+            attr.AttributeType.ClrType.FullName);
+
+        // Recogniser must fire on the MLC-loaded type.
+        Assert.True(KnownAttributes.IsDllImport(attr));
+        Assert.NotNull(KnownAttributes.FindDllImport(fn.Attributes));
+    }
+
+    [Fact]
+    public void StructLayout_From_Mlc_Is_Recognised()
+    {
+        var source = """
+            package P
+            import System.Runtime.InteropServices
+
+            @StructLayout(LayoutKind.Sequential)
+            struct Point {
+                var X int32
+                var Y int32
+            }
+            """;
+
+        var globalScope = BindWithMlc(source);
+        var point = globalScope.Structs.Single(s => s.Name == "Point");
+        var attr = Assert.Single(point.Attributes);
+
+        Assert.NotNull(attr.AttributeType?.ClrType);
+        Assert.NotSame(typeof(System.Runtime.InteropServices.StructLayoutAttribute), attr.AttributeType.ClrType);
+        Assert.Equal(
+            "System.Runtime.InteropServices.StructLayoutAttribute",
+            attr.AttributeType.ClrType.FullName);
+
+        // Recogniser must fire on the MLC-loaded type. If it did not, the
+        // emitter would write StructLayout as a plain CustomAttribute row
+        // instead of encoding it into the TypeDef's pseudo-custom flags.
+        Assert.True(KnownAttributes.IsStructLayout(attr));
+        Assert.NotNull(KnownAttributes.FindStructLayout(point.Attributes));
+    }
+
+    [Fact]
+    public void Sanity_Identity_Compare_Against_Mlc_Type_Is_False()
+    {
+        // Demonstrates *why* #835 matters: a raw `clrType == typeof(X)` check
+        // against an MLC-loaded type is always false even when the FullNames
+        // match. The KnownAttributes recognisers must therefore key off
+        // FullName (via ClrTypeUtilities.IsSameAs) rather than identity.
+        var source = """
+            package P
+            import System
+
+            @Obsolete
+            func Helper() {
+            }
+            """;
+
+        var globalScope = BindWithMlc(source);
+        var helper = globalScope.Functions.Single(f => f.Name == "Helper");
+        var attr = Assert.Single(helper.Attributes);
+
+        var clr = attr.AttributeType.ClrType;
+        Assert.NotNull(clr);
+
+        // Identity compare to the host typeof(...) — *must* be false because
+        // the MLC produces a distinct Type instance.
+        Assert.False(clr == typeof(System.ObsoleteAttribute));
+
+        // FullName-based compare — must be true. This is what
+        // ClrTypeUtilities.IsSameAs implements.
+        Assert.True(ClrTypeUtilities.IsSameAs(clr, typeof(System.ObsoleteAttribute)));
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Issue835TypeofIdentityRegressionGuardTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Issue835TypeofIdentityRegressionGuardTests.cs
@@ -1,0 +1,307 @@
+// <copyright file="Issue835TypeofIdentityRegressionGuardTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #835 regression guard. Scans every compiler / language-server source
+/// file for the forbidden reference-identity pattern
+/// <c>clrType == typeof(X)</c> / <c>clrType != typeof(X)</c>. Any such usage
+/// silently regresses on the BuildTask path, where compiler-consumed
+/// <see cref="System.Type"/> instances are loaded through a
+/// <see cref="System.Reflection.MetadataLoadContext"/> and therefore are
+/// <em>never</em> reference-equal to the host process's <c>typeof()</c>
+/// literals. New occurrences must use
+/// <see cref="GSharp.Core.CodeAnalysis.Symbols.ClrTypeUtilities.IsSameAs(System.Type, System.Type)"/>
+/// (or another structural / FullName-based check) instead.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The guard intentionally errs on the side of being noisy: it flags *every*
+/// surviving <c>== typeof(</c> / <c>!= typeof(</c> in source-position code,
+/// even ones that today are reachable only from the gsc interpreter and would
+/// never see an MLC type. Migrating those keeps the codebase consistent and
+/// removes the trap for future contributors who reuse an existing helper from
+/// the BuildTask path.
+/// </para>
+/// <para>
+/// Doc-comment / string-literal occurrences are ignored. If a genuinely
+/// legitimate reference-identity comparison is added in the future, it must
+/// be appended to <see cref="ExpectedAllowedSites"/> with an inline
+/// justification.
+/// </para>
+/// </remarks>
+public class Issue835TypeofIdentityRegressionGuardTests
+{
+    /// <summary>
+    /// Allow-list of <c>(relative path, lineNumber, justification)</c> tuples
+    /// for legitimate reference-identity comparisons. Empty after issue #835
+    /// — every prior occurrence migrated to <c>IsSameAs</c>.
+    /// </summary>
+    private static readonly (string RelativePath, int Line)[] ExpectedAllowedSites = Array.Empty<(string, int)>();
+
+    private static readonly string[] ScannedRoots = new[]
+    {
+        "src/Core",
+        "src/Compiler",
+        "src/LanguageServer",
+        "src/Sdk",
+    };
+
+    // Matches forbidden reference-identity comparisons against typeof(...) in
+    // *code* position. The pattern is intentionally tight: it requires whitespace
+    // immediately before == / != to avoid matching inside identifiers (e.g.
+    // an imaginary `foo==typeof` would still trip, since `==` is always
+    // surrounded by either whitespace or operators), and it does not match the
+    // textual sequence inside a `// ...` line comment, `/// ...` doc comment,
+    // or a string / verbatim / interpolated literal — those are stripped by
+    // <see cref="StripCommentsAndStrings"/> below before the regex runs.
+    //
+    // A `typeof(X).FullName` / `.Name` / `.AssemblyQualifiedName` projection
+    // followed by `==` / `!=` is a safe string-comparison idiom and is NOT
+    // flagged (negative lookahead in the right-hand branch).
+    private static readonly Regex ForbiddenPattern = new(
+        @"(==|!=)\s*typeof\s*\([^)]*\)\s*(?![.\w])|typeof\s*\([^)]*\)(?!\s*\.(?:FullName|Name|AssemblyQualifiedName|Namespace|IsGenericTypeDefinition|GetTypeInfo))\s*(==|!=)",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void No_ReferenceIdentity_TypeofComparisons_In_Compiler_Sources()
+    {
+        var repoRoot = LocateRepoRoot();
+        var offenders = new List<(string RelativePath, int Line, string Code)>();
+
+        foreach (var root in ScannedRoots)
+        {
+            var rootDir = Path.Combine(repoRoot, root);
+            if (!Directory.Exists(rootDir))
+            {
+                continue;
+            }
+
+            foreach (var file in Directory.EnumerateFiles(rootDir, "*.cs", SearchOption.AllDirectories))
+            {
+                if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                    || file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var relative = Path.GetRelativePath(repoRoot, file).Replace('\\', '/');
+                var lines = File.ReadAllLines(file);
+                for (var i = 0; i < lines.Length; i++)
+                {
+                    var stripped = StripCommentsAndStrings(lines[i]);
+                    if (ForbiddenPattern.IsMatch(stripped))
+                    {
+                        offenders.Add((relative, i + 1, lines[i].Trim()));
+                    }
+                }
+            }
+        }
+
+        // Apply allow-list.
+        var allowed = ExpectedAllowedSites.ToHashSet();
+        var actualOffenders = offenders
+            .Where(o => !allowed.Contains((o.RelativePath, o.Line)))
+            .ToList();
+
+        // Detect a stale allow-list entry: an entry that no longer matches
+        // anything. Stale entries silently weaken the guard.
+        var realLocations = offenders.Select(o => (o.RelativePath, o.Line)).ToHashSet();
+        var stale = allowed.Where(a => !realLocations.Contains(a)).ToList();
+
+        if (actualOffenders.Count > 0)
+        {
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine($"Issue #835 regression: found {actualOffenders.Count} reference-identity typeof comparison(s) in compiler source.");
+            sb.AppendLine("Each silently regresses functionality on the BuildTask (MetadataLoadContext) path.");
+            sb.AppendLine("Replace with `clrType.IsSameAs(typeof(X))` (ClrTypeUtilities) or another FullName-based check.");
+            sb.AppendLine();
+            foreach (var o in actualOffenders)
+            {
+                sb.AppendLine($"  {o.RelativePath}:{o.Line}  {o.Code}");
+            }
+
+            Assert.Fail(sb.ToString());
+        }
+
+        if (stale.Count > 0)
+        {
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine("Stale entries in ExpectedAllowedSites — these no longer match any source line:");
+            foreach (var s in stale)
+            {
+                sb.AppendLine($"  {s.RelativePath}:{s.Line}");
+            }
+
+            Assert.Fail(sb.ToString());
+        }
+    }
+
+    [Fact]
+    public void Helper_StripCommentsAndStrings_Strips_LineComments()
+    {
+        Assert.Equal("x = 1 ", StripCommentsAndStrings("x = 1 // x == typeof(int)"));
+        Assert.Equal("x = 1 ", StripCommentsAndStrings("x = 1 /// x == typeof(int)"));
+    }
+
+    [Fact]
+    public void Helper_StripCommentsAndStrings_Strips_StringLiterals()
+    {
+        Assert.Equal("var s =  + foo", StripCommentsAndStrings("var s = \"x == typeof(int)\" + foo"));
+        Assert.Equal("var s =  + foo", StripCommentsAndStrings("var s = @\"x == typeof(int)\" + foo"));
+    }
+
+    [Fact]
+    public void Helper_ForbiddenPattern_Matches_RawIdentity()
+    {
+        Assert.Matches(ForbiddenPattern, "if (clrType == typeof(int))");
+        Assert.Matches(ForbiddenPattern, "return clrType != typeof(int);");
+        Assert.Matches(ForbiddenPattern, "typeof(int) == clrType");
+        Assert.Matches(ForbiddenPattern, "typeof(int) != clrType");
+        Assert.DoesNotMatch(ForbiddenPattern, "if (clrType.IsSameAs(typeof(int)))");
+        Assert.DoesNotMatch(ForbiddenPattern, "var t = typeof(int);");
+
+        // Safe string-projection comparisons must NOT trip the guard.
+        Assert.DoesNotMatch(ForbiddenPattern, "if (clrType?.FullName == typeof(int).FullName)");
+        Assert.DoesNotMatch(ForbiddenPattern, "if (clrType?.FullName != typeof(int).FullName)");
+        Assert.DoesNotMatch(ForbiddenPattern, "if (typeof(int).FullName == clrType?.FullName)");
+        Assert.DoesNotMatch(ForbiddenPattern, "if (typeof(int).Name == clrType?.Name)");
+    }
+
+    /// <summary>
+    /// Strips C# line comments (<c>//</c> and <c>///</c>) and removes the
+    /// contents of string / verbatim-string / interpolated-string literals.
+    /// Block comments (<c>/* ... */</c>) are not stripped — the guard does not
+    /// see them often and conservatively letting them through risks at most
+    /// false positives, which are easy to fix.
+    /// </summary>
+    private static string StripCommentsAndStrings(string line)
+    {
+        var sb = new System.Text.StringBuilder(line.Length);
+        var i = 0;
+        while (i < line.Length)
+        {
+            // Line comment swallows the rest.
+            if (i + 1 < line.Length && line[i] == '/' && line[i + 1] == '/')
+            {
+                break;
+            }
+
+            // Verbatim or interpolated-verbatim string literal: @"..." or $@"..." / @$"...".
+            var isVerbatim = i < line.Length && line[i] == '@'
+                ? (i + 1 < line.Length && line[i + 1] == '"')
+                : (i + 1 < line.Length && line[i] == '$' && line[i + 1] == '@' && i + 2 < line.Length && line[i + 2] == '"');
+            if (isVerbatim)
+            {
+                // Advance past the prefix to the opening quote.
+                while (i < line.Length && line[i] != '"')
+                {
+                    i++;
+                }
+
+                i++; // skip opening "
+                while (i < line.Length)
+                {
+                    if (line[i] == '"' && i + 1 < line.Length && line[i + 1] == '"')
+                    {
+                        i += 2; // escaped quote in verbatim string
+                        continue;
+                    }
+
+                    if (line[i] == '"')
+                    {
+                        i++; // closing "
+                        break;
+                    }
+
+                    i++;
+                }
+
+                continue;
+            }
+
+            // Regular string literal: "..." (with \" escapes). Also handles
+            // interpolated $"..." identically — we don't need to evaluate the
+            // interpolated expressions, just skip the literal range.
+            var isRegularString = line[i] == '"'
+                || (i + 1 < line.Length && line[i] == '$' && line[i + 1] == '"');
+            if (isRegularString)
+            {
+                while (i < line.Length && line[i] != '"')
+                {
+                    i++;
+                }
+
+                i++; // skip opening "
+                while (i < line.Length)
+                {
+                    if (line[i] == '\\' && i + 1 < line.Length)
+                    {
+                        i += 2;
+                        continue;
+                    }
+
+                    if (line[i] == '"')
+                    {
+                        i++; // closing "
+                        break;
+                    }
+
+                    i++;
+                }
+
+                continue;
+            }
+
+            // Character literal: '...'
+            if (line[i] == '\'')
+            {
+                i++;
+                while (i < line.Length)
+                {
+                    if (line[i] == '\\' && i + 1 < line.Length)
+                    {
+                        i += 2;
+                        continue;
+                    }
+
+                    if (line[i] == '\'')
+                    {
+                        i++;
+                        break;
+                    }
+
+                    i++;
+                }
+
+                continue;
+            }
+
+            sb.Append(line[i]);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "GSharp.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+        return dir.FullName;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #835. Many compiler call-sites compared a CLR `Type` instance against `typeof(X)` by **reference identity** to decide whether the type is a known well-known type (e.g. `IEnumerable<>`, `MethodImplAttribute`, `DllImportAttribute`, `ObsoleteAttribute`, `StructLayoutAttribute`, ...). These comparisons silently fail when the type was loaded via `System.Reflection.MetadataLoadContext` — the same MLC the BuildTask uses — because MLC `Type` instances are **not** reference-equal to the host process's `typeof()` instances. PR #806 fixed five such sites; many remained, causing functionality to silently regress on the BuildTask path while continuing to work on the gsc / Interpreter host.

## Audit findings

- Initial grep for `== typeof` / `typeof(...) ==` across `src/Core`, `src/Compiler`, `src/Sdk`, `src/LanguageServer` surfaced **~200 occurrences**.
- All occurrences fell into a single category — "comparisons that should use a structural/FullName-based check". **No legitimate reference-identity sites** were found.
- All ~200 sites migrated. Files touched (28 source files + 2 new test files):
  - Binding: `Binder`, `KnownAttributes`, `ExpressionBinder` (+ `.Calls`), `Conversion`, `LambdaBinder`, `MemberLookup`, `DeclarationBinder`
  - Lowering: `Lowerer`, `InterpolatedStringHandlerLowerer`, `AsyncMethodBuilderInfo`, `AwaitableShape`, `MoveNextBodyRewriter`, `AsyncIteratorMoveNextBodyBuilder`
  - Emit: `ReflectionMetadataEmitter`, `MethodBodyEmitter` (+ `.Calls`, `.Conversions`, `.MemberAccess`, `.Patterns`), `CustomAttributeEncoder`, `ConversionEmitter`, `StateMachineEmitter`
  - Misc: `BuiltinFunctions`, `Evaluator`, `Symbols/Display/SymbolDisplay`, `Symbols/ClrTypeUtilities`
  - Language server: `LanguageServer/SemanticLookup`

## Fix

Introduce `ClrTypeUtilities.IsSameAs(this Type, Type)` extension method that delegates to the existing structural / FullName-based comparison logic already used by `ClrTypeUtilities.AreSame` (handles closed generics, arrays, byref, pointers, and nulls). Every `clrType == typeof(X)` site becomes `clrType.IsSameAs(typeof(X))`. `KnownAttributes`'s `HashSet<Type>` of reserved-for-compiler attribute types becomes a `HashSet<string>` of `FullName`s. The few sites that benefit from a `bool?` result use `clrType?.IsSameAs(typeof(X)) == true` / `!= true` to keep null-propagation semantics intact.

## Regression guard

`test/Core.Tests/CodeAnalysis/Issue835TypeofIdentityRegressionGuardTests.cs` scans every `.cs` file under `src/Core`, `src/Compiler`, `src/LanguageServer`, `src/Sdk` (with comments and string literals stripped) and **fails the build** if any new `clrType == typeof(X)` / `typeof(X) == clrType` pattern is introduced. `typeof(X).FullName` / `.Name` / `.AssemblyQualifiedName` string projections are explicitly *not* flagged (those are safe). Includes self-tests for the comment/string stripper and the regex, plus an allow-list mechanism (currently empty) for the rare legitimate case.

The guard was verified manually: temporarily reverting one fix made both the guard test *and* the new `Obsolete_From_Mlc_Is_Recognised` test fail; restoring the fix made them pass again.

## New MLC binder tests

`test/Core.Tests/CodeAnalysis/Binding/Issue835MlcAttributeRecognitionTests.cs` adds four tests that drive the binder through a fully MLC-backed reference resolver and confirm:
- `Obsolete_From_Mlc_Is_Recognised`
- `DllImport_From_Mlc_Is_Recognised`
- `StructLayout_From_Mlc_Is_Recognised`
- `Sanity_Identity_Compare_Against_Mlc_Type_Is_False` (directly demonstrates that `clrType == typeof(X)` returns false for an MLC-loaded type, while `clrType.IsSameAs(typeof(X))` returns true)

## Verification

- `dotnet build GSharp.sln`: clean (0 warnings, 0 errors).
- `dotnet test GSharp.sln --no-restore --nologo`: all suites green.
  - Core: 3287 passed / 1 skipped
  - Compiler: 1337 passed
  - Interpreter: 305 passed
  - LanguageServer: 266 passed
  - Extensions: 104 passed
  - Sdk: 32 passed
- `cd website && npm ci && npm run build`: succeeds, no broken links.

## Related

Closes #835
Related #806
Parent #706
