### PR TITLE
refactor(binding): route operator and protocol method lookups through TypeMemberModel (ADR-0112 A8)

### DIFF
--- a/docs/adr/0112-unified-member-resolution.md
+++ b/docs/adr/0112-unified-member-resolution.md
@@ -168,3 +168,25 @@ characterization tests remain green.
 - **Reserved `MemberKinds.NestedType`.** Added as a reserved flag value (not
   included in `All`) for future nested-type routing. Nested-type enumeration is
   not wired in P0; it remains future work to avoid scope creep.
+
+## Addendum — A8: operator and protocol single-method lookups
+
+The A8 consumer-migration PR routes the binder's single-method-by-name probes
+through the canonical layer. No behavior, ordering, or diagnostics changed; the
+new helper is a line-for-line mirror of the instance method it replaces.
+
+- **Canonical single-method helper.** Added
+  `TypeMemberModel.TryGetMethodIncludingInherited(TypeSymbol, string, out
+  FunctionSymbol)`. It mirrors `StructSymbol.TryGetMethodIncludingInherited`
+  exactly: the FIRST instance method by name, in declaration order within each
+  level, walking the base chain this-first — instance methods only, no overload
+  set, no statics. The helper is `StructSymbol`-only by design (all current
+  callers pass a user struct); the original instance method is unchanged.
+
+- **Consumer migrations.** User-operator resolution (unary and binary, left and
+  right operands) in `ExpressionBinder.Operators.cs`, duck-typed iterator
+  probing (`GetEnumerator`/`MoveNext`) in `MemberLookup.cs`, and `using`/`defer`
+  dispose probing (`Dispose`/`DisposeAsync`) in `ConversionClassifier.cs` now
+  call the canonical helper instead of the `StructSymbol` instance method. The
+  surrounding parameter/return-type, accessibility, and bound-node construction
+  logic is unchanged. CLR-reflection operator/dispose fallbacks are untouched.

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1116,7 +1116,7 @@ internal sealed class ConversionClassifier
         // that declares a public parameterless Dispose() (including via
         // IDisposable implementation), route through user-instance-call.
         if (variable.Type is StructSymbol userType
-            && userType.TryGetMethodIncludingInherited("Dispose", out var userDispose)
+            && TypeMemberModel.TryGetMethodIncludingInherited(userType, "Dispose", out var userDispose)
             && userDispose.Parameters.Length == 0
             && (userDispose.Type == TypeSymbol.Void || userDispose.Type == null)
             && userDispose.Accessibility == Accessibility.Public)
@@ -1161,7 +1161,7 @@ internal sealed class ConversionClassifier
 
         // User-defined G# class path: probe for DisposeAsync() returning ValueTask.
         if (variable.Type is StructSymbol userType
-            && userType.TryGetMethodIncludingInherited("DisposeAsync", out var userDisposeAsync)
+            && TypeMemberModel.TryGetMethodIncludingInherited(userType, "DisposeAsync", out var userDisposeAsync)
             && userDisposeAsync.Parameters.Length == 0
             && userDisposeAsync.Accessibility == Accessibility.Public)
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -66,7 +66,7 @@ internal sealed partial class ExpressionBinder
             {
                 FunctionSymbol userOp = null;
                 bool isStructReceiver = false;
-                if (boundOperand.Type is StructSymbol operandStruct && operandStruct.TryGetMethodIncludingInherited(userOpName, out var structOp))
+                if (boundOperand.Type is StructSymbol operandStruct && TypeMemberModel.TryGetMethodIncludingInherited(operandStruct, userOpName, out var structOp))
                 {
                     userOp = structOp;
                     isStructReceiver = true;
@@ -716,12 +716,12 @@ internal sealed partial class ExpressionBinder
                 FunctionSymbol userOp = null;
                 bool leftIsStructReceiver = false;
                 bool rightIsStructReceiver = false;
-                if (boundLeft.Type is StructSymbol leftStruct && leftStruct.TryGetMethodIncludingInherited(userOpName, out var leftOp))
+                if (boundLeft.Type is StructSymbol leftStruct && TypeMemberModel.TryGetMethodIncludingInherited(leftStruct, userOpName, out var leftOp))
                 {
                     userOp = leftOp;
                     leftIsStructReceiver = true;
                 }
-                else if (boundRight.Type is StructSymbol rightStruct && rightStruct.TryGetMethodIncludingInherited(userOpName, out var rightOp))
+                else if (boundRight.Type is StructSymbol rightStruct && TypeMemberModel.TryGetMethodIncludingInherited(rightStruct, userOpName, out var rightOp))
                 {
                     userOp = rightOp;
                     rightIsStructReceiver = true;

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -875,10 +875,10 @@ internal sealed class MemberLookup
     /// <returns><see langword="true"/> when the duck-typed shape matches.</returns>
     public static bool TryGetUserPatternEnumerableElementType(StructSymbol type, out TypeSymbol elementType)
     {
-        if (type.TryGetMethodIncludingInherited("GetEnumerator", out var getEnumerator) &&
+        if (TypeMemberModel.TryGetMethodIncludingInherited(type, "GetEnumerator", out var getEnumerator) &&
             getEnumerator.Parameters.Length == 0 &&
             getEnumerator.Type is StructSymbol enumeratorType &&
-            enumeratorType.TryGetMethodIncludingInherited("MoveNext", out var moveNext) &&
+            TypeMemberModel.TryGetMethodIncludingInherited(enumeratorType, "MoveNext", out var moveNext) &&
             moveNext.Parameters.Length == 0 &&
             moveNext.Type == TypeSymbol.Bool &&
             enumeratorType.TryGetField("Current", out var currentField))

--- a/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
@@ -352,6 +352,34 @@ public static class TypeMemberModel
         return false;
     }
 
+    /// <summary>
+    /// ADR-0112: tries to find the FIRST instance method named <paramref name="name"/>
+    /// on <paramref name="type"/>, walking the base chain this-first (declaration order
+    /// within each level). Mirrors <see cref="StructSymbol.TryGetMethodIncludingInherited"/>:
+    /// instance methods only, no overload set, no statics. Used by user-operator
+    /// resolution and duck-typed protocol probes (iterator, dispose).
+    /// </summary>
+    /// <param name="type">The type to resolve against (user-defined struct/class only).</param>
+    /// <param name="name">The method name.</param>
+    /// <param name="method">The found method on success.</param>
+    /// <returns>True if found.</returns>
+    public static bool TryGetMethodIncludingInherited(TypeSymbol type, string name, out FunctionSymbol method)
+    {
+        if (type is StructSymbol structSymbol)
+        {
+            for (var c = structSymbol; c != null; c = c.BaseClass)
+            {
+                if (c.TryGetMethod(name, out method))
+                {
+                    return true;
+                }
+            }
+        }
+
+        method = null;
+        return false;
+    }
+
     private static IEnumerable<Symbol> EnumerateStructMembers(StructSymbol structSymbol, MemberQuery query)
     {
         for (var c = structSymbol; c != null; c = c.BaseClass)

--- a/test/Core.Tests/CodeAnalysis/Binding/UserOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/UserOperatorTests.cs
@@ -91,6 +91,33 @@ var eq = p == q
         Assert.Equal(true, result.Value);
     }
 
+    [Fact]
+    public void InheritedBinaryOperator_DeclaredOnOpenBase_BindsThroughDerived()
+    {
+        // ADR-0112 A8: a user operator declared on an open base class must be
+        // found when the operands are a derived instance — the binder walks the
+        // base chain via TypeMemberModel.TryGetMethodIncludingInherited.
+        var source = @"
+open class OpBaseVec {
+    var X int32
+}
+
+func (a OpBaseVec) operator +(b OpBaseVec) int32 {
+    return a.X + b.X
+}
+
+class OpDerivedVec : OpBaseVec {
+}
+
+var p = OpDerivedVec{X: 5}
+var q = OpDerivedVec{X: 7}
+var sum = p + q
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(12, result.Value);
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
## Summary
Part of the ADR-0112 unified member-resolution migration (broad scope, task **A8**, the behavior-sensitive one). Routes the binder's single-method-by-name lookups — user operator methods and duck-typed protocol probes (iterator `GetEnumerator`/`MoveNext`, `Dispose`/`DisposeAsync`) — onto a new canonical helper.

## New enabler
`TypeMemberModel.TryGetMethodIncludingInherited(TypeSymbol type, string name, out FunctionSymbol method)` — a line-for-line mirror of `StructSymbol.TryGetMethodIncludingInherited`: StructSymbol-only, first instance method by name in declaration order, this-first base-chain walk, no overload set, no statics.

## Migrated sites (7)
- `ExpressionBinder.Operators.cs` ~69, ~719, ~724 — unary + binary user operator method probes
- `MemberLookup.cs` ~878, ~881 — duck-typed `GetEnumerator` / `MoveNext`
- `ConversionClassifier.cs` ~1119, ~1164 — `Dispose` / `DisposeAsync`

All receivers were already statically `StructSymbol`; surrounding conditions, signature/accessibility checks, and bound-node construction unchanged. `grep` for residual instance-method callers in the binder → **0**. `StructSymbol.TryGetMethodIncludingInherited`/`TryGetMethod` left in place; CLR-reflection paths untouched.

## Parity
Pure refactor; IL and diagnostics byte-identical. The new helper is an exact mirror; no operator-selection / extension-fallback / CLR `op_*` fallback logic changed.

## Tests
Added `UserOperatorTests.InheritedBinaryOperator_DeclaredOnOpenBase_BindsThroughDerived` (operator on an `open class` base, applied through a derived instance) filling an inherited-operator gap. Inherited `Dispose` and duck-typed iterator already covered by existing tests.

## ADR
Appended an A8 addendum to `docs/adr/0112-unified-member-resolution.md`.

## Verification (warnings-as-errors)
- Build: 0 Warning / 0 Error
- Core.Tests: 3413 passed, 1 skipped
- LanguageServer.Tests: 364 passed
- Behavior-sensitive filters (`Operator|Enumerat|Foreach|Dispose|Using|Defer`): Core.Tests 109 passed, Compiler.Tests 101 passed
