### PR TITLE
Add first-class init-only property accessor (#946)

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -202,7 +202,7 @@ Defaults: top-level declarations default to `public` (ADR-0014); top-level `priv
 #### B.11 Members: fields, properties, constructors, statics, enums, attributes
 
 - **Fields** require `var`/`let` (ADR-0067, §B.3).
-- **Properties** → `prop Name T` for auto-properties, with `{ get { … } set(v) { … } }` bodies for computed/custom accessors (ADR-0051, `samples/PropertyRef/Lib/Lib.gs`). `open prop`/`override prop` mirror method virtuality.
+- **Properties** → `prop Name T` for auto-properties, with `{ get { … } set(v) { … } }` bodies for computed/custom accessors (ADR-0051, `samples/PropertyRef/Lib/Lib.gs`). `open prop`/`override prop` mirror method virtuality. A C# **`init` accessor** maps to the first-class G# `init` accessor (issue #946); an init-only auto-property `{ get; init; }` keeps its explicit accessors (it is *not* collapsed to the read-write `prop Name T` auto form, which would lose the init-only semantics). *(Superseded note: earlier revisions mapped C# `init` to G# `set` with an Info gap diagnostic because G# had no `init` accessor; that gap is now closed.)*
 - **Constructors** → `init(params) { … }`, chaining via `: Base(args)` (ADR-0065). C# primary constructors / positional records map to the G# primary-constructor `Name(params)` head.
 - **Static members** → a `shared { … }` block (ADR-0053); except the program entry's static class, which is hoisted to top level (T3, above). Sibling static calls inside a non-entry `shared { }` block are emitted **qualified** (`Geometry.Round(...)`), since an unqualified sibling static call does not resolve there (`GS0130`).
 

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -1108,6 +1108,7 @@ internal sealed class DeclarationBinder
                 bool hasGetter = true;
                 bool hasSetter;
                 bool isAutoProperty;
+                bool isInitOnly = false;
                 string setterParamName = "value";
 
                 if (propSyntax.OpenBraceToken == null)
@@ -1121,17 +1122,28 @@ internal sealed class DeclarationBinder
                     // Has body — check accessors
                     var getAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsGetter);
                     var setAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsSetter);
-                    hasGetter = getAccessor != null || propSyntax.Accessors.IsDefaultOrEmpty;
-                    hasSetter = setAccessor != null;
+                    var initAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsInit);
 
-                    if (setAccessor != null && setAccessor.ParameterIdentifier != null)
+                    // Issue #946: a property may declare a `set` or an `init`
+                    // accessor, but not both (mirrors C#).
+                    if (setAccessor != null && initAccessor != null)
                     {
-                        setterParamName = setAccessor.ParameterIdentifier.Text;
+                        Diagnostics.ReportPropertyHasBothSetAndInit(initAccessor.AccessorKeyword.Location, propName);
+                    }
+
+                    var writeAccessor = setAccessor ?? initAccessor;
+                    hasGetter = getAccessor != null || propSyntax.Accessors.IsDefaultOrEmpty;
+                    hasSetter = writeAccessor != null;
+                    isInitOnly = setAccessor == null && initAccessor != null;
+
+                    if (writeAccessor != null && writeAccessor.ParameterIdentifier != null)
+                    {
+                        setterParamName = writeAccessor.ParameterIdentifier.Text;
                     }
 
                     // Auto-property if accessors have no bodies
                     isAutoProperty = (getAccessor == null || getAccessor.Body == null)
-                                  && (setAccessor == null || setAccessor.Body == null)
+                                  && (writeAccessor == null || writeAccessor.Body == null)
                                   && propSyntax.Accessors.All(a => a.Body == null);
                 }
 
@@ -1186,7 +1198,8 @@ internal sealed class DeclarationBinder
                     isVirtual,
                     isOverride,
                     setterParamName,
-                    declaration: propSyntax)
+                    declaration: propSyntax,
+                    isInitOnly: isInitOnly)
                 {
                     IsIndexer = isIndexer,
                     Parameters = indexerParameters,
@@ -1208,7 +1221,9 @@ internal sealed class DeclarationBinder
                 if (!isAutoProperty)
                 {
                     var getAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsGetter);
-                    var setAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsSetter);
+
+                    // Issue #946: the write accessor is either `set` or `init`.
+                    var setAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsSetterOrInit);
 
                     if (hasGetter && getAccessor?.Body != null)
                     {
@@ -1247,6 +1262,7 @@ internal sealed class DeclarationBinder
                             isOpen: isVirtual,
                             isOverride: isOverride);
                         setterSymbol.IsSpecialName = isIndexer;
+                        setterSymbol.IsInitOnlySetter = isInitOnly;
                         propertySymbol.SetterSymbol = setterSymbol;
                         propertySymbol.SetterBodySyntax = setAccessor.Body;
                     }
@@ -1663,8 +1679,17 @@ internal sealed class DeclarationBinder
                 {
                     var getAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsGetter);
                     var setAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsSetter);
+                    var initAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsInit);
+
+                    // Issue #946: `init` is instance-only; reject it on a static
+                    // property declared inside a `shared` block (ADR-0053).
+                    if (initAccessor != null)
+                    {
+                        Diagnostics.ReportInitAccessorOnStaticProperty(initAccessor.AccessorKeyword.Location, propName);
+                    }
+
                     hasGetter = getAccessor != null || propSyntax.Accessors.IsDefaultOrEmpty;
-                    hasSetter = setAccessor != null;
+                    hasSetter = setAccessor != null || initAccessor != null;
 
                     if (setAccessor != null && setAccessor.ParameterIdentifier != null)
                     {
@@ -2826,11 +2851,24 @@ internal sealed class DeclarationBinder
 
                 bool hasGetter = true;
                 bool hasSetter = false;
+                bool isInitOnly = false;
 
                 if (propSyntax.OpenBraceToken != null)
                 {
                     hasGetter = propSyntax.Accessors.Any(a => a.IsGetter);
-                    hasSetter = propSyntax.Accessors.Any(a => a.IsSetter);
+                    var hasSet = propSyntax.Accessors.Any(a => a.IsSetter);
+                    var hasInit = propSyntax.Accessors.Any(a => a.IsInit);
+
+                    // Issue #946: a property may declare a `set` or an `init`
+                    // accessor, but not both.
+                    if (hasSet && hasInit)
+                    {
+                        var initAccessor = propSyntax.Accessors.First(a => a.IsInit);
+                        Diagnostics.ReportPropertyHasBothSetAndInit(initAccessor.AccessorKeyword.Location, propName);
+                    }
+
+                    hasSetter = hasSet || hasInit;
+                    isInitOnly = !hasSet && hasInit;
                     if (!hasGetter && !hasSetter)
                     {
                         hasGetter = true;
@@ -2852,7 +2890,8 @@ internal sealed class DeclarationBinder
                     isAutoProperty: false,
                     isVirtual: false,
                     isOverride: false,
-                    declaration: propSyntax);
+                    declaration: propSyntax,
+                    isInitOnly: isInitOnly);
 
                 Binder.AttachDocumentation(propSymbol, propSyntax);
                 propertiesBuilder.Add(propSymbol);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -102,6 +102,8 @@ internal sealed partial class ExpressionBinder
                 Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, name);
             }
 
+            EnforceInitOnlyAssignment(implicitProp.Property, receiver: null, syntax.EqualsToken.Location);
+
             reportObsoleteUseIfApplicable(
                 syntax.IdentifierToken.Location,
                 implicitProp.Property,
@@ -134,6 +136,41 @@ internal sealed partial class ExpressionBinder
         var convertedExpression = conversions.BindConversion(syntax.Expression.Location, boundExpression, variable.Type);
 
         return new BoundAssignmentExpression(null, variable, convertedExpression);
+    }
+
+    /// <summary>
+    /// Issue #946: enforces that an <c>init</c>-only property is only assigned
+    /// during object initialization. Assignment is permitted when the current
+    /// binding context is the declaring type's constructor (<c>.ctor</c>) or an
+    /// <c>init</c> accessor, and the receiver is the instance being initialized
+    /// (<c>this</c>). Object/aggregate initializers at the creation site bind
+    /// through <see cref="BindObjectInitializerAssignment"/> and do not call
+    /// this guard, so they are always allowed. Any other assignment reports
+    /// <c>GS0372</c>. Reads are never restricted.
+    /// </summary>
+    /// <param name="prop">The property being assigned.</param>
+    /// <param name="receiver">The bound receiver expression, or <see langword="null"/> for an implicit <c>this</c> receiver.</param>
+    /// <param name="location">The location to report a diagnostic against.</param>
+    private void EnforceInitOnlyAssignment(PropertySymbol prop, BoundExpression receiver, TextLocation location)
+    {
+        if (prop == null || !prop.IsInitOnly)
+        {
+            return;
+        }
+
+        var fn = this.function;
+        var inInitContext = fn != null && (fn.Name == ".ctor" || fn.IsInitOnlySetter);
+        var receiverIsThis = receiver == null
+            || (receiver is BoundVariableExpression bve
+                && fn?.ThisParameter != null
+                && ReferenceEquals(bve.Variable, fn.ThisParameter));
+
+        if (inInitContext && receiverIsThis)
+        {
+            return;
+        }
+
+        Diagnostics.ReportInitOnlyPropertyAssignment(location, prop.Name);
     }
 
     private BoundExpression BindObjectInitializerAssignment(LocalVariableSymbol receiverLocal, TypeSymbol receiverType, PropertyInitializerSyntax initSyntax)
@@ -372,6 +409,7 @@ internal sealed partial class ExpressionBinder
 
                 var propConverted = conversions.BindConversion(syntax.Value.Location, value, prop.Type);
                 var propReceiver = implicitFieldReceiverExpr ?? new BoundVariableExpression(null, variable);
+                EnforceInitOnlyAssignment(prop, propReceiver, syntax.EqualsToken.Location);
                 return new BoundPropertyAssignmentExpression(null, propReceiver, structSymbol, prop, propConverted);
             }
 
@@ -543,6 +581,8 @@ internal sealed partial class ExpressionBinder
                 Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, name);
             }
 
+            EnforceInitOnlyAssignment(implicitProp.Property, receiver: null, syntax.OperatorToken.Location);
+
             return new BoundPropertyAssignmentExpression(
                 null,
                 new BoundVariableExpression(null, implicitProp.Receiver),
@@ -687,6 +727,7 @@ internal sealed partial class ExpressionBinder
 
             var binary = new BoundBinaryExpression(null, leftRead, op, boundRhs);
             var converted = conversions.BindConversion(syntax.Value.Location, binary, prop.Type);
+            EnforceInitOnlyAssignment(prop, boundReceiver, syntax.OperatorToken.Location);
             return new BoundPropertyAssignmentExpression(null, boundReceiver, structSym, prop, converted);
         }
 
@@ -1029,6 +1070,7 @@ internal sealed partial class ExpressionBinder
                 }
 
                 var propConverted = conversions.BindConversion(syntax.Value.Location, value, prop.Type);
+                EnforceInitOnlyAssignment(prop, receiver, syntax.EqualsToken.Location);
                 return new BoundPropertyAssignmentExpression(null, receiver, structSym, prop, propConverted);
             }
 

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -3779,6 +3779,23 @@ internal sealed class StatementBinder
                     return (null, null);
                 }
 
+                // Issue #946: a compound assignment (`+=` / `??=`) to an
+                // init-only property is only legal during object initialization.
+                if (propAccess.Property.IsInitOnly)
+                {
+                    var fn = this.function;
+                    var inInitContext = fn != null && (fn.Name == ".ctor" || fn.IsInitOnlySetter);
+                    var receiverIsThis = propAccess.Receiver == null
+                        || (propAccess.Receiver is BoundVariableExpression rbve
+                            && fn?.ThisParameter != null
+                            && ReferenceEquals(rbve.Variable, fn.ThisParameter));
+                    if (!inInitContext || !receiverIsThis)
+                    {
+                        Diagnostics.ReportInitOnlyPropertyAssignment(syntax.OperatorToken.Location, propAccess.Property.Name);
+                        return (null, null);
+                    }
+                }
+
                 var receiver = propAccess.Receiver == null
                     ? null
                     : CaptureReceiver(syntax, propAccess.Receiver, preStatements);

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -420,6 +420,45 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Issue #946: reports that an <c>init</c>-only property was assigned
+    /// outside of object initialization. An <c>init</c>-only property may only
+    /// be assigned in the declaring type's constructor(s), in an object/
+    /// aggregate initializer at the creation site, or within an <c>init</c>
+    /// accessor of the same instance.
+    /// </summary>
+    /// <param name="location">The text location where the error was found.</param>
+    /// <param name="name">The name of the property.</param>
+    public void ReportInitOnlyPropertyAssignment(TextLocation location, string name)
+    {
+        var message = $"Init-only property '{name}' can only be assigned during object initialization (in a constructor, an object initializer, or an 'init' accessor).";
+        Report(location, "GS0372", message);
+    }
+
+    /// <summary>
+    /// Issue #946: reports that a property declared both a <c>set</c> and an
+    /// <c>init</c> accessor, which is not allowed (mirrors C#'s rule).
+    /// </summary>
+    /// <param name="location">The text location where the error was found.</param>
+    /// <param name="name">The name of the property.</param>
+    public void ReportPropertyHasBothSetAndInit(TextLocation location, string name)
+    {
+        var message = $"Property '{name}' cannot declare both a 'set' and an 'init' accessor.";
+        Report(location, "GS0373", message);
+    }
+
+    /// <summary>
+    /// Issue #946: reports that an <c>init</c>-only accessor was declared on a
+    /// static property. The <c>init</c> accessor is instance-only.
+    /// </summary>
+    /// <param name="location">The text location where the error was found.</param>
+    /// <param name="name">The name of the property.</param>
+    public void ReportInitAccessorOnStaticProperty(TextLocation location, string name)
+    {
+        var message = $"Static property '{name}' cannot declare an 'init' accessor; 'init' is only valid on instance properties.";
+        Report(location, "GS0374", message);
+    }
+
+    /// <summary>
     /// Reports that the specified unary operator is not defined for the specified type.
     /// </summary>
     /// <param name="location">The text location where the error was found.</param>

--- a/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
@@ -295,7 +295,26 @@ internal sealed class MemberDefEmitter
 
         var sigBlob = new BlobBuilder();
         new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
-            .Parameters(1, r => r.Void(), ps => this.encodeTypeSymbol(ps.AddParameter().Type(), prop.Type));
+            .Parameters(
+                1,
+                r =>
+                {
+                    // Issue #946: an `init`-only setter encodes its void return
+                    // with modreq(System.Runtime.CompilerServices.IsExternalInit),
+                    // exactly as a C# 9 init-only setter does. This is how the
+                    // CLR and peer compilers recognize the accessor as init-only.
+                    if (prop.IsInitOnly)
+                    {
+                        var isExternalInit = this.wellKnown.GetIsExternalInitTypeRef();
+                        if (!isExternalInit.IsNil)
+                        {
+                            r.CustomModifiers().AddModifier(isExternalInit, isOptional: false);
+                        }
+                    }
+
+                    r.Void();
+                },
+                ps => this.encodeTypeSymbol(ps.AddParameter().Type(), prop.Type));
 
         var methodAttrs = MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig;
         if (prop.IsVirtual)

--- a/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
+++ b/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
@@ -312,6 +312,23 @@ internal sealed class WellKnownReferences
         return this.getTypeReference(attrType);
     }
 
+    /// <summary>
+    /// Issue #946: returns the TypeRef handle for
+    /// <c>System.Runtime.CompilerServices.IsExternalInit</c>, used as the
+    /// <c>modreq</c> on the void return of an <c>init</c>-only property setter
+    /// (mirroring the C# 9 init-only setter encoding). Resolved against the
+    /// target framework's reference assemblies (every runtime G# targets ships
+    /// this type since .NET 5), falling back to the host runtime's type.
+    /// </summary>
+    /// <returns>The TypeRef entity handle.</returns>
+    public EntityHandle GetIsExternalInitTypeRef()
+    {
+        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.IsExternalInit", out var resolved)
+            ? resolved
+            : typeof(System.Runtime.CompilerServices.IsExternalInit);
+        return this.getTypeReference(attrType);
+    }
+
     public MemberReferenceHandle GetIsReadOnlyAttributeCtorRef()
     {
         if (this.isReadOnlyAttributeCtorRef.HasValue)

--- a/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -240,6 +240,15 @@ public sealed class FunctionSymbol : Symbol
     /// <summary>Gets or sets a value indicating whether this function should be emitted with <c>MethodAttributes.SpecialName</c> (e.g., event accessor methods).</summary>
     public bool IsSpecialName { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether this function is the synthesized
+    /// setter of an <c>init</c>-only property (issue #946). When true the
+    /// emitter stamps the void return with the <c>IsExternalInit</c> modreq,
+    /// and the binder treats the accessor body as an init-assignment context
+    /// (so it may assign other <c>init</c>-only properties on the same instance).
+    /// </summary>
+    public bool IsInitOnlySetter { get; set; }
+
     /// <summary>Gets or sets a value indicating whether this function is declared <c>async</c> (Phase 5.1 / ADR-0023). When true, callers observe the function's return as <c>Task[T]</c> (or <c>Task</c> when no return type was declared) and the body may use <c>await</c>.</summary>
     public bool IsAsync { get; set; }
 

--- a/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
@@ -18,13 +18,14 @@ public sealed class PropertySymbol : Symbol
     /// <param name="type">The property type.</param>
     /// <param name="accessibility">The property accessibility.</param>
     /// <param name="hasGetter">Whether this property has a getter accessor.</param>
-    /// <param name="hasSetter">Whether this property has a setter accessor.</param>
+    /// <param name="hasSetter">Whether this property has a setter accessor (a <c>set</c> or an <c>init</c> accessor).</param>
     /// <param name="isAutoProperty">Whether this is an auto-property (compiler-synthesized backing field).</param>
     /// <param name="isVirtual">Whether this property is virtual (open).</param>
     /// <param name="isOverride">Whether this property overrides a base property.</param>
     /// <param name="setterParameterName">The setter parameter name (defaults to "value").</param>
     /// <param name="isStatic">Whether this property is declared inside a <c>shared</c> block (ADR-0053).</param>
     /// <param name="declaration">The declaring syntax node, or <see langword="null"/> for synthesized properties.</param>
+    /// <param name="isInitOnly">Whether the property's setter is an <c>init</c>-only accessor (issue #946).</param>
     public PropertySymbol(
         string name,
         TypeSymbol type,
@@ -36,7 +37,8 @@ public sealed class PropertySymbol : Symbol
         bool isOverride,
         string setterParameterName = "value",
         bool isStatic = false,
-        PropertyDeclarationSyntax declaration = null)
+        PropertyDeclarationSyntax declaration = null,
+        bool isInitOnly = false)
         : base(name)
     {
         Type = type;
@@ -49,6 +51,7 @@ public sealed class PropertySymbol : Symbol
         SetterParameterName = setterParameterName;
         IsStatic = isStatic;
         Declaration = declaration;
+        IsInitOnly = isInitOnly;
     }
 
     /// <inheritdoc/>
@@ -63,8 +66,19 @@ public sealed class PropertySymbol : Symbol
     /// <summary>Gets a value indicating whether this property has a getter accessor.</summary>
     public bool HasGetter { get; }
 
-    /// <summary>Gets a value indicating whether this property has a setter accessor.</summary>
+    /// <summary>Gets a value indicating whether this property has a setter accessor (a <c>set</c> or an <c>init</c> accessor).</summary>
     public bool HasSetter { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this property's setter is an
+    /// <c>init</c>-only accessor (issue #946). An init-only setter is emitted
+    /// as a <c>set_Prop</c> method whose void return carries the
+    /// <c>System.Runtime.CompilerServices.IsExternalInit</c> modreq, and
+    /// assignment is restricted to object initialization (the declaring type's
+    /// constructors, object/aggregate initializers at the creation site, and
+    /// other <c>init</c> accessors of the same instance).
+    /// </summary>
+    public bool IsInitOnly { get; }
 
     /// <summary>Gets a value indicating whether this is an auto-property (compiler-synthesized backing field).</summary>
     public bool IsAutoProperty { get; }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -2537,15 +2537,15 @@ public class Parser
             var startToken = Current;
 
             if (Current.Kind == SyntaxKind.IdentifierToken &&
-                (Current.Text == "get" || Current.Text == "set"))
+                (Current.Text == "get" || Current.Text == "set" || Current.Text == "init"))
             {
                 var accessorKeyword = NextToken();
 
-                // For set, optionally parse (paramName)
+                // For set/init, optionally parse (paramName)
                 SyntaxToken openParen = null;
                 SyntaxToken paramIdentifier = null;
                 SyntaxToken closeParen = null;
-                if (accessorKeyword.Text == "set" && Current.Kind == SyntaxKind.OpenParenthesisToken)
+                if ((accessorKeyword.Text == "set" || accessorKeyword.Text == "init") && Current.Kind == SyntaxKind.OpenParenthesisToken)
                 {
                     openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
                     paramIdentifier = MatchToken(SyntaxKind.IdentifierToken);

--- a/src/Core/CodeAnalysis/Syntax/PropertyAccessorSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/PropertyAccessorSyntax.cs
@@ -5,7 +5,7 @@
 namespace GSharp.Core.CodeAnalysis.Syntax;
 
 /// <summary>
-/// Represents a single <c>get</c> or <c>set</c> accessor inside a property body (ADR-0051).
+/// Represents a single <c>get</c>, <c>set</c>, or <c>init</c> accessor inside a property body (ADR-0051, issue #946).
 /// </summary>
 public sealed class PropertyAccessorSyntax : SyntaxNode
 {
@@ -63,4 +63,17 @@ public sealed class PropertyAccessorSyntax : SyntaxNode
 
     /// <summary>Gets a value indicating whether this accessor is a setter.</summary>
     public bool IsSetter => AccessorKeyword?.Text == "set";
+
+    /// <summary>
+    /// Gets a value indicating whether this accessor is an <c>init</c>-only
+    /// setter (issue #946). An <c>init</c> accessor is emitted as a
+    /// <c>set_Prop</c> method whose void return carries the
+    /// <c>IsExternalInit</c> modreq; assignment is restricted to object
+    /// initialization (constructors, object initializers, and other
+    /// <c>init</c> accessors).
+    /// </summary>
+    public bool IsInit => AccessorKeyword?.Text == "init";
+
+    /// <summary>Gets a value indicating whether this accessor writes the property (a <c>set</c> or an <c>init</c> accessor).</summary>
+    public bool IsSetterOrInit => IsSetter || IsInit;
 }

--- a/test/Compiler.Tests/Emit/Issue946InitOnlyPropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue946InitOnlyPropertyEmitTests.cs
@@ -1,0 +1,312 @@
+// <copyright file="Issue946InitOnlyPropertyEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #946 regression tests for the first-class <c>init</c> property
+/// accessor. The G# property forms <c>{ get; init; }</c> (auto) and
+/// <c>init { ... }</c> (computed) are exercised end-to-end:
+/// <list type="bullet">
+///   <item>an init-only property set through a C#-style object initializer at
+///   the creation site is read back at runtime;</item>
+///   <item>an init-only property set inside the declaring type's constructor is
+///   read back at runtime;</item>
+///   <item>assigning an init-only property <em>after</em> construction is a
+///   compile error (<c>GS0372</c>);</item>
+///   <item>the emitted <c>set_Prop</c> setter carries the
+///   <c>System.Runtime.CompilerServices.IsExternalInit</c> modreq on its void
+///   return — the standard CLR encoding for init-only setters.</item>
+/// </list>
+/// The run tests compile a hermetic program with <c>gsc</c> in-process, IL
+/// verify the produced assembly, and execute it with <c>dotnet exec</c>.
+/// </summary>
+public class Issue946InitOnlyPropertyEmitTests
+{
+    [Fact]
+    public void AutoInitProperty_SetViaObjectInitializer_RoundTrips()
+    {
+        var source = """
+            package P
+            import System
+
+            class Config {
+                prop Host string { get; init; }
+                prop Port int32 { get; init; }
+            }
+
+            let c = Config() { Host = "localhost", Port = 8080 }
+            Console.WriteLine(c.Host)
+            Console.WriteLine(c.Port)
+            """;
+
+        Assert.Equal("localhost\n8080\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void AutoInitProperty_SetViaConstructor_RoundTrips()
+    {
+        var source = """
+            package P
+            import System
+
+            class Person {
+                prop Name string { get; init; }
+                prop Age int32 { get; init; }
+
+                init(name string) {
+                    this.Name = name
+                    this.Age = 30
+                }
+            }
+
+            let a = Person("ctor")
+            Console.WriteLine(a.Name)
+            Console.WriteLine(a.Age)
+            """;
+
+        Assert.Equal("ctor\n30\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ComputedInitAccessor_WithBody_RunsAtInitialization()
+    {
+        var source = """
+            package P
+            import System
+
+            class Box {
+                var raw int32
+                prop Value int32 {
+                    get { return raw }
+                    init { raw = value * 2 }
+                }
+            }
+
+            let x = Box() { Value = 21 }
+            Console.WriteLine(x.Value)
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EmittedInitSetter_CarriesIsExternalInitModReq()
+    {
+        var source = """
+            package P
+            import System
+
+            class Config {
+                prop Host string { get; init; }
+                prop Port int32 { get; set; }
+            }
+
+            let c = Config() { Host = "h", Port = 1 }
+            Console.WriteLine(c.Host)
+            """;
+
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue946_modreq_").FullName;
+        try
+        {
+            var outPath = Path.Combine(tempDir, "test.dll");
+            var (exit, output) = Compile(source, outPath, tempDir);
+            Assert.True(exit == 0, $"gsc failed: {output}");
+
+            var alc = new AssemblyLoadContext("issue946-modreq", isCollectible: true);
+            try
+            {
+                var asm = alc.LoadFromAssemblyPath(outPath);
+                var configType = asm.GetTypes().FirstOrDefault(t => t.Name == "Config")
+                    ?? throw new InvalidOperationException("Config type not found");
+
+                // The init-only property's setter return must carry the
+                // IsExternalInit modreq; the plain `set;` property must not.
+                var initSetter = configType.GetProperty("Host")!.SetMethod!;
+                var initMods = initSetter.ReturnParameter.GetRequiredCustomModifiers();
+                Assert.Contains(initMods, t => t == typeof(IsExternalInit));
+
+                var plainSetter = configType.GetProperty("Port")!.SetMethod!;
+                var plainMods = plainSetter.ReturnParameter.GetRequiredCustomModifiers();
+                Assert.DoesNotContain(plainMods, t => t == typeof(IsExternalInit));
+            }
+            finally
+            {
+                alc.Unload();
+            }
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public void AssigningInitOnlyProperty_AfterConstruction_IsCompileError()
+    {
+        // Negative test: a plain assignment to an init-only G# property outside
+        // any object-initialization context must report GS0372.
+        var source = """
+            package P
+
+            class Person {
+                prop Name string { get; init; }
+            }
+
+            let a = Person()
+            a.Name = "after"
+            """;
+
+        var tree = SyntaxTree.Parse(SourceText.From(source, "issue946_negative.gs"));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream, refStream: null);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0372");
+    }
+
+    [Fact]
+    public void DeclaringBothSetAndInit_IsCompileError()
+    {
+        var source = """
+            package P
+
+            class C {
+                prop X int32 { get; set; init; }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(SourceText.From(source, "issue946_both.gs"));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream, refStream: null);
+
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0373");
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue946_").FullName;
+        try
+        {
+            var outPath = Path.Combine(tempDir, "test.dll");
+            var (exit, output) = Compile(source, outPath, tempDir);
+            Assert.True(exit == 0, $"gsc failed: {output}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    private static (int Exit, string Output) Compile(string source, string outPath, string tempDir)
+    {
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        File.WriteAllText(srcPath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+
+        foreach (var bcl in BclReferences.Value)
+        {
+            args.Add("/r:" + bcl);
+        }
+
+        args.Add(srcPath);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        return (compileExit, $"stdout:\n{compileOut}\nstderr:\n{compileErr}");
+    }
+
+    private static void TryDeleteDirectory(string dir)
+    {
+        try
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup; the OS reclaims scratch directories later.
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/PropertyParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/PropertyParserTests.cs
@@ -185,4 +185,64 @@ public class PropertyParserTests
         Assert.False(propDecl.IsIndexer);
         Assert.Empty(propDecl.Parameters);
     }
+
+    [Fact]
+    public void ParsesAutoInitProperty()
+    {
+        // Issue #946: `{ get; init; }` bodyless init accessor.
+        const string source = "package P\nclass Foo {\n  prop Name string { get; init; }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var propDecl = structDecl.Properties.Single();
+        Assert.Equal(2, propDecl.Accessors.Length);
+        Assert.True(propDecl.Accessors[0].IsGetter);
+        Assert.True(propDecl.Accessors[1].IsInit);
+        Assert.True(propDecl.Accessors[1].IsSetterOrInit);
+        Assert.False(propDecl.Accessors[1].IsSetter);
+    }
+
+    [Fact]
+    public void ParsesInitProperty_WithBody()
+    {
+        // Issue #946: `init { ... }` accessor with a block body.
+        const string source = "package P\nclass Foo {\n  var raw int32\n  prop X int32 { get { return raw } init { raw = value } }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var propDecl = structDecl.Properties.Single();
+        var initAccessor = propDecl.Accessors.Single(a => a.IsInit);
+        Assert.NotNull(initAccessor.Body);
+    }
+
+    [Fact]
+    public void ParsesInitProperty_WithExplicitParameterName()
+    {
+        // Issue #946: `init(v) { ... }` mirrors `set(v) { ... }`.
+        const string source = "package P\nclass Foo {\n  var raw int32\n  prop X int32 { get { return raw } init(v) { raw = v } }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var propDecl = structDecl.Properties.Single();
+        var initAccessor = propDecl.Accessors.Single(a => a.IsInit);
+        Assert.Equal("v", initAccessor.ParameterIdentifier.Text);
+    }
+
+    [Fact]
+    public void InitConstructor_NotConfusedWithInitAccessor()
+    {
+        // Issue #946: `init(...)` at member level is still a constructor, not a
+        // property accessor; both coexist in one class.
+        const string source = "package P\nclass Foo {\n  prop Name string { get; init; }\n  init(name string) {\n    this.Name = name\n  }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        Assert.Single(structDecl.Constructors);
+        var propDecl = structDecl.Properties.Single();
+        Assert.True(propDecl.Accessors.Single(a => a.IsInit).IsInit);
+    }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/L2TranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L2TranslationTests.cs
@@ -96,6 +96,28 @@ namespace Demo
     }
 
     /// <summary>
+    /// Issue #946: a C# <c>init</c> accessor maps to a first-class G# <c>init</c>
+    /// accessor (previously mapped to <c>set</c> with a gap diagnostic per
+    /// ADR-0115 §B.11).
+    /// </summary>
+    [Fact]
+    public void InitAccessor_TranslatesToInit()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class Config
+    {
+        public string Name { get; init; }
+    }
+}");
+
+        Assert.Contains("get;", printed);
+        Assert.Contains("init;", printed);
+        Assert.DoesNotContain("set;", printed);
+    }
+
+    /// <summary>
     /// ADR-0115 §B.15: a C# <c>with</c>-expression maps to the canonical G#
     /// <c>expr with { Field = value }</c> form (using <c>=</c>); an empty update
     /// list renders <c>expr with { }</c>.

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1108,12 +1108,13 @@ public sealed class CSharpToGSharpTranslator
 
             IReadOnlyList<AccessorDeclarationSyntax> declared = node.AccessorList.Accessors;
             bool anyBodied = declared.Any(a => a.Body != null || a.ExpressionBody != null);
-            bool hasSet = declared.Any(a =>
-                a.IsKind(SyntaxKind.SetAccessorDeclaration) || a.IsKind(SyntaxKind.InitAccessorDeclaration));
+            bool hasSet = declared.Any(a => a.IsKind(SyntaxKind.SetAccessorDeclaration));
             bool hasGet = declared.Any(a => a.IsKind(SyntaxKind.GetAccessorDeclaration));
 
             // A read-write auto-property (all accessors body-less, has get + set)
-            // maps to the canonical auto form `prop Name T` (ADR-0115 §B.11).
+            // maps to the canonical auto form `prop Name T` (ADR-0115 §B.11). An
+            // init-only auto-property (get + init) keeps its explicit accessors so
+            // the init-only semantics are preserved (issue #946).
             if (!anyBodied && hasGet && hasSet)
             {
                 return new List<PropertyAccessor>();
@@ -1129,14 +1130,8 @@ public sealed class CSharpToGSharpTranslator
                 }
                 else if (accessor.IsKind(SyntaxKind.InitAccessorDeclaration))
                 {
-                    // G# has no 'init' accessor (spec property grammar only allows
-                    // get/set); map to 'set' and record the discovered gap.
-                    this.context.Report(new TranslationDiagnostic(
-                        nameof(SyntaxKind.InitAccessorDeclaration),
-                        $"{displayName} uses an 'init' accessor; G# has no 'init' accessor, mapped to 'set' (discovered gap, ADR-0115 §B.11).",
-                        accessor.GetLocation(),
-                        TranslationSeverity.Info));
-                    kind = AccessorKind.Set;
+                    // Issue #946: G# now supports a first-class 'init' accessor.
+                    kind = AccessorKind.Init;
                 }
                 else
                 {

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -441,7 +441,7 @@ SharedMember     = Accessibility? ( MethodDecl | PropertyDecl | EventDecl | Fiel
 FieldDecl        = Accessibility? ( "var" | "let" ) identifier TypeClause ( "=" Expression )? .
 PropertyDecl     = "prop" ( identifier | IndexerHeader ) TypeClause PropertyBody? .
 IndexerHeader    = "this" "[" Parameters "]" .  (* ADR-0118: user indexer member, emitted as the CLR default `Item` property *)
-PropertyAccessor = ( "get" | "set" ( "(" identifier ")" )? ) ( Block | ";" )? .
+PropertyAccessor = ( "get" | ( "set" | "init" ) ( "(" identifier ")" )? ) ( Block | ";" )? .
 EventDecl        = "event" identifier TypeClause EventBody? .
 EventAccessor    = ( "add" | "remove" | "raise" ) ( Block | ";" )? .
 InterfaceBody    = "{" ( InterfaceMethodDecl | PropertyDecl | EventDecl )* "}" .
@@ -474,6 +474,29 @@ receiver's type arguments. An indexer declared without index parameters reports
 `GS0371`. Element **access** (`obj[i]`) currently binds single-parameter
 indexers; multi-parameter and overloaded indexers are reserved for a future
 revision.
+
+#### Init-only accessors (issue #946)
+
+A property may declare an **`init` accessor** in place of `set`, in either the
+auto-property (`prop Name string { get; init; }`) or explicit-body
+(`init { backingField = value }`) form. An `init` accessor behaves like a `set`
+accessor — it writes the property — except that it may only be invoked while the
+object is being initialized:
+
+* inside a constructor of the declaring type,
+* in an object/aggregate initializer at the creation site (`T() { Prop = v }`),
+* or from another `init` accessor of the same instance.
+
+Assigning to an init-only property anywhere else (after construction completes)
+is a compile error, `GS0372`. Reading an init-only property is always allowed.
+A property may not declare both `set` and `init` (`GS0373`), and an `init`
+accessor may not appear on a `shared` (static) property (`GS0374`).
+
+An `init` accessor is emitted as a `set_Prop` method whose `void` return carries
+the `System.Runtime.CompilerServices.IsExternalInit` required-custom-modifier
+(modreq), exactly as C# encodes init-only setters, so the accessor round-trips
+with C# and other CLR consumers. An auto-property `init;` emits a writable
+backing field plus the init-only setter.
 
 ## Expressions
 


### PR DESCRIPTION
## Summary

Implements the C# `init` property accessor as a first-class feature in G# (issue #946). Previously users emulated init-only setters with `private set;`; `init` is now a real accessor with construction-time-only assignment enforcement and correct IL encoding (`IsExternalInit` modreq), so it interops with C# and other CLR consumers.

## Design

**Parsing.** `init;` (auto) and `init { ... }` (explicit body) are accepted wherever `set`/`set;` are, in instance, static, and interface property bodies. The member-level `init(...)` constructor remains distinct — the parser disambiguates by the token following `init` (`(` means constructor; `;`/`{` means accessor).

**Binding / symbols.** An `init` accessor is modeled as a setter (`HasSetter=true`) carrying `PropertySymbol.IsInitOnly=true`, and the synthesized setter `FunctionSymbol` is marked `IsInitOnlySetter`. This reuses all existing "is assignable" logic (object initializers, auto-property backing field writability) and layers the init-only restriction on top. Assignment to an init-only property is allowed **only**:

- inside a constructor of the declaring type,
- in an object/aggregate initializer at the creation site (`T() { Prop = v }`), or
- from another `init` accessor of the same instance.

Any other assignment (after construction) reports **GS0372**. Declaring both `set` and `init` reports **GS0373**; an `init` accessor on a static property reports **GS0374**. Reading is always allowed. CLR-imported init-only properties go through a different bind path and are unaffected (no regression to #522).

**Emit.** The accessor is emitted as `set_Prop` whose `void` return carries the `System.Runtime.CompilerServices.IsExternalInit` required-custom-modifier (modreq), exactly as C# encodes init-only setters. `IsExternalInit` is resolved from the target references with a `typeof(...)` fallback (the repo targets net10, where it ships in `System.Runtime`). Auto-property `init;` emits a writable backing field plus the init-only setter. IL is verifiable; a value set via `init` is readable at runtime.

**cs2gs.** A C# `init` accessor now translates to the G# `init` accessor (previously mapped to `set` with an Info gap diagnostic, ADR-0115 §B.11). An init-only auto-property `{ get; init; }` keeps its explicit accessors instead of collapsing to the read-write `prop Name T` auto form (which would lose the init-only semantics).

## Files changed by area

- **Parser/syntax:** `Parser.cs`, `PropertyAccessorSyntax.cs`
- **Symbols:** `PropertySymbol.cs`, `FunctionSymbol.cs`
- **Binding/diagnostics:** `DeclarationBinder.cs`, `ExpressionBinder.Assignments.cs`, `StatementBinder.cs`, `DiagnosticBag.cs`
- **Emit:** `MemberDefEmitter.cs`, `WellKnownReferences.cs`
- **cs2gs:** `CSharpToGSharpTranslator.cs` (printer/`AccessorKind` already supported), translator test
- **Docs:** `website/docs/ref/spec.md`, `docs/adr/0115-csharp-to-gsharp-migration-tool.md`
- **Tests:** `test/Compiler.Tests/Emit/Issue946InitOnlyPropertyEmitTests.cs`, `test/Core.Tests/CodeAnalysis/Syntax/PropertyParserTests.cs`, `tools/cs2gs/Cs2Gs.Tests/L2TranslationTests.cs`

## Tests

- Auto `{ get; init; }` set via object initializer at creation and read back (compiles and runs).
- Auto `{ get; init; }` set via constructor and read back (compiles and runs).
- Explicit `init { ... }` body computed setter (compiles and runs).
- Emitted setter carries the `IsExternalInit` modreq (reflection assertion on the emitted assembly).
- Negative: assigning the init-only property after construction is a compile error (**GS0372**).
- Negative: declaring both `set` and `init` (**GS0373**).
- Parser unit tests for `init;` and `init { }`, and that `init(...)` ctor is not confused with the accessor.
- cs2gs: C# `init` accessor translates to G# `init`.

All targeted Issue946 tests pass; existing property tests (88), Issue522 (5), cs2gs (112), and full Core.Tests (3437) remain green. Full `dotnet build GSharp.sln -c Release -graph` builds with **0 warnings** (TreatWarningsAsErrors on).

Fixes #946
