### PR TITLE
Fix #891: arrow lambdas as named/extension arguments and extension-method hover

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -561,17 +561,28 @@ internal sealed partial class ExpressionBinder
             return true;
         }
 
+        // Issue #891: a constructor's delegate-typed parameter (e.g.
+        // `Func<HttpClient> httpClientFactory`) target-types an arrow/func
+        // literal argument before it is bound. Without this, an arrow lambda
+        // whose body only throws (`() -> { throw ... }`) infers `() -> void`
+        // and fails to match the `Func<...>` parameter; the call then misroutes
+        // to the single-arg conversion path and reports the misleading GS0162
+        // "named arguments are only supported for data-struct .copy(...)".
+        var ctors = ClrTypeUtilities.SafeGetConstructors(clrType, BindingFlags.Public | BindingFlags.Instance);
+        var ctorParameterLists = ctors.Select(c => c.GetParameters()).ToList();
+
         var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
         for (var i = 0; i < syntax.Arguments.Count; i++)
         {
-            boundArguments.Add(BindExpression(OverloadResolver.UnwrapNamedArgumentValue(syntax.Arguments[i])));
+            var argName = argumentNames.IsDefault ? null : argumentNames[i];
+            boundArguments.Add(BindCallArgumentWithDelegateTargetTyping(
+                syntax.Arguments[i], ctorParameterLists, sourceArgIndex: i, argName: argName, paramOffset: 0));
         }
 
         // Phase A (overload resolution): pick a constructor via the shared
         // "better function member" resolver. Ambiguity surfaces a hard
         // binder diagnostic and the call falls back to the surrounding
         // pipeline (which will diagnose a missing match).
-        var ctors = ClrTypeUtilities.SafeGetConstructors(clrType, BindingFlags.Public | BindingFlags.Instance);
         var argTypes = new System.Type[boundArguments.Count];
         var argsAllTyped = true;
         var hasUserClassArg = false;
@@ -726,6 +737,106 @@ internal sealed partial class ExpressionBinder
             ctorRefKinds);
         result = WrapWithHandlerPrelude(ctorCall, ctorHandlerPrelude, syntax);
         return true;
+    }
+
+    /// <summary>
+    /// Issue #891: binds a single call argument, target-typing arrow/func
+    /// literals against the matching delegate-typed parameter discovered from
+    /// the candidate (constructor or method) parameter lists. This lets an
+    /// arrow lambda — including a statement body that only throws — be bound
+    /// directly as the corresponding delegate (Func/Action) instead of
+    /// inferring a standalone (often void) function type that fails overload
+    /// resolution and misroutes the call.
+    /// </summary>
+    private BoundExpression BindCallArgumentWithDelegateTargetTyping(
+        ExpressionSyntax argumentSyntax,
+        IReadOnlyList<ParameterInfo[]> candidateParameterLists,
+        int sourceArgIndex,
+        string argName,
+        int paramOffset)
+    {
+        var inner = OverloadResolver.UnwrapNamedArgumentValue(argumentSyntax);
+        if (inner is LambdaExpressionSyntax lambdaSyntax
+            && TryResolveDelegateTargetFromCandidates(candidateParameterLists, paramOffset, sourceArgIndex, argName, out var target))
+        {
+            return lambdas.BindLambdaExpression(lambdaSyntax, target);
+        }
+
+        return BindExpression(inner);
+    }
+
+    /// <summary>
+    /// Issue #891: discovers the (non-generic) delegate function type that a
+    /// given argument position maps to across all candidate parameter lists.
+    /// Named arguments are matched by parameter name; positional arguments by
+    /// index (after <paramref name="paramOffset"/>, e.g. an extension method's
+    /// receiver). Returns false when no candidate exposes a closed delegate
+    /// parameter there, or when candidates disagree on the delegate shape.
+    /// </summary>
+    private static bool TryResolveDelegateTargetFromCandidates(
+        IReadOnlyList<ParameterInfo[]> candidateParameterLists,
+        int paramOffset,
+        int sourceArgIndex,
+        string argName,
+        out FunctionTypeSymbol target)
+    {
+        target = null;
+        foreach (var parameters in candidateParameterLists)
+        {
+            int paramIndex;
+            if (!string.IsNullOrEmpty(argName))
+            {
+                paramIndex = -1;
+                for (var p = 0; p < parameters.Length; p++)
+                {
+                    if (string.Equals(parameters[p].Name, argName, StringComparison.Ordinal))
+                    {
+                        paramIndex = p;
+                        break;
+                    }
+                }
+
+                if (paramIndex < 0)
+                {
+                    continue;
+                }
+            }
+            else
+            {
+                paramIndex = sourceArgIndex + paramOffset;
+                if (paramIndex < 0 || paramIndex >= parameters.Length)
+                {
+                    continue;
+                }
+            }
+
+            var parameterType = parameters[paramIndex].ParameterType;
+            if (parameterType == null || parameterType.ContainsGenericParameters)
+            {
+                // Open generic delegate parameters are resolved later, once the
+                // generic method's type arguments have been inferred.
+                continue;
+            }
+
+            if (!MemberLookup.TryGetDelegateFunctionType(parameterType, out var candidate) || candidate == null)
+            {
+                continue;
+            }
+
+            if (target == null)
+            {
+                target = candidate;
+            }
+            else if (!ReferenceEquals(target, candidate) && !target.Equals(candidate))
+            {
+                // Candidates disagree on the delegate shape — leave the lambda
+                // to be bound without a target (overload resolution decides).
+                target = null;
+                return false;
+            }
+        }
+
+        return target != null;
     }
 
     /// <summary>
@@ -974,6 +1085,166 @@ internal sealed partial class ExpressionBinder
         return null;
     }
 
+    /// <summary>
+    /// Issue #891: determines whether the supplied expression is an arrow
+    /// lambda with at least one parameter whose type is omitted, so its
+    /// parameter type(s) must be inferred from a target delegate.
+    /// </summary>
+    private static bool IsUntypedArrowLambda(ExpressionSyntax inner)
+    {
+        if (inner is not LambdaExpressionSyntax lambda)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < lambda.Parameters.Count; i++)
+        {
+            if (lambda.Parameters[i].Type == null)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #891: infers the target delegate type for each deferred un-typed
+    /// arrow lambda argument of a member-style call by probing the applicable
+    /// candidate methods — instance methods on the receiver, imported
+    /// extension methods (LINQ et al.), or static methods of the accessed
+    /// class — with the lambda slots treated as unconstrained. Once the
+    /// (possibly generic) overload is resolved and its type arguments inferred,
+    /// the corresponding closed delegate parameter type target-types the lambda,
+    /// which is then bound in place inside <paramref name="boundArgs"/>.
+    /// </summary>
+    private void ResolveDeferredArrowLambdaArguments(
+        BoundExpression receiver,
+        ImportedClassSymbol classSymbol,
+        string methodName,
+        CallExpressionSyntax ce,
+        System.Type[] explicitTypeArgs,
+        List<int> deferredIndices,
+        BoundExpression[] boundArgs)
+    {
+        var probes = new List<(IReadOnlyList<MethodInfo> Methods, int Offset)>();
+        if (classSymbol != null)
+        {
+            var statics = ClrTypeUtilities.SafeGetMethods(classSymbol.ClassType, BindingFlags.Static | BindingFlags.Public)
+                .Where(m => m.Name == methodName)
+                .ToList();
+            if (statics.Count > 0)
+            {
+                probes.Add((statics, 0));
+            }
+        }
+        else if (receiver?.Type?.ClrType is System.Type receiverClrType)
+        {
+            var instance = ClrTypeUtilities.SafeGetMethodsIncludingInterfaces(receiverClrType, BindingFlags.Instance | BindingFlags.Public)
+                .Where(m => m.Name == methodName)
+                .ToList();
+            if (instance.Count > 0)
+            {
+                probes.Add((instance, 0));
+            }
+
+            var extensions = this.memberLookup.CollectImportedExtensionMethods(methodName);
+            if (extensions.Count > 0)
+            {
+                probes.Add((extensions, 1));
+            }
+        }
+
+        if (probes.Count == 0)
+        {
+            return;
+        }
+
+        var deferred = new HashSet<int>(deferredIndices);
+        foreach (var (methods, offset) in probes)
+        {
+            var argTypes = new System.Type[boundArgs.Length + offset];
+            if (offset == 1)
+            {
+                argTypes[0] = receiver.Type.ClrType;
+            }
+
+            var usable = true;
+            for (var i = 0; i < boundArgs.Length; i++)
+            {
+                if (deferred.Contains(i))
+                {
+                    // An unconstrained lambda slot: null is skipped by generic
+                    // inference and treated as reference-convertible to the
+                    // delegate parameter, so the candidate still applies.
+                    argTypes[i + offset] = null;
+                    continue;
+                }
+
+                var t = GetEffectiveArgumentClrTypeForOverloadResolution(boundArgs[i].Type);
+                if (t == null && boundArgs[i].Type != TypeSymbol.Null)
+                {
+                    usable = false;
+                    break;
+                }
+
+                argTypes[i + offset] = t;
+            }
+
+            if (!usable)
+            {
+                continue;
+            }
+
+            var resolution = OverloadResolution.Resolve(methods, argTypes, explicitTypeArgs, scope.References.MapClrTypeToReferences);
+            if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)
+            {
+                continue;
+            }
+
+            var parameters = resolution.Best.GetParameters();
+            var targets = new Dictionary<int, FunctionTypeSymbol>();
+            var allMapped = true;
+            foreach (var idx in deferredIndices)
+            {
+                var paramIndex = idx + offset;
+                if (paramIndex >= parameters.Length)
+                {
+                    allMapped = false;
+                    break;
+                }
+
+                var parameterType = parameters[paramIndex].ParameterType;
+                if (parameterType == null
+                    || parameterType.ContainsGenericParameters
+                    || !MemberLookup.TryGetDelegateFunctionType(parameterType, out var fn)
+                    || fn == null)
+                {
+                    allMapped = false;
+                    break;
+                }
+
+                targets[idx] = fn;
+            }
+
+            if (!allMapped)
+            {
+                continue;
+            }
+
+            foreach (var idx in deferredIndices)
+            {
+                var inner = OverloadResolver.UnwrapNamedArgumentValue(ce.Arguments[idx]);
+                if (inner is LambdaExpressionSyntax lambdaSyntax)
+                {
+                    boundArgs[idx] = lambdas.BindLambdaExpression(lambdaSyntax, targets[idx]);
+                }
+            }
+
+            return;
+        }
+    }
+
     private BoundExpression BindAccessorCall(BoundExpression receiver, ImportedClassSymbol classSymbol, CallExpressionSyntax ce)
     {
         var methodName = ce.Identifier.Text;
@@ -997,22 +1268,6 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>();
-        foreach (var argument in ce.Arguments)
-        {
-            var inner = OverloadResolver.UnwrapNamedArgumentValue(argument);
-            if (inner is RefArgumentExpressionSyntax refArg)
-            {
-                boundArguments.Add(BindRefArgumentExpression(refArg, parameter: null));
-            }
-            else
-            {
-                boundArguments.Add(BindExpression(inner));
-            }
-        }
-
-        var arguments = boundArguments.ToImmutable();
-
         // Issue #311: resolve an explicit `[T1, T2]` type-argument list (e.g.
         // `Array.Empty[string]()`) into mapped CLR types up front so every
         // generic-method dispatch path below can close the candidate.
@@ -1021,6 +1276,59 @@ internal sealed partial class ExpressionBinder
             Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
             return new BoundErrorExpression(null);
         }
+
+        var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>();
+        var deferredArrowLambdaIndices = new List<int>();
+        var argSlot = 0;
+        foreach (var argument in ce.Arguments)
+        {
+            var inner = OverloadResolver.UnwrapNamedArgumentValue(argument);
+            if (inner is RefArgumentExpressionSyntax refArg)
+            {
+                boundArguments.Add(BindRefArgumentExpression(refArg, parameter: null));
+            }
+            else if (argumentNames.IsDefault && IsUntypedArrowLambda(inner))
+            {
+                // Issue #891: defer binding of an un-typed arrow lambda until
+                // the target delegate type is known. Binding it now would emit
+                // GS0304 (cannot infer parameter type) and produce an error-typed
+                // argument that aborts overload resolution — which is exactly why
+                // `list.Single((c) -> c.Id == "x")` reported "Cannot find function
+                // Single" while the explicit `func(c DoctorCheck) bool { ... }`
+                // form worked. The placeholder keeps argument positions aligned;
+                // the real binding happens once the (possibly generic) overload —
+                // including LINQ extension methods — has been resolved below.
+                deferredArrowLambdaIndices.Add(argSlot);
+                boundArguments.Add(new BoundErrorExpression(inner));
+            }
+            else
+            {
+                boundArguments.Add(BindExpression(inner));
+            }
+
+            argSlot++;
+        }
+
+        if (deferredArrowLambdaIndices.Count > 0)
+        {
+            var mutableArgs = boundArguments.ToArray();
+            ResolveDeferredArrowLambdaArguments(receiver, classSymbol, methodName, ce, explicitTypeArgs, deferredArrowLambdaIndices, mutableArgs);
+
+            // Any lambda whose target could not be inferred is now bound without
+            // a target so the established GS0304 diagnostic still surfaces.
+            foreach (var idx in deferredArrowLambdaIndices)
+            {
+                if (mutableArgs[idx] is BoundErrorExpression placeholder && placeholder.Syntax is LambdaExpressionSyntax pendingLambda)
+                {
+                    mutableArgs[idx] = lambdas.BindLambdaExpression(pendingLambda);
+                }
+            }
+
+            boundArguments.Clear();
+            boundArguments.AddRange(mutableArgs);
+        }
+
+        var arguments = boundArguments.ToImmutable();
 
         if (classSymbol != null)
         {

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -864,6 +864,20 @@ internal sealed class LambdaBinder
         var trailingIsVoidPlaceholder = boundBody is BoundBlockExpression { Expression: BoundLiteralExpression { Type: var trailingLit } }
             && trailingLit == TypeSymbol.Void;
 
+        // Issue #891: a block-body arrow lambda whose body never completes
+        // normally — every path throws (or otherwise terminates) without a
+        // value-producing `return` — has no natural return value. C# treats
+        // such a lambda as convertible to ANY delegate return type (e.g.
+        // `() -> { throw ... }` converts to both `Action` and `Func<string>`).
+        // When a target delegate return type is supplied we therefore adopt it
+        // directly, exactly as the equivalent `func() T { throw ... }` literal
+        // (whose explicit return type a throwing body satisfies) already does.
+        var bodyNeverCompletesNormally = !hasExplicitReturn
+            && trailingIsVoidPlaceholder
+            && boundBody is BoundBlockExpression neverBlock
+            && neverBlock.Statements.Length > 0
+            && ControlFlowGraph.AllPathsReturn(new BoundBlockStatement(syntax.Body, neverBlock.Statements));
+
         // ADR-0076 §3: the candidate set.
         var candidates = new List<TypeSymbol>();
         if (!(hasExplicitReturn && trailingIsVoidPlaceholder))
@@ -886,6 +900,14 @@ internal sealed class LambdaBinder
                 // Strip the Task / Task<T> wrap so we compare against the
                 // awaited type the lambda body actually produces.
                 targetReturn = UnwrapTaskReturnType(targetReturn);
+            }
+
+            // Issue #891: a throwing/never-returning body adopts the target's
+            // return type directly — there is no value to reconcile, so the
+            // synthesized method's signature simply matches the delegate.
+            if (bodyNeverCompletesNormally && targetReturn != null && targetReturn != TypeSymbol.Error)
+            {
+                return targetReturn;
             }
 
             // Issue #889: when the target delegate returns void (e.g.

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -164,6 +164,24 @@ public static class HoverComputer
             return null;
         }
 
+        // Issue #891: when the token is the identifier of an invoked call (e.g.
+        // the `Single` in `report.Checks.Single(...)`), resolve the actual
+        // method the call bound to BEFORE attempting type-name resolution.
+        // Otherwise `ResolveImportedClrType("Single")` matches the unrelated
+        // type `System.Single` (float32) and hover shows the wrong content.
+        // This also handles generic extension methods, which plain reflection
+        // on the receiver type would miss.
+        var invokedCall = FindNodes<CallExpressionSyntax>(tree.Root)
+            .FirstOrDefault(call => MatchesToken(call.Identifier, token));
+        if (invokedCall != null
+            && SemanticLookup.TryResolveInvokedImportedMethod(compilation, token.Text, invokedCall.Arguments.Count, out var invokedMethod, out var invokedOverloadCount))
+        {
+            return new HoverModel(
+                SymbolDisplay.ToDisplayString(invokedMethod, SymbolDisplayFormat.Hover),
+                HoverDocumentationRenderer.Render(GSharp.Core.CodeAnalysis.Documentation.AssemblyDocumentationProvider.Resolve(invokedMethod)),
+                invokedOverloadCount);
+        }
+
         var clrType = SemanticLookup.ResolveImportedClrType(
             tree,
             compilation,

--- a/src/LanguageServer/SemanticLookup.cs
+++ b/src/LanguageServer/SemanticLookup.cs
@@ -111,6 +111,86 @@ public static class SemanticLookup
     }
 
     /// <summary>
+    /// Issue #891: resolves the imported CLR method that an invoked call
+    /// expression bound to. The lowered call nodes do not retain their
+    /// originating syntax, so the match is by method name and arity (the
+    /// extension-method form carries one extra leading parameter for the
+    /// receiver). This returns the exact overload chosen by overload
+    /// resolution — including generic extension methods such as LINQ
+    /// <c>Single&lt;TSource&gt;</c> — so hover can show the invoked method rather
+    /// than an unrelated type that merely shares its name (e.g.
+    /// <c>System.Single</c>).
+    /// </summary>
+    /// <param name="compilation">The compilation whose bound program is searched.</param>
+    /// <param name="methodName">The invoked method's simple name.</param>
+    /// <param name="argumentCount">The number of arguments at the call site.</param>
+    /// <param name="method">On success, the resolved CLR method.</param>
+    /// <param name="overloadCount">On success, the number of same-named overloads on the declaring type.</param>
+    /// <returns><see langword="true"/> when an invoked imported method was found.</returns>
+    public static bool TryResolveInvokedImportedMethod(
+        Compilation compilation,
+        string methodName,
+        int argumentCount,
+        out System.Reflection.MethodInfo method,
+        out int overloadCount)
+    {
+        method = null;
+        overloadCount = 0;
+        if (compilation == null || string.IsNullOrEmpty(methodName))
+        {
+            return false;
+        }
+
+        BoundProgram program;
+        try
+        {
+            program = compilation.BoundProgram;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+
+        foreach (var root in EnumerateBoundRoots(program))
+        {
+            if (root == null)
+            {
+                continue;
+            }
+
+            foreach (var node in FindBoundNodes<BoundNode>(root))
+            {
+                var candidate = node switch
+                {
+                    BoundImportedInstanceCallExpression instanceCall => instanceCall.Method,
+                    BoundImportedCallExpression staticCall => staticCall.Function?.Method,
+                    _ => null,
+                };
+
+                if (candidate == null || !string.Equals(candidate.Name, methodName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                // An instance/static call has one parameter per argument; an
+                // imported extension method dispatched with receiver syntax has
+                // one extra leading parameter (the receiver).
+                var parameterCount = candidate.GetParameters().Length;
+                if (parameterCount != argumentCount && parameterCount != argumentCount + 1)
+                {
+                    continue;
+                }
+
+                method = candidate;
+                overloadCount = CountSameNamedMethods(candidate);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Pre-builds the per-compilation <c>SemanticModel</c> and its references
     /// index. Intended for the workspace warm-up path so that the first
     /// user-facing CodeLens / hover / definition request returns from cache
@@ -971,6 +1051,42 @@ public static class SemanticLookup
     private static bool IsIdentifierStart(char c)
     {
         return c == '_' || char.IsLetter(c);
+    }
+
+    private static IEnumerable<BoundNode> EnumerateBoundRoots(BoundProgram program)
+    {
+        if (program == null)
+        {
+            yield break;
+        }
+
+        if (program.Statement != null)
+        {
+            yield return program.Statement;
+        }
+
+        foreach (var body in program.Functions.Values)
+        {
+            if (body != null)
+            {
+                yield return body;
+            }
+        }
+    }
+
+    private static int CountSameNamedMethods(System.Reflection.MethodInfo method)
+    {
+        var declaringType = method.DeclaringType;
+        if (declaringType == null)
+        {
+            return 1;
+        }
+
+        var count = ClrTypeUtilities.SafeGetMethods(
+                declaringType,
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Instance)
+            .Count(m => string.Equals(m.Name, method.Name, StringComparison.Ordinal) && !m.IsSpecialName);
+        return count > 0 ? count : 1;
     }
 
     private static bool IsIdentifierPart(char c)

--- a/test/Compiler.Tests/Emit/Issue891LambdaArgumentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue891LambdaArgumentEmitTests.cs
@@ -1,0 +1,313 @@
+// <copyright file="Issue891LambdaArgumentEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #891 — arrow lambdas as method/constructor arguments.
+/// <para>
+/// Problem A: an arrow lambda passed as a NAMED argument to a constructor whose
+/// parameter is a <c>Func&lt;...&gt;</c> delegate (skipping an earlier optional
+/// parameter) must target-type to that delegate — including a statement-body
+/// lambda that only throws — instead of misrouting to the data-struct
+/// <c>.copy(...)</c> named-argument path (which reported the misleading
+/// "Named arguments are only supported for data-struct .copy(...)").
+/// </para>
+/// <para>
+/// Problem B: an un-typed arrow lambda passed to a generic LINQ extension method
+/// (<c>Single&lt;TSource&gt;(this IEnumerable&lt;TSource&gt;, Func&lt;TSource,bool&gt;)</c>)
+/// must infer its parameter type from the delegate parameter so the extension
+/// method resolves and the predicate body type-checks to <c>bool</c>.
+/// </para>
+/// </summary>
+public class Issue891LambdaArgumentEmitTests
+{
+    [Fact]
+    public void ProblemA_ArrowLambda_AsNamedFuncArgument_ValueReturning_Runs()
+    {
+        // System.Lazy<T>(Func<T> valueFactory) exercises the single named-argument
+        // routing that previously misrouted to the .copy(...) path.
+        var source = """
+            package P
+            import System
+
+            let box = Lazy[int32](valueFactory: () -> 42)
+            Console.WriteLine(box.Value)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void ProblemA_ArrowLambda_AsNamedFuncArgument_ThrowOnlyBody_Runs()
+    {
+        // A statement-body arrow lambda that only throws has no natural return
+        // value; it must still target-type to Func<string> for the named arg.
+        var source = """
+            package P
+            import System
+
+            let box = Lazy[string](valueFactory: () -> {
+                throw InvalidOperationException("must not be invoked")
+            })
+            Console.WriteLine("ok")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("ok\n", output);
+    }
+
+    [Fact]
+    public void ProblemA_ArrowLambda_AsNamedFuncArgument_SkippingOptionalParameter_Runs()
+    {
+        // Faithful reproduction of the issue's DoctorService-style constructor:
+        //   DoctorService(int logger = 0, Func<string> httpClientFactory = null)
+        // invoked with only the named Func argument so the leading optional
+        // parameter is filled from its default.
+        var helperDir = Directory.CreateTempSubdirectory("gs_issue891_helper_").FullName;
+        try
+        {
+            var helperDll = Path.Combine(helperDir, "Issue891Helper.dll");
+            EmitDoctorServiceAssembly(helperDll);
+
+            var source = """
+                package P
+                import System
+                import Issue891Helper
+
+                let svc = DoctorService(httpClientFactory: () -> "made")
+                Console.WriteLine(svc.Probe())
+                """;
+
+            var output = CompileAndRun(source, referencePaths: new[] { helperDll });
+            Assert.Equal("made\n", output);
+        }
+        finally
+        {
+            try { Directory.Delete(helperDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ProblemA_ArrowLambda_AsNamedFuncArgument_ThrowOnly_SkippingOptionalParameter_Runs()
+    {
+        var helperDir = Directory.CreateTempSubdirectory("gs_issue891_helper_throw_").FullName;
+        try
+        {
+            var helperDll = Path.Combine(helperDir, "Issue891Helper.dll");
+            EmitDoctorServiceAssembly(helperDll);
+
+            // The factory is never invoked, so the throwing body never runs.
+            var source = """
+                package P
+                import System
+                import Issue891Helper
+
+                let svc = DoctorService(httpClientFactory: () -> {
+                    throw InvalidOperationException("HTTP must not be invoked when --skip-network is set")
+                })
+                Console.WriteLine("constructed")
+                """;
+
+            var output = CompileAndRun(source, referencePaths: new[] { helperDll });
+            Assert.Equal("constructed\n", output);
+        }
+        finally
+        {
+            try { Directory.Delete(helperDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ProblemB_ArrowLambda_AsGenericLinqSinglePredicate_Runs()
+    {
+        var source = """
+            package P
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            let nums = List[int32]()
+            nums.Add(1)
+            nums.Add(2)
+            nums.Add(3)
+            let found = nums.Single((x) -> x == 2)
+            Console.WriteLine(found)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void ProblemB_ArrowLambda_PredicateBody_TypeChecksToBool_OverString()
+    {
+        // Mirrors the issue's `report.Checks.Single(c -> c.Id == "audible-api")`
+        // shape: the lambda parameter type is inferred from the delegate, and the
+        // predicate body comparing a string property type-checks to bool.
+        var source = """
+            package P
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            let ids = List[string]()
+            ids.Add("audible-api")
+            ids.Add("network")
+            let net = ids.Single((c) -> c == "network")
+            Console.WriteLine(net)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("network\n", output);
+    }
+
+    /// <summary>
+    /// Emits a tiny assembly <c>Issue891Helper</c> exposing a
+    /// <c>DoctorService</c> class whose constructor mirrors the issue:
+    /// <c>DoctorService(int logger = 0, Func&lt;string&gt; httpClientFactory = null)</c>,
+    /// plus a <c>string Probe()</c> instance method that invokes the factory
+    /// (or returns <c>"none"</c> when it was not supplied).
+    /// </summary>
+    /// <param name="outputPath">Where to write the emitted assembly.</param>
+    private static void EmitDoctorServiceAssembly(string outputPath)
+    {
+        var asmName = new AssemblyName("Issue891Helper");
+        var ab = new PersistedAssemblyBuilder(asmName, typeof(object).Assembly);
+        var module = ab.DefineDynamicModule("Issue891Helper");
+        var type = module.DefineType(
+            "Issue891Helper.DoctorService",
+            TypeAttributes.Public | TypeAttributes.Class);
+
+        var factoryType = typeof(Func<string>);
+        var factoryField = type.DefineField("_factory", factoryType, FieldAttributes.Private);
+
+        var ctor = type.DefineConstructor(
+            MethodAttributes.Public,
+            CallingConventions.HasThis,
+            new[] { typeof(int), factoryType });
+        var loggerParam = ctor.DefineParameter(1, ParameterAttributes.Optional | ParameterAttributes.HasDefault, "logger");
+        loggerParam.SetConstant(0);
+        var factoryParam = ctor.DefineParameter(2, ParameterAttributes.Optional | ParameterAttributes.HasDefault, "httpClientFactory");
+        factoryParam.SetConstant(null);
+
+        var ctorIl = ctor.GetILGenerator();
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Call, typeof(object).GetConstructor(Type.EmptyTypes)!);
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Ldarg_2);
+        ctorIl.Emit(OpCodes.Stfld, factoryField);
+        ctorIl.Emit(OpCodes.Ret);
+
+        var probe = type.DefineMethod(
+            "Probe",
+            MethodAttributes.Public,
+            typeof(string),
+            Type.EmptyTypes);
+        var probeIl = probe.GetILGenerator();
+        var noneLabel = probeIl.DefineLabel();
+        probeIl.Emit(OpCodes.Ldarg_0);
+        probeIl.Emit(OpCodes.Ldfld, factoryField);
+        probeIl.Emit(OpCodes.Brfalse_S, noneLabel);
+        probeIl.Emit(OpCodes.Ldarg_0);
+        probeIl.Emit(OpCodes.Ldfld, factoryField);
+        probeIl.Emit(OpCodes.Callvirt, factoryType.GetMethod("Invoke")!);
+        probeIl.Emit(OpCodes.Ret);
+        probeIl.MarkLabel(noneLabel);
+        probeIl.Emit(OpCodes.Ldstr, "none");
+        probeIl.Emit(OpCodes.Ret);
+
+        type.CreateType();
+        ab.Save(outputPath);
+    }
+
+    private static string CompileAndRun(string source, string[] referencePaths = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue891_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            if (referencePaths != null)
+            {
+                foreach (var reference in referencePaths)
+                {
+                    args.Add("/reference:" + reference);
+                    File.Copy(reference, Path.Combine(tempDir, Path.GetFileName(reference)), overwrite: true);
+                }
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath, additionalReferences: referencePaths);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/LanguageServer.Tests/HoverHandlerTests.cs
+++ b/test/LanguageServer.Tests/HoverHandlerTests.cs
@@ -303,6 +303,60 @@ public class HoverHandlerTests
         Assert.Contains("string", hover.Contents.ToString(), System.StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ComputeHover_ExtensionMethodInvocation_ResolvesToMethod_NotSameNamedType()
+    {
+        // Issue #891 (Problem C): hovering the `Single` LINQ extension method must
+        // resolve to that method, not to the type `System.Single` (float32) which
+        // merely shares the name. Regression: previously hover showed
+        // "struct float32 / Represents a single-precision floating-point number.".
+        const string source =
+            "package P\n" +
+            "import System\n" +
+            "import System.Linq\n" +
+            "import System.Collections.Generic\n" +
+            "func main() {\n" +
+            "    let nums = List[int32]()\n" +
+            "    nums.Add(1)\n" +
+            "    let found = nums.Single((x) -> x == 1)\n" +
+            "    Console.WriteLine(found)\n" +
+            "}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "Single"));
+
+        Assert.NotNull(hover);
+        var value = hover.Contents.ToString();
+        Assert.Contains("Single", value, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("float32", value, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("single-precision", value, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ComputeHover_ExtensionMethodInvocation_WithFuncLiteral_ResolvesToMethod()
+    {
+        // The hover bug was independent of the argument form: the explicit
+        // `func(...) bool { ... }` predicate spelling must also hover to the
+        // method, not the float32 type.
+        const string source =
+            "package P\n" +
+            "import System\n" +
+            "import System.Linq\n" +
+            "import System.Collections.Generic\n" +
+            "func main() {\n" +
+            "    let nums = List[int32]()\n" +
+            "    nums.Add(1)\n" +
+            "    let found = nums.Single(func(x int32) bool { return x == 1 })\n" +
+            "    Console.WriteLine(found)\n" +
+            "}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "Single"));
+
+        Assert.NotNull(hover);
+        var value = hover.Contents.ToString();
+        Assert.Contains("Single", value, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("single-precision", value, System.StringComparison.OrdinalIgnoreCase);
+    }
+
     private static ReferenceResolver CreateReferencePackResolver()
     {
         var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);


### PR DESCRIPTION
Fixes #891

Issue #891 reported three distinct problems when using lambdas as arguments to method/constructor calls. All three are fixed here, with regression tests for each.

## Problem A — arrow lambda as a NAMED argument to a ctor/method taking `Func<...>`
**Symptom:** `DoctorService(httpClientFactory: () -> { throw ... })` failed with the misleading `Named arguments are only supported for data-struct .copy(...).` (GS0162), while the `func() T { ... }` form worked.

**Root cause:** A block-body arrow lambda that only throws infers `() -> void`. CLR constructor overload resolution then fails to match the `Func<...>` parameter (void ≠ Func), and the single named-argument call falls through to the single-arg conversion path, which rebinds the `NamedArgumentExpressionSyntax` directly and reports GS0162.

**Fix:**
- `ExpressionBinder.Calls.cs` (`TryBindClrConstructorFromType`): discover the delegate function-type for each argument position from the candidate constructors (by name for named args, by position otherwise) and target-type arrow/func literal arguments *before* binding, via `BindCallArgumentWithDelegateTargetTyping` / `TryResolveDelegateTargetFromCandidates`.
- `LambdaBinder.cs` (`InferLambdaReturnType`): when a target delegate type is supplied and the lambda body never completes normally (all paths throw), adopt the target's return type — exactly as the equivalent `func() T { throw ... }` literal does. Reuses `ControlFlowGraph.AllPathsReturn`.

## Problem B — arrow lambda passed to a generic LINQ extension method (`Single`)
**Symptom:** `list.Single((x) -> x == 3)` failed with `Cannot find function Single.` / GS0304, while `list.Single(func(x int32) bool { ... })` worked.

**Root cause:** An un-typed arrow lambda parameter cannot be bound bare (GS0304), producing an error-typed argument whose null CLR type aborts overload resolution, so the generic extension method `Single<TSource>` is never matched.

**Fix:** `ExpressionBinder.Calls.cs` (`BindAccessorCall`): un-typed arrow lambda arguments are deferred to a placeholder (suppressing GS0304). `ResolveDeferredArrowLambdaArguments` probes the applicable candidates (instance methods on the receiver, imported extension methods, or static methods of the accessed class) with the lambda slot treated as unconstrained — generic inference skips it and infers `TSource` from the receiver — then re-binds the lambda against the resolved, closed delegate parameter (`Func<TSource,bool>`). The predicate body then type-checks to `bool`.

## Problem C — wrong hover on extension methods
**Symptom:** Hovering the `Single` extension method showed `struct float32` / "Represents a single-precision floating-point number." — i.e. it matched the type `System.Single` by name instead of the method.

**Root cause:** `HoverComputer.BuildImportedClrModel` resolved the token as a type name (`ResolveImportedClrType("Single")` → `System.Single`) before any member resolution, and member resolution had no support for extension methods.

**Fix:**
- `SemanticLookup.cs`: new `TryResolveInvokedImportedMethod` resolves the actual method an invoked call bound to, by scanning the lowered bound program for imported call nodes matching the method name and arity (the extension form carries one extra leading receiver parameter). This naturally handles generic extension methods.
- `HoverComputer.cs`: when the hovered token is the identifier of an invoked call, resolve the invoked method *before* type-name resolution.

## Tests
- `test/Compiler.Tests/Emit/Issue891LambdaArgumentEmitTests.cs` (emit + ilverify + run):
  - named-arg arrow lambda `Func` argument (value-returning and throw-only), incl. a `DoctorService`-style helper assembly whose ctor is `(int logger = 0, Func<string> httpClientFactory = null)` invoked with only the named `Func` argument;
  - LINQ `Single` with an arrow-lambda predicate over `List[int32]` and `List[string]`.
- `test/LanguageServer.Tests/HoverHandlerTests.cs`: hover over the `Single` extension-method invocation resolves to the method (and not `float32`), for both the arrow-lambda and `func(...)` predicate forms.

## Validation
Local `dotnet build GSharp.sln -c Release` succeeds (0 warnings/errors). Full `dotnet test GSharp.sln -c Release`: **5480 passed, 1 skipped, 0 failed** (Core 3340, Compiler 1353, LanguageServer 337, Interpreter 308, Extensions 104, Sdk 38). Compiler.Tests validate emitted IL with ilverify.
