### PR TITLE
refactor(binding): route interface member resolution through TypeMemberModel (ADR-0112 A9, final)

### DIFF
--- a/docs/adr/0112-unified-member-resolution.md
+++ b/docs/adr/0112-unified-member-resolution.md
@@ -190,3 +190,124 @@ new helper is a line-for-line mirror of the instance method it replaces.
   call the canonical helper instead of the `StructSymbol` instance method. The
   surrounding parameter/return-type, accessibility, and bound-node construction
   logic is unchanged. CLR-reflection operator/dispose fallbacks are untouched.
+
+## Addendum — A9: interface member enumeration (final consumer migration)
+
+The A9 consumer-migration PR is the final step of ADR-0112. It routes the
+binder's remaining by-name interface *method* overload-set probes — including the
+interface-method sites deferred from A6 — through the canonical layer, so that no
+genuine by-name user-type member resolution remains outside `TypeMemberModel`. No
+behavior, ordering, IL, or diagnostics changed for any working program.
+
+- **Parity enabler — `EnsureMembersResolved` visibility.**
+  `InterfaceSymbol.EnsureMembersResolved()` changed from `private` to `internal`
+  so the canonical layer (same assembly/namespace) can guarantee the lazy member
+  tables of a *constructed* generic interface instance are substituted/populated
+  before enumeration. `TypeMemberModel.GetMethods`'s interface branch now calls
+  `interfaceSymbol.EnsureMembersResolved()` at the start of the branch, exactly as
+  the original `InterfaceSymbol.GetMethods(name)` did. This is idempotent, adds no
+  `BinderContext` dependency, and only populates the method tables.
+  - In practice the explicit guard is defense-in-depth: the `Methods` /
+    `StaticMethods` property *getters* already invoke `EnsureMembersResolved`, and
+    those getters are what the interface branch reads. The explicit call makes the
+    contract uniform and robust against future refactoring that might read a
+    backing field directly. The other interface branches in `TypeMemberModel`
+    (`EnumerateInterfaceMembers`, `LookupInterfaceMember`) reach methods via those
+    same resolving getters / `TryGetMethod` / `TryGetStaticMethod` accessors (which
+    also resolve), and reach `Properties` / `Events` via eagerly-populated tables
+    (`SetProperties`/`SetEvents`; `TryResolveMembers` substitutes *methods* only).
+    No additional guards were therefore required on the property/event branches —
+    `EnsureMembersResolved` would have no effect there.
+
+- **Dedup parity (verified).** `InterfaceSymbol.GetMethods` does not dedup;
+  `TypeMemberModel.GetMethods` applies `AddMethodsDeduped`
+  (`BoundScope.FunctionSignaturesEqual`). The declaration binder
+  (`DeclarationBinder.cs`, interface member pass) already rejects two same-name
+  methods with identical signatures on one interface via the *same*
+  `FunctionSignaturesEqual`, for both instance and static buckets. Dedup is
+  therefore a no-op for interfaces and order/content are preserved.
+
+- **Consumer migrations (interface method overload sets).** Four sites replaced
+  `<ifaceExpr>.GetMethods(name)` with
+  `TypeMemberModel.GetMethods(<ifaceExpr>, name, MemberQuery.Instance(MemberKinds.Method))`,
+  leaving all surrounding logic (private-helper bucket via `GetPrivateMethods`,
+  `IsInsideSameInterface`, `AddRange`, visibility diagnostics, overload selection,
+  and the default-interface-method `HasDefaultBody` filter) unchanged:
+  - `ExpressionBinder.Calls.cs` — interface-typed receiver dispatch.
+  - `ExpressionBinder.Calls.cs` — type-parameter sealed-interface-constraint dispatch.
+  - `ExpressionBinder.Calls.cs` — default-interface-method probe (then filtered by `HasDefaultBody`).
+  - `OverloadResolver.cs` — implicit-self (`this`) interface method dispatch.
+
+- **Consumer migration (constrained static-virtual enumeration).**
+  `ExpressionBinder.Access.cs` (`BindTypeParameterStaticAccessorStep`, call arm)
+  replaced its hand-rolled `foreach (… in InterfaceConstraint.StaticMethods)` name
+  scan with
+  `TypeMemberModel.GetMethods(tpSym.InterfaceConstraint, methodName, MemberQuery.Static(MemberKinds.Method))`,
+  keeping the param-count match + first-wins at the call site. `GetMethods` already
+  filters by name (so the redundant `candidate.Name == methodName` check was
+  dropped) and preserves declaration order for static interface methods, so the
+  first param-count match is identical. The sibling `NameExpressionSyntax` arm only
+  reports GS0333 (static-virtual properties/constants are deferred) and enumerates
+  nothing, so it was left unchanged.
+
+- **Additional site found by the residual sweep (deferred from A6).**
+  `OverloadResolver.cs` implicit-static-self dispatch inside a static-virtual /
+  private-static interface helper body replaced
+  `implicitStaticIface.GetStaticMethods(name)` with
+  `TypeMemberModel.GetMethods(implicitStaticIface, name, MemberQuery.Static(MemberKinds.Method))`
+  — a clean exact-parity static interface-method by-name lookup mirroring the
+  instance path migrated in A6. The adjacent `GetStaticPrivateMethods` private
+  bucket is left as-is.
+
+- **Explicit exclusions (documented, not migrated).**
+  - `LanguageServer/CrossAssemblyDefinitionResolver.cs` — Category C
+    Go-to-Definition declaration mapping: reverse-maps a CLR `MemberInfo` to a
+    source-declared symbol, gated on `Declaration != null` with bespoke arity
+    matching (`SelectMatchingMethod`). Not by-name resolution.
+  - `ExpressionBinder.Calls.cs` DIM open-method **index** matching
+    (`var overloads = ifaceSym.Methods;` and `ifaceSym.Definition.Methods[idx]`) —
+    behavior-sensitive structural code, not a name lookup.
+  - `InterfaceSymbol.GetPrivateMethods` / `GetStaticPrivateMethods` and the
+    private-helper bucket — a separate concern not modeled by `TypeMemberModel`.
+  - Category C declaration-time table building / interface-impl validation
+    (`Binder.cs`, `DeclarationBinder.cs`, `IncrementalGlobalScopeReuse.cs`) and all
+    CLR-reflection / imported-type paths (`ClrOperatorResolution.cs`,
+    `ConversionClassifier.cs`, `MemberLookup.cs` CLR-contract matching).
+  - Public accessors (`InterfaceSymbol.GetMethods`, `GetStaticMethods`,
+    `StructSymbol.GetMethodsIncludingInherited`, etc.) are retained in place.
+
+- **Residual sweep classification (`src/Core/CodeAnalysis/Binding/`).** Every
+  remaining direct member-table access was classified as (a) declaration-time
+  table building / validation, (b) CLR reflection / imported types, or
+  (c) behavior-sensitive structural (DIM index match; private-method bucket;
+  single-level `StructSymbol.TryGetField` used for delegate-field invocation that
+  needs the declaring type, duck-typed enumerator `Current`, positional/param-name
+  field matching, and declaration-time duplicate-name detection). No category (d)
+  genuine by-name user-type member resolution remains outside `TypeMemberModel`
+  beyond the sites migrated above. The single-level `StructSymbol.TryGetField`
+  sites are *not* exact-parity with the base-walking `TypeMemberModel.TryGetField`
+  and were intentionally left to preserve their narrower (single-level / declaring-
+  type) semantics.
+
+- **Test coverage.** The existing interface, default-interface-method, private
+  interface-helper, generic sealed-interface-constraint, and static-virtual suites
+  (Core.Tests + Compiler.Tests `Interface|DefaultInterface|Constraint|StaticVirtual|Generic`
+  filters) exercise the migrated paths, including constructed (lazily-resolved)
+  generic interface instances, and remain green. A "fails-without-the-enabler"
+  source-level repro is **not constructible**, because the public `Methods` /
+  `StaticMethods` getters already trigger `EnsureMembersResolved` on first access;
+  the explicit guard is robustness/intent documentation rather than a behavior fix,
+  so the existing generic-constraint suites are relied upon.
+
+### Final state of ADR-0112
+
+With A9 the unified member-resolution migration is **complete**: all genuine
+by-name user-type member resolution in the binder — struct and interface, instance
+and static, field/property/event/method, single-member and overload-set — flows
+through `TypeMemberModel`. The remaining direct symbol-table accesses are
+declaration-time table building, CLR reflection, or behavior-sensitive structural
+code that the model deliberately does not abstract. The only known modeling gap is
+the P0-noted absence of interface static *properties* / static *events* on
+`InterfaceSymbol` (no `StaticProperties`/`StaticEvents` tables); surfacing those
+remains future work requiring deeper symbol modeling, independent of this
+migration.

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2462,10 +2462,9 @@ internal sealed partial class ExpressionBinder
                 {
                     var methodName = callSyntax.Identifier.Text;
                     FunctionSymbol slot = null;
-                    foreach (var candidate in tpSym.InterfaceConstraint.StaticMethods)
+                    foreach (var candidate in TypeMemberModel.GetMethods(tpSym.InterfaceConstraint, methodName, MemberQuery.Static(MemberKinds.Method)))
                     {
-                        if (candidate.Name == methodName
-                            && candidate.Parameters.Length == callSyntax.Arguments.Count)
+                        if (candidate.Parameters.Length == callSyntax.Arguments.Count)
                         {
                             slot = candidate;
                             break;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2005,7 +2005,7 @@ internal sealed partial class ExpressionBinder
             // the static receiver type is an interface.
             if (receiver != null && receiver.Type is InterfaceSymbol ifaceRecv)
             {
-                var ifaceOverloads = ifaceRecv.GetMethods(methodName);
+                var ifaceOverloads = TypeMemberModel.GetMethods(ifaceRecv, methodName, MemberQuery.Instance(MemberKinds.Method));
 
                 // ADR-0090 / issue #756: private interface helpers are visible
                 // ONLY when the call is made from inside another member of the
@@ -2056,7 +2056,7 @@ internal sealed partial class ExpressionBinder
             // typed as the interface itself.
             if (receiver != null && receiver.Type is TypeParameterSymbol tpRecv && tpRecv.InterfaceConstraint != null)
             {
-                var tpOverloads = tpRecv.InterfaceConstraint.GetMethods(methodName);
+                var tpOverloads = TypeMemberModel.GetMethods(tpRecv.InterfaceConstraint, methodName, MemberQuery.Instance(MemberKinds.Method));
                 if (tpOverloads.Length > 0)
                 {
                     var tpIfaceMethod = overloads.SelectInstanceOverloadOrReport(tpOverloads, arguments, ce, methodName, argumentNames);
@@ -2396,7 +2396,7 @@ internal sealed partial class ExpressionBinder
                     continue;
                 }
 
-                var candidates = iface.GetMethods(methodName);
+                var candidates = TypeMemberModel.GetMethods(iface, methodName, MemberQuery.Instance(MemberKinds.Method));
                 var defaultsOnly = ImmutableArray.CreateBuilder<FunctionSymbol>();
                 for (var i = 0; i < candidates.Length; i++)
                 {

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -2480,7 +2480,7 @@ internal sealed class OverloadResolver
             if (getCurrentFunction()?.ThisParameter != null
                 && getCurrentFunction().ReceiverType is InterfaceSymbol implicitReceiverIface)
             {
-                var implicitIfaceOverloads = implicitReceiverIface.GetMethods(syntax.Identifier.Text);
+                var implicitIfaceOverloads = TypeMemberModel.GetMethods(implicitReceiverIface, syntax.Identifier.Text, MemberQuery.Instance(MemberKinds.Method));
                 var implicitPrivateIfaceOverloads = implicitReceiverIface.GetPrivateMethods(syntax.Identifier.Text);
                 if (implicitPrivateIfaceOverloads.Length > 0)
                 {
@@ -2509,7 +2509,7 @@ internal sealed class OverloadResolver
             if (getCurrentFunction()?.ThisParameter == null
                 && getCurrentFunction()?.StaticOwnerType is InterfaceSymbol implicitStaticIface)
             {
-                var implicitStaticOverloads = implicitStaticIface.GetStaticMethods(syntax.Identifier.Text);
+                var implicitStaticOverloads = TypeMemberModel.GetMethods(implicitStaticIface, syntax.Identifier.Text, MemberQuery.Static(MemberKinds.Method));
                 var implicitStaticPrivateOverloads = implicitStaticIface.GetStaticPrivateMethods(syntax.Identifier.Text);
                 if (implicitStaticPrivateOverloads.Length > 0)
                 {

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -411,6 +411,23 @@ public sealed class InterfaceSymbol : TypeSymbol
         Declaration = declaration;
     }
 
+    /// <summary>
+    /// Ensures the lazy member tables (<see cref="Methods"/>, <see cref="StaticMethods"/>,
+    /// <see cref="PrivateMethods"/>, <see cref="StaticPrivateMethods"/>) of a constructed
+    /// generic interface instance have been substituted/populated. Idempotent. Exposed as
+    /// <c>internal</c> (ADR-0112 A9) so <see cref="TypeMemberModel"/> can guarantee the same
+    /// resolution the per-accessor getters perform before enumerating member tables directly.
+    /// </summary>
+    internal void EnsureMembersResolved()
+    {
+        if (membersResolved)
+        {
+            return;
+        }
+
+        TryResolveMembers();
+    }
+
     private static string BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments)
     {
         var parts = new string[typeArguments.Length];
@@ -559,16 +576,6 @@ public sealed class InterfaceSymbol : TypeSymbol
         }
 
         membersResolved = true;
-    }
-
-    private void EnsureMembersResolved()
-    {
-        if (membersResolved)
-        {
-            return;
-        }
-
-        TryResolveMembers();
     }
 
     private static TypeSymbol SubstituteType(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> subst)

--- a/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
@@ -107,6 +107,7 @@ public static class TypeMemberModel
 
         if (type is InterfaceSymbol interfaceSymbol)
         {
+            interfaceSymbol.EnsureMembersResolved();
             ImmutableArray<FunctionSymbol>.Builder builder = null;
             if (query.IncludeInstance)
             {


### PR DESCRIPTION
## Summary
**Final task** of the ADR-0112 unified member-resolution migration (broad scope, **A9**: interface member enumeration). Routes the binder's interface method/static-virtual lookups onto the canonical `TypeMemberModel`, including the interface-method sites deferred from A6. After this PR, **no genuine by-name user-type member resolution remains outside `TypeMemberModel`.**

## Enabler
- `InterfaceSymbol.EnsureMembersResolved()` changed `private` → `internal` (relocated to satisfy SA1202).
- `TypeMemberModel.GetMethods`' interface branch now calls `interfaceSymbol.EnsureMembersResolved()` before enumerating, matching what `InterfaceSymbol.GetMethods` did. Idempotent; no `BinderContext` dependency introduced.
- **Dedup parity verified:** DeclarationBinder rejects duplicate same-name/same-signature interface methods (same `BoundScope.FunctionSignaturesEqual` predicate `AddMethodsDeduped` uses), so dedup is a no-op — order/content preserved.

## Migrated sites (6)
1. `Calls.cs` ~2008 — interface receiver method dispatch
2. `Calls.cs` ~2059 — type-parameter interface-constraint dispatch
3. `Calls.cs` ~2399 — default-interface-method probe (kept `HasDefaultBody` filter)
4. `OverloadResolver.cs` ~2483 — implicit-`this` interface method
5. `Access.cs` ~2465 — constrained static-virtual enumeration (`Static(Method)`; dropped now-redundant name check, kept param-count match + first-wins)
6. `OverloadResolver.cs` — implicit-`this` interface **static** method (`GetStaticMethods` → `Static(Method)`), a clean (d) case found in the residual sweep

`GetPrivateMethods` private-helper buckets left as-is.

## Residual sweep (completeness)
All remaining `Binding/` direct member-enumeration hits classified: (a) declaration-time table-building (`DeclarationBinder` interface-impl validation, `Binder`, `IncrementalGlobalScopeReuse`), (b) CLR reflection / imported types, (c) behavior-sensitive structural (DIM open-method index match, private-helper bucket, duck-typing/param-matching). **No remaining genuine (d) by-name user-type resolution.**

## Excluded (documented, Category C / structural)
- `CrossAssemblyDefinitionResolver.cs` — reverse-maps a CLR `MemberInfo` to a source-declared symbol (`Declaration != null` gate + bespoke arity matching); Go-to-Definition declaration mapping, not by-name resolution.
- `Calls.cs` ~3261 `ifaceSym.Methods` — DIM open-method **index** matching, not a name lookup.

## ADR
A9 addendum appended to `docs/adr/0112-unified-member-resolution.md`: enabler, migrations, exclusions, classified sweep, and the **COMPLETE** final state (sole known modeling gap: interface static properties/events, noted since P0).

## Verification (warnings-as-errors)
- Build: 0 Warning / 0 Error
- Core.Tests: 3414 passed
- LanguageServer.Tests: 364 passed
- Sensitive filters `Interface|DefaultInterface|Constraint|StaticVirtual|Generic`: Core 385, Compiler 231; `Method|Overload|Call|Dispatch`: Compiler 244 — all passed
