### PR TITLE
refactor(binding): route static field/property assignment through TypeMemberModel (ADR-0112 A4)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -267,7 +267,7 @@ internal sealed partial class ExpressionBinder
         {
             var staticValue = BindExpression(syntax.Value);
             var fieldName = syntax.FieldIdentifier.Text;
-            if (userStruct.TryGetStaticField(fieldName, out var staticField))
+            if (TypeMemberModel.TryGetStaticField(userStruct, fieldName, out var staticField))
             {
                 if (staticField.IsReadOnly)
                 {
@@ -279,19 +279,16 @@ internal sealed partial class ExpressionBinder
             }
 
             // Issue #263: static property assignment.
-            foreach (var prop in userStruct.StaticProperties)
+            if (TypeMemberModel.TryGetStaticProperty(userStruct, fieldName, out var prop))
             {
-                if (prop.Name == fieldName)
+                if (!prop.HasSetter)
                 {
-                    if (!prop.HasSetter)
-                    {
-                        Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
-                        return new BoundErrorExpression(null);
-                    }
-
-                    var propConverted = conversions.BindConversion(syntax.Value.Location, staticValue, prop.Type);
-                    return new BoundPropertyAssignmentExpression(null, receiver: null, userStruct, prop, propConverted);
+                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
+                    return new BoundErrorExpression(null);
                 }
+
+                var propConverted = conversions.BindConversion(syntax.Value.Location, staticValue, prop.Type);
+                return new BoundPropertyAssignmentExpression(null, receiver: null, userStruct, prop, propConverted);
             }
 
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
@@ -578,7 +575,7 @@ internal sealed partial class ExpressionBinder
         var baseOpSyntaxKind = isAdd ? SyntaxKind.PlusToken : SyntaxKind.MinusToken;
         var boundRhs = BindExpression(syntax.Value);
 
-        if (staticStruct.TryGetStaticField(memberName, out var staticField))
+        if (TypeMemberModel.TryGetStaticField(staticStruct, memberName, out var staticField))
         {
             var leftRead = new BoundFieldAccessExpression(null, receiver: null, staticStruct, staticField);
             var op = BoundBinaryOperator.Bind(baseOpSyntaxKind, staticField.Type, boundRhs.Type);
@@ -600,13 +597,8 @@ internal sealed partial class ExpressionBinder
             return true;
         }
 
-        foreach (var prop in staticStruct.StaticProperties)
+        if (TypeMemberModel.TryGetStaticProperty(staticStruct, memberName, out var prop))
         {
-            if (prop.Name != memberName)
-            {
-                continue;
-            }
-
             if (!prop.HasGetter || !prop.HasSetter)
             {
                 Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, memberName);


### PR DESCRIPTION
## Summary
Part of the ADR-0112 unified member-resolution migration (broad scope, task **A4**). Routes the binder static field/property **assignment** paths onto the canonical `TypeMemberModel` layer, replacing direct `StructSymbol.TryGetStaticField` calls and `foreach (… StaticProperties)` loops.

## Migrated sites — `ExpressionBinder.Assignments.cs`
1. Static field `=` (~270): `userStruct.TryGetStaticField(...)` → `TypeMemberModel.TryGetStaticField(userStruct, ...)`
2. Static property `=` (~282): `foreach (… StaticProperties)` → `TypeMemberModel.TryGetStaticProperty(userStruct, ...)`
3. Static field compound `+=`/`-=` (~578): `staticStruct.TryGetStaticField(...)` → `TypeMemberModel.TryGetStaticField(staticStruct, ...)`
4. Static property compound (~600): `foreach (… StaticProperties)` → `TypeMemberModel.TryGetStaticProperty(staticStruct, ...)`

Owner symbols (`userStruct`/`staticStruct`) and all diagnostics (IsReadOnly, HasGetter/HasSetter, ReportUnableToFindMember fall-through) preserved. `TryGetStaticField`/`TryGetStaticProperty` are single-level, first-by-name — semantically identical to the replaced code. Pure refactor; IL unchanged.

## Tests
Existing coverage in `test/Core.Tests/CodeAnalysis/SharedBlockTests.cs` exercises all four paths (static field/property `=` and `+=`/`-=`, getter/setter-only diagnostics).

## Verification
- Build: 0 Warning / 0 Error (warnings-as-errors)
- Core.Tests: 3411 passed
- LanguageServer.Tests: 364 passed
- Compiler.Tests (batched): 1405 passed

Diff: 4 sites, +10/−18.
