### PR TITLE
Fix #853: Load ref assemblies into memory to avoid file locking

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -206,7 +206,7 @@ public sealed class ReferenceResolver : IDisposable
         {
             try
             {
-                var asm = mlc.LoadFromAssemblyPath(path);
+                var asm = resolver.LoadFromPath(mlc, path);
                 if (asm != null && seen.Add(asm.GetName().FullName))
                 {
                     builder.Add(asm);
@@ -247,7 +247,7 @@ public sealed class ReferenceResolver : IDisposable
 
                 try
                 {
-                    var asm = mlc.LoadFromAssemblyPath(host);
+                    var asm = resolver.LoadFromPath(mlc, host);
                     if (asm != null && seen.Add(asm.GetName().FullName))
                     {
                         builder.Add(asm);
@@ -737,13 +737,33 @@ public sealed class ReferenceResolver : IDisposable
     /// </summary>
     private sealed class FallbackMetadataAssemblyResolver : MetadataAssemblyResolver
     {
-        private readonly PathAssemblyResolver inner;
+        private readonly Dictionary<string, byte[]> assemblyBytes = new(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> unresolved = new(StringComparer.OrdinalIgnoreCase);
         private readonly object gate = new();
 
         public FallbackMetadataAssemblyResolver(IEnumerable<string> paths)
         {
-            inner = new PathAssemblyResolver(paths);
+            // Read each assembly into memory so no file handles are held open.
+            // This prevents MSBuild CopyRefAssembly from being blocked (#853).
+            foreach (var path in paths)
+            {
+                var fileName = Path.GetFileNameWithoutExtension(path);
+                if (!assemblyBytes.ContainsKey(fileName))
+                {
+                    try
+                    {
+                        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                        var bytes = new byte[fs.Length];
+                        fs.ReadExactly(bytes);
+                        assemblyBytes[fileName] = bytes;
+                    }
+                    catch (Exception ex) when (
+                        ex is IOException or UnauthorizedAccessException or BadImageFormatException)
+                    {
+                        // Skip files that can't be read.
+                    }
+                }
+            }
         }
 
         public IEnumerable<string> UnresolvedSimpleNames
@@ -757,30 +777,48 @@ public sealed class ReferenceResolver : IDisposable
             }
         }
 
-        public override Assembly Resolve(MetadataLoadContext context, AssemblyName assemblyName)
+        /// <summary>
+        /// Loads an assembly by path into the given <see cref="MetadataLoadContext"/>
+        /// using in-memory bytes (no file handle held open).
+        /// </summary>
+        public Assembly LoadFromPath(MetadataLoadContext context, string path)
         {
-            try
+            var fileName = Path.GetFileNameWithoutExtension(path);
+            if (assemblyBytes.TryGetValue(fileName, out var bytes))
             {
-                var resolved = inner.Resolve(context, assemblyName);
-                if (resolved != null)
-                {
-                    return resolved;
-                }
-            }
-            catch (Exception ex) when (
-                ex is FileNotFoundException
-                    or FileLoadException
-                    or BadImageFormatException)
-            {
-                // Fall through to record-and-degrade below.
+                return context.LoadFromByteArray(bytes);
             }
 
-            var name = assemblyName?.Name;
-            if (!string.IsNullOrEmpty(name))
+            // Fallback: read from disk with sharing flags.
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            var buffer = new byte[fs.Length];
+            fs.ReadExactly(buffer);
+            return context.LoadFromByteArray(buffer);
+        }
+
+        public override Assembly Resolve(MetadataLoadContext context, AssemblyName assemblyName)
+        {
+            var simpleName = assemblyName?.Name;
+            if (!string.IsNullOrEmpty(simpleName) && assemblyBytes.TryGetValue(simpleName, out var bytes))
+            {
+                try
+                {
+                    return context.LoadFromByteArray(bytes);
+                }
+                catch (Exception ex) when (
+                    ex is FileNotFoundException
+                        or FileLoadException
+                        or BadImageFormatException)
+                {
+                    // Fall through to record-and-degrade below.
+                }
+            }
+
+            if (!string.IsNullOrEmpty(simpleName))
             {
                 lock (gate)
                 {
-                    unresolved.Add(name);
+                    unresolved.Add(simpleName);
                 }
             }
 

--- a/src/LanguageServer/PdbSourceLocator.cs
+++ b/src/LanguageServer/PdbSourceLocator.cs
@@ -171,7 +171,7 @@ public static class PdbSourceLocator
 
         try
         {
-            using var stream = new FileStream(assemblyFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var stream = new FileStream(assemblyFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             using var peReader = new PEReader(stream);
             if (!peReader.HasMetadata)
             {
@@ -300,7 +300,7 @@ public static class PdbSourceLocator
             }
 
             // Probe the PE for an embedded PDB.
-            using var stream = new FileStream(assemblyFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var stream = new FileStream(assemblyFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             using var peReader = new PEReader(stream);
             if (!peReader.HasMetadata)
             {


### PR DESCRIPTION
## Problem

The Language Server keeps reference assembly DLLs (e.g. `obj/Debug/net10.0/ref/Foo.dll`) open via `MetadataLoadContext` + `PathAssemblyResolver`, which memory-maps files and holds handles open. This blocks MSBuild's `CopyRefAssembly` from overwriting them during build.

## Solution

- Replace `PathAssemblyResolver` in `FallbackMetadataAssemblyResolver` with a custom implementation that reads each assembly file entirely into a `byte[]` (using `FileStream` with `FileShare.ReadWrite | FileShare.Delete`), then serves them to `MetadataLoadContext` via `LoadFromByteArray`. No file handles are held open after initial load.
- Update `PdbSourceLocator.cs` to open assembly files with `FileShare.ReadWrite | FileShare.Delete` instead of `FileShare.Read`.

## Testing

All existing tests pass (the 5 pre-existing failures in `AssemblyDocumentationProvider` and cross-project definition tests are unrelated and fail on `main` as well).

Fixes #853