### PR TITLE
Support break/continue inside async `await for` loop body (#937)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundAwaitForRangeStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundAwaitForRangeStatement.cs
@@ -18,7 +18,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// idiom Phase 5.1 uses for plain <c>await</c>). The async-aware
 /// lowering and emit are deferred.
 /// </summary>
-public sealed class BoundAwaitForRangeStatement : BoundStatement
+public sealed class BoundAwaitForRangeStatement : BoundLoopStatement
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundAwaitForRangeStatement"/> class.
@@ -27,12 +27,16 @@ public sealed class BoundAwaitForRangeStatement : BoundStatement
     /// <param name="valueVariable">The element variable.</param>
     /// <param name="stream">The async-stream expression.</param>
     /// <param name="body">The loop body.</param>
+    /// <param name="breakLabel">The break label targeted by <c>break</c> inside the loop body.</param>
+    /// <param name="continueLabel">The continue label targeted by <c>continue</c> inside the loop body.</param>
     public BoundAwaitForRangeStatement(
         SyntaxNode syntax,
         VariableSymbol valueVariable,
         BoundExpression stream,
-        BoundStatement body)
-        : base(syntax)
+        BoundStatement body,
+        BoundLabel breakLabel,
+        BoundLabel continueLabel)
+        : base(syntax, breakLabel, continueLabel)
     {
         ValueVariable = valueVariable;
         Stream = stream;

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -872,7 +872,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundAwaitForRangeStatement(null, node.ValueVariable, stream, body);
+        return new BoundAwaitForRangeStatement(null, node.ValueVariable, stream, body, node.BreakLabel, node.ContinueLabel);
     }
 
     /// <summary>Rewrites a bound yield statement (ADR-0040).</summary>

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -2573,13 +2573,18 @@ internal sealed class StatementBinder
 
     private BoundStatement BindAwaitForRangeStatement(AwaitForRangeStatementSyntax syntax)
     {
+        return BindAwaitForRangeStatementCore(syntax, labelName: null, originatingSyntax: syntax);
+    }
+
+    private BoundStatement BindAwaitForRangeStatementCore(AwaitForRangeStatementSyntax syntax, string labelName, SyntaxNode originatingSyntax)
+    {
         // Phase 5.8 / ADR-0023: `await for v := range stream { … }`.
         // The stream operand must be an `IAsyncEnumerable[T]` (a CLR type
         // that exposes a `GetAsyncEnumerator` method). The value variable
-        // is typed as the stream's element `T`. The interpreter handles
-        // the underlying `MoveNextAsync`/`Current`/`DisposeAsync` cycle
-        // synchronously (matching Phase 5.1's `await` lowering). The
-        // async-aware lowering and emit are deferred.
+        // is typed as the stream's element `T`. Issue #937: the loop body
+        // is bound through BindLoopBody so that `break`, `continue`, and
+        // labeled break/continue resolve to the loop's synthesized labels —
+        // achieving parity with the synchronous `for … in` loop.
         var stream = bindExpression(syntax.Stream);
         if (stream is BoundErrorExpression)
         {
@@ -2594,10 +2599,10 @@ internal sealed class StatementBinder
 
         scope = new BoundScope(scope);
         var variable = bindLocalVariable(syntax.Identifier, isReadOnly: false, type: elementType);
-        var body = BindStatement(syntax.Body);
+        var body = BindLoopBody(syntax.Body, labelName, out var breakLabel, out var continueLabel);
         scope = scope.Parent;
 
-        return new BoundAwaitForRangeStatement(null, variable, stream, body);
+        return new BoundAwaitForRangeStatement(originatingSyntax, variable, stream, body, breakLabel, continueLabel);
     }
 
     private BoundStatement BindYieldStatement(YieldStatementSyntax syntax)
@@ -3193,6 +3198,8 @@ internal sealed class StatementBinder
                 BindForClauseStatementCore((ForClauseStatementSyntax)inner, syntax, labelName),
             SyntaxKind.ForRangeStatement =>
                 BindForRangeStatementCore((ForRangeStatementSyntax)inner, labelName, syntax),
+            SyntaxKind.AwaitForRangeStatement =>
+                BindAwaitForRangeStatementCore((AwaitForRangeStatementSyntax)inner, labelName, syntax),
             _ => BindStatement(inner),
         };
     }
@@ -3208,6 +3215,7 @@ internal sealed class StatementBinder
             SyntaxKind.ForConditionStatement => true,
             SyntaxKind.ForClauseStatement => true,
             SyntaxKind.ForRangeStatement => true,
+            SyntaxKind.AwaitForRangeStatement => true,
             _ => false,
         };
     }

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -439,11 +439,26 @@ public sealed class Evaluator
                 Assign(node.ValueVariable, current);
                 EvaluateStatement((BoundBlockStatement)node.Body);
 
-                // Issue #738: honor in-arm returns / labeled gotos that
-                // escape the loop body. Without this check the iterator
-                // would keep dispatching MoveNextAsync past the transfer.
+                // Issue #937: honor `break`/`continue` (lowered to gotos that
+                // target this loop's break/continue labels) and labeled
+                // gotos / returns that escape the body. A pending goto to
+                // this loop's continue label advances to the next element;
+                // a goto to this loop's break label (or a plain return)
+                // exits the loop; any other pending goto belongs to an
+                // enclosing loop and is left parked so it propagates.
+                if (pendingGotoLabel != null && pendingGotoLabel == node.ContinueLabel)
+                {
+                    pendingGotoLabel = null;
+                    continue;
+                }
+
                 if (isReturning || pendingGotoLabel != null)
                 {
+                    if (pendingGotoLabel == node.BreakLabel)
+                    {
+                        pendingGotoLabel = null;
+                    }
+
                     break;
                 }
             }

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -430,7 +430,7 @@ public sealed class Lowerer : BoundTreeRewriter
         var stream = RewriteExpression(node.Stream);
         var body = RewriteStatement(node.Body);
 
-        var lowered = LowerAwaitForRange(node.ValueVariable, stream, body);
+        var lowered = LowerAwaitForRange(node.ValueVariable, stream, body, node.BreakLabel, node.ContinueLabel);
         return RewriteStatement(lowered);
     }
 
@@ -478,7 +478,7 @@ public sealed class Lowerer : BoundTreeRewriter
         return base.RewritePropertyAssignmentExpression(node);
     }
 
-    private BoundStatement LowerAwaitForRange(VariableSymbol valueVariable, BoundExpression stream, BoundStatement body)
+    private BoundStatement LowerAwaitForRange(VariableSymbol valueVariable, BoundExpression stream, BoundStatement body, BoundLabel breakLabel, BoundLabel continueLabel)
     {
         var streamClr = stream.Type?.ClrType;
         if (streamClr == null)
@@ -572,8 +572,12 @@ public sealed class Lowerer : BoundTreeRewriter
             ImmutableArray.Create<BoundExpression>(new BoundDefaultExpression(null, cancellationTokenType)));
         var enumeratorDecl = new BoundVariableDeclaration(null, enumeratorSymbol, getEnumCall);
 
-        var startLabel = GenerateLabel();
-        var endLabel = GenerateLabel();
+        // Issue #937: the loop's continue label sits at the MoveNextAsync
+        // step (so `continue` advances to the next element) and the break
+        // label sits at the loop exit, still inside the try so the finally's
+        // DisposeAsync await runs when `break` leaves the loop.
+        var startLabel = continueLabel;
+        var endLabel = breakLabel;
         var moreSymbol = new LocalVariableSymbol("$more", isReadOnly: false, type: TypeSymbol.Bool);
 
         var moveNextCall = new BoundImportedInstanceCallExpression(

--- a/test/Compiler.Tests/Emit/Issue937AwaitForBreakContinueEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue937AwaitForBreakContinueEmitTests.cs
@@ -1,0 +1,309 @@
+// <copyright file="Issue937AwaitForBreakContinueEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #937: <c>break</c>, <c>continue</c>, and labeled break/continue were
+/// rejected ("The keyword 'break' can only be used inside of loops.") inside an
+/// <c>await for</c> (async foreach over an <c>IAsyncEnumerable&lt;T&gt;</c>) loop
+/// body, because the binder did not register a loop scope for the async loop the
+/// way the synchronous <c>for … in</c> loop does. These tests verify full parity:
+/// the keywords now bind, lower, and emit with correct runtime semantics.
+/// </summary>
+public class Issue937AwaitForBreakContinueEmitTests
+{
+    #region break inside await for
+
+    [Fact]
+    public void AwaitFor_Break_Compiles_And_Runs()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Nums() IAsyncEnumerable[int32] {
+                yield 1
+                await Task.Delay(1)
+                yield 2
+                yield 3
+                yield 4
+            }
+
+            async func Run() {
+                var sum = 0
+                await for n in Nums() {
+                    if n == 3 {
+                        break
+                    }
+                    sum = sum + n
+                }
+                Console.WriteLine(sum)
+            }
+
+            Run().Wait()
+            """;
+
+        // 1 + 2 added; 3 breaks before 4. Sum = 3.
+        var (_, stdout) = CompileRunCapture(source);
+        Assert.Equal("3", stdout.Trim());
+    }
+
+    #endregion
+
+    #region continue inside await for
+
+    [Fact]
+    public void AwaitFor_Continue_Compiles_And_Runs()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Nums() IAsyncEnumerable[int32] {
+                yield 1
+                await Task.Delay(1)
+                yield 2
+                yield 3
+                yield 4
+            }
+
+            async func Run() {
+                var sum = 0
+                await for n in Nums() {
+                    if n == 2 {
+                        continue
+                    }
+                    if n == 4 {
+                        continue
+                    }
+                    sum = sum + n
+                }
+                Console.WriteLine(sum)
+            }
+
+            Run().Wait()
+            """;
+
+        // 2 and 4 skipped via continue; 1 + 3 added. Sum = 4.
+        var (_, stdout) = CompileRunCapture(source);
+        Assert.Equal("4", stdout.Trim());
+    }
+
+    #endregion
+
+    #region break + continue combined
+
+    [Fact]
+    public void AwaitFor_BreakAndContinue_Compiles_And_Runs()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Nums() IAsyncEnumerable[int32] {
+                yield 1
+                await Task.Delay(1)
+                yield 2
+                yield 3
+                yield 4
+            }
+
+            async func Run() {
+                var sum = 0
+                await for n in Nums() {
+                    if n == 3 {
+                        break
+                    }
+                    if n == 2 {
+                        continue
+                    }
+                    sum = sum + n
+                }
+                Console.WriteLine(sum)
+            }
+
+            Run().Wait()
+            """;
+
+        // 1 added; 2 continues; 3 breaks. Sum = 1.
+        var (_, stdout) = CompileRunCapture(source);
+        Assert.Equal("1", stdout.Trim());
+    }
+
+    #endregion
+
+    #region labeled break / continue across nested await-for loops
+
+    [Fact]
+    public void AwaitFor_LabeledBreakAndContinue_Compiles_And_Runs()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Outer() IAsyncEnumerable[int32] {
+                yield 1
+                await Task.Delay(1)
+                yield 2
+                yield 3
+            }
+
+            async func Inner() IAsyncEnumerable[int32] {
+                yield 10
+                await Task.Delay(1)
+                yield 20
+                yield 30
+            }
+
+            async func Run() {
+                var sum = 0
+            outer:
+                await for a in Outer() {
+                    await for b in Inner() {
+                        if b == 20 {
+                            continue outer
+                        }
+                        if a == 3 {
+                            break outer
+                        }
+                        sum = sum + a + b
+                    }
+                }
+                Console.WriteLine(sum)
+            }
+
+            Run().Wait()
+            """;
+
+        // a=1: b=10 -> sum += 11; b=20 -> continue outer.
+        // a=2: b=10 -> sum += 12 (=23); b=20 -> continue outer.
+        // a=3: b=10 -> break outer.
+        // Sum = 23.
+        var (_, stdout) = CompileRunCapture(source);
+        Assert.Equal("23", stdout.Trim());
+    }
+
+    #endregion
+
+    #region break stops pulling further elements
+
+    [Fact]
+    public void AwaitFor_Break_StopsConsuming()
+    {
+        // The producer prints each element before yielding it. Because the
+        // async stream is pull-based, `break` must stop calling MoveNextAsync,
+        // so the element after the break point is never produced.
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Stream() IAsyncEnumerable[int32] {
+                Console.WriteLine("produce 1")
+                yield 1
+                await Task.Delay(1)
+                Console.WriteLine("produce 2")
+                yield 2
+                Console.WriteLine("produce 3")
+                yield 3
+            }
+
+            async func Run() {
+                var sum = 0
+                await for n in Stream() {
+                    sum = sum + n
+                    if n == 2 {
+                        break
+                    }
+                }
+                Console.WriteLine(sum)
+            }
+
+            Run().Wait()
+            """;
+
+        // 1 and 2 produced and summed; break prevents "produce 3". Sum = 3.
+        var (_, stdout) = CompileRunCapture(source);
+        Assert.Equal("produce 1\nproduce 2\n3", stdout.Trim());
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static (Assembly assembly, string stdout) CompileRunCapture(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_937_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+
+        var captured = new StringWriter();
+        var prevOut2 = Console.Out;
+        Console.SetOut(captured);
+        try
+        {
+            entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { System.Array.Empty<string>() });
+        }
+        finally
+        {
+            Console.SetOut(prevOut2);
+        }
+
+        return (assembly, captured.ToString().Replace("\r\n", "\n"));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Fixes #937. `break`, `continue`, and labeled break/continue are now fully supported inside an `await for` (async foreach over `IAsyncEnumerable[T]`) loop body, with correct runtime semantics — achieving parity with the synchronous `for … in` loop.

## Root cause
`BindAwaitForRangeStatement` bound the loop body with `BindStatement` instead of `BindLoopBody`. Every synchronous loop binds its body through `BindLoopBody`, which pushes a frame (label name + synthesized break/continue labels) onto `BinderContext.LoopStack`. Because the async loop skipped that step, the stack was empty inside the body and `BindBreakStatement`/`BindContinueStatement` reported:

> error GS0120: The keyword 'break' can only be used inside of loops.

## Fix
- **Binder** (`StatementBinder.cs`): `await for` now binds its body via `BindLoopBody`, threading the synthesized break/continue labels into the bound node. Labeled `await for` is supported too (added to `IsLabelableLoop` and the labeled-statement dispatch via a new `BindAwaitForRangeStatementCore`).
- **Bound node** (`BoundAwaitForRangeStatement.cs`): now derives from `BoundLoopStatement`, carrying `BreakLabel`/`ContinueLabel`.
- **Lowering** (`Lowerer.cs`): `LowerAwaitForRange` places the **continue** label at the `MoveNextAsync` step (so `continue` advances to the next element) and the **break** label at the loop exit, still inside the `try`, so `break` exits the loop while the `finally`'s `DisposeAsync` await still runs.
- **Interpreter** (`Evaluator.cs`): `EvaluateAwaitForRangeStatement` distinguishes a pending goto to this loop's continue label (advance) from its break label (exit), and leaves any other pending goto parked so labeled break/continue propagate to an enclosing loop.
- `BoundTreeRewriter` preserves the labels.

## Tests
Added `test/Compiler.Tests/Emit/Issue937AwaitForBreakContinueEmitTests.cs` (compile + run + IL-verify):
- `break` exits the loop
- `continue` skips elements
- combined `break` + `continue`
- labeled `break`/`continue` across nested async loops
- `break` stops pulling further elements (pull-based stream side effects)

```
Passed!  - Failed: 0, Passed: 5, Skipped: 0, Total: 5
```

Full solution builds at **0 warnings** (TreatWarningsAsErrors on).

## Deferred work
None.