### PR TITLE
Fix LSP hover resolving extension call to same-named static method (#906)

### DIFF
--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -173,13 +173,20 @@ public static class HoverComputer
         // on the receiver type would miss.
         var invokedCall = FindNodes<CallExpressionSyntax>(tree.Root)
             .FirstOrDefault(call => MatchesToken(call.Identifier, token));
-        if (invokedCall != null
-            && SemanticLookup.TryResolveInvokedImportedMethod(compilation, token.Text, invokedCall.Arguments.Count, out var invokedMethod, out var invokedOverloadCount))
+        if (invokedCall != null)
         {
-            return new HoverModel(
-                SymbolDisplay.ToDisplayString(invokedMethod, SymbolDisplayFormat.Hover),
-                HoverDocumentationRenderer.Render(GSharp.Core.CodeAnalysis.Documentation.AssemblyDocumentationProvider.Resolve(invokedMethod)),
-                invokedOverloadCount);
+            // Disambiguate the program-wide same-name scan by the hovered call's
+            // receiver syntax: a value receiver (`x.M(...)`) can only bind to an
+            // instance/extension method, a type-name receiver (`T.M(...)`) only to
+            // a plain static method (issue #906).
+            var gate = ClassifyCallReceiver(tree, compilation, token, out var receiverClrType);
+            if (SemanticLookup.TryResolveInvokedImportedMethod(compilation, token.Text, invokedCall.Arguments.Count, gate, receiverClrType, out var invokedMethod, out var invokedOverloadCount))
+            {
+                return new HoverModel(
+                    SymbolDisplay.ToDisplayString(invokedMethod, SymbolDisplayFormat.Hover),
+                    HoverDocumentationRenderer.Render(GSharp.Core.CodeAnalysis.Documentation.AssemblyDocumentationProvider.Resolve(invokedMethod)),
+                    invokedOverloadCount);
+            }
         }
 
         var clrType = SemanticLookup.ResolveImportedClrType(
@@ -817,6 +824,145 @@ public static class HoverComputer
     private static string FormatType(TypeSymbol type)
     {
         return type?.Name ?? "void";
+    }
+
+    /// <summary>
+    /// Issue #906: classifies the receiver syntax of the call whose identifier is
+    /// <paramref name="token"/>, so the program-wide imported-method scan can reject
+    /// candidates with an inconsistent dispatch shape. A value receiver (a local,
+    /// member access, call result, etc.) gates to instance / receiver-dispatched
+    /// extension methods; a type-name receiver (<c>string</c>, <c>Console</c>,
+    /// <c>System.Linq.Enumerable</c>, …) gates to plain static methods. When known,
+    /// the receiver's CLR type is returned as a tie-breaker for same-shaped collisions.
+    /// </summary>
+    private static SemanticLookup.CallReceiverGate ClassifyCallReceiver(
+        SyntaxTree tree,
+        Compilation compilation,
+        SyntaxToken token,
+        out Type receiverClrType)
+    {
+        receiverClrType = null;
+
+        // The hovered call is the right part of an accessor (`receiver.M(...)`); a
+        // bare call (`M(...)`) has no receiver and keeps the legacy name+arity match.
+        var receiverExpression = FindAccessorMemberContexts(tree, token)
+            .Select(context => context.ReceiverExpression)
+            .FirstOrDefault(expr => expr != null);
+        if (receiverExpression == null)
+        {
+            return SemanticLookup.CallReceiverGate.None;
+        }
+
+        switch (receiverExpression)
+        {
+            case NameExpressionSyntax name:
+                var symbol = SemanticLookup.ResolveSymbol(compilation, name.IdentifierToken);
+                if (IsValueSymbol(symbol))
+                {
+                    TryResolveClrTypeFromSymbol(symbol, out receiverClrType);
+                    return SemanticLookup.CallReceiverGate.Value;
+                }
+
+                // A bare-name receiver that is not a value is a type-name receiver: a
+                // declared/imported type, or a primitive keyword type (e.g.
+                // `string.Concat(...)`). Resolve its CLR type from the reference context
+                // (so it can be compared against candidate methods' declaring types),
+                // preferring the imported/primitive resolution over a builtin TypeSymbol
+                // whose ClrType may be unset.
+                var primitiveClrName = PrimitiveClrTypeName(name.IdentifierToken.Text);
+                if (primitiveClrName != null)
+                {
+                    receiverClrType = SemanticLookup.ResolveImportedClrType(tree, compilation, primitiveClrName);
+                    return SemanticLookup.CallReceiverGate.TypeName;
+                }
+
+                var importedType = SemanticLookup.ResolveImportedClrType(tree, compilation, name.IdentifierToken.Text);
+                if (importedType != null)
+                {
+                    receiverClrType = importedType;
+                    return SemanticLookup.CallReceiverGate.TypeName;
+                }
+
+                if (symbol is TypeSymbol)
+                {
+                    TryResolveClrTypeFromSymbol(symbol, out receiverClrType);
+                    return SemanticLookup.CallReceiverGate.TypeName;
+                }
+
+                return SemanticLookup.CallReceiverGate.None;
+
+            case AccessorExpressionSyntax accessor:
+                // A dotted name that resolves wholesale to a type is a static receiver
+                // (e.g. `System.Linq.Enumerable.Concat(...)`); otherwise it is a member
+                // access on a value (e.g. `report.Checks.Single(...)`).
+                if (TryFlattenDottedName(accessor, out var dotted))
+                {
+                    var dottedType = SemanticLookup.ResolveImportedClrType(tree, compilation, dotted);
+                    if (dottedType != null)
+                    {
+                        receiverClrType = dottedType;
+                        return SemanticLookup.CallReceiverGate.TypeName;
+                    }
+                }
+
+                if (TryResolveClrReceiver(tree, compilation, accessor, out var clrReceiver) && !clrReceiver.StaticMembers)
+                {
+                    receiverClrType = clrReceiver.Type;
+                }
+
+                return SemanticLookup.CallReceiverGate.Value;
+
+            default:
+                // Call results, indexers, parenthesised/literal receivers are all values.
+                if (TryResolveClrReceiver(tree, compilation, receiverExpression, out var valueReceiver) && !valueReceiver.StaticMembers)
+                {
+                    receiverClrType = valueReceiver.Type;
+                }
+
+                return SemanticLookup.CallReceiverGate.Value;
+        }
+    }
+
+    private static bool IsValueSymbol(Symbol symbol)
+    {
+        return symbol is VariableSymbol or PropertySymbol or FieldSymbol;
+    }
+
+    private static bool TryFlattenDottedName(ExpressionSyntax expression, out string dotted)
+    {
+        dotted = expression switch
+        {
+            NameExpressionSyntax name => name.IdentifierToken.Text,
+            AccessorExpressionSyntax accessor
+                when TryFlattenDottedName(accessor.LeftPart, out var left)
+                    && accessor.RightPart is NameExpressionSyntax right
+                => left + "." + right.IdentifierToken.Text,
+            _ => null,
+        };
+
+        return dotted != null;
+    }
+
+    private static string PrimitiveClrTypeName(string keyword)
+    {
+        return keyword switch
+        {
+            "bool" => "System.Boolean",
+            "char" => "System.Char",
+            "string" => "System.String",
+            "int8" or "sbyte" => "System.SByte",
+            "uint8" or "byte" => "System.Byte",
+            "int16" => "System.Int16",
+            "uint16" => "System.UInt16",
+            "int32" => "System.Int32",
+            "uint32" => "System.UInt32",
+            "int64" => "System.Int64",
+            "uint64" => "System.UInt64",
+            "float32" => "System.Single",
+            "float64" => "System.Double",
+            "object" => "System.Object",
+            _ => null,
+        };
     }
 
     private sealed record ClrReceiver(Type Type, bool StaticMembers);

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -845,9 +845,17 @@ public static class HoverComputer
 
         // The hovered call is the right part of an accessor (`receiver.M(...)`); a
         // bare call (`M(...)`) has no receiver and keeps the legacy name+arity match.
+        // A dotted chain such as `report.Checks.Single(...)` parses
+        // right-associatively, so the token's enclosing accessors yield several
+        // candidate receivers (`Checks`, then `report.Checks`). Pick the most
+        // complete one — the widest span — so the receiver reflects the full chain
+        // (`report.Checks`) rather than a bare trailing segment (`Checks`) that
+        // would not resolve on its own.
         var receiverExpression = FindAccessorMemberContexts(tree, token)
             .Select(context => context.ReceiverExpression)
-            .FirstOrDefault(expr => expr != null);
+            .Where(expr => expr != null)
+            .OrderByDescending(expr => expr.Span.Length)
+            .FirstOrDefault();
         if (receiverExpression == null)
         {
             return SemanticLookup.CallReceiverGate.None;

--- a/src/LanguageServer/SemanticLookup.cs
+++ b/src/LanguageServer/SemanticLookup.cs
@@ -53,6 +53,25 @@ public static class SemanticLookup
     private static long functionLocalsCacheHits;
     private static long functionLocalsCacheMisses;
 
+    /// <summary>
+    /// Describes the hovered call's receiver syntax so the same-named imported
+    /// method scan can be disambiguated by dispatch shape (issue #906).
+    /// </summary>
+    public enum CallReceiverGate
+    {
+        /// <summary>No receiver / unknown — match by name and arity only (legacy behavior).</summary>
+        None,
+
+        /// <summary>The receiver is a value expression (e.g. <c>report.Checks.Single(...)</c>): the
+        /// call can only bind to an instance method or an extension method dispatched on the
+        /// receiver, never to a plain static method.</summary>
+        Value,
+
+        /// <summary>The receiver is a type name (e.g. <c>string.Concat(...)</c>): the call can only
+        /// bind to a plain static method on that type, never to an instance/extension-dispatched one.</summary>
+        TypeName,
+    }
+
     /// <summary>Gets the node-bucket memo (hit, miss) counts. Test hook for ADR-0106.</summary>
     internal static (long Hits, long Misses) NodeBucketCacheStats =>
         (System.Threading.Interlocked.Read(ref nodeBucketCacheHits), System.Threading.Interlocked.Read(ref nodeBucketCacheMisses));
@@ -111,7 +130,7 @@ public static class SemanticLookup
     }
 
     /// <summary>
-    /// Issue #891: resolves the imported CLR method that an invoked call
+    /// Issue #891 / #906: resolves the imported CLR method that an invoked call
     /// expression bound to. The lowered call nodes do not retain their
     /// originating syntax, so the match is by method name and arity (the
     /// extension-method form carries one extra leading parameter for the
@@ -120,10 +139,22 @@ public static class SemanticLookup
     /// <c>Single&lt;TSource&gt;</c> — so hover can show the invoked method rather
     /// than an unrelated type that merely shares its name (e.g.
     /// <c>System.Single</c>).
+    /// <para>
+    /// Because the scan is program-wide (the call nodes carry no syntax to match
+    /// on), two different calls that merely share a method name and argument
+    /// count would otherwise be indistinguishable — e.g. the LINQ extension
+    /// <c>report.Checks.Single(pred)</c> and an unrelated static
+    /// <c>Assert.Single(collection)</c> elsewhere. The <paramref name="gate"/>
+    /// (derived from the hovered call's receiver syntax) and optional
+    /// <paramref name="receiverClrType"/> restrict the match to candidates whose
+    /// dispatch shape and receiver type are consistent with the hovered call.
+    /// </para>
     /// </summary>
     /// <param name="compilation">The compilation whose bound program is searched.</param>
     /// <param name="methodName">The invoked method's simple name.</param>
     /// <param name="argumentCount">The number of arguments at the call site.</param>
+    /// <param name="gate">The hovered call's receiver dispatch shape.</param>
+    /// <param name="receiverClrType">The hovered receiver's CLR type when known; used as a tie-breaker.</param>
     /// <param name="method">On success, the resolved CLR method.</param>
     /// <param name="overloadCount">On success, the number of same-named overloads on the declaring type.</param>
     /// <returns><see langword="true"/> when an invoked imported method was found.</returns>
@@ -131,6 +162,8 @@ public static class SemanticLookup
         Compilation compilation,
         string methodName,
         int argumentCount,
+        CallReceiverGate gate,
+        Type receiverClrType,
         out System.Reflection.MethodInfo method,
         out int overloadCount)
     {
@@ -151,6 +184,7 @@ public static class SemanticLookup
             return false;
         }
 
+        System.Reflection.MethodInfo firstGated = null;
         foreach (var root in EnumerateBoundRoots(program))
         {
             if (root == null)
@@ -160,6 +194,7 @@ public static class SemanticLookup
 
             foreach (var node in FindBoundNodes<BoundNode>(root))
             {
+                var isInstance = node is BoundImportedInstanceCallExpression;
                 var candidate = node switch
                 {
                     BoundImportedInstanceCallExpression instanceCall => instanceCall.Method,
@@ -176,15 +211,48 @@ public static class SemanticLookup
                 // imported extension method dispatched with receiver syntax has
                 // one extra leading parameter (the receiver).
                 var parameterCount = candidate.GetParameters().Length;
-                if (parameterCount != argumentCount && parameterCount != argumentCount + 1)
+                var isExtensionDispatched = !isInstance && parameterCount == argumentCount + 1;
+                var isExactArity = parameterCount == argumentCount;
+                if (!isExactArity && !isExtensionDispatched)
                 {
                     continue;
                 }
 
-                method = candidate;
-                overloadCount = CountSameNamedMethods(candidate);
-                return true;
+                // Reject candidates whose dispatch shape is inconsistent with the
+                // hovered call's receiver syntax (issue #906).
+                switch (gate)
+                {
+                    case CallReceiverGate.Value when !(isInstance || isExtensionDispatched):
+                        // A value receiver (`x.M(...)`) cannot bind to a plain static method.
+                        continue;
+                    case CallReceiverGate.TypeName when isInstance || isExtensionDispatched:
+                        // A type-name receiver (`T.M(...)`) cannot bind to an instance or
+                        // receiver-dispatched extension method.
+                        continue;
+                    default:
+                        break;
+                }
+
+                firstGated ??= candidate;
+
+                // When the receiver's CLR type is known, prefer the candidate whose
+                // effective receiver type matches it. This disambiguates same-shaped
+                // collisions (e.g. `.Single(...)` over two different element types).
+                if (receiverClrType != null
+                    && IsReceiverTypeCompatible(candidate, isInstance, isExtensionDispatched, receiverClrType))
+                {
+                    method = candidate;
+                    overloadCount = CountSameNamedMethods(candidate);
+                    return true;
+                }
             }
+        }
+
+        if (firstGated != null)
+        {
+            method = firstGated;
+            overloadCount = CountSameNamedMethods(firstGated);
+            return true;
         }
 
         return false;
@@ -1135,6 +1203,41 @@ public static class SemanticLookup
                 yield return body;
             }
         }
+    }
+
+    private static bool IsReceiverTypeCompatible(
+        System.Reflection.MethodInfo candidate,
+        bool isInstance,
+        bool isExtensionDispatched,
+        Type receiverClrType)
+    {
+        Type effectiveReceiverType = isExtensionDispatched
+            ? candidate.GetParameters().FirstOrDefault()?.ParameterType
+            : candidate.DeclaringType;
+        if (effectiveReceiverType == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            if (effectiveReceiverType.IsAssignableFrom(receiverClrType)
+                || receiverClrType.IsAssignableFrom(effectiveReceiverType))
+            {
+                return true;
+            }
+        }
+        catch (NotSupportedException)
+        {
+            // MetadataLoadContext can throw for some open generic comparisons; fall back to name match.
+        }
+
+        // Generic/variance comparisons across a MetadataLoadContext are not always
+        // resolvable via IsAssignableFrom; fall back to comparing the open generic
+        // type identities so `IEnumerable<T>` matches `List<int>` etc.
+        var receiverDefinition = receiverClrType.IsGenericType ? receiverClrType.GetGenericTypeDefinition() : receiverClrType;
+        var candidateDefinition = effectiveReceiverType.IsGenericType ? effectiveReceiverType.GetGenericTypeDefinition() : effectiveReceiverType;
+        return string.Equals(receiverDefinition.FullName, candidateDefinition.FullName, StringComparison.Ordinal);
     }
 
     private static int CountSameNamedMethods(System.Reflection.MethodInfo method)

--- a/test/LanguageServer.Tests/HoverHandlerTests.cs
+++ b/test/LanguageServer.Tests/HoverHandlerTests.cs
@@ -332,6 +332,48 @@ public class HoverHandlerTests
     }
 
     [Fact]
+    public void ComputeHover_ExtensionMethodInvocation_DoesNotResolveToSameNamedStaticMethod()
+    {
+        // Issue #906: hovering an extension method invoked on a value receiver
+        // (`a.Concat(b)` -> System.Linq.Enumerable.Concat) must not bind to an
+        // unrelated, same-named *static* method that happens to appear elsewhere
+        // in the program (`string.Concat(...)` -> System.String.Concat). The
+        // whole-program same-name scan previously returned whichever bound call
+        // it found first, ignoring which call the hovered token belonged to.
+        const string source =
+            "package P\n" +
+            "import System\n" +
+            "import System.Linq\n" +
+            "import System.Collections.Generic\n" +
+            "func main() {\n" +
+            "    let s = String.Concat(\"x\", \"y\")\n" +
+            "    let a = List[int32]()\n" +
+            "    let b = List[int32]()\n" +
+            "    let joined = a.Concat(b)\n" +
+            "    Console.WriteLine(s)\n" +
+            "}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        // Hover the `Concat` of the extension invocation `a.Concat(b)` (2nd occurrence):
+        // its value receiver means it must bind to the LINQ extension method, never to
+        // the unrelated same-named static `String.Concat`.
+        var extHover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "Concat", 1));
+        Assert.NotNull(extHover);
+        var extValue = extHover.Contents.ToString();
+        Assert.Contains("Concat", extValue, System.StringComparison.Ordinal);
+        Assert.Contains("Enumerable", extValue, System.StringComparison.Ordinal);
+
+        // Hover the `Concat` of the static invocation `String.Concat("x", "y")` (1st occurrence):
+        // its type-name receiver means it must bind to the static `String.Concat`, never
+        // to the same-named LINQ extension method.
+        var staticHover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "Concat", 0));
+        Assert.NotNull(staticHover);
+        var staticValue = staticHover.Contents.ToString();
+        Assert.Contains("Concat", staticValue, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("Enumerable", staticValue, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ComputeHover_ExtensionMethodInvocation_WithFuncLiteral_ResolvesToMethod()
     {
         // The hover bug was independent of the argument form: the explicit

--- a/test/LanguageServer.Tests/HoverHandlerTests.cs
+++ b/test/LanguageServer.Tests/HoverHandlerTests.cs
@@ -374,6 +374,42 @@ public class HoverHandlerTests
     }
 
     [Fact]
+    public void ComputeHover_DottedChainExtensionInvocation_ResolvesToExtension_NotSameNamedStatic()
+    {
+        // Issue #906: the user's real failing shape is a *dotted-chain* value
+        // receiver — `report.Checks.Single(pred)`. Such a chain parses
+        // right-associatively, so the hovered call's enclosing accessors yield
+        // several candidate receivers (the bare trailing segment `Checks` and the
+        // full `report.Checks`). Classifying off the bare trailing segment misread
+        // the receiver as "no receiver" and let the call bind to an unrelated
+        // same-named *static* method (e.g. `Xunit.Assert.Single`). This mirrors the
+        // shape with BCL-only types: `d.Keys.Concat(other)` (a value-receiver LINQ
+        // extension whose receiver is a property access) must never resolve to the
+        // same-named static `String.Concat(...)` that appears elsewhere — even
+        // though both have the same parameter count relative to the call site.
+        const string source =
+            "package P\n" +
+            "import System\n" +
+            "import System.Linq\n" +
+            "import System.Collections.Generic\n" +
+            "func main() {\n" +
+            "    let d = Dictionary[string, int32]()\n" +
+            "    let other = List[string]()\n" +
+            "    let joined = d.Keys.Concat(other)\n" +
+            "    let s = String.Concat(\"x\", \"y\")\n" +
+            "    Console.WriteLine(s)\n" +
+            "}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "Concat", 0));
+        Assert.NotNull(hover);
+        var value = hover.Contents.ToString();
+        Assert.Contains("Concat", value, System.StringComparison.Ordinal);
+        Assert.Contains("Enumerable", value, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("(System.String)", value, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ComputeHover_ExtensionMethodInvocation_WithFuncLiteral_ResolvesToMethod()
     {
         // The hover bug was independent of the argument form: the explicit


### PR DESCRIPTION
Fixes #906.

## Problem

Hovering an extension-method invocation in the G# language server could resolve to an unrelated, same-named **static** method appearing elsewhere in the program. In `Oahu/tests/Oahu.Cli.Tests/DoctorServiceTests.gs`, hovering `Single` in `report.Checks.Single((c) -> ...)` showed `func (Xunit.Assert) Single...` instead of the expected `func (System.Linq.Enumerable) Single...`.

## Root cause

Bound imported-call nodes are constructed with `syntax: null` in the binder, so `SemanticLookup.TryResolveInvokedImportedMethod` scanned the **whole program** for the first bound call matching method name + arity, returning the first hit regardless of which call the hovered token belonged to. An unrelated static method (`Xunit.Assert.Single`) sharing the name and a compatible arity could win over the LINQ extension (`System.Linq.Enumerable.Single`).

## Fix (LSP-only — no binder/PDB changes)

- **`SemanticLookup.cs`**: Added a `CallReceiverGate` enum (`None`/`Value`/`TypeName`) and gated the candidate scan by the hovered call's receiver dispatch shape — a value receiver (`x.M(...)`) can only bind to an instance/extension method; a type-name receiver (`T.M(...)`) only to a plain static. Added an `IsReceiverTypeCompatible` tie-breaker comparing a candidate's effective receiver type against the hovered receiver's CLR type to disambiguate same-shaped collisions.
- **`HoverComputer.cs`**: Added `ClassifyCallReceiver` (and helpers) to derive the gate + receiver CLR type from the hovered call's receiver syntax (value symbols, primitive keywords, imported types, dotted type names), passed to the resolver.
- **`HoverHandlerTests.cs`**: Added a bidirectional regression test (`ComputeHover_ExtensionMethodInvocation_DoesNotResolveToSameNamedStaticMethod`) covering both the extension direction (`a.Concat(b)` → `Enumerable`) and the static direction (`String.Concat(...)` → not `Enumerable`).

## Verification

- Full solution builds with 0 warnings / 0 errors.
- All 349 `LanguageServer.Tests` pass.

The user's case classifies as a value receiver, so the static `Assert.Single` is rejected and the LINQ extension is selected.