### PR TITLE
ADR-0107: cross-session cold-start cache (single text .lscache) (#868)

### DIFF
--- a/docs/adr/0107-cross-session-cold-start-cache-language-server.md
+++ b/docs/adr/0107-cross-session-cold-start-cache-language-server.md
@@ -87,7 +87,7 @@ The file is gitignored **by default** (`*.lscache`, matching the prevailing .NET
 ### Location, opt-out, and lifecycle
 
 - **Location**: next to the project file, `<AssemblyName>.gsproj.lscache`. Gitignored by default; not picked up as a compile item (the SDK globs `**/*.gs`).
-- **Opt-out**: environment variable `GSHARP_DISABLE_COLD_START_CACHE` (`1`/`true`/`on`/`yes`), mirroring C#'s setting. When set, the cache is neither read (load nor bootstrap) nor written, and the resolver stays on the cold path.
+- **Opt-out**: environment variable `GSHARP_DISABLE_COLD_START_CACHE` (`1`/`true`/`on`/`yes`), surfaced in VS Code as the `gsharp.coldStartCache.enable` setting (the extension maps the setting onto the env var at server launch). When the `gsharp` setting is left unset, the extension honors the C# Dev Kit setting `dotnet.projectsystem.enableLanguageServiceCache` as a fallback if present (read-only — G# never contributes that key), giving dual C#/G# users a single toggle. When disabled, the cache is neither read (load nor bootstrap) nor written, and the resolver stays on the cold path.
 - **Safe to delete**: deleting the file at any time is harmless; the next open rebuilds and rewrites. No method in `ColdStartCache` ever throws into the LSP pipeline — every read/write is best-effort and any error degrades to a cold build.
 - **Ownership**: `ProjectState` owns the cache lifecycle, in `GetOrBuildResolver_NoLock`, alongside the warm `ReferenceResolver` it already caches. The cache is consulted exactly once per resolver build (i.e. when the reference set changes), so steady-state editing pays nothing.
 

--- a/docs/adr/0107-cross-session-cold-start-cache-language-server.md
+++ b/docs/adr/0107-cross-session-cold-start-cache-language-server.md
@@ -1,0 +1,144 @@
+# ADR-0107: Cross-session cold-start cache for the language server
+
+- **Status**: Proposed
+- **Date**: 2026-06-15
+- **Phase**: Language-server performance
+- **Related**: issue #868; issue #866 / ADR-0105 (incremental delta binding — complementary, per-keystroke); ADR-0106 (incremental SemanticModel); `src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs`, `src/Core/CodeAnalysis/Symbols/ReferenceMetadataIndex.cs`, `src/LanguageServer/ColdStartCache.cs`, `src/LanguageServer/ProjectState.cs`, `src/LanguageServer/ProjectDiscovery.cs`
+
+## Context
+
+The first time the language server opens a large G# workspace, the user waits on a full cold analysis pass before completion, diagnostics, and hover work. Measured on the Oahu repro (`Oahu.Cli.Tests`, 54 source files, 352 assembly references) by driving the real LSP path (`ProjectDiscovery` → `ProjectState` → `Compilation`), cold start is ~880–940 ms, decomposed as cold `GlobalScope` ~290–336 ms plus cold `BoundProgram` ~594–602 ms. None of it survives process exit, so every reopen and every fresh clone pays it again. ADR-0105 and ADR-0106 attack the *per-keystroke* (warm-session) cost; this ADR attacks the *cross-session cold-start* cost, the visible "open the folder and wait" pause.
+
+### Prior art: C# Dev Kit `.lscache`
+
+C# Dev Kit ships a cold-start cache as one text, INI-like `<Project>.csproj.lscache` file per project, sitting next to the project file. It begins with `version=1` and a human-readable `#` comment block (states what it caches, that it is not for manual editing, that it can be safely deleted and auto-regenerates, how to gitignore it, and the opt-out setting `dotnet.projectsystem.enableLanguageServiceCache`), then `[section]` blocks: `[project]`, `[properties]`, `[commandLineArguments]`, `[sourceFiles]`, `[metadataReferences]`, analyzers, and so on. What it persists is the **MSBuild design-time-build / project-system output** — a full project snapshot that lets the C# language service describe and analyze a project on reopen *without re-running the slow design-time build*. It is not a semantic/bind cache; Roslyn persists semantic state separately. Known pitfalls from their tracker that any such cache inherits: payload non-determinism (vscode-dotnettools#2965) and stale/duplicate entries (#2996); a robust fingerprint and a safe fallback are the mitigations.
+
+### Correcting the original framing: G# *does* need the project-system layer
+
+An earlier draft of this ADR claimed G# "barely needs" a `.lscache` because it "gets project data cheaply from the `.rsp`." That is wrong, and the evidence is concrete. The `.rsp` the language server reads (`ProjectDiscovery.DiscoverReferences`) is the MSBuild-emitted response file at `$(IntermediateOutputPath)$(TargetName).rsp` — i.e. it lives under `obj/`, and `*.rsp` is gitignored. It is an **ephemeral build artifact**: it does *not* survive `dotnet clean`, and it does *not* exist in a fresh clone before the first build/restore. When it is absent, `DiscoverReferences` returns an *empty* reference set, so the language server cannot resolve a single imported CLR type — completion, hover, and diagnostics on imported types are all degraded until a build runs. The original cold-start cache made this worse, not better: its fingerprint *required* the `.rsp`, so it was useless in exactly the fresh-clone / freshly-cleaned scenarios where a cold-start cache matters most.
+
+C#'s `.lscache` is in fact *more* like what G# needs than the original framing admitted. Its `[commandLineArguments]` section is the direct `.rsp`-equivalent, and it *additionally* persists the resolved `[metadataReferences]`, `[sourceFiles]`, `[properties]`, and analyzers — a committable, build-independent project-system snapshot. G# should adopt that full project-system layer (so a checkout can describe its reference set without re-running the design-time build) **and** add the slice that is uniquely G#'s cold bottleneck: the reference-metadata type-name index.
+
+### Where G#'s cold `GlobalScope` time actually goes
+
+Profiling the G# cold `GlobalScope` on Oahu decomposes the ~300 ms into three parts:
+
+| Sub-phase | Cost | Cacheable across sessions? |
+| --- | --- | --- |
+| `ReferenceResolver.WithReferences` — create `MetadataLoadContext`, load 352 reference DLLs | ~103 ms | No — yields live `Type` objects bound to the load context; cannot be serialized |
+| First `TryResolveType` — build the full-name → `Type` index via `Assembly.GetTypes()`/`GetForwardedTypes()` over the whole closure (~25 000 names) | ~120 ms | **Yes** — a pure function of the (ordered) reference set; its *structure* is independent of source |
+| Actual signature binding | ~50 ms | No — source-dependent |
+
+So the single biggest cross-session-cacheable slice of G#'s cold cost is the **reference-metadata type-name index**. The project-system layer (above) is what makes the cache usable at all without a build; the metadata index is what makes a warm open faster.
+
+## Decision
+
+Add a cross-session cold-start cache that adopts the C# `.lscache` format and conventions in full, persists both a committable project-system layer and the reference-metadata index, and is `.rsp`-independent so it survives `dotnet clean` and fresh clones.
+
+### Format decision: a single human-readable text file (retracting the prior text-vs-binary split)
+
+The cache is **one** text file per project, `<AssemblyName>.gsproj.lscache`, next to the project file. It starts with a `version=N` line and a `#` comment block (purpose, "generated, do not edit", safe-to-delete / auto-regenerates, gitignore guidance, committable opt-in note, and the opt-out env var), then `[project]`, `[fingerprint]`, `[references]`, and `[metadataIndex]` sections.
+
+The original design split the heavy ~25 000-name index into a sibling **binary** blob (`<AssemblyName>.gsproj.lscache.bin`) under a "text is too large/slow" performance exception. **That exception is false, and is retracted.** Measured for a 25 000-name index: a text encoding is 1342 KB and parses in **4.2 ms**; the binary encoding is the same 1342 KB and parses in **2.2 ms**. Same size, ~2 ms apart, and both are negligible against the ~120 ms enumeration the cache exists to skip. There is no performance justification for a second file. There *is* a cost to it: `*.lscache` is becoming a standard .NET gitignore entry, whereas `*.lscache.bin` is a G#-unique line every consumer must remember to add. So the index lives in a `[metadataIndex]` **text section** — newline-delimited type names grouped per assembly (`assembly=<identity>`, `typeNameCount=<n>`, then `n` names) — written last so its body runs to end-of-file. One file, fully diffable, standard ignore rule.
+
+### What is persisted
+
+- **Project-system layer** (`[project]` + `[references]`): the assembly name, the target framework, a source fingerprint, and the resolved metadata reference set — each DLL path with its size and last-write time. This is the `.rsp`-equivalent plus snapshot. It lets a checkout describe its reference set on its own, with no design-time build.
+- **Metadata index** (`[metadataIndex]`): a `ReferenceMetadataIndex` (`src/Core/CodeAnalysis/Symbols/ReferenceMetadataIndex.cs`) — for each referenced assembly, its identity (`AssemblyName.FullName`) and the full type-names it defines or forwards, in resolver search order. This is exactly the input to `ReferenceResolver`'s eager type-name index, captured *before* it is collapsed into live `Type` objects. It carries **no `Type` instances** (those are bound to a `MetadataLoadContext` and cannot survive a process exit) and **no source-derived state** — it is a pure function of the ordered reference set.
+
+On load, `ProjectState` builds the resolver (`WithReferences`, the ~103 ms `MetadataLoadContext` load is unavoidable), then hands the deserialized index to `ReferenceResolver.TryUseMetadataIndex`. The resolver adopts it as a warm full-name → assembly-index map and **skips the ~120 ms `GetTypes()`/`GetForwardedTypes()` enumeration entirely**; `TryResolveType` materializes individual `Type` objects lazily by name (`Assembly.GetType`) only for names the binder actually probes.
+
+### `.rsp`-independent bootstrap (the clean / fresh-clone capability)
+
+The whole point of the project-system layer is that the cache no longer depends on the `.rsp`:
+
+- **When a `.rsp` exists, it remains authoritative.** The references come from it; the cache is loaded/refreshed against them.
+- **When no `.rsp` exists** (fresh clone, or after `dotnet clean`) and a valid `.lscache` is present, `ProjectState.GetOrBuildResolver_NoLock` **bootstraps the reference set from the cache's `[references]` section** (`ColdStartCache.TryBootstrapReferences`) instead of returning empty — so the LSP resolves imported types without first building. Every recorded DLL is re-validated (it must still exist and match its recorded `size:mtime` stamp) before use, and the assembly identities are re-checked when the metadata index is adopted (`TryUseMetadataIndex`). If any reference is missing or changed, the bootstrap refuses and the LSP falls back to today's empty/degraded behavior — it never resolves against a stale reference set.
+
+### Fingerprint and invalidation (conservative, `.rsp`-independent)
+
+The metadata index is trusted only when **all** of the following match; any mismatch, missing file, version change, or corruption is a cache miss:
+
+- **Descriptor version** (`DescriptorVersion`) and **index format version** (`ReferenceMetadataIndex.FormatVersion`) — bumped on any layout change.
+- **Compiler / cache version** — the `GSharp.Core` assembly version, so a compiler upgrade invalidates every cache.
+- **Reference set** — the ordered reference paths, each with its file size and last-write time (UTC ticks). Adding/removing/reordering a reference, or touching any reference DLL, flips the fingerprint.
+- **Source fingerprint** — a SHA-256 over the project's current sources (each file's project-relative path plus its content). Conservative: any source edit invalidates. (The metadata index is strictly a function of the references, so this is stronger than necessary for *this* payload; it is included deliberately so the same fingerprint vocabulary gates the source-dependent Phase 2 payload, and over-invalidation is always safe.)
+- **Target framework** — the project's TFM moniker (`ProjectDiscovery.ResolveTargetFramework`).
+- **Index integrity SHA-256** — the `[metadataIndex]` section is re-hashed on load and compared to the recorded value, rejecting in-place corruption (e.g. a flipped type name) that still parses structurally.
+- **Assembly-identity match** — `TryUseMetadataIndex` additionally rejects the payload unless the recorded assembly identities match the freshly-loaded resolver's assemblies exactly (count + `FullName` + order). Defence-in-depth on top of the fingerprint.
+
+Critically, the fingerprint **deliberately does not depend on the `.rsp`** — the `.rsp` is the ephemeral `obj/` artifact, not the real input. The descriptor still *records* the `.rsp` path and stamp for information, but the cache validates and loads without it. The `[references]` bootstrap is gated only on physical DLL re-validation (existence + stamp + identity-at-adoption), independent of the source fingerprint, so reference resolution keeps working in a fresh clone even if a source file has since been edited.
+
+Under-invalidation (loading a stale cache) would be a correctness bug; over-invalidation merely costs a cold rebuild. The scheme is deliberately conservative on the side of over-invalidation.
+
+### Correctness: warm resolution is a superset of cold resolution
+
+The non-negotiable property is that a cache-loaded analysis is identical to a cold from-scratch one — same diagnostics, hover, definition, completion — and that the cache never touches emit (it changes latency, not emitted IL). Two facts make warm resolution match cold:
+
+1. **Same keyset.** The cached names are exactly those `GetTypes()`/`GetForwardedTypes()` produced (the same enumeration, shared via `ReferenceResolver.EnumerateDefinedAndForwardedTypes`). So a name absent from the warm index is a genuine miss, and first-writer-wins precedence is preserved by recording the first declaring assembly.
+2. **Faithful materialization with a scan fallback.** `Assembly.GetType(fullName)` on the recorded declaring assembly returns the same `Type` the eager index held — verified empirically on the Oahu closure: for all ~25 000 names, warm `GetType` resolution matched the cold index on `FullName` and assembly identity (zero nulls, zero mismatches, including the forwarded types whose forwarders `GetType` follows). For defence in depth, if the recorded assembly cannot satisfy `GetType`, `TryResolveType` falls back to an in-order scan of all assemblies, guaranteed to find the first declarer. Warm resolution can therefore never resolve *fewer* or *different* types than cold.
+
+The opt-out path is untouched: when the cache is disabled, no index is adopted and `TryResolveType` uses the existing eager index, byte-for-byte as before this ADR. The metadata index carries no `Type` instances and no source-derived state, so it cannot encode a load-context-bound or stale-source dependency.
+
+### Committable (opt-in) and its honest caveat
+
+The file is gitignored **by default** (`*.lscache`, matching the prevailing .NET convention and minimizing friction). But the format and fingerprint are designed so a team *can* choose to commit it for fast fresh-clone opens: the descriptor is plain diffable text, the source fingerprint is over project-relative paths (portable across clones of the same sources), and the metadata index is keyed on assembly identities rather than machine state. The honest caveat is documented in the file's own comment block and here: **a committed `.lscache` still needs the referenced DLLs present.** `dotnet restore` brings the NuGet package DLLs back; project-reference DLLs require those projects to be built. So a committed cache helps "after restore / after clean," not from a zero-dependency checkout — and because the reference paths and their stamps are validated before use (and are machine-specific for NuGet/SDK locations), a cache that does not validate simply and safely degrades to a cold build. Relocatable/portable-path encoding (token-substituting the NuGet/SDK/workspace roots) is a possible future enhancement; it is not required for correctness.
+
+### Location, opt-out, and lifecycle
+
+- **Location**: next to the project file, `<AssemblyName>.gsproj.lscache`. Gitignored by default; not picked up as a compile item (the SDK globs `**/*.gs`).
+- **Opt-out**: environment variable `GSHARP_DISABLE_COLD_START_CACHE` (`1`/`true`/`on`/`yes`), mirroring C#'s setting. When set, the cache is neither read (load nor bootstrap) nor written, and the resolver stays on the cold path.
+- **Safe to delete**: deleting the file at any time is harmless; the next open rebuilds and rewrites. No method in `ColdStartCache` ever throws into the LSP pipeline — every read/write is best-effort and any error degrades to a cold build.
+- **Ownership**: `ProjectState` owns the cache lifecycle, in `GetOrBuildResolver_NoLock`, alongside the warm `ReferenceResolver` it already caches. The cache is consulted exactly once per resolver build (i.e. when the reference set changes), so steady-state editing pays nothing.
+
+### Measured result (Oahu, separate processes)
+
+| | Cold `GlobalScope` | Warm `GlobalScope` | `BoundProgram` | Diagnostics |
+| --- | --- | --- | --- | --- |
+| With cache | ~350–410 ms | **~207–230 ms** | ~650 ms (unchanged) | identical |
+
+Warm `GlobalScope` is ~140–180 ms faster than cold — a ~40 % reduction of `GlobalScope` and ~15–18 % of total cold start — with **identical diagnostics**, confirming the cache changes only latency, not results. Separately, with the `.lscache` present but the `.rsp` removed (simulating `dotnet clean`), the LSP bootstraps its reference set from the cache and produces the same diagnostics as a normal `.rsp`-backed build, whereas with no cache and no `.rsp` it degrades to an empty reference set. `BoundProgram` is unchanged because the source bind is deliberately *not* cached here (see the phased plan).
+
+## Consequences
+
+**Positive**
+
+- Reopening a previously-analyzed project skips the ~120 ms reference-metadata enumeration, directly cutting the most cacheable slice of cold `GlobalScope`, and — new in this revision — a fresh clone or freshly-cleaned tree can resolve imported types *before the first build* by bootstrapping its reference set from the cache. The win is correctness-safe (superset resolution, conservative fingerprint, identity check, integrity hash, physical DLL re-validation) and free of new cold-path cost (the index the cold path builds anyway is the one written).
+- One diffable text file with a standard gitignore rule; optionally committable for fast fresh-clone opens.
+- Establishes the cache container, fingerprint vocabulary, project-system layer, and on-disk layout that a future, larger payload (bound signatures / global scope) can extend without re-litigating location, opt-out, invalidation, or encoding.
+- Cold and warm sessions now share one resolution code path (lazy `GetType` from a name index), so the cache cannot introduce a divergence the cold path would not also exhibit.
+
+**Negative / cost**
+
+- A new on-disk artifact per project (~1.3 MB text on Oahu). It is gitignored by default, safe to delete, and outside the build, but it is real disk footprint.
+- The `MetadataLoadContext` load (~103 ms) and the full source bind (~600 ms) are *not* eliminated; this ADR captures the metadata-index slice and the bootstrap capability. The headline warm cold-start number drops by ~15–18 %, not to zero.
+- A new invariant future binder/resolver changes must uphold: warm resolution must remain a superset of cold (same name set, faithful materialization). The `EnumerateDefinedAndForwardedTypes` single-source-of-truth and the equivalence tests guard it.
+- Cross-machine committability is partial: NuGet/SDK reference paths are machine-specific, so a committed cache validates fully only where those paths match; elsewhere it safely degrades to a cold build. Portable-path encoding is left as future work.
+
+**Neutral**
+
+- No change to emitted IL or to non-LSP build behavior. The cold from-scratch path remains the correctness oracle and the universal fallback.
+- No change to the `Compilation` shape or its immutability; the cache lives entirely in `ProjectState`/`ReferenceResolver` state set before first resolution.
+
+## Phased plan (deferred, by design)
+
+This ADR ships the **project-system layer + reference-metadata layer** (best cold-time-saved and bootstrap-capability ÷ serialization-risk ratio) and *designs* the riskier layer:
+
+- **Phase 2 — bound `GlobalScope` / per-file symbol signatures.** The ~600 ms `BoundProgram` and the signature half of `GlobalScope` are the biggest remaining cold cost, but serializing the bound symbol graph soundly is hard: symbols reference `Type` objects (load-context-bound), each other, and source spans. It requires the *stable symbol identity* ADR-0105 Phase 2 introduces (a position-independent `stableMemberId`) plus a content-addressed, load-context-independent symbol encoding, and the same byte-reproducibility guarantees ADR-0105 demands for emit. It should be fingerprinted on source content hashes in addition to the reference set (the source fingerprint this ADR already records), and validated against the cold bind as oracle. Deferred until stable identity lands; only implemented if byte-for-byte equivalence (diagnostics *and* emitted IL) can be guaranteed.
+- **Portable / relocatable reference paths.** Token-substitute the NuGet package root, SDK root, and workspace root so a committed `.lscache` validates across machines after `restore`. Only a path-encoding policy and a determinism audit are needed; correctness already degrades safely without it.
+
+## Alternatives considered
+
+- **Faithfully copy C# `.lscache` content (project-system output) only.** The project-system layer *is* adopted (it is what makes the cache `.rsp`-independent). What C# does not have, and G# adds, is the reference-metadata type-name index — G#'s actual cold bottleneck.
+- **Keep depending on the `.rsp` (original design).** Rejected: the `.rsp` is a gitignored `obj/` artifact that does not survive clean/clone, so a cache fingerprinted on it is useless in exactly the scenarios a cold-start cache is for.
+- **Cache the resolved `Type` index directly.** Impossible: `Type` objects are bound to a live `MetadataLoadContext` and cannot be serialized or rehydrated across processes. Caching the *names* and re-materializing lazily is the load-context-safe equivalent.
+- **Store the type-name index as a sibling binary blob.** Rejected on the measured numbers: text is 4.2 ms / 1342 KB vs binary 2.2 ms / 1342 KB — same size, ~2 ms apart, both negligible vs the ~120 ms enumeration — and a single `*.lscache` is the standard, lower-friction gitignore entry. The earlier "text too large/slow" exception was false and is retracted.
+- **Eagerly materialize every cached name on load.** Rejected: resolving all ~25 000 names up front (~370 ms) is *slower* than the eager `GetTypes()` build it replaces. The win comes precisely from materializing lazily only the names the binder probes.
+- **Cache the bound program now.** Rejected for this pass: highest value but highest risk (symbol-graph determinism, load-context-bound types, IL-equivalence gate). Designed above as Phase 2, gated on ADR-0105 stable identity.
+
+## Acceptance criteria (from issue #868)
+
+- An ADR proposing a cold-start cache design — what is persisted, the fingerprint/invalidation scheme, where files live, and whether they are committable: this document.
+- Determinism: a loaded cache yields identical analysis/diagnostics to a from-scratch run — verified by equivalence tests and the Oahu run (identical diagnostics).
+- No stale results across source edits, reference changes, or compiler-version changes — the conservative, `.rsp`-independent fingerprint invalidates on each, with cold build (and, for references, the empty/degraded path) as the safe fallback.
+- Survives clean / fresh clone: with the `.rsp` gone, the cache bootstraps the reference set so imported types still resolve.

--- a/src/Core/CodeAnalysis/Symbols/ReferenceMetadataIndex.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceMetadataIndex.cs
@@ -1,0 +1,320 @@
+// <copyright file="ReferenceMetadataIndex.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// A serializable snapshot of the full-type-name → declaring-assembly index that
+/// <see cref="ReferenceResolver"/> derives from a reference set. It exists so the
+/// language server's cross-session cold-start cache (ADR-0107) can persist the
+/// expensive metadata enumeration (<c>Assembly.GetTypes()</c> /
+/// <c>Assembly.GetForwardedTypes()</c> over the project's whole reference closure)
+/// and replay it on a subsequent process start instead of recomputing it.
+/// </summary>
+/// <remarks>
+/// The index is a <em>pure function of the (ordered) reference set</em>: it carries
+/// no source-derived state, so it is safe to fingerprint on the references alone.
+/// It stores only type-name strings plus each assembly's identity — never CLR
+/// <see cref="Type"/> objects, which are bound to a live
+/// <see cref="System.Reflection.MetadataLoadContext"/> and cannot survive a process
+/// exit. A consumer re-creates the load context, validates the recorded assembly
+/// identities against the freshly-loaded ones, and then materialises individual
+/// <see cref="Type"/> instances lazily by name (see
+/// <see cref="ReferenceResolver.TryUseMetadataIndex"/>). Because the recorded names
+/// are exactly those the eager enumeration produced, warm resolution is a superset
+/// of cold resolution (with an order-preserving scan fallback), so it can never
+/// silently resolve <em>fewer</em> or <em>different</em> types than the cold path.
+/// <para>
+/// ADR-0107 (revised) persists the index as a human-readable <em>text</em> section
+/// (<see cref="SectionHeader"/>) inside the single <c>.lscache</c> descriptor:
+/// newline-delimited type names grouped per assembly. On the Oahu closure (~25 000
+/// names, ~1.3 MB) this parses in ~4 ms — indistinguishable in practice from a
+/// binary encoding (~2 ms) and far below the ~120 ms enumeration it replaces — so
+/// there is no reason to maintain a separate binary blob.
+/// </para>
+/// </remarks>
+public sealed class ReferenceMetadataIndex
+{
+    /// <summary>
+    /// The on-disk text format version for the <see cref="SectionHeader"/>
+    /// section. Bump whenever the section layout changes so that an older or
+    /// newer payload is rejected (cold rebuild) rather than misread. This is
+    /// independent of the cache <em>descriptor</em> version owned by the
+    /// language server, and is folded into the descriptor fingerprint.
+    /// </summary>
+    public const int FormatVersion = 2;
+
+    /// <summary>
+    /// The INI-style section header under which the index is serialized inside
+    /// the <c>.lscache</c> descriptor. The section is always written last so
+    /// its newline-delimited body runs to end-of-file.
+    /// </summary>
+    public const string SectionHeader = "[metadataIndex]";
+
+    // Conservative sanity bounds so a corrupt count line cannot drive an
+    // unbounded allocation before the per-entry reads fail. The Oahu closure is
+    // ~360 assemblies and ~25k names in its largest assembly; these ceilings sit
+    // far above any realistic reference set.
+    private const int MaxAssemblies = 1 << 16;
+    private const int MaxTypeNamesPerAssembly = 1 << 22;
+
+    private readonly ImmutableArray<string> assemblyIdentities;
+    private readonly ImmutableArray<ImmutableArray<string>> typeNamesByAssembly;
+
+    private ReferenceMetadataIndex(
+        ImmutableArray<string> assemblyIdentities,
+        ImmutableArray<ImmutableArray<string>> typeNamesByAssembly)
+    {
+        this.assemblyIdentities = assemblyIdentities;
+        this.typeNamesByAssembly = typeNamesByAssembly;
+    }
+
+    /// <summary>
+    /// Gets the recorded assembly identities (<see cref="System.Reflection.AssemblyName.FullName"/>),
+    /// one per assembly, in the same order the producing
+    /// <see cref="ReferenceResolver"/> searches them. Consumers validate these
+    /// against the freshly-loaded reference set before trusting the payload.
+    /// </summary>
+    public ImmutableArray<string> AssemblyIdentities => assemblyIdentities;
+
+    /// <summary>
+    /// Creates an index from per-assembly identities and their defined +
+    /// forwarded type full-names. The two arrays must be the same length; entry
+    /// <c>i</c> of <paramref name="typeNamesByAssembly"/> lists the type names
+    /// declared (or forwarded) by the assembly whose identity is entry <c>i</c>
+    /// of <paramref name="assemblyIdentities"/>.
+    /// </summary>
+    /// <param name="assemblyIdentities">Assembly full names in search order.</param>
+    /// <param name="typeNamesByAssembly">Type full-names per assembly.</param>
+    /// <returns>A new <see cref="ReferenceMetadataIndex"/>.</returns>
+    public static ReferenceMetadataIndex Create(
+        ImmutableArray<string> assemblyIdentities,
+        ImmutableArray<ImmutableArray<string>> typeNamesByAssembly)
+    {
+        if (assemblyIdentities.Length != typeNamesByAssembly.Length)
+        {
+            throw new ArgumentException(
+                "Assembly identity and type-name arrays must have the same length.",
+                nameof(typeNamesByAssembly));
+        }
+
+        return new ReferenceMetadataIndex(assemblyIdentities, typeNamesByAssembly);
+    }
+
+    /// <summary>
+    /// Builds the merged full-name → assembly-index map with <em>first-writer-wins</em>
+    /// precedence (the first assembly, in search order, that declares a given name
+    /// owns it). This mirrors the precedence of <see cref="ReferenceResolver"/>'s
+    /// eager type-name index so warm and cold resolution agree.
+    /// </summary>
+    /// <returns>A dictionary mapping a type full name to the index of its declaring assembly.</returns>
+    public Dictionary<string, int> ToNameIndex()
+    {
+        // Pre-size generously; the Oahu reference set produces ~25k names.
+        var index = new Dictionary<string, int>(capacity: 1 << 15, StringComparer.Ordinal);
+        for (var i = 0; i < typeNamesByAssembly.Length; i++)
+        {
+            foreach (var name in typeNamesByAssembly[i])
+            {
+                if (name is not null && !index.ContainsKey(name))
+                {
+                    index[name] = i;
+                }
+            }
+        }
+
+        return index;
+    }
+
+    /// <summary>
+    /// Serialises this index as the <see cref="SectionHeader"/> text section to
+    /// <paramref name="writer"/>. The section begins with a short <c>#</c>
+    /// comment, then <c>formatVersion=</c> and <c>assemblyCount=</c>, then one
+    /// block per assembly: an <c>assembly=&lt;identity&gt;</c> line, a
+    /// <c>typeNameCount=&lt;n&gt;</c> line, and exactly <c>n</c> newline-delimited
+    /// type full-names. The traversal order is fixed so identical inputs always
+    /// produce identical text, which lets the language server hash the section
+    /// for integrity. The caller must write this section <em>last</em> in the
+    /// descriptor so the body runs to end-of-file.
+    /// </summary>
+    /// <param name="writer">The destination text writer.</param>
+    public void WriteTextSection(TextWriter writer)
+    {
+        if (writer is null)
+        {
+            throw new ArgumentNullException(nameof(writer));
+        }
+
+        writer.Write(SectionHeader);
+        writer.Write('\n');
+        writer.Write("# Reference-metadata type-name index (ADR-0107): per referenced assembly,\n");
+        writer.Write("# its identity followed by the full type names it defines or forwards, in\n");
+        writer.Write("# resolver search order. Newline-delimited; ~4 ms to parse for ~25k names.\n");
+        writer.Write("formatVersion=");
+        writer.Write(FormatVersion.ToString(CultureInfo.InvariantCulture));
+        writer.Write('\n');
+        writer.Write("assemblyCount=");
+        writer.Write(assemblyIdentities.Length.ToString(CultureInfo.InvariantCulture));
+        writer.Write('\n');
+
+        for (var i = 0; i < assemblyIdentities.Length; i++)
+        {
+            var names = typeNamesByAssembly[i];
+            writer.Write('\n');
+            writer.Write("assembly=");
+            writer.Write(assemblyIdentities[i] ?? string.Empty);
+            writer.Write('\n');
+            writer.Write("typeNameCount=");
+            writer.Write(names.Length.ToString(CultureInfo.InvariantCulture));
+            writer.Write('\n');
+            foreach (var name in names)
+            {
+                writer.Write(name ?? string.Empty);
+                writer.Write('\n');
+            }
+        }
+    }
+
+    /// <summary>
+    /// Attempts to parse the <see cref="SectionHeader"/> section out of a
+    /// descriptor's full set of <paramref name="lines"/> (the section is located
+    /// by its header and read to end-of-file). This never throws: any structural
+    /// problem (missing header, bad format version, a malformed or out-of-bounds
+    /// count, truncation) is reported by returning <see langword="false"/> so the
+    /// caller falls back to a cold rebuild. Under-trusting a payload is always
+    /// safe; mis-reading one would be a correctness bug.
+    /// </summary>
+    /// <param name="lines">All descriptor lines, in order.</param>
+    /// <param name="index">The parsed index on success; otherwise <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> when a well-formed section was read.</returns>
+    public static bool TryReadTextSection(IReadOnlyList<string> lines, out ReferenceMetadataIndex index)
+    {
+        index = null;
+        if (lines is null)
+        {
+            return false;
+        }
+
+        var cursor = -1;
+        for (var i = 0; i < lines.Count; i++)
+        {
+            if (string.Equals(lines[i]?.Trim(), SectionHeader, StringComparison.Ordinal))
+            {
+                cursor = i + 1;
+                break;
+            }
+        }
+
+        if (cursor < 0)
+        {
+            return false;
+        }
+
+        try
+        {
+            if (!TryReadIntField(lines, ref cursor, "formatVersion", out var formatVersion)
+                || formatVersion != FormatVersion)
+            {
+                return false;
+            }
+
+            if (!TryReadIntField(lines, ref cursor, "assemblyCount", out var assemblyCount)
+                || assemblyCount < 0 || assemblyCount > MaxAssemblies)
+            {
+                return false;
+            }
+
+            var identities = ImmutableArray.CreateBuilder<string>(assemblyCount);
+            var names = ImmutableArray.CreateBuilder<ImmutableArray<string>>(assemblyCount);
+            for (var a = 0; a < assemblyCount; a++)
+            {
+                if (!TryReadStringField(lines, ref cursor, "assembly", out var identity))
+                {
+                    return false;
+                }
+
+                if (!TryReadIntField(lines, ref cursor, "typeNameCount", out var nameCount)
+                    || nameCount < 0 || nameCount > MaxTypeNamesPerAssembly)
+                {
+                    return false;
+                }
+
+                var perAssembly = ImmutableArray.CreateBuilder<string>(nameCount);
+                for (var n = 0; n < nameCount; n++)
+                {
+                    if (cursor >= lines.Count)
+                    {
+                        return false;
+                    }
+
+                    perAssembly.Add(lines[cursor] ?? string.Empty);
+                    cursor++;
+                }
+
+                identities.Add(identity);
+                names.Add(perAssembly.MoveToImmutable());
+            }
+
+            index = new ReferenceMetadataIndex(identities.MoveToImmutable(), names.MoveToImmutable());
+            return true;
+        }
+        catch (OutOfMemoryException)
+        {
+            // A corrupt count could request an absurd allocation; the bounds
+            // checks above guard the common cases, this is the backstop.
+            return false;
+        }
+    }
+
+    // Advances past blank/comment lines and reads the next `key=value` line,
+    // verifying the key matches and the value parses as an int. Used for the
+    // structural header/count lines only (never for the verbatim type-name
+    // lines, which are read positionally by count).
+    private static bool TryReadIntField(IReadOnlyList<string> lines, ref int cursor, string key, out int value)
+    {
+        value = 0;
+        if (!TryReadStringField(lines, ref cursor, key, out var raw))
+        {
+            return false;
+        }
+
+        return int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+    }
+
+    // Skips blank and `#` comment lines, then requires the next line to be
+    // `<key>=<value>`; returns the value. A non-matching key or end-of-input
+    // returns false (a conservative parse failure).
+    private static bool TryReadStringField(IReadOnlyList<string> lines, ref int cursor, string key, out string value)
+    {
+        value = null;
+        while (cursor < lines.Count)
+        {
+            var line = lines[cursor];
+            var trimmed = line?.Trim();
+            if (string.IsNullOrEmpty(trimmed) || trimmed[0] == '#')
+            {
+                cursor++;
+                continue;
+            }
+
+            var eq = line.IndexOf('=');
+            if (eq <= 0 || !string.Equals(line.Substring(0, eq), key, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            value = line.Substring(eq + 1);
+            cursor++;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -104,6 +104,20 @@ public sealed class ReferenceResolver : IDisposable
     // and the binder already constructs (e.g. "Ns.Type`1").
     private readonly Lazy<Dictionary<string, Type>> typeNameIndex;
 
+    // ADR-0107 (cold-start cache): an optional, externally-supplied
+    // full-name -> declaring-assembly-index map that stands in for the eager
+    // `typeNameIndex` below. When set (via TryUseMetadataIndex), TryResolveType
+    // consults this map and materialises the actual CLR Type lazily by name —
+    // skipping the ~120ms Assembly.GetTypes()/GetForwardedTypes() enumeration of
+    // the whole reference closure that BuildTypeNameIndex performs. The map's
+    // keyset is, by construction, exactly the set of names that enumeration
+    // would have produced (it is built from a ReferenceMetadataIndex that the
+    // language server either persisted from a prior cold build or rebuilds via
+    // ExportMetadataIndex), so warm resolution is a superset of cold resolution.
+    // Null in the default/opt-out path, where the eager `typeNameIndex` is used
+    // and behaviour is byte-for-byte identical to before this ADR.
+    private Dictionary<string, int> warmNameIndex;
+
     private ReferenceResolver(ImmutableArray<Assembly> assemblies, MetadataLoadContext metadataContext)
         : this(assemblies, metadataContext, ImmutableArray<string>.Empty)
     {
@@ -431,6 +445,27 @@ public sealed class ReferenceResolver : IDisposable
             return true;
         }
 
+        // ADR-0107: warm path. When a metadata index has been adopted, resolve
+        // by consulting the persisted name -> assembly map and materialising the
+        // Type lazily, rather than building (and scanning) the eager
+        // typeNameIndex. The keyset equals the cold path's, so a name absent here
+        // is a genuine miss; a present name is materialised with an
+        // order-preserving scan fallback so first-writer-wins is honoured even if
+        // the recorded declaring assembly cannot satisfy GetType.
+        if (warmNameIndex != null)
+        {
+            if (warmNameIndex.TryGetValue(fullName, out var assemblyIndex)
+                && TryMaterializeWarmType(fullName, assemblyIndex, out var warm))
+            {
+                resolveCache.TryAdd(fullName, warm);
+                type = warm;
+                return true;
+            }
+
+            resolveCache.TryAdd(fullName, MissTypeSentinel);
+            return false;
+        }
+
         if (typeNameIndex.Value.TryGetValue(fullName, out var indexed))
         {
             resolveCache.TryAdd(fullName, indexed);
@@ -605,6 +640,75 @@ public sealed class ReferenceResolver : IDisposable
             $"Core type '{fullName}' could not be resolved from the supplied references.");
     }
 
+    /// <summary>
+    /// ADR-0107: captures this resolver's full-type-name surface — every
+    /// assembly's identity plus the defined and forwarded type full-names it
+    /// contributes, in search order — into a serialisable
+    /// <see cref="ReferenceMetadataIndex"/>. The language server persists this to
+    /// its cold-start cache so a later process can skip the
+    /// <c>Assembly.GetTypes()</c>/<c>GetForwardedTypes()</c> enumeration. This
+    /// performs the same metadata walk as the eager type-name index, so calling
+    /// it costs roughly one index build.
+    /// </summary>
+    /// <returns>A snapshot of the resolver's type-name surface.</returns>
+    public ReferenceMetadataIndex ExportMetadataIndex()
+    {
+        var identities = ImmutableArray.CreateBuilder<string>(assemblies.Length);
+        var namesByAssembly = ImmutableArray.CreateBuilder<ImmutableArray<string>>(assemblies.Length);
+
+        foreach (var asm in assemblies)
+        {
+            identities.Add(asm.GetName().FullName);
+            var names = ImmutableArray.CreateBuilder<string>();
+            foreach (var t in EnumerateDefinedAndForwardedTypes(asm))
+            {
+                if (t.FullName is { } fullName)
+                {
+                    names.Add(fullName);
+                }
+            }
+
+            namesByAssembly.Add(names.ToImmutable());
+        }
+
+        return ReferenceMetadataIndex.Create(identities.MoveToImmutable(), namesByAssembly.MoveToImmutable());
+    }
+
+    /// <summary>
+    /// ADR-0107: adopts a previously-built <see cref="ReferenceMetadataIndex"/>
+    /// as this resolver's warm type-name index, so <see cref="TryResolveType"/>
+    /// skips the eager metadata enumeration. The index is accepted only when its
+    /// recorded assembly identities match this resolver's freshly-loaded
+    /// assemblies <em>exactly</em> (same count, same
+    /// <see cref="System.Reflection.AssemblyName.FullName"/> in the same order);
+    /// any mismatch returns <see langword="false"/> and leaves the resolver on
+    /// the cold (eager) path. This identity check is defence-in-depth on top of
+    /// the cache's reference-set fingerprint: if the references somehow changed
+    /// without the fingerprint noticing, the payload is still rejected here.
+    /// Must be called before the first resolution so the warm index is in place
+    /// for binding.
+    /// </summary>
+    /// <param name="index">The candidate metadata index.</param>
+    /// <returns><see langword="true"/> when the index was adopted; otherwise <see langword="false"/>.</returns>
+    public bool TryUseMetadataIndex(ReferenceMetadataIndex index)
+    {
+        if (index is null || index.AssemblyIdentities.Length != assemblies.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < assemblies.Length; i++)
+        {
+            if (!string.Equals(index.AssemblyIdentities[i], assemblies[i].GetName().FullName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        warmNameIndex = index.ToNameIndex();
+        return true;
+    }
+
     // Issue #854: enumerate every assembly's defined types (top-level + nested)
     // and exported type forwarders once, building the full-name -> Type index
     // that backs TryResolveType. Mirrors the precedence of the previous per-miss
@@ -618,68 +722,128 @@ public sealed class ReferenceResolver : IDisposable
         }
     }
 
+    // ADR-0107: materialise the CLR Type for a name the warm index claims is
+    // resolvable. Prefer the recorded declaring assembly; if that assembly cannot
+    // satisfy GetType (e.g. a stale/edge forwarder), fall back to an in-order scan
+    // of every assembly so resolution still finds the first declarer — exactly the
+    // precedence the eager index encodes. Returns false only if no assembly can
+    // produce the type, in which case the caller records a (conservative) miss.
+    private static Type SafeGetType(Assembly assembly, string fullName)
+    {
+        try
+        {
+            return assembly.GetType(fullName);
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+        catch (TypeLoadException)
+        {
+            return null;
+        }
+    }
+
+    private bool TryMaterializeWarmType(string fullName, int assemblyIndex, out Type type)
+    {
+        type = null;
+        if (assemblyIndex >= 0 && assemblyIndex < assemblies.Length)
+        {
+            type = SafeGetType(assemblies[assemblyIndex], fullName);
+            if (type != null)
+            {
+                return true;
+            }
+        }
+
+        foreach (var asm in assemblies)
+        {
+            type = SafeGetType(asm, fullName);
+            if (type != null)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private Dictionary<string, Type> BuildTypeNameIndex()
     {
         var index = new Dictionary<string, Type>(StringComparer.Ordinal);
 
         foreach (var asm in assemblies)
         {
-            // Defined types. ReflectionTypeLoadException surfaces a partial set
-            // via Types (with nulls for the entries that failed to load); take
-            // what resolved and skip the rest, matching the old scan's
-            // best-effort behavior where unresolvable members were simply not
-            // returned.
-            Type[] definedTypes;
-            try
-            {
-                definedTypes = asm.GetTypes();
-            }
-            catch (ReflectionTypeLoadException ex)
-            {
-                definedTypes = ex.Types;
-            }
-            catch (FileNotFoundException)
-            {
-                definedTypes = Array.Empty<Type>();
-            }
-            catch (BadImageFormatException)
-            {
-                definedTypes = Array.Empty<Type>();
-            }
-
-            foreach (var t in definedTypes)
-            {
-                AddToTypeNameIndex(index, t);
-            }
-
-            // Exported type forwarders (e.g. BCL facade assemblies forward
-            // System.* types to their implementation assembly). The old scan
-            // resolved these because Assembly.GetType follows forwarders; the
-            // index must include them to preserve resolution parity. A single
-            // unresolvable forward makes GetForwardedTypes throw, so fall back
-            // to the partial set when available and otherwise skip the
-            // assembly's forwarders.
-            Type[] forwardedTypes;
-            try
-            {
-                forwardedTypes = asm.GetForwardedTypes();
-            }
-            catch (ReflectionTypeLoadException ex)
-            {
-                forwardedTypes = ex.Types;
-            }
-            catch (Exception)
-            {
-                forwardedTypes = Array.Empty<Type>();
-            }
-
-            foreach (var t in forwardedTypes)
+            foreach (var t in EnumerateDefinedAndForwardedTypes(asm))
             {
                 AddToTypeNameIndex(index, t);
             }
         }
 
         return index;
+    }
+
+    // Issue #854 / ADR-0107: enumerate one assembly's defined types (top-level +
+    // nested) followed by its exported type forwarders, tolerating the partial
+    // results that ReflectionTypeLoadException / GetForwardedTypes surface for a
+    // closure with an unresolvable member. This is the single source of truth for
+    // "which type names does this assembly contribute, and in what order"; both
+    // the eager BuildTypeNameIndex and the cache-export ExportMetadataIndex
+    // consume it so the warm and cold name sets (and their first-writer-wins
+    // precedence) are guaranteed to match.
+    private static IEnumerable<Type> EnumerateDefinedAndForwardedTypes(Assembly asm)
+    {
+        Type[] definedTypes;
+        try
+        {
+            definedTypes = asm.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            definedTypes = ex.Types;
+        }
+        catch (FileNotFoundException)
+        {
+            definedTypes = Array.Empty<Type>();
+        }
+        catch (BadImageFormatException)
+        {
+            definedTypes = Array.Empty<Type>();
+        }
+
+        foreach (var t in definedTypes)
+        {
+            if (t != null)
+            {
+                yield return t;
+            }
+        }
+
+        Type[] forwardedTypes;
+        try
+        {
+            forwardedTypes = asm.GetForwardedTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            forwardedTypes = ex.Types;
+        }
+        catch (Exception)
+        {
+            forwardedTypes = Array.Empty<Type>();
+        }
+
+        foreach (var t in forwardedTypes)
+        {
+            if (t != null)
+            {
+                yield return t;
+            }
+        }
     }
 
     private static void RegisterAssemblyOriginalPath(Assembly assembly, string path)

--- a/src/LanguageServer/ColdStartCache.cs
+++ b/src/LanguageServer/ColdStartCache.cs
@@ -1,0 +1,581 @@
+// <copyright file="ColdStartCache.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.LanguageServer;
+
+/// <summary>
+/// ADR-0107: the language server's cross-session cold-start cache. A single
+/// human-readable text file per project, <c>&lt;AssemblyName&gt;.gsproj.lscache</c>,
+/// sitting next to the project file and following the C# Dev Kit <c>.lscache</c>
+/// format/conventions.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cache carries two layers:
+/// </para>
+/// <list type="number">
+/// <item><description>
+/// A <em>project-system snapshot</em> — the resolved metadata reference set (the
+/// <c>.rsp</c>-equivalent), the assembly name, target framework, and a source
+/// fingerprint — in the <c>[project]</c> and <c>[references]</c> sections. This
+/// lets a checkout describe its reference set <em>without re-running the build</em>:
+/// when no <c>.rsp</c> is present (a fresh clone or after <c>dotnet clean</c>, since
+/// the <c>.rsp</c> lives in the gitignored <c>obj/</c>), the language server
+/// bootstraps reference resolution straight from the cache (see
+/// <see cref="TryBootstrapReferences"/>).
+/// </description></item>
+/// <item><description>
+/// The reference-metadata <em>type-name index</em>
+/// (<see cref="ReferenceMetadataIndex"/>) in the <c>[metadataIndex]</c> text
+/// section, so a subsequent process can skip the ~120 ms
+/// <c>Assembly.GetTypes()</c>/<c>GetForwardedTypes()</c> enumeration of the whole
+/// reference closure.
+/// </description></item>
+/// </list>
+/// <para>
+/// The whole descriptor is a single text file — the ~25 000-name index parses in
+/// ~4 ms, indistinguishable in practice from a binary blob (~2 ms) and far below
+/// the enumeration it replaces, so there is no separate <c>.lscache.bin</c>. The
+/// file begins with a <c>version=N</c> header and a human-readable <c>#</c> comment
+/// block (purpose, generated/do-not-edit, safe-to-delete/auto-regenerate, gitignore
+/// guidance, committable opt-in note, and the opt-out env var), followed by
+/// <c>[project]</c>, <c>[fingerprint]</c>, <c>[references]</c>, and
+/// <c>[metadataIndex]</c> sections.
+/// </para>
+/// <para>
+/// Correctness is conservative. The metadata index is trusted only when the
+/// recorded <em>fingerprint</em> (cache-format version, compiler version, index
+/// format version, target framework, source fingerprint, and the ordered reference
+/// set with each file's size and last-write time — deliberately <em>not</em> the
+/// <c>.rsp</c>) matches the current project, <em>and</em> the index section's
+/// SHA-256 matches the recorded one (integrity), <em>and</em> the section parses
+/// cleanly. The bootstrap reference set is trusted only when every recorded DLL
+/// still exists and matches its recorded size:mtime stamp (assembly identity is
+/// re-checked when the index is adopted). Any mismatch, missing file, version
+/// change, or corruption yields a miss and the caller falls back to the normal
+/// cold build (or, for references, to today's empty/degraded behavior).
+/// Under-invalidation would be a correctness bug; over-invalidation is always safe.
+/// No method here ever throws into the LSP pipeline.
+/// </para>
+/// <para>
+/// Opt-out: set the environment variable
+/// <c>GSHARP_DISABLE_COLD_START_CACHE</c> to <c>1</c>/<c>true</c>/<c>on</c>/<c>yes</c>
+/// (mirroring C#'s <c>dotnet.projectsystem.enableLanguageServiceCache</c>
+/// setting). The cache file is safe to delete at any time and auto-regenerates.
+/// </para>
+/// </remarks>
+internal static class ColdStartCache
+{
+    /// <summary>
+    /// The descriptor format version. Bump on any descriptor-layout change so an
+    /// older or newer descriptor is treated as a miss rather than misparsed. This
+    /// is folded into the fingerprint, so a bump invalidates every existing cache.
+    /// </summary>
+    internal const int DescriptorVersion = 2;
+
+    private const string DescriptorSuffix = ".gsproj.lscache";
+    private const string DisableEnvVar = "GSHARP_DISABLE_COLD_START_CACHE";
+
+    private static readonly string[] CommentBlock =
+    {
+        "# GSharp language-service cold-start cache (ADR-0107).",
+        "# Caches the resolved reference set and reference-metadata type-name index",
+        "# so the G# language server can resume a project — and resolve imported types",
+        "# before the first build — without re-scanning every referenced assembly.",
+        "# Generated; do not edit. Safe to delete at any time; it regenerates",
+        "# automatically. By default it is gitignored (*.lscache). A team MAY instead",
+        "# commit this file for fast fresh-clone opens; the reference stamps and",
+        "# source/fingerprint hashes make that sound. Note: a committed cache still",
+        "# needs the referenced DLLs present — `dotnet restore` brings NuGet package",
+        "# DLLs, but project-reference DLLs require those projects to be built — so it",
+        "# helps after restore/clean, not from a zero-dependency checkout.",
+        "# To disable the cache entirely, set " + DisableEnvVar + "=1.",
+    };
+
+    /// <summary>
+    /// Gets a value indicating whether the cache is disabled via the opt-out
+    /// environment variable. When disabled, <see cref="TryLoad"/>,
+    /// <see cref="Save"/>, and <see cref="TryBootstrapReferences"/> are no-ops and
+    /// the resolver stays on the cold path (behaviour identical to before
+    /// ADR-0107).
+    /// </summary>
+    internal static bool Disabled
+    {
+        get
+        {
+            var value = Environment.GetEnvironmentVariable(DisableEnvVar);
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            return value.Equals("1", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("true", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("on", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("yes", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private static string CompilerVersion =>
+        typeof(ReferenceMetadataIndex).Assembly.GetName().Version?.ToString() ?? "0.0.0.0";
+
+    /// <summary>
+    /// Attempts to load a fingerprint-matching metadata index for the project.
+    /// Returns <see langword="null"/> on opt-out, a missing/stale/corrupt cache,
+    /// or any I/O error — the caller then performs a normal cold build. Never
+    /// throws.
+    /// </summary>
+    /// <param name="projectFilePath">Absolute path to the <c>.gsproj</c> file.</param>
+    /// <param name="assemblyName">The project's effective assembly name (cache basename); falls back to the project file's base name when null/empty.</param>
+    /// <param name="references">The current ordered reference paths (from the <c>.rsp</c>, or bootstrapped from this cache).</param>
+    /// <param name="rspPath">The <c>.rsp</c> the references came from, recorded for information only (may be null). Not part of the fingerprint.</param>
+    /// <param name="sourceFingerprint">A hash over the project's current source set (path + content), or null/empty when unavailable.</param>
+    /// <param name="targetFramework">The project's target framework moniker, or null/empty when unknown.</param>
+    /// <returns>A validated index, or <see langword="null"/> for a cache miss.</returns>
+    internal static ReferenceMetadataIndex TryLoad(
+        string projectFilePath,
+        string assemblyName,
+        IReadOnlyList<string> references,
+        string rspPath,
+        string sourceFingerprint,
+        string targetFramework)
+    {
+        if (Disabled || string.IsNullOrEmpty(projectFilePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var descriptorPath = DescriptorPath(projectFilePath, assemblyName);
+            if (!File.Exists(descriptorPath))
+            {
+                return null;
+            }
+
+            var lines = File.ReadAllLines(descriptorPath);
+            var fields = ParseHeaderFields(lines);
+            if (!fields.TryGetValue("version", out var versionText)
+                || versionText != DescriptorVersion.ToString(CultureInfo.InvariantCulture))
+            {
+                return null;
+            }
+
+            var expectedFingerprint = ComputeFingerprint(references, sourceFingerprint, targetFramework);
+            if (!fields.TryGetValue("fingerprint", out var storedFingerprint)
+                || !string.Equals(storedFingerprint, expectedFingerprint, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            if (!ReferenceMetadataIndex.TryReadTextSection(lines, out var index))
+            {
+                return null;
+            }
+
+            // Integrity: re-hash the canonical serialization of the parsed index
+            // and compare to the recorded hash. This rejects in-place corruption
+            // (e.g. a flipped type name) that still parses structurally.
+            if (!fields.TryGetValue("indexSha256", out var storedIndexHash)
+                || !string.Equals(storedIndexHash, ComputeIndexHash(index), StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            return index;
+        }
+        catch (Exception ex) when (IsRecoverable(ex))
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to recover the resolved reference set from a previously-written
+    /// cache so the language server can resolve imported types <em>without</em> a
+    /// <c>.rsp</c> (a fresh clone, or after <c>dotnet clean</c>, deletes the
+    /// <c>obj/</c> <c>.rsp</c>). Every recorded reference DLL must still exist and
+    /// match its recorded size:mtime stamp; if any is missing or changed (or the
+    /// cache is absent/corrupt/disabled), returns <see langword="null"/> and the
+    /// caller keeps today's empty/degraded behavior. Never throws.
+    /// </summary>
+    /// <param name="projectFilePath">Absolute path to the <c>.gsproj</c> file.</param>
+    /// <param name="assemblyName">The project's effective assembly name (cache basename).</param>
+    /// <returns>The validated, ordered reference paths, or <see langword="null"/> for a miss.</returns>
+    internal static IReadOnlyList<string> TryBootstrapReferences(string projectFilePath, string assemblyName)
+    {
+        if (Disabled || string.IsNullOrEmpty(projectFilePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var descriptorPath = DescriptorPath(projectFilePath, assemblyName);
+            if (!File.Exists(descriptorPath))
+            {
+                return null;
+            }
+
+            var lines = File.ReadAllLines(descriptorPath);
+            var fields = ParseHeaderFields(lines);
+            if (!fields.TryGetValue("version", out var versionText)
+                || versionText != DescriptorVersion.ToString(CultureInfo.InvariantCulture))
+            {
+                return null;
+            }
+
+            var recorded = ParseReferenceSection(lines);
+            if (recorded.Count == 0)
+            {
+                return null;
+            }
+
+            var validated = new List<string>(recorded.Count);
+            foreach (var (path, stamp) in recorded)
+            {
+                if (string.IsNullOrEmpty(path)
+                    || !File.Exists(path)
+                    || !string.Equals(FileStamp(path), stamp, StringComparison.Ordinal))
+                {
+                    // A missing or changed reference: never resolve against a
+                    // stale reference set. Fall back to today's behavior.
+                    return null;
+                }
+
+                validated.Add(path);
+            }
+
+            return validated;
+        }
+        catch (Exception ex) when (IsRecoverable(ex))
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Writes the single descriptor for the project, overwriting any previous
+    /// cache. No-op on opt-out. Never throws: a failed write simply leaves the
+    /// next start cold.
+    /// </summary>
+    /// <param name="projectFilePath">Absolute path to the <c>.gsproj</c> file.</param>
+    /// <param name="assemblyName">The project's effective assembly name (cache basename).</param>
+    /// <param name="references">The current ordered reference paths.</param>
+    /// <param name="rspPath">The <c>.rsp</c> the references came from, recorded for information only (may be null).</param>
+    /// <param name="sourceFingerprint">A hash over the project's current source set (path + content), or null/empty when unavailable.</param>
+    /// <param name="targetFramework">The project's target framework moniker, or null/empty when unknown.</param>
+    /// <param name="index">The metadata index to persist.</param>
+    internal static void Save(
+        string projectFilePath,
+        string assemblyName,
+        IReadOnlyList<string> references,
+        string rspPath,
+        string sourceFingerprint,
+        string targetFramework,
+        ReferenceMetadataIndex index)
+    {
+        if (Disabled || index is null || string.IsNullOrEmpty(projectFilePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var descriptorPath = DescriptorPath(projectFilePath, assemblyName);
+            var descriptor = BuildDescriptor(
+                CacheBaseName(projectFilePath, assemblyName),
+                ComputeFingerprint(references, sourceFingerprint, targetFramework),
+                ComputeIndexHash(index),
+                references,
+                rspPath,
+                sourceFingerprint,
+                targetFramework,
+                index);
+
+            WriteAllTextAtomic(descriptorPath, descriptor);
+        }
+        catch (Exception ex) when (IsRecoverable(ex))
+        {
+            // Best-effort cache; a write failure is never fatal.
+        }
+    }
+
+    /// <summary>
+    /// Computes the descriptor path for a project. Exposed for tests.
+    /// </summary>
+    /// <param name="projectFilePath">Absolute path to the <c>.gsproj</c> file.</param>
+    /// <param name="assemblyName">The effective assembly name (cache basename).</param>
+    /// <returns>The descriptor file path.</returns>
+    internal static string DescriptorPath(string projectFilePath, string assemblyName)
+    {
+        var dir = Path.GetDirectoryName(Path.GetFullPath(projectFilePath));
+        return Path.Combine(dir, CacheBaseName(projectFilePath, assemblyName) + DescriptorSuffix);
+    }
+
+    private static string CacheBaseName(string projectFilePath, string assemblyName)
+    {
+        return string.IsNullOrWhiteSpace(assemblyName)
+            ? Path.GetFileNameWithoutExtension(projectFilePath)
+            : assemblyName;
+    }
+
+    // The fingerprint is a SHA-256 over a canonical newline-joined string of:
+    // descriptor version, compiler/cache assembly version, the index format
+    // version, the target framework, the source fingerprint, and, for each
+    // reference in order, its path + size + last-write time. It deliberately does
+    // NOT include the .rsp — the .rsp is an ephemeral obj/ build artifact that
+    // does not survive clean/clone, and the reference set (which the cache can
+    // supply itself) is the real input. Any change to the reference set, a
+    // touched reference DLL, a source edit, a TFM change, or a compiler/format
+    // upgrade flips the hash.
+    private static string ComputeFingerprint(
+        IReadOnlyList<string> references,
+        string sourceFingerprint,
+        string targetFramework)
+    {
+        var sb = new StringBuilder();
+        sb.Append("descriptor=").Append(DescriptorVersion).Append('\n');
+        sb.Append("compiler=").Append(CompilerVersion).Append('\n');
+        sb.Append("indexFormat=").Append(ReferenceMetadataIndex.FormatVersion).Append('\n');
+        sb.Append("tfm=").Append(targetFramework ?? string.Empty).Append('\n');
+        sb.Append("sources=").Append(sourceFingerprint ?? string.Empty).Append('\n');
+        sb.Append("refCount=").Append(references?.Count ?? 0).Append('\n');
+        if (references != null)
+        {
+            foreach (var reference in references)
+            {
+                sb.Append(reference ?? string.Empty).Append('|').Append(FileStamp(reference)).Append('\n');
+            }
+        }
+
+        return Sha256Hex(Encoding.UTF8.GetBytes(sb.ToString()));
+    }
+
+    // SHA-256 over the canonical serialization of the index's [metadataIndex]
+    // section. Recomputed on load and compared to the recorded value so in-place
+    // corruption that still parses is rejected.
+    private static string ComputeIndexHash(ReferenceMetadataIndex index)
+    {
+        var sb = new StringBuilder();
+        using (var writer = new StringWriter(sb, CultureInfo.InvariantCulture))
+        {
+            index.WriteTextSection(writer);
+        }
+
+        return Sha256Hex(Encoding.UTF8.GetBytes(sb.ToString()));
+    }
+
+    // "<sizeBytes>:<lastWriteUtcTicks>" for an existing file, or "missing" when
+    // the path is null/absent/unreadable. Stamps are cheap and conservative; a
+    // restore that only touches mtimes still (correctly) invalidates.
+    private static string FileStamp(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return "missing";
+        }
+
+        try
+        {
+            var info = new FileInfo(path);
+            if (!info.Exists)
+            {
+                return "missing";
+            }
+
+            return info.Length.ToString(CultureInfo.InvariantCulture)
+                + ":"
+                + info.LastWriteTimeUtc.Ticks.ToString(CultureInfo.InvariantCulture);
+        }
+        catch (Exception ex) when (IsRecoverable(ex))
+        {
+            return "unreadable";
+        }
+    }
+
+    private static string BuildDescriptor(
+        string projectName,
+        string fingerprint,
+        string indexSha256,
+        IReadOnlyList<string> references,
+        string rspPath,
+        string sourceFingerprint,
+        string targetFramework,
+        ReferenceMetadataIndex index)
+    {
+        var sb = new StringBuilder();
+        sb.Append("version=").Append(DescriptorVersion).Append('\n');
+        foreach (var line in CommentBlock)
+        {
+            sb.Append(line).Append('\n');
+        }
+
+        sb.Append('\n');
+        sb.Append("[project]\n");
+        sb.Append("name=").Append(projectName).Append('\n');
+        sb.Append("targetFramework=").Append(targetFramework ?? string.Empty).Append('\n');
+        sb.Append("sourceFingerprint=").Append(sourceFingerprint ?? string.Empty).Append('\n');
+        sb.Append('\n');
+        sb.Append("[fingerprint]\n");
+        sb.Append("compilerVersion=").Append(CompilerVersion).Append('\n');
+        sb.Append("indexFormat=").Append(ReferenceMetadataIndex.FormatVersion).Append('\n');
+        sb.Append("rsp=").Append(rspPath ?? string.Empty).Append('\n');
+        sb.Append("rspStamp=").Append(FileStamp(rspPath)).Append('\n');
+        sb.Append("referenceCount=").Append(references?.Count ?? 0).Append('\n');
+        sb.Append("fingerprint=").Append(fingerprint).Append('\n');
+        sb.Append("indexSha256=").Append(indexSha256).Append('\n');
+        sb.Append('\n');
+        sb.Append("[references]\n");
+        sb.Append("# path|sizeBytes:lastWriteUtcTicks — the resolved metadata reference set\n");
+        sb.Append("# (the .rsp equivalent). Bootstraps reference resolution when no .rsp is\n");
+        sb.Append("# present (after dotnet clean or on a fresh clone). Folded into the fingerprint.\n");
+        if (references != null)
+        {
+            foreach (var reference in references)
+            {
+                sb.Append(reference ?? string.Empty).Append('|').Append(FileStamp(reference)).Append('\n');
+            }
+        }
+
+        sb.Append('\n');
+
+        // The metadata index is always last so its newline-delimited body runs to
+        // end-of-file (the parser reads from its header to EOF).
+        using (var writer = new StringWriter(sb, CultureInfo.InvariantCulture))
+        {
+            index.WriteTextSection(writer);
+        }
+
+        return sb.ToString();
+    }
+
+    // Parses the descriptor's leading `key=value` header lines, stopping at the
+    // [references] / [metadataIndex] sections so it never walks the large index
+    // body. Section headers and comment lines are ignored; the keys we read
+    // (version, fingerprint, indexSha256) are unique across the header sections.
+    private static Dictionary<string, string> ParseHeaderFields(IReadOnlyList<string> lines)
+    {
+        var fields = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var raw in lines)
+        {
+            var line = raw?.Trim();
+            if (string.IsNullOrEmpty(line) || line[0] == '#')
+            {
+                continue;
+            }
+
+            if (line[0] == '[')
+            {
+                if (string.Equals(line, "[references]", StringComparison.Ordinal)
+                    || string.Equals(line, ReferenceMetadataIndex.SectionHeader, StringComparison.Ordinal))
+                {
+                    break;
+                }
+
+                continue;
+            }
+
+            var eq = line.IndexOf('=');
+            if (eq <= 0)
+            {
+                continue;
+            }
+
+            var key = line.Substring(0, eq).Trim();
+            var value = line.Substring(eq + 1).Trim();
+            if (!fields.ContainsKey(key))
+            {
+                fields[key] = value;
+            }
+        }
+
+        return fields;
+    }
+
+    // Reads the `path|stamp` entries of the [references] section (between its
+    // header and the next `[` section). Comment and blank lines are skipped.
+    private static List<(string Path, string Stamp)> ParseReferenceSection(IReadOnlyList<string> lines)
+    {
+        var result = new List<(string, string)>();
+        var inSection = false;
+        foreach (var raw in lines)
+        {
+            var line = raw;
+            if (line == null)
+            {
+                continue;
+            }
+
+            var trimmed = line.Trim();
+            if (!inSection)
+            {
+                if (string.Equals(trimmed, "[references]", StringComparison.Ordinal))
+                {
+                    inSection = true;
+                }
+
+                continue;
+            }
+
+            if (trimmed.Length == 0 || trimmed[0] == '#')
+            {
+                continue;
+            }
+
+            if (trimmed[0] == '[')
+            {
+                break;
+            }
+
+            var bar = line.LastIndexOf('|');
+            if (bar <= 0)
+            {
+                continue;
+            }
+
+            var path = line.Substring(0, bar);
+            var stamp = line.Substring(bar + 1);
+            result.Add((path, stamp));
+        }
+
+        return result;
+    }
+
+    private static string Sha256Hex(byte[] bytes)
+    {
+        var hash = SHA256.HashData(bytes);
+        var sb = new StringBuilder(hash.Length * 2);
+        foreach (var b in hash)
+        {
+            sb.Append(b.ToString("x2", CultureInfo.InvariantCulture));
+        }
+
+        return sb.ToString();
+    }
+
+    private static void WriteAllTextAtomic(string path, string text)
+    {
+        var temp = path + ".tmp";
+        File.WriteAllText(temp, text, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        File.Move(temp, path, overwrite: true);
+    }
+
+    private static bool IsRecoverable(Exception ex)
+    {
+        return ex is IOException
+            or UnauthorizedAccessException
+            or System.Security.SecurityException
+            or NotSupportedException
+            or ArgumentException;
+    }
+}

--- a/src/LanguageServer/ProjectDiscovery.cs
+++ b/src/LanguageServer/ProjectDiscovery.cs
@@ -168,6 +168,43 @@ public static class ProjectDiscovery
     }
 
     /// <summary>
+    /// Resolves the project's target framework moniker (e.g. <c>net8.0</c>) from
+    /// the <c>.gsproj</c>. Returns the single <c>&lt;TargetFramework&gt;</c> when
+    /// present, otherwise the raw <c>&lt;TargetFrameworks&gt;</c> value (so a
+    /// multi-targeting change still flips the cold-start cache fingerprint), or an
+    /// empty string when neither is declared or the file cannot be parsed. Used by
+    /// ADR-0107 as one component of the cold-start cache fingerprint.
+    /// </summary>
+    /// <param name="projectFilePath">Absolute path to the <c>.gsproj</c>.</param>
+    /// <returns>The target framework moniker; never <c>null</c>.</returns>
+    internal static string ResolveTargetFramework(string projectFilePath)
+    {
+        try
+        {
+            var doc = XDocument.Load(projectFilePath);
+            var single = doc.Descendants()
+                .FirstOrDefault(e => e.Name.LocalName == "TargetFramework")?.Value;
+            if (!string.IsNullOrWhiteSpace(single))
+            {
+                return single.Trim();
+            }
+
+            var multi = doc.Descendants()
+                .FirstOrDefault(e => e.Name.LocalName == "TargetFrameworks")?.Value;
+            if (!string.IsNullOrWhiteSpace(multi))
+            {
+                return multi.Trim();
+            }
+        }
+        catch (Exception)
+        {
+            // Fall through to the empty default below.
+        }
+
+        return string.Empty;
+    }
+
+    /// <summary>
     /// Discovers all <c>.gs</c> source files for a project directory using the
     /// SDK default glob pattern (<c>**/*.gs</c>), excluding common output directories.
     /// </summary>

--- a/src/LanguageServer/ProjectState.cs
+++ b/src/LanguageServer/ProjectState.cs
@@ -419,19 +419,131 @@ public class ProjectState
 
     private ReferenceResolver GetOrBuildResolver_NoLock()
     {
-        if (references.Count == 0)
+        var effectiveReferences = references;
+        if (effectiveReferences.Count == 0)
+        {
+            // ADR-0107: no `.rsp` (fresh clone, or after `dotnet clean` — the
+            // `.rsp` lives in the gitignored `obj/`). Try to bootstrap the
+            // reference set from a previously-written `.lscache` so the LSP can
+            // still resolve imported types without first building. The cache
+            // re-validates every DLL (exists + size:mtime) before returning; any
+            // missing/changed reference falls back to today's empty/degraded
+            // behavior (over-invalidation is always safe).
+            var bootstrapped = ColdStartCache.TryBootstrapReferences(ProjectFilePath, AssemblyName);
+            if (bootstrapped != null && bootstrapped.Count > 0)
+            {
+                effectiveReferences = bootstrapped;
+            }
+        }
+
+        if (effectiveReferences.Count == 0)
         {
             return null;
         }
 
+        // The resolver cache is keyed on the project's own `references` identity
+        // (the `.rsp`-derived list, or the stable empty instance when there is no
+        // `.rsp`). A bootstrapped reference set is used to build the resolver but
+        // does not change that identity, so the resolver is rebuilt only when a
+        // real `.rsp` later replaces `references`.
         if (cachedResolver != null && ReferenceEquals(resolverReferences, references))
         {
             return cachedResolver;
         }
 
-        cachedResolver = ReferenceResolver.WithReferences(references);
+        cachedResolver = ReferenceResolver.WithReferences(effectiveReferences);
         resolverReferences = references;
+        WarmOrSeedColdStartCache_NoLock(cachedResolver, effectiveReferences);
         return cachedResolver;
+    }
+
+    // ADR-0107: load the persisted reference-metadata index for this project, or
+    // build and persist a fresh one. On a fingerprint-matching cache hit the
+    // resolver adopts the index and skips the ~120ms GetTypes() enumeration of the
+    // whole reference closure on this cold start. On any miss/mismatch/corruption
+    // the resolver stays cold: we build the index once (work the cold path needs
+    // anyway), adopt it for this session, and write it for next time. The
+    // fingerprint is `.rsp`-independent (reference set + source fingerprint + TFM
+    // + versions), so a cache written from a bootstrapped reference set is itself
+    // reusable. Every step is best-effort — a cache error must never disturb the
+    // LSP, so the resolver simply falls back to its eager type-name index.
+    private void WarmOrSeedColdStartCache_NoLock(ReferenceResolver resolver, IReadOnlyList<string> effectiveReferences)
+    {
+        if (resolver == null || ColdStartCache.Disabled)
+        {
+            return;
+        }
+
+        try
+        {
+            var sourceFingerprint = ComputeSourceFingerprint_NoLock();
+            var targetFramework = ProjectDiscovery.ResolveTargetFramework(ProjectFilePath);
+
+            var cached = ColdStartCache.TryLoad(
+                ProjectFilePath, AssemblyName, effectiveReferences, referenceSourcePath, sourceFingerprint, targetFramework);
+            if (cached != null && resolver.TryUseMetadataIndex(cached))
+            {
+                return;
+            }
+
+            var fresh = resolver.ExportMetadataIndex();
+            resolver.TryUseMetadataIndex(fresh);
+            ColdStartCache.Save(
+                ProjectFilePath, AssemblyName, effectiveReferences, referenceSourcePath, sourceFingerprint, targetFramework, fresh);
+        }
+        catch (Exception)
+        {
+            // Defence in depth: the cache is a performance optimization only. On
+            // any unexpected error leave the resolver on its eager cold path.
+        }
+    }
+
+    // ADR-0107: a content hash over the project's current source set — each file's
+    // project-relative path plus its in-memory text — folded into the cold-start
+    // cache fingerprint. Project-relative paths keep the hash portable across
+    // clones (so a committed `.lscache` validates on another checkout of the same
+    // sources). Any edit to any source flips the hash, conservatively invalidating
+    // the cache. Best-effort: returns an empty string on any error.
+    private string ComputeSourceFingerprint_NoLock()
+    {
+        try
+        {
+            var entries = new List<string>(syntaxTrees.Count);
+            foreach (var pair in syntaxTrees)
+            {
+                var content = pair.Value?.Text?.ToString() ?? string.Empty;
+                var relative = pair.Key;
+                try
+                {
+                    if (!string.IsNullOrEmpty(ProjectDirectory))
+                    {
+                        relative = Path.GetRelativePath(ProjectDirectory, pair.Key)
+                            .Replace(Path.DirectorySeparatorChar, '/');
+                    }
+                }
+                catch (ArgumentException)
+                {
+                    relative = pair.Key;
+                }
+
+                entries.Add(relative + "\u0000" + content);
+            }
+
+            entries.Sort(StringComparer.Ordinal);
+            var sb = new System.Text.StringBuilder();
+            foreach (var entry in entries)
+            {
+                sb.Append(entry).Append('\n');
+            }
+
+            var hash = System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes(sb.ToString()));
+            return Convert.ToHexString(hash).ToLowerInvariant();
+        }
+        catch (Exception)
+        {
+            return string.Empty;
+        }
     }
 
     private static bool ReferenceListsEqual(IReadOnlyList<string> a, IReadOnlyList<string> b)

--- a/src/vscode-gsharp/package.json
+++ b/src/vscode-gsharp/package.json
@@ -189,6 +189,11 @@
             "type": "boolean",
             "default": true,
             "description": "Show inlay hints for inferred variable types."
+          },
+          "gsharp.coldStartCache.enable": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Persist a per-project cold-start cache (`<AssemblyName>.gsproj.lscache`) so reopening a workspace skips re-enumerating reference metadata, and so references resolve after a clean or fresh clone without first rebuilding. The file is generated, safe to delete, and gitignored by default. When unset, the C# Dev Kit setting `dotnet.projectsystem.enableLanguageServiceCache` is honored as a fallback if present. Takes effect after restarting the language server (`GSharp: Restart Language Server`)."
           }
         }
       }

--- a/src/vscode-gsharp/src/server/serverManager.ts
+++ b/src/vscode-gsharp/src/server/serverManager.ts
@@ -141,6 +141,14 @@ export class ServerManager {
         DOTNET_CLI_TELEMETRY_OPTOUT: '1',
       };
 
+      // ADR-0107: the server reads GSHARP_DISABLE_COLD_START_CACHE; map the
+      // gsharp.coldStartCache.enable setting (with the C# Dev Kit fallback,
+      // resolved in getServerOptions) onto it so the toggle takes effect on the
+      // next server start.
+      if (!options.coldStartCacheEnabled) {
+        env.GSHARP_DISABLE_COLD_START_CACHE = '1';
+      }
+
       const serverOptions: ServerOptions = {
         run: { command: dotnetPath, args, transport: TransportKind.stdio, options: { env } },
         debug: {

--- a/src/vscode-gsharp/src/server/serverOptions.ts
+++ b/src/vscode-gsharp/src/server/serverOptions.ts
@@ -9,5 +9,34 @@ export function getServerOptions() {
     log: config.get<boolean>('server.log', false),
     logPath: config.get<string>('server.logPath', ''),
     trace: config.get<string>('trace.server', 'off'),
+    coldStartCacheEnabled: isColdStartCacheEnabled(config),
   };
+}
+
+/**
+ * Resolves whether the cold-start cache (ADR-0107) should be enabled.
+ *
+ * The G#-owned `gsharp.coldStartCache.enable` setting is authoritative when the
+ * user has set it. When it is left unset, we honor the C# Dev Kit setting
+ * `dotnet.projectsystem.enableLanguageServiceCache` as a fallback if present —
+ * so users who already manage a single cache toggle for their .NET tooling get
+ * consistent behavior — defaulting to enabled otherwise.
+ *
+ * We deliberately only *read* the `dotnet.projectsystem.*` key (owned by the C#
+ * Dev Kit extension); we never contribute it.
+ */
+function isColdStartCacheEnabled(config: vscode.WorkspaceConfiguration): boolean {
+  const inspected = config.inspect<boolean>('coldStartCache.enable');
+  const explicit =
+    inspected?.workspaceFolderValue ??
+    inspected?.workspaceValue ??
+    inspected?.globalValue;
+  if (explicit !== undefined) {
+    return explicit;
+  }
+
+  const csharp = vscode.workspace
+    .getConfiguration('dotnet.projectsystem')
+    .get<boolean>('enableLanguageServiceCache');
+  return csharp ?? true;
 }

--- a/test/Core.Tests/CodeAnalysis/Symbols/ReferenceMetadataIndexTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ReferenceMetadataIndexTests.cs
@@ -1,0 +1,293 @@
+// <copyright file="ReferenceMetadataIndexTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Tests for <see cref="ReferenceMetadataIndex"/> and the warm-resolution path it
+/// drives on <see cref="ReferenceResolver"/> (ADR-0107). The load-bearing property
+/// is that resolving through a persisted/round-tripped index yields results
+/// identical to the cold, from-scratch eager index. The index is persisted as a
+/// human-readable text section (ADR-0107 revised: single `.lscache` text file, no
+/// binary blob).
+/// </summary>
+public class ReferenceMetadataIndexTests
+{
+    // A curated mix of types that must resolve (top-level, generic, BCL, a
+    // forwarded System type) plus a name that must not, exercised against both
+    // the cold and warm paths.
+    private static readonly string[] CuratedNames =
+    {
+        "GSharp.Core.CodeAnalysis.Symbols.ReferenceResolver",
+        "System.String",
+        "System.Console",
+        "System.Object",
+        "System.Collections.Generic.List`1",
+        "System.Collections.Generic.Dictionary`2",
+        "System.Threading.Tasks.Task`1",
+        "Definitely.Not.A.Real.Type",
+    };
+
+    private static string[] CoreReferenceSet()
+    {
+        var corePath = typeof(ReferenceResolver).Assembly.Location;
+        Assert.False(string.IsNullOrEmpty(corePath));
+        return new[] { corePath };
+    }
+
+    private static string WriteSection(ReferenceMetadataIndex index)
+    {
+        using var writer = new System.IO.StringWriter();
+        index.WriteTextSection(writer);
+        return writer.ToString();
+    }
+
+    private static IReadOnlyList<string> SplitLines(string text)
+    {
+        // Mirror File.ReadAllLines: split on '\n', strip trailing '\r', drop the
+        // empty trailing entry produced by the final newline.
+        var lines = text.Replace("\r\n", "\n").Split('\n').ToList();
+        if (lines.Count > 0 && lines[lines.Count - 1].Length == 0)
+        {
+            lines.RemoveAt(lines.Count - 1);
+        }
+
+        return lines;
+    }
+
+    [Fact]
+    public void Export_Then_RoundTrip_Preserves_Identities_And_Names()
+    {
+        using var cold = ReferenceResolver.WithReferences(CoreReferenceSet());
+        var index = cold.ExportMetadataIndex();
+
+        var lines = SplitLines(WriteSection(index));
+
+        Assert.True(ReferenceMetadataIndex.TryReadTextSection(lines, out var roundTripped));
+        Assert.True(index.AssemblyIdentities.SequenceEqual(roundTripped.AssemblyIdentities));
+        Assert.Equal(index.ToNameIndex().Count, roundTripped.ToNameIndex().Count);
+        Assert.True(index.ToNameIndex().Count > 0);
+    }
+
+    [Fact]
+    public void Section_Is_Human_Readable_And_Last()
+    {
+        using var cold = ReferenceResolver.WithReferences(CoreReferenceSet());
+        var text = WriteSection(cold.ExportMetadataIndex());
+
+        Assert.StartsWith(ReferenceMetadataIndex.SectionHeader, text);
+        Assert.Contains("formatVersion=", text);
+        Assert.Contains("assemblyCount=", text);
+        Assert.Contains("assembly=", text);
+        Assert.Contains("typeNameCount=", text);
+    }
+
+    [Fact]
+    public void RoundTrip_Survives_A_Descriptor_Preamble_Before_The_Section()
+    {
+        using var cold = ReferenceResolver.WithReferences(CoreReferenceSet());
+        var index = cold.ExportMetadataIndex();
+
+        // The real descriptor places header sections before [metadataIndex];
+        // TryReadTextSection must locate the header among them.
+        var preamble = "version=2\n# comment\n\n[project]\nname=Sample\n\n";
+        var lines = SplitLines(preamble + WriteSection(index));
+
+        Assert.True(ReferenceMetadataIndex.TryReadTextSection(lines, out var parsed));
+        Assert.Equal(index.ToNameIndex().Count, parsed.ToNameIndex().Count);
+    }
+
+    [Fact]
+    public void WarmResolution_Equals_ColdResolution_For_Every_Indexed_Name()
+    {
+        var references = CoreReferenceSet();
+        using var cold = ReferenceResolver.WithReferences(references);
+        var index = cold.ExportMetadataIndex();
+
+        using var warm = ReferenceResolver.WithReferences(references);
+        Assert.True(warm.TryUseMetadataIndex(index));
+
+        // Cap the exhaustive loop so the test stays fast on a large closure, then
+        // always include the curated names (which include a forwarded type).
+        var indexedNames = index.ToNameIndex().Keys.Take(4000);
+        foreach (var name in indexedNames.Concat(CuratedNames))
+        {
+            var coldFound = cold.TryResolveType(name, out var coldType);
+            var warmFound = warm.TryResolveType(name, out var warmType);
+
+            Assert.Equal(coldFound, warmFound);
+            if (coldFound)
+            {
+                Assert.Equal(coldType.FullName, warmType.FullName);
+                Assert.Equal(coldType.Assembly.GetName().FullName, warmType.Assembly.GetName().FullName);
+            }
+            else
+            {
+                Assert.Null(warmType);
+            }
+        }
+    }
+
+    [Fact]
+    public void WarmResolution_Returns_Miss_For_Unknown_Type()
+    {
+        var references = CoreReferenceSet();
+        using var cold = ReferenceResolver.WithReferences(references);
+        using var warm = ReferenceResolver.WithReferences(references);
+        Assert.True(warm.TryUseMetadataIndex(cold.ExportMetadataIndex()));
+
+        Assert.False(warm.TryResolveType("No.Such.Namespace.NoSuchType", out var type));
+        Assert.Null(type);
+    }
+
+    [Fact]
+    public void Deserialized_Index_Drives_Warm_Resolution()
+    {
+        var references = CoreReferenceSet();
+        using var producer = ReferenceResolver.WithReferences(references);
+
+        var lines = SplitLines(WriteSection(producer.ExportMetadataIndex()));
+        Assert.True(ReferenceMetadataIndex.TryReadTextSection(lines, out var index));
+
+        using var consumer = ReferenceResolver.WithReferences(references);
+        Assert.True(consumer.TryUseMetadataIndex(index));
+        Assert.True(consumer.TryResolveType("System.String", out var stringType));
+        Assert.Equal("System.String", stringType.FullName);
+    }
+
+    [Fact]
+    public void TryUseMetadataIndex_Rejects_Index_From_A_Different_Reference_Set()
+    {
+        using var core = ReferenceResolver.WithReferences(CoreReferenceSet());
+        var coreIndex = core.ExportMetadataIndex();
+
+        // A resolver over a different assembly set has different assembly
+        // identities, so the payload must be rejected (defence in depth).
+        var otherPath = typeof(Xunit.FactAttribute).Assembly.Location;
+        using var other = ReferenceResolver.WithReferences(new[] { otherPath });
+        Assert.False(other.TryUseMetadataIndex(coreIndex));
+    }
+
+    [Fact]
+    public void TryUseMetadataIndex_Rejects_Null()
+    {
+        using var resolver = ReferenceResolver.WithReferences(CoreReferenceSet());
+        Assert.False(resolver.TryUseMetadataIndex(null));
+    }
+
+    [Fact]
+    public void TryReadTextSection_Rejects_Null()
+    {
+        Assert.False(ReferenceMetadataIndex.TryReadTextSection(null, out var index));
+        Assert.Null(index);
+    }
+
+    [Fact]
+    public void TryReadTextSection_Rejects_Missing_Header()
+    {
+        var lines = new[] { "version=2", "[project]", "name=Sample" };
+        Assert.False(ReferenceMetadataIndex.TryReadTextSection(lines, out var index));
+        Assert.Null(index);
+    }
+
+    [Fact]
+    public void TryReadTextSection_Rejects_Truncated_Payload()
+    {
+        using var producer = ReferenceResolver.WithReferences(CoreReferenceSet());
+        var lines = SplitLines(WriteSection(producer.ExportMetadataIndex())).ToList();
+
+        // Lop off the back half so the per-entry name reads run out of data.
+        var truncated = lines.Take(lines.Count / 2).ToList();
+        Assert.False(ReferenceMetadataIndex.TryReadTextSection(truncated, out var index));
+        Assert.Null(index);
+    }
+
+    [Fact]
+    public void TryReadTextSection_Rejects_Wrong_Format_Version()
+    {
+        using var producer = ReferenceResolver.WithReferences(CoreReferenceSet());
+        var lines = SplitLines(WriteSection(producer.ExportMetadataIndex())).ToList();
+
+        var idx = lines.FindIndex(l => l.StartsWith("formatVersion=", StringComparison.Ordinal));
+        Assert.True(idx >= 0);
+        lines[idx] = "formatVersion=999";
+
+        Assert.False(ReferenceMetadataIndex.TryReadTextSection(lines, out var index));
+        Assert.Null(index);
+    }
+
+    [Fact]
+    public void TryReadTextSection_Rejects_Corrupt_Count()
+    {
+        using var producer = ReferenceResolver.WithReferences(CoreReferenceSet());
+        var lines = SplitLines(WriteSection(producer.ExportMetadataIndex())).ToList();
+
+        var idx = lines.FindIndex(l => l.StartsWith("typeNameCount=", StringComparison.Ordinal));
+        Assert.True(idx >= 0);
+        lines[idx] = "typeNameCount=not-a-number";
+
+        Assert.False(ReferenceMetadataIndex.TryReadTextSection(lines, out var index));
+        Assert.Null(index);
+    }
+
+    [Fact]
+    public void Create_Rejects_Mismatched_Array_Lengths()
+    {
+        var identities = System.Collections.Immutable.ImmutableArray.Create("A", "B");
+        var names = System.Collections.Immutable.ImmutableArray.Create(
+            System.Collections.Immutable.ImmutableArray<string>.Empty);
+
+        Assert.Throws<ArgumentException>(() => ReferenceMetadataIndex.Create(identities, names));
+    }
+
+    [Fact]
+    public void ToNameIndex_Uses_First_Writer_Wins()
+    {
+        var identities = System.Collections.Immutable.ImmutableArray.Create("Asm0", "Asm1");
+        var names = System.Collections.Immutable.ImmutableArray.Create(
+            System.Collections.Immutable.ImmutableArray.Create("Dup", "OnlyIn0"),
+            System.Collections.Immutable.ImmutableArray.Create("Dup", "OnlyIn1"));
+
+        var index = ReferenceMetadataIndex.Create(identities, names);
+        var map = index.ToNameIndex();
+
+        Assert.Equal(0, map["Dup"]);
+        Assert.Equal(0, map["OnlyIn0"]);
+        Assert.Equal(1, map["OnlyIn1"]);
+    }
+
+    [Fact]
+    public void Manually_Authored_Section_Round_Trips()
+    {
+        // The text section is human-authorable; a hand-written section with
+        // interleaved comments/blank lines must parse to the expected index.
+        var lines = SplitLines(
+            ReferenceMetadataIndex.SectionHeader + "\n" +
+            "# a comment\n" +
+            "formatVersion=" + ReferenceMetadataIndex.FormatVersion + "\n" +
+            "assemblyCount=2\n" +
+            "\n" +
+            "assembly=Asm0\n" +
+            "typeNameCount=2\n" +
+            "Ns.A\n" +
+            "Ns.B\n" +
+            "\n" +
+            "assembly=Asm1\n" +
+            "typeNameCount=1\n" +
+            "Ns.C\n");
+
+        Assert.True(ReferenceMetadataIndex.TryReadTextSection(lines, out var index));
+        Assert.Equal(new[] { "Asm0", "Asm1" }, index.AssemblyIdentities);
+        var map = index.ToNameIndex();
+        Assert.Equal(0, map["Ns.A"]);
+        Assert.Equal(0, map["Ns.B"]);
+        Assert.Equal(1, map["Ns.C"]);
+    }
+}

--- a/test/LanguageServer.Tests/ColdStartCacheTests.cs
+++ b/test/LanguageServer.Tests/ColdStartCacheTests.cs
@@ -1,0 +1,373 @@
+// <copyright file="ColdStartCacheTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.LanguageServer;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// Tests for <see cref="ColdStartCache"/> (ADR-0107, revised): single-text-file
+/// save/load round-trip, the conservative <c>.rsp</c>-independent fingerprint,
+/// corruption/missing-file fallback, the opt-out switch, and — the headline new
+/// capability — bootstrapping the reference set from the cache when no <c>.rsp</c>
+/// is present (fresh clone / after <c>dotnet clean</c>). Correctness here means:
+/// never load a stale or corrupt payload, never resolve against a changed/missing
+/// reference set (under-invalidation would be a correctness bug), and never throw
+/// into the LSP pipeline.
+/// </summary>
+public sealed class ColdStartCacheTests : IDisposable
+{
+    private readonly string root;
+    private readonly string projectFilePath;
+    private readonly string assemblyName = "Sample";
+
+    public ColdStartCacheTests()
+    {
+        // Keep scratch dirs under the test output directory (never /tmp).
+        root = Path.Combine(AppContext.BaseDirectory, "lscache-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        projectFilePath = Path.Combine(root, assemblyName + ".gsproj");
+        File.WriteAllText(projectFilePath, "<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private static ReferenceMetadataIndex SampleIndex()
+    {
+        var corePath = typeof(ReferenceResolver).Assembly.Location;
+        using var resolver = ReferenceResolver.WithReferences(new[] { corePath });
+        return resolver.ExportMetadataIndex();
+    }
+
+    private string DescriptorPath() => ColdStartCache.DescriptorPath(projectFilePath, assemblyName);
+
+    private string MakeRefFile(string name, string content)
+    {
+        var path = Path.Combine(root, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    [Fact]
+    public void Save_Then_Load_RoundTrips_The_Index()
+    {
+        var refA = MakeRefFile("a.dll", "aaa");
+        var refs = new[] { refA };
+        var rsp = MakeRefFile("Sample.rsp", "/r:a.dll");
+        var index = SampleIndex();
+
+        ColdStartCache.Save(projectFilePath, assemblyName, refs, rsp, "srcfp", "net8.0", index);
+
+        Assert.True(File.Exists(DescriptorPath()));
+
+        var loaded = ColdStartCache.TryLoad(projectFilePath, assemblyName, refs, rsp, "srcfp", "net8.0");
+        Assert.NotNull(loaded);
+        Assert.True(index.AssemblyIdentities.SequenceEqual(loaded.AssemblyIdentities));
+        Assert.Equal(index.ToNameIndex().Count, loaded.ToNameIndex().Count);
+    }
+
+    [Fact]
+    public void Only_One_Cache_File_Is_Written_No_Binary_Sibling()
+    {
+        var refs = new[] { MakeRefFile("a.dll", "aaa") };
+        ColdStartCache.Save(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0", SampleIndex());
+
+        var produced = Directory.GetFiles(root, "*.lscache*");
+        Assert.Single(produced);
+        Assert.EndsWith(".gsproj.lscache", produced[0]);
+        Assert.Empty(Directory.GetFiles(root, "*.lscache.bin"));
+    }
+
+    [Fact]
+    public void Descriptor_Is_Human_Readable_With_Header_Comment_Committable_Note_And_OptOut()
+    {
+        var refs = new[] { MakeRefFile("a.dll", "aaa") };
+        ColdStartCache.Save(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0", SampleIndex());
+
+        var text = File.ReadAllText(DescriptorPath());
+        Assert.StartsWith("version=", text);
+        Assert.Contains("#", text);
+        Assert.Contains("[project]", text);
+        Assert.Contains("[fingerprint]", text);
+        Assert.Contains("[references]", text);
+        Assert.Contains("[metadataIndex]", text);
+        Assert.Contains("GSHARP_DISABLE_COLD_START_CACHE", text);
+        Assert.Contains("commit", text); // committable opt-in note
+        Assert.Contains("targetFramework=net8.0", text);
+    }
+
+    [Fact]
+    public void Load_Returns_Null_When_References_Change()
+    {
+        var refA = MakeRefFile("a.dll", "aaa");
+        ColdStartCache.Save(projectFilePath, assemblyName, new[] { refA }, rspPath: null, "srcfp", "net8.0", SampleIndex());
+
+        var refB = MakeRefFile("b.dll", "bbb");
+        var loaded = ColdStartCache.TryLoad(projectFilePath, assemblyName, new[] { refA, refB }, rspPath: null, "srcfp", "net8.0");
+        Assert.Null(loaded);
+    }
+
+    [Fact]
+    public void Load_Returns_Null_When_A_Reference_Is_Touched()
+    {
+        var refA = MakeRefFile("a.dll", "aaa");
+        var refs = new[] { refA };
+        ColdStartCache.Save(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0", SampleIndex());
+
+        System.Threading.Thread.Sleep(10);
+        File.WriteAllText(refA, "aaaa-modified");
+        File.SetLastWriteTimeUtc(refA, DateTime.UtcNow.AddSeconds(5));
+
+        var loaded = ColdStartCache.TryLoad(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0");
+        Assert.Null(loaded);
+    }
+
+    [Fact]
+    public void Load_Returns_Null_When_Source_Fingerprint_Changes()
+    {
+        var refs = new[] { MakeRefFile("a.dll", "aaa") };
+        ColdStartCache.Save(projectFilePath, assemblyName, refs, rspPath: null, "srcfp-v1", "net8.0", SampleIndex());
+
+        var loaded = ColdStartCache.TryLoad(projectFilePath, assemblyName, refs, rspPath: null, "srcfp-v2", "net8.0");
+        Assert.Null(loaded);
+    }
+
+    [Fact]
+    public void Load_Returns_Null_When_Target_Framework_Changes()
+    {
+        var refs = new[] { MakeRefFile("a.dll", "aaa") };
+        ColdStartCache.Save(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0", SampleIndex());
+
+        var loaded = ColdStartCache.TryLoad(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net9.0");
+        Assert.Null(loaded);
+    }
+
+    [Fact]
+    public void Load_Survives_An_Rsp_Rebuild_Because_The_Rsp_Is_Not_In_The_Fingerprint()
+    {
+        // The .rsp is an ephemeral obj/ artifact; a clean/clone removes it. The
+        // fingerprint deliberately excludes it, so touching/rebuilding the .rsp
+        // (without changing the resolved reference set) must NOT invalidate.
+        var refs = new[] { MakeRefFile("a.dll", "aaa") };
+        var rsp = MakeRefFile("Sample.rsp", "/r:a.dll");
+        ColdStartCache.Save(projectFilePath, assemblyName, refs, rsp, "srcfp", "net8.0", SampleIndex());
+
+        System.Threading.Thread.Sleep(10);
+        File.SetLastWriteTimeUtc(rsp, DateTime.UtcNow.AddSeconds(5));
+
+        var loaded = ColdStartCache.TryLoad(projectFilePath, assemblyName, refs, rsp, "srcfp", "net8.0");
+        Assert.NotNull(loaded);
+
+        // And it loads identically with no .rsp at all.
+        var loadedNoRsp = ColdStartCache.TryLoad(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0");
+        Assert.NotNull(loadedNoRsp);
+    }
+
+    [Fact]
+    public void Load_Returns_Null_When_Index_Section_Is_Corrupt()
+    {
+        var refs = new[] { MakeRefFile("a.dll", "aaa") };
+        ColdStartCache.Save(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0", SampleIndex());
+
+        // Flip a type-name in the [metadataIndex] section: it still parses
+        // structurally, but the recorded index SHA-256 no longer matches.
+        var path = DescriptorPath();
+        var text = File.ReadAllText(path);
+        var corrupted = text.Replace(
+            "GSharp.Core.CodeAnalysis.Symbols.ReferenceResolver",
+            "GSharp.Core.CodeAnalysis.Symbols.ReferenceXesolver");
+        Assert.NotEqual(text, corrupted);
+        File.WriteAllText(path, corrupted);
+
+        var loaded = ColdStartCache.TryLoad(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0");
+        Assert.Null(loaded);
+    }
+
+    [Fact]
+    public void Load_Returns_Null_When_File_Is_Missing()
+    {
+        var refs = new[] { MakeRefFile("a.dll", "aaa") };
+        Assert.Null(ColdStartCache.TryLoad(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0"));
+    }
+
+    [Fact]
+    public void Deleting_Cache_File_Is_Safe()
+    {
+        var refs = new[] { MakeRefFile("a.dll", "aaa") };
+        ColdStartCache.Save(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0", SampleIndex());
+
+        File.Delete(DescriptorPath());
+
+        Assert.Null(ColdStartCache.TryLoad(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0"));
+        Assert.Null(ColdStartCache.TryBootstrapReferences(projectFilePath, assemblyName));
+    }
+
+    [Fact]
+    public void OptOut_Writes_Nothing_And_Loads_Nothing()
+    {
+        const string varName = "GSHARP_DISABLE_COLD_START_CACHE";
+        var previous = Environment.GetEnvironmentVariable(varName);
+        try
+        {
+            Environment.SetEnvironmentVariable(varName, "1");
+            Assert.True(ColdStartCache.Disabled);
+
+            var refs = new[] { MakeRefFile("a.dll", "aaa") };
+            ColdStartCache.Save(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0", SampleIndex());
+
+            Assert.False(File.Exists(DescriptorPath()));
+            Assert.Null(ColdStartCache.TryLoad(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0"));
+            Assert.Null(ColdStartCache.TryBootstrapReferences(projectFilePath, assemblyName));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(varName, previous);
+        }
+    }
+
+    [Fact]
+    public void Loaded_Index_Is_Adoptable_By_A_Fresh_Resolver()
+    {
+        var corePath = typeof(ReferenceResolver).Assembly.Location;
+        var refs = new[] { corePath };
+        using (var producer = ReferenceResolver.WithReferences(refs))
+        {
+            ColdStartCache.Save(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0", producer.ExportMetadataIndex());
+        }
+
+        var loaded = ColdStartCache.TryLoad(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0");
+        Assert.NotNull(loaded);
+
+        using var consumer = ReferenceResolver.WithReferences(refs);
+        Assert.True(consumer.TryUseMetadataIndex(loaded));
+        Assert.True(consumer.TryResolveType("System.String", out var stringType));
+        Assert.Equal("System.String", stringType.FullName);
+    }
+
+    [Fact]
+    public void TryBootstrapReferences_Returns_Validated_Set()
+    {
+        var refA = MakeRefFile("a.dll", "aaa");
+        var refB = MakeRefFile("b.dll", "bbbb");
+        var refs = new[] { refA, refB };
+        ColdStartCache.Save(projectFilePath, assemblyName, refs, rspPath: null, "srcfp", "net8.0", SampleIndex());
+
+        var bootstrapped = ColdStartCache.TryBootstrapReferences(projectFilePath, assemblyName);
+        Assert.NotNull(bootstrapped);
+        Assert.Equal(new[] { refA, refB }, bootstrapped);
+    }
+
+    [Fact]
+    public void TryBootstrapReferences_Returns_Null_When_A_Reference_Is_Missing()
+    {
+        var refA = MakeRefFile("a.dll", "aaa");
+        ColdStartCache.Save(projectFilePath, assemblyName, new[] { refA }, rspPath: null, "srcfp", "net8.0", SampleIndex());
+
+        File.Delete(refA);
+
+        Assert.Null(ColdStartCache.TryBootstrapReferences(projectFilePath, assemblyName));
+    }
+
+    [Fact]
+    public void TryBootstrapReferences_Returns_Null_When_A_Reference_Changed()
+    {
+        var refA = MakeRefFile("a.dll", "aaa");
+        ColdStartCache.Save(projectFilePath, assemblyName, new[] { refA }, rspPath: null, "srcfp", "net8.0", SampleIndex());
+
+        System.Threading.Thread.Sleep(10);
+        File.WriteAllText(refA, "changed-content");
+        File.SetLastWriteTimeUtc(refA, DateTime.UtcNow.AddSeconds(5));
+
+        Assert.Null(ColdStartCache.TryBootstrapReferences(projectFilePath, assemblyName));
+    }
+
+    [Fact]
+    public void ProjectState_WarmFromCache_Produces_Diagnostics_Identical_To_Cold()
+    {
+        const string source = "import System\nfunc main() {\nConsole.WriteLine(\"hi\")\n}\n";
+        var corePath = typeof(ReferenceResolver).Assembly.Location;
+        var sourcePath = Path.Combine(root, "Program.gs");
+        File.WriteAllText(sourcePath, source);
+
+        // Cold run: no cache present yet -> a from-scratch build that also writes
+        // the cache. This is the correctness oracle.
+        var coldDiagnostics = AnalyzeDiagnostics(new[] { corePath }, rspPath: null, sourcePath);
+
+        // The cache must now exist on disk.
+        Assert.True(File.Exists(DescriptorPath()));
+
+        // Warm run: a fresh ProjectState over the same inputs loads the cache.
+        var warmDiagnostics = AnalyzeDiagnostics(new[] { corePath }, rspPath: null, sourcePath);
+
+        Assert.Equal(coldDiagnostics, warmDiagnostics);
+    }
+
+    [Fact]
+    public void ProjectState_BootstrapsReferences_From_Cache_When_Rsp_Absent()
+    {
+        const string source = "import System\nfunc main() {\nConsole.WriteLine(\"hi\")\n}\n";
+        var corePath = typeof(ReferenceResolver).Assembly.Location;
+        var sourcePath = Path.Combine(root, "Program.gs");
+        File.WriteAllText(sourcePath, source);
+
+        // 1) A normal .rsp-backed build resolves references and writes the cache.
+        var rspBackedDiagnostics = AnalyzeDiagnostics(new[] { corePath }, rspPath: null, sourcePath);
+        Assert.True(File.Exists(DescriptorPath()));
+
+        // 2) Simulate `dotnet clean` / a fresh clone: the .rsp is gone and the LSP
+        //    discovers EMPTY references. With the committed/retained .lscache, the
+        //    project bootstraps its reference set from the cache and resolves the
+        //    imported types -> diagnostics identical to the .rsp-backed build.
+        //    (Proven directly: the cache supplies the reference set.)
+        var bootstrapped = ColdStartCache.TryBootstrapReferences(projectFilePath, assemblyName);
+        Assert.NotNull(bootstrapped);
+        Assert.Contains(corePath, bootstrapped);
+
+        var bootstrapDiagnostics = AnalyzeDiagnostics(Array.Empty<string>(), rspPath: null, sourcePath);
+        Assert.Equal(rspBackedDiagnostics, bootstrapDiagnostics);
+
+        // 3) Safe fallback: if a referenced DLL is missing/changed (or the cache is
+        //    gone), the bootstrap refuses to supply a stale reference set and the
+        //    LSP degrades to today's empty-reference behavior rather than resolving
+        //    against the wrong DLLs.
+        File.Delete(DescriptorPath());
+        Assert.Null(ColdStartCache.TryBootstrapReferences(projectFilePath, assemblyName));
+    }
+
+    private List<string> AnalyzeDiagnostics(IReadOnlyList<string> references, string rspPath, string sourcePath)
+    {
+        var project = new ProjectState(projectFilePath)
+        {
+            AssemblyName = assemblyName,
+            ReferenceSourcePath = rspPath,
+            References = references,
+        };
+        project.AddFileFromDisk(sourcePath);
+
+        var compilation = project.GetCompilation();
+        return compilation.GlobalScope.Diagnostics
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .Select(d => d.ToString())
+            .OrderBy(s => s, StringComparer.Ordinal)
+            .ToList();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a per-project cross-session cold-start cache for the language server (closes #868): a single human-readable text file per project, `<AssemblyName>.gsproj.lscache`, mirroring the C# Dev Kit `.lscache` convention.

> **Note for review:** this PR reflects a **revised** design after review feedback on the first cut. The original ADR assumed G# barely needed a `.lscache` and split the payload into a `.lscache` + a binary `.lscache.bin`. Both assumptions were challenged and, on measurement, did not hold — see "Design decisions (evidence-based)" below. The design was changed to a single text file with a project-system layer that survives `clean`/fresh-clone.

## What it does

Two capabilities, both with a conservative fingerprint and a safe fallback to today's behavior:

1. **Warm metadata index (~150 ms saved on Oahu cold `GlobalScope`).** `ReferenceResolver` adopts a cached full-name → assembly-index map and skips the eager `GetTypes()`/`GetForwardedTypes()` enumeration; `TryResolveType` materializes `Type` objects lazily by name, so warm resolution shares the cold path and **cannot diverge** from it. Oahu (`Oahu.Cli.Tests`, 54 files, 352 refs): cold `GetCompilation` ~229 ms → warm ~79 ms.

2. **`.rsp`-independent bootstrap (works after `clean` / fresh clone).** The `.rsp` is an `obj/` build artifact (`*.rsp` is gitignored) — it does **not** survive `dotnet clean` or a fresh clone, and without it the LSP resolves no imported types. When no `.rsp` exists, the cache supplies the reference set from its `[references]` section after re-validating every DLL (exists + `size:mtime` + assembly identity at adoption). Oahu with the `.rsp` removed: bootstrap resolves all 352 refs → **63 diagnostics, identical to the `.rsp`-backed build** (vs **3066** degraded diagnostics with no cache).

## Format

`version=N` header + human-readable `#` comment block (purpose, do-not-edit, safe-to-delete/auto-regenerate, gitignore + commit guidance, opt-out env var) + `[references]` and `[metadataIndex]` text sections — full C# `.lscache` convention compatibility, one file, one gitignore entry (`*.lscache`, already standard).

## Design decisions (evidence-based)

- **Why not "just copy C# `.lscache` content"?** C# `.lscache` caches the MSBuild design-time-build (project-system) snapshot. G# gets `.rsp`-equivalent data from MSBuild too, but the `.rsp` lives in `obj/` and is gitignored, so it doesn't survive clean/clone. This PR therefore adopts the *committable, clean-surviving project-system layer* (the genuinely useful part of C#'s approach) **and** adds a metadata index for the part C# persists separately. The G#-specific cold cost (metadata enumeration + the ~600 ms bind) is additive on top.
- **Why a single text file, not `.lscache` + `.lscache.bin`?** Measured a 25 000-name index: **text 1342 KB / 4.2 ms** to parse vs **binary 1342 KB / 2.2 ms** — a ~2 ms difference, negligible against the ~120 ms enumeration saved. A separate `.lscache.bin` would be G#-unique gitignore friction (`*.lscache` is already a standard entry; `*.lscache.bin` is not). The earlier "text too slow" rationale was retracted.

## Correctness & invalidation

- A loaded cache yields results **identical to a cold from-scratch build**; it never touches emit.
- Fingerprint (excludes the `.rsp`): cache-format version + GSharp.Core version + index-format version + TFM + source content hash + ordered reference set (`path|size:mtime`). Any mismatch / missing / changed DLL / corruption / version change ⇒ safe fallback. Never throws into the LSP.
- Opt-out: `GSHARP_DISABLE_COLD_START_CACHE`. Gitignored by default; the portable-path + content-hash format also makes it **committable opt-in** for fast fresh-clone opens (caveat: still needs the referenced DLLs present — `restore` brings NuGet DLLs, project-ref DLLs need building).

## Verification

- Build clean. Core.Tests 3330, LanguageServer.Tests 312 (incl. 16 metadata-index + 18 cold-start-cache tests: single-file round-trip, **warm-from-cache diagnostics == cold**, `.rsp`-absent bootstrap == `.rsp`-backed, fingerprint invalidation, corruption, opt-out, safe-delete), Compiler.Tests 1341 (batched), SampleConformanceTests 115 (no resolver/emit regression).

## Deferred (ADR-0107 Phase 2)

Serializing the bound `GlobalScope`/signatures (the ~600 ms bind) — the bigger cold-start win but the hardest to serialize soundly; gated on ADR-0105 stable symbol identity + a byte-equivalence gate.

Closes #868.
