### PR TITLE
Fix GS9998 for member index-assignment in state machines (#887)

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
@@ -497,6 +497,75 @@ public static class MoveNextBodyRewriter
                 return node;
             }
 
+            protected override BoundExpression RewriteClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
+            {
+                ImmutableArray<BoundExpression>.Builder argBuilder = null;
+                for (var i = 0; i < node.Arguments.Length; i++)
+                {
+                    var oldArg = node.Arguments[i];
+                    var newArg = RewriteExpression(oldArg);
+                    if (newArg != oldArg && argBuilder == null)
+                    {
+                        argBuilder = ImmutableArray.CreateBuilder<BoundExpression>(node.Arguments.Length);
+                        for (var j = 0; j < i; j++)
+                        {
+                            argBuilder.Add(node.Arguments[j]);
+                        }
+                    }
+
+                    if (argBuilder != null)
+                    {
+                        argBuilder.Add(newArg);
+                    }
+                }
+
+                var rewrittenArgs = argBuilder?.ToImmutable() ?? node.Arguments;
+                var rewrittenValue = RewriteExpression(node.Value);
+
+                // If the target (e.g. a Dictionary) is hoisted into a
+                // state-machine field, the BoundClrIndexAssignmentExpression
+                // shape can't reference the field directly (Target is a
+                // VariableSymbol the base rewriter never visits). Mirror the
+                // closure-boxing fix (issue #618): switch to the expression
+                // target form reading the hoisted field. The target is a
+                // reference type, so writing the indexer through the field's
+                // value mutates the same underlying object.
+                if (node.Target != null && TryGetHoistedField(node.Target, out var targetField))
+                {
+                    return BoundClrIndexAssignmentExpression.WithExpressionTarget(
+                        null,
+                        ctx.ReadField(targetField),
+                        node.Indexer,
+                        rewrittenArgs,
+                        rewrittenValue,
+                        node.Type);
+                }
+
+                if (node.TargetExpression != null)
+                {
+                    var rewrittenTarget = RewriteExpression(node.TargetExpression);
+                    if (rewrittenTarget != node.TargetExpression || argBuilder != null || rewrittenValue != node.Value)
+                    {
+                        return BoundClrIndexAssignmentExpression.WithExpressionTarget(
+                            null,
+                            rewrittenTarget,
+                            node.Indexer,
+                            rewrittenArgs,
+                            rewrittenValue,
+                            node.Type);
+                    }
+
+                    return node;
+                }
+
+                if (argBuilder != null || rewrittenValue != node.Value)
+                {
+                    return new BoundClrIndexAssignmentExpression(null, node.Target, node.Indexer, rewrittenArgs, rewrittenValue, node.Type);
+                }
+
+                return node;
+            }
+
             protected override BoundStatement RewriteTryStatement(BoundTryStatement node)
             {
                 // The emitter stores the caught exception into a LOCAL slot via

--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
@@ -367,6 +367,50 @@ public static class AsyncIteratorMoveNextBodyBuilder
                 return node;
             }
 
+            // Issue #887: an index assignment (`arr[i] = v`, `m[k] = v`) whose
+            // target temp is hoisted into a state-machine field can't reference
+            // the field through its VariableSymbol target. Switch to the
+            // expression target form reading the hoisted field (same fix as
+            // closure boxing, issue #618).
+            protected override BoundExpression RewriteIndexAssignmentExpression(BoundIndexAssignmentExpression node)
+            {
+                if (node.Target != null && ctx.fieldMap.TryGetValue(node.Target, out var targetField))
+                {
+                    return BoundIndexAssignmentExpression.WithExpressionTarget(
+                        null,
+                        ctx.ReadField(targetField),
+                        RewriteExpression(node.Index),
+                        RewriteExpression(node.Value),
+                        node.Type);
+                }
+
+                return base.RewriteIndexAssignmentExpression(node);
+            }
+
+            // Issue #887: same fix for CLR-indexer writes (e.g. `dict["k"] = v`
+            // or `psi.Environment["k"] = v`) whose target temp is hoisted.
+            protected override BoundExpression RewriteClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
+            {
+                if (node.Target != null && ctx.fieldMap.TryGetValue(node.Target, out var targetField))
+                {
+                    var args = ImmutableArray.CreateBuilder<BoundExpression>(node.Arguments.Length);
+                    foreach (var argument in node.Arguments)
+                    {
+                        args.Add(RewriteExpression(argument));
+                    }
+
+                    return BoundClrIndexAssignmentExpression.WithExpressionTarget(
+                        null,
+                        ctx.ReadField(targetField),
+                        node.Indexer,
+                        args.MoveToImmutable(),
+                        RewriteExpression(node.Value),
+                        node.Type);
+                }
+
+                return base.RewriteClrIndexAssignmentExpression(node);
+            }
+
             protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
             {
                 yieldIndex++;

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorMoveNextBodyBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorMoveNextBodyBuilder.cs
@@ -348,6 +348,64 @@ public static class IteratorMoveNextBodyBuilder
 
             return base.RewriteVariableDeclaration(node);
         }
+
+        // Issue #887: an index assignment (`arr[i] = v`, `m[k] = v`) whose
+        // target temp is hoisted into a state-machine field can't reference the
+        // field through its VariableSymbol target. Switch to the expression
+        // target form reading the hoisted field (same fix as closure boxing,
+        // issue #618).
+        protected override BoundExpression RewriteIndexAssignmentExpression(BoundIndexAssignmentExpression node)
+        {
+            if (node.Target != null && this.fieldMap.TryGetValue(node.Target, out var targetField))
+            {
+                return BoundIndexAssignmentExpression.WithExpressionTarget(
+                    null,
+                    this.ReadHoistedField(targetField),
+                    this.RewriteExpression(node.Index),
+                    this.RewriteExpression(node.Value),
+                    node.Type);
+            }
+
+            return base.RewriteIndexAssignmentExpression(node);
+        }
+
+        // Issue #887: same fix for CLR-indexer writes (e.g. `dict["k"] = v` or
+        // `psi.Environment["k"] = v`) whose target temp is hoisted into a field.
+        protected override BoundExpression RewriteClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
+        {
+            if (node.Target != null && this.fieldMap.TryGetValue(node.Target, out var targetField))
+            {
+                return BoundClrIndexAssignmentExpression.WithExpressionTarget(
+                    null,
+                    this.ReadHoistedField(targetField),
+                    node.Indexer,
+                    this.RewriteArguments(node.Arguments),
+                    this.RewriteExpression(node.Value),
+                    node.Type);
+            }
+
+            return base.RewriteClrIndexAssignmentExpression(node);
+        }
+
+        private ImmutableArray<BoundExpression> RewriteArguments(ImmutableArray<BoundExpression> arguments)
+        {
+            var builder = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
+            foreach (var argument in arguments)
+            {
+                builder.Add(this.RewriteExpression(argument));
+            }
+
+            return builder.MoveToImmutable();
+        }
+
+        private BoundExpression ReadHoistedField(FieldSymbol field)
+        {
+            return new BoundFieldAccessExpression(
+                null,
+                new BoundVariableExpression(null, this.thisParameter),
+                this.smClass,
+                field);
+        }
     }
 
     public static IteratorMoveNextBody Build(
@@ -542,6 +600,50 @@ public static class IteratorMoveNextBodyBuilder
             }
 
             return base.RewriteVariableDeclaration(node);
+        }
+
+        // Issue #887: an index assignment (`arr[i] = v`, `m[k] = v`) whose
+        // target temp is hoisted into a state-machine field can't reference the
+        // field through its VariableSymbol target. Switch to the expression
+        // target form reading the hoisted field (same fix as closure boxing,
+        // issue #618).
+        protected override BoundExpression RewriteIndexAssignmentExpression(BoundIndexAssignmentExpression node)
+        {
+            if (node.Target != null && this.fieldMap.TryGetValue(node.Target, out var targetField))
+            {
+                return BoundIndexAssignmentExpression.WithExpressionTarget(
+                    null,
+                    this.FieldRead(targetField),
+                    this.RewriteExpression(node.Index),
+                    this.RewriteExpression(node.Value),
+                    node.Type);
+            }
+
+            return base.RewriteIndexAssignmentExpression(node);
+        }
+
+        // Issue #887: same fix for CLR-indexer writes (e.g. `dict["k"] = v` or
+        // `psi.Environment["k"] = v`) whose target temp is hoisted into a field.
+        protected override BoundExpression RewriteClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
+        {
+            if (node.Target != null && this.fieldMap.TryGetValue(node.Target, out var targetField))
+            {
+                var args = ImmutableArray.CreateBuilder<BoundExpression>(node.Arguments.Length);
+                foreach (var argument in node.Arguments)
+                {
+                    args.Add(this.RewriteExpression(argument));
+                }
+
+                return BoundClrIndexAssignmentExpression.WithExpressionTarget(
+                    null,
+                    this.FieldRead(targetField),
+                    node.Indexer,
+                    args.MoveToImmutable(),
+                    this.RewriteExpression(node.Value),
+                    node.Type);
+            }
+
+            return base.RewriteClrIndexAssignmentExpression(node);
         }
 
         protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue887ClrIndexerAssignmentAsyncEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue887ClrIndexerAssignmentAsyncEmitTests.cs
@@ -1,0 +1,214 @@
+// <copyright file="Issue887ClrIndexerAssignmentAsyncEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #887: an index assignment through a member (e.g. <c>obj.Map["k"] = v</c>
+/// on a <c>Dictionary</c>, or <c>psi.Environment["k"] = v</c>) inside a
+/// state-machine method (<c>async func</c>, iterator, or async iterator)
+/// previously failed at emit with GS9998
+/// "Variable '&lt;idxAsn#&gt;' has no local slot or parameter index". The
+/// synthesized index-assignment receiver temp was hoisted into a state-machine
+/// field, but the index-assignment bound nodes keep their receiver as a raw
+/// <see cref="GSharp.Core.CodeAnalysis.Symbols.VariableSymbol"/> that the
+/// MoveNext rewriters never redirected to the hoisted field. These tests verify
+/// emit succeeds and the writes persist.
+/// </summary>
+public class Issue887ClrIndexerAssignmentAsyncEmitTests
+{
+    private readonly ITestOutputHelper output;
+
+    public Issue887ClrIndexerAssignmentAsyncEmitTests(ITestOutputHelper output)
+    {
+        this.output = output;
+    }
+
+    [Fact]
+    public void MemberClrIndexerAssignment_InAsync_PersistsWrites()
+    {
+        var result = this.CompileAndRun(
+            @"package R
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+
+class Wrap { prop Map Dictionary[string,string]
+    init(m Dictionary[string,string]) { Map = m }
+}
+
+async func run() string {
+    let h = Dictionary[string,string]()
+    let w = Wrap(h)
+    w.Map[""FOO""] = ""1""
+    w.Map[""BAR""] = ""2""
+    await Task.Yield()
+    return w.Map[""FOO""] + w.Map[""BAR""]
+}
+
+var t = run()
+t.Wait()
+Console.WriteLine(t.Result)
+",
+            "Issue887Async");
+
+        Assert.Contains("12", result);
+    }
+
+    [Fact]
+    public void ProcessStartInfo_ObjectInitializer_AndEnvironmentIndexer_InAsync()
+    {
+        // The original repro shape from the issue: an object initializer block
+        // followed by `psi.Environment[...] = ...` CLR-indexer writes, all inside
+        // an async func.
+        var result = this.CompileAndRun(
+            @"package R
+import System
+import System.Diagnostics
+import System.Threading.Tasks
+
+async func run() int32 {
+    let psi = ProcessStartInfo(""dotnet"")
+    {
+        RedirectStandardOutput = true,
+        UseShellExecute = false
+    }
+    psi.Environment[""OAHU_NO_TUI""] = ""1""
+    psi.Environment[""NO_COLOR""] = ""1""
+    await Task.Yield()
+    Console.WriteLine(psi.Environment[""OAHU_NO_TUI""] + psi.Environment[""NO_COLOR""])
+    return 0
+}
+
+var t = run()
+t.Wait()
+",
+            "Issue887Psi");
+
+        Assert.Contains("11", result);
+    }
+
+    [Fact]
+    public void MemberClrIndexerAssignment_InIterator_PersistsWrites()
+    {
+        var result = this.CompileAndRun(
+            @"package R
+import System
+import System.Collections.Generic
+
+class Wrap { prop Map Dictionary[string,string]
+    init(m Dictionary[string,string]) { Map = m }
+}
+
+func gen() sequence[int32] {
+    let w = Wrap(Dictionary[string,string]())
+    w.Map[""FOO""] = ""1""
+    yield 1
+    Console.WriteLine(w.Map[""FOO""])
+    yield 2
+}
+
+for x in gen() {
+    Console.WriteLine(x)
+}
+",
+            "Issue887Iter");
+
+        Assert.Contains("1", result);
+    }
+
+    [Fact]
+    public void MemberClrIndexerAssignment_InAsyncIterator_Emits()
+    {
+        // Async iterator (IAsyncEnumerable) state machine: emit must succeed
+        // when a hoisted receiver temp feeds a CLR-indexer write.
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(
+            @"package R
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+
+class Wrap { prop Map Dictionary[string,string]
+    init(m Dictionary[string,string]) { Map = m }
+}
+
+func gen() IAsyncEnumerable[int32] {
+    let w = Wrap(Dictionary[string,string]())
+    w.Map[""FOO""] = ""1""
+    yield 1
+    await Task.Yield()
+    w.Map[""BAR""] = ""2""
+    yield 2
+}
+"));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        foreach (var diagnostic in result.Diagnostics)
+        {
+            this.output.WriteLine(diagnostic.ToString());
+        }
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+    }
+
+    private string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        foreach (var diagnostic in result.Diagnostics)
+        {
+            this.output.WriteLine(diagnostic.ToString());
+        }
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().First(t => t.Name == "<Program>");
+            var entry = programType.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #887.

## Problem
A member CLR-indexer write such as `psi.Environment["k"] = v` or `obj.Map["k"] = v` (on a `Dictionary`) inside an `async func` failed at emit:

> error GS9998: InvalidOperationException: Variable '<idxAsn#>' has no local slot or parameter index in the current method.

The LSP showed no errors while editing; the failure only surfaced at emit time.

## Root cause
The index write binds to a synthesized receiver temp (`<idxAsn#>`) carried on a `BoundClrIndexAssignmentExpression`. That node stores its receiver as a **raw `VariableSymbol` Target** which the bound-tree rewriter never visits. The async capture walker correctly **hoists** the temp into a state-machine field, but the MoveNext rewriter only redirects `BoundVariableExpression` references — so the raw symbol survived unrewritten and the emitter had no slot for it.

The async MoveNext rewriter already handled the native map/slice variant (`BoundIndexAssignmentExpression`) but was **missing the CLR-indexer override**. While investigating I found the **iterator** and **async-iterator** MoveNext builders had the same latent gap for **both** index-assignment node kinds.

## Fix
Add the missing MoveNext-rewriter overrides so a hoisted index-assignment `Target` is redirected to its state-machine field via the existing `WithExpressionTarget` form (the same approach as the closure-boxing fix, issue #618):

- `src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs` — `RewriteClrIndexAssignmentExpression`
- `src/Core/CodeAnalysis/Lowering/Iterators/IteratorMoveNextBodyBuilder.cs` — both index-assignment overrides (in both nested rewriters)
- `src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs` — both index-assignment overrides

## Tests
New `Issue887ClrIndexerAssignmentAsyncEmitTests.cs` covers async (including the exact `ProcessStartInfo` object-initializer + `Environment[...]` repro from the issue), iterator, and async-iterator. All pass with correct runtime results.

- Full **Core.Tests**: 3340 passed, 1 skipped.
- **Compiler.Tests** async/iterator subset: 116 passed.
