### PR TITLE
Automatically acquire the .NET 10 runtime via the .NET Install Tool

### DIFF
--- a/src/vscode-gsharp/CHANGELOG.md
+++ b/src/vscode-gsharp/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to the GSharp VS Code extension will be documented in this f
 - CodeLens (reference counts, including on members of structs, interfaces, and enums; 0-refs and stale-tree fixes)
 - Workspace symbol search
 - Code snippets covering the current grammar: `pkg`, `fn`, `afn`, `extfn`, `lambda`, `main`, `if`, `ife`, `for`, `forin`, `while`, `class`, `classp`, `struct`, `datastruct`, `inlinestruct`, `record`, `enum`, `interface`, `delegate`, `prop`, `autoprop`, `event`, `shared`, `match`, `matchexpr`, `ternary`, `try`, `defer`, `go`, `scope`, `select`, `chan`, `using`, `refparam`, `outparam`, `letref`, `doc`, `ann`
+- Automatic .NET runtime acquisition: when no compatible `net10.0` runtime is found on PATH or via the .NET Install Tool, the extension now downloads one on demand through the Install Tool's `dotnet.acquire` API (mirroring the C# extension) and pins the server to it via `DOTNET_ROOT`/`DOTNET_MULTILEVEL_LOOKUP`, so the language server works out of the box on machines that only have an older runtime. The actionable "Install .NET" prompt is now a last resort, shown only when automatic acquisition cannot complete (e.g. offline with nothing cached).
 - Debug configuration provider (gsharp → coreclr)
 - Auto-generate launch.json and tasks.json
 - Test explorer integration

--- a/src/vscode-gsharp/README.md
+++ b/src/vscode-gsharp/README.md
@@ -21,7 +21,7 @@ Rich language support for the [G# programming language](https://github.com/David
 
 ## Requirements
 
-- [.NET 10 Runtime](https://dotnet.microsoft.com/download/dotnet/10.0) or newer (the language server targets `net10.0`; acquired automatically via the .NET Install Tool extension when not already on the machine). If a compatible runtime is missing, the extension shows an actionable prompt instead of failing silently.
+- [.NET 10 Runtime](https://dotnet.microsoft.com/download/dotnet/10.0) or newer (the language server targets `net10.0`). When a compatible runtime is not already on the machine, the extension automatically downloads one via the [.NET Install Tool](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.vscode-dotnet-runtime) (installed as a dependency). If automatic acquisition is not possible (for example, the machine is offline with nothing cached), the extension shows a single actionable prompt instead of failing silently.
 - [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) (for debugging support)
 
 ## Extension Settings

--- a/src/vscode-gsharp/src/server/serverManager.ts
+++ b/src/vscode-gsharp/src/server/serverManager.ts
@@ -40,6 +40,7 @@ import {
   getServerPath,
   DotnetRuntimeMissingError,
   DOTNET_DOWNLOAD_URL,
+  ResolvedDotnetRuntime,
 } from '../utils/dotnetResolver';
 import { getServerOptions } from './serverOptions';
 import { Logger } from '../utils/logger';
@@ -122,9 +123,9 @@ export class ServerManager {
     try {
       this.setStatus('starting');
 
-      let dotnetPath: string;
+      let dotnetRuntime: ResolvedDotnetRuntime;
       try {
-        dotnetPath = await resolveDotnetRuntime(this.context);
+        dotnetRuntime = await resolveDotnetRuntime(this.context, this.logger);
       } catch (err) {
         if (err instanceof DotnetRuntimeMissingError) {
           this.reportMissingRuntime(err);
@@ -132,6 +133,7 @@ export class ServerManager {
         }
         throw err;
       }
+      const dotnetPath = dotnetRuntime.dotnetPath;
 
       const serverPath = getServerPath(this.context);
       const options = getServerOptions();
@@ -155,6 +157,8 @@ export class ServerManager {
 
       const env: NodeJS.ProcessEnv = {
         ...process.env,
+        // Pin the host to the resolved/acquired runtime (DOTNET_ROOT, DOTNET_MULTILEVEL_LOOKUP).
+        ...dotnetRuntime.env,
         DOTNET_EnableDiagnostics: '0',
         DOTNET_CLI_UI_LANGUAGE: 'en',
         DOTNET_NOLOGO: '1',
@@ -306,7 +310,8 @@ export class ServerManager {
     this.logger.error(err.message);
 
     const message =
-      `${err.message} Install the .NET ${err.requiredVersion} runtime, then run ` +
+      `${err.message} Automatic acquisition via the .NET Install Tool did not succeed ` +
+      `(you may be offline). Install the .NET ${err.requiredVersion} runtime manually, then run ` +
       `"GSharp: Restart Language Server".`;
     void vscode.window
       .showErrorMessage(message, 'Install .NET', 'Show Output')

--- a/src/vscode-gsharp/src/test/dotnetRuntimeAcquire.test.ts
+++ b/src/vscode-gsharp/src/test/dotnetRuntimeAcquire.test.ts
@@ -1,0 +1,121 @@
+import * as vscode from 'vscode';
+import * as childProcess from 'child_process';
+import {
+  resolveDotnetRuntime,
+  DotnetRuntimeMissingError,
+  REQUIRED_DOTNET_VERSION,
+} from '../utils/dotnetResolver';
+import { Logger } from '../utils/logger';
+
+jest.mock('child_process', () => ({
+  execFileSync: jest.fn(),
+}));
+
+const execFileSyncMock = childProcess.execFileSync as unknown as jest.Mock;
+let executeCommandMock: jest.Mock;
+let getExtensionMock: jest.Mock;
+
+function fakeLogger(): Logger {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    show: jest.fn(),
+    dispose: jest.fn(),
+  } as unknown as Logger;
+}
+
+const context = {} as vscode.ExtensionContext;
+
+const NETCORE_10 = 'Microsoft.NETCore.App 10.0.0 [/x]';
+const NETCORE_8 = 'Microsoft.NETCore.App 8.0.28 [/x]';
+
+describe('resolveDotnetRuntime', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    execFileSyncMock.mockReset();
+    executeCommandMock = jest.fn(async () => undefined);
+    getExtensionMock = jest.fn(() => undefined);
+    (vscode.commands as { executeCommand: unknown }).executeCommand = executeCommandMock;
+    (vscode.extensions as { getExtension: unknown }).getExtension = getExtensionMock;
+  });
+
+  it('uses PATH dotnet when it exposes a compatible runtime (no Install Tool round-trip)', async () => {
+    execFileSyncMock.mockReturnValue(NETCORE_10);
+
+    const result = await resolveDotnetRuntime(context, fakeLogger());
+
+    expect(result).toEqual({ dotnetPath: 'dotnet', env: {} });
+    expect(getExtensionMock).not.toHaveBeenCalled();
+    expect(executeCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the existing runtime found via dotnet.findPath and pins DOTNET_ROOT', async () => {
+    // PATH only has .NET 8; findPath returns a managed .NET 10 host.
+    execFileSyncMock.mockImplementation((cmd: string) =>
+      cmd === 'dotnet' ? NETCORE_8 : NETCORE_10,
+    );
+    getExtensionMock.mockReturnValue({ isActive: true, activate: jest.fn() });
+    executeCommandMock.mockImplementation(async (command: string) => {
+      if (command === 'dotnet.findPath') {
+        return { dotnetPath: '/managed/dotnet/dotnet' };
+      }
+      return undefined;
+    });
+
+    const result = await resolveDotnetRuntime(context, fakeLogger());
+
+    expect(result.dotnetPath).toBe('/managed/dotnet/dotnet');
+    expect(result.env.DOTNET_ROOT).toBe('/managed/dotnet');
+    expect(result.env.DOTNET_MULTILEVEL_LOOKUP).toBe('0');
+    // Must not have attempted to download when an existing runtime was found.
+    expect(executeCommandMock).not.toHaveBeenCalledWith('dotnet.acquire', expect.anything());
+  });
+
+  it('acquires a runtime when none exists on PATH or via findPath', async () => {
+    execFileSyncMock.mockImplementation((cmd: string) =>
+      cmd === 'dotnet' ? NETCORE_8 : NETCORE_10,
+    );
+    getExtensionMock.mockReturnValue({ isActive: false, activate: jest.fn() });
+    executeCommandMock.mockImplementation(async (command: string) => {
+      switch (command) {
+        case 'dotnet.findPath':
+          return undefined;
+        case 'dotnet.acquireStatus':
+          return undefined;
+        case 'dotnet.acquire':
+          return { dotnetPath: '/acquired/dotnet/dotnet' };
+        default:
+          return undefined;
+      }
+    });
+
+    const result = await resolveDotnetRuntime(context, fakeLogger());
+
+    expect(result.dotnetPath).toBe('/acquired/dotnet/dotnet');
+    expect(result.env.DOTNET_ROOT).toBe('/acquired/dotnet');
+    expect(executeCommandMock).toHaveBeenCalledWith('dotnet.acquire', expect.objectContaining({
+      version: REQUIRED_DOTNET_VERSION,
+      mode: 'runtime',
+    }));
+  });
+
+  it('throws DotnetRuntimeMissingError when the Install Tool is unavailable', async () => {
+    execFileSyncMock.mockReturnValue(NETCORE_8);
+    getExtensionMock.mockReturnValue(undefined);
+
+    await expect(resolveDotnetRuntime(context, fakeLogger())).rejects.toBeInstanceOf(
+      DotnetRuntimeMissingError,
+    );
+  });
+
+  it('throws DotnetRuntimeMissingError when acquisition yields nothing', async () => {
+    execFileSyncMock.mockReturnValue(NETCORE_8);
+    getExtensionMock.mockReturnValue({ isActive: true, activate: jest.fn() });
+    executeCommandMock.mockResolvedValue(undefined);
+
+    await expect(resolveDotnetRuntime(context, fakeLogger())).rejects.toBeInstanceOf(
+      DotnetRuntimeMissingError,
+    );
+  });
+});

--- a/src/vscode-gsharp/src/utils/dotnetResolver.ts
+++ b/src/vscode-gsharp/src/utils/dotnetResolver.ts
@@ -1,25 +1,69 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
+import { Logger } from './logger';
 
 /**
  * The major version of the .NET runtime the bundled GSharp language server targets
  * (see build/gsharp.build.props NetCoreAppTargetFramework = net10.0). The server cannot
- * be hosted by an older runtime, so we verify a compatible runtime is present before
- * launching it and degrade gracefully when it is missing.
+ * be hosted by an older runtime, so we locate (and, if necessary, acquire) a compatible
+ * runtime before launching it and degrade gracefully when none can be obtained.
  */
 export const REQUIRED_DOTNET_MAJOR_VERSION = 10;
 
-/** The `major.minor` string passed to the .NET Install Tool when locating a runtime. */
+/** The `major.minor` string passed to the .NET Install Tool when locating/acquiring a runtime. */
 export const REQUIRED_DOTNET_VERSION = `${REQUIRED_DOTNET_MAJOR_VERSION}.0`;
 
-/** Download page shown to the user when no compatible runtime can be found. */
+/** Download page shown to the user when no compatible runtime can be found or acquired. */
 export const DOTNET_DOWNLOAD_URL = 'https://dotnet.microsoft.com/download/dotnet/10.0';
+
+/** Extension id of the .NET Install Tool we depend on to find/acquire runtimes. */
+const DOTNET_INSTALL_TOOL_EXTENSION_ID = 'ms-dotnettools.vscode-dotnet-runtime';
+
+/** The id we present to the .NET Install Tool as the requesting extension. */
+const REQUESTING_EXTENSION_ID = 'gsharp.vscode-gsharp';
+
+// Minimal subset of the .NET Install Tool's API surface that we use.
+// See https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/commands.md
+type DotnetInstallMode = 'sdk' | 'runtime' | 'aspnetcore';
+type DotnetVersionSpecRequirement = 'equal' | 'greater_than_or_equal' | 'less_than_or_equal';
+
+interface IDotnetAcquireContext {
+  version: string;
+  requestingExtensionId?: string;
+  architecture?: string | null;
+  mode?: DotnetInstallMode;
+}
+
+interface IDotnetFindPathContext {
+  acquireContext: IDotnetAcquireContext;
+  versionSpecRequirement: DotnetVersionSpecRequirement;
+  rejectPreviews?: boolean;
+}
+
+interface IDotnetAcquireResult {
+  dotnetPath: string;
+}
+
+/**
+ * The resolved host used to launch the language server, together with any environment
+ * variables that must be set so the host loads the intended runtime.
+ */
+export interface ResolvedDotnetRuntime {
+  /** Path to the `dotnet` executable (or just `dotnet` when relying on PATH). */
+  dotnetPath: string;
+  /**
+   * Environment overlay to apply when spawning the server. Empty when relying on PATH;
+   * pins DOTNET_ROOT / DOTNET_MULTILEVEL_LOOKUP when the host was resolved or acquired
+   * via the .NET Install Tool so the server runs on exactly that runtime.
+   */
+  env: NodeJS.ProcessEnv;
+}
 
 /**
  * Thrown by {@link resolveDotnetRuntime} when no .NET runtime capable of hosting the
- * language server can be located. Callers should surface a single, actionable message
- * rather than letting the server crash-loop.
+ * language server can be located or acquired. Callers should surface a single, actionable
+ * message rather than letting the server crash-loop.
  */
 export class DotnetRuntimeMissingError extends Error {
   constructor(
@@ -101,48 +145,160 @@ function dotnetPathHasCompatibleRuntime(dotnetPath: string): boolean {
 }
 
 /**
- * Resolves a `dotnet` host capable of running the GSharp language server.
+ * Builds the environment overlay that pins the server to the runtime beside
+ * {@link dotnetPath}, matching the C# extension's behavior. This prevents the host from
+ * rolling forward to (or down to) some other runtime discovered via multilevel lookup.
+ */
+function hostEnvironmentFor(dotnetPath: string): NodeJS.ProcessEnv {
+  return {
+    DOTNET_ROOT: path.dirname(dotnetPath),
+    DOTNET_MULTILEVEL_LOOKUP: '0',
+  };
+}
+
+/** Resolves the requesting architecture for acquisition (Node arch terminology). */
+function currentArchitecture(): string {
+  return process.arch;
+}
+
+/**
+ * Asks the .NET Install Tool to locate an already-installed compatible runtime without
+ * downloading anything. Returns the host path, or `undefined` if none is found.
+ */
+async function findExistingRuntime(logger: Logger): Promise<string | undefined> {
+  const findPathRequest: IDotnetFindPathContext = {
+    acquireContext: {
+      version: REQUIRED_DOTNET_VERSION,
+      requestingExtensionId: REQUESTING_EXTENSION_ID,
+      architecture: currentArchitecture(),
+      mode: 'runtime',
+    },
+    versionSpecRequirement: 'greater_than_or_equal',
+    // Reject previews: the server is not started with DOTNET_ROLL_FORWARD_TO_PRERELEASE,
+    // so a preview-only host would not actually be able to run it.
+    rejectPreviews: true,
+  };
+
+  const result = await vscode.commands.executeCommand<IDotnetAcquireResult | undefined>(
+    'dotnet.findPath',
+    findPathRequest,
+  );
+
+  if (result?.dotnetPath && dotnetPathHasCompatibleRuntime(result.dotnetPath)) {
+    logger.info(`Found existing .NET runtime via the .NET Install Tool: ${result.dotnetPath}`);
+    return result.dotnetPath;
+  }
+
+  return undefined;
+}
+
+/**
+ * Acquires a compatible runtime via the .NET Install Tool, downloading it into the
+ * tool's user-level managed folder if it is not already present. Returns the host path,
+ * or `undefined` if acquisition did not yield a usable host.
+ */
+async function acquireRuntime(logger: Logger): Promise<string | undefined> {
+  // The acquire API only accepts a major.minor version; it installs the latest patch.
+  const acquireContext: IDotnetAcquireContext = {
+    version: REQUIRED_DOTNET_VERSION,
+    requestingExtensionId: REQUESTING_EXTENSION_ID,
+    architecture: currentArchitecture(),
+    mode: 'runtime',
+  };
+
+  // Fast path: a previous acquisition may already have installed the runtime.
+  let result = await vscode.commands.executeCommand<IDotnetAcquireResult | undefined>(
+    'dotnet.acquireStatus',
+    acquireContext,
+  );
+
+  if (!result?.dotnetPath) {
+    logger.info(
+      `No compatible .NET ${REQUIRED_DOTNET_VERSION} runtime found; acquiring one via the .NET Install Tool...`,
+    );
+    // Surface the Install Tool's own output channel so the user can watch download progress.
+    await vscode.commands.executeCommand('dotnet.showAcquisitionLog');
+    result = await vscode.commands.executeCommand<IDotnetAcquireResult | undefined>(
+      'dotnet.acquire',
+      acquireContext,
+    );
+  }
+
+  if (!result?.dotnetPath) {
+    return undefined;
+  }
+
+  // On Linux the runtime may need additional native dependencies before it can run.
+  if (process.platform === 'linux') {
+    try {
+      await vscode.commands.executeCommand('dotnet.ensureDotnetDependencies', {
+        command: result.dotnetPath,
+        arguments: ['--list-runtimes'],
+      });
+    } catch (err) {
+      logger.warn(
+        `dotnet.ensureDotnetDependencies failed; continuing anyway: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  logger.info(`Acquired .NET runtime via the .NET Install Tool: ${result.dotnetPath}`);
+  return result.dotnetPath;
+}
+
+/**
+ * Resolves a `dotnet` host capable of running the GSharp language server, acquiring one
+ * automatically when necessary.
  *
  * Resolution order:
  *   1. A `dotnet` on PATH that exposes a `Microsoft.NETCore.App` runtime >= the required major.
- *   2. A runtime located (or acquired) via the ms-dotnettools.vscode-dotnet-runtime extension.
+ *   2. An existing compatible runtime located via the ms-dotnettools.vscode-dotnet-runtime extension.
+ *   3. A runtime downloaded and installed on demand via the same extension's acquire API.
  *
- * @throws {DotnetRuntimeMissingError} when no compatible runtime can be located.
+ * @throws {DotnetRuntimeMissingError} when no compatible runtime can be located or acquired
+ * (e.g. the .NET Install Tool is unavailable or the machine is offline with nothing cached).
  */
 export async function resolveDotnetRuntime(
   _context: vscode.ExtensionContext,
-): Promise<string> {
-  // 1. Prefer a compatible runtime already on PATH.
+  logger: Logger,
+): Promise<ResolvedDotnetRuntime> {
+  // 1. Prefer a compatible runtime already on PATH (no Install Tool round-trip needed).
   if (pathDotnetHasCompatibleRuntime()) {
-    return 'dotnet';
+    logger.info('Using compatible .NET runtime found on PATH.');
+    return { dotnetPath: 'dotnet', env: {} };
   }
 
-  // 2. Ask the .NET Install Tool to find (or acquire) a compatible runtime.
-  const dotnetExtension = vscode.extensions.getExtension(
-    'ms-dotnettools.vscode-dotnet-runtime',
-  );
-  if (dotnetExtension) {
-    if (!dotnetExtension.isActive) {
-      await dotnetExtension.activate();
+  // 2 & 3. Use the .NET Install Tool to find or acquire a compatible runtime.
+  const dotnetExtension = vscode.extensions.getExtension(DOTNET_INSTALL_TOOL_EXTENSION_ID);
+  if (!dotnetExtension) {
+    throw new DotnetRuntimeMissingError(
+      REQUIRED_DOTNET_VERSION,
+      'The .NET Install Tool extension is not available.',
+    );
+  }
+
+  if (!dotnetExtension.isActive) {
+    await dotnetExtension.activate();
+  }
+
+  try {
+    const existing = await findExistingRuntime(logger);
+    if (existing) {
+      return { dotnetPath: existing, env: hostEnvironmentFor(existing) };
     }
-    try {
-      const result = await vscode.commands.executeCommand<{ dotnetPath: string } | undefined>(
-        'dotnet.findPath',
-        {
-          acquireContext: {
-            version: REQUIRED_DOTNET_VERSION,
-            requestingExtensionId: 'gsharp.vscode-gsharp',
-            mode: 'runtime',
-          },
-          versionSpecRequirement: 'greater_than_or_equal',
-        },
-      );
-      if (result?.dotnetPath && dotnetPathHasCompatibleRuntime(result.dotnetPath)) {
-        return result.dotnetPath;
-      }
-    } catch {
-      // Fall through to the missing-runtime error below.
+
+    const acquired = await acquireRuntime(logger);
+    if (acquired) {
+      return { dotnetPath: acquired, env: hostEnvironmentFor(acquired) };
     }
+  } catch (err) {
+    logger.error('Failed to resolve a .NET runtime via the .NET Install Tool', err);
+    throw new DotnetRuntimeMissingError(
+      REQUIRED_DOTNET_VERSION,
+      err instanceof Error ? err.message : String(err),
+    );
   }
 
   throw new DotnetRuntimeMissingError(REQUIRED_DOTNET_VERSION);


### PR DESCRIPTION
## Problem

PR #879 made the extension fail gracefully when the bundled `net10.0` language server has no compatible runtime to host it: instead of a crash-toast cascade, it detects the missing runtime (via PATH and `dotnet.findPath`) and shows a single "Install .NET" prompt. But the user still has to go install .NET 10 by hand before the LSP works.

We already take an `extensionDependency` on the **.NET Install Tool** (`ms-dotnettools.vscode-dotnet-runtime`), so we can do better and just acquire the runtime for them — the same thing the C# extension does.

## Change

`resolveDotnetRuntime` now downloads a compatible runtime on demand, mirroring vscode-csharp's `DotnetRuntimeExtensionResolver`.

New resolution order:
1. A `dotnet` already on **PATH** exposing a `Microsoft.NETCore.App` >= 10 (no Install Tool round-trip).
2. An existing runtime located via **`dotnet.findPath`** (`greater_than_or_equal`, `rejectPreviews`).
3. **New:** a runtime **acquired on demand** via `dotnet.acquireStatus` -> `dotnet.showAcquisitionLog` -> `dotnet.acquire` (`mode: runtime`, `version: 10.0`); `dotnet.ensureDotnetDependencies` is invoked on Linux.
4. `DotnetRuntimeMissingError` only when acquisition truly cannot complete (e.g. offline with nothing cached or the Install Tool unavailable).

`resolveDotnetRuntime` now returns `{ dotnetPath, env }` and pins the host to the resolved/acquired runtime via `DOTNET_ROOT` / `DOTNET_MULTILEVEL_LOOKUP` (same as the C# extension), so the server cannot roll forward/back onto a different runtime. `serverManager` merges that env overlay and the "Install .NET" prompt becomes a last resort, with updated wording noting that automatic acquisition was attempted first.

## Tests

- New `dotnetRuntimeAcquire.test.ts` covering the PATH fast path, the `findPath` hit, the `acquire` fallback (asserting `DOTNET_ROOT` pinning and the `dotnet.acquire` call), and both error paths (Install Tool unavailable / acquisition yields nothing).
- Existing parser/error tests unchanged.

## Verification

- `npm run test:unit` -> 13 passed
- `npm run lint` -> clean
- `tsc --noEmit` -> clean
- `npm run compile` (esbuild + server build) -> succeeds

## Docs

- README requirement now accurately describes automatic acquisition (with offline-fallback note).
- CHANGELOG entry added.
