### PR TITLE
Fix #919: resolve lowercase primitive aliases (e.g. string.Empty) as static-member receivers

### DIFF
--- a/docs/adr/0113-predefined-alias-static-member-receiver.md
+++ b/docs/adr/0113-predefined-alias-static-member-receiver.md
@@ -1,0 +1,80 @@
+# ADR-0113: Predefined type aliases as static-member-access receivers
+
+- **Status**: Accepted
+- **Date**: 2026-06-21
+- **Phase**: Phase 8 — naming polish
+- **Closes**: Issue #919 (`string.Empty` doesn't resolve as expected)
+- **Related**: ADR-0098 (friendly numeric type aliases); ADR-0044 (numeric primitive coverage); ADR-0112 (unified member resolution)
+
+## Context
+
+G# spells the built-in value and reference primitives with lowercase
+keyword aliases — `string`, `bool`, `char`, `object`, the width-bearing
+numeric names (`int32`, `uint8`, `float64`, …), and the friendly numeric
+aliases added by ADR-0098 (`int`, `long`, `byte`, …). In every
+**type-clause** position these names resolve to the canonical
+`TypeSymbol` (and the underlying CLR type) through `Binder.LookupType`.
+
+However, when one of these names appeared as the **receiver of a static
+member access** — for example `string.Empty` or `int32.MaxValue` — the
+expression binder failed to resolve it. The accessor binder's left-name
+resolution only consulted imports, imported classes, user type aliases,
+and generic type parameters; the predefined keyword aliases are none of
+those, so binding fell through to the "cannot find type" path:
+
+```
+error GS0159: Cannot find function FromResult.
+error GS0157: Cannot find type string. Are you missing an import?
+```
+
+The capitalized BCL spelling (`String.Empty`, `Int32.MaxValue`) worked,
+because `String` resolves as an imported CLR class via `import System`.
+This left an inconsistency: the same type was a valid static-access
+receiver under its CLR name but not under its canonical G# keyword name.
+
+## Decision
+
+A predefined primitive type alias is a valid receiver for static member
+access and binds identically to the equivalent CLR-named type.
+
+In the accessor binder's left-name resolution, after the import / alias /
+type-parameter lookups fail, the receiver name is resolved through the
+same `LookupType` path used by type clauses. When it maps to a predefined
+primitive `TypeSymbol` with a backing CLR type, an `ImportedClassSymbol`
+over that CLR type is created and the right-hand member is bound against
+it — the exact mechanism the capitalized form already uses.
+
+This makes the following forms resolve consistently, with or without
+`import System`:
+
+| Form                | Underlying CLR type | Notes                          |
+| ------------------- | ------------------- | ------------------------------ |
+| `string.Empty`      | `System.String`     | static field                   |
+| `int32.MaxValue`    | `System.Int32`      | canonical width-bearing alias  |
+| `int.MaxValue`      | `System.Int32`      | friendly alias (ADR-0098)      |
+| `object.ReferenceEquals(a, b)` | `System.Object` | static method            |
+
+### Scope and ordering
+
+- The predefined-alias resolution runs **only after** the import,
+  imported-class, and user-type-alias lookups have failed. Because the
+  primitive keyword aliases are reserved names that cannot be redeclared
+  (`Binder.IsPrimitiveTypeName`), this fallback never shadows a
+  user-declared alias or an imported type.
+- `void` is excluded: it has a CLR type but is meaningless as a
+  static-access receiver, so the ordinary "cannot find type" diagnostic
+  still applies.
+- User struct/enum aliases (which have a null `ClrType`) are unaffected;
+  they continue to bind through their existing static-access paths.
+
+## Consequences
+
+- `string.Empty` and the other predefined aliases now resolve as
+  static-member-access receivers, matching the capitalized CLR spelling
+  and the type-clause behavior of the same names.
+- No new syntax or language rule is introduced; this aligns expression
+  binding with the already-documented alias resolution. Diagnostics,
+  `typeof`, `nameof`, hover, and IL continue to use the canonical name.
+- The fix is purely additive in the binder. No emitter or runtime change
+  is required: the resulting bound tree is identical to what the
+  capitalized form produced.

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -647,6 +647,16 @@ internal sealed partial class ExpressionBinder
                 // the constraint interface's static-virtual table.
                 return BindTypeParameterStaticAccessorStep(tpSym, leftName, rightPart);
             }
+            else if (TryResolvePredefinedTypeReceiver(name, leftName, out var predefinedClass))
+            {
+                // Issue #919: a lowercase predefined primitive type alias used as
+                // the receiver of a static member access (e.g. `string.Empty`,
+                // `int32.MaxValue`). The earlier import/alias lookups only match
+                // the capitalized CLR name (`String`, `Int32`); the keyword form
+                // is resolved here to the same underlying CLR type so static
+                // member access binds identically to the capitalized form.
+                classSymbol = predefinedClass;
+            }
             else
             {
                 Diagnostics.ReportUnableToFindType(leftName.Location, name);
@@ -669,6 +679,46 @@ internal sealed partial class ExpressionBinder
         }
 
         return BindAccessorStep(receiver, classSymbol, rightPart);
+    }
+
+    /// <summary>
+    /// Issue #919: resolves a lowercase predefined primitive type alias used as
+    /// the receiver of a static member access (e.g. <c>string.Empty</c>,
+    /// <c>int32.MaxValue</c>, <c>object.ReferenceEquals(...)</c>) to an
+    /// <see cref="ImportedClassSymbol"/> over its underlying CLR type.
+    /// </summary>
+    /// <remarks>
+    /// This runs only after the import/alias/imported-class lookups have failed,
+    /// so it never shadows a user alias or an imported type. The keyword aliases
+    /// (<c>string</c>, <c>int32</c>, <c>bool</c>, ...) are reserved names that
+    /// cannot be redeclared, so resolving them here is unambiguous and mirrors
+    /// the capitalized CLR-name form (<c>String</c>, <c>Int32</c>) that already
+    /// binds through <see cref="BoundScope.TryLookupImportedClass"/>.
+    /// </remarks>
+    /// <param name="name">The identifier text written as the accessor receiver.</param>
+    /// <param name="declaration">The receiver name syntax (for symbol provenance).</param>
+    /// <param name="classSymbol">The resolved CLR class symbol on success.</param>
+    /// <returns><see langword="true"/> when <paramref name="name"/> is a predefined primitive alias with a backing CLR type.</returns>
+    private bool TryResolvePredefinedTypeReceiver(string name, ExpressionSyntax declaration, out ImportedClassSymbol classSymbol)
+    {
+        classSymbol = null;
+
+        var typeSymbol = lookupType(name);
+
+        // Only genuine predefined primitive aliases carry a non-null ClrType and
+        // are not already handled by an earlier branch. User struct/enum aliases
+        // (resolved by TryLookupTypeAlias) have a null ClrType and are excluded.
+        // `void` has a CLR type but is meaningless as a static-access receiver, so
+        // exclude it and let the normal "cannot find type" diagnostic apply.
+        if (typeSymbol == null
+            || typeSymbol.ClrType == null
+            || ReferenceEquals(typeSymbol, TypeSymbol.Void))
+        {
+            return false;
+        }
+
+        classSymbol = new ImportedClassSymbol(typeSymbol.ClrType, declaration);
+        return true;
     }
 
     private BoundExpression BindNullConditionalAccessExpression(AccessorExpressionSyntax syntax)

--- a/test/Compiler.Tests/Emit/ClrInteropEmitTests.cs
+++ b/test/Compiler.Tests/Emit/ClrInteropEmitTests.cs
@@ -165,6 +165,27 @@ public class ClrInteropEmitTests
         Assert.Contains("RepeatIterator", output);
     }
 
+    [Fact]
+    public void LowercasePrimitiveAlias_StaticMemberAccess_EmitsAndRuns()
+    {
+        // Issue #919: `string.Empty` and `int32.MaxValue` (lowercase predefined
+        // aliases as static-member-access receivers) must compile and run with
+        // the same behavior as the capitalized `String.Empty` / `Int32.MaxValue`
+        // forms — and without requiring `import System`.
+        var source = """
+            package P
+            import System
+
+            let empty = string.Empty
+            Console.WriteLine(empty.Length)
+            Console.WriteLine(int32.MaxValue)
+            Console.WriteLine(int.MaxValue)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n2147483647\n2147483647\n", output);
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_clr_emit_").FullName;

--- a/test/Core.Tests/CodeAnalysis/Binding/ClrMemberAccessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClrMemberAccessTests.cs
@@ -131,6 +131,59 @@ var e = String.Empty
     }
 
     [Fact]
+    public void StringEmpty_LowercaseAlias_Binds()
+    {
+        // Issue #919: the lowercase `string` predefined alias must resolve as a
+        // static-member-access receiver identically to the capitalized `String`
+        // form — and without requiring `import System`, since `string` is a
+        // built-in keyword alias for System.String.
+        var source = @"
+var e = string.Empty
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(string.Empty, result.Value);
+    }
+
+    [Fact]
+    public void Int32MaxValue_LowercaseAlias_Binds()
+    {
+        // Issue #919: the same fix applies to the other lowercase primitive
+        // aliases. `int32.MaxValue` must bind like `Int32.MaxValue`.
+        var source = @"
+var m = int32.MaxValue
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(int.MaxValue, result.Value);
+    }
+
+    [Fact]
+    public void IntFriendlyAliasMaxValue_Binds()
+    {
+        // Issue #919 / ADR-0098: friendly numeric aliases (`int`) route to the
+        // same canonical CLR type, so static member access binds too.
+        var source = @"
+var m = int.MaxValue
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(int.MaxValue, result.Value);
+    }
+
+    [Fact]
+    public void StringEmpty_LowercaseAlias_UnknownMember_Diagnoses()
+    {
+        // The lowercase alias receiver still reports unknown members rather than
+        // silently binding.
+        var source = @"
+var e = string.NotAReal
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
     public void StaticProperty_UnknownMember_Diagnoses()
     {
         var source = @"


### PR DESCRIPTION
Fixes #919

## Root cause

Using a lowercase predefined primitive alias as the receiver of a static
member access — e.g. `string.Empty` or `int32.MaxValue` — failed to bind:

```
error GS0159: Cannot find function FromResult.
error GS0157: Cannot find type string. Are you missing an import?
```

The accessor binder's left-name resolution in `ExpressionBinder.Access.cs`
only consulted imports, imported CLR classes, user type aliases, and generic
type parameters. The predefined keyword aliases (`string`, `bool`, `char`,
`object`, the width-bearing numeric names, and the ADR-0098 friendly
aliases) are none of those, so binding fell through to the "cannot find
type" diagnostic. The capitalized BCL spelling (`String.Empty`,
`Int32.MaxValue`) worked only because `String` resolves as an imported CLR
class via `import System`.

## Fix

After the existing import/alias/type-parameter lookups fail, resolve the
receiver name through the same `LookupType` path used by type clauses. When
it maps to a predefined primitive `TypeSymbol` with a backing CLR type, wrap
that CLR type in an `ImportedClassSymbol` and bind the right-hand member
against it — the exact mechanism the capitalized form already uses. This is
purely additive in the binder; the resulting bound tree (and emitted IL) is
identical to the capitalized form.

Scope/ordering safeguards:
- Runs only after import/imported-class/user-alias lookups fail. Primitive
  keyword aliases are reserved and cannot be shadowed, so this never shadows
  a user alias or imported type.
- `void` is excluded (meaningless as a static-access receiver).
- User struct/enum aliases (null `ClrType`) are unaffected.

Now `string.Empty`, `int32.MaxValue`, `int.MaxValue`, and
`object.ReferenceEquals(...)` all resolve consistently, with or without
`import System`.

## Files changed
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs` — new
  `TryResolvePredefinedTypeReceiver` fallback in accessor left-name
  resolution.
- `test/Core.Tests/CodeAnalysis/Binding/ClrMemberAccessTests.cs` — binding
  tests for `string.Empty`, `int32.MaxValue`, `int.MaxValue`, and an
  unknown-member negative case.
- `test/Compiler.Tests/Emit/ClrInteropEmitTests.cs` — emit-parity test.
- `docs/adr/0113-predefined-alias-static-member-receiver.md` — ADR.

## Validation
- `dotnet build GSharp.sln -c Release -graph` — succeeded, 0 warnings/errors.
- `dotnet test test/Core.Tests --filter CodeAnalysis.Binding` — 1818 passed.
- `dotnet test test/Compiler.Tests --filter ClrInteropEmitTests -- xUnit.MaxParallelThreads=2` — 8 passed.
