### PR TITLE
Fix top-level `private` IL accessibility mismatch (#909)

### DIFF
--- a/docs/adr/0109-top-level-private-accessibility.md
+++ b/docs/adr/0109-top-level-private-accessibility.md
@@ -1,0 +1,165 @@
+# ADR-0109: Top-level `private` maps to IL `assembly` (internal)
+
+- **Status**: Accepted
+- **Date**: 2026-06-20
+- **Phase**: Phase 5 — generics & dogfooded core
+- **Closes**: Issue #909 (top-level `private func` causes runtime `MethodAccessException` when called from another type)
+- **Related**: ADR-0066 (top-level statements / synthetic `<Program>` host);
+  ADR-0090 (private interface helper methods)
+
+## Context
+
+G# top-level declarations (functions written directly in a package, not
+inside a `class`/`struct`/`interface`) are emitted as static members of a
+synthetic per-package `<Program>` type. A sibling top-level `class` in the
+same file/assembly is emitted as its own CLR `TypeDef`.
+
+The binder's accessibility model treats a top-level `private` function as
+reachable from sibling top-level types in the same assembly — so it
+*permits* a user `class` to call a top-level `private func`. But emission
+mapped source `private` to IL `MethodAttributes.Private`
+(`src/Core/CodeAnalysis/Emit/AccessibilityMap.cs`), and the CLR enforces
+IL `private` as *private-to-the-declaring-type* (`<Program>`). The binder's
+model and the emitted IL therefore **disagreed**, producing a clean compile
+followed by a runtime fault:
+
+```gsharp
+package Oahu.Cli.Tests
+
+import System
+
+private func Helper() string {
+    return "hello"
+}
+
+class Greeter {
+    func CallIt() string {
+        return Helper()        // direct call
+    }
+    func MakeDelegate() Func[string] {
+        return Helper          // method-group delegate
+    }
+}
+```
+
+```
+System.MethodAccessException: Attempt by method
+'Oahu.Cli.Tests.Greeter.CallIt()' to access method
+'Oahu.Cli.Tests.<Program>.Helper()' failed.
+```
+
+`ilverify` likewise flagged the emitted assembly with
+`[MethodAccess] ... Method is not visible.` for both the direct call and the
+method-group-delegate (`ldftn`) forms. Default (no-modifier) top-level
+functions were unaffected — they are emitted `public static` and already
+worked; only an *explicit* `private` modifier was broken.
+
+A top-level `private` most naturally means "module/file-private, not
+exported from the assembly". The closest CLR accessibility for that intent
+is IL `assembly` (internal): visible to every type in the same assembly, but
+not exported to consumers.
+
+## Decision
+
+Emit top-level `private` functions — members of the synthetic `<Program>`
+type — as IL `assembly` (internal) instead of IL `private`, so the IL
+accessibility matches what the binder already permits (cross-type access
+within the assembly).
+
+The remapping lives in the single accessibility-mapping helper used by every
+function-emit path:
+
+```csharp
+// AccessibilityMap.cs
+public static MethodAttributes ToMethodVisibility(
+    Accessibility accessibility, bool isTopLevelProgramMember)
+{
+    if (isTopLevelProgramMember && accessibility == Accessibility.Private)
+    {
+        return MethodAttributes.Assembly; // IL `assembly` (internal)
+    }
+
+    return ToMethodVisibility(accessibility);
+}
+
+public static bool IsTopLevelProgramMember(FunctionSymbol function)
+    => !function.IsInstanceMethod && function.StaticOwnerType is null;
+```
+
+`ReflectionMetadataEmitter` passes
+`AccessibilityMap.IsTopLevelProgramMember(function)` at all three function
+MethodDef-visibility sites — the ordinary function path (`EmitFunction`), the
+P/Invoke path (`EmitPInvokeFunction`), and the `@LibraryImport` outer-stub
+path (`EmitLibraryImportFunction`) — so every kind of top-level `private`
+function is emitted consistently.
+
+A function is a `<Program>` member when it is **not** an instance method
+(`ReceiverType is null`) and carries **no** `StaticOwnerType` (which is set
+for `shared`/static methods owned by a user `struct`/`class`/`interface`).
+This covers plain top-level functions, extension functions, and
+non-capturing lambda host methods — all hosted on `<Program>` — while
+excluding every member of a user-defined type.
+
+## Consequences
+
+### Positive
+
+- The repro compiles, passes `ilverify`, and executes without
+  `MethodAccessException` for **both** the direct call `Helper()` and the
+  method-group delegate `return Helper`.
+- The binder's existing accessibility model and the emitted IL now agree, so
+  "compiles clean but faults at runtime" can no longer occur for this case.
+- No binder/diagnostic changes are required; existing code that legitimately
+  calls top-level `private` helpers from sibling top-level types keeps
+  working, now soundly.
+
+### Negative
+
+- A top-level `private` function is technically reachable by any type in the
+  same assembly (IL `assembly`), which is slightly broader than the word
+  "private" might suggest. This matches the binder's already-permitted
+  semantics and the "module/file-private, not exported" intent; it does not
+  export the member from the assembly.
+
+### Out of scope
+
+- User-type `private` is deliberately **unchanged**: a `private`
+  method/field on a normal `class`/`struct`/`interface` still maps to IL
+  `private` and the CLR continues to enforce real type privacy. The
+  remapping is gated strictly on `IsTopLevelProgramMember`.
+- Default (no-modifier) top-level functions remain `public static`.
+- Tightening top-level `private` to be genuinely type-private (e.g. by
+  moving top-level members into per-file nested types) is not pursued here.
+
+## Test coverage
+
+`test/Compiler.Tests/Emit/Issue909TopLevelPrivateAccessibilityEmitTests.cs`:
+
+- `TopLevelPrivateFunc_DirectCallFromSiblingType_Runs` — compiles, runs
+  `ilverify`, and executes the direct-call repro; asserts output `hello`.
+- `TopLevelPrivateFunc_MethodGroupDelegateFromSiblingType_Runs` — same for
+  the method-group-delegate (`return Helper`) form.
+- `TopLevelPrivateFunc_BothFormsTogether_Runs` — exercises both forms in one
+  assembly.
+- `TopLevelPrivateFunc_IsEmittedAssemblyVisible` — reads the emitted
+  metadata and asserts the top-level `Helper` MethodDef is IL `assembly`.
+- `UserClassPrivateMethod_RemainsIlPrivate` — guard asserting that a
+  `private` method on a user `class` is still emitted IL `private`
+  (scoping is preserved; user-type privacy is not weakened).
+
+## Alternatives considered
+
+- **Option 2 — compile-time accessibility diagnostic.** Keep IL `private`
+  and instead make the binder *reject* cross-type access to a top-level
+  `private` function, surfacing a compile error rather than a runtime fault.
+  This was rejected because it removes useful, already-working behavior
+  (top-level `private` helpers shared among sibling top-level types in a
+  file are idiomatic), changes the language in a more restrictive direction,
+  and would require reworking the binder's accessibility model rather than
+  aligning emission with it. Option 1 keeps the permissive, ergonomic
+  behavior the binder already implements and simply makes the emitted IL
+  honest about it.
+- **Per-file nested host type.** Emit each file's top-level members into a
+  distinct nested type so `private` could be genuinely type-private. This is
+  a much larger metadata-layout change to `<Program>` hosting for no
+  user-visible benefit over Option 1, and was rejected as out of scope.

--- a/src/Core/CodeAnalysis/Emit/AccessibilityMap.cs
+++ b/src/Core/CodeAnalysis/Emit/AccessibilityMap.cs
@@ -61,4 +61,57 @@ internal static class AccessibilityMap
                 return MethodAttributes.Public;
         }
     }
+
+    /// <summary>
+    /// Issue #909 / ADR-0109: maps a function's source accessibility to IL
+    /// <see cref="MethodAttributes"/> visibility, accounting for whether the
+    /// function is a top-level member of the synthetic <c>&lt;Program&gt;</c>
+    /// type.
+    /// <para>
+    /// Top-level <c>private</c> functions live on <c>&lt;Program&gt;</c>, but the
+    /// binder's accessibility model treats them as assembly-visible: sibling
+    /// top-level types (e.g. a user <c>class</c>) in the same assembly may call
+    /// them. Mapping source <c>private</c> to IL <see cref="MethodAttributes.Private"/>
+    /// makes the CLR enforce private-to-<c>&lt;Program&gt;</c>, which DISAGREES
+    /// with the binder and yields a runtime <see cref="System.MethodAccessException"/>
+    /// despite a clean compile. We therefore emit top-level <c>private</c> as IL
+    /// <c>assembly</c> (internal) so the IL accessibility matches what the binder
+    /// already permits.
+    /// </para>
+    /// <para>
+    /// This remapping is scoped to <c>&lt;Program&gt;</c> members ONLY. A
+    /// <c>private</c> member of a user-defined <c>class</c>/<c>struct</c>/
+    /// <c>interface</c> keeps IL <see cref="MethodAttributes.Private"/> so the
+    /// CLR continues to enforce real user-type privacy.
+    /// </para>
+    /// </summary>
+    /// <param name="accessibility">The source accessibility of the function.</param>
+    /// <param name="isTopLevelProgramMember">
+    /// <c>true</c> when the function is hosted on the synthetic
+    /// <c>&lt;Program&gt;</c> type (see <see cref="IsTopLevelProgramMember"/>).
+    /// </param>
+    /// <returns>The IL visibility <see cref="MethodAttributes"/>.</returns>
+    public static MethodAttributes ToMethodVisibility(Accessibility accessibility, bool isTopLevelProgramMember)
+    {
+        if (isTopLevelProgramMember && accessibility == Accessibility.Private)
+        {
+            return MethodAttributes.Assembly;
+        }
+
+        return ToMethodVisibility(accessibility);
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="function"/> is emitted as a top-level
+    /// member of the synthetic <c>&lt;Program&gt;</c> type (as opposed to a
+    /// member of a user-defined type). Instance methods are owned by their
+    /// declaring type and static methods carry a non-null
+    /// <see cref="FunctionSymbol.StaticOwnerType"/>; everything else (plain
+    /// top-level functions, extension functions, and non-capturing lambda host
+    /// methods) is hosted on <c>&lt;Program&gt;</c>.
+    /// </summary>
+    /// <param name="function">The function being emitted.</param>
+    /// <returns><c>true</c> when the function is a <c>&lt;Program&gt;</c> member.</returns>
+    public static bool IsTopLevelProgramMember(FunctionSymbol function)
+        => !function.IsInstanceMethod && function.StaticOwnerType is null;
 }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -3927,7 +3927,7 @@ internal sealed class ReflectionMetadataEmitter
         // The synthesized entry point must remain Public so the runtime can find it.
         var visibility = isEntryPoint && function.Declaration is null
             ? MethodAttributes.Public
-            : AccessibilityMap.ToMethodVisibility(function.Accessibility);
+            : AccessibilityMap.ToMethodVisibility(function.Accessibility, AccessibilityMap.IsTopLevelProgramMember(function));
 
         // Instance methods omit MethodAttributes.Static. Phase 3.B.3 sub-step 3
         // models open/override per ADR-0017 for classes:
@@ -4376,7 +4376,7 @@ internal sealed class ReflectionMetadataEmitter
         // mirrors the ImplMap; we set MethodImplAttributes.PreserveSig when
         // the metadata says so (default true) so the CLR does not synthesise
         // an HRESULT-to-exception translation.
-        var visibility = AccessibilityMap.ToMethodVisibility(function.Accessibility);
+        var visibility = AccessibilityMap.ToMethodVisibility(function.Accessibility, AccessibilityMap.IsTopLevelProgramMember(function));
         var methodAttrs = visibility | MethodAttributes.HideBySig | MethodAttributes.Static | MethodAttributes.PinvokeImpl;
         var implAttrs = MethodImplAttributes.IL | MethodImplAttributes.Managed;
         if (pInvoke.PreserveSig)
@@ -4590,7 +4590,7 @@ internal sealed class ReflectionMetadataEmitter
                     }
                 });
 
-        var outerVisibility = AccessibilityMap.ToMethodVisibility(function.Accessibility);
+        var outerVisibility = AccessibilityMap.ToMethodVisibility(function.Accessibility, AccessibilityMap.IsTopLevelProgramMember(function));
         var outerMethodAttrs = outerVisibility | MethodAttributes.HideBySig | MethodAttributes.Static;
         var outerImplAttrs = MethodImplAttributes.IL | MethodImplAttributes.Managed;
 

--- a/test/Compiler.Tests/Emit/Issue909TopLevelPrivateAccessibilityEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue909TopLevelPrivateAccessibilityEmitTests.cs
@@ -1,0 +1,303 @@
+// <copyright file="Issue909TopLevelPrivateAccessibilityEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #909 — a top-level <c>private func</c> lives on the synthetic
+/// <c>&lt;Program&gt;</c> type. The binder permits sibling top-level types in
+/// the same assembly to call it (its accessibility model treats top-level
+/// <c>private</c> as assembly-visible), but emission used to map source
+/// <c>private</c> to IL <see cref="MethodAttributes.Private"/>, which the CLR
+/// enforces as private-to-the-declaring-type (<c>&lt;Program&gt;</c>). The
+/// binder and the emitted IL therefore disagreed: clean compile, runtime
+/// <see cref="MethodAccessException"/>.
+///
+/// The fix (ADR-0109, option 1) emits top-level <c>private</c> members of the
+/// synthetic <c>&lt;Program&gt;</c> type as IL <c>assembly</c> (internal) so the
+/// IL accessibility matches what the binder already permits. Both the direct
+/// call <c>Helper()</c> and the method-group delegate <c>return Helper</c> must
+/// execute without <see cref="MethodAccessException"/>.
+///
+/// This remapping is scoped to <c>&lt;Program&gt;</c> members ONLY — a
+/// <c>private</c> method on a user-defined <c>class</c>/<c>struct</c> stays IL
+/// <c>private</c>.
+/// </summary>
+public class Issue909TopLevelPrivateAccessibilityEmitTests
+{
+    [Fact]
+    public void TopLevelPrivateFunc_DirectCallFromSiblingType_Runs()
+    {
+        CompileVerifyAndRun("""
+            package Oahu.Cli.Tests
+
+            import System
+
+            private func Helper() string {
+                return "hello"
+            }
+
+            class Greeter {
+                func CallIt() string {
+                    return Helper()
+                }
+            }
+
+            func Main() {
+                let g = Greeter()
+                Console.WriteLine(g.CallIt())
+            }
+            """, "hello\n");
+    }
+
+    [Fact]
+    public void TopLevelPrivateFunc_MethodGroupDelegateFromSiblingType_Runs()
+    {
+        CompileVerifyAndRun("""
+            package Oahu.Cli.Tests
+
+            import System
+
+            private func Helper() string {
+                return "hello"
+            }
+
+            class Greeter {
+                func MakeDelegate() Func[string] {
+                    return Helper
+                }
+            }
+
+            func Main() {
+                let g = Greeter()
+                let d = g.MakeDelegate()
+                Console.WriteLine(d())
+            }
+            """, "hello\n");
+    }
+
+    [Fact]
+    public void TopLevelPrivateFunc_BothFormsTogether_Runs()
+    {
+        CompileVerifyAndRun("""
+            package Oahu.Cli.Tests
+
+            import System
+
+            private func Helper() string {
+                return "hello"
+            }
+
+            class Greeter {
+                func CallIt() string {
+                    return Helper()
+                }
+                func MakeDelegate() Func[string] {
+                    return Helper
+                }
+            }
+
+            func Main() {
+                let g = Greeter()
+                Console.WriteLine(g.CallIt())
+                let d = g.MakeDelegate()
+                Console.WriteLine(d())
+            }
+            """, "hello\nhello\n");
+    }
+
+    /// <summary>
+    /// Guard: a top-level <c>private func</c> must be emitted IL
+    /// <c>assembly</c> (internal), NOT IL <c>private</c>.
+    /// </summary>
+    [Fact]
+    public void TopLevelPrivateFunc_IsEmittedAssemblyVisible()
+    {
+        var dll = CompileToDll("""
+            package Oahu.Cli.Tests
+
+            import System
+
+            private func Helper() string {
+                return "hello"
+            }
+
+            func Main() {
+                Console.WriteLine(Helper())
+            }
+            """);
+        try
+        {
+            var attrs = GetMethodAttributes(dll, "<Program>", "Helper");
+            Assert.Equal(MethodAttributes.Assembly, attrs & MethodAttributes.MemberAccessMask);
+        }
+        finally
+        {
+            TryDeleteDir(Path.GetDirectoryName(dll));
+        }
+    }
+
+    /// <summary>
+    /// Guard: a <c>private</c> method on a USER class must remain IL
+    /// <c>private</c> — the remapping is scoped to <c>&lt;Program&gt;</c> only
+    /// and must NOT weaken real user-type <c>private</c>.
+    /// </summary>
+    [Fact]
+    public void UserClassPrivateMethod_RemainsIlPrivate()
+    {
+        var dll = CompileToDll("""
+            package Oahu.Cli.Tests
+
+            import System
+
+            class Greeter {
+                private func Secret() string {
+                    return "secret"
+                }
+                func Reveal() string {
+                    return Secret()
+                }
+            }
+
+            func Main() {
+                let g = Greeter()
+                Console.WriteLine(g.Reveal())
+            }
+            """);
+        try
+        {
+            var attrs = GetMethodAttributes(dll, "Greeter", "Secret");
+            Assert.Equal(MethodAttributes.Private, attrs & MethodAttributes.MemberAccessMask);
+        }
+        finally
+        {
+            TryDeleteDir(Path.GetDirectoryName(dll));
+        }
+    }
+
+    private static MethodAttributes GetMethodAttributes(string dllPath, string typeName, string methodName)
+    {
+        using var fs = File.OpenRead(dllPath);
+        using var pe = new PEReader(fs);
+        var mr = pe.GetMetadataReader();
+        foreach (var typeHandle in mr.TypeDefinitions)
+        {
+            var type = mr.GetTypeDefinition(typeHandle);
+            if (mr.GetString(type.Name) != typeName)
+            {
+                continue;
+            }
+
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = mr.GetMethodDefinition(methodHandle);
+                if (mr.GetString(method.Name) == methodName)
+                {
+                    return method.Attributes;
+                }
+            }
+        }
+
+        throw new Xunit.Sdk.XunitException($"method {typeName}.{methodName} not found in {dllPath}");
+    }
+
+    private static void CompileVerifyAndRun(string source, string expected)
+    {
+        var dll = CompileToDll(source);
+        try
+        {
+            IlVerifier.Verify(dll);
+
+            var runtimeConfigPath = Path.ChangeExtension(dll, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + dll + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            Assert.Equal(expected, stdout.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            TryDeleteDir(Path.GetDirectoryName(dll));
+        }
+    }
+
+    private static string CompileToDll(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue909_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+            srcPath,
+        };
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+        return outPath;
+    }
+
+    private static void TryDeleteDir(string dir)
+    {
+        try
+        {
+            if (dir != null)
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes #909

## Root cause
Top-level declarations are emitted as static members of the synthetic per-package `<Program>` type, while a sibling top-level `class` is emitted as its own CLR `TypeDef`. The binder's accessibility model treats a top-level `private` function as reachable from sibling top-level types in the same assembly — so it permits a user `class` to call a top-level `private func`. But emission mapped source `private` to IL `MethodAttributes.Private` (`src/Core/CodeAnalysis/Emit/AccessibilityMap.cs`), which the CLR enforces as *private-to-the-declaring-type* (`<Program>`).

The binder's model and the emitted IL **disagreed**: clean compile, then at runtime:

```
System.MethodAccessException: Attempt by method 'Oahu.Cli.Tests.Greeter.CallIt()' to access method 'Oahu.Cli.Tests.<Program>.Helper()' failed.
```

`ilverify` also flagged `[MethodAccess] ... Method is not visible.` for both the direct call `Helper()` and the method-group delegate `return Helper` (`ldftn`). Default (no-modifier) top-level funcs were already `public static` and worked; only an explicit `private` was broken.

## The fix (ADR-0109, option 1)
Emit top-level `private` members of `<Program>` as IL `assembly` (internal) so the IL accessibility matches what the binder already permits (cross-type access within the assembly). A top-level `private` most naturally means "module/file-private, not exported from the assembly", which maps to IL `assembly`.

The remapping lives in the shared `AccessibilityMap` helper:

```csharp
public static MethodAttributes ToMethodVisibility(Accessibility accessibility, bool isTopLevelProgramMember)
{
    if (isTopLevelProgramMember && accessibility == Accessibility.Private)
        return MethodAttributes.Assembly; // IL `assembly` (internal)
    return ToMethodVisibility(accessibility);
}

public static bool IsTopLevelProgramMember(FunctionSymbol function)
    => !function.IsInstanceMethod && function.StaticOwnerType is null;
```

`ReflectionMetadataEmitter` passes the predicate at all three function MethodDef-visibility sites: the ordinary path (`EmitFunction`), P/Invoke (`EmitPInvokeFunction`), and the `@LibraryImport` outer stub (`EmitLibraryImportFunction`).

## Scoping (user-type `private` unchanged)
The remapping is gated strictly on `IsTopLevelProgramMember` — not an instance method (`ReceiverType is null`) **and** no `StaticOwnerType` (set for `shared`/static members of user `struct`/`class`/`interface`). A `private` method/field on a user-defined type still maps to IL `private` and is still CLR-enforced. Default (no-modifier) top-level funcs stay `public static`.

## Tests
`test/Compiler.Tests/Emit/Issue909TopLevelPrivateAccessibilityEmitTests.cs` (compile + `ilverify` + execute):
- direct call `Helper()` from a sibling `class` — runs, prints `hello`
- method-group delegate `return Helper` — runs, prints `hello`
- both forms together
- metadata assertion: top-level `Helper` MethodDef is IL `assembly`
- guard: `private` method on a user `class` is still IL `private`

Confirmed both failing forms now execute without `MethodAccessException`. Full local build + test suite green.

See **ADR-0109** (`docs/adr/0109-top-level-private-accessibility.md`) for the decision and the rejected option 2 (compile-time accessibility diagnostic).