### PR TITLE
ADR-0105: incremental (delta) binding for the language server (#866)

### DIFF
--- a/docs/adr/0105-incremental-delta-binding-language-server.md
+++ b/docs/adr/0105-incremental-delta-binding-language-server.md
@@ -1,0 +1,147 @@
+# ADR-0105: Incremental (delta) binding for the language server
+
+- **Status**: Proposed
+- **Date**: 2026-06-15
+- **Phase**: Language-server performance
+- **Related**: issue #866; issue #868 (cross-session cold-start cache — complementary); ADR-0002 (concurrency model); `src/LanguageServer/ProjectState.cs`, `src/Core/CodeAnalysis/Compilation/Compilation.cs`, `src/Core/CodeAnalysis/Binding/Binder.cs`
+
+## Context
+
+On large multi-file G# projects the language server's per-keystroke latency for completion, diagnostics, and the first model-dependent request after an edit is dominated by a **full-program re-bind**. Every edit produces a fresh `Compilation` whose `GlobalScope` and `BoundProgram` are bound from scratch across *all* files, even when only one file — often only one method body — changed. The cost scales with workspace size, not edit size.
+
+### How the re-bind happens today
+
+`ProjectState.GetCompilation()` is the single funnel every LSP feature goes through. On each edit `ProjectState.UpdateFile` re-parses the changed file and calls `Invalidate()`; the next `GetCompilation()` constructs a brand-new `new Compilation(resolver, trees)` with **no `Previous` chain**:
+
+```csharp
+// src/LanguageServer/ProjectState.cs (GetCompilation, simplified)
+var trees = syntaxTrees.Values.ToArray();
+compilation = new Compilation(resolver, trees);   // Previous == null
+```
+
+A fresh `Compilation` has empty lazy caches, so the first access re-binds everything:
+
+- `Compilation.GlobalScope` → `Binder.BindGlobalScope(Previous?.GlobalScope == null, allTrees, ...)` — re-resolves every package, import, type alias, delegate, interface, enum, struct, and function *signature* across all files.
+- `Compilation.BoundProgram` → `Binder.BindProgram(GlobalScope, ...)` — re-binds and lowers **every** method/function body, walking `globalScope.Functions`, every `struct.Methods`, property/event accessors, constructors, and top-level statements.
+
+### Measured cost (Oahu, `Oahu.Cli.Tests`, 54 source files, 352 assembly references)
+
+Numbers captured on the local repro workspace `~/GitHub/DavidObando/Oahu` by driving the real LSP path (`ProjectDiscovery` → `ProjectState` → `Compilation.GlobalScope` / `BoundProgram`), median of 7 keystroke iterations, two runs:
+
+| Phase | `GlobalScope` | `BoundProgram` | Total |
+| --- | --- | --- | --- |
+| Cold (first compilation, includes metadata load of 352 refs) | ~290–336 ms | ~594–602 ms | ~880–940 ms |
+| Steady-state keystroke (one file changed → fresh `Compilation`) | ~12–15 ms | ~360–390 ms | ~372–403 ms |
+
+Two things stand out:
+
+1. **The per-keystroke cost is dominated by `BoundProgram` (~360–390 ms): re-binding every body.** That is the architectural ceiling the LSP layer cannot push past with constant-factor work.
+2. **Warm `GlobalScope` is already cheap (~12–15 ms).** The expensive part of cold `GlobalScope` is one-time CLR metadata loading, which `ReferenceResolver` already caches across compilations (it survives in `ProjectState.cachedResolver`). So signature re-binding itself is not the bottleneck on a warm session — *body* re-binding is.
+
+On top of these binder numbers the LSP `SemanticModel` build (`SemanticLookup.BuildModelUncached`) and reference-index build add their own per-edit cost, but those are keyed on the `Compilation` instance and invalidate naturally when the compilation is replaced; they are out of scope here.
+
+### Why the binder is well-shaped for delta binding
+
+The expensive part is also the most cacheable part:
+
+- `Binder.BindProgram` binds **each body independently** from `parentScope`: `new Binder(parentScope, function); binder.statements.BindStatement(function.Declaration.Body)`. A bound body is effectively a pure function of `(GlobalScope, body syntax)`. That is exactly the shape needed for per-method caching and reuse.
+- `Compilation.GlobalScope` and `BoundProgram` are already lazy and cached per instance (guarded by `Interlocked.CompareExchange`).
+- Lowering is already body-local for synthesized names: `Lowerer.Lower` constructs a **fresh `Lowerer` per body**, and the `Label{n}` counter (`labelCount`) is an instance field. Synthesized label names therefore depend only on a body's own shape, not on sibling bodies or binding order.
+
+The gap is identity. `BindProgram` keys bodies by `FunctionSymbol`, and every new `Compilation` constructs **fresh symbol instances**. A body cache keyed on the symbol instance would never hit across edits, and a bound body from compilation *N* references *N*'s symbols, so it cannot be spliced into compilation *N+1* without those symbols also being reused.
+
+## Decision
+
+Adopt a **two-phase delta-binding architecture**, designed here and implemented in follow-up work. This ADR fixes the design contract — stable identity, invalidation, determinism, and where the cache lives — so the phases can land incrementally without re-litigating the architecture.
+
+### Phase 1 — Incremental body binding
+
+Cache each lowered `BoundBlockStatement` keyed by a **stable function identity plus body content**, conceptually `(stableMemberId, bodyHash)`:
+
+- `stableMemberId` is a position-independent identity for the member: e.g. `(sourceFilePath, containing-type path, member name, parameter-type signature)`. It must *not* depend on a symbol object reference, a `SyntaxNode` reference, or a source span (spans shift when earlier text changes).
+- `bodyHash` is a content hash of the member's body syntax (and anything else its binding depends on beyond `GlobalScope` — see invalidation).
+
+On a re-bind, `BindProgram` looks up each member: if `stableMemberId` is unchanged and `bodyHash` matches, **reuse the cached lowered body** instead of re-binding and re-lowering. A single-file edit then re-binds only the bodies in that file (and any whose binding depended on changed signatures — see Phase 2). Determinism is preserved because the cached body is byte-for-byte the one a from-scratch bind would have produced (body-local label counters; no cross-body state).
+
+Phase 1 is *correct in isolation but rarely hits* until Phase 2 lands, because reused bodies reference symbols from `GlobalScope`. That is the explicit motivation for Phase 2.
+
+### Phase 2 — Incremental `GlobalScope` via per-file symbol tables
+
+Make `GlobalScope` composable from **per-file declaration tables** that carry **stable symbol identity**:
+
+- Each source file binds its own declarations (signatures only) into a per-file table. `GlobalScope` is the composition of those tables plus references.
+- When a file is edited, only that file's table is rebound. **If the file's *signatures* are unchanged** (body-only edit), its symbols are **reused by identity** — the same `FunctionSymbol`/`StructSymbol`/… instances flow into the new `GlobalScope`. This is what makes Phase 1's cache hit on the common case (typing inside a method body).
+- **If a file's signatures changed**, that file's symbols are rebuilt, and any *dependent* files (those whose binding referenced the changed symbols) are invalidated transitively.
+
+The existing `Compilation.Previous` chain is **not** the vehicle for this: it is append-only / REPL-oriented (each link *adds* trees; `BindGlobalScope` walks `previous.Functions` cumulatively). Delta binding needs *replace-one-file* semantics, which the append-only chain cannot express. Phase 2 therefore introduces per-file tables as a first-class concept rather than overloading `Previous`.
+
+### Stable symbol identity
+
+Phase 1 and Phase 2 both depend on symbols having an identity that survives across compilations:
+
+- A symbol's identity is its `stableMemberId` (file + type path + name + signature), independent of object reference and source span.
+- When a file is rebound and a declaration's signature is byte-identical, the binder **reuses the prior symbol instance** for that identity rather than allocating a new one.
+- Equality/hashing on cache keys uses `stableMemberId`, never `ReferenceEquals` on symbols or `SyntaxNode`s.
+
+This is the load-bearing invariant. Without it, "reuse" silently degrades to "re-bind," and reused bodies would reference stale symbols (a correctness bug, not just a perf miss).
+
+### Cache invalidation rules
+
+Define invalidation precisely; over-invalidation costs performance, under-invalidation is a correctness bug:
+
+- **Body-only edit** (signatures of all members in the file unchanged): rebind only that file's bodies; reuse that file's *symbols* and all *other files'* bodies and symbols.
+- **Signature edit** in a file (parameter/return/field/type changes, new/removed/renamed member): rebuild that file's symbol table; invalidate and rebind the bodies of every file that *referenced* a changed symbol (tracked via a dependency set recorded during body binding — at minimum "this body referenced symbol X").
+- **Import / package / type-alias edit**: treat as project-wide for now (full `GlobalScope` rebind), since these change name resolution globally; a finer model can come later.
+- **Reference (`.rsp`) change**: invalidate the whole project (already handled — `ReferenceResolver` and `compilation` are dropped when references change).
+
+The conservative default when a dependency cannot be proven absent is to invalidate, so correctness never depends on the precision of dependency tracking.
+
+### Determinism
+
+Emit must remain bit-for-bit deterministic (the binder/lowerer feed both the LSP *and* `dotnet build`). Two rules:
+
+1. **Reused bodies are identical bodies.** A cached lowered body is only reused when `(stableMemberId, bodyHash)` matches, so it is exactly what a from-scratch bind would have produced. Synthesized names are body-local (fresh `Lowerer`, instance `labelCount`), so reuse cannot perturb a sibling body's names.
+2. **No shared mutable counters across bodies.** If body binding is ever parallelized for additional speedup, any synthesized-name source must remain per-method-local (as `labelCount` already is) or be assigned in a deterministic post-pass over a stable member ordering. Parallelizing `BindProgram` *without* this guarantee is explicitly disallowed by this ADR.
+
+The acceptance gate for implementation is that the full emit/IL-verification suite (and the refactoring baseline) is unchanged with delta binding enabled.
+
+### Where the cache lives
+
+The body/symbol caches are **per-project, owned by `ProjectState`**, not stored on a single `Compilation` instance:
+
+- `ProjectState` already owns the per-edit lifecycle (`UpdateFile` → `Invalidate` → `GetCompilation`) and the warm `ReferenceResolver`. It is the natural home for "what did the previous compilation bind."
+- `GetCompilation()` changes from "always `new Compilation(trees)`" to "build a new `Compilation` that is *seeded* with the prior per-file symbol tables and body cache, rebinding only the dirty files." The exact seeding mechanism (a new `Compilation` constructor/option vs. an internal binder entry point that accepts prior tables) is an implementation detail deferred to Phase 2, but it must keep `Compilation` immutable-per-instance so the LSP's `ConditionalWeakTable`-keyed model/index caches keep invalidating correctly.
+
+## Consequences
+
+**Positive**
+
+- Per-keystroke latency becomes proportional to *edit size*, not workspace size: a body-only edit re-binds one body instead of ~all of them, targeting the measured ~360–390 ms `BoundProgram` cost directly.
+- The design composes with the LSP work already done (parallel reference index, single-pass `SemanticModel`, per-file `Resolve` scoping); those reduced the constant factors, this removes the architectural ceiling.
+- Stable symbol identity is independently useful (more robust cross-file navigation and rename).
+
+**Negative / cost**
+
+- Added memory: retaining per-file symbol tables and a body cache across edits.
+- Added complexity in the binder's most correctness-sensitive area; invalidation bugs manifest as subtle stale-symbol or stale-diagnostic issues.
+- A new invariant (stable identity / no symbol-reference equality in cache keys) that future binder changes must uphold.
+
+**Neutral**
+
+- No change to emitted IL or to non-LSP build behavior; the from-scratch path remains the correctness oracle and the fallback.
+- Phase 1 can land first behind the design without user-visible effect until Phase 2 enables cache hits; this de-risks the rollout but means Phase 1 alone is not shippable as a perf win.
+- This ADR targets only the *per-keystroke* (warm) cost. The *cold-start* cost — the ~880–940 ms first-open bind, dominated by one-time reference metadata loading — is a separate axis tracked in issue #868 (a cross-session cold-start cache, analogous to C# Dev Kit's `.lscache`). The two are complementary and share the determinism / content-addressed-key requirements stated here.
+
+## Alternatives considered
+
+- **Do nothing / keep optimizing constant factors.** Rejected: the measured ~360–390 ms is the re-bind floor; no constant-factor work removes it.
+- **Parallelize `BindProgram` only.** Binding bodies concurrently could cut wall-clock time, but it risks non-deterministic synthesized names (shared counters) and still does *O(workspace)* work per keystroke. Useful as a complementary optimization, but not a substitute for delta binding, and gated on the determinism rule above.
+- **Lazy / on-demand body binding for only the active file.** Bind the edited file's bodies eagerly and defer others until requested. Simpler, but diagnostics are inherently whole-project (an edit in file A can introduce errors surfaced in file B), so "active file only" gives wrong/partial diagnostics. Delta binding keeps whole-project correctness while doing minimal work.
+- **Coarse per-file body cache keyed by `SyntaxTree`/span without stable identity.** Cheap to build but unsound: spans shift on edits and symbols are fresh per compilation, so reused bodies would reference stale symbols. Rejected in favor of explicit stable identity.
+- **Reuse the existing `Compilation.Previous` chain.** Rejected: it is append-only and cumulative, with no replace-one-file semantics; modeling an edit as "append" would grow the chain unboundedly and re-bind cumulatively.
+
+## Acceptance criteria (from issue #866)
+
+- Editing inside a single method body in a large multi-file project re-binds only that body (and genuinely dependent reanalysis), not the whole program.
+- Emit remains bit-for-bit deterministic.
+- No regressions in diagnostics / hover / definition / completion correctness.

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -822,6 +822,31 @@ public sealed class Binder
     /// </param>
     /// <returns>A bound program.</returns>
     public static BoundProgram BindProgram(BoundGlobalScope globalScope, ReferenceResolver references, BoundBodyCache cache)
+        => BindProgram(globalScope, references, cache, dirtyTrees: null);
+
+    /// <summary>
+    /// Produces a bound program, optionally reusing previously bound member
+    /// bodies from <paramref name="cache"/> and, for ADR-0105 Phase 2 delta
+    /// binding, <em>forcing a fresh re-bind</em> of every member whose body
+    /// syntax belongs to a tree in <paramref name="dirtyTrees"/>.
+    /// </summary>
+    /// <param name="globalScope">The global scope.</param>
+    /// <param name="references">The reference resolver (see other overloads).</param>
+    /// <param name="cache">The optional per-project bound-body cache.</param>
+    /// <param name="dirtyTrees">
+    /// ADR-0105 Phase 2: the set of freshly-parsed syntax trees whose member
+    /// bodies must be re-bound from scratch (and re-stored) rather than served
+    /// from <paramref name="cache"/>. This is how the language server's
+    /// incremental path re-binds <em>only</em> the edited file's bodies while
+    /// the symbol instances are reused: members in an unedited file hit the
+    /// cache by symbol identity, members in the edited (dirty) file are always
+    /// rebound so their lowered bodies and diagnostics reflect the new source
+    /// text and spans exactly as a full rebuild would. <see langword="null"/>
+    /// (or empty) means "no dirty trees" — every member may be served from the
+    /// cache when the soundness gate allows it.
+    /// </param>
+    /// <returns>A bound program.</returns>
+    public static BoundProgram BindProgram(BoundGlobalScope globalScope, ReferenceResolver references, BoundBodyCache cache, ImmutableHashSet<SyntaxTree> dirtyTrees)
     {
         var parentScope = CreateParentScope(globalScope, references, preprocessorSymbols: globalScope?.PreprocessorSymbols);
 
@@ -846,7 +871,7 @@ public sealed class Binder
                     continue;
                 }
 
-                var loweredBody = BindBodyWithCache(cache, globalScope, function, function.Declaration.Body, diagnostics, () =>
+                var loweredBody = BindBodyWithCache(cache, dirtyTrees, function, function.Declaration.Body, diagnostics, () =>
                 {
                     var binder = new Binder(parentScope, function);
                     var body = binder.statements.BindStatement(function.Declaration.Body);
@@ -882,7 +907,7 @@ public sealed class Binder
 
             foreach (var method in structSym.Methods)
             {
-                var loweredBody = BindBodyWithCache(cache, globalScope, method, method.Declaration.Body, diagnostics, () =>
+                var loweredBody = BindBodyWithCache(cache, dirtyTrees, method, method.Declaration.Body, diagnostics, () =>
                 {
                     var binder = new Binder(parentScope, method);
                     var body = binder.statements.BindStatement(method.Declaration.Body);
@@ -921,7 +946,7 @@ public sealed class Binder
                     continue;
                 }
 
-                BindInterfaceMethodBody(cache, globalScope, parentScope, method, functionBodies, diagnostics);
+                BindInterfaceMethodBody(cache, dirtyTrees, parentScope, method, functionBodies, diagnostics);
             }
         }
 
@@ -943,7 +968,7 @@ public sealed class Binder
                     continue;
                 }
 
-                BindInterfaceMethodBody(cache, globalScope, parentScope, method, functionBodies, diagnostics);
+                BindInterfaceMethodBody(cache, dirtyTrees, parentScope, method, functionBodies, diagnostics);
             }
         }
 
@@ -963,7 +988,7 @@ public sealed class Binder
                         continue;
                     }
 
-                    BindInterfaceMethodBody(cache, globalScope, parentScope, method, functionBodies, diagnostics);
+                    BindInterfaceMethodBody(cache, dirtyTrees, parentScope, method, functionBodies, diagnostics);
                 }
             }
 
@@ -976,7 +1001,7 @@ public sealed class Binder
                         continue;
                     }
 
-                    BindInterfaceMethodBody(cache, globalScope, parentScope, method, functionBodies, diagnostics);
+                    BindInterfaceMethodBody(cache, dirtyTrees, parentScope, method, functionBodies, diagnostics);
                 }
             }
         }
@@ -1003,7 +1028,7 @@ public sealed class Binder
                     continue;
                 }
 
-                var ctorLoweredBody = BindBodyWithCache(cache, globalScope, ctor.Function, ctor.Declaration.Body, diagnostics, () =>
+                var ctorLoweredBody = BindBodyWithCache(cache, dirtyTrees, ctor.Function, ctor.Declaration.Body, diagnostics, () =>
                 {
                     var ctorBinder = new Binder(parentScope, ctor.Function);
                     var ctorBody = ctorBinder.statements.BindStatement(ctor.Declaration.Body);
@@ -1035,7 +1060,7 @@ public sealed class Binder
                 continue;
             }
 
-            BindStructMemberBody(cache, globalScope, parentScope, deinit.Function, deinit.Declaration.Body, structSym, functionBodies, diagnostics);
+            BindStructMemberBody(cache, dirtyTrees, parentScope, deinit.Function, deinit.Declaration.Body, structSym, functionBodies, diagnostics);
         }
 
         // ADR-0051: bind computed property accessor bodies. These are analogous
@@ -1053,12 +1078,12 @@ public sealed class Binder
 
                     if (prop.GetterSymbol != null && prop.GetterBodySyntax != null)
                     {
-                        BindStructMemberBody(cache, globalScope, parentScope, prop.GetterSymbol, prop.GetterBodySyntax, structSym, functionBodies, diagnostics, prop.GetterBodySyntax.OpenBraceToken.Location);
+                        BindStructMemberBody(cache, dirtyTrees, parentScope, prop.GetterSymbol, prop.GetterBodySyntax, structSym, functionBodies, diagnostics, prop.GetterBodySyntax.OpenBraceToken.Location);
                     }
 
                     if (prop.SetterSymbol != null && prop.SetterBodySyntax != null)
                     {
-                        BindStructMemberBody(cache, globalScope, parentScope, prop.SetterSymbol, prop.SetterBodySyntax, structSym, functionBodies, diagnostics);
+                        BindStructMemberBody(cache, dirtyTrees, parentScope, prop.SetterSymbol, prop.SetterBodySyntax, structSym, functionBodies, diagnostics);
                     }
                 }
             }
@@ -1075,18 +1100,18 @@ public sealed class Binder
 
                     if (ev.AddMethodSymbol != null && ev.AddBodySyntax != null)
                     {
-                        BindStructMemberBody(cache, globalScope, parentScope, ev.AddMethodSymbol, ev.AddBodySyntax, structSym, functionBodies, diagnostics);
+                        BindStructMemberBody(cache, dirtyTrees, parentScope, ev.AddMethodSymbol, ev.AddBodySyntax, structSym, functionBodies, diagnostics);
                     }
 
                     if (ev.RemoveMethodSymbol != null && ev.RemoveBodySyntax != null)
                     {
-                        BindStructMemberBody(cache, globalScope, parentScope, ev.RemoveMethodSymbol, ev.RemoveBodySyntax, structSym, functionBodies, diagnostics);
+                        BindStructMemberBody(cache, dirtyTrees, parentScope, ev.RemoveMethodSymbol, ev.RemoveBodySyntax, structSym, functionBodies, diagnostics);
                     }
 
                     // Issue #257: bind raise accessor body.
                     if (ev.RaiseMethodSymbol != null && ev.RaiseBodySyntax != null)
                     {
-                        BindStructMemberBody(cache, globalScope, parentScope, ev.RaiseMethodSymbol, ev.RaiseBodySyntax, structSym, functionBodies, diagnostics);
+                        BindStructMemberBody(cache, dirtyTrees, parentScope, ev.RaiseMethodSymbol, ev.RaiseBodySyntax, structSym, functionBodies, diagnostics);
                     }
                 }
             }
@@ -1109,12 +1134,12 @@ public sealed class Binder
 
                 if (prop.GetterSymbol != null && prop.GetterBodySyntax != null)
                 {
-                    BindStructMemberBody(cache, globalScope, parentScope, prop.GetterSymbol, prop.GetterBodySyntax, structSym, functionBodies, diagnostics, prop.GetterBodySyntax.OpenBraceToken.Location);
+                    BindStructMemberBody(cache, dirtyTrees, parentScope, prop.GetterSymbol, prop.GetterBodySyntax, structSym, functionBodies, diagnostics, prop.GetterBodySyntax.OpenBraceToken.Location);
                 }
 
                 if (prop.SetterSymbol != null && prop.SetterBodySyntax != null)
                 {
-                    BindStructMemberBody(cache, globalScope, parentScope, prop.SetterSymbol, prop.SetterBodySyntax, structSym, functionBodies, diagnostics);
+                    BindStructMemberBody(cache, dirtyTrees, parentScope, prop.SetterSymbol, prop.SetterBodySyntax, structSym, functionBodies, diagnostics);
                 }
             }
         }
@@ -1136,18 +1161,18 @@ public sealed class Binder
 
                 if (ev.AddMethodSymbol != null && ev.AddBodySyntax != null)
                 {
-                    BindStructMemberBody(cache, globalScope, parentScope, ev.AddMethodSymbol, ev.AddBodySyntax, structSym, functionBodies, diagnostics);
+                    BindStructMemberBody(cache, dirtyTrees, parentScope, ev.AddMethodSymbol, ev.AddBodySyntax, structSym, functionBodies, diagnostics);
                 }
 
                 if (ev.RemoveMethodSymbol != null && ev.RemoveBodySyntax != null)
                 {
-                    BindStructMemberBody(cache, globalScope, parentScope, ev.RemoveMethodSymbol, ev.RemoveBodySyntax, structSym, functionBodies, diagnostics);
+                    BindStructMemberBody(cache, dirtyTrees, parentScope, ev.RemoveMethodSymbol, ev.RemoveBodySyntax, structSym, functionBodies, diagnostics);
                 }
 
                 // Issue #257: bind raise accessor body for static events.
                 if (ev.RaiseMethodSymbol != null && ev.RaiseBodySyntax != null)
                 {
-                    BindStructMemberBody(cache, globalScope, parentScope, ev.RaiseMethodSymbol, ev.RaiseBodySyntax, structSym, functionBodies, diagnostics);
+                    BindStructMemberBody(cache, dirtyTrees, parentScope, ev.RaiseMethodSymbol, ev.RaiseBodySyntax, structSym, functionBodies, diagnostics);
                 }
             }
         }
@@ -1167,7 +1192,7 @@ public sealed class Binder
                     continue;
                 }
 
-                BindStructMethodBody(cache, globalScope, parentScope, method, structSym, functionBodies, diagnostics);
+                BindStructMethodBody(cache, dirtyTrees, parentScope, method, structSym, functionBodies, diagnostics);
             }
         }
 
@@ -1197,8 +1222,8 @@ public sealed class Binder
     }
 
     /// <summary>
-    /// ADR-0105 (Phase 1) helper shared by every member-body bind site in
-    /// <see cref="BindProgram(BoundGlobalScope, ReferenceResolver, BoundBodyCache)"/>.
+    /// ADR-0105 helper shared by every member-body bind site in
+    /// <see cref="BindProgram(BoundGlobalScope, ReferenceResolver, BoundBodyCache, ImmutableHashSet{SyntaxTree})"/>.
     /// On a <em>sound</em> cache hit it returns the cached lowered body and
     /// appends the cached per-body diagnostics; otherwise it invokes
     /// <paramref name="bindAndLower"/> (which performs the exact same
@@ -1208,7 +1233,13 @@ public sealed class Binder
     /// the full-rebuild path with no behavioral difference.
     /// </summary>
     /// <param name="cache">The optional bound-body cache.</param>
-    /// <param name="globalScope">The global scope the bind is running against (the soundness-gate token).</param>
+    /// <param name="dirtyTrees">
+    /// ADR-0105 Phase 2: when <paramref name="bodySyntax"/> belongs to one of
+    /// these freshly-parsed (edited) trees, the cache read is <em>bypassed</em>
+    /// so the body is always rebound from scratch (and re-stored) — its lowered
+    /// form and diagnostics then reflect the new source text and spans exactly
+    /// as a full rebuild would. <see langword="null"/> means no dirty trees.
+    /// </param>
     /// <param name="member">The member symbol whose body is being bound.</param>
     /// <param name="bodySyntax">The body syntax that will be bound and lowered.</param>
     /// <param name="diagnostics">The program-level diagnostics accumulator to append to.</param>
@@ -1216,15 +1247,20 @@ public sealed class Binder
     /// <returns>The lowered body — reused on a sound hit, freshly produced otherwise.</returns>
     private static BoundBlockStatement BindBodyWithCache(
         BoundBodyCache cache,
-        BoundGlobalScope globalScope,
+        ImmutableHashSet<SyntaxTree> dirtyTrees,
         FunctionSymbol member,
         SyntaxNode bodySyntax,
         ImmutableArray<Diagnostic>.Builder diagnostics,
         Func<(BoundBlockStatement Body, ImmutableArray<Diagnostic> Diagnostics)> bindAndLower)
     {
-        if (cache != null
+        var isDirty = dirtyTrees != null
+            && bodySyntax?.SyntaxTree != null
+            && dirtyTrees.Contains(bodySyntax.SyntaxTree);
+
+        if (!isDirty
+            && cache != null
             && bodySyntax != null
-            && cache.TryReuse(globalScope, member, bodySyntax, out var reusedBody, out var reusedDiagnostics))
+            && cache.TryReuse(member, bodySyntax, out var reusedBody, out var reusedDiagnostics))
         {
             diagnostics.AddRange(reusedDiagnostics);
             return reusedBody;
@@ -1232,7 +1268,7 @@ public sealed class Binder
 
         var (body, bodyDiagnostics) = bindAndLower();
         diagnostics.AddRange(bodyDiagnostics);
-        cache?.Store(globalScope, member, bodySyntax, body, bodyDiagnostics);
+        cache?.Store(member, bodySyntax, body, bodyDiagnostics);
         return body;
     }
 
@@ -1244,20 +1280,20 @@ public sealed class Binder
     /// through <see cref="BindBodyWithCache"/> and registers the body.
     /// </summary>
     /// <param name="cache">The optional bound-body cache.</param>
-    /// <param name="globalScope">The global scope (soundness-gate token).</param>
+    /// <param name="dirtyTrees">ADR-0105 Phase 2: freshly-parsed (edited) trees whose member bodies must be rebound rather than served from the cache.</param>
     /// <param name="parentScope">The parent scope bodies are bound against.</param>
     /// <param name="method">The interface method whose body is being bound.</param>
     /// <param name="functionBodies">The function-body map to register the lowered body in.</param>
     /// <param name="diagnostics">The program-level diagnostics accumulator.</param>
     private static void BindInterfaceMethodBody(
         BoundBodyCache cache,
-        BoundGlobalScope globalScope,
+        ImmutableHashSet<SyntaxTree> dirtyTrees,
         BoundScope parentScope,
         FunctionSymbol method,
         ImmutableDictionary<FunctionSymbol, BoundBlockStatement>.Builder functionBodies,
         ImmutableArray<Diagnostic>.Builder diagnostics)
     {
-        var loweredBody = BindBodyWithCache(cache, globalScope, method, method.Declaration.Body, diagnostics, () =>
+        var loweredBody = BindBodyWithCache(cache, dirtyTrees, method, method.Declaration.Body, diagnostics, () =>
         {
             var binder = new Binder(parentScope, method);
             var body = binder.statements.BindStatement(method.Declaration.Body);
@@ -1282,7 +1318,7 @@ public sealed class Binder
     /// through <see cref="BindBodyWithCache"/> and registers the body.
     /// </summary>
     /// <param name="cache">The optional bound-body cache.</param>
-    /// <param name="globalScope">The global scope (soundness-gate token).</param>
+    /// <param name="dirtyTrees">ADR-0105 Phase 2: freshly-parsed (edited) trees whose member bodies must be rebound rather than served from the cache.</param>
     /// <param name="parentScope">The parent scope bodies are bound against.</param>
     /// <param name="member">The member whose body is being bound.</param>
     /// <param name="bodySyntax">The body syntax to bind and lower.</param>
@@ -1292,7 +1328,7 @@ public sealed class Binder
     /// <param name="allPathsReturnLocation">When non-null, the location at which to report a missing all-paths return.</param>
     private static void BindStructMemberBody(
         BoundBodyCache cache,
-        BoundGlobalScope globalScope,
+        ImmutableHashSet<SyntaxTree> dirtyTrees,
         BoundScope parentScope,
         FunctionSymbol member,
         StatementSyntax bodySyntax,
@@ -1301,7 +1337,7 @@ public sealed class Binder
         ImmutableArray<Diagnostic>.Builder diagnostics,
         TextLocation? allPathsReturnLocation = null)
     {
-        var loweredBody = BindBodyWithCache(cache, globalScope, member, bodySyntax, diagnostics, () =>
+        var loweredBody = BindBodyWithCache(cache, dirtyTrees, member, bodySyntax, diagnostics, () =>
         {
             var binder = new Binder(parentScope, member);
             var body = binder.statements.BindStatement(bodySyntax);
@@ -1326,7 +1362,7 @@ public sealed class Binder
     /// and registers the body.
     /// </summary>
     /// <param name="cache">The optional bound-body cache.</param>
-    /// <param name="globalScope">The global scope (soundness-gate token).</param>
+    /// <param name="dirtyTrees">ADR-0105 Phase 2: freshly-parsed (edited) trees whose member bodies must be rebound rather than served from the cache.</param>
     /// <param name="parentScope">The parent scope bodies are bound against.</param>
     /// <param name="method">The method whose body is being bound.</param>
     /// <param name="structSym">The declaring type used as the lowering context.</param>
@@ -1334,14 +1370,14 @@ public sealed class Binder
     /// <param name="diagnostics">The program-level diagnostics accumulator.</param>
     private static void BindStructMethodBody(
         BoundBodyCache cache,
-        BoundGlobalScope globalScope,
+        ImmutableHashSet<SyntaxTree> dirtyTrees,
         BoundScope parentScope,
         FunctionSymbol method,
         StructSymbol structSym,
         ImmutableDictionary<FunctionSymbol, BoundBlockStatement>.Builder functionBodies,
         ImmutableArray<Diagnostic>.Builder diagnostics)
     {
-        var loweredBody = BindBodyWithCache(cache, globalScope, method, method.Declaration.Body, diagnostics, () =>
+        var loweredBody = BindBodyWithCache(cache, dirtyTrees, method, method.Declaration.Body, diagnostics, () =>
         {
             var binder = new Binder(parentScope, method);
             var body = binder.statements.BindStatement(method.Declaration.Body);

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -798,6 +798,31 @@ public sealed class Binder
     /// <returns>A bound program.</returns>
     public static BoundProgram BindProgram(BoundGlobalScope globalScope, ReferenceResolver references = null)
     {
+        return BindProgram(globalScope, references, cache: null);
+    }
+
+    /// <summary>
+    /// Produces a bound program from the specified global scope, optionally
+    /// reusing previously bound member bodies from <paramref name="cache"/>
+    /// (ADR-0105 Phase 1).
+    /// </summary>
+    /// <param name="globalScope">The global scope.</param>
+    /// <param name="references">
+    /// The reference resolver used to resolve imported CLR types inside function
+    /// and method bodies. See the parameterless overload for details.
+    /// </param>
+    /// <param name="cache">
+    /// An optional per-project bound-body cache. When supplied, each member body
+    /// is looked up before binding; a <em>sound</em> hit (see
+    /// <see cref="BoundBodyCache"/> for the soundness gate) reuses the cached
+    /// lowered body and diagnostics verbatim, while a miss binds and lowers from
+    /// scratch and stores the result. When <see langword="null"/>, this method
+    /// behaves exactly like the full-rebuild path. The cache never changes the
+    /// emitted IL or the diagnostics relative to a from-scratch bind.
+    /// </param>
+    /// <returns>A bound program.</returns>
+    public static BoundProgram BindProgram(BoundGlobalScope globalScope, ReferenceResolver references, BoundBodyCache cache)
+    {
         var parentScope = CreateParentScope(globalScope, references, preprocessorSymbols: globalScope?.PreprocessorSymbols);
 
         var functionBodies = ImmutableDictionary.CreateBuilder<FunctionSymbol, BoundBlockStatement>();
@@ -821,22 +846,25 @@ public sealed class Binder
                     continue;
                 }
 
-                var binder = new Binder(parentScope, function);
-                var body = binder.statements.BindStatement(function.Declaration.Body);
-                var loweredBody = Lowerer.Lower(body);
-
-                if (function.Type != TypeSymbol.Void && !IsIteratorReturnType(function.Type) && !ControlFlowGraph.AllPathsReturn(loweredBody))
+                var loweredBody = BindBodyWithCache(cache, globalScope, function, function.Declaration.Body, diagnostics, () =>
                 {
-                    binder.Diagnostics.ReportAllPathsMustReturn(function.Declaration.Identifier.Location);
-                }
+                    var binder = new Binder(parentScope, function);
+                    var body = binder.statements.BindStatement(function.Declaration.Body);
+                    var lowered = Lowerer.Lower(body);
 
-                // ADR-0060 items #4/#5: out-parameter definite-assignment and
-                // 'ref'-arg unassigned-before-read checks.
-                RefKindDefiniteAssignmentAnalyzer.Analyze(loweredBody, function, binder.Diagnostics);
+                    if (function.Type != TypeSymbol.Void && !IsIteratorReturnType(function.Type) && !ControlFlowGraph.AllPathsReturn(lowered))
+                    {
+                        binder.Diagnostics.ReportAllPathsMustReturn(function.Declaration.Identifier.Location);
+                    }
+
+                    // ADR-0060 items #4/#5: out-parameter definite-assignment and
+                    // 'ref'-arg unassigned-before-read checks.
+                    RefKindDefiniteAssignmentAnalyzer.Analyze(lowered, function, binder.Diagnostics);
+
+                    return (lowered, binder.Diagnostics.ToImmutableArray());
+                });
 
                 functionBodies.Add(function, loweredBody);
-
-                diagnostics.AddRange(binder.Diagnostics);
             }
 
             scope = scope.Previous;
@@ -854,17 +882,21 @@ public sealed class Binder
 
             foreach (var method in structSym.Methods)
             {
-                var binder = new Binder(parentScope, method);
-                var body = binder.statements.BindStatement(method.Declaration.Body);
-                var loweredBody = Lowerer.Lower(body, structSym);
-
-                if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(loweredBody))
+                var loweredBody = BindBodyWithCache(cache, globalScope, method, method.Declaration.Body, diagnostics, () =>
                 {
-                    binder.Diagnostics.ReportAllPathsMustReturn(method.Declaration.Identifier.Location);
-                }
+                    var binder = new Binder(parentScope, method);
+                    var body = binder.statements.BindStatement(method.Declaration.Body);
+                    var lowered = Lowerer.Lower(body, structSym);
+
+                    if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(lowered))
+                    {
+                        binder.Diagnostics.ReportAllPathsMustReturn(method.Declaration.Identifier.Location);
+                    }
+
+                    return (lowered, binder.Diagnostics.ToImmutableArray());
+                });
 
                 functionBodies.Add(method, loweredBody);
-                diagnostics.AddRange(binder.Diagnostics);
             }
         }
 
@@ -889,17 +921,7 @@ public sealed class Binder
                     continue;
                 }
 
-                var binder = new Binder(parentScope, method);
-                var body = binder.statements.BindStatement(method.Declaration.Body);
-                var loweredBody = Lowerer.Lower(body);
-
-                if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(loweredBody))
-                {
-                    binder.Diagnostics.ReportAllPathsMustReturn(method.Declaration.Identifier.Location);
-                }
-
-                functionBodies.Add(method, loweredBody);
-                diagnostics.AddRange(binder.Diagnostics);
+                BindInterfaceMethodBody(cache, globalScope, parentScope, method, functionBodies, diagnostics);
             }
         }
 
@@ -921,17 +943,7 @@ public sealed class Binder
                     continue;
                 }
 
-                var binder = new Binder(parentScope, method);
-                var body = binder.statements.BindStatement(method.Declaration.Body);
-                var loweredBody = Lowerer.Lower(body);
-
-                if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(loweredBody))
-                {
-                    binder.Diagnostics.ReportAllPathsMustReturn(method.Declaration.Identifier.Location);
-                }
-
-                functionBodies.Add(method, loweredBody);
-                diagnostics.AddRange(binder.Diagnostics);
+                BindInterfaceMethodBody(cache, globalScope, parentScope, method, functionBodies, diagnostics);
             }
         }
 
@@ -951,17 +963,7 @@ public sealed class Binder
                         continue;
                     }
 
-                    var binder = new Binder(parentScope, method);
-                    var body = binder.statements.BindStatement(method.Declaration.Body);
-                    var loweredBody = Lowerer.Lower(body);
-
-                    if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(loweredBody))
-                    {
-                        binder.Diagnostics.ReportAllPathsMustReturn(method.Declaration.Identifier.Location);
-                    }
-
-                    functionBodies.Add(method, loweredBody);
-                    diagnostics.AddRange(binder.Diagnostics);
+                    BindInterfaceMethodBody(cache, globalScope, parentScope, method, functionBodies, diagnostics);
                 }
             }
 
@@ -974,17 +976,7 @@ public sealed class Binder
                         continue;
                     }
 
-                    var binder = new Binder(parentScope, method);
-                    var body = binder.statements.BindStatement(method.Declaration.Body);
-                    var loweredBody = Lowerer.Lower(body);
-
-                    if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(loweredBody))
-                    {
-                        binder.Diagnostics.ReportAllPathsMustReturn(method.Declaration.Identifier.Location);
-                    }
-
-                    functionBodies.Add(method, loweredBody);
-                    diagnostics.AddRange(binder.Diagnostics);
+                    BindInterfaceMethodBody(cache, globalScope, parentScope, method, functionBodies, diagnostics);
                 }
             }
         }
@@ -1011,19 +1003,22 @@ public sealed class Binder
                     continue;
                 }
 
-                var ctorBinder = new Binder(parentScope, ctor.Function);
-                var ctorBody = ctorBinder.statements.BindStatement(ctor.Declaration.Body);
-
-                // ADR-0065 §2 Rule 3: a `convenience init` body must begin
-                // with a `init(args)` self-delegation expression-statement.
-                if (ctor.IsConvenience)
+                var ctorLoweredBody = BindBodyWithCache(cache, globalScope, ctor.Function, ctor.Declaration.Body, diagnostics, () =>
                 {
-                    VerifyConvenienceInitDelegatesFirst(ctor, ctorBody, ctorBinder.Diagnostics);
-                }
+                    var ctorBinder = new Binder(parentScope, ctor.Function);
+                    var ctorBody = ctorBinder.statements.BindStatement(ctor.Declaration.Body);
 
-                var ctorLoweredBody = Lowerer.Lower(ctorBody, structSym);
+                    // ADR-0065 §2 Rule 3: a `convenience init` body must begin
+                    // with a `init(args)` self-delegation expression-statement.
+                    if (ctor.IsConvenience)
+                    {
+                        VerifyConvenienceInitDelegatesFirst(ctor, ctorBody, ctorBinder.Diagnostics);
+                    }
+
+                    var lowered = Lowerer.Lower(ctorBody, structSym);
+                    return (lowered, ctorBinder.Diagnostics.ToImmutableArray());
+                });
                 functionBodies.Add(ctor.Function, ctorLoweredBody);
-                diagnostics.AddRange(ctorBinder.Diagnostics);
             }
         }
 
@@ -1040,11 +1035,7 @@ public sealed class Binder
                 continue;
             }
 
-            var deinitBinder = new Binder(parentScope, deinit.Function);
-            var deinitBody = deinitBinder.statements.BindStatement(deinit.Declaration.Body);
-            var loweredDeinitBody = Lowerer.Lower(deinitBody, structSym);
-            functionBodies.Add(deinit.Function, loweredDeinitBody);
-            diagnostics.AddRange(deinitBinder.Diagnostics);
+            BindStructMemberBody(cache, globalScope, parentScope, deinit.Function, deinit.Declaration.Body, structSym, functionBodies, diagnostics);
         }
 
         // ADR-0051: bind computed property accessor bodies. These are analogous
@@ -1062,26 +1053,12 @@ public sealed class Binder
 
                     if (prop.GetterSymbol != null && prop.GetterBodySyntax != null)
                     {
-                        var binder = new Binder(parentScope, prop.GetterSymbol);
-                        var body = binder.statements.BindStatement(prop.GetterBodySyntax);
-                        var loweredBody = Lowerer.Lower(body, structSym);
-
-                        if (!ControlFlowGraph.AllPathsReturn(loweredBody))
-                        {
-                            binder.Diagnostics.ReportAllPathsMustReturn(prop.GetterBodySyntax.OpenBraceToken.Location);
-                        }
-
-                        functionBodies.Add(prop.GetterSymbol, loweredBody);
-                        diagnostics.AddRange(binder.Diagnostics);
+                        BindStructMemberBody(cache, globalScope, parentScope, prop.GetterSymbol, prop.GetterBodySyntax, structSym, functionBodies, diagnostics, prop.GetterBodySyntax.OpenBraceToken.Location);
                     }
 
                     if (prop.SetterSymbol != null && prop.SetterBodySyntax != null)
                     {
-                        var binder = new Binder(parentScope, prop.SetterSymbol);
-                        var body = binder.statements.BindStatement(prop.SetterBodySyntax);
-                        var loweredBody = Lowerer.Lower(body, structSym);
-                        functionBodies.Add(prop.SetterSymbol, loweredBody);
-                        diagnostics.AddRange(binder.Diagnostics);
+                        BindStructMemberBody(cache, globalScope, parentScope, prop.SetterSymbol, prop.SetterBodySyntax, structSym, functionBodies, diagnostics);
                     }
                 }
             }
@@ -1098,30 +1075,18 @@ public sealed class Binder
 
                     if (ev.AddMethodSymbol != null && ev.AddBodySyntax != null)
                     {
-                        var binder = new Binder(parentScope, ev.AddMethodSymbol);
-                        var body = binder.statements.BindStatement(ev.AddBodySyntax);
-                        var loweredBody = Lowerer.Lower(body, structSym);
-                        functionBodies.Add(ev.AddMethodSymbol, loweredBody);
-                        diagnostics.AddRange(binder.Diagnostics);
+                        BindStructMemberBody(cache, globalScope, parentScope, ev.AddMethodSymbol, ev.AddBodySyntax, structSym, functionBodies, diagnostics);
                     }
 
                     if (ev.RemoveMethodSymbol != null && ev.RemoveBodySyntax != null)
                     {
-                        var binder = new Binder(parentScope, ev.RemoveMethodSymbol);
-                        var body = binder.statements.BindStatement(ev.RemoveBodySyntax);
-                        var loweredBody = Lowerer.Lower(body, structSym);
-                        functionBodies.Add(ev.RemoveMethodSymbol, loweredBody);
-                        diagnostics.AddRange(binder.Diagnostics);
+                        BindStructMemberBody(cache, globalScope, parentScope, ev.RemoveMethodSymbol, ev.RemoveBodySyntax, structSym, functionBodies, diagnostics);
                     }
 
                     // Issue #257: bind raise accessor body.
                     if (ev.RaiseMethodSymbol != null && ev.RaiseBodySyntax != null)
                     {
-                        var binder = new Binder(parentScope, ev.RaiseMethodSymbol);
-                        var body = binder.statements.BindStatement(ev.RaiseBodySyntax);
-                        var loweredBody = Lowerer.Lower(body, structSym);
-                        functionBodies.Add(ev.RaiseMethodSymbol, loweredBody);
-                        diagnostics.AddRange(binder.Diagnostics);
+                        BindStructMemberBody(cache, globalScope, parentScope, ev.RaiseMethodSymbol, ev.RaiseBodySyntax, structSym, functionBodies, diagnostics);
                     }
                 }
             }
@@ -1144,26 +1109,12 @@ public sealed class Binder
 
                 if (prop.GetterSymbol != null && prop.GetterBodySyntax != null)
                 {
-                    var binder = new Binder(parentScope, prop.GetterSymbol);
-                    var body = binder.statements.BindStatement(prop.GetterBodySyntax);
-                    var loweredBody = Lowerer.Lower(body, structSym);
-
-                    if (!ControlFlowGraph.AllPathsReturn(loweredBody))
-                    {
-                        binder.Diagnostics.ReportAllPathsMustReturn(prop.GetterBodySyntax.OpenBraceToken.Location);
-                    }
-
-                    functionBodies.Add(prop.GetterSymbol, loweredBody);
-                    diagnostics.AddRange(binder.Diagnostics);
+                    BindStructMemberBody(cache, globalScope, parentScope, prop.GetterSymbol, prop.GetterBodySyntax, structSym, functionBodies, diagnostics, prop.GetterBodySyntax.OpenBraceToken.Location);
                 }
 
                 if (prop.SetterSymbol != null && prop.SetterBodySyntax != null)
                 {
-                    var binder = new Binder(parentScope, prop.SetterSymbol);
-                    var body = binder.statements.BindStatement(prop.SetterBodySyntax);
-                    var loweredBody = Lowerer.Lower(body, structSym);
-                    functionBodies.Add(prop.SetterSymbol, loweredBody);
-                    diagnostics.AddRange(binder.Diagnostics);
+                    BindStructMemberBody(cache, globalScope, parentScope, prop.SetterSymbol, prop.SetterBodySyntax, structSym, functionBodies, diagnostics);
                 }
             }
         }
@@ -1185,30 +1136,18 @@ public sealed class Binder
 
                 if (ev.AddMethodSymbol != null && ev.AddBodySyntax != null)
                 {
-                    var binder = new Binder(parentScope, ev.AddMethodSymbol);
-                    var body = binder.statements.BindStatement(ev.AddBodySyntax);
-                    var loweredBody = Lowerer.Lower(body, structSym);
-                    functionBodies.Add(ev.AddMethodSymbol, loweredBody);
-                    diagnostics.AddRange(binder.Diagnostics);
+                    BindStructMemberBody(cache, globalScope, parentScope, ev.AddMethodSymbol, ev.AddBodySyntax, structSym, functionBodies, diagnostics);
                 }
 
                 if (ev.RemoveMethodSymbol != null && ev.RemoveBodySyntax != null)
                 {
-                    var binder = new Binder(parentScope, ev.RemoveMethodSymbol);
-                    var body = binder.statements.BindStatement(ev.RemoveBodySyntax);
-                    var loweredBody = Lowerer.Lower(body, structSym);
-                    functionBodies.Add(ev.RemoveMethodSymbol, loweredBody);
-                    diagnostics.AddRange(binder.Diagnostics);
+                    BindStructMemberBody(cache, globalScope, parentScope, ev.RemoveMethodSymbol, ev.RemoveBodySyntax, structSym, functionBodies, diagnostics);
                 }
 
                 // Issue #257: bind raise accessor body for static events.
                 if (ev.RaiseMethodSymbol != null && ev.RaiseBodySyntax != null)
                 {
-                    var binder = new Binder(parentScope, ev.RaiseMethodSymbol);
-                    var body = binder.statements.BindStatement(ev.RaiseBodySyntax);
-                    var loweredBody = Lowerer.Lower(body, structSym);
-                    functionBodies.Add(ev.RaiseMethodSymbol, loweredBody);
-                    diagnostics.AddRange(binder.Diagnostics);
+                    BindStructMemberBody(cache, globalScope, parentScope, ev.RaiseMethodSymbol, ev.RaiseBodySyntax, structSym, functionBodies, diagnostics);
                 }
             }
         }
@@ -1228,17 +1167,7 @@ public sealed class Binder
                     continue;
                 }
 
-                var binder = new Binder(parentScope, method);
-                var body = binder.statements.BindStatement(method.Declaration.Body);
-                var loweredBody = Lowerer.Lower(body, structSym);
-
-                if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(loweredBody))
-                {
-                    binder.Diagnostics.ReportAllPathsMustReturn(method.Declaration.Identifier.Location);
-                }
-
-                functionBodies.Add(method, loweredBody);
-                diagnostics.AddRange(binder.Diagnostics);
+                BindStructMethodBody(cache, globalScope, parentScope, method, structSym, functionBodies, diagnostics);
             }
         }
 
@@ -1265,6 +1194,168 @@ public sealed class Binder
         {
             Imports = globalScope.Imports,
         };
+    }
+
+    /// <summary>
+    /// ADR-0105 (Phase 1) helper shared by every member-body bind site in
+    /// <see cref="BindProgram(BoundGlobalScope, ReferenceResolver, BoundBodyCache)"/>.
+    /// On a <em>sound</em> cache hit it returns the cached lowered body and
+    /// appends the cached per-body diagnostics; otherwise it invokes
+    /// <paramref name="bindAndLower"/> (which performs the exact same
+    /// bind/lower/post-check work the call site would have done inline),
+    /// appends the produced diagnostics, and stores the result for later reuse.
+    /// When <paramref name="cache"/> is <see langword="null"/> this is exactly
+    /// the full-rebuild path with no behavioral difference.
+    /// </summary>
+    /// <param name="cache">The optional bound-body cache.</param>
+    /// <param name="globalScope">The global scope the bind is running against (the soundness-gate token).</param>
+    /// <param name="member">The member symbol whose body is being bound.</param>
+    /// <param name="bodySyntax">The body syntax that will be bound and lowered.</param>
+    /// <param name="diagnostics">The program-level diagnostics accumulator to append to.</param>
+    /// <param name="bindAndLower">Produces the freshly bound+lowered body and its diagnostics on a miss.</param>
+    /// <returns>The lowered body — reused on a sound hit, freshly produced otherwise.</returns>
+    private static BoundBlockStatement BindBodyWithCache(
+        BoundBodyCache cache,
+        BoundGlobalScope globalScope,
+        FunctionSymbol member,
+        SyntaxNode bodySyntax,
+        ImmutableArray<Diagnostic>.Builder diagnostics,
+        Func<(BoundBlockStatement Body, ImmutableArray<Diagnostic> Diagnostics)> bindAndLower)
+    {
+        if (cache != null
+            && bodySyntax != null
+            && cache.TryReuse(globalScope, member, bodySyntax, out var reusedBody, out var reusedDiagnostics))
+        {
+            diagnostics.AddRange(reusedDiagnostics);
+            return reusedBody;
+        }
+
+        var (body, bodyDiagnostics) = bindAndLower();
+        diagnostics.AddRange(bodyDiagnostics);
+        cache?.Store(globalScope, member, bodySyntax, body, bodyDiagnostics);
+        return body;
+    }
+
+    /// <summary>
+    /// ADR-0105 (Phase 1) helper for the four structurally identical interface
+    /// member-body bind loops (default-interface methods, static-virtual
+    /// defaults, and private instance/static helpers). Each lowers without a
+    /// declaring-type context and runs the all-paths-return check, then routes
+    /// through <see cref="BindBodyWithCache"/> and registers the body.
+    /// </summary>
+    /// <param name="cache">The optional bound-body cache.</param>
+    /// <param name="globalScope">The global scope (soundness-gate token).</param>
+    /// <param name="parentScope">The parent scope bodies are bound against.</param>
+    /// <param name="method">The interface method whose body is being bound.</param>
+    /// <param name="functionBodies">The function-body map to register the lowered body in.</param>
+    /// <param name="diagnostics">The program-level diagnostics accumulator.</param>
+    private static void BindInterfaceMethodBody(
+        BoundBodyCache cache,
+        BoundGlobalScope globalScope,
+        BoundScope parentScope,
+        FunctionSymbol method,
+        ImmutableDictionary<FunctionSymbol, BoundBlockStatement>.Builder functionBodies,
+        ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
+        var loweredBody = BindBodyWithCache(cache, globalScope, method, method.Declaration.Body, diagnostics, () =>
+        {
+            var binder = new Binder(parentScope, method);
+            var body = binder.statements.BindStatement(method.Declaration.Body);
+            var lowered = Lowerer.Lower(body);
+
+            if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(lowered))
+            {
+                binder.Diagnostics.ReportAllPathsMustReturn(method.Declaration.Identifier.Location);
+            }
+
+            return (lowered, binder.Diagnostics.ToImmutableArray());
+        });
+
+        functionBodies.Add(method, loweredBody);
+    }
+
+    /// <summary>
+    /// ADR-0105 (Phase 1) helper for struct/class member bodies bound with a
+    /// declaring-type lowering context (computed-property accessors, event
+    /// accessors and destructors). Optionally runs the all-paths-return check
+    /// at <paramref name="allPathsReturnLocation"/> when supplied. Routes
+    /// through <see cref="BindBodyWithCache"/> and registers the body.
+    /// </summary>
+    /// <param name="cache">The optional bound-body cache.</param>
+    /// <param name="globalScope">The global scope (soundness-gate token).</param>
+    /// <param name="parentScope">The parent scope bodies are bound against.</param>
+    /// <param name="member">The member whose body is being bound.</param>
+    /// <param name="bodySyntax">The body syntax to bind and lower.</param>
+    /// <param name="structSym">The declaring type used as the lowering context.</param>
+    /// <param name="functionBodies">The function-body map to register the lowered body in.</param>
+    /// <param name="diagnostics">The program-level diagnostics accumulator.</param>
+    /// <param name="allPathsReturnLocation">When non-null, the location at which to report a missing all-paths return.</param>
+    private static void BindStructMemberBody(
+        BoundBodyCache cache,
+        BoundGlobalScope globalScope,
+        BoundScope parentScope,
+        FunctionSymbol member,
+        StatementSyntax bodySyntax,
+        StructSymbol structSym,
+        ImmutableDictionary<FunctionSymbol, BoundBlockStatement>.Builder functionBodies,
+        ImmutableArray<Diagnostic>.Builder diagnostics,
+        TextLocation? allPathsReturnLocation = null)
+    {
+        var loweredBody = BindBodyWithCache(cache, globalScope, member, bodySyntax, diagnostics, () =>
+        {
+            var binder = new Binder(parentScope, member);
+            var body = binder.statements.BindStatement(bodySyntax);
+            var lowered = Lowerer.Lower(body, structSym);
+
+            if (allPathsReturnLocation != null && !ControlFlowGraph.AllPathsReturn(lowered))
+            {
+                binder.Diagnostics.ReportAllPathsMustReturn(allPathsReturnLocation.Value);
+            }
+
+            return (lowered, binder.Diagnostics.ToImmutableArray());
+        });
+
+        functionBodies.Add(member, loweredBody);
+    }
+
+    /// <summary>
+    /// ADR-0105 (Phase 1) helper for struct/class <em>method</em> bodies bound
+    /// with a declaring-type lowering context (instance methods and
+    /// <c>shared</c> static methods). Runs the void/iterator-guarded
+    /// all-paths-return check, routes through <see cref="BindBodyWithCache"/>
+    /// and registers the body.
+    /// </summary>
+    /// <param name="cache">The optional bound-body cache.</param>
+    /// <param name="globalScope">The global scope (soundness-gate token).</param>
+    /// <param name="parentScope">The parent scope bodies are bound against.</param>
+    /// <param name="method">The method whose body is being bound.</param>
+    /// <param name="structSym">The declaring type used as the lowering context.</param>
+    /// <param name="functionBodies">The function-body map to register the lowered body in.</param>
+    /// <param name="diagnostics">The program-level diagnostics accumulator.</param>
+    private static void BindStructMethodBody(
+        BoundBodyCache cache,
+        BoundGlobalScope globalScope,
+        BoundScope parentScope,
+        FunctionSymbol method,
+        StructSymbol structSym,
+        ImmutableDictionary<FunctionSymbol, BoundBlockStatement>.Builder functionBodies,
+        ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
+        var loweredBody = BindBodyWithCache(cache, globalScope, method, method.Declaration.Body, diagnostics, () =>
+        {
+            var binder = new Binder(parentScope, method);
+            var body = binder.statements.BindStatement(method.Declaration.Body);
+            var lowered = Lowerer.Lower(body, structSym);
+
+            if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(lowered))
+            {
+                binder.Diagnostics.ReportAllPathsMustReturn(method.Declaration.Identifier.Location);
+            }
+
+            return (lowered, binder.Diagnostics.ToImmutableArray());
+        });
+
+        functionBodies.Add(method, loweredBody);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/BoundBodyCache.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBodyCache.cs
@@ -1,0 +1,216 @@
+// <copyright file="BoundBodyCache.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0105 (Phase 1) — a per-project cache of lowered member bodies keyed by a
+/// <em>stable, content-addressed</em> identity rather than by symbol object
+/// reference, syntax-node reference, or source span.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cache key is conceptually <c>(stableMemberId, bodyHash)</c>:
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     <c>stableMemberId</c> is position-independent: source file path, owning
+///     package, containing-type path (if any) and the member's name +
+///     parameter-type signature (via <see cref="Binder.FormatOverloadSignature"/>).
+///     It deliberately depends on <em>none</em> of: a symbol object reference, a
+///     <see cref="SyntaxNode"/> reference, or a <see cref="Text.TextSpan"/> —
+///     all of which shift when earlier text changes.
+///   </description></item>
+///   <item><description>
+///     <c>bodyHash</c> is a content hash (SHA-256) of the member body's source
+///     text. Any change to the body — including whitespace — produces a
+///     different hash and therefore a miss. This is intentionally conservative:
+///     over-invalidation only costs a re-bind, whereas under-invalidation would
+///     be a correctness bug.
+///   </description></item>
+/// </list>
+/// <para>
+/// <strong>Soundness gate (critical — read ADR-0105 "Stable symbol identity"
+/// and "Determinism").</strong> A lowered body references symbols drawn from a
+/// particular <see cref="BoundGlobalScope"/>. Until ADR-0105 Phase 2 introduces
+/// per-file symbol tables with stable symbol identity, every fresh
+/// <see cref="Compilation.Compilation"/> allocates <em>fresh</em> symbol
+/// instances, so a body cached against compilation <c>N</c>'s symbols cannot be
+/// spliced into compilation <c>N+1</c> without silently referencing stale
+/// symbols. To keep emit and diagnostics bit-for-bit identical to the
+/// full-rebuild path, reuse is therefore gated on the cached body having been
+/// bound against the <em>same</em> <see cref="BoundGlobalScope"/> instance
+/// (reference equality), which guarantees the referenced symbols are the exact
+/// same instances. Across language-server edits this gate is (by design)
+/// almost never satisfied — Phase 1 lands the infrastructure with a near-zero
+/// hit-rate and no user-visible effect, exactly as ADR-0105 states. Phase 2
+/// will replace this gate with a symbol-identity-based check so that body-only
+/// edits hit.
+/// </para>
+/// <para>
+/// The cached entry carries both the lowered <see cref="BoundBlockStatement"/>
+/// and the per-body diagnostics, so reuse reproduces diagnostics exactly.
+/// </para>
+/// <para>This type is thread-safe.</para>
+/// </remarks>
+public sealed class BoundBodyCache
+{
+    private readonly ConcurrentDictionary<BoundBodyCacheKey, Entry> entries = new();
+
+    private long hits;
+    private long misses;
+    private long stores;
+
+    /// <summary>Gets the number of sound cache hits (reused bodies) served so far.</summary>
+    public long Hits => Interlocked.Read(ref hits);
+
+    /// <summary>Gets the number of cache misses (bodies that had to be bound from scratch) so far.</summary>
+    public long Misses => Interlocked.Read(ref misses);
+
+    /// <summary>Gets the number of bodies stored into the cache so far.</summary>
+    public long Stores => Interlocked.Read(ref stores);
+
+    /// <summary>
+    /// Computes the stable, content-addressed key for a member body. Returns
+    /// <see langword="false"/> when a stable key cannot be formed (e.g. a body
+    /// with no backing source text), in which case the caller must treat the
+    /// lookup as a miss and bind from scratch.
+    /// </summary>
+    /// <param name="member">The member symbol whose body is being bound.</param>
+    /// <param name="bodySyntax">The body syntax that will be bound and lowered.</param>
+    /// <param name="key">The computed stable key, when this method returns true.</param>
+    /// <returns><see langword="true"/> when a stable key was formed.</returns>
+    public static bool TryCreateKey(FunctionSymbol member, SyntaxNode bodySyntax, out BoundBodyCacheKey key)
+    {
+        key = default;
+        if (member == null || bodySyntax == null)
+        {
+            return false;
+        }
+
+        var sourceText = bodySyntax.SyntaxTree?.Text;
+        if (sourceText == null)
+        {
+            return false;
+        }
+
+        var filePath = sourceText.FileName ?? string.Empty;
+        var packagePath = member.Package?.Name ?? string.Empty;
+        var typePath = ComputeContainingTypePath(member);
+        var signature = Binder.FormatOverloadSignature(member);
+        var stableMemberId = string.Concat(filePath, "|", packagePath, "|", typePath, "|", signature);
+
+        var bodyText = sourceText.ToString(bodySyntax.Span);
+        var bodyHash = ComputeHash(bodyText);
+
+        key = new BoundBodyCacheKey(stableMemberId, bodyHash);
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts a <em>sound</em> reuse of a previously cached lowered body for
+    /// <paramref name="member"/>. A hit is returned only when the stable key
+    /// matches <em>and</em> the cached body was bound against the same
+    /// <paramref name="scope"/> instance (the soundness gate described on this
+    /// type). On a sound hit, <paramref name="loweredBody"/> and
+    /// <paramref name="diagnostics"/> are exactly what a from-scratch bind would
+    /// have produced.
+    /// </summary>
+    /// <param name="scope">The global scope the current bind is running against.</param>
+    /// <param name="member">The member symbol whose body is being bound.</param>
+    /// <param name="bodySyntax">The body syntax that would be bound and lowered.</param>
+    /// <param name="loweredBody">The reused lowered body, on a sound hit.</param>
+    /// <param name="diagnostics">The reused per-body diagnostics, on a sound hit.</param>
+    /// <returns><see langword="true"/> on a sound hit; otherwise <see langword="false"/>.</returns>
+    public bool TryReuse(
+        BoundGlobalScope scope,
+        FunctionSymbol member,
+        SyntaxNode bodySyntax,
+        out BoundBlockStatement loweredBody,
+        out ImmutableArray<Diagnostic> diagnostics)
+    {
+        loweredBody = null;
+        diagnostics = ImmutableArray<Diagnostic>.Empty;
+
+        if (scope == null || !TryCreateKey(member, bodySyntax, out var key))
+        {
+            return false;
+        }
+
+        if (entries.TryGetValue(key, out var entry) && ReferenceEquals(entry.Scope, scope))
+        {
+            loweredBody = entry.LoweredBody;
+            diagnostics = entry.Diagnostics;
+            Interlocked.Increment(ref hits);
+            return true;
+        }
+
+        Interlocked.Increment(ref misses);
+        return false;
+    }
+
+    /// <summary>
+    /// Stores a freshly bound and lowered body (and its diagnostics) for later
+    /// reuse, tagged with the <paramref name="scope"/> it was bound against so
+    /// the soundness gate can be enforced on lookup.
+    /// </summary>
+    /// <param name="scope">The global scope the body was bound against.</param>
+    /// <param name="member">The member symbol whose body was bound.</param>
+    /// <param name="bodySyntax">The body syntax that was bound and lowered.</param>
+    /// <param name="loweredBody">The lowered body to cache.</param>
+    /// <param name="diagnostics">The per-body diagnostics to cache alongside the body.</param>
+    public void Store(
+        BoundGlobalScope scope,
+        FunctionSymbol member,
+        SyntaxNode bodySyntax,
+        BoundBlockStatement loweredBody,
+        ImmutableArray<Diagnostic> diagnostics)
+    {
+        if (scope == null || loweredBody == null || !TryCreateKey(member, bodySyntax, out var key))
+        {
+            return;
+        }
+
+        entries[key] = new Entry(scope, loweredBody, diagnostics.IsDefault ? ImmutableArray<Diagnostic>.Empty : diagnostics);
+        Interlocked.Increment(ref stores);
+    }
+
+    private static string ComputeContainingTypePath(FunctionSymbol member)
+    {
+        var owner = member.ReceiverType ?? member.StaticOwnerType ?? member.ExtensionReceiverType;
+        return owner?.Name ?? string.Empty;
+    }
+
+    private static string ComputeHash(string text)
+    {
+        var bytes = Encoding.UTF8.GetBytes(text ?? string.Empty);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash);
+    }
+
+    private sealed class Entry
+    {
+        public Entry(BoundGlobalScope scope, BoundBlockStatement loweredBody, ImmutableArray<Diagnostic> diagnostics)
+        {
+            Scope = scope;
+            LoweredBody = loweredBody;
+            Diagnostics = diagnostics;
+        }
+
+        public BoundGlobalScope Scope { get; }
+
+        public BoundBlockStatement LoweredBody { get; }
+
+        public ImmutableArray<Diagnostic> Diagnostics { get; }
+    }
+}

--- a/src/Core/CodeAnalysis/Binding/BoundBodyCache.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBodyCache.cs
@@ -42,20 +42,28 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// <para>
 /// <strong>Soundness gate (critical — read ADR-0105 "Stable symbol identity"
 /// and "Determinism").</strong> A lowered body references symbols drawn from a
-/// particular <see cref="BoundGlobalScope"/>. Until ADR-0105 Phase 2 introduces
-/// per-file symbol tables with stable symbol identity, every fresh
-/// <see cref="Compilation.Compilation"/> allocates <em>fresh</em> symbol
-/// instances, so a body cached against compilation <c>N</c>'s symbols cannot be
-/// spliced into compilation <c>N+1</c> without silently referencing stale
-/// symbols. To keep emit and diagnostics bit-for-bit identical to the
-/// full-rebuild path, reuse is therefore gated on the cached body having been
-/// bound against the <em>same</em> <see cref="BoundGlobalScope"/> instance
-/// (reference equality), which guarantees the referenced symbols are the exact
-/// same instances. Across language-server edits this gate is (by design)
-/// almost never satisfied — Phase 1 lands the infrastructure with a near-zero
-/// hit-rate and no user-visible effect, exactly as ADR-0105 states. Phase 2
-/// will replace this gate with a symbol-identity-based check so that body-only
-/// edits hit.
+/// particular <see cref="BoundGlobalScope"/>: the member's own parameters and
+/// locals, the sibling functions/types it calls, and so on. Splicing such a
+/// body into a different compilation is only sound if those referenced symbol
+/// <em>instances</em> are the exact instances that compilation uses (the
+/// emitter and binder key members by reference identity, not by signature).
+/// </para>
+/// <para>
+/// ADR-0105 <strong>Phase 2</strong> establishes that identity: a body-only,
+/// single-file edit produces a new <see cref="Compilation.Compilation"/> that
+/// <em>reuses the prior compilation's symbol instances</em> (the edited file's
+/// declarations are re-pointed at the freshly-parsed syntax via
+/// <see cref="IncrementalGlobalScopeReuse"/>; every other file's symbols flow
+/// through unchanged). Because the symbol instances survive across the edit,
+/// the soundness gate is the <em>symbol identity of the member</em>: a cached
+/// body is reused only when the member symbol presented on lookup is the
+/// <em>same instance</em> that produced the stored body
+/// (<see cref="object.ReferenceEquals(object, object)"/> on the member). On the
+/// from-scratch / full-rebuild path every member is a fresh instance, so the
+/// gate correctly forces a re-bind there (a stale-symbol splice can never
+/// occur). This replaces Phase 1's <see cref="BoundGlobalScope"/>-reference
+/// gate, which never hit across compilations because each one allocated fresh
+/// symbols.
 /// </para>
 /// <para>
 /// The cached entry carries both the lowered <see cref="BoundBlockStatement"/>
@@ -120,20 +128,18 @@ public sealed class BoundBodyCache
     /// <summary>
     /// Attempts a <em>sound</em> reuse of a previously cached lowered body for
     /// <paramref name="member"/>. A hit is returned only when the stable key
-    /// matches <em>and</em> the cached body was bound against the same
-    /// <paramref name="scope"/> instance (the soundness gate described on this
-    /// type). On a sound hit, <paramref name="loweredBody"/> and
-    /// <paramref name="diagnostics"/> are exactly what a from-scratch bind would
-    /// have produced.
+    /// matches <em>and</em> the cached body was bound for the same
+    /// <paramref name="member"/> symbol instance (the symbol-identity soundness
+    /// gate described on this type). On a sound hit, <paramref name="loweredBody"/>
+    /// and <paramref name="diagnostics"/> are exactly what a from-scratch bind
+    /// would have produced.
     /// </summary>
-    /// <param name="scope">The global scope the current bind is running against.</param>
     /// <param name="member">The member symbol whose body is being bound.</param>
     /// <param name="bodySyntax">The body syntax that would be bound and lowered.</param>
     /// <param name="loweredBody">The reused lowered body, on a sound hit.</param>
     /// <param name="diagnostics">The reused per-body diagnostics, on a sound hit.</param>
     /// <returns><see langword="true"/> on a sound hit; otherwise <see langword="false"/>.</returns>
     public bool TryReuse(
-        BoundGlobalScope scope,
         FunctionSymbol member,
         SyntaxNode bodySyntax,
         out BoundBlockStatement loweredBody,
@@ -142,12 +148,12 @@ public sealed class BoundBodyCache
         loweredBody = null;
         diagnostics = ImmutableArray<Diagnostic>.Empty;
 
-        if (scope == null || !TryCreateKey(member, bodySyntax, out var key))
+        if (!TryCreateKey(member, bodySyntax, out var key))
         {
             return false;
         }
 
-        if (entries.TryGetValue(key, out var entry) && ReferenceEquals(entry.Scope, scope))
+        if (entries.TryGetValue(key, out var entry) && ReferenceEquals(entry.Member, member))
         {
             loweredBody = entry.LoweredBody;
             diagnostics = entry.Diagnostics;
@@ -161,27 +167,25 @@ public sealed class BoundBodyCache
 
     /// <summary>
     /// Stores a freshly bound and lowered body (and its diagnostics) for later
-    /// reuse, tagged with the <paramref name="scope"/> it was bound against so
-    /// the soundness gate can be enforced on lookup.
+    /// reuse, tagged with the <paramref name="member"/> instance it was bound
+    /// for so the symbol-identity soundness gate can be enforced on lookup.
     /// </summary>
-    /// <param name="scope">The global scope the body was bound against.</param>
     /// <param name="member">The member symbol whose body was bound.</param>
     /// <param name="bodySyntax">The body syntax that was bound and lowered.</param>
     /// <param name="loweredBody">The lowered body to cache.</param>
     /// <param name="diagnostics">The per-body diagnostics to cache alongside the body.</param>
     public void Store(
-        BoundGlobalScope scope,
         FunctionSymbol member,
         SyntaxNode bodySyntax,
         BoundBlockStatement loweredBody,
         ImmutableArray<Diagnostic> diagnostics)
     {
-        if (scope == null || loweredBody == null || !TryCreateKey(member, bodySyntax, out var key))
+        if (loweredBody == null || !TryCreateKey(member, bodySyntax, out var key))
         {
             return;
         }
 
-        entries[key] = new Entry(scope, loweredBody, diagnostics.IsDefault ? ImmutableArray<Diagnostic>.Empty : diagnostics);
+        entries[key] = new Entry(member, loweredBody, diagnostics.IsDefault ? ImmutableArray<Diagnostic>.Empty : diagnostics);
         Interlocked.Increment(ref stores);
     }
 
@@ -200,14 +204,14 @@ public sealed class BoundBodyCache
 
     private sealed class Entry
     {
-        public Entry(BoundGlobalScope scope, BoundBlockStatement loweredBody, ImmutableArray<Diagnostic> diagnostics)
+        public Entry(FunctionSymbol member, BoundBlockStatement loweredBody, ImmutableArray<Diagnostic> diagnostics)
         {
-            Scope = scope;
+            Member = member;
             LoweredBody = loweredBody;
             Diagnostics = diagnostics;
         }
 
-        public BoundGlobalScope Scope { get; }
+        public FunctionSymbol Member { get; }
 
         public BoundBlockStatement LoweredBody { get; }
 

--- a/src/Core/CodeAnalysis/Binding/BoundBodyCacheKey.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBodyCacheKey.cs
@@ -1,0 +1,67 @@
+// <copyright file="BoundBodyCacheKey.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0105 (Phase 1) — the stable, content-addressed key of a cached member
+/// body: a <see cref="StableMemberId"/> (position-independent member identity)
+/// paired with a <see cref="BodyHash"/> (content hash of the body's source
+/// text). Equality and hashing are value-based and use only these two strings,
+/// never a symbol or <see cref="Syntax.SyntaxNode"/> reference, so a key is
+/// identical across re-parses of byte-identical text and differs whenever the
+/// body changes.
+/// </summary>
+public readonly struct BoundBodyCacheKey : IEquatable<BoundBodyCacheKey>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundBodyCacheKey"/> struct.
+    /// </summary>
+    /// <param name="stableMemberId">The position-independent member identity.</param>
+    /// <param name="bodyHash">The content hash of the member body's source text.</param>
+    public BoundBodyCacheKey(string stableMemberId, string bodyHash)
+    {
+        StableMemberId = stableMemberId ?? string.Empty;
+        BodyHash = bodyHash ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Gets the position-independent member identity (source file path, owning
+    /// package, containing-type path and name + parameter-type signature).
+    /// </summary>
+    public string StableMemberId { get; }
+
+    /// <summary>Gets the content hash of the member body's source text.</summary>
+    public string BodyHash { get; }
+
+    /// <summary>Determines whether two keys are equal.</summary>
+    /// <param name="left">The left key.</param>
+    /// <param name="right">The right key.</param>
+    /// <returns><see langword="true"/> when the keys are equal.</returns>
+    public static bool operator ==(BoundBodyCacheKey left, BoundBodyCacheKey right) => left.Equals(right);
+
+    /// <summary>Determines whether two keys are not equal.</summary>
+    /// <param name="left">The left key.</param>
+    /// <param name="right">The right key.</param>
+    /// <returns><see langword="true"/> when the keys are not equal.</returns>
+    public static bool operator !=(BoundBodyCacheKey left, BoundBodyCacheKey right) => !left.Equals(right);
+
+    /// <inheritdoc/>
+    public bool Equals(BoundBodyCacheKey other) =>
+        string.Equals(StableMemberId, other.StableMemberId, StringComparison.Ordinal)
+        && string.Equals(BodyHash, other.BodyHash, StringComparison.Ordinal);
+
+    /// <inheritdoc/>
+    public override bool Equals(object obj) => obj is BoundBodyCacheKey other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(
+        StringComparer.Ordinal.GetHashCode(StableMemberId ?? string.Empty),
+        StringComparer.Ordinal.GetHashCode(BodyHash ?? string.Empty));
+
+    /// <inheritdoc/>
+    public override string ToString() => $"{StableMemberId}#{BodyHash}";
+}

--- a/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
@@ -266,7 +266,7 @@ public sealed class BoundGlobalScope
     /// Gets the active preprocessor symbol set used by
     /// <c>[Conditional("SYMBOL")]</c> call-site elision (ADR-0047 §6 /
     /// issue #176). Threaded onto the bound global scope so that
-    /// <see cref="Binder.BindProgram"/> — which builds its own scope chain
+    /// <see cref="Binder.BindProgram(BoundGlobalScope, Symbols.ReferenceResolver)"/> — which builds its own scope chain
     /// from this snapshot — can rehydrate the same symbol set when binding
     /// function bodies. Defaults to <see cref="ImmutableHashSet{T}.Empty"/>.
     /// </summary>

--- a/src/Core/CodeAnalysis/Binding/BoundProgram.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundProgram.cs
@@ -255,7 +255,7 @@ public sealed class BoundProgram
     /// Gets the explicit (user-written) import symbols declared across all
     /// syntax trees. Implicit compiler-synthesized imports (e.g. the implicit
     /// <c>import System</c>) are excluded. Populated by
-    /// <see cref="Binding.Binder.BindProgram"/> from the bound global scope;
+    /// <see cref="Binding.Binder.BindProgram(BoundGlobalScope, Symbols.ReferenceResolver)"/> from the bound global scope;
     /// the PDB emitter uses this to produce per-file <c>ImportScope</c> chains.
     /// </summary>
     public ImmutableArray<ImportSymbol> Imports { get; internal set; } = ImmutableArray<ImportSymbol>.Empty;

--- a/src/Core/CodeAnalysis/Binding/IncrementalGlobalScopeReuse.cs
+++ b/src/Core/CodeAnalysis/Binding/IncrementalGlobalScopeReuse.cs
@@ -21,35 +21,64 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// <para>
 /// The reuse vehicle is the previous compilation's <see cref="BoundGlobalScope"/>
 /// itself: when exactly one file changed and that change is a <em>body-only</em>
-/// edit (package, imports, type aliases, and every declaration signature are
-/// byte-identical; only plain <c>func</c>/method block bodies differ), the new
-/// compilation reuses the prior <see cref="BoundGlobalScope"/> wholesale. Every
-/// symbol instance therefore survives the edit, which is exactly the identity
-/// the <see cref="BoundBodyCache"/>'s soundness gate and the emitter (which keys
+/// edit (package, imports, type aliases, fields, enum members, delegate
+/// signatures, and every declaration signature are byte-identical; only the
+/// statement blocks of body-bearing members differ), the new compilation reuses
+/// the prior <see cref="BoundGlobalScope"/> wholesale. Every symbol instance
+/// therefore survives the edit, which is exactly the identity the
+/// <see cref="BoundBodyCache"/>'s soundness gate and the emitter (which keys
 /// members by reference) require.
 /// </para>
 /// <para>
 /// The edited file's reused symbols are <em>re-pointed</em> at the freshly
-/// parsed syntax tree (<see cref="FunctionSymbol.RepointDeclaration"/>,
-/// <see cref="StructSymbol.RepointDeclaration"/>) so that re-binding their
-/// bodies binds the new text and reports diagnostics at the new spans, and so
-/// language-server navigation resolves to current source. Re-binding of those
-/// bodies is forced by passing the edited tree as a <c>dirtyTree</c> to
-/// <see cref="Binder.BindProgram(BoundGlobalScope, ReferenceResolver, BoundBodyCache, System.Collections.Immutable.ImmutableHashSet{SyntaxTree})"/>.
+/// parsed syntax tree so that re-binding their bodies binds the new text and
+/// reports diagnostics at the new spans, and so language-server navigation
+/// resolves to current source. This covers every body-bearing member kind:
+/// top-level functions, struct/class instance and static methods, interface
+/// default / static-virtual / private helper methods
+/// (<see cref="FunctionSymbol.RepointDeclaration"/>), constructors
+/// (<see cref="ConstructorSymbol.RepointDeclaration"/>), destructors
+/// (<see cref="DeinitSymbol.RepointDeclaration"/>), computed-property accessor
+/// bodies (<see cref="PropertySymbol.RepointDeclaration"/>), and explicit event
+/// accessor bodies (<see cref="EventSymbol.RepointDeclaration"/>). The owning
+/// struct and interface type symbols are re-pointed too
+/// (<see cref="StructSymbol.RepointDeclaration"/>,
+/// <see cref="InterfaceSymbol.RepointDeclaration"/>). Re-binding of every
+/// re-pointed body is forced by passing the edited tree as a <c>dirtyTree</c> to
+/// <see cref="Binder.BindProgram(BoundGlobalScope, ReferenceResolver, BoundBodyCache, System.Collections.Immutable.ImmutableHashSet{SyntaxTree})"/>;
+/// because each body's backing syntax now belongs to the dirty tree, the
+/// per-body cache read is bypassed and the body binds fresh.
 /// </para>
 /// <para>
-/// This phase deliberately supports only the dominant editing shape — plain
-/// top-level functions and struct/class instance/static methods. Any file
-/// containing constructors, destructors, computed properties, explicit events,
-/// interfaces, enums, delegates, or top-level statements falls back to a full
-/// rebuild (over-invalidation is always safe; under-invalidation would be a
-/// correctness bug). Broadening the supported member surface and adding cache
-/// eviction are tracked as Phase 3 follow-ups.
+/// Structural identity is proven by a <em>skeleton diff</em>: blanking the body
+/// blocks of <em>every</em> body-bearing member and requiring the remaining text
+/// to be byte-identical guarantees that the only change is inside bodies and
+/// that the set and order of every declaration is unchanged — so each reused
+/// member can be re-pointed by positional mapping. Anything that is <em>not</em>
+/// a member body — a field initializer, an auto-property, an enum member, a
+/// delegate signature, any member signature, an import, a type alias, the
+/// package clause — stays in the skeleton, so any change to it makes the
+/// skeletons differ and forces a full rebuild (correctness-preserving
+/// over-invalidation).
+/// </para>
+/// <para>
+/// The single remaining outright bail is a file containing top-level statements
+/// (the synthesized <c>&lt;Main&gt;$</c> entry-point body): that body is bound
+/// from <see cref="BoundGlobalScope.Statements"/> rather than from a
+/// member-declaration node, so it is not member-addressable for re-pointing.
+/// Such a file falls back to a full rebuild.
 /// </para>
 /// </remarks>
 public static class IncrementalGlobalScopeReuse
 {
     private const string BodyPlaceholder = "\u0000\u0000GS_BODY\u0000\u0000";
+
+    private enum EventAccessorKind
+    {
+        Add,
+        Remove,
+        Raise,
+    }
 
     /// <summary>
     /// Attempts to turn <paramref name="scope"/> (the previous compilation's
@@ -89,36 +118,40 @@ public static class IncrementalGlobalScopeReuse
         }
 
         // The edited file must not contain any construct this phase cannot
-        // re-point soundly (see remarks). Reject on either side.
+        // re-point soundly (top-level statements only — see remarks). Reject on
+        // either side.
         if (ContainsUnsupportedConstruct(previousTree) || ContainsUnsupportedConstruct(updatedTree))
         {
             return false;
         }
 
-        var previousFunctions = CollectFunctionDeclarations(previousTree);
-        var updatedFunctions = CollectFunctionDeclarations(updatedTree);
-
-        // Blank out plain function/method bodies and require everything else —
+        // Blank out every body-bearing member body and require everything else —
         // package, imports, type aliases, every declaration signature, fields,
-        // struct headers — to be byte-identical. A signature edit, added or
-        // removed member, or any non-body change makes the skeletons differ.
-        var previousSkeleton = BuildSkeleton(previousText, previousFunctions);
-        var updatedSkeleton = BuildSkeleton(updatedText, updatedFunctions);
+        // enum members, delegate signatures, struct/interface headers — to be
+        // byte-identical. A signature edit, added/removed member, or any
+        // non-body change makes the skeletons differ.
+        var previousSkeleton = BuildSkeleton(previousText, CollectBodySpans(previousTree));
+        var updatedSkeleton = BuildSkeleton(updatedText, CollectBodySpans(updatedTree));
+        if (previousSkeleton == null || updatedSkeleton == null)
+        {
+            return false;
+        }
+
         if (!string.Equals(previousSkeleton, updatedSkeleton, System.StringComparison.Ordinal))
         {
             return false;
         }
 
         // Skeleton equality guarantees identical structure, hence identical
-        // function/struct counts and ordering; assert defensively.
-        if (previousFunctions.Count != updatedFunctions.Count)
-        {
-            return false;
-        }
-
-        var previousStructs = CollectStructDeclarations(previousTree);
-        var updatedStructs = CollectStructDeclarations(updatedTree);
-        if (previousStructs.Count != updatedStructs.Count)
+        // per-kind declaration counts and ordering. Build a positional map for
+        // each declaration kind; defensively assert matching counts.
+        if (!TryBuildPositionalMap<FunctionDeclarationSyntax>(previousTree, updatedTree, out var functionMap)
+            || !TryBuildPositionalMap<StructDeclarationSyntax>(previousTree, updatedTree, out var structMap)
+            || !TryBuildPositionalMap<InterfaceDeclarationSyntax>(previousTree, updatedTree, out var interfaceMap)
+            || !TryBuildPositionalMap<ConstructorDeclarationSyntax>(previousTree, updatedTree, out var constructorMap)
+            || !TryBuildPositionalMap<DeinitDeclarationSyntax>(previousTree, updatedTree, out var deinitMap)
+            || !TryBuildPositionalMap<PropertyDeclarationSyntax>(previousTree, updatedTree, out var propertyMap)
+            || !TryBuildPositionalMap<EventDeclarationSyntax>(previousTree, updatedTree, out var eventMap))
         {
             return false;
         }
@@ -140,24 +173,9 @@ public static class IncrementalGlobalScopeReuse
             }
         }
 
-        // Map each previous declaration node to its positional counterpart in
-        // the re-parsed tree.
-        var functionMap = new Dictionary<FunctionDeclarationSyntax, FunctionDeclarationSyntax>(previousFunctions.Count);
-        for (var i = 0; i < previousFunctions.Count; i++)
-        {
-            functionMap[previousFunctions[i]] = updatedFunctions[i];
-        }
-
-        var structMap = new Dictionary<StructDeclarationSyntax, StructDeclarationSyntax>(previousStructs.Count);
-        for (var i = 0; i < previousStructs.Count; i++)
-        {
-            structMap[previousStructs[i]] = updatedStructs[i];
-        }
-
-        // Gather the reused symbols that belong to the edited file. Every one
-        // must have a mapped replacement node; otherwise the structural
-        // assumptions do not hold and we fall back rather than risk a stale
-        // re-point.
+        // ---- Phase 1: gather every reused member whose backing syntax belongs
+        // to the edited file, validating that each maps to a positional
+        // counterpart. Nothing is mutated yet; on any unmapped member we bail.
         var functionsToRepoint = new List<(FunctionSymbol Symbol, FunctionDeclarationSyntax Updated)>();
         foreach (var function in EnumerateFunctionSymbols(scope))
         {
@@ -192,8 +210,123 @@ public static class IncrementalGlobalScopeReuse
             structsToRepoint.Add((structSymbol, updated));
         }
 
-        // All validation passed — apply the re-point. This is the only
-        // mutation, and it only swaps backing syntax (signature byte-identical).
+        var interfacesToRepoint = new List<(InterfaceSymbol Symbol, InterfaceDeclarationSyntax Updated)>();
+        foreach (var interfaceSymbol in scope.Interfaces)
+        {
+            var declaration = interfaceSymbol.Declaration;
+            if (declaration == null || declaration.SyntaxTree != previousTree)
+            {
+                continue;
+            }
+
+            if (!interfaceMap.TryGetValue(declaration, out var updated))
+            {
+                return false;
+            }
+
+            interfacesToRepoint.Add((interfaceSymbol, updated));
+        }
+
+        var constructorsToRepoint = new List<(ConstructorSymbol Symbol, ConstructorDeclarationSyntax Updated)>();
+        var deinitsToRepoint = new List<(DeinitSymbol Symbol, DeinitDeclarationSyntax Updated)>();
+        var propertiesToRepoint = new List<(PropertySymbol Symbol, PropertyDeclarationSyntax Updated, BlockStatementSyntax Getter, BlockStatementSyntax Setter)>();
+        var eventsToRepoint = new List<(EventSymbol Symbol, EventDeclarationSyntax Updated, BlockStatementSyntax Add, BlockStatementSyntax Remove, BlockStatementSyntax Raise)>();
+
+        foreach (var structSymbol in scope.Structs)
+        {
+            // Constructors (ADR-0063 §9). Synthesized primary constructors carry
+            // no declaration node and have no rebindable body — skip them.
+            if (!structSymbol.ExplicitConstructors.IsDefaultOrEmpty)
+            {
+                foreach (var ctor in structSymbol.ExplicitConstructors)
+                {
+                    var declaration = ctor.Declaration;
+                    if (declaration == null || declaration.SyntaxTree != previousTree)
+                    {
+                        continue;
+                    }
+
+                    if (!constructorMap.TryGetValue(declaration, out var updated))
+                    {
+                        return false;
+                    }
+
+                    constructorsToRepoint.Add((ctor, updated));
+                }
+            }
+
+            // Destructor (ADR-0068 / issue #698).
+            var deinit = structSymbol.Deinitializer;
+            if (deinit?.Declaration != null && deinit.Declaration.SyntaxTree == previousTree)
+            {
+                if (!deinitMap.TryGetValue(deinit.Declaration, out var updated))
+                {
+                    return false;
+                }
+
+                deinitsToRepoint.Add((deinit, updated));
+            }
+
+            // Computed-property accessor bodies (ADR-0051), instance + static.
+            foreach (var prop in EnumerateProperties(structSymbol))
+            {
+                var declaration = prop.Declaration;
+                if (declaration == null || declaration.SyntaxTree != previousTree)
+                {
+                    continue;
+                }
+
+                if (!propertyMap.TryGetValue(declaration, out var updated))
+                {
+                    return false;
+                }
+
+                var newGetter = GetAccessorBody(updated, isGetter: true);
+                var newSetter = GetAccessorBody(updated, isGetter: false);
+
+                // The accessor shape must match (skeleton equality guarantees
+                // it); refuse rather than risk dropping or inventing a body.
+                if ((prop.GetterBodySyntax != null) != (newGetter != null)
+                    || (prop.SetterBodySyntax != null) != (newSetter != null))
+                {
+                    return false;
+                }
+
+                propertiesToRepoint.Add((prop, updated, newGetter, newSetter));
+            }
+
+            // Explicit event accessor bodies (ADR-0052 / issue #257), instance + static.
+            foreach (var ev in EnumerateEvents(structSymbol))
+            {
+                var declaration = ev.Declaration;
+                if (declaration == null || declaration.SyntaxTree != previousTree)
+                {
+                    continue;
+                }
+
+                if (!eventMap.TryGetValue(declaration, out var updated))
+                {
+                    return false;
+                }
+
+                var newAdd = GetEventAccessorBody(updated, EventAccessorKind.Add);
+                var newRemove = GetEventAccessorBody(updated, EventAccessorKind.Remove);
+                var newRaise = GetEventAccessorBody(updated, EventAccessorKind.Raise);
+
+                if ((ev.AddBodySyntax != null) != (newAdd != null)
+                    || (ev.RemoveBodySyntax != null) != (newRemove != null)
+                    || (ev.RaiseBodySyntax != null) != (newRaise != null))
+                {
+                    return false;
+                }
+
+                eventsToRepoint.Add((ev, updated, newAdd, newRemove, newRaise));
+            }
+        }
+
+        // ---- Phase 2: all validation passed — apply the re-point. This is the
+        // only mutation, and it only swaps backing syntax (signatures and
+        // accessor shapes are byte-identical).
         foreach (var (symbol, updated) in functionsToRepoint)
         {
             symbol.RepointDeclaration(updated);
@@ -202,6 +335,36 @@ public static class IncrementalGlobalScopeReuse
         foreach (var (symbol, updated) in structsToRepoint)
         {
             symbol.RepointDeclaration(updated);
+        }
+
+        foreach (var (symbol, updated) in interfacesToRepoint)
+        {
+            symbol.RepointDeclaration(updated);
+        }
+
+        foreach (var (symbol, updated) in constructorsToRepoint)
+        {
+            symbol.RepointDeclaration(updated);
+        }
+
+        foreach (var (symbol, updated) in deinitsToRepoint)
+        {
+            symbol.RepointDeclaration(updated);
+        }
+
+        foreach (var (symbol, updated, getter, setter) in propertiesToRepoint)
+        {
+            symbol.RepointDeclaration(updated);
+            symbol.GetterBodySyntax = getter;
+            symbol.SetterBodySyntax = setter;
+        }
+
+        foreach (var (symbol, updated, add, remove, raise) in eventsToRepoint)
+        {
+            symbol.RepointDeclaration(updated);
+            symbol.AddBodySyntax = add;
+            symbol.RemoveBodySyntax = remove;
+            symbol.RaiseBodySyntax = raise;
         }
 
         return true;
@@ -232,72 +395,188 @@ public static class IncrementalGlobalScopeReuse
                 }
             }
         }
+
+        // Interface default / static-virtual / private helper methods carry
+        // FunctionDeclarationSyntax declarations and rebindable bodies.
+        foreach (var interfaceSymbol in scope.Interfaces)
+        {
+            foreach (var method in EnumerateInterfaceMethods(interfaceSymbol))
+            {
+                yield return method;
+            }
+        }
+    }
+
+    private static IEnumerable<FunctionSymbol> EnumerateInterfaceMethods(InterfaceSymbol interfaceSymbol)
+    {
+        if (!interfaceSymbol.Methods.IsDefaultOrEmpty)
+        {
+            foreach (var method in interfaceSymbol.Methods)
+            {
+                yield return method;
+            }
+        }
+
+        if (!interfaceSymbol.StaticMethods.IsDefaultOrEmpty)
+        {
+            foreach (var method in interfaceSymbol.StaticMethods)
+            {
+                yield return method;
+            }
+        }
+
+        if (!interfaceSymbol.PrivateMethods.IsDefaultOrEmpty)
+        {
+            foreach (var method in interfaceSymbol.PrivateMethods)
+            {
+                yield return method;
+            }
+        }
+
+        if (!interfaceSymbol.StaticPrivateMethods.IsDefaultOrEmpty)
+        {
+            foreach (var method in interfaceSymbol.StaticPrivateMethods)
+            {
+                yield return method;
+            }
+        }
+    }
+
+    private static IEnumerable<PropertySymbol> EnumerateProperties(StructSymbol structSymbol)
+    {
+        if (!structSymbol.Properties.IsDefaultOrEmpty)
+        {
+            foreach (var prop in structSymbol.Properties)
+            {
+                yield return prop;
+            }
+        }
+
+        if (!structSymbol.StaticProperties.IsDefaultOrEmpty)
+        {
+            foreach (var prop in structSymbol.StaticProperties)
+            {
+                yield return prop;
+            }
+        }
+    }
+
+    private static IEnumerable<EventSymbol> EnumerateEvents(StructSymbol structSymbol)
+    {
+        if (!structSymbol.Events.IsDefaultOrEmpty)
+        {
+            foreach (var ev in structSymbol.Events)
+            {
+                yield return ev;
+            }
+        }
+
+        if (!structSymbol.StaticEvents.IsDefaultOrEmpty)
+        {
+            foreach (var ev in structSymbol.StaticEvents)
+            {
+                yield return ev;
+            }
+        }
     }
 
     private static bool ContainsUnsupportedConstruct(SyntaxTree tree)
     {
         foreach (var node in Descendants(tree.Root))
         {
-            switch (node)
+            // Top-level statements feed the synthesized <Main>$ entry-point body,
+            // which is bound from BoundGlobalScope.Statements rather than from a
+            // member-declaration node — so it cannot be re-pointed. Bail.
+            if (node is GlobalStatementSyntax)
             {
-                case ConstructorDeclarationSyntax:
-                case DeinitDeclarationSyntax:
-                case InterfaceDeclarationSyntax:
-                case EnumDeclarationSyntax:
-                case DelegateDeclarationSyntax:
-                case GlobalStatementSyntax:
-                case EventDeclarationSyntax:
-                    return true;
-                case PropertyDeclarationSyntax property:
-                    // Auto-properties (no accessor body) are fine; a computed
-                    // property carries a rebindable accessor body this phase
-                    // does not re-point, so fall back.
-                    if (property.Accessors.Any(a => a.Body != null))
-                    {
-                        return true;
-                    }
-
-                    break;
+                return true;
             }
         }
 
         return false;
     }
 
-    private static List<FunctionDeclarationSyntax> CollectFunctionDeclarations(SyntaxTree tree)
+    private static bool TryBuildPositionalMap<TNode>(
+        SyntaxTree previousTree,
+        SyntaxTree updatedTree,
+        out Dictionary<TNode, TNode> map)
+        where TNode : SyntaxNode
+    {
+        var previous = CollectDeclarations<TNode>(previousTree);
+        var updated = CollectDeclarations<TNode>(updatedTree);
+        if (previous.Count != updated.Count)
+        {
+            map = null;
+            return false;
+        }
+
+        map = new Dictionary<TNode, TNode>(previous.Count);
+        for (var i = 0; i < previous.Count; i++)
+        {
+            map[previous[i]] = updated[i];
+        }
+
+        return true;
+    }
+
+    private static List<TNode> CollectDeclarations<TNode>(SyntaxTree tree)
+        where TNode : SyntaxNode
     {
         return Descendants(tree.Root)
-            .OfType<FunctionDeclarationSyntax>()
+            .OfType<TNode>()
             .OrderBy(d => d.Span.Start)
             .ToList();
     }
 
-    private static List<StructDeclarationSyntax> CollectStructDeclarations(SyntaxTree tree)
+    /// <summary>
+    /// Collects, in ascending span order, the source spans of every body-bearing
+    /// member body in the file: function/method bodies (top-level, struct,
+    /// interface), constructor and destructor bodies, computed-property accessor
+    /// bodies and explicit event accessor bodies. Bodies nested inside another
+    /// collected body (e.g. a local function) are naturally subsumed by the
+    /// outer span and skipped by <see cref="BuildSkeleton"/>.
+    /// </summary>
+    private static List<TextSpan> CollectBodySpans(SyntaxTree tree)
     {
-        return Descendants(tree.Root)
-            .OfType<StructDeclarationSyntax>()
-            .OrderBy(d => d.Span.Start)
-            .ToList();
+        var spans = new List<TextSpan>();
+        foreach (var node in Descendants(tree.Root))
+        {
+            switch (node)
+            {
+                case FunctionDeclarationSyntax function when function.Body != null:
+                    spans.Add(function.Body.Span);
+                    break;
+                case ConstructorDeclarationSyntax ctor when ctor.Body != null:
+                    spans.Add(ctor.Body.Span);
+                    break;
+                case DeinitDeclarationSyntax deinit when deinit.Body != null:
+                    spans.Add(deinit.Body.Span);
+                    break;
+                case PropertyAccessorSyntax propAccessor when propAccessor.Body != null:
+                    spans.Add(propAccessor.Body.Span);
+                    break;
+                case EventAccessorSyntax eventAccessor when eventAccessor.Body != null:
+                    spans.Add(eventAccessor.Body.Span);
+                    break;
+            }
+        }
+
+        spans.Sort((a, b) => a.Start.CompareTo(b.Start));
+        return spans;
     }
 
-    private static string BuildSkeleton(SourceText text, List<FunctionDeclarationSyntax> functions)
+    private static string BuildSkeleton(SourceText text, List<TextSpan> bodySpans)
     {
         var builder = new StringBuilder();
         var position = 0;
-        foreach (var function in functions)
+        foreach (var span in bodySpans)
         {
-            var body = function.Body;
-            if (body == null)
-            {
-                continue;
-            }
-
-            var span = body.Span;
+            // A body whose start lies within the already-consumed prefix is
+            // nested inside an outer body that has already been blanked — skip
+            // it (its text is part of the placeholder for the enclosing body).
             if (span.Start < position)
             {
-                // Defensive: function bodies never nest, so spans should be
-                // disjoint and ascending. If they are not, give up.
-                return null;
+                continue;
             }
 
             builder.Append(text.ToString(TextSpan.FromBounds(position, span.Start)));
@@ -307,6 +586,40 @@ public static class IncrementalGlobalScopeReuse
 
         builder.Append(text.ToString(TextSpan.FromBounds(position, text.Length)));
         return builder.ToString();
+    }
+
+    private static BlockStatementSyntax GetAccessorBody(PropertyDeclarationSyntax property, bool isGetter)
+    {
+        foreach (var accessor in property.Accessors)
+        {
+            if (isGetter ? accessor.IsGetter : accessor.IsSetter)
+            {
+                return accessor.Body;
+            }
+        }
+
+        return null;
+    }
+
+    private static BlockStatementSyntax GetEventAccessorBody(EventDeclarationSyntax eventDeclaration, EventAccessorKind kind)
+    {
+        foreach (var accessor in eventDeclaration.Accessors)
+        {
+            var matches = kind switch
+            {
+                EventAccessorKind.Add => accessor.IsAdd,
+                EventAccessorKind.Remove => accessor.IsRemove,
+                EventAccessorKind.Raise => accessor.IsRaise,
+                _ => false,
+            };
+
+            if (matches)
+            {
+                return accessor.Body;
+            }
+        }
+
+        return null;
     }
 
     private static IEnumerable<SyntaxNode> Descendants(SyntaxNode root)

--- a/src/Core/CodeAnalysis/Binding/IncrementalGlobalScopeReuse.cs
+++ b/src/Core/CodeAnalysis/Binding/IncrementalGlobalScopeReuse.cs
@@ -1,0 +1,329 @@
+// <copyright file="IncrementalGlobalScopeReuse.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0105 Phase 2 — establishes <em>stable symbol identity</em> across a
+/// language-server edit so a body-only change to a single file re-binds only
+/// that file's member bodies while every unchanged file's bodies are served
+/// from the <see cref="BoundBodyCache"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The reuse vehicle is the previous compilation's <see cref="BoundGlobalScope"/>
+/// itself: when exactly one file changed and that change is a <em>body-only</em>
+/// edit (package, imports, type aliases, and every declaration signature are
+/// byte-identical; only plain <c>func</c>/method block bodies differ), the new
+/// compilation reuses the prior <see cref="BoundGlobalScope"/> wholesale. Every
+/// symbol instance therefore survives the edit, which is exactly the identity
+/// the <see cref="BoundBodyCache"/>'s soundness gate and the emitter (which keys
+/// members by reference) require.
+/// </para>
+/// <para>
+/// The edited file's reused symbols are <em>re-pointed</em> at the freshly
+/// parsed syntax tree (<see cref="FunctionSymbol.RepointDeclaration"/>,
+/// <see cref="StructSymbol.RepointDeclaration"/>) so that re-binding their
+/// bodies binds the new text and reports diagnostics at the new spans, and so
+/// language-server navigation resolves to current source. Re-binding of those
+/// bodies is forced by passing the edited tree as a <c>dirtyTree</c> to
+/// <see cref="Binder.BindProgram(BoundGlobalScope, ReferenceResolver, BoundBodyCache, System.Collections.Immutable.ImmutableHashSet{SyntaxTree})"/>.
+/// </para>
+/// <para>
+/// This phase deliberately supports only the dominant editing shape — plain
+/// top-level functions and struct/class instance/static methods. Any file
+/// containing constructors, destructors, computed properties, explicit events,
+/// interfaces, enums, delegates, or top-level statements falls back to a full
+/// rebuild (over-invalidation is always safe; under-invalidation would be a
+/// correctness bug). Broadening the supported member surface and adding cache
+/// eviction are tracked as Phase 3 follow-ups.
+/// </para>
+/// </remarks>
+public static class IncrementalGlobalScopeReuse
+{
+    private const string BodyPlaceholder = "\u0000\u0000GS_BODY\u0000\u0000";
+
+    /// <summary>
+    /// Attempts to turn <paramref name="scope"/> (the previous compilation's
+    /// global scope) into the global scope for an edit that replaced
+    /// <paramref name="previousTree"/> with <paramref name="updatedTree"/>,
+    /// when that edit is a supported body-only change. On success the edited
+    /// file's reused symbols are re-pointed at <paramref name="updatedTree"/>
+    /// and the method returns <see langword="true"/>; the caller then builds a
+    /// new compilation that reuses <paramref name="scope"/> and marks
+    /// <paramref name="updatedTree"/> dirty. On any failure the method returns
+    /// <see langword="false"/> <em>without mutating anything</em>, and the
+    /// caller must perform a full rebuild.
+    /// </summary>
+    /// <param name="scope">The previous compilation's bound global scope.</param>
+    /// <param name="previousTree">The file's syntax tree before the edit.</param>
+    /// <param name="updatedTree">The file's freshly parsed syntax tree after the edit.</param>
+    /// <returns><see langword="true"/> when the edit was a supported body-only change and reuse was applied.</returns>
+    public static bool TryRepointBodyOnlyEdit(BoundGlobalScope scope, SyntaxTree previousTree, SyntaxTree updatedTree)
+    {
+        if (scope == null || previousTree == null || updatedTree == null)
+        {
+            return false;
+        }
+
+        // Chained (REPL) scopes are not produced by the language server; reuse
+        // only the single-link shape the LSP builds.
+        if (scope.Previous != null)
+        {
+            return false;
+        }
+
+        var previousText = previousTree.Text;
+        var updatedText = updatedTree.Text;
+        if (previousText == null || updatedText == null)
+        {
+            return false;
+        }
+
+        // The edited file must not contain any construct this phase cannot
+        // re-point soundly (see remarks). Reject on either side.
+        if (ContainsUnsupportedConstruct(previousTree) || ContainsUnsupportedConstruct(updatedTree))
+        {
+            return false;
+        }
+
+        var previousFunctions = CollectFunctionDeclarations(previousTree);
+        var updatedFunctions = CollectFunctionDeclarations(updatedTree);
+
+        // Blank out plain function/method bodies and require everything else —
+        // package, imports, type aliases, every declaration signature, fields,
+        // struct headers — to be byte-identical. A signature edit, added or
+        // removed member, or any non-body change makes the skeletons differ.
+        var previousSkeleton = BuildSkeleton(previousText, previousFunctions);
+        var updatedSkeleton = BuildSkeleton(updatedText, updatedFunctions);
+        if (!string.Equals(previousSkeleton, updatedSkeleton, System.StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Skeleton equality guarantees identical structure, hence identical
+        // function/struct counts and ordering; assert defensively.
+        if (previousFunctions.Count != updatedFunctions.Count)
+        {
+            return false;
+        }
+
+        var previousStructs = CollectStructDeclarations(previousTree);
+        var updatedStructs = CollectStructDeclarations(updatedTree);
+        if (previousStructs.Count != updatedStructs.Count)
+        {
+            return false;
+        }
+
+        // Reusing the prior scope keeps the prior (signature-level) diagnostics
+        // verbatim. For unchanged files their spans are still correct, but the
+        // edited file's spans may have shifted — so refuse the fast path when
+        // the edited file contributed any global-scope diagnostic, to keep
+        // diagnostics bit-for-bit identical to a full rebuild.
+        var editedFile = previousText.FileName;
+        if (!string.IsNullOrEmpty(editedFile))
+        {
+            foreach (var diagnostic in scope.Diagnostics)
+            {
+                if (string.Equals(diagnostic.Location.Text?.FileName, editedFile, System.StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+        }
+
+        // Map each previous declaration node to its positional counterpart in
+        // the re-parsed tree.
+        var functionMap = new Dictionary<FunctionDeclarationSyntax, FunctionDeclarationSyntax>(previousFunctions.Count);
+        for (var i = 0; i < previousFunctions.Count; i++)
+        {
+            functionMap[previousFunctions[i]] = updatedFunctions[i];
+        }
+
+        var structMap = new Dictionary<StructDeclarationSyntax, StructDeclarationSyntax>(previousStructs.Count);
+        for (var i = 0; i < previousStructs.Count; i++)
+        {
+            structMap[previousStructs[i]] = updatedStructs[i];
+        }
+
+        // Gather the reused symbols that belong to the edited file. Every one
+        // must have a mapped replacement node; otherwise the structural
+        // assumptions do not hold and we fall back rather than risk a stale
+        // re-point.
+        var functionsToRepoint = new List<(FunctionSymbol Symbol, FunctionDeclarationSyntax Updated)>();
+        foreach (var function in EnumerateFunctionSymbols(scope))
+        {
+            var declaration = function.Declaration;
+            if (declaration == null || declaration.SyntaxTree != previousTree)
+            {
+                continue;
+            }
+
+            if (!functionMap.TryGetValue(declaration, out var updated))
+            {
+                return false;
+            }
+
+            functionsToRepoint.Add((function, updated));
+        }
+
+        var structsToRepoint = new List<(StructSymbol Symbol, StructDeclarationSyntax Updated)>();
+        foreach (var structSymbol in scope.Structs)
+        {
+            var declaration = structSymbol.Declaration;
+            if (declaration == null || declaration.SyntaxTree != previousTree)
+            {
+                continue;
+            }
+
+            if (!structMap.TryGetValue(declaration, out var updated))
+            {
+                return false;
+            }
+
+            structsToRepoint.Add((structSymbol, updated));
+        }
+
+        // All validation passed — apply the re-point. This is the only
+        // mutation, and it only swaps backing syntax (signature byte-identical).
+        foreach (var (symbol, updated) in functionsToRepoint)
+        {
+            symbol.RepointDeclaration(updated);
+        }
+
+        foreach (var (symbol, updated) in structsToRepoint)
+        {
+            symbol.RepointDeclaration(updated);
+        }
+
+        return true;
+    }
+
+    private static IEnumerable<FunctionSymbol> EnumerateFunctionSymbols(BoundGlobalScope scope)
+    {
+        foreach (var function in scope.Functions)
+        {
+            yield return function;
+        }
+
+        foreach (var structSymbol in scope.Structs)
+        {
+            if (!structSymbol.Methods.IsDefaultOrEmpty)
+            {
+                foreach (var method in structSymbol.Methods)
+                {
+                    yield return method;
+                }
+            }
+
+            if (!structSymbol.StaticMethods.IsDefaultOrEmpty)
+            {
+                foreach (var method in structSymbol.StaticMethods)
+                {
+                    yield return method;
+                }
+            }
+        }
+    }
+
+    private static bool ContainsUnsupportedConstruct(SyntaxTree tree)
+    {
+        foreach (var node in Descendants(tree.Root))
+        {
+            switch (node)
+            {
+                case ConstructorDeclarationSyntax:
+                case DeinitDeclarationSyntax:
+                case InterfaceDeclarationSyntax:
+                case EnumDeclarationSyntax:
+                case DelegateDeclarationSyntax:
+                case GlobalStatementSyntax:
+                case EventDeclarationSyntax:
+                    return true;
+                case PropertyDeclarationSyntax property:
+                    // Auto-properties (no accessor body) are fine; a computed
+                    // property carries a rebindable accessor body this phase
+                    // does not re-point, so fall back.
+                    if (property.Accessors.Any(a => a.Body != null))
+                    {
+                        return true;
+                    }
+
+                    break;
+            }
+        }
+
+        return false;
+    }
+
+    private static List<FunctionDeclarationSyntax> CollectFunctionDeclarations(SyntaxTree tree)
+    {
+        return Descendants(tree.Root)
+            .OfType<FunctionDeclarationSyntax>()
+            .OrderBy(d => d.Span.Start)
+            .ToList();
+    }
+
+    private static List<StructDeclarationSyntax> CollectStructDeclarations(SyntaxTree tree)
+    {
+        return Descendants(tree.Root)
+            .OfType<StructDeclarationSyntax>()
+            .OrderBy(d => d.Span.Start)
+            .ToList();
+    }
+
+    private static string BuildSkeleton(SourceText text, List<FunctionDeclarationSyntax> functions)
+    {
+        var builder = new StringBuilder();
+        var position = 0;
+        foreach (var function in functions)
+        {
+            var body = function.Body;
+            if (body == null)
+            {
+                continue;
+            }
+
+            var span = body.Span;
+            if (span.Start < position)
+            {
+                // Defensive: function bodies never nest, so spans should be
+                // disjoint and ascending. If they are not, give up.
+                return null;
+            }
+
+            builder.Append(text.ToString(TextSpan.FromBounds(position, span.Start)));
+            builder.Append(BodyPlaceholder);
+            position = span.End;
+        }
+
+        builder.Append(text.ToString(TextSpan.FromBounds(position, text.Length)));
+        return builder.ToString();
+    }
+
+    private static IEnumerable<SyntaxNode> Descendants(SyntaxNode root)
+    {
+        var stack = new Stack<SyntaxNode>();
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            var node = stack.Pop();
+            yield return node;
+            foreach (var child in node.GetChildren())
+            {
+                if (child != null)
+                {
+                    stack.Push(child);
+                }
+            }
+        }
+    }
+}

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -153,6 +153,32 @@ public class Compilation
     public BoundBodyCache BodyCache { get; set; }
 
     /// <summary>
+    /// Gets or sets a pre-bound <see cref="BoundGlobalScope"/> to reuse instead
+    /// of re-binding from the syntax trees (ADR-0105 Phase 2). The language
+    /// server sets this when a single-file, body-only edit lets the previous
+    /// compilation's global scope (and therefore every symbol instance) be
+    /// reused — the prerequisite for the <see cref="BoundBodyCache"/>'s
+    /// symbol-identity soundness gate to hit and for the emitter, which keys
+    /// members by reference, to remain correct. When set, <see cref="GlobalScope"/>
+    /// returns it verbatim instead of re-binding from the syntax trees.
+    /// The edited file's symbols are expected to have been re-pointed at the new
+    /// syntax via <see cref="IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit"/>
+    /// before this is set. Defaults to <see langword="null"/> (full rebuild).
+    /// </summary>
+    public BoundGlobalScope ReusedGlobalScope { get; set; }
+
+    /// <summary>
+    /// Gets or sets the set of syntax trees whose member bodies must be re-bound
+    /// from source rather than served from the <see cref="BoundBodyCache"/>
+    /// (ADR-0105 Phase 2). For a body-only edit this is the single re-parsed
+    /// file: its unchanged-but-shifted members would otherwise cache-hit and
+    /// return bodies bound at stale spans, so they are forced to rebind (which
+    /// then refreshes their cached entry). Unchanged files are absent and hit
+    /// the cache. Defaults to <see langword="null"/> (no forced re-bind).
+    /// </summary>
+    public System.Collections.Immutable.ImmutableHashSet<SyntaxTree> DirtyBodyTrees { get; set; }
+
+    /// <summary>
     /// Gets the global scope.
     /// </summary>
     public BoundGlobalScope GlobalScope
@@ -161,7 +187,8 @@ public class Compilation
         {
             if (globalScope == null)
             {
-                var globalScope = Binder.BindGlobalScope(Previous?.GlobalScope, SyntaxTrees, References, ImplicitSystemImport, PreprocessorSymbols, IsLibrary);
+                var globalScope = ReusedGlobalScope
+                    ?? Binder.BindGlobalScope(Previous?.GlobalScope, SyntaxTrees, References, ImplicitSystemImport, PreprocessorSymbols, IsLibrary);
                 Interlocked.CompareExchange(ref this.globalScope, globalScope, null);
             }
 
@@ -192,7 +219,7 @@ public class Compilation
         {
             if (boundProgram == null)
             {
-                var bp = Binder.BindProgram(GlobalScope, References, BodyCache);
+                var bp = Binder.BindProgram(GlobalScope, References, BodyCache, DirtyBodyTrees);
                 Interlocked.CompareExchange(ref this.boundProgram, bp, null);
             }
 

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -139,6 +139,20 @@ public class Compilation
     public bool WarnOnMissingDocumentation { get; set; }
 
     /// <summary>
+    /// Gets or sets the optional per-project bound-body cache (ADR-0105
+    /// Phase 1). When set, <see cref="BoundProgram"/> threads it through
+    /// <see cref="Binder.BindProgram(BoundGlobalScope, ReferenceResolver, BoundBodyCache)"/>
+    /// so unchanged member bodies can be reused across compilations <em>when
+    /// reuse is provably sound</em> (see <see cref="BoundBodyCache"/>). The
+    /// cache is owned externally (by the language server's per-project
+    /// <c>ProjectState</c>) and lives across the immutable, per-edit
+    /// <see cref="Compilation"/> instances; it never changes emitted IL or
+    /// diagnostics relative to the full-rebuild path. Defaults to
+    /// <see langword="null"/>, which is exactly the historical behavior.
+    /// </summary>
+    public BoundBodyCache BodyCache { get; set; }
+
+    /// <summary>
     /// Gets the global scope.
     /// </summary>
     public BoundGlobalScope GlobalScope
@@ -169,7 +183,7 @@ public class Compilation
     /// compilation after a file edit). Hot paths such as the language server's
     /// per-keystroke diagnostics, hover, definition, and semantic-token
     /// requests should reuse this cached instance rather than re-invoking
-    /// <see cref="Binder.BindProgram"/>, which can take hundreds of
+    /// <see cref="Binder.BindProgram(BoundGlobalScope, Symbols.ReferenceResolver)"/>, which can take hundreds of
     /// milliseconds on projects with large reference graphs.
     /// </remarks>
     public BoundProgram BoundProgram
@@ -178,7 +192,7 @@ public class Compilation
         {
             if (boundProgram == null)
             {
-                var bp = Binder.BindProgram(GlobalScope, References);
+                var bp = Binder.BindProgram(GlobalScope, References, BodyCache);
                 Interlocked.CompareExchange(ref this.boundProgram, bp, null);
             }
 

--- a/src/Core/CodeAnalysis/Symbols/ConstructorSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ConstructorSymbol.cs
@@ -34,7 +34,7 @@ public sealed class ConstructorSymbol
     public FunctionSymbol Function { get; }
 
     /// <summary>Gets the declaring syntax node, or <see langword="null"/> when this is a compiler-synthesized constructor (ADR-0065 §5).</summary>
-    public ConstructorDeclarationSyntax Declaration { get; }
+    public ConstructorDeclarationSyntax Declaration { get; private set; }
 
     /// <summary>Gets the constructor parameters (excluding the implicit <c>this</c>).</summary>
     public System.Collections.Immutable.ImmutableArray<ParameterSymbol> Parameters => Function.Parameters;
@@ -77,5 +77,20 @@ public sealed class ConstructorSymbol
     public void MarkSynthesizedFromPrimaryConstructor()
     {
         IsSynthesizedFromPrimaryConstructor = true;
+    }
+
+    /// <summary>
+    /// ADR-0105 Phase 2 — re-points this (reused) constructor at the declaration
+    /// node of a freshly-parsed syntax tree whose constructor signature is
+    /// byte-identical to the previous one (a body-only edit). Only the backing
+    /// syntax — and therefore the body text and source spans — changes; the
+    /// symbol's identity (including <see cref="Function"/> and its parameters)
+    /// is preserved so cross-compilation reuse stays sound. Intended to be
+    /// called only by <see cref="Binding.IncrementalGlobalScopeReuse"/>.
+    /// </summary>
+    /// <param name="declaration">The corresponding declaration in the re-parsed tree.</param>
+    internal void RepointDeclaration(ConstructorDeclarationSyntax declaration)
+    {
+        Declaration = declaration;
     }
 }

--- a/src/Core/CodeAnalysis/Symbols/DeinitSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/DeinitSymbol.cs
@@ -39,8 +39,22 @@ public sealed class DeinitSymbol
     public FunctionSymbol Function { get; }
 
     /// <summary>Gets the declaring syntax node.</summary>
-    public DeinitDeclarationSyntax Declaration { get; }
+    public DeinitDeclarationSyntax Declaration { get; private set; }
 
     /// <summary>Gets the owning class.</summary>
     public StructSymbol DeclaringType => Function.ReceiverType as StructSymbol;
+
+    /// <summary>
+    /// ADR-0105 Phase 2 — re-points this (reused) destructor at the declaration
+    /// node of a freshly-parsed syntax tree whose declaration is byte-identical
+    /// to the previous one (a body-only edit). Only the backing syntax — and
+    /// therefore the body text and source spans — changes; the symbol's identity
+    /// is preserved so cross-compilation reuse stays sound. Intended to be called
+    /// only by <see cref="Binding.IncrementalGlobalScopeReuse"/>.
+    /// </summary>
+    /// <param name="declaration">The corresponding declaration in the re-parsed tree.</param>
+    internal void RepointDeclaration(DeinitDeclarationSyntax declaration)
+    {
+        Declaration = declaration;
+    }
 }

--- a/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
@@ -64,7 +64,7 @@ public sealed class EventSymbol : Symbol
     public bool IsStatic { get; }
 
     /// <summary>Gets the declaring syntax node, or <see langword="null"/> for synthesized events.</summary>
-    public EventDeclarationSyntax Declaration { get; }
+    public EventDeclarationSyntax Declaration { get; private set; }
 
     /// <summary>Gets or sets the synthesized backing delegate field (null for explicit accessors).</summary>
     public FieldSymbol BackingField { get; set; }
@@ -86,4 +86,21 @@ public sealed class EventSymbol : Symbol
 
     /// <summary>Gets or sets the explicit raise body syntax (issue #257). Null when no <c>raise</c> accessor is declared.</summary>
     public Syntax.BlockStatementSyntax RaiseBodySyntax { get; set; }
+
+    /// <summary>
+    /// ADR-0105 Phase 2 — re-points this (reused) event at the declaration node
+    /// of a freshly-parsed syntax tree whose event signature and accessor shape
+    /// are byte-identical to the previous one (a body-only edit). The caller is
+    /// responsible for re-pointing <see cref="AddBodySyntax"/>,
+    /// <see cref="RemoveBodySyntax"/> and <see cref="RaiseBodySyntax"/> at the
+    /// corresponding accessor bodies in the re-parsed tree. The symbol's identity
+    /// (including the add/remove/raise method symbols) is preserved so
+    /// cross-compilation reuse stays sound. Intended to be called only by
+    /// <see cref="Binding.IncrementalGlobalScopeReuse"/>.
+    /// </summary>
+    /// <param name="declaration">The corresponding declaration in the re-parsed tree.</param>
+    internal void RepointDeclaration(EventDeclarationSyntax declaration)
+    {
+        Declaration = declaration;
+    }
 }

--- a/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -157,7 +157,7 @@ public sealed class FunctionSymbol : Symbol
     /// <summary>
     /// Gets the declaration of the function.
     /// </summary>
-    public FunctionDeclarationSyntax Declaration { get; }
+    public FunctionDeclarationSyntax Declaration { get; private set; }
 
     /// <summary>
     /// Gets the package this function belongs to. <c>null</c> for built-in
@@ -296,4 +296,19 @@ public sealed class FunctionSymbol : Symbol
 
     /// <summary>Gets a value indicating whether this function is a P/Invoke stub (ADR-0086).</summary>
     public bool IsPInvoke => PInvokeMetadata != null;
+
+    /// <summary>
+    /// ADR-0105 Phase 2 — re-points this (reused) function symbol at the
+    /// declaration node of a freshly-parsed syntax tree whose member signature
+    /// is byte-identical to the previous one (a body-only edit). Only the
+    /// backing syntax — and therefore the body text and source spans — changes;
+    /// the symbol's identity and signature are preserved so cross-compilation
+    /// reuse stays sound. Intended to be called only by
+    /// <see cref="Binding.IncrementalGlobalScopeReuse"/>.
+    /// </summary>
+    /// <param name="declaration">The corresponding declaration in the re-parsed tree.</param>
+    internal void RepointDeclaration(FunctionDeclarationSyntax declaration)
+    {
+        Declaration = declaration;
+    }
 }

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -67,7 +67,7 @@ public sealed class InterfaceSymbol : TypeSymbol
     public Accessibility Accessibility { get; }
 
     /// <summary>Gets the declaring syntax node.</summary>
-    public InterfaceDeclarationSyntax Declaration { get; }
+    public InterfaceDeclarationSyntax Declaration { get; private set; }
 
     /// <summary>Gets the package this interface lives in.</summary>
     public string PackageName { get; }
@@ -380,6 +380,22 @@ public sealed class InterfaceSymbol : TypeSymbol
     public static bool HasDefaultBody(FunctionSymbol method)
     {
         return method != null && method.Declaration?.Body != null;
+    }
+
+    /// <summary>
+    /// ADR-0105 Phase 2 — re-points this (reused) interface symbol at the
+    /// declaration node of a freshly-parsed syntax tree whose declaration is
+    /// byte-identical to the previous one (a body-only edit). Only the backing
+    /// syntax — and therefore source spans — changes; the symbol's identity and
+    /// its method symbols are preserved so cross-compilation reuse stays sound.
+    /// The interface's default/private/static-virtual method bodies are
+    /// re-pointed separately via their <see cref="FunctionSymbol.RepointDeclaration(FunctionDeclarationSyntax)"/>.
+    /// Intended to be called only by <see cref="Binding.IncrementalGlobalScopeReuse"/>.
+    /// </summary>
+    /// <param name="declaration">The corresponding declaration in the re-parsed tree.</param>
+    internal void RepointDeclaration(InterfaceDeclarationSyntax declaration)
+    {
+        Declaration = declaration;
     }
 
     private static string BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments)

--- a/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
@@ -82,7 +82,7 @@ public sealed class PropertySymbol : Symbol
     public bool IsStatic { get; }
 
     /// <summary>Gets the declaring syntax node, or <see langword="null"/> for synthesized properties.</summary>
-    public PropertyDeclarationSyntax Declaration { get; }
+    public PropertyDeclarationSyntax Declaration { get; private set; }
 
     /// <summary>Gets or sets the synthesized backing field symbol for auto-properties. Null for computed properties.</summary>
     public FieldSymbol BackingField { get; set; }
@@ -98,4 +98,21 @@ public sealed class PropertySymbol : Symbol
 
     /// <summary>Gets or sets the setter accessor body syntax (for computed properties). Null for auto-properties.</summary>
     public Syntax.BlockStatementSyntax SetterBodySyntax { get; set; }
+
+    /// <summary>
+    /// ADR-0105 Phase 2 — re-points this (reused) property at the declaration
+    /// node of a freshly-parsed syntax tree whose property signature and
+    /// accessor shape are byte-identical to the previous one (a body-only edit).
+    /// The caller is responsible for re-pointing <see cref="GetterBodySyntax"/>
+    /// and <see cref="SetterBodySyntax"/> at the corresponding accessor bodies in
+    /// the re-parsed tree. The symbol's identity (including
+    /// <see cref="GetterSymbol"/>/<see cref="SetterSymbol"/>) is preserved so
+    /// cross-compilation reuse stays sound. Intended to be called only by
+    /// <see cref="Binding.IncrementalGlobalScopeReuse"/>.
+    /// </summary>
+    /// <param name="declaration">The corresponding declaration in the re-parsed tree.</param>
+    internal void RepointDeclaration(PropertyDeclarationSyntax declaration)
+    {
+        Declaration = declaration;
+    }
 }

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -159,7 +159,7 @@ public sealed class StructSymbol : TypeSymbol
     public Accessibility Accessibility { get; }
 
     /// <summary>Gets the declaring syntax node.</summary>
-    public StructDeclarationSyntax Declaration { get; }
+    public StructDeclarationSyntax Declaration { get; private set; }
 
     /// <summary>Gets the package the struct lives in.</summary>
     public string PackageName { get; }
@@ -750,6 +750,20 @@ public sealed class StructSymbol : TypeSymbol
 
         var key = BuildArgsKey(typeArguments);
         return ConstructedCache.GetOrAdd((definition, key), _ => CreateConstructed(definition, typeArguments));
+    }
+
+    /// <summary>
+    /// ADR-0105 Phase 2 — re-points this (reused) struct symbol at the
+    /// declaration node of a freshly-parsed syntax tree whose declaration is
+    /// byte-identical to the previous one (a body-only edit). Only the backing
+    /// syntax — and therefore source spans — changes; the symbol's identity is
+    /// preserved so cross-compilation reuse stays sound. Intended to be called
+    /// only by <see cref="Binding.IncrementalGlobalScopeReuse"/>.
+    /// </summary>
+    /// <param name="declaration">The corresponding declaration in the re-parsed tree.</param>
+    internal void RepointDeclaration(StructDeclarationSyntax declaration)
+    {
+        Declaration = declaration;
     }
 
     private static string BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments)

--- a/src/LanguageServer/ProjectState.cs
+++ b/src/LanguageServer/ProjectState.cs
@@ -21,6 +21,17 @@ public class ProjectState
 {
     private readonly object compilationLock = new();
     private readonly ConcurrentDictionary<string, SyntaxTree> syntaxTrees = new(StringComparer.OrdinalIgnoreCase);
+
+    // ADR-0105 (Phase 1): the per-project bound-body cache. It is owned here —
+    // alongside the per-edit lifecycle (UpdateFile -> Invalidate ->
+    // GetCompilation) and the warm cachedResolver — and seeded into every
+    // Compilation this project produces so unchanged member bodies can be
+    // reused across edits when reuse is provably sound. Until ADR-0105 Phase 2
+    // gives symbols stable cross-compilation identity, the cache's soundness
+    // gate makes reuse a near-no-op (it never alters emitted IL or
+    // diagnostics); the infrastructure lands now without user-visible effect.
+    private readonly Core.CodeAnalysis.Binding.BoundBodyCache bodyCache = new();
+
     private Compilation compilation;
     private bool isDirty = true;
     private IReadOnlyList<string> references = Array.Empty<string>();
@@ -227,6 +238,14 @@ public class ProjectState
                     ? new Compilation(resolver, trees)
                     : new Compilation(trees);
             }
+
+            // ADR-0105 (Phase 1): seed the project-owned body cache into the
+            // freshly constructed Compilation. The Compilation stays immutable
+            // per instance (the cache is external state set once at
+            // construction), so the language server's ConditionalWeakTable
+            // model/index caches keyed on the Compilation instance keep
+            // invalidating correctly.
+            compilation.BodyCache = bodyCache;
 
             isDirty = false;
             return compilation;

--- a/src/LanguageServer/ProjectState.cs
+++ b/src/LanguageServer/ProjectState.cs
@@ -226,6 +226,24 @@ public class ProjectState
 
             var trees = syntaxTrees.Values.ToArray();
             var resolver = GetOrBuildResolver_NoLock();
+
+            // ADR-0105 (Phase 2): attempt the incremental fast path — a single
+            // file changed and that change is a body-only edit, so we can reuse
+            // the previous compilation's BoundGlobalScope (and therefore every
+            // symbol instance) and let the BoundBodyCache serve every unchanged
+            // file's bodies, re-binding only the edited file. On any mismatch
+            // this returns null and we fall back to a full rebuild below
+            // (over-invalidation is always safe; under-invalidation would be a
+            // correctness bug).
+            var incremental = TryBuildIncrementalCompilation_NoLock(trees, resolver);
+            if (incremental != null)
+            {
+                compilation = incremental;
+                compilation.BodyCache = bodyCache;
+                isDirty = false;
+                return compilation;
+            }
+
             if (trees.Length == 0)
             {
                 compilation = resolver != null
@@ -250,6 +268,113 @@ public class ProjectState
             isDirty = false;
             return compilation;
         }
+    }
+
+    /// <summary>
+    /// ADR-0105 (Phase 2): attempts to construct the next <see cref="Compilation"/>
+    /// incrementally when the only change since <see cref="compilation"/> is a
+    /// body-only edit to a single file. On success returns a new compilation
+    /// that reuses the previous <c>BoundGlobalScope</c> (with the edited file's
+    /// symbols re-pointed at the new syntax) and marks the edited tree dirty so
+    /// only its bodies are re-bound; every other file's bodies are served from
+    /// the shared <see cref="bodyCache"/>. Returns <see langword="null"/> for
+    /// every other edit shape (signature edit, import/package/alias change,
+    /// multiple files changed, add/remove, or a reference change), forcing the
+    /// caller's full rebuild. Must be called under <see cref="compilationLock"/>.
+    /// </summary>
+    /// <param name="trees">The current set of syntax trees.</param>
+    /// <param name="resolver">The current reference resolver (may be null).</param>
+    /// <returns>An incrementally-built compilation, or <see langword="null"/> to fall back.</returns>
+    private Compilation TryBuildIncrementalCompilation_NoLock(SyntaxTree[] trees, ReferenceResolver resolver)
+    {
+        var previous = compilation;
+        if (previous == null || trees.Length == 0)
+        {
+            return null;
+        }
+
+        // A reference (.rsp) change is project-wide — fall back. Comparing the
+        // resolver instance is sufficient: GetOrBuildResolver_NoLock returns the
+        // same cached instance until references change, when it is rebuilt.
+        if (!ReferenceEquals(previous.References, resolver))
+        {
+            return null;
+        }
+
+        // The REPL/append chain shape is not produced here; only handle the flat
+        // single-compilation shape the language server builds.
+        if (previous.Previous != null)
+        {
+            return null;
+        }
+
+        // Pair the previous and current trees by file path. Any added or removed
+        // file makes this not a single-file body edit.
+        var previousTrees = previous.SyntaxTrees;
+        if (previousTrees.Length != trees.Length)
+        {
+            return null;
+        }
+
+        var previousByPath = new Dictionary<string, SyntaxTree>(previousTrees.Length, StringComparer.OrdinalIgnoreCase);
+        foreach (var tree in previousTrees)
+        {
+            var name = tree.Text?.FileName;
+            if (string.IsNullOrEmpty(name))
+            {
+                return null;
+            }
+
+            previousByPath[NormalizePath(name)] = tree;
+        }
+
+        SyntaxTree changedPrevious = null;
+        SyntaxTree changedUpdated = null;
+        foreach (var tree in trees)
+        {
+            var name = tree.Text?.FileName;
+            if (string.IsNullOrEmpty(name) || !previousByPath.TryGetValue(NormalizePath(name), out var prevTree))
+            {
+                return null;
+            }
+
+            if (ReferenceEquals(prevTree, tree))
+            {
+                continue;
+            }
+
+            if (changedUpdated != null)
+            {
+                // More than one file changed — fall back.
+                return null;
+            }
+
+            changedPrevious = prevTree;
+            changedUpdated = tree;
+        }
+
+        if (changedUpdated == null)
+        {
+            // Nothing actually changed (should not happen when dirty), but if so
+            // there is nothing to rebind — let the caller reuse normally.
+            return null;
+        }
+
+        // Reuse the previous global scope and re-point the edited file's symbols
+        // at the new syntax. This both validates the edit is body-only and (on
+        // success) performs the only mutation. On failure nothing is mutated.
+        var reusedScope = previous.GlobalScope;
+        if (!Core.CodeAnalysis.Binding.IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(reusedScope, changedPrevious, changedUpdated))
+        {
+            return null;
+        }
+
+        var incremental = resolver != null
+            ? new Compilation(resolver, trees)
+            : new Compilation(trees);
+        incremental.ReusedGlobalScope = reusedScope;
+        incremental.DirtyBodyTrees = System.Collections.Immutable.ImmutableHashSet.Create(changedUpdated);
+        return incremental;
     }
 
     private void RefreshReferencesFromSourceFile_NoLock()

--- a/test/Core.Tests/CodeAnalysis/Binding/BoundBodyCacheTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/BoundBodyCacheTests.cs
@@ -1,0 +1,327 @@
+// <copyright file="BoundBodyCacheTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0105 (Phase 1) — tests for <see cref="BoundBodyCache"/>: the
+/// content-addressed bound-body cache and its soundness gate.
+/// </summary>
+public class BoundBodyCacheTests
+{
+    /// <summary>
+    /// (a) A cache-backed bind reuses the exact lowered body a from-scratch
+    /// bind produced: same object reference and byte-identical
+    /// <see cref="BoundNodePrinter"/> output. Reuse is only sound when the
+    /// cached body was bound against the same <see cref="BoundGlobalScope"/>
+    /// instance, so we drive two binds over the <em>same</em> scope.
+    /// </summary>
+    [Fact]
+    public void CacheBackedBind_Reuses_ByteIdentical_Bodies()
+    {
+        var source = """
+            package P
+            func Add(a int, b int) int {
+                var s = a + b
+                return s
+            }
+            func Loop() int {
+                var total = 0
+                for var i = 0; i < 10; i++ {
+                    total = total + i
+                }
+                return total
+            }
+            """;
+        var globalScope = BindGlobalScope(source);
+
+        var cache = new BoundBodyCache();
+        var fromScratch = Binder.BindProgram(globalScope, references: null);
+        var firstWithCache = Binder.BindProgram(globalScope, references: null, cache);
+        var secondWithCache = Binder.BindProgram(globalScope, references: null, cache);
+
+        Assert.True(cache.Stores > 0);
+        Assert.True(cache.Hits > 0);
+
+        foreach (var function in globalScope.Functions)
+        {
+            // The second cache-backed bind reuses the very object the first
+            // bind stored (proving an actual hit, not a silent re-bind).
+            Assert.Same(firstWithCache.Functions[function], secondWithCache.Functions[function]);
+
+            // And the cached body is byte-for-byte what a from-scratch bind
+            // produced.
+            Assert.Equal(Print(fromScratch.Functions[function]), Print(secondWithCache.Functions[function]));
+        }
+
+        // Diagnostics are reproduced exactly across the cache boundary.
+        Assert.Equal(Print(fromScratch.Diagnostics), Print(secondWithCache.Diagnostics));
+    }
+
+    /// <summary>
+    /// (b) The stable key is identical across re-parses of byte-identical text
+    /// (position-independent identity), and DIFFERENT when the member body
+    /// changes (content-addressed).
+    /// </summary>
+    [Fact]
+    public void StableKey_Is_Stable_Across_Reparse_And_Changes_With_Body()
+    {
+        const string original = """
+            package P
+            func F(x int) int {
+                return x + 1
+            }
+            """;
+
+        // A leading comment shifts every span downward but must NOT change the
+        // stable key: identity is file + type + signature + body-text, never a
+        // span or node reference.
+        const string spanShifted = """
+            package P
+            // an unrelated leading comment that shifts spans
+            func F(x int) int {
+                return x + 1
+            }
+            """;
+
+        const string bodyChanged = """
+            package P
+            func F(x int) int {
+                return x + 2
+            }
+            """;
+
+        var keyOriginal = KeyOfFirstFunction(original);
+        var keyReparsed = KeyOfFirstFunction(original);
+        var keyShifted = KeyOfFirstFunction(spanShifted);
+        var keyChanged = KeyOfFirstFunction(bodyChanged);
+
+        Assert.Equal(keyOriginal, keyReparsed);
+        Assert.Equal(keyOriginal.GetHashCode(), keyReparsed.GetHashCode());
+        Assert.Equal(keyOriginal, keyShifted);
+        Assert.NotEqual(keyOriginal, keyChanged);
+    }
+
+    /// <summary>
+    /// (c) Editing one file does not corrupt another file's bound body. Two
+    /// files contribute distinct functions; reuse serves each its own body and
+    /// never cross-contaminates, and a body change in one file does not alter
+    /// the other file's key.
+    /// </summary>
+    [Fact]
+    public void Reuse_Does_Not_Corrupt_Other_Files_Bodies()
+    {
+        var fileA = SyntaxTree.Parse(SourceText.From(
+            """
+            package P
+            func Alpha() int {
+                return 111
+            }
+            """, fileName: "A.gs"));
+        var fileB = SyntaxTree.Parse(SourceText.From(
+            """
+            package P
+            func Beta() int {
+                return 222
+            }
+            """, fileName: "B.gs"));
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA, fileB));
+
+        var cache = new BoundBodyCache();
+        var fromScratch = Binder.BindProgram(globalScope, references: null);
+        Binder.BindProgram(globalScope, references: null, cache); // populate
+        var reused = Binder.BindProgram(globalScope, references: null, cache); // hit
+
+        var alpha = globalScope.Functions.Single(f => f.Name == "Alpha");
+        var beta = globalScope.Functions.Single(f => f.Name == "Beta");
+
+        // Each reused body matches its own from-scratch counterpart...
+        Assert.Equal(Print(fromScratch.Functions[alpha]), Print(reused.Functions[alpha]));
+        Assert.Equal(Print(fromScratch.Functions[beta]), Print(reused.Functions[beta]));
+
+        // ...and the two bodies remain distinct (no cross-file leakage).
+        Assert.NotEqual(Print(reused.Functions[alpha]), Print(reused.Functions[beta]));
+
+        // Changing file B's body must not change file A's stable key.
+        var editedB = SyntaxTree.Parse(SourceText.From(
+            """
+            package P
+            func Beta() int {
+                return 999
+            }
+            """, fileName: "B.gs"));
+        var editedScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA, editedB));
+
+        Assert.Equal(KeyOf(globalScope, "Alpha"), KeyOf(editedScope, "Alpha"));
+        Assert.NotEqual(KeyOf(globalScope, "Beta"), KeyOf(editedScope, "Beta"));
+    }
+
+    /// <summary>
+    /// Soundness gate: a body cached against one <see cref="BoundGlobalScope"/>
+    /// instance is NEVER reused for a different scope instance (which would
+    /// reference stale, freshly-allocated symbols). This is what keeps Phase 1
+    /// correct — and is why reuse is a near-no-op until Phase 2 gives symbols
+    /// stable cross-compilation identity.
+    /// </summary>
+    [Fact]
+    public void SoundnessGate_Blocks_Reuse_Across_Different_Scope_Instances()
+    {
+        const string source = """
+            package P
+            func F() int {
+                return 42
+            }
+            """;
+
+        var scope1 = BindGlobalScope(source);
+        var scope2 = BindGlobalScope(source); // identical text, fresh symbols
+
+        var cache = new BoundBodyCache();
+        var program1 = Binder.BindProgram(scope1, references: null, cache); // populate against scope1
+
+        var hitsBefore = cache.Hits;
+        var program2 = Binder.BindProgram(scope2, references: null, cache); // must NOT reuse scope1's bodies
+        var hitsAfter = cache.Hits;
+
+        Assert.Equal(hitsBefore, hitsAfter);
+
+        var f1 = scope1.Functions.Single(f => f.Name == "F");
+        var f2 = scope2.Functions.Single(f => f.Name == "F");
+
+        // Different scope → freshly bound body (different object), even though
+        // the printed form is identical text.
+        Assert.NotSame(program1.Functions[f1], program2.Functions[f2]);
+        Assert.Equal(Print(program1.Functions[f1]), Print(program2.Functions[f2]));
+    }
+
+    /// <summary>
+    /// The optional cache parameter never changes <see cref="BindProgram"/>'s
+    /// output for a wide member surface (functions, instance/static methods,
+    /// computed properties): bodies and diagnostics are byte-identical to the
+    /// full-rebuild path.
+    /// </summary>
+    [Fact]
+    public void CachePath_Matches_FullRebuild_For_Mixed_Members()
+    {
+        var source = """
+            package P
+            struct Counter {
+                var value int
+
+                func Bump() int {
+                    value = value + 1
+                    return value
+                }
+
+                var Doubled int {
+                    get { return value * 2 }
+                }
+            }
+            func Top(n int) int {
+                if n > 0 {
+                    return n
+                }
+                return 0
+            }
+            """;
+        var globalScope = BindGlobalScope(source);
+
+        var noCache = Binder.BindProgram(globalScope, references: null);
+        var withCache = Binder.BindProgram(globalScope, references: null, new BoundBodyCache());
+
+        Assert.Equal(Print(noCache.Diagnostics), Print(withCache.Diagnostics));
+
+        foreach (var function in noCache.Functions.Keys)
+        {
+            Assert.Equal(Print(noCache.Functions[function]), Print(withCache.Functions[function]));
+        }
+    }
+
+    /// <summary>
+    /// Emit is bit-for-bit identical whether the bound program came from a
+    /// cache hit or a from-scratch bind. A sound cache hit reuses the same
+    /// lowered bodies, and emit is a pure function of the bound program, so the
+    /// emitted PE must be byte-identical — the load-bearing determinism
+    /// guarantee from ADR-0105.
+    /// </summary>
+    [Fact]
+    public void Emit_Is_ByteIdentical_For_CacheHit_Vs_FromScratch()
+    {
+        var source = """
+            package P
+            func Add(a int, b int) int {
+                var s = a + b
+                return s
+            }
+            func Choose(n int) int {
+                if n > 0 {
+                    return n
+                }
+                return 0 - n
+            }
+            """;
+        var globalScope = BindGlobalScope(source);
+
+        var fromScratch = Binder.BindProgram(globalScope, references: null);
+
+        var cache = new BoundBodyCache();
+        Binder.BindProgram(globalScope, references: null, cache); // populate
+        var fromCache = Binder.BindProgram(globalScope, references: null, cache); // hit
+        Assert.True(cache.Hits > 0);
+
+        var fromScratchPe = EmitToBytes(fromScratch);
+        var fromCachePe = EmitToBytes(fromCache);
+
+        Assert.Equal(fromScratchPe, fromCachePe);
+    }
+
+    private static byte[] EmitToBytes(BoundProgram program)
+    {
+        using var stream = new MemoryStream();
+        GSharp.Core.CodeAnalysis.Emit.ReflectionMetadataEmitter.Emit(program, stream, references: null, assemblyName: "CacheDeterminism");
+        return stream.ToArray();
+    }
+
+    private static BoundGlobalScope BindGlobalScope(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+
+    private static BoundBodyCacheKey KeyOfFirstFunction(string source)
+    {
+        var globalScope = BindGlobalScope(source);
+        var function = globalScope.Functions.First(f => f.Declaration != null);
+        Assert.True(BoundBodyCache.TryCreateKey(function, function.Declaration.Body, out var key));
+        return key;
+    }
+
+    private static BoundBodyCacheKey KeyOf(BoundGlobalScope globalScope, string functionName)
+    {
+        var function = globalScope.Functions.Single(f => f.Name == functionName);
+        Assert.True(BoundBodyCache.TryCreateKey(function, function.Declaration.Body, out var key));
+        return key;
+    }
+
+    private static string Print(BoundNode node)
+    {
+        var writer = new StringWriter();
+        node.WriteTo(writer);
+        return writer.ToString();
+    }
+
+    private static string Print(ImmutableArray<Diagnostic> diagnostics) =>
+        string.Join("\n", diagnostics.Select(d => $"{d.Id}:{d.Severity}:{d.Message}"));
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/IncrementalGlobalScopeReuseTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/IncrementalGlobalScopeReuseTests.cs
@@ -251,25 +251,308 @@ public class IncrementalGlobalScopeReuseTests
     }
 
     /// <summary>
-    /// A file containing a computed property (an accessor body this phase does
-    /// not re-point) is rejected even for a plain body edit elsewhere in it, so
-    /// reuse falls back rather than risk stale accessor spans.
+    /// ADR-0105 Phase 2 (broadened member surface) — a body-only edit to a
+    /// method in a file that <em>also</em> contains a constructor now takes the
+    /// fast path: the reused constructor and method symbols are re-pointed at
+    /// the new syntax and the result is bit-for-bit identical to a full rebuild.
+    /// This is the headline repro fix (test files with <c>init()</c>).
     /// </summary>
     [Fact]
-    public void ComputedProperty_File_IsRejected_ByReuse()
+    public void Constructor_File_BodyEdit_TakesFastPath_AndIsByteIdentical()
     {
         var fileA = Parse("A.gs", """
             package P
-            struct Counter {
-                var value int
-
-                func Bump() int {
-                    value = value + 1
-                    return value
+            class Rect {
+                var Width int32
+                var Height int32
+                init(w int32, h int32) {
+                    Width = w
+                    Height = h
                 }
+                func Area() int32 {
+                    return Width * Height
+                }
+            }
+            """);
+        var fileB = Parse("B.gs", """
+            package P
+            func MakeArea() int32 {
+                var r = Rect(3, 4)
+                return r.Area()
+            }
+            """);
 
-                var Doubled int {
-                    get { return value * 2 }
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA, fileB));
+        var cache = new BoundBodyCache();
+        Binder.BindProgram(scope, references: null, cache); // populate
+        var hitsBefore = cache.Hits;
+
+        // Edit a method body, leaving the constructor's signature (and the whole
+        // skeleton) byte-identical.
+        var editedA = Parse("A.gs", """
+            package P
+            class Rect {
+                var Width int32
+                var Height int32
+                init(w int32, h int32) {
+                    Width = w
+                    Height = h
+                }
+                func Area() int32 {
+                    return Width * Height + 0
+                }
+            }
+            """);
+
+        Assert.True(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));
+        var fast = Binder.BindProgram(scope, references: null, cache, ImmutableHashSet.Create(editedA));
+
+        // B's body is served from the cache (unchanged); A's bodies were forced
+        // to re-bind (dirty).
+        Assert.True(cache.Hits > hitsBefore);
+
+        var fullScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(editedA, fileB));
+        var full = Binder.BindProgram(fullScope, references: null);
+
+        Assert.Equal(EmitToBytes(full), EmitToBytes(fast));
+        Assert.Equal(Print(full.Diagnostics), Print(fast.Diagnostics));
+    }
+
+    /// <summary>
+    /// A body-only edit also takes the fast path when the file additionally
+    /// declares a constructor whose <em>own</em> body is the thing being edited.
+    /// </summary>
+    [Fact]
+    public void Constructor_BodyEdit_RebindsConstructorBody()
+    {
+        var fileA = Parse("A.gs", """
+            package P
+            class Box {
+                var V int32
+                init(v int32) {
+                    V = v
+                }
+            }
+            """);
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA));
+        var cache = new BoundBodyCache();
+        Binder.BindProgram(scope, references: null, cache);
+
+        var editedA = Parse("A.gs", """
+            package P
+            class Box {
+                var V int32
+                init(v int32) {
+                    V = v + 1
+                }
+            }
+            """);
+
+        Assert.True(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));
+        var fast = Binder.BindProgram(scope, references: null, cache, ImmutableHashSet.Create(editedA));
+
+        var fullScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(editedA));
+        var full = Binder.BindProgram(fullScope, references: null);
+
+        // The constructor body re-bound to the new text and matches a full
+        // rebuild byte-for-byte.
+        foreach (var fastFn in fast.Functions.Keys)
+        {
+            var fullFn = full.Functions.Keys.Single(f => f.Name == fastFn.Name && f.Parameters.Length == fastFn.Parameters.Length);
+            Assert.Equal(Print(full.Functions[fullFn]), Print(fast.Functions[fastFn]));
+        }
+
+        Assert.Equal(EmitToBytes(full), EmitToBytes(fast));
+    }
+
+    /// <summary>
+    /// A body-only edit to a method in a file that also declares a computed
+    /// property takes the fast path; the property's accessor body is re-pointed
+    /// at the new tree and the program is byte-identical to a full rebuild.
+    /// </summary>
+    [Fact]
+    public void ComputedProperty_File_BodyEdit_TakesFastPath_AndIsByteIdentical()
+    {
+        var fileA = Parse("A.gs", """
+            package P
+            class Counter {
+                var n int32
+                prop Doubled int32 {
+                    get { return n * 2 }
+                }
+                func Bump() int32 {
+                    return n + 1
+                }
+            }
+            """);
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA));
+        var cache = new BoundBodyCache();
+        Binder.BindProgram(scope, references: null, cache);
+
+        // Edit the getter accessor body itself.
+        var editedA = Parse("A.gs", """
+            package P
+            class Counter {
+                var n int32
+                prop Doubled int32 {
+                    get { return n * 3 }
+                }
+                func Bump() int32 {
+                    return n + 1
+                }
+            }
+            """);
+
+        Assert.True(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));
+        var fast = Binder.BindProgram(scope, references: null, cache, ImmutableHashSet.Create(editedA));
+
+        var fullScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(editedA));
+        var full = Binder.BindProgram(fullScope, references: null);
+
+        Assert.Equal(EmitToBytes(full), EmitToBytes(fast));
+        Assert.Equal(Print(full.Diagnostics), Print(fast.Diagnostics));
+
+        // The re-pointed getter body reflects the edit.
+        var getter = fast.Functions.Keys.Single(f => f.Name == "get_Doubled");
+        Assert.Contains("3", Print(fast.Functions[getter]));
+    }
+
+    /// <summary>
+    /// A body-only edit to an explicit-event accessor (add/remove/raise) takes
+    /// the fast path and is byte-identical to a full rebuild.
+    /// </summary>
+    [Fact]
+    public void ExplicitEvent_File_BodyEdit_TakesFastPath_AndIsByteIdentical()
+    {
+        var fileA = Parse("A.gs", """
+            package P
+            class Notifier {
+                var c int32
+                public event Changed func() {
+                    add { }
+                    remove { }
+                    raise { }
+                }
+                func Ping() int32 {
+                    return c + 1
+                }
+            }
+            """);
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA));
+        var cache = new BoundBodyCache();
+        Binder.BindProgram(scope, references: null, cache);
+
+        var editedA = Parse("A.gs", """
+            package P
+            class Notifier {
+                var c int32
+                public event Changed func() {
+                    add { }
+                    remove { }
+                    raise { }
+                }
+                func Ping() int32 {
+                    return c + 2
+                }
+            }
+            """);
+
+        Assert.True(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));
+        var fast = Binder.BindProgram(scope, references: null, cache, ImmutableHashSet.Create(editedA));
+
+        var fullScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(editedA));
+        var full = Binder.BindProgram(fullScope, references: null);
+
+        Assert.Equal(EmitToBytes(full), EmitToBytes(fast));
+        Assert.Equal(Print(full.Diagnostics), Print(fast.Diagnostics));
+    }
+
+    /// <summary>
+    /// A body-only edit to a default-interface-method body takes the fast path
+    /// and is byte-identical to a full rebuild.
+    /// </summary>
+    [Fact]
+    public void InterfaceDefaultMethod_BodyEdit_TakesFastPath_AndIsByteIdentical()
+    {
+        var fileA = Parse("A.gs", """
+            package P
+            interface IGreeter {
+                func Hello() string {
+                    return "hi"
+                }
+            }
+            """);
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA));
+        var cache = new BoundBodyCache();
+        Binder.BindProgram(scope, references: null, cache);
+
+        var editedA = Parse("A.gs", """
+            package P
+            interface IGreeter {
+                func Hello() string {
+                    return "hello"
+                }
+            }
+            """);
+
+        Assert.True(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));
+        var fast = Binder.BindProgram(scope, references: null, cache, ImmutableHashSet.Create(editedA));
+
+        var fullScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(editedA));
+        var full = Binder.BindProgram(fullScope, references: null);
+
+        Assert.Equal(EmitToBytes(full), EmitToBytes(fast));
+        Assert.Equal(Print(full.Diagnostics), Print(fast.Diagnostics));
+
+        var hello = fast.Functions.Keys.Single(f => f.Name == "Hello");
+        Assert.Contains("hello", Print(fast.Functions[hello]));
+    }
+
+    /// <summary>
+    /// A constructor <em>signature</em> edit (changing a ctor parameter type) is
+    /// not a body-only edit, so reuse is refused and the caller full-rebuilds.
+    /// </summary>
+    [Fact]
+    public void ConstructorSignatureEdit_IsRejected_ByReuse()
+    {
+        var fileA = Parse("A.gs", """
+            package P
+            class Box {
+                var V int32
+                init(v int32) {
+                    V = v
+                }
+            }
+            """);
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA));
+
+        // Constructor parameter type changed int32 -> int64: a signature edit.
+        var editedA = Parse("A.gs", """
+            package P
+            class Box {
+                var V int32
+                init(v int64) {
+                    V = v
+                }
+            }
+            """);
+
+        Assert.False(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));
+    }
+
+    /// <summary>
+    /// A computed-property <em>signature</em> edit (changing the property type)
+    /// makes the skeleton differ, so reuse is refused.
+    /// </summary>
+    [Fact]
+    public void ComputedPropertySignatureEdit_IsRejected_ByReuse()
+    {
+        var fileA = Parse("A.gs", """
+            package P
+            class Counter {
+                var n int32
+                prop Doubled int32 {
+                    get { return n }
                 }
             }
             """);
@@ -277,18 +560,40 @@ public class IncrementalGlobalScopeReuseTests
 
         var editedA = Parse("A.gs", """
             package P
-            struct Counter {
-                var value int
-
-                func Bump() int {
-                    value = value + 2
-                    return value
-                }
-
-                var Doubled int {
-                    get { return value * 2 }
+            class Counter {
+                var n int32
+                prop Doubled int64 {
+                    get { return n }
                 }
             }
+            """);
+
+        Assert.False(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));
+    }
+
+    /// <summary>
+    /// Top-level statements remain an outright bail: the synthesized
+    /// <c>&lt;Main&gt;$</c> body is bound from the global scope's statements, not
+    /// a member-declaration node, so it is not re-pointable.
+    /// </summary>
+    [Fact]
+    public void TopLevelStatements_File_IsRejected_ByReuse()
+    {
+        var fileA = Parse("A.gs", """
+            package P
+            func Helper() int32 {
+                return 1
+            }
+            var x = Helper()
+            """);
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA));
+
+        var editedA = Parse("A.gs", """
+            package P
+            func Helper() int32 {
+                return 2
+            }
+            var x = Helper()
             """);
 
         Assert.False(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));

--- a/test/Core.Tests/CodeAnalysis/Binding/IncrementalGlobalScopeReuseTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/IncrementalGlobalScopeReuseTests.cs
@@ -1,0 +1,316 @@
+// <copyright file="IncrementalGlobalScopeReuseTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0105 (Phase 2) — tests for <see cref="IncrementalGlobalScopeReuse"/> and
+/// the dirty-tree-aware <see cref="Binder.BindProgram(BoundGlobalScope, ReferenceResolver, BoundBodyCache, ImmutableHashSet{SyntaxTree})"/>
+/// path: a single-file, body-only edit reuses the previous global scope (and
+/// therefore every symbol instance), re-binds only the edited file's bodies,
+/// and serves every other file's bodies from the <see cref="BoundBodyCache"/>
+/// — while remaining bit-for-bit identical to a full rebuild.
+/// </summary>
+public class IncrementalGlobalScopeReuseTests
+{
+    /// <summary>
+    /// A body-only edit to one file in a multi-file project reuses the cached
+    /// bodies of every unchanged file (cache hits, same symbol identity) and
+    /// re-binds only the edited file's body.
+    /// </summary>
+    [Fact]
+    public void BodyOnlyEdit_ReusesUnchangedBodies_AndRebindsOnlyEditedFile()
+    {
+        var fileA = Parse("A.gs", """
+            package P
+            func A() int {
+                return 1
+            }
+            """);
+        var fileB = Parse("B.gs", """
+            package P
+            func B() int {
+                return 2
+            }
+            """);
+        var fileC = Parse("C.gs", """
+            package P
+            func C() int {
+                return 3
+            }
+            """);
+
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA, fileB, fileC));
+        var cache = new BoundBodyCache();
+
+        // Populate the cache from the initial full bind.
+        Binder.BindProgram(scope, references: null, cache);
+        var hitsBefore = cache.Hits;
+        var storesBefore = cache.Stores;
+
+        // Body-only edit to A.gs (signature identical, only the literal changes).
+        var editedA = Parse("A.gs", """
+            package P
+            func A() int {
+                return 100
+            }
+            """);
+
+        Assert.True(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));
+
+        var dirty = ImmutableHashSet.Create(editedA);
+        var program = Binder.BindProgram(scope, references: null, cache, dirty);
+
+        // Exactly the two unchanged files (B, C) hit the cache; A's single body
+        // was forced to re-bind (dirty) and re-stored.
+        Assert.Equal(hitsBefore + 2, cache.Hits);
+        Assert.Equal(storesBefore + 1, cache.Stores);
+
+        // The re-bound A body reflects the new source text.
+        var a = scope.Functions.Single(f => f.Name == "A");
+        Assert.Contains("100", Print(program.Functions[a]));
+    }
+
+    /// <summary>
+    /// The fast path is bit-for-bit identical to a full rebuild on the edited
+    /// trees: same emitted IL and same diagnostics. This is the load-bearing
+    /// determinism guarantee — the cache/reuse must never change output. The
+    /// scenario includes a cross-file call (B calls A) so the reused body in B
+    /// keeps referring to the re-pointed symbol in A.
+    /// </summary>
+    [Fact]
+    public void FastPath_Emit_And_Diagnostics_Are_ByteIdentical_To_FullRebuild()
+    {
+        var fileA = Parse("A.gs", """
+            package P
+            func Helper(x int) int {
+                return x * 2
+            }
+            """);
+        var fileB = Parse("B.gs", """
+            package P
+            func UseHelper(y int) int {
+                return Helper(y) + 1
+            }
+            """);
+
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA, fileB));
+        var cache = new BoundBodyCache();
+        Binder.BindProgram(scope, references: null, cache); // populate
+
+        var editedA = Parse("A.gs", """
+            package P
+            func Helper(x int) int {
+                return x * 2 + 7
+            }
+            """);
+
+        Assert.True(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));
+        var fast = Binder.BindProgram(scope, references: null, cache, ImmutableHashSet.Create(editedA));
+
+        // Full rebuild over the post-edit trees, no reuse, no cache.
+        var fullScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(editedA, fileB));
+        var full = Binder.BindProgram(fullScope, references: null);
+
+        Assert.Equal(EmitToBytes(full), EmitToBytes(fast));
+        Assert.Equal(Print(full.Diagnostics), Print(fast.Diagnostics));
+    }
+
+    /// <summary>
+    /// Cross-file <em>type</em> dependency: file B constructs and uses a struct
+    /// declared in file A. A body-only edit to a method in A must not corrupt
+    /// B's reused body — both must match a full rebuild exactly.
+    /// </summary>
+    [Fact]
+    public void CrossFileTypeDependency_BodyEdit_DoesNotCorruptDependent()
+    {
+        var fileA = Parse("A.gs", """
+            package P
+            struct Point {
+                var X int
+                var Y int
+
+                func Area() int {
+                    return X * Y
+                }
+            }
+            """);
+        var fileB = Parse("B.gs", """
+            package P
+            func MakeArea() int {
+                var p = Point{X: 3, Y: 4}
+                return p.Area()
+            }
+            """);
+
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA, fileB));
+        var cache = new BoundBodyCache();
+        Binder.BindProgram(scope, references: null, cache); // populate
+
+        var editedA = Parse("A.gs", """
+            package P
+            struct Point {
+                var X int
+                var Y int
+
+                func Area() int {
+                    return X * Y + 0
+                }
+            }
+            """);
+
+        Assert.True(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));
+        var fast = Binder.BindProgram(scope, references: null, cache, ImmutableHashSet.Create(editedA));
+
+        var fullScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(editedA, fileB));
+        var full = Binder.BindProgram(fullScope, references: null);
+
+        Assert.Equal(Print(full.Diagnostics), Print(fast.Diagnostics));
+
+        // Pair functions by name across the two scopes and compare their bound
+        // bodies byte-for-byte (covers both the edited method and the reused
+        // dependent in B). Names are unique in this program.
+        foreach (var fastFn in fast.Functions.Keys)
+        {
+            var fullFn = full.Functions.Keys.Single(f => f.Name == fastFn.Name);
+            Assert.Equal(Print(full.Functions[fullFn]), Print(fast.Functions[fastFn]));
+        }
+    }
+
+    /// <summary>
+    /// A signature edit (changing a parameter type) is NOT a body-only edit, so
+    /// reuse is refused — the caller must full-rebuild, which correctly re-binds
+    /// dependents against the new signature.
+    /// </summary>
+    [Fact]
+    public void SignatureEdit_IsRejected_ByReuse()
+    {
+        var fileA = Parse("A.gs", """
+            package P
+            func Helper(x int) int {
+                return x * 2
+            }
+            """);
+        var fileB = Parse("B.gs", """
+            package P
+            func UseHelper(y int) int {
+                return Helper(y) + 1
+            }
+            """);
+
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA, fileB));
+
+        // Parameter type changed int -> int32: a signature edit, not body-only.
+        var editedA = Parse("A.gs", """
+            package P
+            func Helper(x int32) int {
+                return x * 2
+            }
+            """);
+
+        Assert.False(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));
+    }
+
+    /// <summary>
+    /// Adding a new declaration to a file is rejected (the skeleton differs), so
+    /// reuse falls back to a full rebuild.
+    /// </summary>
+    [Fact]
+    public void AddedDeclaration_IsRejected_ByReuse()
+    {
+        var fileA = Parse("A.gs", """
+            package P
+            func A() int {
+                return 1
+            }
+            """);
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA));
+
+        var editedA = Parse("A.gs", """
+            package P
+            func A() int {
+                return 1
+            }
+            func Added() int {
+                return 2
+            }
+            """);
+
+        Assert.False(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));
+    }
+
+    /// <summary>
+    /// A file containing a computed property (an accessor body this phase does
+    /// not re-point) is rejected even for a plain body edit elsewhere in it, so
+    /// reuse falls back rather than risk stale accessor spans.
+    /// </summary>
+    [Fact]
+    public void ComputedProperty_File_IsRejected_ByReuse()
+    {
+        var fileA = Parse("A.gs", """
+            package P
+            struct Counter {
+                var value int
+
+                func Bump() int {
+                    value = value + 1
+                    return value
+                }
+
+                var Doubled int {
+                    get { return value * 2 }
+                }
+            }
+            """);
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA));
+
+        var editedA = Parse("A.gs", """
+            package P
+            struct Counter {
+                var value int
+
+                func Bump() int {
+                    value = value + 2
+                    return value
+                }
+
+                var Doubled int {
+                    get { return value * 2 }
+                }
+            }
+            """);
+
+        Assert.False(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));
+    }
+
+    private static SyntaxTree Parse(string fileName, string source) =>
+        SyntaxTree.Parse(SourceText.From(source, fileName));
+
+    private static byte[] EmitToBytes(BoundProgram program)
+    {
+        using var stream = new MemoryStream();
+        GSharp.Core.CodeAnalysis.Emit.ReflectionMetadataEmitter.Emit(program, stream, references: null, assemblyName: "Phase2Determinism");
+        return stream.ToArray();
+    }
+
+    private static string Print(BoundNode node)
+    {
+        var writer = new StringWriter();
+        node.WriteTo(writer);
+        return writer.ToString();
+    }
+
+    private static string Print(ImmutableArray<Diagnostic> diagnostics) =>
+        string.Join("\n", diagnostics.Select(d => $"{d.Id}:{d.Severity}:{d.Message}"));
+}

--- a/test/LanguageServer.Tests/IncrementalDeltaBindingTests.cs
+++ b/test/LanguageServer.Tests/IncrementalDeltaBindingTests.cs
@@ -105,4 +105,65 @@ public class IncrementalDeltaBindingTests
         Assert.Null(comp2.ReusedGlobalScope);
         Assert.NotSame(comp1.GlobalScope, comp2.GlobalScope);
     }
+
+    /// <summary>
+    /// ADR-0105 Phase 2 (broadened member surface) — the headline repro: a file
+    /// containing a constructor (<c>init()</c>) now takes the incremental fast
+    /// path for a pure in-body edit instead of falling back to a full rebuild.
+    /// </summary>
+    [Fact]
+    public void BodyOnlyEdit_FileWithConstructor_ReusesGlobalScope()
+    {
+        var project = new ProjectState("/test/project.gsproj");
+        project.UpdateFile(
+            FileA,
+            "package P\nclass Box {\n    var V int32\n    init(v int32) {\n        V = v\n    }\n    func Get() int32 {\n        return V\n    }\n}\n");
+        project.UpdateFile(FileB, "package P\nfunc Use() int32 {\n    var b = Box(1)\n    return b.Get()\n}\n");
+
+        var comp1 = project.GetCompilation();
+        _ = comp1.BoundProgram;
+        var cache = comp1.BodyCache;
+        Assert.NotNull(cache);
+        var hitsBefore = cache.Hits;
+
+        // Pure in-body edit to the method (constructor signature unchanged).
+        project.UpdateFile(
+            FileA,
+            "package P\nclass Box {\n    var V int32\n    init(v int32) {\n        V = v\n    }\n    func Get() int32 {\n        return V + 0\n    }\n}\n");
+        var comp2 = project.GetCompilation();
+
+        // Fast path engaged: the global scope (and every symbol) is reused.
+        Assert.Same(comp1.GlobalScope, comp2.ReusedGlobalScope);
+        Assert.Same(comp1.GlobalScope, comp2.GlobalScope);
+
+        _ = comp2.BoundProgram;
+
+        // b.gs was served from the cache.
+        Assert.True(cache.Hits > hitsBefore);
+    }
+
+    /// <summary>
+    /// A computed-property type change in a constructor-bearing file is a
+    /// signature edit, so the fast path is correctly refused.
+    /// </summary>
+    [Fact]
+    public void SignatureEdit_FileWithComputedProperty_FallsBackToFullRebuild()
+    {
+        var project = new ProjectState("/test/project.gsproj");
+        project.UpdateFile(
+            FileA,
+            "package P\nclass Counter {\n    var n int32\n    prop Doubled int32 {\n        get { return n }\n    }\n}\n");
+
+        var comp1 = project.GetCompilation();
+        _ = comp1.BoundProgram;
+
+        // Property type changes int32 -> int64: a signature edit.
+        project.UpdateFile(
+            FileA,
+            "package P\nclass Counter {\n    var n int32\n    prop Doubled int64 {\n        get { return n }\n    }\n}\n");
+        var comp2 = project.GetCompilation();
+
+        Assert.Null(comp2.ReusedGlobalScope);
+        Assert.NotSame(comp1.GlobalScope, comp2.GlobalScope);
+    }
 }

--- a/test/LanguageServer.Tests/IncrementalDeltaBindingTests.cs
+++ b/test/LanguageServer.Tests/IncrementalDeltaBindingTests.cs
@@ -1,0 +1,108 @@
+// <copyright file="IncrementalDeltaBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// ADR-0105 (Phase 2) — end-to-end tests driving the real language-server path
+/// (<see cref="ProjectState.UpdateFile"/> + <see cref="ProjectState.GetCompilation"/>,
+/// a fresh <c>Compilation</c> per edit). They prove that a single-file,
+/// body-only edit reuses the previous compilation's global scope and serves the
+/// unchanged files' bodies from the shared <c>BoundBodyCache</c>, while edits
+/// that are not provably body-only fall back to a full rebuild.
+/// </summary>
+public class IncrementalDeltaBindingTests
+{
+    private const string FileA = "/test/a.gs";
+    private const string FileB = "/test/b.gs";
+    private const string FileC = "/test/c.gs";
+
+    [Fact]
+    public void BodyOnlyEdit_ReusesGlobalScope_AndServesCacheHitsForUnchangedFiles()
+    {
+        var project = new ProjectState("/test/project.gsproj");
+        project.UpdateFile(FileA, "package P\nfunc A() int {\n    return 1\n}\n");
+        project.UpdateFile(FileB, "package P\nfunc B() int {\n    return 2\n}\n");
+        project.UpdateFile(FileC, "package P\nfunc C() int {\n    return 3\n}\n");
+
+        var comp1 = project.GetCompilation();
+        _ = comp1.BoundProgram; // populate the per-project body cache
+        var cache = comp1.BodyCache;
+        Assert.NotNull(cache);
+        var hitsBefore = cache.Hits;
+        var storesBefore = cache.Stores;
+
+        // Body-only edit to a.gs — only the returned literal changes.
+        project.UpdateFile(FileA, "package P\nfunc A() int {\n    return 100\n}\n");
+        var comp2 = project.GetCompilation();
+
+        Assert.NotSame(comp1, comp2);
+
+        // Fast path taken: comp2 reuses comp1's bound global scope (and therefore
+        // every symbol instance), and marks a.gs as the only dirty body tree.
+        Assert.Same(comp1.GlobalScope, comp2.ReusedGlobalScope);
+        Assert.Same(comp1.GlobalScope, comp2.GlobalScope);
+
+        _ = comp2.BoundProgram;
+
+        // b.gs and c.gs were served from the cache; only a.gs re-bound and re-stored.
+        Assert.Equal(hitsBefore + 2, cache.Hits);
+        Assert.Equal(storesBefore + 1, cache.Stores);
+    }
+
+    [Fact]
+    public void SignatureEdit_FallsBackToFullRebuild()
+    {
+        var project = new ProjectState("/test/project.gsproj");
+        project.UpdateFile(FileA, "package P\nfunc Helper(x int) int {\n    return x * 2\n}\n");
+        project.UpdateFile(FileB, "package P\nfunc UseHelper(y int) int {\n    return Helper(y) + 1\n}\n");
+
+        var comp1 = project.GetCompilation();
+        _ = comp1.BoundProgram;
+
+        // Parameter type changes — a signature edit, not body-only.
+        project.UpdateFile(FileA, "package P\nfunc Helper(x int32) int {\n    return x * 2\n}\n");
+        var comp2 = project.GetCompilation();
+
+        Assert.NotSame(comp1, comp2);
+        Assert.Null(comp2.ReusedGlobalScope);
+        Assert.NotSame(comp1.GlobalScope, comp2.GlobalScope);
+    }
+
+    [Fact]
+    public void MultipleFilesChanged_FallsBackToFullRebuild()
+    {
+        var project = new ProjectState("/test/project.gsproj");
+        project.UpdateFile(FileA, "package P\nfunc A() int {\n    return 1\n}\n");
+        project.UpdateFile(FileB, "package P\nfunc B() int {\n    return 2\n}\n");
+
+        var comp1 = project.GetCompilation();
+        _ = comp1.BoundProgram;
+
+        project.UpdateFile(FileA, "package P\nfunc A() int {\n    return 10\n}\n");
+        project.UpdateFile(FileB, "package P\nfunc B() int {\n    return 20\n}\n");
+        var comp2 = project.GetCompilation();
+
+        Assert.Null(comp2.ReusedGlobalScope);
+        Assert.NotSame(comp1.GlobalScope, comp2.GlobalScope);
+    }
+
+    [Fact]
+    public void FileAdded_FallsBackToFullRebuild()
+    {
+        var project = new ProjectState("/test/project.gsproj");
+        project.UpdateFile(FileA, "package P\nfunc A() int {\n    return 1\n}\n");
+
+        var comp1 = project.GetCompilation();
+        _ = comp1.BoundProgram;
+
+        project.UpdateFile(FileB, "package P\nfunc B() int {\n    return 2\n}\n");
+        var comp2 = project.GetCompilation();
+
+        Assert.Null(comp2.ReusedGlobalScope);
+        Assert.NotSame(comp1.GlobalScope, comp2.GlobalScope);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **ADR-0105 — incremental (delta) binding for the language server** (closes #866), removing the full-program re-bind on every keystroke that dominated LSP latency on large multi-file projects.

Measured on the Oahu repro (`Oahu.Cli.Tests`, 54 files, 352 refs):

| | Before | After |
| --- | --- | --- |
| Body-only keystroke `BoundProgram` | ~360–390 ms | **~30 ms** |
| Body-only keystroke in a file with `func init()` (`CoreAuthServiceTests.gs`) | ~501 ms full rebuild | **~55 ms** fast path |

## What's in this PR

**ADR-0105** (`docs/adr/0105-…md`) — design doc backed by fresh Oahu profiling: phased delta binding, stable symbol identity, cache invalidation, determinism.

**Phase 1 — body-binding cache.** A per-project `BoundBodyCache` keyed by stable, content-addressed identity (`file | package | type | overload-signature` + SHA-256 body hash). Threaded through a new `BindProgram(globalScope, references, cache)` overload; the existing 2-arg overload (and all emit paths) is unchanged.

**Phase 2 — incremental `GlobalScope` reuse.** On a single-file **body-only** edit, the new `Compilation` reuses the prior `BoundGlobalScope` wholesale (preserving symbol reference-identity, which the emitter requires), re-pointing the edited file's members at the freshly-parsed syntax so only those bodies re-bind. A skeleton diff (blank every body-bearing member body, byte-compare the rest) proves the edit is body-only; the soundness gate keys on member symbol identity. Covers **all body-bearing members** — functions, struct/static methods, constructors, destructors, computed-property & event accessors, interface default/static-virtual/private methods. Only top-level statements (`<Main>$`) fall back to a full rebuild. Any signature / import / multi-file / reference change full-rebuilds (over-invalidation is always safe).

## Correctness & determinism

- **Emit is bit-for-bit identical** to the full-rebuild path (byte-equality tests for ctor/property/event/interface files) and **ilverify-clean**.
- Two-phase validate-then-mutate; conservative full-rebuild fallback throughout.
- New tests: `BoundBodyCacheTests`, `IncrementalGlobalScopeReuseTests` (Core), `IncrementalDeltaBindingTests` (LanguageServer) — cache-hit-after-body-edit, stable-key behavior, soundness gate, cross-file dependencies, signature-edit invalidation, emit byte-equality.

## Verification

- `dotnet build GSharp.sln` clean (0 warnings).
- Core.Tests 3314, LanguageServer.Tests 289, Interpreter.Tests 308 pass; Compiler.Tests pass (Emit run in batches to avoid the known single-process OOM); ilverify clean.

## Known follow-ups (not in this PR)

- **#869** — the LSP `SemanticModel` (`SemanticLookup.BuildModelUncached`) still rebuilds fully per edit (keyed on the `Compilation` instance); it's the next completion/hover latency win and is independent of this binder work.
- Params / fields / enum members / delegate signatures aren't re-pointed, so their **LSP navigation spans** stay stale on the fast path until the next full rebuild — IL and diagnostics are unaffected.
- No `BoundBodyCache` eviction/pruning yet.

Closes #866.
