### PR TITLE
Improve G# LSP dev experience: colorization, async/CLR display, object-initializer hover & completion

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
+++ b/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
@@ -384,6 +384,8 @@ public static class SymbolDisplay
 
     private static void AppendProperty(PartBuilder builder, SymbolDisplayFormat format, PropertySymbol property)
     {
+        builder.Keyword("prop");
+        builder.Space();
         builder.Add(SymbolDisplayPartKind.PropertyName, property.Name);
         builder.Space();
         builder.Type(FormatType(property.Type));
@@ -522,6 +524,18 @@ public static class SymbolDisplay
 
     private static void AppendClrMethod(PartBuilder builder, SymbolDisplayFormat format, MethodInfo method)
     {
+        // ADR-0023 parity: a CLR method compiled from `async`/`await` exposes a
+        // `Task[R]` (or `ValueTask[R]`) return in metadata, but G# renders async
+        // functions as `async func ... R` with the awaited result type. Mirror
+        // that here so an imported `async Task<R> M(...)` hovers as
+        // `async func (T) M(...) R` rather than the leaked `func ... Task[R]`.
+        var isAsync = format.IncludeModifiers && IsClrAsyncMethod(method);
+        if (isAsync)
+        {
+            builder.Keyword("async");
+            builder.Space();
+        }
+
         builder.Keyword("func");
         builder.Space();
 
@@ -551,11 +565,66 @@ public static class SymbolDisplay
 
         builder.Punctuation(")");
 
-        if (!method.ReturnType.IsSameAs(typeof(void)))
+        var returnType = isAsync ? UnwrapTaskReturnType(method.ReturnType) : method.ReturnType;
+        if (!returnType.IsSameAs(typeof(void)))
         {
             builder.Space();
-            builder.Type(FormatClrTypeName(method.ReturnType, format.QualifyNames));
+            builder.Type(FormatClrTypeName(returnType, format.QualifyNames));
         }
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when a reflected CLR method was compiled from an
+    /// <c>async</c> method (carries <c>AsyncStateMachineAttribute</c>). Uses
+    /// <see cref="MemberInfo.GetCustomAttributesData"/> rather than the generic
+    /// <c>GetCustomAttribute&lt;T&gt;()</c> so it works for methods loaded
+    /// through a <c>MetadataLoadContext</c> (the production <c>gsc</c> reference
+    /// path), where reflection-only types cannot be matched by runtime identity.
+    /// </summary>
+    private static bool IsClrAsyncMethod(MethodInfo method)
+    {
+        foreach (var attribute in method.GetCustomAttributesData())
+        {
+            if (attribute.AttributeType?.FullName == "System.Runtime.CompilerServices.AsyncStateMachineAttribute")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Unwraps the awaited result type of an async return: <c>Task[R]</c> /
+    /// <c>ValueTask[R]</c> resolve to <c>R</c>, the non-generic <c>Task</c> /
+    /// <c>ValueTask</c> resolve to <c>void</c>, and any other shape (e.g. an
+    /// async <c>IAsyncEnumerable[T]</c> iterator, or <c>async void</c>) is
+    /// returned unchanged. FullName matching keeps this correct under a
+    /// <c>MetadataLoadContext</c>.
+    /// </summary>
+    private static Type UnwrapTaskReturnType(Type returnType)
+    {
+        if (returnType == null)
+        {
+            return null;
+        }
+
+        if (returnType.IsGenericType && !returnType.IsGenericTypeDefinition)
+        {
+            var definitionName = returnType.GetGenericTypeDefinition()?.FullName;
+            if (definitionName == "System.Threading.Tasks.Task`1"
+                || definitionName == "System.Threading.Tasks.ValueTask`1")
+            {
+                return returnType.GetGenericArguments()[0];
+            }
+
+            return returnType;
+        }
+
+        return returnType.FullName == "System.Threading.Tasks.Task"
+            || returnType.FullName == "System.Threading.Tasks.ValueTask"
+            ? typeof(void)
+            : returnType;
     }
 
     private static string QualifiedName(SymbolDisplayFormat format, string packageName, string name)
@@ -569,7 +638,78 @@ public static class SymbolDisplay
 
     private static string FormatType(TypeSymbol type)
     {
-        return type == null || IsVoid(type) ? "void" : type.Name;
+        if (type == null || IsVoid(type))
+        {
+            return "void";
+        }
+
+        // Reconstruct the display name from the type's structure rather than
+        // returning the raw TypeSymbol.Name. For constructed generics backed by
+        // a CLR type (e.g. Task[string]) that raw name is the assembly-qualified
+        // Type.FullName (`System.Threading.Tasks.Task`1[[System.String, ...]]`),
+        // which leaks into hover. Recursing also keeps wrapper syntax in G# form
+        // (`[]T`, `T?`, `sequence[T]`, ...) while rendering imported element
+        // types nicely.
+        switch (type)
+        {
+            case NullableTypeSymbol nullable:
+                return $"{FormatType(nullable.UnderlyingType)}?";
+            case SliceTypeSymbol slice:
+                return $"[]{FormatType(slice.ElementType)}";
+            case AsyncSequenceTypeSymbol asyncSequence:
+                return $"sequence[{FormatType(asyncSequence.ElementType)}]";
+            case SequenceTypeSymbol sequence:
+                return $"sequence[{FormatType(sequence.ElementType)}]";
+            case MapTypeSymbol map:
+                return $"map[{FormatType(map.KeyType)},{FormatType(map.ValueType)}]";
+            case TupleTypeSymbol tuple:
+                return $"({string.Join(", ", tuple.ElementTypes.Select(FormatType))})";
+            case ImportedTypeSymbol imported:
+                return FormatImportedType(imported);
+            default:
+                return type.Name;
+        }
+    }
+
+    /// <summary>
+    /// Renders an <see cref="ImportedTypeSymbol"/> with a friendly, G#-flavored
+    /// name. A plain imported type is formatted from its CLR <see cref="Type"/>
+    /// (so constructed generics become <c>Outer[Arg]</c> and primitives map to
+    /// their G# spellings). A #313 symbolic construction — whose CLR form is
+    /// type-erased to <c>object</c> — is rebuilt from its open definition plus
+    /// the symbolic <see cref="ImportedTypeSymbol.TypeArguments"/>.
+    /// </summary>
+    private static string FormatImportedType(ImportedTypeSymbol imported)
+    {
+        if (!imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            var definition = imported.OpenDefinition;
+            var baseName = StripGenericArity(definition?.FullName ?? definition?.Name) ?? imported.Name;
+            var args = string.Join(", ", imported.TypeArguments.Select(a => a == null ? "?" : FormatType(a)));
+            return $"{baseName}[{args}]";
+        }
+
+        return FormatClrTypeName(imported.ClrType, qualifyNames: true);
+    }
+
+    /// <summary>
+    /// Strips the CLR generic-arity suffix (<c>`1</c>) and normalizes nested
+    /// type separators (<c>+</c> to <c>.</c>) from a reflected type name.
+    /// </summary>
+    private static string StripGenericArity(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return name;
+        }
+
+        var tickIndex = name.IndexOf('`');
+        if (tickIndex >= 0)
+        {
+            name = name.Substring(0, tickIndex);
+        }
+
+        return name.Replace('+', '.');
     }
 
     private static string FormatClrMemberName(Type declaringType, string name, SymbolDisplayFormat format)

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -289,7 +289,7 @@ public static class HoverComputer
         member = null;
         overloadCount = 0;
 
-        foreach (var context in FindAccessorMemberContexts(tree, token))
+        foreach (var context in FindAccessorMemberContexts(tree, token).Concat(FindObjectInitializerMemberContexts(tree, token)))
         {
             if (!TryResolveClrReceiver(tree, compilation, context.ReceiverExpression, out var receiver))
             {
@@ -351,8 +351,10 @@ public static class HoverComputer
             return null;
         }
 
-        // Case 1: member access expression (e.g. var x = person.Name)
-        foreach (var context in FindAccessorMemberContexts(tree, token))
+        // Case 1: member access expression (e.g. var x = person.Name), or an
+        // object-initializer property name (e.g. Point() { X = 1 }) whose receiver
+        // is the constructed G# struct/class type.
+        foreach (var context in FindAccessorMemberContexts(tree, token).Concat(FindObjectInitializerMemberContexts(tree, token)))
         {
             var structSymbol = ResolveReceiverStructSymbol(tree, compilation, context.ReceiverExpression);
             if (structSymbol != null)
@@ -548,6 +550,33 @@ public static class HoverComputer
         }
     }
 
+    /// <summary>
+    /// Issue #522 / #897: yields the member-resolution context for a token that is the
+    /// <see cref="PropertyInitializerSyntax.PropertyIdentifier"/> of a C#-style object
+    /// initializer (<c>T(args) { Prop = v }</c>). The "receiver" is the constructor call
+    /// (<see cref="ObjectCreationExpressionSyntax.Target"/>) whose constructed type the
+    /// property/field is looked up on — mirroring the accessor member contexts so the
+    /// same CLR and G# resolution paths apply to initializer property names.
+    /// </summary>
+    private static IEnumerable<(ExpressionSyntax ReceiverExpression, string MemberName)> FindObjectInitializerMemberContexts(SyntaxTree tree, SyntaxToken token)
+    {
+        if (token == null || token.Kind != SyntaxKind.IdentifierToken)
+        {
+            yield break;
+        }
+
+        foreach (var creation in FindNodes<ObjectCreationExpressionSyntax>(tree.Root))
+        {
+            foreach (var initializer in creation.Initializers)
+            {
+                if (MatchesToken(initializer.PropertyIdentifier, token))
+                {
+                    yield return (creation.Target, initializer.PropertyIdentifier.Text);
+                }
+            }
+        }
+    }
+
     private static bool TryResolveAccessorMemberContext(
         SyntaxTree tree,
         ExpressionSyntax expression,
@@ -626,6 +655,19 @@ public static class HoverComputer
             case CallExpressionSyntax call when TryResolveClrTypeFromSymbol(SemanticLookup.ResolveSymbol(compilation, call.Identifier), out var callType):
                 receiver = new ClrReceiver(callType, StaticMembers: false);
                 return true;
+            case CallExpressionSyntax constructorCall:
+                // A constructor call on an imported CLR type (e.g. `ProcessStartInfo("x")`)
+                // whose identifier does not resolve to a symbol: fall back to resolving the
+                // type by name so instance members of the constructed object are available
+                // (object-initializer property names, etc.).
+                var constructedType = SemanticLookup.ResolveImportedClrType(tree, compilation, constructorCall.Identifier.Text);
+                if (constructedType != null)
+                {
+                    receiver = new ClrReceiver(constructedType, StaticMembers: false);
+                    return true;
+                }
+
+                break;
             case AccessorExpressionSyntax accessor when TryResolveClrMemberExpression(tree, compilation, accessor, out var memberType):
                 receiver = new ClrReceiver(memberType, StaticMembers: false);
                 return true;
@@ -1324,6 +1366,15 @@ public static class CompletionComputer
             return memberItems;
         }
 
+        // Issue #522 / #897: inside a C#-style object-initializer block
+        // (`T(args) { <caret> }`), offer the writable instance members of the
+        // constructed type instead of the global keyword/symbol list.
+        var initializerItems = TryComputeObjectInitializerCompletions(content, compilation, offset);
+        if (initializerItems != null)
+        {
+            return initializerItems;
+        }
+
         var items = new List<CompletionItem>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
 
@@ -1430,6 +1481,203 @@ public static class CompletionComputer
         }
 
         return items;
+    }
+
+    /// <summary>
+    /// Issue #522 / #897: when the caret sits inside a C#-style object-initializer
+    /// block (<c>T(args) { Prop = v, &lt;caret&gt; }</c>) in a property-name position,
+    /// returns the writable instance members (settable properties / writable fields)
+    /// of the constructed type. Returns <see langword="null"/> when the caret is not
+    /// in such a position so the caller falls back to the global completion list.
+    /// </summary>
+    private static IReadOnlyList<CompletionItem> TryComputeObjectInitializerCompletions(DocumentContent content, Compilation compilation, int offset)
+    {
+        var root = content.SyntaxTree.Root;
+
+        // Well-formed initializer: the brace block parses as an ObjectCreationExpression.
+        var creation = EnumerateNodes(root).OfType<ObjectCreationExpressionSyntax>()
+            .Where(c => IsInInitializerNamePosition(c, offset))
+            .OrderBy(c => c.Span.Length)
+            .FirstOrDefault();
+        var receiver = creation?.Target;
+
+        // Mid-typing recovery: `T(args) { Partial }` with no `=` parses the brace
+        // block as a standalone BlockStatement abutting the constructor call. Recover
+        // the constructor call as the receiver so the first property name still completes.
+        receiver ??= TryFindOrphanInitializerReceiver(root, offset);
+        if (receiver == null)
+        {
+            return null;
+        }
+
+        var (function, locals) = SemanticLookup.GetExpressionBindingContext(compilation, content.SyntaxTree, offset);
+        var receiverType = GSharp.Core.CodeAnalysis.Binding.Binder.TryInferExpressionType(
+            compilation.GlobalScope,
+            compilation.References,
+            function,
+            locals,
+            receiver);
+        if (receiverType == null)
+        {
+            // Caret is in an initializer position but the target type can't be inferred —
+            // suppress the global list rather than offering irrelevant keywords/symbols.
+            return new List<CompletionItem>();
+        }
+
+        var items = new List<CompletionItem>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        AddObjectInitializerMembers(receiverType, items, seen);
+        return items;
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="offset"/> sits inside the braces of
+    /// <paramref name="creation"/> in a property-name position — i.e. not within the
+    /// value expression of an existing initializer (where the global list belongs).
+    /// </summary>
+    private static bool IsInInitializerNamePosition(ObjectCreationExpressionSyntax creation, int offset)
+    {
+        var open = creation.OpenBraceToken;
+        if (open == null || open.IsMissing)
+        {
+            return false;
+        }
+
+        var start = open.Span.End;
+        var end = creation.CloseBraceToken != null && !creation.CloseBraceToken.IsMissing
+            ? creation.CloseBraceToken.Span.Start
+            : creation.Span.End;
+        if (offset < start || offset > end)
+        {
+            return false;
+        }
+
+        foreach (var initializer in creation.Initializers)
+        {
+            var equals = initializer.EqualsToken;
+            if (equals != null && !equals.IsMissing && offset >= equals.Span.Start && offset <= initializer.Span.End)
+            {
+                // Caret is on the value side of `Prop = value` — defer to the global list.
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Recovers the constructor call that an object-initializer block belongs to when
+    /// the block failed to parse as an <see cref="ObjectCreationExpressionSyntax"/>
+    /// (e.g. the first property name typed without a trailing <c>=</c>). The block then
+    /// parses as a standalone <see cref="BlockStatementSyntax"/> abutting the call.
+    /// </summary>
+    private static ExpressionSyntax TryFindOrphanInitializerReceiver(SyntaxNode root, int offset)
+    {
+        var block = EnumerateNodes(root).OfType<BlockStatementSyntax>()
+            .Where(b => b.OpenBraceToken != null
+                && !b.OpenBraceToken.IsMissing
+                && offset >= b.OpenBraceToken.Span.End
+                && offset <= (b.CloseBraceToken != null && !b.CloseBraceToken.IsMissing ? b.CloseBraceToken.Span.Start : b.Span.End))
+            .OrderBy(b => b.Span.Length)
+            .FirstOrDefault();
+        if (block == null)
+        {
+            return null;
+        }
+
+        var braceStart = block.OpenBraceToken.Span.Start;
+
+        // The receiver is a constructor call (or object creation) whose end immediately
+        // precedes the block's open brace, separated only by whitespace.
+        ExpressionSyntax best = null;
+        foreach (var node in EnumerateNodes(root))
+        {
+            if (node is not ExpressionSyntax candidate)
+            {
+                continue;
+            }
+
+            if (node is not (CallExpressionSyntax or ObjectCreationExpressionSyntax))
+            {
+                continue;
+            }
+
+            if (candidate.Span.End <= braceStart
+                && IsWhitespaceBetween(root.SyntaxTree, candidate.Span.End, braceStart)
+                && (best == null || candidate.Span.End > best.Span.End))
+            {
+                best = candidate;
+            }
+        }
+
+        return best;
+    }
+
+    private static bool IsWhitespaceBetween(SyntaxTree tree, int start, int end)
+    {
+        if (end <= start)
+        {
+            return true;
+        }
+
+        var text = tree.Text.ToString(start, end - start);
+        foreach (var ch in text)
+        {
+            if (!char.IsWhiteSpace(ch))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Adds the writable instance members (settable properties / writable fields) of
+    /// <paramref name="receiverType"/> as object-initializer completions.
+    /// </summary>
+    private static void AddObjectInitializerMembers(TypeSymbol receiverType, List<CompletionItem> items, HashSet<string> seen)
+    {
+        if (receiverType is StructSymbol structSymbol)
+        {
+            for (var current = structSymbol; current != null; current = current.BaseClass)
+            {
+                foreach (var field in current.Fields)
+                {
+                    AddItem(items, seen, field.Name, CompletionItemKind.Field, HoverComputer.FormatSymbol(field));
+                }
+
+                foreach (var property in current.Properties)
+                {
+                    AddItem(items, seen, property.Name, CompletionItemKind.Property, $"{property.Name}: {property.Type?.Name}");
+                }
+            }
+
+            return;
+        }
+
+        var clrType = receiverType?.ClrType;
+        if (clrType == null)
+        {
+            return;
+        }
+
+        var flags = BindingFlags.Public | BindingFlags.Instance;
+        foreach (var property in ClrTypeUtilities.SafeGetProperties(clrType, flags))
+        {
+            if (property.CanWrite && property.GetIndexParameters().Length == 0)
+            {
+                AddItem(items, seen, property.Name, CompletionItemKind.Property, $"{property.Name}: {property.PropertyType.Name}");
+            }
+        }
+
+        foreach (var field in ClrTypeUtilities.SafeGetFields(clrType, flags))
+        {
+            if (!field.IsInitOnly && !field.IsLiteral)
+            {
+                AddItem(items, seen, field.Name, CompletionItemKind.Field, $"{field.Name}: {field.FieldType.Name}");
+            }
+        }
     }
 
     private static FunctionDeclarationSyntax FindContainingFunction(SyntaxTree tree, int offset)

--- a/src/LanguageServer/SemanticTokensHandler.cs
+++ b/src/LanguageServer/SemanticTokensHandler.cs
@@ -91,7 +91,7 @@ public static class SemanticTokensComputer
             }
 
             // Interpolated string literals are decomposed: literal text is classified as String,
-            // while the hole expressions are tokenized as real code (identifiers, keywords, numbers).
+            // while the hole expressions are tokenized as real code (identifiers, numbers).
             if (token.Kind == SyntaxKind.InterpolatedStringToken)
             {
                 EmitInterpolatedStringTokens(builder, tree, text, token.Span, compilation, declarationPositions);
@@ -136,8 +136,8 @@ public static class SemanticTokensComputer
 
         // Collect classified hole tokens plus the hole-expression spans. String filler is emitted
         // only for the literal/delimiter text OUTSIDE the holes; inside a hole, classified tokens
-        // (identifiers, keywords, numbers) are overlaid and the remaining code (operators,
-        // punctuation, member names the model can't resolve) is left for the TextMate grammar so it
+        // (identifiers, numbers) are overlaid and the remaining code (operators, punctuation,
+        // keywords, member names the model can't resolve) is left for the TextMate grammar so it
         // is colored as code rather than as part of the surrounding string.
         var holeTokens = new List<(GSharp.Core.CodeAnalysis.Text.TextSpan Span, SemanticTokenType Type, SemanticTokenModifier[] Modifiers)>();
         var holeSpans = new List<GSharp.Core.CodeAnalysis.Text.TextSpan>();
@@ -371,11 +371,14 @@ public static class SemanticTokensComputer
             return (SemanticTokenType.Number, System.Array.Empty<SemanticTokenModifier>());
         }
 
-        // Keywords
-        if (IsKeyword(token.Kind))
-        {
-            return (SemanticTokenType.Keyword, System.Array.Empty<SemanticTokenModifier>());
-        }
+        // Keywords are intentionally NOT classified as semantic tokens. The
+        // TextMate grammar already colors them via fine-grained scopes
+        // (keyword.control, keyword.declaration, keyword.modifier, ...). Emitting
+        // a single flat semantic `keyword` type would override those scopes once
+        // the language server initializes, causing a visible color shift (e.g.
+        // control keywords recoloring from their `keyword.control` color to the
+        // generic `keyword` color). Leaving keywords to TextMate keeps their
+        // color stable across the LSP handshake under every theme.
 
         // Operators and punctuation — not classified as semantic tokens
         if (IsOperatorOrPunctuation(token.Kind))
@@ -468,11 +471,6 @@ public static class SemanticTokensComputer
         }
 
         return modifiers.ToArray();
-    }
-
-    private static bool IsKeyword(SyntaxKind kind)
-    {
-        return kind >= SyntaxKind.AsyncKeyword && kind <= SyntaxKind.FinallyKeyword;
     }
 
     private static bool IsOperatorOrPunctuation(SyntaxKind kind)

--- a/test/Core.Tests/CodeAnalysis/Symbols/SymbolDisplayAsyncClrMethodTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/SymbolDisplayAsyncClrMethodTests.cs
@@ -1,0 +1,87 @@
+// <copyright file="SymbolDisplayAsyncClrMethodTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Symbols.Display;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// ADR-0023 parity for imported CLR methods: a reflected <c>async</c> method
+/// exposes a <c>Task[R]</c> / <c>ValueTask[R]</c> return in metadata, but
+/// <see cref="SymbolDisplay"/> renders it as <c>async func ... R</c> to match
+/// how G#-authored <c>async func</c> declarations display.
+/// </summary>
+public class SymbolDisplayAsyncClrMethodTests
+{
+    [Fact]
+    public void AsyncTaskOfT_RendersAsAsyncFuncWithUnwrappedResult()
+    {
+        var method = typeof(AsyncClrMethodSamples).GetMethod(nameof(AsyncClrMethodSamples.AsyncResult));
+
+        var rendered = SymbolDisplay.ToDisplayString(method, SymbolDisplayFormat.Signature);
+
+        Assert.Equal("async func AsyncResult(name string) int32", rendered);
+    }
+
+    [Fact]
+    public void AsyncNonGenericTask_RendersAsAsyncFuncWithNoReturnType()
+    {
+        var method = typeof(AsyncClrMethodSamples).GetMethod(nameof(AsyncClrMethodSamples.AsyncNoResult));
+
+        var rendered = SymbolDisplay.ToDisplayString(method, SymbolDisplayFormat.Signature);
+
+        Assert.Equal("async func AsyncNoResult()", rendered);
+    }
+
+    [Fact]
+    public void AsyncValueTaskOfT_RendersAsAsyncFuncWithUnwrappedResult()
+    {
+        var method = typeof(AsyncClrMethodSamples).GetMethod(nameof(AsyncClrMethodSamples.AsyncValueResult));
+
+        var rendered = SymbolDisplay.ToDisplayString(method, SymbolDisplayFormat.Signature);
+
+        Assert.Equal("async func AsyncValueResult() int32", rendered);
+    }
+
+    [Fact]
+    public void NonAsyncTaskOfT_KeepsTaskReturnAndNoAsyncModifier()
+    {
+        // A method that returns Task<int> WITHOUT being compiled from async/await
+        // is genuinely Task-returning to the caller, so the display must not hide
+        // it nor add the `async` modifier.
+        var method = typeof(AsyncClrMethodSamples).GetMethod(nameof(AsyncClrMethodSamples.PlainTask));
+
+        var rendered = SymbolDisplay.ToDisplayString(method, SymbolDisplayFormat.Signature);
+
+        Assert.Equal("func PlainTask() Task[int32]", rendered);
+    }
+
+    [Fact]
+    public void AsyncMethod_HoverFormat_IncludesReceiverAndUnwrappedResult()
+    {
+        var method = typeof(AsyncClrMethodSamples).GetMethod(nameof(AsyncClrMethodSamples.AsyncResult));
+
+        var rendered = SymbolDisplay.ToDisplayString(method, SymbolDisplayFormat.Hover);
+
+        Assert.StartsWith("async func (", rendered);
+        Assert.EndsWith(") AsyncResult(name string) int32", rendered);
+    }
+}
+
+#pragma warning disable CS1998 // async method without await: intentional — the test only inspects metadata, not runtime behavior.
+internal static class AsyncClrMethodSamples
+{
+    public static async Task<int> AsyncResult(string name) => name.Length;
+
+    public static async Task AsyncNoResult()
+    {
+    }
+
+    public static async ValueTask<int> AsyncValueResult() => 1;
+
+    public static Task<int> PlainTask() => Task.FromResult(1);
+}
+#pragma warning restore CS1998

--- a/test/Core.Tests/CodeAnalysis/Symbols/SymbolDisplayImportedTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/SymbolDisplayImportedTypeTests.cs
@@ -1,0 +1,76 @@
+// <copyright file="SymbolDisplayImportedTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Symbols.Display;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Hover/type display for symbols typed as imported CLR types. A constructed
+/// generic such as <c>Task[string]</c> must render with its friendly G# name
+/// rather than the raw assembly-qualified <see cref="System.Type.FullName"/>
+/// that <see cref="TypeSymbol.Name"/> carries for closed generics.
+/// </summary>
+public class SymbolDisplayImportedTypeTests
+{
+    private static string Render(TypeSymbol type)
+    {
+        var local = new LocalVariableSymbol("v", isReadOnly: true, type);
+        return SymbolDisplay.ToDisplayString(local, SymbolDisplayFormat.Hover);
+    }
+
+    [Fact]
+    public void LocalVariable_OfConstructedGenericTask_RendersFriendlyName()
+    {
+        var type = ImportedTypeSymbol.Get(typeof(Task<string>));
+
+        Assert.Equal("(local variable) v System.Threading.Tasks.Task[string]", Render(type));
+    }
+
+    [Fact]
+    public void LocalVariable_OfNonGenericImportedType_RendersQualifiedName()
+    {
+        var type = ImportedTypeSymbol.Get(typeof(System.Diagnostics.Process));
+
+        Assert.Equal("(local variable) v System.Diagnostics.Process", Render(type));
+    }
+
+    [Fact]
+    public void LocalVariable_OfNestedGeneric_RendersFriendlyArguments()
+    {
+        var type = ImportedTypeSymbol.Get(typeof(Dictionary<string, List<int>>));
+
+        Assert.Equal(
+            "(local variable) v System.Collections.Generic.Dictionary[string, System.Collections.Generic.List[int32]]",
+            Render(type));
+    }
+
+    [Fact]
+    public void LocalVariable_OfNullableImportedGeneric_KeepsGSharpNullableSyntax()
+    {
+        var type = NullableTypeSymbol.Get(ImportedTypeSymbol.Get(typeof(Task<string>)));
+
+        Assert.Equal("(local variable) v System.Threading.Tasks.Task[string]?", Render(type));
+    }
+
+    [Fact]
+    public void LocalVariable_OfSliceOfImportedGeneric_KeepsGSharpSliceSyntax()
+    {
+        var type = SliceTypeSymbol.Get(ImportedTypeSymbol.Get(typeof(Task<string>)));
+
+        Assert.Equal("(local variable) v []System.Threading.Tasks.Task[string]", Render(type));
+    }
+
+    [Fact]
+    public void LocalVariable_OfPrimitive_RendersGSharpSpelling()
+    {
+        var type = ImportedTypeSymbol.Get(typeof(int));
+
+        Assert.Equal("(local variable) v int32", Render(type));
+    }
+}

--- a/test/LanguageServer.Tests/ObjectInitializerHoverCompletionTests.cs
+++ b/test/LanguageServer.Tests/ObjectInitializerHoverCompletionTests.cs
@@ -1,0 +1,188 @@
+// <copyright file="ObjectInitializerHoverCompletionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.LanguageServer;
+using GSharp.LanguageServer.Protocol;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// Issue #897: hover and completion inside C#-style object-initializer blocks
+/// (<c>T(args) { Prop = v }</c>) — the property names resolve against the
+/// constructed type for both imported CLR types and user-defined G# classes.
+/// </summary>
+public class ObjectInitializerHoverCompletionTests
+{
+    [Fact]
+    public void ComputeHover_OnClrInitializerProperty_ResolvesAgainstConstructedType()
+    {
+        const string source = "import System.Diagnostics\n"
+            + "func main() {\n"
+            + "    let psi = ProcessStartInfo(\"dotnet\") {\n"
+            + "        RedirectStandardOutput = true,\n"
+            + "        UseShellExecute = false\n"
+            + "    }\n"
+            + "}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "RedirectStandardOutput"));
+
+        Assert.NotNull(hover);
+        var value = hover.Contents.ToString();
+        Assert.Contains("System.Diagnostics.ProcessStartInfo.RedirectStandardOutput", value, System.StringComparison.Ordinal);
+        Assert.Contains("bool", value, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ComputeHover_OnSecondClrInitializerProperty_Resolves()
+    {
+        const string source = "import System.Diagnostics\n"
+            + "func main() {\n"
+            + "    let psi = ProcessStartInfo(\"dotnet\") {\n"
+            + "        RedirectStandardOutput = true,\n"
+            + "        UseShellExecute = false\n"
+            + "    }\n"
+            + "}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "UseShellExecute"));
+
+        Assert.NotNull(hover);
+        Assert.Contains("System.Diagnostics.ProcessStartInfo.UseShellExecute", hover.Contents.ToString(), System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ComputeHover_OnGSharpClassInitializerProperty_ResolvesToPropertySymbol()
+    {
+        const string source = "class Box {\n"
+            + "    prop Width int32\n"
+            + "    prop Height int32\n"
+            + "    init() { }\n"
+            + "}\n"
+            + "func main() {\n"
+            + "    let b = Box() { Width = 5, Height = 6 }\n"
+            + "}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "Width", occurrence: 1));
+
+        Assert.NotNull(hover);
+        var value = hover.Contents.ToString();
+        Assert.Contains("Width", value, System.StringComparison.Ordinal);
+        Assert.Contains("int32", value, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ComputeCompletions_InsideClrInitializerBlock_OffersWritableMembers()
+    {
+        const string source = "import System.Diagnostics\n"
+            + "func main() {\n"
+            + "    let psi = ProcessStartInfo(\"dotnet\") {\n"
+            + "        RedirectStandardOutput = true,\n"
+            + "        \n"
+            + "    }\n"
+            + "}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        // Caret on the blank line inside the initializer block (a name position).
+        var position = LanguageServerTestHelpers.PositionOf(source, "        \n    }", occurrence: 0);
+        var caret = new Position(position.Line, 8);
+
+        var items = CompletionComputer.ComputeCompletions(content, caret);
+
+        Assert.Contains(items, i => i.Label == "UseShellExecute" && i.Kind == CompletionItemKind.Property);
+        Assert.Contains(items, i => i.Label == "RedirectStandardError" && i.Kind == CompletionItemKind.Property);
+
+        // The global keyword list must be suppressed inside the initializer block.
+        Assert.DoesNotContain(items, i => i.Label == "let" && i.Kind == CompletionItemKind.Keyword);
+    }
+
+    [Fact]
+    public void ComputeCompletions_InsideEmptyClrInitializerBlock_OffersWritableMembers()
+    {
+        const string source = "import System.Diagnostics\n"
+            + "func main() {\n"
+            + "    let psi = ProcessStartInfo(\"dotnet\") {  }\n"
+            + "}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        // Caret between the two braces.
+        var bracePos = LanguageServerTestHelpers.PositionOf(source, "{  }");
+        var caret = new Position(bracePos.Line, bracePos.Character + 2);
+
+        var items = CompletionComputer.ComputeCompletions(content, caret);
+
+        Assert.Contains(items, i => i.Label == "UseShellExecute" && i.Kind == CompletionItemKind.Property);
+    }
+
+    [Fact]
+    public void ComputeCompletions_WhileTypingFirstClrInitializerProperty_OffersWritableMembers()
+    {
+        // Mid-typing the very first property name without a trailing `=` parses the
+        // brace block as a standalone block (no ObjectCreationExpression). The orphan
+        // recovery still offers the constructed type's writable members.
+        const string source = "import System.Diagnostics\n"
+            + "func main() {\n"
+            + "    let psi = ProcessStartInfo(\"dotnet\") {\n"
+            + "        Redirect\n"
+            + "    }\n"
+            + "}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var namePos = LanguageServerTestHelpers.PositionOf(source, "Redirect");
+        var caret = new Position(namePos.Line, namePos.Character + "Redirect".Length);
+
+        var items = CompletionComputer.ComputeCompletions(content, caret);
+
+        Assert.Contains(items, i => i.Label == "RedirectStandardOutput" && i.Kind == CompletionItemKind.Property);
+        Assert.DoesNotContain(items, i => i.Label == "let" && i.Kind == CompletionItemKind.Keyword);
+    }
+
+    [Fact]
+    public void ComputeCompletions_InsideGSharpClassInitializerBlock_OffersProperties()
+    {
+        const string source = "class Box {\n"
+            + "    prop Width int32\n"
+            + "    prop Height int32\n"
+            + "    init() { }\n"
+            + "}\n"
+            + "func main() {\n"
+            + "    let b = Box() {  }\n"
+            + "}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var bracePos = LanguageServerTestHelpers.PositionOf(source, "{  }");
+        var caret = new Position(bracePos.Line, bracePos.Character + 2);
+
+        var items = CompletionComputer.ComputeCompletions(content, caret);
+
+        Assert.Contains(items, i => i.Label == "Width" && i.Kind == CompletionItemKind.Property);
+        Assert.Contains(items, i => i.Label == "Height" && i.Kind == CompletionItemKind.Property);
+    }
+
+    [Fact]
+    public void ComputeCompletions_InValuePositionOfInitializer_FallsBackToGlobalList()
+    {
+        const string source = "import System.Diagnostics\n"
+            + "func main() {\n"
+            + "    let psi = ProcessStartInfo(\"dotnet\") {\n"
+            + "        RedirectStandardOutput = \n"
+            + "    }\n"
+            + "}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        // Caret right after `RedirectStandardOutput = ` (value position).
+        var eqPos = LanguageServerTestHelpers.PositionOf(source, "RedirectStandardOutput = ");
+        var caret = new Position(eqPos.Line, eqPos.Character + "RedirectStandardOutput = ".Length);
+
+        var items = CompletionComputer.ComputeCompletions(content, caret);
+
+        // Value position offers the regular global list (keywords/symbols), not the
+        // initializer's writable members.
+        Assert.Contains(items, i => i.Label == "true" && i.Kind == CompletionItemKind.Keyword);
+        Assert.DoesNotContain(items, i => i.Label == "UseShellExecute");
+    }
+}

--- a/test/LanguageServer.Tests/SemanticTokensHandlerTests.cs
+++ b/test/LanguageServer.Tests/SemanticTokensHandlerTests.cs
@@ -12,16 +12,17 @@ namespace GSharp.LanguageServer.Tests;
 public class SemanticTokensHandlerTests
 {
     [Fact]
-    public void Tokenize_ClassifiesKeywords()
+    public void Tokenize_DoesNotClassifyKeywords()
     {
         const string source = "var x = 42\n";
         var content = LanguageServerTestHelpers.Content(source);
         var tokens = GetTokens(content);
 
-        // "var" should be classified as keyword (index 12)
+        // Keywords are intentionally left to the TextMate grammar so their color
+        // stays stable across the LSP handshake. "var" must NOT be emitted as a
+        // semantic token.
         var varToken = FindToken(tokens, 0, 0, 3);
-        Assert.NotNull(varToken);
-        Assert.Equal(TokenTypeIndex("Keyword"), varToken.Value.TokenType);
+        Assert.Null(varToken);
     }
 
     [Fact]
@@ -57,10 +58,9 @@ public class SemanticTokensHandlerTests
         var content = LanguageServerTestHelpers.Content(source);
         var tokens = GetTokens(content);
 
-        // "func" keyword
+        // "func" keyword is left to the TextMate grammar — no semantic token.
         var funcKeyword = FindToken(tokens, 0, 0, 4);
-        Assert.NotNull(funcKeyword);
-        Assert.Equal(TokenTypeIndex("Keyword"), funcKeyword.Value.TokenType);
+        Assert.Null(funcKeyword);
 
         // "add" identifier should be Function with Declaration modifier
         var addToken = FindToken(tokens, 0, 5, 3);
@@ -109,11 +109,10 @@ public class SemanticTokensHandlerTests
         var content = LanguageServerTestHelpers.Content(source);
         var tokens = GetTokens(content);
 
-        // ADR-0078: the `struct` keyword IS the declaration head; it sits at
-        // column 0 with length 6.
+        // ADR-0078: the `struct` keyword IS the declaration head, but keywords
+        // are left to the TextMate grammar, so it emits no semantic token.
         var structKeyword = FindToken(tokens, 0, 0, 6);
-        Assert.NotNull(structKeyword);
-        Assert.Equal(TokenTypeIndex("Keyword"), structKeyword.Value.TokenType);
+        Assert.Null(structKeyword);
 
         // "Point" should be Struct with Declaration (position 7, length 5).
         var pointToken = FindToken(tokens, 0, 7, 5);


### PR DESCRIPTION
Four related editor-experience improvements to the G# language server and symbol display.

## 1. Stable token colorization
Keywords no longer change color once the LSP initializes. The semantic-tokens handler stopped emitting a flat `keyword` semantic token, so the TextMate grammar keeps owning keyword coloring (e.g. `async` no longer flips from pink to yellow under *GSharp Synthwave Dark*). This also works correctly under third-party themes that have no notion of G#.

## 2. Async / CLR symbol display
- Imported **async** CLR methods now render as `async func (...) R` (unwrapping `Task`/`ValueTask`) instead of `func (...) Task[R]`.
- Constructed-generic imported types render with friendly G# syntax — e.g. hovering a `Task<string>` local now shows `Task[string]` instead of the assembly-qualified CLR name `System.Threading.Tasks.Task` 1[[System.String, System.Runtime, ...]].

## 3. Object-initializer hover & completion
Hover and completion now work inside C#-style object-initializer blocks (`T(args) { Prop = v }`):
- **Hover** on an initializer property name resolves against the constructed type — for both imported CLR types (e.g. `ProcessStartInfo`) and user-defined G# classes/structs.
- **Completion** inside the block offers only the type's *writable* members (settable properties / writable fields), suppresses the global keyword list in name position, and falls back to the global list in value position (`Prop = <caret>`). Includes a parser-recovery path so the first property name still completes while being typed.

## Testing
- New tests: `ObjectInitializerHoverCompletionTests` (8), `SymbolDisplayAsyncClrMethodTests` (5), `SymbolDisplayImportedTypeTests` (6), plus updated `SemanticTokensHandlerTests`.
- Full `LanguageServer.Tests` suite passes (348), new Core symbol-display tests pass (11), full solution builds clean.
