### PR TITLE
Route object-initializer completion through TypeMemberModel (ADR-0112 A1)

### DIFF
--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -1840,19 +1840,11 @@ public static class CompletionComputer
     {
         if (receiverType is StructSymbol structSymbol)
         {
-            for (var current = structSymbol; current != null; current = current.BaseClass)
-            {
-                foreach (var field in current.Fields)
-                {
-                    AddItem(items, seen, field.Name, CompletionItemKind.Field, HoverComputer.FormatSymbol(field));
-                }
-
-                foreach (var property in current.Properties)
-                {
-                    AddItem(items, seen, property.Name, CompletionItemKind.Property, $"{property.Name}: {property.Type?.Name}");
-                }
-            }
-
+            // ADR-0112 A1: route object-initializer completion through the canonical
+            // member-resolution layer. Instance fields/properties, walking the base
+            // chain, preserves the historic enumeration (fields then properties per
+            // level) and the same writable-member set object initializers accept.
+            AddStructMembersFromModel(items, seen, structSymbol, MemberQuery.Instance(MemberKinds.Field | MemberKinds.Property));
             return;
         }
 

--- a/test/LanguageServer.Tests/ObjectInitializerHoverCompletionTests.cs
+++ b/test/LanguageServer.Tests/ObjectInitializerHoverCompletionTests.cs
@@ -164,6 +164,41 @@ public class ObjectInitializerHoverCompletionTests
     }
 
     [Fact]
+    public void ComputeCompletions_InsideGSharpClassInitializerBlock_OffersInheritedAndOwnFieldsAndProperties()
+    {
+        // ADR-0112 A1 parity: object-initializer completion routes through the
+        // canonical TypeMemberModel. The offered set must include this-type and
+        // inherited instance fields and properties (settable members object
+        // initializers accept), walking the base chain.
+        const string source = "open class Base {\n"
+            + "    prop BaseProp int32\n"
+            + "    var baseField int32\n"
+            + "}\n"
+            + "class Derived : Base {\n"
+            + "    prop Width int32\n"
+            + "    var height int32\n"
+            + "    init() { }\n"
+            + "}\n"
+            + "func main() {\n"
+            + "    let d = Derived() {  }\n"
+            + "}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var bracePos = LanguageServerTestHelpers.PositionOf(source, "{  }");
+        var caret = new Position(bracePos.Line, bracePos.Character + 2);
+
+        var items = CompletionComputer.ComputeCompletions(content, caret);
+
+        // Own members.
+        Assert.Contains(items, i => i.Label == "Width" && i.Kind == CompletionItemKind.Property);
+        Assert.Contains(items, i => i.Label == "height" && i.Kind == CompletionItemKind.Field);
+
+        // Inherited members from the base class.
+        Assert.Contains(items, i => i.Label == "BaseProp" && i.Kind == CompletionItemKind.Property);
+        Assert.Contains(items, i => i.Label == "baseField" && i.Kind == CompletionItemKind.Field);
+    }
+
+    [Fact]
     public void ComputeCompletions_InValuePositionOfInitializer_FallsBackToGlobalList()
     {
         const string source = "import System.Diagnostics\n"


### PR DESCRIPTION
## Summary

ADR-0112 migration task **A1**. Routes the language server's object-initializer completion enumeration through the canonical `TypeMemberModel` layer, removing a raw `BaseClass`-chain loop. Pure refactor — no behavior change.

## What changed

- `src/LanguageServer/HoverComputer.cs` — `AddObjectInitializerMembers` (StructSymbol branch) now calls `AddStructMembersFromModel(..., MemberQuery.Instance(MemberKinds.Field | MemberKinds.Property))` instead of manually iterating `current.Fields`/`current.Properties` up the base chain.

## Parity

- `TypeMemberModel.EnumerateMembers` yields fields-then-properties per base level walking the base chain — identical order to the old loop.
- Same `AddItem` labels/kinds/detail strings for fields and properties.
- Instance-only + inherited, matching the prior instance-only base-chain walk.
- The struct branch applied no writability filter before; the model path applies none either (no new filtering). The CLR branch is untouched.

## Validation

- Release build: 0 warnings, 0 errors.
- Added `ComputeCompletions_InsideGSharpClassInitializerBlock_OffersInheritedAndOwnFieldsAndProperties` (object initializer on a derived class offers own + inherited fields/properties).
- LanguageServer.Tests 364 passed; Core.Tests 3411 passed / 1 skipped.

Part of the broad-scope migration of all member-resolution operations onto the unified `TypeMemberModel` (follows P0 #925).
