### PR TITLE
Fix delegate return-type covariance and CLR lambda target-typing (#908)

### DIFF
--- a/docs/adr/0108-delegate-return-type-covariance.md
+++ b/docs/adr/0108-delegate-return-type-covariance.md
@@ -1,0 +1,155 @@
+# ADR-0108: Delegate return-type covariance and lambda target-typing on CLR method calls
+
+- **Status**: Accepted
+- **Date**: 2026-06-20
+- **Phase**: Phase 5 — generics & dogfooded core
+- **Closes**: Issue #908 (arrow lambda with covariant body type rejected on CLR method calls)
+- **Related**: ADR-0105/0106 (incremental binding); the lambda/delegate
+  target-typing work in #889 (arrow lambdas as `System.Action`/void
+  delegates), #891 (lambdas as named/extension-method arguments), #893
+  (func-literal trailing-return IL)
+
+## Context
+
+When a G# value is passed where a delegate type (`Func<...>` / `Action<...>`)
+is expected, the supplied function literal must be convertible to that
+delegate. Two compounding gaps made an otherwise-valid call fail:
+
+1. **No delegate return-type covariance.** Overload resolution required a
+   lambda's inferred function type to match the delegate parameter
+   essentially exactly. A function returning a *derived/implementing*
+   type was rejected where one returning the *base/interface* was wanted,
+   even though the conversion is reference-preserving and sound. So even
+   the explicit literal
+
+   ```gs
+   RootCommandFactory.Create(func() NullLoggerFactory { return NullLoggerFactory.Instance })
+   ```
+
+   failed with `GS0159` against a `Func<ILoggerFactory>` parameter,
+   despite `NullLoggerFactory : ILoggerFactory`.
+
+2. **CLR method calls did not target-type lambda arguments.** Delegate
+   target-typing of a lambda argument (binding the lambda against the
+   parameter's delegate type so its return type is *pinned* rather than
+   inferred from the body) was wired only into the constructor call path.
+   Plain CLR static/instance method calls bound the arrow lambda with its
+   natural, body-derived return type before resolution, so
+
+   ```gs
+   RootCommandFactory.Create(() -> NullLoggerFactory.Instance)
+   ```
+
+   inferred `() -> NullLoggerFactory` and never matched
+   `Func<ILoggerFactory>`.
+
+The combination meant the arrow form never bound on CLR calls, and the
+explicit form only worked when the return type was spelled as the exact
+interface. C# accepts both: delegate creation allows reference covariance
+on the return type, and lambdas are target-typed from the parameter.
+
+## Decision
+
+Both gaps are closed, matching C#/CLR delegate semantics (reference
+conversions only).
+
+1. **Delegate return-type covariance in conversion classification.** A new
+   `ImplicitConversionKind.DelegateReturnCovariance` is recognised when
+   classifying a function-typed value against a delegate parameter whose
+   parameter lists match and whose return type is a base class or
+   implemented interface of the source's return type (a
+   reference-preserving upcast). It is ranked *worst* among implicit
+   conversions so an exact return-type match always wins betterness.
+   Delegate signatures are read cross-context-safely — via the delegate's
+   `Invoke` method and, as a fallback, the closed `Func`/`Action` generic
+   arguments — so the classification works even when the delegate type
+   originates from a different `MetadataLoadContext`. Only class→base and
+   class→interface reference upcasts are accepted; **no** value-type,
+   boxing, or other variant conversions are permitted. The explicit
+   func-literal form then flows through the existing erased-adapter path
+   that converts the produced return value, yielding valid IL for the
+   constructed delegate.
+
+2. **Lambda target-typing on CLR static and instance method calls.** The
+   accessor-call binding path now collects candidate delegate parameter
+   lists from the applicable static, instance, and extension method
+   candidates and target-types arrow-lambda arguments against them (the
+   same `BindCallArgumentWithDelegateTargetTyping` mechanism previously
+   limited to constructors). The arrow lambda's return type is pinned from
+   the parameter's delegate return type rather than inferred from the body
+   expression, so `() -> TDerived()` binds directly against `() -> TBase`.
+
+### Incidental cross-context correctness fixes
+
+Reproducing #908 surfaced two latent `MetadataLoadContext` (MLC) bugs that
+this change also fixes, because the covariance check exercises cross-MLC
+type relationships:
+
+- `ClrTypeUtilities.IsAssignableByName` no longer trusts a spurious
+  cross-MLC `Type.IsAssignableFrom == false`; it falls through to the
+  by-name base/interface walk so genuinely-assignable types across MLCs
+  are recognised.
+- The `FunctionTypeSymbol` cache is cleared on `ReferenceResolver.Dispose`,
+  preventing disposed-MLC types from resurfacing in a later compilation
+  (which previously raised `ObjectDisposedException`).
+
+## Consequences
+
+### Positive
+
+- Both `() -> derivedValue` and `func() Derived { return derivedValue }`
+  bind against a `Func<Base>` parameter on CLR **static** and **instance**
+  methods, with valid, ilverify-clean IL that executes correctly at
+  runtime.
+- G# delegate conversions now align with C#/CLR reference covariance, so
+  C# reference samples that rely on it port verbatim.
+- The two MLC fixes harden cross-assembly binding generally, beyond this
+  feature.
+
+### Negative / trade-offs
+
+- `DelegateReturnCovariance` adds a special-case ranked conversion. It is
+  deliberately ranked last so it can never shadow an exact match, but it
+  is one more entry a maintainer must keep in mind when reasoning about
+  overload betterness.
+- Candidate delegate-parameter collection on accessor calls does a little
+  extra work to pre-resolve target types before binding lambda arguments;
+  the cost is bounded by the candidate set and only paid when a lambda
+  argument is present.
+
+### Out of scope
+
+- Delegate **parameter-type** contravariance (a lambda accepting a base
+  parameter where a derived is expected) is not addressed here; only
+  return-type covariance. A follow-up ADR can extend the classifier if
+  demand surfaces.
+- Generic variance on user-defined delegate types beyond the BCL
+  `Func`/`Action` family is unchanged.
+
+## Test coverage
+
+- `test/Compiler.Tests/Emit/Issue908DelegateReturnCovarianceEmitTests.cs`
+  — arrow lambda and explicit-derived-return func literal, each passed to
+  a CLR static method and a CLR instance method expecting `Func<TBase>`
+  with a `TDerived` body (e.g. `Func<Stream>` satisfied by `MemoryStream`).
+  Each compiled assembly is run through ilverify and executed; the runtime
+  output is asserted.
+
+## Alternatives considered
+
+- **Require an explicit `as` cast on the body** (`() -> derived as Base`).
+  Rejected: it is the existing workaround, is noisy, and diverges from C#.
+- **Only fix target-typing (gap 2) and rely on exact match.** Rejected: it
+  would leave the explicit `func() Derived { ... }` form broken and would
+  not handle cases where the body's natural type is more derived than the
+  delegate return type.
+- **A general variant-conversion table.** Rejected as over-broad for this
+  issue and a risk to soundness; the change is scoped to reference-
+  preserving delegate return covariance.
+
+## References
+
+- C# spec, *Delegate compatibility* and *Method group / anonymous-function
+  conversions* (reference covariance on delegate return types).
+- ECMA-335 — delegate `Invoke` signature and reference-conversion rules.
+- Issue #908 — original report, repro, and root-cause analysis.

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1109,6 +1109,59 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Issue #908: collects the parameter lists of the CLR methods a member-style
+    /// call could resolve to — static methods of the accessed class, or instance
+    /// methods on the receiver plus imported extension methods — so an arrow
+    /// lambda argument can be target-typed from its matching delegate parameter
+    /// before binding. Extension-method parameter lists have their leading
+    /// <c>this</c> receiver parameter stripped so every returned list aligns at a
+    /// zero parameter offset, matching the positional argument indices.
+    /// </summary>
+    private List<ParameterInfo[]> CollectDelegateTargetCandidateParameterLists(
+        BoundExpression receiver,
+        ImportedClassSymbol classSymbol,
+        string methodName)
+    {
+        var result = new List<ParameterInfo[]>();
+        if (classSymbol != null)
+        {
+            foreach (var m in ClrTypeUtilities.SafeGetMethods(classSymbol.ClassType, BindingFlags.Static | BindingFlags.Public)
+                .Where(m => m.Name == methodName))
+            {
+                result.Add(m.GetParameters());
+            }
+
+            return result;
+        }
+
+        if (receiver?.Type?.ClrType is System.Type receiverClrType)
+        {
+            foreach (var m in ClrTypeUtilities.SafeGetMethodsIncludingInterfaces(receiverClrType, BindingFlags.Instance | BindingFlags.Public)
+                .Where(m => m.Name == methodName))
+            {
+                result.Add(m.GetParameters());
+            }
+        }
+
+        foreach (var ext in this.memberLookup.CollectImportedExtensionMethods(methodName))
+        {
+            var extParams = ext.GetParameters();
+            if (extParams.Length == 0)
+            {
+                continue;
+            }
+
+            // Strip the leading `this` receiver parameter so positional indices
+            // line up with the call's explicit arguments (offset 0).
+            var stripped = new ParameterInfo[extParams.Length - 1];
+            System.Array.Copy(extParams, 1, stripped, 0, stripped.Length);
+            result.Add(stripped);
+        }
+
+        return result;
+    }
+
+    /// <summary>
     /// Issue #891: infers the target delegate type for each deferred un-typed
     /// arrow lambda argument of a member-style call by probing the applicable
     /// candidate methods — instance methods on the receiver, imported
@@ -1801,6 +1854,8 @@ internal sealed partial class ExpressionBinder
 
         var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>();
         var deferredArrowLambdaIndices = new List<int>();
+        List<ParameterInfo[]> delegateTargetCandidateParams = null;
+        var delegateTargetCandidatesComputed = false;
         var argSlot = 0;
         foreach (var argument in ce.Arguments)
         {
@@ -1822,6 +1877,29 @@ internal sealed partial class ExpressionBinder
                 // including LINQ extension methods — has been resolved below.
                 deferredArrowLambdaIndices.Add(argSlot);
                 boundArguments.Add(new BoundErrorExpression(inner));
+            }
+            else if (inner is LambdaExpressionSyntax)
+            {
+                // Issue #908: target-type an arrow lambda argument from the
+                // matching delegate-typed parameter of the applicable CLR
+                // static/instance/extension methods before binding it, mirroring
+                // the constructor path (BindCallArgumentWithDelegateTargetTyping).
+                // Without this, `Factory.CreateStatic(() -> MemoryStream())`
+                // binds the lambda with its body-derived return type
+                // (`() -> MemoryStream`) before overload resolution and fails to
+                // match a `Func<Stream>` parameter (GS0159). Pinning the return
+                // type from the delegate target yields `() -> Stream` directly so
+                // the call resolves and the produced delegate is created over a
+                // method whose return already matches the parameter.
+                if (!delegateTargetCandidatesComputed)
+                {
+                    delegateTargetCandidatesComputed = true;
+                    delegateTargetCandidateParams = CollectDelegateTargetCandidateParameterLists(receiver, classSymbol, methodName);
+                }
+
+                var argName = argumentNames.IsDefault ? null : argumentNames[argSlot];
+                boundArguments.Add(BindCallArgumentWithDelegateTargetTyping(
+                    argument, delegateTargetCandidateParams, sourceArgIndex: argSlot, argName: argName, paramOffset: 0));
             }
             else
             {

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -113,6 +113,22 @@ internal static class OverloadResolution
         /// materializes this conversion.
         /// </summary>
         LambdaToVoidDelegate = 9,
+
+        /// <summary>
+        /// Issue #908: a delegate value whose return type is a derived /
+        /// implementing reference type converting to a delegate parameter with
+        /// the same parameter signature but a base / interface return type
+        /// (e.g. <c>Func&lt;MemoryStream&gt;</c> → <c>Func&lt;Stream&gt;</c>, or
+        /// <c>() -&gt; NullLoggerFactory</c> → <c>Func&lt;ILoggerFactory&gt;</c>).
+        /// This mirrors C#/CLR reference-preserving delegate return-type
+        /// covariance. Ranked last (worst) so an exact (identity) delegate match
+        /// always wins when both are applicable. The binder's void-izing /
+        /// erasing rebind (<c>RebindFunctionLiteralDelegateArguments</c>)
+        /// materializes the return conversion for a <c>func</c>/arrow literal
+        /// argument so the produced delegate is created over a method whose
+        /// return type already matches the target.
+        /// </summary>
+        DelegateReturnCovariance = 10,
     }
 
     /// <summary>
@@ -241,6 +257,21 @@ internal static class OverloadResolution
             && ClrTypeUtilities.IsDelegateType(source))
         {
             return ImplicitConversionKind.Reference;
+        }
+
+        // Issue #908: delegate return-type covariance. A delegate value whose
+        // return type is a derived / implementing reference type is applicable
+        // to a delegate parameter with the same parameter signature but a
+        // base / interface return type (e.g. Func<MemoryStream> → Func<Stream>,
+        // () -> NullLoggerFactory → Func<ILoggerFactory>), mirroring C#/CLR
+        // reference-preserving delegate covariance. Checked here — before the
+        // assignability / base-type-walk blocks below — because a func/arrow
+        // literal's natural delegate type is a host-runtime Func<> closed over
+        // MetadataLoadContext type arguments, on which those reflection probes
+        // throw. Ranked last so an exact (identity) delegate match always wins.
+        if (IsDelegateReturnCovariant(target, source))
+        {
+            return ImplicitConversionKind.DelegateReturnCovariance;
         }
 
         if (ReferenceEquals(target.Assembly, source.Assembly) || target.GetType() == source.GetType())
@@ -1071,6 +1102,207 @@ internal static class OverloadResolution
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Issue #908: determines whether <paramref name="source"/> is a delegate
+    /// type whose parameter signature is identical to delegate
+    /// <paramref name="target"/> but whose return type is a derived /
+    /// implementing reference type of the target's return type — i.e. a
+    /// reference-preserving delegate return-type covariance
+    /// (<c>Func&lt;MemoryStream&gt;</c> → <c>Func&lt;Stream&gt;</c>,
+    /// <c>() -&gt; NullLoggerFactory</c> → <c>Func&lt;ILoggerFactory&gt;</c>).
+    /// Parameter and return types are compared by name to remain safe across
+    /// reflection contexts (the target parameter is typically loaded through a
+    /// <c>MetadataLoadContext</c> while the literal's natural <c>Func&lt;...&gt;</c>
+    /// may be a host-runtime constructed type). Only reference conversions are
+    /// accepted (no value-type / boxing / numeric conversions), matching C#'s
+    /// variance rules.
+    /// </summary>
+    /// <param name="target">The candidate delegate parameter type.</param>
+    /// <param name="source">The argument's natural delegate type.</param>
+    /// <returns><see langword="true"/> when the covariant conversion applies.</returns>
+    private static bool IsDelegateReturnCovariant(Type target, Type source)
+    {
+        if (!ClrTypeUtilities.IsDelegateType(target) || !ClrTypeUtilities.IsDelegateType(source))
+        {
+            return false;
+        }
+
+        if (!TryGetDelegateSignature(target, out var targetParams, out var targetReturn)
+            || !TryGetDelegateSignature(source, out var sourceParams, out var sourceReturn))
+        {
+            return false;
+        }
+
+        if (targetReturn is null || sourceReturn is null)
+        {
+            return false;
+        }
+
+        // Identity return types are handled by the normal delegate identity /
+        // assignability paths; covariance only applies when they differ.
+        if (ClrTypeUtilities.AreSame(targetReturn, sourceReturn))
+        {
+            return false;
+        }
+
+        // Reference-preserving only: both return types must be reference types
+        // (no value-type covariance, no boxing).
+        if (targetReturn.IsValueType || sourceReturn.IsValueType
+            || string.Equals(targetReturn.FullName, "System.Void", StringComparison.Ordinal)
+            || string.Equals(sourceReturn.FullName, "System.Void", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!IsReferencePreservingUpcast(targetReturn, sourceReturn))
+        {
+            return false;
+        }
+
+        // Parameter signatures must match exactly (by name, cross-context safe).
+        if (targetParams.Length != sourceParams.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < targetParams.Length; i++)
+        {
+            if (!ClrTypeUtilities.AreSame(targetParams[i], sourceParams[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #908: extracts a delegate type's parameter types and return type.
+    /// Prefers the <c>Invoke</c> method, but falls back to decomposing the
+    /// generic arguments of a closed <c>System.Func`N</c> / <c>System.Action`N</c>
+    /// shape. The fallback is required because a <c>func</c>/arrow literal's
+    /// natural delegate type is built by <c>FunctionTypeSymbol.BuildClrType</c>
+    /// as a host-runtime <c>Func&lt;&gt;</c> closed over
+    /// <see cref="System.Reflection.MetadataLoadContext"/> type arguments, on
+    /// which <see cref="Type.GetMethod(string)"/> throws.
+    /// </summary>
+    private static bool TryGetDelegateSignature(Type delegateType, out Type[] parameterTypes, out Type returnType)
+    {
+        parameterTypes = Array.Empty<Type>();
+        returnType = null;
+
+        try
+        {
+            var invoke = delegateType.GetMethod("Invoke");
+            if (invoke != null)
+            {
+                var ps = invoke.GetParameters();
+                var result = new Type[ps.Length];
+                for (var i = 0; i < ps.Length; i++)
+                {
+                    result[i] = ps[i].ParameterType;
+                }
+
+                parameterTypes = result;
+                returnType = invoke.ReturnType;
+                return true;
+            }
+        }
+        catch (Exception)
+        {
+            // Cross-context constructed Func<>/Action<> — fall back to the
+            // generic-argument decomposition below.
+        }
+
+        var fullName = delegateType.FullName;
+        if (fullName == null || !delegateType.IsGenericType)
+        {
+            return false;
+        }
+
+        Type[] genericArgs;
+        try
+        {
+            genericArgs = delegateType.GetGenericArguments();
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+
+        if (fullName.StartsWith("System.Func`", StringComparison.Ordinal) && genericArgs.Length >= 1)
+        {
+            // Func<T1,...,Tn,TResult>: trailing argument is the return type.
+            var ps = new Type[genericArgs.Length - 1];
+            Array.Copy(genericArgs, ps, ps.Length);
+            parameterTypes = ps;
+            returnType = genericArgs[genericArgs.Length - 1];
+            return true;
+        }
+
+        if (fullName.StartsWith("System.Action`", StringComparison.Ordinal))
+        {
+            // Action<T1,...,Tn>: void return, all generic arguments are parameters.
+            parameterTypes = genericArgs;
+            returnType = typeof(void);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #908: determines whether <paramref name="source"/> is
+    /// reference-convertible (an upcast) to <paramref name="target"/> — i.e.
+    /// <paramref name="target"/> is the same type, an interface implemented by
+    /// <paramref name="source"/>, or a base class of <paramref name="source"/>.
+    /// Compared by name so it is robust across reflection contexts.
+    /// </summary>
+    private static bool IsReferencePreservingUpcast(Type target, Type source)
+    {
+        if (ClrTypeUtilities.AreSame(target, source))
+        {
+            return true;
+        }
+
+        if (string.Equals(target.FullName, "System.Object", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (target.IsInterface && ClrTypeUtilities.ImplementsInterfaceByName(source, target))
+        {
+            return true;
+        }
+
+        for (var baseType = SafeBaseType(source); baseType != null; baseType = SafeBaseType(baseType))
+        {
+            if (ClrTypeUtilities.AreSame(baseType, target))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #908: returns <see cref="Type.BaseType"/>, swallowing the reflection
+    /// load failures that cross-context constructed generics can throw during a
+    /// base-type walk.
+    /// </summary>
+    private static Type SafeBaseType(Type type)
+    {
+        try
+        {
+            return type.BaseType;
+        }
+        catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -161,7 +161,21 @@ internal static class ClrTypeUtilities
         {
             try
             {
-                return target.IsAssignableFrom(source);
+                if (target.IsAssignableFrom(source))
+                {
+                    return true;
+                }
+
+                // Issue #908: do NOT treat a `false` here as authoritative. The
+                // `target.GetType() == source.GetType()` guard also fires when the
+                // two types are the same reflection-kind (e.g. both
+                // MetadataLoadContext RoTypes) but originate from *different*
+                // context instances — across two separate compilations sharing a
+                // process. There, IsAssignableFrom compares base types by
+                // reference and returns a spurious `false` even for a genuine
+                // upcast (e.g. MemoryStream → Stream). Fall through to the
+                // by-name walk, which is reference-context independent and only
+                // ever returns true for real inheritance / implementation.
             }
             catch (InvalidOperationException)
             {

--- a/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
@@ -157,6 +157,20 @@ public sealed class FunctionTypeSymbol : TypeSymbol
         return Cache.GetOrAdd(cacheKey, _ => new FunctionTypeSymbol(name, parameterTypes, normalizedFlags, returnType ?? TypeSymbol.Void));
     }
 
+    /// <summary>
+    /// Clears the process-wide function-type cache. Cached instances eagerly
+    /// build a host-runtime <c>System.Func</c>/<c>System.Action</c> CLR type
+    /// (see <see cref="BuildClrType"/>) that can close over types projected
+    /// from a <see cref="System.Reflection.MetadataLoadContext"/>. When that
+    /// context is disposed at the end of a compilation, reusing the cached
+    /// entry in a later compilation running in the same process throws
+    /// <see cref="System.ObjectDisposedException"/>. The
+    /// <see cref="ReferenceResolver"/> calls this on dispose alongside
+    /// <see cref="ImportedTypeSymbol.ClearCache"/> so each compilation rebuilds
+    /// function types against its own live reflection context.
+    /// </summary>
+    internal static void ClearCache() => Cache.Clear();
+
     private static void AppendIdentityKey(System.Text.StringBuilder builder, TypeSymbol type)
     {
         switch (type)

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -166,6 +166,13 @@ public sealed class ReferenceResolver : IDisposable
         // cache organically; the only cost is a cold cache on the next
         // compilation that reuses the same process.
         ImportedTypeSymbol.ClearCache();
+
+        // FunctionTypeSymbol eagerly closes a host-runtime Func/Action over
+        // MetadataLoadContext-projected type arguments, so its process-wide
+        // cache can likewise pin (and later resurface) types from this disposed
+        // context across compilations in the same process (issue #908). Clear
+        // it for the same reason.
+        FunctionTypeSymbol.ClearCache();
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue908DelegateReturnCovarianceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue908DelegateReturnCovarianceEmitTests.cs
@@ -1,0 +1,259 @@
+// <copyright file="Issue908DelegateReturnCovarianceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #908 — an arrow lambda (or explicit-but-derived-return <c>func</c>
+/// literal) whose body yields a <em>derived</em> reference type must bind where
+/// a <c>Func&lt;TBase&gt;</c> delegate parameter is expected, on CLR static AND
+/// instance method calls. Two compounding gaps are exercised:
+/// <list type="number">
+/// <item><description>
+/// Delegate return-type covariance in conversion / overload resolution: a
+/// function value of type <c>() -&gt; TDerived</c> satisfies a parameter typed
+/// <c>() -&gt; TBase</c> (mirroring C#/CLR reference-preserving delegate
+/// covariance). This covers the explicit <c>func() TDerived { ... }</c> form
+/// whose declared return type is not overridden by target-typing.
+/// </description></item>
+/// <item><description>
+/// Target-typing of lambda arguments on plain CLR static and instance method
+/// calls (previously wired only into the constructor path), so the arrow
+/// lambda's return type is pinned from the parameter's delegate type before
+/// overload resolution rather than from its body.
+/// </description></item>
+/// </list>
+/// The covariance scenario uses BCL <c>Stream</c> / <c>MemoryStream</c>
+/// (<c>MemoryStream : Stream</c>) so the produced delegate is created over a
+/// method whose return is covariance-compatible and the emitted IL verifies.
+/// </summary>
+public class Issue908DelegateReturnCovarianceEmitTests
+{
+    [Fact]
+    public void ArrowLambda_DerivedBody_ToStaticFuncBaseParameter_Runs()
+    {
+        RunWithHelper("""
+            package P
+            import System
+            import System.IO
+            import Issue908Helper
+
+            let r = Factory.CreateStatic(() -> MemoryStream())
+            Console.WriteLine(r)
+            """, "MemoryStream\n");
+    }
+
+    [Fact]
+    public void ExplicitDerivedReturnFuncLiteral_ToStaticFuncBaseParameter_Runs()
+    {
+        RunWithHelper("""
+            package P
+            import System
+            import System.IO
+            import Issue908Helper
+
+            let r = Factory.CreateStatic(func() MemoryStream { return MemoryStream() })
+            Console.WriteLine(r)
+            """, "MemoryStream\n");
+    }
+
+    [Fact]
+    public void ArrowLambda_DerivedBody_ToInstanceFuncBaseParameter_Runs()
+    {
+        RunWithHelper("""
+            package P
+            import System
+            import System.IO
+            import Issue908Helper
+
+            let f = Factory()
+            let r = f.CreateInstance(() -> MemoryStream())
+            Console.WriteLine(r)
+            """, "MemoryStream\n");
+    }
+
+    [Fact]
+    public void ExplicitDerivedReturnFuncLiteral_ToInstanceFuncBaseParameter_Runs()
+    {
+        RunWithHelper("""
+            package P
+            import System
+            import System.IO
+            import Issue908Helper
+
+            let f = Factory()
+            let r = f.CreateInstance(func() MemoryStream { return MemoryStream() })
+            Console.WriteLine(r)
+            """, "MemoryStream\n");
+    }
+
+    private static void RunWithHelper(string source, string expected)
+    {
+        var helperDir = Directory.CreateTempSubdirectory("gs_issue908_helper_").FullName;
+        try
+        {
+            var helperDll = Path.Combine(helperDir, "Issue908Helper.dll");
+            EmitFactoryAssembly(helperDll);
+            var output = CompileAndRun(source, referencePaths: new[] { helperDll });
+            Assert.Equal(expected, output);
+        }
+        finally
+        {
+            try { Directory.Delete(helperDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Emits a tiny assembly <c>Issue908Helper</c> exposing a <c>Factory</c>
+    /// class with a public parameterless constructor, a static
+    /// <c>string CreateStatic(Func&lt;Stream&gt;)</c> method, and an instance
+    /// <c>string CreateInstance(Func&lt;Stream&gt;)</c> method. Each invokes the
+    /// supplied factory and returns the runtime type name of the produced
+    /// stream (e.g. <c>"MemoryStream"</c>).
+    /// </summary>
+    /// <param name="outputPath">Where to write the emitted assembly.</param>
+    private static void EmitFactoryAssembly(string outputPath)
+    {
+        var asmName = new AssemblyName("Issue908Helper");
+        var ab = new PersistedAssemblyBuilder(asmName, typeof(object).Assembly);
+        var module = ab.DefineDynamicModule("Issue908Helper");
+        var type = module.DefineType(
+            "Issue908Helper.Factory",
+            TypeAttributes.Public | TypeAttributes.Class);
+
+        var factoryType = typeof(Func<Stream>);
+        var invoke = factoryType.GetMethod("Invoke")!;
+        var getType = typeof(object).GetMethod("GetType", Type.EmptyTypes)!;
+        var getName = typeof(Type).GetProperty("Name")!.GetGetMethod()!;
+
+        // public Factory() { }
+        var ctor = type.DefineConstructor(
+            MethodAttributes.Public,
+            CallingConventions.HasThis,
+            Type.EmptyTypes);
+        var ctorIl = ctor.GetILGenerator();
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Call, typeof(object).GetConstructor(Type.EmptyTypes)!);
+        ctorIl.Emit(OpCodes.Ret);
+
+        // public static string CreateStatic(Func<Stream> f) => f().GetType().Name;
+        var createStatic = type.DefineMethod(
+            "CreateStatic",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(string),
+            new[] { factoryType });
+        createStatic.DefineParameter(1, ParameterAttributes.None, "f");
+        var staticIl = createStatic.GetILGenerator();
+        staticIl.Emit(OpCodes.Ldarg_0);
+        staticIl.Emit(OpCodes.Callvirt, invoke);
+        staticIl.Emit(OpCodes.Callvirt, getType);
+        staticIl.Emit(OpCodes.Callvirt, getName);
+        staticIl.Emit(OpCodes.Ret);
+
+        // public string CreateInstance(Func<Stream> f) => f().GetType().Name;
+        var createInstance = type.DefineMethod(
+            "CreateInstance",
+            MethodAttributes.Public,
+            typeof(string),
+            new[] { factoryType });
+        createInstance.DefineParameter(1, ParameterAttributes.None, "f");
+        var instanceIl = createInstance.GetILGenerator();
+        instanceIl.Emit(OpCodes.Ldarg_1);
+        instanceIl.Emit(OpCodes.Callvirt, invoke);
+        instanceIl.Emit(OpCodes.Callvirt, getType);
+        instanceIl.Emit(OpCodes.Callvirt, getName);
+        instanceIl.Emit(OpCodes.Ret);
+
+        type.CreateType();
+        ab.Save(outputPath);
+    }
+
+    private static string CompileAndRun(string source, string[] referencePaths = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue908_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            if (referencePaths != null)
+            {
+                foreach (var reference in referencePaths)
+                {
+                    args.Add("/reference:" + reference);
+                    File.Copy(reference, Path.Combine(tempDir, Path.GetFileName(reference)), overwrite: true);
+                }
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath, additionalReferences: referencePaths);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #908

## Problem

Arrow lambdas — and explicit derived-return func literals — whose body yields a derived reference type were rejected with `error GS0159: Cannot find function ...` when passed to a CLR method parameter expecting `Func<TBase>`:

```gsharp
// FAILS today (GS0159): arrow lambda return inferred as the body type NullLoggerFactory
let b = RootCommandFactory.Create(() -> NullLoggerFactory.Instance)
// Also FAILS: explicit-but-derived return literal
let c = RootCommandFactory.Create(func() NullLoggerFactory { return NullLoggerFactory.Instance })
```

`NullLoggerFactory` implements `ILoggerFactory`, so `() -> NullLoggerFactory` should be usable where `Func<ILoggerFactory>` is expected (delegate return-type covariance / target-typing).

## Root cause — two compounding gaps (both fixed)

### Gap 1: No delegate return-type covariance in overload resolution / conversion
The binder required a lambda/func-literal's function type to match the delegate parameter essentially exactly and would not accept `() -> TDerived` where `() -> TBase` was wanted, even though `TDerived : TBase`. This affected even the explicit literal form.

**Fix:** `OverloadResolution.ClassifyImplicit` now recognizes a reference-preserving delegate return covariance via a new `ImplicitConversionKind.DelegateReturnCovariance` (ranked last/worst so an exact identity delegate match always wins). Delegate signatures are read in a cross-reflection-context-safe way (`Invoke`, with a generic-argument fallback for closed `System.Func`/`System.Action`), and only reference-preserving upcasts (class → base class / implemented interface) are accepted — no value-type, boxing, or numeric variance, matching C#/CLR delegate variance. The covariance check is placed *before* the assignability/base-walk blocks that throw on cross-context constructed types. For the explicit func-literal form, the existing `RebindFunctionLiteralDelegateArguments` then builds an erased adapter that converts the return value to the base type, so the produced `Func<TBase>` is valid IL.

### Gap 2: CLR method calls didn't target-type lambda arguments
Delegate target-typing of a lambda argument (`BindCallArgumentWithDelegateTargetTyping` → `TryResolveDelegateTargetFromCandidates` → `LambdaBinder.BindLambdaExpression(syntax, target)`) was wired only into the **constructor** call path. Plain CLR static/instance method calls bound the arrow lambda with its natural body-derived return type before resolution.

**Fix:** `ExpressionBinder.BindAccessorCall` now collects the candidate delegate parameter lists for the call (static methods of the class, or instance methods on the receiver plus imported extension methods with the leading `this` stripped) and target-types arrow-lambda arguments through the same `BindCallArgumentWithDelegateTargetTyping` path used by constructors. The arrow lambda's return type is pinned from the parameter's delegate type, so `() -> TDerived()` binds directly as `() -> TBase` and the delegate is created over a method whose return already matches (clean, exact IL).

### Two latent cross-reflection-context bugs (surfaced + fixed)
- `ClrTypeUtilities.IsAssignableByName` returned a spurious `false` when the two types came from **different** `MetadataLoadContext` instances of the same reflection kind (the `target.GetType() == source.GetType()` fast-path fired and `IsAssignableFrom` compared base types by reference). It now falls through to the context-independent by-name interface/base-class walk instead of trusting that `false`.
- `FunctionTypeSymbol` eagerly closes a host-runtime `Func`/`Action` over MLC-projected type arguments, but its process-wide cache (keyed by type name) was never cleared, resurfacing types from a **disposed** context across compilations in the same process (`ObjectDisposedException`). It is now cleared on `ReferenceResolver.Dispose` alongside `ImportedTypeSymbol.ClearCache`.

## Tests
New `Issue908DelegateReturnCovarianceEmitTests` cover all four combinations — arrow lambda and explicit derived-return func literal, each passed to a CLR **static** and **instance** method expecting `Func<Stream>` with a `MemoryStream` body. Each test compiles, runs ilverify, and executes the emitted assembly to confirm the produced delegate works at runtime (prints `MemoryStream`).

## Validation
- `dotnet build GSharp.sln --configuration Release --no-restore -graph` → Build succeeded.
- `dotnet test GSharp.sln --configuration Release --no-build` → **0 failed**. Compiler.Tests 1374 passed, Core.Tests 3357 passed / 1 skipped, LanguageServer.Tests 350, Interpreter.Tests 308, Extensions.Tests 104, Sdk.Tests 38. No regressions to prior #889/#891/#893 lambda/delegate work.

## Files changed
- `src/Core/CodeAnalysis/Binding/OverloadResolution.cs` — delegate return-type covariance classification + helpers.
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs` — target-type lambda args on CLR static/instance/extension method calls.
- `src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs` — cross-context `IsAssignableByName` robustness.
- `src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs` + `ReferenceResolver.cs` — clear stale function-type cache on dispose.
- `test/Compiler.Tests/Emit/Issue908DelegateReturnCovarianceEmitTests.cs` — regression tests.