### PR TITLE
Fix LSP responsiveness, multi-file resolution, and cross-assembly navigation

### DIFF
--- a/src/LanguageServer/CrossAssemblyDefinitionResolver.cs
+++ b/src/LanguageServer/CrossAssemblyDefinitionResolver.cs
@@ -64,6 +64,16 @@ internal static class CrossAssemblyDefinitionResolver
             return true;
         }
 
+        // Tier 3 — source-text search. Preferred over the PDB for workspace-local assemblies
+        // because it lands on the actual type-declaration identifier; the PDB only knows method
+        // sequence points, so it lands on the first executable line (e.g. inside a constructor)
+        // and can't locate types with no method bodies (interfaces). Only does real work for
+        // assemblies built from a project under the workspace; everything else falls through.
+        if (TryResolveTypeBySourceSearch(assemblyPath, type, out location))
+        {
+            return true;
+        }
+
         if (PdbSourceLocator.TryGetTypeSourceLocation(assemblyPath, type.MetadataToken, out var pdbLocation))
         {
             location = ToLocation(pdbLocation);
@@ -99,6 +109,13 @@ internal static class CrossAssemblyDefinitionResolver
             && declaringType != null
             && workspace.TryGetProjectByOutputAssembly(assemblyPath, out var siblingProject)
             && TryResolveMethodInSiblingProject(siblingProject, declaringType, method, out location))
+        {
+            return true;
+        }
+
+        // Tier 3 — source-text search (preferred over the PDB for workspace-local assemblies; the
+        // PDB token from a stripped ref-assembly often doesn't match the runtime PDB).
+        if (TryResolveMemberBySourceSearch(assemblyPath, declaringType, method.Name, out location))
         {
             return true;
         }
@@ -146,6 +163,11 @@ internal static class CrossAssemblyDefinitionResolver
             return true;
         }
 
+        if (TryResolveMemberBySourceSearch(assemblyPath, declaringType, property.Name, out location))
+        {
+            return true;
+        }
+
         var accessor = property.GetGetMethod(nonPublic: true) ?? property.GetSetMethod(nonPublic: true);
         if (accessor != null && PdbSourceLocator.TryGetMethodSourceLocation(assemblyPath, accessor.MetadataToken, out var pdbLocation))
         {
@@ -188,6 +210,11 @@ internal static class CrossAssemblyDefinitionResolver
             return true;
         }
 
+        if (TryResolveMemberBySourceSearch(assemblyPath, declaringType, field.Name, out location))
+        {
+            return true;
+        }
+
         return declaringType != null && TryResolveType(workspace, declaringType, out location);
     }
 
@@ -221,6 +248,11 @@ internal static class CrossAssemblyDefinitionResolver
             return true;
         }
 
+        if (TryResolveMemberBySourceSearch(assemblyPath, declaringType, evt.Name, out location))
+        {
+            return true;
+        }
+
         var accessor = evt.GetAddMethod(nonPublic: true) ?? evt.GetRemoveMethod(nonPublic: true);
         if (accessor != null && PdbSourceLocator.TryGetMethodSourceLocation(assemblyPath, accessor.MetadataToken, out var pdbLocation))
         {
@@ -229,6 +261,223 @@ internal static class CrossAssemblyDefinitionResolver
         }
 
         return declaringType != null && TryResolveType(workspace, declaringType, out location);
+    }
+
+    internal static bool TryResolveTypeBySourceSearch(string assemblyPath, Type type, out Location location)
+    {
+        location = null;
+
+        var projectDirectory = DeriveProjectDirectory(assemblyPath);
+        if (projectDirectory == null || !System.IO.Directory.Exists(projectDirectory))
+        {
+            return false;
+        }
+
+        var simpleName = type.Name;
+        var backtick = simpleName.IndexOf('`');
+        if (backtick > 0)
+        {
+            simpleName = simpleName.Substring(0, backtick);
+        }
+
+        if (string.IsNullOrEmpty(simpleName))
+        {
+            return false;
+        }
+
+        // Match a C#/G# type declaration: a type keyword, optional modifiers/`record struct`,
+        // then the simple name as a whole word, all before any `{`, `:`, `(`, or end of line.
+        var pattern = @"\b(?:interface|class|struct|enum|record)\b[^\r\n{:(]*?\b"
+            + System.Text.RegularExpressions.Regex.Escape(simpleName) + @"\b";
+        var regex = new System.Text.RegularExpressions.Regex(pattern);
+
+        foreach (var sourceFile in EnumerateProjectSources(projectDirectory))
+        {
+            string text;
+            try
+            {
+                text = System.IO.File.ReadAllText(sourceFile);
+            }
+            catch (System.IO.IOException)
+            {
+                continue;
+            }
+
+            var match = regex.Match(text);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            // Point at the type name itself, not the leading keyword.
+            var nameIndex = text.IndexOf(simpleName, match.Index, StringComparison.Ordinal);
+            if (nameIndex < 0)
+            {
+                nameIndex = match.Index;
+            }
+
+            var (line, character) = OffsetToLineColumn(text, nameIndex);
+            location = new Location
+            {
+                Uri = DocumentUri.FromFileSystemPath(sourceFile),
+                Range = new Range(new Position(line, character), new Position(line, character + simpleName.Length)),
+            };
+            return true;
+        }
+
+        return false;
+    }
+
+    // Tier-3 member navigation: scans the declaring type's source file(s) (under the workspace)
+    // for a member declaration of memberName. Distinguishes a declaration from a call/usage by
+    // requiring the member name to be preceded, on the same line, by a return/field type (and
+    // optional modifiers) and followed by `(`, `{`, `=`, or `;`. Best-effort: returns the first
+    // plausible declaration found.
+    internal static bool TryResolveMemberBySourceSearch(string assemblyPath, Type declaringType, string memberName, out Location location)
+    {
+        location = null;
+        if (declaringType == null || string.IsNullOrEmpty(memberName))
+        {
+            return false;
+        }
+
+        var projectDirectory = DeriveProjectDirectory(assemblyPath);
+        if (projectDirectory == null || !System.IO.Directory.Exists(projectDirectory))
+        {
+            return false;
+        }
+
+        var typeName = declaringType.Name;
+        var backtick = typeName.IndexOf('`');
+        if (backtick > 0)
+        {
+            typeName = typeName.Substring(0, backtick);
+        }
+
+        var typeRegex = new System.Text.RegularExpressions.Regex(
+            @"\b(?:interface|class|struct|enum|record)\b[^\r\n{:(]*?\b"
+            + System.Text.RegularExpressions.Regex.Escape(typeName) + @"\b");
+
+        // A member declaration line: leading indentation, optional attributes, optional modifiers,
+        // a return/field type token, then the member name, then `(` (method), `<` (generic method),
+        // `{` (property), `=` (expression body / field init), or `;` (field / abstract member).
+        var memberRegex = new System.Text.RegularExpressions.Regex(
+            @"(?m)^[ \t]*(?:\[[^\]]*\][ \t]*)*(?:[\w.<>\[\],?]+[ \t]+)+"
+            + System.Text.RegularExpressions.Regex.Escape(memberName)
+            + @"[ \t]*(?:<[^>]*>)?[ \t]*[({=;]");
+
+        foreach (var sourceFile in EnumerateProjectSources(projectDirectory))
+        {
+            string text;
+            try
+            {
+                text = System.IO.File.ReadAllText(sourceFile);
+            }
+            catch (System.IO.IOException)
+            {
+                continue;
+            }
+
+            // Only search files that declare the owning type (handles partial types across files
+            // and avoids matching a same-named member on an unrelated type).
+            if (!typeRegex.IsMatch(text))
+            {
+                continue;
+            }
+
+            var match = memberRegex.Match(text);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            var nameIndex = text.IndexOf(memberName, match.Index, StringComparison.Ordinal);
+            if (nameIndex < 0)
+            {
+                nameIndex = match.Index;
+            }
+
+            var (line, character) = OffsetToLineColumn(text, nameIndex);
+            location = new Location
+            {
+                Uri = DocumentUri.FromFileSystemPath(sourceFile),
+                Range = new Range(new Position(line, character), new Position(line, character + memberName.Length)),
+            };
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Derives the owning project directory from a built assembly path by trimming everything
+    /// at and below the MSBuild <c>obj</c> (or <c>bin</c>) output folder, e.g.
+    /// <c>/repo/src/Lib/obj/Debug/net10.0/ref/Lib.dll</c> → <c>/repo/src/Lib</c>.
+    /// </summary>
+    private static string DeriveProjectDirectory(string assemblyPath)
+    {
+        var directory = System.IO.Path.GetDirectoryName(assemblyPath);
+        while (!string.IsNullOrEmpty(directory))
+        {
+            var leaf = System.IO.Path.GetFileName(directory);
+            var parent = System.IO.Path.GetDirectoryName(directory);
+            if (string.Equals(leaf, "obj", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(leaf, "bin", StringComparison.OrdinalIgnoreCase))
+            {
+                return parent;
+            }
+
+            directory = parent;
+        }
+
+        return null;
+    }
+
+    private static System.Collections.Generic.IEnumerable<string> EnumerateProjectSources(string projectDirectory)
+    {
+        System.Collections.Generic.IEnumerable<string> files;
+        try
+        {
+            files = System.IO.Directory
+                .EnumerateFiles(projectDirectory, "*.cs", System.IO.SearchOption.AllDirectories)
+                .Concat(System.IO.Directory.EnumerateFiles(projectDirectory, "*.gs", System.IO.SearchOption.AllDirectories));
+        }
+        catch (System.IO.IOException)
+        {
+            yield break;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            yield break;
+        }
+
+        foreach (var file in files)
+        {
+            // Skip generated output so a copy in obj/ doesn't shadow the real source.
+            if (file.Contains($"{System.IO.Path.DirectorySeparatorChar}obj{System.IO.Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)
+                || file.Contains($"{System.IO.Path.DirectorySeparatorChar}bin{System.IO.Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            yield return file;
+        }
+    }
+
+    private static (int Line, int Character) OffsetToLineColumn(string text, int offset)
+    {
+        var line = 0;
+        var lineStart = 0;
+        for (var i = 0; i < offset && i < text.Length; i++)
+        {
+            if (text[i] == '\n')
+            {
+                line++;
+                lineStart = i + 1;
+            }
+        }
+
+        return (line, offset - lineStart);
     }
 
     private static bool TryResolveTypeInSiblingProject(ProjectState siblingProject, Type type, out Location location)

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -1025,6 +1025,8 @@ public static class DefinitionComputer
             StructSymbol s when s.Declaration != null => s.Declaration.Identifier,
             EnumSymbol e when e.Declaration != null => e.Declaration.Identifier,
             EnumMemberSymbol m => FindEnumMemberToken(m),
+            PropertySymbol p when p.Declaration != null => p.Declaration.Identifier,
+            EventSymbol ev when ev.Declaration != null => ev.Declaration.Identifier,
             FieldSymbol field => FindFieldToken(compilation, field),
             VariableSymbol variable => FindVariableToken(compilation, variable),
             _ => null,
@@ -1432,7 +1434,7 @@ public static class CompletionComputer
             var receiverExpression = ReconstructReceiverExpression(content, chainRoot, accessor);
             if (receiverExpression != null)
             {
-                var (function, locals) = SemanticLookup.GetExpressionBindingContext(compilation, offset);
+                var (function, locals) = SemanticLookup.GetExpressionBindingContext(compilation, content.SyntaxTree, offset);
                 var receiverType = GSharp.Core.CodeAnalysis.Binding.Binder.TryInferExpressionType(
                     compilation.GlobalScope,
                     compilation.References,
@@ -1456,6 +1458,15 @@ public static class CompletionComputer
         {
             case VariableSymbol variable:
                 AddInstanceTypeMembers(items, seen, variable.Type);
+                break;
+            case PropertySymbol property:
+                AddInstanceTypeMembers(items, seen, property.Type);
+                break;
+            case FieldSymbol field:
+                AddInstanceTypeMembers(items, seen, field.Type);
+                break;
+            case EventSymbol @event:
+                AddInstanceTypeMembers(items, seen, @event.Type);
                 break;
             case EnumSymbol enumSymbol:
                 AddEnumMembers(items, seen, enumSymbol);

--- a/src/LanguageServer/SemanticLookup.cs
+++ b/src/LanguageServer/SemanticLookup.cs
@@ -122,11 +122,17 @@ public static class SemanticLookup
     /// types for member completions on arbitrary expressions.
     /// </summary>
     /// <param name="compilation">The compilation to inspect.</param>
+    /// <param name="tree">The syntax tree the offset belongs to; scopes the function search to that file.</param>
     /// <param name="offset">The source offset of the expression.</param>
     /// <returns>The enclosing function symbol and the in-scope local symbols.</returns>
-    public static (FunctionSymbol Function, IReadOnlyList<VariableSymbol> Locals) GetExpressionBindingContext(Compilation compilation, int offset)
+    public static (FunctionSymbol Function, IReadOnlyList<VariableSymbol> Locals) GetExpressionBindingContext(Compilation compilation, SyntaxTree tree, int offset)
     {
-        var funcDecl = FindNodes<FunctionDeclarationSyntax>(compilation.SyntaxTrees.Select(t => t.Root))
+        // Spans are per-file offsets; restrict the search to the supplied tree so a function
+        // in another file can't be chosen by offset overlap in a multi-file compilation.
+        var roots = tree != null
+            ? new[] { tree.Root }
+            : compilation.SyntaxTrees.Select(t => t.Root);
+        var funcDecl = FindNodes<FunctionDeclarationSyntax>(roots)
             .Where(f => f.Span.Start <= offset && offset <= f.Span.End)
             .OrderBy(f => f.Span.Length)
             .FirstOrDefault();
@@ -792,12 +798,27 @@ public static class SemanticLookup
         // per CodeLens request) this dominated request latency. Precomputing the
         // per-tree node lists in BuildModelUncached makes those fallback paths
         // O(number of decls), not O(number of nodes across the workspace).
-        private FunctionDeclarationSyntax[] cachedFunctionDeclarations;
-        private StructDeclarationSyntax[] cachedStructDeclarations;
+        // Per-file views keyed by file name. The Resolve fallback runs FindContainingFunction /
+        // ResolveImplicitThisMember for *every* identifier token in *every* tree when the reference
+        // index is built (CodeLens / FindReferences). Iterating a whole-workspace flat list per
+        // token is O(tokens x decls) and took ~145s to build the index on a 54-file project.
+        // Bucketing by file makes each token scan only its own file's declarations. Keyed by file
+        // name (not tree instance) so interpolation-hole tokens — whose re-parsed sub-tree shares
+        // the file name and uses absolute spans — land in the right bucket.
+        private Dictionary<string, FunctionDeclarationSyntax[]> cachedFunctionsByFile;
+        private Dictionary<string, StructDeclarationSyntax[]> cachedStructsByFile;
         private Dictionary<SyntaxTree, AccessorExpressionSyntax[]> cachedAccessorsByTree;
         private Dictionary<SyntaxTree, FieldAssignmentExpressionSyntax[]> cachedFieldAssignmentsByTree;
         private Dictionary<SyntaxTree, ForRangeStatementSyntax[]> cachedForRangesByTree;
         private Dictionary<SyntaxTree, AwaitForRangeStatementSyntax[]> cachedAwaitForRangesByTree;
+
+        // (file, span) of every member-access identifier and field-assignment identifier. Resolve
+        // runs ResolveAsMemberAccess + IsRightOfMemberAccess for *every* token; without this set
+        // each non-member token (the vast majority) still scanned its file's accessors twice. An
+        // O(1) span lookup lets non-member tokens bail out immediately, which is the dominant cost
+        // of the reference-index build.
+        private HashSet<(string, int, int)> memberAccessTokenSpans;
+        private HashSet<(string, int, int)> fieldAssignmentTokenSpans;
 
         public SemanticModel(
             Compilation compilation,
@@ -826,16 +847,79 @@ public static class SemanticLookup
                 }
             }
 
-            // Precompute per-compilation node lists once so the Resolve fallback
-            // chain doesn't re-walk every tree on every token. See the field
-            // declarations above for the motivation.
-            var trees = this.compilation.SyntaxTrees;
-            this.cachedFunctionDeclarations = FindNodes<FunctionDeclarationSyntax>(trees.Select(t => t.Root)).ToArray();
-            this.cachedStructDeclarations = FindNodes<StructDeclarationSyntax>(trees.Select(t => t.Root)).ToArray();
-            this.cachedAccessorsByTree = trees.ToDictionary(t => t, t => FindNodes<AccessorExpressionSyntax>(t.Root).ToArray());
-            this.cachedFieldAssignmentsByTree = trees.ToDictionary(t => t, t => FindNodes<FieldAssignmentExpressionSyntax>(t.Root).ToArray());
-            this.cachedForRangesByTree = trees.ToDictionary(t => t, t => FindNodes<ForRangeStatementSyntax>(t.Root).ToArray());
-            this.cachedAwaitForRangesByTree = trees.ToDictionary(t => t, t => FindNodes<AwaitForRangeStatementSyntax>(t.Root).ToArray());
+            // Precompute per-compilation node lists. Resolve's fallback chain and the reference
+            // index need function/struct/accessor/field-assignment/for-range nodes; collecting all
+            // of them in a single parallel pass over each tree (instead of six separate FindNodes
+            // walks) keeps the per-edit SemanticModel rebuild cheap on large workspaces.
+            var treeArray = this.compilation.SyntaxTrees.ToArray();
+            var buckets = new NodeBuckets[treeArray.Length];
+            System.Threading.Tasks.Parallel.For(0, treeArray.Length, i => buckets[i] = CollectNodes(treeArray[i].Root));
+
+            this.cachedAccessorsByTree = new Dictionary<SyntaxTree, AccessorExpressionSyntax[]>(treeArray.Length);
+            this.cachedFieldAssignmentsByTree = new Dictionary<SyntaxTree, FieldAssignmentExpressionSyntax[]>(treeArray.Length);
+            this.cachedForRangesByTree = new Dictionary<SyntaxTree, ForRangeStatementSyntax[]>(treeArray.Length);
+            this.cachedAwaitForRangesByTree = new Dictionary<SyntaxTree, AwaitForRangeStatementSyntax[]>(treeArray.Length);
+            var functionsByFile = new Dictionary<string, List<FunctionDeclarationSyntax>>();
+            var structsByFile = new Dictionary<string, List<StructDeclarationSyntax>>();
+            this.memberAccessTokenSpans = new HashSet<(string, int, int)>();
+            this.fieldAssignmentTokenSpans = new HashSet<(string, int, int)>();
+
+            for (var i = 0; i < treeArray.Length; i++)
+            {
+                var tree = treeArray[i];
+                var bucket = buckets[i];
+                this.cachedAccessorsByTree[tree] = bucket.Accessors.ToArray();
+                this.cachedFieldAssignmentsByTree[tree] = bucket.FieldAssignments.ToArray();
+                this.cachedForRangesByTree[tree] = bucket.ForRanges.ToArray();
+                this.cachedAwaitForRangesByTree[tree] = bucket.AwaitForRanges.ToArray();
+
+                var fileName = tree.Text?.FileName ?? string.Empty;
+                if (bucket.Functions.Count > 0)
+                {
+                    if (!functionsByFile.TryGetValue(fileName, out var fns))
+                    {
+                        fns = new List<FunctionDeclarationSyntax>();
+                        functionsByFile[fileName] = fns;
+                    }
+
+                    fns.AddRange(bucket.Functions);
+                }
+
+                if (bucket.Structs.Count > 0)
+                {
+                    if (!structsByFile.TryGetValue(fileName, out var sts))
+                    {
+                        sts = new List<StructDeclarationSyntax>();
+                        structsByFile[fileName] = sts;
+                    }
+
+                    sts.AddRange(bucket.Structs);
+                }
+
+                foreach (var accessor in bucket.Accessors)
+                {
+                    foreach (var memberToken in EnumerateAccessorMemberTokens(accessor.RightPart))
+                    {
+                        var key = SpanKey(memberToken);
+                        if (key.HasValue)
+                        {
+                            this.memberAccessTokenSpans.Add(key.Value);
+                        }
+                    }
+                }
+
+                foreach (var assign in bucket.FieldAssignments)
+                {
+                    var key = SpanKey(assign.FieldIdentifier);
+                    if (key.HasValue)
+                    {
+                        this.fieldAssignmentTokenSpans.Add(key.Value);
+                    }
+                }
+            }
+
+            this.cachedFunctionsByFile = functionsByFile.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToArray());
+            this.cachedStructsByFile = structsByFile.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToArray());
         }
 
         public Symbol Resolve(SyntaxToken token)
@@ -941,10 +1025,18 @@ public static class SemanticLookup
 
         private Dictionary<Symbol, List<SyntaxToken>> BuildReferencesIndex()
         {
-            var index = new Dictionary<Symbol, List<SyntaxToken>>();
-            foreach (var tree in this.compilation.SyntaxTrees)
+            // Resolving every identifier token in the workspace is the dominant cost of the index
+            // build (the only thing that touches the model is read-only — all lookup tables are
+            // built once in the constructor — so the per-tree walks are independent). Resolve them
+            // in parallel across trees, then merge the per-tree partials in tree order to preserve
+            // a stable reference ordering.
+            var trees = this.compilation.SyntaxTrees;
+            var partials = new Dictionary<Symbol, List<SyntaxToken>>[trees.Length];
+
+            System.Threading.Tasks.Parallel.For(0, trees.Length, i =>
             {
-                foreach (var token in EnumerateTokens(tree.Root))
+                var local = new Dictionary<Symbol, List<SyntaxToken>>();
+                foreach (var token in EnumerateTokens(trees[i].Root))
                 {
                     if (token.IsMissing || token.Kind != SyntaxKind.IdentifierToken)
                     {
@@ -957,13 +1049,30 @@ public static class SemanticLookup
                         continue;
                     }
 
-                    if (!index.TryGetValue(symbol, out var list))
+                    if (!local.TryGetValue(symbol, out var list))
                     {
                         list = new List<SyntaxToken>();
-                        index[symbol] = list;
+                        local[symbol] = list;
                     }
 
                     list.Add(token);
+                }
+
+                partials[i] = local;
+            });
+
+            var index = new Dictionary<Symbol, List<SyntaxToken>>();
+            foreach (var partial in partials)
+            {
+                foreach (var pair in partial)
+                {
+                    if (!index.TryGetValue(pair.Key, out var list))
+                    {
+                        list = new List<SyntaxToken>();
+                        index[pair.Key] = list;
+                    }
+
+                    list.AddRange(pair.Value);
                 }
             }
 
@@ -978,6 +1087,31 @@ public static class SemanticLookup
             }
 
             return (token.SyntaxTree.Text.FileName ?? string.Empty, token.Span.Start, token.Span.End);
+        }
+
+        private static IEnumerable<SyntaxToken> EnumerateAccessorMemberTokens(ExpressionSyntax rightPart)
+        {
+            switch (rightPart)
+            {
+                case NameExpressionSyntax name:
+                    yield return name.IdentifierToken;
+                    break;
+                case CallExpressionSyntax call:
+                    yield return call.Identifier;
+                    break;
+                case AccessorExpressionSyntax nested:
+                    foreach (var t in EnumerateAccessorMemberTokens(nested.LeftPart))
+                    {
+                        yield return t;
+                    }
+
+                    foreach (var t in EnumerateAccessorMemberTokens(nested.RightPart))
+                    {
+                        yield return t;
+                    }
+
+                    break;
+            }
         }
 
         private static Symbol LookupMember(StructSymbol structSymbol, string memberName)
@@ -1025,7 +1159,13 @@ public static class SemanticLookup
             // implicit `this` receiver.
             StructDeclarationSyntax enclosing = null;
             var enclosingBodyLength = int.MaxValue;
-            foreach (var decl in this.cachedStructDeclarations)
+            var fileName = token.SyntaxTree?.Text?.FileName ?? string.Empty;
+            if (!this.cachedStructsByFile.TryGetValue(fileName, out var structs))
+            {
+                return null;
+            }
+
+            foreach (var decl in structs)
             {
                 foreach (var method in decl.Methods)
                 {
@@ -1075,40 +1215,18 @@ public static class SemanticLookup
 
         private bool IsRightOfMemberAccess(SyntaxToken token)
         {
-            // Cheap text-free check used to suppress fallback lookups. A token whose tree
-            // contains an AccessorExpressionSyntax or FieldAssignmentExpressionSyntax at this
-            // span is treated as a member name, and must not be resolved by name as a local
-            // or global.
-            if (token?.SyntaxTree == null)
+            // Cheap text-free check used to suppress fallback lookups. A token whose span is the
+            // member identifier of an AccessorExpressionSyntax or the field identifier of a
+            // FieldAssignmentExpressionSyntax is treated as a member name, and must not be
+            // resolved by name as a local or global. Backed by the precomputed O(1) span sets.
+            var spanKey = SpanKey(token);
+            if (!spanKey.HasValue)
             {
                 return false;
             }
 
-            if (this.cachedAccessorsByTree.TryGetValue(token.SyntaxTree, out var accessors))
-            {
-                foreach (var accessor in accessors)
-                {
-                    if (accessor.RightPart.Span.Start <= token.Span.Start
-                        && token.Span.End <= accessor.RightPart.Span.End
-                        && AccessorRightContainsMemberToken(accessor.RightPart, token))
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            if (this.cachedFieldAssignmentsByTree.TryGetValue(token.SyntaxTree, out var assignments))
-            {
-                foreach (var assign in assignments)
-                {
-                    if (TokenMatches(assign.FieldIdentifier, token))
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
+            return this.memberAccessTokenSpans.Contains(spanKey.Value)
+                || this.fieldAssignmentTokenSpans.Contains(spanKey.Value);
         }
 
         private static bool AccessorRightContainsMemberToken(ExpressionSyntax rightPart, SyntaxToken token)
@@ -1129,56 +1247,54 @@ public static class SemanticLookup
 
         private Symbol ResolveAsMemberAccess(SyntaxToken token)
         {
-            if (token == null || token.Kind != SyntaxKind.IdentifierToken)
+            if (token?.SyntaxTree == null || token.Kind != SyntaxKind.IdentifierToken)
             {
                 return null;
             }
 
-            // Walk the token's own tree first (covers the common case and works even when
-            // the compilation does not contain this tree — e.g. a stale DocumentContent).
-            // Then walk every compilation tree to support cross-file resolution.
-            var trees = new HashSet<SyntaxTree>();
-            if (token.SyntaxTree != null)
+            // A token physically lives in exactly one file, so its enclosing member-access
+            // expression is in that same tree (or, for an interpolation hole, the hole's
+            // re-parsed sub-tree which the token already points at). Scanning every compilation
+            // tree here was both wrong (spans are per-file offsets) and O(tokens x all-accessors)
+            // — it made the reference-index build take ~145s on a 54-file project.
+            var tree = token.SyntaxTree;
+
+            // Fast path: the vast majority of tokens are not member-access targets. An O(1) span
+            // check lets them bail out before scanning the file's accessors/assignments.
+            var spanKey = SpanKey(token);
+            if (!spanKey.HasValue
+                || (!this.memberAccessTokenSpans.Contains(spanKey.Value) && !this.fieldAssignmentTokenSpans.Contains(spanKey.Value)))
             {
-                trees.Add(token.SyntaxTree);
+                return null;
             }
 
-            foreach (var t in this.compilation.SyntaxTrees)
+            foreach (var accessor in this.GetAccessorsForTree(tree)
+                         .Where(a => a.RightPart.Span.Start <= token.Span.Start && token.Span.End <= a.RightPart.Span.End)
+                         .OrderBy(a => a.Span.Length))
             {
-                trees.Add(t);
-            }
-
-            foreach (var tree in trees)
-            {
-                var accessors = this.GetAccessorsForTree(tree);
-                foreach (var accessor in accessors
-                             .Where(a => a.RightPart.Span.Start <= token.Span.Start && token.Span.End <= a.RightPart.Span.End)
-                             .OrderBy(a => a.Span.Length))
+                if (TryDriveAccessorTarget(tree, accessor.RightPart, accessor.LeftPart, token, out var receiverExpr, out var memberName))
                 {
-                    if (TryDriveAccessorTarget(tree, accessor.RightPart, accessor.LeftPart, token, out var receiverExpr, out var memberName))
-                    {
-                        var receiverType = this.ResolveReceiverTypeSymbol(tree, receiverExpr);
-                        var member = LookupTypeMember(receiverType, memberName);
-                        if (member != null)
-                        {
-                            return member;
-                        }
-                    }
-                }
-
-                foreach (var assign in this.GetFieldAssignmentsForTree(tree))
-                {
-                    if (!TokenMatches(assign.FieldIdentifier, token))
-                    {
-                        continue;
-                    }
-
-                    var receiverType = AsTypeSymbol(this.Resolve(assign.Receiver));
-                    var member = LookupTypeMember(receiverType, assign.FieldIdentifier.Text);
+                    var receiverType = this.ResolveReceiverTypeSymbol(tree, receiverExpr);
+                    var member = LookupTypeMember(receiverType, memberName);
                     if (member != null)
                     {
                         return member;
                     }
+                }
+            }
+
+            foreach (var assign in this.GetFieldAssignmentsForTree(tree))
+            {
+                if (!TokenMatches(assign.FieldIdentifier, token))
+                {
+                    continue;
+                }
+
+                var receiverType = AsTypeSymbol(this.Resolve(assign.Receiver));
+                var member = LookupTypeMember(receiverType, assign.FieldIdentifier.Text);
+                if (member != null)
+                {
+                    return member;
                 }
             }
 
@@ -1311,7 +1427,13 @@ public static class SemanticLookup
         {
             FunctionDeclarationSyntax best = null;
             var bestLength = int.MaxValue;
-            foreach (var f in this.cachedFunctionDeclarations)
+            var fileName = token.SyntaxTree?.Text?.FileName ?? string.Empty;
+            if (!this.cachedFunctionsByFile.TryGetValue(fileName, out var functions))
+            {
+                return null;
+            }
+
+            foreach (var f in functions)
             {
                 if (f.Span.Start <= token.Span.Start && token.Span.End <= f.Span.End && f.Span.Length < bestLength)
                 {
@@ -1411,6 +1533,58 @@ public static class SemanticLookup
                 "void" => TypeSymbol.Void,
                 _ => null,
             };
+        }
+
+        private static NodeBuckets CollectNodes(SyntaxNode root)
+        {
+            var buckets = new NodeBuckets();
+            CollectNodes(root, buckets);
+            return buckets;
+        }
+
+        private static void CollectNodes(SyntaxNode node, NodeBuckets buckets)
+        {
+            switch (node)
+            {
+                case FunctionDeclarationSyntax f:
+                    buckets.Functions.Add(f);
+                    break;
+                case StructDeclarationSyntax s:
+                    buckets.Structs.Add(s);
+                    break;
+                case AccessorExpressionSyntax a:
+                    buckets.Accessors.Add(a);
+                    break;
+                case FieldAssignmentExpressionSyntax fa:
+                    buckets.FieldAssignments.Add(fa);
+                    break;
+                case ForRangeStatementSyntax fr:
+                    buckets.ForRanges.Add(fr);
+                    break;
+                case AwaitForRangeStatementSyntax afr:
+                    buckets.AwaitForRanges.Add(afr);
+                    break;
+            }
+
+            foreach (var child in node.GetChildren())
+            {
+                CollectNodes(child, buckets);
+            }
+        }
+
+        private sealed class NodeBuckets
+        {
+            public List<FunctionDeclarationSyntax> Functions { get; } = new();
+
+            public List<StructDeclarationSyntax> Structs { get; } = new();
+
+            public List<AccessorExpressionSyntax> Accessors { get; } = new();
+
+            public List<FieldAssignmentExpressionSyntax> FieldAssignments { get; } = new();
+
+            public List<ForRangeStatementSyntax> ForRanges { get; } = new();
+
+            public List<AwaitForRangeStatementSyntax> AwaitForRanges { get; } = new();
         }
     }
 }

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -20,8 +20,14 @@ using Range = GSharp.LanguageServer.Protocol.Range;
 namespace GSharp.LanguageServer.Server;
 
 /// <summary>
-/// Hosts the LSP method handlers and dispatches them through StreamJsonRpc. All handlers are
-/// serialized through a single gate so document mutations are applied before subsequent reads.
+/// Hosts the LSP method handlers and dispatches them through StreamJsonRpc. Concurrency
+/// follows Roslyn's RequestExecutionQueue model: mutating ("write") requests
+/// (didOpen/didChange/didSave/didClose/watchedFiles) hold a single gate for their brief
+/// body so the mutation is fully applied before later requests snapshot, while non-mutating
+/// ("read") requests only take the gate to capture an ordered, immutable document snapshot
+/// and then run their computation off the gate on the thread pool. This keeps reads fully
+/// concurrent and ensures a slow read (e.g. the first cold workspace bind) never blocks
+/// other reads or editing.
 /// </summary>
 public sealed class LspServer
 {
@@ -275,163 +281,230 @@ public sealed class LspServer
     }
 
     [JsonRpcMethod("textDocument/hover", UseSingleObjectParameterDeserialization = true)]
-    public Task<Hover> HoverAsync(HoverParams request)
-        => this.GuardAsync(() => this.TryGet(request.TextDocument, out var content)
-            ? HoverComputer.ComputeHover(content, request.Position)
-            : null);
+    public Task<Hover> HoverAsync(HoverParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => HoverComputer.ComputeHover(content, request.Position),
+            null,
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/definition", UseSingleObjectParameterDeserialization = true)]
-    public Task<Location> DefinitionAsync(DefinitionParams request)
-        => this.GuardAsync(() => this.TryGet(request.TextDocument, out var content)
-            ? DefinitionComputer.ComputeDefinition(request.TextDocument.Uri, content, request.Position)
-            : null);
+    public Task<Location> DefinitionAsync(DefinitionParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => DefinitionComputer.ComputeDefinition(request.TextDocument.Uri, content, request.Position),
+            null,
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/references", UseSingleObjectParameterDeserialization = true)]
-    public Task<Location[]> ReferencesAsync(ReferenceParams request)
-        => this.GuardAsync(() => this.TryGet(request.TextDocument, out var content)
-            ? ReferencesComputer.ComputeReferences(request.TextDocument.Uri, content, request.Position, request.Context?.IncludeDeclaration ?? false).ToArray()
-            : Array.Empty<Location>());
+    public Task<Location[]> ReferencesAsync(ReferenceParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => ReferencesComputer.ComputeReferences(request.TextDocument.Uri, content, request.Position, request.Context?.IncludeDeclaration ?? false).ToArray(),
+            Array.Empty<Location>(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/documentHighlight", UseSingleObjectParameterDeserialization = true)]
-    public Task<DocumentHighlight[]> DocumentHighlightAsync(DocumentHighlightParams request)
-        => this.GuardAsync(() =>
-        {
-            if (!this.TryGet(request.TextDocument, out var content))
+    public Task<DocumentHighlight[]> DocumentHighlightAsync(DocumentHighlightParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) =>
             {
-                return Array.Empty<DocumentHighlight>();
-            }
-
-            var tokens = ReferencesComputer.ComputeReferenceTokens(content, request.Position, includeDeclaration: true);
-            return tokens.Select(t => new DocumentHighlight
-            {
-                Range = SemanticLookup.ToRange(t),
-                Kind = DocumentHighlightKind.Text,
-            }).ToArray();
-        });
+                var tokens = ReferencesComputer.ComputeReferenceTokens(content, request.Position, includeDeclaration: true);
+                return tokens.Select(t => new DocumentHighlight
+                {
+                    Range = SemanticLookup.ToRange(t),
+                    Kind = DocumentHighlightKind.Text,
+                }).ToArray();
+            },
+            Array.Empty<DocumentHighlight>(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/documentSymbol", UseSingleObjectParameterDeserialization = true)]
-    public Task<SymbolInformationOrDocumentSymbol[]> DocumentSymbolAsync(DocumentSymbolParams request)
-        => this.GuardAsync(() => this.TryGet(request.TextDocument, out var content)
-            ? DocumentSymbolComputer.ComputeDocumentSymbols(content).ToArray()
-            : Array.Empty<SymbolInformationOrDocumentSymbol>());
+    public Task<SymbolInformationOrDocumentSymbol[]> DocumentSymbolAsync(DocumentSymbolParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => DocumentSymbolComputer.ComputeDocumentSymbols(content).ToArray(),
+            Array.Empty<SymbolInformationOrDocumentSymbol>(),
+            cancellationToken);
 
     [JsonRpcMethod("workspace/symbol", UseSingleObjectParameterDeserialization = true)]
-    public Task<WorkspaceSymbol[]> WorkspaceSymbolAsync(WorkspaceSymbolParams request)
-        => this.GuardAsync(() =>
-        {
-            var query = request.Query ?? string.Empty;
-            var results = new List<WorkspaceSymbol>();
-            foreach (var pair in this.documentContentService.AllDocuments)
+    public Task<WorkspaceSymbol[]> WorkspaceSymbolAsync(WorkspaceSymbolParams request, CancellationToken cancellationToken = default)
+        => this.ReadWorkspaceAsync(
+            (docs, ct) =>
             {
-                WorkspaceSymbolHandler.CollectSymbols(results, pair.Key, pair.Value, query);
-            }
+                var query = request.Query ?? string.Empty;
+                var results = new List<WorkspaceSymbol>();
+                foreach (var pair in docs)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    WorkspaceSymbolHandler.CollectSymbols(results, pair.Key, pair.Value, query);
+                }
 
-            return results.ToArray();
-        });
+                return results.ToArray();
+            },
+            Array.Empty<WorkspaceSymbol>(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/completion", UseSingleObjectParameterDeserialization = true)]
-    public Task<CompletionList> CompletionAsync(CompletionParams request)
-        => this.GuardAsync(() => this.TryGet(request.TextDocument, out var content)
-            ? new CompletionList(CompletionComputer.ComputeCompletions(content, request.Position))
-            : new CompletionList());
+    public Task<CompletionList> CompletionAsync(CompletionParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => new CompletionList(CompletionComputer.ComputeCompletions(content, request.Position)),
+            new CompletionList(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/signatureHelp", UseSingleObjectParameterDeserialization = true)]
-    public Task<SignatureHelp> SignatureHelpAsync(SignatureHelpParams request)
-        => this.GuardAsync(() => this.TryGet(request.TextDocument, out var content)
-            ? SignatureHelpComputer.ComputeSignatureHelp(content, request.Position)
-            : null);
+    public Task<SignatureHelp> SignatureHelpAsync(SignatureHelpParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => SignatureHelpComputer.ComputeSignatureHelp(content, request.Position),
+            null,
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/rename", UseSingleObjectParameterDeserialization = true)]
-    public Task<WorkspaceEdit> RenameAsync(RenameParams request)
-        => this.GuardAsync(() => this.TryGet(request.TextDocument, out var content)
-            ? RenameComputer.ComputeRename(request.TextDocument.Uri, content, request.Position, request.NewName)
-            : null);
+    public Task<WorkspaceEdit> RenameAsync(RenameParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => RenameComputer.ComputeRename(request.TextDocument.Uri, content, request.Position, request.NewName),
+            null,
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/prepareRename", UseSingleObjectParameterDeserialization = true)]
-    public Task<Range> PrepareRenameAsync(PrepareRenameParams request)
-        => this.GuardAsync(() => this.ComputePrepareRename(request));
+    public Task<Range> PrepareRenameAsync(PrepareRenameParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => this.ComputePrepareRename(content, request),
+            null,
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/codeAction", UseSingleObjectParameterDeserialization = true)]
-    public Task<CommandOrCodeActionContainer> CodeActionAsync(CodeActionParams request)
-        => this.GuardAsync(() => this.TryGet(request.TextDocument, out var content)
-            ? CodeActionComputer.ComputeCodeActions(request.TextDocument.Uri, content, request.Range)
-            : new CommandOrCodeActionContainer());
+    public Task<CommandOrCodeActionContainer> CodeActionAsync(CodeActionParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => CodeActionComputer.ComputeCodeActions(request.TextDocument.Uri, content, request.Range),
+            new CommandOrCodeActionContainer(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/codeLens", UseSingleObjectParameterDeserialization = true)]
-    public Task<CodeLens[]> CodeLensAsync(CodeLensParams request)
-        => this.GuardAsync(() => this.TryGet(request.TextDocument, out var content)
-            ? CodeLensComputer.ComputeLenses(content, request.TextDocument.Uri?.ToString()).ToArray()
-            : Array.Empty<CodeLens>());
+    public Task<CodeLens[]> CodeLensAsync(CodeLensParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => CodeLensComputer.ComputeLenses(content, request.TextDocument.Uri?.ToString()).ToArray(),
+            Array.Empty<CodeLens>(),
+            cancellationToken);
 
     [JsonRpcMethod("gsharp/discoverTests")]
-    public Task<TestDiscoveryItem[]> DiscoverTestsAsync()
-        => this.GuardAsync(() =>
-        {
-            var results = new List<TestDiscoveryItem>();
-            foreach (var pair in this.documentContentService.AllDocuments)
+    public Task<TestDiscoveryItem[]> DiscoverTestsAsync(CancellationToken cancellationToken = default)
+        => this.ReadWorkspaceAsync(
+            (docs, ct) =>
             {
-                results.AddRange(TestDiscoveryComputer.ComputeTests(pair.Key, pair.Value));
-            }
+                var results = new List<TestDiscoveryItem>();
+                foreach (var pair in docs)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    results.AddRange(TestDiscoveryComputer.ComputeTests(pair.Key, pair.Value));
+                }
 
-            return results.ToArray();
-        });
+                return results.ToArray();
+            },
+            Array.Empty<TestDiscoveryItem>(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/inlayHint", UseSingleObjectParameterDeserialization = true)]
-    public Task<InlayHint[]> InlayHintAsync(InlayHintParams request)
-        => this.GuardAsync(() => this.TryGet(request.TextDocument, out var content)
-            ? InlayHintComputer.ComputeHints(content).ToArray()
-            : Array.Empty<InlayHint>());
+    public Task<InlayHint[]> InlayHintAsync(InlayHintParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => InlayHintComputer.ComputeHints(content).ToArray(),
+            Array.Empty<InlayHint>(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/foldingRange", UseSingleObjectParameterDeserialization = true)]
-    public Task<FoldingRange[]> FoldingRangeAsync(FoldingRangeParams request)
-        => this.GuardAsync(() => this.TryGet(request.TextDocument, out var content)
-            ? FoldingComputer.ComputeFoldings(content).ToArray()
-            : Array.Empty<FoldingRange>());
+    public Task<FoldingRange[]> FoldingRangeAsync(FoldingRangeParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => FoldingComputer.ComputeFoldings(content).ToArray(),
+            Array.Empty<FoldingRange>(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/selectionRange", UseSingleObjectParameterDeserialization = true)]
-    public Task<SelectionRange[]> SelectionRangeAsync(SelectionRangeParams request)
-        => this.GuardAsync(() =>
-        {
-            if (!this.TryGet(request.TextDocument, out var content) || request.Positions == null)
-            {
-                return Array.Empty<SelectionRange>();
-            }
-
-            return request.Positions.Select(p => SelectionRangeComputer.ComputeSelectionRange(content, p)).ToArray();
-        });
+    public Task<SelectionRange[]> SelectionRangeAsync(SelectionRangeParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => request.Positions == null
+                ? Array.Empty<SelectionRange>()
+                : request.Positions.Select(p => SelectionRangeComputer.ComputeSelectionRange(content, p)).ToArray(),
+            Array.Empty<SelectionRange>(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/semanticTokens/full", UseSingleObjectParameterDeserialization = true)]
-    public Task<SemanticTokens> SemanticTokensFullAsync(SemanticTokensParams request)
-        => this.GuardAsync(() => this.ComputeSemanticTokens(request.TextDocument));
+    public Task<SemanticTokens> SemanticTokensFullAsync(SemanticTokensParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => this.ComputeSemanticTokens(content),
+            EmptySemanticTokens(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/semanticTokens/range", UseSingleObjectParameterDeserialization = true)]
-    public Task<SemanticTokens> SemanticTokensRangeAsync(SemanticTokensRangeParams request)
-        => this.GuardAsync(() => this.ComputeSemanticTokens(request.TextDocument));
+    public Task<SemanticTokens> SemanticTokensRangeAsync(SemanticTokensRangeParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => this.ComputeSemanticTokens(content),
+            EmptySemanticTokens(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/formatting", UseSingleObjectParameterDeserialization = true)]
-    public Task<TextEdit[]> FormattingAsync(DocumentFormattingParams request)
-        => this.GuardAsync(() => this.FormatDocument(request.TextDocument));
+    public Task<TextEdit[]> FormattingAsync(DocumentFormattingParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => this.FormatDocument(content),
+            Array.Empty<TextEdit>(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/rangeFormatting", UseSingleObjectParameterDeserialization = true)]
-    public Task<TextEdit[]> RangeFormattingAsync(DocumentRangeFormattingParams request)
-        => this.GuardAsync(() => this.FormatDocument(request.TextDocument));
+    public Task<TextEdit[]> RangeFormattingAsync(DocumentRangeFormattingParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => this.FormatDocument(content),
+            Array.Empty<TextEdit>(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/onTypeFormatting", UseSingleObjectParameterDeserialization = true)]
-    public Task<TextEdit[]> OnTypeFormattingAsync(DocumentOnTypeFormattingParams request)
-        => this.GuardAsync(() => this.FormatDocument(request.TextDocument));
+    public Task<TextEdit[]> OnTypeFormattingAsync(DocumentOnTypeFormattingParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => this.FormatDocument(content),
+            Array.Empty<TextEdit>(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/implementation", UseSingleObjectParameterDeserialization = true)]
-    public Task<Location[]> ImplementationAsync(ImplementationParams request)
-        => this.GuardAsync(() => this.ComputeImplementation(request));
+    public Task<Location[]> ImplementationAsync(ImplementationParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => this.ComputeImplementation(content, request),
+            Array.Empty<Location>(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/typeDefinition", UseSingleObjectParameterDeserialization = true)]
-    public Task<Location[]> TypeDefinitionAsync(TypeDefinitionParams request)
-        => this.GuardAsync(() => this.ComputeTypeDefinition(request));
+    public Task<Location[]> TypeDefinitionAsync(TypeDefinitionParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => this.ComputeTypeDefinition(content, request),
+            Array.Empty<Location>(),
+            cancellationToken);
 
     [JsonRpcMethod("textDocument/linkedEditingRange", UseSingleObjectParameterDeserialization = true)]
-    public Task<LinkedEditingRanges> LinkedEditingRangeAsync(LinkedEditingRangeParams request)
-        => this.GuardAsync(() => this.ComputeLinkedEditingRanges(request));
+    public Task<LinkedEditingRanges> LinkedEditingRangeAsync(LinkedEditingRangeParams request, CancellationToken cancellationToken = default)
+        => this.ReadDocumentAsync(
+            request.TextDocument,
+            (content, ct) => this.ComputeLinkedEditingRanges(content, request),
+            null,
+            cancellationToken);
 
+    // Mutating ("write") path. Mirrors Roslyn's RequestExecutionQueue handling of
+    // MutatesSolutionState=true requests: the gate is held for the whole (brief,
+    // parse-only) body so the mutation is fully applied before any later request
+    // captures its snapshot. didOpen/didChange/didSave/didClose/watchedFiles use this.
     private async Task<T> GuardAsync<T>(Func<T> body, [System.Runtime.CompilerServices.CallerMemberName] string caller = null)
     {
         await this.gate.WaitAsync().ConfigureAwait(false);
@@ -463,6 +536,130 @@ public sealed class LspServer
             this.gate.Release();
         }
     }
+
+    // Non-mutating ("read") path. Mirrors Roslyn's RequestExecutionQueue handling of
+    // non-mutating requests: the request's snapshot (here, the immutable DocumentContent)
+    // is captured serially under the gate so it reflects every prior mutation, and the
+    // gate is held only for that O(1) capture. The actual computation then runs OFF the
+    // gate on the thread pool via Task.Run so that:
+    //   * concurrent read requests never serialize behind one another, and
+    //   * a long-running read (e.g. the first cold full-workspace bind, ~17s on a large
+    //     workspace) never blocks unrelated reads or, crucially, a didChange while typing.
+    // Roslyn likewise dispatches non-mutating work via Task.Run "to enforce parallelizability".
+    // CancellationToken is honored end-to-end: StreamJsonRpc maps the LSP $/cancelRequest
+    // notification onto this token, so superseded hovers/highlights abort instead of
+    // consuming a thread-pool thread to completion.
+    private async Task<T> ReadDocumentAsync<T>(
+        TextDocumentIdentifier identifier,
+        Func<DocumentContent, CancellationToken, T> compute,
+        T missing,
+        CancellationToken cancellationToken,
+        [System.Runtime.CompilerServices.CallerMemberName] string caller = null)
+    {
+        DocumentContent content;
+        try
+        {
+            await this.gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (!this.TryGet(identifier, out content) || content == null)
+                {
+                    return missing;
+                }
+            }
+            finally
+            {
+                this.gate.Release();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Issue #816: even the snapshot lookup can throw (a faulted content service).
+            // Degrade to "no result" rather than surfacing an error popup to the client.
+            LogHandlerException(caller, ex);
+            return missing;
+        }
+
+        return await Task.Run(
+            () =>
+            {
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return compute(content, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    LogHandlerException(caller, ex);
+                    return missing;
+                }
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    // Non-mutating read over the whole open-document set (workspace symbols, test
+    // discovery). The document list is snapshotted under the gate, then enumerated and
+    // computed off the gate, identical in spirit to <see cref="ReadDocumentAsync{T}"/>.
+    private async Task<T> ReadWorkspaceAsync<T>(
+        Func<IReadOnlyList<KeyValuePair<string, DocumentContent>>, CancellationToken, T> compute,
+        T missing,
+        CancellationToken cancellationToken,
+        [System.Runtime.CompilerServices.CallerMemberName] string caller = null)
+    {
+        IReadOnlyList<KeyValuePair<string, DocumentContent>> documents;
+        try
+        {
+            await this.gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                documents = this.documentContentService.AllDocuments.ToList();
+            }
+            finally
+            {
+                this.gate.Release();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogHandlerException(caller, ex);
+            return missing;
+        }
+
+        return await Task.Run(
+            () =>
+            {
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return compute(documents, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    LogHandlerException(caller, ex);
+                    return missing;
+                }
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static SemanticTokens EmptySemanticTokens()
+        => new SemanticTokens { Data = System.Collections.Immutable.ImmutableArray<int>.Empty };
 
     private static void LogHandlerException(string handler, Exception ex)
     {
@@ -613,13 +810,8 @@ public sealed class LspServer
         return Convert.ToHexString(bytes);
     }
 
-    private SemanticTokens ComputeSemanticTokens(TextDocumentIdentifier identifier)
+    private SemanticTokens ComputeSemanticTokens(DocumentContent content)
     {
-        if (!this.TryGet(identifier, out var content))
-        {
-            return new SemanticTokens { Data = System.Collections.Immutable.ImmutableArray<int>.Empty };
-        }
-
         var document = new SemanticTokensDocument(SemanticTokensHandler.Legend);
         var builder = document.Create();
         SemanticTokensComputer.Tokenize(builder, content);
@@ -627,13 +819,8 @@ public sealed class LspServer
         return document.GetSemanticTokens();
     }
 
-    private TextEdit[] FormatDocument(TextDocumentIdentifier identifier)
+    private TextEdit[] FormatDocument(DocumentContent content)
     {
-        if (!this.TryGet(identifier, out var content))
-        {
-            return Array.Empty<TextEdit>();
-        }
-
         var sourceText = content.SyntaxTree.Text;
         var originalText = sourceText.ToString();
         var formatted = FormattingEngine.Format(originalText);
@@ -654,13 +841,8 @@ public sealed class LspServer
         };
     }
 
-    private Range ComputePrepareRename(PrepareRenameParams request)
+    private Range ComputePrepareRename(DocumentContent content, PrepareRenameParams request)
     {
-        if (!this.TryGet(request.TextDocument, out var content))
-        {
-            return null;
-        }
-
         var offset = SemanticLookup.ToOffset(content, request.Position);
         var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
         if (token == null || token.Kind != SyntaxKind.IdentifierToken)
@@ -678,13 +860,8 @@ public sealed class LspServer
         return SemanticLookup.CanRename(symbol) ? SemanticLookup.ToRange(token) : null;
     }
 
-    private Location[] ComputeImplementation(ImplementationParams request)
+    private Location[] ComputeImplementation(DocumentContent content, ImplementationParams request)
     {
-        if (!this.TryGet(request.TextDocument, out var content))
-        {
-            return Array.Empty<Location>();
-        }
-
         var offset = SemanticLookup.ToOffset(content, request.Position);
         var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
         if (token == null || token.Kind != SyntaxKind.IdentifierToken)
@@ -720,13 +897,8 @@ public sealed class LspServer
         return locations.ToArray();
     }
 
-    private Location[] ComputeTypeDefinition(TypeDefinitionParams request)
+    private Location[] ComputeTypeDefinition(DocumentContent content, TypeDefinitionParams request)
     {
-        if (!this.TryGet(request.TextDocument, out var content))
-        {
-            return Array.Empty<Location>();
-        }
-
         var offset = SemanticLookup.ToOffset(content, request.Position);
         var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
         if (token == null || token.Kind != SyntaxKind.IdentifierToken)
@@ -770,13 +942,8 @@ public sealed class LspServer
         };
     }
 
-    private LinkedEditingRanges ComputeLinkedEditingRanges(LinkedEditingRangeParams request)
+    private LinkedEditingRanges ComputeLinkedEditingRanges(DocumentContent content, LinkedEditingRangeParams request)
     {
-        if (!this.TryGet(request.TextDocument, out var content))
-        {
-            return null;
-        }
-
         var tree = content.SyntaxTree;
         var offset = SemanticLookup.ToOffset(content, request.Position);
         var token = SemanticLookup.FindTokenAt(tree, offset);

--- a/test/LanguageServer.Tests/CompletionHandlerTests.cs
+++ b/test/LanguageServer.Tests/CompletionHandlerTests.cs
@@ -125,6 +125,46 @@ public class CompletionHandlerTests
     }
 
     [Fact]
+    public void ComputeCompletions_AfterDotOnImplicitThisProperty_OffersMemberTypeMembers()
+    {
+        // `Item.` where Item is a property of the enclosing class (implicit-this access).
+        // Previously the receiver switch had no PropertySymbol case, so this returned nothing.
+        const string source = "class Inner {\n    prop Value int32\n}\nclass Outer {\n    prop Item Inner\n    func F() {\n        Item.\n    }\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, After(source, "Item."));
+
+        Assert.Contains(items, i => i.Label == "Value");
+        Assert.DoesNotContain(items, i => i.Kind == CompletionItemKind.Keyword);
+    }
+
+    [Fact]
+    public void ComputeCompletions_AfterDotOnImplicitThisField_OffersMemberTypeMembers()
+    {
+        // `item.` where item is a field of the enclosing class (implicit-this access).
+        const string source = "class Inner {\n    prop Value int32\n}\nclass Outer {\n    var item Inner\n    func F() {\n        item.\n    }\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, After(source, "item."));
+
+        Assert.Contains(items, i => i.Label == "Value");
+        Assert.DoesNotContain(items, i => i.Kind == CompletionItemKind.Keyword);
+    }
+
+    [Fact]
+    public void ComputeCompletions_AfterDotOnImplicitThisPropertyOfPrimitiveType_OffersClrMembers()
+    {
+        // Matches the reported case: a property of a primitive type accessed via implicit this.
+        const string source = "class Rect {\n    prop Width int32\n    func Area() {\n        Width.\n    }\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, After(source, "Width."));
+
+        Assert.Contains(items, i => i.Label == "ToString" && i.Kind == CompletionItemKind.Method);
+        Assert.DoesNotContain(items, i => i.Kind == CompletionItemKind.Keyword);
+    }
+
+    [Fact]
     public void ComputeCompletions_AfterDotOnEnumType_OffersEnumMembers()
     {
         const string source = "enum Color { Red, Green, Blue }\nfunc use() {\nColor.\n}\n";

--- a/test/LanguageServer.Tests/CrossAssemblyNavigationTests.cs
+++ b/test/LanguageServer.Tests/CrossAssemblyNavigationTests.cs
@@ -1,0 +1,108 @@
+// <copyright file="CrossAssemblyNavigationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using GSharp.LanguageServer.Protocol;
+using GSharp.LanguageServer.Server;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// Regression coverage for cross-assembly Go-to-Definition (Tier 2, portable-PDB
+/// navigation) and for CodeLens in a real project context. These exercise the exact
+/// "navigate to a C# type/member in the same solution" and "reference lenses" features.
+/// They use the repo's own C#-compiled <c>GSharp.Core.dll</c> (with its sidecar PDB and
+/// <c>.cs</c> sources on disk) as a faithful stand-in for a sibling C# project.
+/// </summary>
+public class CrossAssemblyNavigationTests
+{
+    [Fact]
+    public void Tier2_PdbNavigation_ResolvesCSharpCompiledTypeToSource()
+    {
+        var type = typeof(GSharp.Core.CodeAnalysis.Symbols.PropertySymbol);
+        var asmPath = type.Assembly.Location;
+        if (!HasPortablePdb(asmPath))
+        {
+            return; // No PDB in this build configuration — navigation is intentionally a no-op.
+        }
+
+        var ok = PdbSourceLocator.TryGetTypeSourceLocation(asmPath, type.MetadataToken, out var loc);
+
+        Assert.True(ok, "Tier-2 PDB navigation should resolve a C#-compiled type to source.");
+        Assert.Contains("PropertySymbol", loc.FilePath);
+    }
+
+    [Fact]
+    public void GoToDefinition_OnCSharpTypeReferencedFromGsharp_NavigatesToSource()
+    {
+        // The "C# type in the same solution" scenario: a G# project references a C#
+        // assembly and uses one of its types; go-to-definition lands in the C# source.
+        var corePath = typeof(GSharp.Core.CodeAnalysis.Text.SourceText).Assembly.Location;
+        if (!HasPortablePdb(corePath))
+        {
+            return;
+        }
+
+        const string source = "import GSharp.Core.CodeAnalysis.Text\n\nfunc F(s SourceText) {\n}\n";
+
+        var project = new ProjectState(Path.Combine(Path.GetTempPath(), "e2e", "e2e.gsproj"));
+        project.References = new[] { corePath };
+        project.UpdateFile("/tmp/e2e/a.gs", source);
+        var tree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree.Parse(
+            GSharp.Core.CodeAnalysis.Text.SourceText.From(source, "/tmp/e2e/a.gs"));
+        var lines = Enumerable.Range(0, source.Length).Where(i => source[i] == '\n').ToList();
+        var content = new DocumentContent(tree, lines, project, new WorkspaceState());
+        var uri = DocumentUri.From("file:///tmp/e2e/a.gs");
+
+        var loc = DefinitionComputer.ComputeDefinition(uri, content, LanguageServerTestHelpers.PositionOf(source, "SourceText", 0));
+
+        Assert.NotNull(loc);
+        Assert.Contains("SourceText", loc.Uri.GetFileSystemPath());
+    }
+
+    [Fact]
+    public async Task CodeLens_InProjectContext_ReturnsReferenceLenses()
+    {
+        var rootDir = Path.Combine(Path.GetTempPath(), "gscl_" + Guid.NewGuid().ToString("N"));
+        var projDir = Path.Combine(rootDir, "Demo");
+        Directory.CreateDirectory(projDir);
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(projDir, "Demo.gsproj"),
+                "<Project Sdk=\"Gsharp.NET.Sdk\">\n  <PropertyGroup><OutputType>Library</OutputType><TargetFramework>net10.0</TargetFramework><AssemblyName>Demo</AssemblyName></PropertyGroup>\n</Project>\n");
+
+            const string source = "package Demo\n\nclass Rect {\n    prop Width int32\n    prop Height int32\n    func Area() int32 { return Width * Height }\n}\n\nclass User {\n    func Make() Rect { return Rect() }\n}\n";
+            var gsPath = Path.Combine(projDir, "Rect.gs");
+            File.WriteAllText(gsPath, source);
+
+            var workspace = new WorkspaceState();
+            WorkspaceInitializer.Initialize(workspace, rootDir);
+            var server = new LspServer(new DocumentContentService(), workspace);
+            var uri = DocumentUri.FromFileSystemPath(gsPath);
+            await server.DidOpenAsync(new DidOpenTextDocumentParams
+            {
+                TextDocument = new TextDocumentItem { Uri = uri, Text = source },
+            });
+
+            var lenses = await server.CodeLensAsync(new CodeLensParams { TextDocument = new TextDocumentIdentifier { Uri = uri } });
+
+            Assert.NotNull(lenses);
+            Assert.NotEmpty(lenses);
+            // The Rect class declaration carries a reference lens (referenced by User.Make).
+            Assert.Contains(lenses, l => l.Command != null && l.Command.Title.Contains("reference"));
+        }
+        finally
+        {
+            try { Directory.Delete(rootDir, recursive: true); } catch { }
+        }
+    }
+
+    private static bool HasPortablePdb(string assemblyPath)
+        => !string.IsNullOrEmpty(assemblyPath) && File.Exists(Path.ChangeExtension(assemblyPath, ".pdb"));
+}

--- a/test/LanguageServer.Tests/CrossAssemblySourceSearchTests.cs
+++ b/test/LanguageServer.Tests/CrossAssemblySourceSearchTests.cs
@@ -1,0 +1,104 @@
+// <copyright file="CrossAssemblySourceSearchTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// Regression tests for Tier-3 cross-assembly navigation (source-text search). Portable PDBs
+/// only record sequence points for method bodies, so go-to-definition on a C# interface (or any
+/// type with no executable code) can't be located via the PDB; instead the owning project's
+/// source files are scanned for the declaration.
+/// </summary>
+public class CrossAssemblySourceSearchTests
+{
+    [Fact]
+    public void SourceSearch_FindsInterfaceDeclaration_FromSiblingProjectLayout()
+    {
+        // Mimic the standard MSBuild layout: <project>/obj/.../<asm>.dll with sources under
+        // <project>. Tier 2 (PDB) can't resolve interfaces, so Tier 3 must find the source.
+        var projectDir = Path.Combine(Path.GetTempPath(), "gsxasm_" + Guid.NewGuid().ToString("N"), "MyLib");
+        var objDll = Path.Combine(projectDir, "obj", "Debug", "net10.0", "ref", "MyLib.dll");
+        Directory.CreateDirectory(Path.GetDirectoryName(objDll));
+        Directory.CreateDirectory(Path.Combine(projectDir, "Auth"));
+        try
+        {
+            File.WriteAllText(objDll, "not-a-real-dll"); // only the path matters for Tier 3
+            var srcFile = Path.Combine(projectDir, "Auth", "Broker.cs");
+            File.WriteAllText(srcFile, "namespace X\n{\n    public interface IAuthCallbackBroker\n    {\n        void Solve();\n    }\n}\n");
+
+            // type is only consulted for its simple name (matches the declared interface).
+            var ok = CrossAssemblyDefinitionResolver.TryResolveTypeBySourceSearch(objDll, typeof(IAuthCallbackBroker), out var location);
+
+            Assert.True(ok);
+            Assert.NotNull(location);
+            Assert.Equal(srcFile, location.Uri.GetFileSystemPath());
+            Assert.Equal(2, location.Range.Start.Line); // `public interface IAuthCallbackBroker` is line 2 (0-based)
+        }
+        finally
+        {
+            try { Directory.Delete(Path.GetDirectoryName(projectDir), recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void SourceSearch_ReturnsFalse_WhenAssemblyNotUnderProjectLayout()
+    {
+        // A NuGet/SDK assembly path with no obj/bin project root must not match anything.
+        var ok = CrossAssemblyDefinitionResolver.TryResolveTypeBySourceSearch(
+            "/usr/share/dotnet/shared/Microsoft.NETCore.App/10.0.0/System.Runtime.dll",
+            typeof(IDummyAuthCallbackBroker),
+            out var location);
+
+        Assert.False(ok);
+        Assert.Null(location);
+    }
+
+    [Fact]
+    public void MemberSourceSearch_FindsMethodDeclaration_NotCallSites()
+    {
+        var projectDir = Path.Combine(Path.GetTempPath(), "gsxmem_" + Guid.NewGuid().ToString("N"), "MyLib");
+        var objDll = Path.Combine(projectDir, "obj", "Debug", "net10.0", "ref", "MyLib.dll");
+        Directory.CreateDirectory(Path.GetDirectoryName(objDll));
+        try
+        {
+            File.WriteAllText(objDll, "not-a-real-dll");
+            var srcFile = Path.Combine(projectDir, "Service.cs");
+            // Call site of ToCliRegion appears first; the declaration is later. The search must
+            // skip the call and land on the declaration.
+            File.WriteAllText(
+                srcFile,
+                "namespace X\n{\n    public sealed class CoreAuthService\n    {\n        public int Use() => ToCliRegion(0) + 1;\n\n        public static int ToCliRegion(int region) => region;\n    }\n}\n");
+
+            var ok = CrossAssemblyDefinitionResolver.TryResolveMemberBySourceSearch(objDll, typeof(CoreAuthService), "ToCliRegion", out var location);
+
+            Assert.True(ok);
+            Assert.NotNull(location);
+            Assert.Equal(srcFile, location.Uri.GetFileSystemPath());
+            // The declaration `public static int ToCliRegion(...)` is on line 6 (0-based).
+            Assert.Equal(6, location.Range.Start.Line);
+        }
+        finally
+        {
+            try { Directory.Delete(Path.GetDirectoryName(projectDir), recursive: true); } catch { }
+        }
+    }
+
+    // A type whose simple name matches the interface declared in the synthetic source above.
+    private interface IAuthCallbackBroker
+    {
+    }
+
+    private interface IDummyAuthCallbackBroker
+    {
+    }
+
+    // A type whose simple name matches the class declared in the member-search source above.
+    private sealed class CoreAuthService
+    {
+    }
+}

--- a/test/LanguageServer.Tests/DefinitionHandlerTests.cs
+++ b/test/LanguageServer.Tests/DefinitionHandlerTests.cs
@@ -65,4 +65,48 @@ public class DefinitionHandlerTests
 
         Assert.Null(location);
     }
+
+    [Fact]
+    public void ComputeDefinition_PropertyUsageGoesToDeclaration()
+    {
+        // Implicit-this property usage (`Width` inside a method) must navigate to the
+        // property declaration. Previously FindDeclarationToken had no PropertySymbol case.
+        const string source = "class Rect {\n    prop Width int32\n    func Double() int32 { return Width + Width }\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var uri = DocumentUri.From("file:///def.gs");
+
+        var location = DefinitionComputer.ComputeDefinition(uri, content, LanguageServerTestHelpers.PositionOf(source, "Width", 1));
+
+        Assert.NotNull(location);
+        Assert.Equal(uri, location.Uri);
+        // Declaration identifier "Width" is on line 1 (0-based).
+        Assert.Equal(1, location.Range.Start.Line);
+    }
+
+    [Fact]
+    public void ComputeDefinition_ExplicitPropertyAccessGoesToDeclaration()
+    {
+        // `this.Width` member access must navigate to the property declaration.
+        const string source = "class Rect {\n    prop Width int32\n    func Get() int32 { return this.Width }\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var uri = DocumentUri.From("file:///def.gs");
+
+        var location = DefinitionComputer.ComputeDefinition(uri, content, LanguageServerTestHelpers.PositionOf(source, "Width", 1));
+
+        Assert.NotNull(location);
+        Assert.Equal(1, location.Range.Start.Line);
+    }
+
+    [Fact]
+    public void ComputeDefinition_MethodUsageGoesToDeclaration()
+    {
+        const string source = "class Calc {\n    func Add(a int32, b int32) int32 { return a + b }\n    func Run() int32 { return Add(1, 2) }\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var uri = DocumentUri.From("file:///def.gs");
+
+        var location = DefinitionComputer.ComputeDefinition(uri, content, LanguageServerTestHelpers.PositionOf(source, "Add", 1));
+
+        Assert.NotNull(location);
+        Assert.Equal(1, location.Range.Start.Line);
+    }
 }

--- a/test/LanguageServer.Tests/LspServerConcurrencyTests.cs
+++ b/test/LanguageServer.Tests/LspServerConcurrencyTests.cs
@@ -1,0 +1,83 @@
+// <copyright file="LspServerConcurrencyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GSharp.LanguageServer.Protocol;
+using GSharp.LanguageServer.Server;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// Locks in the request-concurrency model (mirrors Roslyn's RequestExecutionQueue):
+/// non-mutating ("read") requests capture an ordered snapshot under the intake gate and
+/// then compute off the gate, so they run concurrently and honor cancellation. Previously
+/// every handler held a single gate for its entire computation, serializing all language
+/// services behind the slowest in-flight request (e.g. the first cold workspace bind),
+/// which made the editor appear unresponsive.
+/// </summary>
+public class LspServerConcurrencyTests
+{
+    private const string Source = @"package Demo
+
+func Add(a int32, b int32) int32 {
+    return a + b
+}
+";
+
+    [Fact]
+    public async Task ReadHandlers_HonorAlreadyCancelledToken()
+    {
+        var server = new LspServer(new DocumentContentService(), new WorkspaceState());
+        var uri = DocumentUri.From("file:///concurrency-cancel.gs");
+        await server.DidOpenAsync(new DidOpenTextDocumentParams
+        {
+            TextDocument = new TextDocumentItem { Uri = uri, Text = Source },
+        });
+
+        var id = new TextDocumentIdentifier { Uri = uri };
+        var cancelled = new CancellationToken(canceled: true);
+
+        // A request whose token is already cancelled (e.g. a superseded hover that the
+        // client cancelled via $/cancelRequest) must abort instead of computing to
+        // completion and tying up a thread.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => server.HoverAsync(new HoverParams { TextDocument = id, Position = new Position(2, 9) }, cancelled));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => server.SemanticTokensFullAsync(new SemanticTokensParams { TextDocument = id }, cancelled));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => server.DocumentSymbolAsync(new DocumentSymbolParams { TextDocument = id }, cancelled));
+    }
+
+    [Fact]
+    public async Task ReadHandlers_RunConcurrently_WithoutDeadlock()
+    {
+        var server = new LspServer(new DocumentContentService(), new WorkspaceState());
+        var uri = DocumentUri.From("file:///concurrency-parallel.gs");
+        await server.DidOpenAsync(new DidOpenTextDocumentParams
+        {
+            TextDocument = new TextDocumentItem { Uri = uri, Text = Source },
+        });
+
+        var id = new TextDocumentIdentifier { Uri = uri };
+
+        // Fire a burst of independent read requests at once. With the old single-gate
+        // model these serialized; they must now all complete (the property under test is
+        // simply that concurrent reads neither deadlock nor corrupt shared state).
+        var reads = Enumerable.Range(0, 32).Select(_ => Task.Run(async () =>
+        {
+            await server.DocumentSymbolAsync(new DocumentSymbolParams { TextDocument = id });
+            await server.FoldingRangeAsync(new FoldingRangeParams { TextDocument = id });
+            await server.SemanticTokensFullAsync(new SemanticTokensParams { TextDocument = id });
+            await server.HoverAsync(new HoverParams { TextDocument = id, Position = new Position(2, 9) });
+        }));
+
+        await Task.WhenAll(reads);
+    }
+}

--- a/test/LanguageServer.Tests/LspServerMemberFeatureTests.cs
+++ b/test/LanguageServer.Tests/LspServerMemberFeatureTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="LspServerMemberFeatureTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GSharp.LanguageServer.Protocol;
+using GSharp.LanguageServer.Server;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// End-to-end coverage (through the real <see cref="LspServer"/> request pipeline, including
+/// didOpen, diagnostic pulls and didChange edits) for class-member features that resolve a
+/// property/field receiver: go-to-definition, member completion, and reference code lens.
+/// Regression guard for the member-symbol resolution gaps that returned no result.
+/// </summary>
+public class LspServerMemberFeatureTests
+{
+    [Fact]
+    public async Task PropertyMemberFeatures_WorkAfterEditsAndDiagnostics()
+    {
+        var rootDir = Path.Combine(Path.GetTempPath(), "gsmf_" + Guid.NewGuid().ToString("N"));
+        var projDir = Path.Combine(rootDir, "Demo");
+        Directory.CreateDirectory(projDir);
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(projDir, "Demo.gsproj"),
+                "<Project Sdk=\"Gsharp.NET.Sdk\">\n  <PropertyGroup><OutputType>Library</OutputType><TargetFramework>net10.0</TargetFramework><AssemblyName>Demo</AssemblyName></PropertyGroup>\n</Project>\n");
+
+            var v1 = "package Demo\n\nclass Rect {\n    prop Width int32\n    prop Height int32\n    func Area() int32 { return Width }\n}\n";
+            var gsPath = Path.Combine(projDir, "Rect.gs");
+            File.WriteAllText(gsPath, v1);
+
+            var workspace = new WorkspaceState();
+            WorkspaceInitializer.Initialize(workspace, rootDir);
+            var server = new LspServer(new DocumentContentService(), workspace);
+            var uri = DocumentUri.FromFileSystemPath(gsPath);
+            var id = new TextDocumentIdentifier { Uri = uri };
+
+            await server.DidOpenAsync(new DidOpenTextDocumentParams { TextDocument = new TextDocumentItem { Uri = uri, Text = v1 } });
+            _ = await server.DocumentDiagnosticAsync(new DocumentDiagnosticParams { TextDocument = id }, CancellationToken.None);
+
+            // Edit (didChange), then pull diagnostics — mirrors the real editor lifecycle.
+            var v2 = "package Demo\n\nclass Rect {\n    prop Width int32\n    prop Height int32\n    func Area() int32 { return Width * Height }\n}\n";
+            File.WriteAllText(gsPath, v2);
+            await ChangeAsync(server, uri, v2, 2);
+            _ = await server.DocumentDiagnosticAsync(new DocumentDiagnosticParams { TextDocument = id }, CancellationToken.None);
+
+            // 1) go-to-definition on the implicit-this property usage `Width`.
+            var def = await server.DefinitionAsync(new DefinitionParams { TextDocument = id, Position = LanguageServerTestHelpers.PositionOf(v2, "Width", 1) });
+            Assert.NotNull(def);
+            Assert.Equal(3, def.Range.Start.Line); // `prop Width` declaration
+
+            // 2) reference code lens is produced for the file.
+            var lenses = await server.CodeLensAsync(new CodeLensParams { TextDocument = id });
+            Assert.NotNull(lenses);
+            Assert.NotEmpty(lenses);
+
+            // 3) member completion after `Width.` (property receiver).
+            var v3 = "package Demo\n\nclass Rect {\n    prop Width int32\n    prop Height int32\n    func Area() int32 { return Width. }\n}\n";
+            File.WriteAllText(gsPath, v3);
+            await ChangeAsync(server, uri, v3, 3);
+            var dotPos = LanguageServerTestHelpers.PositionOf(v3, "Width.", 0);
+            var completion = await server.CompletionAsync(new CompletionParams
+            {
+                TextDocument = id,
+                Position = new Position(dotPos.Line, dotPos.Character + "Width.".Length),
+            });
+            Assert.NotNull(completion);
+            Assert.NotEmpty(completion.Items);
+            Assert.DoesNotContain(completion.Items, i => i.Kind == CompletionItemKind.Keyword);
+        }
+        finally
+        {
+            try { Directory.Delete(rootDir, recursive: true); } catch { }
+        }
+    }
+
+    private static Task ChangeAsync(LspServer server, DocumentUri uri, string text, int version)
+        => server.DidChangeAsync(new DidChangeTextDocumentParams
+        {
+            TextDocument = new VersionedTextDocumentIdentifier { Uri = uri, Version = version },
+            ContentChanges = new List<TextDocumentContentChangeEvent> { new TextDocumentContentChangeEvent { Text = text } },
+        });
+}

--- a/test/LanguageServer.Tests/SemanticLookupCrossFileTests.cs
+++ b/test/LanguageServer.Tests/SemanticLookupCrossFileTests.cs
@@ -1,0 +1,67 @@
+// <copyright file="SemanticLookupCrossFileTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// Regression tests for cross-file symbol resolution. Syntax spans are per-file offsets, so
+/// in a multi-file compilation the SemanticModel's span-based lookups
+/// (FindContainingFunction, ResolveImplicitThisMember) must restrict themselves to the token's
+/// own tree. Before that guard, a declaration in another file whose offset range overlapped the
+/// token's offset would shadow the real one, causing hover / go-to-definition / completion on
+/// locals and implicit-this members to resolve to the wrong file or to nothing.
+/// </summary>
+public class SemanticLookupCrossFileTests
+{
+    // Two structurally identical classes in two files: `Width` sits at the same offset in both,
+    // and their method bodies share the same span — so a non-tree-scoped lookup can pick the
+    // wrong file's type.
+    private const string Template =
+        "class {0} {{\n    prop Width int32\n    func M() int32 {{\n        return Width\n    }}\n}}\n";
+
+    [Fact]
+    public void ResolveImplicitThisProperty_PicksDeclarationFromTokensOwnFile()
+    {
+        var srcA = string.Format(Template, "AA");
+        var treeA = SyntaxTree.Parse(SourceText.From(srcA, "/a.gs"));
+        var treeB = SyntaxTree.Parse(SourceText.From(string.Format(Template, "BB"), "/b.gs"));
+
+        // Put B first so a cross-file collision would resolve the token to B.
+        var compilation = new Compilation(treeB, treeA);
+
+        var off = srcA.IndexOf("return Width", StringComparison.Ordinal) + "return ".Length;
+        var token = SemanticLookup.FindTokenAt(treeA, off);
+        var symbol = SemanticLookup.ResolveSymbol(compilation, token) as PropertySymbol;
+
+        Assert.NotNull(symbol);
+        Assert.NotNull(symbol.Declaration);
+        Assert.Equal("/a.gs", symbol.Declaration.Identifier.SyntaxTree.Text.FileName);
+    }
+
+    [Fact]
+    public void ResolveLocal_InMethodBody_ResolvesAcrossMultipleFiles()
+    {
+        // A local inside a class method must resolve even when many other files are present.
+        const string withLocal = "class CC {{\n    func M() int32 {{\n        var answer = {0}\n        return answer\n    }}\n}}\n";
+        var srcA = string.Format(withLocal, "1");
+        var treeA = SyntaxTree.Parse(SourceText.From(srcA, "/a.gs"));
+        var treeB = SyntaxTree.Parse(SourceText.From(string.Format(withLocal, "2").Replace("CC", "DD"), "/b.gs"));
+
+        var compilation = new Compilation(treeB, treeA);
+
+        var off = srcA.IndexOf("return answer", StringComparison.Ordinal) + "return ".Length;
+        var token = SemanticLookup.FindTokenAt(treeA, off);
+        var symbol = SemanticLookup.ResolveSymbol(compilation, token);
+
+        Assert.IsType<LocalVariableSymbol>(symbol);
+        Assert.Equal("answer", symbol.Name);
+    }
+}


### PR DESCRIPTION
LSP fixes and performance work found while debugging an unresponsive editor on a large multi-file project (54 files). All changes are language-server-only; the compiler/Core is untouched.

## Responsiveness
Requests now follow a Roslyn-style mutating/non-mutating split (mirrors `RequestExecutionQueue`): mutating handlers (`didOpen`/`didChange`/…) hold the gate for their brief, parse-only body; read handlers snapshot the immutable `DocumentContent` under the gate, then compute **off the gate** on the thread pool and honor cancellation. A slow read (e.g. the first cold workspace bind) no longer head-of-line-blocks other reads or typing.

## Correctness — multi-file resolution
Fixed the root cause of hover/go-to-definition/completion returning nothing for locals and class members in real multi-file projects: `SemanticModel` span-based lookups (`FindContainingFunction`, `ResolveImplicitThisMember`, member access, `GetExpressionBindingContext`) compared **per-file offsets across all trees**, so a declaration in another file could shadow the real one. They are now scoped to the token's own file (by file name, so interpolation-hole sub-trees still match). Also:

- go-to-definition now handles `PropertySymbol`/`EventSymbol` (`FindDeclarationToken`)
- member completion now handles `PropertySymbol`/`FieldSymbol`/`EventSymbol` receivers

## Cross-assembly navigation
Added a Tier-3 source-text search and reordered cross-assembly go-to-definition to **Tier 1 (sibling G#) → Tier 3 (source search) → Tier 2 (PDB)**. Tier 3 lands on the actual declaration identifier (vs the PDB's first executable line) and can resolve types with no method bodies (interfaces). Covers types and methods/properties/fields/events; the PDB tier remains the fallback for assemblies whose source isn't under the workspace.

## Performance
- Parallelized the reference-index build and scoped `ResolveAsMemberAccess` to the token's own tree — CodeLens reference-index build dropped from ~145 s to ~6 s on the 54-file project (it previously timed out and never displayed).
- Build the `SemanticModel`'s node caches in a single parallel pass instead of six sequential whole-workspace tree walks.

The remaining per-keystroke latency ceiling is the full-program re-bind; the architectural fix (incremental/delta binding) is tracked in #866.

## Tests
`LanguageServer.Tests` 283/283 pass, including new coverage:
- `LspServerConcurrencyTests` — cancellation + concurrent reads
- `SemanticLookupCrossFileTests` — cross-file resolution
- `LspServerMemberFeatureTests` — property def/completion/codelens through the full pipeline with edits
- `CrossAssemblyNavigationTests` / `CrossAssemblySourceSearchTests` — Tier-2/Tier-3 navigation

`dotnet build GSharp.sln` is clean (0 warnings).
