### PR TITLE
Fix optional parameters on static (shared) method calls (#936)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1159,6 +1159,24 @@ internal sealed partial class ExpressionBinder
             var isVariadic = method.Parameters.Length > 0 && method.Parameters[method.Parameters.Length - 1].IsVariadic;
             var fixedParamCount = isVariadic ? method.Parameters.Length - 1 : method.Parameters.Length;
 
+            // ADR-0063 / issue #936: count the leading non-optional parameters.
+            // A static (`shared`) call may omit any trailing parameter that
+            // declares a default value, mirroring the instance-call path in
+            // OverloadResolver. Omitted slots are synthesized below from each
+            // parameter's captured default constant.
+            var requiredParamCount = method.Parameters.Length;
+            for (var i = method.Parameters.Length - 1; i >= 0; i--)
+            {
+                if (method.Parameters[i].HasExplicitDefaultValue)
+                {
+                    requiredParamCount = i;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
             if (isVariadic)
             {
                 if (arguments.Length < fixedParamCount)
@@ -1167,7 +1185,7 @@ internal sealed partial class ExpressionBinder
                     return new BoundErrorExpression(null);
                 }
             }
-            else if (arguments.Length != method.Parameters.Length)
+            else if (arguments.Length < requiredParamCount || arguments.Length > method.Parameters.Length)
             {
                 Diagnostics.ReportWrongArgumentCount(ce.Location, method.Name, method.Parameters.Length, arguments.Length);
                 return new BoundErrorExpression(null);
@@ -1294,7 +1312,25 @@ internal sealed partial class ExpressionBinder
             }
             else
             {
-                permutedArgs = arguments;
+                // ADR-0063 / issue #936: pad any trailing optional parameters
+                // the static call omitted with their captured default values so
+                // the per-position conversion loop binds the full parameter
+                // list (matching instance-method behavior).
+                if (arguments.Length < method.Parameters.Length)
+                {
+                    var padded = ImmutableArray.CreateBuilder<BoundExpression>(method.Parameters.Length);
+                    padded.AddRange(arguments);
+                    for (var i = arguments.Length; i < method.Parameters.Length; i++)
+                    {
+                        padded.Add(OverloadResolver.CreateOptionalUserDefaultArgument(method.Parameters[i]));
+                    }
+
+                    permutedArgs = padded.MoveToImmutable();
+                }
+                else
+                {
+                    permutedArgs = arguments;
+                }
             }
 
             var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(permutedArgs.Length);

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -665,7 +665,9 @@ internal sealed class OverloadResolver
     /// primitive/string previously captured on the parameter symbol; <c>nil</c>
     /// becomes a <see cref="BoundDefaultExpression"/>.
     /// </summary>
-    private static BoundExpression CreateOptionalUserDefaultArgument(ParameterSymbol parameter)
+    /// <param name="parameter">The omitted optional parameter.</param>
+    /// <returns>The bound default-value argument for the omitted slot.</returns>
+    internal static BoundExpression CreateOptionalUserDefaultArgument(ParameterSymbol parameter)
     {
         if (!parameter.HasExplicitDefaultValue)
         {

--- a/test/Compiler.Tests/Emit/Issue936StaticOptionalParameterEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue936StaticOptionalParameterEmitTests.cs
@@ -1,0 +1,172 @@
+// <copyright file="Issue936StaticOptionalParameterEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #936 / ADR-0063 — emit + IL-verify coverage for default/optional
+/// parameter values on static (<c>shared</c>) user-type method calls.
+///
+/// The reported symptom was a BINDER refusal
+/// (<c>GS0144: Function 'Req' requires 1 arguments but was given 0.</c>)
+/// when a <c>shared</c> method declaring a default parameter value was
+/// called while omitting that argument. Instance methods already honored
+/// the declared default; the static-call path
+/// (<c>ExpressionBinder.BindUserTypeStaticCall</c>) refused the call on a
+/// strict arity check and never synthesized the omitted default.
+///
+/// These tests cover the end-to-end PE-emission path with
+/// <c>ilverify</c> for the shapes the binder fix unblocks:
+///   - single trailing optional parameter omitted,
+///   - required + multiple optional parameters with a mix of supplied and
+///     omitted trailing arguments,
+///   - all optional parameters supplied explicitly (regression guard).
+/// </summary>
+public class Issue936StaticOptionalParameterEmitTests
+{
+    #region Single optional parameter omitted
+
+    [Fact]
+    public void SharedStatic_SingleOptional_Omitted_UsesDefault()
+    {
+        var source = """
+            package Probe
+
+            class Greeter {
+                shared {
+                    func Greeting(title string = "Book") string {
+                        return "Hello ${title}"
+                    }
+                }
+            }
+
+            public var result = Greeter.Greeting()
+            """;
+
+        var assembly = CompileAndRun(source);
+        var result = GetResult<string>(assembly);
+        Assert.Equal("Hello Book", result);
+    }
+
+    #endregion
+
+    #region Mix of required + optional parameters
+
+    [Fact]
+    public void SharedStatic_RequiredPlusOptionals_OmittedTrailing_UsesDefaults()
+    {
+        var source = """
+            package Probe
+
+            class Greeter {
+                shared {
+                    func Make(prefix string, title string = "Book", count int32 = 3) string {
+                        return "${prefix}:${title}:${count}"
+                    }
+                }
+            }
+
+            public var allDefaults = Greeter.Make("A")
+            public var oneSupplied = Greeter.Make("B", "Mag")
+            public var allSupplied = Greeter.Make("C", "Cd", 9)
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal("A:Book:3", GetField<string>(assembly, "allDefaults"));
+        Assert.Equal("B:Mag:3", GetField<string>(assembly, "oneSupplied"));
+        Assert.Equal("C:Cd:9", GetField<string>(assembly, "allSupplied"));
+    }
+
+    #endregion
+
+    #region Numeric defaults
+
+    [Fact]
+    public void SharedStatic_NumericOptional_Omitted_UsesDefault()
+    {
+        var source = """
+            package Probe
+
+            class Calc {
+                shared {
+                    func Add(a int32, b int32 = 40) int32 {
+                        return a + b
+                    }
+                }
+            }
+
+            public var result = Calc.Add(2)
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(42, GetResult<int>(assembly));
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static Assembly CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_936_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        return assembly;
+    }
+
+    private static T GetResult<T>(Assembly assembly) => GetField<T>(assembly, "result");
+
+    private static T GetField<T>(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var resultField = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (T)resultField!.GetValue(null)!;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Root cause
Calling a static (`shared`) user-type method while omitting a parameter that declares a default value failed with:

```
error GS0144: Function 'Req' requires 1 arguments but was given 0.
```

Instance-method calls honor declared defaults (handled in `OverloadResolver`), but the static-call path in `ExpressionBinder.BindUserTypeStaticCall` used a strict arity check (`arguments.Length != method.Parameters.Length`) and never synthesized the omitted default values.

## Fix
`BindUserTypeStaticCall` now mirrors the instance-call semantics:

- Computes the count of leading **required** (non-default) parameters.
- Accepts calls supplying between the required count and the full parameter count (non-variadic path).
- Pads omitted trailing optional slots with each parameter's captured default constant via `OverloadResolver.CreateOptionalUserDefaultArgument` (promoted from `private` to `internal`) before the per-position conversion loop, so the correct default constant values are emitted and runtime behavior matches instance methods.

Handles the general case: single optional, required + multiple optionals, and partially-supplied trailing optionals.

## Files changed
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs` — required-count computation + padding of omitted optionals on the static-call path.
- `src/Core/CodeAnalysis/Binding/OverloadResolver.cs` — `CreateOptionalUserDefaultArgument` made `internal` for reuse.
- `test/Compiler.Tests/Emit/Issue936StaticOptionalParameterEmitTests.cs` — new emit+run regression tests.

## Tests
New `Issue936StaticOptionalParameterEmitTests` (3 tests) compile, IL-verify, run, and assert the default values are applied: Passed 3/3. Related static-call suites (Issue798/Issue812/Adr0112UserMethodGroup) still pass (12/12). Full solution builds with 0 warnings.

Fixes #936
