### PR TITLE
fix(binder): infer untyped arrow-lambda params for body-typed generic selectors (Select)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1243,6 +1243,178 @@ internal sealed partial class ExpressionBinder
 
             return;
         }
+
+        // Follow-up to issue #891: the full-inference path above could not
+        // map every deferred lambda — typically because the matching generic
+        // method's lambda RETURN type is a method type parameter that is only
+        // inferable from the lambda body (e.g.
+        // Select<TSource,TResult>(IEnumerable<TSource>, Func<TSource,TResult>)).
+        // Fall back to partial inference: infer the type parameters reachable
+        // from the non-lambda arguments (so the lambda's *parameter* types close)
+        // and bind each lambda against a target carrying only those parameter
+        // types, leaving its return type to be inferred from the body.
+        foreach (var (methods, offset) in probes)
+        {
+            if (TryMapDeferredLambdaParameterTargets(methods, offset, receiver, ce, deferredIndices, boundArgs, out var partialTargets))
+            {
+                foreach (var idx in deferredIndices)
+                {
+                    var inner = OverloadResolver.UnwrapNamedArgumentValue(ce.Arguments[idx]);
+                    if (inner is LambdaExpressionSyntax lambdaSyntax && partialTargets.TryGetValue(idx, out var target))
+                    {
+                        boundArgs[idx] = lambdas.BindLambdaExpression(lambdaSyntax, target, inferReturnTypeFromBody: true);
+                    }
+                }
+
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Follow-up to issue #891: partial-inference fallback for <see cref="ResolveDeferredArrowLambdaArguments"/>.
+    /// For each candidate generic method, infers the type parameters reachable
+    /// from the non-lambda argument CLR types and resolves the closed parameter
+    /// types of every deferred lambda's delegate (arity-matched to the lambda),
+    /// even when the delegate's return type remains an un-inferred method type
+    /// parameter. Builds a per-slot <see cref="FunctionTypeSymbol"/> target that
+    /// carries only the closed parameter types. Candidates must agree on the
+    /// resulting parameter types; otherwise the fallback declines (preserving the
+    /// existing GS0304 behaviour) to avoid binding against an ambiguous shape.
+    /// </summary>
+    private bool TryMapDeferredLambdaParameterTargets(
+        IReadOnlyList<MethodInfo> methods,
+        int offset,
+        BoundExpression receiver,
+        CallExpressionSyntax ce,
+        List<int> deferredIndices,
+        BoundExpression[] boundArgs,
+        out Dictionary<int, FunctionTypeSymbol> targets)
+    {
+        targets = null;
+
+        var deferred = new HashSet<int>(deferredIndices);
+        var argTypes = new System.Type[boundArgs.Length + offset];
+        if (offset == 1)
+        {
+            if (receiver?.Type?.ClrType is not System.Type receiverClrType)
+            {
+                return false;
+            }
+
+            argTypes[0] = receiverClrType;
+        }
+
+        for (var i = 0; i < boundArgs.Length; i++)
+        {
+            if (deferred.Contains(i))
+            {
+                argTypes[i + offset] = null;
+                continue;
+            }
+
+            var t = GetEffectiveArgumentClrTypeForOverloadResolution(boundArgs[i].Type);
+            if (t == null && boundArgs[i].Type != TypeSymbol.Null)
+            {
+                return false;
+            }
+
+            argTypes[i + offset] = t;
+        }
+
+        var lambdaParamIndices = new List<int>();
+        var arities = new List<int>();
+        var argIndexByParamIndex = new Dictionary<int, int>();
+        foreach (var idx in deferredIndices)
+        {
+            var inner = OverloadResolver.UnwrapNamedArgumentValue(ce.Arguments[idx]);
+            if (inner is not LambdaExpressionSyntax lambda)
+            {
+                return false;
+            }
+
+            var paramIndex = idx + offset;
+            lambdaParamIndices.Add(paramIndex);
+            arities.Add(lambda.Parameters.Count);
+            argIndexByParamIndex[paramIndex] = idx;
+        }
+
+        Dictionary<int, System.Type[]> agreed = null;
+        foreach (var method in methods)
+        {
+            if (method == null || (!method.IsGenericMethodDefinition && !method.IsGenericMethod))
+            {
+                continue;
+            }
+
+            if (!OverloadResolution.TryInferDeferredLambdaParameterTypes(method, argTypes, lambdaParamIndices, arities, out var closed))
+            {
+                continue;
+            }
+
+            if (agreed == null)
+            {
+                agreed = closed;
+            }
+            else if (!DeferredLambdaParameterTypesAgree(agreed, closed))
+            {
+                return false;
+            }
+        }
+
+        if (agreed == null)
+        {
+            return false;
+        }
+
+        var built = new Dictionary<int, FunctionTypeSymbol>();
+        foreach (var kv in agreed)
+        {
+            var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(kv.Value.Length);
+            foreach (var clr in kv.Value)
+            {
+                var symbol = TypeSymbol.FromClrType(clr);
+                if (symbol == null || symbol == TypeSymbol.Error)
+                {
+                    return false;
+                }
+
+                parameterTypes.Add(symbol);
+            }
+
+            // The return slot is a placeholder; binding passes
+            // inferReturnTypeFromBody so the lambda infers its own return type.
+            built[argIndexByParamIndex[kv.Key]] = FunctionTypeSymbol.Get(parameterTypes.ToImmutable(), default, TypeSymbol.Object);
+        }
+
+        targets = built;
+        return true;
+    }
+
+    private static bool DeferredLambdaParameterTypesAgree(Dictionary<int, System.Type[]> a, Dictionary<int, System.Type[]> b)
+    {
+        if (a.Count != b.Count)
+        {
+            return false;
+        }
+
+        foreach (var kv in a)
+        {
+            if (!b.TryGetValue(kv.Key, out var other) || other.Length != kv.Value.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < kv.Value.Length; i++)
+            {
+                if (!ClrTypeUtilities.AreSame(kv.Value[i], other[i]))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     private BoundExpression BindAccessorCall(BoundExpression receiver, ImportedClassSymbol classSymbol, CallExpressionSyntax ce)

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -385,8 +385,15 @@ internal sealed class LambdaBinder
     /// when the parameter types should be inferred from a target. When
     /// non-null and arity matches, omitted parameter type clauses are
     /// filled in from this target.</param>
+    /// <param name="inferReturnTypeFromBody">Follow-up to issue #891: when <see langword="true"/>,
+    /// the target's return slot is ignored for return-type inference — the
+    /// lambda's return type is computed purely from its body. Used by the
+    /// deferred-lambda partial-inference path, where the target carries only
+    /// closed parameter types (the delegate's return type is an un-inferred
+    /// method type parameter and a placeholder occupies the target's return
+    /// slot).</param>
     /// <returns>The bound lambda as a <see cref="BoundFunctionLiteralExpression"/>.</returns>
-    public BoundExpression BindLambdaExpression(LambdaExpressionSyntax syntax, FunctionTypeSymbol targetFunctionType = null)
+    public BoundExpression BindLambdaExpression(LambdaExpressionSyntax syntax, FunctionTypeSymbol targetFunctionType = null, bool inferReturnTypeFromBody = false)
     {
         if (bindLambdaBodyExpression == null)
         {
@@ -501,7 +508,7 @@ internal sealed class LambdaBinder
         // body lambda with explicit `return` statements, the void trailing
         // produced by the body-binding pipeline is replaced by the common
         // type of all return-statement expressions.
-        var returnType = InferLambdaReturnType(boundBody, syntax, targetFunctionType, isAsync);
+        var returnType = InferLambdaReturnType(boundBody, syntax, inferReturnTypeFromBody ? null : targetFunctionType, isAsync);
 
         // ADR-0058: a managed-pointer (*T) cannot be used as a lambda return
         // type because CLR Func<> delegates cannot carry by-ref type arguments.

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -780,6 +780,223 @@ internal static class OverloadResolution
     }
 
     /// <summary>
+    /// Partial method type inference for deferred arrow-lambda arguments
+    /// (follow-up to issue #891). When a generic method's lambda
+    /// parameter return type is a method type parameter that can only be
+    /// inferred from the lambda body (e.g.
+    /// <c>Select&lt;TSource,TResult&gt;(this IEnumerable&lt;TSource&gt;, Func&lt;TSource,TResult&gt;)</c>),
+    /// full inference via <see cref="TryInferTypeArguments"/> fails because
+    /// <c>TResult</c> has no bound. This routine instead infers only the type
+    /// parameters reachable from the supplied (non-lambda) argument types, then
+    /// resolves each requested delegate parameter's <em>parameter</em> CLR types
+    /// through those bounds. It succeeds for a slot only when every delegate
+    /// parameter type is fully closed — the delegate's return type may remain an
+    /// un-inferred method type parameter (it is later inferred from the lambda
+    /// body, which now has typed parameters to bind against).
+    /// </summary>
+    /// <param name="method">The candidate method (open generic definition or a
+    /// constructed generic method whose definition is used for inference).</param>
+    /// <param name="argTypes">CLR types of the supplied arguments in parameter
+    /// order; deferred lambda slots are passed as <see langword="null"/>.</param>
+    /// <param name="lambdaParameterIndices">Parameter indices (aligned to
+    /// <paramref name="argTypes"/>) that correspond to deferred lambdas.</param>
+    /// <param name="expectedArities">The expected delegate arity (lambda
+    /// parameter count) for each entry of <paramref name="lambdaParameterIndices"/>.</param>
+    /// <param name="closedLambdaParameterTypes">On success, maps each requested
+    /// parameter index to the closed CLR parameter types of its delegate.</param>
+    /// <returns>Whether closed parameter types were determined for every
+    /// requested lambda slot.</returns>
+    public static bool TryInferDeferredLambdaParameterTypes(
+        MethodInfo method,
+        IReadOnlyList<Type> argTypes,
+        IReadOnlyList<int> lambdaParameterIndices,
+        IReadOnlyList<int> expectedArities,
+        out Dictionary<int, Type[]> closedLambdaParameterTypes)
+    {
+        closedLambdaParameterTypes = null;
+        if (method is null || argTypes is null || lambdaParameterIndices is null || expectedArities is null)
+        {
+            return false;
+        }
+
+        MethodInfo openMethod;
+        ParameterInfo[] parameters;
+        try
+        {
+            openMethod = method.IsGenericMethodDefinition
+                ? method
+                : (method.IsGenericMethod ? method.GetGenericMethodDefinition() : method);
+            if (!openMethod.IsGenericMethodDefinition)
+            {
+                return false;
+            }
+
+            parameters = openMethod.GetParameters();
+        }
+        catch (Exception ex) when (IsMetadataLoadFailure(ex))
+        {
+            return false;
+        }
+
+        if (parameters.Length < argTypes.Count)
+        {
+            return false;
+        }
+
+        var bounds = new Dictionary<string, Type>(StringComparer.Ordinal);
+        for (var i = 0; i < argTypes.Count; i++)
+        {
+            var arg = argTypes[i];
+            if (arg is null)
+            {
+                continue;
+            }
+
+            try
+            {
+                if (!UnifyForInference(parameters[i].ParameterType, arg, bounds))
+                {
+                    return false;
+                }
+            }
+            catch (Exception ex) when (IsMetadataLoadFailure(ex))
+            {
+                return false;
+            }
+        }
+
+        var result = new Dictionary<int, Type[]>();
+        for (var k = 0; k < lambdaParameterIndices.Count; k++)
+        {
+            var paramIndex = lambdaParameterIndices[k];
+            if (paramIndex < 0 || paramIndex >= parameters.Length)
+            {
+                return false;
+            }
+
+            MethodInfo invoke;
+            ParameterInfo[] invokeParams;
+            try
+            {
+                var delegateType = parameters[paramIndex].ParameterType;
+                if (delegateType is null)
+                {
+                    return false;
+                }
+
+                invoke = delegateType.GetMethod("Invoke");
+                if (invoke is null)
+                {
+                    return false;
+                }
+
+                invokeParams = invoke.GetParameters();
+            }
+            catch (Exception ex) when (IsMetadataLoadFailure(ex))
+            {
+                return false;
+            }
+
+            if (invokeParams.Length != expectedArities[k])
+            {
+                return false;
+            }
+
+            var closedParams = new Type[invokeParams.Length];
+            for (var p = 0; p < invokeParams.Length; p++)
+            {
+                if (!TryCloseInferredType(invokeParams[p].ParameterType, bounds, out closedParams[p]))
+                {
+                    return false;
+                }
+            }
+
+            result[paramIndex] = closedParams;
+        }
+
+        closedLambdaParameterTypes = result;
+        return true;
+    }
+
+    /// <summary>
+    /// Substitutes inferred method-type-parameter <paramref name="bounds"/> into
+    /// <paramref name="type"/>, succeeding only when the result is fully closed
+    /// (contains no remaining generic parameters). Used by
+    /// <see cref="TryInferDeferredLambdaParameterTypes"/> to close a delegate's
+    /// parameter types while leaving an un-inferred return type unresolved.
+    /// </summary>
+    private static bool TryCloseInferredType(Type type, IReadOnlyDictionary<string, Type> bounds, out Type closed)
+    {
+        closed = null;
+        if (type is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            if (type.IsGenericParameter)
+            {
+                if (!bounds.TryGetValue(type.Name, out var bound)
+                    || bound is null
+                    || bound.IsGenericParameter
+                    || bound.ContainsGenericParameters)
+                {
+                    return false;
+                }
+
+                closed = bound;
+                return true;
+            }
+
+            if (!type.ContainsGenericParameters)
+            {
+                closed = type;
+                return true;
+            }
+
+            if (type.IsByRef)
+            {
+                return TryCloseInferredType(type.GetElementType(), bounds, out closed);
+            }
+
+            if (type.IsArray)
+            {
+                if (!TryCloseInferredType(type.GetElementType(), bounds, out var elem))
+                {
+                    return false;
+                }
+
+                closed = elem.MakeArrayType();
+                return true;
+            }
+
+            if (type.IsGenericType)
+            {
+                var def = type.GetGenericTypeDefinition();
+                var args = type.GetGenericArguments();
+                var closedArgs = new Type[args.Length];
+                for (var i = 0; i < args.Length; i++)
+                {
+                    if (!TryCloseInferredType(args[i], bounds, out closedArgs[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                closed = def.MakeGenericType(closedArgs);
+                return true;
+            }
+        }
+        catch (Exception ex) when (IsMetadataLoadFailure(ex) || ex is ArgumentException || ex is InvalidOperationException)
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Determines whether an exception thrown while reflecting over a candidate's
     /// signature is a metadata/assembly load failure (issue #321, generalized in
     /// issue #338). Delegates to the single shared predicate in

--- a/test/Compiler.Tests/Emit/Issue891LambdaArgumentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue891LambdaArgumentEmitTests.cs
@@ -25,7 +25,9 @@ namespace GSharp.Compiler.Tests.Emit;
 /// Problem B: an un-typed arrow lambda passed to a generic LINQ extension method
 /// (<c>Single&lt;TSource&gt;(this IEnumerable&lt;TSource&gt;, Func&lt;TSource,bool&gt;)</c>)
 /// must infer its parameter type from the delegate parameter so the extension
-/// method resolves and the predicate body type-checks to <c>bool</c>.
+/// method resolves and the predicate body type-checks to <c>bool</c>. A follow-up
+/// extends this to selectors whose result type is only inferable from the body
+/// (<c>Select&lt;TSource,TResult&gt;(IEnumerable&lt;TSource&gt;, Func&lt;TSource,TResult&gt;)</c>).
 /// </para>
 /// </summary>
 public class Issue891LambdaArgumentEmitTests
@@ -169,6 +171,60 @@ public class Issue891LambdaArgumentEmitTests
 
         var output = CompileAndRun(source);
         Assert.Equal("network\n", output);
+    }
+
+    [Fact]
+    public void ProblemB_ArrowLambda_AsGenericLinqSelector_BodyInferredResult_Runs()
+    {
+        // Follow-up to issue #891: an un-typed arrow lambda passed to
+        // Select<TSource,TResult>(IEnumerable<TSource>, Func<TSource,TResult>)
+        // must infer its parameter type from the receiver (TSource) even though
+        // TResult is only inferable from the lambda body. Previously this
+        // reported "Cannot find function Select" / GS0304 and only worked with a
+        // typed parameter (`(x int32) -> ...`).
+        var source = """
+            package P
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            let nums = List[int32]()
+            nums.Add(1)
+            nums.Add(2)
+            nums.Add(3)
+            let doubled = nums.Select((x) -> x * 2).ToList()
+            Console.WriteLine(doubled.Count)
+            Console.WriteLine(doubled[2])
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n6\n", output);
+    }
+
+    [Fact]
+    public void ProblemB_ArrowLambda_AsGenericLinqSelector_ProjectsToDifferentType_Runs()
+    {
+        // The selector's result type (TResult) is inferred from the body: a
+        // string-valued body must yield a HashSet[string], not HashSet[object].
+        // Mirrors the issue's `report.Checks.Select((c) -> c.Id).ToHashSet()`
+        // shape where the projection accesses a member of the inferred element.
+        var source = """
+            package P
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            let words = List[string]()
+            words.Add("audible-api")
+            words.Add("net")
+            words.Add("audible-api")
+            let ids = words.Select((w) -> w.ToUpper()).ToHashSet()
+            Console.WriteLine(ids.Count)
+            Console.WriteLine(ids.Contains("NET"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\nTrue\n", output);
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

An untyped arrow lambda passed to a generic method whose lambda **return type is a separate method type parameter** failed to bind. The canonical case is `Select`:

```gsharp
// fails today (GS0159 "Cannot find function Select" + GS0304):
let ids = report.Checks.Select((c) -> c.Id).ToHashSet()

// only works with an explicit parameter type:
let ids = report.Checks.Select((c DoctorCheck) -> c.Id).ToHashSet()
```

Untyped arrow lambdas are bound *after* overload resolution (deferred, per #891). The deferred resolver only succeeded when **full** method type inference closed the candidate — fine for `Single<T>(IEnumerable<T>, Func<T,bool>)` (return is a fixed `bool`), but `Select<TSource,TResult>(IEnumerable<TSource>, Func<TSource,TResult>)` has `TResult` inferable **only from the lambda body**. Full inference failed, the candidate was discarded, and the lambda fell through to bind with no target → `GS0304`.

## Fix

Adds a **partial-inference fallback** to the deferred arrow-lambda resolver (follow-up to #891):

- **`OverloadResolution.TryInferDeferredLambdaParameterTypes`** — infers the type parameters reachable from the non-lambda arguments (e.g. `TSource` from the receiver) and resolves each deferred lambda's closed delegate *parameter* types, even when the delegate's return type stays an un-inferred type parameter.
- **`ExpressionBinder.TryMapDeferredLambdaParameterTargets`** — builds a per-slot `FunctionTypeSymbol` carrying only the closed parameter types (arity-matched, requiring agreement across candidate overloads to stay safe) and binds the lambda with a new `BindLambdaExpression(inferReturnTypeFromBody: true)` flag so the return type is computed purely from the body (avoids an incorrect widening of `TResult` to `object`). The real overload resolution then infers `TResult` from the now-typed lambda.

Behaviour is unchanged when partial inference is ambiguous or can't close the parameter types — the existing `GS0304` path still fires.

## Validation

- New emit regressions: int-valued selector (`Select((x) -> x * 2)`) and a projecting selector to a different type (`Select((w) -> w.ToUpper()).ToHashSet()` → correctly `HashSet[string]`, not `HashSet[object]`).
- All passing: 8 Issue891 emit, 149 Core overload/lambda, 69 Compiler LINQ/lambda emit, 16 Interpreter lambda/LINQ tests. Output ilverifies.

The LSP shares this binder, so the VS Code diagnostic from the original report is resolved too.

## Known limitation (tracked separately)

This does **not** cover receivers whose generic element type is a **user type defined in the same compilation** (no CLR `Type` yet) — that affects both `Single` and `Select` identically and is a pre-existing limitation, filed as #903.
