### PR TITLE
Fix #856: Quote paths with spaces in response file to fix Windows builds

### DIFF
--- a/src/Compiler/Compiler.csproj
+++ b/src/Compiler/Compiler.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="GSharp.Compiler.Tests" />
+    <InternalsVisibleTo Include="GSharp.Sdk.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
+++ b/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
@@ -126,11 +126,11 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
 
         var args = new List<string>
         {
-            $"/out:{Path.Combine(this.OutputPath, this.OutputName)}.dll",
+            QuoteIfNeeded($"/out:{Path.Combine(this.OutputPath, this.OutputName)}.dll"),
         };
         if (!string.IsNullOrEmpty(this.OutputName))
         {
-            args.Add($"/assemblyname:{this.OutputName}");
+            args.Add(QuoteIfNeeded($"/assemblyname:{this.OutputName}"));
         }
 
         if (!string.IsNullOrEmpty(this.OutputType))
@@ -151,12 +151,12 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
 
         if (!string.IsNullOrEmpty(this.PdbFile))
         {
-            args.Add($"/pdb:{this.PdbFile}");
+            args.Add(QuoteIfNeeded($"/pdb:{this.PdbFile}"));
         }
 
         if (!string.IsNullOrEmpty(this.SourceLink))
         {
-            args.Add($"/sourcelink:{this.SourceLink}");
+            args.Add(QuoteIfNeeded($"/sourcelink:{this.SourceLink}"));
         }
 
         if (ParseBool(this.EmbedAllSources))
@@ -176,12 +176,12 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
 
         if (!string.IsNullOrEmpty(this.RefAssembly))
         {
-            args.Add($"/refout:{this.RefAssembly}");
+            args.Add(QuoteIfNeeded($"/refout:{this.RefAssembly}"));
         }
 
         if (!string.IsNullOrEmpty(this.DocumentationFile))
         {
-            args.Add($"/doc:{this.DocumentationFile}");
+            args.Add(QuoteIfNeeded($"/doc:{this.DocumentationFile}"));
         }
 
         if (!string.IsNullOrEmpty(this.NoWarn))
@@ -201,12 +201,12 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
 
         foreach (var r in this.References)
         {
-            args.Add($"/r:{r.ItemSpec}");
+            args.Add(QuoteIfNeeded($"/r:{r.ItemSpec}"));
         }
 
         foreach (var s in this.Compile)
         {
-            args.Add(s.ItemSpec);
+            args.Add(QuoteIfNeeded(s.ItemSpec));
         }
 
         if (!string.IsNullOrEmpty(this.ResponseFilePath))
@@ -289,6 +289,38 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
         }
 
         return proc.ExitCode == 0 && !this.Log.HasLoggedErrors;
+    }
+
+    /// <summary>
+    /// Wraps <paramref name="value"/> in double quotes if it contains a
+    /// whitespace character. The gsc response file tokenizer
+    /// (<c>Program.TokenizeResponseFileLine</c>) splits on unquoted whitespace,
+    /// so any argument that embeds a space (e.g. a reference path under
+    /// <c>C:\Program Files\dotnet\...</c>) must be quoted to survive
+    /// tokenization as a single token. See issue #856.
+    /// </summary>
+    /// <param name="value">Raw argument text to be written to the response file.</param>
+    /// <returns>
+    /// <paramref name="value"/> unchanged when it is null, empty, or contains
+    /// no whitespace; otherwise the value wrapped in a single pair of double
+    /// quotes.
+    /// </returns>
+    internal static string QuoteIfNeeded(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        for (int i = 0; i < value.Length; i++)
+        {
+            if (char.IsWhiteSpace(value[i]))
+            {
+                return "\"" + value + "\"";
+            }
+        }
+
+        return value;
     }
 
     /// <summary>

--- a/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj
+++ b/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj
@@ -35,6 +35,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="GSharp.Sdk.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Package layout mirrors peachpie's SDK NuGet:
            sdk/Sdk.props, sdk/Sdk.targets
            build/Gsharp.NET.Sdk.props, build/Gsharp.NET.Current.Sdk.targets, build/Gsharp.NET.Core.Sdk.targets

--- a/test/Sdk.Tests/Issue856QuotePathsWithSpacesTests.cs
+++ b/test/Sdk.Tests/Issue856QuotePathsWithSpacesTests.cs
@@ -1,0 +1,77 @@
+// <copyright file="Issue856QuotePathsWithSpacesTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Gsharp.NET.Sdk.Tools;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Sdk.Tests;
+
+/// <summary>
+/// Regression coverage for issue #856: on Windows, when <c>dotnet</c> is
+/// installed under <c>C:\Program Files\dotnet\...</c>, reference paths the
+/// BuildTask writes into the gsc response file embed a literal space. The
+/// response-file tokenizer in <c>gsc</c> splits on unquoted whitespace, so
+/// arguments with embedded spaces must be wrapped in double quotes by the
+/// BuildTask. These tests pin both halves of that contract: the
+/// <see cref="BuildTask.QuoteIfNeeded(string)"/> producer-side helper and the
+/// <see cref="Program.TokenizeResponseFileLine(string)"/> consumer-side parser.
+/// </summary>
+public class Issue856QuotePathsWithSpacesTests
+{
+    [Fact]
+    public void QuoteIfNeeded_NoSpace_LeavesValueUnchanged()
+    {
+        Assert.Equal("/r:C:\\NoSpaces\\foo.dll", BuildTask.QuoteIfNeeded("/r:C:\\NoSpaces\\foo.dll"));
+    }
+
+    [Fact]
+    public void QuoteIfNeeded_WithSpace_WrapsInQuotes()
+    {
+        Assert.Equal(
+            "\"/r:C:\\Program Files\\dotnet\\packs\\Microsoft.NETCore.App.Ref\\Microsoft.CSharp.dll\"",
+            BuildTask.QuoteIfNeeded("/r:C:\\Program Files\\dotnet\\packs\\Microsoft.NETCore.App.Ref\\Microsoft.CSharp.dll"));
+    }
+
+    [Fact]
+    public void QuoteIfNeeded_NullOrEmpty_PassesThrough()
+    {
+        Assert.Null(BuildTask.QuoteIfNeeded(null));
+        Assert.Equal(string.Empty, BuildTask.QuoteIfNeeded(string.Empty));
+    }
+
+    [Fact]
+    public void QuotedReferencePath_RoundTrips_Through_ResponseFileTokenizer()
+    {
+        const string raw = "/r:C:\\Program Files\\dotnet\\packs\\Microsoft.NETCore.App.Ref\\Microsoft.CSharp.dll";
+
+        var line = BuildTask.QuoteIfNeeded(raw);
+        var tokens = Program.TokenizeResponseFileLine(line);
+
+        var token = Assert.Single(tokens);
+        Assert.Equal(raw, token);
+    }
+
+    [Fact]
+    public void QuotedSourcePath_RoundTrips_Through_ResponseFileTokenizer()
+    {
+        const string raw = "C:\\Users\\Alice With Space\\src\\main.gs";
+
+        var line = BuildTask.QuoteIfNeeded(raw);
+        var tokens = Program.TokenizeResponseFileLine(line);
+
+        var token = Assert.Single(tokens);
+        Assert.Equal(raw, token);
+    }
+
+    [Fact]
+    public void UnquotedPathWithSpace_GetsSplit_DemonstratingTheBug()
+    {
+        // This is the original #856 failure mode: without quoting, the path
+        // is broken into two tokens at the embedded space.
+        const string raw = "/r:C:\\Program Files\\dotnet\\Microsoft.CSharp.dll";
+        var tokens = Program.TokenizeResponseFileLine(raw);
+        Assert.Equal(2, tokens.Count);
+    }
+}

--- a/test/Sdk.Tests/Sdk.Tests.csproj
+++ b/test/Sdk.Tests/Sdk.Tests.csproj
@@ -6,4 +6,18 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sdk\Gsharp.NET.Sdk\Gsharp.NET.Sdk.csproj" />
+    <ProjectReference Include="@(GsharpCompiler)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- BuildTask derives from Microsoft.Build.Utilities.Task, so the test
+         project needs the matching assemblies on its reference closure to
+         resolve the base type. The SDK project marks them PrivateAssets="all"
+         to keep them out of its NuGet, so they don't flow transitively. -->
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.13.9" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.13.9" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Fixes #856. On Windows, when `dotnet` is installed under the default `C:\Program Files\dotnet` location, the SDK BuildTask wrote reference paths containing a literal space into the gsc response file. The compiler's response-file tokenizer (`Program.TokenizeResponseFileLine`) splits on unquoted whitespace, so lines like:

```
/r:C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\10.0.0\ref\net10.0\Microsoft.CSharp.dll
```

were broken into two tokens (`/r:C:\Program` and `Files\dotnet\...\Microsoft.CSharp.dll`), producing GS-prefixed reference-resolution errors on every Windows machine using the default install path.

## Fix

Add an internal `BuildTask.QuoteIfNeeded` helper that wraps any response-file argument containing whitespace in double quotes. The existing tokenizer already strips outer quotes and preserves embedded spaces as a single token, so the fix is purely producer-side.

Apply `QuoteIfNeeded` to every path-bearing argument written to the response file:

- `/out:`, `/assemblyname:`
- `/pdb:`, `/sourcelink:`, `/refout:`, `/doc:`
- `/r:<reference>` and bare source file paths

The `GsharpCompilerFullPath` and `ResponseFilePath` passed on the `dotnet` `ProcessStartInfo` command line were already quoted, so no change is needed there.

## Tests

New `test/Sdk.Tests/Issue856QuotePathsWithSpacesTests.cs` pins both halves of the contract:

1. `QuoteIfNeeded` produces the correct quoting (passthrough on null/empty/no-whitespace, quoted on space).
2. The resulting line round-trips back to the original argument through `Program.TokenizeResponseFileLine` for both reference paths and source paths.
3. The pre-fix failure mode (unquoted path with space → two tokens) is pinned so any future regression of the producer side is caught immediately.

To expose the helpers to the test, `InternalsVisibleTo GSharp.Sdk.Tests` is added on both the SDK project and the Compiler project, and the test project gains the `ProjectReference`s plus the `Microsoft.Build.*` packages needed to resolve `Microsoft.Build.Utilities.Task` (the SDK marks them `PrivateAssets="all"` so they don't flow transitively).

## Validation

- `dotnet build GSharp.sln`: ✅ 0 warnings, 0 errors
- `dotnet test test/Sdk.Tests/`: ✅ 38/38 passed (6 new tests)
- `dotnet test GSharp.sln`: ✅ all suites green
  - Sdk.Tests: 38
  - Extensions.Tests: 104
  - Interpreter.Tests: 308
  - LanguageServer.Tests: 266
  - Core.Tests: 3294 (1 skipped baseline)
  - Compiler.Tests: 1341