### PR TITLE
Fix for-in over List[T] erasing same-compilation user element type (#939)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -2828,7 +2828,16 @@ internal sealed class StatementBinder
             // OpenDefinition for the enumerable / dictionary shape and map
             // each open CLR type argument back to the symbolic argument so
             // the loop variable's type is the user's `T` (not `object`).
-            case ImportedTypeSymbol openImp when openImp.HasTypeParameterArgument && openImp.OpenDefinition != null:
+            //
+            // Issue #939: this path must also fire when the symbolic type
+            // argument is a *same-compilation* user `class`/`data struct`
+            // (e.g. `List[Item]`). Such arguments are not type parameters, so
+            // `HasTypeParameterArgument` is false, yet their CLR type is still
+            // erased to `<object>` on the closed `ClrType`. Mirror the indexer
+            // path's `MapErasedIndexerElementType` substitutability test so the
+            // loop variable recovers the member-bearing user `Item` symbol
+            // rather than the erased `object`.
+            case ImportedTypeSymbol openImp when openImp.OpenDefinition != null && openImp.HasSubstitutableTypeArgument:
                 if (MemberLookup.TryGetClrDictionaryTypes(openImp.OpenDefinition, out var openDKey, out var openDVal))
                 {
                     iterationKind = ForRangeKind.Dictionary;

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -757,7 +757,7 @@ public sealed class Lowerer : BoundTreeRewriter
             TypeSymbol keyAccessType = TypeSymbol.FromClrType(keyProp.PropertyType);
             TypeSymbol valueAccessType = TypeSymbol.FromClrType(valueProp.PropertyType);
             if (kvpType is ImportedTypeSymbol kvpImp
-                && kvpImp.HasTypeParameterArgument
+                && kvpImp.HasSubstitutableTypeArgument
                 && kvpImp.TypeArguments.Length == 2)
             {
                 keyAccessType = kvpImp.TypeArguments[0];
@@ -1006,7 +1006,7 @@ public sealed class Lowerer : BoundTreeRewriter
                 openDef = typeof(System.Collections.Generic.IEnumerable<>);
                 typeArguments = ImmutableArray.Create<TypeSymbol>(seq.ElementType);
                 break;
-            case ImportedTypeSymbol imp when imp.HasTypeParameterArgument && imp.OpenDefinition != null:
+            case ImportedTypeSymbol imp when imp.HasSubstitutableTypeArgument && imp.OpenDefinition != null:
                 openDef = imp.OpenDefinition;
                 typeArguments = imp.TypeArguments;
                 break;
@@ -1172,7 +1172,7 @@ public sealed class Lowerer : BoundTreeRewriter
                 // BoundClrPropertyAccessExpression carries the user's `T`.
                 TypeSymbol currentType = null;
                 if (enumeratorType is ImportedTypeSymbol enumImp
-                    && enumImp.HasTypeParameterArgument
+                    && enumImp.HasSubstitutableTypeArgument
                     && !enumImp.TypeArguments.IsDefaultOrEmpty)
                 {
                     currentType = enumImp.TypeArguments[0];

--- a/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
@@ -66,6 +66,29 @@ public sealed class ImportedTypeSymbol : TypeSymbol
         !TypeArguments.IsDefaultOrEmpty && TypeArguments.Any(TypeSymbol.ContainsTypeParameter);
 
     /// <summary>
+    /// Gets a value indicating whether this symbol's symbolic type arguments
+    /// should be substituted back through its <see cref="OpenDefinition"/> when
+    /// projecting member / element types (issue #939).
+    /// This is broader than <see cref="HasTypeParameterArgument"/>: it also
+    /// holds when an argument is a <em>same-compilation</em> user
+    /// <c>class</c>/<c>data struct</c> (whose <see cref="TypeSymbol.ClrType"/>
+    /// is <see langword="null"/> because its CLR type is still being built and
+    /// the closed shape is erased to <c>object</c>), or a nested constructed
+    /// generic with symbolic arguments (e.g. <c>List[List[MyGs]]</c>). The
+    /// indexer path (<c>MapErasedIndexerElementType</c>) and the for-in
+    /// enumerable path both rely on this so iterating <c>List[Item]</c>
+    /// recovers the member-bearing user <c>Item</c> symbol rather than the
+    /// type-erased <c>object</c>.
+    /// </summary>
+    public bool HasSubstitutableTypeArgument =>
+        !TypeArguments.IsDefaultOrEmpty
+        && (HasTypeParameterArgument
+            || TypeArguments.Any(static a => a.ClrType == null
+                || (a is ImportedTypeSymbol nested
+                    && nested.OpenDefinition != null
+                    && !nested.TypeArguments.IsDefaultOrEmpty)));
+
+    /// <summary>
     /// Gets or creates the imported type symbol for the given CLR type.
     /// </summary>
     /// <param name="type">The CLR type.</param>

--- a/test/Compiler.Tests/Emit/Issue939ForInUserElementTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue939ForInUserElementTypeEmitTests.cs
@@ -1,0 +1,304 @@
+// <copyright file="Issue939ForInUserElementTypeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #939: iterating a <c>List[T]</c> (or any CLR generic enumerable)
+/// whose element type <c>T</c> is a <em>same-compilation</em> user type
+/// (a <c>class</c> or a <c>data struct</c>) used to erase the loop
+/// variable's type in the <c>for … in …</c> binder. Member access on the
+/// loop variable then failed with <c>GS0158</c> / <c>GS0159</c> even though
+/// the equivalent indexer access bound fine.
+/// <para>
+/// Root cause: the for-in binder (and the matching enumerator lowering)
+/// only mapped the open CLR element type back through the receiver's
+/// symbolic type arguments when <c>HasTypeParameterArgument</c> was true
+/// (i.e. the argument was an in-scope generic parameter such as <c>T</c>).
+/// For a concrete same-compilation user type the argument is not a type
+/// parameter, so the receiver fell through to the type-erased
+/// <c>List&lt;object&gt;</c> path and the loop variable collapsed to
+/// <c>object</c>. The fix broadens the predicate to
+/// <c>HasSubstitutableTypeArgument</c>, mirroring the indexer path, so the
+/// loop variable recovers the member-bearing user symbol.
+/// </para>
+/// <para>
+/// These tests compile, IL-verify, and actually run programs that iterate
+/// a <c>List[Item]</c> with <c>for it in xs { … it.Name … }</c> and assert
+/// the runtime output, covering both the <c>data struct</c> and the
+/// <c>class</c> element-type cases.
+/// </para>
+/// </summary>
+public class Issue939ForInUserElementTypeEmitTests
+{
+    [Fact]
+    public void ForIn_ListOfDataStructItem_MemberAccess_Compiles_And_Runs()
+    {
+        // The exact repro from issue #939: data struct element type.
+        var source = """
+            package GapCheck
+            import System
+            import System.Collections.Generic
+
+            data struct Item(Name string, Price int32)
+
+            var xs = List[Item]()
+            xs.Add(Item{Name: "a", Price: 1})
+            xs.Add(Item{Name: "b", Price: 2})
+            for it in xs {
+                Console.WriteLine(it.Name)
+                Console.WriteLine(it.Price)
+            }
+            """;
+
+        Assert.Equal("a\n1\nb\n2\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ForIn_ListOfClassItem_MemberAccess_Compiles_And_Runs()
+    {
+        // The issue notes `class Item(...)` fails identically — verify the
+        // reference-type element type works end to end too.
+        var source = """
+            package GapCheck
+            import System
+            import System.Collections.Generic
+
+            class Item(Name string, Price int32)
+
+            var xs = List[Item]()
+            xs.Add(Item{Name: "a", Price: 1})
+            xs.Add(Item{Name: "b", Price: 2})
+            for it in xs {
+                Console.WriteLine(it.Name)
+                Console.WriteLine(it.Price)
+            }
+            """;
+
+        Assert.Equal("a\n1\nb\n2\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ForIn_ListOfDataStructItem_SumsMembers_Compiles_And_Runs()
+    {
+        // Reads a member into an accumulator so the loop variable's type is
+        // exercised in arithmetic, not just a passthrough WriteLine.
+        var source = """
+            package GapCheck
+            import System
+            import System.Collections.Generic
+
+            data struct Item(Name string, Price int32)
+
+            var xs = List[Item]()
+            xs.Add(Item{Name: "a", Price: 10})
+            xs.Add(Item{Name: "b", Price: 32})
+            var total = 0
+            for it in xs {
+                total = total + it.Price
+            }
+            Console.WriteLine(total)
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ForIn_NestedListOfListOfDataStructItem_Compiles_And_Runs()
+    {
+        // Nested generic: `List[List[Item]]`. The outer loop variable must
+        // recover `List[Item]` (member-bearing) and the inner loop variable
+        // must recover `Item`.
+        var source = """
+            package GapCheck
+            import System
+            import System.Collections.Generic
+
+            data struct Item(Name string, Price int32)
+
+            var outer = List[List[Item]]()
+            var inner = List[Item]()
+            inner.Add(Item{Name: "deep", Price: 7})
+            outer.Add(inner)
+            for lst in outer {
+                for it in lst {
+                    Console.WriteLine(it.Name)
+                    Console.WriteLine(it.Price)
+                }
+            }
+            """;
+
+        Assert.Equal("deep\n7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ForIn_DictionaryWithDataStructValue_TwoVar_Compiles_And_Runs()
+    {
+        // Sibling enumerable that shares the for-in open-receiver path: a
+        // `Dictionary[string, Item]` two-variable range must recover the
+        // user `Item` for the value variable (pre-fix this also erased to
+        // `object`).
+        var source = """
+            package GapCheck
+            import System
+            import System.Collections.Generic
+
+            data struct Item(Name string, Price int32)
+
+            var d = Dictionary[string, Item]()
+            d.Add("k", Item{Name: "dictval", Price: 3})
+            for key, v in d {
+                Console.WriteLine(key)
+                Console.WriteLine(v.Name)
+                Console.WriteLine(v.Price)
+            }
+            """;
+
+        Assert.Equal("k\ndictval\n3\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ForIn_DictionaryWithClassValue_TwoVar_Compiles_And_Runs()
+    {
+        // Same as above but with a reference-type (class) value.
+        var source = """
+            package GapCheck
+            import System
+            import System.Collections.Generic
+
+            class Item(Name string, Price int32)
+
+            var d = Dictionary[string, Item]()
+            d.Add("k", Item{Name: "dictval", Price: 3})
+            for key, v in d {
+                Console.WriteLine(key)
+                Console.WriteLine(v.Name)
+                Console.WriteLine(v.Price)
+            }
+            """;
+
+        Assert.Equal("k\ndictval\n3\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ForIn_ListOfPrimitive_StillCompiles_And_Runs()
+    {
+        // Regression guard: the primitive element control must keep working
+        // after broadening the open-receiver predicate.
+        var source = """
+            package GapCheck
+            import System
+            import System.Collections.Generic
+
+            var ns = List[int32]()
+            ns.Add(5)
+            ns.Add(6)
+            for n in ns {
+                Console.WriteLine(n)
+            }
+            """;
+
+        Assert.Equal("5\n6\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ForIn_ListOfNativeTuple_StillCompiles_And_Runs()
+    {
+        // Regression guard: the native-tuple element control must keep
+        // working after broadening the open-receiver predicate.
+        var source = """
+            package GapCheck
+            import System
+            import System.Collections.Generic
+
+            var ts = List[(string, int32)]()
+            ts.Add(("x", 9))
+            for t in ts {
+                Console.WriteLine(t.Item1)
+                Console.WriteLine(t.Item2)
+            }
+            """;
+
+        Assert.Equal("x\n9\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue939_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Iterating a `List[T]` (or any CLR generic enumerable) whose element type `T` is a **same-compilation** user `class`/`data struct` (e.g. `List[Item]`) erased the loop variable's type in the `for … in …` binder. Member access on the loop variable then failed with **GS0158** ("Cannot find member") / **GS0159**, even though the equivalent indexer access `list[i].Member` bound correctly.

```gsharp
data struct Item(Name string, Price int32)
var xs = List[Item]()
xs.Add(Item{Name: "a", Price: 1})
for it in xs {
    Console.WriteLine(it.Name)   // pre-fix: error GS0158 / GS0159
}
```

`class Item(...)` failed identically.

## Root cause

The for-in binder and the matching enumerator lowering only mapped the open CLR element type back through the receiver's symbolic type arguments when `ImportedTypeSymbol.HasTypeParameterArgument` was true — i.e. when the argument was an *in-scope generic parameter* such as `T`.

For a **concrete same-compilation user type** the argument is not a type parameter, so `HasTypeParameterArgument` is `false`. The receiver therefore fell through to the type-erased `List<object>` path and the loop variable collapsed to `object` (which has no `Name`/`Price`). The indexer path already handled this correctly via a broader substitutability test in `MapErasedIndexerElementType` (it also triggers when an argument's `ClrType == null`, which is the case for same-compilation user types whose CLR type is still being built).

## Fix

Introduce `ImportedTypeSymbol.HasSubstitutableTypeArgument`, mirroring the indexer path's test (true for in-scope type parameters, same-compilation user-type args with a null `ClrType`, and nested constructed generics), and use it in the four places that gated on `HasTypeParameterArgument` along the for-in open-receiver path:

- `StatementBinder` for-in open-receiver branch — loop variable element/key/value type
- `Lowerer.TryBuildSymbolicOpenGetEnumeratorCall` — synthesise the symbolic `IEnumerator[Element]`
- `Lowerer.TryBuildMoveNextAndCurrent` — symbolic `Current` type
- `Lowerer.LowerCollectionRange` dictionary branch — symbolic `Key`/`Value` access types

This types `it` as the user `Item` (carrying its members) for both `data struct` and `class` element types, iterates and reads members correctly at runtime, handles nested `List[List[Item]]`, and additionally fixes the sibling `Dictionary[string, Item]` two-variable range (previously erased to `object`; without this change the binder fix alone would have turned that into an emit-time `NullReferenceException`). Primitive, native-tuple, array, and open-generic-parameter (`IEnumerable[T]`) cases are unchanged.

## Tests

New `Issue939ForInUserElementTypeEmitTests` (compile + IL-verify + **run**, asserting stdout):

- `List[Item]` with a **data struct** `Item` (issue repro) — `it.Name`/`it.Price`
- `List[Item]` with a **class** `Item`
- member accumulation in a loop body
- nested `List[List[Item]]`
- `Dictionary[string, Item]` two-var range, data struct and class value
- primitive and native-tuple regression guards

```
Passed!  - Failed: 0, Passed: 8  - Issue939
Passed!  - Failed: 0, Passed: 62 - Issue774/538/693/671/520/652/903/833 (regression)
Passed!  - Failed: 0, Passed: 82 - Core.Tests ForRange/ForIn/Enumerable/Iteration
```

Full solution builds at **0 warnings** (TreatWarningsAsErrors on, StyleCop clean).

### Note (out of scope / pre-existing)

Indexer access `xs[0]` on a `List[<data struct>]` value type already segfaults at runtime on `main` (value-type boxing in the indexer read path) — independent of this change and of the GS0158 binder bug. Left untouched to keep this PR surgical.

Fixes #939
