### PR TITLE
refactor(binding): route instance method overload sets through TypeMemberModel (ADR-0112 A6)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -220,7 +220,7 @@ internal sealed partial class ExpressionBinder
             && function?.ThisParameter != null
             && function.ReceiverType is StructSymbol implicitThisStruct)
         {
-            var methods = implicitThisStruct.GetMethodsIncludingInherited(bareName.IdentifierToken.Text);
+            var methods = TypeMemberModel.GetMethods(implicitThisStruct, bareName.IdentifierToken.Text, MemberQuery.Instance(MemberKinds.Method));
             if (!methods.IsDefaultOrEmpty)
             {
                 var receiver = new BoundVariableExpression(null, function.ThisParameter);
@@ -248,7 +248,7 @@ internal sealed partial class ExpressionBinder
 
             if (boundReceiver.Type is StructSymbol receiverStruct)
             {
-                var methods = receiverStruct.GetMethodsIncludingInherited(memberName.IdentifierToken.Text);
+                var methods = TypeMemberModel.GetMethods(receiverStruct, memberName.IdentifierToken.Text, MemberQuery.Instance(MemberKinds.Method));
                 if (!methods.IsDefaultOrEmpty)
                 {
                     var group = BuildInstanceMethodGroup(boundReceiver, methods);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2073,7 +2073,7 @@ internal sealed partial class ExpressionBinder
             // if receiver is a user struct symbol.
             if (receiver != null && receiver.Type is StructSymbol userClass)
             {
-                var userOverloads = userClass.GetMethodsIncludingInherited(methodName);
+                var userOverloads = TypeMemberModel.GetMethods(userClass, methodName, MemberQuery.Instance(MemberKinds.Method));
                 if (userOverloads.Length > 0)
                 {
                     var userMethod = overloads.SelectInstanceOverloadOrReport(userOverloads, arguments, ce, methodName, argumentNames);
@@ -2146,7 +2146,7 @@ internal sealed partial class ExpressionBinder
         // fallback for imported CLR types.)
         if (receiver.Type is StructSymbol userClassPriority)
         {
-            var priorityOverloads = userClassPriority.GetMethodsIncludingInherited(methodName);
+            var priorityOverloads = TypeMemberModel.GetMethods(userClassPriority, methodName, MemberQuery.Instance(MemberKinds.Method));
             if (priorityOverloads.Length > 0)
             {
                 var userMethodPriority = overloads.SelectInstanceOverloadOrReport(priorityOverloads, arguments, ce, methodName, argumentNames);

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -2455,7 +2455,7 @@ internal sealed class OverloadResolver
             if (getCurrentFunction()?.ThisParameter != null
                 && getCurrentFunction().ReceiverType is StructSymbol implicitReceiverStruct)
             {
-                var implicitOverloads = implicitReceiverStruct.GetMethodsIncludingInherited(syntax.Identifier.Text);
+                var implicitOverloads = TypeMemberModel.GetMethods(implicitReceiverStruct, syntax.Identifier.Text, MemberQuery.Instance(MemberKinds.Method));
                 if (implicitOverloads.Length > 0)
                 {
                     var implicitMethod = SelectInstanceOverloadOrReport(implicitOverloads, boundArguments.ToImmutable(), syntax, syntax.Identifier.Text, argumentNames);

--- a/test/Compiler.Tests/Emit/Adr0112UserMethodGroupEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Adr0112UserMethodGroupEmitTests.cs
@@ -135,6 +135,63 @@ public class Adr0112UserMethodGroupEmitTests
         Assert.Equal("21\n", CompileAndRun(source));
     }
 
+    [Fact]
+    public void InheritedInstanceMethodGroup_ViaReceiver_EmitsAndRuns()
+    {
+        // ADR-0112 A6: the method group resolves an instance method inherited
+        // from a base class through TypeMemberModel.GetMethods' this-first base
+        // walk (formerly StructSymbol.GetMethodsIncludingInherited). Unique type
+        // names avoid FunctionTypeSymbol.Cache aliasing across in-process runs.
+        var source = """
+            package P
+            import System
+
+            open class A6InhGroupBase {
+                var seed int32
+                func Seed() int32 { return seed }
+            }
+
+            class A6InhGroupDerived : A6InhGroupBase {
+            }
+
+            func A6UseSeed(f () -> int32) int32 { return f() }
+
+            var d = A6InhGroupDerived{ seed: 33 }
+            Console.WriteLine(A6UseSeed(d.Seed))
+            """;
+
+        Assert.Equal("33\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InheritedBareInstanceMethodGroup_InsideDerivedMethod_EmitsAndRuns()
+    {
+        // ADR-0112 A6: the bare implicit-`this` method group inside a derived
+        // class method resolves a base-class instance method via the inherited
+        // base walk in TypeMemberModel.GetMethods.
+        var source = """
+            package P
+            import System
+
+            open class A6BareInhBase {
+                var amount int32
+                func Amount() int32 { return amount }
+            }
+
+            class A6BareInhDerived : A6BareInhBase {
+                func AsDelegate() int32 {
+                    var f () -> int32 = Amount
+                    return f()
+                }
+            }
+
+            var x = A6BareInhDerived{ amount: 17 }
+            Console.WriteLine(x.AsDelegate())
+            """;
+
+        Assert.Equal("17\n", CompileAndRun(source));
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_adr0112_emit_").FullName;


### PR DESCRIPTION
## Summary
Part of the ADR-0112 unified member-resolution migration (broad scope, task **A6**). Routes the binder's user-defined **instance method overload-set** resolution onto the canonical `TypeMemberModel.GetMethods(type, name, MemberQuery.Instance(MemberKinds.Method))`, replacing direct `StructSymbol.GetMethodsIncludingInherited` calls.

`TypeMemberModel.GetMethods` for a `StructSymbol` with `Instance(Method)` is byte-identical to `GetMethodsIncludingInherited`: this-first base-chain walk over instance-only `c.Methods`, signature dedup via `BoundScope.FunctionSignaturesEqual`, same empty/default handling. Pure refactor — overload resolution results and IL unchanged.

## Migrated sites (5)
1. `ExpressionBinder.Calls.cs` ~2076 — `userOverloads` (instance call dispatch)
2. `ExpressionBinder.Calls.cs` ~2149 — `priorityOverloads` (user-class-priority dispatch)
3. `ExpressionBinder.Async.cs` ~223 — bare implicit-`this` method group → delegate
4. `ExpressionBinder.Async.cs` ~251 — `recv.Method` method group → delegate
5. `OverloadResolver.cs` ~2458 — implicit-`this` sibling-method call dispatch

## Deferred to A9 (intentionally untouched)
Interface method sites `Calls.cs` ~2008/2059/2399 (`InterfaceSymbol.GetMethods`) — these call `EnsureMembersResolved()` before reading `Methods`, which `TypeMemberModel.GetMethods` does not yet do. Migrating needs an enabler (ensure interface members resolved inside the model), handled with the other interface gaps in A9. CLR-reflection method paths remain Category B (out of scope). `StructSymbol.GetMethodsIncludingInherited` left in place (still used by declaration-time validation in `DeclarationBinder`).

## Tests
Added 2 focused emit tests filling the inherited-overload method-group gap (`Adr0112UserMethodGroupEmitTests.cs`, unique type names to avoid `FunctionTypeSymbol.Cache` aliasing): `InheritedInstanceMethodGroup_ViaReceiver_EmitsAndRuns`, `InheritedBareInstanceMethodGroup_InsideDerivedMethod_EmitsAndRuns`. Existing overload-resolution / method-group / DefaultInterfaceMethods tests all pass.

## Verification (warnings-as-errors)
- Build: 0 Warning / 0 Error
- Core.Tests: 3411 passed, 1 skipped
- LanguageServer.Tests: 364 passed
- Compiler.Tests (batched): 1408 passed
