### PR TITLE
Workspace-wide, live, grouped Test Explorer discovery

### DIFF
--- a/docs/vscode-gsharp-spec.md
+++ b/docs/vscode-gsharp-spec.md
@@ -588,11 +588,12 @@ Since GSharp targets produce standard .NET assemblies, debugging uses the existi
 
 Integrate with VS Code's Testing API (`vscode.TestController`):
 
-1. Discover test files and methods via the language server (custom LSP request `gsharp/discoverTests`)
-2. Create `TestItem` hierarchy: Project → File → Test Function
-3. Run tests via `dotnet test` on the `.gsproj`
+1. Discover test files and methods via the language server (custom LSP request `gsharp/discoverTests`). Discovery is workspace-wide: the server scans every source file across all discovered projects (not just open editor buffers), overlaying open buffers so unsaved edits win, so the Test Explorer is fully populated after a build even before any file is opened.
+2. Build a grouped `TestItem` hierarchy: a top-level node per project labelled `<project-name> (<tfm>)` (e.g. `Oahu.Cli.Tests (net10.0)`), matching the C# Dev Kit presentation, with a middle grouping node per test class labelled with its fully-qualified type name `<namespace>.<class>` (e.g. `Oahu.Cli.Tests.App.CredentialStoreTests`), and the individual test methods beneath it.
+3. Run tests via `dotnet test` on the owning project's `.gsproj` (each project group carries its project path, so multi-project workspaces run against the correct project).
 4. Parse test results and map back to source locations
 5. Support CodeLens "Run Test | Debug Test" above test functions
+6. Keep the Test Explorer live: re-run discovery (debounced) on document edits/opens/saves and on `.gs` file-system create/delete/change events, plus an initial discovery once the language server is ready.
 
 ### 5.6 Build Diagnostics
 

--- a/src/LanguageServer/DiscoveredProject.cs
+++ b/src/LanguageServer/DiscoveredProject.cs
@@ -20,13 +20,15 @@ public sealed class DiscoveredProject
     /// <param name="references">Absolute paths to assembly references (from the MSBuild-emitted response file).</param>
     /// <param name="referenceSourcePath">Absolute path to the <c>.rsp</c> the references were parsed from, or <c>null</c> when none was found.</param>
     /// <param name="assemblyName">The project's effective <c>AssemblyName</c> (i.e. the basename of the output DLL). Used by cross-project navigation to map an imported symbol's declaring assembly back to the owning project.</param>
+    /// <param name="targetFramework">The project's target framework moniker (e.g. <c>net10.0</c>), parsed from the <c>.gsproj</c>; may be <c>null</c> when undeclared or unparseable.</param>
     public DiscoveredProject(
         string projectFilePath,
         IReadOnlyList<string> sourceFiles,
         IReadOnlyList<string> projectReferences,
         IReadOnlyList<string> references = null,
         string referenceSourcePath = null,
-        string assemblyName = null)
+        string assemblyName = null,
+        string targetFramework = null)
     {
         ProjectFilePath = projectFilePath;
         SourceFiles = sourceFiles;
@@ -34,6 +36,7 @@ public sealed class DiscoveredProject
         References = references ?? System.Array.Empty<string>();
         ReferenceSourcePath = referenceSourcePath;
         AssemblyName = assemblyName;
+        TargetFramework = targetFramework;
     }
 
     /// <summary>
@@ -77,4 +80,13 @@ public sealed class DiscoveredProject
     /// file's basename.
     /// </summary>
     public string AssemblyName { get; }
+
+    /// <summary>
+    /// Gets the project's target framework moniker (e.g. <c>net10.0</c>), parsed
+    /// from the <c>.gsproj</c>'s <c>&lt;TargetFramework&gt;</c> (or raw
+    /// <c>&lt;TargetFrameworks&gt;</c>) element. May be <c>null</c> or empty when
+    /// neither is declared or the file could not be parsed. Surfaced to the VS Code
+    /// Test Explorer so test groups can be labelled <c>&lt;project&gt; (&lt;tfm&gt;)</c>.
+    /// </summary>
+    public string TargetFramework { get; }
 }

--- a/src/LanguageServer/ProjectDiscovery.cs
+++ b/src/LanguageServer/ProjectDiscovery.cs
@@ -59,6 +59,7 @@ public static class ProjectDiscovery
         var projectReferences = DiscoverProjectReferences(projectFilePath, projectDir);
         var (references, referenceSourcePath) = DiscoverReferences(projectFilePath, projectDir);
         var assemblyName = ResolveAssemblyName(projectFilePath);
+        var targetFramework = ResolveTargetFramework(projectFilePath);
 
         return new DiscoveredProject(
             Path.GetFullPath(projectFilePath),
@@ -66,7 +67,8 @@ public static class ProjectDiscovery
             projectReferences,
             references,
             referenceSourcePath,
-            assemblyName);
+            assemblyName,
+            targetFramework);
     }
 
     /// <summary>

--- a/src/LanguageServer/ProjectState.cs
+++ b/src/LanguageServer/ProjectState.cs
@@ -72,6 +72,15 @@ public class ProjectState
     public string AssemblyName { get; set; }
 
     /// <summary>
+    /// Gets or sets the project's target framework moniker (e.g. <c>net10.0</c>),
+    /// parsed from the <c>.gsproj</c> by <see cref="ProjectDiscovery"/>. Surfaced to
+    /// the VS Code Test Explorer so discovered tests can be grouped under a
+    /// <c>&lt;project&gt; (&lt;tfm&gt;)</c> node. May be <c>null</c> or empty when the
+    /// project was constructed without discovery or declares no target framework.
+    /// </summary>
+    public string TargetFramework { get; set; }
+
+    /// <summary>
     /// Gets the set of source file paths currently in this project.
     /// </summary>
     public IReadOnlyCollection<string> SourceFiles => syntaxTrees.Keys.ToList();

--- a/src/LanguageServer/Protocol/TestModels.cs
+++ b/src/LanguageServer/Protocol/TestModels.cs
@@ -25,6 +25,14 @@ public sealed class TestDiscoveryItem
     public int Line { get; set; }
 
     /// <summary>
+    /// For a project grouping node, the absolute path to the owning <c>.gsproj</c>
+    /// so the client can run <c>dotnet test</c> against the correct project. Null on
+    /// the test/class items nested beneath the group (they inherit it from the group).
+    /// </summary>
+    [JsonPropertyName("projectFile")]
+    public string ProjectFile { get; set; }
+
+    /// <summary>
     /// A <c>dotnet test --filter "FullyQualifiedName~&lt;value&gt;"</c> token uniquely
     /// (or near-uniquely) identifying this test, e.g. <c>MyTestClass.MyTest</c> for a
     /// method or <c>MyTest</c> for a top-level test function. Null for grouping nodes.

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -396,20 +396,62 @@ public sealed class LspServer
 
     [JsonRpcMethod("gsharp/discoverTests")]
     public Task<TestDiscoveryItem[]> DiscoverTestsAsync(CancellationToken cancellationToken = default)
-        => this.ReadWorkspaceAsync(
-            (docs, ct) =>
-            {
-                var results = new List<TestDiscoveryItem>();
-                foreach (var pair in docs)
-                {
-                    ct.ThrowIfCancellationRequested();
-                    results.AddRange(TestDiscoveryComputer.ComputeTests(pair.Key, pair.Value));
-                }
-
-                return results.ToArray();
-            },
+        => this.ReadTestSnapshotAsync(
+            (sources, ct) => GroupDiscoveredTests(sources, ct),
             Array.Empty<TestDiscoveryItem>(),
             cancellationToken);
+
+    // Builds the Test Explorer tree: a top-level grouping node per project, labelled
+    // "<project-name> (<tfm>)" (matching the C# Dev Kit presentation), whose children are
+    // the class/function items discovered in that project's sources. Loose files that
+    // belong to no project are emitted at the top level, ungrouped, preserving prior
+    // behavior for single-file scenarios.
+    private static TestDiscoveryItem[] GroupDiscoveredTests(IReadOnlyList<TestSource> sources, CancellationToken ct)
+    {
+        var results = new List<TestDiscoveryItem>();
+        var grouped = new Dictionary<string, (string Label, string ProjectFile, List<TestDiscoveryItem> Children)>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var source in sources)
+        {
+            ct.ThrowIfCancellationRequested();
+            var items = TestDiscoveryComputer.ComputeTests(source.Uri, source.Tree);
+            if (items.Count == 0)
+            {
+                continue;
+            }
+
+            if (string.IsNullOrEmpty(source.ProjectFile))
+            {
+                // Loose / project-less file: keep its items at the top level.
+                results.AddRange(items);
+                continue;
+            }
+
+            if (!grouped.TryGetValue(source.ProjectFile, out var bucket))
+            {
+                bucket = (source.ProjectLabel, source.ProjectFile, new List<TestDiscoveryItem>());
+                grouped[source.ProjectFile] = bucket;
+            }
+
+            bucket.Children.AddRange(items);
+        }
+
+        foreach (var bucket in grouped.Values.OrderBy(b => b.Label, StringComparer.Ordinal))
+        {
+            results.Add(new TestDiscoveryItem
+            {
+                Id = "project:" + bucket.ProjectFile,
+                Label = bucket.Label,
+                Uri = DocumentUri.FromFileSystemPath(bucket.ProjectFile).ToString(),
+                Line = 0,
+                Filter = null,
+                ProjectFile = bucket.ProjectFile,
+                Children = bucket.Children.ToArray(),
+            });
+        }
+
+        return results.ToArray();
+    }
 
     [JsonRpcMethod("textDocument/inlayHint", UseSingleObjectParameterDeserialization = true)]
     public Task<InlayHint[]> InlayHintAsync(InlayHintParams request, CancellationToken cancellationToken = default)
@@ -656,6 +698,167 @@ public sealed class LspServer
                 }
             },
             cancellationToken).ConfigureAwait(false);
+    }
+
+    // Non-mutating read over the whole workspace's test-bearing source files (the
+    // gsharp/discoverTests request). Unlike ReadWorkspaceAsync — which only sees
+    // currently-open editor buffers — this snapshots every parsed source tree across
+    // all discovered projects, then overlays open buffers so unsaved edits win. This
+    // is what makes the Test Explorer reflect every test in the workspace (even in
+    // files that have never been opened) after a build. The snapshot is captured under
+    // the gate; the (immutable) syntax trees are walked off the gate on the thread pool.
+    private async Task<T> ReadTestSnapshotAsync<T>(
+        Func<IReadOnlyList<TestSource>, CancellationToken, T> compute,
+        T missing,
+        CancellationToken cancellationToken,
+        [System.Runtime.CompilerServices.CallerMemberName] string caller = null)
+    {
+        IReadOnlyList<TestSource> sources;
+        try
+        {
+            await this.gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                sources = this.SnapshotTestSources_NoLock();
+            }
+            finally
+            {
+                this.gate.Release();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogHandlerException(caller, ex);
+            return missing;
+        }
+
+        return await Task.Run(
+            () =>
+            {
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return compute(sources, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    LogHandlerException(caller, ex);
+                    return missing;
+                }
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    // Builds the de-duplicated set of test sources used by discovery: every project
+    // source tree keyed by absolute path (carrying its owning project's identity), with
+    // open editor buffers overlaid on top so in-flight edits are reflected and loose
+    // (project-less) open files are included.
+    private IReadOnlyList<TestSource> SnapshotTestSources_NoLock()
+    {
+        var byPath = new Dictionary<string, TestSource>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var project in this.workspaceState.Projects)
+        {
+            var projectFile = project.ProjectFilePath;
+            var projectLabel = ProjectLabel(project);
+            foreach (var file in project.SourceFiles)
+            {
+                if (project.TryGetSyntaxTree(file, out var tree) && tree != null)
+                {
+                    var path = PathKeyFor(tree, file);
+                    byPath[path] = new TestSource(DocumentUri.FromFileSystemPath(file).ToString(), tree, projectFile, projectLabel);
+                }
+            }
+        }
+
+        foreach (var pair in this.documentContentService.AllDocuments)
+        {
+            var tree = pair.Value?.SyntaxTree;
+            if (tree == null)
+            {
+                continue;
+            }
+
+            // Open buffers win over the on-disk project tree so the explorer reflects
+            // unsaved edits; preserve the client's own URI string so run-at-cursor
+            // matching stays byte-for-byte identical to the editor's document URI.
+            var path = PathKeyFor(tree, pair.Key);
+
+            // Reuse the project association captured above when the file is a known project
+            // source; otherwise resolve it (e.g. a freshly created, not-yet-globbed file).
+            string projectFile = null;
+            string projectLabel = null;
+            if (byPath.TryGetValue(path, out var existing))
+            {
+                projectFile = existing.ProjectFile;
+                projectLabel = existing.ProjectLabel;
+            }
+            else
+            {
+                var owning = this.workspaceState.GetProjectForFile(path);
+                if (owning != null)
+                {
+                    projectFile = owning.ProjectFilePath;
+                    projectLabel = ProjectLabel(owning);
+                }
+            }
+
+            byPath[path] = new TestSource(pair.Key, tree, projectFile, projectLabel);
+        }
+
+        return byPath.Values
+            .OrderBy(s => s.Uri, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static string ProjectLabel(ProjectState project)
+    {
+        var name = Path.GetFileNameWithoutExtension(project.ProjectFilePath);
+        var tfm = project.TargetFramework;
+        return string.IsNullOrEmpty(tfm) ? name : $"{name} ({tfm})";
+    }
+
+    private static string PathKeyFor(SyntaxTree tree, string fallback)
+    {
+        var fileName = tree?.Text?.FileName;
+        var candidate = !string.IsNullOrEmpty(fileName) ? fileName : fallback;
+        try
+        {
+            return Path.GetFullPath(candidate);
+        }
+        catch (Exception)
+        {
+            return candidate ?? string.Empty;
+        }
+    }
+
+    // A single test-bearing source: its emitted URI, parsed (immutable) tree, and the
+    // identity of the owning project (null for loose files) used to build the grouping node.
+    private readonly struct TestSource
+    {
+        public TestSource(string uri, SyntaxTree tree, string projectFile, string projectLabel)
+        {
+            Uri = uri;
+            Tree = tree;
+            ProjectFile = projectFile;
+            ProjectLabel = projectLabel;
+        }
+
+        public string Uri { get; }
+
+        public SyntaxTree Tree { get; }
+
+        public string ProjectFile { get; }
+
+        public string ProjectLabel { get; }
     }
 
     private static SemanticTokens EmptySemanticTokens()

--- a/src/LanguageServer/TestDiscoveryComputer.cs
+++ b/src/LanguageServer/TestDiscoveryComputer.cs
@@ -35,14 +35,27 @@ public static class TestDiscoveryComputer
     /// <param name="content">The document content to scan.</param>
     /// <returns>The discovered top-level test items (class groups and free test functions).</returns>
     public static IReadOnlyList<TestDiscoveryItem> ComputeTests(string uri, DocumentContent content)
+        => ComputeTests(uri, content?.SyntaxTree);
+
+    /// <summary>
+    /// Computes the discovered tests for a single syntax tree. This overload lets
+    /// workspace-wide discovery scan a project's parsed source files directly,
+    /// without requiring each file to be open in an editor buffer.
+    /// </summary>
+    /// <param name="uri">The document URI (used on every emitted item).</param>
+    /// <param name="syntaxTree">The parsed syntax tree to scan.</param>
+    /// <returns>The discovered top-level test items (class groups and free test functions).</returns>
+    public static IReadOnlyList<TestDiscoveryItem> ComputeTests(string uri, SyntaxTree syntaxTree)
     {
         var items = new List<TestDiscoveryItem>();
-        if (content?.SyntaxTree?.Root == null)
+        if (syntaxTree?.Root == null)
         {
             return items;
         }
 
-        foreach (var member in content.SyntaxTree.Root.Members)
+        var namespaceName = ComputeNamespace(syntaxTree);
+
+        foreach (var member in syntaxTree.Root.Members)
         {
             switch (member)
             {
@@ -59,10 +72,17 @@ public static class TestDiscoveryComputer
 
                     if (methods.Length > 0)
                     {
+                        // The middle grouping node is the fully-qualified type name
+                        // (<namespace>.<class>) — e.g. "Oahu.Cli.Tests.App.CredentialStoreTests" —
+                        // so the Test Explorer reads Project (tfm) / Namespace.Class / Test.
+                        var qualified = string.IsNullOrEmpty(namespaceName)
+                            ? className
+                            : namespaceName + "." + className;
+
                         items.Add(new TestDiscoveryItem
                         {
-                            Id = uri + "#" + className,
-                            Label = className,
+                            Id = uri + "#" + qualified,
+                            Label = qualified,
                             Uri = uri,
                             Line = LineOf(type.Identifier),
                             Filter = null,
@@ -75,6 +95,24 @@ public static class TestDiscoveryComputer
         }
 
         return items;
+    }
+
+    /// <summary>
+    /// Extracts the document's declared package (namespace) as a dotted string, or an
+    /// empty string when the file declares no <c>package</c>. Used to qualify the test
+    /// grouping node's label in the Test Explorer.
+    /// </summary>
+    /// <param name="syntaxTree">The parsed syntax tree to inspect.</param>
+    /// <returns>The dotted package name, or the empty string.</returns>
+    public static string ComputeNamespace(SyntaxTree syntaxTree)
+    {
+        var package = syntaxTree?.Root?.Members.OfType<PackageSyntax>().FirstOrDefault();
+        if (package == null)
+        {
+            return string.Empty;
+        }
+
+        return string.Concat(package.IdentifiersWithDots.Select(t => t.Text));
     }
 
     private static bool IsTest(FunctionDeclarationSyntax function)

--- a/src/LanguageServer/WorkspaceInitializer.cs
+++ b/src/LanguageServer/WorkspaceInitializer.cs
@@ -30,6 +30,7 @@ public static class WorkspaceInitializer
         {
             var project = workspaceState.AddProject(disc.ProjectFilePath);
             project.AssemblyName = disc.AssemblyName;
+            project.TargetFramework = disc.TargetFramework;
             project.ProjectReferences = disc.ProjectReferences;
             project.ReferenceSourcePath = disc.ReferenceSourcePath;
             project.References = disc.References;

--- a/src/vscode-gsharp/src/extension.ts
+++ b/src/vscode-gsharp/src/extension.ts
@@ -31,6 +31,7 @@ export async function activate(context: vscode.ExtensionContext) {
       if (serverManager) {
         logger.info('Restarting language server...');
         await serverManager.restart();
+        testing.refresh();
       }
     }),
     vscode.commands.registerCommand('gsharp.openOutput', () => {
@@ -41,7 +42,11 @@ export async function activate(context: vscode.ExtensionContext) {
   registerBuildCommands(context, diagnosticsManager, logger);
   registerProjectCommands(context);
   registerReferenceFeatures(context);
-  registerTestingFeatures(context, () => serverManager?.getClient(), logger);
+  const testing = registerTestingFeatures(context, () => serverManager?.getClient(), logger);
+
+  // The server is running once start() resolves; kick off an initial test discovery
+  // so the Test Explorer is populated immediately (even before any .gs file is opened).
+  testing.refresh();
 
   // Register debugger
   registerDebugger(context);

--- a/src/vscode-gsharp/src/features/testing.ts
+++ b/src/vscode-gsharp/src/features/testing.ts
@@ -10,6 +10,7 @@ interface TestItem {
   uri: string;
   line: number;
   filter?: string;
+  projectFile?: string;
   children?: TestItem[];
 }
 
@@ -17,11 +18,16 @@ interface TestItem {
 // token, as reported by the language server's gsharp/discoverTests response.
 const testFilters = new Map<string, string>();
 
+// Maps a vscode.TestItem id to the absolute path of the `.gsproj` that owns it, so a
+// run targets the correct project. Project grouping nodes carry the path explicitly;
+// nested items inherit it from their ancestor group during tree construction.
+const itemProjects = new Map<string, string>();
+
 export function registerTestingFeatures(
   context: vscode.ExtensionContext,
   getClient: () => LanguageClient | undefined,
   logger: Logger,
-) {
+): { refresh: () => void } {
   const testController = vscode.tests.createTestController('gsharp-tests', 'GSharp Tests');
   context.subscriptions.push(testController);
 
@@ -46,6 +52,54 @@ export function registerTestingFeatures(
     }
   };
 
+  // Keep the Test Explorer continuously in sync with the workspace. The server
+  // discovers tests across every project source file (not just open buffers), so
+  // re-running discovery on edits, opens, saves, and file-system changes is what
+  // delivers live updates as the user types or builds. A debounce coalesces bursts
+  // of keystrokes and lets the language server process the corresponding didChange
+  // notifications before we re-query.
+  let discoveryTimer: NodeJS.Timeout | undefined;
+  const scheduleDiscovery = () => {
+    if (discoveryTimer) {
+      clearTimeout(discoveryTimer);
+    }
+    discoveryTimer = setTimeout(() => {
+      discoveryTimer = undefined;
+      void discoverTests(testController, getClient, logger);
+    }, 400);
+  };
+
+  const isGSharp = (document: vscode.TextDocument) =>
+    document.languageId === 'gsharp' || document.uri.fsPath.endsWith('.gs');
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeTextDocument((e) => {
+      if (isGSharp(e.document)) {
+        scheduleDiscovery();
+      }
+    }),
+    vscode.workspace.onDidOpenTextDocument((doc) => {
+      if (isGSharp(doc)) {
+        scheduleDiscovery();
+      }
+    }),
+    vscode.workspace.onDidSaveTextDocument((doc) => {
+      if (isGSharp(doc)) {
+        scheduleDiscovery();
+      }
+    }),
+    vscode.workspace.onDidCreateFiles(() => scheduleDiscovery()),
+    vscode.workspace.onDidDeleteFiles(() => scheduleDiscovery()),
+    vscode.workspace.onDidRenameFiles(() => scheduleDiscovery()),
+  );
+
+  // Catch source changes made outside the editor (e.g. branch switches, builds).
+  const watcher = vscode.workspace.createFileSystemWatcher('**/*.gs');
+  watcher.onDidCreate(() => scheduleDiscovery());
+  watcher.onDidDelete(() => scheduleDiscovery());
+  watcher.onDidChange(() => scheduleDiscovery());
+  context.subscriptions.push(watcher);
+
   // Register commands for running tests at cursor
   context.subscriptions.push(
     vscode.commands.registerCommand('gsharp.test.runInContext', async () => {
@@ -55,6 +109,8 @@ export function registerTestingFeatures(
       await runTestAtCursor(testController, getClient, logger, true);
     }),
   );
+
+  return { refresh: scheduleDiscovery };
 }
 
 async function runTestAtCursor(
@@ -154,13 +210,18 @@ async function discoverTests(
 function populateTestItems(controller: vscode.TestController, tests: TestItem[]) {
   controller.items.replace([]);
   testFilters.clear();
+  itemProjects.clear();
   for (const test of tests) {
-    const item = buildTestItem(controller, test);
+    const item = buildTestItem(controller, test, undefined);
     controller.items.add(item);
   }
 }
 
-function buildTestItem(controller: vscode.TestController, test: TestItem): vscode.TestItem {
+function buildTestItem(
+  controller: vscode.TestController,
+  test: TestItem,
+  inheritedProjectFile: string | undefined,
+): vscode.TestItem {
   const item = controller.createTestItem(test.id, test.label, vscode.Uri.parse(test.uri));
   item.range = new vscode.Range(test.line, 0, test.line, 0);
 
@@ -168,9 +229,14 @@ function buildTestItem(controller: vscode.TestController, test: TestItem): vscod
     testFilters.set(test.id, test.filter);
   }
 
+  const projectFile = test.projectFile ?? inheritedProjectFile;
+  if (projectFile) {
+    itemProjects.set(test.id, projectFile);
+  }
+
   if (test.children) {
     for (const child of test.children) {
-      item.children.add(buildTestItem(controller, child));
+      item.children.add(buildTestItem(controller, child, projectFile));
     }
   }
 
@@ -213,7 +279,8 @@ async function runTests(
 ) {
   const run = controller.createTestRun(request);
 
-  // Collect all test items to run
+  // Collect the top-level items the user asked to run (specific selection, or the
+  // whole controller when no include is given).
   const items: vscode.TestItem[] = [];
   if (request.include) {
     request.include.forEach((item) => items.push(item));
@@ -223,56 +290,142 @@ async function runTests(
 
   for (const item of items) {
     if (token.isCancellationRequested) break;
-    run.started(item);
+    forEachLeaf(item, (leaf) => run.started(leaf));
   }
 
   try {
-    // Find the project file and run tests via dotnet test
-    const projectFiles = await vscode.workspace.findFiles('**/*.gsproj', '**/node_modules/**', 1);
-    if (projectFiles.length === 0) {
+    // Group the selection by the owning project so each `dotnet test` invocation runs
+    // against the correct `.gsproj`. A multi-project workspace (e.g. several test
+    // projects) would otherwise always run against an arbitrary first project.
+    const groups = await groupItemsByProject(items);
+    if (groups.size === 0) {
       for (const item of items) {
-        run.errored(item, new vscode.TestMessage('No .gsproj file found.'));
+        forEachLeaf(item, (leaf) =>
+          run.errored(leaf, new vscode.TestMessage('No .gsproj file found.')),
+        );
       }
       run.end();
       return;
     }
 
-    const projectFile = projectFiles[0].fsPath;
-    const args = ['test', projectFile, '--logger', 'trx'];
-
-    // When specific tests are selected, restrict the run with a --filter.
-    // An empty expression (e.g. the whole suite) runs the entire project.
-    const filterExpression = request.include ? buildFilterExpression(items) : undefined;
-    if (filterExpression) {
-      args.push('--filter', filterExpression);
-    }
-
-    if (debug) {
-      await debugTests(projectFiles[0], args, items, run, logger, token);
-    } else {
-      const task = new vscode.Task(
-        { type: 'gsharp', task: 'test', project: projectFile },
-        vscode.TaskScope.Workspace,
-        'test',
-        'gsharp',
-        new vscode.ShellExecution('dotnet', args),
-      );
-
-      await vscode.tasks.executeTask(task);
-
-      // Mark all as passed (actual result parsing from TRX would be added here)
-      for (const item of items) {
-        run.passed(item);
-      }
+    for (const [projectFile, group] of groups) {
+      if (token.isCancellationRequested) break;
+      // Omit the filter when running an entire project (the project group node, or a
+      // bare "run all"); otherwise restrict the run to exactly the selected tests.
+      const filterExpression = group.runAll ? undefined : buildFilterExpression(group.items);
+      await runProject(projectFile, group.items, filterExpression, run, logger, debug, token);
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     for (const item of items) {
-      run.errored(item, new vscode.TestMessage(message));
+      forEachLeaf(item, (leaf) => run.errored(leaf, new vscode.TestMessage(message)));
     }
   }
 
   run.end();
+}
+
+/**
+ * Buckets the selected items by the absolute path of the `.gsproj` that owns them.
+ * A top-level grouping node with no test filter of its own (i.e. a project group) marks
+ * its bucket as "run all", so the whole project runs without a `--filter`. Items whose
+ * project cannot be determined (loose files, or an older server) fall back to the first
+ * `.gsproj` discovered in the workspace.
+ */
+async function groupItemsByProject(
+  items: vscode.TestItem[],
+): Promise<Map<string, { items: vscode.TestItem[]; runAll: boolean }>> {
+  const groups = new Map<string, { items: vscode.TestItem[]; runAll: boolean }>();
+  let fallback: string | undefined;
+
+  for (const item of items) {
+    let projectFile = projectFileForItem(item);
+    if (!projectFile) {
+      if (fallback === undefined) {
+        const found = await vscode.workspace.findFiles('**/*.gsproj', '**/node_modules/**', 1);
+        fallback = found.length > 0 ? found[0].fsPath : '';
+      }
+      projectFile = fallback;
+    }
+
+    if (!projectFile) {
+      continue;
+    }
+
+    let group = groups.get(projectFile);
+    if (!group) {
+      group = { items: [], runAll: false };
+      groups.set(projectFile, group);
+    }
+
+    group.items.push(item);
+    if (!item.parent && !testFilters.has(item.id)) {
+      group.runAll = true;
+    }
+  }
+
+  return groups;
+}
+
+function projectFileForItem(item: vscode.TestItem): string | undefined {
+  let current: vscode.TestItem | undefined = item;
+  while (current) {
+    const projectFile = itemProjects.get(current.id);
+    if (projectFile) {
+      return projectFile;
+    }
+    current = current.parent;
+  }
+  return undefined;
+}
+
+function forEachLeaf(item: vscode.TestItem, fn: (leaf: vscode.TestItem) => void) {
+  if (item.children.size === 0) {
+    fn(item);
+    return;
+  }
+  item.children.forEach((child) => forEachLeaf(child, fn));
+}
+
+async function runProject(
+  projectFile: string,
+  items: vscode.TestItem[],
+  filterExpression: string | undefined,
+  run: vscode.TestRun,
+  logger: Logger,
+  debug: boolean,
+  token: vscode.CancellationToken,
+) {
+  const leaves: vscode.TestItem[] = [];
+  for (const item of items) {
+    forEachLeaf(item, (leaf) => leaves.push(leaf));
+  }
+
+  const args = ['test', projectFile, '--logger', 'trx'];
+  if (filterExpression) {
+    args.push('--filter', filterExpression);
+  }
+
+  const projectUri = vscode.Uri.file(projectFile);
+  if (debug) {
+    await debugTests(projectUri, args, leaves, run, logger, token);
+    return;
+  }
+
+  const task = new vscode.Task(
+    { type: 'gsharp', task: 'test', project: projectFile },
+    vscode.TaskScope.Workspace,
+    'test',
+    'gsharp',
+    new vscode.ShellExecution('dotnet', args),
+  );
+
+  await vscode.tasks.executeTask(task);
+
+  // Mark all as passed (actual result parsing from TRX would be added here).
+  for (const leaf of leaves) {
+    run.passed(leaf);
+  }
 }
 
 /**

--- a/test/LanguageServer.Tests/TestDiscoveryComputerTests.cs
+++ b/test/LanguageServer.Tests/TestDiscoveryComputerTests.cs
@@ -41,6 +41,23 @@ public class TestDiscoveryComputerTests
     }
 
     [Fact]
+    public void ComputeTests_QualifiesClassLabelWithNamespace()
+    {
+        const string source = "package Foo.Bar\n\nclass MyTests {\n  @Fact\n  func PassesA() {\n  }\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var tests = TestDiscoveryComputer.ComputeTests("file:///t.gs", content);
+
+        var group = Assert.Single(tests);
+        Assert.Equal("Foo.Bar.MyTests", group.Label);
+
+        // The run filter token remains the unqualified Class.Method (dotnet test's
+        // FullyQualifiedName~ is a substring match, so it still resolves correctly).
+        var method = Assert.Single(group.Children);
+        Assert.Equal("MyTests.PassesA", method.Filter);
+    }
+
+    [Fact]
     public void ComputeTests_IgnoresFunctionsWithoutTestAttribute()
     {
         const string source = "func plainHelper() {\n}\n";

--- a/test/LanguageServer.Tests/TestDiscoveryWorkspaceTests.cs
+++ b/test/LanguageServer.Tests/TestDiscoveryWorkspaceTests.cs
@@ -1,0 +1,149 @@
+// <copyright file="TestDiscoveryWorkspaceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using GSharp.LanguageServer.Protocol;
+using GSharp.LanguageServer.Server;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// Locks in workspace-wide test discovery: the <c>gsharp/discoverTests</c> request must
+/// surface every test across all project source files — even files that were never opened
+/// in an editor — so the VS Code Test Explorer is populated after a build without the user
+/// having to open each file. Open editor buffers are overlaid so in-flight edits win.
+/// </summary>
+public class TestDiscoveryWorkspaceTests : IDisposable
+{
+    private readonly string root;
+
+    public TestDiscoveryWorkspaceTests()
+    {
+        this.root = Path.Combine(Path.GetTempPath(), "gsharp-testdiscovery-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(this.root);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(this.root, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public async Task DiscoverTests_FindsTestsInUnopenedProjectFiles()
+    {
+        var fileA = this.WriteFile("AlphaTests.gs", "class AlphaTests {\n  @Fact\n  func PassesA() {\n  }\n}\n");
+        var fileB = this.WriteFile("BetaTests.gs", "@Test\nfunc TopLevelBeta() {\n}\n");
+
+        var workspace = new WorkspaceState();
+        var project = workspace.AddProject(Path.Combine(this.root, "Demo.gsproj"));
+        project.TargetFramework = "net10.0";
+        foreach (var file in new[] { fileA, fileB })
+        {
+            project.AddFileFromDisk(file);
+            workspace.RegisterFile(file, project);
+        }
+
+        // Note: no DidOpenAsync calls — discovery must not depend on open buffers.
+        var server = new LspServer(new DocumentContentService(), workspace);
+
+        var tests = await server.DiscoverTestsAsync();
+
+        // Tests are grouped under a single "<project> (<tfm>)" node.
+        var group = Assert.Single(tests);
+        Assert.Equal("Demo (net10.0)", group.Label);
+        Assert.Equal(project.ProjectFilePath, group.ProjectFile);
+        Assert.NotNull(group.Children);
+        Assert.Contains(group.Children, c => c.Label == "AlphaTests" && c.Children != null && c.Children.Any(m => m.Label == "PassesA"));
+        Assert.Contains(group.Children, c => c.Label == "TopLevelBeta");
+    }
+
+    [Fact]
+    public async Task DiscoverTests_GroupsByProject()
+    {
+        var dirA = Directory.CreateDirectory(Path.Combine(this.root, "A")).FullName;
+        var dirB = Directory.CreateDirectory(Path.Combine(this.root, "B")).FullName;
+        var fileA = WriteTo(dirA, "ATests.gs", "@Fact\nfunc InA() {\n}\n");
+        var fileB = WriteTo(dirB, "BTests.gs", "@Fact\nfunc InB() {\n}\n");
+
+        var workspace = new WorkspaceState();
+        var projectA = workspace.AddProject(Path.Combine(dirA, "A.gsproj"));
+        projectA.TargetFramework = "net10.0";
+        projectA.AddFileFromDisk(fileA);
+        workspace.RegisterFile(fileA, projectA);
+
+        var projectB = workspace.AddProject(Path.Combine(dirB, "B.gsproj"));
+        projectB.TargetFramework = "net10.0";
+        projectB.AddFileFromDisk(fileB);
+        workspace.RegisterFile(fileB, projectB);
+
+        var server = new LspServer(new DocumentContentService(), workspace);
+
+        var tests = await server.DiscoverTestsAsync();
+
+        Assert.Equal(2, tests.Length);
+        var groupA = Assert.Single(tests, t => t.Label == "A (net10.0)");
+        var groupB = Assert.Single(tests, t => t.Label == "B (net10.0)");
+        Assert.Contains(groupA.Children, c => c.Label == "InA");
+        Assert.Contains(groupB.Children, c => c.Label == "InB");
+    }
+
+    [Fact]
+    public async Task DiscoverTests_OpenBufferEditsOverrideDiskContent()
+    {
+        var file = this.WriteFile("EditableTests.gs", "class EditableTests {\n  @Fact\n  func Original() {\n  }\n}\n");
+
+        var docs = new DocumentContentService();
+        var workspace = new WorkspaceState();
+        var project = workspace.AddProject(Path.Combine(this.root, "Demo.gsproj"));
+        project.AddFileFromDisk(file);
+        workspace.RegisterFile(file, project);
+
+        var server = new LspServer(docs, workspace);
+        var uri = DocumentUri.FromFileSystemPath(file);
+
+        // Simulate the user typing a brand-new test into the open buffer; discovery must
+        // reflect the in-memory edit rather than the (now stale) on-disk content.
+        await server.DidOpenAsync(new DidOpenTextDocumentParams
+        {
+            TextDocument = new TextDocumentItem
+            {
+                Uri = uri,
+                Text = "class EditableTests {\n  @Fact\n  func Original() {\n  }\n\n  @Fact\n  func Added() {\n  }\n}\n",
+            },
+        });
+
+        var tests = await server.DiscoverTestsAsync();
+
+        var projectGroup = Assert.Single(tests);
+        Assert.Equal("Demo", projectGroup.Label);
+        var group = Assert.Single(projectGroup.Children, t => t.Label == "EditableTests");
+        Assert.NotNull(group.Children);
+        Assert.Contains(group.Children, c => c.Label == "Added");
+        Assert.Contains(group.Children, c => c.Label == "Original");
+    }
+
+    private static string WriteTo(string dir, string name, string content)
+    {
+        var path = Path.Combine(dir, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private string WriteFile(string name, string content)
+    {
+        var path = Path.Combine(this.root, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+}


### PR DESCRIPTION
## Problem

Opening a workspace with G# xUnit tests showed **no tests** in the Test Explorer, even after a full build. Tests only appeared after a file containing them was opened, and the list never updated as you typed. Discovery was limited to currently-open editor buffers and ran only once on workspace open.

Repro: open `DavidObando/Oahu` (two test projects, many test files) — the explorer stayed empty until a test file was opened.

## Changes

### Server (`gsharp/discoverTests`)
- **Workspace-wide discovery**: scans every parsed source tree across all discovered projects (not just open buffers), overlaying open buffers so unsaved edits win. Tests now appear after a build without opening any file.
- **Grouped hierarchy**: `Project (tfm)` / `Namespace.Class` / `Test`, e.g.
  ```
  Oahu.Cli.Tests (net10.0)
  └── Oahu.Cli.Tests.App.CredentialStoreTests
      ├── Factory_Returns_Platform_Appropriate_Store
      └── Unsupported_Store_Always_Throws_With_Reason
  ```
  TFM is threaded from the `.gsproj` through `DiscoveredProject`/`ProjectState`; the middle node is the fully-qualified type name. Each project group carries its `.gsproj` path.

### Extension
- **Live updates**: re-runs discovery (debounced) on document edits/opens/saves and `.gs` file-system create/delete/change events, plus an initial discovery once the language server is ready.
- **Project-aware runs**: `dotnet test` now targets the project that owns the selected tests. Previously multi-project workspaces always ran against an arbitrary first project (so running a test in the second project did nothing).

## Tests
- New `TestDiscoveryComputerTests.ComputeTests_QualifiesClassLabelWithNamespace`.
- New `TestDiscoveryWorkspaceTests` covering unopened-file discovery, open-buffer override, and per-project grouping.
- Full `LanguageServer.Tests` suite: **316/316 pass**. Extension `tsc`/`eslint`/esbuild clean. Full `GSharp.sln` builds.

## Docs
- Updated `docs/vscode-gsharp-spec.md` §5.5.