### PR TITLE
Resolve predicate lambdas in Assert.DoesNotContain (#932)

### DIFF
--- a/docs/adr/0074-arrow-lambda-and-colon-switch-arms.md
+++ b/docs/adr/0074-arrow-lambda-and-colon-switch-arms.md
@@ -95,12 +95,17 @@ xs.Where((x int32) -> { val parity = x % 2; parity == 0 })
 
 Concrete decisions:
 
-- **Parameter list is always parenthesized.** The single-parameter
-  shorthand `x -> body` is **not** supported. The parenthesized form
-  reads identically for zero, one, and many parameters; it preserves
-  trivial disambiguation against `x -> y` reading as a comparison-style
-  chain in an unrelated context; and it leaves the syntactic door open
-  for future shorthand without commitment.
+- **Parameter list is parenthesized, with a single-parameter shorthand.**
+  The parenthesized form `(x) -> body` reads identically for zero, one,
+  and many parameters. In addition, **issue
+  [#932](https://github.com/DavidObando/gsharp/issues/932) added the
+  single-parameter shorthand `x -> body`** as exact sugar for `(x) -> body`
+  (one untyped parameter whose type is inferred from the target delegate
+  via the #716 machinery). This is unambiguous: `->` is not an
+  expression-level binary operator in G#, so `IDENT ->` at expression
+  position cannot begin any other construct (function-type clauses
+  `(T) -> R` are parsed in type context and the deprecated switch-arm
+  `case v -> r` in pattern context). See revised alternative C below.
 - **Parameter types are mandatory.** Lambda-parameter type inference
   ("target-typed lambdas") is explicitly the scope of [#716](https://github.com/DavidObando/gsharp/issues/716)
   and is left to that PR. Until #716 lands, every lambda parameter
@@ -264,14 +269,18 @@ us from picking between `=>` and `->` later.
 
 ### C. Single-parameter shorthand `x -> body`
 
-Considered and rejected for v0. The shorthand is convenient in pipelines
-but introduces real ambiguity with `name -> expr` reading as a binary
-expression (the lexer treats `->` as its own token, but the parser would
-have to decide between "binary operator at expression level" and "lambda
-introducer" without a parenthesised parameter list). Deferring the
-shorthand keeps every lambda's surface shape consistent and leaves the
-door open to add `x int32 -> body` (typed shorthand) once type-inferred
-parameters land in #716.
+Considered and rejected for v0, then **adopted in issue
+[#932](https://github.com/DavidObando/gsharp/issues/932)**. The original
+v0 concern was a feared ambiguity with `name -> expr` reading as a binary
+expression. In practice that ambiguity does not exist: `->` is never an
+expression-level binary operator in G#, so a bare `IDENT ->` at
+expression position is otherwise always a parse error. With target-typed
+lambda parameters delivered by #716, the shorthand became pure sugar for
+the parenthesised single-parameter form `(x) -> body` — one untyped
+parameter inferred from the target delegate — and is now accepted at
+primary-expression position. The parser commits to a lambda the moment it
+sees `IDENT ->`; the parenthesised form remains the canonical spelling
+for zero- and multi-parameter lambdas.
 
 ### D. Arrow-lambda body forced to `{ … }` block
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1533,10 +1533,17 @@ internal sealed partial class ExpressionBinder
     {
         targets = null;
 
-        // Symbolic recovery is anchored on the receiver's symbolic
-        // TypeArguments. Without a receiver type symbol there is nothing to
-        // recover (the CLR paths handle static/accessor calls).
-        if (receiver?.Type == null)
+        // Symbolic recovery is anchored on the candidate's symbolic argument
+        // vector: the receiver's symbolic TypeArguments for instance/extension
+        // calls, or — for a static call (issue #932:
+        // `Assert.DoesNotContain(items, i -> ...)`) — the same-compilation user
+        // type carried by a non-deferred argument such as `items : List[Item]`.
+        // An extension probe (offset == 1) places the receiver in slot 0, so it
+        // genuinely needs a receiver; a static/instance probe (offset == 0) does
+        // not. The success gate below (`anySameCompilationType`) still ensures
+        // this path only fires — and pre-empts the CLR erasure paths — when a
+        // real same-compilation user type is recovered.
+        if (offset == 1 && receiver?.Type == null)
         {
             return false;
         }
@@ -1692,8 +1699,6 @@ internal sealed partial class ExpressionBinder
 
                 slotTargets[idx] = parameterTypes.ToImmutable();
             }
-
-            var dbgMapped = slotTargets.TryGetValue(deferredIndices[0], out var dbgSt) && dbgSt.Length > 0 ? dbgSt[0]?.ToString() : "-";
 
             if (!candidateUsable || slotTargets.Count != deferredIndices.Count)
             {

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -861,6 +861,21 @@ internal sealed class MemberLookup
                 return false;
             case NullableTypeSymbol nullable when nullable.UnderlyingType != null:
                 return TryProjectErasedClrType(nullable.UnderlyingType, out erased);
+            case FunctionTypeSymbol fn:
+                // Issue #932: a func/arrow literal whose natural delegate type
+                // closes over a same-compilation user class (whose ClrType is
+                // still null during binding) has a null FunctionType.ClrType, so
+                // overload resolution would otherwise reject every candidate
+                // (GS0159) before even classifying the delegate parameter — e.g.
+                // `Assert.DoesNotContain(items, func(i LibraryItem) bool { ... })`
+                // where `items : List[LibraryItem]`. Erase the literal's natural
+                // Func<...>/Action<...> shape, mapping each symbolic component the
+                // same way the generic-argument erasure does (user class → its
+                // imported base or `object`, enum → int32), so the produced
+                // delegate's parameter/return types line up with the inferred
+                // (erased) element type and the structural delegate conversion
+                // applies.
+                return TryProjectErasedDelegateClrType(fn, out erased);
             default:
                 return false;
         }
@@ -1592,5 +1607,125 @@ internal sealed class MemberLookup
             yield return baseType;
             baseType = baseType.BaseType;
         }
+    }
+
+    /// <summary>
+    /// Issue #932: builds an erased CLR <c>System.Func&lt;...&gt;</c> /
+    /// <c>System.Action&lt;...&gt;</c> delegate type for a
+    /// <see cref="FunctionTypeSymbol"/> whose natural <c>ClrType</c> is null
+    /// because one of its parameter / return types is symbolic (a
+    /// same-compilation user class, enum, or open type parameter). Each
+    /// component is erased through <see cref="TryEraseDelegateComponentClrType"/>
+    /// so the result matches the erasure the surrounding generic call applies to
+    /// its other arguments.
+    /// </summary>
+    /// <param name="functionType">The literal's bound function type.</param>
+    /// <param name="erased">On success, the erased delegate CLR type.</param>
+    /// <returns><see langword="true"/> when an erased delegate type was built.</returns>
+    private static bool TryProjectErasedDelegateClrType(FunctionTypeSymbol functionType, out Type erased)
+    {
+        erased = null;
+        if (functionType == null)
+        {
+            return false;
+        }
+
+        var paramClr = new Type[functionType.ParameterTypes.Length];
+        for (var i = 0; i < paramClr.Length; i++)
+        {
+            if (!TryEraseDelegateComponentClrType(functionType.ParameterTypes[i], out paramClr[i]))
+            {
+                return false;
+            }
+        }
+
+        var isVoid = functionType.ReturnType == null || functionType.ReturnType == TypeSymbol.Void;
+        Type returnClr = null;
+        if (!isVoid && !TryEraseDelegateComponentClrType(functionType.ReturnType, out returnClr))
+        {
+            return false;
+        }
+
+        erased = isVoid
+            ? BuildActionClrType(paramClr)
+            : BuildFuncClrType(paramClr, returnClr);
+        return erased != null;
+    }
+
+    /// <summary>
+    /// Issue #932: erases a single delegate parameter / return
+    /// <see cref="TypeSymbol"/> to a CLR <see cref="System.Type"/>, mapping
+    /// symbolic shapes the same way <see cref="ImportedClassSymbol"/>'s
+    /// argument-type erasure does (user class → its imported base or
+    /// <c>object</c>, enum → <c>int32</c>); non-symbolic and other erasable
+    /// shapes fall back to <see cref="TryProjectErasedClrType"/>.
+    /// </summary>
+    /// <param name="t">The component type to erase.</param>
+    /// <param name="clr">On success, the erased CLR type.</param>
+    /// <returns><see langword="true"/> when an erasure exists.</returns>
+    private static bool TryEraseDelegateComponentClrType(TypeSymbol t, out Type clr)
+    {
+        clr = null;
+        if (t == null)
+        {
+            return false;
+        }
+
+        if (t.ClrType != null)
+        {
+            clr = t.ClrType;
+            return true;
+        }
+
+        switch (t)
+        {
+            case StructSymbol { IsClass: true } userClass:
+                clr = userClass.ImportedBaseType?.ClrType ?? typeof(object);
+                return true;
+            case EnumSymbol:
+                clr = typeof(int);
+                return true;
+            default:
+                return TryProjectErasedClrType(t, out clr);
+        }
+    }
+
+    private static Type BuildActionClrType(Type[] paramClr) => paramClr.Length switch
+    {
+        0 => typeof(Action),
+        1 => typeof(Action<>).MakeGenericType(paramClr),
+        2 => typeof(Action<,>).MakeGenericType(paramClr),
+        3 => typeof(Action<,,>).MakeGenericType(paramClr),
+        4 => typeof(Action<,,,>).MakeGenericType(paramClr),
+        5 => typeof(Action<,,,,>).MakeGenericType(paramClr),
+        6 => typeof(Action<,,,,,>).MakeGenericType(paramClr),
+        7 => typeof(Action<,,,,,,>).MakeGenericType(paramClr),
+        8 => typeof(Action<,,,,,,,>).MakeGenericType(paramClr),
+        _ => null,
+    };
+
+    private static Type BuildFuncClrType(Type[] paramClr, Type returnClr)
+    {
+        if (returnClr == null)
+        {
+            return null;
+        }
+
+        var args = new Type[paramClr.Length + 1];
+        Array.Copy(paramClr, args, paramClr.Length);
+        args[paramClr.Length] = returnClr;
+        return paramClr.Length switch
+        {
+            0 => typeof(Func<>).MakeGenericType(args),
+            1 => typeof(Func<,>).MakeGenericType(args),
+            2 => typeof(Func<,,>).MakeGenericType(args),
+            3 => typeof(Func<,,,>).MakeGenericType(args),
+            4 => typeof(Func<,,,,>).MakeGenericType(args),
+            5 => typeof(Func<,,,,,>).MakeGenericType(args),
+            6 => typeof(Func<,,,,,,>).MakeGenericType(args),
+            7 => typeof(Func<,,,,,,,>).MakeGenericType(args),
+            8 => typeof(Func<,,,,,,,,>).MakeGenericType(args),
+            _ => null,
+        };
     }
 }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -129,6 +129,26 @@ internal static class OverloadResolution
         /// return type already matches the target.
         /// </summary>
         DelegateReturnCovariance = 10,
+
+        /// <summary>
+        /// Issue #932: a <c>func</c>/arrow literal (whose natural CLR type is a
+        /// <c>System.Func&lt;...&gt;</c> / <c>System.Action&lt;...&gt;</c>)
+        /// converting to a structurally identical but differently-named
+        /// delegate parameter — same parameter types and same return type, but
+        /// a distinct delegate definition (e.g. a
+        /// <c>func(T) bool</c> literal targeting <c>System.Predicate&lt;T&gt;</c>,
+        /// as in <c>Assert.DoesNotContain(items, func(i Item) bool { ... })</c>).
+        /// C# allows a lambda to target any compatible delegate type; G#'s
+        /// natural delegate type for a literal is always <c>Func</c>/<c>Action</c>,
+        /// so without this the literal would never match parameters typed as
+        /// <c>Predicate&lt;T&gt;</c>, <c>Comparison&lt;T&gt;</c>, etc. Ranked
+        /// last (worst) so an exact (identity) delegate match always wins when
+        /// both are applicable. The binder's erasing rebind
+        /// (<c>RebindFunctionLiteralDelegateArguments</c>) and the emitter's
+        /// delegate-to-delegate adaptation materialize the conversion to the
+        /// chosen delegate type.
+        /// </summary>
+        DelegateStructuralMatch = 11,
     }
 
     /// <summary>
@@ -364,6 +384,20 @@ internal static class OverloadResolution
         if (IsValueReturningDelegateToVoidDelegate(target, source))
         {
             return ImplicitConversionKind.LambdaToVoidDelegate;
+        }
+
+        // Issue #932: a func/arrow literal whose natural delegate type is a
+        // Func<...>/Action<...> is applicable to a structurally identical but
+        // differently-named delegate parameter (same parameter types and same
+        // return type), e.g. `func(i Item) bool { ... }` → System.Predicate<Item>
+        // for `Assert.DoesNotContain(items, predicate)`. Ranked lowest so an
+        // exact (identity) delegate match always wins when both apply. Checked
+        // last because the covariance / void-discard cases above already cover
+        // the differing-return-type shapes; this only handles the exact-shape
+        // delegate-kind mismatch.
+        if (IsStructurallyCompatibleDelegate(target, source))
+        {
+            return ImplicitConversionKind.DelegateStructuralMatch;
         }
 
         return ImplicitConversionKind.None;
@@ -1179,6 +1213,70 @@ internal static class OverloadResolution
     }
 
     /// <summary>
+    /// Issue #932: determines whether <paramref name="source"/> and
+    /// <paramref name="target"/> are two distinct delegate types with an
+    /// identical <c>Invoke</c> shape — the same parameter types and the same
+    /// return type. A <c>func</c>/arrow literal's natural delegate type is a
+    /// <c>System.Func&lt;...&gt;</c> / <c>System.Action&lt;...&gt;</c>, but a
+    /// CLR API may type the parameter as a structurally identical, differently
+    /// named delegate (e.g. <c>System.Predicate&lt;T&gt;</c>,
+    /// <c>System.Comparison&lt;T&gt;</c>). C# lets a lambda target any
+    /// compatible delegate type, so G# must treat the literal as applicable to
+    /// such a parameter. Parameter and return types are compared by name to
+    /// remain safe across reflection contexts (the target parameter is
+    /// typically loaded through a <c>MetadataLoadContext</c> while the literal's
+    /// natural <c>Func&lt;...&gt;</c> is a live-runtime constructed type). The
+    /// exact-return-type requirement keeps this distinct from
+    /// <see cref="IsDelegateReturnCovariant"/> (differing returns) and
+    /// <see cref="IsValueReturningDelegateToVoidDelegate"/> (void discard),
+    /// which handle the non-identity return shapes.
+    /// </summary>
+    /// <param name="target">The candidate delegate parameter type.</param>
+    /// <param name="source">The argument's natural delegate type.</param>
+    /// <returns><see langword="true"/> when the structural delegate conversion applies.</returns>
+    private static bool IsStructurallyCompatibleDelegate(Type target, Type source)
+    {
+        if (!ClrTypeUtilities.IsDelegateType(target) || !ClrTypeUtilities.IsDelegateType(source))
+        {
+            return false;
+        }
+
+        // Same delegate definition is already handled by the identity /
+        // assignability paths; this conversion only bridges distinct kinds.
+        if (ClrTypeUtilities.AreSame(target, source))
+        {
+            return false;
+        }
+
+        if (!TryGetDelegateSignature(target, out var targetParams, out var targetReturn)
+            || !TryGetDelegateSignature(source, out var sourceParams, out var sourceReturn))
+        {
+            return false;
+        }
+
+        if (targetReturn is null || sourceReturn is null
+            || !ClrTypeUtilities.AreSame(targetReturn, sourceReturn))
+        {
+            return false;
+        }
+
+        if (targetParams.Length != sourceParams.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < targetParams.Length; i++)
+        {
+            if (!ClrTypeUtilities.AreSame(targetParams[i], sourceParams[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Issue #908: extracts a delegate type's parameter types and return type.
     /// Prefers the <c>Invoke</c> method, but falls back to decomposing the
     /// generic arguments of a closed <c>System.Func`N</c> / <c>System.Action`N</c>
@@ -1250,7 +1348,63 @@ internal static class OverloadResolution
             return true;
         }
 
-        return false;
+        // Issue #932: any other closed generic delegate (e.g.
+        // System.Predicate<T>, System.Comparison<T>, System.Converter<TIn,TOut>)
+        // whose constructed Invoke is unreachable across reflection contexts.
+        // Read the Invoke signature off the open generic definition — which is
+        // always in metadata — then substitute the closed type arguments into
+        // each generic-parameter slot. This generalises the Func/Action special
+        // cases above to the whole delegate surface a func/arrow literal may
+        // target.
+        try
+        {
+            var definition = delegateType.GetGenericTypeDefinition();
+            var defInvoke = definition.GetMethod("Invoke");
+            if (defInvoke == null)
+            {
+                return false;
+            }
+
+            var defParams = defInvoke.GetParameters();
+            var resolvedParams = new Type[defParams.Length];
+            for (var i = 0; i < defParams.Length; i++)
+            {
+                resolvedParams[i] = SubstituteGenericParameter(defParams[i].ParameterType, genericArgs);
+            }
+
+            parameterTypes = resolvedParams;
+            returnType = SubstituteGenericParameter(defInvoke.ReturnType, genericArgs);
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Issue #932: maps a (possibly generic-parameter) type drawn from a
+    /// delegate's open-definition <c>Invoke</c> signature to the corresponding
+    /// closed type argument. A bare generic parameter <c>T</c> is replaced by
+    /// <paramref name="genericArgs"/> at its <see cref="Type.GenericParameterPosition"/>;
+    /// every other type is returned unchanged. Only the direct-parameter case
+    /// is needed for the BCL delegates a func/arrow literal targets
+    /// (<c>Predicate&lt;T&gt;</c>, <c>Comparison&lt;T&gt;</c>,
+    /// <c>Converter&lt;TIn,TOut&gt;</c>).
+    /// </summary>
+    /// <param name="type">A type from the open definition's Invoke signature.</param>
+    /// <param name="genericArgs">The closed delegate's type arguments.</param>
+    /// <returns>The substituted type.</returns>
+    private static Type SubstituteGenericParameter(Type type, Type[] genericArgs)
+    {
+        if (type != null && type.IsGenericParameter
+            && type.GenericParameterPosition >= 0
+            && type.GenericParameterPosition < genericArgs.Length)
+        {
+            return genericArgs[type.GenericParameterPosition];
+        }
+
+        return type;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -5711,6 +5711,17 @@ public class Parser
                 // tokens match a lambda shape.
                 return ParseLambdaExpression();
 
+            case SyntaxKind.IdentifierToken when Peek(1).Kind == SyntaxKind.RightArrowToken:
+                // Issue #932: a single-identifier arrow lambda `x -> body` is
+                // accepted as shorthand for the parenthesised single-parameter
+                // form `(x) -> body`. Disambiguation is unconditional here: in
+                // an expression position `IDENT ->` cannot begin any other
+                // construct (function-type clauses `(T) -> R` and the
+                // deprecated switch-arm `case v -> r` are parsed in their own
+                // type/pattern contexts, never via primary-expression
+                // dispatch), so committing to a lambda is always correct.
+                return ParseSingleIdentifierLambdaExpression();
+
             case SyntaxKind.SwitchKeyword:
                 return ParsePostfixChain(ParseSwitchExpression());
 
@@ -6084,6 +6095,25 @@ public class Parser
             ? ParseBlockExpression()
             : ParseExpression();
         return new LambdaExpressionSyntax(syntaxTree, asyncModifier, openParen, parameters, closeParen, arrow, body);
+    }
+
+    // Issue #932: parses the single-identifier arrow-lambda shorthand
+    // `x -> body`, equivalent to the parenthesised `(x) -> body`. The opening
+    // and closing parentheses are absent (the corresponding tokens are left
+    // null and are skipped by SyntaxNode child enumeration / span computation),
+    // and the sole parameter carries no type clause, so the binder infers its
+    // type from the target delegate exactly as it does for `(x) -> body` (or
+    // reports GS0304 when no target type is in scope).
+    private LambdaExpressionSyntax ParseSingleIdentifierLambdaExpression()
+    {
+        var identifier = MatchToken(SyntaxKind.IdentifierToken);
+        var parameter = new ParameterSyntax(syntaxTree, identifier, ellipsisToken: null, type: null);
+        var parameters = new SeparatedSyntaxList<ParameterSyntax>(ImmutableArray.Create<SyntaxNode>(parameter));
+        var arrow = MatchToken(SyntaxKind.RightArrowToken);
+        var body = Current.Kind == SyntaxKind.OpenBraceToken
+            ? ParseBlockExpression()
+            : ParseExpression();
+        return new LambdaExpressionSyntax(syntaxTree, asyncModifier: null, openParenToken: null, parameters, closeParenToken: null, arrow, body);
     }
 
     // ADR-0076 / issue #716: arrow-lambda parameter lists allow each parameter's

--- a/test/Compiler.Tests/XunitAssertOverloadResolutionTests.cs
+++ b/test/Compiler.Tests/XunitAssertOverloadResolutionTests.cs
@@ -313,9 +313,139 @@ public class XunitAssertOverloadResolutionTests
             """);
     }
 
+    [Fact]
+    public void Issue932_AssertDoesNotContain_PredicateFuncLiteral_UserType_Resolves()
+    {
+        // Issue #932: `Assert.DoesNotContain<T>(IEnumerable<T>, Predicate<T>)`
+        // must resolve when the predicate is a G# function literal whose
+        // natural type is `Func[T,bool]`. A function literal's natural
+        // delegate is structurally identical to `Predicate[T]` but differently
+        // named, so overload resolution must treat it as convertible. The
+        // element type here is a same-compilation user class (`LibraryItem`),
+        // which is the case that previously failed with GS0159.
+        AssertGsCompilesCleanly("""
+            package Probe.Tests
+            import Xunit
+            import System.Collections.Generic
+
+            class LibraryItem {
+                var Asin string
+            }
+
+            class P {
+                @Fact
+                func DoesNotContainFunc() {
+                    var items = List[LibraryItem]()
+                    Assert.DoesNotContain(items, func (i LibraryItem) bool { return i.Asin == "A3" })
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public void Issue932_AssertDoesNotContain_PredicateArrowLambda_UserType_Resolves()
+    {
+        // Issue #932: the parenthesised arrow-lambda spelling
+        // `(i) -> i.Asin == "A3"` must resolve against the predicate overload.
+        // The untyped arrow lambda flows through the deferred-inference path,
+        // which must recover the same-compilation element type from the
+        // `items : List[LibraryItem]` argument (not erase it to `object`) so
+        // the lambda body's `i.Asin` member access binds.
+        AssertGsCompilesCleanly("""
+            package Probe.Tests
+            import Xunit
+            import System.Collections.Generic
+
+            class LibraryItem {
+                var Asin string
+            }
+
+            class P {
+                @Fact
+                func DoesNotContainArrow() {
+                    var items = List[LibraryItem]()
+                    Assert.DoesNotContain(items, (i) -> i.Asin == "A3")
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public void Issue932_AssertDoesNotContain_PredicateBareArrowLambda_UserType_Resolves()
+    {
+        // Issue #932: the bare single-identifier arrow-lambda spelling
+        // `i -> i.Asin == "A3"` (exactly as written in the issue) must parse
+        // as a single-parameter lambda and resolve against the predicate
+        // overload.
+        AssertGsCompilesCleanly("""
+            package Probe.Tests
+            import Xunit
+            import System.Collections.Generic
+
+            class LibraryItem {
+                var Asin string
+            }
+
+            class P {
+                @Fact
+                func DoesNotContainBareArrow() {
+                    var items = List[LibraryItem]()
+                    Assert.DoesNotContain(items, i -> i.Asin == "A3")
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public void Issue932_AssertDoesNotContain_PredicateLambda_StringElement_Resolves()
+    {
+        // Issue #932: the same predicate overload must resolve for a BCL
+        // element type (`string`) across all three lambda spellings.
+        AssertGsCompilesCleanly("""
+            package Probe.Tests
+            import Xunit
+            import System.Collections.Generic
+
+            class P {
+                @Fact
+                func DoesNotContainStrings() {
+                    var items = List[string]()
+                    Assert.DoesNotContain(items, func (i string) bool { return i == "A3" })
+                    Assert.DoesNotContain(items, (i) -> i == "A3")
+                    Assert.DoesNotContain(items, i -> i == "A3")
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public void Issue932_AssertContains_PredicateLambda_UserType_Resolves()
+    {
+        // Issue #932: the structurally-compatible-delegate conversion applies
+        // uniformly to the sibling `Assert.Contains<T>(IEnumerable<T>,
+        // Predicate<T>)` overload as well.
+        AssertGsCompilesCleanly("""
+            package Probe.Tests
+            import Xunit
+            import System.Collections.Generic
+
+            class LibraryItem {
+                var Asin string
+            }
+
+            class P {
+                @Fact
+                func ContainsPredicate() {
+                    var items = List[LibraryItem]()
+                    Assert.Contains(items, func (i LibraryItem) bool { return i.Asin == "A3" })
+                    Assert.Contains(items, i -> i.Asin == "A3")
+                }
+            }
+            """);
+    }
+
     private static void AssertGsCompilesCleanly(string source)
         => CompileGsAgainstReferences(source, ReferenceModeTpa);
-
     /// <summary>
     /// Issue #504-reopen: drives gsc with the same reference-assembly closure
     /// real users get from the SDK (ref-pack facades + xUnit) — NOT the test

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue714LambdaParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue714LambdaParserTests.cs
@@ -101,20 +101,26 @@ public class Issue714LambdaParserTests
     }
 
     [Fact]
-    public void Parses_LambdaExpression_DoesNotConsumeBareIdentifierArrow()
+    public void Parses_BareIdentifierArrow_AsSingleParameterLambda()
     {
-        // No single-param shorthand (per ADR-0074): bare `x -> e` must NOT be
-        // taken as a lambda. It is a parse error / unrelated form. The token
-        // sequence `x -> e` at expression position should at minimum not be
-        // parsed as a LambdaExpression.
+        // Issue #932: the single-identifier arrow shorthand `x -> e` is now
+        // accepted as exact sugar for `(x) -> e` (one untyped parameter). This
+        // revises the original ADR-0074 decision (which rejected the
+        // shorthand); see ADR-0074 alternative C. `->` is never an
+        // expression-level binary operator, so committing `IDENT ->` to a
+        // lambda is unambiguous.
         const string source = """
             package P
-            let f = x -> x + 1
+            func apply(f Func[int32, int32]) int32 { return f(3) }
+            let v = apply(x -> x + 1)
             """;
         var tree = SyntaxTree.Parse(source);
-        // We don't care which exact diagnostic appears; only that the parser
-        // did not silently accept a shorthand-lambda form.
-        Assert.False(Walk(tree.Root).OfType<LambdaExpressionSyntax>().Any());
+        Assert.Empty(tree.Diagnostics);
+
+        var lambda = FindFirst<LambdaExpressionSyntax>(tree);
+        Assert.Single(lambda.Parameters);
+        Assert.Null(lambda.OpenParenToken);
+        Assert.Null(lambda.CloseParenToken);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes #932. Both lambda spellings of the predicate overload of xUnit's
`Assert.DoesNotContain` (and the sibling `Assert.Contains`) now compile and bind:

```gsharp
Assert.DoesNotContain(items, func (i LibraryItem) bool { return i.Asin == "A3" })
Assert.DoesNotContain(items, (i) -> i.Asin == "A3")
Assert.DoesNotContain(items, i -> i.Asin == "A3")   // bare single-identifier arrow
```

Previously all forms failed with `error GS0159: Cannot find function DoesNotContain`
(and, for the arrow form over a same-compilation element type, a follow-on
`GS0158 Cannot find member Asin`).

## Root cause

The target overload is `DoesNotContain<T>(IEnumerable<T>, System.Predicate<T>)`.
Three distinct layers blocked resolution:

1. **No structural delegate conversion.** A G# `func`/arrow literal's natural CLR
   type is always `Func<...>`/`Action<...>`. Overload resolution had no conversion
   from `Func<T,bool>` to a structurally identical but differently-named delegate
   such as `Predicate<T>`, so the predicate overload never applied.
2. **Null `ClrType` for same-compilation element types.** For `List[LibraryItem]`
   where `LibraryItem` is compiled in the same unit, the func literal's
   `FunctionTypeSymbol.ClrType` is null, so resolution bailed (GS0159) before it
   ever classified the delegate parameter.
3. **Static-call deferred arrow inference.** The untyped arrow lambda flows through
   the `#903` symbolic-recovery path, which was gated on a non-null receiver and so
   skipped static calls like `Assert.DoesNotContain`, falling back to CLR erasure
   that bound the lambda parameter as `object` (→ GS0158 on `i.Asin`).

## Fix

- **`OverloadResolution.cs`** — new `DelegateStructuralMatch` implicit-conversion
  kind (ranked last, so an identity delegate match always wins) + 
  `IsStructurallyCompatibleDelegate`; `TryGetDelegateSignature` generalised to read
  any generic delegate's `Invoke` from its open definition (robust across
  reflection contexts, e.g. MLC-loaded `Predicate<T>`).
- **`MemberLookup.cs`** — erase a `FunctionTypeSymbol` with a null `ClrType` to an
  erased `Func`/`Action` (user class → imported base/`object`, enum → `int32`),
  matching how `List[LibraryItem]` erases to `List[object]`.
- **`ExpressionBinder.Calls.cs`** — anchor the `#903` symbolic recovery on the
  symbolic argument vector for static/instance probes, not just on a receiver.
- **`Parser.cs` + ADR-0074** — accept the single-identifier arrow shorthand
  `x -> body` as exact sugar for `(x) -> body` (the issue's bare-arrow spelling).
  `->` is never an expression-level binary operator, so the shorthand is
  unambiguous; ADR-0074 alternative C is revised to record the decision.

## Tests

- `test/Compiler.Tests/XunitAssertOverloadResolutionTests.cs` — 5 new `Issue932_*`
  tests covering `func`, parenthesised-arrow, and bare-arrow spellings over a
  same-compilation user class and a BCL `string` element type, plus a `Contains`
  variant. All pass.
- `test/Core.Tests/.../Issue714LambdaParserTests.cs` — the prior test asserting the
  shorthand is rejected is replaced by `Parses_BareIdentifierArrow_AsSingleParameterLambda`.

Validation: full `dotnet build GSharp.sln -c Release -graph` is clean (0 warnings);
the targeted XunitAssert (20), lambda parser/binding (60), full Syntax (585), and
binding/overload (1842) suites all pass. End-to-end run of a compiled exe confirms
the emitted `Predicate<Item>` delegates evaluate correctly at runtime.
