### PR TITLE
refactor(binding): route pattern/literal/destructuring field resolution through TypeMemberModel (ADR-0112 A7)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -58,7 +58,7 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            if (!structType.TryGetFieldIncludingInherited(fieldName, out var field, out var declaringType))
+            if (!TypeMemberModel.TryGetFieldIncludingInherited(structType, fieldName, MemberQuery.Instance(MemberKinds.Field), out var field, out var declaringType))
             {
                 Diagnostics.ReportUnableToFindMember(initSyntax.FieldIdentifier.Location, fieldName);
                 continue;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -488,7 +488,7 @@ internal sealed partial class ExpressionBinder
                 // consistent with Phase 4.1 call-site inference).
                 foreach (var initSyntax in syntax.Initializers)
                 {
-                    if (!structSymbol.TryGetFieldIncludingInherited(initSyntax.FieldIdentifier.Text, out var field, out _))
+                    if (!TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, initSyntax.FieldIdentifier.Text, MemberQuery.Instance(MemberKinds.Field), out var field, out _))
                     {
                         continue;
                     }
@@ -540,7 +540,7 @@ internal sealed partial class ExpressionBinder
         foreach (var initSyntax in syntax.Initializers)
         {
             var fieldName = initSyntax.FieldIdentifier.Text;
-            if (!structSymbol.TryGetFieldIncludingInherited(fieldName, out var field, out _))
+            if (!TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, fieldName, MemberQuery.Instance(MemberKinds.Field), out var field, out _))
             {
                 Diagnostics.ReportUnableToFindMember(initSyntax.FieldIdentifier.Location, fieldName);
                 continue;

--- a/src/Core/CodeAnalysis/Binding/PatternBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/PatternBinder.cs
@@ -185,7 +185,7 @@ internal sealed class PatternBinder
 
         foreach (var fieldSyntax in syntax.Fields)
         {
-            if (!structType.TryGetFieldIncludingInherited(fieldSyntax.Identifier.Text, out var field, out _))
+            if (!TypeMemberModel.TryGetFieldIncludingInherited(structType, fieldSyntax.Identifier.Text, MemberQuery.Instance(MemberKinds.Field), out var field, out _))
             {
                 Diagnostics.ReportUndefinedFieldOnType(fieldSyntax.Identifier.Location, fieldSyntax.Identifier.Text, discriminantType);
                 fields.Add(new BoundPropertyPatternField(syntax, new FieldSymbol(fieldSyntax.Identifier.Text, TypeSymbol.Error, Accessibility.Public), BindPattern(fieldSyntax.Pattern, TypeSymbol.Error)));

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -968,7 +968,7 @@ internal sealed class StatementBinder
                 continue;
             }
 
-            if (!structType.TryGetFieldIncludingInherited(fieldName, out var field, out var declaringType))
+            if (!TypeMemberModel.TryGetFieldIncludingInherited(structType, fieldName, MemberQuery.Instance(MemberKinds.Field), out var field, out var declaringType))
             {
                 Diagnostics.ReportUnableToFindMember(fieldSyntax.FieldIdentifier.Location, fieldName);
                 continue;

--- a/test/Core.Tests/CodeAnalysis/Binding/InheritedFieldResolutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/InheritedFieldResolutionTests.cs
@@ -1,0 +1,61 @@
+// <copyright file="InheritedFieldResolutionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0112 A7: focused coverage for inherited-field resolution in the binder
+/// sites routed through <see cref="TypeMemberModel.TryGetFieldIncludingInherited"/>.
+/// Each method uses unique type names because FunctionTypeSymbol.Cache aliases by
+/// type-name string across in-process compilations.
+/// </summary>
+public class InheritedFieldResolutionTests
+{
+    [Fact]
+    public void PropertyPattern_MatchesInheritedField()
+    {
+        // PatternBinder: property pattern resolves a field declared on a base type.
+        var source = @"
+open class InhPatBase { var PatField int32 }
+class InhPatDerived : InhPatBase {}
+let d = InhPatDerived{PatField: 5}
+let r = switch d { case { PatField: 5 }: 1 default: 0 }
+r
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void NamedDeconstruction_BindsInheritedField()
+    {
+        // StatementBinder: `let { Field = local } = expr` resolves an inherited field.
+        var source = @"
+open data class InhDecBase { var DecField int32 }
+data class InhDecDerived : InhDecBase { var Own int32 }
+let d = InhDecDerived{DecField: 9, Own: 0}
+let { DecField = a } = d
+a
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(9, result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Summary
Part of the ADR-0112 unified member-resolution migration (broad scope, task **A7**). Routes the binder's remaining instance-field probes in pattern matching, struct/object literals, generic inference, and destructuring onto the canonical `TypeMemberModel.TryGetFieldIncludingInherited(..., MemberQuery.Instance(MemberKinds.Field), ...)`, replacing the last instance-method `StructSymbol.TryGetFieldIncludingInherited` binder callers.

`TypeMemberModel.TryGetFieldIncludingInherited` with `Instance(Field)` is byte-identical to `StructSymbol.TryGetFieldIncludingInherited`: this-first base-chain walk, instance-only `c.TryGetField`, same `declaringType` semantics, same null-on-miss. Same transformation as PR A3. Pure refactor — IL and diagnostics unchanged.

## Migrated sites (5)
1. `ExpressionBinder.Calls.cs` ~61 — object-override field init (`out var declaringType`)
2. `ExpressionBinder.Literals.cs` ~491 — generic type-arg inference from initializer (`out _`)
3. `ExpressionBinder.Literals.cs` ~543 — struct literal field init (`out _`)
4. `PatternBinder.cs` ~188 — property pattern field (`out _`)
5. `StatementBinder.cs` ~971 — struct destructuring binding (`out var declaringType`)

`grep` for residual instance-method `TryGetFieldIncludingInherited` callers in the binder → **0 matches**. `StructSymbol.TryGetFieldIncludingInherited` left in place (may have other callers/tests).

## Tests
Added `InheritedFieldResolutionTests.cs` covering two genuine inherited-field gaps: `PropertyPattern_MatchesInheritedField` (site 4) and `NamedDeconstruction_BindsInheritedField` (site 5). Existing coverage: inherited-field struct-literal init, destructuring/copy, property patterns.

## Verification (warnings-as-errors)
- Build: 0 Warning / 0 Error
- Core.Tests: 3413 passed, 1 skipped
- LanguageServer.Tests: 364 passed
- Compiler.Tests (batched): 1410 passed

## Note (out of scope, no behavior change)
A pre-existing interpreter `.copy(...)` limitation for inherited fields was observed and confirmed to be baseline behavior (verified by stashing the binder edits). This refactor leaves it byte-identical and does not address it.
