### PR TITLE
fix(emit): nested classes with init() constructors now emit .ctor (#920)

### DIFF
--- a/docs/adr/0114-nested-class-constructor-emission.md
+++ b/docs/adr/0114-nested-class-constructor-emission.md
@@ -1,0 +1,123 @@
+# ADR-0114: Nested (and forward-referenced) class constructor emission
+
+- **Status**: Accepted
+- **Date**: 2026-06-21
+- **Phase**: Phase 5 — generics & dogfooded core
+- **Closes**: Issue #920 (inner/nested classes don't appear to emit `.ctor`)
+- **Related**: ADR-0110 (nested type declarations); ADR-0063 §9 (`init(...)` overloads); ADR-0065 §5 (synthesized primary ctor); #306 (base-constructor initializer); #503/#523 (closure / capture-box ctor pre-registration)
+
+## Context
+
+ADR-0110 made user-declared nested types (`class` / `struct` /
+`interface` / `enum` inside a `class` or `struct` body) flow through the
+binder and emitter as real CLR nested `TypeDef`s. Construction of a
+nested type with the implicit/default constructor worked. But a nested
+**class** that declared an explicit `init()` constructor failed to emit:
+
+```gsharp
+class Outer {
+    class CBRecordingBroker : IAuthCallbackBroker {
+        prop MfaAnswer string
+        init() { MfaAnswer = "000000" }
+    }
+
+    func Make() {
+        var bb = CBRecordingBroker() { MfaAnswer = "987654" }  // GS9998
+    }
+}
+```
+
+```
+error GS9998: InvalidOperationException:
+  Type 'CBRecordingBroker' has no emitted primary ctor.
+```
+
+### Root cause
+
+The emitter resolves a `newobj` site (`EmitConstructorCall`) by looking
+up the constructed type's ctor handle in one of three caches:
+`ExplicitCtorHandles` (keyed by the selected `init` overload),
+`ClassPrimaryCtorHandles`, or `ClassCtorHandles` (keyed by the
+`StructSymbol`). Those caches are populated **while a class's method
+bodies are emitted** (`EmitClassMethodBodies`), which records the ctor
+handle *before* the class's own methods.
+
+To survive a construction site that is emitted **before** the
+constructed class's own body, `EmitCore` pre-registers ctor handles from
+the planner's reserved MethodDef rows. The existing pre-registration loop
+only covered:
+
+- state-machine classes (iterator/async kickoff `newobj`), and
+- synthesized closure classes and capture boxes, plus user classes whose
+  ctor is **default-only** (no explicit `init`, no base initializer, no
+  primary ctor).
+
+Classes with an explicit `init(...)`, a base-constructor initializer, or
+a primary constructor were **not** pre-registered. Their handles only
+became available once `EmitClassMethodBodies` reached them.
+
+For nested classes this is fatal *every time*: the enclosing class's
+method bodies are emitted in the top-level class pass, which runs
+strictly **before** the unified nested-type pass (ADR-0110) that records
+nested ctors. So `Outer.Make()` — emitted in the top-level pass — could
+never see `CBRecordingBroker`'s ctor handle. The same latent ordering
+bug also affected two **top-level** classes when the constructing class
+was declared before the constructed explicit-ctor class:
+
+```gsharp
+class A { func Make() { let b = B() } }   // GS9998: B has no emitted primary ctor
+class B { prop X int32  init() { X = 9 } }
+```
+
+The default-ctor nested case worked only because it happened to land in
+the pre-registration loop's default-only branch.
+
+## Decision
+
+Generalize the ctor pre-registration in `EmitCore` so **every** non-SM
+user class has its constructor handle(s) claimed from the planner's
+reserved rows *before any method body is emitted*. The new loop mirrors
+`EmitClassMethodBodies`' exact handle assignment, so the pre-registered
+handles are byte-identical to those produced during emission:
+
+- **Explicit `init(...)` class** — each declared overload (and the
+  synthesized-from-primary designated init) occupies a contiguous
+  MethodDef row starting at the planner's `classCtorRows[c]`. Record
+  `ExplicitCtorHandles[overload_i] = row + i`; the first overload also
+  becomes the `ClassCtorHandles` / `ClassPrimaryCtorHandles` handle.
+- **Base-initializer class (#306)** — the single forwarding ctor at
+  `classCtorRows[c]` becomes both the class and primary handle.
+- **Default-only class** (incl. closures and capture boxes) — the
+  default ctor at `classCtorRows[c]` becomes the class handle, plus the
+  optional separate primary-ctor row when the class declares a primary
+  constructor.
+
+This subsumes the previous closure / capture-box / default-only loop, so
+that loop is removed. State-machine classes keep their separate, earlier
+pre-registration.
+
+## Consequences
+
+- Nested classes with `init()` constructors now emit correctly and can
+  be constructed from an enclosing method, from top-level code, with the
+  object-initializer form (`T() { Prop = v }`), and dispatched through an
+  interface they implement.
+- A latent forward-reference bug for **top-level** explicit-ctor /
+  primary-ctor / base-initializer classes is also fixed: a class may now
+  construct another class declared later in the file regardless of ctor
+  shape.
+- No metadata-layout change: pre-registration only claims the rows the
+  planner already reserved and the emitter would have produced, so emit
+  output for previously-working programs is unchanged (verified by the
+  existing ctor/closure/SM/nested emit suites).
+
+## Alternatives considered
+
+- **Reorder emission so constructed types precede constructors.** A
+  topological sort over construction edges is fragile (cycles via mutual
+  construction are legal) and would perturb MethodDef row order, breaking
+  byte-stability for existing programs.
+- **Resolve ctor tokens lazily / fix up after emission.** The metadata
+  builder appends rows append-only; a second fix-up pass would duplicate
+  the row-planning logic the planner already owns. Pre-registering from
+  the planner's reserved rows reuses the single source of truth.

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1707,38 +1707,67 @@ internal sealed class ReflectionMetadataEmitter
             this.cache.ClassCtorHandles[c] = MetadataTokens.MethodDefinitionHandle(classCtorRows[c]);
         }
 
-        // Issue #503: pre-register synthesized closure class ctor handles too.
-        // Closure classes live at the END of nonSmClasses (they are appended
-        // after user aggregates so user TypeDefs come first), but a user
-        // class's `init` body or instance method may construct a capturing
-        // lambda whose closure class hasn't had its ctor emitted yet —
-        // EmitFunctionLiteral would then throw "Closure class … has no
-        // emitted constructor". The closure ctor's MethodDef row is already
-        // reserved by the planner at line ~733, so claim that handle up-front
-        // (same trick used for SM classes above). The actual ctor body is
-        // still emitted in the planned row order during the main nonSmClasses
-        // loop below.
-        //
-        // Issue #523: the same hazard applies to capture-box classes. A box
-        // class has no explicit ctor and no primary ctor, so its
-        // EmitClassDefaultConstructor row is the one reserved at classCtorRows
-        // — pre-register that handle so any earlier-emitted method body
-        // can `newobj` the box before its body is materialized.
+        // Issue #503 / #523 / #920: pre-register EVERY non-SM user class's
+        // constructor handle(s) from the planned ctor rows BEFORE any method
+        // body is emitted. A class method (or `init` body) may `newobj` another
+        // class — including a sibling class declared later, a capturing-lambda
+        // closure class, a capture box, or a NESTED class — whose ctor body is
+        // emitted later in the pass. Without an up-front handle the construction
+        // site cannot resolve the ctor token and EmitConstructorCall throws
+        // "Type '…' has no emitted primary ctor." (issue #920: this always bites
+        // nested classes, because the enclosing class's method bodies are
+        // emitted in the top-level pass strictly before the unified nested-type
+        // pass that records nested ctors). The closure ctor's MethodDef row is
+        // already reserved by the planner at line ~733, and PlanClassMethods has
+        // reserved classCtorRows/classPrimaryCtorRows for every other class
+        // (top-level and nested), so claim those handles now (same trick used
+        // for SM classes above). The actual ctor bodies are still emitted in the
+        // planned row order during the class-method-body pass below; this loop
+        // mirrors EmitClassMethodBodies' exact per-overload / primary /
+        // base-forwarding row assignment so the pre-registered handles equal the
+        // handles produced during emission.
         foreach (var c in nonSmClasses)
         {
-            var isSynthesizedClosure = this.closures.SynthesizedClosureClasses.Contains(c);
-            var hasDefaultOnlyCtor = c.ExplicitConstructor == null
-                && c.BaseConstructorInitializer == null
-                && !c.HasPrimaryConstructor;
-
-            if (!isSynthesizedClosure && !hasDefaultOnlyCtor)
+            if (!classCtorRows.TryGetValue(c, out var firstCtorRow))
             {
                 continue;
             }
 
-            if (classCtorRows.TryGetValue(c, out var classCtorRow))
+            if (c.ExplicitConstructor != null)
             {
-                this.cache.ClassCtorHandles[c] = MetadataTokens.MethodDefinitionHandle(classCtorRow);
+                // ADR-0063 §9 / ADR-0065 §5: each declared `init(...)` overload
+                // (and the synthesized-from-primary designated init) occupies a
+                // contiguous MethodDef row starting at firstCtorRow. The first
+                // overload also doubles as the legacy class/primary ctor handle.
+                var firstHandle = MetadataTokens.MethodDefinitionHandle(firstCtorRow);
+                for (int i = 0; i < c.ExplicitConstructors.Length; i++)
+                {
+                    this.cache.ExplicitCtorHandles[c.ExplicitConstructors[i]] =
+                        MetadataTokens.MethodDefinitionHandle(firstCtorRow + i);
+                }
+
+                this.cache.ClassCtorHandles[c] = firstHandle;
+                this.cache.ClassPrimaryCtorHandles[c] = firstHandle;
+            }
+            else if (c.BaseConstructorInitializer != null)
+            {
+                // Issue #306: a single forwarding ctor occupies firstCtorRow and
+                // serves as both the class ctor and the primary ctor handle.
+                var forwardingHandle = MetadataTokens.MethodDefinitionHandle(firstCtorRow);
+                this.cache.ClassCtorHandles[c] = forwardingHandle;
+                this.cache.ClassPrimaryCtorHandles[c] = forwardingHandle;
+            }
+            else
+            {
+                // Default-only ctor (covers user classes with no ctor, capture
+                // boxes, and synthesized closure classes) plus an optional
+                // separate primary ctor row.
+                this.cache.ClassCtorHandles[c] = MetadataTokens.MethodDefinitionHandle(firstCtorRow);
+
+                if (c.HasPrimaryConstructor && classPrimaryCtorRows.TryGetValue(c, out var primaryRow))
+                {
+                    this.cache.ClassPrimaryCtorHandles[c] = MetadataTokens.MethodDefinitionHandle(primaryRow);
+                }
             }
         }
 

--- a/test/Compiler.Tests/Emit/Issue920NestedClassCtorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue920NestedClassCtorEmitTests.cs
@@ -1,0 +1,278 @@
+// <copyright file="Issue920NestedClassCtorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #920 / ADR-0110: a nested (user-declared, nested-inside-another-type)
+/// class that declares an <c>init()</c> constructor — or whose ctor body is
+/// emitted later in the emission pass than a construction site — must have its
+/// ctor handle pre-registered so <c>newobj</c> sites resolve it. Before the fix
+/// the emitter threw "Type '…' has no emitted primary ctor." because the
+/// enclosing class's method bodies are emitted strictly before the unified
+/// nested-type pass that records nested ctors.
+/// <para>
+/// IMPORTANT: every same-compilation user type gets a UNIQUE name per test
+/// method, because <c>FunctionTypeSymbol.Cache</c> aliases by type-name string
+/// and would otherwise surface stale symbols across tests.
+/// </para>
+/// </summary>
+public class Issue920NestedClassCtorEmitTests
+{
+    [Fact]
+    public void NestedClassWithInitCtor_ConstructedFromEnclosingMethod_Runs()
+    {
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            class Outer920A {
+                class Inner920A {
+                    prop X int32
+                    init() {
+                        X = 5
+                    }
+                    func Get() int32 {
+                        return X
+                    }
+                }
+
+                func Make() int32 {
+                    let i = Inner920A()
+                    return i.Get()
+                }
+            }
+
+            let o = Outer920A()
+            Console.WriteLine(o.Make())
+            """);
+
+        Assert.Equal("5\n", output);
+    }
+
+    [Fact]
+    public void NestedClassWithInitCtor_ObjectInitializerConstruction_Runs()
+    {
+        // The exact issue #920 reproduction: a nested class implementing an
+        // interface, with an init() that sets defaults, constructed with an
+        // object-initializer that overrides one property.
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            interface IBroker920B {
+                func Answer() string;
+            }
+
+            class Outer920B {
+                class CBRecordingBroker920B : IBroker920B {
+                    prop MfaAnswer string
+                    prop CvfAnswer string
+                    prop MfaCalls int32
+
+                    init() {
+                        MfaAnswer = "000000"
+                        CvfAnswer = "0000"
+                        MfaCalls = 0
+                    }
+
+                    func Answer() string {
+                        return MfaAnswer
+                    }
+                }
+
+                func Make() string {
+                    var bb = CBRecordingBroker920B() { MfaAnswer = "987654" }
+                    return bb.Answer()
+                }
+            }
+
+            let o = Outer920B()
+            Console.WriteLine(o.Make())
+            """);
+
+        Assert.Equal("987654\n", output);
+    }
+
+    [Fact]
+    public void NestedClassWithInitCtor_DispatchedThroughInterface_Runs()
+    {
+        // Construct the nested class, upcast it to the nested-implemented
+        // interface, and dispatch through the interface.
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            interface IBroker920C {
+                func Answer() string;
+            }
+
+            class Outer920C {
+                class Broker920C : IBroker920C {
+                    prop Value string
+                    init() {
+                        Value = "from-init"
+                    }
+                    func Answer() string {
+                        return Value
+                    }
+                }
+
+                func Make() string {
+                    var i IBroker920C = Broker920C()
+                    return i.Answer()
+                }
+            }
+
+            let o = Outer920C()
+            Console.WriteLine(o.Make())
+            """);
+
+        Assert.Equal("from-init\n", output);
+    }
+
+    [Fact]
+    public void TopLevelClass_ConstructsLaterDeclaredInitCtorClass_Runs()
+    {
+        // The same root cause also affected two TOP-LEVEL classes when the
+        // constructing class is declared before the constructed (explicit-ctor)
+        // class. Pre-registration fixes both shapes.
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            class Builder920D {
+                func Make() int32 {
+                    let w = Widget920D()
+                    return w.Get()
+                }
+            }
+
+            class Widget920D {
+                prop X int32
+                init() {
+                    X = 9
+                }
+                func Get() int32 {
+                    return X
+                }
+            }
+
+            let b = Builder920D()
+            Console.WriteLine(b.Make())
+            """);
+
+        Assert.Equal("9\n", output);
+    }
+
+    [Fact]
+    public void NestedClassWithInitCtor_ConstructedFromTopLevelCode_Runs()
+    {
+        // A nested class constructed directly from top-level program code (not
+        // only from an enclosing method) must also resolve its ctor.
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            class Outer920E {
+                class Inner920E {
+                    prop N int32
+                    init() {
+                        N = 42
+                    }
+                    func Get() int32 {
+                        return N
+                    }
+                }
+            }
+
+            let i = Inner920E()
+            Console.WriteLine(i.Get())
+            """);
+
+        Assert.Equal("42\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue920_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}):\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue910NestedTypeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue910NestedTypeBinderTests.cs
@@ -149,6 +149,33 @@ public class Issue910NestedTypeBinderTests
         Assert.Same(outer, inner.ContainingType);
     }
 
+    [Fact]
+    public void NestedClassInClass_WithInitConstructor_BindsExplicitConstructor()
+    {
+        // Issue #920: a nested class that declares an `init()` constructor must
+        // bind that constructor onto the nested StructSymbol just like a
+        // top-level class, so the emitter can record its ctor handle.
+        var scope = BindSource("""
+            class Outer920 {
+                class Inner920 {
+                    prop X int32
+                    init() {
+                        X = 5
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        var inner = (StructSymbol)scope.TypeAliases["Inner920"];
+        var outer = (StructSymbol)scope.TypeAliases["Outer920"];
+        Assert.Same(outer, inner.ContainingType);
+        Assert.True(inner.IsClass);
+        Assert.NotNull(inner.ExplicitConstructor);
+        Assert.Single(inner.ExplicitConstructors);
+    }
+
     private static BoundGlobalScope BindSource(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
## Summary

Fixes #920.

Nested (user-declared, nested-inside-another-type) **classes** with an explicit `init()` constructor failed to emit:

```
error GS9998: InvalidOperationException: Type 'CBRecordingBroker' has no emitted primary ctor.
```

## Root cause

`EmitConstructorCall` resolves a `newobj` site from the `ExplicitCtorHandles` / `ClassPrimaryCtorHandles` / `ClassCtorHandles` caches, which are populated while a class's method bodies are emitted (`EmitClassMethodBodies`). To survive a construction site emitted *before* the constructed class's body, `EmitCore` pre-registers ctor handles up-front from the planner's reserved MethodDef rows — but the existing loop only covered state-machine classes, synthesized closures, capture boxes, and **default-only** user classes. Classes with an explicit `init(...)`, a base-constructor initializer, or a primary constructor were **not** pre-registered.

Nested classes hit this **every time**: the enclosing class's method bodies are emitted in the top-level class pass, which runs strictly **before** the unified nested-type pass (ADR-0110) that records nested ctors. So an enclosing method constructing a nested `init()`-class could never see the nested ctor handle. The same latent ordering bug also affected two **top-level** classes when the constructing class was declared before the constructed explicit-ctor class:

```gsharp
class A { func Make() { let b = B() } }   // GS9998
class B { prop X int32  init() { X = 9 } }
```

## Fix

Generalize the ctor pre-registration in `EmitCore` so **every** non-SM user class claims its constructor handle(s) from the planner's reserved rows before any method body is emitted, mirroring `EmitClassMethodBodies`' exact per-overload / primary / base-forwarding row assignment. The pre-registered handles are byte-identical to the emitted handles, so there is **no metadata-layout change**. The previous closure/capture-box/default-only loop is subsumed and removed; state-machine pre-registration is untouched.

This fully implements class-in-class (and class-in-struct) ctor emission — nothing is deferred. Verified working: construction from an enclosing method, from top-level code, the object-initializer form `T() { Prop = v }`, properties/fields initialization, and interface dispatch on the nested class.

## Tests

- `test/Compiler.Tests/Emit/Issue920NestedClassCtorEmitTests.cs` — 5 emit tests (compile + ilverify + run): nested `init()` class from enclosing method, object-initializer form, interface dispatch, nested class from top-level code, and the top-level forward-reference shape. Unique per-test type names to avoid `FunctionTypeSymbol.Cache` aliasing.
- `test/Core.Tests/.../Issue910NestedTypeBinderTests.cs` — binder test asserting a nested `init()` constructor binds onto the nested `StructSymbol`.

## ADR

`docs/adr/0114-nested-class-constructor-emission.md` extends the nested-type story from ADR-0110.

## Build / test commands run

- `dotnet build GSharp.sln -c Release --no-restore -graph` → succeeded, 0 warnings/errors.
- `dotnet test test/Compiler.Tests/... --filter Issue920NestedClassCtorEmitTests -- xUnit.MaxParallelThreads=2` → **5 passed**.
- `dotnet test test/Core.Tests/... --filter Issue910NestedTypeBinderTests` → **7 passed**.
- Regression: `Issue910NestedTypeEmitTests` (10), `Issue656/524/671/819` ctor suites (36), closure/deinit/nested suites (44), `Issue810` iterator SM (8) → all passed.

## Deferred work

None.