### PR TITLE
Fix TextMate string grammar to support backslash escapes

### DIFF
--- a/src/vscode-gsharp/CHANGELOG.md
+++ b/src/vscode-gsharp/CHANGELOG.md
@@ -33,3 +33,7 @@ All notable changes to the GSharp VS Code extension will be documented in this f
 - Server crash recovery with exponential backoff
 - Language status bar item (Starting → Ready → Error)
 - Project context status bar item
+
+### Fixed
+
+- TextMate string grammar now recognizes backslash escape sequences (`\"`, `\\`, `\n`, `\t`, `\0`, `\a`, `\b`, `\f`, `\r`, `\v`, `\xNN`, `\uNNNN`, `\UNNNNNNNN`) so an escaped quote like `"text \""` no longer terminates the string early and bleeds string coloring into the rest of the file; unrecognized escapes are flagged as invalid

--- a/src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json
+++ b/src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json
@@ -57,16 +57,25 @@
       "end": "\"",
       "applyEndPatternLast": true,
       "patterns": [
-        {
-          "name": "constant.character.escape.quote.gsharp",
-          "match": "\"\""
-        },
+        { "include": "#string-escape" },
         {
           "name": "constant.character.escape.dollar.gsharp",
           "match": "\\$\\$"
         },
         { "include": "#interpolation-braced" },
         { "include": "#interpolation-ident" }
+      ]
+    },
+    "string-escape": {
+      "patterns": [
+        {
+          "name": "constant.character.escape.gsharp",
+          "match": "\\\\(['\"\\\\0abfnrtv]|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})"
+        },
+        {
+          "name": "invalid.illegal.unrecognized-string-escape.gsharp",
+          "match": "\\\\."
+        }
       ]
     },
     "raw-string": {

--- a/website/src/theme/prism-include-languages.ts
+++ b/website/src/theme/prism-include-languages.ts
@@ -62,13 +62,13 @@ function registerGSharp(Prism: typeof PrismNamespace): void {
           },
         },
         'string-escape': {
-          pattern: /\\(?:u[0-9a-fA-F]{4}|x[0-9a-fA-F]+|.)/,
+          pattern: /\\(?:u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8}|x[0-9a-fA-F]{1,4}|.)/,
           alias: 'char',
         },
       },
     },
     char: {
-      pattern: /'(?:\\(?:u[0-9a-fA-F]{4}|x[0-9a-fA-F]+|.)|[^'\\\r\n])'/,
+      pattern: /'(?:\\(?:u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8}|x[0-9a-fA-F]{1,4}|.)|[^'\\\r\n])'/,
       greedy: true,
     },
     'class-name': [


### PR DESCRIPTION
## Problem

A G# file containing an escaped quote, e.g.:

```gsharp
var x = "text \"";
```

caused the VS Code syntax highlighter to color the **rest of the file** as if it were inside a string. The TextMate grammar treated doubled-quote (`""`) as the only string escape and never handled backslash escapes. Since G#'s lexer uses C#/Go-style backslash escapes, `\"` was parsed as a `\` literal followed by a closing `"`, terminating the string early; the next `"` then opened a new string that ran to the end of the file.

## Fix

- **`src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json`**: Replace the `""` escape rule with a `string-escape` rule matching the lexer's full escape set (`\' \" \\ \0 \a \b \f \n \r \t \v`, `\xNN`, `\uNNNN`, `\UNNNNNNNN`), plus an `invalid.illegal` catch-all for unrecognized escapes. The Markdown injection grammar reuses `source.gsharp`, so it's covered too.
- **`website/src/theme/prism-include-languages.ts`**: Prism's `string` pattern already consumed `\\.` correctly, but I tightened the `string-escape`/`char` patterns to recognize `\UNNNNNNNN` and bound `\x` to 1-4 hex digits, matching the lexer.
- **`src/vscode-gsharp/CHANGELOG.md`**: Added a Fixed entry.

## Verification

Tokenized the affected cases with `vscode-textmate`:

- `"text \""` &rarr; `\"` is an `constant.character.escape`, the next `"` closes the string, and the trailing `;` returns to normal code (no bleed-through).
- `\n`, `\t`, `\u0041`, `\U0001F600`, `\x41` recognized as escapes.
- Invalid `\q` flagged `invalid.illegal.unrecognized-string-escape`.

Website `tsc --noEmit` passes.