### PR TITLE
Fix #855: Set DocumentationFile in targets where IntermediateOutputPath is resolved

### DIFF
--- a/src/Sdk/Gsharp.NET.Sdk.Bootstrap/build/Gsharp.NET.Sdk.Bootstrap.targets
+++ b/src/Sdk/Gsharp.NET.Sdk.Bootstrap/build/Gsharp.NET.Sdk.Bootstrap.targets
@@ -35,6 +35,10 @@
     <!-- Take ownership of CoreCompile; the only dependency is the standard
          _ComputeNonExistentFileProperty helper. -->
     <CoreCompileDependsOn>_ComputeNonExistentFileProperty</CoreCompileDependsOn>
+
+    <!-- Issue #855: set DocumentationFile here (in targets) where
+         IntermediateOutputPath and TargetName are resolved. -->
+    <DocumentationFile Condition=" '$(GenerateDocumentationFile)' == 'true' and '$(DocumentationFile)' == '' ">$(IntermediateOutputPath)$(TargetName).xml</DocumentationFile>
   </PropertyGroup>
 
   <UsingTask AssemblyFile="$(GsharpToolFullPath)" TaskName="Gsharp.NET.Sdk.Tools.BuildTask" Condition="Exists('$(GsharpToolFullPath)')" />

--- a/src/Sdk/Gsharp.NET.Sdk/Sdk/Sdk.props
+++ b/src/Sdk/Gsharp.NET.Sdk/Sdk/Sdk.props
@@ -15,9 +15,10 @@
     <ProduceReferenceAssembly Condition=" '$(ProduceReferenceAssembly)' == '' ">true</ProduceReferenceAssembly>
 
     <!-- Phase 7.7b: enable XML documentation file generation for library
-         projects so consumers get IntelliSense / XML doc hover. -->
+         projects so consumers get IntelliSense / XML doc hover.
+         NOTE: DocumentationFile is set in Gsharp.NET.Core.Sdk.targets where
+         IntermediateOutputPath and TargetName are already resolved (#855). -->
     <GenerateDocumentationFile Condition=" '$(GenerateDocumentationFile)' == '' and '$(OutputType)' != 'Exe' ">true</GenerateDocumentationFile>
-    <DocumentationFile Condition=" '$(GenerateDocumentationFile)' == 'true' and '$(DocumentationFile)' == '' ">$(IntermediateOutputPath)$(TargetName).xml</DocumentationFile>
 
     <!-- Phase 7.7b: ensure dotnet pack produces a .snupkg symbol package
          carrying the Portable PDB alongside the main .nupkg. -->

--- a/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
+++ b/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
@@ -11,6 +11,14 @@
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_GsharpGetRefAssemblyForPack</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
+  <!-- Phase 7.7b / Issue #855: set DocumentationFile here (in targets) where
+       IntermediateOutputPath and TargetName are already resolved by the .NET SDK.
+       Setting it in Sdk.props caused both properties to be empty, producing a
+       bare '.xml' filename. -->
+  <PropertyGroup>
+    <DocumentationFile Condition=" '$(GenerateDocumentationFile)' == 'true' and '$(DocumentationFile)' == '' ">$(IntermediateOutputPath)$(TargetName).xml</DocumentationFile>
+  </PropertyGroup>
+
   <!-- Locate and add mscorlib unless NoStdLib. Mirrors peachpie's Core.Sdk.targets. -->
   <ItemGroup Condition=" '$(NoStdLib)' != 'true' ">
     <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" Condition=" '$(FrameworkPathOverride)' != '' " />


### PR DESCRIPTION
## Problem

`Sdk.props` line 20 set `DocumentationFile` using `$(IntermediateOutputPath)$(TargetName).xml`, but both properties are empty at props evaluation time (they're defined later by Microsoft.NET.Sdk targets). This caused `DocumentationFile` to resolve to a bare `.xml` filename in the project root.

## Fix

- **Removed** the `DocumentationFile` assignment from `Sdk.props` (kept the `GenerateDocumentationFile` boolean which is fine in props).
- **Added** the `DocumentationFile` property in `Gsharp.NET.Core.Sdk.targets` where `IntermediateOutputPath` and `TargetName` are already resolved.
- **Added** the same defensive assignment in `Gsharp.NET.Sdk.Bootstrap.targets` for consistency.

Fixes #855