### PR TITLE
Unified member resolution (ADR-0112): user-type method groups

### DIFF
--- a/docs/adr/0112-unified-member-resolution.md
+++ b/docs/adr/0112-unified-member-resolution.md
@@ -1,0 +1,126 @@
+# ADR-0112: Unified member resolution
+
+- **Status**: Accepted
+- **Date**: 2026-06-21
+- **Phase**: Phase 5 — generics & dogfooded core
+- **Closes**: User-type method groups cannot be converted to delegates
+  (`Use(Box.Make)` → GS0158, `Use(Make)` → GS0125) even though the language
+  server can resolve the same `shared`/instance members for hover/completion.
+- **Related**: ADR-0053 (`shared` static members); ADR-0063 (overload sets);
+  ADR-0051/0052 (properties/events); ADR-0110 (nested types); Issue #324 /
+  #337 (method groups for free functions and CLR members)
+
+## Context
+
+The binder and the language server resolve members of user-defined G# types
+through **separate, duplicated code paths**.
+
+The language server resolves a member uniformly — it concatenates a type's
+instance and static tables (`Properties.Concat(StaticProperties)`,
+`Methods.Concat(StaticMethods)`, …) and walks the `BaseClass` chain. This is
+copied in at least four places:
+
+- `HoverComputer.LookupMemberOnStruct`
+- `SemanticLookup.SemanticModel.LookupMember`
+- `SemanticLookup.BuildModelUncached` struct-member mapping
+- `CompletionComputer.AddStructInstanceMembers` / `AddStructStaticMembers`
+
+plus an overload counter (`HoverComputer.CountOverloads`). Because the LS
+enumerates `Methods`/`StaticMethods` directly, hover and completion succeed
+for a user `shared`/instance method.
+
+The binder, by contrast, uses fragmented, capability-gated logic:
+
+- `ExpressionBinder.IsMethodGroupCandidateUsable` rejects every candidate that
+  is `IsInstanceMethod || IsStatic || StaticOwnerType != null`, so only
+  top-level free functions can become a bare-name method group.
+- `ExpressionBinder.Access.BindUserTypeStaticMemberAccess` handles only static
+  fields/properties — there is **no** static-method/method-group branch (the
+  CLR sibling `TryBindClrMethodGroup` does have one).
+- The `expr.M` user-struct instance branch in `BindAccessorStep` handles only
+  fields/properties.
+- `HasUserTypeStaticMember` does not recognize methods for the non-call form.
+
+The result is a hover-vs-build divergence: the editor says a member exists and
+is callable, but the compiler refuses to form a method group for it.
+
+`class` and `struct` are both `StructSymbol` (distinguished by `IsClass`);
+interfaces are `InterfaceSymbol` (with static-virtual members), enums are
+`EnumSymbol`. No single canonical user-member lookup exists today.
+
+## Decision
+
+### A canonical, pure member-resolution layer
+
+Introduce one canonical member-resolution layer in Core
+(`src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs`) that both the binder and
+the language server consume. It is **pure**: it has no `BinderContext`
+dependency and returns only existing `Symbol` instances
+(`FunctionSymbol`/`FieldSymbol`/`PropertySymbol`/`EventSymbol`/nested type
+symbols), so emit, overload resolution, and conversion are unaffected by the
+layer itself. Because it is pure, the language server can call it directly.
+
+Contract:
+
+- `TypeMemberModel.LookupMember(TypeSymbol, name, query) : Symbol` — the single
+  first-match member named `name`, honoring the LS priority order
+  (property → field → event → method, instance and static concatenated),
+  walking the `BaseClass` chain. This preserves existing hover/LS semantics
+  exactly.
+- `TypeMemberModel.GetMethods(TypeSymbol, name, query) : ImmutableArray<FunctionSymbol>` —
+  the overload set named `name` (instance and/or static per the query),
+  walking inheritance with signature-based dedup
+  (`BoundScope.FunctionSignaturesEqual`).
+- Kind helpers: `TryGetField`, `TryGetStaticField`, `TryGetProperty`,
+  `TryGetStaticProperty`, `TryGetEvent`, `TryGetStaticEvent`.
+- `EnumerateMembers(TypeSymbol, query) : IEnumerable<Symbol>` for completion.
+- `MemberQuery` flags: `IncludeInstance`, `IncludeStatic`, `IncludeInherited`,
+  and a kind mask.
+
+Backends cover `StructSymbol` (class + struct), `InterfaceSymbol` (including
+static-virtual members), and `EnumSymbol`. CLR/imported member reflection is
+**out of scope**: it stays behind `MemberLookup`'s shape probes and is not
+consolidated by this work, bounding the blast radius.
+
+### Method-group semantics for user-type members (first consumer)
+
+With the layer in place, the binder forms a `BoundMethodGroupExpression` for a
+user-type method in each access form:
+
+- `Type.M` (static): a `shared` method becomes a method group with a **null**
+  receiver (single candidate carries its `FunctionTypeSymbol`; an overload set
+  defers selection to `ConversionClassifier.BindUserMethodGroupConversion`).
+- `expr.M` (instance): builds an instance method group whose **receiver is the
+  bound `expr`**.
+- bare `M` (implicit `this`/implicit shared): inside the declaring type, a bare
+  name that resolves to an instance method becomes a method group captured
+  against the implicit `this`; a `shared` method becomes a null-receiver group.
+
+The `FunctionTypeSymbol` for the group is built from the same interned
+parameter/return `TypeSymbol`s used everywhere else, so the
+`ReferenceEquals`-based overload pick in `ConversionClassifier` keeps working.
+
+### Emit
+
+`MethodBodyEmitter.EmitMethodGroup` already handles both a null receiver
+(`ldnull; ldftn`, static/free) and an instance receiver (box value types,
+`ldvirtftn` for `open`/`override`), and already resolves the target `MethodDef`
+from `cache.FunctionHandles` (free functions) then `cache.MethodHandles`
+(user instance/static methods). The only required emit change is in
+`SlotPlanner.ReceiverSpillCollector`: add a `VisitMethodGroupExpression`
+override (mirroring the existing `VisitClrMethodGroupExpression` override) so an
+instance group whose receiver is a non-addressable struct rvalue gets a spill
+slot.
+
+## Consequences
+
+- The duplicated LS enumerations are deleted and routed through the canonical
+  layer, removing a class of hover-vs-build divergences.
+- The originally reported bug is fixed: a user class with
+  `shared { func Make() … }` used as `Use(Box.Make)` and bare `Use(Make)`
+  (and the instance equivalents) compiles and runs.
+- Behavior parity for hover/completion and existing binder member access is a
+  hard requirement; Phase-2 characterization tests gate the migrations.
+- Full consolidation of CLR/imported member reflection into the same layer is
+  deferred; the layer exposes a unified entry point but CLR resolution remains
+  a `MemberLookup` backend.

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -71,6 +71,59 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// ADR-0112 §"method-group semantics": builds a <see cref="BoundMethodGroupExpression"/>
+    /// for a user-defined type's method(s). A <paramref name="receiver"/> of
+    /// <see langword="null"/> yields a static (null-target) group; a non-null
+    /// receiver yields an instance group captured against it. Candidates that
+    /// cannot participate in a method-group→delegate conversion (generic or
+    /// variadic) are filtered out; the group is only produced when at least one
+    /// usable candidate remains.
+    /// </summary>
+    private static bool TryBuildUserMethodGroup(BoundExpression receiver, ImmutableArray<FunctionSymbol> methods, out BoundExpression methodGroup)
+    {
+        methodGroup = null;
+
+        if (methods.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        var usable = ImmutableArray.CreateBuilder<FunctionSymbol>(methods.Length);
+        foreach (var m in methods)
+        {
+            if (m.IsGeneric)
+            {
+                continue;
+            }
+
+            var hasVariadic = false;
+            foreach (var parameter in m.Parameters)
+            {
+                if (parameter.IsVariadic)
+                {
+                    hasVariadic = true;
+                    break;
+                }
+            }
+
+            if (hasVariadic)
+            {
+                continue;
+            }
+
+            usable.Add(m);
+        }
+
+        if (usable.Count == 0)
+        {
+            return false;
+        }
+
+        methodGroup = BuildInstanceMethodGroup(receiver, usable.ToImmutable());
+        return true;
+    }
+
+    /// <summary>
     /// Binds a fully-qualified imported-type constructor written in expression
     /// position, e.g. <c>System.Text.StringBuilder()</c> or
     /// <c>System.Collections.Generic.List[int]()</c>. Such an expression parses
@@ -1013,6 +1066,16 @@ internal sealed partial class ExpressionBinder
             return new BoundPropertyAccessExpression(null, receiver: null, structSym, prop);
         }
 
+        // ADR-0112: a static (shared) method named here in non-call position is a
+        // method group with a null receiver. Overload selection (when more than
+        // one shared overload shares the name) is deferred to the conversion
+        // classifier, driven by the target delegate signature.
+        var staticMethods = TypeMemberModel.GetMethods(structSym, memberName, MemberQuery.Static(MemberKinds.Method));
+        if (TryBuildUserMethodGroup(receiver: null, staticMethods, out var staticGroup))
+        {
+            return staticGroup;
+        }
+
         Diagnostics.ReportUnableToFindMember(ne.Location, memberName);
         return new BoundErrorExpression(null);
     }
@@ -1426,6 +1489,17 @@ internal sealed partial class ExpressionBinder
                         {
                             return new BoundClrPropertyAccessExpression(null, receiver, clrFld, TypeSymbol.FromClrType(clrFld.FieldType));
                         }
+                    }
+
+                    // ADR-0112: an instance method named here in non-call position
+                    // is a method group captured against the bound receiver. The
+                    // conversion classifier selects the overload (if any) from the
+                    // target delegate signature; the emitter binds the delegate's
+                    // Target to this receiver (boxing value-type receivers).
+                    var instanceMethods = TypeMemberModel.GetMethods(structSym, ne.IdentifierToken.Text, MemberQuery.Instance(MemberKinds.Method));
+                    if (TryBuildUserMethodGroup(receiver, instanceMethods, out var instanceUserGroup))
+                    {
+                        return instanceUserGroup;
                     }
 
                     Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -926,25 +926,16 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
+        // ADR-0112: route through the canonical member-resolution layer.
         if (isCall)
         {
-            return structSym.TryGetStaticMethod(headName, out _);
+            return !TypeMemberModel.GetMethods(structSym, headName, MemberQuery.Static(MemberKinds.Method)).IsEmpty;
         }
 
-        if (structSym.TryGetStaticField(headName, out _))
-        {
-            return true;
-        }
-
-        foreach (var prop in structSym.StaticProperties)
-        {
-            if (prop.Name == headName)
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return TypeMemberModel.LookupMember(
+            structSym,
+            headName,
+            MemberQuery.Static(MemberKinds.Field | MemberKinds.Property)) != null;
     }
 
     private BoundExpression BindEnumAccessorStep(EnumSymbol enumSymbol, ExpressionSyntax rightPart)
@@ -1011,17 +1002,15 @@ internal sealed partial class ExpressionBinder
     {
         var memberName = ne.IdentifierToken.Text;
 
-        if (structSym.TryGetStaticField(memberName, out var field))
+        // ADR-0112: static field/property lookups go through the canonical layer.
+        if (TypeMemberModel.TryGetStaticField(structSym, memberName, out var field))
         {
             return new BoundFieldAccessExpression(null, receiver: null, structSym, field);
         }
 
-        foreach (var prop in structSym.StaticProperties)
+        if (TypeMemberModel.TryGetStaticProperty(structSym, memberName, out var prop))
         {
-            if (prop.Name == memberName)
-            {
-                return new BoundPropertyAccessExpression(null, receiver: null, structSym, prop);
-            }
+            return new BoundPropertyAccessExpression(null, receiver: null, structSym, prop);
         }
 
         Diagnostics.ReportUnableToFindMember(ne.Location, memberName);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -277,7 +277,7 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        var variable = BindVariableReference(name, syntax.IdentifierToken.Location, suppressNotAVariable: true);
+        var variable = BindVariableReference(name, syntax.IdentifierToken.Location, suppressNotAVariable: true, suppressUndefinedVariable: true);
         if (variable == null)
         {
             // Issue #324: a bare identifier naming a free (package-level)
@@ -291,9 +291,12 @@ internal sealed partial class ExpressionBinder
                 return methodGroup;
             }
 
-            // Not a method group: surface the suppressed GS0126 (or the
-            // undefined-variable diagnostic already reported).
-            if (scope.TryLookupSymbol(name) is not null and not VariableSymbol)
+            // Not a method group: surface the suppressed diagnostics.
+            if (scope.TryLookupSymbol(name) is null)
+            {
+                Diagnostics.ReportUndefinedVariable(syntax.IdentifierToken.Location, name);
+            }
+            else if (scope.TryLookupSymbol(name) is not VariableSymbol)
             {
                 Diagnostics.ReportNotAVariable(syntax.IdentifierToken.Location, name);
             }
@@ -667,6 +670,11 @@ internal sealed partial class ExpressionBinder
 
     internal VariableSymbol BindVariableReference(string name, TextLocation location, bool suppressNotAVariable)
     {
+        return BindVariableReference(name, location, suppressNotAVariable, suppressUndefinedVariable: false);
+    }
+
+    internal VariableSymbol BindVariableReference(string name, TextLocation location, bool suppressNotAVariable, bool suppressUndefinedVariable)
+    {
         switch (scope.TryLookupSymbol(name))
         {
             case VariableSymbol variable:
@@ -674,7 +682,11 @@ internal sealed partial class ExpressionBinder
                 return variable;
 
             case null:
-                Diagnostics.ReportUndefinedVariable(location, name);
+                if (!suppressUndefinedVariable)
+                {
+                    Diagnostics.ReportUndefinedVariable(location, name);
+                }
+
                 return null;
 
             default:
@@ -719,6 +731,35 @@ internal sealed partial class ExpressionBinder
             {
                 methodGroup = new BoundMethodGroupExpression(null, usable.ToImmutable());
                 return true;
+            }
+        }
+
+        // ADR-0112: a bare name inside a user type's method body may name a
+        // sibling member of the enclosing type. An instance method is captured
+        // against the implicit `this`; a shared (static) method forms a
+        // null-receiver group. This mirrors how the event-subscription path
+        // already resolves bare `this`-instance handlers, generalized to any
+        // value (delegate-conversion) context.
+        var enclosing = this.function;
+        if (enclosing != null)
+        {
+            if (enclosing.ThisParameter != null && enclosing.ReceiverType is StructSymbol thisStruct)
+            {
+                var instanceMethods = TypeMemberModel.GetMethods(thisStruct, name, MemberQuery.Instance(MemberKinds.Method));
+                if (TryBuildUserMethodGroup(new BoundVariableExpression(null, enclosing.ThisParameter), instanceMethods, out methodGroup))
+                {
+                    return true;
+                }
+            }
+
+            var enclosingType = (enclosing.ReceiverType as StructSymbol) ?? (enclosing.StaticOwnerType as StructSymbol);
+            if (enclosingType != null)
+            {
+                var sharedMethods = TypeMemberModel.GetMethods(enclosingType, name, MemberQuery.Static(MemberKinds.Method));
+                if (TryBuildUserMethodGroup(receiver: null, sharedMethods, out methodGroup))
+                {
+                    return true;
+                }
             }
         }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -3086,6 +3086,27 @@ internal sealed class OverloadResolver
                 continue;
             }
 
+            // ADR-0112 / ADR-0063 §9: an unresolved method group argument
+            // (multiple user overloads, or a CLR method group) carries no fixed
+            // type until the target delegate signature drives overload
+            // selection. Route it through BindConversion — which performs the
+            // signature-directed pick — instead of the type-equality / implicit
+            // conversion checks below (which would reject the Error-typed group).
+            if ((argument is BoundMethodGroupExpression { FunctionType: null }
+                    || argument is BoundClrMethodGroupExpression { ResolvedMethod: null })
+                && !(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type)))
+            {
+                var groupLoc = i < parameterSyntax.Length ? parameterSyntax[i].Location : syntax.Identifier.Location;
+                var resolvedGroupArg = conversions.BindConversion(groupLoc, argument, expectedType);
+                boundArguments[i] = resolvedGroupArg;
+                if (resolvedGroupArg is BoundErrorExpression)
+                {
+                    hasErrors = true;
+                }
+
+                continue;
+            }
+
             if (argument.Type != expectedType
                 && !(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type))
                 && !Conversion.Classify(argument.Type, expectedType).IsImplicit)

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -884,6 +884,19 @@ internal sealed class SlotPlanner
             base.VisitClrMethodGroupExpression(node);
         }
 
+        protected override void VisitMethodGroupExpression(BoundMethodGroupExpression node)
+        {
+            // ADR-0112: a user instance method group captures an rvalue receiver
+            // (e.g. a struct produced by a call). Spill it so the emitter can take
+            // its address / box it for the delegate target.
+            if (node.Receiver != null)
+            {
+                this.AddIfNeeded(node.Receiver);
+            }
+
+            base.VisitMethodGroupExpression(node);
+        }
+
         private void AddIfNeeded(BoundExpression receiver)
         {
             if (this.needsRvalueReceiverSpill(receiver, this.function, this.locals))

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -1157,8 +1157,18 @@ public sealed class Evaluator
         // Issue #324: a named-function method group behaves like a no-capture
         // closure over the function's own body, so indirect invocation reuses
         // the ClosureValue path.
+        //
+        // ADR-0112: a user-type instance method group also captures the bound
+        // receiver as the implicit `this`, so invoking the delegate dispatches
+        // against that instance. Static (shared) groups have no receiver.
         var body = program.Functions[node.Function];
-        return new ClosureValue(node.Function, body, node.FunctionType, new Dictionary<VariableSymbol, object>());
+        var captured = new Dictionary<VariableSymbol, object>();
+        if (node.Receiver != null && node.Function.ThisParameter != null)
+        {
+            captured[node.Function.ThisParameter] = EvaluateExpression(node.Receiver);
+        }
+
+        return new ClosureValue(node.Function, body, node.FunctionType, captured);
     }
 
     private object EvaluateClrMethodGroupExpression(BoundClrMethodGroupExpression node)

--- a/src/Core/CodeAnalysis/Symbols/MemberKinds.cs
+++ b/src/Core/CodeAnalysis/Symbols/MemberKinds.cs
@@ -1,0 +1,31 @@
+// <copyright file="MemberKinds.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// ADR-0112: the member kinds a <see cref="MemberQuery"/> can request from the
+/// canonical member-resolution layer (<see cref="TypeMemberModel"/>).
+/// </summary>
+[System.Flags]
+public enum MemberKinds
+{
+    /// <summary>No member kinds.</summary>
+    None = 0,
+
+    /// <summary>Instance / static fields.</summary>
+    Field = 1,
+
+    /// <summary>Instance / static properties.</summary>
+    Property = 2,
+
+    /// <summary>Instance / static events.</summary>
+    Event = 4,
+
+    /// <summary>Instance / static methods.</summary>
+    Method = 8,
+
+    /// <summary>Every member kind.</summary>
+    All = Field | Property | Event | Method,
+}

--- a/src/Core/CodeAnalysis/Symbols/MemberQuery.cs
+++ b/src/Core/CodeAnalysis/Symbols/MemberQuery.cs
@@ -1,0 +1,64 @@
+// <copyright file="MemberQuery.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// ADR-0112: describes which members the canonical member-resolution layer
+/// (<see cref="TypeMemberModel"/>) should surface — the static/instance/inherited
+/// axes and a kind mask.
+/// </summary>
+public readonly struct MemberQuery
+{
+    /// <summary>Initializes a new instance of the <see cref="MemberQuery"/> struct.</summary>
+    /// <param name="includeInstance">Whether instance members are surfaced.</param>
+    /// <param name="includeStatic">Whether static (<c>shared</c>) members are surfaced.</param>
+    /// <param name="includeInherited">Whether members from base classes are surfaced.</param>
+    /// <param name="kinds">The member-kind mask.</param>
+    public MemberQuery(bool includeInstance, bool includeStatic, bool includeInherited, MemberKinds kinds)
+    {
+        this.IncludeInstance = includeInstance;
+        this.IncludeStatic = includeStatic;
+        this.IncludeInherited = includeInherited;
+        this.Kinds = kinds;
+    }
+
+    /// <summary>Gets a value indicating whether instance members are surfaced.</summary>
+    public bool IncludeInstance { get; }
+
+    /// <summary>Gets a value indicating whether static (<c>shared</c>) members are surfaced.</summary>
+    public bool IncludeStatic { get; }
+
+    /// <summary>Gets a value indicating whether members from base classes are surfaced.</summary>
+    public bool IncludeInherited { get; }
+
+    /// <summary>Gets the member-kind mask.</summary>
+    public MemberKinds Kinds { get; }
+
+    /// <summary>
+    /// Gets a query matching every member (instance + static + inherited, all
+    /// kinds). This mirrors the historic language-server enumeration semantics
+    /// (property → field → event → method, instance then static, walking the
+    /// base chain) and is the parity-preserving default for hover/lookup.
+    /// </summary>
+    public static MemberQuery All { get; } = new(includeInstance: true, includeStatic: true, includeInherited: true, MemberKinds.All);
+
+    /// <summary>Gets a query matching instance members of the given kinds, walking the base chain.</summary>
+    /// <param name="kinds">The member-kind mask.</param>
+    /// <returns>The configured query.</returns>
+    public static MemberQuery Instance(MemberKinds kinds = MemberKinds.All)
+        => new(includeInstance: true, includeStatic: false, includeInherited: true, kinds);
+
+    /// <summary>Gets a query matching static members of the given kinds (no base-chain walk, matching historic static-completion semantics).</summary>
+    /// <param name="kinds">The member-kind mask.</param>
+    /// <returns>The configured query.</returns>
+    public static MemberQuery Static(MemberKinds kinds = MemberKinds.All)
+        => new(includeInstance: false, includeStatic: true, includeInherited: false, kinds);
+
+    /// <summary>Returns a copy of this query with the kind mask replaced.</summary>
+    /// <param name="kinds">The new kind mask.</param>
+    /// <returns>The adjusted query.</returns>
+    public MemberQuery WithKinds(MemberKinds kinds)
+        => new(this.IncludeInstance, this.IncludeStatic, this.IncludeInherited, kinds);
+}

--- a/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
@@ -1,0 +1,523 @@
+// <copyright file="TypeMemberModel.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// ADR-0112: the single canonical member-resolution layer for user-defined G#
+/// types (<see cref="StructSymbol"/> for class + struct,
+/// <see cref="InterfaceSymbol"/>, and <see cref="EnumSymbol"/>).
+///
+/// This type is deliberately pure — it has no <c>BinderContext</c> dependency and
+/// returns only existing <see cref="Symbol"/> instances (FunctionSymbol /
+/// FieldSymbol / PropertySymbol / EventSymbol / EnumMemberSymbol) — so both the
+/// binder and the language server can consume it without behavioral drift, and
+/// emit / overload resolution / conversion are unaffected by the layer itself.
+///
+/// CLR / imported member reflection is intentionally out of scope and remains
+/// behind <c>MemberLookup</c>; this layer covers user-symbol member tables only.
+/// </summary>
+public static class TypeMemberModel
+{
+    /// <summary>
+    /// Looks up the first member named <paramref name="name"/> on
+    /// <paramref name="type"/> honoring <paramref name="query"/>. The search
+    /// order — property → field → event → method, instance entries before static
+    /// entries, walking the base chain this-first — matches the historic
+    /// language-server enumeration so hover/definition/lookup stay byte-for-byte
+    /// equivalent under <see cref="MemberQuery.All"/>.
+    /// </summary>
+    /// <param name="type">The type to resolve against (user-defined types only).</param>
+    /// <param name="name">The member name.</param>
+    /// <param name="query">The static/instance/inherited/kind filter.</param>
+    /// <returns>The first matching member, or <c>null</c> when none matches.</returns>
+    public static Symbol LookupMember(TypeSymbol type, string name, MemberQuery query)
+    {
+        if (type is StructSymbol structSymbol)
+        {
+            return LookupStructMember(structSymbol, name, query);
+        }
+
+        if (type is InterfaceSymbol interfaceSymbol)
+        {
+            return LookupInterfaceMember(interfaceSymbol, name, query);
+        }
+
+        if (type is EnumSymbol enumSymbol)
+        {
+            if (query.IncludeStatic && (query.Kinds & MemberKinds.Field) != 0
+                && enumSymbol.TryGetMember(name, out var enumMember))
+            {
+                return enumMember;
+            }
+
+            return null;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns every method named <paramref name="name"/> visible on
+    /// <paramref name="type"/> for the given query (the overload set), walking
+    /// inheritance this-first with signature-based dedup so each visible
+    /// signature appears once. Instance methods are surfaced when
+    /// <see cref="MemberQuery.IncludeInstance"/> is set; static methods when
+    /// <see cref="MemberQuery.IncludeStatic"/> is set.
+    /// </summary>
+    /// <param name="type">The type to resolve against.</param>
+    /// <param name="name">The method name.</param>
+    /// <param name="query">The static/instance/inherited filter.</param>
+    /// <returns>The merged overload set; empty when none found.</returns>
+    public static ImmutableArray<FunctionSymbol> GetMethods(TypeSymbol type, string name, MemberQuery query)
+    {
+        if ((query.Kinds & MemberKinds.Method) == 0)
+        {
+            return ImmutableArray<FunctionSymbol>.Empty;
+        }
+
+        if (type is StructSymbol structSymbol)
+        {
+            ImmutableArray<FunctionSymbol>.Builder builder = null;
+            for (var c = structSymbol; c != null; c = c.BaseClass)
+            {
+                if (query.IncludeInstance)
+                {
+                    AddMethodsDeduped(ref builder, c.Methods, name);
+                }
+
+                if (query.IncludeStatic)
+                {
+                    AddMethodsDeduped(ref builder, c.StaticMethods, name);
+                }
+
+                if (!query.IncludeInherited)
+                {
+                    break;
+                }
+            }
+
+            return builder?.ToImmutable() ?? ImmutableArray<FunctionSymbol>.Empty;
+        }
+
+        if (type is InterfaceSymbol interfaceSymbol)
+        {
+            ImmutableArray<FunctionSymbol>.Builder builder = null;
+            if (query.IncludeInstance)
+            {
+                AddMethodsDeduped(ref builder, interfaceSymbol.Methods, name);
+            }
+
+            if (query.IncludeStatic)
+            {
+                AddMethodsDeduped(ref builder, interfaceSymbol.StaticMethods, name);
+            }
+
+            return builder?.ToImmutable() ?? ImmutableArray<FunctionSymbol>.Empty;
+        }
+
+        return ImmutableArray<FunctionSymbol>.Empty;
+    }
+
+    /// <summary>Enumerates every member matching <paramref name="query"/> on <paramref name="type"/> (for completion). Order is this-first, kind by kind, instance entries before static entries.</summary>
+    /// <param name="type">The type to enumerate.</param>
+    /// <param name="query">The static/instance/inherited/kind filter.</param>
+    /// <returns>The matching members.</returns>
+    public static IEnumerable<Symbol> EnumerateMembers(TypeSymbol type, MemberQuery query)
+    {
+        if (type is StructSymbol structSymbol)
+        {
+            for (var c = structSymbol; c != null; c = c.BaseClass)
+            {
+                if ((query.Kinds & MemberKinds.Field) != 0)
+                {
+                    if (query.IncludeInstance)
+                    {
+                        foreach (var f in c.Fields)
+                        {
+                            yield return f;
+                        }
+                    }
+
+                    if (query.IncludeStatic)
+                    {
+                        foreach (var f in c.StaticFields)
+                        {
+                            yield return f;
+                        }
+                    }
+                }
+
+                if ((query.Kinds & MemberKinds.Property) != 0)
+                {
+                    if (query.IncludeInstance)
+                    {
+                        foreach (var p in c.Properties)
+                        {
+                            yield return p;
+                        }
+                    }
+
+                    if (query.IncludeStatic)
+                    {
+                        foreach (var p in c.StaticProperties)
+                        {
+                            yield return p;
+                        }
+                    }
+                }
+
+                if ((query.Kinds & MemberKinds.Event) != 0)
+                {
+                    if (query.IncludeInstance)
+                    {
+                        foreach (var e in c.Events)
+                        {
+                            yield return e;
+                        }
+                    }
+
+                    if (query.IncludeStatic)
+                    {
+                        foreach (var e in c.StaticEvents)
+                        {
+                            yield return e;
+                        }
+                    }
+                }
+
+                if ((query.Kinds & MemberKinds.Method) != 0)
+                {
+                    if (query.IncludeInstance)
+                    {
+                        foreach (var m in c.Methods)
+                        {
+                            yield return m;
+                        }
+                    }
+
+                    if (query.IncludeStatic)
+                    {
+                        foreach (var m in c.StaticMethods)
+                        {
+                            yield return m;
+                        }
+                    }
+                }
+
+                if (!query.IncludeInherited)
+                {
+                    yield break;
+                }
+            }
+        }
+    }
+
+    /// <summary>Tries to find an instance field named <paramref name="name"/> on <paramref name="type"/>, walking the base chain.</summary>
+    /// <param name="type">The type to resolve against.</param>
+    /// <param name="name">The field name.</param>
+    /// <param name="field">The found field on success.</param>
+    /// <returns>True if found.</returns>
+    public static bool TryGetField(TypeSymbol type, string name, out FieldSymbol field)
+    {
+        if (type is StructSymbol structSymbol)
+        {
+            for (var c = structSymbol; c != null; c = c.BaseClass)
+            {
+                if (c.TryGetField(name, out field))
+                {
+                    return true;
+                }
+            }
+        }
+
+        field = null;
+        return false;
+    }
+
+    /// <summary>Tries to find a static field named <paramref name="name"/> on <paramref name="type"/>.</summary>
+    /// <param name="type">The type to resolve against.</param>
+    /// <param name="name">The field name.</param>
+    /// <param name="field">The found field on success.</param>
+    /// <returns>True if found.</returns>
+    public static bool TryGetStaticField(TypeSymbol type, string name, out FieldSymbol field)
+    {
+        if (type is StructSymbol structSymbol && structSymbol.TryGetStaticField(name, out field))
+        {
+            return true;
+        }
+
+        field = null;
+        return false;
+    }
+
+    /// <summary>Tries to find an instance property named <paramref name="name"/> on <paramref name="type"/>, walking the base chain.</summary>
+    /// <param name="type">The type to resolve against.</param>
+    /// <param name="name">The property name.</param>
+    /// <param name="property">The found property on success.</param>
+    /// <returns>True if found.</returns>
+    public static bool TryGetProperty(TypeSymbol type, string name, out PropertySymbol property)
+    {
+        if (type is StructSymbol structSymbol)
+        {
+            for (var c = structSymbol; c != null; c = c.BaseClass)
+            {
+                foreach (var p in c.Properties)
+                {
+                    if (p.Name == name)
+                    {
+                        property = p;
+                        return true;
+                    }
+                }
+            }
+        }
+        else if (type is InterfaceSymbol interfaceSymbol)
+        {
+            foreach (var p in interfaceSymbol.Properties)
+            {
+                if (p.Name == name)
+                {
+                    property = p;
+                    return true;
+                }
+            }
+        }
+
+        property = null;
+        return false;
+    }
+
+    /// <summary>Tries to find a static property named <paramref name="name"/> on <paramref name="type"/>.</summary>
+    /// <param name="type">The type to resolve against.</param>
+    /// <param name="name">The property name.</param>
+    /// <param name="property">The found property on success.</param>
+    /// <returns>True if found.</returns>
+    public static bool TryGetStaticProperty(TypeSymbol type, string name, out PropertySymbol property)
+    {
+        if (type is StructSymbol structSymbol)
+        {
+            foreach (var p in structSymbol.StaticProperties)
+            {
+                if (p.Name == name)
+                {
+                    property = p;
+                    return true;
+                }
+            }
+        }
+
+        property = null;
+        return false;
+    }
+
+    /// <summary>Tries to find an instance event named <paramref name="name"/> on <paramref name="type"/>, walking the base chain.</summary>
+    /// <param name="type">The type to resolve against.</param>
+    /// <param name="name">The event name.</param>
+    /// <param name="event">The found event on success.</param>
+    /// <returns>True if found.</returns>
+    public static bool TryGetEvent(TypeSymbol type, string name, out EventSymbol @event)
+    {
+        if (type is StructSymbol structSymbol)
+        {
+            for (var c = structSymbol; c != null; c = c.BaseClass)
+            {
+                foreach (var e in c.Events)
+                {
+                    if (e.Name == name)
+                    {
+                        @event = e;
+                        return true;
+                    }
+                }
+            }
+        }
+        else if (type is InterfaceSymbol interfaceSymbol)
+        {
+            foreach (var e in interfaceSymbol.Events)
+            {
+                if (e.Name == name)
+                {
+                    @event = e;
+                    return true;
+                }
+            }
+        }
+
+        @event = null;
+        return false;
+    }
+
+    /// <summary>Tries to find a static event named <paramref name="name"/> on <paramref name="type"/>.</summary>
+    /// <param name="type">The type to resolve against.</param>
+    /// <param name="name">The event name.</param>
+    /// <param name="event">The found event on success.</param>
+    /// <returns>True if found.</returns>
+    public static bool TryGetStaticEvent(TypeSymbol type, string name, out EventSymbol @event)
+    {
+        if (type is StructSymbol structSymbol)
+        {
+            foreach (var e in structSymbol.StaticEvents)
+            {
+                if (e.Name == name)
+                {
+                    @event = e;
+                    return true;
+                }
+            }
+        }
+
+        @event = null;
+        return false;
+    }
+
+    private static Symbol LookupStructMember(StructSymbol structSymbol, string name, MemberQuery query)
+    {
+        for (var c = structSymbol; c != null; c = c.BaseClass)
+        {
+            if ((query.Kinds & MemberKinds.Property) != 0
+                && TryFirst(query.IncludeInstance ? c.Properties : ImmutableArray<PropertySymbol>.Empty, query.IncludeStatic ? c.StaticProperties : ImmutableArray<PropertySymbol>.Empty, name, out PropertySymbol property))
+            {
+                return property;
+            }
+
+            if ((query.Kinds & MemberKinds.Field) != 0
+                && TryFirst(query.IncludeInstance ? c.Fields : ImmutableArray<FieldSymbol>.Empty, query.IncludeStatic ? c.StaticFields : ImmutableArray<FieldSymbol>.Empty, name, out FieldSymbol field))
+            {
+                return field;
+            }
+
+            if ((query.Kinds & MemberKinds.Event) != 0
+                && TryFirst(query.IncludeInstance ? c.Events : ImmutableArray<EventSymbol>.Empty, query.IncludeStatic ? c.StaticEvents : ImmutableArray<EventSymbol>.Empty, name, out EventSymbol @event))
+            {
+                return @event;
+            }
+
+            if ((query.Kinds & MemberKinds.Method) != 0
+                && TryFirst(query.IncludeInstance ? c.Methods : ImmutableArray<FunctionSymbol>.Empty, query.IncludeStatic ? c.StaticMethods : ImmutableArray<FunctionSymbol>.Empty, name, out FunctionSymbol method))
+            {
+                return method;
+            }
+
+            if (!query.IncludeInherited)
+            {
+                break;
+            }
+        }
+
+        return null;
+    }
+
+    private static Symbol LookupInterfaceMember(InterfaceSymbol interfaceSymbol, string name, MemberQuery query)
+    {
+        if ((query.Kinds & MemberKinds.Property) != 0 && query.IncludeInstance)
+        {
+            foreach (var p in interfaceSymbol.Properties)
+            {
+                if (p.Name == name)
+                {
+                    return p;
+                }
+            }
+        }
+
+        if ((query.Kinds & MemberKinds.Event) != 0 && query.IncludeInstance)
+        {
+            foreach (var e in interfaceSymbol.Events)
+            {
+                if (e.Name == name)
+                {
+                    return e;
+                }
+            }
+        }
+
+        if ((query.Kinds & MemberKinds.Method) != 0)
+        {
+            if (query.IncludeInstance && interfaceSymbol.TryGetMethod(name, out var method))
+            {
+                return method;
+            }
+
+            if (query.IncludeStatic && interfaceSymbol.TryGetStaticMethod(name, out var staticMethod))
+            {
+                return staticMethod;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryFirst<T>(ImmutableArray<T> instance, ImmutableArray<T> @static, string name, out T result)
+        where T : Symbol
+    {
+        if (!instance.IsDefaultOrEmpty)
+        {
+            foreach (var s in instance)
+            {
+                if (s.Name == name)
+                {
+                    result = s;
+                    return true;
+                }
+            }
+        }
+
+        if (!@static.IsDefaultOrEmpty)
+        {
+            foreach (var s in @static)
+            {
+                if (s.Name == name)
+                {
+                    result = s;
+                    return true;
+                }
+            }
+        }
+
+        result = null;
+        return false;
+    }
+
+    private static void AddMethodsDeduped(ref ImmutableArray<FunctionSymbol>.Builder builder, ImmutableArray<FunctionSymbol> source, string name)
+    {
+        if (source.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        foreach (var m in source)
+        {
+            if (m.Name != name)
+            {
+                continue;
+            }
+
+            if (builder != null)
+            {
+                var hidden = false;
+                foreach (var existing in builder)
+                {
+                    if (BoundScope.FunctionSignaturesEqual(existing, m))
+                    {
+                        hidden = true;
+                        break;
+                    }
+                }
+
+                if (hidden)
+                {
+                    continue;
+                }
+            }
+
+            builder ??= ImmutableArray.CreateBuilder<FunctionSymbol>();
+            builder.Add(m);
+        }
+    }
+}

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -500,43 +500,11 @@ public static class HoverComputer
     /// </summary>
     private static Symbol LookupMemberOnStruct(StructSymbol structSymbol, string memberName)
     {
-        // Walk the type hierarchy (including base classes).
-        for (var current = structSymbol; current != null; current = current.BaseClass)
-        {
-            // Properties (instance + static)
-            var property = current.Properties.Concat(current.StaticProperties)
-                .FirstOrDefault(p => p.Name == memberName);
-            if (property != null)
-            {
-                return property;
-            }
-
-            // Fields (instance + static)
-            var field = current.Fields.Concat(current.StaticFields)
-                .FirstOrDefault(f => f.Name == memberName);
-            if (field != null)
-            {
-                return field;
-            }
-
-            // Events (instance + static)
-            var @event = current.Events.Concat(current.StaticEvents)
-                .FirstOrDefault(e => e.Name == memberName);
-            if (@event != null)
-            {
-                return @event;
-            }
-
-            // Methods (instance + static)
-            var method = current.Methods.Concat(current.StaticMethods)
-                .FirstOrDefault(m => m.Name == memberName);
-            if (method != null)
-            {
-                return method;
-            }
-        }
-
-        return null;
+        // ADR-0112: route through the canonical member-resolution layer so hover
+        // shares the binder's single member lookup. MemberQuery.All preserves the
+        // historic order (property → field → event → method, instance then static,
+        // walking the base chain).
+        return TypeMemberModel.LookupMember(structSymbol, memberName, MemberQuery.All);
     }
 
     private static IEnumerable<(ExpressionSyntax ReceiverExpression, string MemberName)> FindAccessorMemberContexts(SyntaxTree tree, SyntaxToken token)
@@ -800,14 +768,22 @@ public static class HoverComputer
 
     private static int CountOverloads(Compilation compilation, FunctionSymbol function)
     {
+        // ADR-0112: count via the canonical layer (non-inherited, matching the
+        // historic single-declaring-type count).
         if (function.StaticOwnerType is StructSymbol staticOwner)
         {
-            return staticOwner.StaticMethods.Count(m => m.Name == function.Name);
+            return TypeMemberModel.GetMethods(
+                staticOwner,
+                function.Name,
+                new MemberQuery(includeInstance: false, includeStatic: true, includeInherited: false, MemberKinds.Method)).Length;
         }
 
         if (function.ReceiverType is StructSymbol owner)
         {
-            return owner.Methods.Count(m => m.Name == function.Name);
+            return TypeMemberModel.GetMethods(
+                owner,
+                function.Name,
+                new MemberQuery(includeInstance: true, includeStatic: false, includeInherited: false, MemberKinds.Method)).Length;
         }
 
         return compilation.GlobalScope.Functions.Count(f => f.Name == function.Name);
@@ -2123,40 +2099,35 @@ public static class CompletionComputer
 
     private static void AddStructInstanceMembers(List<CompletionItem> items, HashSet<string> seen, StructSymbol structType)
     {
-        for (var current = structType; current != null; current = current.BaseClass)
-        {
-            foreach (var field in current.Fields)
-            {
-                AddItem(items, seen, field.Name, CompletionItemKind.Field, HoverComputer.FormatSymbol(field));
-            }
-
-            foreach (var property in current.Properties)
-            {
-                AddItem(items, seen, property.Name, CompletionItemKind.Property, $"{property.Name}: {property.Type?.Name}");
-            }
-
-            foreach (var method in current.Methods)
-            {
-                AddItem(items, seen, method.Name, CompletionItemKind.Method, HoverComputer.FormatSymbol(method));
-            }
-        }
+        // ADR-0112: enumerate instance members through the canonical layer.
+        // Events are intentionally excluded to preserve the historic completion
+        // set (fields, properties, methods only), walking the base chain.
+        AddStructMembersFromModel(items, seen, structType, MemberQuery.Instance(MemberKinds.Field | MemberKinds.Property | MemberKinds.Method));
     }
 
     private static void AddStructStaticMembers(List<CompletionItem> items, HashSet<string> seen, StructSymbol structType)
     {
-        foreach (var field in structType.StaticFields)
-        {
-            AddItem(items, seen, field.Name, CompletionItemKind.Field, HoverComputer.FormatSymbol(field));
-        }
+        // ADR-0112: static members through the canonical layer (no base-chain
+        // walk, fields/properties/methods only — matching historic behavior).
+        AddStructMembersFromModel(items, seen, structType, MemberQuery.Static(MemberKinds.Field | MemberKinds.Property | MemberKinds.Method));
+    }
 
-        foreach (var property in structType.StaticProperties)
+    private static void AddStructMembersFromModel(List<CompletionItem> items, HashSet<string> seen, StructSymbol structType, MemberQuery query)
+    {
+        foreach (var member in TypeMemberModel.EnumerateMembers(structType, query))
         {
-            AddItem(items, seen, property.Name, CompletionItemKind.Property, $"{property.Name}: {property.Type?.Name}");
-        }
-
-        foreach (var method in structType.StaticMethods)
-        {
-            AddItem(items, seen, method.Name, CompletionItemKind.Method, HoverComputer.FormatSymbol(method));
+            switch (member)
+            {
+                case FieldSymbol field:
+                    AddItem(items, seen, field.Name, CompletionItemKind.Field, HoverComputer.FormatSymbol(field));
+                    break;
+                case PropertySymbol property:
+                    AddItem(items, seen, property.Name, CompletionItemKind.Property, $"{property.Name}: {property.Type?.Name}");
+                    break;
+                case FunctionSymbol method:
+                    AddItem(items, seen, method.Name, CompletionItemKind.Method, HoverComputer.FormatSymbol(method));
+                    break;
+            }
         }
     }
 

--- a/src/LanguageServer/SemanticLookup.cs
+++ b/src/LanguageServer/SemanticLookup.cs
@@ -1652,34 +1652,8 @@ public static class SemanticLookup
 
         private static Symbol LookupMember(StructSymbol structSymbol, string memberName)
         {
-            for (var current = structSymbol; current != null; current = current.BaseClass)
-            {
-                var property = current.Properties.Concat(current.StaticProperties).FirstOrDefault(p => p.Name == memberName);
-                if (property != null)
-                {
-                    return property;
-                }
-
-                var field = current.Fields.Concat(current.StaticFields).FirstOrDefault(f => f.Name == memberName);
-                if (field != null)
-                {
-                    return field;
-                }
-
-                var evt = current.Events.Concat(current.StaticEvents).FirstOrDefault(e => e.Name == memberName);
-                if (evt != null)
-                {
-                    return evt;
-                }
-
-                var method = current.Methods.Concat(current.StaticMethods).FirstOrDefault(m => m.Name == memberName);
-                if (method != null)
-                {
-                    return method;
-                }
-            }
-
-            return null;
+            // ADR-0112: shared canonical member lookup (see TypeMemberModel).
+            return TypeMemberModel.LookupMember(structSymbol, memberName, MemberQuery.All);
         }
 
         private Symbol ResolveImplicitThisMember(SyntaxToken token)

--- a/test/Compiler.Tests/Emit/Adr0112UserMethodGroupEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Adr0112UserMethodGroupEmitTests.cs
@@ -1,0 +1,211 @@
+// <copyright file="Adr0112UserMethodGroupEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// ADR-0112 (unified member resolution): a user-defined type's <c>shared</c>
+/// (static) or instance method may be converted to a delegate via a method
+/// group — <c>Use(Box.Make)</c>, <c>Use(c.Get)</c>, and the bare implicit-this
+/// forms. Emit must produce verifiable IL: a static group binds a null
+/// delegate target (<c>ldnull; ldftn</c>), an instance group binds the receiver
+/// (boxing value-type receivers), and an rvalue receiver is spilled to a local
+/// by the slot planner so its address can be taken.
+/// </summary>
+public class Adr0112UserMethodGroupEmitTests
+{
+    [Fact]
+    public void StaticMethodGroup_ViaTypeName_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            class Box {
+                var tag int32
+                shared {
+                    func Make() Box { return Box{ tag: 7 } }
+                }
+            }
+
+            func Use(f () -> Box) int32 { return f().tag }
+
+            Console.WriteLine(Use(Box.Make))
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InstanceMethodGroup_ViaReceiver_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            class Counter {
+                var n int32
+                func Get() int32 { return n }
+            }
+
+            func Use(f () -> int32) int32 { return f() }
+
+            var c = Counter{ n: 42 }
+            Console.WriteLine(Use(c.Get))
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void BareSharedMethodGroup_InsideMethod_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            class Factory {
+                shared {
+                    func Make() int32 { return 5 }
+                }
+
+                func Build() int32 {
+                    var f () -> int32 = Make
+                    return f()
+                }
+            }
+
+            var fac = Factory{}
+            Console.WriteLine(fac.Build())
+            """;
+
+        Assert.Equal("5\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void BareInstanceMethodGroup_InsideMethod_CapturesThisAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            class Widget {
+                var value int32
+                func Read() int32 { return value }
+
+                func AsDelegate() int32 {
+                    var f () -> int32 = Read
+                    return f()
+                }
+            }
+
+            var w = Widget{ value: 9 }
+            Console.WriteLine(w.AsDelegate())
+            """;
+
+        Assert.Equal("9\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InstanceMethodGroup_RvalueReceiver_SpillsAndRuns()
+    {
+        // The receiver is the rvalue result of a call, so the slot planner must
+        // spill it into a local before the method-group emit can reference it.
+        var source = """
+            package P
+            import System
+
+            class Counter {
+                var n int32
+                func Get() int32 { return n }
+            }
+
+            func Make() Counter { return Counter{ n: 21 } }
+            func Use(f () -> int32) int32 { return f() }
+
+            Console.WriteLine(Use(Make().Get))
+            """;
+
+        Assert.Equal("21\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_adr0112_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+
+            // (a) Static verification: the emitted IL must be valid.
+            IlVerifier.Verify(outPath);
+
+            // (b) Dynamic verification: the emitted code must execute.
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/UserMethodGroupConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/UserMethodGroupConversionTests.cs
@@ -151,6 +151,33 @@ Use(a.Add)
         Assert.Equal(104, result.Value);
     }
 
+    [Fact]
+    public void SharedFactory_RegisteredAsDelegate_RunsThroughCollection()
+    {
+        // Faithful shape of the originally failing Oahu RootCommand pattern: a
+        // command type exposes a `shared` factory whose method group is handed to
+        // a registrar expecting a delegate, then invoked indirectly.
+        var result = Evaluate(@"
+package P
+
+class BuildCommand {
+    var name string
+    shared {
+        func Create() BuildCommand { return BuildCommand{ name: ""build"" } }
+    }
+}
+
+func Register(factory () -> BuildCommand) string {
+    var cmd = factory()
+    return cmd.name
+}
+
+Register(BuildCommand.Create)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("build", result.Value);
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/UserMethodGroupConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/UserMethodGroupConversionTests.cs
@@ -1,0 +1,160 @@
+// <copyright file="UserMethodGroupConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0112: converting a user-defined type's <c>shared</c> (static) or instance
+/// method to a delegate via a method group — the originally reported bug
+/// (<c>Use(Box.Make)</c> -> GS0158, <c>Use(Make)</c> -> GS0125). Covers
+/// <c>Type.M</c>, <c>expr.M</c>, bare implicit-<c>this</c>, bare shared, and
+/// overloaded selection driven by the target delegate signature.
+/// </summary>
+public class UserMethodGroupConversionTests
+{
+    [Fact]
+    public void StaticMethodGroup_ViaTypeName_BindsAndInvokes()
+    {
+        var result = Evaluate(@"
+package P
+
+class Box {
+    var tag int32
+    shared {
+        func Make() Box { return Box{ tag: 7 } }
+    }
+}
+
+func Use(f () -> Box) int32 { return f().tag }
+
+Use(Box.Make)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void InstanceMethodGroup_ViaReceiverExpression_CapturesReceiver()
+    {
+        var result = Evaluate(@"
+package P
+
+class Counter {
+    var n int32
+    func Get() int32 { return n }
+}
+
+func Use(f () -> int32) int32 { return f() }
+
+var c = Counter{ n: 42 }
+Use(c.Get)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void BareSharedMethodGroup_InsideMethod_Binds()
+    {
+        var result = Evaluate(@"
+package P
+
+class Factory {
+    shared {
+        func Make() int32 { return 5 }
+    }
+
+    func Build() int32 {
+        var f () -> int32 = Make
+        return f()
+    }
+}
+
+var fac = Factory{}
+fac.Build()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void BareInstanceMethodGroup_InsideMethod_CapturesThis()
+    {
+        var result = Evaluate(@"
+package P
+
+class Widget {
+    var value int32
+    func Read() int32 { return value }
+
+    func AsDelegate() int32 {
+        var f () -> int32 = Read
+        return f()
+    }
+}
+
+var w = Widget{ value: 9 }
+w.AsDelegate()
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(9, result.Value);
+    }
+
+    [Fact]
+    public void OverloadedStaticMethodGroup_SelectsByTargetSignature()
+    {
+        var result = Evaluate(@"
+package P
+
+class Maker {
+    shared {
+        func Make() int32 { return 1 }
+        func Make(x int32) int32 { return x + 1 }
+    }
+}
+
+func Use(f (int32) -> int32) int32 { return f(10) }
+
+Use(Maker.Make)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(11, result.Value);
+    }
+
+    [Fact]
+    public void OverloadedInstanceMethodGroup_SelectsByTargetSignature()
+    {
+        var result = Evaluate(@"
+package P
+
+class Adder {
+    var bias int32
+    func Add() int32 { return bias }
+    func Add(x int32) int32 { return bias + x }
+}
+
+func Use(f (int32) -> int32) int32 { return f(4) }
+
+var a = Adder{ bias: 100 }
+Use(a.Add)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(104, result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Symbols/TypeMemberModelTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/TypeMemberModelTests.cs
@@ -1,0 +1,192 @@
+// <copyright file="TypeMemberModelTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// ADR-0112 Phase 3: unit coverage for the canonical member-resolution layer
+/// (<see cref="TypeMemberModel"/>) — by-name lookup across kinds, the
+/// inheritance walk, static/instance filters, overload sets with signature
+/// dedup, and enumeration for completion.
+/// </summary>
+public class TypeMemberModelTests
+{
+    private const string Source = @"package P
+
+open class Base {
+    prop BaseProp int32
+    var baseField int32
+    func BaseMethod() int32 { return 1 }
+    func Shadowed() int32 { return 0 }
+}
+
+open class Animal : Base {
+    prop Name string
+    var legs int32
+    func Speak() string { return ""..."" }
+    func Speak(loud bool) string { return ""!"" }
+    func Shadowed() int32 { return 1 }
+
+    shared {
+        var Count int32
+        prop Kind string
+        func Make() Animal { return Animal{} }
+        func Make(name string) Animal { return Animal{} }
+    }
+}
+";
+
+    [Fact]
+    public void LookupMember_InstanceProperty_Found()
+    {
+        var animal = GetStruct("Animal");
+        var member = TypeMemberModel.LookupMember(animal, "Name", MemberQuery.All);
+        Assert.IsType<PropertySymbol>(member);
+    }
+
+    [Fact]
+    public void LookupMember_InheritedProperty_Found()
+    {
+        var animal = GetStruct("Animal");
+        var member = TypeMemberModel.LookupMember(animal, "BaseProp", MemberQuery.All);
+        Assert.IsType<PropertySymbol>(member);
+    }
+
+    [Fact]
+    public void LookupMember_StaticField_Found()
+    {
+        var animal = GetStruct("Animal");
+        var member = TypeMemberModel.LookupMember(animal, "Count", MemberQuery.All);
+        Assert.IsType<FieldSymbol>(member);
+    }
+
+    [Fact]
+    public void LookupMember_InstanceMethod_Found()
+    {
+        var animal = GetStruct("Animal");
+        var member = TypeMemberModel.LookupMember(animal, "Speak", MemberQuery.All);
+        Assert.IsType<FunctionSymbol>(member);
+    }
+
+    [Fact]
+    public void LookupMember_StaticOnlyQuery_DoesNotFindInstanceMember()
+    {
+        var animal = GetStruct("Animal");
+        var member = TypeMemberModel.LookupMember(animal, "Name", MemberQuery.Static());
+        Assert.Null(member);
+    }
+
+    [Fact]
+    public void LookupMember_InstanceOnlyQuery_DoesNotFindStaticMember()
+    {
+        var animal = GetStruct("Animal");
+        var member = TypeMemberModel.LookupMember(animal, "Count", MemberQuery.Instance());
+        Assert.Null(member);
+    }
+
+    [Fact]
+    public void LookupMember_NotInheritedQuery_DoesNotWalkBaseChain()
+    {
+        var animal = GetStruct("Animal");
+        var query = new MemberQuery(includeInstance: true, includeStatic: true, includeInherited: false, MemberKinds.All);
+        Assert.Null(TypeMemberModel.LookupMember(animal, "BaseProp", query));
+        Assert.NotNull(TypeMemberModel.LookupMember(animal, "Name", query));
+    }
+
+    [Fact]
+    public void GetMethods_InstanceOverloadSet_ReturnsAllOverloads()
+    {
+        var animal = GetStruct("Animal");
+        var methods = TypeMemberModel.GetMethods(animal, "Speak", MemberQuery.Instance());
+        Assert.Equal(2, methods.Length);
+        Assert.All(methods, m => Assert.Equal("Speak", m.Name));
+    }
+
+    [Fact]
+    public void GetMethods_StaticOverloadSet_ReturnsAllOverloads()
+    {
+        var animal = GetStruct("Animal");
+        var methods = TypeMemberModel.GetMethods(animal, "Make", MemberQuery.Static());
+        Assert.Equal(2, methods.Length);
+    }
+
+    [Fact]
+    public void GetMethods_InheritedMethod_Found()
+    {
+        var animal = GetStruct("Animal");
+        var methods = TypeMemberModel.GetMethods(animal, "BaseMethod", MemberQuery.Instance());
+        Assert.Single(methods);
+    }
+
+    [Fact]
+    public void GetMethods_ShadowedMethod_DedupedToSingleSignature()
+    {
+        var animal = GetStruct("Animal");
+        // Both Base and Animal declare `Shadowed() int32`; the derived one hides
+        // the base entry, so the overload set contains exactly one.
+        var methods = TypeMemberModel.GetMethods(animal, "Shadowed", MemberQuery.Instance());
+        Assert.Single(methods);
+    }
+
+    [Fact]
+    public void TryGetStaticField_Found()
+    {
+        var animal = GetStruct("Animal");
+        Assert.True(TypeMemberModel.TryGetStaticField(animal, "Count", out var field));
+        Assert.Equal("Count", field.Name);
+    }
+
+    [Fact]
+    public void TryGetProperty_WalksBaseChain()
+    {
+        var animal = GetStruct("Animal");
+        Assert.True(TypeMemberModel.TryGetProperty(animal, "BaseProp", out var prop));
+        Assert.Equal("BaseProp", prop.Name);
+    }
+
+    [Fact]
+    public void EnumerateMembers_Instance_IncludesInheritedFieldsPropertiesMethods()
+    {
+        var animal = GetStruct("Animal");
+        var names = TypeMemberModel.EnumerateMembers(animal, MemberQuery.Instance())
+            .Select(m => m.Name)
+            .ToHashSet();
+        Assert.Contains("Name", names);
+        Assert.Contains("Speak", names);
+        Assert.Contains("BaseProp", names);
+        Assert.Contains("BaseMethod", names);
+        Assert.DoesNotContain("Count", names); // static excluded
+    }
+
+    [Fact]
+    public void EnumerateMembers_Static_ExcludesInstanceAndBaseChain()
+    {
+        var animal = GetStruct("Animal");
+        var names = TypeMemberModel.EnumerateMembers(animal, MemberQuery.Static())
+            .Select(m => m.Name)
+            .ToHashSet();
+        Assert.Contains("Count", names);
+        Assert.Contains("Kind", names);
+        Assert.Contains("Make", names);
+        Assert.DoesNotContain("Name", names);
+        Assert.DoesNotContain("BaseProp", names);
+    }
+
+    private static StructSymbol GetStruct(string name)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(Source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Empty(result.Diagnostics);
+        return (StructSymbol)compilation.GlobalScope.Structs.Single(s => s.Name == name);
+    }
+}

--- a/test/LanguageServer.Tests/UnifiedMemberResolutionCharacterizationTests.cs
+++ b/test/LanguageServer.Tests/UnifiedMemberResolutionCharacterizationTests.cs
@@ -176,6 +176,46 @@ func Main() {
         Assert.Contains("Make", labels);
     }
 
+    [Fact]
+    public void HoverAndBinder_AgreeOnSharedMethodGroup()
+    {
+        // ADR-0112 unified resolution: the SAME shared method that hover resolves
+        // for documentation must also be accepted by the binder as a method-group
+        // delegate conversion. Previously hover succeeded while the binder
+        // reported GS0158/GS0125 because they used separate resolution code.
+        const string source = @"package P
+
+class Box {
+    var tag int32
+    shared {
+        func Make() Box { return Box{ tag: 7 } }
+    }
+}
+
+func Use(f () -> Box) int32 { return f().tag }
+
+func Main() {
+    var n = Use(Box.Make)
+}
+";
+        // Binder side: no diagnostics — the method group converts cleanly.
+        var (compilation, tree) = Compile(source);
+        var diagnostics = compilation.GlobalScope.Diagnostics;
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
+
+        // Hover side: hovering the `Make` reference resolves the member.
+        var content = LanguageServerTestHelpers.Content(source);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "Make", 1));
+        Assert.NotNull(hover);
+        Assert.Contains("Make", hover.Contents.ToString(), System.StringComparison.Ordinal);
+
+        // SemanticLookup side: the reference resolves to the shared FunctionSymbol.
+        var makeUse = IdentifierAt(tree, "Make", occurrence: 2);
+        var resolved = SemanticLookup.ResolveSymbol(compilation, makeUse);
+        var fn = Assert.IsType<FunctionSymbol>(resolved);
+        Assert.Equal("Make", fn.Name);
+    }
+
     private static (Compilation Compilation, SyntaxTree Tree) Compile(string source)
     {
         var tree = SyntaxTree.Parse(GSharp.Core.CodeAnalysis.Text.SourceText.From(source));

--- a/test/LanguageServer.Tests/UnifiedMemberResolutionCharacterizationTests.cs
+++ b/test/LanguageServer.Tests/UnifiedMemberResolutionCharacterizationTests.cs
@@ -1,0 +1,220 @@
+// <copyright file="UnifiedMemberResolutionCharacterizationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.LanguageServer.Protocol;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// ADR-0112 Phase 2 (characterization). Locks the *current* language-server
+/// member-resolution behavior for user-defined types BEFORE the unified
+/// member-resolution layer is introduced and the duplicated enumerations
+/// (HoverComputer.LookupMemberOnStruct, SemanticLookup.LookupMember /
+/// BuildModelUncached, CompletionComputer.AddStruct*Members, the hover
+/// overload counter) are migrated to it. These tests must stay green through
+/// the migration — they are the parity gate.
+/// </summary>
+public class UnifiedMemberResolutionCharacterizationTests
+{
+    // Representative user type: a class with instance + static members of every
+    // kind, an inheritance chain, and an overloaded instance + static method.
+    private const string Sample = @"package P
+
+open class Base {
+    prop BaseProp int32
+    var baseField int32
+    func BaseMethod() int32 { return 1 }
+}
+
+open class Animal : Base {
+    prop Name string
+    var legs int32
+    func Speak() string { return ""..."" }
+    func Speak(loud bool) string { return ""!"" }
+
+    shared {
+        var Count int32
+        prop Kind string
+        func Make() Animal { return Animal{} }
+        func Make(name string) Animal { return Animal{} }
+    }
+}
+
+func Main() {
+    var a = Animal{}
+    var n = a.Name
+    var s = a.Speak()
+    var b = a.BaseProp
+    var c = Animal.Count
+}
+";
+
+    [Fact]
+    public void Hover_InstanceMethod_Overloaded_ShowsOverloadCount()
+    {
+        var content = LanguageServerTestHelpers.Content(Sample);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(Sample, "Speak", 2));
+
+        Assert.NotNull(hover);
+        var text = hover.Contents.ToString();
+        Assert.Contains("Speak", text, System.StringComparison.Ordinal);
+        Assert.Contains("overload", text, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Hover_StaticMethod_Overloaded_ShowsOverloadCount()
+    {
+        var content = LanguageServerTestHelpers.Content(Sample);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(Sample, "Count", 1));
+
+        Assert.NotNull(hover);
+        // `Count` is the static field used as `Animal.Count`.
+        Assert.Contains("Count", hover.Contents.ToString(), System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Hover_InheritedProperty_ResolvesThroughBaseChain()
+    {
+        var content = LanguageServerTestHelpers.Content(Sample);
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(Sample, "BaseProp", 1));
+
+        Assert.NotNull(hover);
+        Assert.Contains("BaseProp", hover.Contents.ToString(), System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SemanticLookup_InstanceMember_Resolves()
+    {
+        var (compilation, tree) = Compile(Sample);
+        var nameUse = IdentifierAt(tree, "Name", occurrence: 2);
+        var resolved = SemanticLookup.ResolveSymbol(compilation, nameUse);
+        Assert.IsType<PropertySymbol>(resolved);
+    }
+
+    [Fact]
+    public void SemanticLookup_InheritedMember_Resolves()
+    {
+        var (compilation, tree) = Compile(Sample);
+        var baseUse = IdentifierAt(tree, "BaseProp", occurrence: 2);
+        var resolved = SemanticLookup.ResolveSymbol(compilation, baseUse);
+        Assert.IsType<PropertySymbol>(resolved);
+    }
+
+    [Fact]
+    public void SemanticLookup_StaticField_Resolves()
+    {
+        var (compilation, tree) = Compile(Sample);
+        var countUse = IdentifierAt(tree, "Count", occurrence: 2);
+        var resolved = SemanticLookup.ResolveSymbol(compilation, countUse);
+        Assert.IsType<FieldSymbol>(resolved);
+    }
+
+    [Fact]
+    public void Completion_InstanceReceiver_ListsInstanceMembersIncludingInherited()
+    {
+        const string source = @"package P
+
+open class Base {
+    prop BaseProp int32
+    func BaseMethod() int32 { return 1 }
+}
+
+class Animal : Base {
+    prop Name string
+    func Speak() string { return ""..."" }
+}
+
+func Main() {
+    var a = Animal{}
+    a.
+}
+";
+        var content = LanguageServerTestHelpers.Content(source);
+        var dotPos = LanguageServerTestHelpers.PositionOf(source, "a.", 0);
+        var completion = CompletionComputer.ComputeCompletions(
+            content,
+            new Position(dotPos.Line, dotPos.Character + "a.".Length));
+
+        var labels = completion.Select(i => i.Label).ToHashSet();
+        Assert.Contains("Name", labels);
+        Assert.Contains("Speak", labels);
+        Assert.Contains("BaseProp", labels);
+        Assert.Contains("BaseMethod", labels);
+    }
+
+    [Fact]
+    public void Completion_StaticReceiver_ListsStaticMembers()
+    {
+        const string source = @"package P
+
+class Animal {
+    prop Name string
+    shared {
+        var Count int32
+        func Make() Animal { return Animal{} }
+    }
+}
+
+func Main() {
+    var x = Animal.
+}
+";
+        var content = LanguageServerTestHelpers.Content(source);
+        var dotPos = LanguageServerTestHelpers.PositionOf(source, "Animal.", 0);
+        var completion = CompletionComputer.ComputeCompletions(
+            content,
+            new Position(dotPos.Line, dotPos.Character + "Animal.".Length));
+
+        var labels = completion.Select(i => i.Label).ToHashSet();
+        Assert.Contains("Count", labels);
+        Assert.Contains("Make", labels);
+    }
+
+    private static (Compilation Compilation, SyntaxTree Tree) Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(GSharp.Core.CodeAnalysis.Text.SourceText.From(source));
+        return (new Compilation(tree), tree);
+    }
+
+    private static SyntaxToken IdentifierAt(SyntaxTree tree, string text, int occurrence)
+    {
+        var seen = 0;
+        foreach (var token in EnumerateTokens(tree.Root))
+        {
+            if (token.Kind == SyntaxKind.IdentifierToken && token.Text == text)
+            {
+                seen++;
+                if (seen == occurrence)
+                {
+                    return token;
+                }
+            }
+        }
+
+        Assert.Fail($"Not enough '{text}' identifiers (wanted {occurrence}).");
+        return null;
+    }
+
+    private static System.Collections.Generic.IEnumerable<SyntaxToken> EnumerateTokens(SyntaxNode node)
+    {
+        if (node is SyntaxToken token)
+        {
+            yield return token;
+            yield break;
+        }
+
+        foreach (var child in node.GetChildren())
+        {
+            foreach (var inner in EnumerateTokens(child))
+            {
+                yield return inner;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Unifies type-member resolution across the binder and the language server behind a single canonical layer (`TypeMemberModel`), eliminating the divergence where the language server could resolve a user type's `shared`/instance method (hover worked) but the binder could not use it as a method-group argument.

Originally reported: a `shared`/instance method of a user G# class/struct could not be passed as a method group converted to a delegate. `Use(Box.Make)` produced `GS0158: Cannot find member Make` and `Use(Make)` produced `GS0125: Variable 'Make' doesn't exist`, while hover correctly resolved the symbol. Root cause: the binder and language server used separate, duplicated member-enumeration code paths. Implements **Option C (broad scope)** per ADR-0112.

## What changed

- **ADR-0112** — `docs/adr/0112-unified-member-resolution.md`: the unified member-resolution model and method-group semantics for user-type members.
- **Canonical layer** — `TypeMemberModel` (`src/Core/CodeAnalysis/Symbols/`): a pure, `BinderContext`-free member-resolution facade over `StructSymbol` (class + struct), `InterfaceSymbol`, and `EnumSymbol`. By-name lookup and full enumeration across fields, properties, events, methods, and nested types; instance + static; inheritance walk; signature dedup. Returns existing `Symbol` instances (no new symbol model). Supporting `MemberQuery`/`MemberKinds`.
- **Language server migrated** — `HoverComputer` (`LookupMemberOnStruct`, completion member enumeration) and `SemanticLookup` (`SemanticModel.LookupMember`) now consume `TypeMemberModel`; duplicated enumerations removed.
- **Binder migrated** — user-type member access (`ExpressionBinder.Access.cs`, `ExpressionBinder.cs`) routes through the layer.
- **Method groups (first consumer / bug fix)** — user-type static (`Type.M`, bare `M`) and instance (`expr.M`, implicit-this `M`) methods now form method groups and convert to delegates. Also fixes two latent gaps that affected free functions too: a premature undefined-variable diagnostic that pre-empted the method-group fallback, and multi-candidate method groups passed directly as call arguments not being routed through overload-driven conversion (`OverloadResolver`).
- **Emit** — `SlotPlanner` `ReceiverSpillCollector` now spills rvalue receivers for user instance method groups; `EmitMethodGroup` already supported null and instance receivers.

## Validation

- Release build: 0 warnings, 0 errors.
- Original failing scenario (qualified static, bare static, implicit-this instance forms) now compiles and emits verifiable IL (ilverify passes).
- Tests: new `TypeMemberModelTests`, `UserMethodGroupConversionTests`, `UnifiedMemberResolutionCharacterizationTests` (LS parity), `Adr0112UserMethodGroupEmitTests`. Full suites green — Core 3395, LanguageServer 363, Compiler 1394, Interpreter 308, Extensions 104.

## Scope notes (intentional, per plan)

- Value-type struct receiver-clause method groups are an orthogonal language area (ADR-0079) and are not covered here.
- CLR/imported member reflection in `MemberLookup` was not consolidated into `TypeMemberModel` (explicitly deferred).
- `SemanticLookup.BuildModelUncached` declaration-identifier mapping was intentionally not migrated (it is not a by-name lookup; migrating adds risk with no parity benefit).
