### PR TITLE
Fix #889: support arrow lambdas as delegate (System.Action/Func) arguments

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -308,6 +308,30 @@ internal sealed class ConversionClassifier
             return createErasedFunctionLiteralAdapter(literal, targetFunctionType);
         }
 
+        // Issue #889: a `func`/arrow literal whose natural return type carries a
+        // value (e.g. `() -> called = called + 1`, inferred as `() -> int32`)
+        // converts to a void-returning delegate target (System.Action, a named
+        // void delegate, or a `(...) -> void` function type) by discarding the
+        // trailing value — mirroring the `func() { ... }` statement-body form
+        // that already yields void. Void-ize the literal through the erased
+        // adapter (which now drops the return value), then continue the
+        // conversion against the real delegate target.
+        if (expression is BoundFunctionLiteralExpression voidCandidateLiteral
+            && voidCandidateLiteral.FunctionType is FunctionTypeSymbol voidCandidateFnType
+            && voidCandidateFnType.ReturnType != TypeSymbol.Void
+            && voidCandidateFnType.ReturnType != TypeSymbol.Error
+            && MemberLookup.TryGetDelegateFunctionTypeFromSymbol(type, out var voidTargetFnType)
+            && voidTargetFnType.ReturnType == TypeSymbol.Void
+            && voidTargetFnType.Arity == voidCandidateFnType.Arity
+            && !ReferenceEquals(type, voidCandidateFnType))
+        {
+            var voidized = createErasedFunctionLiteralAdapter(voidCandidateLiteral, voidTargetFnType);
+            if (!ReferenceEquals(voidized, voidCandidateLiteral))
+            {
+                return BindConversion(diagnosticLocation, voidized, type, allowExplicit);
+            }
+        }
+
         var conversion = Conversion.Classify(expression.Type, type);
 
         if (!conversion.Exists)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1034,10 +1034,15 @@ internal sealed partial class ExpressionBinder
                 var staticRebound = RebindFormattableInterpolationArguments(staticExpandedArgs, ce.Arguments, staticParameters, staticDownstreamMapping);
                 var staticHandlerArgs = ApplyInterpolatedStringHandlers(staticParameters, staticRebound, receiver: null, ce.Location, staticDownstreamMapping, out var staticHandlerPrelude, out _);
 
+                // Issue #889: void-ize value-returning func/arrow literals passed
+                // to void-returning delegate parameters (System.Action / Action<...>)
+                // before CLR parameter conversion, mirroring the instance path.
+                var staticDelegateArgs = RebindFunctionLiteralDelegateArguments(staticHandlerArgs, staticParameters, staticDownstreamMapping);
+
                 // Issue #506 follow-up: ensure value-type → object boxing fires
                 // for fixed-arity CLR static calls (e.g. `String.Format("{0}", 42)`
                 // selecting the fixed `(string, object)` overload).
-                var staticConvertedArgs = conversions.BindClrParameterConversions(staticHandlerArgs, staticParameters, ce, staticDownstreamMapping);
+                var staticConvertedArgs = conversions.BindClrParameterConversions(staticDelegateArgs, staticParameters, ce, staticDownstreamMapping);
                 var staticArguments = OverloadResolver.BuildOrderedCallArguments(staticConvertedArgs, staticDownstreamMapping, staticParameters);
                 var refKinds = ComputeArgumentRefKinds(staticParameters);
                 overloads.ValidateRefArguments(staticArguments, refKinds, methodName, ce.Location);

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -888,6 +888,19 @@ internal sealed class LambdaBinder
                 targetReturn = UnwrapTaskReturnType(targetReturn);
             }
 
+            // Issue #889: when the target delegate returns void (e.g.
+            // System.Action), an arrow lambda whose body is an expression
+            // (assignment, call, increment, ...) discards that value — exactly
+            // like the equivalent `func() { ... }` literal whose statement body
+            // yields void. Pin the return type to void so the synthesized
+            // method's signature matches the Action/void-delegate target and
+            // the trailing expression is emitted as a value-discarding
+            // statement (see EmitTrailingExpression).
+            if (targetReturn == TypeSymbol.Void)
+            {
+                return TypeSymbol.Void;
+            }
+
             if (targetReturn != null && candidates.All(c => c == TypeSymbol.Error || Conversion.Classify(c, targetReturn).IsImplicit))
             {
                 return targetReturn;
@@ -1161,9 +1174,23 @@ internal sealed class LambdaBinder
         protected override BoundStatement RewriteReturnStatement(BoundReturnStatement node)
         {
             var rewritten = (BoundReturnStatement)base.RewriteReturnStatement(node);
-            if (this.adapterReturnType == TypeSymbol.Void || rewritten.Expression == null)
+            if (rewritten.Expression == null)
             {
                 return rewritten;
+            }
+
+            // Issue #889: when the adapter erases a value-returning literal to a
+            // void-returning delegate (e.g. a `func`/arrow literal flowing into
+            // System.Action), the inner `return <value>;` must drop its value:
+            // evaluate the expression for its side effects, then `return;`. A
+            // bare `return <value>;` against a void method is invalid IL.
+            if (this.adapterReturnType == TypeSymbol.Void)
+            {
+                return new BoundBlockStatement(
+                    rewritten.Syntax,
+                    ImmutableArray.Create<BoundStatement>(
+                        new BoundExpressionStatement(rewritten.Syntax, rewritten.Expression),
+                        new BoundReturnStatement(rewritten.Syntax, expression: null)));
             }
 
             if (rewritten.Expression.Type == this.adapterReturnType)

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -866,6 +866,35 @@ internal sealed class MemberLookup
     }
 
     /// <summary>
+    /// Issue #889: resolves the <see cref="FunctionTypeSymbol"/> shape of any
+    /// delegate-like target type — a native G# function type, a user-declared
+    /// named delegate (<see cref="DelegateTypeSymbol"/>), or an imported CLR
+    /// delegate (<c>System.Action</c>/<c>System.Func</c>/named delegates).
+    /// Used to target-type lambda/func literals against delegate parameters
+    /// and variable slots.
+    /// </summary>
+    /// <param name="type">The candidate delegate-like target type.</param>
+    /// <param name="functionType">The matching function-type symbol, on success.</param>
+    /// <returns><see langword="true"/> when the type is delegate-like.</returns>
+    public static bool TryGetDelegateFunctionTypeFromSymbol(TypeSymbol type, out FunctionTypeSymbol functionType)
+    {
+        functionType = null;
+        switch (type)
+        {
+            case null:
+                return false;
+            case FunctionTypeSymbol fn:
+                functionType = fn;
+                return true;
+            case DelegateTypeSymbol del:
+                functionType = del.EquivalentFunctionType;
+                return functionType != null;
+            default:
+                return type.ClrType != null && TryGetDelegateFunctionType(type.ClrType, out functionType);
+        }
+    }
+
+    /// <summary>
     /// Probes <paramref name="delegateType"/> for the canonical delegate
     /// shape (<see cref="System.MulticastDelegate"/>-derived, or
     /// <c>System.Func`N</c>/<c>System.Action`N</c>) and exposes the

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -100,6 +100,19 @@ internal static class OverloadResolution
         /// matching C#.
         /// </summary>
         InterpolatedStringToFormattable = 8,
+
+        /// <summary>
+        /// Issue #889: a value-returning <c>func</c>/arrow literal (whose
+        /// natural CLR type is a <c>Func&lt;...&gt;</c>) converting to a
+        /// void-returning delegate parameter (<c>System.Action</c> /
+        /// <c>Action&lt;...&gt;</c> or a named void delegate) by discarding the
+        /// trailing value. Ranked last (worst) so that, when both a matching
+        /// <c>Func&lt;...&gt;</c> overload and an <c>Action</c> overload are
+        /// applicable, the value-preserving <c>Func</c> overload still wins —
+        /// matching C#'s preference. Only the binder's void-izing rebind
+        /// materializes this conversion.
+        /// </summary>
+        LambdaToVoidDelegate = 9,
     }
 
     /// <summary>
@@ -308,6 +321,18 @@ internal static class OverloadResolution
             && InterpolatedStringHandlerInfo.IsHandlerType(target))
         {
             return ImplicitConversionKind.InterpolatedStringHandler;
+        }
+
+        // Issue #889: a value-returning func/arrow literal (whose natural CLR
+        // type is a Func<...>) is applicable to a void-returning delegate
+        // parameter (System.Action / Action<...> / a named void delegate) by
+        // discarding the trailing value. Ranked lowest so a value-preserving
+        // Func<...> overload always wins when both are applicable. The binder's
+        // void-izing rebind (RebindFunctionLiteralDelegateArguments) materializes
+        // the actual discard for the selected literal argument.
+        if (IsValueReturningDelegateToVoidDelegate(target, source))
+        {
+            return ImplicitConversionKind.LambdaToVoidDelegate;
         }
 
         return ImplicitConversionKind.None;
@@ -765,6 +790,71 @@ internal static class OverloadResolution
     /// <returns>Whether the exception represents a tolerable load failure.</returns>
     private static bool IsMetadataLoadFailure(Exception ex) =>
         ClrTypeUtilities.IsMetadataLoadFailure(ex);
+
+    /// <summary>
+    /// Issue #889: determines whether <paramref name="source"/> is a delegate
+    /// type that returns a value (e.g. <c>Func&lt;...&gt;</c>) whose parameter
+    /// list matches a void-returning delegate <paramref name="target"/> (e.g.
+    /// <c>System.Action</c> / <c>Action&lt;...&gt;</c>). Parameter and return
+    /// types are compared by name to remain safe across reflection contexts
+    /// (the target may be loaded through a <c>MetadataLoadContext</c> while the
+    /// literal's natural <c>Func&lt;...&gt;</c> is a live-runtime type).
+    /// </summary>
+    /// <param name="target">The candidate void-returning delegate parameter type.</param>
+    /// <param name="source">The argument's natural delegate type.</param>
+    /// <returns><see langword="true"/> when the discard conversion applies.</returns>
+    private static bool IsValueReturningDelegateToVoidDelegate(Type target, Type source)
+    {
+        if (!ClrTypeUtilities.IsDelegateType(target) || !ClrTypeUtilities.IsDelegateType(source))
+        {
+            return false;
+        }
+
+        MethodInfo targetInvoke;
+        MethodInfo sourceInvoke;
+        try
+        {
+            targetInvoke = target.GetMethod("Invoke");
+            sourceInvoke = source.GetMethod("Invoke");
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+
+        if (targetInvoke is null || sourceInvoke is null)
+        {
+            return false;
+        }
+
+        // Target must return void; source must return a value.
+        if (!string.Equals(targetInvoke.ReturnType.FullName, "System.Void", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (string.Equals(sourceInvoke.ReturnType.FullName, "System.Void", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var targetParams = targetInvoke.GetParameters();
+        var sourceParams = sourceInvoke.GetParameters();
+        if (targetParams.Length != sourceParams.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < targetParams.Length; i++)
+        {
+            if (!ClrTypeUtilities.AreSame(targetParams[i].ParameterType, sourceParams[i].ParameterType))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /// <summary>
     /// Evaluates a single candidate for applicability against the supplied

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -397,6 +397,43 @@ internal sealed class OverloadResolver
     }
 
     /// <summary>
+    /// Issue #889: when a <c>func</c>/arrow literal argument has a value-typed
+    /// natural return (e.g. <c>() -> called = called + 1</c> inferred as
+    /// <c>() -> int32</c>) but the target parameter is a void-returning
+    /// delegate (<c>System.Action</c>, a named void delegate, or a
+    /// <c>(...) -> void</c> function type), void-ize the literal so its trailing
+    /// value is discarded — matching the existing <c>func() { ... }</c>
+    /// statement-body behaviour. Returns the converted argument through
+    /// <paramref name="result"/> on success. Has no effect for non-literal
+    /// arguments or non-void delegate targets, so genuine type-mismatch
+    /// diagnostics still fire on the regular path.
+    /// </summary>
+    private bool TryConvertLiteralArgumentToVoidDelegate(BoundExpression argument, TypeSymbol expectedType, TextLocation location, out BoundExpression result)
+    {
+        result = null;
+        if (expectedType == null
+            || !tryGetFunctionLiteral(argument, out var literal)
+            || literal.FunctionType is not FunctionTypeSymbol literalFnType
+            || literalFnType.ReturnType == TypeSymbol.Void
+            || literalFnType.ReturnType == TypeSymbol.Error
+            || !MemberLookup.TryGetDelegateFunctionTypeFromSymbol(expectedType, out var targetFnType)
+            || targetFnType.ReturnType != TypeSymbol.Void
+            || targetFnType.Arity != literalFnType.Arity)
+        {
+            return false;
+        }
+
+        var converted = conversions.BindConversion(location, literal, expectedType);
+        if (converted is BoundErrorExpression)
+        {
+            return false;
+        }
+
+        result = converted;
+        return true;
+    }
+
+    /// <summary>
     /// ADR-0063: thin wrapper around <see cref="SelectBestInstanceOverload"/>
     /// that reports the standard ambiguity / no-applicable-overload diagnostics
     /// when more than one candidate is supplied. When a single candidate is
@@ -1552,6 +1589,13 @@ internal sealed class OverloadResolver
             if (argument.Type != parameter.Type
                 && !Conversion.Classify(argument.Type, parameter.Type).IsImplicit)
             {
+                // Issue #889: arrow/func literal → void-returning delegate.
+                if (TryConvertLiteralArgumentToVoidDelegate(argument, parameter.Type, parameterSyntax[i].Location, out var voidDelegateArg))
+                {
+                    boundArguments[i] = voidDelegateArg;
+                    continue;
+                }
+
                 if (conversions.TryApplyUserDefinedImplicitArgumentConversion(argument, parameter.Type, out var convertedArg))
                 {
                     boundArguments[i] = convertedArg;
@@ -1888,6 +1932,13 @@ internal sealed class OverloadResolver
             if (argument.Type != parameter.Type
                 && !Conversion.Classify(argument.Type, parameter.Type).IsImplicit)
             {
+                // Issue #889: arrow/func literal → void-returning delegate.
+                if (TryConvertLiteralArgumentToVoidDelegate(argument, parameter.Type, argLocation, out var voidDelegateArg))
+                {
+                    convertedArguments.Add(voidDelegateArg);
+                    continue;
+                }
+
                 if (conversions.TryApplyUserDefinedImplicitArgumentConversion(argument, parameter.Type, out var convertedArg))
                 {
                     convertedArguments.Add(convertedArg);
@@ -2145,6 +2196,13 @@ internal sealed class OverloadResolver
             if (argument.Type != parameter.Type
                 && !Conversion.Classify(argument.Type, parameter.Type).IsImplicit)
             {
+                // Issue #889: arrow/func literal → void-returning delegate.
+                if (TryConvertLiteralArgumentToVoidDelegate(argument, parameter.Type, argLocation, out var voidDelegateArg))
+                {
+                    convertedArgs.Add(voidDelegateArg);
+                    continue;
+                }
+
                 if (conversions.TryApplyUserDefinedImplicitArgumentConversion(argument, parameter.Type, out var convertedArg))
                 {
                     convertedArgs.Add(convertedArg);
@@ -3032,6 +3090,14 @@ internal sealed class OverloadResolver
                 && !(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type))
                 && !Conversion.Classify(argument.Type, expectedType).IsImplicit)
             {
+                // Issue #889: arrow/func literal → void-returning delegate.
+                var voidDelegateLoc = i < parameterSyntax.Length ? parameterSyntax[i].Location : syntax.Identifier.Location;
+                if (TryConvertLiteralArgumentToVoidDelegate(argument, expectedType, voidDelegateLoc, out var voidDelegateArg))
+                {
+                    boundArguments[i] = voidDelegateArg;
+                    continue;
+                }
+
                 if (conversions.TryApplyUserDefinedImplicitArgumentConversion(argument, expectedType, out var convertedArg))
                 {
                     boundArguments[i] = convertedArg;

--- a/test/Compiler.Tests/Emit/Issue889ArrowLambdaActionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue889ArrowLambdaActionEmitTests.cs
@@ -1,0 +1,265 @@
+// <copyright file="Issue889ArrowLambdaActionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #889 — an arrow lambda <c>() -&gt; expr</c> whose trailing expression
+/// yields a value (so its natural type is a <c>Func&lt;...&gt;</c>) can be
+/// passed where a void-returning delegate (<c>System.Action</c> /
+/// <c>Action&lt;...&gt;</c> or a named void delegate) is expected. The binder
+/// target-types the literal to the delegate parameter, discarding the trailing
+/// value, exactly as the <c>func() { ... }</c> statement-body form does. These
+/// tests exercise variable assignment, user-function arguments, imported-CLR
+/// (static method) arguments, and confirm that value-returning
+/// <c>func(...) T</c> delegates keep their natural typing.
+/// </summary>
+public class Issue889ArrowLambdaActionEmitTests
+{
+    [Fact]
+    public void ArrowLambda_ToActionVariable_DiscardsValue_AndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            var called = 0
+            let act Action = () -> called = called + 1
+            act()
+            act()
+            Console.WriteLine(called)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void ArrowLambda_CompoundAssignment_ToActionVariable_Runs()
+    {
+        var source = """
+            package P
+            import System
+
+            var called = 0
+            let act Action = () -> called += 1
+            act()
+            Console.WriteLine(called)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void ArrowLambda_PassedToUserFunctionExpectingAction_Runs()
+    {
+        var source = """
+            package P
+            import System
+
+            func register(restore Action) {
+              restore()
+            }
+
+            var called = 0
+            register(() -> called = called + 1)
+            Console.WriteLine(called)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void ArrowLambda_WithParameter_PassedToUserFunctionExpectingActionOfInt_Runs()
+    {
+        var source = """
+            package P
+            import System
+
+            func apply(a func(int32), v int32) {
+              a(v)
+            }
+
+            var total = 0
+            apply((x int32) -> total = total + x, 42)
+            Console.WriteLine(total)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void ArrowLambda_ValueReturning_KeepsNaturalFuncTyping()
+    {
+        // Natural typing is preserved: a value-returning func type still works
+        // (the void-izing only kicks in when the *target* is a void delegate).
+        var source = """
+            package P
+            import System
+
+            let f func() int32 = () -> 41 + 1
+            Console.WriteLine(f())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void ArrowLambda_PassedToImportedStaticMethodExpectingAction_Runs()
+    {
+        // Mirrors the exact issue scenario: a CLR static method whose sole
+        // parameter is System.Action, invoked from G# with an arrow lambda
+        // whose body yields a value.
+        var helperDir = Directory.CreateTempSubdirectory("gs_issue889_helper_").FullName;
+        try
+        {
+            var helperDll = Path.Combine(helperDir, "Issue889Helper.dll");
+            EmitActionRunnerAssembly(helperDll);
+
+            var source = """
+                package P
+                import System
+                import Issue889Helper
+
+                var called = 0
+                Runner.RunIt(() -> called = called + 1)
+                Console.WriteLine(called)
+                """;
+
+            var output = CompileAndRun(source, referencePaths: new[] { helperDll });
+            Assert.Equal("1\n", output);
+        }
+        finally
+        {
+            try { Directory.Delete(helperDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Emits a tiny assembly <c>Issue889Helper</c> exposing
+    /// <c>public static class Runner { public static void RunIt(Action a) =&gt; a(); }</c>
+    /// so the imported-CLR static-call path can be exercised against a real
+    /// <c>System.Action</c> parameter.
+    /// </summary>
+    /// <param name="outputPath">Where to write the emitted assembly.</param>
+    private static void EmitActionRunnerAssembly(string outputPath)
+    {
+        var asmName = new AssemblyName("Issue889Helper");
+        var ab = new PersistedAssemblyBuilder(asmName, typeof(object).Assembly);
+        var module = ab.DefineDynamicModule("Issue889Helper");
+        var type = module.DefineType(
+            "Issue889Helper.Runner",
+            TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed);
+
+        var method = type.DefineMethod(
+            "RunIt",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(void),
+            new[] { typeof(Action) });
+        method.DefineParameter(1, ParameterAttributes.None, "a");
+
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, typeof(Action).GetMethod("Invoke")!);
+        il.Emit(OpCodes.Ret);
+
+        type.CreateType();
+        ab.Save(outputPath);
+    }
+
+    private static string CompileAndRun(string source, string[] referencePaths = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue889_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            if (referencePaths != null)
+            {
+                foreach (var reference in referencePaths)
+                {
+                    args.Add("/reference:" + reference);
+
+                    // Co-locate the reference next to the emitted exe so the
+                    // runtime can load it from the application base directory.
+                    File.Copy(reference, Path.Combine(tempDir, Path.GetFileName(reference)), overwrite: true);
+                }
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath, additionalReferences: referencePaths);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #889

## Root cause
Arrow lambdas (`() -> expr`) could not be passed where a void-returning delegate such as `System.Action` was expected, while the `func() { ... }` statement-body form worked.

This is a *natural-typing* gap. An arrow lambda whose trailing expression yields a value — e.g. `() -> called = called + 1` (an assignment evaluates to `int32`) — infers the natural type `() -> int32`, which is **not** convertible to `() -> void` (`System.Action`). The `func() { ... }` form has a statement body, so it naturally returns void. This matches C#, where `var f = () => x++;` is a `Func<int>`; the fix is therefore **target-typing** the literal to the delegate parameter, not changing its natural type.

## Fix
Void-izes a `func`/arrow **literal** to a void-returning delegate by discarding its trailing value — mirroring the existing `func` statement-body behaviour and C#'s lambda-to-`Action` conversion:

- **LambdaBinder** — when the target delegate returns void, pin the inferred return type to void; the erased-adapter rewriter now drops the trailing value (`return <v>;` → `<v>; return;`), producing valid void IL.
- **ConversionClassifier** — void-ize function literals on direct `BindConversion` paths (covers `let a Action = () -> ...`).
- **OverloadResolver** — void-ize literal arguments at user function / constructor / instance call sites before the wrong-argument-type gate.
- **OverloadResolution** — add a lowest-priority `LambdaToVoidDelegate` conversion kind so that a value-returning `Func` overload still wins betterness, while enabling imported-CLR method resolution (e.g. `CliEnvironment.RegisterRestore(Action)`).
- **ExpressionBinder.Calls** — void-ize literal args on the static imported-call path, mirroring the instance path.
- **MemberLookup** — add `TryGetDelegateFunctionTypeFromSymbol` to resolve the function-type shape of native function types, named delegates, and imported CLR delegates.

Void-izing is restricted to function **literals**, so natural typing for function-typed *values* is preserved and existing overload-resolution behaviour is unchanged (e.g. `Task.Run(() -> ...)` still prefers the `Func` overload).

## Tests
New `test/Compiler.Tests/Emit/Issue889ArrowLambdaActionEmitTests.cs` (CompileAndRun + ilverify) covering:
- arrow lambda → `System.Action` variable (assignment and `+=`),
- arrow lambda passed to a user function expecting `Action` / `func(int32)`,
- value-returning `func() int32` keeps natural typing,
- arrow lambda passed to an **imported static method** taking `System.Action` (mirrors the issue; helper assembly emitted via `PersistedAssemblyBuilder`).

## Local results
- `dotnet build GSharp.sln -c Release --no-restore -graph` → **Build succeeded** (0 warnings, 0 errors).
- `dotnet test GSharp.sln -c Release --no-build` → **all green**: Sdk 38, Extensions 104, Interpreter 308, LanguageServer 326, Core 3340 (1 skipped), Compiler 1347. **0 failures.**