### PR TITLE
Add binary null-coalescing operator a ?? b; remove ?: (#941)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ import Gsharp.Extensions.Optional
 let name string? = "ada"
 
 let upper = name.Map((s string) -> s.ToUpper())
-Console.WriteLine(upper ?: "<absent>")           // ADA
+Console.WriteLine(upper ?? "<absent>")           // ADA
 
 let absent string? = nil
 Console.WriteLine(absent.OrElse("default"))      // default
 
 let short = name.Filter((s string) -> s.Length <= 2)
-Console.WriteLine(short ?: "<filtered out>")     // <filtered out>
+Console.WriteLine(short ?? "<filtered out>")     // <filtered out>
 ```
 
 ### `scope` + `async` / `await`

--- a/design/Gsharp-design-v0.2.md
+++ b/design/Gsharp-design-v0.2.md
@@ -15,7 +15,7 @@ Nullability is part of the type. Reference types are non-null by default; nullab
 ```gs
 let s : string  = "hello"   // non-null
 let m : string? = nil       // nullable
-let n = m?.length ?: 0      // safe call + Elvis
+let n = m?.length ?? 0      // safe call + null-coalescing
 let k = m!!.length          // null-assert (throws if nil)
 if m != nil {
   Console.WriteLine(m.length)   // smart cast: m is `string` here

--- a/docs/adr/0001-null-model.md
+++ b/docs/adr/0001-null-model.md
@@ -22,7 +22,7 @@ Adopt the **Kotlin-style** model:
 - Reference types are non-null by default. Nullability is opted into with the postfix `?` type operator: `string?`, `User?`, `List[int]?`.
 - Value types use the same `T?` spelling, lowered to `System.Nullable<T>` in IL.
 - `nil` is the only inhabitant of the bottom of nullable types; assigning `nil` to a non-nullable is a binder diagnostic.
-- Operators: safe call `?.`, Elvis `?:`, null-assert `!!`.
+- Operators: safe call `?.`, null-coalescing `??` (originally spelled `?:`; respelled by ADR-0116, issue #941), null-assert `!!`.
 - Flow-typed smart casts narrow a nullable to non-null after a `!= nil` check inside the controlled block.
 - The reference resolver honors `[Nullable]` / `[NullableContext]` attributes from imported assemblies so BCL APIs project their declared nullability into GSharp.
 

--- a/docs/adr/0072-null-coalescing-compound-assignment.md
+++ b/docs/adr/0072-null-coalescing-compound-assignment.md
@@ -3,11 +3,17 @@
 - **Status**: Accepted
 - **Date**: 2026-06-12
 - **Phase**: Phase 9 — language depth / null-handling ergonomics
-- **Related**: ADR-0001 (nullable reference types), ADR-0066 (`?:` null-coalescing read), parent [#706](https://github.com/DavidObando/gsharp/issues/706) (control-flow polish), this ADR [#709](https://github.com/DavidObando/gsharp/issues/709)
+- **Related**: ADR-0001 (nullable reference types), ADR-0001 (`?:` null-coalescing read, now spelled `??` per ADR-0116), parent [#706](https://github.com/DavidObando/gsharp/issues/706) (control-flow polish), this ADR [#709](https://github.com/DavidObando/gsharp/issues/709)
+
+> **Update (ADR-0116, issue #941):** The null-coalescing **read** operator was
+> respelled from `a ?: b` to `a ?? b` and the `?:` spelling was removed. Where
+> this ADR shows `?:` below it now reads `??`; the `??=` compound assignment
+> described here is unchanged.
 
 ## Context
 
-G# spells the null-coalescing **read** as `a ?: b` — `b` is returned only
+G# spells the null-coalescing **read** as `a ?? b` (originally `a ?: b`; see
+ADR-0116) — `b` is returned only
 when `a` is nil, with short-circuit semantics. There is no compound form for
 the very common "assign default if currently nil" pattern, so today programmers
 write the long-hand:
@@ -21,7 +27,7 @@ if cfg.Endpoint == nil {
 …or the read-and-write pair:
 
 ```gs
-cfg.Endpoint = cfg.Endpoint ?: "https://example.com"
+cfg.Endpoint = cfg.Endpoint ?? "https://example.com"
 ```
 
 The first is verbose and easy to forget; the second re-evaluates the receiver
@@ -46,7 +52,7 @@ Add `??=` as a **statement-only** compound assignment with these semantics:
 
 The operator is the three-character sequence `??=` (two `?` followed by `=`).
 The lexer recognizes the sequence directly. G# does **not** introduce a bare
-`??` token (its null-coalescing read remains `?:` from ADR-0066); the doubled
+`??` token (its null-coalescing read was `?:` at the time of this ADR; ADR-0116 later made the read itself `??`); the doubled
 `?` only appears as part of `??=`. Whitespace inside the sequence is not
 allowed.
 
@@ -192,7 +198,7 @@ avoided because the interpreter only reads `node.Receiver` (the
   path), so the change is small and self-contained.
 - Guarantees single evaluation of receiver and RHS — a property that the
   hand-written `if x == nil { x = b() }` form already gives but that the
-  one-line `x = x ?: b()` form does not.
+  one-line `x = x ?? b()` form does not.
 
 ### Negative
 

--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -160,8 +160,8 @@ the flag is emitted exactly on the methods listed above.
 
 ### Why no `Option<T>`?
 
-G# already has structural nullable types (`T?`), the Elvis operator
-(`?:`), null-safe member access (`?.`), the bang operator (`!!`),
+G# already has structural nullable types (`T?`), the null-coalescing operator
+(`??`, originally `?:` — see ADR-0116), null-safe member access (`?.`), the bang operator (`!!`),
 smart casts (`if x is T y { ... }`), and the `nil` literal.
 Introducing a wrapper `Option<T>` would compete with the existing
 surface for no semantic gain and would force every user of the
@@ -266,17 +266,17 @@ hatch under `src/Sdk/Gsharp.Extensions/*.cs` works today.
   explicit `[T struct]` overload (HasValue-aware lowering), at
   which point each path is statically chosen and the emit fix
   becomes mechanical.
-- **L3. Native `?:` over nullable value types.**
+- **L3. Native `??` over nullable value types.**
   ([issue #752](https://github.com/DavidObando/gsharp/issues/752))
   **Closed.** Issue #519 introduced the HasValue-based lowering
-  for value-type `Nullable<T>` LHS in the `?:` emit path; issue
+  for value-type `Nullable<T>` LHS in the `??` emit path; issue
   #752 finished the job by switching the non-null branch's unwrap
   from `Nullable<T>::get_Value()` to the cheaper
   `GetValueOrDefault()` (no boxing, no callvirt, no redundant
   throw path) and by giving the coalesce its own scratch slot
-  separate from the receiver-spill slot so `(v ?: 0).ToString()`
+  separate from the receiver-spill slot so `(v ?? 0).ToString()`
   emits verifiable IL. The `Optional` and `Sequences` samples
-  now use `?:` directly on `int32?` receivers; the `OrElse` /
+  now use `??` directly on `int32?` receivers; the `OrElse` /
   `OrCompute` helpers remain available for deferred / computed
   fallbacks but are no longer the only safe surface.
 

--- a/docs/adr/0099-lsp-nil-quick-fixes.md
+++ b/docs/adr/0099-lsp-nil-quick-fixes.md
@@ -9,7 +9,7 @@
 ## Context
 
 G# has had nullable types (`T?`), the postfix null-assertion operator
-`!!`, the Elvis/null-coalescing expression operator `?:`, the
+`!!`, the null-coalescing expression operator `??` (originally `?:`; respelled by ADR-0116), the
 null-conditional member access `?.`, and the null-conditional index
 access `?[…]` for several releases. The binder emits a small family of
 diagnostics whenever a user writes code that does not yet thread these
@@ -24,7 +24,7 @@ operators through correctly:
 | `GS0274` | `DiagnosticBag.ReportNilNotAssignableToNonNullableParameter` | A literal `nil` was passed to a non-nullable parameter. |
 
 Without quick-fixes the user is stuck consulting prose docs (or
-guessing) to remember which of `?.`, `?:`, or `!!` is appropriate. The
+guessing) to remember which of `?.`, `??`, or `!!` is appropriate. The
 issue (parent #706 §6.4) asks the LSP to surface those three rewrites
 as `textDocument/codeAction` results directly off the diagnostic.
 
@@ -43,8 +43,8 @@ re-parsing.
 | Operator | Trigger diagnostics | Edit |
 | -------- | ------------------- | ---- |
 | `.` → `?.` | `GS0158` on the right-hand identifier of an `AccessorExpressionSyntax` whose left-part is statically nullable (chained `?.`, literal `nil`, or a local/parameter/field whose declared type-clause text ends with `?`). | Replace the dot token's span with `?.`. |
-| `expr` → `(expr ?: <default>)` | `GS0154` / `GS0155` / `GS0156` whose diagnostic message contains the canonical `'T?'` → `'T'` pair. `GS0274` is excluded — the source is literal `nil`, the rewrite is degenerate. | Replace the diagnostic span with `(<original> ?: <default>)`, where `<default>` is a primitive-aware literal (`""`, `0`, `false`, `default`). |
-| `expr` → `(expr!!)` | Same as `?:`. | Replace the diagnostic span with `(<original>!!)`. |
+| `expr` → `(expr ?? <default>)` | `GS0154` / `GS0155` / `GS0156` whose diagnostic message contains the canonical `'T?'` → `'T'` pair. `GS0274` is excluded — the source is literal `nil`, the rewrite is degenerate. | Replace the diagnostic span with `(<original> ?? <default>)`, where `<default>` is a primitive-aware literal (`""`, `0`, `false`, `default`). |
+| `expr` → `(expr!!)` | Same as `??`. | Replace the diagnostic span with `(<original>!!)`. |
 
 ### Edit-construction strategy
 
@@ -60,7 +60,7 @@ rewrites** rather than syntax-tree rewrites for three reasons:
    syntax-tree rewrite would force the server to claim ownership of
    the in-flight text.
 3. The three rewrites are extremely narrow (`.` → `?.`, span → `(span
-   ?: x)`, span → `(span!!)`). A syntax-tree rewrite would need a
+   ?? x)`, span → `(span!!)`). A syntax-tree rewrite would need a
    formatter pass to reconstruct trivia for the surrounding parens,
    which adds complexity for no gain.
 
@@ -82,7 +82,7 @@ acceptance criteria:
   whose result type is nullable, the rewrite is *not* offered yet — a
   future refinement can re-bind the left-part to recover the type.
   The user is no worse off than today; the diagnostic still surfaces.
-- The `?:` and `!!` rewrites are gated on the diagnostic message
+- The `??` and `!!` rewrites are gated on the diagnostic message
   carrying the `'T?'` → `'T'` pair the binder produces verbatim from
   `TypeSymbol.ToString()`. This is robust against the binder reporting
   the same code (`GS0155`) for non-nullable mismatches.
@@ -94,7 +94,7 @@ The provider must remain silent for:
 - Diagnostics outside the requested range.
 - Diagnostic codes not in the supported set (any of the existing
   GS0001…GS0153, GS0157, GS0159…, etc.).
-- `GS0274` on literal `nil`, where wrapping `nil` in `?:` or `!!` is
+- `GS0274` on literal `nil`, where wrapping `nil` in `??` or `!!` is
   always wrong — the only sensible fix is to make the parameter
   nullable, which the diagnostic message already suggests.
 
@@ -138,7 +138,7 @@ The provider must remain silent for:
   the edit text, applies the edit, and re-binds to confirm the
   triggering diagnostic is no longer reported.
 - Negative tests cover: a `GS0158` on a non-nullable receiver (no
-  `?.` fix), a `GS0274` on literal `nil` (no `?:` / `!!`), an
+  `?.` fix), a `GS0274` on literal `nil` (no `??` / `!!`), an
   unrelated diagnostic (no nullable fixes at all), and a request range
   that does not overlap any diagnostic span.
 

--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -299,9 +299,12 @@ A C# target-typed `new()` emits the **explicit constructed type** inferred from 
 > `translation-unsupported` record (`IndexerDeclaration`) and does not attempt a
 > mapping. Filed as **#944**.
 >
-> **Null-coalescing operator `??` — discovered compiler gap.** `value ?? fallback`
-> has no G# spelling; the parser rejects `??` (`GS0005`). Surfaced as a clean
-> `translation-unsupported` record (`CoalesceExpression`). Filed as **#941**.
+> **Null-coalescing operator `??` — RESOLVED (#941).** `value ?? fallback` now
+> maps directly to G#'s `??` null-coalescing operator. Originally this was a
+> compiler gap (G# spelled the read `?:` and the parser rejected `??`); issue
+> #941 / ADR-0116 respelled the G# operator to `??` and removed `?:`, so the
+> translator emits `value ?? fallback` verbatim. No longer surfaced as a
+> `translation-unsupported` record.
 >
 > **Member access on a bare-identifier element access — discovered compiler gap.**
 > `values[i].Member` (a single **bare-identifier** index immediately followed by

--- a/docs/adr/0116-null-coalescing-operator-spelling.md
+++ b/docs/adr/0116-null-coalescing-operator-spelling.md
@@ -1,0 +1,91 @@
+# ADR-0116: Null-coalescing operator spelled `??` (replacing `?:`)
+
+- **Status**: Accepted
+- **Date**: 2026-06-22
+- **Phase**: Phase 9 — language depth / null-handling ergonomics
+- **Related**: ADR-0001 (null model), ADR-0072 (`??=` null-coalescing compound assignment), ADR-0084 (Optional/Sequences extensions), issue [#941](https://github.com/DavidObando/gsharp/issues/941)
+
+## Context
+
+G# originally spelled the binary null-coalescing **read** operator as `a ?: b`
+(the "Elvis" operator, introduced under ADR-0001 / Phase 3.C.3): evaluate `a`;
+if it is non-nil yield `a`, otherwise evaluate and yield `b`. Short-circuit
+semantics guarantee `b` is only evaluated when `a` reads as nil.
+
+When the null-coalescing **compound assignment** `a ??= b` was added under
+ADR-0072 (issue #709), it deliberately adopted the C# spelling (`??=`) while the
+**read** retained the divergent `?:` spelling. This left G# with two
+inconsistent spellings for the same concept:
+
+- read: `a ?: b`
+- assign-if-nil: `a ??= b`
+
+C#, TypeScript/JavaScript, Swift, Kotlin (`?:` is Kotlin-only), and most of the
+adjacent ecosystem spell the null-coalescing read as `a ?? b`, with `??=` as the
+compound form. The `?:` spelling also visually collides with the ternary
+conditional `cond ? a : b` (ADR-0062), which G# also supports — `a ?: b` reads
+like a "ternary with an empty true-arm", which it is not.
+
+Issue #941 resolves the inconsistency by making the read operator `??`, matching
+`??=` and the broader ecosystem.
+
+## Decision
+
+1. **`a ?? b` is the binary null-coalescing operator.** It carries exactly the
+   semantics, binding, lowering, and emit that `?:` previously had
+   (`BoundBinaryOperatorKind.NullCoalesce`): evaluate `a`; if non-nil, yield `a`;
+   otherwise evaluate and yield `b`. The right operand is evaluated lazily. The
+   result type is the best common type of the operands (`T` when `b` is
+   non-nullable `T`, `T?` when `b` is itself `T?`). Works for nullable reference
+   types and `Nullable<T>` value types.
+
+2. **The `?:` spelling is removed entirely.** The lexer no longer produces a
+   `QuestionColonToken`; the `SyntaxKind.QuestionColonToken` member is renamed to
+   `QuestionQuestionToken`. Any source that writes `a ?: b` now fails to parse
+   (GS0005). This is an **intentional breaking change** with no soft-phasing —
+   all in-repo consumers (samples, tests, golden files, SDK `.gs` sources, the
+   spec, and the cs2gs migration tool) are migrated to `??` in the same change.
+
+3. **Precedence and associativity match C#.** `??` is **right-associative** and
+   sits at a precedence strictly **below `||`** (logical or) and **above** the
+   ternary conditional. Thus `a ?? b ?? c` parses as `a ?? (b ?? c)`, and
+   `a ?? b ? c : d` parses as `(a ?? b) ? c : d`. The parser handles `??` in a
+   dedicated `ParseNullCoalescingExpression` layer between the
+   (left-associative) binary-operator loop and the ternary/assignment tail,
+   rather than inside the binary precedence table, so it can be right-associative
+   while remaining lower-precedence than every left-associative binary operator.
+
+4. **`??=` is unchanged.** The compound assignment from ADR-0072 keeps its
+   spelling, lowering, and statement-only status.
+
+## Consequences
+
+### Positive
+
+- One consistent spelling for the null-coalescing family (`??` read, `??=`
+  assign), matching `??=` and the C#/TS/JS ecosystem; lower learning curve.
+- Removes the visual collision between `?:` and the ternary `? :`.
+- Reuses the entire existing `NullCoalesce` binder/lowering/emit machinery — the
+  change is concentrated in the lexer, parser, and the single operator-token
+  check in `BoundBinaryOperator.Bind`.
+
+### Negative
+
+- Breaking change: existing `?:` source no longer compiles. Accepted per issue
+  #941 ("all current consumers are aware of this breaking change and we do not
+  need any soft-phasing of the switch").
+
+### Neutral
+
+- ADR-0001, ADR-0072, and ADR-0084 retain their historical narrative; their
+  inline operator references are updated to `??` and annotated to point here.
+- The cs2gs migration tool now emits `??` for C# `??` (previously surfaced as an
+  unsupported gap — ADR-0115).
+
+## Alternatives considered
+
+- **Keep both `?:` and `??` as synonyms.** Rejected: dual spellings perpetuate
+  the inconsistency and complicate the lexer/parser/spec indefinitely. Issue #941
+  explicitly calls for removing `?:`.
+- **Spell the read `?:` and the assign `?:=`.** Rejected: diverges from the
+  entire ecosystem and keeps the ternary collision; `??=` already shipped.

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -177,10 +177,10 @@ PropertyInitializer
 PropertyPattern
 PropertyPatternField
 PublicKeyword
-QuestionColonToken
 QuestionDotToken
 QuestionOpenBracketToken
 QuestionQuestionEqualsToken
+QuestionQuestionToken
 QuestionToken
 RangeKeyword
 RefArgumentExpression

--- a/samples/AddressBook.gs
+++ b/samples/AddressBook.gs
@@ -1,10 +1,10 @@
 // file: AddressBook.gs
 // Phase 3 exit sample. Combines class declarations with primary constructors
 // and instance methods (3.B.3 / ADR-0017), nullable types (3.C.1 / ADR-0020),
-// the nil literal (3.C.2), the Elvis (?:) and null-assertion (!!) operators
+// the nil literal (3.C.2), the null-coalescing (??) and null-assertion (!!) operators
 // (3.C.3), the null-conditional access operator (3.C.3b), and string
 // interpolation (1.1 / ADR-0011). The lookup helper returns a nullable
-// `Contact?` so callers can choose between Elvis-default and the
+// `Contact?` so callers can choose between null-coalescing-default and the
 // "I-know-this-is-present" assertion. Runs through the conformance harness
 // on the emit backend; the interpreter exercises the same constructs in
 // Phase 3.C unit tests.
@@ -40,10 +40,10 @@ var book = Book(
     Contact("Carol", "carol@example.com"))
 
 var hit = book.Find("Bob")
-Console.WriteLine(hit?.Display() ?: "no match")
+Console.WriteLine(hit?.Display() ?? "no match")
 
 var miss = book.Find("Zoe")
-Console.WriteLine(miss?.Display() ?: "no match")
+Console.WriteLine(miss?.Display() ?? "no match")
 
 // `!!` asserts non-null and lets us reach members on the result directly.
 var forced = book.Find("Alice")!!

--- a/samples/GsharpExtensionsOptional.gs
+++ b/samples/GsharpExtensionsOptional.gs
@@ -7,8 +7,8 @@
 // (`where T : class` vs `where T : struct`) during overload resolution
 // and picks the correct overload based on the receiver type.
 // Issue #752 / ADR-0084 L3 also closed the last value-typed gap: the
-// Elvis (`?:`) operator now emits verifiable IL on a nullable struct
-// receiver, so `count ?: -1` is preferred over `.OrElse(-1)` in
+// null-coalescing (`??`) operator now emits verifiable IL on a nullable struct
+// receiver, so `count ?? -1` is preferred over `.OrElse(-1)` in
 // idiomatic G# code (the helper remains available for lazy/computed
 // fallbacks and for receiver clauses that need a method call shape).
 // The Gsharp.Extensions.* namespaces are explicit-import only — nothing here
@@ -25,7 +25,7 @@ let name string? = "ada"
 
 // Map: lift a pure function over the present value.
 let upper = name.Map(func(s string) string { return s.ToUpper() })
-Console.WriteLine(upper ?: "<absent>")
+Console.WriteLine(upper ?? "<absent>")
 
 // FlatMap: chain a function that itself returns T?.
 let firstChar = upper.FlatMap(func(s string) string? {
@@ -34,7 +34,7 @@ let firstChar = upper.FlatMap(func(s string) string? {
     }
     return nil
 })
-Console.WriteLine(firstChar ?: "<absent>")
+Console.WriteLine(firstChar ?? "<absent>")
 
 // OrElse: project to a non-nullable fallback.
 let absent string? = nil
@@ -45,7 +45,7 @@ Console.WriteLine(absent.OrCompute(func() string { return "computed" }))
 
 // Filter: drop the value when it fails the predicate.
 let short = name.Filter(func(s string) bool { return s.Length <= 2 })
-Console.WriteLine(short ?: "<filtered out>")
+Console.WriteLine(short ?? "<filtered out>")
 
 // IfPresent: side-effect only when present.
 name.IfPresent(func(s string) {
@@ -62,18 +62,18 @@ Console.WriteLine(name.OrThrow("name was missing"))
 // --- Value-typed nullables (T : struct) --------------------------------------
 // ADR-0088 / issue #750: the binder picks the struct overload based on the
 // receiver's CLR shape (Nullable<T>) and the `where T : struct` constraint.
-// Issue #752 / ADR-0084 L3: `?:` is now the canonical fallback shape; the
+// Issue #752 / ADR-0084 L3: `??` is now the canonical fallback shape; the
 // `OrCompute` helper remains for the deferred-default case.
 
 let count int32? = 7
 let doubled = count.Map(func(n int32) int32 { return n * 2 })
-Console.WriteLine(doubled ?: -1)
+Console.WriteLine(doubled ?? -1)
 
 let none int32? = nil
-Console.WriteLine(none ?: -1)
+Console.WriteLine(none ?? -1)
 
 let positive = count.Filter(func(n int32) bool { return n > 0 })
-Console.WriteLine(positive ?: -1)
+Console.WriteLine(positive ?? -1)
 
 count.IfPresent(func(n int32) {
     Console.WriteLine("count present: " + n.ToString())

--- a/samples/GsharpExtensionsSequences.gs
+++ b/samples/GsharpExtensionsSequences.gs
@@ -79,31 +79,31 @@ for v in evens.Interleave(odds) {
 
 // --- Safe terminals ----------------------------------------------------------
 
-Console.WriteLine("FirstOrNil(names): " + (Sequences.Of("alpha", "beta").FirstOrNil() ?: "<none>"))
-Console.WriteLine("FirstOrNil(empty): " + (Sequences.Empty[string]().FirstOrNil() ?: "<none>"))
+Console.WriteLine("FirstOrNil(names): " + (Sequences.Of("alpha", "beta").FirstOrNil() ?? "<none>"))
+Console.WriteLine("FirstOrNil(empty): " + (Sequences.Empty[string]().FirstOrNil() ?? "<none>"))
 
-Console.WriteLine("LastOrNil(names): " + (Sequences.Of("alpha", "beta").LastOrNil() ?: "<none>"))
+Console.WriteLine("LastOrNil(names): " + (Sequences.Of("alpha", "beta").LastOrNil() ?? "<none>"))
 
-Console.WriteLine("SingleOrNil(one): " + (Sequences.Of("solo").SingleOrNil() ?: "<none>"))
-Console.WriteLine("SingleOrNil(many): " + (Sequences.Of("a", "b").SingleOrNil() ?: "<none>"))
+Console.WriteLine("SingleOrNil(one): " + (Sequences.Of("solo").SingleOrNil() ?? "<none>"))
+Console.WriteLine("SingleOrNil(many): " + (Sequences.Of("a", "b").SingleOrNil() ?? "<none>"))
 
 // Value-type terminals share the canonical name with the reference-typed
 // surface: ADR-0088 (issue #750) lets the binder honour generic constraints
 // so `FirstOrNil` resolves to the struct overload on int sequences.
-// Issue #752 / ADR-0084 L3: the Elvis (`?:`) operator now emits verifiable
+// Issue #752 / ADR-0084 L3: the null-coalescing (`??`) operator now emits verifiable
 // IL on a nullable struct receiver, so we apply it directly to the
 // value-typed terminals instead of routing through `.OrElse(-1)`.
 let firstVal = Sequences.Of(11, 22, 33).FirstOrNil()
-Console.WriteLine("FirstOrNil(value): " + (firstVal ?: -1).ToString())
+Console.WriteLine("FirstOrNil(value): " + (firstVal ?? -1).ToString())
 
 let lastVal = Sequences.Of(11, 22, 33).LastOrNil()
-Console.WriteLine("LastOrNil(value): " + (lastVal ?: -1).ToString())
+Console.WriteLine("LastOrNil(value): " + (lastVal ?? -1).ToString())
 
 let solo = Sequences.Of(42).SingleOrNil()
-Console.WriteLine("SingleOrNil(value, one): " + (solo ?: -1).ToString())
+Console.WriteLine("SingleOrNil(value, one): " + (solo ?? -1).ToString())
 
 let manyVals = Sequences.Of(1, 2).SingleOrNil()
-Console.WriteLine("SingleOrNil(value, many): " + (manyVals ?: -1).ToString())
+Console.WriteLine("SingleOrNil(value, many): " + (manyVals ?? -1).ToString())
 
 // --- Collectors --------------------------------------------------------------
 

--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -148,14 +148,14 @@ public sealed class BoundBinaryOperator
             return new BoundBinaryOperator(syntaxKind, kind, leftType, rightType, TypeSymbol.Bool);
         }
 
-        // Phase 3.C.3 / ADR-0001: null-coalescing `?:` returns the left if
+        // Issue #941 / ADR-0001: null-coalescing `??` returns the left if
         // non-nil, otherwise the right. Type is the underlying of the left
         // side (when the right is the same underlying or is itself nullable
         // with that underlying).
         //
         // Issue #614 audit: intentionally a single arm — there is only ONE
         // null-coalescing operator token; no combinatorial dimension to tabulate.
-        if (syntaxKind == SyntaxKind.QuestionColonToken)
+        if (syntaxKind == SyntaxKind.QuestionQuestionToken)
         {
             TypeSymbol leftUnderlying = leftType is NullableTypeSymbol leftNullable ? leftNullable.UnderlyingType : leftType;
             TypeSymbol rightUnderlying = rightType is NullableTypeSymbol rightNullable ? rightNullable.UnderlyingType : rightType;

--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperatorKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperatorKind.cs
@@ -105,8 +105,8 @@ public enum BoundBinaryOperatorKind
     LogicalOr,
 
     /// <summary>
-    /// Used when a QuestionColonToken (Phase 3.C.3 / ADR-0001) is used as the
-    /// null-coalescing (Elvis) binary operator. Evaluates the left operand;
+    /// Used when a QuestionQuestionToken (Issue #941 / ADR-0001) is used as the
+    /// null-coalescing (`??`) binary operator. Evaluates the left operand;
     /// if non-nil, returns it; otherwise evaluates and returns the right.
     /// </summary>
     NullCoalesce,

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -164,7 +164,7 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitBinary(BoundBinaryExpression b)
     {
-        // Phase 3.C.3: `?:` (NullCoalesce). Short-circuit on the left.
+        // Issue #941 / Phase 3.C.3: `??` (NullCoalesce). Short-circuit on the left.
         if (b.Op.Kind == BoundBinaryOperatorKind.NullCoalesce)
         {
             // P3-5 / Issue #420: `dup; brtrue` is only legal for object
@@ -183,7 +183,7 @@ internal sealed partial class MethodBodyEmitter
                 if (!this.nullableCoalesceSpillSlots.TryGetValue(b, out var slot))
                 {
                     throw new InvalidOperationException(
-                        "No scratch slot pre-allocated for value-type Nullable<T> '?:' LHS — "
+                        "No scratch slot pre-allocated for value-type Nullable<T> '??' LHS — "
                         + "check NullableValueTypeCoalesceCollector and the prepass in CollectLocalsAndLabels.");
                 }
 
@@ -253,7 +253,7 @@ internal sealed partial class MethodBodyEmitter
                 if (!this.nullableCoalesceSpillSlots.TryGetValue(b, out var tpSlot))
                 {
                     throw new InvalidOperationException(
-                        "No scratch slot pre-allocated for class-constrained `T?` '?:' LHS — "
+                        "No scratch slot pre-allocated for class-constrained `T?` '??' LHS — "
                         + "check NullableValueTypeCoalesceCollector and the prepass in CollectLocalsAndLabels.");
                 }
 
@@ -278,7 +278,7 @@ internal sealed partial class MethodBodyEmitter
             }
 
             // Defensive: any other value-typed LHS (raw struct or enum)
-            // remains unsupported by `?:`. Today the encoder rejects
+            // remains unsupported by `??`. Today the encoder rejects
             // nullable user-defined structs/enums, so this branch is
             // unreachable from valid source, but fail loudly rather
             // than silently producing PEVerify-rejected IL.
@@ -286,7 +286,7 @@ internal sealed partial class MethodBodyEmitter
             if (ReflectionMetadataEmitter.IsValueTypeSymbol(leftType))
             {
                 throw new NotSupportedException(
-                    $"Null-coalesce '?:' over value-type operand '{leftType?.Name}' is not yet supported by the emitter. "
+                    $"Null-coalesce '??' over value-type operand '{leftType?.Name}' is not yet supported by the emitter. "
                     + "The current `dup; brtrue` short-circuit is invalid IL for struct stack values; a HasValue/Value "
                     + "(or box-before-brtrue) emit path is required when nullable value types are supported.");
             }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
@@ -535,7 +535,7 @@ internal sealed class MethodBodyPlanner
             receiverSpillSlots[unwrap] = slot;
         }
 
-        // Issue #519 / #752 / ADR-0084 L3: `?:` whose LHS is a value-type
+        // Issue #519 / #752 / ADR-0084 L3: `??` whose LHS is a value-type
         // `Nullable<T>` lowers at emit time to a HasValue/GetValueOrDefault
         // sequence that needs a `Nullable<T>`-typed temp slot (it cannot
         // use `dup; brtrue`, which is invalid IL for value-type stack
@@ -545,7 +545,7 @@ internal sealed class MethodBodyPlanner
         //
         // The slot lives in its OWN dictionary (separate from
         // `receiverSpillSlots`) because the same binary node may also be
-        // the receiver of an instance call — `(v ?: 0).ToString()` — in
+        // the receiver of an instance call — `(v ?? 0).ToString()` — in
         // which case the receiver-spill collector independently
         // allocates an underlying-`T`-typed slot to take `ldloca` of the
         // call receiver. Conflating the two slots in one dictionary
@@ -1148,7 +1148,7 @@ internal sealed class MethodBodyPlanner
         return sink;
     }
 
-    // Issue #519: each `?:` whose LHS is a value-type `Nullable<T>` lowers at
+    // Issue #519: each `??` whose LHS is a value-type `Nullable<T>` lowers at
     // emit time to a HasValue branch that needs a `Nullable<T>`-typed temp
     // slot. The slot is keyed by the binary expression node and typed as the
     // LHS's NullableTypeSymbol so `EncodeTypeSymbol` emits the proper

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -1066,7 +1066,7 @@ internal sealed class SlotPlanner
     }
 
     // Issue #519: walks the bound tree collecting every `BoundBinaryExpression`
-    // whose operator is `NullCoalesce` (`?:`) and whose LHS needs an emit-time
+    // whose operator is `NullCoalesce` (`??`) and whose LHS needs an emit-time
     // spill slot. Two shapes qualify:
     //
     //   * Value-type `Nullable<T>` LHS — the emitter spills the LHS once and
@@ -1082,7 +1082,7 @@ internal sealed class SlotPlanner
     //     `ReflectionMetadataEmitter.GetElementTypeToken`), and the emitter
     //     probes its non-nullness via `box !!T; brfalse fallback`.
     //
-    // Reference-type `?:` over a concrete reference type (string?, Func<T>?,
+    // Reference-type `??` over a concrete reference type (string?, Func<T>?,
     // sequence[T], etc.) uses the existing `dup; brtrue; pop; rhs` pattern
     // and needs no slot.
     private sealed class NullableValueTypeCoalesceCollector : BoundTreeWalker

--- a/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
+++ b/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
@@ -653,7 +653,7 @@ internal sealed class WellKnownReferences
 
     // Issue #752 / ADR-0084 L3: returns a callable MemberRef for
     // `System.Nullable<T>::GetValueOrDefault()` closed over the supplied value-type
-    // underlying CLR type. Used by `?:` emit on a value-type `Nullable<T>` operand
+    // underlying CLR type. Used by `??` emit on a value-type `Nullable<T>` operand
     // on the non-null branch: since `HasValue` was just observed true, the result
     // is the same as `get_Value()` but without the BCL's redundant HasValue check
     // and exception path. No boxing, no callvirt.
@@ -679,7 +679,7 @@ internal sealed class WellKnownReferences
     }
 
     // Issue #519: returns a callable MemberRef for `System.Nullable<T>::get_HasValue`
-    // closed over the supplied value-type underlying CLR type. Used by `?:` emit
+    // closed over the supplied value-type underlying CLR type. Used by `??` emit
     // on a value-type `Nullable<T>` operand to branch on the presence flag without
     // box/dup tricks (which are illegal on a struct stack value).
     public MemberReferenceHandle GetNullableGetHasValueReference(Type underlyingValueType)

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -2964,7 +2964,7 @@ public sealed class Evaluator
         // (value-type) to a BoundDefaultExpression so the emitter can
         // materialise `default(Nullable<T>)` via ldloca/initobj/ldloc; the
         // interpreter must mirror that by producing the absent-value sentinel
-        // (null) so `?:`, `!!`, and equality checks see a missing value.
+        // (null) so `??`, `!!`, and equality checks see a missing value.
         if (node.Type is Symbols.NullableTypeSymbol)
         {
             return null;

--- a/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
@@ -129,7 +129,7 @@ public static class NullableLifting
         // level (encoded as `GENERICINST System.Nullable`1<MVAR>`). All
         // emit-side decisions that distinguish value-type Nullable from
         // reference-type Nullable (slot-based default-init, newobj lift,
-        // HasValue branching in `?:`) must treat the open struct case
+        // HasValue branching in `??`) must treat the open struct case
         // the same as a closed value type.
         if (nullable?.UnderlyingType is TypeParameterSymbol tp && tp.HasValueTypeConstraint)
         {

--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -315,11 +315,6 @@ public sealed class Lexer
                     kind = SyntaxKind.QuestionDotToken;
                     position++;
                 }
-                else if (Current == ':')
-                {
-                    kind = SyntaxKind.QuestionColonToken;
-                    position++;
-                }
                 else if (Current == '[')
                 {
                     // ADR-0073 / issue #710: `?[` null-conditional indexing
@@ -333,11 +328,19 @@ public sealed class Lexer
                 else if (Current == '?' && Peek(1) == '=')
                 {
                     // ADR-0072 / issue #709: `??=` null-coalescing compound
-                    // assignment. We do NOT tokenize bare `??` — G# uses
-                    // `?:` for null-coalescing. The doubled-`?` sequence is
-                    // recognised here only as the prefix of `??=`.
+                    // assignment. The doubled-`?` followed by `=` is the
+                    // compound-assignment form.
                     kind = SyntaxKind.QuestionQuestionEqualsToken;
                     position += 2;
+                }
+                else if (Current == '?')
+                {
+                    // Issue #941: `??` binary null-coalescing operator. The
+                    // bare doubled-`?` (not followed by `=`) yields the
+                    // null-coalescing read `a ?? b`. (The former `?:` Elvis
+                    // spelling was removed in favor of `??`.)
+                    kind = SyntaxKind.QuestionQuestionToken;
+                    position++;
                 }
                 else
                 {

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -5448,7 +5448,7 @@ public class Parser
             return new AssignmentExpressionSyntax(syntaxTree, identifierToken2, equalsToken, binary);
         }
 
-        var expression = ParseBinaryExpression();
+        var expression = ParseNullCoalescingExpression();
 
         // Issue #507: indexer assignment whose target is an arbitrary expression
         // (e.g. `obj.Member[k] = v`, `a.b.c[k] = v`, `(GetThing())[i] = v`). The
@@ -5535,6 +5535,27 @@ public class Parser
         }
 
         return expression;
+    }
+
+    // Issue #941: `a ?? b` binary null-coalescing operator. Parsed as its own
+    // layer between the binary-operator loop and the assignment/ternary tail so
+    // that it (a) binds at a precedence strictly below `||` (the lowest binary
+    // operator), and (b) is right-associative, so `a ?? b ?? c` parses as
+    // `a ?? (b ?? c)` — matching C#'s `??`. The produced node is an ordinary
+    // BinaryExpressionSyntax with a QuestionQuestionToken operator, so the
+    // binder/emitter reuse the existing NullCoalesce machinery.
+    private ExpressionSyntax ParseNullCoalescingExpression()
+    {
+        var left = ParseBinaryExpression();
+
+        if (Current.Kind == SyntaxKind.QuestionQuestionToken)
+        {
+            var operatorToken = NextToken();
+            var right = ParseNullCoalescingExpression();
+            return new BinaryExpressionSyntax(syntaxTree, left, operatorToken, right);
+        }
+
+        return left;
     }
 
     private ExpressionSyntax ParseBinaryExpression(int parentPrecedence = 0)

--- a/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -74,10 +74,15 @@ public static class SyntaxFacts
                 return 2;
 
             case SyntaxKind.PipePipeToken:               // logical or
-            case SyntaxKind.QuestionColonToken:          // Phase 3.C.3 / ADR-0001: null-coalescing
                 return 1;
 
             default:
+
+                // Issue #941: `??` null-coalescing is NOT handled by the
+                // left-associative binary loop. It is parsed separately by
+                // Parser.ParseNullCoalescingExpression so it can be
+                // right-associative and sit at a precedence strictly below `||`.
+                // Returning 0 here keeps the binary loop from consuming it.
                 return 0;
         }
 #pragma warning restore SA1025 // Code should not contain multiple whitespace in a row
@@ -353,8 +358,8 @@ public static class SyntaxFacts
                 return "?";
             case SyntaxKind.QuestionDotToken:
                 return "?.";
-            case SyntaxKind.QuestionColonToken:
-                return "?:";
+            case SyntaxKind.QuestionQuestionToken:
+                return "??";
             case SyntaxKind.QuestionQuestionEqualsToken:
                 return "??=";
             case SyntaxKind.QuestionOpenBracketToken:

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -62,7 +62,7 @@ public enum SyntaxKind
     BangBangToken,
     QuestionToken,
     QuestionDotToken,
-    QuestionColonToken,
+    QuestionQuestionToken,
     QuestionQuestionEqualsToken,
 
     // ADR-0073 / issue #710: prefix token for `a?[i]` null-conditional indexing.

--- a/src/LanguageServer/CodeActionComputer.cs
+++ b/src/LanguageServer/CodeActionComputer.cs
@@ -26,7 +26,7 @@ namespace GSharp.LanguageServer;
 ///     is nullable (GS0158 with a nullable receiver type).</description>
 ///   </item>
 ///   <item>
-///     <description><c>expr</c> → <c>(expr ?: default)</c> on a nullable
+///     <description><c>expr</c> → <c>(expr ?? default)</c> on a nullable
 ///     value used where a non-nullable value is required (GS0154 / GS0155
 ///     / GS0156 / GS0274).</description>
 ///   </item>

--- a/src/LanguageServer/NullabilityQuickFixes.cs
+++ b/src/LanguageServer/NullabilityQuickFixes.cs
@@ -29,7 +29,7 @@ namespace GSharp.LanguageServer;
 ///     of type <c>T?</c>).</description>
 ///   </item>
 ///   <item>
-///     <description><c>expr</c> → <c>(expr ?: default)</c> for supplying
+///     <description><c>expr</c> → <c>(expr ?? default)</c> for supplying
 ///     a default when a nullable is used in a non-nullable position
 ///     (GS0154 / GS0155 / GS0156).</description>
 ///   </item>
@@ -51,9 +51,9 @@ internal static class NullabilityQuickFixes
     public const string NullConditionalAccessTitle = "Use null-conditional access '?.'";
 
     /// <summary>
-    /// Title shown for the Elvis / null-coalescing default quick fix.
+    /// Title shown for the null-coalescing default quick fix.
     /// </summary>
-    public const string ElvisDefaultTitle = "Provide default with '?:'";
+    public const string ElvisDefaultTitle = "Provide default with '??'";
 
     /// <summary>
     /// Title shown for the postfix <c>!!</c> null-assertion quick fix.
@@ -114,7 +114,7 @@ internal static class NullabilityQuickFixes
     }
 
     /// <summary>
-    /// Builds the Elvis-default (<c>?:</c>) and null-assertion (<c>!!</c>)
+    /// Builds the null-coalescing-default (<c>??</c>) and null-assertion (<c>!!</c>)
     /// rewrites for a diagnostic that indicates a nullable value flowing
     /// into a non-nullable position. The detector inspects the diagnostic
     /// message for the canonical <c>'T?'</c> → <c>'T'</c> pair surfaced
@@ -147,7 +147,7 @@ internal static class NullabilityQuickFixes
 
         var original = sourceText.Substring(span.Start, span.Length);
 
-        // GS0274 fires on the literal `nil`, where `nil ?: X` and `nil!!`
+        // GS0274 fires on the literal `nil`, where `nil ?? X` and `nil!!`
         // are both degenerate (the user wants to provide a real value or
         // make the parameter nullable). Skip the rewrites — the original
         // diagnostic already carries the canonical suggestion in its
@@ -163,8 +163,8 @@ internal static class NullabilityQuickFixes
         yield return BuildReplacement(
             uri,
             range,
-            $"Provide default with '?: {elvisDefault}'",
-            $"({original} ?: {elvisDefault})");
+            $"Provide default with '?? {elvisDefault}'",
+            $"({original} ?? {elvisDefault})");
 
         yield return BuildReplacement(
             uri,
@@ -408,7 +408,7 @@ internal static class NullabilityQuickFixes
 
     /// <summary>
     /// Picks a sensible literal for the right-hand side of the synthesised
-    /// <c>?:</c> rewrite. The user is expected to replace it with a real
+    /// <c>??</c> rewrite. The user is expected to replace it with a real
     /// default; the goal here is to produce a snippet that parses and
     /// type-checks for the common built-ins.
     /// </summary>

--- a/src/Sdk/Gsharp.Extensions/Optional/Optional.gs
+++ b/src/Sdk/Gsharp.Extensions/Optional/Optional.gs
@@ -206,7 +206,7 @@ func (self T?) FlatMap[T struct, U struct](f (T) -> U?) U? {
 /// @returns the receiver's value when present, otherwise `defaultValue`.
 @MethodImpl(MethodImplOptions.AggressiveInlining)
 func (self T?) OrElse[T class](defaultValue T) T {
-    return self ?: defaultValue
+    return self ?? defaultValue
 }
 
 /// Returns the present value-typed value, or `defaultValue` if the

--- a/test/Compiler.Tests/Emit/Issue519CoalesceNullableEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue519CoalesceNullableEmitTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>
-/// Issue #519: applying the null-coalescing operator <c>?:</c> to a CLR
+/// Issue #519: applying the null-coalescing operator <c>??</c> to a CLR
 /// <c>Nullable&lt;T&gt;</c> value previously crashed the emit phase silently
 /// (<c>MSB4181</c> with no <c>GS####</c> diagnostic). The cause was the value-
 /// type guard at the binary emit site rejecting any nullable value-type LHS
@@ -23,11 +23,11 @@ namespace GSharp.Compiler.Tests.Emit;
 ///
 /// These tests pin down the new behaviour:
 /// <list type="bullet">
-///   <item><c>Nullable&lt;T&gt; ?: T</c> for <c>bool?</c> and <c>int32?</c>, both
+///   <item><c>Nullable&lt;T&gt; ?? T</c> for <c>bool?</c> and <c>int32?</c>, both
 ///   the present and absent branches, against locals and CLR properties.</item>
-///   <item><c>Nullable&lt;T&gt; ?: Nullable&lt;T&gt;</c> preserves the wrapper
+///   <item><c>Nullable&lt;T&gt; ?? Nullable&lt;T&gt;</c> preserves the wrapper
 ///   shape and threads <c>nil</c> through both sides.</item>
-///   <item>Chained <c>a ?: b ?: c</c> over nullable operands routes through the
+///   <item>Chained <c>a ?? b ?? c</c> over nullable operands routes through the
 ///   right operand correctly when the LHSs are <c>nil</c>.</item>
 ///   <item>Reference-typed nullables (<c>string?</c>) continue to use the
 ///   existing <c>dup; brtrue</c> path and are not regressed.</item>
@@ -48,11 +48,11 @@ public class Issue519CoalesceNullableEmitTests
             import System
 
             var a bool? = true
-            var v bool = a ?: false
+            var v bool = a ?? false
             Console.WriteLine(v)
 
             var b bool? = false
-            var w bool = b ?: true
+            var w bool = b ?? true
             Console.WriteLine(w)
             """;
 
@@ -69,11 +69,11 @@ public class Issue519CoalesceNullableEmitTests
             import System
 
             var a bool? = nil
-            var v bool = a ?: true
+            var v bool = a ?? true
             Console.WriteLine(v)
 
             var b bool? = nil
-            var w bool = b ?: false
+            var w bool = b ?? false
             Console.WriteLine(w)
             """;
 
@@ -90,7 +90,7 @@ public class Issue519CoalesceNullableEmitTests
             import System
 
             var a int32? = 7
-            var v int32 = a ?: 99
+            var v int32 = a ?? 99
             Console.WriteLine(v)
             """;
 
@@ -107,7 +107,7 @@ public class Issue519CoalesceNullableEmitTests
             import System
 
             var a int32? = nil
-            var v int32 = a ?: 99
+            var v int32 = a ?? 99
             Console.WriteLine(v)
             """;
 
@@ -129,7 +129,7 @@ public class Issue519CoalesceNullableEmitTests
 
             var a int32? = 7
             var b int32? = 99
-            var r int32? = a ?: b
+            var r int32? = a ?? b
             Console.WriteLine(r!!)
             """;
 
@@ -147,7 +147,7 @@ public class Issue519CoalesceNullableEmitTests
 
             var a int32? = nil
             var b int32? = 42
-            var r int32? = a ?: b
+            var r int32? = a ?? b
             Console.WriteLine(r!!)
             """;
 
@@ -168,7 +168,7 @@ public class Issue519CoalesceNullableEmitTests
 
             var a int32? = nil
             var b int32? = nil
-            var r int32? = a ?: b
+            var r int32? = a ?? b
             var o object = r
             Console.Write("[")
             Console.Write(o)
@@ -182,7 +182,7 @@ public class Issue519CoalesceNullableEmitTests
     [Fact]
     public void CoalesceNullableInt_Chained_AllNil_ReturnsLastLiteral()
     {
-        // `a ?: b ?: c` parses right-associatively as `a ?: (b ?: c)`.
+        // `a ?? b ?? c` parses right-associatively as `a ?? (b ?? c)`.
         // Both `a` and `b` are value-type Nullable<int>, so the emitter
         // pre-allocates two separate scratch slots (one per BoundBinary
         // expression). When all left operands are nil the final literal
@@ -195,7 +195,7 @@ public class Issue519CoalesceNullableEmitTests
             var a int32? = nil
             var b int32? = nil
             var c int32 = 99
-            var r int32 = a ?: b ?: c
+            var r int32 = a ?? b ?? c
             Console.WriteLine(r)
             """;
 
@@ -214,7 +214,7 @@ public class Issue519CoalesceNullableEmitTests
             var a int32? = nil
             var b int32? = 7
             var c int32 = 99
-            var r int32 = a ?: b ?: c
+            var r int32 = a ?? b ?? c
             Console.WriteLine(r)
             """;
 
@@ -233,7 +233,7 @@ public class Issue519CoalesceNullableEmitTests
             var a int32? = 1
             var b int32? = 7
             var c int32 = 99
-            var r int32 = a ?: b ?: c
+            var r int32 = a ?? b ?? c
             Console.WriteLine(r)
             """;
 
@@ -256,11 +256,11 @@ public class Issue519CoalesceNullableEmitTests
 
             var s = Settings()
             s.Flag = true
-            var v bool = s.Flag ?: false
+            var v bool = s.Flag ?? false
             Console.WriteLine(v)
 
             s.Flag = false
-            var w bool = s.Flag ?: true
+            var w bool = s.Flag ?? true
             Console.WriteLine(w)
             """;
 
@@ -279,11 +279,11 @@ public class Issue519CoalesceNullableEmitTests
 
             var s = Settings()
             s.Flag = nil
-            var v bool = s.Flag ?: true
+            var v bool = s.Flag ?? true
             Console.WriteLine(v)
 
             s.Flag = nil
-            var w bool = s.Flag ?: false
+            var w bool = s.Flag ?? false
             Console.WriteLine(w)
             """;
 
@@ -302,11 +302,11 @@ public class Issue519CoalesceNullableEmitTests
 
             var s = Settings()
             s.Count = 7
-            var v int32 = s.Count ?: 99
+            var v int32 = s.Count ?? 99
             Console.WriteLine(v)
 
             s.Count = nil
-            var w int32 = s.Count ?: 99
+            var w int32 = s.Count ?? 99
             Console.WriteLine(w)
             """;
 
@@ -327,11 +327,11 @@ public class Issue519CoalesceNullableEmitTests
             import System
 
             var s string? = "hello"
-            var r string = s ?: "fallback"
+            var r string = s ?? "fallback"
             Console.WriteLine(r)
 
             var t string? = nil
-            var u string = t ?: "fallback"
+            var u string = t ?? "fallback"
             Console.WriteLine(u)
             """;
 

--- a/test/Compiler.Tests/Emit/Issue571LocationRegressionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue571LocationRegressionTests.cs
@@ -31,7 +31,7 @@ public class Issue571LocationRegressionTests
 
             var x int32? = 42
             var y int32? = nil
-            var v int32 = x ?: 0
+            var v int32 = x ?? 0
             Console.WriteLine(v)
             Console.WriteLine(y)
             """;

--- a/test/Compiler.Tests/Emit/Issue750ConstraintOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue750ConstraintOverloadEmitTests.cs
@@ -36,7 +36,7 @@ public class Issue750ConstraintOverloadEmitTests
             let upper = name.Map(func(s string) string { return s.ToUpper() })
             let doubled = count.Map(func(n int32) int32 { return n * 2 })
 
-            Console.WriteLine(upper ?: "<none>")
+            Console.WriteLine(upper ?? "<none>")
             Console.WriteLine(doubled.OrElse(-1).ToString())
             """;
 
@@ -54,7 +54,7 @@ public class Issue750ConstraintOverloadEmitTests
 
             let absent string? = nil
             let mapped = absent.Map(func(s string) string { return s.ToUpper() })
-            Console.WriteLine(mapped ?: "<none>")
+            Console.WriteLine(mapped ?? "<none>")
             """;
 
         var output = CompileAndRun(source);
@@ -113,7 +113,7 @@ public class Issue750ConstraintOverloadEmitTests
             let names = Sequences.Of("alpha", "beta")
             let nums = Sequences.Of(11, 22, 33)
 
-            Console.WriteLine(names.FirstOrNil() ?: "<none>")
+            Console.WriteLine(names.FirstOrNil() ?? "<none>")
             Console.WriteLine(nums.FirstOrNil().OrElse(-1).ToString())
             """;
 

--- a/test/Compiler.Tests/Emit/Issue751RichReceiverEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue751RichReceiverEmitTests.cs
@@ -29,7 +29,7 @@ public class Issue751RichReceiverEmitTests
             import System
 
             func (self string?) OrElse(fb string) string {
-                return self ?: fb
+                return self ?? fb
             }
 
             var present string? = "hi"

--- a/test/Compiler.Tests/Emit/Issue752ElvisNullableValueTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue752ElvisNullableValueTypeEmitTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>
-/// Issue #752 / ADR-0084 L3: the Elvis (<c>?:</c>) operator over a value-type
+/// Issue #752 / ADR-0084 L3: the null-coalescing (<c>??</c>) operator over a value-type
 /// <c>Nullable&lt;T&gt;</c> receiver. Issue #519 introduced the HasValue-based
 /// emit path; this file pins down the exact patterns enumerated in #752 and
 /// guards against regression in the cheaper <c>GetValueOrDefault()</c> shape
@@ -38,7 +38,7 @@ public class Issue752ElvisNullableValueTypeEmitTests
             import System
 
             let v int32? = nil
-            let n = v ?: 0
+            let n = v ?? 0
             Console.WriteLine(n)
             """;
 
@@ -58,7 +58,7 @@ public class Issue752ElvisNullableValueTypeEmitTests
             import System
 
             let v int32? = 42
-            let n = v ?: 0
+            let n = v ?? 0
             Console.WriteLine(n)
             """;
 
@@ -69,7 +69,7 @@ public class Issue752ElvisNullableValueTypeEmitTests
     [Fact]
     public void Elvis_NullableInt_Nested_BothNullableOperands_ChainsThroughRightArm()
     {
-        // `(a ?: b) ?: 0` — both inner operands are `int32?`. The inner
+        // `(a ?? b) ?? 0` — both inner operands are `int32?`. The inner
         // expression's result is `int32?` (preserving wrapper shape per
         // existing typing rules), and the outer's result is `int32`.
         // Two separate spill slots are pre-allocated, one per BoundBinary.
@@ -80,7 +80,7 @@ public class Issue752ElvisNullableValueTypeEmitTests
 
             let a int32? = nil
             let b int32? = 7
-            let n = (a ?: b) ?: 0
+            let n = (a ?? b) ?? 0
             Console.WriteLine(n)
             """;
 
@@ -100,7 +100,7 @@ public class Issue752ElvisNullableValueTypeEmitTests
 
             let a int32? = nil
             let b int32? = nil
-            let n = (a ?: b) ?: 0
+            let n = (a ?? b) ?? 0
             Console.WriteLine(n)
             """;
 
@@ -121,11 +121,11 @@ public class Issue752ElvisNullableValueTypeEmitTests
             import System
 
             let s string? = nil
-            let r string = s ?: "missing"
+            let r string = s ?? "missing"
             Console.WriteLine(r)
 
             let t string? = "hello"
-            let u string = t ?: "missing"
+            let u string = t ?? "missing"
             Console.WriteLine(u)
             """;
 
@@ -147,7 +147,7 @@ public class Issue752ElvisNullableValueTypeEmitTests
 
             let a int32? = nil
             let b int32? = 99
-            let r int32? = a ?: b
+            let r int32? = a ?? b
             Console.WriteLine(r!!)
             """;
 
@@ -158,7 +158,7 @@ public class Issue752ElvisNullableValueTypeEmitTests
     [Fact]
     public void Elvis_NullableInt_ReceiverOfInstanceCall_TakesAddressOfUnderlyingResult()
     {
-        // Repro at the heart of #752: when the `?:` result is the
+        // Repro at the heart of #752: when the `??` result is the
         // receiver of an instance call on the underlying value type
         // (e.g. `.ToString()`), the emitter needs TWO distinct
         // scratch slots — a `Nullable<T>`-typed slot for the HasValue
@@ -175,10 +175,10 @@ public class Issue752ElvisNullableValueTypeEmitTests
             import System
 
             let v int32? = 42
-            Console.WriteLine((v ?: -1).ToString())
+            Console.WriteLine((v ?? -1).ToString())
 
             let w int32? = nil
-            Console.WriteLine((w ?: -1).ToString())
+            Console.WriteLine((w ?? -1).ToString())
             """;
 
         var output = CompileAndRun(source);

--- a/test/Compiler.Tests/Emit/Issue814OrNilOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue814OrNilOverloadEmitTests.cs
@@ -81,7 +81,7 @@ public class Issue814OrNilOverloadEmitTests
             }
 
             public var head = ""
-            head = ([]string{"alpha", "beta"}).FirstOrNil() ?: "<none>"
+            head = ([]string{"alpha", "beta"}).FirstOrNil() ?? "<none>"
             """;
 
         var assembly = CompileAndRun(source);
@@ -107,7 +107,7 @@ public class Issue814OrNilOverloadEmitTests
             }
 
             public var head = 0
-            head = ([]int32{11, 22, 33}).FirstOrNil() ?: -1
+            head = ([]int32{11, 22, 33}).FirstOrNil() ?? -1
             """;
 
         var assembly = CompileAndRun(source);
@@ -133,7 +133,7 @@ public class Issue814OrNilOverloadEmitTests
             }
 
             public var head = ""
-            head = ([]string{}).FirstOrNil() ?: "<none>"
+            head = ([]string{}).FirstOrNil() ?? "<none>"
             """;
 
         var assembly = CompileAndRun(source);
@@ -159,7 +159,7 @@ public class Issue814OrNilOverloadEmitTests
             }
 
             public var head = 0
-            head = ([]int32{}).FirstOrNil() ?: -1
+            head = ([]int32{}).FirstOrNil() ?? -1
             """;
 
         var assembly = CompileAndRun(source);
@@ -188,8 +188,8 @@ public class Issue814OrNilOverloadEmitTests
 
             public var sLast = ""
             public var nLast = 0
-            sLast = ([]string{"a", "b", "c"}).LastOrNil() ?: "<none>"
-            nLast = ([]int32{10, 20, 30}).LastOrNil() ?: -1
+            sLast = ([]string{"a", "b", "c"}).LastOrNil() ?? "<none>"
+            nLast = ([]int32{10, 20, 30}).LastOrNil() ?? -1
             """;
 
         var assembly = CompileAndRun(source);
@@ -230,9 +230,9 @@ public class Issue814OrNilOverloadEmitTests
             public var sSolo = ""
             public var nSolo = 0
             public var sNone = ""
-            sSolo = ([]string{"x"}).SingleOrNil() ?: "<none>"
-            nSolo = ([]int32{42}).SingleOrNil() ?: -1
-            sNone = ([]string{"a", "b"}).SingleOrNil() ?: "<none>"
+            sSolo = ([]string{"x"}).SingleOrNil() ?? "<none>"
+            nSolo = ([]int32{42}).SingleOrNil() ?? -1
+            sNone = ([]string{"a", "b"}).SingleOrNil() ?? "<none>"
             """;
 
         var assembly = CompileAndRun(source);

--- a/test/Compiler.Tests/Emit/Issue831OpenTNilCompareEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue831OpenTNilCompareEmitTests.cs
@@ -12,14 +12,14 @@ namespace GSharp.Compiler.Tests.Emit;
 /// <summary>
 /// Issue #831 / ADR-0084 follow-up. End-to-end emit + IL-verify
 /// coverage for `T? == nil` / `T? != nil` and the closely-related
-/// `self!!` / `self ?: defaultValue` patterns where `T` is an open
+/// `self!!` / `self ?? defaultValue` patterns where `T` is an open
 /// type parameter constrained with `[T class]` (or left unconstrained).
 ///
 /// Pre-fix the emitter naively produced
 ///
 ///   ldarg.0; ldnull; ceq            // for `== nil`
 ///   ldarg.0; dup; brtrue; ...        // for `!!`
-///   ldarg.0; dup; brtrue; ...        // for `?:`
+///   ldarg.0; dup; brtrue; ...        // for `??`
 ///
 /// against an opaque `!!T` stack value — the runtime JIT tolerated it
 /// for reference-typed T but `ilverify` rejected the IL with
@@ -100,7 +100,7 @@ public class Issue831OpenTNilCompareEmitTests
     public void OpenTNullCoalesce_ClassConstrained_Verifiable()
     {
         // Mirrors `OrElse[T class]` from Optional.gs:
-        // `func (self T?) OrElse[T class](defaultValue T) T { return self ?: defaultValue }`.
+        // `func (self T?) OrElse[T class](defaultValue T) T { return self ?? defaultValue }`.
         // Pre-fix the bottom-of-EmitBinary `dup; brtrue` emitted an
         // invalid `dup` over an opaque `!!T` slot. The fix spills the
         // LHS to a `!!T`-typed slot and probes via `box; brfalse`.
@@ -109,7 +109,7 @@ public class Issue831OpenTNilCompareEmitTests
             import System
 
             func OrElse[T class](self T?, defaultValue T) T {
-                return self ?: defaultValue
+                return self ?? defaultValue
             }
 
             var present string? = "value"

--- a/test/Compiler.Tests/Emit/Issue941NullCoalescingOperatorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue941NullCoalescingOperatorEmitTests.cs
@@ -1,0 +1,307 @@
+// <copyright file="Issue941NullCoalescingOperatorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #941: the binary null-coalescing operator <c>a ?? b</c> (replacing the
+/// removed <c>?:</c> spelling). Evaluates <c>a</c>; if non-nil yields <c>a</c>,
+/// otherwise evaluates and yields <c>b</c>. The right operand is evaluated
+/// lazily, <c>??</c> is right-associative and binds lower than <c>||</c>, and the
+/// removed <c>?:</c> spelling is now a parse error (GS0005).
+///
+/// Each test compiles via <c>gsc</c>, IL-verifies the produced PE, then executes
+/// it under <c>dotnet exec</c> and asserts on captured stdout.
+/// </summary>
+public class Issue941NullCoalescingOperatorEmitTests
+{
+    [Fact]
+    public void ReferenceTypeFallback_LeftNil_ReturnsRight()
+    {
+        var source = """
+            package P
+
+            import System
+
+            func OrDefault(value string?, fallback string) string {
+                return value ?? fallback
+            }
+
+            Console.WriteLine(OrDefault(nil, "fallback"))
+            Console.WriteLine(OrDefault("present", "fallback"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("fallback\npresent\n", output);
+    }
+
+    [Fact]
+    public void NullableValueTypeFallback_LeftNil_ReturnsRightUnderlying()
+    {
+        var source = """
+            package P
+
+            import System
+
+            let absent int32? = nil
+            let present int32? = 7
+            Console.WriteLine((absent ?? -1).ToString())
+            Console.WriteLine((present ?? -1).ToString())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("-1\n7\n", output);
+    }
+
+    [Fact]
+    public void Chained_RightAssociative_FallsThroughToFirstNonNil()
+    {
+        var source = """
+            package P
+
+            import System
+
+            let a string? = nil
+            let b string? = nil
+            let c string? = "third"
+            Console.WriteLine(a ?? b ?? c ?? "last")
+
+            let x string? = nil
+            let y string? = "second"
+            Console.WriteLine(x ?? y ?? "last")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("third\nsecond\n", output);
+    }
+
+    [Fact]
+    public void ShortCircuit_RightSideNotEvaluated_WhenLeftNonNil()
+    {
+        // The right operand has an observable side effect (prints SIDE). When
+        // the left operand is non-nil, the right operand must NOT be evaluated,
+        // so SIDE must not appear in stdout.
+        var source = """
+            package P
+
+            import System
+
+            func Side() string {
+                Console.WriteLine("SIDE")
+                return "from-side"
+            }
+
+            let present string? = "present"
+            Console.WriteLine(present ?? Side())
+
+            let absent string? = nil
+            Console.WriteLine(absent ?? Side())
+            """;
+
+        var output = CompileAndRun(source);
+
+        // present branch: prints "present" and never calls Side().
+        // absent branch: calls Side() (prints "SIDE") then yields "from-side".
+        Assert.Equal("present\nSIDE\nfrom-side\n", output);
+    }
+
+    [Fact]
+    public void CompoundAssignment_StillWorks()
+    {
+        // Regression guard: `??=` (ADR-0072) continues to work unchanged
+        // alongside the new `??` read operator.
+        var source = """
+            package P
+
+            import System
+
+            var x string? = nil
+            x ??= "defaulted"
+            Console.WriteLine(x ?? "n/a")
+
+            var y string? = "kept"
+            y ??= "ignored"
+            Console.WriteLine(y ?? "n/a")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("defaulted\nkept\n", output);
+    }
+
+    [Fact]
+    public void RemovedElvisSpelling_IsParseError()
+    {
+        // Issue #941: the former `?:` null-coalescing spelling was removed.
+        // `a ?: b` no longer parses — the lexer yields `?` then `:`, and the
+        // parser reports GS0005.
+        var source = """
+            package P
+
+            import System
+
+            let x string? = nil
+            Console.WriteLine(x ?: "fallback")
+            """;
+
+        var (exitCode, _, diagnostics) = CompileExpectingFailure(source);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0005", diagnostics);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Diagnostics) CompileExpectingFailure(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue941_err_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            return (compileExit, compileOut.ToString(), compileOut.ToString() + compileErr.ToString());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue941_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Compiler.Tests/Emit/NullableLiftedBinaryOperatorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/NullableLiftedBinaryOperatorEmitTests.cs
@@ -15,7 +15,7 @@ namespace GSharp.Compiler.Tests.Emit;
 /// PR N-4 / §6.1 / C# §7.3.7: lifted binary operators over a value-type
 /// <c>Nullable&lt;T&gt;</c>. Adds arithmetic / bitwise / equality /
 /// ordering operators on <c>T?</c> using the same HasValue / get_Value
-/// emit shape established by PR #541 (<c>!!</c>) and PR #544 (<c>?:</c>).
+/// emit shape established by PR #541 (<c>!!</c>) and PR #544 (<c>??</c>).
 ///
 /// These tests pin down the new behaviour:
 /// <list type="bullet">
@@ -218,7 +218,7 @@ public class NullableLiftedBinaryOperatorEmitTests
             var a int32? = 3
             var b int32? = 5
             var s = a + b
-            Console.WriteLine(s ?: -1)
+            Console.WriteLine(s ?? -1)
             """;
 
         Assert.Equal("8\n", CompileAndRun(source));
@@ -236,9 +236,9 @@ public class NullableLiftedBinaryOperatorEmitTests
             var s1 = a + n
             var s2 = n + a
             var s3 = n + n
-            Console.WriteLine(s1 ?: -1)
-            Console.WriteLine(s2 ?: -1)
-            Console.WriteLine(s3 ?: -1)
+            Console.WriteLine(s1 ?? -1)
+            Console.WriteLine(s2 ?? -1)
+            Console.WriteLine(s3 ?? -1)
             """;
 
         Assert.Equal("-1\n-1\n-1\n", CompileAndRun(source));
@@ -255,8 +255,8 @@ public class NullableLiftedBinaryOperatorEmitTests
             var b int32? = 4
             var diff = a - b
             var prod = a * b
-            Console.WriteLine(diff ?: 0)
-            Console.WriteLine(prod ?: 0)
+            Console.WriteLine(diff ?? 0)
+            Console.WriteLine(prod ?? 0)
             """;
 
         Assert.Equal("6\n40\n", CompileAndRun(source));
@@ -273,8 +273,8 @@ public class NullableLiftedBinaryOperatorEmitTests
             var b int32? = 5
             var q = a / b
             var r = a % b
-            Console.WriteLine(q ?: -1)
-            Console.WriteLine(r ?: -1)
+            Console.WriteLine(q ?? -1)
+            Console.WriteLine(r ?? -1)
             """;
 
         Assert.Equal("3\n2\n", CompileAndRun(source));
@@ -294,9 +294,9 @@ public class NullableLiftedBinaryOperatorEmitTests
             var orV  = a | b
             var andV = a & b
             var xorV = a ^ b
-            Console.WriteLine(orV  ?: -1)
-            Console.WriteLine(andV ?: -1)
-            Console.WriteLine(xorV ?: -1)
+            Console.WriteLine(orV  ?? -1)
+            Console.WriteLine(andV ?? -1)
+            Console.WriteLine(xorV ?? -1)
             """;
 
         Assert.Equal("7\n2\n5\n", CompileAndRun(source));
@@ -314,9 +314,9 @@ public class NullableLiftedBinaryOperatorEmitTests
             var orV  = a | n
             var andV = n & a
             var xorV = n ^ n
-            Console.WriteLine(orV  ?: -1)
-            Console.WriteLine(andV ?: -1)
-            Console.WriteLine(xorV ?: -1)
+            Console.WriteLine(orV  ?? -1)
+            Console.WriteLine(andV ?? -1)
+            Console.WriteLine(xorV ?? -1)
             """;
 
         Assert.Equal("-1\n-1\n-1\n", CompileAndRun(source));
@@ -336,10 +336,10 @@ public class NullableLiftedBinaryOperatorEmitTests
 
             var a int32? = 7
             var s = a + 3
-            Console.WriteLine(s ?: -1)
+            Console.WriteLine(s ?? -1)
 
             var t = 3 + a
-            Console.WriteLine(t ?: -1)
+            Console.WriteLine(t ?? -1)
 
             Console.WriteLine(a == 7)
             Console.WriteLine(7 == a)
@@ -359,7 +359,7 @@ public class NullableLiftedBinaryOperatorEmitTests
 
             var n int32? = nil
             var s = n + 3
-            Console.WriteLine(s ?: -1)
+            Console.WriteLine(s ?? -1)
             Console.WriteLine(n == 7)
             Console.WriteLine(7 != n)
             Console.WriteLine(n < 9)
@@ -413,7 +413,7 @@ public class NullableLiftedBinaryOperatorEmitTests
     [Fact]
     public void NullableCoalesce_StillWorksAfterLift()
     {
-        // Regression: PR #544's `?:` lowering must still own value-type
+        // Regression: PR #544's `??` lowering must still own value-type
         // Nullable<T> NullCoalesce — it is excluded from the lifted
         // collector and stays in receiverSpillSlots.
         var source = """
@@ -422,8 +422,8 @@ public class NullableLiftedBinaryOperatorEmitTests
 
             var a int32? = 7
             var n int32? = nil
-            Console.WriteLine(a ?: 99)
-            Console.WriteLine(n ?: 99)
+            Console.WriteLine(a ?? 99)
+            Console.WriteLine(n ?? 99)
             """;
 
         Assert.Equal("7\n99\n", CompileAndRun(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue751RichReceiverBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue751RichReceiverBinderTests.cs
@@ -30,7 +30,7 @@ public class Issue751RichReceiverBinderTests
     {
         var source = @"
 func (self string?) OrElse(fb string) string {
-    return self ?: fb
+    return self ?? fb
 }
 
 var x string? = ""hi""

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue796FunctionAndSequenceNilCompareBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue796FunctionAndSequenceNilCompareBinderTests.cs
@@ -48,7 +48,7 @@ func (self T?) OrCompute[T class](factory () -> T) T {
     if factory == nil {
         throw ArgumentNullException(""factory"")
     }
-    return self ?: factory()
+    return self ?? factory()
 }
 ";
         Assert.Empty(GetErrors(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue814OrNilOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue814OrNilOverloadTests.cs
@@ -109,7 +109,7 @@ func (self sequence[T]) FirstOrNil[T struct]() T? {
 }
 
 let strs = []string{ ""alpha"", ""beta"" }
-let head = strs.FirstOrNil() ?: ""<none>""
+let head = strs.FirstOrNil() ?? ""<none>""
 head
 ";
         var result = Evaluate(source);
@@ -136,7 +136,7 @@ func (self sequence[T]) FirstOrNil[T struct]() T? {
 }
 
 let nums = []int32{ 11, 22, 33 }
-let head = nums.FirstOrNil() ?: -1
+let head = nums.FirstOrNil() ?? -1
 head
 ";
         var result = Evaluate(source);

--- a/test/Core.Tests/CodeAnalysis/Binding/NullSafeOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/NullSafeOperatorTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>
-/// Phase 3.C.3 — null-safe operators <c>?:</c> (Elvis) and postfix <c>!!</c>
+/// Phase 3.C.3 — null-safe operators <c>??</c> (null-coalescing) and postfix <c>!!</c>
 /// (null assertion), plus Phase 3.C.3b null-conditional member access
 /// <c>?.</c>.
 /// </summary>
@@ -24,7 +24,7 @@ public class NullSafeOperatorTests
     {
         var source = @"
 var x int32? = nil
-x ?: 42
+x ?? 42
 ";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
@@ -36,7 +36,7 @@ x ?: 42
     {
         var source = @"
 var x int32? = 7
-x ?: 42
+x ?? 42
 ";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
@@ -74,7 +74,7 @@ x!!
         // (the whole expression's type becomes string?).
         var source = @"
 var s string? = nil
-s?.ToUpper() ?: ""fallback""
+s?.ToUpper() ?? ""fallback""
 ";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);
@@ -86,7 +86,7 @@ s?.ToUpper() ?: ""fallback""
     {
         var source = @"
 var s string? = ""hi""
-s?.ToUpper() ?: ""fallback""
+s?.ToUpper() ?? ""fallback""
 ";
         var result = Evaluate(source);
         Assert.Empty(result.Diagnostics);

--- a/test/Core.Tests/CodeAnalysis/Emit/NullCoalesceValueTypeGuardTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/NullCoalesceValueTypeGuardTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 namespace GSharp.Core.Tests.CodeAnalysis.Emit;
 
 /// <summary>
-/// Issue #420 / P3-5: the null-coalesce (<c>??</c> / <c>?:</c>) emit path uses
+/// Issue #420 / P3-5: the null-coalesce (<c>??</c>) emit path uses
 /// <c>dup; brtrue</c> which is only legal for object references and primitive
 /// integers — it is invalid IL for struct stack values (including
 /// <c>Nullable&lt;T&gt;</c> over a value type).
@@ -41,7 +41,7 @@ public class NullCoalesceValueTypeGuardTests
         const string Source = @"package NullCoalesceRefNonNil
 import System
 var s string? = ""hello""
-var r string = s ?: ""fallback""
+var r string = s ?? ""fallback""
 Console.WriteLine(r)
 ";
         var stdout = CompileLoadInvokeCaptureStdout(Source, nameof(NullCoalesce_ReferenceType_LeftNonNil_ReturnsLeft));
@@ -54,7 +54,7 @@ Console.WriteLine(r)
         const string Source = @"package NullCoalesceRefNil
 import System
 var s string? = nil
-var r string = s ?: ""fallback""
+var r string = s ?? ""fallback""
 Console.WriteLine(r)
 ";
         var stdout = CompileLoadInvokeCaptureStdout(Source, nameof(NullCoalesce_ReferenceType_LeftNil_ReturnsRight));
@@ -64,7 +64,7 @@ Console.WriteLine(r)
     [Fact]
     public void NullCoalesce_ValueType_LeftNullableInt_LeftNil_ReturnsRight()
     {
-        // Issue #519: `int? ?: 0` previously aborted emit because `dup;
+        // Issue #519: `int? ?? 0` previously aborted emit because `dup;
         // brtrue` is invalid IL for the `Nullable<int>` struct on the
         // stack. The emitter now spills the LHS into a pre-allocated
         // `Nullable<int>` slot and branches on `Nullable<T>::get_HasValue`,
@@ -73,7 +73,7 @@ Console.WriteLine(r)
         const string Source = @"package NullCoalesceValueTypeNil
 import System
 var n int32? = nil
-var r int32 = n ?: 99
+var r int32 = n ?? 99
 Console.WriteLine(r)
 ";
         var stdout = CompileLoadInvokeCaptureStdout(Source, nameof(NullCoalesce_ValueType_LeftNullableInt_LeftNil_ReturnsRight));
@@ -89,7 +89,7 @@ Console.WriteLine(r)
         const string Source = @"package NullCoalesceValueTypePresent
 import System
 var n int32? = 7
-var r int32 = n ?: 99
+var r int32 = n ?? 99
 Console.WriteLine(r)
 ";
         var stdout = CompileLoadInvokeCaptureStdout(Source, nameof(NullCoalesce_ValueType_LeftNullableInt_LeftPresent_ReturnsUnderlying));

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue709NullCoalescingAssignmentLexerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue709NullCoalescingAssignmentLexerTests.cs
@@ -12,7 +12,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
 /// Issue #709 / ADR-0072: lexer-level coverage for the new <c>??=</c>
 /// null-coalescing compound assignment operator. The doubled-question-mark
 /// is recognized only as part of the three-character <c>??=</c> sequence —
-/// the bare <c>?</c>, the existing <c>?:</c>-null-coalescing-read, and the
+/// the bare <c>?</c>, the <c>??</c>-null-coalescing-read, and the
 /// existing <c>?.</c>-safe-navigation tokens must keep their meaning.
 /// </summary>
 public class Issue709NullCoalescingAssignmentLexerTests
@@ -26,11 +26,22 @@ public class Issue709NullCoalescingAssignmentLexerTests
     }
 
     [Fact]
+    public void Lexes_QuestionQuestion_AsSingleToken()
+    {
+        // Issue #941: bare `??` is the null-coalescing read operator.
+        var tokens = SyntaxTree.ParseTokens("??").ToList();
+        Assert.Equal(SyntaxKind.QuestionQuestionToken, tokens[0].Kind);
+        Assert.Equal("??", tokens[0].Text);
+    }
+
+    [Fact]
     public void Lexes_QuestionColon_AsSeparateTokens()
     {
+        // Issue #941: `?:` was removed. It now lexes as a `?` followed by a
+        // separate `:` (no longer a single QuestionColonToken).
         var tokens = SyntaxTree.ParseTokens("?:").ToList();
-        Assert.Equal(SyntaxKind.QuestionColonToken, tokens[0].Kind);
-        Assert.Equal("?:", tokens[0].Text);
+        Assert.Equal(SyntaxKind.QuestionToken, tokens[0].Kind);
+        Assert.Equal(SyntaxKind.ColonToken, tokens[1].Kind);
     }
 
     [Fact]
@@ -54,15 +65,14 @@ public class Issue709NullCoalescingAssignmentLexerTests
     }
 
     [Fact]
-    public void Lexes_QuestionQuestionWithoutEquals_AsTwoQuestionTokens()
+    public void Lexes_QuestionQuestionWithoutEquals_AsNullCoalescingToken()
     {
-        // G# does not introduce a bare `??` token — it falls back to two
-        // separate `?` tokens (which the parser will reject in any context
-        // that does not expect them, but the lexer must not synthesize a
-        // new token kind for the two-character sequence).
+        // Per issue #941, bare `??` is the binary null-coalescing operator and
+        // lexes as a single QuestionQuestionToken (distinct from the `??=`
+        // compound-assignment token).
         var tokens = SyntaxTree.ParseTokens("??").ToList();
-        Assert.Equal(SyntaxKind.QuestionToken, tokens[0].Kind);
-        Assert.Equal(SyntaxKind.QuestionToken, tokens[1].Kind);
+        Assert.Equal(SyntaxKind.QuestionQuestionToken, tokens[0].Kind);
+        Assert.Equal("??", tokens[0].Text);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue709NullCoalescingAssignmentParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue709NullCoalescingAssignmentParserTests.cs
@@ -100,13 +100,13 @@ public class Issue709NullCoalescingAssignmentParserTests
     public void Parses_RhsAsExpression()
     {
         // RHS may be any expression — ensure precedence works out so that
-        // `a ??= b ?: c` parses as `a ??= (b ?: c)` (the `?:` is a
-        // higher-precedence binary expression bound left-to-right).
+        // `a ??= b ?? c` parses as `a ??= (b ?? c)` (the `??` read binds
+        // right-associatively and lower than `||`).
         const string source = """
             package P
             var x string? = nil
             var y string? = nil
-            x ??= y ?: "fallback"
+            x ??= y ?? "fallback"
             """;
         var stmt = GetSingleAssignmentInBlock(source);
         Assert.NotNull(stmt.Value);
@@ -114,17 +114,16 @@ public class Issue709NullCoalescingAssignmentParserTests
     }
 
     [Fact]
-    public void Reports_Diagnostic_OnBareQuestionQuestion_WithoutEquals()
+    public void Parses_BareQuestionQuestion_AsNullCoalescingExpression()
     {
-        // G# does not introduce a bare `??` token; the lexer emits two
-        // `?` tokens. Parsing `a ?? b` as a statement must surface at
-        // least one parser diagnostic instead of silently accepting it.
+        // Issue #941: bare `a ?? b` is now THE null-coalescing read operator
+        // and parses cleanly (the former `?:` spelling was removed).
         const string source = """
             package P
             var x string? = nil
-            x ?? "v"
+            var y string = x ?? "v"
             """;
         var tree = SyntaxTree.Parse(source);
-        Assert.NotEmpty(tree.Diagnostics);
+        Assert.Empty(tree.Diagnostics);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue710NullConditionalIndexingLexerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue710NullConditionalIndexingLexerTests.cs
@@ -12,7 +12,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
 /// Issue #710 / ADR-0073: lexer-level coverage for the new <c>?[</c>
 /// null-conditional indexing prefix. The token is recognised only when
 /// <c>[</c> immediately follows <c>?</c> with no intervening trivia — so
-/// the existing <c>?.</c>, <c>?:</c>, <c>??=</c>, and bare-<c>?</c>
+/// the existing <c>?.</c>, <c>??</c>, <c>??=</c>, and bare-<c>?</c>
 /// (type-annotation) tokens keep their meanings, and a true ternary
 /// <c>cond ? [arr] : [arr]</c> (with whitespace separating <c>?</c> and
 /// <c>[</c>) keeps lexing as two tokens.
@@ -63,10 +63,11 @@ public class Issue710NullConditionalIndexingLexerTests
     }
 
     [Fact]
-    public void Lexes_QuestionColon_StillAsNullCoalescingRead()
+    public void Lexes_QuestionQuestion_AsNullCoalescingRead()
     {
-        var tokens = SyntaxTree.ParseTokens("?:").ToList();
-        Assert.Equal(SyntaxKind.QuestionColonToken, tokens[0].Kind);
+        // Issue #941: `??` is the null-coalescing read operator (formerly `?:`).
+        var tokens = SyntaxTree.ParseTokens("??").ToList();
+        Assert.Equal(SyntaxKind.QuestionQuestionToken, tokens[0].Kind);
     }
 
     [Fact]

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -177,10 +177,10 @@ PropertyInitializer
 PropertyPattern
 PropertyPatternField
 PublicKeyword
-QuestionColonToken
 QuestionDotToken
 QuestionOpenBracketToken
 QuestionQuestionEqualsToken
+QuestionQuestionToken
 QuestionToken
 RangeKeyword
 RefArgumentExpression

--- a/test/Extensions.Tests/NoAutoImportTests.cs
+++ b/test/Extensions.Tests/NoAutoImportTests.cs
@@ -26,7 +26,7 @@ import System
 
 let names []string = []string { ""alpha"", ""beta"" }
 let head = names.FirstOrNil()
-Console.WriteLine(head ?: ""<none>"")
+Console.WriteLine(head ?? ""<none>"")
 ";
 
     private const string SnippetWithImport = @"
@@ -37,7 +37,7 @@ import Gsharp.Extensions.Sequences
 
 let names []string = []string { ""alpha"", ""beta"" }
 let head = names.FirstOrNil()
-Console.WriteLine(head ?: ""<none>"")
+Console.WriteLine(head ?? ""<none>"")
 ";
 
     [Fact]

--- a/test/Interpreter.Tests/Issue750ConstraintOverloadInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue750ConstraintOverloadInterpreterTests.cs
@@ -72,7 +72,7 @@ public class Issue750ConstraintOverloadInterpreterTests
             let names = Sequences.Of("alpha", "beta")
             let nums = Sequences.Of(11, 22, 33)
 
-            Console.WriteLine(names.FirstOrNil() ?: "<none>")
+            Console.WriteLine(names.FirstOrNil() ?? "<none>")
             Console.WriteLine(nums.FirstOrNil().OrElse(-1).ToString())
             """;
 
@@ -91,7 +91,7 @@ public class Issue750ConstraintOverloadInterpreterTests
             let nums = Sequences.Of(11, 22, 33)
             let solo = Sequences.Of(42)
 
-            Console.WriteLine(names.LastOrNil() ?: "<none>")
+            Console.WriteLine(names.LastOrNil() ?? "<none>")
             Console.WriteLine(nums.LastOrNil().OrElse(-1).ToString())
             Console.WriteLine(solo.SingleOrNil().OrElse(-1).ToString())
             """;

--- a/test/Interpreter.Tests/Issue751RichReceiverInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue751RichReceiverInterpreterTests.cs
@@ -22,7 +22,7 @@ public class Issue751RichReceiverInterpreterTests
     {
         var source = """
             func (self string?) OrElse(fb string) string {
-                return self ?: fb
+                return self ?? fb
             }
 
             var present string? = "hi"

--- a/test/Interpreter.Tests/Issue752ElvisNullableValueTypeInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue752ElvisNullableValueTypeInterpreterTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>
-/// Issue #752 / ADR-0084 L3: interpreter parity for the Elvis (<c>?:</c>)
+/// Issue #752 / ADR-0084 L3: interpreter parity for the null-coalescing (<c>??</c>)
 /// operator over value-type <c>Nullable&lt;T&gt;</c> receivers. The
 /// interpreter stores nullables as their underlying boxed payload (or
 /// <c>null</c> when absent), so the existing <c>left ?? right</c> path
@@ -26,7 +26,7 @@ public class Issue752ElvisNullableValueTypeInterpreterTests
     {
         var source = """
             let v int32? = nil
-            let n = v ?: 0
+            let n = v ?? 0
             Console.WriteLine(n)
             """;
 
@@ -38,7 +38,7 @@ public class Issue752ElvisNullableValueTypeInterpreterTests
     {
         var source = """
             let v int32? = 42
-            let n = v ?: 0
+            let n = v ?? 0
             Console.WriteLine(n)
             """;
 
@@ -51,7 +51,7 @@ public class Issue752ElvisNullableValueTypeInterpreterTests
         var source = """
             let a int32? = nil
             let b int32? = 7
-            let n = (a ?: b) ?: 0
+            let n = (a ?? b) ?? 0
             Console.WriteLine(n)
             """;
 
@@ -64,7 +64,7 @@ public class Issue752ElvisNullableValueTypeInterpreterTests
         var source = """
             let a int32? = nil
             let b int32? = nil
-            let n = (a ?: b) ?: 0
+            let n = (a ?? b) ?? 0
             Console.WriteLine(n)
             """;
 
@@ -77,7 +77,7 @@ public class Issue752ElvisNullableValueTypeInterpreterTests
         var source = """
             let a int32? = nil
             let b int32? = 99
-            let r int32? = a ?: b
+            let r int32? = a ?? b
             Console.WriteLine(r!!)
             """;
 
@@ -89,11 +89,11 @@ public class Issue752ElvisNullableValueTypeInterpreterTests
     {
         var source = """
             let s string? = nil
-            let r string = s ?: "missing"
+            let r string = s ?? "missing"
             Console.WriteLine(r)
 
             let t string? = "hello"
-            let u string = t ?: "missing"
+            let u string = t ?? "missing"
             Console.WriteLine(u)
             """;
 
@@ -105,10 +105,10 @@ public class Issue752ElvisNullableValueTypeInterpreterTests
     {
         var source = """
             let v int32? = 42
-            Console.WriteLine((v ?: -1).ToString())
+            Console.WriteLine((v ?? -1).ToString())
 
             let w int32? = nil
-            Console.WriteLine((w ?: -1).ToString())
+            Console.WriteLine((w ?? -1).ToString())
             """;
 
         Assert.Equal("42\n-1\n", RunSubmission(source));

--- a/test/LanguageServer.Tests/CodeActionHandlerTests.cs
+++ b/test/LanguageServer.Tests/CodeActionHandlerTests.cs
@@ -92,14 +92,14 @@ public class CodeActionHandlerTests
 
         var actions = CodeActionComputer.ComputeCodeActions(uri, content, range).ToList();
 
-        var elvis = Assert.Single(actions, a => a.CodeAction.Title.StartsWith("Provide default with '?:", System.StringComparison.Ordinal));
+        var elvis = Assert.Single(actions, a => a.CodeAction.Title.StartsWith("Provide default with '??", System.StringComparison.Ordinal));
         var bang = Assert.Single(actions, a => a.CodeAction.Title == NullabilityQuickFixes.NullAssertionTitle);
 
         Assert.Equal(CodeActionKind.QuickFix, elvis.CodeAction.Kind);
         Assert.Equal(CodeActionKind.QuickFix, bang.CodeAction.Kind);
 
         var elvisEdit = elvis.CodeAction.Edit.Changes[uri].Single();
-        Assert.Equal("(x ?: \"\")", elvisEdit.NewText);
+        Assert.Equal("(x ?? \"\")", elvisEdit.NewText);
 
         var bangEdit = bang.CodeAction.Edit.Changes[uri].Single();
         Assert.Equal("(x!!)", bangEdit.NewText);
@@ -132,11 +132,11 @@ func main() {
 
         var actions = CodeActionComputer.ComputeCodeActions(uri, content, range).ToList();
 
-        var elvis = Assert.Single(actions, a => a.CodeAction.Title.StartsWith("Provide default with '?:", System.StringComparison.Ordinal));
+        var elvis = Assert.Single(actions, a => a.CodeAction.Title.StartsWith("Provide default with '??", System.StringComparison.Ordinal));
         var bang = Assert.Single(actions, a => a.CodeAction.Title == NullabilityQuickFixes.NullAssertionTitle);
 
         var elvisEdit = elvis.CodeAction.Edit.Changes[uri].Single();
-        Assert.Equal("(x ?: \"\")", elvisEdit.NewText);
+        Assert.Equal("(x ?? \"\")", elvisEdit.NewText);
 
         var bangEdit = bang.CodeAction.Edit.Changes[uri].Single();
         Assert.Equal("(x!!)", bangEdit.NewText);
@@ -151,7 +151,7 @@ func main() {
     public void NullableValueFixes_NotOfferedForLiteralNil()
     {
         // GS0274 fires on a literal `nil` flowing into a non-nullable parameter. Wrapping `nil`
-        // in `?:` or `!!` is degenerate — the user has to make the parameter nullable instead
+        // in `??` or `!!` is degenerate — the user has to make the parameter nullable instead
         // (see the diagnostic's own suggestion).
         const string source = @"func f(s string) {}
 func main() {
@@ -166,7 +166,7 @@ func main() {
         var actions = CodeActionComputer.ComputeCodeActions(uri, content, range).ToList();
 
         Assert.DoesNotContain(actions, a => a.CodeAction.Title == NullabilityQuickFixes.NullAssertionTitle);
-        Assert.DoesNotContain(actions, a => a.CodeAction.Title.StartsWith("Provide default with '?:", System.StringComparison.Ordinal));
+        Assert.DoesNotContain(actions, a => a.CodeAction.Title.StartsWith("Provide default with '??", System.StringComparison.Ordinal));
     }
 
     [Fact]
@@ -186,7 +186,7 @@ func main() {
 
         Assert.DoesNotContain(actions, a => a.CodeAction.Title == NullabilityQuickFixes.NullAssertionTitle);
         Assert.DoesNotContain(actions, a => a.CodeAction.Title == NullabilityQuickFixes.NullConditionalAccessTitle);
-        Assert.DoesNotContain(actions, a => a.CodeAction.Title.StartsWith("Provide default with '?:", System.StringComparison.Ordinal));
+        Assert.DoesNotContain(actions, a => a.CodeAction.Title.StartsWith("Provide default with '??", System.StringComparison.Ordinal));
     }
 
     [Fact]
@@ -205,7 +205,7 @@ func main() {
         var actions = CodeActionComputer.ComputeCodeActions(uri, content, range).ToList();
 
         Assert.DoesNotContain(actions, a => a.CodeAction.Title == NullabilityQuickFixes.NullAssertionTitle);
-        Assert.DoesNotContain(actions, a => a.CodeAction.Title.StartsWith("Provide default with '?:", System.StringComparison.Ordinal));
+        Assert.DoesNotContain(actions, a => a.CodeAction.Title.StartsWith("Provide default with '??", System.StringComparison.Ordinal));
     }
 
     private static string ApplyEdit(string source, TextEdit edit)

--- a/tools/cs2gs/Cs2Gs.Tests/L3TranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L3TranslationTests.cs
@@ -270,24 +270,22 @@ namespace Demo
     }
 
     /// <summary>
-    /// ADR-0115 §B gap: the C# null-coalescing operator <c>??</c> has no G# form
-    /// (GS0005), so it surfaces as a clean unsupported diagnostic.
+    /// Issue #941: the C# null-coalescing operator <c>??</c> now maps directly
+    /// to G#'s <c>??</c> operator (the former <c>?:</c> gap is resolved).
     /// </summary>
     [Fact]
-    public void NullCoalescing_SurfacesAsUnsupported()
+    public void NullCoalescing_TranslatesToQuestionQuestion()
     {
-        TranslationContext context = TranslateForDiagnostics(@"
+        string translated = TranslateUnit(@"
 namespace Demo
 {
     public static class CoalesceHost
     {
-        public static string OrEmpty(string value) => value ?? string.Empty;
+        public static string OrElse(string value, string fallback) => value ?? fallback;
     }
 }");
 
-        Assert.Contains(
-            context.Diagnostics,
-            d => d.IsUnsupported && d.ConstructKind == "CoalesceExpression");
+        Assert.Contains("value ?? fallback", translated);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1828,17 +1828,9 @@ public sealed class CSharpToGSharpTranslator
                     return this.TranslateWith(with);
 
                 case BinaryExpressionSyntax binary:
-                    // Null-coalescing `a ?? b` has no canonical G# form; the parser
-                    // rejects `??` (GS0005). Surface it as a clean per-construct gap
-                    // rather than emitting an unparseable operator (ADR-0115 §B gap #TBD).
-                    if (binary.IsKind(SyntaxKind.CoalesceExpression))
-                    {
-                        this.context.ReportUnsupported(
-                            binary,
-                            "null-coalescing operator '??' has no canonical G# form (GS0005: operator not supported); emitted a placeholder (ADR-0115 §B gap).");
-                        return new IdentifierExpression("nil");
-                    }
-
+                    // Issue #941: C# null-coalescing `a ?? b` now maps directly to
+                    // G#'s `a ?? b` (the operator token text is identical), so it
+                    // flows through the generic binary translation below.
                     return new BinaryExpression(
                         this.TranslateExpression(binary.Left),
                         binary.OperatorToken.Text,

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -36,7 +36,7 @@ The public specification page is [Language specification](/docs/ref/spec). It is
 G# uses width-bearing fixed-size integer names such as `int8`, `uint16`, `int32`, and `uint64` so the type's size is visible in source and consistent with names like `float32` and `float64`.  replaced the earlier C#-style integer names while the language was still pre-stable; `nint` and `nuint` remain the native-width integer spellings.  /  layers ten friendly aliases (`int`, `uint`, `long`, `ulong`, `short`, `ushort`, `byte`, `sbyte`, `float`, `double`) on top of the canonical names: they resolve at the binder, are interchangeable with the width-bearing spellings everywhere, and diagnostics, `typeof`, hover, and IL always print the canonical name. The canonical width-bearing spellings remain preferred in documentation and public library APIs. 
 ## Does G# have `null`?
 
-G# uses `nil`, not `null`, and nullability is part of the type. A non-nullable `T` cannot receive `nil`; a nullable `T?` can. The language includes safe access `?.`, null coalescing `?:`, and null assertion `!!`. This is the language nullability model.
+G# uses `nil`, not `null`, and nullability is part of the type. A non-nullable `T` cannot receive `nil`; a nullable `T?` can. The language includes safe access `?.`, null coalescing `??`, and null assertion `!!`. This is the language nullability model.
 
 ## How is concurrency modeled?
 

--- a/website/docs/guide/effective-gsharp.md
+++ b/website/docs/guide/effective-gsharp.md
@@ -89,7 +89,7 @@ Use imported CLR extension methods when they fit existing .NET conventions; G# r
 
 ## Error handling
 
-Use CLR exceptions for exceptional failures and let `try`/`catch`/`finally` show the lifetime of recovery logic. Catch the most specific type available. Use `nil` and nullable types for absence, not `null`. When unwrapping a nullable value, prefer explicit checks or `?:`; reserve `!!` for places where failure should be immediate and obvious.
+Use CLR exceptions for exceptional failures and let `try`/`catch`/`finally` show the lifetime of recovery logic. Catch the most specific type available. Use `nil` and nullable types for absence, not `null`. When unwrapping a nullable value, prefer explicit checks or `??`; reserve `!!` for places where failure should be immediate and obvious.
 
 ```gsharp
 try {

--- a/website/docs/guide/errors-and-cleanup.md
+++ b/website/docs/guide/errors-and-cleanup.md
@@ -42,10 +42,10 @@ Catch clauses name a local and may specify a type. Prefer specific exception typ
 
 ## Nullable absence is not an exception
 
-Use nullable types and `nil` for expected absence. Use exceptions for failure paths that interrupt normal control flow. `?:` is the null-coalescing operator, `?.` is null-conditional access, and `!!` asserts non-null.
+Use nullable types and `nil` for expected absence. Use exceptions for failure paths that interrupt normal control flow. `??` is the null-coalescing operator, `?.` is null-conditional access, and `!!` asserts non-null.
 
 ```gsharp
-let display = user?.Name ?: "anonymous"
+let display = user?.Name ?? "anonymous"
 ```
 
 ## Defer

--- a/website/docs/guide/expressions-and-statements.md
+++ b/website/docs/guide/expressions-and-statements.md
@@ -23,8 +23,8 @@ Arguments may be positional, named (`f(timeout: 30, retries: 3)`), or ref-kind-p
 ```gsharp
 let p = Point{X: 3, Y: 4}
 let q = p with { X = 10 }
-let value = maybePoint?.X ?: 0
-let first = matrix?[0]?[0] ?: -1
+let value = maybePoint?.X ?? 0
+let first = matrix?[0]?[0] ?? -1
 let kind = (p.X + p.Y).GetType()
 ```
 

--- a/website/docs/guide/lexical-structure.md
+++ b/website/docs/guide/lexical-structure.md
@@ -48,6 +48,6 @@ Console.WriteLine("$$ stays literal")
 
 ## Operators and punctuation
 
-G# includes compact operators plus CLR-oriented additions: null assertion `!!`, null-conditional access `?.`, null-conditional indexing `?[`, null coalescing `?:`, null-coalescing compound assignment `??=`, channel receive and send `<-`, switch-expression arrows `->`, and annotations introduced by `@`. Compound assignment exists for arithmetic, bitwise, bit-clear, and shift operators.
+G# includes compact operators plus CLR-oriented additions: null assertion `!!`, null-conditional access `?.`, null-conditional indexing `?[`, null coalescing `??`, null-coalescing compound assignment `??=`, channel receive and send `<-`, switch-expression arrows `->`, and annotations introduced by `@`. Compound assignment exists for arithmetic, bitwise, bit-clear, and shift operators.
 
 `while`, `null`, `nameof`, `typeof`, and `make` are not all keywords. `while` and `null` are not implemented language forms; use `for condition { ... }` and `nil`.

--- a/website/docs/guide/types-and-values.md
+++ b/website/docs/guide/types-and-values.md
@@ -10,7 +10,7 @@ G# combines concise aggregate and collection syntax with CLR type identity. Use 
 
 ## Nil and nullable values
 
-`nil` is the null literal. Nullable types are written with `?`, such as `string?`. A non-null value converts to its nullable form, and `nil` converts to nullable types. `null` is not a literal in G#. Use `?:` for null coalescing, `?.` for null-conditional access, and `!!` only when a failed assertion should throw immediately.
+`nil` is the null literal. Nullable types are written with `?`, such as `string?`. A non-null value converts to its nullable form, and `nil` converts to nullable types. `null` is not a literal in G#. Use `??` for null coalescing, `?.` for null-conditional access, and `!!` only when a failed assertion should throw immediately.
 
 If you type the C# spelling `null` in a value position and no symbol named `null` exists in scope, the binder reports `GS0273` ("`'null'` is not a literal in G#. Did you mean `'nil'`?") and recovers by treating the identifier as `nil`, so target-type contexts (`let x string? = null`, `Foo(null)` where `Foo` takes `T?`, `x == null`) continue to typecheck. The diagnostic is suppressed when `null` resolves to a real symbol (a function, local, or field named `null` is legal because `null` is not a keyword).
 

--- a/website/docs/ref/feature-matrix.md
+++ b/website/docs/ref/feature-matrix.md
@@ -29,7 +29,7 @@ This matrix summarizes feature support in the compiler emit path (`gsc`) and the
 | Width-bearing integer names | Supported | Supported | Canonical names are `int32`, `uint64`, and related widths. ADR-0098 / issue #729 additionally accepts the friendly aliases `int`, `uint`, `long`, `ulong`, `short`, `ushort`, `byte`, `sbyte`, `float`, and `double`; they resolve to the canonical `TypeSymbol` at the binder, so diagnostics, `typeof`, hover, and IL print the canonical name. |
 | Numeric conversions | Supported | Supported | ADR-0044 widening lattice plus explicit conversions. |
 | `object` universal upper bound | Supported | Supported | Boxing and object equality are implemented. |
-| Nullable `T?`, `nil`, `!!`, `?:`, `?.`, `?[i]` | Supported | Supported | `!!` throws in the evaluator when the value is nil. `?[i]` (ADR-0073) short-circuits indexing to `nil` when the receiver is nil. |
+| Nullable `T?`, `nil`, `!!`, `??`, `?.`, `?[i]` | Supported | Supported | `!!` throws in the evaluator when the value is nil. `?[i]` (ADR-0073) short-circuits indexing to `nil` when the receiver is nil. |
 | Arrays and slices | Supported | Supported | Slices are backed by arrays; `append` copies. `len` / `cap` / `append` require `import Gsharp.Extensions.Go` (ADR-0083, GS0317); the .NET-idiomatic alternative is `.Length` and (for mutable lists) `List[T].Add`. |
 | Maps | Supported | Supported | Backed by `Dictionary[K,V]`; `delete` and `len` are implemented. Both require `import Gsharp.Extensions.Go` (ADR-0083, GS0317); .NET-idiomatic alternatives are `.Remove(k)` and `.Count`. |
 | Tuples and multi-return | Supported | Supported | Multi-value return syntax is represented as tuple literals. |

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -31,7 +31,7 @@ The lexer produces identifiers, reserved keywords, literal tokens, punctuation a
 ```text
 +  +=  ++  -  -=  --  *  *=  /  /=  %  %=  (  )  [  ]  {  }
 :  ;  ,  .  ...  ^  ^=  &  &&  &=  &^  &^=  |  |=  ||
-=  ==  !  !=  !!  ?  ?.  ?[  ?:  ??=  <  <=  <-  ->  <<  <<=  >  >=  >>  >>=  @
+=  ==  !  !=  !!  ?  ?.  ?[  ??  ??=  <  <=  <-  ->  <<  <<=  >  >=  >>  >>=  @
 ```
 
 The `:=` sequence is still lexed (as `ColonEqualsToken`) for diagnostic
@@ -157,7 +157,7 @@ Integral types are `int8`, `uint8`, `int16`, `uint16`, `int32`, `uint32`, `int64
 
 ### Object and nil
 
-`object` is the universal upper bound. Values backed by CLR types and user value types can implicitly convert or box to `object`; explicit conversions can unbox to CLR value types. Nullable types are written by appending `?` to a type clause. `nil` converts implicitly to nullable types but not to non-nullable types. Postfix `!!` asserts non-null and `?:` is null coalescing.
+`object` is the universal upper bound. Values backed by CLR types and user value types can implicitly convert or box to `object`; explicit conversions can unbox to CLR value types. Nullable types are written by appending `?` to a type clause. `nil` converts implicitly to nullable types but not to non-nullable types. Postfix `!!` asserts non-null and `??` is null coalescing.
 
 ### Arrays and slices
 
@@ -455,15 +455,22 @@ Unary operators bind tighter than binary operators. Binary operators are left-as
 
 | Precedence | Operators | Meaning |
 | --- | --- | --- |
-| 7 | `+`, `-`, `!`, `^`, `*`, `&`, `<-`, `await` | unary |
-| 6 | `*`, `/`, `%`, `<<`, `>>`, `&`, `&^` | multiplicative, shifts, bitwise and, bit clear |
-| 5 | `+`, `-`, `\|`, `^` | additive, bitwise or, xor |
-| 4 | `==`, `!=`, `<`, `<=`, `>`, `>=`, `is`, `as` | equality, comparison, type test, safe cast |
-| 3 | `&&` | logical and |
-| 2 | `\|\|`, `?:` | logical or and null coalescing |
+| 8 | `+`, `-`, `!`, `^`, `*`, `&`, `<-`, `await` | unary |
+| 7 | `*`, `/`, `%`, `<<`, `>>`, `&`, `&^` | multiplicative, shifts, bitwise and, bit clear |
+| 6 | `+`, `-`, `\|`, `^` | additive, bitwise or, xor |
+| 5 | `==`, `!=`, `<`, `<=`, `>`, `>=`, `is`, `as` | equality, comparison, type test, safe cast |
+| 4 | `&&` | logical and |
+| 3 | `\|\|` | logical or |
+| 2 | `??` | null coalescing (right-associative) |
 | 1 | `?` … `:` … | conditional (ternary, right-associative) |
 
 The conditional expression `cond ? whenTrue : whenFalse` (ADR-0062) requires `cond` to be `bool` and the two branches to share a common type. Mismatched branches report `GS0263`. The narrow ADR-0061 form `ref cond ? lhs : rhs` (and its `out` / `in` siblings) survives as a payload to a ref-kind argument; diagnostics `GS0260`–`GS0262` apply there.
+
+### Null-coalescing operator `??` (Issue #941)
+
+The binary null-coalescing operator `a ?? b` evaluates `a`; if it is non-nil the result is `a`, otherwise `b` is evaluated and yields the result. The right operand `b` is evaluated **lazily** — only when `a` reads as nil. The left operand must be of a nullable type (a nullable reference type `T?` or a `Nullable<T>` value type); for a value-type `T?`, "is nil" is `HasValue == false`. The result type is the best common type of the operands: when both sides share an underlying type `T`, the result is `T` (when `b` is non-nullable) or `T?` (when `b` is itself nullable).
+
+`??` is **right-associative** and sits at a precedence below `||` (logical or) and above the ternary conditional, so `a ?? b ?? c` parses as `a ?? (b ?? c)` and `a ?? b ? c : d` parses as `(a ?? b) ? c : d`. The compound form `a ??= b` (ADR-0072) is the assignment analogue. (G# previously spelled this operator `?:`; that spelling was removed in favor of `??` — see ADR-0116.)
 
 ### Type-test and safe-cast operators
 
@@ -1127,7 +1134,8 @@ Assignment        ::= identifier '=' Assignment
                     | '*' PrefixExpression '=' Assignment                (* indirect (pointer) assignment, ADR-0060 *)
                     | (identifier | PostfixExpression) ('+=' | '-=') Assignment   (* event subscribe / unsubscribe *)
                     | ConditionalExpression
-ConditionalExpression ::= WithExpression ('?' Assignment ':' Assignment)?   (* ternary, ADR-0062 *)
+ConditionalExpression ::= NullCoalescingExpression ('?' Assignment ':' Assignment)?   (* ternary, ADR-0062 *)
+NullCoalescingExpression ::= WithExpression ('??' NullCoalescingExpression)?  (* right-assoc null-coalescing, Issue #941 *)
 WithExpression    ::= BinaryExpression ('with' '{' FieldEqualsList? '}')*    (* non-destructive record update *)
 CompoundAssign    ::= '+=' | '-=' | '*=' | '/=' | '%=' | '^=' | '&=' | '|=' | '&^=' | '<<=' | '>>=' | '??='
 BinaryExpression  ::= PrefixExpression BinaryTail*
@@ -1137,7 +1145,7 @@ BinaryOperator    ::= '*' | '/' | '%' | '<<' | '>>' | '&' | '&^'
                     | '+' | '-' | '|' | '^'
                     | '==' | '!=' | '<' | '<=' | '>' | '>='
                     | '&&'
-                    | '||' | '?:'                                        (* '?:' is null-coalescing, ADR-0001 *)
+                    | '||'
 PrefixExpression  ::= ('+' | '-' | '!' | '^' | '*' | '&' | '<-' | 'await') PrefixExpression | PostfixExpression
 PostfixExpression ::= PrimaryExpression PostfixOp*
 PostfixOp         ::= '!!' | ('.' | '?.') NameOrCall | ('[' | '?[') Expression ']'

--- a/website/docs/release-notes.md
+++ b/website/docs/release-notes.md
@@ -154,7 +154,7 @@ The `0.1` version base identifies the current pre-1.0 line. This is not a dated 
 
 - Packages, imports, import aliases, top-level declarations, and multi-file or multi-package compilation.
 - Width-bearing primitive names such as `int32`, `uint64`, `float32`, and `float64`, plus `bool`, `char`, `string`, `object`, `decimal`, `nint`, `nuint`, and `void`.
-- Nullable `T?` types with `nil`, `?.`, `?:`, and `!!`.
+- Nullable `T?` types with `nil`, `?.`, `??`, and `!!`.
 - Structs, classes, interfaces, enums, `data struct`, `record` as a `data struct` alias, and `inline struct` value wrappers.
 - Generic functions and types with square-bracket type parameters and arguments, constraints, method inference, and CLR variance support where applicable.
 - Fixed arrays, slices, maps, tuples, function values, delegates, `sequence[T]`, `async sequence[T]`, and iterator `yield` support.

--- a/website/docs/tooling/lsp.md
+++ b/website/docs/tooling/lsp.md
@@ -84,12 +84,12 @@ The current quick-fix set targets the nil-related diagnostics introduced by ADR-
 | Diagnostic | Trigger | Offered rewrites |
 | --- | --- | --- |
 | `GS0158` (`Cannot find member X.`) | A `.` member access whose left-part is statically nullable (chained `?.`, literal `nil`, or a local/parameter/field whose declared type-clause text ends with `?`). | `Use null-conditional access '?.'` — rewrites the dot token to `?.`. |
-| `GS0154` (`Parameter 'p' requires a value of type 'T' but was given a value of type 'T?'.`) | Any argument of type `T?` passed to a parameter typed `T`. | `Provide default with '?: <literal>'` and `Assert non-nil with '!!'`. |
+| `GS0154` (`Parameter 'p' requires a value of type 'T' but was given a value of type 'T?'.`) | Any argument of type `T?` passed to a parameter typed `T`. | `Provide default with '?? <literal>'` and `Assert non-nil with '!!'`. |
 | `GS0155` (`Cannot convert type 'T?' to 'T'.`) | Any expression of type `T?` used where `T` is required (assignment, return, conditional arm, …). | Same as GS0154. |
 | `GS0156` (`Cannot convert type 'T?' to 'T'. An explicit conversion exists ...`) | Same shape as GS0155 with an explicit conversion available. | Same as GS0154. |
 | `GS0274` (`'nil' cannot be assigned to parameter 'p' of non-nullable type 'T'; …`) | Literal `nil` flowing to a non-nullable parameter. | No quick fix — the diagnostic message already carries the canonical suggestion (make the parameter nullable). |
 
-The Elvis rewrite picks a sensible default literal per primitive target type (`""` for `string`, `0` for the numeric primitives, `false` for `bool`, `default` otherwise) so the inserted snippet parses and type-checks immediately; the user is expected to replace it with a real default. Both the Elvis and the null-assertion rewrite wrap the original expression in parentheses, so the replacement is syntactically self-contained regardless of the surrounding operator precedence.
+The null-coalescing rewrite picks a sensible default literal per primitive target type (`""` for `string`, `0` for the numeric primitives, `false` for `bool`, `default` otherwise) so the inserted snippet parses and type-checks immediately; the user is expected to replace it with a real default. Both the null-coalescing and the null-assertion rewrite wrap the original expression in parentheses, so the replacement is syntactically self-contained regardless of the surrounding operator precedence.
 
 ## Connecting an editor
 

--- a/website/docs/tutorials/data-and-types.md
+++ b/website/docs/tutorials/data-and-types.md
@@ -89,10 +89,10 @@ var book = Book(
     Contact("Carol", "carol@example.com"))
 
 var hit = book.Find("Bob")
-Console.WriteLine(hit?.Display() ?: "no match")
+Console.WriteLine(hit?.Display() ?? "no match")
 
 var miss = book.Find("Zoe")
-Console.WriteLine(miss?.Display() ?: "no match")
+Console.WriteLine(miss?.Display() ?? "no match")
 
 // `!!` asserts non-null and lets us reach members on the result directly.
 var forced = book.Find("Alice")!!
@@ -107,7 +107,7 @@ no match
 Alice <alice@example.com>
 ```
 
-`Contact?` means the function can return `nil`. Use `?.` to call only when non-nil, `?[i]` to index only when non-nil, `?:` to provide a fallback, and `!!` when you want a runtime assertion that the value is present.
+`Contact?` means the function can return `nil`. Use `?.` to call only when non-nil, `?[i]` to index only when non-nil, `??` to provide a fallback, and `!!` when you want a runtime assertion that the value is present.
 
 ## 3. Use data structs for structural values
 


### PR DESCRIPTION
## Summary
Implements the binary null-coalescing operator **`a ?? b`** in the G# compiler and **removes the previous `a ?: b` spelling entirely** as an intentional breaking change (per #941 — all consumers are aware; no soft-phasing).

`a ?? b` evaluates `a`; if non-nil it yields `a`, otherwise it evaluates and yields `b`. This is the expression analogue of the already-supported `??=` compound assignment (ADR-0072 / #709).

## How `??` is implemented
- **Lexer**: `QuestionColonToken` renamed to `QuestionQuestionToken`; the lexer now emits `??` as a single token. `??=` is unchanged. `?:` no longer lexes as an operator.
- **Parser**: a dedicated `ParseNullCoalescingExpression` layer makes `??` **right-associative** and **lower precedence than `||`** (matches C#). Chains `a ?? b ?? c` parse correctly. `??=` statement parsing is unaffected.
- **Binder/lowering/emit**: the existing `NullCoalesce` bound-operator machinery is re-pointed from `?:` onto `??`. Semantics are preserved exactly — best-common result type, **lazy** right-operand evaluation, and correct behaviour for both nullable value types and reference types.

## Breaking removal of `?:`
`a ?: b` is removed from the lexer/parser and now produces `error GS0005`. Dead `?:`-specific paths were removed. Documented in the new **ADR-0116**.

## Migration performed (repo-wide off `?:`)
- **Compiler**: lexer, parser, SyntaxFacts, SyntaxKind, binder, operator comments in emit/eval.
- **Samples & SDK**: `samples/*.gs`, `src/Sdk/Gsharp.Extensions/Optional/Optional.gs`.
- **Tests**: ~20 unit/emit/interpreter/binder tests + golden files updated; coverage-matrix golden regenerated.
- **Docs/ADR**: spec grammar + operator tables, README, design doc, website docs; new ADR-0116; ADR-0072/0001/0084/0099/0115 annotated.
- **LSP**: nil quick-fix now emits `??`.
- **cs2gs**: now translates C# `??` directly to G# `??` (ADR-0115 §B gap resolved).

## Tests added (Issue941)
- reference-type fallback, nullable value-type fallback, right-associative chaining `a ?? b ?? c`, lazy short-circuit (right side not evaluated when left is non-nil — proven via side effect), `??=` still works, and `a ?: b` is now a GS0005 parse error.

All targeted suites pass (emit null-coalescing, parser/lexer, binder, interpreter, cs2gs, LSP, extensions, coverage matrix). Full solution builds at **0 warnings** (TreatWarningsAsErrors on).

Fixes #941
