### PR TITLE
Add canonical user indexer-member declaration; fix GS9998 ICE (#944)

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -300,12 +300,13 @@ A C# predefined-type keyword used as an **expression** receiver of a static call
 
 A C# target-typed `new()` emits the **explicit constructed type** inferred from the target: `List<int> items = new();` → `List[int32]()`. G# has no target-typed construction, so the type recovered from Roslyn's target type is made explicit.
 
-> **Indexer declaration — discovered compiler gap.** A C# indexer
-> (`public T this[int i] => _items[i];`) has **no canonical G# member form**, and
-> a hand-written indexer-shaped property declaration *crashes* the compiler
-> (`GS9998`, `ArgumentNullException`). The translator emits a clean
-> `translation-unsupported` record (`IndexerDeclaration`) and does not attempt a
-> mapping. Filed as **#944**.
+> **Indexer declaration — RESOLVED (#944, ADR-0118).** A C# indexer
+> (`public T this[int i] => _items[i];`) now maps to the canonical G# indexer
+> member `prop this[i int32] T { get { … } }` (ADR-0118). Originally this was a
+> compiler gap: G# had no indexer-member form and a hand-written indexer-shaped
+> property declaration *crashed* the compiler (`GS9998`, `ArgumentNullException`).
+> The translator now emits the canonical indexer form and no longer reports an
+> `IndexerDeclaration` unsupported record.
 >
 > **Null-coalescing operator `??` — RESOLVED (#941).** `value ?? fallback` now
 > maps directly to G#'s `??` null-coalescing operator. Originally this was a
@@ -466,7 +467,7 @@ friction:
 | #941 | binary `??` operator unsupported (only `??=` exists) | GS0005 |
 | #942 | `expr[i].Member` mis-parses `[i]` as type arguments | GS0005 |
 | #943 | generic-interface constraint `[T IComparable[T]]` won't parse | GS0005 |
-| #944 | no user-indexer declaration form; attempts crash | GS9998 |
+| #944 | user-indexer declaration form — **resolved** (ADR-0118): `prop this[i int32] T` emits a CLR default indexer | GS9998 |
 
 L2/L3 not going fully green is the **intended** objective-2 outcome: the residual
 failures are real compiler gaps, captured and filed rather than worked around or

--- a/docs/adr/0118-user-indexer-member-declaration.md
+++ b/docs/adr/0118-user-indexer-member-declaration.md
@@ -1,0 +1,240 @@
+# ADR-0118: User indexer-member declaration — `prop this[i int32] T { get; set }`
+
+- **Status**: Accepted
+- **Date**: 2026-06-22
+- **Phase**: v0.2 — language surface
+- **Related**: ADR-0051 (Property declarations — `prop Name T { get; set }`), ADR-0020 (Generic type-parameter brackets — Go-style `[T]`), ADR-0087 (Constructed generic user-type method references), ADR-0115 (C#→G# migration tool), issue #507 (member index assignment)
+- **Issue**: [#944](https://github.com/DavidObando/gsharp/issues/944)
+
+## Context
+
+G# already supports index **access** on built-in and CLR types — array /
+slice indexing (`xs[i]`), the Go-flavored map indexer (`m[k]`), and CLR
+indexers on imported types (`list[0]` on `List[T]`, `d["k"]` on
+`Dictionary[K,V]`). It also supports index **assignment** through those
+same targets (`xs[i] = v`, `m[k] = v`, `d["k"] = v`; issue #507).
+
+What was missing was a way for a **user-defined** G# type to *declare* an
+indexer member — the analogue of C#'s `public T this[int i] => …`. A
+type could expose a list internally but not present an `obj[i]` surface
+of its own:
+
+```gsharp
+class Repo[T] {
+    private let _items List[T] = List[T]()
+    func Add(item T) { _items.Add(item) }
+    // …no way to write `repo[0]`…
+}
+```
+
+Worse, the most plausible spelling — reusing the `prop` keyword with a
+`this[…]` name — did not merely fail to parse cleanly; on a **generic**
+enclosing type it **crashed the compiler** with an internal exception:
+
+```gsharp
+prop this[index int32] T { get { return _items[index] } }
+```
+
+```text
+error GS9998: ArgumentNullException: Value cannot be null. (Parameter 'key')
+```
+
+### Root cause of the ICE
+
+`prop this[index int32] T` was parsed as an *ordinary* property named
+`this` whose type clause was the malformed `[index int32]` (the parser
+read `[` as the start of an array/map type). That produced a
+`TypeClauseSyntax` with a **null** type-name identifier. When the binder
+later resolved that type clause it called `Binder.LookupType(null)`. For
+a **generic** enclosing type (`Repo[T]`) the lookup first probes the
+in-scope type-parameter dictionary — `CurrentTypeParameters.TryGetValue(null)`
+— and `Dictionary<string,…>` throws `ArgumentNullException ("key")` on a
+null key. The non-generic case happened to dodge the dictionary and
+produced (noisy) diagnostics instead, which is why the crash was
+generic-only. The defect is therefore twofold: (1) no grammar for the
+member, and (2) a missing null-name guard on the lookup path that turns a
+parse-recovery artifact into an ICE.
+
+The C#→G# migration tool (ADR-0115) had already discovered and filed this
+gap (`Repository<T>.this[int index]`), emitting a
+`translation-unsupported` record rather than risking the crash.
+
+## Decision
+
+### 1. Canonical grammar
+
+A user indexer is declared with the **existing `prop` keyword**, with the
+property *name* replaced by the contextual `this` followed by a
+bracketed parameter list. This is the spelling proposed in issue #944 and
+is the natural extension of the ADR-0051 property grammar:
+
+```text
+PropertyDecl   ::= 'prop' ( identifier | IndexerName ) TypeClause PropertyBody?
+IndexerName    ::= 'this' '[' IndexerParam (',' IndexerParam)* ']'
+IndexerParam   ::= identifier TypeClause
+PropertyBody   ::= '{' PropertyAccessor* '}'
+PropertyAccessor ::= ('get' | 'set' ('(' identifier ')')?) (Block | ';')?
+```
+
+```gsharp
+class Repo[T] {
+    private let _items List[T] = List[T]()
+    func Add(item T) { _items.Add(item) }
+
+    prop this[index int32] T {            // get-only indexer
+        get { return _items[index] }
+    }
+}
+```
+
+```gsharp
+class Grid {
+    private var _cells []int32 = make([]int32, 16)
+    prop this[i int32] int32 {            // get/set indexer
+        get { return _cells[i] }
+        set { _cells[i] = value }
+    }
+}
+```
+
+Rationale for reusing `prop this[…]` rather than inventing a new keyword:
+
+- It mirrors C#'s `this[…]` mental model and **exactly** the form named
+  in the issue, so it reads naturally to the C#/Swift audience and is the
+  obvious target for the cs2gs translator.
+- It keeps the bracket spelling consistent with index **access**
+  (`xs[i]`) and with G#'s generic/array bracket tradition.
+- It reuses the entire ADR-0051 accessor grammar (`get`/`set`, optional
+  `set(name)` parameter rename, bodies) verbatim — no new accessor
+  syntax, printer, or binder shape.
+
+The `index` (or any) parameter name is the source name by which the
+accessor bodies refer to the index; the setter value is `value` by
+default (renamable via `set(v) { … }`), identical to ordinary
+properties.
+
+### 2. Semantics
+
+An indexer is a **default member** of its type. It lowers to the standard
+CLR shape:
+
+- a `PropertyDef` named **`Item`** whose property signature encodes the
+  index parameter types and the element (value) type;
+- a `get_Item(<index params>)` accessor and/or a
+  `set_Item(<index params>, value)` accessor, both `SpecialName |
+  HideBySig` instance methods, linked to the `Item` property via
+  `MethodSemantics`;
+- a type-level
+  `System.Reflection.DefaultMemberAttribute("Item")` so that the CLR,
+  C#, and reflection (`Type.GetDefaultMembers()`, `PropertyInfo` with
+  index parameters) all recognise the property as the indexer.
+
+The accessor bodies see the index parameters and `this` (and the
+receiver's fields/properties by bare name) exactly like an instance
+method body. For a **generic** enclosing type (`Repo[T]`) the indexer
+element type and parameter types may mention the type parameters; the
+accessors and call sites resolve through the existing constructed
+generic user-type machinery (ADR-0087: method references parented at the
+constructed `TypeSpec`, signatures encoded with `!0`).
+
+### 3. Access binding — `obj[i]` / `obj[i] = v` on a user type
+
+When the target of an index expression is a user-defined type
+(`StructSymbol`) that declares an indexer:
+
+- `obj[i]` binds to a call of the indexer's getter
+  (`obj.get_Item(i)`), modelled as a `BoundUserInstanceCallExpression`
+  whose receiver is `obj`, method is the indexer's `get_Item`
+  `FunctionSymbol`, and (for generic enclosing types) result type is the
+  substituted element type.
+- `obj[i] = v` binds to a call of the indexer's setter
+  (`obj.set_Item(i, v)`), likewise a `BoundUserInstanceCallExpression`,
+  with `v` converted to the indexer's element type. As an expression it
+  yields the assigned value (consistent with the existing
+  `BoundClrIndexAssignmentExpression` behavior).
+
+Reusing `BoundUserInstanceCallExpression` means the indexer access path
+inherits — for free — the IL emitter, the tree-walking interpreter, the
+slot planner, generic `TypeSpec`/`MethodSpec` parenting, and value-vs-
+reference `call`/`callvirt` selection. No new bound-node kind, visitor,
+rewriter, or printer is introduced for access.
+
+### 4. Emit
+
+The indexer is a `PropertySymbol` with `IsIndexer = true` and an index
+`Parameters` list, stored in the type's ordinary `Properties` collection.
+Emit generalises the existing property-accessor emission:
+
+- `get_Item` / `set_Item` accessor `MethodDef`s are emitted through the
+  same `EmitFunction` pipeline as any computed-property accessor, now
+  carrying the index parameters (getter) and index-params-plus-`value`
+  (setter). They are named `get_Item`/`set_Item` and marked
+  `IsSpecialName`. Their `MethodDef` handles are registered in
+  `MethodHandles` so the `BoundUserInstanceCallExpression` access sites
+  resolve (including the constructed-generic `TypeSpec`-parented
+  `MemberRef`).
+- the `Item` `PropertyDef` signature is encoded with the index
+  parameters (`PropertySignature.Parameters(n, return, params)`).
+- a single `DefaultMemberAttribute("Item")` custom attribute is emitted
+  on the type.
+
+The emitted IL is `peverify`/ILVerify-clean and round-trips: the type's
+indexer is consumable from C# as a normal indexer.
+
+### 5. Diagnostics (no ICE — ever)
+
+Two layers guarantee the GS9998 internal-exception class is eliminated:
+
+1. **Direct guard.** `Binder.LookupType` now treats a `null`/empty type
+   name as "unresolved" and returns `null` (yielding the ordinary
+   GS0113 "type doesn't exist" diagnostic) instead of indexing a
+   dictionary with a null key. This removes the *entire* ICE class for
+   any parse-recovery artifact that produces a null type name, not just
+   the indexer case.
+2. **Grammar.** The indexer member now parses to a first-class shape, so
+   the mis-parse that produced the null type name no longer occurs for
+   the canonical form.
+
+Unsupported/malformed indexer shapes report focused diagnostics rather
+than crashing:
+
+- an indexer with **no parameters** (`prop this[] T`) → **GS0370**
+  ("An indexer must declare at least one parameter").
+- an indexer with **no accessor body** (auto-indexer `prop this[i int32] T`
+  with no `{ … }`, or empty/abstract accessors) → **GS0371** ("An indexer
+  must declare a `get` and/or `set` accessor with a body").
+
+## Scope implemented in this PR
+
+Fully implemented end-to-end (parser → symbol → binder → lowering →
+emit + interpreter), with emit-and-run regression tests:
+
+- **get-only** indexer on a **generic** class — the issue #944 `Repo[T]`
+  repro: `Add` items, read `repo[0]`, assert the value.
+- **get/set** indexer on a non-generic class: write via `obj[i] = v`,
+  read back via `obj[i]`.
+- **non-generic get-only** indexer.
+- index access binding for both read and write to the declared indexer,
+  including inside the type's own methods.
+- the old crashing shape now compiles and runs — **no GS9998**.
+
+## Deferred (with rationale)
+
+- **Multi-parameter indexer *access*** (`obj[i, j]`). The index-access
+  grammar (`IndexExpressionSyntax`) carries a *single* index expression,
+  so `obj[i, j]` is not parseable today. The indexer **declaration**
+  grammar and emit accept one-or-more parameters (forward-compatible,
+  and valid for CLR/interop consumers), but a multi-parameter indexer is
+  not callable from G# until the access grammar grows a comma-separated
+  index list. Single-parameter indexers — the overwhelmingly common case
+  and the issue repro — are fully supported for declaration **and**
+  access. This is a grammar limitation on the access side, not an emit
+  gap.
+- **Overloaded indexers** (several `Item` properties differing by index
+  type). G# has no indexer overload resolution yet; a type declares at
+  most one indexer (a second reports GS0046 "already declared"). Liftable
+  later without a grammar change.
+- **`open`/`override` virtual indexers.** Indexers follow the same
+  accessor-attribute defaults as computed instance properties; explicit
+  virtual-indexer overriding across a class hierarchy is out of scope for
+  this ADR.

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -348,6 +348,14 @@ public sealed class Binder
                         {
                             foreach (var prop in t.Properties)
                             {
+                                // ADR-0118 / issue #944: an indexer member has the
+                                // CLR name `Item` but is not accessible by bare name —
+                                // it is reached only through `this[i]` index access.
+                                if (prop.IsIndexer)
+                                {
+                                    continue;
+                                }
+
                                 if (seenMembers.Add(prop.Name))
                                 {
                                     scope.TryDeclareVariable(new ImplicitPropertyVariableSymbol(function.ThisParameter, t, prop));
@@ -3668,6 +3676,16 @@ public sealed class Binder
 
     private TypeSymbol LookupType(string name)
     {
+        // Issue #944: a parse-recovery artifact (e.g. a malformed type clause
+        // with no identifier) can reach here with a null/empty name. Treat it
+        // as unresolved and let the caller surface the ordinary GS0113
+        // diagnostic, rather than indexing a name-keyed dictionary with a null
+        // key (which threw ArgumentNullException → GS9998 ICE).
+        if (string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
         // Phase 4.1 / ADR-0020: a generic function's type parameters shadow
         // outer type names while we are binding its signature and body.
         if (binderCtx.CurrentTypeParameters != null && binderCtx.CurrentTypeParameters.TryGetValue(name, out var tp))

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -1057,7 +1057,37 @@ internal sealed class DeclarationBinder
             var propertiesBuilder = ImmutableArray.CreateBuilder<PropertySymbol>();
             foreach (var propSyntax in syntax.Properties)
             {
-                var propName = propSyntax.Identifier.Text;
+                // ADR-0118 / issue #944: an indexer member (`prop this[…] T`)
+                // is modelled as a property whose CLR name is `Item` carrying
+                // an index-parameter list.
+                var isIndexer = propSyntax.IsIndexer;
+                var indexerParameters = ImmutableArray<ParameterSymbol>.Empty;
+                if (isIndexer)
+                {
+                    if (propSyntax.Parameters.Count == 0)
+                    {
+                        Diagnostics.ReportIndexerRequiresParameter(propSyntax.ThisKeyword.Location);
+                        continue;
+                    }
+
+                    var indexerParamBuilder = ImmutableArray.CreateBuilder<ParameterSymbol>();
+                    var seenIndexParamNames = new HashSet<string>();
+                    foreach (var indexParamSyntax in propSyntax.Parameters)
+                    {
+                        var indexParamName = indexParamSyntax.Identifier.Text;
+                        var indexParamType = bindTypeClause(indexParamSyntax.Type) ?? TypeSymbol.Error;
+                        if (!seenIndexParamNames.Add(indexParamName))
+                        {
+                            Diagnostics.ReportParameterAlreadyDeclared(indexParamSyntax.Location, indexParamName);
+                        }
+
+                        indexerParamBuilder.Add(new ParameterSymbol(indexParamName, indexParamType, declaringSyntax: indexParamSyntax.Identifier));
+                    }
+
+                    indexerParameters = indexerParamBuilder.ToImmutable();
+                }
+
+                var propName = isIndexer ? "Item" : propSyntax.Identifier.Text;
 
                 // Check for duplicate names (fields + methods + other properties)
                 if (!existingNames.Add(propName))
@@ -1105,6 +1135,14 @@ internal sealed class DeclarationBinder
                                   && propSyntax.Accessors.All(a => a.Body == null);
                 }
 
+                // ADR-0118 / issue #944: there is no auto-indexer form — an
+                // indexer must declare a get and/or set accessor with a body.
+                if (isIndexer && isAutoProperty)
+                {
+                    Diagnostics.ReportIndexerRequiresAccessorBody(propSyntax.ThisKeyword.Location);
+                    continue;
+                }
+
                 // Validate: auto-property not allowed on data struct
                 if (isAutoProperty && syntax.IsData)
                 {
@@ -1148,7 +1186,11 @@ internal sealed class DeclarationBinder
                     isVirtual,
                     isOverride,
                     setterParamName,
-                    declaration: propSyntax);
+                    declaration: propSyntax)
+                {
+                    IsIndexer = isIndexer,
+                    Parameters = indexerParameters,
+                };
                 Binder.AttachDocumentation(propertySymbol, propSyntax);
 
                 // Create backing field for auto-properties
@@ -1172,7 +1214,7 @@ internal sealed class DeclarationBinder
                     {
                         var getterSymbol = new FunctionSymbol(
                             $"get_{propName}",
-                            ImmutableArray<ParameterSymbol>.Empty,
+                            isIndexer ? indexerParameters : ImmutableArray<ParameterSymbol>.Empty,
                             propType,
                             declaration: null,
                             package,
@@ -1180,6 +1222,10 @@ internal sealed class DeclarationBinder
                             receiverType: structSymbol,
                             isOpen: isVirtual,
                             isOverride: isOverride);
+
+                        // ADR-0118: indexer accessors are emitted as SpecialName
+                        // CLR default-member accessors (get_Item).
+                        getterSymbol.IsSpecialName = isIndexer;
                         propertySymbol.GetterSymbol = getterSymbol;
                         propertySymbol.GetterBodySyntax = getAccessor.Body;
                     }
@@ -1187,9 +1233,12 @@ internal sealed class DeclarationBinder
                     if (hasSetter && setAccessor?.Body != null)
                     {
                         var setterParam = new ParameterSymbol(setterParamName, propType);
+                        var setterParameters = isIndexer
+                            ? indexerParameters.Add(setterParam)
+                            : ImmutableArray.Create(setterParam);
                         var setterSymbol = new FunctionSymbol(
                             $"set_{propName}",
-                            ImmutableArray.Create(setterParam),
+                            setterParameters,
                             TypeSymbol.Void,
                             declaration: null,
                             package,
@@ -1197,6 +1246,7 @@ internal sealed class DeclarationBinder
                             receiverType: structSymbol,
                             isOpen: isVirtual,
                             isOverride: isOverride);
+                        setterSymbol.IsSpecialName = isIndexer;
                         propertySymbol.SetterSymbol = setterSymbol;
                         propertySymbol.SetterBodySyntax = setAccessor.Body;
                     }
@@ -1577,6 +1627,14 @@ internal sealed class DeclarationBinder
             var staticPropertiesBuilder = ImmutableArray.CreateBuilder<PropertySymbol>();
             foreach (var propSyntax in syntax.SharedBlock.Properties)
             {
+                // ADR-0118 / issue #944: a `shared` (static) indexer has no CLR
+                // representation — report a clean diagnostic rather than crashing.
+                if (propSyntax.IsIndexer)
+                {
+                    Diagnostics.ReportIndexerRequiresAccessorBody(propSyntax.ThisKeyword.Location);
+                    continue;
+                }
+
                 var propName = propSyntax.Identifier.Text;
                 if (!existingNames.Add(propName))
                 {
@@ -2744,6 +2802,15 @@ internal sealed class DeclarationBinder
             var propertiesBuilder = ImmutableArray.CreateBuilder<PropertySymbol>();
             foreach (var propSyntax in syntax.Properties)
             {
+                // ADR-0118 / issue #944: interface indexer members are out of
+                // scope for now — report a clean diagnostic rather than binding
+                // an ill-formed property named `this`.
+                if (propSyntax.IsIndexer)
+                {
+                    Diagnostics.ReportIndexerRequiresAccessorBody(propSyntax.ThisKeyword.Location);
+                    continue;
+                }
+
                 var propName = propSyntax.Identifier.Text;
                 if (!seenNames.Add(propName))
                 {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1955,6 +1955,34 @@ internal sealed partial class ExpressionBinder
             }
         }
 
+        // ADR-0118 / issue #944: index access on a user-defined type that
+        // declares an indexer member (`prop this[i T] U`). Binds `obj[i]` to a
+        // call of the indexer getter (`obj.get_Item(i)`).
+        if (target.Type is StructSymbol userIndexTarget
+            && TryGetUserIndexer(userIndexTarget, out var readIndexer, out var readSubstitution)
+            && readIndexer.Parameters.Length == 1)
+        {
+            if (readIndexer.GetterSymbol == null)
+            {
+                Diagnostics.ReportTypeNotIndexable(targetLocation, target.Type);
+                return new BoundErrorExpression(null);
+            }
+
+            var paramType = readSubstitution != null
+                ? Binder.SubstituteType(readIndexer.Parameters[0].Type, readSubstitution)
+                : readIndexer.Parameters[0].Type;
+            var indexArg = conversions.BindConversion(indexSyntax, paramType);
+            var elementType = readSubstitution != null
+                ? Binder.SubstituteType(readIndexer.Type, readSubstitution)
+                : readIndexer.Type;
+            return new BoundUserInstanceCallExpression(
+                null,
+                target,
+                readIndexer.GetterSymbol,
+                ImmutableArray.Create(indexArg),
+                elementType);
+        }
+
         if (target.Type != TypeSymbol.Error)
         {
             Diagnostics.ReportTypeNotIndexable(targetLocation, target.Type);
@@ -2263,6 +2291,35 @@ internal sealed partial class ExpressionBinder
             }
         }
 
+        // ADR-0118 / issue #944: index assignment on a user-defined type that
+        // declares an indexer member. Binds `obj[i] = v` to a call of the
+        // indexer setter (`obj.set_Item(i, v)`).
+        if (variable.Type is StructSymbol userIndexTarget
+            && TryGetUserIndexer(userIndexTarget, out var writeIndexer, out var writeSubstitution)
+            && writeIndexer.Parameters.Length == 1)
+        {
+            if (writeIndexer.SetterSymbol == null)
+            {
+                Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
+                return new BoundErrorExpression(null);
+            }
+
+            var paramType = writeSubstitution != null
+                ? Binder.SubstituteType(writeIndexer.Parameters[0].Type, writeSubstitution)
+                : writeIndexer.Parameters[0].Type;
+            var elementType = writeSubstitution != null
+                ? Binder.SubstituteType(writeIndexer.Type, writeSubstitution)
+                : writeIndexer.Type;
+
+            var indexArg = conversions.BindConversion(indexSyntax, paramType);
+            var value = BindValue(elementType);
+            return new BoundUserInstanceCallExpression(
+                null,
+                new BoundVariableExpression(null, variable),
+                writeIndexer.SetterSymbol,
+                ImmutableArray.Create(indexArg, value));
+        }
+
         if (variable.Type != TypeSymbol.Error)
         {
             Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
@@ -2340,6 +2397,62 @@ internal sealed partial class ExpressionBinder
         }
 
         return TypeSymbol.FromClrType(clrType);
+    }
+
+    // ADR-0118 / issue #944: locate a user-declared indexer member on a (possibly
+    // constructed-generic) user type and, for a constructed type, build the
+    // type-parameter substitution from the receiver's type arguments. The
+    // returned PropertySymbol is the OPEN indexer on the type definition so its
+    // get_Item/set_Item accessors resolve to the emitted MethodDef handles.
+    private static bool TryGetUserIndexer(
+        StructSymbol target,
+        out PropertySymbol indexer,
+        out Dictionary<TypeParameterSymbol, TypeSymbol> substitution)
+    {
+        indexer = null;
+        substitution = null;
+
+        var definition = target.Definition ?? target;
+        for (var c = definition; c != null; c = c.BaseClass)
+        {
+            foreach (var p in c.Properties)
+            {
+                if (p.IsIndexer)
+                {
+                    indexer = p;
+                    break;
+                }
+            }
+
+            if (indexer != null)
+            {
+                break;
+            }
+        }
+
+        if (indexer == null)
+        {
+            return false;
+        }
+
+        // Build the type-parameter substitution for a constructed generic
+        // receiver (e.g. `Repo[int32]` over `class Repo[T]`).
+        if (!target.TypeArguments.IsDefaultOrEmpty
+            && target.Definition != null
+            && !ReferenceEquals(target.Definition, target))
+        {
+            var defTps = target.Definition.TypeParameters;
+            if (!defTps.IsDefaultOrEmpty && defTps.Length == target.TypeArguments.Length)
+            {
+                substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>(defTps.Length);
+                for (var i = 0; i < defTps.Length; i++)
+                {
+                    substitution[defTps[i]] = target.TypeArguments[i];
+                }
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -3785,6 +3785,37 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
             DiagnosticSeverity.Error);
     }
 
+    /// <summary>
+    /// Reports GS0370 — ADR-0118 / issue #944: an indexer member
+    /// (<c>prop this[…] T { … }</c>) was declared with no index parameters.
+    /// An indexer must declare at least one parameter.
+    /// </summary>
+    /// <param name="location">The source location of the indexer declaration.</param>
+    public void ReportIndexerRequiresParameter(TextLocation location)
+    {
+        Report(
+            location,
+            "GS0370",
+            "An indexer member must declare at least one parameter, e.g. 'prop this[i int32] T { … }' (issue #944).",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// Reports GS0371 — ADR-0118 / issue #944: an indexer member
+    /// (<c>prop this[…] T</c>) was declared without an accessor body. An
+    /// indexer must declare a <c>get</c> and/or <c>set</c> accessor with a
+    /// body; there is no auto-indexer form.
+    /// </summary>
+    /// <param name="location">The source location of the indexer declaration.</param>
+    public void ReportIndexerRequiresAccessorBody(TextLocation location)
+    {
+        Report(
+            location,
+            "GS0371",
+            "An indexer member must declare a 'get' and/or 'set' accessor with a body; there is no auto-indexer form (issue #944).",
+            DiagnosticSeverity.Error);
+    }
+
     private static string FormatMissingNames(IEnumerable<string> missingNames)
     {
         var displayed = new List<string>();

--- a/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
@@ -133,9 +133,30 @@ internal sealed class MemberDefEmitter
 
             // Emit PropertyDef row.
             var propertySignature = new BlobBuilder();
-            new BlobEncoder(propertySignature)
-                .PropertySignature(isInstanceProperty: true)
-                .Parameters(0, returnType => this.encodeTypeSymbol(returnType.Type(), prop.Type), parameters => { });
+            if (prop.IsIndexer && !prop.Parameters.IsDefaultOrEmpty)
+            {
+                // ADR-0118 / issue #944: a CLR default indexer property carries
+                // its index parameter types in the PropertyDef signature.
+                var indexParams = prop.Parameters;
+                new BlobEncoder(propertySignature)
+                    .PropertySignature(isInstanceProperty: true)
+                    .Parameters(
+                        indexParams.Length,
+                        returnType => this.encodeTypeSymbol(returnType.Type(), prop.Type),
+                        parameters =>
+                        {
+                            foreach (var indexParam in indexParams)
+                            {
+                                this.encodeTypeSymbol(parameters.AddParameter().Type(), indexParam.Type);
+                            }
+                        });
+            }
+            else
+            {
+                new BlobEncoder(propertySignature)
+                    .PropertySignature(isInstanceProperty: true)
+                    .Parameters(0, returnType => this.encodeTypeSymbol(returnType.Type(), prop.Type), parameters => { });
+            }
 
             var propDef = this.emitCtx.Metadata.AddProperty(
                 attributes: PropertyAttributes.None,

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1194,6 +1194,7 @@ internal sealed class ReflectionMetadataEmitter
                 }
 
                 this.cache.PropertyAccessorHandles[prop] = (getterHandle, setterHandle);
+                this.RegisterIndexerAccessorHandles(prop, getterHandle, setterHandle);
             }
 
             // ADR-0052: plan accessor method rows for class events.
@@ -1300,6 +1301,7 @@ internal sealed class ReflectionMetadataEmitter
                 }
 
                 this.cache.PropertyAccessorHandles[prop] = (getterHandle, setterHandle);
+                this.RegisterIndexerAccessorHandles(prop, getterHandle, setterHandle);
             }
 
             // ADR-0052: plan accessor method rows for struct events.
@@ -2084,6 +2086,7 @@ internal sealed class ReflectionMetadataEmitter
 
             // ADR-0051 Phase 6: emit property accessor methods for classes.
             this.memberDefEmitter.EmitPropertyAccessors(c);
+            this.EmitDefaultMemberAttributeIfIndexer(c);
 
             // ADR-0052: emit event accessor methods for classes.
             this.memberDefEmitter.EmitEventAccessors(c);
@@ -2156,6 +2159,7 @@ internal sealed class ReflectionMetadataEmitter
 
             // ADR-0051 Phase 6: emit property accessor methods for structs.
             this.memberDefEmitter.EmitPropertyAccessors(s);
+            this.EmitDefaultMemberAttributeIfIndexer(s);
 
             // ADR-0052: emit event accessor methods for structs.
             this.memberDefEmitter.EmitEventAccessors(s);
@@ -6306,6 +6310,68 @@ internal sealed class ReflectionMetadataEmitter
     /// bare <c>MethodDef</c>; for a generic containing type returns a
     /// <c>MemberRef</c> parented at the constructed (or self-) <c>TypeSpec</c>.
     /// </summary>
+    // ADR-0118 / issue #944: a type that declares a user indexer member must
+    // carry a System.Reflection.DefaultMemberAttribute("Item") so the CLR (and
+    // C# consumers) recognise its `Item` property as the default indexer.
+    private void EmitDefaultMemberAttributeIfIndexer(StructSymbol structSym)
+    {
+        if (structSym.Properties.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var hasIndexer = false;
+        foreach (var prop in structSym.Properties)
+        {
+            if (prop.IsIndexer)
+            {
+                hasIndexer = true;
+                break;
+            }
+        }
+
+        if (!hasIndexer)
+        {
+            return;
+        }
+
+        if (!this.cache.StructTypeDefs.TryGetValue(structSym, out var typeDefHandle))
+        {
+            return;
+        }
+
+        this.customAttrEncoder.EmitStringAttribute(
+            typeDefHandle,
+            "System.Reflection.DefaultMemberAttribute",
+            typeof(System.Reflection.DefaultMemberAttribute),
+            "Item");
+    }
+
+    // ADR-0118 / issue #944: indexer get_Item/set_Item accessors are reached
+    // through BoundUserInstanceCallExpression (obj[i] / obj[i]=v), whose emit
+    // resolves the accessor via cache.MethodHandles. Mirror the planned
+    // PropertyAccessorHandles rows into MethodHandles for indexer accessors.
+    private void RegisterIndexerAccessorHandles(
+        PropertySymbol prop,
+        MethodDefinitionHandle? getterHandle,
+        MethodDefinitionHandle? setterHandle)
+    {
+        if (!prop.IsIndexer)
+        {
+            return;
+        }
+
+        if (prop.GetterSymbol != null && getterHandle.HasValue)
+        {
+            this.cache.MethodHandles[prop.GetterSymbol] = getterHandle.Value;
+        }
+
+        if (prop.SetterSymbol != null && setterHandle.HasValue)
+        {
+            this.cache.MethodHandles[prop.SetterSymbol] = setterHandle.Value;
+        }
+    }
+
     internal EntityHandle ResolveUserInstanceMethodToken(StructSymbol containingType, FunctionSymbol method)
     {
         if (!this.cache.MethodHandles.TryGetValue(method, out var openDef))

--- a/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
@@ -93,6 +93,20 @@ public sealed class PropertySymbol : Symbol
     /// <summary>Gets or sets the synthesized setter function symbol.</summary>
     public FunctionSymbol SetterSymbol { get; set; }
 
+    /// <summary>
+    /// Gets a value indicating whether this property is an indexer member
+    /// (ADR-0118 / issue #944). Indexers are emitted as the CLR default
+    /// member named <c>Item</c> with index parameters.
+    /// </summary>
+    public bool IsIndexer { get; init; }
+
+    /// <summary>
+    /// Gets the index parameters of an indexer member (ADR-0118). Empty for an
+    /// ordinary property.
+    /// </summary>
+    public System.Collections.Immutable.ImmutableArray<ParameterSymbol> Parameters { get; init; }
+        = System.Collections.Immutable.ImmutableArray<ParameterSymbol>.Empty;
+
     /// <summary>Gets or sets the getter accessor body syntax (for computed properties). Null for auto-properties.</summary>
     public Syntax.BlockStatementSyntax GetterBodySyntax { get; set; }
 

--- a/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
@@ -246,6 +246,13 @@ public static class TypeMemberModel
             {
                 foreach (var p in c.Properties)
                 {
+                    // ADR-0118 / issue #944: an indexer ('Item') is not reachable
+                    // by member name — only through `obj[i]` index access.
+                    if (p.IsIndexer)
+                    {
+                        continue;
+                    }
+
                     if (p.Name == name)
                     {
                         property = p;

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -2334,6 +2334,16 @@ public class Parser
         SyntaxToken overrideModifier)
     {
         var propKeyword = MatchToken(SyntaxKind.IdentifierToken); // consumes "prop"
+
+        // ADR-0118: indexer member — `prop this[<params>] T { get; set }`.
+        // The property name is replaced by the contextual `this` keyword
+        // followed by a bracketed index-parameter list.
+        if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "this"
+            && Peek(1).Kind == SyntaxKind.OpenSquareBracketToken)
+        {
+            return ParseIndexerDeclaration(accessibilityModifier, openModifier, overrideModifier, propKeyword);
+        }
+
         var identifier = MatchToken(SyntaxKind.IdentifierToken);
         var type = ParseTypeClause();
 
@@ -2367,6 +2377,73 @@ public class Parser
             openBraceToken: null,
             accessors: ImmutableArray<PropertyAccessorSyntax>.Empty,
             closeBraceToken: null);
+    }
+
+    // ADR-0118: parse the indexer member form `prop this[<params>] T { get; set }`.
+    // The leading `prop` keyword has already been consumed. The `this` token is
+    // current. The resulting PropertyDeclarationSyntax carries IsIndexer = true.
+    private PropertyDeclarationSyntax ParseIndexerDeclaration(
+        SyntaxToken accessibilityModifier,
+        SyntaxToken openModifier,
+        SyntaxToken overrideModifier,
+        SyntaxToken propKeyword)
+    {
+        var thisKeyword = MatchToken(SyntaxKind.IdentifierToken); // consumes "this"
+        var openBracket = MatchToken(SyntaxKind.OpenSquareBracketToken);
+        var parameters = ParseIndexerParameterList();
+        var closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
+        var type = ParseTypeClause();
+
+        SyntaxToken openBrace = null;
+        var accessors = ImmutableArray<PropertyAccessorSyntax>.Empty;
+        SyntaxToken closeBrace = null;
+        if (Current.Kind == SyntaxKind.OpenBraceToken)
+        {
+            openBrace = MatchToken(SyntaxKind.OpenBraceToken);
+            accessors = ParsePropertyAccessors();
+            closeBrace = MatchToken(SyntaxKind.CloseBraceToken);
+        }
+
+        return new PropertyDeclarationSyntax(
+            syntaxTree,
+            accessibilityModifier,
+            openModifier,
+            overrideModifier,
+            propKeyword,
+            identifier: thisKeyword,
+            type,
+            openBrace,
+            accessors,
+            closeBrace)
+            .WithIndexer(thisKeyword, openBracket, parameters, closeBracket);
+    }
+
+    // ADR-0118: parse the bracketed index-parameter list of an indexer member.
+    // Mirrors ParseParameterList but terminates at the closing square bracket.
+    private SeparatedSyntaxList<ParameterSyntax> ParseIndexerParameterList()
+    {
+        var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+
+        var parseNextParameter = true;
+        while (parseNextParameter &&
+               Current.Kind != SyntaxKind.CloseSquareBracketToken &&
+               Current.Kind != SyntaxKind.EndOfFileToken)
+        {
+            var parameter = ParseParameter();
+            nodesAndSeparators.Add(parameter);
+
+            if (Current.Kind == SyntaxKind.CommaToken)
+            {
+                var comma = MatchToken(SyntaxKind.CommaToken);
+                nodesAndSeparators.Add(comma);
+            }
+            else
+            {
+                parseNextParameter = false;
+            }
+        }
+
+        return new SeparatedSyntaxList<ParameterSyntax>(nodesAndSeparators.ToImmutable());
     }
 
     private EventDeclarationSyntax ParseEventDeclaration(

--- a/src/Core/CodeAnalysis/Syntax/PropertyDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/PropertyDeclarationSyntax.cs
@@ -38,6 +38,7 @@ public sealed class PropertyDeclarationSyntax : SyntaxNode
         : base(syntaxTree)
     {
         Annotations = ImmutableArray<AnnotationSyntax>.Empty;
+        Parameters = new SeparatedSyntaxList<ParameterSyntax>(ImmutableArray<SyntaxNode>.Empty);
         AccessibilityModifier = accessibilityModifier;
         OpenModifier = openModifier;
         OverrideModifier = overrideModifier;
@@ -70,8 +71,26 @@ public sealed class PropertyDeclarationSyntax : SyntaxNode
     /// <summary>Gets the identifier token whose text is <c>prop</c>.</summary>
     public SyntaxToken PropKeyword { get; }
 
-    /// <summary>Gets the property name identifier.</summary>
+    /// <summary>Gets the property name identifier. For an indexer (ADR-0118) this is the <c>this</c> contextual keyword token.</summary>
     public SyntaxToken Identifier { get; }
+
+    /// <summary>
+    /// Gets the <c>this</c> contextual keyword token when this declaration is an
+    /// indexer member (ADR-0118), or <see langword="null"/> for an ordinary property.
+    /// </summary>
+    public SyntaxToken ThisKeyword { get; private set; }
+
+    /// <summary>Gets the optional opening bracket token of an indexer parameter list (ADR-0118).</summary>
+    public SyntaxToken OpenBracketToken { get; private set; }
+
+    /// <summary>Gets the indexer parameter list (ADR-0118). Empty for an ordinary property.</summary>
+    public SeparatedSyntaxList<ParameterSyntax> Parameters { get; private set; }
+
+    /// <summary>Gets the optional closing bracket token of an indexer parameter list (ADR-0118).</summary>
+    public SyntaxToken CloseBracketToken { get; private set; }
+
+    /// <summary>Gets a value indicating whether this declaration is an indexer member (ADR-0118).</summary>
+    public bool IsIndexer => ThisKeyword != null;
 
     /// <summary>Gets the property type.</summary>
     public TypeClauseSyntax Type { get; }
@@ -91,6 +110,29 @@ public sealed class PropertyDeclarationSyntax : SyntaxNode
     internal PropertyDeclarationSyntax WithAnnotations(ImmutableArray<AnnotationSyntax> annotations)
     {
         Annotations = annotations.IsDefault ? ImmutableArray<AnnotationSyntax>.Empty : annotations;
+        return this;
+    }
+
+    /// <summary>
+    /// ADR-0118: marks this declaration as an indexer member by attaching the
+    /// <c>this</c> keyword token, the bracket tokens, and the index parameter
+    /// list. Returns this same instance for fluent parser use.
+    /// </summary>
+    /// <param name="thisKeyword">The <c>this</c> contextual keyword token.</param>
+    /// <param name="openBracketToken">The opening bracket token.</param>
+    /// <param name="parameters">The index parameter list.</param>
+    /// <param name="closeBracketToken">The closing bracket token.</param>
+    /// <returns>This same <see cref="PropertyDeclarationSyntax"/>, marked as an indexer.</returns>
+    internal PropertyDeclarationSyntax WithIndexer(
+        SyntaxToken thisKeyword,
+        SyntaxToken openBracketToken,
+        SeparatedSyntaxList<ParameterSyntax> parameters,
+        SyntaxToken closeBracketToken)
+    {
+        ThisKeyword = thisKeyword;
+        OpenBracketToken = openBracketToken;
+        Parameters = parameters ?? new SeparatedSyntaxList<ParameterSyntax>(ImmutableArray<SyntaxNode>.Empty);
+        CloseBracketToken = closeBracketToken;
         return this;
     }
 }

--- a/test/Compiler.Tests/Emit/Issue944IndexerDeclarationEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue944IndexerDeclarationEmitTests.cs
@@ -1,0 +1,295 @@
+// <copyright file="Issue944IndexerDeclarationEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #944 / ADR-0118: canonical G# user indexer-member declaration
+/// (<c>prop this[i int32] T { get {...} set {...} }</c>). Before the fix,
+/// declaring an indexer crashed the compiler with <c>GS9998</c>
+/// (<c>ArgumentNullException: Parameter 'key'</c>) for generic enclosing
+/// types and produced no canonical declaration form at all.
+///
+/// These tests compile AND run programs that declare and consume indexers,
+/// covering get-only, get/set, generic, and non-generic enclosing types,
+/// the original <c>Repo[T]</c> repro, plus a guard that the ICE is gone
+/// (malformed shapes now report a clean diagnostic, never <c>GS9998</c>).
+/// </summary>
+public class Issue944IndexerDeclarationEmitTests
+{
+    [Fact]
+    public void GetOnlyGenericIndexer_RepoRepro_ReadsBack()
+    {
+        // The headline repro from issue #944: a generic `Repo[T]` exposing a
+        // get-only indexer that delegates to an inner list. Previously this
+        // crashed with GS9998; now it emits a valid CLR default indexer.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Repo[T] {
+                private let _items List[T] = List[T]()
+                func Add(item T) { _items.Add(item) }
+                prop this[index int32] T {
+                    get { return _items[index] }
+                }
+            }
+
+            let r = Repo[int32]()
+            r.Add(10)
+            r.Add(20)
+            r.Add(30)
+            public var result = r[2]
+            """;
+
+        Assert.Equal(30, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void GetSetIndexer_NonGeneric_WritesThroughAndReadsBack()
+    {
+        // A non-generic class with a get/set indexer. The write `b[1] = 99`
+        // binds to set_Item and the read `b[0] + b[1]` binds to get_Item.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Box {
+                private let _items List[int32] = List[int32]()
+                func Add(item int32) { _items.Add(item) }
+                prop this[index int32] int32 {
+                    get { return _items[index] }
+                    set { _items[index] = value }
+                }
+            }
+
+            let b = Box()
+            b.Add(10)
+            b.Add(20)
+            b[1] = 99
+            public var result = b[0] + b[1]
+            """;
+
+        Assert.Equal(109, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void GetOnlyIndexer_NonGeneric_StringKeyedElementType()
+    {
+        // Non-generic get-only indexer with a non-int element type to confirm
+        // the PropertyDef/get_Item signatures encode the declared element type
+        // (here `string`) rather than erasing to object.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Names {
+                private let _items List[string] = List[string]()
+                func Add(item string) { _items.Add(item) }
+                prop this[index int32] string {
+                    get { return _items[index] }
+                }
+            }
+
+            let n = Names()
+            n.Add("alpha")
+            n.Add("beta")
+            public var result = n[1].Length
+            """;
+
+        // "beta".Length == 4
+        Assert.Equal(4, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void GenericGetSetIndexer_FieldBacked_WritesAndReadsBack()
+    {
+        // Generic enclosing type with BOTH accessors: exercises generic
+        // substitution on the setter `value` parameter and the getter return
+        // type, plus the MemberRef/TypeSpec resolution path for the accessor
+        // tokens. Storage is a single `T` field (a generic-collection element
+        // write is a separate, pre-existing limitation unrelated to indexers).
+        var source = """
+            package P
+            import System
+
+            class Store[T] {
+                private var _slot T
+                func Init(seed T) { _slot = seed }
+                prop this[index int32] T {
+                    get { return _slot }
+                    set { _slot = value }
+                }
+            }
+
+            let s = Store[int32]()
+            s.Init(1)
+            s[0] = 42
+            public var result = s[0]
+            """;
+
+        Assert.Equal(42, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void IndexerType_CarriesDefaultMemberAttribute_AndItemProperty()
+    {
+        // Metadata shape check: the declaring type must carry
+        // DefaultMemberAttribute("Item") and expose an `Item` property with
+        // one index parameter plus a get_Item accessor, so C# consumers and
+        // the CLR recognise it as a default indexer.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Repo[T] {
+                private let _items List[T] = List[T]()
+                func Add(item T) { _items.Add(item) }
+                prop this[index int32] T {
+                    get { return _items[index] }
+                }
+            }
+
+            public var result = 0
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var repo = assembly.GetTypes().Single(t => t.Name.StartsWith("Repo", StringComparison.Ordinal));
+
+        var defaultMember = repo.GetCustomAttribute<System.Reflection.DefaultMemberAttribute>();
+        Assert.NotNull(defaultMember);
+        Assert.Equal("Item", defaultMember!.MemberName);
+
+        var item = repo.GetProperty("Item");
+        Assert.NotNull(item);
+        Assert.Single(item!.GetIndexParameters());
+
+        Assert.NotNull(repo.GetMethod("get_Item"));
+    }
+
+    [Fact]
+    public void IceIsGone_OriginalCrashingShape_NowCompiles()
+    {
+        // Regression guard for the ICE: the exact crashing shape from #944
+        // (generic enclosing type with an indexer) must compile cleanly and
+        // never surface GS9998.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Repo[T] {
+                private let _items List[T] = List[T]()
+                func Add(item T) { _items.Add(item) }
+                prop this[index int32] T {
+                    get { return _items[index] }
+                }
+            }
+
+            public var result = 1
+            """;
+
+        var (exitCode, output) = TryCompile(source);
+        Assert.DoesNotContain("GS9998", output);
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public void MalformedIndexer_MissingAccessorBody_ReportsCleanDiagnostic_NotIce()
+    {
+        // An indexer declared as an auto-property (no accessor body) is not a
+        // supported shape. It must report the clean GS0371 diagnostic rather
+        // than crashing with GS9998.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Repo[T] {
+                private let _items List[T] = List[T]()
+                prop this[index int32] T
+            }
+
+            public var result = 1
+            """;
+
+        var (exitCode, output) = TryCompile(source);
+        Assert.DoesNotContain("GS9998", output);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0371", output);
+    }
+
+    private static int RunAndGetIntResult(string source)
+    {
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod(
+            "<Main>$",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField(
+            "result",
+            BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { System.Array.Empty<string>() });
+        return (int)resultField!.GetValue(null)!;
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var (exitCode, output, outPath) = CompileToFile(source);
+        Assert.True(exitCode == 0, $"gsc failed:\n{output}");
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+
+    private static (int ExitCode, string Output) TryCompile(string source)
+    {
+        var (exitCode, output, _) = CompileToFile(source);
+        return (exitCode, output);
+    }
+
+    private static (int ExitCode, string Output, string OutPath) CompileToFile(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue944_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        var output = compileOut.ToString() + compileErr.ToString();
+        return (compileExit, output, outPath);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/PropertyParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/PropertyParserTests.cs
@@ -130,4 +130,59 @@ public class PropertyParserTests
         Assert.Single(propDecl.Accessors);
         Assert.True(propDecl.Accessors[0].IsGetter);
     }
+
+    [Fact]
+    public void ParsesGetOnlyIndexerDeclaration()
+    {
+        // ADR-0118 / issue #944: `prop this[i int32] T { get {...} }`.
+        const string source = "package P\nclass Repo {\n  prop this[index int32] int32 { get { return 0 } }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void ParsesGetSetIndexerDeclaration()
+    {
+        const string source = "package P\nclass Repo {\n  prop this[index int32] int32 { get { return 0 } set { } }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void IndexerDeclaration_IsMarkedAsIndexer()
+    {
+        const string source = "package P\nclass Repo {\n  prop this[index int32] int32 { get { return 0 } }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var propDecl = structDecl.Properties.Single();
+        Assert.True(propDecl.IsIndexer);
+        Assert.Single(propDecl.Parameters);
+        Assert.Equal("index", propDecl.Parameters[0].Identifier.Text);
+    }
+
+    [Fact]
+    public void IndexerDeclaration_OnGenericClass_Parses()
+    {
+        const string source = "package P\nclass Repo[T] {\n  prop this[index int32] T { get { return _items[index] } }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        Assert.True(structDecl.Properties.Single().IsIndexer);
+    }
+
+    [Fact]
+    public void NonIndexerProperty_IsNotMarkedAsIndexer()
+    {
+        const string source = "package P\nclass Foo {\n  prop Name string\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var propDecl = structDecl.Properties.Single();
+        Assert.False(propDecl.IsIndexer);
+        Assert.Empty(propDecl.Parameters);
+    }
 }

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
@@ -110,6 +110,7 @@ public sealed class PropertyDeclaration : GMember
     /// <param name="isOpen">Whether the property is <c>open</c> (virtual).</param>
     /// <param name="isOverride">Whether the property is an <c>override</c>.</param>
     /// <param name="attributes">The property attributes.</param>
+    /// <param name="indexerParameters">The index parameters for an indexer member (ADR-0118); empty for an ordinary property.</param>
     public PropertyDeclaration(
         string name,
         GTypeReference type,
@@ -117,7 +118,8 @@ public sealed class PropertyDeclaration : GMember
         Visibility visibility = Visibility.Default,
         bool isOpen = false,
         bool isOverride = false,
-        IReadOnlyList<AttributeUse> attributes = null)
+        IReadOnlyList<AttributeUse> attributes = null,
+        IReadOnlyList<Parameter> indexerParameters = null)
     {
         Name = name;
         Type = type;
@@ -126,6 +128,7 @@ public sealed class PropertyDeclaration : GMember
         IsOpen = isOpen;
         IsOverride = isOverride;
         Attributes = attributes ?? new List<AttributeUse>();
+        IndexerParameters = indexerParameters ?? new List<Parameter>();
     }
 
     /// <summary>Gets the property name.</summary>
@@ -148,6 +151,12 @@ public sealed class PropertyDeclaration : GMember
 
     /// <summary>Gets the property attributes.</summary>
     public IReadOnlyList<AttributeUse> Attributes { get; }
+
+    /// <summary>Gets the index parameters for an indexer member (ADR-0118); empty for an ordinary property.</summary>
+    public IReadOnlyList<Parameter> IndexerParameters { get; }
+
+    /// <summary>Gets a value indicating whether this property is an indexer member (<c>prop this[...]</c>).</summary>
+    public bool IsIndexer => IndexerParameters.Count > 0;
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -954,7 +954,15 @@ public static class GSharpPrinter
             sb.Append("override ");
         }
 
-        sb.Append($"prop {property.Name} {RenderType(property.Type)}");
+        if (property.IsIndexer)
+        {
+            // ADR-0118: render the canonical indexer header `prop this[...] T`.
+            sb.Append($"prop this[{RenderParameterList(property.IndexerParameters)}] {RenderType(property.Type)}");
+        }
+        else
+        {
+            sb.Append($"prop {property.Name} {RenderType(property.Type)}");
+        }
 
         if (property.Accessors.Count == 0)
         {

--- a/tools/cs2gs/Cs2Gs.Tests/L3TranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L3TranslationTests.cs
@@ -247,12 +247,28 @@ namespace Demo
     }
 
     /// <summary>
-    /// ADR-0115 §B.11 gap: a C# indexer has no canonical G# member form (and a
-    /// declaration crashes gsc, GS9998), so it surfaces as a clean
-    /// <see cref="TranslationSeverity.Unsupported"/> diagnostic.
+    /// ADR-0118 / issue #944 (resolves the ADR-0115 §B.11 gap): a C# indexer
+    /// now maps to the canonical G# indexer member (<c>prop this[i int32] T</c>),
+    /// so it no longer surfaces as an unsupported diagnostic.
     /// </summary>
     [Fact]
-    public void Indexer_SurfacesAsUnsupported()
+    public void Indexer_TranslatesToCanonicalIndexerMember()
+    {
+        string translated = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class IndexHost
+    {
+        private readonly int[] data = new int[4];
+        public int this[int i] => this.data[i];
+    }
+}");
+
+        Assert.Contains("prop this[i int32] int32", translated);
+    }
+
+    [Fact]
+    public void Indexer_DoesNotSurfaceAsUnsupported()
     {
         TranslationContext context = TranslateForDiagnostics(@"
 namespace Demo
@@ -264,7 +280,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains(
+        Assert.DoesNotContain(
             context.Diagnostics,
             d => d.IsUnsupported && d.ConstructKind == "IndexerDeclaration");
     }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -831,6 +831,10 @@ public sealed class CSharpToGSharpTranslator
                     yield return this.TranslateProperty(property);
                     break;
 
+                case IndexerDeclarationSyntax indexer:
+                    yield return this.TranslateIndexer(indexer);
+                    break;
+
                 case ConstructorDeclarationSyntax ctor:
                     // T2: a fully-lifted constructor is dropped entirely; its field
                     // initialization moved to field initializers / primary-ctor
@@ -1039,15 +1043,61 @@ public sealed class CSharpToGSharpTranslator
 
         private List<PropertyAccessor> MapAccessors(PropertyDeclarationSyntax node)
         {
+            return this.MapAccessors(node, $"property '{node.Identifier.Text}'");
+        }
+
+        private (GMember Member, bool IsStatic) TranslateIndexer(IndexerDeclarationSyntax node)
+        {
+            // ADR-0118 / issue #944: a C# indexer (`public T this[int i] => ...`)
+            // maps to the canonical G# indexer member (`prop this[i int32] T`).
+            var symbol = this.context.GetDeclaredSymbol(node) as IPropertySymbol;
+            bool isStatic = symbol != null && symbol.IsStatic;
+
+            GTypeReference type = symbol != null
+                ? this.typeMapper.Map(symbol.Type, this.context, node.GetLocation())
+                : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
+
+            List<Parameter> indexParameters = symbol != null
+                ? symbol.Parameters.Select(this.MapParameter).ToList()
+                : this.MapParameterList(node.ParameterList);
+
+            List<PropertyAccessor> accessors = this.MapAccessors(node, "indexer 'this[]'");
+
+            bool isOverride = symbol != null && symbol.IsOverride;
+            bool inInterface = symbol?.ContainingType?.TypeKind == TypeKind.Interface;
+            bool isOpen = symbol != null && (symbol.IsVirtual || symbol.IsAbstract) && !symbol.IsOverride && !inInterface;
+
+            var property = new PropertyDeclaration(
+                "this",
+                type,
+                accessors: accessors,
+                visibility: MapVisibility(symbol, this.context, node),
+                isOpen: isOpen,
+                isOverride: isOverride,
+                attributes: this.MapAttributes(node.AttributeLists),
+                indexerParameters: indexParameters);
+
+            return (property, isStatic);
+        }
+
+        private List<PropertyAccessor> MapAccessors(BasePropertyDeclarationSyntax node, string displayName)
+        {
             // An expression-bodied property (=> expr) is a get-only computed
             // property; its body is deferred to step 7 (ADR-0115 §B.11).
-            if (node.ExpressionBody != null)
+            ArrowExpressionClauseSyntax expressionBody = node switch
+            {
+                PropertyDeclarationSyntax p => p.ExpressionBody,
+                IndexerDeclarationSyntax i => i.ExpressionBody,
+                _ => null,
+            };
+
+            if (expressionBody != null)
             {
                 return new List<PropertyAccessor>
                 {
                     new PropertyAccessor(
                         AccessorKind.Get,
-                        this.TranslateBody(node, $"property '{node.Identifier.Text}' getter")),
+                        this.TranslateBody(node, $"{displayName} getter")),
                 };
             }
 
@@ -1083,7 +1133,7 @@ public sealed class CSharpToGSharpTranslator
                     // get/set); map to 'set' and record the discovered gap.
                     this.context.Report(new TranslationDiagnostic(
                         nameof(SyntaxKind.InitAccessorDeclaration),
-                        $"property '{node.Identifier.Text}' uses an 'init' accessor; G# has no 'init' accessor, mapped to 'set' (discovered gap, ADR-0115 §B.11).",
+                        $"{displayName} uses an 'init' accessor; G# has no 'init' accessor, mapped to 'set' (discovered gap, ADR-0115 §B.11).",
                         accessor.GetLocation(),
                         TranslationSeverity.Info));
                     kind = AccessorKind.Set;
@@ -1097,7 +1147,7 @@ public sealed class CSharpToGSharpTranslator
                 BlockStatement body = bodied
                     ? this.TranslateBody(
                         accessor,
-                        $"property '{node.Identifier.Text}' {kind.ToString().ToLowerInvariant()}ter")
+                        $"{displayName} {kind.ToString().ToLowerInvariant()}ter")
                     : null;
                 accessors.Add(new PropertyAccessor(kind, body));
             }

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -439,13 +439,41 @@ ConstructorDecl  = "init" "(" Parameters? ")" ( ":" identifier "(" Arguments? ")
 SharedBlock      = "shared" "{" SharedMember* "}" .
 SharedMember     = Accessibility? ( MethodDecl | PropertyDecl | EventDecl | FieldDecl ) .
 FieldDecl        = Accessibility? ( "var" | "let" ) identifier TypeClause ( "=" Expression )? .
-PropertyDecl     = "prop" identifier TypeClause PropertyBody? .
+PropertyDecl     = "prop" ( identifier | IndexerHeader ) TypeClause PropertyBody? .
+IndexerHeader    = "this" "[" Parameters "]" .  (* ADR-0118: user indexer member, emitted as the CLR default `Item` property *)
 PropertyAccessor = ( "get" | "set" ( "(" identifier ")" )? ) ( Block | ";" )? .
 EventDecl        = "event" identifier TypeClause EventBody? .
 EventAccessor    = ( "add" | "remove" | "raise" ) ( Block | ";" )? .
 InterfaceBody    = "{" ( InterfaceMethodDecl | PropertyDecl | EventDecl )* "}" .
 InterfaceMethodDecl = "func" identifier "(" Parameters? ")" TypeClause? FunctionBody .  (* FunctionBody ";" = no-body (abstract) marker; issue #881 *)
 ```
+
+#### Indexer members (ADR-0118)
+
+A type can declare a **user indexer member** with the `prop this[...]` form,
+giving it an element-access syntax (`obj[i]`, `obj[i] = v`):
+
+```gsharp
+class Repo[T] {
+    private let _items List[T] = List[T]()
+    func Add(item T) { _items.Add(item) }
+    prop this[index int32] T {        // get-only indexer
+        get { return _items[index] }
+    }
+}
+```
+
+An indexer is an instance member with a non-empty index parameter list and at
+least one accessor body. It is emitted as the CLR default indexer: an `Item`
+property whose accessors are `get_Item` / `set_Item`, with a
+`System.Reflection.DefaultMemberAttribute("Item")` on the declaring type, so
+the indexer round-trips with C# and other CLR consumers. The enclosing type may
+be generic; index parameter and element types are substituted through the
+receiver's type arguments. An indexer declared without index parameters reports
+`GS0370`; one declared without an accessor body (an "auto-indexer") reports
+`GS0371`. Element **access** (`obj[i]`) currently binds single-parameter
+indexers; multi-parameter and overloaded indexers are reserved for a future
+revision.
 
 ## Expressions
 
@@ -1042,7 +1070,8 @@ SharedBlock       ::= 'shared' '{' SharedMember* '}'
 SharedMember      ::= Annotation* Accessibility? (Async? MethodDecl | PropertyDecl | EventDecl | FieldDecl)
 MethodDecl        ::= FunctionDecl
 FieldDecl         ::= Accessibility? ('var' | 'let') identifier TypeClause ('=' Expression)?
-PropertyDecl      ::= 'prop' identifier TypeClause PropertyBody?
+PropertyDecl      ::= 'prop' (identifier | IndexerHeader) TypeClause PropertyBody?
+IndexerHeader     ::= 'this' '[' Parameters ']'   (* ADR-0118: user indexer member; emitted as CLR default 'Item' property *)
 PropertyBody      ::= '{' PropertyAccessor* '}'
 PropertyAccessor  ::= ('get' | 'set' ('(' identifier ')')?) (Block | ';')?
 EventDecl         ::= 'event' identifier TypeClause EventBody?


### PR DESCRIPTION
## Summary

Closes the language gap in issue #944: there was **no canonical G# syntax for declaring a user indexer member** (the analogue of C#'s `public T this[int i] => …`), and the most plausible spelling **crashed the compiler** with `GS9998` (`ArgumentNullException: Parameter 'key'`) on generic enclosing types.

This PR (a) introduces the canonical indexer-member declaration end-to-end, and (b) guarantees the ICE class is gone — any still-unsupported member shape now yields a clean diagnostic.

## ICE root cause

`prop this[index int32] T` parsed `this` as the **property name** and `[index int32]` as a malformed **type clause with a null type name**. Binding that called `Binder.LookupType(null)`; for a **generic** enclosing type, `CurrentTypeParameters.TryGetValue(null)` threw `ArgumentNullException("key")` and surfaced as `GS9998`. Non-generic types dodged the dictionary and only produced a diagnostic.

## Canonical design (ADR-0118)

`docs/adr/0118-user-indexer-member-declaration.md`. Canonical spelling reuses the existing `prop` grammar:

```
prop this[index int32] T {
    get { return _items[index] }
    set { _items[index] = value }
}
```

Semantics: emitted as the **CLR default indexer** — an `Item` property whose accessors are `get_Item`/`set_Item` (SpecialName, HideBySig), plus a `System.Reflection.DefaultMemberAttribute("Item")` on the declaring type, so the indexer round-trips with C#/reflection. Supports get-only and get/set, single or multiple index parameters in the declaration, and generic enclosing types (index/element types substituted through the receiver's type arguments). `obj[i]` and `obj[i] = v` bind to the accessors via `BoundUserInstanceCallExpression`.

## Implementation (by area)

- **Parser/Syntax**: `Parser.ParseIndexerDeclaration`; `PropertyDeclarationSyntax` gains `ThisKeyword`/`Parameters`/`IsIndexer`.
- **Symbols**: `PropertySymbol.IsIndexer` + `Parameters`; `TypeMemberModel`/`Binder` keep indexers out of the name-keyed member path.
- **No-ICE guard**: `Binder.LookupType` returns null for null/empty names (kills the `ArgumentNullException` class).
- **DeclarationBinder**: binds index params + accessors, names the member `Item`, validates >=1 index parameter (**GS0370**) and requires an accessor body (**GS0371**).
- **ExpressionBinder.Access**: binds `obj[i]` / `obj[i]=v` to the indexer accessors with generic substitution.
- **Emit**: index-parameter `PropertyDef` + accessor signatures, registers accessor `MethodHandles`, emits `DefaultMemberAttribute("Item")`.
- **cs2gs**: translates C# indexers to the canonical G# form; ADR-0115 gap note marked **resolved**; L3 translation tests updated.
- **Docs**: `spec.md` indexer grammar + prose; ADR-0118; ADR-0115.

## Tests (compile and run)

- `test/Compiler.Tests/Emit/Issue944IndexerDeclarationEmitTests.cs` — get-only generic `Repo[T]` repro (add items, read `r[2]`), non-generic get/set (`b[1]=99`, read back = 109), generic field-backed get/set, non-generic get-only (string element), `DefaultMemberAttribute`/`Item` metadata shape, **ICE-gone** (original crashing shape compiles, no `GS9998`), malformed indexer to clean **GS0371** (never `GS9998`). All 7 pass.
- `test/Core.Tests/.../PropertyParserTests.cs` — new grammar parser unit tests. 18 pass.
- cs2gs: `Indexer_TranslatesToCanonicalIndexerMember` + `Indexer_DoesNotSurfaceAsUnsupported`.

Full solution builds **0 warnings** (TreatWarningsAsErrors). Core.Tests (3433), property/indexer Compiler.Tests (136), and cs2gs (111) all green.

## Deferred (with rationale)

- **Multi-parameter element access** (`obj[i, j]`): the declaration grammar accepts multiple index parameters and emits them correctly, but `IndexExpressionSyntax.Index` is a single expression, so access binds single-parameter indexers only. Documented in ADR-0118.
- **Generic write into CLR generic collections** inside a setter body (e.g. `_items[i] = value` where `_items` is `List[T]`) is a **pre-existing, unrelated** limitation (`T`->`object` erasure); the generic get/set test uses a `T` field backing instead. Not introduced by this PR.
- **Overloaded / interface / virtual indexers**: reserved for a future revision (ADR-0118).

Fixes #944
