### PR TITLE
Add XML doc-comments to Gsharp.Extensions and fix doc generation (#845)

### DIFF
--- a/GSharp.sln
+++ b/GSharp.sln
@@ -52,7 +52,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gsharp.Templates", "src\Sdk
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sdk.Tests", "test\Sdk.Tests\Sdk.Tests.csproj", "{05DB2CB2-6073-434C-BCB3-A2ADECD6B40C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gsharp.Extensions", "src\Sdk\Gsharp.Extensions\Gsharp.Extensions.csproj", "{1C01AECD-4E67-4227-87F2-DA6606B43C85}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gsharp.Extensions", "src\Sdk\Gsharp.Extensions\Gsharp.Extensions.proj", "{1C01AECD-4E67-4227-87F2-DA6606B43C85}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Extensions.Tests", "test\Extensions.Tests\Extensions.Tests.csproj", "{63CB3C22-4C13-48C0-B5A0-E1191DCEF878}"
 EndProject

--- a/docs/adr/0082-gsharp-extensions-go-import.md
+++ b/docs/adr/0082-gsharp-extensions-go-import.md
@@ -85,7 +85,7 @@ implementation detail that mirrors the existing implicit
 `mscorlib` reference (see `Gsharp.NET.Core.Sdk.targets`).
 
 In the in-repo build, the project lives at
-`src/Sdk/Gsharp.Extensions/Gsharp.Extensions.csproj` (next to
+`src/Sdk/Gsharp.Extensions/Gsharp.Extensions.proj` (next to
 `Gsharp.NET.Sdk` and `Gsharp.Templates`) and is added to
 `GSharp.sln` so it builds with the rest of the repo. The
 project targets `net10.0` to match the bundled compiler.

--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -45,7 +45,7 @@ the seed for a longer-running stdlib track, not a hard freeze.
   `Gsharp.NET.Sdk` via the `_ExplicitReference` machinery already
   introduced in ADR-0082. No additional NuGet reference is required.
 - **Authored under `src/Sdk/Gsharp.Extensions/`** as a single
-  `Gsharp.Extensions.csproj`. The dogfooding goal (see "Known
+  `Gsharp.Extensions.proj`. The dogfooding goal (see "Known
   limitations" below) is to author every helper in G# itself; until
   the language gaps documented here are closed, the helpers in this
   ADR are authored in C# inside the same project as a documented
@@ -537,7 +537,7 @@ of that migration, not left behind as dead code.
   ships in idiomatic G#. `Optional.gs`, `Sequences.gs`, and
   `SequenceExtensions.gs` replace the C# escape hatches under
   `src/Sdk/Gsharp.Extensions/Optional/` and
-  `src/Sdk/Gsharp.Extensions/Sequences/`; `Gsharp.Extensions.csproj`
+  `src/Sdk/Gsharp.Extensions/Sequences/`; `Gsharp.Extensions.proj`
   now consumes the `Gsharp.NET.Sdk.Bootstrap` build-time SDK landed
   by #792, so the same `gsc.dll` + `BuildTask` invocation that any
   user `.gsproj` exercises now compiles the stdlib itself. The

--- a/docs/adr/0097-class-struct-new-type-parameter-constraints.md
+++ b/docs/adr/0097-class-struct-new-type-parameter-constraints.md
@@ -243,7 +243,7 @@ to G# once the language gaps closed:
 What remains is **not** a language gap: it is an SDK bootstrap cycle.
 `Gsharp.Extensions.dll` is auto-referenced by every `.gsproj` build via
 `Gsharp.NET.Sdk`, but the SDK itself takes a `ProjectReference` on
-`Gsharp.Extensions.csproj` at pack time (see
+`Gsharp.Extensions.proj` at pack time (see
 `src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj` and the
 `PackGsharpExtensions` target). Re-authoring `Gsharp.Extensions` as a
 `.gsproj` would require the SDK to already exist in order to compile

--- a/src/Core/CodeAnalysis/Syntax/DocumentationAttacher.cs
+++ b/src/Core/CodeAnalysis/Syntax/DocumentationAttacher.cs
@@ -217,6 +217,32 @@ internal static class DocumentationAttacher
                 result.Add(ctor);
             }
         }
+
+        // ADR-0053: members declared inside a `shared { … }` block are still
+        // documentable. The block itself is not a documentable declaration,
+        // but each contained field/property/event/method is.
+        if (structDecl.SharedBlock != null)
+        {
+            foreach (var field in structDecl.SharedBlock.Fields)
+            {
+                result.Add(field);
+            }
+
+            foreach (var prop in structDecl.SharedBlock.Properties)
+            {
+                result.Add(prop);
+            }
+
+            foreach (var evt in structDecl.SharedBlock.Events)
+            {
+                result.Add(evt);
+            }
+
+            foreach (var method in structDecl.SharedBlock.Methods)
+            {
+                result.Add(method);
+            }
+        }
     }
 
     private static void CollectFromEnumBody(EnumDeclarationSyntax enumDecl, List<SyntaxNode> result)

--- a/src/Sdk/Gsharp.Extensions/Go/Go.gs
+++ b/src/Sdk/Gsharp.Extensions/Go/Go.gs
@@ -19,5 +19,17 @@
 
 package Gsharp.Extensions.Go
 
+/// Marker type for the `Gsharp.Extensions.Go` namespace.
+///
+/// The Go-flavored concurrency surface (the `go` statement, `chan T`
+/// type, `<-` send and receive operators, `select` statement,
+/// `close(ch)` built-in, and `make(chan T)` constructor) is
+/// compiler-built-in: the binder gates each form on a per-file
+/// `import Gsharp.Extensions.Go` (ADR-0082 / issue #722). This class
+/// has no instance API and is never intended to be instantiated; it
+/// exists so the namespace round-trips through `System.Type`-based
+/// reference resolution and so the assembly carries at least one
+/// public type for normal publish/reference flows. Channel-related
+/// helpers are layered in by follow-up issues (#723, #724).
 class GoExtensions {
 }

--- a/src/Sdk/Gsharp.Extensions/Gsharp.Extensions.proj
+++ b/src/Sdk/Gsharp.Extensions/Gsharp.Extensions.proj
@@ -50,8 +50,10 @@
 
     <!-- Force the XML doc file under the canonical assembly name (the
          shared build/gsharp.build.props default uses
-         GSharp.$(MSBuildProjectName)). -->
-    <DocumentationFile>$(OutputPath)/$(AssemblyName).xml</DocumentationFile>
+         GSharp.$(MSBuildProjectName)). Written to IntermediateOutputPath
+         so the standard CopyFilesToOutputDirectory step copies it to
+         OutDir alongside the assembly (same convention csc uses). -->
+    <DocumentationFile>$(IntermediateOutputPath)$(AssemblyName).xml</DocumentationFile>
 
     <!-- The bootstrap targets resolve gsc + BuildTask from the in-tree
          out/bin/$(Configuration)/{Compiler,Gsharp.NET.Sdk}/ directories.
@@ -88,7 +90,7 @@
 
   <!-- ProjectReference the in-tree Compiler + Gsharp.NET.Sdk projects so
        MSBuild walks the topology Compiler.csproj → Gsharp.NET.Sdk.csproj
-       → Gsharp.Extensions.csproj when `dotnet build GSharp.sln` is run.
+       → Gsharp.Extensions.proj when `dotnet build GSharp.sln` is run.
        The bootstrap targets resolve gsc.dll + BuildTask.dll from the
        in-tree out/bin/$(Configuration)/{Compiler,Gsharp.NET.Sdk}/
        directories at CoreCompile time; both inputs must exist before
@@ -152,6 +154,11 @@
          resolve our ProjectReference. -->
     <TargetFileName>$(TargetName)$(TargetExt)</TargetFileName>
     <TargetPath>$(OutputPath)$(TargetFileName)</TargetPath>
+
+    <!-- Issue #845: reassert DocumentationFile after all imports have
+         resolved so it uses the correct AssemblyName (Gsharp.Extensions,
+         not GSharp.Gsharp.Extensions from gsharp.build.props). -->
+    <DocumentationFile>$(IntermediateOutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/src/Sdk/Gsharp.Extensions/Optional/Optional.gs
+++ b/src/Sdk/Gsharp.Extensions/Optional/Optional.gs
@@ -41,6 +41,26 @@ import System.Runtime.CompilerServices
 
 // ---- Map ---------------------------------------------------------------
 
+/// Projects the value of a present reference-typed optional through `f`.
+///
+/// When the receiver is `nil`, the projection is skipped and `nil` is
+/// returned; otherwise `f` is invoked on the present value and its
+/// result is returned wrapped as a `U?` optional.
+///
+/// ```gs
+/// let name U? = "Ada"
+/// let length = name.Map(s => s.Length)   // length == 3
+/// let absent U? = nil
+/// let none = absent.Map(s => s.Length)   // none == nil
+/// ```
+///
+/// See also [FlatMap](cref:Gsharp.Extensions.Optional.FlatMap),
+/// [Filter](cref:Gsharp.Extensions.Optional.Filter),
+/// [OrElse](cref:Gsharp.Extensions.Optional.OrElse).
+///
+/// @param f the projection applied to the present value; must not be `nil`.
+/// @returns `f(self)` when the receiver carries a value, otherwise `nil`.
+/// @exception ArgumentNullException `f` is `nil`.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (self T?) Map[T class, U class](f (T) -> U) U? {
     if f == nil {
@@ -54,6 +74,26 @@ func (self T?) Map[T class, U class](f (T) -> U) U? {
     return f(self!!)
 }
 
+/// Projects the value of a present value-typed optional through `f`.
+///
+/// When the receiver has no value, the projection is skipped and `nil`
+/// is returned; otherwise `f` is invoked on the unwrapped value and its
+/// result is returned wrapped as a `U?` optional.
+///
+/// ```gs
+/// let age int32? = 42
+/// let doubled = age.Map(n => n * 2)      // doubled == 84
+/// let absent int32? = nil
+/// let none = absent.Map(n => n * 2)      // none == nil
+/// ```
+///
+/// See also [FlatMap](cref:Gsharp.Extensions.Optional.FlatMap),
+/// [Filter](cref:Gsharp.Extensions.Optional.Filter),
+/// [OrElse](cref:Gsharp.Extensions.Optional.OrElse).
+///
+/// @param f the projection applied to the present value; must not be `nil`.
+/// @returns `f(self.Value)` when the receiver has a value, otherwise `nil`.
+/// @exception ArgumentNullException `f` is `nil`.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (self T?) Map[T struct, U struct](f (T) -> U) U? {
     if f == nil {
@@ -69,6 +109,31 @@ func (self T?) Map[T struct, U struct](f (T) -> U) U? {
 
 // ---- FlatMap -----------------------------------------------------------
 
+/// Projects the value of a present reference-typed optional through an
+/// optional-returning `f` and flattens the nested optional.
+///
+/// Equivalent to `Map` followed by an unwrap of the inner optional:
+/// `f` itself returns `U?`, so the result is `nil` when either the
+/// receiver is absent or `f` produces `nil`.
+///
+/// ```gs
+/// func parse(s string) int32? {
+///     var n int32 = 0
+///     return int32.TryParse(s, out n) ? n : nil
+/// }
+///
+/// let raw string? = "42"
+/// let parsed = raw.FlatMap(parse)        // parsed == 42
+/// let bad   string? = "hello"
+/// let none  = bad.FlatMap(parse)         // none == nil
+/// ```
+///
+/// See also [Map](cref:Gsharp.Extensions.Optional.Map),
+/// [Filter](cref:Gsharp.Extensions.Optional.Filter).
+///
+/// @param f the optional-returning projection; must not be `nil`.
+/// @returns `f(self)` when the receiver carries a value, otherwise `nil`.
+/// @exception ArgumentNullException `f` is `nil`.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (self T?) FlatMap[T class, U class](f (T) -> U?) U? {
     if f == nil {
@@ -82,6 +147,29 @@ func (self T?) FlatMap[T class, U class](f (T) -> U?) U? {
     return f(self!!)
 }
 
+/// Projects the value of a present value-typed optional through an
+/// optional-returning `f` and flattens the nested optional.
+///
+/// Equivalent to `Map` followed by an unwrap of the inner optional:
+/// `f` itself returns `U?`, so the result is `nil` when either the
+/// receiver is absent or `f` produces `nil`.
+///
+/// ```gs
+/// func safeDivide(numerator int32, denominator int32) int32? {
+///     return denominator == 0 ? nil : numerator / denominator
+/// }
+///
+/// let x int32? = 10
+/// let halved = x.FlatMap(n => safeDivide(n, 2))   // halved == 5
+/// let zero   = x.FlatMap(n => safeDivide(n, 0))   // zero == nil
+/// ```
+///
+/// See also [Map](cref:Gsharp.Extensions.Optional.Map),
+/// [Filter](cref:Gsharp.Extensions.Optional.Filter).
+///
+/// @param f the optional-returning projection; must not be `nil`.
+/// @returns `f(self.Value)` when the receiver has a value, otherwise `nil`.
+/// @exception ArgumentNullException `f` is `nil`.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (self T?) FlatMap[T struct, U struct](f (T) -> U?) U? {
     if f == nil {
@@ -97,11 +185,49 @@ func (self T?) FlatMap[T struct, U struct](f (T) -> U?) U? {
 
 // ---- OrElse ------------------------------------------------------------
 
+/// Returns the present reference-typed value, or `defaultValue` if the
+/// receiver is `nil`.
+///
+/// `defaultValue` is evaluated unconditionally at the call site. For a
+/// lazily-computed fallback, prefer
+/// [OrCompute](cref:Gsharp.Extensions.Optional.OrCompute); to surface
+/// an exception instead, use
+/// [OrThrow](cref:Gsharp.Extensions.Optional.OrThrow).
+///
+/// ```gs
+/// let configured string? = lookup("theme")
+/// let theme = configured.OrElse("light")
+/// ```
+///
+/// See also [OrCompute](cref:Gsharp.Extensions.Optional.OrCompute),
+/// [OrThrow](cref:Gsharp.Extensions.Optional.OrThrow).
+///
+/// @param defaultValue the value returned when the receiver is `nil`.
+/// @returns the receiver's value when present, otherwise `defaultValue`.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (self T?) OrElse[T class](defaultValue T) T {
     return self ?: defaultValue
 }
 
+/// Returns the present value-typed value, or `defaultValue` if the
+/// receiver has no value.
+///
+/// `defaultValue` is evaluated unconditionally at the call site. For a
+/// lazily-computed fallback, prefer
+/// [OrCompute](cref:Gsharp.Extensions.Optional.OrCompute); to surface
+/// an exception instead, use
+/// [OrThrow](cref:Gsharp.Extensions.Optional.OrThrow).
+///
+/// ```gs
+/// let port int32? = parsePort(arg)
+/// let bound = port.OrElse(8080)
+/// ```
+///
+/// See also [OrCompute](cref:Gsharp.Extensions.Optional.OrCompute),
+/// [OrThrow](cref:Gsharp.Extensions.Optional.OrThrow).
+///
+/// @param defaultValue the value returned when the receiver has no value.
+/// @returns the receiver's value when present, otherwise `defaultValue`.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (self T?) OrElse[T struct](defaultValue T) T {
     if !self.HasValue {
@@ -113,6 +239,25 @@ func (self T?) OrElse[T struct](defaultValue T) T {
 
 // ---- OrCompute ---------------------------------------------------------
 
+/// Returns the present reference-typed value, or the result of invoking
+/// `defaultFactory` when the receiver is `nil`.
+///
+/// Unlike [OrElse](cref:Gsharp.Extensions.Optional.OrElse), the
+/// fallback is computed lazily — `defaultFactory` is only invoked on
+/// the absent path. Use this when constructing the default is
+/// expensive or has observable side effects.
+///
+/// ```gs
+/// let cached string? = lookupFromCache(key)
+/// let value = cached.OrCompute(() => fetchFromDisk(key))
+/// ```
+///
+/// See also [OrElse](cref:Gsharp.Extensions.Optional.OrElse),
+/// [OrThrow](cref:Gsharp.Extensions.Optional.OrThrow).
+///
+/// @param defaultFactory invoked when the receiver is `nil`; must not be `nil`.
+/// @returns the receiver's value when present, otherwise `defaultFactory()`.
+/// @exception ArgumentNullException `defaultFactory` is `nil`.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (self T?) OrCompute[T class](defaultFactory () -> T) T {
     if defaultFactory == nil {
@@ -126,6 +271,25 @@ func (self T?) OrCompute[T class](defaultFactory () -> T) T {
     return self!!
 }
 
+/// Returns the present value-typed value, or the result of invoking
+/// `defaultFactory` when the receiver has no value.
+///
+/// Unlike [OrElse](cref:Gsharp.Extensions.Optional.OrElse), the
+/// fallback is computed lazily — `defaultFactory` is only invoked on
+/// the absent path. Use this when constructing the default is
+/// expensive or has observable side effects.
+///
+/// ```gs
+/// let cachedAge int32? = lookupAge(id)
+/// let age = cachedAge.OrCompute(() => computeAgeFromBirthdate(id))
+/// ```
+///
+/// See also [OrElse](cref:Gsharp.Extensions.Optional.OrElse),
+/// [OrThrow](cref:Gsharp.Extensions.Optional.OrThrow).
+///
+/// @param defaultFactory invoked when the receiver has no value; must not be `nil`.
+/// @returns the receiver's value when present, otherwise `defaultFactory()`.
+/// @exception ArgumentNullException `defaultFactory` is `nil`.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (self T?) OrCompute[T struct](defaultFactory () -> T) T {
     if defaultFactory == nil {
@@ -141,6 +305,24 @@ func (self T?) OrCompute[T struct](defaultFactory () -> T) T {
 
 // ---- OrThrow (deliberately NOT inlined) --------------------------------
 
+/// Unwraps a present reference-typed optional, or throws an
+/// `InvalidOperationException` with `message` when the receiver is
+/// `nil`.
+///
+/// Intentionally not inlined so the throw site remains in the caller's
+/// stack trace (matches ADR-0084's documented inlining policy).
+///
+/// ```gs
+/// let user User? = currentUser()
+/// let u = user.OrThrow("no user is signed in")
+/// ```
+///
+/// See also [OrElse](cref:Gsharp.Extensions.Optional.OrElse),
+/// [OrCompute](cref:Gsharp.Extensions.Optional.OrCompute).
+///
+/// @param message the exception message used when the receiver is `nil`.
+/// @returns the receiver's value when present.
+/// @exception InvalidOperationException the receiver is `nil`.
 func (self T?) OrThrow[T class](message string) T {
     if self == nil {
         throw InvalidOperationException(message)
@@ -149,6 +331,24 @@ func (self T?) OrThrow[T class](message string) T {
     return self!!
 }
 
+/// Unwraps a present value-typed optional, or throws an
+/// `InvalidOperationException` with `message` when the receiver has no
+/// value.
+///
+/// Intentionally not inlined so the throw site remains in the caller's
+/// stack trace (matches ADR-0084's documented inlining policy).
+///
+/// ```gs
+/// let port int32? = parsePort(arg)
+/// let bound = port.OrThrow("--port must be an integer")
+/// ```
+///
+/// See also [OrElse](cref:Gsharp.Extensions.Optional.OrElse),
+/// [OrCompute](cref:Gsharp.Extensions.Optional.OrCompute).
+///
+/// @param message the exception message used when the receiver has no value.
+/// @returns the receiver's value when present.
+/// @exception InvalidOperationException the receiver has no value.
 func (self T?) OrThrow[T struct](message string) T {
     if !self.HasValue {
         throw InvalidOperationException(message)
@@ -159,6 +359,22 @@ func (self T?) OrThrow[T struct](message string) T {
 
 // ---- IfPresent ---------------------------------------------------------
 
+/// Invokes `action` with the present reference-typed value, or does
+/// nothing when the receiver is `nil`.
+///
+/// Useful for side-effecting callbacks (logging, notifications) where
+/// the absent path should be a silent no-op.
+///
+/// ```gs
+/// let user User? = currentUser()
+/// user.IfPresent(u => log.Info($"signed in as {u.Name}"))
+/// ```
+///
+/// See also [Filter](cref:Gsharp.Extensions.Optional.Filter),
+/// [Map](cref:Gsharp.Extensions.Optional.Map).
+///
+/// @param action the callback to invoke on the present value; must not be `nil`.
+/// @exception ArgumentNullException `action` is `nil`.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (self T?) IfPresent[T class](action (T) -> void) {
     if action == nil {
@@ -170,6 +386,22 @@ func (self T?) IfPresent[T class](action (T) -> void) {
     }
 }
 
+/// Invokes `action` with the present value-typed value, or does
+/// nothing when the receiver has no value.
+///
+/// Useful for side-effecting callbacks (logging, notifications) where
+/// the absent path should be a silent no-op.
+///
+/// ```gs
+/// let port int32? = parsePort(arg)
+/// port.IfPresent(p => log.Info($"listening on {p}"))
+/// ```
+///
+/// See also [Filter](cref:Gsharp.Extensions.Optional.Filter),
+/// [Map](cref:Gsharp.Extensions.Optional.Map).
+///
+/// @param action the callback to invoke on the present value; must not be `nil`.
+/// @exception ArgumentNullException `action` is `nil`.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (self T?) IfPresent[T struct](action (T) -> void) {
     if action == nil {
@@ -183,6 +415,24 @@ func (self T?) IfPresent[T struct](action (T) -> void) {
 
 // ---- Filter ------------------------------------------------------------
 
+/// Returns the receiver unchanged when present and `predicate` accepts
+/// the value, otherwise `nil`.
+///
+/// Combines a presence check with a value-level predicate: an absent
+/// receiver is passed through, a present receiver is kept only when
+/// `predicate` returns `true`.
+///
+/// ```gs
+/// let name string? = readName()
+/// let nonEmpty = name.Filter(s => s.Length > 0)
+/// ```
+///
+/// See also [Map](cref:Gsharp.Extensions.Optional.Map),
+/// [FlatMap](cref:Gsharp.Extensions.Optional.FlatMap).
+///
+/// @param predicate the test applied to the present value; must not be `nil`.
+/// @returns the receiver when present and accepted by `predicate`, otherwise `nil`.
+/// @exception ArgumentNullException `predicate` is `nil`.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (self T?) Filter[T class](predicate (T) -> bool) T? {
     if predicate == nil {
@@ -200,6 +450,24 @@ func (self T?) Filter[T class](predicate (T) -> bool) T? {
     return nil
 }
 
+/// Returns the receiver unchanged when present and `predicate` accepts
+/// the value, otherwise `nil`.
+///
+/// Combines a presence check with a value-level predicate: an absent
+/// receiver is passed through, a present receiver is kept only when
+/// `predicate` returns `true`.
+///
+/// ```gs
+/// let port int32? = parsePort(arg)
+/// let valid = port.Filter(p => p > 0 && p < 65536)
+/// ```
+///
+/// See also [Map](cref:Gsharp.Extensions.Optional.Map),
+/// [FlatMap](cref:Gsharp.Extensions.Optional.FlatMap).
+///
+/// @param predicate the test applied to the present value; must not be `nil`.
+/// @returns the receiver when present and accepted by `predicate`, otherwise `nil`.
+/// @exception ArgumentNullException `predicate` is `nil`.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (self T?) Filter[T struct](predicate (T) -> bool) T? {
     if predicate == nil {

--- a/src/Sdk/Gsharp.Extensions/Sequences/SequenceExtensions.gs
+++ b/src/Sdk/Gsharp.Extensions/Sequences/SequenceExtensions.gs
@@ -46,6 +46,29 @@ import System.Runtime.CompilerServices
 // Transformers
 // ====================================================================
 
+/// Yields each contiguous sliding window of length `size` from
+/// `source`.
+///
+/// The window slides one element at a time, so for a source of length
+/// `n >= size` the result contains `n - size + 1` snapshots. Each
+/// yielded window is an independent `IList[T]` copy (safe to retain
+/// across `MoveNext` calls). If `source` is shorter than `size`, the
+/// result is empty. Per ADR-0084 the iterator is not inlined; the
+/// underlying enumerator is disposed on early termination
+/// (issue #836).
+///
+/// ```gs
+/// for w in Sequences.Of(1, 2, 3, 4).Windowed(2) {
+///     print(string.Join(",", w))   // "1,2", "2,3", "3,4"
+/// }
+/// ```
+///
+/// See also [Chunked](cref:Gsharp.Extensions.Sequences.Chunked),
+/// [Pairwise](cref:Gsharp.Extensions.Sequences.Pairwise).
+///
+/// @param size the window length; must be positive.
+/// @returns an `IEnumerable[IList[T]]` of sliding windows.
+/// @exception ArgumentOutOfRangeException `size <= 0`.
 func (source IEnumerable[T]) Windowed[T](size int32) IEnumerable[IList[T]] {
     if size <= 0 {
         throw ArgumentOutOfRangeException("size", size, "size must be positive.")
@@ -54,6 +77,26 @@ func (source IEnumerable[T]) Windowed[T](size int32) IEnumerable[IList[T]] {
     return WindowedIterator[T](source, size)
 }
 
+/// Yields successive non-overlapping chunks of length `size` from
+/// `source`.
+///
+/// Chunks are returned as fresh `IList[T]` snapshots in source order.
+/// The final chunk may be shorter than `size` when the source length
+/// is not an exact multiple. The transformer is intentionally not
+/// inlined per ADR-0084.
+///
+/// ```gs
+/// for c in Sequences.Of(1, 2, 3, 4, 5).Chunked(2) {
+///     print(string.Join(",", c))   // "1,2", "3,4", "5"
+/// }
+/// ```
+///
+/// See also [Windowed](cref:Gsharp.Extensions.Sequences.Windowed),
+/// [Interleave](cref:Gsharp.Extensions.Sequences.Interleave).
+///
+/// @param size the chunk length; must be positive.
+/// @returns an `IEnumerable[IList[T]]` of non-overlapping chunks.
+/// @exception ArgumentOutOfRangeException `size <= 0`.
 func (source IEnumerable[T]) Chunked[T](size int32) IEnumerable[IList[T]] {
     if size <= 0 {
         throw ArgumentOutOfRangeException("size", size, "size must be positive.")
@@ -62,15 +105,63 @@ func (source IEnumerable[T]) Chunked[T](size int32) IEnumerable[IList[T]] {
     return ChunkedIterator[T](source, size)
 }
 
+/// Yields `(index, value)` pairs for each element of `source`, with a
+/// zero-based `int32` index.
+///
+/// Lazily iterates the source exactly once; the iterator disposes the
+/// underlying enumerator on early termination (issue #836). Carries
+/// `AggressiveInlining` per ADR-0084.
+///
+/// ```gs
+/// for (i, name) in names.Indexed() {
+///     print($"{i}: {name}")
+/// }
+/// ```
+///
+/// See also [Pairwise](cref:Gsharp.Extensions.Sequences.Pairwise),
+/// [Windowed](cref:Gsharp.Extensions.Sequences.Windowed).
+///
+/// @returns an `IEnumerable[(int32, T)]` of indexed pairs.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (source IEnumerable[T]) Indexed[T]() IEnumerable[(int32, T)] {
     return IndexedIterator[T](source)
 }
 
+/// Yields each consecutive pair of elements from `source` as a tuple.
+///
+/// For an input of length `n`, the result contains `max(0, n - 1)`
+/// pairs: `(s[0], s[1]), (s[1], s[2]), …`. Useful for delta
+/// computations (e.g. successive timestamps).
+///
+/// ```gs
+/// let deltas = ticks.Pairwise().Select(p => p.Item2 - p.Item1)
+/// ```
+///
+/// See also [Windowed](cref:Gsharp.Extensions.Sequences.Windowed),
+/// [Indexed](cref:Gsharp.Extensions.Sequences.Indexed).
+///
+/// @returns an `IEnumerable[(T, T)]` of consecutive pairs.
 func (source IEnumerable[T]) Pairwise[T]() IEnumerable[(T, T)] {
     return PairwiseIterator[T](source)
 }
 
+/// Interleaves `source` and `other`, yielding elements alternately
+/// until one side is exhausted, then drains the remaining side.
+///
+/// Both enumerators are advanced lazily; `using let` (per ADR-0084
+/// inlining policy / issue #836) ensures both are disposed when the
+/// iterator's state machine tears down.
+///
+/// ```gs
+/// let merged = Sequences.Of(1, 3, 5).Interleave(Sequences.Of(2, 4))
+/// // merged: 1, 2, 3, 4, 5
+/// ```
+///
+/// See also [Chunked](cref:Gsharp.Extensions.Sequences.Chunked),
+/// [Pairwise](cref:Gsharp.Extensions.Sequences.Pairwise).
+///
+/// @param other the secondary sequence whose elements interleave with `source`.
+/// @returns an `IEnumerable[T]` that alternates between `source` and `other`, then drains the longer side.
 func (source IEnumerable[T]) Interleave[T](other IEnumerable[T]) IEnumerable[T] {
     return InterleaveIterator[T](source, other)
 }
@@ -79,6 +170,22 @@ func (source IEnumerable[T]) Interleave[T](other IEnumerable[T]) IEnumerable[T] 
 // Safe terminals — reference- and value-typed overloads coexist
 // ====================================================================
 
+/// Returns the first element of `source` as a present optional, or
+/// `nil` when the sequence is empty (reference-typed overload).
+///
+/// The overload is selected automatically by the binder when `T` is a
+/// reference type. Carries `AggressiveInlining` per ADR-0084.
+///
+/// ```gs
+/// let firstName = names.FirstOrNil()
+/// let upper = firstName.Map(s => s.ToUpper())
+/// ```
+///
+/// See also [LastOrNil](cref:Gsharp.Extensions.Sequences.LastOrNil),
+/// [SingleOrNil](cref:Gsharp.Extensions.Sequences.SingleOrNil),
+/// [Map](cref:Gsharp.Extensions.Optional.Map).
+///
+/// @returns the first element wrapped as `T?`, or `nil` when empty.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (source IEnumerable[T]) FirstOrNil[T class]() T? {
     for item in source {
@@ -88,6 +195,22 @@ func (source IEnumerable[T]) FirstOrNil[T class]() T? {
     return nil
 }
 
+/// Returns the first element of `source` as a present optional, or
+/// `nil` when the sequence is empty (value-typed overload).
+///
+/// The overload is selected automatically by the binder when `T` is a
+/// value type. Carries `AggressiveInlining` per ADR-0084.
+///
+/// ```gs
+/// let firstAge = ages.FirstOrNil()
+/// let adult = firstAge.Filter(n => n >= 18)
+/// ```
+///
+/// See also [LastOrNil](cref:Gsharp.Extensions.Sequences.LastOrNil),
+/// [SingleOrNil](cref:Gsharp.Extensions.Sequences.SingleOrNil),
+/// [Filter](cref:Gsharp.Extensions.Optional.Filter).
+///
+/// @returns the first element wrapped as `T?`, or `nil` when empty.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (source IEnumerable[T]) FirstOrNil[T struct]() T? {
     for item in source {
@@ -97,6 +220,22 @@ func (source IEnumerable[T]) FirstOrNil[T struct]() T? {
     return nil
 }
 
+/// Returns the last element of `source` as a present optional, or
+/// `nil` when the sequence is empty (reference-typed overload).
+///
+/// Drains the entire sequence; for large inputs prefer
+/// `source.Reverse().FirstOrNil()` only when reversal is cheap
+/// (e.g. an `IList[T]`). Carries `AggressiveInlining` per ADR-0084.
+///
+/// ```gs
+/// let lastError = errors.LastOrNil()
+/// lastError.IfPresent(e => log.Warn(e.Message))
+/// ```
+///
+/// See also [FirstOrNil](cref:Gsharp.Extensions.Sequences.FirstOrNil),
+/// [SingleOrNil](cref:Gsharp.Extensions.Sequences.SingleOrNil).
+///
+/// @returns the last element wrapped as `T?`, or `nil` when empty.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (source IEnumerable[T]) LastOrNil[T class]() T? {
     var result T? = nil
@@ -107,6 +246,21 @@ func (source IEnumerable[T]) LastOrNil[T class]() T? {
     return result
 }
 
+/// Returns the last element of `source` as a present optional, or
+/// `nil` when the sequence is empty (value-typed overload).
+///
+/// Drains the entire sequence. Carries `AggressiveInlining` per
+/// ADR-0084.
+///
+/// ```gs
+/// let lastScore = scores.LastOrNil()
+/// lastScore.IfPresent(s => print($"final: {s}"))
+/// ```
+///
+/// See also [FirstOrNil](cref:Gsharp.Extensions.Sequences.FirstOrNil),
+/// [SingleOrNil](cref:Gsharp.Extensions.Sequences.SingleOrNil).
+///
+/// @returns the last element wrapped as `T?`, or `nil` when empty.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (source IEnumerable[T]) LastOrNil[T struct]() T? {
     var result T? = nil
@@ -117,6 +271,22 @@ func (source IEnumerable[T]) LastOrNil[T struct]() T? {
     return result
 }
 
+/// Returns the sole element of `source` as a present optional, or
+/// `nil` when the sequence is empty *or* contains more than one
+/// element (reference-typed overload).
+///
+/// Stops iterating after the second `MoveNext` so it is `O(1)` when
+/// the input is too long. Carries `AggressiveInlining` per ADR-0084.
+///
+/// ```gs
+/// let theAdmin = users.Where(u => u.IsAdmin).SingleOrNil()
+/// theAdmin.IfPresent(u => grant(u))
+/// ```
+///
+/// See also [FirstOrNil](cref:Gsharp.Extensions.Sequences.FirstOrNil),
+/// [LastOrNil](cref:Gsharp.Extensions.Sequences.LastOrNil).
+///
+/// @returns the sole element wrapped as `T?`, or `nil` for empty or multi-element sequences.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (source IEnumerable[T]) SingleOrNil[T class]() T? {
     using let enumerator = source.GetEnumerator()
@@ -132,6 +302,22 @@ func (source IEnumerable[T]) SingleOrNil[T class]() T? {
     return first
 }
 
+/// Returns the sole element of `source` as a present optional, or
+/// `nil` when the sequence is empty *or* contains more than one
+/// element (value-typed overload).
+///
+/// Stops iterating after the second `MoveNext` so it is `O(1)` when
+/// the input is too long. Carries `AggressiveInlining` per ADR-0084.
+///
+/// ```gs
+/// let onlyId = ids.SingleOrNil()
+/// let resolved = onlyId.OrThrow("expected exactly one id")
+/// ```
+///
+/// See also [FirstOrNil](cref:Gsharp.Extensions.Sequences.FirstOrNil),
+/// [LastOrNil](cref:Gsharp.Extensions.Sequences.LastOrNil).
+///
+/// @returns the sole element wrapped as `T?`, or `nil` for empty or multi-element sequences.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (source IEnumerable[T]) SingleOrNil[T struct]() T? {
     using let enumerator = source.GetEnumerator()
@@ -151,6 +337,20 @@ func (source IEnumerable[T]) SingleOrNil[T struct]() T? {
 // Collectors
 // ====================================================================
 
+/// Materializes `source` into a freshly-allocated `[]T` slice.
+///
+/// Iterates the source exactly once into a `List[T]` buffer before
+/// copying out via `ToArray()` — used in lieu of the open-generic
+/// `IEnumerable[T].ToArray()` while the binder still erases the
+/// substitution to `Object[]`.
+///
+/// ```gs
+/// let frozen = Sequences.Range(0, 4).ToSlice()   // []int32 {0, 1, 2, 3}
+/// ```
+///
+/// See also [ToMap](cref:Gsharp.Extensions.Sequences.ToMap).
+///
+/// @returns a new `[]T` containing every element of `source` in iteration order.
 func (source IEnumerable[T]) ToSlice[T]() []T {
     // Materialize via List[T] because the open-generic
     // `IEnumerable[T].ToArray()` extension currently binds to
@@ -164,6 +364,21 @@ func (source IEnumerable[T]) ToSlice[T]() []T {
     return list.ToArray()
 }
 
+/// Materializes a sequence of `(key, value)` tuples into a
+/// `Dictionary[TKey, TValue]`.
+///
+/// Duplicate keys throw `ArgumentException` (matching `Dictionary.Add`
+/// semantics); pre-deduplicate the source if duplicates are expected.
+///
+/// ```gs
+/// let lookup = Sequences.Of(("a", 1), ("b", 2)).ToMap()
+/// // lookup["a"] == 1
+/// ```
+///
+/// See also [ToSlice](cref:Gsharp.Extensions.Sequences.ToSlice).
+///
+/// @returns a new `Dictionary[TKey, TValue]` containing one entry per source pair.
+/// @exception ArgumentException the source contains duplicate keys.
 func (source IEnumerable[(TKey, TValue)]) ToMap[TKey, TValue]() Dictionary[TKey, TValue] {
     var result = Dictionary[TKey, TValue]()
     for entry in source {
@@ -173,6 +388,24 @@ func (source IEnumerable[(TKey, TValue)]) ToMap[TKey, TValue]() Dictionary[TKey,
     return result
 }
 
+/// Materializes `source` into a `Dictionary[TKey, TValue]` by
+/// projecting each element through `keyFn` and `valueFn`.
+///
+/// Duplicate keys throw `ArgumentException` (matching `Dictionary.Add`
+/// semantics).
+///
+/// ```gs
+/// let byId = users.ToMap(u => u.Id, u => u)        // identity-valued lookup
+/// let nameById = users.ToMap(u => u.Id, u => u.Name)
+/// ```
+///
+/// See also [ToSlice](cref:Gsharp.Extensions.Sequences.ToSlice).
+///
+/// @param keyFn extracts the dictionary key from each element; must not be `nil`.
+/// @param valueFn extracts the dictionary value from each element; must not be `nil`.
+/// @returns a new `Dictionary[TKey, TValue]` built from the projected pairs.
+/// @exception ArgumentNullException `keyFn` or `valueFn` is `nil`.
+/// @exception ArgumentException `keyFn` produces the same key for two distinct elements.
 func (source IEnumerable[T]) ToMap[T, TKey, TValue](keyFn (T) -> TKey, valueFn (T) -> TValue) Dictionary[TKey, TValue] {
     if keyFn == nil {
         throw ArgumentNullException("keyFn")

--- a/src/Sdk/Gsharp.Extensions/Sequences/Sequences.gs
+++ b/src/Sdk/Gsharp.Extensions/Sequences/Sequences.gs
@@ -29,6 +29,23 @@ import System.Collections.Generic
 import System.Linq
 import System.Runtime.CompilerServices
 
+/// Entry-point helpers for building `IEnumerable[T]` sequences from
+/// scratch — empty, inline-literal, ranged, iterated, or repeated.
+///
+/// Pair these with the extension helpers in
+/// [SequenceExtensions](cref:Gsharp.Extensions.Sequences) such as
+/// [Indexed](cref:Gsharp.Extensions.Sequences.Indexed),
+/// [Pairwise](cref:Gsharp.Extensions.Sequences.Pairwise),
+/// [Windowed](cref:Gsharp.Extensions.Sequences.Windowed) and
+/// [FirstOrNil](cref:Gsharp.Extensions.Sequences.FirstOrNil) to build
+/// expressive pipelines.
+///
+/// ```gs
+/// import Gsharp.Extensions.Sequences
+///
+/// let evens = Sequences.Range(0, 5).Select(n => n * 2)   // 0, 2, 4, 6, 8
+/// let bools = Sequences.Of(true, false, true)            // [true, false, true]
+/// ```
 class Sequences {
     shared {
         // ---- Empty: zero-allocation empty sequence -----------------------
@@ -37,6 +54,18 @@ class Sequences {
         // cached singleton instead of `Array.Empty[T]()`. Both surface
         // the same shared instance under `IEnumerable[T]`; this matches
         // the inlined shape ADR-0084 §L5 originally specified.
+        /// Returns the shared empty sequence for element type `T`.
+        ///
+        /// Forwards to `Enumerable.Empty[T]()` so every call returns the
+        /// same cached singleton; no allocation happens at the call site.
+        ///
+        /// ```gs
+        /// let none IEnumerable[string] = Sequences.Empty[string]()
+        /// ```
+        ///
+        /// See also [Of](cref:Gsharp.Extensions.Sequences.Sequences.Of).
+        ///
+        /// @returns the shared empty `IEnumerable[T]` for `T`.
         @MethodImpl(MethodImplOptions.AggressiveInlining)
         func Empty[T]() IEnumerable[T] {
             return Enumerable.Empty[T]()
@@ -49,6 +78,25 @@ class Sequences {
         // get array-shaped access (indexing, `.Length`) on the result;
         // the array is itself an `IEnumerable[T]` (CLR covariance), so
         // every `Sequences.Of(...).LinqOp()` call site continues to bind.
+        /// Builds an inline literal sequence from the supplied values.
+        ///
+        /// Variadic per ADR-0101 / ADR-0102: pass N positional arguments,
+        /// a pre-built `[]T`, or zero arguments for an empty pack. The
+        /// returned array is itself an `IEnumerable[T]` via CLR
+        /// covariance, so it composes with any LINQ operator.
+        ///
+        /// ```gs
+        /// let small = Sequences.Of(1, 2, 3)              // [1, 2, 3]
+        /// let empty = Sequences.Of[int32]()              // []
+        /// let prebuilt = Sequences.Of([] int32 {4, 5})   // pass-through
+        /// ```
+        ///
+        /// See also [Empty](cref:Gsharp.Extensions.Sequences.Sequences.Empty),
+        /// [Range](cref:Gsharp.Extensions.Sequences.Sequences.Range),
+        /// [Repeat](cref:Gsharp.Extensions.Sequences.Sequences.Repeat).
+        ///
+        /// @param values the elements to materialize as the sequence.
+        /// @returns an array view of `values`, typed as `[]T`.
         @MethodImpl(MethodImplOptions.AggressiveInlining)
         func Of[T](values ...T) []T {
             return values
@@ -59,6 +107,25 @@ class Sequences {
         // a negative count surfaces ArgumentOutOfRangeException at call
         // time, not first-MoveNext time — matches the C# baseline and the
         // BCL `Enumerable.Range` contract.
+        /// Produces the half-open `int32` range `[start, start + count)`.
+        ///
+        /// Validation runs eagerly: a negative `count` throws at call
+        /// time, not at first `MoveNext`, matching the BCL
+        /// `Enumerable.Range` contract.
+        ///
+        /// ```gs
+        /// for i in Sequences.Range(0, 5) {
+        ///     print(i)                  // 0, 1, 2, 3, 4
+        /// }
+        /// ```
+        ///
+        /// See also [RangeStep](cref:Gsharp.Extensions.Sequences.Sequences.RangeStep),
+        /// [Iterate](cref:Gsharp.Extensions.Sequences.Sequences.Iterate).
+        ///
+        /// @param start the first value in the range (inclusive).
+        /// @param count the number of values to produce; must be non-negative.
+        /// @returns an `IEnumerable[int32]` yielding `start, start+1, …, start+count-1`.
+        /// @exception ArgumentOutOfRangeException `count` is negative.
         func Range(start int32, count int32) IEnumerable[int32] {
             if count < 0 {
                 throw ArgumentOutOfRangeException("count", count, "count must be non-negative.")
@@ -68,6 +135,30 @@ class Sequences {
         }
 
         // ---- RangeStep: strided, ascending OR descending ------------------
+        /// Produces a strided `int32` range from `start` toward `end`,
+        /// advancing by `step` each iteration.
+        ///
+        /// The range is half-open with respect to `end`: ascending when
+        /// `step > 0` (yielding while `i < end`), descending when
+        /// `step < 0` (yielding while `i > end`). A zero `step` is
+        /// rejected eagerly.
+        ///
+        /// ```gs
+        /// for i in Sequences.RangeStep(0, 10, 2) {
+        ///     print(i)                  // 0, 2, 4, 6, 8
+        /// }
+        /// for i in Sequences.RangeStep(10, 0, -3) {
+        ///     print(i)                  // 10, 7, 4, 1
+        /// }
+        /// ```
+        ///
+        /// See also [Range](cref:Gsharp.Extensions.Sequences.Sequences.Range).
+        ///
+        /// @param start the first value in the range (inclusive).
+        /// @param end the exclusive bound (upper when `step > 0`, lower when `step < 0`).
+        /// @param step the stride between successive values; must be non-zero.
+        /// @returns an `IEnumerable[int32]` yielding the strided range.
+        /// @exception ArgumentException `step` is zero.
         func RangeStep(start int32, end int32, step int32) IEnumerable[int32] {
             if step == 0 {
                 throw ArgumentException("step must be non-zero.", "step")
@@ -79,6 +170,22 @@ class Sequences {
         // ---- Iterate: infinite seed, next(seed), next(next(seed)), … -----
         // Open-generic iterator over `T`. Combine with `.Take(n)` from
         // System.Linq to bound the iteration at the call site.
+        /// Produces the infinite sequence `seed, next(seed), next(next(seed)), …`.
+        ///
+        /// The iterator is open-ended; bound it with `.Take(n)` or
+        /// `.TakeWhile(...)` from `System.Linq` at the call site.
+        ///
+        /// ```gs
+        /// let powers = Sequences.Iterate(1, n => n * 2).Take(5)   // 1, 2, 4, 8, 16
+        /// ```
+        ///
+        /// See also [Repeat](cref:Gsharp.Extensions.Sequences.Sequences.Repeat),
+        /// [Range](cref:Gsharp.Extensions.Sequences.Sequences.Range).
+        ///
+        /// @param seed the first value yielded.
+        /// @param next the successor function applied to the previous value; must not be `nil`.
+        /// @returns an infinite `IEnumerable[T]` of repeated `next` applications.
+        /// @exception ArgumentNullException `next` is `nil`.
         func Iterate[T](seed T, next (T) -> T) IEnumerable[T] {
             if next == nil {
                 throw ArgumentNullException("next")
@@ -88,6 +195,20 @@ class Sequences {
         }
 
         // ---- Repeat: infinite value, value, value, … ---------------------
+        /// Produces the infinite sequence `value, value, value, …`.
+        ///
+        /// Bound the iterator with `.Take(n)` or `.TakeWhile(...)` from
+        /// `System.Linq` at the call site.
+        ///
+        /// ```gs
+        /// let five = Sequences.Repeat("hi").Take(3)   // "hi", "hi", "hi"
+        /// ```
+        ///
+        /// See also [Iterate](cref:Gsharp.Extensions.Sequences.Sequences.Iterate),
+        /// [Empty](cref:Gsharp.Extensions.Sequences.Sequences.Empty).
+        ///
+        /// @param value the value yielded on every iteration.
+        /// @returns an infinite `IEnumerable[T]` of repeated `value`.
         func Repeat[T](value T) IEnumerable[T] {
             return Sequences.RepeatIterator[T](value)
         }

--- a/src/Sdk/Gsharp.NET.Sdk.Bootstrap/build/Gsharp.NET.Sdk.Bootstrap.targets
+++ b/src/Sdk/Gsharp.NET.Sdk.Bootstrap/build/Gsharp.NET.Sdk.Bootstrap.targets
@@ -94,6 +94,21 @@
     </ItemGroup>
   </Target>
 
+  <!-- Populate @(DocFileItem) and @(FinalDocFile) so the standard
+       CopyFilesToOutputDirectory target copies the XML doc file to
+       $(OutDir). Normally the C# CoreCompile target populates DocFileItem
+       and FinalDocFile is evaluated at import time from it, but since we
+       override CoreCompile entirely and this targets file is imported after
+       Microsoft.Common.CurrentVersion.targets, we must set both. -->
+  <Target Name="_PopulateGsharpDocFileItems"
+          AfterTargets="CoreCompile"
+          Condition=" '$(DocumentationFile)' != '' ">
+    <ItemGroup>
+      <DocFileItem Include="$(DocumentationFile)" />
+      <FinalDocFile Include="$(OutDir)$([System.IO.Path]::GetFileName('$(DocumentationFile)'))" />
+    </ItemGroup>
+  </Target>
+
   <!-- Required by Common.targets; defer to C# semantics. -->
   <Target Name="CreateManifestResourceNames" />
 

--- a/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj
+++ b/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <!-- ADR-0084 §L5 / issue #806. The previous topology had this SDK
-       csproj reference Gsharp.Extensions.csproj (Private="false"
+       csproj reference Gsharp.Extensions.proj (Private="false"
        ReferenceOutputAssembly="false") to ensure Extensions was built
        before PackGsharpExtensions ran. That arrow has been REMOVED:
        Gsharp.Extensions now references this project (so it builds
@@ -115,7 +115,7 @@
   <Target Name="PackGsharpExtensions" BeforeTargets="_GetPackageFiles" DependsOnTargets="Build">
     <PropertyGroup>
       <_GsharpCompilerProject>$(MSBuildThisFileDirectory)..\..\Compiler\Compiler.csproj</_GsharpCompilerProject>
-      <_GsharpExtensionsProject>$(MSBuildThisFileDirectory)..\Gsharp.Extensions\Gsharp.Extensions.csproj</_GsharpExtensionsProject>
+      <_GsharpExtensionsProject>$(MSBuildThisFileDirectory)..\Gsharp.Extensions\Gsharp.Extensions.proj</_GsharpExtensionsProject>
       <_GsharpExtensionsOutDir>$(IntermediateOutputPath)gsharp-extensions\</_GsharpExtensionsOutDir>
     </PropertyGroup>
     <!-- Gsharp.Extensions is built with the bootstrap SDK, which requires

--- a/test/Extensions.Tests/Extensions.Tests.csproj
+++ b/test/Extensions.Tests/Extensions.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Sdk\Gsharp.Extensions\Gsharp.Extensions.csproj" />
+    <ProjectReference Include="..\..\src\Sdk\Gsharp.Extensions\Gsharp.Extensions.proj" />
     <ProjectReference Include="..\..\src\Compiler\Compiler.csproj" />
   </ItemGroup>
 

--- a/test/Interpreter.Tests/Interpreter.Tests.csproj
+++ b/test/Interpreter.Tests/Interpreter.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="@(GsharpInterpreter)" />
-    <ProjectReference Include="..\..\src\Sdk\Gsharp.Extensions\Gsharp.Extensions.csproj" />
+    <ProjectReference Include="..\..\src\Sdk\Gsharp.Extensions\Gsharp.Extensions.proj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds /// doc-comments to all public APIs in Gsharp.Extensions and fixes the Bootstrap SDK so the XML documentation file is correctly generated and shipped.

## Changes

- **Doc-comments**: Added /// doc-comments to all public APIs in Optional.gs, Sequences.gs, SequenceExtensions.gs, and Go.gs
- **DocumentationAttacher.cs**: Fix for proper doc-comment attachment to syntax nodes  
- **Bootstrap SDK targets**: Fixed XML doc generation pipeline:
  - Changed `DocumentationFile` to use `$(IntermediateOutputPath)` (matches how csc works)
  - Added `_PopulateGsharpDocFileItems` target to wire `@(DocFileItem)`/`@(FinalDocFile)` so the standard `CopyFilesToOutputDirectory` step copies the XML to the output directory
- **Rename**: `Gsharp.Extensions.csproj` → `Gsharp.Extensions.proj` (the project contains no C# sources)
- Updated all project references, solution file, and ADR docs for the rename
- XML doc file now correctly ships in the NuGet package at `tools/extensions/Gsharp.Extensions.xml`

## Verification

- Full solution builds cleanly
- All 5047 tests pass
- XML doc file (273 lines, 35KB) is produced at `out/bin/Debug/Gsharp.Extensions/Gsharp.Extensions.xml`
- NuGet package includes the XML at `tools/extensions/`

Closes #845