### PR TITLE
Spill sub-expression awaits nested inside try/using bodies

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -98,6 +98,9 @@ public static class SpillSequenceSpiller
                 case BoundIfStatement ifStmt:
                     return RewriteIfStatement(ifStmt, builder);
 
+                case BoundTryStatement tryStmt:
+                    return RewriteTryStatement(tryStmt, builder);
+
                 case BoundBlockStatement nested:
                     var rewritten = RewriteBlock(nested);
                     builder.Add(rewritten);
@@ -111,7 +114,6 @@ public static class SpillSequenceSpiller
                 case BoundGotoStatement:
                 case BoundConditionalGotoStatement:
                 case BoundThrowStatement:
-                case BoundTryStatement:
                 case BoundScopeStatement:
                 case BoundChannelSendStatement:
                 case BoundGoStatement:
@@ -236,6 +238,78 @@ public static class SpillSequenceSpiller
 
             builder.Add(new BoundIfStatement(null, condition, thenStmt, elseStmt));
             return true;
+        }
+
+        /// <summary>
+        /// Spills sub-expression awaits nested inside a <see cref="BoundTryStatement"/>'s
+        /// protected block (and, defensively, its handler/finally blocks). Awaits in the
+        /// try body are legal suspension points that <see cref="MoveNextBodyRewriter"/>
+        /// handles once they sit at statement top-level, but they only reach that form
+        /// if the spiller descends into the try region. Treating the try as an opaque
+        /// await-free leaf (the prior behaviour) left a sub-expression await such as
+        /// <c>F(await G())</c> unspilled, leaking a <see cref="BoundAwaitExpression"/>
+        /// into the emitted MoveNext body.
+        /// </summary>
+        private bool RewriteTryStatement(BoundTryStatement tryStmt, ImmutableArray<BoundStatement>.Builder builder)
+        {
+            var tryBlock = RewriteNestedBody(tryStmt.TryBlock, out var tryChanged);
+
+            var catchesChanged = false;
+            var catchBuilder = ImmutableArray.CreateBuilder<BoundCatchClause>(tryStmt.CatchClauses.Length);
+            foreach (var clause in tryStmt.CatchClauses)
+            {
+                var body = RewriteNestedBody(clause.Body, out var clauseChanged);
+                catchesChanged |= clauseChanged;
+                catchBuilder.Add(clauseChanged
+                    ? new BoundCatchClause(clause.ExceptionType, clause.Variable, body)
+                    : clause);
+            }
+
+            var finallyBlock = RewriteNestedBody(tryStmt.FinallyBlock, out var finallyChanged);
+
+            if (!tryChanged && !catchesChanged && !finallyChanged)
+            {
+                builder.Add(tryStmt);
+                return false;
+            }
+
+            builder.Add(new BoundTryStatement(
+                tryStmt.Syntax,
+                tryBlock,
+                catchesChanged ? catchBuilder.ToImmutable() : tryStmt.CatchClauses,
+                finallyBlock));
+            return true;
+        }
+
+        /// <summary>
+        /// Spills a try/catch/finally sub-block. Returns the rewritten body and
+        /// reports whether anything changed.
+        /// </summary>
+        private BoundStatement RewriteNestedBody(BoundStatement body, out bool changed)
+        {
+            if (body == null)
+            {
+                changed = false;
+                return null;
+            }
+
+            if (body is BoundBlockStatement block)
+            {
+                var rewritten = RewriteBlock(block);
+                changed = !ReferenceEquals(rewritten, block);
+                return rewritten;
+            }
+
+            var nestedBuilder = ImmutableArray.CreateBuilder<BoundStatement>();
+            changed = RewriteStatementToList(body, nestedBuilder);
+            if (!changed)
+            {
+                return body;
+            }
+
+            return nestedBuilder.Count == 1
+                ? nestedBuilder[0]
+                : new BoundBlockStatement(body.Syntax, nestedBuilder.ToImmutable());
         }
 
         /// <summary>

--- a/test/Compiler.Tests/Emit/AsyncSpilledAwaitInTryEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AsyncSpilledAwaitInTryEmitTests.cs
@@ -1,0 +1,164 @@
+// <copyright file="AsyncSpilledAwaitInTryEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Regression tests for a spilled <c>await</c> (an await appearing as a
+/// sub-expression, e.g. a call argument) nested inside a <c>try</c> region —
+/// including the <c>try</c>/<c>finally</c> that <c>using</c> lowers to.
+/// <para>The <see cref="GSharp.Core.CodeAnalysis.Lowering.Async.SpillSequenceSpiller"/>
+/// previously treated <c>BoundTryStatement</c> as an await-free leaf and never
+/// descended into the protected block, so an await such as <c>F(await G())</c>
+/// inside a <c>try</c>/<c>using</c> body was never lifted to statement
+/// top-level. That left a raw <c>BoundAwaitExpression</c> in the synthesized
+/// <c>MoveNext()</c> body, which the emitter rejected with
+/// <c>GS9998: Bound expression kind 'AwaitExpression' is not yet supported by
+/// the emitter.</c> These tests assert the program now emits, verifies, and
+/// runs to the correct result.</para>
+/// </summary>
+public class AsyncSpilledAwaitInTryEmitTests
+{
+    [Fact]
+    public void Spilled_Await_Inside_Using_Block_Emits_And_Runs()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            class Probe : IDisposable {
+                init() {}
+                func Dispose() {}
+            }
+
+            func AddAsync(a int32, b int32) Task[int32] {
+                return Task.FromResult(a + b)
+            }
+
+            func Sum(a int32, b int32) int32 {
+                return a + b
+            }
+
+            async func Compute() int32 {
+                var total = 0
+                using let p = Probe()
+                total = Sum(await AddAsync(1, 2), await AddAsync(3, 4))
+                return total
+            }
+
+            public var result = 0
+            result = Compute().Result
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetType("<Program>") ?? FindProgram(assembly);
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField("result", BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        Assert.Equal(10, (int)resultField!.GetValue(null)!);
+    }
+
+    [Fact]
+    public void Spilled_Await_Inside_TryCatch_Emits_And_Runs()
+    {
+        var source = """
+            package P
+
+            import System
+            import System.Threading.Tasks
+
+            func ValueAsync(n int32) Task[int32] {
+                return Task.FromResult(n)
+            }
+
+            func Sum(a int32, b int32) int32 {
+                return a + b
+            }
+
+            async func Compute() int32 {
+                var total = 0
+                try {
+                    total = Sum(await ValueAsync(40), await ValueAsync(2))
+                } catch (e Exception) {
+                    total = -1
+                }
+                return total
+            }
+
+            public var result = 0
+            result = Compute().Result
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = FindProgram(assembly);
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField("result", BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        Assert.Equal(42, (int)resultField!.GetValue(null)!);
+    }
+
+    private static Type FindProgram(Assembly assembly)
+    {
+        foreach (var t in assembly.GetTypes())
+        {
+            if (t.Name == "<Program>")
+            {
+                return t;
+            }
+        }
+
+        throw new InvalidOperationException("No <Program> type found.");
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_async_spill_try_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/SpillSequenceSpillerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/SpillSequenceSpillerTests.cs
@@ -397,6 +397,55 @@ public class SpillSequenceSpillerTests
         Assert.True(spillCount >= 2, $"Expected at least 2 spill temps but got {spillCount}.");
     }
 
+    [Fact]
+    public void Spilled_Await_Inside_Try_Block_Is_Spilled()
+    {
+        // Arrange: try { f(sideEffect(), await task) }
+        // The spiller must descend into the protected block and lift the
+        // sub-expression await to statement top-level. Previously the try was
+        // treated as an await-free leaf, leaving the raw await for the emitter.
+        var arg0 = MakeCall("sideEffect", TypeSymbol.Int32);
+        var arg1 = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int32);
+        var call = new BoundCallExpression(
+            null,
+            MakeFunction("f", TypeSymbol.Int32, TypeSymbol.Int32, TypeSymbol.Int32),
+            ImmutableArray.Create<BoundExpression>(arg0, arg1));
+        var tryBlock = new BoundBlockStatement(
+            null,
+            ImmutableArray.Create<BoundStatement>(new BoundExpressionStatement(null, call)));
+        var tryStmt = new BoundTryStatement(
+            null,
+            tryBlock,
+            ImmutableArray<BoundCatchClause>.Empty,
+            null);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
+
+        // Act
+        var result = SpillSequenceSpiller.Rewrite(body);
+
+        // Assert: the try block body is rewritten with spill temps; no
+        // sub-expression await survives below statement level.
+        Assert.NotSame(body, result);
+        var rewrittenTry = Assert.IsType<BoundTryStatement>(result.Statements[0]);
+        var rewrittenBlock = Assert.IsType<BoundBlockStatement>(rewrittenTry.TryBlock);
+        Assert.True(
+            rewrittenBlock.Statements.Length >= 2,
+            "Expected spill statements inside the try block.");
+
+        var hasSpillTemp = false;
+        foreach (var s in rewrittenBlock.Statements)
+        {
+            if (s is BoundVariableDeclaration d
+                && d.Variable.Name.StartsWith(GeneratedNames.SpillTempPrefix))
+            {
+                hasSpillTemp = true;
+                break;
+            }
+        }
+
+        Assert.True(hasSpillTemp, "Expected a spill temp declaration inside the try block.");
+    }
+
     private static BoundCallExpression MakeCall(string name, TypeSymbol returnType)
     {
         var func = new FunctionSymbol(


### PR DESCRIPTION
## Summary

Fixes an emit failure where an `async` method containing a **spilled `await`** (an `await` used as a sub-expression, e.g. a call argument) **inside a `try` region** — including the try/finally that `using` and `defer` lower to — failed to compile with:

```
error GS9998: EmitDiagnosticException: Bound expression kind 'AwaitExpression' is not yet supported by the emitter.
```

### Root cause

`SpillSequenceSpiller` listed `BoundTryStatement` as an await-free **leaf** and never descended into the protected block. `AsyncExceptionHandlerRewriter` only lifts awaits out of **catch/finally** handlers, not sub-expression awaits in the **try body**. So a spilled await such as `F(await G())` inside a `try`/`using` body was never lifted to statement top-level, leaving a raw `BoundAwaitExpression` in the synthesized `MoveNext()` body, which the emitter rejects.

Because the leaked await is a synthesized node with **null syntax**, the diagnostic location defaults to `(1,1,1,1)` of the *first* source tree — which misleadingly points at an unrelated file (this is what made it look like a cross-file bug).

### Behavior matrix (confirmed by bisection)

| Case | Before |
| --- | --- |
| `await` as a statement inside `try` | OK |
| spilled `await` **not** in a `try` | OK |
| spilled `await` **inside** `try`/`using`/`catch` | **GS9998** |

### Fix

`SpillSequenceSpiller` now descends into `BoundTryStatement`, spilling the try block (and, for completeness, catch/finally bodies) so nested awaits reach statement top-level where `MoveNextBodyRewriter` already handles them.

## Tests

- **`SpillSequenceSpillerTests`** — unit test asserting the spiller descends into try blocks and emits a spill temp inside the protected region.
- **`AsyncSpilledAwaitInTryEmitTests`** — emit + ilverify + run coverage for a spilled await inside `using` (result 10) and inside `try`/`catch` (result 42).

All async / spill / try / using / iterator tests pass locally (68 + 99 + 53 + 14 existing, plus 2 new emit tests).

### Repro (minimal)

```gsharp
async func W() {
    using let t = TempDir()
    Eq("s3cret", await GetAsync("alice"))   // spilled await inside using (=try/finally)
}
```