### PR TITLE
Route instance field access/assignment through TypeMemberModel (ADR-0112 A3)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1498,16 +1498,15 @@ internal sealed partial class ExpressionBinder
                 }
                 else if (receiver != null && receiver.Type is StructSymbol structSym)
                 {
-                    // Walk base chain to find the field.
-                    for (var c = structSym; c != null; c = c.BaseClass)
+                    // ADR-0112 A3: this-first base-chain instance field walk via
+                    // the canonical member-resolution layer, surfacing the
+                    // declaring struct so the emitted field token names the right owner.
+                    if (TypeMemberModel.TryGetFieldIncludingInherited(structSym, ne.IdentifierToken.Text, MemberQuery.Instance(MemberKinds.Field), out var field, out var declaringType))
                     {
-                        if (c.TryGetField(ne.IdentifierToken.Text, out var field))
-                        {
-                            // Issue #186 / #175: dotted field read fires
-                            // GS0204 if the field carries `@Obsolete`.
-                            reportObsoleteUseIfApplicable(ne.IdentifierToken.Location, field, $"{c.Name}.{field.Name}");
-                            return new BoundFieldAccessExpression(null, receiver, c, field);
-                        }
+                        // Issue #186 / #175: dotted field read fires
+                        // GS0204 if the field carries `@Obsolete`.
+                        reportObsoleteUseIfApplicable(ne.IdentifierToken.Location, field, $"{declaringType.Name}.{field.Name}");
+                        return new BoundFieldAccessExpression(null, receiver, declaringType, field);
                     }
 
                     // ADR-0051: check properties before reporting "unable to find member".

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -176,7 +176,7 @@ internal sealed partial class ExpressionBinder
 
         if (receiverType is StructSymbol structSymbol)
         {
-            if (structSymbol.TryGetFieldIncludingInherited(propertyName, out var field, out _))
+            if (TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, propertyName, MemberQuery.Instance(MemberKinds.Field), out var field, out _))
             {
                 var value = BindExpression(initSyntax.Value);
                 var converted = conversions.BindConversion(initSyntax.Value.Location, value, field.Type);
@@ -362,7 +362,7 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        if (!structSymbol.TryGetFieldIncludingInherited(syntax.FieldIdentifier.Text, out var field, out _))
+        if (!TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, syntax.FieldIdentifier.Text, MemberQuery.Instance(MemberKinds.Field), out var field, out _))
         {
             // ADR-0051: check if it's a property.
             if (TypeMemberModel.TryGetProperty(structSymbol, syntax.FieldIdentifier.Text, out var prop))
@@ -649,28 +649,26 @@ internal sealed partial class ExpressionBinder
         var baseOpSyntaxKind = isAdd ? SyntaxKind.PlusToken : SyntaxKind.MinusToken;
         var boundRhs = BindExpression(syntax.Value);
 
-        // Walk base chain to find the field.
-        for (var c = structSym; c != null; c = c.BaseClass)
+        // ADR-0112 A3: this-first base-chain instance field walk, using the
+        // declaring struct as the owner for both the read access and assignment.
+        if (TypeMemberModel.TryGetFieldIncludingInherited(structSym, memberName, MemberQuery.Instance(MemberKinds.Field), out var field, out var declaringType))
         {
-            if (c.TryGetField(memberName, out var field))
+            if (field.IsReadOnly)
             {
-                if (field.IsReadOnly)
-                {
-                    Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, memberName);
-                }
-
-                var leftRead = new BoundFieldAccessExpression(null, boundReceiver, c, field);
-                var op = BoundBinaryOperator.Bind(baseOpSyntaxKind, field.Type, boundRhs.Type);
-                if (op == null)
-                {
-                    Diagnostics.ReportUndefinedBinaryOperator(syntax.OperatorToken.Location, syntax.OperatorToken.Text, field.Type, boundRhs.Type);
-                    return new BoundErrorExpression(null);
-                }
-
-                var binary = new BoundBinaryExpression(null, leftRead, op, boundRhs);
-                var converted = conversions.BindConversion(syntax.Value.Location, binary, field.Type);
-                return BoundFieldAssignmentExpression.WithExpressionReceiver(null, boundReceiver, c, field, converted);
+                Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, memberName);
             }
+
+            var leftRead = new BoundFieldAccessExpression(null, boundReceiver, declaringType, field);
+            var op = BoundBinaryOperator.Bind(baseOpSyntaxKind, field.Type, boundRhs.Type);
+            if (op == null)
+            {
+                Diagnostics.ReportUndefinedBinaryOperator(syntax.OperatorToken.Location, syntax.OperatorToken.Text, field.Type, boundRhs.Type);
+                return new BoundErrorExpression(null);
+            }
+
+            var binary = new BoundBinaryExpression(null, leftRead, op, boundRhs);
+            var converted = conversions.BindConversion(syntax.Value.Location, binary, field.Type);
+            return BoundFieldAssignmentExpression.WithExpressionReceiver(null, boundReceiver, declaringType, field, converted);
         }
 
         // ADR-0051: check properties.
@@ -1006,24 +1004,22 @@ internal sealed partial class ExpressionBinder
         // User-defined struct/class receiver → field or property write.
         if (receiverType is StructSymbol structSym)
         {
-            // Walk base chain to find the field.
-            for (var c = structSym; c != null; c = c.BaseClass)
+            // ADR-0112 A3: this-first base-chain instance field walk, using the
+            // declaring struct as the owner for the emitted assignment.
+            if (TypeMemberModel.TryGetFieldIncludingInherited(structSym, fieldName, MemberQuery.Instance(MemberKinds.Field), out var field, out var declaringType))
             {
-                if (c.TryGetField(fieldName, out var field))
+                if (field.IsReadOnly)
                 {
-                    if (field.IsReadOnly)
-                    {
-                        Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
-                    }
-
-                    reportObsoleteUseIfApplicable(
-                        syntax.FieldIdentifier.Location,
-                        field,
-                        $"{c.Name}.{field.Name}");
-
-                    var converted = conversions.BindConversion(syntax.Value.Location, value, field.Type);
-                    return BoundFieldAssignmentExpression.WithExpressionReceiver(null, receiver, c, field, converted);
+                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
                 }
+
+                reportObsoleteUseIfApplicable(
+                    syntax.FieldIdentifier.Location,
+                    field,
+                    $"{declaringType.Name}.{field.Name}");
+
+                var converted = conversions.BindConversion(syntax.Value.Location, value, field.Type);
+                return BoundFieldAssignmentExpression.WithExpressionReceiver(null, receiver, declaringType, field, converted);
             }
 
             // ADR-0051: check properties before reporting "unable to find member".

--- a/test/Compiler.Tests/Emit/FieldAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/FieldAssignmentEmitTests.cs
@@ -129,6 +129,82 @@ public class FieldAssignmentEmitTests
         Assert.Equal(15, RunAndGetIntResult(source));
     }
 
+    [Fact]
+    public void InheritedField_Read_ThroughDerivedReceiver()
+    {
+        // ADR-0112 A3: reading an inherited field through a derived receiver.
+        // The emitted ldfld token must name the DECLARING (base) struct, so the
+        // declaring-type path in TypeMemberModel.TryGetFieldIncludingInherited
+        // is exercised. ilverify (in CompileToAssembly) pins token correctness.
+        var source = """
+            package P
+            import System
+
+            open class Base {
+                var BaseVal int32 = 7
+            }
+
+            class Derived : Base {
+                var DerivedVal int32 = 2
+            }
+
+            var d = Derived()
+            public var result = d.BaseVal
+            """;
+
+        Assert.Equal(7, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void InheritedField_Write_ThroughDerivedReceiver()
+    {
+        // ADR-0112 A3: writing an inherited field through a derived receiver.
+        // The emitted stfld token must name the DECLARING (base) struct.
+        var source = """
+            package P
+            import System
+
+            open class Base {
+                var BaseVal int32 = 7
+            }
+
+            class Derived : Base {
+                var DerivedVal int32 = 2
+            }
+
+            var d = Derived()
+            d.BaseVal = 55
+            public var result = d.BaseVal
+            """;
+
+        Assert.Equal(55, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void InheritedField_CompoundAssignment_ThroughDerivedReceiver()
+    {
+        // ADR-0112 A3: compound (+=) assignment on an inherited field exercises
+        // the chained-compound declaring-type path for both read and write.
+        var source = """
+            package P
+            import System
+
+            open class Base {
+                var BaseVal int32 = 7
+            }
+
+            class Derived : Base {
+                var DerivedVal int32 = 2
+            }
+
+            var d = Derived()
+            d.BaseVal += 3
+            public var result = d.BaseVal
+            """;
+
+        Assert.Equal(10, RunAndGetIntResult(source));
+    }
+
     private static int RunAndGetIntResult(string source)
     {
         var assembly = CompileToAssembly(source, target: "exe");


### PR DESCRIPTION
## Summary

ADR-0112 migration task **A3**. Routes the binder's instance field access/assignment off raw `BaseClass`-chain loops (and the `StructSymbol.TryGetFieldIncludingInherited` primitive) onto `TypeMemberModel.TryGetFieldIncludingInherited`, which returns the declaring struct needed for emitted field tokens. Pure refactor — IL parity preserved.

## What changed (5 instance-field sites)

1. `ExpressionBinder.Access.cs` (~1502) — instance field READ: `c`-loop → single call; `declaringType` used for the `BoundFieldAccessExpression` owner and the obsolete message.
2. `ExpressionBinder.Assignments.cs` (~653) — compound `+=`/`-=`: loop → call; `declaringType` for read + `WithExpressionReceiver` owner; `IsReadOnly` diagnostic preserved.
3. `ExpressionBinder.Assignments.cs` (~1008) — member field WRITE: loop → call; `declaringType` for owner + obsolete message.
4. `ExpressionBinder.Assignments.cs` (~179) — object-initializer assign: primitive → model; **owner kept as the receiver `structSymbol`** (declaring discarded), exact behavior preserved.
5. `ExpressionBinder.Assignments.cs` (~365) — `with`/field-assign: primitive → model; owner semantics unchanged.

Untouched (separate tasks): events (A5), static field/property (A4), method overload sets (A6), pattern/literal fields (A7).

## Parity

`TypeMemberModel.TryGetFieldIncludingInherited(type, name, MemberQuery.Instance(MemberKinds.Field), …)` performs the same this-first base-chain `TryGetField` walk and returns the same declaring struct as the old loops/primitive. No discrepancy found; emitted IL unchanged.

## Validation

- Release build: 0 warnings, 0 errors.
- New `FieldAssignmentEmitTests`: read / write / compound-assign of an **inherited** field through a derived receiver (exercises the declaring-type path; ilverify passes).
- Core.Tests 3411 / 1 skipped; LanguageServer.Tests 364; Compiler.Tests (batched) 1405 — incl. emit + ilverify.

Follows P0 #925, A1 #926, A2 #927.
