### PR TITLE
Extend TypeMemberModel: declaring-type field lookup, interface/enum enumeration (ADR-0112 P0)

### DIFF
--- a/docs/adr/0112-unified-member-resolution.md
+++ b/docs/adr/0112-unified-member-resolution.md
@@ -124,3 +124,47 @@ slot.
 - Full consolidation of CLR/imported member reflection into the same layer is
   deferred; the layer exposes a unified entry point but CLR resolution remains
   a `MemberLookup` backend.
+
+## Addendum — P0 enabler additions
+
+The P0 enabler PR (`feat(symbols): TypeMemberModel P0`) extended the canonical
+layer with purely additive capabilities that the later consumer-migration PRs
+depend on. No existing behavior, ordering, or signatures changed; the parity
+characterization tests remain green.
+
+- **Declaring-type field lookup.** Added
+  `TypeMemberModel.TryGetFieldIncludingInherited(TypeSymbol, string, MemberQuery,
+  out FieldSymbol, out StructSymbol declaringType)`. It mirrors
+  `StructSymbol.TryGetFieldIncludingInherited` (this-first base-chain walk) but
+  lives behind the canonical layer and honors the `MemberQuery` axes
+  (instance-before-static at each level, inherited toggle, `Field` kind). The
+  binder needs the declaring `StructSymbol` to build
+  `BoundFieldAccessExpression`. The original `TryGetField` is unchanged.
+
+- **Interface and enum enumeration.** `EnumerateMembers` now handles
+  `InterfaceSymbol` and `EnumSymbol` in addition to `StructSymbol`. Interface
+  enumeration surfaces instance properties/events/methods plus static methods
+  per the query/kinds (mirroring `LookupMember`/`GetMethods`). Enum enumeration
+  surfaces enum members as static fields (mirroring the enum path in
+  `LookupMember`). The existing `StructSymbol` enumeration order/behavior is
+  preserved exactly (extracted unchanged into `EnumerateStructMembers`).
+
+- **Property-lookup consolidation.**
+  `MemberLookup.TryGetPropertyIncludingInherited` now delegates to
+  `TypeMemberModel.TryGetProperty`, removing the duplicated base-chain
+  instance-property walk. The two were verified behaviorally equivalent (same
+  base-chain order, same first-match); the public signature and callers are
+  unchanged in this PR.
+
+- **Interface static coverage / known gap.** Interface static *methods* are
+  covered by `LookupMember`, `GetMethods`, and now `EnumerateMembers`.
+  `InterfaceSymbol` does not currently model static *properties* or static
+  *events* (no `StaticProperties`/`StaticEvents` tables), so
+  `TryGetStaticProperty`/`TryGetStaticEvent` expose only what the symbol model
+  supports. Surfacing interface static properties/events would require deeper
+  `InterfaceSymbol` modeling and is deferred as future work for the A9
+  migration.
+
+- **Reserved `MemberKinds.NestedType`.** Added as a reserved flag value (not
+  included in `All`) for future nested-type routing. Nested-type enumeration is
+  not wired in P0; it remains future work to avoid scope creep.

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1165,23 +1165,11 @@ internal sealed class MemberLookup
     /// <returns><see langword="true"/> when a property is found.</returns>
     public static bool TryGetPropertyIncludingInherited(StructSymbol type, string name, out PropertySymbol property)
     {
-        var current = type;
-        while (current != null)
-        {
-            foreach (var p in current.Properties)
-            {
-                if (p.Name == name)
-                {
-                    property = p;
-                    return true;
-                }
-            }
-
-            current = current.BaseClass;
-        }
-
-        property = null;
-        return false;
+        // ADR-0112 P0: the base-chain instance-property walk is now owned by the
+        // canonical member-resolution layer. This method delegates so the single
+        // implementation lives in TypeMemberModel.TryGetProperty (same base-chain
+        // order, same first-match semantics).
+        return TypeMemberModel.TryGetProperty(type, name, out property);
     }
 
     // ----- Indexer / Nullable<> / extension-method probes (instance helpers) -----

--- a/src/Core/CodeAnalysis/Symbols/MemberKinds.cs
+++ b/src/Core/CodeAnalysis/Symbols/MemberKinds.cs
@@ -26,6 +26,12 @@ public enum MemberKinds
     /// <summary>Instance / static methods.</summary>
     Method = 8,
 
+    /// <summary>
+    /// Reserved for future nested-type routing (ADR-0112 P0). Not included in
+    /// <see cref="All"/>; nested-type enumeration is not yet wired (future work).
+    /// </summary>
+    NestedType = 16,
+
     /// <summary>Every member kind.</summary>
     All = Field | Property | Event | Method,
 }

--- a/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
@@ -132,90 +132,20 @@ public static class TypeMemberModel
     {
         if (type is StructSymbol structSymbol)
         {
-            for (var c = structSymbol; c != null; c = c.BaseClass)
-            {
-                if ((query.Kinds & MemberKinds.Field) != 0)
-                {
-                    if (query.IncludeInstance)
-                    {
-                        foreach (var f in c.Fields)
-                        {
-                            yield return f;
-                        }
-                    }
-
-                    if (query.IncludeStatic)
-                    {
-                        foreach (var f in c.StaticFields)
-                        {
-                            yield return f;
-                        }
-                    }
-                }
-
-                if ((query.Kinds & MemberKinds.Property) != 0)
-                {
-                    if (query.IncludeInstance)
-                    {
-                        foreach (var p in c.Properties)
-                        {
-                            yield return p;
-                        }
-                    }
-
-                    if (query.IncludeStatic)
-                    {
-                        foreach (var p in c.StaticProperties)
-                        {
-                            yield return p;
-                        }
-                    }
-                }
-
-                if ((query.Kinds & MemberKinds.Event) != 0)
-                {
-                    if (query.IncludeInstance)
-                    {
-                        foreach (var e in c.Events)
-                        {
-                            yield return e;
-                        }
-                    }
-
-                    if (query.IncludeStatic)
-                    {
-                        foreach (var e in c.StaticEvents)
-                        {
-                            yield return e;
-                        }
-                    }
-                }
-
-                if ((query.Kinds & MemberKinds.Method) != 0)
-                {
-                    if (query.IncludeInstance)
-                    {
-                        foreach (var m in c.Methods)
-                        {
-                            yield return m;
-                        }
-                    }
-
-                    if (query.IncludeStatic)
-                    {
-                        foreach (var m in c.StaticMethods)
-                        {
-                            yield return m;
-                        }
-                    }
-                }
-
-                if (!query.IncludeInherited)
-                {
-                    yield break;
-                }
-            }
+            return EnumerateStructMembers(structSymbol, query);
         }
+
+        if (type is InterfaceSymbol interfaceSymbol)
+        {
+            return EnumerateInterfaceMembers(interfaceSymbol, query);
+        }
+
+        if (type is EnumSymbol enumSymbol)
+        {
+            return EnumerateEnumMembers(enumSymbol, query);
+        }
+
+        return System.Linq.Enumerable.Empty<Symbol>();
     }
 
     /// <summary>Tries to find an instance field named <paramref name="name"/> on <paramref name="type"/>, walking the base chain.</summary>
@@ -237,6 +167,52 @@ public static class TypeMemberModel
         }
 
         field = null;
+        return false;
+    }
+
+    /// <summary>
+    /// ADR-0112 P0: tries to find a field named <paramref name="name"/> on
+    /// <paramref name="type"/> while also surfacing the <see cref="StructSymbol"/>
+    /// that actually declares it — the binder needs the declaring struct to build
+    /// a <c>BoundFieldAccessExpression</c>. This mirrors
+    /// <see cref="StructSymbol.TryGetFieldIncludingInherited"/> for the
+    /// declaring-type semantics but honors <paramref name="query"/> (instance
+    /// before static at each level, this-first base-chain walk, stopping when
+    /// <see cref="MemberQuery.IncludeInherited"/> is unset).
+    /// </summary>
+    /// <param name="type">The type to resolve against (user-defined struct/class only).</param>
+    /// <param name="name">The field name.</param>
+    /// <param name="query">The static/instance/inherited filter.</param>
+    /// <param name="field">The found field on success.</param>
+    /// <param name="declaringType">The struct that actually declares the field on success.</param>
+    /// <returns>True if found.</returns>
+    public static bool TryGetFieldIncludingInherited(TypeSymbol type, string name, MemberQuery query, out FieldSymbol field, out StructSymbol declaringType)
+    {
+        if ((query.Kinds & MemberKinds.Field) != 0 && type is StructSymbol structSymbol)
+        {
+            for (var c = structSymbol; c != null; c = c.BaseClass)
+            {
+                if (query.IncludeInstance && c.TryGetField(name, out field))
+                {
+                    declaringType = c;
+                    return true;
+                }
+
+                if (query.IncludeStatic && c.TryGetStaticField(name, out field))
+                {
+                    declaringType = c;
+                    return true;
+                }
+
+                if (!query.IncludeInherited)
+                {
+                    break;
+                }
+            }
+        }
+
+        field = null;
+        declaringType = null;
         return false;
     }
 
@@ -374,6 +350,154 @@ public static class TypeMemberModel
 
         @event = null;
         return false;
+    }
+
+    private static IEnumerable<Symbol> EnumerateStructMembers(StructSymbol structSymbol, MemberQuery query)
+    {
+        for (var c = structSymbol; c != null; c = c.BaseClass)
+        {
+            if ((query.Kinds & MemberKinds.Field) != 0)
+            {
+                if (query.IncludeInstance)
+                {
+                    foreach (var f in c.Fields)
+                    {
+                        yield return f;
+                    }
+                }
+
+                if (query.IncludeStatic)
+                {
+                    foreach (var f in c.StaticFields)
+                    {
+                        yield return f;
+                    }
+                }
+            }
+
+            if ((query.Kinds & MemberKinds.Property) != 0)
+            {
+                if (query.IncludeInstance)
+                {
+                    foreach (var p in c.Properties)
+                    {
+                        yield return p;
+                    }
+                }
+
+                if (query.IncludeStatic)
+                {
+                    foreach (var p in c.StaticProperties)
+                    {
+                        yield return p;
+                    }
+                }
+            }
+
+            if ((query.Kinds & MemberKinds.Event) != 0)
+            {
+                if (query.IncludeInstance)
+                {
+                    foreach (var e in c.Events)
+                    {
+                        yield return e;
+                    }
+                }
+
+                if (query.IncludeStatic)
+                {
+                    foreach (var e in c.StaticEvents)
+                    {
+                        yield return e;
+                    }
+                }
+            }
+
+            if ((query.Kinds & MemberKinds.Method) != 0)
+            {
+                if (query.IncludeInstance)
+                {
+                    foreach (var m in c.Methods)
+                    {
+                        yield return m;
+                    }
+                }
+
+                if (query.IncludeStatic)
+                {
+                    foreach (var m in c.StaticMethods)
+                    {
+                        yield return m;
+                    }
+                }
+            }
+
+            if (!query.IncludeInherited)
+            {
+                yield break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// ADR-0112 P0: enumerates an interface's members for completion. Interfaces
+    /// have no base-chain modeling here, so this surfaces the interface's own
+    /// instance properties/events/methods plus static methods, honoring the
+    /// query. (InterfaceSymbol does not currently model static
+    /// properties/events; see the ADR-0112 P0 addendum.)
+    /// </summary>
+    private static IEnumerable<Symbol> EnumerateInterfaceMembers(InterfaceSymbol interfaceSymbol, MemberQuery query)
+    {
+        if ((query.Kinds & MemberKinds.Property) != 0 && query.IncludeInstance)
+        {
+            foreach (var p in interfaceSymbol.Properties)
+            {
+                yield return p;
+            }
+        }
+
+        if ((query.Kinds & MemberKinds.Event) != 0 && query.IncludeInstance)
+        {
+            foreach (var e in interfaceSymbol.Events)
+            {
+                yield return e;
+            }
+        }
+
+        if ((query.Kinds & MemberKinds.Method) != 0)
+        {
+            if (query.IncludeInstance)
+            {
+                foreach (var m in interfaceSymbol.Methods)
+                {
+                    yield return m;
+                }
+            }
+
+            if (query.IncludeStatic)
+            {
+                foreach (var m in interfaceSymbol.StaticMethods)
+                {
+                    yield return m;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// ADR-0112 P0: enumerates an enum's members for completion. Enum members
+    /// are surfaced as static fields, mirroring the enum handling in
+    /// <see cref="LookupMember"/>.
+    /// </summary>
+    private static IEnumerable<Symbol> EnumerateEnumMembers(EnumSymbol enumSymbol, MemberQuery query)
+    {
+        if (query.IncludeStatic && (query.Kinds & MemberKinds.Field) != 0)
+        {
+            foreach (var member in enumSymbol.Members)
+            {
+                yield return member;
+            }
+        }
     }
 
     private static Symbol LookupStructMember(StructSymbol structSymbol, string name, MemberQuery query)

--- a/test/Core.Tests/CodeAnalysis/Symbols/TypeMemberModelTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/TypeMemberModelTests.cs
@@ -43,6 +43,20 @@ open class Animal : Base {
         func Make(name string) Animal { return Animal{} }
     }
 }
+
+interface IShape {
+    prop Area int32 { get }
+    func Describe() string;
+    shared {
+        func Create() string;
+    }
+}
+
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
 ";
 
     [Fact]
@@ -154,6 +168,104 @@ open class Animal : Base {
     }
 
     [Fact]
+    public void TryGetFieldIncludingInherited_OwnField_ReturnsDeclaringType()
+    {
+        var animal = GetStruct("Animal");
+        Assert.True(TypeMemberModel.TryGetFieldIncludingInherited(animal, "legs", MemberQuery.Instance(), out var field, out var declaring));
+        Assert.Equal("legs", field.Name);
+        Assert.Equal("Animal", declaring.Name);
+    }
+
+    [Fact]
+    public void TryGetFieldIncludingInherited_InheritedField_ReturnsBaseDeclaringType()
+    {
+        var animal = GetStruct("Animal");
+        Assert.True(TypeMemberModel.TryGetFieldIncludingInherited(animal, "baseField", MemberQuery.Instance(), out var field, out var declaring));
+        Assert.Equal("baseField", field.Name);
+        Assert.Equal("Base", declaring.Name);
+    }
+
+    [Fact]
+    public void TryGetFieldIncludingInherited_StaticField_Found()
+    {
+        var animal = GetStruct("Animal");
+        Assert.True(TypeMemberModel.TryGetFieldIncludingInherited(animal, "Count", MemberQuery.Static(), out var field, out var declaring));
+        Assert.Equal("Count", field.Name);
+        Assert.Equal("Animal", declaring.Name);
+    }
+
+    [Fact]
+    public void TryGetFieldIncludingInherited_InstanceQuery_DoesNotFindStatic()
+    {
+        var animal = GetStruct("Animal");
+        Assert.False(TypeMemberModel.TryGetFieldIncludingInherited(animal, "Count", MemberQuery.Instance(), out _, out _));
+    }
+
+    [Fact]
+    public void TryGetFieldIncludingInherited_NotInheritedQuery_DoesNotWalkBaseChain()
+    {
+        var animal = GetStruct("Animal");
+        var query = new MemberQuery(includeInstance: true, includeStatic: false, includeInherited: false, MemberKinds.Field);
+        Assert.False(TypeMemberModel.TryGetFieldIncludingInherited(animal, "baseField", query, out _, out _));
+    }
+
+    [Fact]
+    public void EnumerateMembers_Interface_SurfacesInstanceAndStaticMembers()
+    {
+        var shape = GetInterface("IShape");
+        var names = TypeMemberModel.EnumerateMembers(shape, MemberQuery.All)
+            .Select(m => m.Name)
+            .ToHashSet();
+        Assert.Contains("Area", names);
+        Assert.Contains("Describe", names);
+        Assert.Contains("Create", names);
+    }
+
+    [Fact]
+    public void EnumerateMembers_Interface_StaticOnly_ExcludesInstance()
+    {
+        var shape = GetInterface("IShape");
+        var names = TypeMemberModel.EnumerateMembers(shape, MemberQuery.Static())
+            .Select(m => m.Name)
+            .ToHashSet();
+        Assert.Contains("Create", names);
+        Assert.DoesNotContain("Describe", names);
+        Assert.DoesNotContain("Area", names);
+    }
+
+    [Fact]
+    public void EnumerateMembers_Enum_SurfacesMembers()
+    {
+        var color = GetEnum("Color");
+        var names = TypeMemberModel.EnumerateMembers(color, MemberQuery.All)
+            .Select(m => m.Name)
+            .ToHashSet();
+        Assert.Contains("Red", names);
+        Assert.Contains("Green", names);
+        Assert.Contains("Blue", names);
+    }
+
+    [Fact]
+    public void EnumerateMembers_Enum_InstanceOnly_IsEmpty()
+    {
+        var color = GetEnum("Color");
+        Assert.Empty(TypeMemberModel.EnumerateMembers(color, MemberQuery.Instance()));
+    }
+
+    [Fact]
+    public void TryGetProperty_MatchesMemberLookupIncludingInherited_AcrossInheritance()
+    {
+        var animal = GetStruct("Animal");
+        foreach (var name in new[] { "Name", "BaseProp", "Missing" })
+        {
+            var modelFound = TypeMemberModel.TryGetProperty(animal, name, out var modelProp);
+            var lookupFound = GSharp.Core.CodeAnalysis.Binding.MemberLookup.TryGetPropertyIncludingInherited(animal, name, out var lookupProp);
+            Assert.Equal(modelFound, lookupFound);
+            Assert.Same(modelProp, lookupProp);
+        }
+    }
+
+    [Fact]
     public void EnumerateMembers_Instance_IncludesInheritedFieldsPropertiesMethods()
     {
         var animal = GetStruct("Animal");
@@ -188,5 +300,23 @@ open class Animal : Base {
         var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
         Assert.Empty(result.Diagnostics);
         return (StructSymbol)compilation.GlobalScope.Structs.Single(s => s.Name == name);
+    }
+
+    private static InterfaceSymbol GetInterface(string name)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(Source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Empty(result.Diagnostics);
+        return compilation.GlobalScope.Interfaces.Single(s => s.Name == name);
+    }
+
+    private static EnumSymbol GetEnum(string name)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(Source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Empty(result.Diagnostics);
+        return compilation.GlobalScope.Enums.Single(s => s.Name == name);
     }
 }


### PR DESCRIPTION
## Summary

First follow-up to ADR-0112 (PR #921). Extends the canonical `TypeMemberModel` member-resolution layer to close capability gaps needed by the upcoming consumer-migration PRs. **Purely additive — no consumer call sites are migrated in this PR, and no existing behavior changes.**

## What changed

- **`TypeMemberModel`**
  - Added `TryGetFieldIncludingInherited(TypeSymbol, string, MemberQuery, out FieldSymbol, out StructSymbol declaringType)` — declaring-struct field lookup honoring instance/static/inherited axes (binder needs the declaring struct to build `BoundFieldAccessExpression`).
  - `EnumerateMembers` now dispatches to per-kind helpers and covers `InterfaceSymbol` (instance properties/events/methods + static methods) and `EnumSymbol` (members as static fields), in addition to the unchanged `StructSymbol` behavior.
- **`MemberLookup.TryGetPropertyIncludingInherited`** now delegates to `TypeMemberModel.TryGetProperty` (signature and callers unchanged) — consolidates a duplicated base-chain property walk.
- **`MemberKinds`** gains a reserved `NestedType` flag (not in `All`) for future nested-type routing.
- **ADR-0112** gains a "P0 enabler additions" addendum documenting the above and noting that `InterfaceSymbol` has no static-property/event tables (interface static property/event surfacing deferred to the A9 task).

## Validation

- Release build: 0 warnings, 0 errors.
- New `TypeMemberModelTests`: declaring-type field lookup (own/inherited/static/instance-only/non-inherited), interface & enum enumeration, and a property-lookup equivalence test proving `MemberLookup.TryGetPropertyIncludingInherited` ≡ `TypeMemberModel.TryGetProperty` across inheritance.
- Suites green: Core.Tests 3411 passed / 1 skipped, LanguageServer.Tests 363, Compiler.Tests 1402.

## Context

This is task **P0** of the broad-scope migration that moves every remaining member-resolution operation in the binder and language server onto the unified `TypeMemberModel`. Subsequent PRs migrate individual consumer groups (object-initializer completion, property lookup, instance field/property access, static access, events, method overload sets, patterns/literals, operators/intrinsics, interface/cross-assembly resolvers).
