### PR TITLE
Fix #890: never emit documentSymbol entries with empty names

### DIFF
--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -1111,6 +1111,19 @@ public static class DefinitionComputer
 
 public static class DocumentSymbolComputer
 {
+    // Fallback names used when a declaration's identifier token is missing
+    // (Text == null) or empty. Incomplete or error declarations produce such
+    // synthesized tokens; the LSP `textDocument/documentSymbol` response must
+    // never contain a symbol with a null/empty name, otherwise the
+    // vscode-languageclient converter throws "name must not be falsy" and the
+    // Outline view / breadcrumbs break (issue #890).
+    private const string AnonymousFunctionName = "<function>";
+    private const string AnonymousVariableName = "<variable>";
+    private const string AnonymousStructName = "<struct>";
+    private const string AnonymousEnumName = "<enum>";
+    private const string AnonymousFieldName = "<field>";
+    private const string AnonymousEnumMemberName = "<member>";
+
     public static IReadOnlyList<SymbolInformationOrDocumentSymbol> ComputeDocumentSymbols(DocumentContent content)
     {
         var result = new List<SymbolInformationOrDocumentSymbol>();
@@ -1123,7 +1136,7 @@ public static class DocumentSymbolComputer
                 case FunctionDeclarationSyntax func:
                     result.Add(new SymbolInformationOrDocumentSymbol(new DocumentSymbol
                     {
-                        Name = func.Identifier.Text,
+                        Name = SymbolName(func.Identifier, AnonymousFunctionName),
                         Kind = LspSymbolKind.Function,
                         Range = SemanticLookup.ToRange(text, func.Span),
                         SelectionRange = SemanticLookup.ToRange(func.Identifier),
@@ -1132,7 +1145,7 @@ public static class DocumentSymbolComputer
                 case GlobalStatementSyntax { Statement: VariableDeclarationSyntax variable }:
                     result.Add(new SymbolInformationOrDocumentSymbol(new DocumentSymbol
                     {
-                        Name = variable.Identifier.Text,
+                        Name = SymbolName(variable.Identifier, AnonymousVariableName),
                         Kind = LspSymbolKind.Variable,
                         Range = SemanticLookup.ToRange(text, variable.Span),
                         SelectionRange = SemanticLookup.ToRange(variable.Identifier),
@@ -1144,7 +1157,7 @@ public static class DocumentSymbolComputer
                     {
                         children.Add(new DocumentSymbol
                         {
-                            Name = field.Identifier.Text,
+                            Name = SymbolName(field.Identifier, AnonymousFieldName),
                             Kind = LspSymbolKind.Field,
                             Range = SemanticLookup.ToRange(text, field.Span),
                             SelectionRange = SemanticLookup.ToRange(field.Identifier),
@@ -1153,7 +1166,7 @@ public static class DocumentSymbolComputer
 
                     result.Add(new SymbolInformationOrDocumentSymbol(new DocumentSymbol
                     {
-                        Name = structDecl.Identifier.Text,
+                        Name = SymbolName(structDecl.Identifier, AnonymousStructName),
                         Kind = LspSymbolKind.Struct,
                         Range = SemanticLookup.ToRange(text, structDecl.Span),
                         SelectionRange = SemanticLookup.ToRange(structDecl.Identifier),
@@ -1166,7 +1179,7 @@ public static class DocumentSymbolComputer
                     {
                         enumChildren.Add(new DocumentSymbol
                         {
-                            Name = enumMember.Identifier.Text,
+                            Name = SymbolName(enumMember.Identifier, AnonymousEnumMemberName),
                             Kind = LspSymbolKind.EnumMember,
                             Range = SemanticLookup.ToRange(text, enumMember.Span),
                             SelectionRange = SemanticLookup.ToRange(enumMember.Identifier),
@@ -1175,7 +1188,7 @@ public static class DocumentSymbolComputer
 
                     result.Add(new SymbolInformationOrDocumentSymbol(new DocumentSymbol
                     {
-                        Name = enumDecl.Identifier.Text,
+                        Name = SymbolName(enumDecl.Identifier, AnonymousEnumName),
                         Kind = LspSymbolKind.Enum,
                         Range = SemanticLookup.ToRange(text, enumDecl.Span),
                         SelectionRange = SemanticLookup.ToRange(enumDecl.Identifier),
@@ -1186,6 +1199,16 @@ public static class DocumentSymbolComputer
         }
 
         return result;
+    }
+
+    // Resolves a symbol name from an identifier token, substituting a non-empty
+    // fallback when the token is missing/synthesized (Text == null) or empty or
+    // whitespace. Guarantees the returned name is never null or empty so the
+    // emitted DocumentSymbol always satisfies the LSP protocol contract.
+    private static string SymbolName(SyntaxToken identifier, string fallback)
+    {
+        var name = identifier?.Text;
+        return string.IsNullOrWhiteSpace(name) ? fallback : name;
     }
 }
 

--- a/test/LanguageServer.Tests/DocumentSymbolHandlerTests.cs
+++ b/test/LanguageServer.Tests/DocumentSymbolHandlerTests.cs
@@ -66,4 +66,65 @@ public class DocumentSymbolHandlerTests
         Assert.Equal(2, symbols.Count);
         Assert.All(symbols, s => Assert.Equal(LspSymbolKind.Variable, s.DocumentSymbol.Kind));
     }
+
+    // Regression tests for issue #890: the language server must never emit a
+    // DocumentSymbol with a null/empty name. Incomplete or error declarations
+    // produce missing identifier tokens (Text == null), which previously leaked
+    // into the documentSymbol response and caused the vscode-languageclient
+    // converter to throw "name must not be falsy".
+    [Theory]
+    [InlineData("func () int32 { return 0 }\n")]
+    [InlineData("struct {\nvar X int32\n}\n")]
+    [InlineData("enum { Red, Green }\n")]
+    [InlineData("let = 42\n")]
+    [InlineData("func\n")]
+    [InlineData("struct\n")]
+    [InlineData("enum\n")]
+    public void ComputeDocumentSymbols_NeverEmitsEmptyName(string source)
+    {
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var symbols = DocumentSymbolComputer.ComputeDocumentSymbols(content);
+
+        AssertNoEmptyNames(symbols.Select(s => s.DocumentSymbol));
+    }
+
+    [Fact]
+    public void ComputeDocumentSymbols_AnonymousStructMembersHaveNames()
+    {
+        // A struct with a missing name still surfaces its (named) fields; none of
+        // those child symbols may have an empty name either.
+        const string source = "struct {\nvar X int32\nvar Y int32\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var symbols = DocumentSymbolComputer.ComputeDocumentSymbols(content);
+
+        AssertNoEmptyNames(symbols.Select(s => s.DocumentSymbol));
+    }
+
+    [Fact]
+    public void ComputeDocumentSymbols_ValidSymbolsStillPresentAlongsideErrors()
+    {
+        // A valid function next to an incomplete one: the valid symbol must keep
+        // its real name and the incomplete one must not produce an empty name.
+        const string source = "func valid() int32 { return 1 }\nfunc () int32 { return 0 }\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var symbols = DocumentSymbolComputer.ComputeDocumentSymbols(content);
+
+        AssertNoEmptyNames(symbols.Select(s => s.DocumentSymbol));
+        Assert.Contains(symbols, s => s.DocumentSymbol.Name == "valid");
+    }
+
+    private static void AssertNoEmptyNames(System.Collections.Generic.IEnumerable<DocumentSymbol> symbols)
+    {
+        foreach (var symbol in symbols)
+        {
+            Assert.False(string.IsNullOrEmpty(symbol.Name), "DocumentSymbol.Name must not be null or empty.");
+            if (symbol.Children != null)
+            {
+                AssertNoEmptyNames(symbol.Children);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #890

## Root cause
The VSCode extension repeatedly logged:

```
[Error] Request textDocument/documentSymbol failed.
Error: name must not be falsy
```

`SyntaxToken.IsMissing` is defined as `Text == null`, and the parser's
`MatchToken` returns a token with `null` `Text` whenever an expected token is
missing. For incomplete or error declarations — e.g. `func`/`struct`/`enum`
with no name, or `let = 42` — the identifier token is synthesized with a
`null` `Text`.

`DocumentSymbolComputer.ComputeDocumentSymbols` copied `Identifier.Text`
straight into `DocumentSymbol.Name`, so the `textDocument/documentSymbol`
response contained symbols whose `name` was `null`/empty (falsy). The
`vscode-languageclient` `asDocumentSymbols` protocol converter validates that
every symbol has a non-empty `name` and throws **"name must not be falsy"**,
which breaks the Outline view and breadcrumbs for the affected file.

## Fix
Guard every symbol-construction site in `DocumentSymbolComputer` with a new
`SymbolName(SyntaxToken identifier, string fallback)` helper that substitutes a
sensible, non-empty fallback name whenever the identifier token is missing,
empty, or whitespace:

- `<function>`, `<variable>`, `<struct>`, `<enum>` for top-level declarations
- `<field>`, `<member>` for struct fields and enum members (child symbols)

This covers **every** node kind the computer can emit (functions, global
variables, structs + their fields, enums + their members), so a null/empty
`name` can never reach the protocol layer. The fix is in the language server
source, not the bundled extension artifact.

## Tests
Added regression tests in `DocumentSymbolHandlerTests` that:
- assert no returned `DocumentSymbol` (or any child) ever has an empty/null
  name for a range of incomplete declarations, and
- confirm valid symbols still appear with their correct names alongside
  incomplete ones.

## Local build + test results
- `dotnet build GSharp.sln -c Release --no-restore -graph` → succeeded, 0 errors
- `dotnet test GSharp.sln -c Release --no-build` → all green:
  - LanguageServer.Tests: 335 passed
  - Core.Tests: 3340 passed (1 skipped)
  - Compiler.Tests: 1347 passed
  - Interpreter.Tests: 308 passed
  - Extensions.Tests: 104 passed
  - Sdk.Tests: 38 passed
  - **0 failures**

## Files changed
- `src/LanguageServer/HoverComputer.cs` — `DocumentSymbolComputer` fix
- `test/LanguageServer.Tests/DocumentSymbolHandlerTests.cs` — regression tests
