### PR TITLE
Fix #858: Fix 3 LanguageServer.Tests that fail in CI on Linux Release

### DIFF
--- a/src/Core/CodeAnalysis/Documentation/AssemblyDocumentationProvider.cs
+++ b/src/Core/CodeAnalysis/Documentation/AssemblyDocumentationProvider.cs
@@ -235,17 +235,7 @@ public sealed class AssemblyDocumentationProvider
     // XML documentation alongside the reference assemblies.
     private static string DiscoverXmlPath(Assembly assembly)
     {
-        string location;
-        try
-        {
-            location = assembly.Location;
-        }
-        catch (NotSupportedException)
-        {
-            return null;
-        }
-
-        if (string.IsNullOrEmpty(location))
+        if (!GSharp.Core.CodeAnalysis.Symbols.ReferenceResolver.TryGetAssemblyPath(assembly, out var location))
         {
             return null;
         }

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Runtime.CompilerServices;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
@@ -54,6 +55,14 @@ public sealed class ReferenceResolver : IDisposable
     private readonly ImmutableArray<Assembly> assemblies;
     private readonly MetadataLoadContext metadataContext;
     private readonly ImmutableArray<string> missingTransitiveReferences;
+
+    // Process-wide registry of original on-disk paths for assemblies loaded
+    // via LoadFromByteArray (whose Assembly.Location is empty). Populated by
+    // FallbackMetadataAssemblyResolver and consulted by TryGetAssemblyPath /
+    // AssemblyDocumentationProvider so doc-XML discovery and cross-assembly
+    // navigation keep working after #853 (which switched ref-pack loading
+    // from PathAssemblyResolver to LoadFromByteArray to avoid file locking).
+    private static readonly ConditionalWeakTable<Assembly, string> AssemblyOriginalPaths = new();
 
     // Memoizes TryResolveType results for the lifetime of this resolver.
     //
@@ -140,6 +149,53 @@ public sealed class ReferenceResolver : IDisposable
     /// (issue #340).
     /// </summary>
     public ImmutableArray<string> MissingTransitiveReferences => missingTransitiveReferences;
+
+    /// <summary>
+    /// Recovers the on-disk path that <paramref name="assembly"/> was
+    /// originally loaded from. Falls back to the per-process registry that
+    /// <see cref="ReferenceResolver"/> populates whenever an assembly is read
+    /// into a <see cref="MetadataLoadContext"/> from in-memory bytes (so
+    /// MSBuild's <c>CopyRefAssembly</c> task is not blocked — see #853 / #858),
+    /// which is the case where <see cref="Assembly.Location"/> returns the
+    /// empty string. Used by
+    /// <c>AssemblyDocumentationProvider.DiscoverXmlPath</c> to locate the
+    /// companion XML doc file, and by
+    /// <c>CrossAssemblyDefinitionResolver</c> to locate the originating
+    /// sibling project / portable PDB for cross-assembly Go-to-Definition.
+    /// </summary>
+    /// <param name="assembly">An assembly returned by a resolver.</param>
+    /// <param name="path">The original on-disk path on success.</param>
+    /// <returns><see langword="true"/> when a non-empty path was recovered.</returns>
+    public static bool TryGetAssemblyPath(Assembly assembly, out string path)
+    {
+        path = null;
+        if (assembly == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var location = assembly.Location;
+            if (!string.IsNullOrEmpty(location))
+            {
+                path = location;
+                return true;
+            }
+        }
+        catch (NotSupportedException)
+        {
+            // Dynamic / in-memory assemblies throw on Location access; fall through.
+        }
+
+        if (AssemblyOriginalPaths.TryGetValue(assembly, out var registered) && !string.IsNullOrEmpty(registered))
+        {
+            path = registered;
+            return true;
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Gets a resolver that searches the runtime's currently loaded
@@ -544,6 +600,16 @@ public sealed class ReferenceResolver : IDisposable
             $"Core type '{fullName}' could not be resolved from the supplied references.");
     }
 
+    private static void RegisterAssemblyOriginalPath(Assembly assembly, string path)
+    {
+        if (assembly == null || string.IsNullOrEmpty(path))
+        {
+            return;
+        }
+
+        AssemblyOriginalPaths.AddOrUpdate(assembly, path);
+    }
+
     private static ImmutableArray<Assembly> BuildHostAssemblies()
     {
         var builder = ImmutableArray.CreateBuilder<Assembly>();
@@ -738,6 +804,7 @@ public sealed class ReferenceResolver : IDisposable
     private sealed class FallbackMetadataAssemblyResolver : MetadataAssemblyResolver
     {
         private readonly Dictionary<string, byte[]> assemblyBytes = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, string> assemblyPaths = new(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> unresolved = new(StringComparer.OrdinalIgnoreCase);
         private readonly object gate = new();
 
@@ -756,6 +823,7 @@ public sealed class ReferenceResolver : IDisposable
                         var bytes = new byte[fs.Length];
                         fs.ReadExactly(bytes);
                         assemblyBytes[fileName] = bytes;
+                        assemblyPaths[fileName] = path;
                     }
                     catch (Exception ex) when (
                         ex is IOException or UnauthorizedAccessException or BadImageFormatException)
@@ -764,6 +832,17 @@ public sealed class ReferenceResolver : IDisposable
                     }
                 }
             }
+        }
+
+        public bool TryGetOriginalPath(string simpleName, out string path)
+        {
+            if (!string.IsNullOrEmpty(simpleName))
+            {
+                return assemblyPaths.TryGetValue(simpleName, out path);
+            }
+
+            path = null;
+            return false;
         }
 
         public IEnumerable<string> UnresolvedSimpleNames
@@ -784,16 +863,22 @@ public sealed class ReferenceResolver : IDisposable
         public Assembly LoadFromPath(MetadataLoadContext context, string path)
         {
             var fileName = Path.GetFileNameWithoutExtension(path);
+            Assembly asm;
             if (assemblyBytes.TryGetValue(fileName, out var bytes))
             {
-                return context.LoadFromByteArray(bytes);
+                asm = context.LoadFromByteArray(bytes);
+            }
+            else
+            {
+                // Fallback: read from disk with sharing flags.
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                var buffer = new byte[fs.Length];
+                fs.ReadExactly(buffer);
+                asm = context.LoadFromByteArray(buffer);
             }
 
-            // Fallback: read from disk with sharing flags.
-            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-            var buffer = new byte[fs.Length];
-            fs.ReadExactly(buffer);
-            return context.LoadFromByteArray(buffer);
+            RegisterAssemblyOriginalPath(asm, path);
+            return asm;
         }
 
         public override Assembly Resolve(MetadataLoadContext context, AssemblyName assemblyName)
@@ -803,7 +888,13 @@ public sealed class ReferenceResolver : IDisposable
             {
                 try
                 {
-                    return context.LoadFromByteArray(bytes);
+                    var asm = context.LoadFromByteArray(bytes);
+                    if (assemblyPaths.TryGetValue(simpleName, out var originalPath))
+                    {
+                        RegisterAssemblyOriginalPath(asm, originalPath);
+                    }
+
+                    return asm;
                 }
                 catch (Exception ex) when (
                     ex is FileNotFoundException

--- a/src/LanguageServer/CrossAssemblyDefinitionResolver.cs
+++ b/src/LanguageServer/CrossAssemblyDefinitionResolver.cs
@@ -559,19 +559,10 @@ internal static class CrossAssemblyDefinitionResolver
 
     private static string TryGetAssemblyPath(Assembly assembly)
     {
-        if (assembly == null)
-        {
-            return null;
-        }
-
-        try
-        {
-            var location = assembly.Location;
-            return string.IsNullOrEmpty(location) ? null : location;
-        }
-        catch (NotSupportedException)
-        {
-            return null;
-        }
+        // Delegates to ReferenceResolver.TryGetAssemblyPath which falls back
+        // to the per-process registry of original paths for assemblies loaded
+        // via MetadataLoadContext.LoadFromByteArray (whose Assembly.Location
+        // is the empty string). See #853 / #858.
+        return ReferenceResolver.TryGetAssemblyPath(assembly, out var path) ? path : null;
     }
 }

--- a/test/LanguageServer.Tests/HoverHandlerTests.cs
+++ b/test/LanguageServer.Tests/HoverHandlerTests.cs
@@ -307,8 +307,28 @@ public class HoverHandlerTests
     {
         var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
         var dotnetRoot = Directory.GetParent(runtimeDir).Parent.Parent.FullName;
-        var tfm = $"net{System.Environment.Version.Major}.0";
-        var refDir = Path.Combine(dotnetRoot, "packs", "Microsoft.NETCore.App.Ref", System.Environment.Version.ToString(3), "ref", tfm);
+        var major = System.Environment.Version.Major;
+        var tfm = $"net{major}.0";
+
+        // Discover the actual installed ref pack directory. Globbing rather
+        // than hard-coding Environment.Version.ToString(3) tolerates the
+        // common CI shape where the running runtime (e.g. "10.0.0") and the
+        // installed ref pack (e.g. "10.0.9") have different patch versions
+        // (#858). Pick the highest-versioned ref pack whose TFM directory
+        // exists.
+        var packRoot = Path.Combine(dotnetRoot, "packs", "Microsoft.NETCore.App.Ref");
+        Assert.True(Directory.Exists(packRoot), $"Ref pack root '{packRoot}' not found.");
+
+        var refDir = Directory.EnumerateDirectories(packRoot)
+            .Select(d => new { Dir = d, Ref = Path.Combine(d, "ref", tfm) })
+            .Where(x => Directory.Exists(x.Ref))
+            .OrderByDescending(x => TryParseVersion(Path.GetFileName(x.Dir)))
+            .Select(x => x.Ref)
+            .FirstOrDefault();
+
+        Assert.NotNull(refDir);
         return ReferenceResolver.WithReferences(Directory.GetFiles(refDir, "*.dll"));
+
+        static Version TryParseVersion(string s) => Version.TryParse(s, out var v) ? v : new Version(0, 0);
     }
 }


### PR DESCRIPTION
Closes #858.

## Root cause

The fix for #853 (load reference assemblies into memory to avoid file locking
via MSBuild's `CopyRefAssembly`) switched `FallbackMetadataAssemblyResolver`
from `PathAssemblyResolver` to `MetadataLoadContext.LoadFromByteArray`. As a
side effect, `Assembly.Location` is the empty string for every reference
loaded that way. Two LSP features depended on it:

- **`AssemblyDocumentationProvider.DiscoverXmlPath`** used `Assembly.Location`
  to find the companion `.xml` doc file. With Location empty, doc XML
  discovery returned `null` for every imported CLR member — hover docs
  silently broke for ref-pack types.
- **`CrossAssemblyDefinitionResolver.TryGetAssemblyPath`** used
  `Assembly.Location` to discover the originating sibling project / portable
  PDB for cross-assembly Go-to-Definition. Same root cause — Location empty,
  so the resolver returned `null` and F12 jumped nowhere.

The 3rd failure — `AssemblyDocumentationProvider_ResolvesClrMemberDocsFromReferencePack` —
had its own minor cause: the test built the ref-pack path from
`System.Environment.Version.ToString(3)` (e.g. `10.0.0` on the runtime), but
the installed ref pack on CI is versioned independently (e.g. `10.0.9`), so
the path didn't exist.

## Fix

- `ReferenceResolver` now maintains a process-wide
  `ConditionalWeakTable<Assembly, string>` mapping each in-memory-loaded
  assembly to its original on-disk path. `FallbackMetadataAssemblyResolver`
  registers entries from both its `LoadFromPath` and `Resolve` entry points,
  so any assembly that flows out of the `MetadataLoadContext` can be
  reverse-mapped to a file.
- New public `ReferenceResolver.TryGetAssemblyPath(Assembly, out string)`
  prefers `Assembly.Location` (host-runtime assemblies) and falls back to the
  registry (MLC byte-array loads).
- Both `AssemblyDocumentationProvider.DiscoverXmlPath` and
  `CrossAssemblyDefinitionResolver.TryGetAssemblyPath` now go through this
  single API.
- `HoverHandlerTests.CreateReferencePackResolver` enumerates
  `packs/Microsoft.NETCore.App.Ref/*/ref/net{major}.0/` and picks the
  highest-versioned directory that actually exists, instead of hard-coding
  `Environment.Version.ToString(3)`.

## Verification

All 3 previously failing tests now pass locally (Release; also Debug):

```
Passed!  - Failed: 0, Passed: 266, Skipped: 0, Total: 266 - GSharp.LanguageServer.Tests.dll
```

Full `dotnet test GSharp.sln -c Release` is green (Core: 3294, Compiler: 1341,
Extensions: 104, Interpreter: 308, LanguageServer: 266, Sdk: 32).

## Production impact beyond the tests

These tests were the canary for two genuine regressions in the language
server caused by #853:

- Hover docs for any CLR API loaded via the reference resolver returned
  empty summaries.
- Go-to-Definition across sibling G# projects and into NuGet packages with
  PDBs no longer found anything.

Both are now restored.
