### PR TITLE
Gracefully handle missing .NET runtime on language server activation (#871)

### DIFF
--- a/src/vscode-gsharp/CHANGELOG.md
+++ b/src/vscode-gsharp/CHANGELOG.md
@@ -37,3 +37,5 @@ All notable changes to the GSharp VS Code extension will be documented in this f
 ### Fixed
 
 - TextMate string grammar now recognizes backslash escape sequences (`\"`, `\\`, `\n`, `\t`, `\0`, `\a`, `\b`, `\f`, `\r`, `\v`, `\xNN`, `\uNNNN`, `\UNNNNNNNN`) so an escaped quote like `"text \""` no longer terminates the string early and bleeds string coloring into the rest of the file; unrecognized escapes are flagged as invalid
+- Language server activation now degrades gracefully when a compatible .NET runtime is missing (#871): the extension verifies a `Microsoft.NETCore.App` runtime matching the server's target major version is available before launching, and when it is absent it shows a single actionable error (with "Install .NET" / "Show Output" actions) instead of a stream of crash toasts and an endless restart loop. The extension also owns the restart policy and suppresses the underlying LanguageClient's default crash notifications.
+

--- a/src/vscode-gsharp/README.md
+++ b/src/vscode-gsharp/README.md
@@ -21,7 +21,7 @@ Rich language support for the [G# programming language](https://github.com/David
 
 ## Requirements
 
-- [.NET Runtime](https://dotnet.microsoft.com/download) (acquired automatically via the .NET Install Tool extension)
+- [.NET 10 Runtime](https://dotnet.microsoft.com/download/dotnet/10.0) or newer (the language server targets `net10.0`; acquired automatically via the .NET Install Tool extension when not already on the machine). If a compatible runtime is missing, the extension shows an actionable prompt instead of failing silently.
 - [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) (for debugging support)
 
 ## Extension Settings

--- a/src/vscode-gsharp/jest.config.js
+++ b/src/vscode-gsharp/jest.config.js
@@ -4,4 +4,7 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/test/**/*.test.ts'],
   moduleFileExtensions: ['ts', 'js', 'json'],
+  moduleNameMapper: {
+    '^vscode$': '<rootDir>/test-mocks/vscode.js',
+  },
 };

--- a/src/vscode-gsharp/src/server/serverManager.ts
+++ b/src/vscode-gsharp/src/server/serverManager.ts
@@ -7,6 +7,8 @@ import {
   State,
   TransportKind,
   InitializeParams,
+  ErrorAction,
+  CloseAction,
 } from 'vscode-languageclient/node';
 
 class GSharpLanguageClient extends LanguageClient {
@@ -33,7 +35,12 @@ class GSharpLanguageClient extends LanguageClient {
   }
 }
 
-import { resolveDotnetRuntime, getServerPath } from '../utils/dotnetResolver';
+import {
+  resolveDotnetRuntime,
+  getServerPath,
+  DotnetRuntimeMissingError,
+  DOTNET_DOWNLOAD_URL,
+} from '../utils/dotnetResolver';
 import { getServerOptions } from './serverOptions';
 import { Logger } from '../utils/logger';
 
@@ -45,6 +52,7 @@ export class ServerManager {
   private restartTimer: NodeJS.Timeout | undefined;
   private startPromise: Promise<void> | undefined;
   private isStopping = false;
+  private fatalError = false;
   private statusItem: vscode.LanguageStatusItem;
 
   constructor(
@@ -100,6 +108,7 @@ export class ServerManager {
   async restart(): Promise<void> {
     await this.stop();
     this.restartCount = 0;
+    this.fatalError = false;
     await this.start();
   }
 
@@ -112,7 +121,18 @@ export class ServerManager {
 
     try {
       this.setStatus('starting');
-      const dotnetPath = await resolveDotnetRuntime(this.context);
+
+      let dotnetPath: string;
+      try {
+        dotnetPath = await resolveDotnetRuntime(this.context);
+      } catch (err) {
+        if (err instanceof DotnetRuntimeMissingError) {
+          this.reportMissingRuntime(err);
+          return;
+        }
+        throw err;
+      }
+
       const serverPath = getServerPath(this.context);
       const options = getServerOptions();
 
@@ -169,6 +189,17 @@ export class ServerManager {
           onChange: true,
           onSave: true,
         },
+        // ServerManager owns the restart policy (see handleServerStopped), so suppress
+        // the LanguageClient's own crash toasts and "crashed N times" cascade and route
+        // everything through our logger / status item instead.
+        initializationFailedHandler: (error) => {
+          this.logger.error('Language server initialization failed', error);
+          return false;
+        },
+        errorHandler: {
+          error: () => ({ action: ErrorAction.Continue, handled: true }),
+          closed: () => ({ action: CloseAction.DoNotRestart, handled: true }),
+        },
         initializationOptions: {
           formattingIndentSize: vscode.workspace
             .getConfiguration('gsharp')
@@ -223,7 +254,7 @@ export class ServerManager {
   }
 
   private handleServerStopped() {
-    if (this.isStopping || this.restartTimer) {
+    if (this.isStopping || this.fatalError || this.restartTimer) {
       return;
     }
 
@@ -263,6 +294,29 @@ export class ServerManager {
     } catch (err) {
       this.logger.warn(`Failed to stop language server cleanly: ${this.formatError(err)}`);
     }
+  }
+
+  private reportMissingRuntime(err: DotnetRuntimeMissingError) {
+    // A missing runtime is unrecoverable without user action: stop the restart loop
+    // and surface a single, actionable message instead of a stream of crash toasts.
+    this.fatalError = true;
+    this.clearRestartTimer();
+    this.client = undefined;
+    this.setStatus('error');
+    this.logger.error(err.message);
+
+    const message =
+      `${err.message} Install the .NET ${err.requiredVersion} runtime, then run ` +
+      `"GSharp: Restart Language Server".`;
+    void vscode.window
+      .showErrorMessage(message, 'Install .NET', 'Show Output')
+      .then((selection) => {
+        if (selection === 'Install .NET') {
+          void vscode.env.openExternal(vscode.Uri.parse(DOTNET_DOWNLOAD_URL));
+        } else if (selection === 'Show Output') {
+          this.logger.show();
+        }
+      });
   }
 
   private reportMissingServer(serverPath: string) {

--- a/src/vscode-gsharp/src/test/dotnetResolver.test.ts
+++ b/src/vscode-gsharp/src/test/dotnetResolver.test.ts
@@ -1,0 +1,67 @@
+import {
+  hasCompatibleNetCoreAppRuntime,
+  DotnetRuntimeMissingError,
+  REQUIRED_DOTNET_MAJOR_VERSION,
+  REQUIRED_DOTNET_VERSION,
+} from '../utils/dotnetResolver';
+
+describe('hasCompatibleNetCoreAppRuntime', () => {
+  const required = REQUIRED_DOTNET_MAJOR_VERSION;
+
+  it('returns true when a runtime with the required major is present', () => {
+    const output = [
+      'Microsoft.AspNetCore.App 10.0.0 [/usr/share/dotnet/shared/Microsoft.AspNetCore.App]',
+      'Microsoft.NETCore.App 10.0.0 [/usr/share/dotnet/shared/Microsoft.NETCore.App]',
+    ].join('\n');
+    expect(hasCompatibleNetCoreAppRuntime(output, required)).toBe(true);
+  });
+
+  it('returns true when a newer major runtime is present', () => {
+    const output = 'Microsoft.NETCore.App 11.0.1 [/usr/share/dotnet/shared/Microsoft.NETCore.App]';
+    expect(hasCompatibleNetCoreAppRuntime(output, required)).toBe(true);
+  });
+
+  it('returns false when only an older runtime is present (the issue #871 case)', () => {
+    const output = 'Microsoft.NETCore.App 8.0.28 [/usr/share/dotnet/shared/Microsoft.NETCore.App]';
+    expect(hasCompatibleNetCoreAppRuntime(output, required)).toBe(false);
+  });
+
+  it('ignores AspNetCore/WindowsDesktop runtimes when matching the shared framework', () => {
+    const output = [
+      'Microsoft.AspNetCore.App 10.0.0 [/usr/share/dotnet/shared/Microsoft.AspNetCore.App]',
+      'Microsoft.WindowsDesktop.App 10.0.0 [/x]',
+      'Microsoft.NETCore.App 8.0.28 [/usr/share/dotnet/shared/Microsoft.NETCore.App]',
+    ].join('\n');
+    expect(hasCompatibleNetCoreAppRuntime(output, required)).toBe(false);
+  });
+
+  it('handles CRLF line endings', () => {
+    const output =
+      'Microsoft.NETCore.App 8.0.28 [/x]\r\nMicrosoft.NETCore.App 10.0.0 [/y]\r\n';
+    expect(hasCompatibleNetCoreAppRuntime(output, required)).toBe(true);
+  });
+
+  it('returns false for empty output', () => {
+    expect(hasCompatibleNetCoreAppRuntime('', required)).toBe(false);
+  });
+
+  it('selects the highest available major across multiple lines', () => {
+    const output = [
+      'Microsoft.NETCore.App 6.0.0 [/x]',
+      'Microsoft.NETCore.App 7.0.0 [/y]',
+      'Microsoft.NETCore.App 9.0.0 [/z]',
+    ].join('\n');
+    expect(hasCompatibleNetCoreAppRuntime(output, required)).toBe(false);
+    expect(hasCompatibleNetCoreAppRuntime(output, 9)).toBe(true);
+  });
+});
+
+describe('DotnetRuntimeMissingError', () => {
+  it('carries the required version and a descriptive message', () => {
+    const err = new DotnetRuntimeMissingError(REQUIRED_DOTNET_VERSION);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('DotnetRuntimeMissingError');
+    expect(err.requiredVersion).toBe(REQUIRED_DOTNET_VERSION);
+    expect(err.message).toContain(REQUIRED_DOTNET_VERSION);
+  });
+});

--- a/src/vscode-gsharp/src/utils/dotnetResolver.ts
+++ b/src/vscode-gsharp/src/utils/dotnetResolver.ts
@@ -1,38 +1,151 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
+/**
+ * The major version of the .NET runtime the bundled GSharp language server targets
+ * (see build/gsharp.build.props NetCoreAppTargetFramework = net10.0). The server cannot
+ * be hosted by an older runtime, so we verify a compatible runtime is present before
+ * launching it and degrade gracefully when it is missing.
+ */
+export const REQUIRED_DOTNET_MAJOR_VERSION = 10;
+
+/** The `major.minor` string passed to the .NET Install Tool when locating a runtime. */
+export const REQUIRED_DOTNET_VERSION = `${REQUIRED_DOTNET_MAJOR_VERSION}.0`;
+
+/** Download page shown to the user when no compatible runtime can be found. */
+export const DOTNET_DOWNLOAD_URL = 'https://dotnet.microsoft.com/download/dotnet/10.0';
+
+/**
+ * Thrown by {@link resolveDotnetRuntime} when no .NET runtime capable of hosting the
+ * language server can be located. Callers should surface a single, actionable message
+ * rather than letting the server crash-loop.
+ */
+export class DotnetRuntimeMissingError extends Error {
+  constructor(
+    public readonly requiredVersion: string,
+    public readonly detail?: string,
+  ) {
+    super(
+      `The GSharp language server requires the .NET ${requiredVersion} runtime, which was not found.`,
+    );
+    this.name = 'DotnetRuntimeMissingError';
+  }
+}
+
+/**
+ * Parses the output of `dotnet --list-runtimes` and reports whether a
+ * `Microsoft.NETCore.App` runtime with a major version >= {@link requiredMajor} exists.
+ *
+ * Each line looks like: `Microsoft.NETCore.App 10.0.0 [/usr/share/dotnet/shared/...]`.
+ */
+export function hasCompatibleNetCoreAppRuntime(
+  listRuntimesOutput: string,
+  requiredMajor: number,
+): boolean {
+  if (!listRuntimesOutput) {
+    return false;
+  }
+
+  for (const rawLine of listRuntimesOutput.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line.startsWith('Microsoft.NETCore.App ')) {
+      continue;
+    }
+
+    const match = /^Microsoft\.NETCore\.App\s+(\d+)\./.exec(line);
+    if (match) {
+      const major = Number.parseInt(match[1], 10);
+      if (Number.isFinite(major) && major >= requiredMajor) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Returns true if the `dotnet` host on PATH exposes a compatible runtime. Returns false
+ * when `dotnet` is absent or only ships older runtimes.
+ */
+function pathDotnetHasCompatibleRuntime(): boolean {
+  try {
+    const output = execFileSync('dotnet', ['--list-runtimes'], {
+      stdio: 'pipe',
+      encoding: 'utf8',
+    });
+    return hasCompatibleNetCoreAppRuntime(output, REQUIRED_DOTNET_MAJOR_VERSION);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validates that the dotnet host at {@link dotnetPath} can host the server. The
+ * .NET Install Tool may hand back a host that only resolves older runtimes, so we
+ * verify the runtime list before trusting it.
+ */
+function dotnetPathHasCompatibleRuntime(dotnetPath: string): boolean {
+  try {
+    const output = execFileSync(dotnetPath, ['--list-runtimes'], {
+      stdio: 'pipe',
+      encoding: 'utf8',
+    });
+    return hasCompatibleNetCoreAppRuntime(output, REQUIRED_DOTNET_MAJOR_VERSION);
+  } catch {
+    // If we cannot enumerate runtimes (e.g. an unexpected host layout), assume the
+    // Install Tool knows what it returned rather than blocking startup outright.
+    return true;
+  }
+}
+
+/**
+ * Resolves a `dotnet` host capable of running the GSharp language server.
+ *
+ * Resolution order:
+ *   1. A `dotnet` on PATH that exposes a `Microsoft.NETCore.App` runtime >= the required major.
+ *   2. A runtime located (or acquired) via the ms-dotnettools.vscode-dotnet-runtime extension.
+ *
+ * @throws {DotnetRuntimeMissingError} when no compatible runtime can be located.
+ */
 export async function resolveDotnetRuntime(
   _context: vscode.ExtensionContext,
 ): Promise<string> {
-  // Check if dotnet is available on PATH first
-  try {
-    execSync('dotnet --version', { stdio: 'pipe' });
+  // 1. Prefer a compatible runtime already on PATH.
+  if (pathDotnetHasCompatibleRuntime()) {
     return 'dotnet';
-  } catch {
-    // dotnet not on PATH, try the .NET Install Tool extension
   }
 
-  const dotnetExtension = vscode.extensions.getExtension('ms-dotnettools.vscode-dotnet-runtime');
+  // 2. Ask the .NET Install Tool to find (or acquire) a compatible runtime.
+  const dotnetExtension = vscode.extensions.getExtension(
+    'ms-dotnettools.vscode-dotnet-runtime',
+  );
   if (dotnetExtension) {
     if (!dotnetExtension.isActive) {
       await dotnetExtension.activate();
     }
     try {
-      const result = await vscode.commands.executeCommand<{ dotnetPath: string }>(
+      const result = await vscode.commands.executeCommand<{ dotnetPath: string } | undefined>(
         'dotnet.findPath',
-        { requestingExtensionId: 'gsharp.vscode-gsharp' },
+        {
+          acquireContext: {
+            version: REQUIRED_DOTNET_VERSION,
+            requestingExtensionId: 'gsharp.vscode-gsharp',
+            mode: 'runtime',
+          },
+          versionSpecRequirement: 'greater_than_or_equal',
+        },
       );
-      if (result?.dotnetPath) {
+      if (result?.dotnetPath && dotnetPathHasCompatibleRuntime(result.dotnetPath)) {
         return result.dotnetPath;
       }
     } catch {
-      // Fall through
+      // Fall through to the missing-runtime error below.
     }
   }
 
-  // Last resort — hope it's on PATH
-  return 'dotnet';
+  throw new DotnetRuntimeMissingError(REQUIRED_DOTNET_VERSION);
 }
 
 export function getServerPath(context: vscode.ExtensionContext): string {

--- a/src/vscode-gsharp/test-mocks/vscode.js
+++ b/src/vscode-gsharp/test-mocks/vscode.js
@@ -1,0 +1,31 @@
+// Minimal stub of the VS Code API so unit tests can import modules that reference
+// `vscode` without running inside the extension host. Extend as tests require.
+module.exports = {
+  extensions: {
+    getExtension: () => undefined,
+  },
+  commands: {
+    executeCommand: async () => undefined,
+  },
+  workspace: {
+    getConfiguration: () => ({
+      get: (_key, fallback) => fallback,
+    }),
+  },
+  window: {
+    showErrorMessage: async () => undefined,
+    createOutputChannel: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      show: () => {},
+      dispose: () => {},
+    }),
+  },
+  env: {
+    openExternal: async () => true,
+  },
+  Uri: {
+    parse: (value) => ({ toString: () => value }),
+  },
+};


### PR DESCRIPTION
Fixes #871.

## Problem

The bundled GSharp language server targets `net10.0`, but the extension launched it unconditionally. On a machine with only an older runtime (e.g. .NET 8), the server exited with code 150 (`You must install or update .NET to run this application`). The `vscode-languageclient` reacted with a cascade of error toasts — *"Server initialization failed"*, *"couldn't create connection to server"*, *"The GSharp Language Server server crashed 5 times…"* — before giving up. Two restart loops (the client's own + the extension's) compounded the noise.

## Fix

The extension now verifies a compatible runtime is present **before** launching, and degrades gracefully when it is missing.

- **`dotnetResolver.ts`**
  - Checks PATH via `dotnet --list-runtimes` for a `Microsoft.NETCore.App` runtime whose major version is `>=` the server's target (10).
  - Asks the .NET Install Tool (`dotnet.findPath`) for a `>= 10.0` runtime, validating the returned host actually exposes a compatible runtime.
  - Throws a typed `DotnetRuntimeMissingError` when nothing suitable is found.
- **`serverManager.ts`**
  - Catches `DotnetRuntimeMissingError` and shows **one** actionable error (`Install .NET` → download page, `Show Output`) instead of a toast cascade. Marks the failure fatal so the restart loop does not spin.
  - Becomes the single owner of restart policy: supplies an `errorHandler` (`DoNotRestart`) and `initializationFailedHandler` that route through the logger/status item and suppress the LanguageClient's default crash toasts. This also removes the previous dueling restart loops.

## Tests

- New jest unit tests for the runtime parser (including the exact .NET-8-only case from the issue) and the error type.
- Added a minimal `vscode` mock + jest `moduleNameMapper` so util modules can be unit-tested outside the extension host.

## Verification

- `npm run test:unit` → 8 passed
- `npm run lint` → clean
- `tsc --noEmit` → clean
- `npm run compile` (esbuild + server build) → succeeds

## Docs

- CHANGELOG and README updated (requirement now states .NET 10+, with graceful-prompt note).