### PR TITLE
Support nested type declarations (class/struct/interface/enum inside class/struct)

### DIFF
--- a/docs/adr/0110-nested-type-declarations.md
+++ b/docs/adr/0110-nested-type-declarations.md
@@ -1,0 +1,197 @@
+# ADR-0110: Nested type declarations
+
+- **Status**: Accepted
+- **Date**: 2026-06-20
+- **Phase**: Phase 5 — generics & dogfooded core
+- **Closes**: Issue #910 (nested type declarations inside a class/struct are unsupported and produce a misleading parse-error cascade)
+- **Related**: ADR-0017 (sealed-by-default classes); ADR-0078 (sealed hierarchies); #526/#569 (construction/type-clause resolution of *imported* CLR nested types); ADR-0109 (top-level accessibility)
+
+## Context
+
+A `class` or `struct` body could not declare a nested type. The
+class/struct body member loop in `Parser.cs` dispatched only on member
+kinds — fields (`var`/`let`), `func`, `prop`, `event`, `init`,
+constructors, and destructors — and had **no** production for the
+`class` / `struct` / `interface` / `enum` keywords. A nested type
+declaration was therefore misparsed as a malformed field, which cascaded
+into a sequence of misleading errors, e.g.:
+
+```gsharp
+class Outer {
+    class Inner {                 // GS0113 Type '' doesn't exist
+        func Hello() string {     // GS0288 field-keyword expected
+            return "hi"
+        }
+    }                             // GS0005 unexpected <ClassKeyword>
+    func Make() string {
+        let i = Inner()
+        return i.Hello()
+    }
+}
+```
+
+Nested types were simply absent from the aggregate-member grammar even
+though the rest of the pipeline already had most of the machinery: the
+binder registers every user type in a flat type-alias scope, and the
+emitter already produced CLR nested `TypeDef`s for compiler-synthesized
+state machines and closures (`EmitNestedStructTypeDef`,
+`AccessibilityMap.MapNestedTypeAccessibility`,
+`MetadataBuilder.AddNestedType`). What was missing was a source-level
+spelling and the wiring to make a *user-declared* nested type flow
+through parse → bind → emit.
+
+A hard constraint shapes the emit design: ECMA-335 §II.22.32 requires
+the **enclosing** `TypeDef` row to precede the **nested** `TypeDef` row,
+and the `Field`/`MethodDef` list columns must be monotonically
+non-decreasing across `TypeDef` rows. The emitter assigns rows in a
+fixed kind-partitioned order: interfaces → classes → structs → enums →
+`<Program>` → state-machine types. That order already guarantees
+"enclosing before nested" for several kind/encloser combinations but
+*not* for all of them.
+
+## Decision
+
+### Grammar
+
+`class` / `struct` / `interface` / `enum` are accepted as members of a
+`class` or `struct` body. The body member loop detects an (optional
+accessibility modifier followed by an) aggregate-declaration head and
+reuses the existing top-level `ParseAggregateDeclaration` routine, so a
+nested type is parsed by exactly the same code as a top-level one. The
+parsed nested declarations are stored on a new
+`StructDeclarationSyntax.NestedTypes` list. Because the top-level
+routine is reused, nesting is **recursive**: a nested type may itself
+contain nested types (`Outer.Middle.Inner`).
+
+### Binding & name resolution
+
+`DeclarationBinder.BindNestedTypeDeclarations` binds each nested
+declaration through the same per-kind binders used for top-level types
+and calls `SetContainingType` on the resulting symbol
+(`StructSymbol`/`EnumSymbol`/`InterfaceSymbol` each gained a
+`ContainingType` property). Nested types register in the same flat
+type-alias scope as top-level types, keyed by their **simple** name.
+
+Consequences of the flat scope:
+
+- A nested type resolves by its **unqualified** simple name from
+  anywhere the type is visible — in particular from the enclosing type's
+  own members, which satisfies the issue's `Inner()` construction inside
+  `Outer.Make()`.
+- Qualified `Outer.Inner` resolution for **user-declared** nested types
+  is *not* newly added here. (Dotted resolution of *imported* CLR nested
+  types via `#526`/`#569` is unaffected.) Authors reference a nested user
+  type by its simple name.
+- Because the simple name is global, two distinct enclosers cannot
+  declare nested types with the same simple name in one compilation; the
+  second triggers the normal "symbol already declared" diagnostic.
+
+### Accessibility
+
+A nested type's IL visibility is mapped with
+`AccessibilityMap.MapNestedTypeAccessibility`
+(`internal → NestedAssembly`, `private → NestedPrivate`, otherwise
+`NestedPublic`) and it is emitted with an empty namespace; the enclosing
+`TypeDef` qualifies the name.
+
+### Emit
+
+`TypeDefEmitter.EmitStructTypeDef` / `EmitEnumTypeDef` /
+`EmitInterfaceTypeDef` are nested-aware: when `ContainingType != null`
+they use the nested accessibility flags and empty namespace.
+`ReflectionMetadataEmitter` adds a `NestedClass` row
+(`AddNestedType(nested, enclosing)`) for every user nested type, with the
+enclosing handle taken from `cache.StructTypeDefs[containingType]`.
+
+### Supported combinations
+
+The kind-partitioned emission order already satisfies ECMA-335 §II.22.32
+("enclosing row < nested row") for these combinations, which are emitted
+as **true CLR nested types** and verified to pass ilverify and execute:
+
+| Nested kind | in `class` | in `struct` |
+|-------------|:----------:|:-----------:|
+| `class`     | ✅          | ⛔ GS0369    |
+| `struct`    | ✅          | ✅           |
+| `enum`      | ✅          | ✅           |
+| `interface` | ⛔ GS0369   | ⛔ GS0369    |
+
+This covers the issue's core requirements (nested class-in-class and
+nested struct-in-struct/class) plus nested enums.
+
+### Deferred combinations (dedicated diagnostic, not a cascade)
+
+A nested **`interface`** (in any encloser) and a nested **`class`
+inside a `struct`** would place the nested `TypeDef` row *before* its
+enclosing row under the current emission order (interfaces are emitted
+first; classes are emitted before structs), violating ECMA-335
+§II.22.32 and producing metadata the CLR loader rejects at run time.
+Emitting these correctly would require a global enclosing-before-nested
+emission order shared by row-planning and emission across all four kind
+partitions — a large, risky refactor of the metadata emitter.
+
+For these two combinations the binder reports a **single dedicated
+diagnostic, `GS0369`**, instead of the old misleading parse cascade. The
+nested type is still parsed and bound (so its body is checked and
+references do not produce secondary "type doesn't exist" noise), but it
+is not marked nested and the compile fails on `GS0369` alone, with a
+message that names the exact unsupported combination and points the
+author to move the type to the top level.
+
+## Consequences
+
+**Positive**
+
+- The issue's exact example compiles, passes ilverify, and runs.
+- Five of the eight kind/encloser combinations are emitted as real CLR
+  nested types with correct nested accessibility, usable from the
+  enclosing type's members and reflectable as `Outer+Inner`.
+- Recursive nesting works to arbitrary depth.
+- The remaining combinations fail with one clear, actionable diagnostic
+  instead of a three-error cascade.
+
+**Negative / out-of-scope**
+
+- Nested `interface` (any encloser) and nested `class`-in-`struct` are
+  deferred behind `GS0369` until the emitter gains a unified
+  enclosing-before-nested type ordering.
+- User-declared nested types are visible by their **simple** name across
+  the whole compilation; qualified `Outer.Inner` resolution for user
+  types is not added here, and two enclosers cannot reuse a nested simple
+  name.
+
+**Neutral**
+
+- No change to imported CLR nested-type resolution (`#526`/`#569`).
+
+## Test coverage
+
+- **Parser** (`Issue910NestedTypeParserTests`): all four nested kinds in
+  both `class` and `struct` enclosers, recursive nesting, accessibility
+  modifier on a nested type, and sibling members alongside a nested type.
+- **Binder** (`Issue910NestedTypeBinderTests`): `ContainingType` is set
+  for supported combinations, recursive `ContainingType` chaining, and
+  `GS0369` fires for the two deferred combinations.
+- **Emit** (`Issue910NestedTypeEmitTests`): the issue's exact example
+  plus every supported combination compiles, passes ilverify, and
+  executes; a reflection assertion proves `Inner` is a real CLR nested
+  type of `Outer`; and the two deferred combinations surface `GS0369`
+  with no `GS0288`/`GS0005` cascade.
+
+## Alternatives considered
+
+- **Diagnostic-only (no real support).** The issue offered a fallback of
+  emitting a clear dedicated diagnostic for *all* nested declarations.
+  Rejected: it leaves a useful, widely-expected language feature
+  unimplemented when most of the infrastructure already existed. We
+  implement real nesting for every combination the emitter can order
+  correctly and reserve the diagnostic only for the genuinely
+  hard-to-order combinations.
+- **Unified enclosing-before-nested emission order for all kinds.** This
+  would support every combination but requires reworking row-planning and
+  emission across the interface/class/struct/enum partitions
+  simultaneously, with high regression risk to the existing emitter.
+  Deferred to a follow-up; tracked by `GS0369`.
+- **Emit deferred nested types as top-level types.** They would run but
+  would not be true CLR nested types, silently diverging from the
+  declared shape. Rejected in favour of an explicit diagnostic.

--- a/docs/adr/0110-nested-type-declarations.md
+++ b/docs/adr/0110-nested-type-declarations.md
@@ -43,11 +43,14 @@ through parse → bind → emit.
 A hard constraint shapes the emit design: ECMA-335 §II.22.32 requires
 the **enclosing** `TypeDef` row to precede the **nested** `TypeDef` row,
 and the `Field`/`MethodDef` list columns must be monotonically
-non-decreasing across `TypeDef` rows. The emitter assigns rows in a
-fixed kind-partitioned order: interfaces → classes → structs → enums →
-`<Program>` → state-machine types. That order already guarantees
-"enclosing before nested" for several kind/encloser combinations but
-*not* for all of them.
+non-decreasing across `TypeDef` rows. The emitter historically assigned
+rows in a fixed kind-partitioned order: interfaces → classes → structs →
+enums → `<Program>` → state-machine types. That order guarantees
+"enclosing before nested" for *some* kind/encloser combinations but not
+all of them (a nested `interface`, or a `class` nested in a `struct`,
+would place the nested row before its encloser). The Decision below
+replaces it with a unified pre-order nested block that satisfies the
+constraint for every combination.
 
 ## Decision
 
@@ -103,58 +106,71 @@ they use the nested accessibility flags and empty namespace.
 (`AddNestedType(nested, enclosing)`) for every user nested type, with the
 enclosing handle taken from `cache.StructTypeDefs[containingType]`.
 
+#### Unified emission order (ECMA-335 §II.22.32 compliant)
+
+ECMA-335 §II.22.32 requires every nested type's `TypeDef` row to come
+*after* its enclosing type's `TypeDef` row — otherwise the CLR loader
+rejects the image with `BadImageFormatException: Enclosing type(s) not
+found`. The original implementation emitted `TypeDef` rows in a fixed
+*kind-partitioned* order (interfaces, then classes, then structs, then
+enums). No fixed kind order can satisfy bidirectional nesting: a
+`struct`-in-`class` needs `class` rows before `struct` rows, while a
+`class`-in-`struct` needs the opposite — a contradiction. Nested
+interfaces are even worse, since interfaces were always emitted first.
+
+`ReflectionMetadataEmitter.EmitCore` therefore emits all **user nested
+types in a single contiguous block** placed *after* every top-level type
+and *before* the per-package `<Program>` and state-machine `TypeDef`s.
+Within that block, types are visited in a stable **pre-order traversal**
+(`nestedOrdered`): each enclosing type is emitted first, then its direct
+children (kind-sorted interface → class → struct → enum), recursing into
+each child before its next sibling. Because every enclosing type — be it
+top-level or an outer nested type — is emitted before any of its
+descendants, §II.22.32 holds for *all* kind/encloser combinations.
+
+The same `nestedOrdered` sequence drives all four metadata passes —
+field-row planning, method-row planning, `TypeDef` emission, and
+`MethodDef` body emission — so the monotonically non-decreasing
+`FieldList`/`MethodList` columns of the `TypeDef` table stay consistent
+(each `TypeDef` owns a contiguous field/method range). The `NestedClass`
+table is likewise populated in `nestedOrdered` order, which yields nested
+`TypeDef` RIDs in increasing order and keeps that sorted metadata table
+valid. Top-level (non-nested) programs produce an empty nested block, so
+their metadata is **byte-identical** to before the refactor.
+
 ### Supported combinations
 
-The kind-partitioned emission order already satisfies ECMA-335 §II.22.32
-("enclosing row < nested row") for these combinations, which are emitted
-as **true CLR nested types** and verified to pass ilverify and execute:
+All four nested kinds in both enclosers are emitted as **true CLR nested
+types**, verified to pass ilverify and execute:
 
 | Nested kind | in `class` | in `struct` |
 |-------------|:----------:|:-----------:|
-| `class`     | ✅          | ⛔ GS0369    |
+| `class`     | ✅          | ✅           |
 | `struct`    | ✅          | ✅           |
 | `enum`      | ✅          | ✅           |
-| `interface` | ⛔ GS0369   | ⛔ GS0369    |
+| `interface` | ✅          | ✅           |
 
-This covers the issue's core requirements (nested class-in-class and
-nested struct-in-struct/class) plus nested enums.
-
-### Deferred combinations (dedicated diagnostic, not a cascade)
-
-A nested **`interface`** (in any encloser) and a nested **`class`
-inside a `struct`** would place the nested `TypeDef` row *before* its
-enclosing row under the current emission order (interfaces are emitted
-first; classes are emitted before structs), violating ECMA-335
-§II.22.32 and producing metadata the CLR loader rejects at run time.
-Emitting these correctly would require a global enclosing-before-nested
-emission order shared by row-planning and emission across all four kind
-partitions — a large, risky refactor of the metadata emitter.
-
-For these two combinations the binder reports a **single dedicated
-diagnostic, `GS0369`**, instead of the old misleading parse cascade. The
-nested type is still parsed and bound (so its body is checked and
-references do not produce secondary "type doesn't exist" noise), but it
-is not marked nested and the compile fails on `GS0369` alone, with a
-message that names the exact unsupported combination and points the
-author to move the type to the top level.
+This covers the issue's core requirements and every kind/encloser
+combination — including the nested `interface` (any encloser) and nested
+`class`-in-`struct` cases that an earlier iteration deferred. Recursive
+nesting works to arbitrary depth.
 
 ## Consequences
 
 **Positive**
 
 - The issue's exact example compiles, passes ilverify, and runs.
-- Five of the eight kind/encloser combinations are emitted as real CLR
-  nested types with correct nested accessibility, usable from the
-  enclosing type's members and reflectable as `Outer+Inner`.
+- All eight kind/encloser combinations are emitted as real CLR nested
+  types with correct nested accessibility, usable from the enclosing
+  type's members and reflectable as `Outer+Inner`.
 - Recursive nesting works to arbitrary depth.
-- The remaining combinations fail with one clear, actionable diagnostic
-  instead of a three-error cascade.
+- The unified pre-order emission block lifts the earlier ECMA-335
+  §II.22.32 ordering limitation for *all* kinds while keeping non-nested
+  programs byte-identical, so there is no remaining nested-type
+  diagnostic to surface.
 
 **Negative / out-of-scope**
 
-- Nested `interface` (any encloser) and nested `class`-in-`struct` are
-  deferred behind `GS0369` until the emitter gains a unified
-  enclosing-before-nested type ordering.
 - User-declared nested types are visible by their **simple** name across
   the whole compilation; qualified `Outer.Inner` resolution for user
   types is not added here, and two enclosers cannot reuse a nested simple
@@ -170,13 +186,15 @@ author to move the type to the top level.
   both `class` and `struct` enclosers, recursive nesting, accessibility
   modifier on a nested type, and sibling members alongside a nested type.
 - **Binder** (`Issue910NestedTypeBinderTests`): `ContainingType` is set
-  for supported combinations, recursive `ContainingType` chaining, and
-  `GS0369` fires for the two deferred combinations.
+  for every nested kind/encloser combination (class, struct, interface,
+  enum) and recursive `ContainingType` chaining.
 - **Emit** (`Issue910NestedTypeEmitTests`): the issue's exact example
-  plus every supported combination compiles, passes ilverify, and
-  executes; a reflection assertion proves `Inner` is a real CLR nested
-  type of `Outer`; and the two deferred combinations surface `GS0369`
-  with no `GS0288`/`GS0005` cascade.
+  plus every kind/encloser combination compiles, passes ilverify, and
+  executes — including a `class`-in-`struct` constructed and used from an
+  enclosing method, and a nested `interface` (in both a `class` and a
+  `struct`) implemented by a sibling nested class and dispatched through;
+  a reflection assertion proves `Inner` is a real CLR nested type of
+  `Outer`.
 
 ## Alternatives considered
 
@@ -184,14 +202,13 @@ author to move the type to the top level.
   emitting a clear dedicated diagnostic for *all* nested declarations.
   Rejected: it leaves a useful, widely-expected language feature
   unimplemented when most of the infrastructure already existed. We
-  implement real nesting for every combination the emitter can order
-  correctly and reserve the diagnostic only for the genuinely
-  hard-to-order combinations.
-- **Unified enclosing-before-nested emission order for all kinds.** This
-  would support every combination but requires reworking row-planning and
-  emission across the interface/class/struct/enum partitions
-  simultaneously, with high regression risk to the existing emitter.
-  Deferred to a follow-up; tracked by `GS0369`.
-- **Emit deferred nested types as top-level types.** They would run but
-  would not be true CLR nested types, silently diverging from the
-  declared shape. Rejected in favour of an explicit diagnostic.
+  implement real nesting for every kind/encloser combination.
+- **Fixed kind-partitioned emission order.** Keeping the historical
+  interface/class/struct/enum partition order cannot satisfy
+  bidirectional nesting (`struct`-in-`class` and `class`-in-`struct`
+  impose contradictory partition orders, and nested interfaces can never
+  follow their encloser). Rejected in favour of the unified pre-order
+  nested block.
+- **Emit nested types as top-level types.** They would run but would not
+  be true CLR nested types, silently diverging from the declared shape.
+  Rejected in favour of real nesting.

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -1865,14 +1865,12 @@ internal sealed class DeclarationBinder
     /// <c>SetContainingType</c>. Nested-in-nested declarations are handled
     /// recursively because the per-kind binders bind their own nested types.
     /// <para>
-    /// Two kind/encloser combinations are deferred (ADR-0110): a nested
-    /// <c>interface</c> (in any encloser) and a nested <c>class</c> inside a
-    /// <c>struct</c>. Emitting them as true CLR nested types would violate
-    /// ECMA-335 §II.22.32 (enclosing TypeDef row must precede the nested row)
-    /// under the current kind-partitioned emission order. For these we still
-    /// bind and register the type (so the body is checked and references do not
-    /// cascade) but report the dedicated GS0369 diagnostic instead of marking it
-    /// nested, which replaces the previous misleading parse-error cascade.
+    /// All four nested kinds (<c>class</c>/<c>struct</c>/<c>interface</c>/
+    /// <c>enum</c>) inside either encloser (<c>class</c> or <c>struct</c>) are
+    /// emitted as real CLR nested types. The emitter materialises every
+    /// enclosing TypeDef row before its nested rows (ECMA-335 §II.22.32) via a
+    /// unified pre-order emission pass (ADR-0110), so no kind/encloser
+    /// combination needs to be deferred.
     /// </para>
     /// </summary>
     private void BindNestedTypeDeclarations(StructDeclarationSyntax containerSyntax, TypeSymbol containerSymbol, PackageSymbol package)
@@ -1882,30 +1880,13 @@ internal sealed class DeclarationBinder
             return;
         }
 
-        var enclosingIsClass = containerSymbol is StructSymbol cs && cs.IsClass;
-        var enclosingKind = enclosingIsClass ? "class" : "struct";
-
         foreach (var nested in containerSyntax.NestedTypes)
         {
             switch (nested)
             {
                 case StructDeclarationSyntax nestedStruct:
                     var nestedStructSymbol = BindStructDeclaration(nestedStruct, package);
-
-                    // A nested class inside a struct is deferred (ECMA ordering).
-                    if (nestedStructSymbol != null && nestedStruct.IsClass && !enclosingIsClass)
-                    {
-                        Diagnostics.ReportUnsupportedNestedTypeCombination(
-                            nestedStruct.Identifier.Location,
-                            "class",
-                            nestedStructSymbol.Name,
-                            enclosingKind);
-                    }
-                    else
-                    {
-                        nestedStructSymbol?.SetContainingType(containerSymbol);
-                    }
-
+                    nestedStructSymbol?.SetContainingType(containerSymbol);
                     break;
 
                 case EnumDeclarationSyntax nestedEnum:
@@ -1918,14 +1899,7 @@ internal sealed class DeclarationBinder
                     if (nestedInterfaceSymbol != null)
                     {
                         BindInterfaceMembers(nestedInterface, nestedInterfaceSymbol, package);
-
-                        // A nested interface is deferred (ECMA ordering): report
-                        // GS0369 and do NOT mark it nested (emit as top-level).
-                        Diagnostics.ReportUnsupportedNestedTypeCombination(
-                            nestedInterface.Identifier.Location,
-                            "interface",
-                            nestedInterfaceSymbol.Name,
-                            enclosingKind);
+                        nestedInterfaceSymbol.SetContainingType(containerSymbol);
                     }
 
                     break;

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -263,14 +263,14 @@ internal sealed class DeclarationBinder
         }
     }
 
-    internal void BindEnumDeclaration(EnumDeclarationSyntax syntax, PackageSymbol package)
+    internal EnumSymbol BindEnumDeclaration(EnumDeclarationSyntax syntax, PackageSymbol package)
     {
         var name = syntax.Identifier.Text;
 
         if (isPrimitiveTypeName(name))
         {
             Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
-            return;
+            return null;
         }
 
         var accessibility = resolveAccessibility(syntax.AccessibilityModifier);
@@ -326,16 +326,18 @@ internal sealed class DeclarationBinder
         {
             Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
         }
+
+        return enumSymbol;
     }
 
-    internal void BindStructDeclaration(StructDeclarationSyntax syntax, PackageSymbol package)
+    internal StructSymbol BindStructDeclaration(StructDeclarationSyntax syntax, PackageSymbol package)
     {
         var name = syntax.Identifier.Text;
 
         if (isPrimitiveTypeName(name))
         {
             Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
-            return;
+            return null;
         }
 
         var accessibility = resolveAccessibility(syntax.AccessibilityModifier);
@@ -356,7 +358,7 @@ internal sealed class DeclarationBinder
                 }
             }
 
-            BindStructDeclarationBody(syntax, package, accessibility, name, typeParameters);
+            return BindStructDeclarationBody(syntax, package, accessibility, name, typeParameters);
         }
         finally
         {
@@ -364,7 +366,7 @@ internal sealed class DeclarationBinder
         }
     }
 
-    private void BindStructDeclarationBody(
+    private StructSymbol BindStructDeclarationBody(
         StructDeclarationSyntax syntax,
         PackageSymbol package,
         Accessibility accessibility,
@@ -1847,6 +1849,88 @@ internal sealed class DeclarationBinder
 
         // ADR-0068 / issue #698: bind the optional class destructor (`deinit { … }`).
         BindDeinitDeclaration(syntax, structSymbol, package);
+
+        // Issue #910 / ADR-0110: bind nested type declarations (class / struct /
+        // interface / enum) declared inside this aggregate's body, recording the
+        // enclosing type so the emitter materialises real CLR nested types.
+        BindNestedTypeDeclarations(syntax, structSymbol, package);
+
+        return structSymbol;
+    }
+
+    /// <summary>
+    /// Issue #910 / ADR-0110: binds the nested type declarations declared in a
+    /// class or struct body. Each nested declaration is bound through the same
+    /// driver used for top-level types and tagged with its enclosing type via
+    /// <c>SetContainingType</c>. Nested-in-nested declarations are handled
+    /// recursively because the per-kind binders bind their own nested types.
+    /// <para>
+    /// Two kind/encloser combinations are deferred (ADR-0110): a nested
+    /// <c>interface</c> (in any encloser) and a nested <c>class</c> inside a
+    /// <c>struct</c>. Emitting them as true CLR nested types would violate
+    /// ECMA-335 §II.22.32 (enclosing TypeDef row must precede the nested row)
+    /// under the current kind-partitioned emission order. For these we still
+    /// bind and register the type (so the body is checked and references do not
+    /// cascade) but report the dedicated GS0369 diagnostic instead of marking it
+    /// nested, which replaces the previous misleading parse-error cascade.
+    /// </para>
+    /// </summary>
+    private void BindNestedTypeDeclarations(StructDeclarationSyntax containerSyntax, TypeSymbol containerSymbol, PackageSymbol package)
+    {
+        if (containerSyntax.NestedTypes.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var enclosingIsClass = containerSymbol is StructSymbol cs && cs.IsClass;
+        var enclosingKind = enclosingIsClass ? "class" : "struct";
+
+        foreach (var nested in containerSyntax.NestedTypes)
+        {
+            switch (nested)
+            {
+                case StructDeclarationSyntax nestedStruct:
+                    var nestedStructSymbol = BindStructDeclaration(nestedStruct, package);
+
+                    // A nested class inside a struct is deferred (ECMA ordering).
+                    if (nestedStructSymbol != null && nestedStruct.IsClass && !enclosingIsClass)
+                    {
+                        Diagnostics.ReportUnsupportedNestedTypeCombination(
+                            nestedStruct.Identifier.Location,
+                            "class",
+                            nestedStructSymbol.Name,
+                            enclosingKind);
+                    }
+                    else
+                    {
+                        nestedStructSymbol?.SetContainingType(containerSymbol);
+                    }
+
+                    break;
+
+                case EnumDeclarationSyntax nestedEnum:
+                    var nestedEnumSymbol = BindEnumDeclaration(nestedEnum, package);
+                    nestedEnumSymbol?.SetContainingType(containerSymbol);
+                    break;
+
+                case InterfaceDeclarationSyntax nestedInterface:
+                    var nestedInterfaceSymbol = DeclareInterfaceSymbol(nestedInterface, package);
+                    if (nestedInterfaceSymbol != null)
+                    {
+                        BindInterfaceMembers(nestedInterface, nestedInterfaceSymbol, package);
+
+                        // A nested interface is deferred (ECMA ordering): report
+                        // GS0369 and do NOT mark it nested (emit as top-level).
+                        Diagnostics.ReportUnsupportedNestedTypeCombination(
+                            nestedInterface.Identifier.Location,
+                            "interface",
+                            nestedInterfaceSymbol.Name,
+                            enclosingKind);
+                    }
+
+                    break;
+            }
+        }
     }
 
     internal void VerifyInterfaceImplementations()

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -3765,34 +3765,6 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
             DiagnosticSeverity.Error);
     }
 
-    /// <summary>
-    /// Reports GS0369 — issue #910 / ADR-0110: a nested type declaration uses a
-    /// kind/encloser combination that cannot yet be emitted as a true CLR nested
-    /// type. The supported combinations are nested <c>class</c>/<c>struct</c>/
-    /// <c>enum</c> inside a <c>class</c>, and nested <c>struct</c>/<c>enum</c>
-    /// inside a <c>struct</c>. A nested <c>interface</c> (in any encloser) and a
-    /// nested <c>class</c> inside a <c>struct</c> are deferred because they would
-    /// violate ECMA-335 §II.22.32 (enclosing TypeDef row must precede the nested
-    /// row) under the current kind-partitioned emission order. This dedicated
-    /// diagnostic replaces the previous misleading parse-error cascade.
-    /// </summary>
-    /// <param name="location">The text location of the nested type identifier.</param>
-    /// <param name="nestedKind">The nested type's kind keyword (e.g. <c>interface</c>).</param>
-    /// <param name="nestedName">The nested type's name.</param>
-    /// <param name="enclosingKind">The enclosing type's kind keyword (<c>class</c>/<c>struct</c>).</param>
-    public void ReportUnsupportedNestedTypeCombination(
-        TextLocation location,
-        string nestedKind,
-        string nestedName,
-        string enclosingKind)
-    {
-        var message =
-            $"Nested {nestedKind} '{nestedName}' inside a {enclosingKind} is not yet supported (ADR-0110 / issue #910). "
-            + "Supported nested declarations are class/struct/enum inside a class, and struct/enum inside a struct. "
-            + $"Move '{nestedName}' to the top level.";
-        Report(location, "GS0369", message, DiagnosticSeverity.Error);
-    }
-
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -3765,6 +3765,34 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
             DiagnosticSeverity.Error);
     }
 
+    /// <summary>
+    /// Reports GS0369 — issue #910 / ADR-0110: a nested type declaration uses a
+    /// kind/encloser combination that cannot yet be emitted as a true CLR nested
+    /// type. The supported combinations are nested <c>class</c>/<c>struct</c>/
+    /// <c>enum</c> inside a <c>class</c>, and nested <c>struct</c>/<c>enum</c>
+    /// inside a <c>struct</c>. A nested <c>interface</c> (in any encloser) and a
+    /// nested <c>class</c> inside a <c>struct</c> are deferred because they would
+    /// violate ECMA-335 §II.22.32 (enclosing TypeDef row must precede the nested
+    /// row) under the current kind-partitioned emission order. This dedicated
+    /// diagnostic replaces the previous misleading parse-error cascade.
+    /// </summary>
+    /// <param name="location">The text location of the nested type identifier.</param>
+    /// <param name="nestedKind">The nested type's kind keyword (e.g. <c>interface</c>).</param>
+    /// <param name="nestedName">The nested type's name.</param>
+    /// <param name="enclosingKind">The enclosing type's kind keyword (<c>class</c>/<c>struct</c>).</param>
+    public void ReportUnsupportedNestedTypeCombination(
+        TextLocation location,
+        string nestedKind,
+        string nestedName,
+        string enclosingKind)
+    {
+        var message =
+            $"Nested {nestedKind} '{nestedName}' inside a {enclosingKind} is not yet supported (ADR-0110 / issue #910). "
+            + "Supported nested declarations are class/struct/enum inside a class, and struct/enum inside a struct. "
+            + $"Move '{nestedName}' to the top level.";
+        Report(location, "GS0369", message, DiagnosticSeverity.Error);
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -774,6 +774,123 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         var interfaces = this.emitCtx.Program.Interfaces;
+        var enumsAll = this.emitCtx.Program.Enums;
+
+        // Issue #910 / ADR-0110: split user-declared NESTED types (their
+        // ContainingType is set by BindNestedTypeDeclarations) from top-level
+        // ones. Top-level types keep their historical kind-partitioned emission
+        // order (so non-nested programs are byte-identical). Every nested type
+        // — regardless of kind/encloser combination — is emitted in a single
+        // unified pre-order block AFTER all top-level types so that each
+        // enclosing TypeDef row always precedes its nested rows, satisfying
+        // ECMA-335 §II.22.32 for every combination (including nested interfaces
+        // and class-in-struct, which no fixed kind partition can order).
+        // Closure/state-machine types never set ContainingType, so they stay in
+        // the top-level partitions and their nesting is handled separately.
+        static bool IsUserNested(TypeSymbol t) => t switch
+        {
+            StructSymbol ss => ss.ContainingType != null,
+            EnumSymbol es => es.ContainingType != null,
+            InterfaceSymbol ifs => ifs.ContainingType != null,
+            _ => false,
+        };
+
+        static TypeSymbol ContainingOf(TypeSymbol t) => t switch
+        {
+            StructSymbol ss => ss.ContainingType,
+            EnumSymbol es => es.ContainingType,
+            InterfaceSymbol ifs => ifs.ContainingType,
+            _ => null,
+        };
+
+        var topInterfaces = interfaces.Where(i => !IsUserNested(i)).ToList();
+        var topClasses = nonSmClasses.Where(c => !IsUserNested(c)).ToList();
+        var topStructs = nonSmStructs.Where(s => !IsUserNested(s)).ToList();
+        var topEnums = enumsAll.Where(e => !IsUserNested(e)).ToList();
+
+        // Build the unified nested-type pre-order: each enclosing type is
+        // followed by its nested children (recursively), with siblings ordered
+        // interface → class → struct → enum so an implementer is emitted after
+        // any sibling interface it implements (mirrors the global "interfaces
+        // first" convention used for top-level types).
+        var nestedChildrenByParent = new Dictionary<TypeSymbol, List<TypeSymbol>>();
+        void RegisterNestedChild(TypeSymbol child)
+        {
+            var parent = ContainingOf(child);
+            if (parent == null)
+            {
+                return;
+            }
+
+            if (!nestedChildrenByParent.TryGetValue(parent, out var list))
+            {
+                list = new List<TypeSymbol>();
+                nestedChildrenByParent[parent] = list;
+            }
+
+            list.Add(child);
+        }
+
+        foreach (var i in interfaces.Where(IsUserNested))
+        {
+            RegisterNestedChild(i);
+        }
+
+        foreach (var c in nonSmClasses.Where(IsUserNested))
+        {
+            RegisterNestedChild(c);
+        }
+
+        foreach (var s in nonSmStructs.Where(IsUserNested))
+        {
+            RegisterNestedChild(s);
+        }
+
+        foreach (var e in enumsAll.Where(IsUserNested))
+        {
+            RegisterNestedChild(e);
+        }
+
+        var nestedOrdered = new List<TypeSymbol>();
+        void VisitNested(TypeSymbol parent)
+        {
+            if (!nestedChildrenByParent.TryGetValue(parent, out var children))
+            {
+                return;
+            }
+
+            foreach (var child in children)
+            {
+                nestedOrdered.Add(child);
+                VisitNested(child);
+            }
+        }
+
+        foreach (var i in topInterfaces)
+        {
+            VisitNested(i);
+        }
+
+        foreach (var c in topClasses)
+        {
+            VisitNested(c);
+        }
+
+        foreach (var s in topStructs)
+        {
+            VisitNested(s);
+        }
+
+        foreach (var e in topEnums)
+        {
+            VisitNested(e);
+        }
+
+        // Per-nested-type FieldList/MethodList boundary pointers, assigned in
+        // nested pre-order so the monotone-non-decreasing TypeDef column
+        // invariant holds across the nested block.
+        var nestedFieldListRow = new Dictionary<TypeSymbol, int>();
+        var nestedMethodListRow = new Dictionary<TypeSymbol, int>();
 
         // Field-row planning: non-SM types first, then SM types. This ensures
         // fieldList pointers are non-decreasing when <Program> (which owns no
@@ -793,58 +910,15 @@ internal sealed class ReflectionMetadataEmitter
         int nextFieldRow = 1;
         var structFirstFieldRow = new Dictionary<StructSymbol, int>();
 
-        // Walk non-SM types for field assignment.
-        foreach (var s in nonSmClasses)
+        // Issue #910 / ADR-0110: field-row planning for one aggregate (class or
+        // struct). Shared by the top-level field pass and the nested-type pass
+        // so a nested aggregate's FieldDef range is assigned in the same order
+        // its TypeDef row is emitted, preserving the monotone fieldList column.
+        void PlanAggregateFields(StructSymbol s)
         {
             structFirstFieldRow[s] = nextFieldRow;
             nextFieldRow += s.Fields.Length;
-            // ADR-0051 Phase 6: backing fields for auto-properties.
-            foreach (var p in s.Properties)
-            {
-                if (p.IsAutoProperty && p.BackingField != null && !s.Fields.Contains(p.BackingField))
-                {
-                    nextFieldRow++;
-                }
-            }
 
-            // ADR-0052: backing fields for field-like events.
-            foreach (var ev in s.Events)
-            {
-                if (ev.IsFieldLike && ev.BackingField != null)
-                {
-                    nextFieldRow++;
-                }
-            }
-
-            // ADR-0053: static fields from shared block.
-            if (!s.StaticFields.IsDefaultOrEmpty)
-            {
-                nextFieldRow += s.StaticFields.Length;
-            }
-
-            // Issue #263: backing fields for static auto-properties.
-            foreach (var p in s.StaticProperties)
-            {
-                if (p.IsAutoProperty && p.BackingField != null)
-                {
-                    nextFieldRow++;
-                }
-            }
-
-            // Issue #263: backing fields for static field-like events.
-            foreach (var ev in s.StaticEvents)
-            {
-                if (ev.IsFieldLike && ev.BackingField != null)
-                {
-                    nextFieldRow++;
-                }
-            }
-        }
-
-        foreach (var s in nonSmStructs)
-        {
-            structFirstFieldRow[s] = nextFieldRow;
-            nextFieldRow += s.Fields.Length;
             // ADR-0051 Phase 6: backing fields for auto-properties.
             foreach (var p in s.Properties)
             {
@@ -889,16 +963,52 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         // Issue #193: each user-defined enum contributes 1 instance field
-        // (value__) plus one literal field per member. Enum field rows are
-        // planned right after non-SM struct fields so the enum TypeDef can
-        // be emitted between non-SM struct TypeDefs and <Program> without
-        // violating the monotone fieldList constraint.
-        var enums = this.emitCtx.Program.Enums;
+        // (value__) plus one literal field per member.
+        var enums = enumsAll;
         var enumFirstFieldRow = new Dictionary<EnumSymbol, int>();
-        foreach (var e in enums)
+        void PlanEnumFields(EnumSymbol e)
         {
             enumFirstFieldRow[e] = nextFieldRow;
             nextFieldRow += 1 + e.Members.Length;
+        }
+
+        // Walk top-level non-SM types for field assignment (classes, then
+        // structs, then enums) — historical kind-partitioned order.
+        foreach (var s in topClasses)
+        {
+            PlanAggregateFields(s);
+        }
+
+        foreach (var s in topStructs)
+        {
+            PlanAggregateFields(s);
+        }
+
+        // Enum field rows are planned right after non-SM struct fields so the
+        // enum TypeDef can be emitted between non-SM struct TypeDefs and the
+        // nested block without violating the monotone fieldList constraint.
+        foreach (var e in topEnums)
+        {
+            PlanEnumFields(e);
+        }
+
+        // Issue #910 / ADR-0110: nested-type field rows form a contiguous block
+        // after all top-level field rows and before <Program>/global fields.
+        foreach (var nested in nestedOrdered)
+        {
+            nestedFieldListRow[nested] = nextFieldRow;
+            switch (nested)
+            {
+                case StructSymbol ns:
+                    PlanAggregateFields(ns);
+                    break;
+                case EnumSymbol ne:
+                    PlanEnumFields(ne);
+                    break;
+
+                // Interfaces own no fields; the boundary pointer above is what
+                // their nested TypeDef row will reference.
+            }
         }
 
         // Issue #191: user-declared top-level var/let/const live as static
@@ -931,13 +1041,9 @@ internal sealed class ReflectionMetadataEmitter
 
         var moduleFirstFieldRow = 1;
 
-        // Phase 3.B.4: plan method rows for interface abstract methods FIRST.
-        // Interface TypeDefs sit between <Module> and the class TypeDefs in
-        // row order so their methodList pointer (= first abstract method) is
-        // strictly less than the first class ctor row.
         int methodRow = 1;
         var interfaceFirstMethodRow = new Dictionary<InterfaceSymbol, int>();
-        foreach (var i in interfaces)
+        void PlanInterfaceMethods(InterfaceSymbol i)
         {
             interfaceFirstMethodRow[i] = methodRow;
             foreach (var m in i.Methods)
@@ -1001,6 +1107,15 @@ internal sealed class ReflectionMetadataEmitter
             }
         }
 
+        // Phase 3.B.4: plan method rows for interface abstract methods FIRST.
+        // Interface TypeDefs sit between <Module> and the class TypeDefs in
+        // row order so their methodList pointer (= first abstract method) is
+        // strictly less than the first class ctor row.
+        foreach (var i in topInterfaces)
+        {
+            PlanInterfaceMethods(i);
+        }
+
         // ADR-0059 / issue #255: plan method rows for each named delegate
         // (one ctor + one Invoke per delegate) AFTER interface methods and
         // BEFORE non-SM class ctors. The delegate TypeDef rows themselves are
@@ -1019,7 +1134,7 @@ internal sealed class ReflectionMetadataEmitter
         var classCtorRows = new Dictionary<StructSymbol, int>();
         var classPrimaryCtorRows = new Dictionary<StructSymbol, int>();
         var aggregateMethodHandles = new Dictionary<FunctionSymbol, MethodDefinitionHandle>();
-        foreach (var c in nonSmClasses)
+        void PlanClassMethods(StructSymbol c)
         {
             classCtorRows[c] = methodRow++;
 
@@ -1135,13 +1250,18 @@ internal sealed class ReflectionMetadataEmitter
             }
         }
 
+        foreach (var c in topClasses)
+        {
+            PlanClassMethods(c);
+        }
+
         // Plan method rows for non-SM structs.
         var structFirstMethodRows = new Dictionary<StructSymbol, int>();
-        foreach (var s in nonSmStructs)
+        void PlanStructMethods(StructSymbol s)
         {
             if (s.Methods.IsDefaultOrEmpty && !s.IsInline && !s.IsData && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty && s.StaticProperties.IsDefaultOrEmpty && s.StaticEvents.IsDefaultOrEmpty && s.StaticFieldInitializers.IsEmpty)
             {
-                continue;
+                return;
             }
 
             structFirstMethodRows[s] = methodRow;
@@ -1236,6 +1356,36 @@ internal sealed class ReflectionMetadataEmitter
             }
         }
 
+        foreach (var s in topStructs)
+        {
+            PlanStructMethods(s);
+        }
+
+        // Issue #910 / ADR-0110: nested-type method rows form a contiguous
+        // block after all top-level method rows and before the per-package
+        // <Program> ctor/method rows. Each nested type records its methodList
+        // boundary so the monotone MethodList column holds across the block.
+        int firstNestedMethodRow = methodRow;
+        foreach (var nested in nestedOrdered)
+        {
+            nestedMethodListRow[nested] = methodRow;
+            switch (nested)
+            {
+                case InterfaceSymbol ni:
+                    PlanInterfaceMethods(ni);
+                    break;
+                case StructSymbol ns when ns.IsClass:
+                    PlanClassMethods(ns);
+                    break;
+                case StructSymbol ns:
+                    PlanStructMethods(ns);
+                    break;
+
+                // Enums own no methods; the boundary pointer above is the row
+                // their nested TypeDef will reference.
+            }
+        }
+
         int firstPackageCtorRow = methodRow;
 
         // 2. <Module> type (TypeDef row #1 must always be <Module> per ECMA-335).
@@ -1251,7 +1401,7 @@ internal sealed class ReflectionMetadataEmitter
         // rows. Interfaces have no fields and only abstract method bodies, so
         // they are the simplest TypeDefs to emit. Their methodList points at
         // the first of their reserved abstract method rows.
-        foreach (var i in interfaces)
+        foreach (var i in topInterfaces)
         {
             this.typeDefEmitter.EmitInterfaceTypeDef(i, interfaceFirstMethodRow[i], 1);
         }
@@ -1266,9 +1416,11 @@ internal sealed class ReflectionMetadataEmitter
             this.typeDefEmitter.EmitDelegateTypeDef(d, delegateCtorRows[d]);
         }
 
-        // 2b. Emit non-SM class TypeDefs (so methodLists stay non-decreasing),
-        // then non-SM struct TypeDefs. SM types are emitted AFTER <Program>.
-        foreach (var c in nonSmClasses)
+        // Issue #910 / ADR-0110: emit one class TypeDef row plus its
+        // InterfaceImpl rows. Shared by the top-level class pass and the nested
+        // block so nested classes are real CLR nested types with identical
+        // interface-implementation metadata.
+        void EmitClassTypeDefRow(StructSymbol c)
         {
             this.typeDefEmitter.EmitStructTypeDef(c, structFirstFieldRow[c], classCtorRows[c]);
 
@@ -1312,48 +1464,80 @@ internal sealed class ReflectionMetadataEmitter
             }
         }
 
-        foreach (var s in nonSmStructs)
+        // Issue #242: the ECMA-335 methodList column must be monotonically
+        // non-decreasing across TypeDef rows. A struct without methods must use
+        // the NEXT available method row — the first method row of the next
+        // top-level struct that HAS methods, or the start of the nested-type
+        // method block (firstNestedMethodRow) when none follows.
+        int TopStructMethodListRow(StructSymbol s)
         {
-            // Issue #242: the ECMA-335 methodList column must be monotonically
-            // non-decreasing across TypeDef rows. Structs without methods must
-            // use the NEXT available method row (i.e., the first method row of
-            // the next struct that HAS methods, or firstPackageCtorRow). We
-            // compute this by scanning forward.
-            int methodListRow;
             if (structFirstMethodRows.TryGetValue(s, out var firstStructMethodRow))
             {
-                methodListRow = firstStructMethodRow;
+                return firstStructMethodRow;
             }
-            else
-            {
-                // Find the next struct (in emission order) that has methods.
-                methodListRow = firstPackageCtorRow;
-                bool foundSelf = false;
-                foreach (var s2 in nonSmStructs)
-                {
-                    if (ReferenceEquals(s2, s))
-                    {
-                        foundSelf = true;
-                        continue;
-                    }
 
-                    if (foundSelf && structFirstMethodRows.TryGetValue(s2, out var nextMethodRow))
-                    {
-                        methodListRow = nextMethodRow;
-                        break;
-                    }
+            var methodListRow = firstNestedMethodRow;
+            bool foundSelf = false;
+            foreach (var s2 in topStructs)
+            {
+                if (ReferenceEquals(s2, s))
+                {
+                    foundSelf = true;
+                    continue;
+                }
+
+                if (foundSelf && structFirstMethodRows.TryGetValue(s2, out var nextMethodRow))
+                {
+                    methodListRow = nextMethodRow;
+                    break;
                 }
             }
 
-            this.typeDefEmitter.EmitStructTypeDef(s, structFirstFieldRow[s], methodListRow);
+            return methodListRow;
         }
 
-        // Issue #193: emit enum TypeDefs between non-SM structs and <Program>.
-        // Each enum has no methods, so its methodList points at the same row
-        // <Program>'s package ctor will live (firstPackageCtorRow).
-        foreach (var e in enums)
+        // 2b. Emit non-SM class TypeDefs (so methodLists stay non-decreasing),
+        // then non-SM struct TypeDefs. SM types are emitted AFTER <Program>.
+        foreach (var c in topClasses)
         {
-            this.typeDefEmitter.EmitEnumTypeDef(e, enumFirstFieldRow[e], firstPackageCtorRow);
+            EmitClassTypeDefRow(c);
+        }
+
+        foreach (var s in topStructs)
+        {
+            this.typeDefEmitter.EmitStructTypeDef(s, structFirstFieldRow[s], TopStructMethodListRow(s));
+        }
+
+        // Issue #193: emit enum TypeDefs between non-SM structs and the nested
+        // block. Each enum has no methods, so its methodList points at the
+        // first nested-type method row (or firstPackageCtorRow when no nested
+        // types follow — the two are equal in that case).
+        foreach (var e in topEnums)
+        {
+            this.typeDefEmitter.EmitEnumTypeDef(e, enumFirstFieldRow[e], firstNestedMethodRow);
+        }
+
+        // Issue #910 / ADR-0110: emit the unified nested-type block. Every
+        // enclosing TypeDef row (top-level above, or an earlier nested row) is
+        // already emitted, so each nested row satisfies ECMA-335 §II.22.32. The
+        // NestedClass rows themselves are added in the post-pass below.
+        foreach (var nested in nestedOrdered)
+        {
+            switch (nested)
+            {
+                case InterfaceSymbol ni:
+                    this.typeDefEmitter.EmitInterfaceTypeDef(ni, interfaceFirstMethodRow[ni], nestedFieldListRow[ni]);
+                    break;
+                case StructSymbol ns when ns.IsClass:
+                    EmitClassTypeDefRow(ns);
+                    break;
+                case StructSymbol ns:
+                    this.typeDefEmitter.EmitStructTypeDef(ns, structFirstFieldRow[ns], nestedMethodListRow[ns]);
+                    break;
+                case EnumSymbol ne:
+                    this.typeDefEmitter.EmitEnumTypeDef(ne, enumFirstFieldRow[ne], nestedMethodListRow[ne]);
+                    break;
+            }
         }
 
         // 3. Group functions by their declaring package. One <Program> type
@@ -1684,7 +1868,7 @@ internal sealed class ReflectionMetadataEmitter
 
         // === PHASE B: Emit MethodDefs in row order ===
         // B1. Interface methods (abstract + default-interface methods).
-        foreach (var i in interfaces)
+        void EmitInterfaceMethodBodies(InterfaceSymbol i)
         {
             foreach (var m in i.Methods)
             {
@@ -1761,8 +1945,13 @@ internal sealed class ReflectionMetadataEmitter
             this.memberDefEmitter.EmitInterfaceEventAccessors(i);
         }
 
+        foreach (var i in topInterfaces)
+        {
+            EmitInterfaceMethodBodies(i);
+        }
+
         // B2. Non-SM class ctors + instance methods.
-        foreach (var c in nonSmClasses)
+        void EmitClassMethodBodies(StructSymbol c)
         {
             if (c.ExplicitConstructor != null)
             {
@@ -1900,8 +2089,13 @@ internal sealed class ReflectionMetadataEmitter
             this.EmitStaticVirtualMethodImpls(c);
         }
 
+        foreach (var c in topClasses)
+        {
+            EmitClassMethodBodies(c);
+        }
+
         // 4b. Non-SM struct methods.
-        foreach (var s in nonSmStructs)
+        void EmitStructMethodBodies(StructSymbol s)
         {
             if (s.IsInline)
             {
@@ -1917,7 +2111,7 @@ internal sealed class ReflectionMetadataEmitter
 
             if (s.Methods.IsDefaultOrEmpty && s.Properties.IsDefaultOrEmpty && s.Events.IsDefaultOrEmpty && s.StaticMethods.IsDefaultOrEmpty && s.StaticProperties.IsDefaultOrEmpty && s.StaticEvents.IsDefaultOrEmpty && s.StaticFieldInitializers.IsEmpty)
             {
-                continue;
+                return;
             }
 
             foreach (var m in s.Methods)
@@ -1971,6 +2165,32 @@ internal sealed class ReflectionMetadataEmitter
             // row points the interface slot's MethodDef at the implementer's
             // static MethodDef on the struct's TypeDef.
             this.EmitStaticVirtualMethodImpls(s);
+        }
+
+        foreach (var s in topStructs)
+        {
+            EmitStructMethodBodies(s);
+        }
+
+        // B3.5 / Issue #910 / ADR-0110: emit method bodies for the unified
+        // nested-type block, in the same pre-order the rows were planned and
+        // the TypeDefs emitted, so MethodDef row order stays consistent.
+        foreach (var nested in nestedOrdered)
+        {
+            switch (nested)
+            {
+                case InterfaceSymbol ni:
+                    EmitInterfaceMethodBodies(ni);
+                    break;
+                case StructSymbol ns when ns.IsClass:
+                    EmitClassMethodBodies(ns);
+                    break;
+                case StructSymbol ns:
+                    EmitStructMethodBodies(ns);
+                    break;
+
+                // Enums own no method bodies.
+            }
         }
 
         // Phase 4 emit parity (F2, type-erased): now that every generic
@@ -2067,35 +2287,24 @@ internal sealed class ReflectionMetadataEmitter
             }
         }
 
-        foreach (var c in nonSmClasses)
+        // Issue #910 / ADR-0110: emit NestedClass rows in the same pre-order
+        // the nested TypeDef rows were assigned. The NestedClass metadata table
+        // must be sorted by the nested-type RID; nestedOrdered yields nested
+        // handles in monotonically increasing RID order, so iterating it keeps
+        // the table sorted across all nested kinds (class/struct/enum/interface).
+        foreach (var nested in nestedOrdered)
         {
-            if (c.ContainingType != null && this.cache.StructTypeDefs.TryGetValue(c, out var nh))
+            switch (nested)
             {
-                AddUserNestedTypeRow(c, nh);
-            }
-        }
-
-        foreach (var s in nonSmStructs)
-        {
-            if (s.ContainingType != null && this.cache.StructTypeDefs.TryGetValue(s, out var nh))
-            {
-                AddUserNestedTypeRow(s, nh);
-            }
-        }
-
-        foreach (var e in enums)
-        {
-            if (e.ContainingType != null && this.cache.EnumTypeDefs.TryGetValue(e, out var nh))
-            {
-                AddUserNestedTypeRow(e, nh);
-            }
-        }
-
-        foreach (var i in interfaces)
-        {
-            if (i.ContainingType != null && this.cache.InterfaceTypeDefs.TryGetValue(i, out var nh))
-            {
-                AddUserNestedTypeRow(i, nh);
+                case StructSymbol ns when this.cache.StructTypeDefs.TryGetValue(ns, out var nsh):
+                    AddUserNestedTypeRow(ns, nsh);
+                    break;
+                case EnumSymbol ne when this.cache.EnumTypeDefs.TryGetValue(ne, out var neh):
+                    AddUserNestedTypeRow(ne, neh);
+                    break;
+                case InterfaceSymbol ni when this.cache.InterfaceTypeDefs.TryGetValue(ni, out var nih):
+                    AddUserNestedTypeRow(ni, nih);
+                    break;
             }
         }
 

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -2044,6 +2044,61 @@ internal sealed class ReflectionMetadataEmitter
             }
         }
 
+        // Issue #910 / ADR-0110: NestedClass rows for user-declared nested
+        // types (class/struct/enum/interface declared inside a class/struct
+        // body). The enclosing TypeDef row was emitted before the nested row
+        // (ECMA-335 §II.22.32) because of the kind-partitioned emission order;
+        // see BindNestedTypeDeclarations and the emission-order notes above.
+        // The enclosing handle is always a StructSymbol (class or struct).
+        void AddUserNestedTypeRow(TypeSymbol nested, TypeDefinitionHandle nestedHandle)
+        {
+            TypeSymbol containing = nested switch
+            {
+                StructSymbol ss => ss.ContainingType,
+                EnumSymbol es => es.ContainingType,
+                InterfaceSymbol ifs => ifs.ContainingType,
+                _ => null,
+            };
+
+            if (containing is StructSymbol enclosingStruct
+                && this.cache.StructTypeDefs.TryGetValue(enclosingStruct, out var enclosingHandle))
+            {
+                this.emitCtx.Metadata.AddNestedType(nestedHandle, enclosingHandle);
+            }
+        }
+
+        foreach (var c in nonSmClasses)
+        {
+            if (c.ContainingType != null && this.cache.StructTypeDefs.TryGetValue(c, out var nh))
+            {
+                AddUserNestedTypeRow(c, nh);
+            }
+        }
+
+        foreach (var s in nonSmStructs)
+        {
+            if (s.ContainingType != null && this.cache.StructTypeDefs.TryGetValue(s, out var nh))
+            {
+                AddUserNestedTypeRow(s, nh);
+            }
+        }
+
+        foreach (var e in enums)
+        {
+            if (e.ContainingType != null && this.cache.EnumTypeDefs.TryGetValue(e, out var nh))
+            {
+                AddUserNestedTypeRow(e, nh);
+            }
+        }
+
+        foreach (var i in interfaces)
+        {
+            if (i.ContainingType != null && this.cache.InterfaceTypeDefs.TryGetValue(i, out var nh))
+            {
+                AddUserNestedTypeRow(i, nh);
+            }
+        }
+
         // NestedType entries. Each SM is nested inside its declaring type:
         // capture-bearing async lambda SMs inside their closure class,
         // an instance-method kickoff's SM inside the receiver type (so the

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -339,6 +339,21 @@ internal sealed class TypeDefEmitter
             firstField = MetadataTokens.FieldDefinitionHandle(firstFieldRow);
         }
 
+        // Issue #910: a user type declared inside a class/struct body
+        // (structSym.ContainingType != null) is emitted as a CLR nested
+        // TypeDef. Nested types carry NestedPublic/NestedAssembly/NestedPrivate
+        // visibility (never the top-level Public/NotPublic flags) and an empty
+        // namespace; the enclosing TypeDef qualifies the name. A NestedClass
+        // metadata row linking this TypeDef to its encloser is emitted later in
+        // ReflectionMetadataEmitter once both handles exist.
+        var isNestedType = structSym.ContainingType != null;
+        var typeAccessibility = isNestedType
+            ? AccessibilityMap.MapNestedTypeAccessibility(structSym.Accessibility)
+            : AccessibilityMap.MapTypeAccessibility(structSym.Accessibility);
+        var structNamespace = isNestedType
+            ? default(StringHandle)
+            : this.emitCtx.Metadata.GetOrAddString(structSym.PackageName ?? string.Empty);
+
         TypeAttributes typeAttrs;
         EntityHandle baseType;
         if (structSym.IsClass)
@@ -354,7 +369,7 @@ internal sealed class TypeDefEmitter
             var classAttrs = TypeAttributes.Class
                 | ResolveClassLayoutFlag(structSym) | TypeAttributes.AnsiClass
                 | TypeAttributes.BeforeFieldInit
-                | AccessibilityMap.MapTypeAccessibility(structSym.Accessibility);
+                | typeAccessibility;
             if (!structSym.IsOpen && !structSym.IsSealedHierarchy)
             {
                 classAttrs |= TypeAttributes.Sealed;
@@ -387,7 +402,7 @@ internal sealed class TypeDefEmitter
         {
             typeAttrs = ResolveStructLayoutFlag(structSym) | TypeAttributes.Sealed
                 | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit
-                | AccessibilityMap.MapTypeAccessibility(structSym.Accessibility);
+                | typeAccessibility;
             baseType = this.wellKnown.ValueTypeRef;
         }
 
@@ -399,7 +414,7 @@ internal sealed class TypeDefEmitter
         var typeDefName = MangleGenericName(structSym.Name, structSym.TypeParameters);
         var handle2 = this.emitCtx.Metadata.AddTypeDefinition(
             attributes: typeAttrs,
-            @namespace: this.emitCtx.Metadata.GetOrAddString(structSym.PackageName ?? string.Empty),
+            @namespace: structNamespace,
             name: this.emitCtx.Metadata.GetOrAddString(typeDefName),
             baseType: baseType,
             fieldList: firstField,
@@ -563,13 +578,21 @@ internal sealed class TypeDefEmitter
         // assert below that the first AddFieldDefinition call matches.
         var firstFieldHandle = MetadataTokens.FieldDefinitionHandle(this.emitCtx.Metadata.GetRowCount(TableIndex.Field) + 1);
 
+        // Issue #910: a nested enum (declared inside a class/struct body) is
+        // emitted with nested visibility and an empty namespace.
+        var enumNested = enumSym.ContainingType != null;
+        var enumNamespace = enumNested
+            ? default(StringHandle)
+            : this.emitCtx.Metadata.GetOrAddString(enumSym.PackageName ?? string.Empty);
         var typeAttrs = TypeAttributes.Class | TypeAttributes.Sealed
             | TypeAttributes.AnsiClass | TypeAttributes.AutoLayout
-            | AccessibilityMap.MapTypeAccessibility(enumSym.Accessibility);
+            | (enumNested
+                ? AccessibilityMap.MapNestedTypeAccessibility(enumSym.Accessibility)
+                : AccessibilityMap.MapTypeAccessibility(enumSym.Accessibility));
 
         var enumTypeDef = this.emitCtx.Metadata.AddTypeDefinition(
             attributes: typeAttrs,
-            @namespace: this.emitCtx.Metadata.GetOrAddString(enumSym.PackageName ?? string.Empty),
+            @namespace: enumNamespace,
             name: this.emitCtx.Metadata.GetOrAddString(enumSym.Name),
             baseType: enumTypeRef,
             fieldList: firstFieldHandle,
@@ -632,13 +655,19 @@ internal sealed class TypeDefEmitter
     /// <param name="firstFieldRow">The first field row for the next aggregate (interfaces own no fields, so this is forwarded as their fieldList).</param>
     public void EmitInterfaceTypeDef(InterfaceSymbol ifaceSym, int firstMethodRow, int firstFieldRow)
     {
+        var ifaceNested = ifaceSym.ContainingType != null;
+        var ifaceNamespace = ifaceNested
+            ? default(StringHandle)
+            : this.emitCtx.Metadata.GetOrAddString(ifaceSym.PackageName ?? string.Empty);
         var typeAttrs = TypeAttributes.Interface | TypeAttributes.Abstract
             | TypeAttributes.AutoLayout | TypeAttributes.AnsiClass
-            | AccessibilityMap.MapTypeAccessibility(ifaceSym.Accessibility);
+            | (ifaceNested
+                ? AccessibilityMap.MapNestedTypeAccessibility(ifaceSym.Accessibility)
+                : AccessibilityMap.MapTypeAccessibility(ifaceSym.Accessibility));
         var typeDefName = MangleGenericName(ifaceSym.Name, ifaceSym.TypeParameters);
         var handle = this.emitCtx.Metadata.AddTypeDefinition(
             attributes: typeAttrs,
-            @namespace: this.emitCtx.Metadata.GetOrAddString(ifaceSym.PackageName ?? string.Empty),
+            @namespace: ifaceNamespace,
             name: this.emitCtx.Metadata.GetOrAddString(typeDefName),
             baseType: default(EntityHandle),
             fieldList: MetadataTokens.FieldDefinitionHandle(firstFieldRow),

--- a/src/Core/CodeAnalysis/Symbols/EnumSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/EnumSymbol.cs
@@ -44,8 +44,21 @@ public sealed class EnumSymbol : TypeSymbol
     /// <summary>Gets the enum members in declaration order.</summary>
     public ImmutableArray<EnumMemberSymbol> Members { get; private set; }
 
+    /// <summary>
+    /// Gets the enclosing user-defined type when this enum is a nested type
+    /// declaration (ADR-0110 / issue #910), or <c>null</c> when top-level.
+    /// </summary>
+    public TypeSymbol ContainingType { get; private set; }
+
     /// <summary>Gets the CLR underlying enum for values.</summary>
     public TypeSymbol UnderlyingType => TypeSymbol.Int32;
+
+    /// <summary>Sets <see cref="ContainingType"/> (ADR-0110 / issue #910).</summary>
+    /// <param name="containingType">The enclosing user-defined type.</param>
+    public void SetContainingType(TypeSymbol containingType)
+    {
+        ContainingType = containingType;
+    }
 
     /// <summary>Sets the enum members after the owning enum symbol has been created.</summary>
     /// <param name="members">The enum members in declaration order.</param>

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -146,6 +146,12 @@ public sealed class InterfaceSymbol : TypeSymbol
     /// <summary>Gets the event signatures declared on this interface (ADR-0052). Populated by the binder via <see cref="SetEvents"/>.</summary>
     public ImmutableArray<EventSymbol> Events { get; private set; } = ImmutableArray<EventSymbol>.Empty;
 
+    /// <summary>
+    /// Gets the enclosing user-defined type when this interface is a nested
+    /// type declaration (ADR-0110 / issue #910), or <c>null</c> when top-level.
+    /// </summary>
+    public TypeSymbol ContainingType { get; private set; }
+
     /// <summary>Gets the type parameters when this is a generic definition (Phase 4.3c / ADR-0020).</summary>
     public ImmutableArray<TypeParameterSymbol> TypeParameters { get; private set; } = ImmutableArray<TypeParameterSymbol>.Empty;
 
@@ -157,6 +163,13 @@ public sealed class InterfaceSymbol : TypeSymbol
 
     /// <summary>Gets the original generic definition when this is a constructed instance; otherwise <c>this</c>.</summary>
     public InterfaceSymbol Definition { get; }
+
+    /// <summary>Sets <see cref="ContainingType"/> (ADR-0110 / issue #910).</summary>
+    /// <param name="containingType">The enclosing user-defined type.</param>
+    public void SetContainingType(TypeSymbol containingType)
+    {
+        ContainingType = containingType;
+    }
 
     /// <summary>Sets <see cref="Methods"/>. Intended to be called once by the binder.</summary>
     /// <param name="methods">The bound method signatures.</param>

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -319,6 +319,22 @@ public sealed class StructSymbol : TypeSymbol
     /// </summary>
     public DeinitSymbol Deinitializer { get; private set; }
 
+    /// <summary>
+    /// Gets the enclosing user-defined type when this type is a nested type
+    /// declaration (ADR-0110 / issue #910), or <c>null</c> when this is a
+    /// top-level type. Populated by the binder; consumed by the emitter to
+    /// emit a CLR nested <c>TypeDef</c> with the corresponding
+    /// <c>NestedClass</c> row and nested accessibility.
+    /// </summary>
+    public TypeSymbol ContainingType { get; private set; }
+
+    /// <summary>Sets <see cref="ContainingType"/> (ADR-0110 / issue #910). Intended to be called exactly once by the binder for a nested type declaration.</summary>
+    /// <param name="containingType">The enclosing user-defined type.</param>
+    public void SetContainingType(TypeSymbol containingType)
+    {
+        ContainingType = containingType;
+    }
+
     /// <summary>Sets <see cref="ImportedBaseType"/> after binding (issue #296). Intended to be called exactly once by the binder for a class inheriting an imported CLR base.</summary>
     /// <param name="importedBaseType">The imported CLR base type symbol.</param>
     public void SetImportedBaseType(TypeSymbol importedBaseType)

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -465,7 +465,19 @@ public class Parser
     /// </summary>
     private bool TryDetectAggregateDeclarationHead()
     {
-        var offset = 0;
+        return TryDetectAggregateDeclarationHead(0);
+    }
+
+    /// <summary>
+    /// Issue #910: offset-aware variant of <see cref="TryDetectAggregateDeclarationHead()"/>
+    /// used by the class/struct body member loop to recognise a nested type
+    /// declaration head that may be preceded by an accessibility modifier
+    /// (already peeked at <paramref name="startOffset"/>). The scan does not
+    /// consume tokens.
+    /// </summary>
+    private bool TryDetectAggregateDeclarationHead(int startOffset)
+    {
+        var offset = startOffset;
         var saw = new HashSet<string>(System.StringComparer.Ordinal);
         while (true)
         {
@@ -1462,6 +1474,7 @@ public class Parser
         var constructors = ImmutableArray.CreateBuilder<ConstructorDeclarationSyntax>();
         DeinitDeclarationSyntax structDecl_deinit = null;
         SharedBlockSyntax structDecl_sharedBlock = null;
+        var nestedTypes = ImmutableArray.CreateBuilder<MemberSyntax>();
 
         // ADR-0078 / issue #718: the body block `{ ... }` is optional for any
         // aggregate that uses the new declaration head. The bodyless form is
@@ -1517,6 +1530,47 @@ public class Parser
             // the default target is `field`; for method members the existing
             // method-binder path picks them up via MemberSyntax.Annotations.
             var memberAnnotations = ParseAnnotations();
+
+            // Issue #910 / ADR-0110: nested type declarations (class / struct /
+            // interface / enum) inside a class or struct body. The declaration
+            // head may be preceded by an optional accessibility modifier. Reuse
+            // the shared top-level aggregate parser so nested types accept the
+            // full declaration grammar (modifiers, type parameters, base
+            // clauses, bodies, and recursive nesting).
+            {
+                var nestedHeadOffset = (Current.Kind == SyntaxKind.PublicKeyword
+                    || Current.Kind == SyntaxKind.InternalKeyword
+                    || Current.Kind == SyntaxKind.PrivateKeyword) ? 1 : 0;
+
+                if (TryDetectAggregateDeclarationHead(nestedHeadOffset))
+                {
+                    SyntaxToken nestedAccessibility = null;
+                    if (nestedHeadOffset == 1)
+                    {
+                        nestedAccessibility = NextToken();
+                    }
+
+                    var nestedType = ParseAggregateDeclaration(nestedAccessibility);
+                    nestedType.WithAnnotations(memberAnnotations);
+                    nestedTypes.Add(nestedType);
+
+                    // A nested discriminated-union enum desugars into a sealed
+                    // base plus one class per case (queued on
+                    // pendingSyntheticMembers). Drain them as siblings of the
+                    // nested type so they remain nested within this body.
+                    while (pendingSyntheticMembers.Count > 0)
+                    {
+                        nestedTypes.Add(pendingSyntheticMembers.Dequeue());
+                    }
+
+                    if (Current == startToken)
+                    {
+                        NextToken();
+                    }
+
+                    continue;
+                }
+            }
 
             // Phase 3.B.3 sub-step 2b: method declarations inside the body.
             // Use the existing `func Name(args) Ret { body }` parser; the
@@ -1814,6 +1868,7 @@ public class Parser
         structDecl.BaseConstructorCloseParenthesisToken = baseCtorCloseParen;
         structDecl.Constructors = constructors.ToImmutable();
         structDecl.Deinitializer = structDecl_deinit;
+        structDecl.NestedTypes = nestedTypes.ToImmutable();
         return structDecl;
     }
 

--- a/src/Core/CodeAnalysis/Syntax/StructDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/StructDeclarationSyntax.cs
@@ -469,4 +469,8 @@ public sealed class StructDeclarationSyntax : MemberSyntax
 
     /// <summary>Gets or sets the optional user-defined <c>deinit</c> declaration (ADR-0068 / issue #698). Non-null only when the class body declares exactly one <c>deinit</c>; assigned by the parser. The parser reports GS0290 on any subsequent duplicate and stores only the first.</summary>
     public DeinitDeclarationSyntax Deinitializer { get; set; }
+
+    /// <summary>Gets or sets the nested type declarations (<c>class</c> / <c>struct</c> / <c>interface</c> / <c>enum</c>) declared inside this aggregate's body (ADR-0110 / issue #910). Empty for types that declare none. Each element is a <see cref="StructDeclarationSyntax"/>, <see cref="InterfaceDeclarationSyntax"/>, or <see cref="EnumDeclarationSyntax"/>. Assigned by the parser.</summary>
+    public ImmutableArray<MemberSyntax> NestedTypes { get; set; }
+        = ImmutableArray<MemberSyntax>.Empty;
 }

--- a/test/Compiler.Tests/Emit/Issue910NestedTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue910NestedTypeEmitTests.cs
@@ -100,12 +100,13 @@ public class Issue910NestedTypeEmitTests
     }
 
     [Fact]
-    public void NestedClassInStruct_ReportsDedicatedDiagnostic_NotCascade()
+    public void NestedClassInStruct_ConstructedFromEnclosingMethod_Runs()
     {
-        // ADR-0110: a nested class inside a struct is deferred (ECMA-335
-        // §II.22.32 ordering). The compiler must surface the single dedicated
-        // GS0369 diagnostic instead of the old misleading parse-error cascade.
-        var diagnostics = CompileExpectingFailure("""
+        // Issue #910 / ADR-0110: a class nested in a struct is now emitted as a
+        // real CLR nested type (the unified emission-order refactor guarantees
+        // the enclosing struct TypeDef row precedes the nested class row per
+        // ECMA-335 §II.22.32). Construct it from an enclosing method and run.
+        var output = CompileAndRun("""
             package P
 
             import System
@@ -118,13 +119,16 @@ public class Issue910NestedTypeEmitTests
                 }
             }
 
+            func (o Outer) Make() string {
+                let i = Inner()
+                return i.Hello()
+            }
+
             let o = Outer{}
-            Console.WriteLine("unused")
+            Console.WriteLine(o.Make())
             """);
 
-        Assert.Contains("GS0369", diagnostics);
-        Assert.DoesNotContain("GS0288", diagnostics);
-        Assert.DoesNotContain("GS0005", diagnostics);
+        Assert.Equal("from-nested-class\n", output);
     }
 
     [Fact]
@@ -190,12 +194,12 @@ public class Issue910NestedTypeEmitTests
     }
 
     [Fact]
-    public void NestedInterfaceInClass_ReportsDedicatedDiagnostic_NotCascade()
+    public void NestedInterfaceInClass_ImplementedAndCalledThrough_Runs()
     {
-        // ADR-0110: a nested interface is deferred (ECMA-335 §II.22.32
-        // ordering). A single dedicated GS0369 diagnostic replaces the old
-        // misleading parse-error cascade.
-        var diagnostics = CompileExpectingFailure("""
+        // Issue #910 / ADR-0110: a nested interface is now emitted as a real
+        // CLR nested type. A sibling nested class implements it; an enclosing
+        // method upcasts to the interface and dispatches through it.
+        var output = CompileAndRun("""
             package P
 
             import System
@@ -204,14 +208,58 @@ public class Issue910NestedTypeEmitTests
                 interface IInner {
                     func Hello() string;
                 }
+
+                class Impl : IInner {
+                    func Hello() string {
+                        return "from-nested-interface"
+                    }
+                }
+
+                func Make() string {
+                    var i IInner = Impl{}
+                    return i.Hello()
+                }
             }
 
-            Console.WriteLine("unused")
+            let o = Outer()
+            Console.WriteLine(o.Make())
             """);
 
-        Assert.Contains("GS0369", diagnostics);
-        Assert.DoesNotContain("GS0288", diagnostics);
-        Assert.DoesNotContain("GS0005", diagnostics);
+        Assert.Equal("from-nested-interface\n", output);
+    }
+
+    [Fact]
+    public void NestedInterfaceInStruct_ImplementedAndCalledThrough_Runs()
+    {
+        // Issue #910 / ADR-0110: a nested interface inside a struct is also a
+        // real CLR nested type. A sibling nested class implements it.
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            struct Outer {
+                interface IInner {
+                    func Hello() string;
+                }
+
+                class Impl : IInner {
+                    func Hello() string {
+                        return "iface-in-struct"
+                    }
+                }
+            }
+
+            func (o Outer) Make() string {
+                var i IInner = Impl{}
+                return i.Hello()
+            }
+
+            let o = Outer{}
+            Console.WriteLine(o.Make())
+            """);
+
+        Assert.Equal("iface-in-struct\n", output);
     }
 
     [Fact]
@@ -342,50 +390,6 @@ public class Issue910NestedTypeEmitTests
             }
 
             return stdout.Replace("\r\n", "\n");
-        }
-        finally
-        {
-            try { Directory.Delete(tempDir, recursive: true); } catch { }
-        }
-    }
-
-    private static string CompileExpectingFailure(string source)
-    {
-        var tempDir = Directory.CreateTempSubdirectory("gs_issue910_emit_err_").FullName;
-        try
-        {
-            var srcPath = Path.Combine(tempDir, "test.gs");
-            var outPath = Path.Combine(tempDir, "test.dll");
-            File.WriteAllText(srcPath, source);
-
-            var args = new[]
-            {
-                "/out:" + outPath,
-                "/target:exe",
-                "/targetframework:net10.0",
-                "/nowarn:GS9100",
-                srcPath,
-            };
-
-            using var compileOut = new StringWriter();
-            using var compileErr = new StringWriter();
-            var prevOut = Console.Out;
-            var prevErr = Console.Error;
-            Console.SetOut(compileOut);
-            Console.SetError(compileErr);
-            int compileExit;
-            try
-            {
-                compileExit = Program.Main(args);
-            }
-            finally
-            {
-                Console.SetOut(prevOut);
-                Console.SetError(prevErr);
-            }
-
-            Assert.True(compileExit != 0, $"expected compile to fail but it succeeded:\nstdout:\n{compileOut}");
-            return compileOut.ToString() + compileErr.ToString();
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue910NestedTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue910NestedTypeEmitTests.cs
@@ -1,0 +1,430 @@
+// <copyright file="Issue910NestedTypeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #910 / ADR-0110: nested type declarations (<c>class</c> / <c>struct</c>
+/// / <c>interface</c> / <c>enum</c>) inside a <c>class</c> or <c>struct</c> body
+/// must be emitted as real CLR nested types with nested accessibility, be
+/// usable from the enclosing type's members, pass ilverify, and execute.
+/// </summary>
+public class Issue910NestedTypeEmitTests
+{
+    [Fact]
+    public void IssueExample_NestedClassInClass_ConstructedFromEnclosingMethod_Runs()
+    {
+        var output = CompileAndRun("""
+            package Oahu.Cli.Tests
+
+            import System
+
+            class Outer {
+                class Inner {
+                    func Hello() string {
+                        return "hi"
+                    }
+                }
+
+                func Make() string {
+                    let i = Inner()
+                    return i.Hello()
+                }
+            }
+
+            let o = Outer()
+            Console.WriteLine(o.Make())
+            """);
+
+        Assert.Equal("hi\n", output);
+    }
+
+    [Fact]
+    public void NestedStructInStruct_ConstructedFromEnclosingMethod_Runs()
+    {
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            struct Outer {
+                struct Inner {
+                    var X int32
+                }
+            }
+
+            func (o Outer) Make() int32 {
+                let i = Inner{X: 41}
+                return i.X + 1
+            }
+
+            let o = Outer{}
+            Console.WriteLine(o.Make())
+            """);
+
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void NestedStructInClass_ConstructedFromEnclosingMethod_Runs()
+    {
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            class Outer {
+                struct Point {
+                    var X int32
+                    var Y int32
+                }
+
+                func Sum() int32 {
+                    let p = Point{X: 3, Y: 4}
+                    return p.X + p.Y
+                }
+            }
+
+            let o = Outer()
+            Console.WriteLine(o.Sum())
+            """);
+
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void NestedClassInStruct_ReportsDedicatedDiagnostic_NotCascade()
+    {
+        // ADR-0110: a nested class inside a struct is deferred (ECMA-335
+        // §II.22.32 ordering). The compiler must surface the single dedicated
+        // GS0369 diagnostic instead of the old misleading parse-error cascade.
+        var diagnostics = CompileExpectingFailure("""
+            package P
+
+            import System
+
+            struct Outer {
+                class Inner {
+                    func Hello() string {
+                        return "from-nested-class"
+                    }
+                }
+            }
+
+            let o = Outer{}
+            Console.WriteLine("unused")
+            """);
+
+        Assert.Contains("GS0369", diagnostics);
+        Assert.DoesNotContain("GS0288", diagnostics);
+        Assert.DoesNotContain("GS0005", diagnostics);
+    }
+
+    [Fact]
+    public void NestedEnumInClass_UsedFromEnclosingMethod_Runs()
+    {
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            class Outer {
+                enum Color {
+                    Red,
+                    Green,
+                    Blue,
+                }
+
+                func Pick() int32 {
+                    let c = Color.Green
+                    if c == Color.Green {
+                        return 1
+                    }
+                    return 0
+                }
+            }
+
+            let o = Outer()
+            Console.WriteLine(o.Pick())
+            """);
+
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void NestedEnumInStruct_UsedFromEnclosingMethod_Runs()
+    {
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            struct Outer {
+                enum Color {
+                    Red,
+                    Green,
+                    Blue,
+                }
+            }
+
+            func (o Outer) Pick() int32 {
+                let c = Color.Blue
+                if c == Color.Blue {
+                    return 2
+                }
+                return 0
+            }
+
+            let o = Outer{}
+            Console.WriteLine(o.Pick())
+            """);
+
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void NestedInterfaceInClass_ReportsDedicatedDiagnostic_NotCascade()
+    {
+        // ADR-0110: a nested interface is deferred (ECMA-335 §II.22.32
+        // ordering). A single dedicated GS0369 diagnostic replaces the old
+        // misleading parse-error cascade.
+        var diagnostics = CompileExpectingFailure("""
+            package P
+
+            import System
+
+            class Outer {
+                interface IInner {
+                    func Hello() string;
+                }
+            }
+
+            Console.WriteLine("unused")
+            """);
+
+        Assert.Contains("GS0369", diagnostics);
+        Assert.DoesNotContain("GS0288", diagnostics);
+        Assert.DoesNotContain("GS0005", diagnostics);
+    }
+
+    [Fact]
+    public void IssueExample_EmitsRealNestedClrType()
+    {
+        // ADR-0110: the supported combinations are emitted as real CLR nested
+        // TypeDefs. Verify via reflection that Inner is nested inside Outer.
+        var assembly = CompileToLibrary("""
+            package Oahu.Cli.Tests
+
+            class Outer {
+                class Inner {
+                    func Hello() string {
+                        return "hi"
+                    }
+                }
+
+                func Make() string {
+                    let i = Inner()
+                    return i.Hello()
+                }
+            }
+            """);
+
+        var outer = System.Linq.Enumerable.Single(assembly.GetTypes(), t => t.Name == "Outer");
+        var inner = outer.GetNestedType("Inner", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(inner);
+        Assert.True(inner!.IsNested);
+        Assert.Equal(outer, inner.DeclaringType);
+    }
+
+    [Fact]
+    public void RecursivelyNestedClass_ConstructedFromInnermostMethod_Runs()
+    {
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            class Outer {
+                class Middle {
+                    class Inner {
+                        func N() int32 {
+                            return 7
+                        }
+                    }
+
+                    func Make() int32 {
+                        let i = Inner()
+                        return i.N()
+                    }
+                }
+
+                func Make() int32 {
+                    let m = Middle()
+                    return m.Make()
+                }
+            }
+
+            let o = Outer()
+            Console.WriteLine(o.Make())
+            """);
+
+        Assert.Equal("7\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue910_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}):\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileExpectingFailure(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue910_emit_err_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit != 0, $"expected compile to fail but it succeeded:\nstdout:\n{compileOut}");
+            return compileOut.ToString() + compileErr.ToString();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static System.Reflection.Assembly CompileToLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue910_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(compileExit == 0, $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
+        return System.Reflection.Assembly.Load(File.ReadAllBytes(outPath));
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue910NestedTypeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue910NestedTypeBinderTests.cs
@@ -16,9 +16,9 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// Issue #910 / ADR-0110: binder coverage for nested type declarations. A
 /// nested type is registered as a member of the enclosing type (its
 /// <see cref="StructSymbol.ContainingType"/> / <see cref="EnumSymbol.ContainingType"/>
-/// is set), resolves by simple name from the enclosing type's members, and the
-/// two deferred kind/encloser combinations (nested interface; nested class in a
-/// struct) report the dedicated GS0369 diagnostic instead of a parse cascade.
+/// / <see cref="InterfaceSymbol.ContainingType"/> is set) and resolves by simple
+/// name from the enclosing type's members, for every nested kind (class, struct,
+/// interface, enum) in either encloser (class or struct).
 /// </summary>
 public class Issue910NestedTypeBinderTests
 {
@@ -110,7 +110,7 @@ public class Issue910NestedTypeBinderTests
     }
 
     [Fact]
-    public void NestedClassInStruct_ReportsGs0369()
+    public void NestedClassInStruct_BindsWithoutDiagnostics_AndSetsContainingType()
     {
         var scope = BindSource("""
             struct Outer {
@@ -122,11 +122,17 @@ public class Issue910NestedTypeBinderTests
             }
             """);
 
-        Assert.Contains(GetBinderDiagnostics(scope), d => d.Id == "GS0369");
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        var inner = (StructSymbol)scope.TypeAliases["Inner"];
+        var outer = (StructSymbol)scope.TypeAliases["Outer"];
+        Assert.Same(outer, inner.ContainingType);
+        Assert.True(inner.IsClass);
+        Assert.False(outer.IsClass);
     }
 
     [Fact]
-    public void NestedInterfaceInClass_ReportsGs0369()
+    public void NestedInterfaceInClass_BindsWithoutDiagnostics_AndSetsContainingType()
     {
         var scope = BindSource("""
             class Outer {
@@ -136,7 +142,11 @@ public class Issue910NestedTypeBinderTests
             }
             """);
 
-        Assert.Contains(GetBinderDiagnostics(scope), d => d.Id == "GS0369");
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        var inner = (InterfaceSymbol)scope.TypeAliases["IInner"];
+        var outer = (StructSymbol)scope.TypeAliases["Outer"];
+        Assert.Same(outer, inner.ContainingType);
     }
 
     private static BoundGlobalScope BindSource(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue910NestedTypeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue910NestedTypeBinderTests.cs
@@ -1,0 +1,152 @@
+// <copyright file="Issue910NestedTypeBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #910 / ADR-0110: binder coverage for nested type declarations. A
+/// nested type is registered as a member of the enclosing type (its
+/// <see cref="StructSymbol.ContainingType"/> / <see cref="EnumSymbol.ContainingType"/>
+/// is set), resolves by simple name from the enclosing type's members, and the
+/// two deferred kind/encloser combinations (nested interface; nested class in a
+/// struct) report the dedicated GS0369 diagnostic instead of a parse cascade.
+/// </summary>
+public class Issue910NestedTypeBinderTests
+{
+    [Fact]
+    public void NestedClassInClass_BindsWithoutDiagnostics_AndSetsContainingType()
+    {
+        var scope = BindSource("""
+            class Outer {
+                class Inner {
+                    func Hello() string {
+                        return "hi"
+                    }
+                }
+
+                func Make() string {
+                    let i = Inner()
+                    return i.Hello()
+                }
+            }
+            """);
+
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        var inner = (StructSymbol)scope.TypeAliases["Inner"];
+        var outer = (StructSymbol)scope.TypeAliases["Outer"];
+        Assert.Same(outer, inner.ContainingType);
+    }
+
+    [Fact]
+    public void NestedStructInStruct_BindsWithoutDiagnostics_AndSetsContainingType()
+    {
+        var scope = BindSource("""
+            struct Outer {
+                struct Inner {
+                    var X int32
+                }
+            }
+            """);
+
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        var inner = (StructSymbol)scope.TypeAliases["Inner"];
+        var outer = (StructSymbol)scope.TypeAliases["Outer"];
+        Assert.Same(outer, inner.ContainingType);
+        Assert.False(inner.IsClass);
+    }
+
+    [Fact]
+    public void NestedEnumInClass_BindsWithoutDiagnostics_AndSetsContainingType()
+    {
+        var scope = BindSource("""
+            class Outer {
+                enum Color {
+                    Red,
+                    Green,
+                }
+            }
+            """);
+
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        var color = (EnumSymbol)scope.TypeAliases["Color"];
+        var outer = (StructSymbol)scope.TypeAliases["Outer"];
+        Assert.Same(outer, color.ContainingType);
+    }
+
+    [Fact]
+    public void RecursivelyNestedClass_AllLevelsBind_AndContainingTypesChain()
+    {
+        var scope = BindSource("""
+            class Outer {
+                class Middle {
+                    class Inner {
+                        func N() int32 {
+                            return 7
+                        }
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        var outer = (StructSymbol)scope.TypeAliases["Outer"];
+        var middle = (StructSymbol)scope.TypeAliases["Middle"];
+        var inner = (StructSymbol)scope.TypeAliases["Inner"];
+        Assert.Same(outer, middle.ContainingType);
+        Assert.Same(middle, inner.ContainingType);
+    }
+
+    [Fact]
+    public void NestedClassInStruct_ReportsGs0369()
+    {
+        var scope = BindSource("""
+            struct Outer {
+                class Inner {
+                    func Hello() string {
+                        return "hi"
+                    }
+                }
+            }
+            """);
+
+        Assert.Contains(GetBinderDiagnostics(scope), d => d.Id == "GS0369");
+    }
+
+    [Fact]
+    public void NestedInterfaceInClass_ReportsGs0369()
+    {
+        var scope = BindSource("""
+            class Outer {
+                interface IInner {
+                    func Hello() string;
+                }
+            }
+            """);
+
+        Assert.Contains(GetBinderDiagnostics(scope), d => d.Id == "GS0369");
+    }
+
+    private static BoundGlobalScope BindSource(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+
+    private static System.Collections.Generic.IEnumerable<GSharp.Core.CodeAnalysis.Diagnostic> GetBinderDiagnostics(BoundGlobalScope scope)
+    {
+        return scope.Diagnostics;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue910NestedTypeParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue910NestedTypeParserTests.cs
@@ -1,0 +1,247 @@
+// <copyright file="Issue910NestedTypeParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #910 / ADR-0110: parser-level tests for nested type declarations
+/// (<c>class</c> / <c>struct</c> / <c>interface</c> / <c>enum</c>) declared
+/// inside a <c>class</c> or <c>struct</c> body. Before this change the
+/// aggregate-member grammar had no production for nested types, so each one
+/// was misparsed as a malformed field and produced a misleading error cascade.
+/// </summary>
+public class Issue910NestedTypeParserTests
+{
+    [Fact]
+    public void NestedClassInClass_ParsesWithoutDiagnostics()
+    {
+        const string source = """
+            package P
+            class Outer {
+                class Inner {
+                    func Hello() string {
+                        return "hi"
+                    }
+                }
+
+                func Make() string {
+                    let i = Inner()
+                    return i.Hello()
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var outer = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var nested = Assert.Single(outer.NestedTypes);
+        var inner = Assert.IsType<StructDeclarationSyntax>(nested);
+        Assert.True(inner.IsClass);
+        Assert.Equal("Inner", inner.Identifier.Text);
+    }
+
+    [Fact]
+    public void NestedStructInStruct_ParsesWithoutDiagnostics()
+    {
+        const string source = """
+            package P
+            struct Outer {
+                struct Inner {
+                    var X int32 = 0
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var outer = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var nested = Assert.Single(outer.NestedTypes);
+        var inner = Assert.IsType<StructDeclarationSyntax>(nested);
+        Assert.False(inner.IsClass);
+        Assert.Equal("Inner", inner.Identifier.Text);
+    }
+
+    [Fact]
+    public void NestedStructInClass_ParsesWithoutDiagnostics()
+    {
+        const string source = """
+            package P
+            class Outer {
+                struct Inner {
+                    var X int32 = 0
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var outer = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var inner = Assert.IsType<StructDeclarationSyntax>(Assert.Single(outer.NestedTypes));
+        Assert.False(inner.IsClass);
+    }
+
+    [Fact]
+    public void NestedClassInStruct_ParsesWithoutDiagnostics()
+    {
+        const string source = """
+            package P
+            struct Outer {
+                class Inner {
+                    func Hello() string {
+                        return "hi"
+                    }
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var outer = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var inner = Assert.IsType<StructDeclarationSyntax>(Assert.Single(outer.NestedTypes));
+        Assert.True(inner.IsClass);
+    }
+
+    [Fact]
+    public void NestedInterfaceInClass_ParsesWithoutDiagnostics()
+    {
+        const string source = """
+            package P
+            class Outer {
+                interface IInner {
+                    func Hello() string;
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var outer = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var inner = Assert.IsType<InterfaceDeclarationSyntax>(Assert.Single(outer.NestedTypes));
+        Assert.Equal("IInner", inner.Identifier.Text);
+    }
+
+    [Fact]
+    public void NestedEnumInClass_ParsesWithoutDiagnostics()
+    {
+        const string source = """
+            package P
+            class Outer {
+                enum Color {
+                    Red,
+                    Green,
+                    Blue,
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var outer = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var inner = Assert.IsType<EnumDeclarationSyntax>(Assert.Single(outer.NestedTypes));
+        Assert.Equal("Color", inner.Identifier.Text);
+    }
+
+    [Fact]
+    public void NestedEnumInStruct_ParsesWithoutDiagnostics()
+    {
+        const string source = """
+            package P
+            struct Outer {
+                enum Color {
+                    Red,
+                    Green,
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var outer = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        Assert.IsType<EnumDeclarationSyntax>(Assert.Single(outer.NestedTypes));
+    }
+
+    [Fact]
+    public void RecursivelyNestedTypes_Parse()
+    {
+        const string source = """
+            package P
+            class Outer {
+                class Middle {
+                    class Inner {
+                        func N() int32 {
+                            return 7
+                        }
+                    }
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var outer = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var middle = Assert.IsType<StructDeclarationSyntax>(Assert.Single(outer.NestedTypes));
+        var inner = Assert.IsType<StructDeclarationSyntax>(Assert.Single(middle.NestedTypes));
+        Assert.Equal("Inner", inner.Identifier.Text);
+    }
+
+    [Fact]
+    public void NestedTypeWithAccessibilityModifier_Parses()
+    {
+        const string source = """
+            package P
+            class Outer {
+                private class Inner {
+                    var X int32 = 0
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var outer = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var inner = Assert.IsType<StructDeclarationSyntax>(Assert.Single(outer.NestedTypes));
+        Assert.NotNull(inner.AccessibilityModifier);
+        Assert.Equal(SyntaxKind.PrivateKeyword, inner.AccessibilityModifier.Kind);
+    }
+
+    [Fact]
+    public void EnclosingTypeMembersStillParse_AlongsideNestedType()
+    {
+        const string source = """
+            package P
+            class Outer {
+                var Count int32 = 0
+
+                class Inner {
+                    var X int32 = 0
+                }
+
+                func Bump() int32 {
+                    return Count
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var outer = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        Assert.Single(outer.NestedTypes);
+        Assert.Single(outer.Fields);
+        Assert.Single(outer.Methods);
+    }
+}


### PR DESCRIPTION
Fixes #910

## Summary

Nested type declarations (`class` / `struct` / `interface` / `enum` declared inside a `class` or `struct` body) were unsupported and produced a misleading parse-error cascade (GS0113 / GS0288 / GS0005). This PR implements **real CLR nested-type support end-to-end for every nested kind in either encloser** — no combination is deferred.

The issue's exact example now compiles, passes ilverify, and executes:

```gsharp
class Outer {
    class Inner {
        func Hello() string { return "hi" }
    }
    func Make() string {
        let i = Inner()
        return i.Hello()
    }
}
```

## Changes

**Parser** (`Parser.cs`, `StructDeclarationSyntax.cs`): `class`/`struct`/`interface`/`enum` (with an optional accessibility modifier) are accepted as members of a `class`/`struct` body by reusing the existing top-level `ParseAggregateDeclaration` routine — so nesting is **recursive** (`Outer.Middle.Inner`). Parsed nested declarations are stored on `StructDeclarationSyntax.NestedTypes`.

**Binder / Symbols** (`DeclarationBinder.cs`, `StructSymbol`/`EnumSymbol`/`InterfaceSymbol`): each type symbol gains a `ContainingType` set by `BindNestedTypeDeclarations`, which binds each nested declaration with the same per-kind binder used for top-level types. **All** nested kinds (including `interface`, and `class`-in-`struct`) are marked nested. Nested types register in the flat type-alias scope and resolve by their **simple** name from the enclosing type's members.

**Emit — unified emission-order refactor** (`ReflectionMetadataEmitter.cs`, `TypeDefEmitter.cs`, `AccessibilityMap`): `EmitStructTypeDef`/`EmitEnumTypeDef`/`EmitInterfaceTypeDef` are nested-aware — when `ContainingType != null` they use `MapNestedTypeAccessibility` (`internal→NestedAssembly`, `private→NestedPrivate`, else `NestedPublic`) and an empty namespace.

`ReflectionMetadataEmitter.EmitCore` now emits **all user nested types in a single contiguous pre-order block** placed after every top-level type and before the per-package `<Program>` and state-machine `TypeDef`s. Each enclosing `TypeDef` row (top-level or an outer nested type) is materialised before any of its descendants, so **ECMA-335 §II.22.32** (enclosing row < nested row) holds for *every* kind/encloser combination. A fixed kind-partitioned order cannot do this — `struct`-in-`class` and `class`-in-`struct` impose contradictory partition orders, and nested interfaces can never follow their encloser. The same `nestedOrdered` pre-order sequence drives field-row planning, method-row planning, `TypeDef` emission, `MethodDef` body emission, and `NestedClass` row insertion, preserving the monotone `FieldList`/`MethodList` columns and the sorted `NestedClass` table. Non-nested programs produce an empty nested block, so their metadata is **byte-identical** to before.

## Supported nested kind × encloser combinations

All emitted as **true CLR nested types**, verified by ilverify + execution + a reflection assertion (`Inner.IsNested`, `DeclaringType == Outer`):

| Nested kind | in `class` | in `struct` |
|-------------|:----------:|:-----------:|
| `class`     | ✅          | ✅           |
| `struct`    | ✅          | ✅           |
| `enum`      | ✅          | ✅           |
| `interface` | ✅          | ✅           |

Every kind/encloser combination is now a real nested type. Recursive nesting works to arbitrary depth.

## GS0369 removed

The earlier dedicated deferral diagnostic `GS0369` (nested interface / `class`-in-`struct`) is **removed** — those combinations are fully supported, so the diagnostic is no longer reachable. Its definition (`DiagnosticBag.ReportUnsupportedNestedTypeCombination`) and the binder gate are deleted.

## Name resolution & accessibility

- Unqualified simple-name resolution of a nested type works from the enclosing type's members and across the compilation (flat type-alias scope).
- Qualified `Outer.Inner` resolution for **user-declared** nested types is not newly added (imported CLR nested-type resolution from #526/#569 is unaffected). A consequence is that two enclosers can't reuse a nested simple name in one compilation.
- IL visibility uses `MapNestedTypeAccessibility`.

See **ADR-0110** (`docs/adr/0110-nested-type-declarations.md`) for the full design, the unified emission-order decision, consequences, test coverage, and alternatives considered.

## Tests

- `Issue910NestedTypeParserTests` — all four kinds in both enclosers, recursion, accessibility modifier, sibling members.
- `Issue910NestedTypeBinderTests` — `ContainingType` set for every nested kind/encloser combination (class, struct, interface, enum) and recursive chaining.
- `Issue910NestedTypeEmitTests` — issue example + **every** kind/encloser combination (ilverify + execute), including `class`-in-`struct` constructed and used, and a nested `interface` (in a `class` and in a `struct`) implemented by a sibling nested class and dispatched through; reflection proof of real nesting.

## Local build + test

`dotnet build GSharp.sln -c Release -graph` — succeeded (0 warnings/errors).

`dotnet test` (all projects) — all green:
- Core.Tests: 3373 passed, 1 skipped
- Compiler.Tests: 1389 passed
- Interpreter.Tests: 308 passed
- LanguageServer.Tests: 350 passed
- Extensions.Tests: 104 passed
- Sdk.Tests: 38 passed
