### PR TITLE
Unify property lookup on TypeMemberModel.TryGetProperty (ADR-0112 A2)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -1103,7 +1103,7 @@ internal sealed class DeclarationBinder
                 PropertySymbol overriddenProperty = null;
                 if (isOverride)
                 {
-                    if (structSymbol.BaseClass == null || !MemberLookup.TryGetPropertyIncludingInherited(structSymbol.BaseClass, propName, out var baseProp))
+                    if (structSymbol.BaseClass == null || !TypeMemberModel.TryGetProperty(structSymbol.BaseClass, propName, out var baseProp))
                     {
                         Diagnostics.ReportNoBaseMethodToOverride(propSyntax.Identifier.Location, propName);
                     }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1511,7 +1511,7 @@ internal sealed partial class ExpressionBinder
                     }
 
                     // ADR-0051: check properties before reporting "unable to find member".
-                    if (MemberLookup.TryGetPropertyIncludingInherited(structSym, ne.IdentifierToken.Text, out var prop))
+                    if (TypeMemberModel.TryGetProperty(structSym, ne.IdentifierToken.Text, out var prop))
                     {
                         if (!prop.HasGetter)
                         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -183,7 +183,7 @@ internal sealed partial class ExpressionBinder
                 return new BoundFieldAssignmentExpression(initSyntax, receiverLocal, structSymbol, field, converted);
             }
 
-            if (MemberLookup.TryGetPropertyIncludingInherited(structSymbol, propertyName, out var prop))
+            if (TypeMemberModel.TryGetProperty(structSymbol, propertyName, out var prop))
             {
                 if (!prop.HasSetter)
                 {
@@ -365,7 +365,7 @@ internal sealed partial class ExpressionBinder
         if (!structSymbol.TryGetFieldIncludingInherited(syntax.FieldIdentifier.Text, out var field, out _))
         {
             // ADR-0051: check if it's a property.
-            if (MemberLookup.TryGetPropertyIncludingInherited(structSymbol, syntax.FieldIdentifier.Text, out var prop))
+            if (TypeMemberModel.TryGetProperty(structSymbol, syntax.FieldIdentifier.Text, out var prop))
             {
                 if (!prop.HasSetter)
                 {
@@ -674,7 +674,7 @@ internal sealed partial class ExpressionBinder
         }
 
         // ADR-0051: check properties.
-        if (MemberLookup.TryGetPropertyIncludingInherited(structSym, memberName, out var prop))
+        if (TypeMemberModel.TryGetProperty(structSym, memberName, out var prop))
         {
             if (!prop.HasGetter || !prop.HasSetter)
             {
@@ -1027,7 +1027,7 @@ internal sealed partial class ExpressionBinder
             }
 
             // ADR-0051: check properties before reporting "unable to find member".
-            if (MemberLookup.TryGetPropertyIncludingInherited(structSym, fieldName, out var prop))
+            if (TypeMemberModel.TryGetProperty(structSym, fieldName, out var prop))
             {
                 if (!prop.HasSetter)
                 {

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1155,23 +1155,6 @@ internal sealed class MemberLookup
         return null;
     }
 
-    /// <summary>
-    /// Walks <paramref name="type"/> and its base-class chain looking for a
-    /// user-declared property with the given <paramref name="name"/>.
-    /// </summary>
-    /// <param name="type">The starting user struct symbol.</param>
-    /// <param name="name">The property name to find.</param>
-    /// <param name="property">The matching property symbol, on success.</param>
-    /// <returns><see langword="true"/> when a property is found.</returns>
-    public static bool TryGetPropertyIncludingInherited(StructSymbol type, string name, out PropertySymbol property)
-    {
-        // ADR-0112 P0: the base-chain instance-property walk is now owned by the
-        // canonical member-resolution layer. This method delegates so the single
-        // implementation lives in TypeMemberModel.TryGetProperty (same base-chain
-        // order, same first-match semantics).
-        return TypeMemberModel.TryGetProperty(type, name, out property);
-    }
-
     // ----- Indexer / Nullable<> / extension-method probes (instance helpers) -----
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Symbols/TypeMemberModelTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/TypeMemberModelTests.cs
@@ -253,16 +253,18 @@ enum Color {
     }
 
     [Fact]
-    public void TryGetProperty_MatchesMemberLookupIncludingInherited_AcrossInheritance()
+    public void TryGetProperty_ResolvesAcrossInheritance()
     {
         var animal = GetStruct("Animal");
-        foreach (var name in new[] { "Name", "BaseProp", "Missing" })
-        {
-            var modelFound = TypeMemberModel.TryGetProperty(animal, name, out var modelProp);
-            var lookupFound = GSharp.Core.CodeAnalysis.Binding.MemberLookup.TryGetPropertyIncludingInherited(animal, name, out var lookupProp);
-            Assert.Equal(modelFound, lookupFound);
-            Assert.Same(modelProp, lookupProp);
-        }
+
+        Assert.True(TypeMemberModel.TryGetProperty(animal, "Name", out var nameProp));
+        Assert.NotNull(nameProp);
+
+        Assert.True(TypeMemberModel.TryGetProperty(animal, "BaseProp", out var baseProp));
+        Assert.NotNull(baseProp);
+
+        Assert.False(TypeMemberModel.TryGetProperty(animal, "Missing", out var missingProp));
+        Assert.Null(missingProp);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

ADR-0112 migration task **A2**. Completes the unification of user-type property lookup: redirects every caller of `MemberLookup.TryGetPropertyIncludingInherited` to call `TypeMemberModel.TryGetProperty` directly, and removes the now-redundant wrapper. Pure refactor — `MemberLookup.TryGetPropertyIncludingInherited` was already a thin delegate to `TypeMemberModel.TryGetProperty` (P0 #925), so behavior is identical.

## What changed

- Redirected 6 call sites to `TypeMemberModel.TryGetProperty`:
  - `ExpressionBinder.Access.cs:1514`
  - `ExpressionBinder.Assignments.cs:186, 368, 677, 1030`
  - `DeclarationBinder.cs:1106` (`.BaseClass`)
- Deleted `MemberLookup.TryGetPropertyIncludingInherited` (+ doc comment).
- Re-pointed the P0 equivalence test to `TryGetProperty_ResolvesAcrossInheritance` (own + inherited + miss), keeping inheritance coverage.

## Validation

- `grep` confirms zero `TryGetPropertyIncludingInherited` references remain in src/ or test/.
- Release build: 0 warnings, 0 errors.
- Core.Tests 3411 passed / 1 skipped; LanguageServer.Tests 364 passed; Compiler.Tests (batched) 1402 passed.

Follows P0 #925 and A1 #926 in the broad-scope migration of all member-resolution operations onto the unified `TypeMemberModel`.
