### PR TITLE
Fix #893: return trailing expression value from func literals

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -309,6 +309,18 @@ internal sealed class LambdaBinder
         Scope = outerScope;
         setCurrentFunction(outerFunction);
 
+        // Issue #893: a value-returning function literal `func(p T) R { ... <expr> }`
+        // whose block body ends in a bare trailing expression treats that expression
+        // as the implicit return value (mirroring arrow-lambda semantics). Without
+        // this rewrite the trailing expression binds to a BoundExpressionStatement
+        // that the emitter pops and discards, leaving a non-void method body with no
+        // `ret` — invalid IL that the CLR rejects with InvalidProgramException at
+        // runtime. Rewrite the trailing expression-statement into a converted
+        // `return` so the literal actually returns its value. Void literals keep the
+        // existing statement-body handling (no implicit return) so the #889
+        // Action-style void-delegate path is preserved.
+        body = SynthesizeFunctionLiteralTrailingReturn((BoundBlockStatement)body, syntax, returnType);
+
         var captured = CollectCapturedVariables(body, synthetic.Parameters);
 
         // Issue #367: a by-ref-like (`ref struct`) local cannot be captured by a
@@ -712,6 +724,52 @@ internal sealed class LambdaBinder
         }
 
         return element;
+    }
+
+    // Issue #893: rewrite a value-returning function-literal block body so a bare
+    // trailing expression statement becomes the implicit `return` value. This is
+    // the multi-statement-block analogue of the arrow-lambda EmitTrailingExpression
+    // path: `func(c T) R { ...; <expr> }` returns `<expr>` converted to `R`.
+    //
+    // Only applies when the declared return type is a real value type (not void and
+    // not the error placeholder) and the last statement is a non-void expression
+    // statement that is not already a return. Void function literals are left as-is
+    // so the issue #889 statement-body / Action-delegate path keeps emitting a body
+    // with no value return.
+    private BoundBlockStatement SynthesizeFunctionLiteralTrailingReturn(
+        BoundBlockStatement body,
+        FunctionLiteralExpressionSyntax syntax,
+        TypeSymbol returnType)
+    {
+        if (returnType == TypeSymbol.Void || returnType == TypeSymbol.Error)
+        {
+            return body;
+        }
+
+        var statements = body.Statements;
+        if (statements.Length == 0)
+        {
+            return body;
+        }
+
+        if (statements[^1] is not BoundExpressionStatement trailingStatement)
+        {
+            return body;
+        }
+
+        var trailing = trailingStatement.Expression;
+        if (trailing.Type == TypeSymbol.Void || trailing.Type == TypeSymbol.Error)
+        {
+            return body;
+        }
+
+        var trailingConverted = trailing.Type == returnType
+            ? trailing
+            : conversions.BindConversion(trailingStatement.Syntax.Location, trailing, returnType);
+
+        var rewritten = statements.ToBuilder();
+        rewritten[^1] = new BoundReturnStatement(trailingStatement.Syntax, trailingConverted);
+        return new BoundBlockStatement(body.Syntax, rewritten.ToImmutable());
     }
 
     // ADR-0076 / issue #716: synthesise the trailing return / expression-

--- a/test/Compiler.Tests/Emit/Issue893FuncLiteralTrailingReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue893FuncLiteralTrailingReturnEmitTests.cs
@@ -1,0 +1,249 @@
+// <copyright file="Issue893FuncLiteralTrailingReturnEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #893 — a value-returning function literal
+/// <c>func(p T) R { ... &lt;trailing-expr&gt; }</c> whose block body ends in a bare
+/// trailing expression must treat that expression as the implicit return value.
+/// <para>
+/// Before the fix the trailing expression bound to a discarded expression
+/// statement, so the emitted method had a non-void signature but no <c>ret</c>
+/// returning a value. The CLR rejected the body with
+/// <c>System.InvalidProgramException</c> at runtime (and ilverify flagged the
+/// invalid IL). This was most visible when such a literal was passed as a
+/// <c>Func&lt;TSource,bool&gt;</c> predicate to a generic LINQ method like
+/// <c>Single</c> / <c>Where</c>, exactly as in the issue's
+/// <c>report.Checks.Single(func(c DoctorCheck) bool { c.Id == "audible-api" })</c>.
+/// </para>
+/// </summary>
+public class Issue893FuncLiteralTrailingReturnEmitTests
+{
+    [Fact]
+    public void FuncLiteralPredicate_TrailingBoolExpression_AsLinqSinglePredicate_Runs()
+    {
+        // Faithful shape of the issue: a `func(c T) bool { <comparison> }` literal
+        // passed straight to LINQ Single<TSource>(IEnumerable<TSource>, Func<TSource,bool>).
+        var source = """
+            package P
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            let ids = List[string]()
+            ids.Add("audible-api")
+            ids.Add("network")
+            let net = ids.Single(func(c string) bool { c == "network" })
+            Console.WriteLine(net)
+            """;
+
+        Assert.Equal("network\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void FuncLiteralPredicate_TrailingBoolExpression_AsLinqWherePredicate_Runs()
+    {
+        var source = """
+            package P
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            let nums = List[int32]()
+            nums.Add(1)
+            nums.Add(2)
+            nums.Add(3)
+            nums.Add(4)
+            let evens = nums.Where(func(n int32) bool { n % 2 == 0 })
+            Console.WriteLine(evens.Count())
+            """;
+
+        Assert.Equal("2\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void FuncLiteral_TrailingExpression_WithPrefixStatements_ReturnsTrailingValue()
+    {
+        // A multi-statement block whose final statement is a bare expression: the
+        // prefix statements run, then the trailing expression is the return value.
+        var source = """
+            package P
+            import System
+
+            let doubleThenAddOne = func(x int32) int32 {
+                let doubled = x * 2
+                doubled + 1
+            }
+            Console.WriteLine(doubleThenAddOne(20))
+            """;
+
+        Assert.Equal("41\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void FuncLiteral_TrailingExpression_RequiringConversion_ReturnsConvertedValue()
+    {
+        // The trailing expression's type (int32) differs from the declared return
+        // type (int64); it must be converted on the synthesized return.
+        var source = """
+            package P
+            import System
+
+            let widen = func(x int32) int64 { x + 1 }
+            Console.WriteLine(widen(41))
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void FuncLiteral_TrailingExpression_InsideAsyncMethod_ClosureContext_Runs()
+    {
+        // Mirrors the issue's setting: the predicate literal is created inside an
+        // async function and captures an outer local (closure context), then is
+        // passed to LINQ Single. Exercises the trailing-return rewrite for a
+        // value-returning literal that lives in a state machine / display class.
+        var source = """
+            package P
+            import System
+            import System.Linq
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func findAsync(items List[string], wanted string) string {
+                await Task.Yield()
+                return items.Single(func(c string) bool { c == wanted })
+            }
+
+            let data = List[string]()
+            data.Add("audible-api")
+            data.Add("network")
+            data.Add("disk")
+            let found = findAsync(data, "network").GetAwaiter().GetResult()
+            Console.WriteLine(found)
+            """;
+
+        Assert.Equal("network\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void FuncLiteral_VoidBody_StatementOnly_StillRunsWithoutImplicitReturn()
+    {
+        // Regression guard for issue #889: a void function literal (Action-style)
+        // must NOT gain an implicit value return from its trailing expression
+        // statement; it stays a statement body.
+        var source = """
+            package P
+            import System
+
+            let act = func(s string) { Console.WriteLine(s) }
+            act("ok")
+            """;
+
+        Assert.Equal("ok\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void FuncLiteral_ExplicitReturn_StillRuns()
+    {
+        // A value-returning literal that already ends in an explicit `return` must
+        // be left untouched by the trailing-return rewrite.
+        var source = """
+            package P
+            import System
+
+            let pick = func(flag bool) int32 {
+                if flag {
+                    return 1
+                }
+                return 2
+            }
+            Console.WriteLine(pick(true))
+            Console.WriteLine(pick(false))
+            """;
+
+        Assert.Equal("1\n2\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue893_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+
+            // (a) Static verification: the emitted IL must be valid.
+            IlVerifier.Verify(outPath);
+
+            // (b) Dynamic verification: the emitted code must execute without an
+            // InvalidProgramException (the runtime symptom in issue #893).
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #893

## Symptom
A G# program using a value-returning function literal `func(c DoctorCheck) bool { c.Id == "audible-api" }` as a predicate to a generic method (e.g. LINQ `Single`/`Where`) **compiled cleanly but threw `System.InvalidProgramException` at runtime**:

```
System.InvalidProgramException : Common Language Runtime detected an invalid program.
   at ...<lambda>(DoctorCheck c)
   at System.Linq.Enumerable.Single[TSource](IEnumerable`1, Func`2)
```

## Root cause (why the IL was invalid)
For a function literal `func(p T) R { ... <trailing-expr> }`, `LambdaBinder.BindFunctionLiteralExpression` bound the block body verbatim. A bare trailing expression therefore became a `BoundExpressionStatement` — **not** a return. The method-body emitter emits an expression statement by evaluating the expression and `pop`-ing its value, and it only caps a body with a synthetic trailing `ret` **when the function return type is `void`** (`ReflectionMetadataEmitter.cs`). So a non-`void` literal like `func(c string) bool { c == "network" }` produced a method with a `bool` return signature, **no `ret` that returns a value, and the body fell off the end** — invalid IL that ilverify rejects and the CLR refuses to run.

The arrow-lambda path (`(c) -> c == "network"`) already handled this by synthesizing a converted `return` from the trailing expression (`EmitTrailingExpression`); the `func(...) {}` block form did not.

## The fix
In `LambdaBinder.BindFunctionLiteralExpression`, after binding the body, rewrite a value-returning literal's trailing bare expression statement into a `return` statement, converting the expression to the declared return type (`SynthesizeFunctionLiteralTrailingReturn`). This mirrors the arrow-lambda semantics:

- Declared return type is a real value type (`!= void`, `!= error`) **and** the last statement is a non-`void` expression statement → it becomes `return <converted-expr>`.
- `void` literals are left untouched, preserving the issue #889 Action-style statement-body / void-delegate behavior (no implicit value return).
- Literals already ending in an explicit `return` are unaffected.

## Tests
`test/Compiler.Tests/Emit/Issue893FuncLiteralTrailingReturnEmitTests.cs` — each case runs **ilverify** on the emitted assembly **and executes it** (asserting no `InvalidProgramException`):

- `func(c string) bool { c == "network" }` passed to LINQ `Single` (faithful issue shape)
- `func(n int32) bool { n % 2 == 0 }` passed to LINQ `Where`
- trailing expression with prefix statements
- trailing expression requiring a widening conversion (`int32` -> `int64`)
- predicate literal created inside an `async` function capturing an outer local, passed to `Single` (closure/state-machine context, matching the issue's `async func` test)
- regression guards: void statement-body literal (#889) and explicit-`return` literal

## Verification
- `dotnet build GSharp.sln -c Release` ✅
- `dotnet test GSharp.sln -c Release` ✅ — Compiler.Tests 1360, Core.Tests 3340 (1 skip), Interpreter.Tests 308, LanguageServer.Tests 337, Extensions.Tests 104, Sdk.Tests 38 — all green.
- Emitted IL now **passes ilverify** and **executes without `InvalidProgramException`**.

Files changed:
- `src/Core/CodeAnalysis/Binding/LambdaBinder.cs`
- `test/Compiler.Tests/Emit/Issue893FuncLiteralTrailingReturnEmitTests.cs`
