### PR TITLE
Fix #854: index referenced types to eliminate per-lookup assembly scan

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -179,6 +179,7 @@ internal sealed partial class ExpressionBinder
         // Build the candidate dotted prefixes (everything before the simple
         // type name), most specific first.
         var prefixCandidates = new List<string>();
+        var seenPrefixes = new HashSet<string>(System.StringComparer.Ordinal);
         if (!string.IsNullOrEmpty(namespacePrefix))
         {
             prefixCandidates.Add(namespacePrefix);
@@ -208,6 +209,17 @@ internal sealed partial class ExpressionBinder
 
         foreach (var prefix in prefixCandidates)
         {
+            // Issue #854: the candidate list frequently contains duplicate
+            // prefixes (e.g. the raw namespacePrefix also surfaces as an
+            // import-relative candidate). Resolution is deterministic per name,
+            // so probing the same prefix twice can never change the outcome —
+            // skip repeats to avoid redundant resolver lookups and, in the
+            // generic branch, redundant type-argument binding.
+            if (!seenPrefixes.Add(prefix))
+            {
+                continue;
+            }
+
             if (arity > 0)
             {
                 var mangled = prefix + "." + typeSimpleName + "`" + arity;

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -85,6 +85,25 @@ public sealed class ReferenceResolver : IDisposable
     private static readonly Type MissTypeSentinel = typeof(NotFoundSentinel);
     private readonly ConcurrentDictionary<string, Type> resolveCache = new(StringComparer.Ordinal);
 
+    // Issue #854: a lazily-built, full-name -> Type index over every assembly in
+    // `assemblies`. The previous TryResolveType implementation scanned all
+    // references on every cache miss (Assembly.GetType per assembly), which on a
+    // project with a large reference closure — e.g. the Oahu test project pulls
+    // in the Microsoft.AspNetCore.App framework reference for 352 assemblies —
+    // costs ~1.9ms per *miss*. The binder issues tens of thousands of distinct
+    // speculative probes (one candidate per declared import for every accessor
+    // expression), so the cumulative scan cost dominated build time (~80s of a
+    // ~83s compile). Building this index once (top-level + nested type
+    // definitions plus exported type forwarders) is ~150ms for that reference
+    // set and turns every subsequent resolution into an O(1) dictionary lookup.
+    //
+    // First-writer-wins mirrors the old scan, which returned the first assembly
+    // in `assemblies` order that declared the requested name. The index is keyed
+    // by Type.FullName, which uses '+' for nested types and the `arity backtick
+    // suffix for open generics — exactly the spellings Assembly.GetType accepts
+    // and the binder already constructs (e.g. "Ns.Type`1").
+    private readonly Lazy<Dictionary<string, Type>> typeNameIndex;
+
     private ReferenceResolver(ImmutableArray<Assembly> assemblies, MetadataLoadContext metadataContext)
         : this(assemblies, metadataContext, ImmutableArray<string>.Empty)
     {
@@ -95,6 +114,9 @@ public sealed class ReferenceResolver : IDisposable
         this.assemblies = assemblies;
         this.metadataContext = metadataContext;
         this.missingTransitiveReferences = missingTransitiveReferences;
+        this.typeNameIndex = new Lazy<Dictionary<string, Type>>(
+            this.BuildTypeNameIndex,
+            System.Threading.LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
     private sealed class NotFoundSentinel
@@ -409,28 +431,11 @@ public sealed class ReferenceResolver : IDisposable
             return true;
         }
 
-        foreach (var asm in assemblies)
+        if (typeNameIndex.Value.TryGetValue(fullName, out var indexed))
         {
-            Type candidate;
-            try
-            {
-                candidate = asm.GetType(fullName, throwOnError: false, ignoreCase: false);
-            }
-            catch (FileNotFoundException)
-            {
-                continue;
-            }
-            catch (BadImageFormatException)
-            {
-                continue;
-            }
-
-            if (candidate != null)
-            {
-                resolveCache.TryAdd(fullName, candidate);
-                type = candidate;
-                return true;
-            }
+            resolveCache.TryAdd(fullName, indexed);
+            type = indexed;
+            return true;
         }
 
         resolveCache.TryAdd(fullName, MissTypeSentinel);
@@ -598,6 +603,83 @@ public sealed class ReferenceResolver : IDisposable
 
         throw new InvalidOperationException(
             $"Core type '{fullName}' could not be resolved from the supplied references.");
+    }
+
+    // Issue #854: enumerate every assembly's defined types (top-level + nested)
+    // and exported type forwarders once, building the full-name -> Type index
+    // that backs TryResolveType. Mirrors the precedence of the previous per-miss
+    // scan: assemblies are visited in `assemblies` order and the first declarer
+    // of a given full name wins (later duplicates are ignored).
+    private static void AddToTypeNameIndex(Dictionary<string, Type> index, Type t)
+    {
+        if (t?.FullName is { } name && !index.ContainsKey(name))
+        {
+            index[name] = t;
+        }
+    }
+
+    private Dictionary<string, Type> BuildTypeNameIndex()
+    {
+        var index = new Dictionary<string, Type>(StringComparer.Ordinal);
+
+        foreach (var asm in assemblies)
+        {
+            // Defined types. ReflectionTypeLoadException surfaces a partial set
+            // via Types (with nulls for the entries that failed to load); take
+            // what resolved and skip the rest, matching the old scan's
+            // best-effort behavior where unresolvable members were simply not
+            // returned.
+            Type[] definedTypes;
+            try
+            {
+                definedTypes = asm.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                definedTypes = ex.Types;
+            }
+            catch (FileNotFoundException)
+            {
+                definedTypes = Array.Empty<Type>();
+            }
+            catch (BadImageFormatException)
+            {
+                definedTypes = Array.Empty<Type>();
+            }
+
+            foreach (var t in definedTypes)
+            {
+                AddToTypeNameIndex(index, t);
+            }
+
+            // Exported type forwarders (e.g. BCL facade assemblies forward
+            // System.* types to their implementation assembly). The old scan
+            // resolved these because Assembly.GetType follows forwarders; the
+            // index must include them to preserve resolution parity. A single
+            // unresolvable forward makes GetForwardedTypes throw, so fall back
+            // to the partial set when available and otherwise skip the
+            // assembly's forwarders.
+            Type[] forwardedTypes;
+            try
+            {
+                forwardedTypes = asm.GetForwardedTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                forwardedTypes = ex.Types;
+            }
+            catch (Exception)
+            {
+                forwardedTypes = Array.Empty<Type>();
+            }
+
+            foreach (var t in forwardedTypes)
+            {
+                AddToTypeNameIndex(index, t);
+            }
+        }
+
+        return index;
     }
 
     private static void RegisterAssemblyOriginalPath(Assembly assembly, string path)

--- a/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
@@ -208,6 +208,33 @@ public class ReferenceResolverTests
         Assert.Null(missSecond);
     }
 
+    [Fact]
+    public void TryResolveType_ResolvesTypesAcrossEverySuppliedAssembly()
+    {
+        // Issue #854: TryResolveType is backed by a full-name index built once
+        // over the entire reference set. This guards the property the previous
+        // per-assembly scan guaranteed — that a name defined in *any* supplied
+        // assembly resolves, not just the first — so the index must span every
+        // assembly. System.String lives in the core library, System.Console in
+        // System.Console.dll, and Task`1 in System.Private.CoreLib/Threading,
+        // covering distinct assemblies in the supplied set.
+        var resolver = BuildMetadataLoadContextResolver();
+
+        Assert.True(resolver.TryResolveType("System.String", out var stringType));
+        Assert.True(resolver.TryResolveType("System.Console", out var consoleType));
+        Assert.True(resolver.TryResolveType("System.Collections.Generic.List`1", out var listType));
+
+        Assert.NotNull(stringType);
+        Assert.NotNull(consoleType);
+        Assert.NotNull(listType);
+
+        // Types must originate from the resolver's isolated MetadataLoadContext,
+        // not the gsc host runtime (a regression here would reintroduce the
+        // cross-context identity mismatches the resolver exists to prevent).
+        Assert.NotSame(typeof(string), stringType);
+        Assert.NotSame(typeof(System.Console), consoleType);
+    }
+
     private static ReferenceResolver BuildMetadataLoadContextResolver()
     {
         // Supplying explicit assembly paths forces ReferenceResolver to load


### PR DESCRIPTION
## Problem

Migrating the Oahu unit-test project from C# to G# made it compile **~100x slower** (issue #854). On the repro (`DavidObando/Oahu`, branch `gs-tests-replace-cs`, ~6,400 lines across 54 `.gs` files), the test project alone took **~83s** while every C# project built in under 2s.

## Root cause (profiled)

A `dotnet-trace` of `gsc` showed **`ReferenceResolver.TryResolveType` at ~52% inclusive (~80s)**. It scanned **every referenced assembly** via `Assembly.GetType` on each cache miss. The Oahu test project pulls in the `Microsoft.AspNetCore.App` framework reference, so the reference closure is **352 assemblies** and each miss cost **~1.9ms**. The binder amplifies this by issuing tens of thousands of distinct speculative probes (one candidate per declared `import` for every accessor expression). `N x 1.9ms` is approximately the observed time.

A micro-benchmark over the real 352-reference set:

| operation | cost |
|---|---|
| one miss (scan 352 assemblies) | **1.87 ms** |
| build full-name index once (incl. forwarders) | **~150 ms** |
| index lookup | **~0 ms** |

## Fix

- **`ReferenceResolver`**: build a lazy full-name to Type index once per resolver -- defined + nested types (`GetTypes()`) plus `GetForwardedTypes()` so BCL facade forwarders still resolve -- first-writer-wins to preserve assembly-order precedence. `TryResolveType` is now an O(1) dictionary lookup. Audited siblings (`TryResolveNestedType`, `MapClrTypeToReferences`, `GetCoreType`) -- they only funnel through `TryResolveType`/`Type.GetNestedType`, no other scans.
- **Binder**: behavior-preserving dedupe of candidate prefixes in `TryResolveQualifiedClrType`.

## Result

**Oahu test project: ~74s to ~1.4s (~53x faster)** locally, with **identical diagnostics and emitted assembly**. Re-profiling confirms the bottleneck is gone; remaining time is genuine, well-distributed binding/emit work.

## Validation

Full suite green: Core **3295**, Compiler **1341**, LanguageServer **266**, Interpreter **308**, Extensions **104**, Sdk **32** -- 0 failures. Added a `ReferenceResolver` regression test for cross-assembly resolution.

Closes #854.
