### PR TITLE
refactor(binding): route event subscription resolution through TypeMemberModel (ADR-0112 A5)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -448,6 +448,11 @@ internal sealed partial class ExpressionBinder
         var isAdd = syntax.OperatorToken.Kind == SyntaxKind.PlusEqualsToken;
 
         // Try implicit `this` event: walk the receiver type's events (including inherited).
+        // ADR-0112 A5: intentionally NOT routed through TypeMemberModel.TryGetEvent —
+        // that helper returns only the event, not the declaring base level, whereas
+        // this bound node must carry the *declaring* type `t` as its owner. Collapsing
+        // into TryGetEvent(receiverStruct, …) would change the owner from the declaring
+        // base to the derived type, breaking bound-node parity. Left as a manual walk.
         if (function?.ThisParameter != null && function.ReceiverType is StructSymbol receiverStruct)
         {
             for (var t = receiverStruct; t != null; t = t.BaseClass)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -79,13 +79,7 @@ internal sealed partial class ExpressionBinder
             // Try matching an event first; if no match, fall through to
             // ADR-0053 static field/property compound assignment instead of
             // reporting an immediate "unable to find member".
-            EventSymbol ev = null;
-            if (!staticStruct.StaticEvents.IsDefaultOrEmpty)
-            {
-                ev = staticStruct.StaticEvents.FirstOrDefault(e => e.Name == eventName);
-            }
-
-            if (ev != null)
+            if (TypeMemberModel.TryGetStaticEvent(staticStruct, eventName, out var ev))
             {
                 var userHandler = BindEventSubscriptionHandler(syntax.Value, ev.Type);
                 return new BoundEventSubscriptionExpression(null, receiver: null, staticStruct, ev, userHandler, isAdd);
@@ -111,14 +105,14 @@ internal sealed partial class ExpressionBinder
             }
 
             // Check for user-defined event on a StructSymbol before falling through to CLR reflection.
-            if (boundReceiver.Type is StructSymbol userStruct && !userStruct.Events.IsDefaultOrEmpty)
+            // ADR-0112 A5: TryGetEvent walks the base chain, so inherited instance
+            // events on `open class` bases now resolve (parity with the bare-`this`
+            // path in BindBareEventOrCompoundAssignment). The owner symbol remains
+            // `userStruct` (the receiver's static type) to preserve the bound-node shape.
+            if (boundReceiver.Type is StructSymbol userStruct && TypeMemberModel.TryGetEvent(userStruct, eventName, out var ev))
             {
-                var ev = userStruct.Events.FirstOrDefault(e => e.Name == eventName);
-                if (ev != null)
-                {
-                    var userHandler = BindEventSubscriptionHandler(syntax.Value, ev.Type);
-                    return new BoundEventSubscriptionExpression(null, boundReceiver, userStruct, ev, userHandler, isAdd);
-                }
+                var userHandler = BindEventSubscriptionHandler(syntax.Value, ev.Type);
+                return new BoundEventSubscriptionExpression(null, boundReceiver, userStruct, ev, userHandler, isAdd);
             }
 
             receiverClrType = boundReceiver.Type?.ClrType;

--- a/test/Compiler.Tests/Emit/EventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/EventEmitTests.cs
@@ -883,6 +883,162 @@ public class EventEmitTests
         }
     }
 
+    [Fact]
+    public void Adr0112A5_InheritedInstanceEvent_SubscribesThroughDerivedReceiver()
+    {
+        // ADR-0112 A5: instance event subscription on an explicit receiver now
+        // routes through TypeMemberModel.TryGetEvent, which walks the base
+        // chain. An instance event declared on an `open class` base must
+        // resolve when subscribed through a derived receiver. Before A5 the
+        // single-level `userStruct.Events` lookup fell through to an error.
+        var source = """
+            package MyLib
+            import System
+
+            class A5InhCounter {
+                var Value int32
+                init() { Value = 0 }
+                func Bump() { Value = Value + 1 }
+            }
+
+            open class A5InhBase {
+                public event A5InhChanged EventHandler
+                init() { }
+            }
+
+            class A5InhDerived : A5InhBase {
+                init() { }
+            }
+
+            class A5InhProbe {
+                var Counter A5InhCounter
+                var D A5InhDerived
+                init() {
+                    Counter = A5InhCounter()
+                    D = A5InhDerived()
+                    var c = Counter
+                    D.A5InhChanged += func(s object, e EventArgs) {
+                        c.Bump()
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var probeType = assembly.GetTypes().Single(t => t.Name == "A5InhProbe");
+        var baseType = assembly.GetTypes().Single(t => t.Name == "A5InhBase");
+        var counterType = assembly.GetTypes().Single(t => t.Name == "A5InhCounter");
+
+        var probe = Activator.CreateInstance(probeType)!;
+        var derived = probeType.GetField("D")!.GetValue(probe)!;
+        var counter = probeType.GetField("Counter")!.GetValue(probe)!;
+
+        // The backing field is declared on the base type.
+        var backingField = baseType.GetField("A5InhChanged", BindingFlags.NonPublic | BindingFlags.Instance);
+        var del = (Delegate)backingField!.GetValue(derived)!;
+        Assert.NotNull(del);
+
+        del.DynamicInvoke(derived, EventArgs.Empty);
+        del.DynamicInvoke(derived, EventArgs.Empty);
+
+        Assert.Equal(2, (int)counterType.GetField("Value")!.GetValue(counter)!);
+    }
+
+    [Fact]
+    public void Adr0112A5_ImmediateInstanceEvent_SubscribesUnchanged()
+    {
+        // ADR-0112 A5 parity: subscribing to an event declared directly on the
+        // receiver's own type must still bind and fire (no behavior change).
+        var source = """
+            package MyLib
+            import System
+
+            class A5ImmCounter {
+                var Value int32
+                init() { Value = 0 }
+                func Bump() { Value = Value + 1 }
+            }
+
+            class A5ImmSource {
+                public event A5ImmChanged EventHandler
+                init() { }
+            }
+
+            class A5ImmProbe {
+                var Counter A5ImmCounter
+                var Src A5ImmSource
+                init() {
+                    Counter = A5ImmCounter()
+                    Src = A5ImmSource()
+                    var c = Counter
+                    Src.A5ImmChanged += func(s object, e EventArgs) {
+                        c.Bump()
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var probeType = assembly.GetTypes().Single(t => t.Name == "A5ImmProbe");
+        var sourceType = assembly.GetTypes().Single(t => t.Name == "A5ImmSource");
+        var counterType = assembly.GetTypes().Single(t => t.Name == "A5ImmCounter");
+
+        var probe = Activator.CreateInstance(probeType)!;
+        var src = probeType.GetField("Src")!.GetValue(probe)!;
+        var counter = probeType.GetField("Counter")!.GetValue(probe)!;
+
+        var backingField = sourceType.GetField("A5ImmChanged", BindingFlags.NonPublic | BindingFlags.Instance);
+        var del = (Delegate)backingField!.GetValue(src)!;
+        del.DynamicInvoke(src, EventArgs.Empty);
+
+        Assert.Equal(1, (int)counterType.GetField("Value")!.GetValue(counter)!);
+    }
+
+    [Fact]
+    public void Adr0112A5_StaticEvent_SubscribesUnchanged()
+    {
+        // ADR-0112 A5 parity: static event subscription (Issue #263) now routes
+        // through TypeMemberModel.TryGetStaticEvent (single-level, first-by-name)
+        // and must bind and fire exactly as before.
+        var source = """
+            package MyLib
+            import System
+
+            class A5StatCounter {
+                var Value int32
+                init() { Value = 0 }
+                func Bump() { Value = Value + 1 }
+            }
+
+            class A5StatBus {
+                shared {
+                    public event A5StatPing EventHandler
+                }
+                var Counter A5StatCounter
+                init() {
+                    Counter = A5StatCounter()
+                    var c = Counter
+                    A5StatBus.A5StatPing += func(s object, e EventArgs) {
+                        c.Bump()
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var busType = assembly.GetTypes().Single(t => t.Name == "A5StatBus");
+        var counterType = assembly.GetTypes().Single(t => t.Name == "A5StatCounter");
+
+        var probe = Activator.CreateInstance(busType)!;
+        var counter = busType.GetField("Counter")!.GetValue(probe)!;
+
+        var backingField = busType.GetField("A5StatPing", BindingFlags.NonPublic | BindingFlags.Static);
+        var del = (Delegate)backingField!.GetValue(null)!;
+        del.DynamicInvoke(busType, EventArgs.Empty);
+
+        Assert.Equal(1, (int)counterType.GetField("Value")!.GetValue(counter)!);
+    }
+
     private static Assembly CompileToAssembly(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_event_emit_").FullName;


### PR DESCRIPTION
## Summary
Part of the ADR-0112 unified member-resolution migration (broad scope, task **A5**). Routes the binder's event-subscription resolution (`+=`/`-=` on user-defined events) onto the canonical `TypeMemberModel` layer.

## Migrated sites
**Site 1 — `ExpressionBinder.Async.cs` (static event, #263):** `staticStruct.StaticEvents.FirstOrDefault(...)` → `TypeMemberModel.TryGetStaticEvent(staticStruct, ...)`. Exact parity (single-level, first-by-name). ADR-0053 fall-through preserved.

**Site 2 — `ExpressionBinder.Async.cs` (instance event, #648):** `userStruct.Events.FirstOrDefault(...)` → `TypeMemberModel.TryGetEvent(userStruct, ...)`. Owner symbol kept as `userStruct`. **Sanctioned consistency fix:** the model helper walks the base chain, so inherited instance events now resolve via an explicit receiver — matching the bare-`this` path which already walked the base chain. Covered by a new regression test; breaks no existing test or ilverify.

**Site 3 — `ExpressionBinder.Assignments.cs` (bare `this`):** left **as-is** (documented inline). The manual base-walk passes the *declaring* level as the bound-node owner; `TryGetEvent` surfaces only the event, not the declaring type, so migrating would change the owner symbol and break parity.

Out of scope (untouched): `IncrementalGlobalScopeReuse.cs`, `Binder.cs`, `DeclarationBinder.cs` (declaration-time enumeration), CLR-reflection paths.

## Tests (`EventEmitTests.cs`, unique type names per method)
- `Adr0112A5_InheritedInstanceEvent_SubscribesThroughDerivedReceiver` — `open class` base event subscribed via derived receiver; binds, emits, ilverifies, fires (counter==2).
- `Adr0112A5_ImmediateInstanceEvent_SubscribesUnchanged` — immediate-level instance parity.
- `Adr0112A5_StaticEvent_SubscribesUnchanged` — static parity.

## Verification (warnings-as-errors)
- Build: 0 Warning / 0 Error
- Core.Tests: 3411 passed, 1 skipped
- LanguageServer.Tests: 364 passed
- Compiler.Tests (batched): 1408 passed
