### PR TITLE
Expand completion to trigger as you type (#917)

### DIFF
--- a/docs/adr/0111-completion-as-you-type-language-server.md
+++ b/docs/adr/0111-completion-as-you-type-language-server.md
@@ -1,0 +1,101 @@
+# ADR-0111: Completion-as-you-type triggering policy
+
+- **Status**: Proposed
+- **Date**: 2026-06-21
+- **Phase**: Language-server developer experience
+- **Related**: issue #917; ADR-0105/0106/0107 (language-server behavior); `src/LanguageServer/Server/ServerCapabilitiesFactory.cs`, `src/LanguageServer/HoverComputer.cs` (`CompletionComputer`), `src/vscode-gsharp/package.json`
+
+## Context
+
+G# completion lists historically surfaced only in a narrow set of contexts — most
+visibly after typing a member-access dot (`.`), which is the single completion
+trigger character the server advertises. Comparable tooling (Pylance for Python,
+the C# Dev Kit) instead shows completions continuously as the developer types
+identifiers, member names, and keywords. Issue #917 asks us to expand automatic
+triggering so the list appears while typing ordinary code — without spamming
+irrelevant popups.
+
+Two mechanisms drive when an editor asks a language server for completions:
+
+1. **Trigger characters** advertised in `CompletionOptions.triggerCharacters`. The
+   editor invokes the server when one of these characters is typed
+   (`CompletionTriggerKind.TriggerCharacter`).
+2. **Implicit ("24x7") IntelliSense**, controlled entirely on the editor side by
+   `editor.quickSuggestions`. When enabled, the editor invokes *every* registered
+   completion provider as identifier characters are typed
+   (`CompletionTriggerKind.Invoke`) and filters the returned list against the word
+   under the caret.
+
+A naïve way to "trigger on every letter" would be to list the whole alphabet as
+server trigger characters. Pylance and Roslyn deliberately do **not** do this: it
+produces redundant requests, fights the editor's own filtering, and couples the
+server to one client's keystroke model. The idiomatic approach is to leave trigger
+characters minimal and rely on `editor.quickSuggestions` for as-you-type behavior,
+while ensuring the server returns a correctly *ranged* candidate list when invoked
+implicitly mid-identifier (so the editor replaces the typed prefix instead of
+inserting alongside it).
+
+## Decision
+
+Completion-as-you-type is enabled through the **editor's implicit IntelliSense**,
+not through an expanded server trigger-character set:
+
+1. **Client (`src/vscode-gsharp/package.json`).** Contribute
+   `configurationDefaults` for the `[gsharp]` language scope that turns implicit
+   suggestions on by default and keeps them relevant:
+
+   ```jsonc
+   "[gsharp]": {
+     "editor.quickSuggestions": { "other": "on", "comments": "off", "strings": "off" },
+     "editor.suggestOnTriggerCharacters": true,
+     "editor.quickSuggestionsDelay": 10,
+     "editor.wordBasedSuggestions": "off"
+   }
+   ```
+
+   Quick suggestions fire for code (not comments/strings), trigger characters still
+   work, and word-based suggestions are disabled so the LSP list is not duplicated
+   by raw editor-buffer words. These are *defaults*: users can still override any of
+   them.
+
+2. **Server trigger characters remain minimal.** `CompletionOptions.TriggerCharacters`
+   stays `["."]` for member access. The alphabet is intentionally **not** added.
+
+3. **Server completion handler is hardened for mid-identifier invocation.**
+   `CompletionComputer.ComputeCompletions` now computes the span of the partial
+   identifier immediately preceding the caret and attaches it as an explicit
+   `textEdit` replacement range (with `newText` = the candidate label) to every
+   plain candidate — global keywords/symbols/types as well as member-access
+   results. Snippet items that carry their own `insertText` are left untouched, and
+   when there is no identifier prefix at the caret (e.g. right after `.`) no range is
+   attached so the editor applies its own word-range heuristics.
+
+## Consequences
+
+- **Positive.** Typing an identifier, keyword, or partial member name now surfaces a
+  filtered completion list by default, matching the Pylance / C# Dev Kit DX. The
+  explicit replacement range makes the editor replace the typed prefix cleanly
+  rather than producing doubled text. Member completion after `.`, hover, and
+  signature help are unaffected because trigger characters and their handlers are
+  unchanged.
+- **Neutral.** The behavior is a default, fully overridable per user or workspace via
+  standard `editor.*` settings. The existing (currently unwired) `gsharp.completion.triggerOnDot`
+  setting is left in place.
+- **Negative / bounded.** Relying on the editor's `quickSuggestions` means a client
+  that does not honor `configurationDefaults` (a non-VS Code LSP client) will not get
+  as-you-type behavior automatically; such clients must enable implicit completion
+  themselves. This is acceptable: the server still answers `Invoke`-kind requests
+  correctly, so any client that asks gets a properly ranged list.
+
+## Alternatives considered
+
+- **Advertise every identifier character as a server trigger character.** Rejected:
+  redundant requests on every keystroke, fights the editor's filtering, couples the
+  server to a specific keystroke model, and is not what mature servers (Pylance,
+  Roslyn) do.
+- **Add `(`, space, etc. as trigger characters.** Rejected as noisy and overlapping
+  with signature help (`(`, `,`); implicit IntelliSense already covers these
+  positions without extra popups.
+- **Server-side prefix filtering** (returning only candidates matching the typed
+  prefix). Rejected: the editor already filters/sorts against the word under the
+  caret, and server-side filtering would break incremental typing and fuzzy matching.

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -1511,13 +1511,20 @@ public static class CompletionComputer
         var compilation = content.Project?.GetCompilation() ?? new Compilation(content.SyntaxTree);
         var offset = SemanticLookup.ToOffset(content, position);
 
+        // Issue #917: completion-as-you-type. When the caret sits in (or immediately
+        // after) a partial identifier — e.g. `prin<caret>` or `x.To<caret>` — compute
+        // the prefix's span so each candidate carries an explicit replacement range.
+        // This lets the editor filter/replace the partial word correctly when the list
+        // is invoked implicitly mid-identifier rather than only after a trigger char.
+        var replacementRange = ComputeReplacementRange(content, offset);
+
         // Member-access context (`receiver.<caret>`): offer the receiver's members
         // instead of the global keyword/symbol list. Returns null only when the
         // caret is not positioned after a member-access dot.
         var memberItems = TryComputeMemberCompletions(content, compilation, offset);
         if (memberItems != null)
         {
-            return memberItems;
+            return ApplyReplacementRange(memberItems, replacementRange);
         }
 
         // Issue #522 / #897: inside a C#-style object-initializer block
@@ -1526,7 +1533,7 @@ public static class CompletionComputer
         var initializerItems = TryComputeObjectInitializerCompletions(content, compilation, offset);
         if (initializerItems != null)
         {
-            return initializerItems;
+            return ApplyReplacementRange(initializerItems, replacementRange);
         }
 
         var items = new List<CompletionItem>();
@@ -1632,6 +1639,69 @@ public static class CompletionComputer
                     Kind = CompletionItemKind.TypeParameter,
                 });
             }
+        }
+
+        return ApplyReplacementRange(items, replacementRange);
+    }
+
+    /// <summary>
+    /// Issue #917: computes the source span of the partial identifier immediately
+    /// preceding <paramref name="offset"/> (the run of identifier characters ending at
+    /// the caret). Returns <see langword="null"/> when the caret is not directly after
+    /// an identifier character (e.g. right after a <c>.</c> trigger, or at the start of
+    /// a fresh token) so the editor falls back to its own word-range heuristics.
+    /// </summary>
+    private static Range ComputeReplacementRange(DocumentContent content, int offset)
+    {
+        var text = content.SyntaxTree.Text;
+        if (offset <= 0 || offset > text.Length)
+        {
+            return null;
+        }
+
+        var start = offset;
+        while (start > 0 && IsIdentifierChar(text[start - 1]))
+        {
+            start--;
+        }
+
+        if (start == offset)
+        {
+            // No identifier prefix at the caret — nothing to anchor a replacement to.
+            return null;
+        }
+
+        return SemanticLookup.ToRange(text, new TextSpan(start, offset - start));
+    }
+
+    private static bool IsIdentifierChar(char c) => char.IsLetterOrDigit(c) || c == '_';
+
+    /// <summary>
+    /// Issue #917: attaches the partial-identifier replacement range (<paramref name="replacementRange"/>)
+    /// to every plain (non-snippet) candidate so the editor replaces the typed prefix
+    /// instead of inserting alongside it. Snippet items (which carry their own
+    /// <see cref="CompletionItem.InsertText"/>) are left untouched. A <see langword="null"/>
+    /// range leaves the list unchanged so the editor applies its default word range.
+    /// </summary>
+    private static IReadOnlyList<CompletionItem> ApplyReplacementRange(IReadOnlyList<CompletionItem> items, Range replacementRange)
+    {
+        if (replacementRange == null || items.Count == 0)
+        {
+            return items;
+        }
+
+        foreach (var item in items)
+        {
+            if (item.InsertText != null || item.TextEdit != null)
+            {
+                continue;
+            }
+
+            item.TextEdit = new TextEdit
+            {
+                Range = replacementRange,
+                NewText = item.Label,
+            };
         }
 
         return items;

--- a/src/LanguageServer/Protocol/Models.cs
+++ b/src/LanguageServer/Protocol/Models.cs
@@ -279,6 +279,10 @@ public sealed class CompletionItem
     [JsonPropertyName("filterText")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string FilterText { get; set; }
+
+    [JsonPropertyName("textEdit")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public TextEdit TextEdit { get; set; }
 }
 
 public sealed class CompletionList

--- a/src/vscode-gsharp/CHANGELOG.md
+++ b/src/vscode-gsharp/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to the GSharp VS Code extension will be documented in this f
 - Server crash recovery with exponential backoff
 - Language status bar item (Starting → Ready → Error)
 - Project context status bar item
+- Completion-as-you-type (issue #917): completions now appear automatically while typing identifiers, keywords, and member names — not only after a `.` — matching the Pylance / C# Dev Kit experience. Enabled by default for `.gs` files via `configurationDefaults` (`editor.quickSuggestions` for code, with word-based suggestions disabled so the LSP list is not duplicated); fully overridable per user/workspace. The language server attaches an explicit replacement range to each candidate so the typed prefix is replaced cleanly. See ADR-0111.
 
 ### Changed
 

--- a/src/vscode-gsharp/package.json
+++ b/src/vscode-gsharp/package.json
@@ -84,6 +84,18 @@
         "path": "./snippets/gsharp.json"
       }
     ],
+    "configurationDefaults": {
+      "[gsharp]": {
+        "editor.quickSuggestions": {
+          "other": "on",
+          "comments": "off",
+          "strings": "off"
+        },
+        "editor.suggestOnTriggerCharacters": true,
+        "editor.quickSuggestionsDelay": 10,
+        "editor.wordBasedSuggestions": "off"
+      }
+    },
     "themes": [
       {
         "label": "GSharp Ember Dark",

--- a/test/LanguageServer.Tests/CompletionHandlerTests.cs
+++ b/test/LanguageServer.Tests/CompletionHandlerTests.cs
@@ -253,6 +253,82 @@ public class CompletionHandlerTests
         Assert.Empty(items);
     }
 
+    [Fact]
+    public void ComputeCompletions_WhileTypingBareIdentifier_OffersGlobalCandidates()
+    {
+        // Issue #917: completion-as-you-type. The caret sits in a partial identifier
+        // (`ans`) with no leading dot; the global list must still be offered so the
+        // editor can filter it down to the matching symbol.
+        const string source = "let answer = 42\nans\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, After(source, "ans"));
+
+        Assert.Contains(items, i => i.Label == "answer" && i.Kind == CompletionItemKind.Variable);
+        Assert.Contains(items, i => i.Label == "let" && i.Kind == CompletionItemKind.Keyword);
+    }
+
+    [Fact]
+    public void ComputeCompletions_WhileTypingBareIdentifier_SetsReplacementRangeOverPrefix()
+    {
+        // Issue #917: each plain candidate must carry an explicit replacement range
+        // spanning the typed prefix so the editor replaces `ans` rather than inserting
+        // alongside it.
+        const string source = "let answer = 42\nans\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var caret = After(source, "ans");
+        var items = CompletionComputer.ComputeCompletions(content, caret);
+
+        var answer = Assert.Single(items, i => i.Label == "answer");
+        Assert.NotNull(answer.TextEdit);
+        Assert.Equal("answer", answer.TextEdit.NewText);
+
+        // The prefix `ans` starts at column 0 on line 1 and ends at the caret.
+        var prefixStart = LanguageServerTestHelpers.PositionOf(source, "ans");
+        Assert.Equal(prefixStart.Line, answer.TextEdit.Range.Start.Line);
+        Assert.Equal(prefixStart.Character, answer.TextEdit.Range.Start.Character);
+        Assert.Equal(caret.Line, answer.TextEdit.Range.End.Line);
+        Assert.Equal(caret.Character, answer.TextEdit.Range.End.Character);
+    }
+
+    [Fact]
+    public void ComputeCompletions_AtTokenStartWithoutPrefix_LeavesItemsRangeless()
+    {
+        // With no identifier prefix at the caret (a fresh position), the server leaves
+        // the replacement range unset so the editor applies its own word-range heuristics.
+        const string source = "let answer = 42\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, new Position(0, 0));
+
+        var keyword = Assert.Single(items, i => i.Label == "let");
+        Assert.Null(keyword.TextEdit);
+    }
+
+    [Fact]
+    public void ComputeCompletions_WhileTypingPartialMemberAfterDot_OffersMembersAndRange()
+    {
+        // Issue #917: `x.To<caret>` — partial member name after a dot. Member completion
+        // must still resolve the receiver's members (no keyword soup) and anchor the
+        // replacement range to the partial member text being typed.
+        const string source = "var x int32 = 42\nx.To\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var caret = After(source, "x.To");
+        var items = CompletionComputer.ComputeCompletions(content, caret);
+
+        var toString = Assert.Single(items, i => i.Label == "ToString");
+        Assert.Equal(CompletionItemKind.Method, toString.Kind);
+        Assert.DoesNotContain(items, i => i.Kind == CompletionItemKind.Keyword);
+
+        Assert.NotNull(toString.TextEdit);
+        var prefixStart = LanguageServerTestHelpers.PositionOf(source, "To", 0);
+        Assert.Equal(prefixStart.Line, toString.TextEdit.Range.Start.Line);
+        Assert.Equal(prefixStart.Character, toString.TextEdit.Range.Start.Character);
+        Assert.Equal(caret.Character, toString.TextEdit.Range.End.Character);
+    }
+
     private static Position After(string source, string marker)
     {
         var start = LanguageServerTestHelpers.PositionOf(source, marker);


### PR DESCRIPTION
Fixes #917

## Summary

Completion lists previously surfaced almost exclusively after typing a member-access dot (`.`). This PR enables **completion-as-you-type** — the list now appears automatically while typing identifiers, keywords, and member names, matching the Pylance / C# Dev Kit experience, without spamming irrelevant popups.

### How it works
There are two mechanisms an editor uses to ask for completions: server **trigger characters**, and the editor's **implicit ("24x7") IntelliSense** (`editor.quickSuggestions`). The idiomatic approach (Pylance, Roslyn) is to keep trigger characters minimal and rely on implicit IntelliSense for typing, while ensuring the server returns a correctly *ranged* list when invoked mid-identifier. This PR does exactly that.

### Changes
- **`src/vscode-gsharp/package.json`** — contribute `configurationDefaults` for the `[gsharp]` scope:
  - `editor.quickSuggestions` on for code (off in comments/strings)
  - `editor.suggestOnTriggerCharacters: true`
  - `editor.quickSuggestionsDelay: 10`
  - `editor.wordBasedSuggestions: "off"` (so raw buffer words don't duplicate the LSP list)
  - These are *defaults* and remain fully user/workspace-overridable.
- **`src/LanguageServer/HoverComputer.cs` (`CompletionComputer`)** — harden `ComputeCompletions` for implicit mid-identifier invocation: compute the partial-identifier prefix span at the caret and attach it as an explicit `textEdit` replacement range (with `newText` = label) to every plain candidate — global keywords/symbols/types **and** member-access results. Snippet items (their own `insertText`) and the prefix-less post-`.` case are left to the editor's word-range heuristics.
- **`src/LanguageServer/Protocol/Models.cs`** — add `CompletionItem.textEdit`.
- Server trigger characters stay `["."]` by design; the alphabet is intentionally **not** advertised (see ADR for rationale). Member completion, hover, and signature help are unchanged.

## ADR decision
**Added ADR-0111** (`docs/adr/0111-completion-as-you-type-language-server.md`). The repo documents LSP behavior in ADRs (0105–0107), and this establishes a new convention for how completion triggering works (implicit IntelliSense + ranged candidates rather than an expanded trigger-character set), so it warrants an ADR.

## Test evidence
- **Restore tools:** `dotnet tool restore` ✅
- **Build:** `dotnet build GSharp.sln --configuration Release --no-restore -graph` → **Build succeeded, 0 warnings, 0 errors** ✅
- **Tests:** `dotnet test test/LanguageServer.Tests` → **Passed! Failed: 0, Passed: 354, Skipped: 0** ✅ (4 new tests added in `CompletionHandlerTests.cs`):
  - bare-identifier completion (no leading dot) offers global candidates
  - replacement range spans the typed prefix exactly
  - prefix-less caret leaves the range unset (editor heuristics)
  - partial-member-after-dot still resolves members + ranges, no keyword soup
  - existing `.` member completion / suppression tests still pass
- **Extension:** `npm run compile` ✅, `npm run lint` ✅, `npm run test:unit` → 13 passed ✅

## Notes
No existing trigger-character assertions needed updating (none assert the set). Nothing left incomplete.
