### PR TITLE
Fix Windows-only LSP errors: URI %3A decoding and quoted .rsp lines

### DIFF
--- a/src/LanguageServer/ProjectDiscovery.cs
+++ b/src/LanguageServer/ProjectDiscovery.cs
@@ -103,6 +103,13 @@ public static class ProjectDiscovery
                 continue;
             }
 
+            // MSBuild on Windows may quote entire switch lines when values contain
+            // spaces (e.g. "/r:C:\Program Files\..."). Strip outer quotes first.
+            if (trimmed.Length >= 2 && trimmed[0] == '"' && trimmed[trimmed.Length - 1] == '"')
+            {
+                trimmed = trimmed.Substring(1, trimmed.Length - 2);
+            }
+
             if (!(trimmed[0] == '/' || trimmed[0] == '-'))
             {
                 continue;

--- a/src/LanguageServer/Protocol/Models.cs
+++ b/src/LanguageServer/Protocol/Models.cs
@@ -41,7 +41,19 @@ public sealed class DocumentUri : IEquatable<DocumentUri>
         {
             try
             {
-                return new Uri(this.uri).LocalPath;
+                var local = new Uri(this.uri).LocalPath;
+
+                // On Windows, VS Code may percent-encode the drive-letter colon
+                // (e.g. "file:///c%3A/Users/..."). System.Uri decodes %3A back to
+                // ':' but keeps a leading '/' that is only valid on Unix, producing
+                // "/c:/Users/..." instead of "c:\Users\...". Strip it so the path
+                // is a valid Windows drive-rooted path.
+                if (local.Length >= 3 && local[0] == '/' && char.IsLetter(local[1]) && local[2] == ':')
+                {
+                    local = local.Substring(1);
+                }
+
+                return local;
             }
             catch (UriFormatException)
             {

--- a/test/LanguageServer.Tests/DocumentUriTests.cs
+++ b/test/LanguageServer.Tests/DocumentUriTests.cs
@@ -1,0 +1,88 @@
+// <copyright file="DocumentUriTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Runtime.InteropServices;
+using GSharp.LanguageServer.Protocol;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+public class DocumentUriTests
+{
+    [Fact]
+    public void GetFileSystemPath_FileUri_ReturnsPath()
+    {
+        // file:///path/to/file.gs is valid on both platforms
+        var uri = DocumentUri.From("file:///path/to/file.gs");
+        var path = uri.GetFileSystemPath();
+
+        Assert.NotNull(path);
+        Assert.Contains("file.gs", path);
+    }
+
+    [Fact]
+    public void GetFileSystemPath_NonFileUri_ReturnsRawUri()
+    {
+        var uri = DocumentUri.From("untitled:Untitled-1");
+        Assert.Equal("untitled:Untitled-1", uri.GetFileSystemPath());
+    }
+
+    [Fact]
+    public void GetFileSystemPath_Null_ReturnsNull()
+    {
+        var uri = DocumentUri.From("");
+        Assert.Null(uri.GetFileSystemPath());
+    }
+
+    [Theory]
+    [InlineData("file:///c%3A/Users/foo/bar.gs")]
+    [InlineData("file:///C%3A/Users/foo/bar.gs")]
+    [InlineData("file:///c:/Users/foo/bar.gs")]
+    [InlineData("file:///C:/Users/foo/bar.gs")]
+    public void GetFileSystemPath_WindowsDriveLetter_StripsLeadingSlash(string rawUri)
+    {
+        var uri = DocumentUri.From(rawUri);
+        var path = uri.GetFileSystemPath();
+
+        // On all platforms, the result must NOT start with '/' when a drive
+        // letter follows. Without the fix, %3A-encoded URIs produced
+        // "/c:/Users/..." which Windows turned into the bogus "C:\c:\...".
+        Assert.NotNull(path);
+        Assert.False(path.StartsWith("/"), $"Path should not start with '/': {path}");
+        Assert.True(char.IsLetter(path[0]), $"Path should start with a drive letter: {path}");
+    }
+
+    [Fact]
+    public void GetFileSystemPath_PercentEncodedColon_RoundTrips_OnWindows()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        // VS Code commonly sends "file:///c%3A/..." on Windows.
+        var uri = DocumentUri.From("file:///c%3A/Users/foo/bar.gs");
+        var path = uri.GetFileSystemPath();
+
+        // Must be a valid rooted Windows path that Path.GetFullPath won't mangle.
+        var full = System.IO.Path.GetFullPath(path);
+        Assert.DoesNotContain(@"c:\c:", full, System.StringComparison.OrdinalIgnoreCase);
+        Assert.EndsWith("bar.gs", full);
+    }
+
+    [Fact]
+    public void FromFileSystemPath_RoundTrips()
+    {
+        // This tests the opposite direction: path → URI → path
+        var original = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? @"C:\Users\foo\bar.gs"
+            : "/home/foo/bar.gs";
+        var uri = DocumentUri.FromFileSystemPath(original);
+        var roundTripped = uri.GetFileSystemPath();
+
+        Assert.Equal(
+            System.IO.Path.GetFullPath(original),
+            System.IO.Path.GetFullPath(roundTripped));
+    }
+}

--- a/test/LanguageServer.Tests/ProjectDiscoveryTests.cs
+++ b/test/LanguageServer.Tests/ProjectDiscoveryTests.cs
@@ -277,6 +277,35 @@ public class ProjectDiscoveryTests
         }
     }
 
+    [Fact]
+    public void ParseReferencesFromResponseFile_HandlesOuterQuotedLines()
+    {
+        // On Windows, MSBuild wraps the entire switch in quotes when the path
+        // contains spaces (e.g. "C:\Program Files\...").
+        var tempPath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllLines(tempPath, new[]
+            {
+                "/out:foo.dll",
+                "\"/r:/path with spaces/A.dll\"",
+                "\"-reference:/path with spaces/B.dll\"",
+                "/r:C/plain/path/C.dll",
+            });
+
+            var refs = ProjectDiscovery.ParseReferencesFromResponseFile(tempPath);
+
+            Assert.Equal(3, refs.Count);
+            Assert.Equal("/path with spaces/A.dll", refs[0]);
+            Assert.Equal("/path with spaces/B.dll", refs[1]);
+            Assert.Equal("C/plain/path/C.dll", refs[2]);
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
     private static string FindSamplesDir()
     {
         var dir = Directory.GetCurrentDirectory();


### PR DESCRIPTION
Fixes #885

Two Windows-specific bugs prevented the language server from resolving projects and references correctly:

**Bug 1 - URI %3A decoding** (src/LanguageServer/Protocol/Models.cs): VS Code sends percent-encoded drive-letter colons (file:///c%3A/...). Uri.LocalPath decoded %3A but kept a leading /, producing /c:/Users/... which Path.GetFullPath mangled into C:\c:\Users\.... This broke all file-to-project lookups - every file compiled standalone without cross-file awareness.

**Bug 2 - Quoted .rsp lines** (src/LanguageServer/ProjectDiscovery.cs): MSBuild on Windows wraps entire switches in quotes when paths contain spaces. The parser only recognized lines starting with / or -, silently dropping all core .NET framework references. For the Oahu E2E test project, only 15 of 182 references were loaded.

Both bugs are Windows-specific (macOS has no drive letters and no Program Files paths).

**Verification:**
- References discovered for E2E test project: 15 to 182
- All 4 URI format variants now resolve correctly to their project
- 238/238 LanguageServer tests pass (10 new tests added)
