### PR TITLE
Inline field initializers in type bodies (#948)

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -82,6 +82,8 @@ The immutability decision is driven by Roslyn's definite-assignment/data-flow an
 
 When **every** constructor parameter is consumed by exactly one direct `_f = param` assignment, the explicit constructor is **dropped entirely** (its remaining `_f = expr` statements have all become field initializers). If any statement does not fit the pattern (a non-assignment statement, a parameter used in an expression, a duplicate/unconsumed parameter, multiple constructors, a record) the constructor is left untouched and translated as-is — and, since issue #947, the resulting `let` field assigned inside the explicit `init(...)` is now **valid, compiling G#** rather than a `GS0127` error. Chosen over option (b) (a privacy-preserving `var` field) because for L1 the primary-constructor form yields clean, idiomatic G# when liftable; the public-visibility change is recorded for the human to review.
 
+Since issue #948, the inline field initializers the translator emits here — `private let _f T = expr` from a lifted constructor assignment, a `var`/`let` field carrying a C# field initializer, and `const _f T = expr` from a C# `const` field — are **directly compiling G#**: the G# compiler honors inline `const`/`let`/`var` field initializers in a type body, running instance initializers before each constructor body and folding `const` initializers to compile-time literal fields. No constructor-assignment workaround is needed for these forms.
+
 #### B.4 `class` vs `struct` vs `data class` vs `data struct` — ADR-0029, ADR-0025, ADR-0078, spec §Structs…
 
 | C# | G# |

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -476,7 +476,7 @@ See [ADR-0067](adr/0067-fields-require-var-keyword.md). Field declarations insid
 
 | ID | Severity | Description | Example trigger |
 |----|----------|-------------|-----------------|
-| GS0288 | Error | Field declarations require a `var` (mutable) or `let` (read-only) keyword. | `struct Point { X int32 }` — must be written as `var X int32` (mutable) or `let X int32` (read-only). |
+| GS0288 | Error | Field declarations require a `var` (mutable), `let` (read-only), or `const` (compile-time constant) keyword. | `struct Point { X int32 }` — must be written as `var X int32` (mutable), `let X int32` (read-only), or `const X int32 = …` (constant). |
 
 ## Class destructor diagnostics (GS0289–GS0292)
 
@@ -669,6 +669,18 @@ the ECMA-335 II.23.4 FieldMarshal blob encoding for each accepted form,
 and the interaction with ADR-0086 (`@DllImport`), ADR-0092
 (`@LibraryImport`), ADR-0093 (struct marshalling), ADR-0094 (ref/out/in),
 and ADR-0095 (function pointers).
+
+## Inline field initializer diagnostics (GS0375–GS0377)
+
+Issue #948 added inline `const`/`let`/`var` field initializers (`= expr` on a
+field declaration in a type body). The following diagnostics enforce their
+constraints.
+
+| ID | Severity | Summary |
+| --- | --- | --- |
+| GS0375 | Error | A `const` field requires an initializer (e.g. `const X int32 = 10`). |
+| GS0376 | Error | A `const` field initializer must be a compile-time constant expression. |
+| GS0377 | Error | A field initializer cannot reference the instance member or constructor parameter `{name}` (initializers run before the constructor body, so `this` is not available — assign it in an `init(...)` constructor instead). |
 
 ## Internal compiler error diagnostics (GS9998–GS9999)
 

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -403,6 +403,25 @@ public sealed class Binder
                     }
                 }
 
+                // Issue #948: const fields are static for bare-name resolution
+                // inside the declaring type's members. Their reads are inlined
+                // as the compile-time constant value by the emitter/interpreter.
+                if (!ownerStruct.ConstFields.IsDefaultOrEmpty)
+                {
+                    foreach (var fld in ownerStruct.ConstFields)
+                    {
+                        if (paramNames.Contains(fld.Name) || seenMembers.Contains(fld.Name))
+                        {
+                            continue;
+                        }
+
+                        if (seenMembers.Add(fld.Name))
+                        {
+                            scope.TryDeclareVariable(new ImplicitStaticFieldVariableSymbol(ownerStruct, fld));
+                        }
+                    }
+                }
+
                 if (!ownerStruct.StaticProperties.IsDefaultOrEmpty)
                 {
                     foreach (var prop in ownerStruct.StaticProperties)

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -461,6 +461,12 @@ internal sealed class DeclarationBinder
         // symbol exists) and emit them into every constructor body.
         var pendingInstanceInitializers = new List<(FieldSymbol Field, ExpressionSyntax InitSyntax, TypeSymbol FieldType)>();
 
+        // Issue #948: const fields declared in the type body are implicitly
+        // static literal fields. They are diverted out of the instance field
+        // list and bound (folded to a constant) after the struct symbol exists.
+        var constFieldsBuilder = ImmutableArray.CreateBuilder<FieldSymbol>();
+        var pendingConstInitializers = new List<(FieldSymbol Field, FieldDeclarationSyntax Syntax, TypeSymbol FieldType)>();
+
         foreach (var fieldSyntax in syntax.Fields)
         {
             var fieldName = fieldSyntax.Identifier.Text;
@@ -495,6 +501,37 @@ internal sealed class DeclarationBinder
             }
 
             var fieldAccessibility = resolveAccessibility(fieldSyntax.AccessibilityModifier);
+
+            // Issue #948: a `const` field is a compile-time constant — it is
+            // implicitly static and read-only and emitted as a literal field.
+            if (fieldSyntax.IsConst)
+            {
+                var constFieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: true, isStatic: true, isConst: true);
+                Binder.AttachDocumentation(constFieldSymbol, fieldSyntax);
+
+                if (!fieldSyntax.Annotations.IsDefaultOrEmpty)
+                {
+                    constFieldSymbol.SetAttributes(BindAttributes(
+                        fieldSyntax.Annotations,
+                        AttributeTargetKind.Field,
+                        Binder.FieldDeclarationAllowedTargets,
+                        "a field declaration",
+                        System.AttributeTargets.Field));
+                }
+
+                if (fieldSyntax.Initializer == null)
+                {
+                    Diagnostics.ReportConstFieldRequiresInitializer(fieldSyntax.Identifier.Location, fieldName);
+                }
+                else
+                {
+                    pendingConstInitializers.Add((constFieldSymbol, fieldSyntax, fieldType));
+                }
+
+                constFieldsBuilder.Add(constFieldSymbol);
+                continue;
+            }
+
             var fieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: syntax.IsInline || fieldSyntax.IsReadOnly);
             Binder.AttachDocumentation(fieldSymbol, fieldSyntax);
 
@@ -763,15 +800,57 @@ internal sealed class DeclarationBinder
         // instance-field initializer expressions and install them on the symbol.
         if (pendingInstanceInitializers.Count > 0)
         {
+            // Issue #948: an instance field initializer runs before the
+            // constructor body, so it cannot reference `this`, other instance
+            // members, or constructor parameters (matching C#). Collect the
+            // forbidden names so we can report a precise diagnostic.
+            var instanceMemberNames = new HashSet<string>(System.StringComparer.Ordinal) { "this" };
+            foreach (var f in fields)
+            {
+                instanceMemberNames.Add(f.Name);
+            }
+
+            foreach (var p in primaryCtorParameters)
+            {
+                instanceMemberNames.Add(p.Name);
+            }
+
             var instanceInitBuilder = ImmutableDictionary.CreateBuilder<FieldSymbol, BoundExpression>();
             foreach (var (fieldSym, initSyntax, fieldType) in pendingInstanceInitializers)
             {
+                if (TryFindInstanceMemberReference(initSyntax, instanceMemberNames, out var offendingName, out var offendingLocation))
+                {
+                    Diagnostics.ReportFieldInitializerCannotReferenceInstanceMember(offendingLocation, offendingName);
+                    continue;
+                }
+
                 var boundInit = bindExpression(initSyntax);
                 var convertedInit = conversions.BindConversion(initSyntax.Location, boundInit, fieldType);
                 instanceInitBuilder[fieldSym] = convertedInit;
             }
 
             structSymbol.SetInstanceFieldInitializers(instanceInitBuilder.ToImmutable());
+        }
+
+        // Issue #948: bind and fold the deferred const-field initializers to a
+        // compile-time constant, then install the const fields on the symbol.
+        if (constFieldsBuilder.Count > 0)
+        {
+            foreach (var (constField, fieldSyntaxNode, fieldType) in pendingConstInitializers)
+            {
+                var boundInit = bindExpression(fieldSyntaxNode.Initializer);
+                var convertedInit = conversions.BindConversion(fieldSyntaxNode.Initializer.Location, boundInit, fieldType);
+                if (TryFoldConstantFieldValue(convertedInit, fieldType, out var constantValue))
+                {
+                    constField.SetConstantValue(constantValue);
+                }
+                else if (boundInit is not BoundErrorExpression && convertedInit is not BoundErrorExpression)
+                {
+                    Diagnostics.ReportConstFieldInitializerNotConstant(fieldSyntaxNode.Initializer.Location, constField.Name);
+                }
+            }
+
+            structSymbol.SetConstFields(constFieldsBuilder.ToImmutable());
         }
 
         if (!scope.TryDeclareTypeAlias(name, structSymbol))
@@ -1433,6 +1512,7 @@ internal sealed class DeclarationBinder
         {
             // Static fields
             var staticFieldsBuilder = ImmutableArray.CreateBuilder<FieldSymbol>();
+            var sharedConstFieldsBuilder = ImmutableArray.CreateBuilder<FieldSymbol>();
             var initializersBuilder = ImmutableDictionary.CreateBuilder<FieldSymbol, BoundExpression>();
             foreach (var fieldSyntax in syntax.SharedBlock.Fields)
             {
@@ -1465,6 +1545,47 @@ internal sealed class DeclarationBinder
                 }
 
                 var fieldAccessibility = resolveAccessibility(fieldSyntax.AccessibilityModifier);
+
+                // Issue #948: a `const` declared inside a `shared` block is also
+                // a compile-time constant literal field (const is implicitly
+                // static, so `shared` is redundant but accepted).
+                if (fieldSyntax.IsConst)
+                {
+                    var sharedConstField = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: true, isStatic: true, isConst: true);
+                    Binder.AttachDocumentation(sharedConstField, fieldSyntax);
+
+                    if (!fieldSyntax.Annotations.IsDefaultOrEmpty)
+                    {
+                        sharedConstField.SetAttributes(BindAttributes(
+                            fieldSyntax.Annotations,
+                            AttributeTargetKind.Field,
+                            Binder.FieldDeclarationAllowedTargets,
+                            "a field declaration",
+                            System.AttributeTargets.Field));
+                    }
+
+                    if (fieldSyntax.Initializer == null)
+                    {
+                        Diagnostics.ReportConstFieldRequiresInitializer(fieldSyntax.Identifier.Location, fieldName);
+                    }
+                    else
+                    {
+                        var boundConst = bindExpression(fieldSyntax.Initializer);
+                        var convertedConst = conversions.BindConversion(fieldSyntax.Initializer.Location, boundConst, fieldType);
+                        if (TryFoldConstantFieldValue(convertedConst, fieldType, out var sharedConstValue))
+                        {
+                            sharedConstField.SetConstantValue(sharedConstValue);
+                        }
+                        else if (boundConst is not BoundErrorExpression && convertedConst is not BoundErrorExpression)
+                        {
+                            Diagnostics.ReportConstFieldInitializerNotConstant(fieldSyntax.Initializer.Location, fieldName);
+                        }
+                    }
+
+                    sharedConstFieldsBuilder.Add(sharedConstField);
+                    continue;
+                }
+
                 var fieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: fieldSyntax.IsReadOnly, isStatic: true);
 
                 if (!fieldSyntax.Annotations.IsDefaultOrEmpty)
@@ -1494,6 +1615,13 @@ internal sealed class DeclarationBinder
             if (initializersBuilder.Count > 0)
             {
                 structSymbol.SetStaticFieldInitializers(initializersBuilder.ToImmutable());
+            }
+
+            // Issue #948: merge any const fields declared inside the shared block
+            // with the body-level const fields already installed on the symbol.
+            if (sharedConstFieldsBuilder.Count > 0)
+            {
+                structSymbol.SetConstFields(structSymbol.ConstFields.AddRange(sharedConstFieldsBuilder.ToImmutable()));
             }
 
             // Static methods
@@ -2549,6 +2677,251 @@ internal sealed class DeclarationBinder
         }
 
         return $"{method.Name}({string.Join(", ", names)})";
+    }
+
+    /// <summary>
+    /// Issue #948: scans an instance field initializer expression for a
+    /// reference to <c>this</c>, another instance member, or a constructor
+    /// parameter. Such references are illegal because instance field
+    /// initializers run before the constructor body (matching C#).
+    /// </summary>
+    /// <param name="node">The initializer expression syntax to scan.</param>
+    /// <param name="forbiddenNames">Instance member and constructor parameter names.</param>
+    /// <param name="offendingName">The first offending name found.</param>
+    /// <param name="offendingLocation">The location of the first offending reference.</param>
+    /// <returns>True when an illegal reference was found.</returns>
+    private static bool TryFindInstanceMemberReference(
+        SyntaxNode node,
+        HashSet<string> forbiddenNames,
+        out string offendingName,
+        out TextLocation offendingLocation)
+    {
+        if (node is NameExpressionSyntax nameExpr &&
+            forbiddenNames.Contains(nameExpr.IdentifierToken.Text))
+        {
+            offendingName = nameExpr.IdentifierToken.Text;
+            offendingLocation = nameExpr.IdentifierToken.Location;
+            return true;
+        }
+
+        foreach (var child in node.GetChildren())
+        {
+            if (TryFindInstanceMemberReference(child, forbiddenNames, out offendingName, out offendingLocation))
+            {
+                return true;
+            }
+        }
+
+        offendingName = null;
+        offendingLocation = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #948: attempts to fold a bound const-field initializer to a
+    /// compile-time constant value coerced to the field's CLR primitive type.
+    /// Handles literal expressions (optionally wrapped in numeric/identity
+    /// conversions) and unary negation of a numeric literal. Returns
+    /// <c>false</c> for non-constant expressions so the caller can report a
+    /// diagnostic.
+    /// </summary>
+    /// <param name="bound">The bound (already type-converted) initializer expression.</param>
+    /// <param name="fieldType">The declared const field type.</param>
+    /// <param name="value">The folded constant value on success.</param>
+    /// <returns>True when a compile-time constant was produced.</returns>
+    private static bool TryFoldConstantFieldValue(BoundExpression bound, TypeSymbol fieldType, out object value)
+    {
+        value = null;
+        if (!TryEvaluateConstant(bound, out var raw))
+        {
+            return false;
+        }
+
+        if (raw == null)
+        {
+            // A null literal is only valid for reference-typed const fields
+            // (e.g. `const s string = nil`); the Constant row stores a null.
+            value = null;
+            return !fieldType.ClrType?.IsValueType ?? true;
+        }
+
+        var targetClr = fieldType.ClrType;
+        if (targetClr == null)
+        {
+            return false;
+        }
+
+        if (targetClr.IsEnum)
+        {
+            targetClr = System.Enum.GetUnderlyingType(targetClr);
+        }
+
+        try
+        {
+            value = targetClr == raw.GetType()
+                ? raw
+                : System.Convert.ChangeType(raw, targetClr, System.Globalization.CultureInfo.InvariantCulture);
+            return true;
+        }
+        catch (System.Exception ex) when (ex is System.InvalidCastException or System.FormatException or System.OverflowException or System.ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Issue #948: evaluates a bound expression to a compile-time constant
+    /// (a literal, a conversion over a constant, or a unary +/- over a numeric
+    /// constant). Returns <c>false</c> for any non-constant shape.
+    /// </summary>
+    /// <param name="bound">The bound expression.</param>
+    /// <param name="value">The constant value on success.</param>
+    /// <returns>True when the expression is a compile-time constant.</returns>
+    private static bool TryEvaluateConstant(BoundExpression bound, out object value)
+    {
+        switch (bound)
+        {
+            case BoundLiteralExpression lit:
+                value = lit.Value;
+                return true;
+
+            case BoundConversionExpression conv:
+                return TryEvaluateConstant(conv.Expression, out value);
+
+            case BoundUnaryExpression unary
+                when unary.Op.Kind is BoundUnaryOperatorKind.Negation or BoundUnaryOperatorKind.Identity
+                && TryEvaluateConstant(unary.Operand, out var operand)
+                && operand != null:
+                value = NegateIfNeeded(operand, unary.Op.Kind == BoundUnaryOperatorKind.Negation);
+                return value != null;
+
+            case BoundBinaryExpression binary
+                when TryEvaluateConstant(binary.Left, out var left)
+                && TryEvaluateConstant(binary.Right, out var right)
+                && left != null
+                && right != null:
+                value = FoldBinary(binary.Op.Kind, left, right);
+                return value != null;
+
+            default:
+                value = null;
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Issue #948: folds a binary operation over two constant operands. Supports
+    /// the constant-expression forms allowed in C# const initializers that the
+    /// const-field feature commonly needs: numeric arithmetic and string
+    /// concatenation. Returns <c>null</c> for unsupported shapes.
+    /// </summary>
+    private static object FoldBinary(BoundBinaryOperatorKind kind, object left, object right)
+    {
+        if (left is string || right is string)
+        {
+            return kind == BoundBinaryOperatorKind.Sum ? string.Concat(left, right) : null;
+        }
+
+        if (left is decimal || right is decimal)
+        {
+            if (!TryToDecimal(left, out var ld) || !TryToDecimal(right, out var rd))
+            {
+                return null;
+            }
+
+            return kind switch
+            {
+                BoundBinaryOperatorKind.Sum => ld + rd,
+                BoundBinaryOperatorKind.Difference => ld - rd,
+                BoundBinaryOperatorKind.Product => ld * rd,
+                BoundBinaryOperatorKind.Quotient when rd != 0 => ld / rd,
+                _ => (object)null,
+            };
+        }
+
+        if (left is double || left is float || right is double || right is float)
+        {
+            var ld = System.Convert.ToDouble(left, System.Globalization.CultureInfo.InvariantCulture);
+            var rd = System.Convert.ToDouble(right, System.Globalization.CultureInfo.InvariantCulture);
+            return kind switch
+            {
+                BoundBinaryOperatorKind.Sum => ld + rd,
+                BoundBinaryOperatorKind.Difference => ld - rd,
+                BoundBinaryOperatorKind.Product => ld * rd,
+                BoundBinaryOperatorKind.Quotient when rd != 0 => ld / rd,
+                _ => (object)null,
+            };
+        }
+
+        if (!TryToInt64(left, out var li) || !TryToInt64(right, out var ri))
+        {
+            return null;
+        }
+
+        return kind switch
+        {
+            BoundBinaryOperatorKind.Sum => li + ri,
+            BoundBinaryOperatorKind.Difference => li - ri,
+            BoundBinaryOperatorKind.Product => li * ri,
+            BoundBinaryOperatorKind.Quotient when ri != 0 => li / ri,
+            BoundBinaryOperatorKind.Remainder when ri != 0 => li % ri,
+            BoundBinaryOperatorKind.ShiftLeft => li << (int)ri,
+            BoundBinaryOperatorKind.ShiftRight => li >> (int)ri,
+            BoundBinaryOperatorKind.BitwiseAnd => li & ri,
+            BoundBinaryOperatorKind.BitwiseOr => li | ri,
+            BoundBinaryOperatorKind.BitwiseXor => li ^ ri,
+            _ => (object)null,
+        };
+    }
+
+    private static bool TryToInt64(object value, out long result)
+    {
+        switch (value)
+        {
+            case int or long or short or sbyte or byte or ushort or uint:
+                result = System.Convert.ToInt64(value, System.Globalization.CultureInfo.InvariantCulture);
+                return true;
+            case char c:
+                result = c;
+                return true;
+            default:
+                result = 0;
+                return false;
+        }
+    }
+
+    private static bool TryToDecimal(object value, out decimal result)
+    {
+        try
+        {
+            result = System.Convert.ToDecimal(value, System.Globalization.CultureInfo.InvariantCulture);
+            return true;
+        }
+        catch (System.Exception ex) when (ex is System.InvalidCastException or System.FormatException or System.OverflowException)
+        {
+            result = 0;
+            return false;
+        }
+    }
+
+    private static object NegateIfNeeded(object operand, bool negate)
+    {
+        if (!negate)
+        {
+            return operand;
+        }
+
+        return operand switch
+        {
+            int i => -i,
+            long l => -l,
+            short s => -s,
+            sbyte sb => -sb,
+            float f => -f,
+            double d => -d,
+            decimal m => -m,
+            _ => null,
+        };
     }
 
     private static string GetBaseClauseTypeDisplayName(TypeClauseSyntax typeClause)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -557,6 +557,30 @@ internal sealed partial class ExpressionBinder
             inits.Add(new BoundFieldInitializer(field, valueExpr));
         }
 
+        // Issue #948: a value-type (struct / data struct) composite literal
+        // zero-initializes the storage and then assigns the listed fields. For
+        // a value type there is no constructor that could run inline field
+        // initializers, so apply each declared `= expr` initializer here for any
+        // field the literal omitted. (For class/data-class literals the
+        // synthesized default constructor — invoked by `newobj` — already runs
+        // the instance field initializers, so this only applies to value types.)
+        if (!structSymbol.IsClass && !structSymbol.InstanceFieldInitializers.IsEmpty)
+        {
+            foreach (var field in structSymbol.Fields)
+            {
+                if (seenFieldNames.Contains(field.Name))
+                {
+                    continue;
+                }
+
+                if (structSymbol.InstanceFieldInitializers.TryGetValue(field, out var initExpr))
+                {
+                    inits.Add(new BoundFieldInitializer(field, initExpr));
+                    seenFieldNames.Add(field.Name);
+                }
+            }
+        }
+
         return new BoundStructLiteralExpression(null, structSymbol, inits.ToImmutable());
     }
 

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -961,8 +961,45 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     /// <param name="location">The location of the offending token.</param>
     public void ReportFieldDeclarationRequiresVarOrLet(TextLocation location)
     {
-        var message = "Field declarations require a 'var' (mutable) or 'let' (read-only) keyword.";
+        var message = "Field declarations require a 'var' (mutable), 'let' (read-only), or 'const' (compile-time constant) keyword.";
         Report(location, "GS0288", message);
+    }
+
+    /// <summary>
+    /// Issue #948: a <c>const</c> field must be given an initializer (a
+    /// compile-time constant value). Reported when a <c>const</c> field
+    /// declaration omits the <c>= expr</c> initializer.
+    /// </summary>
+    /// <param name="location">The location of the const field identifier.</param>
+    /// <param name="name">The const field name.</param>
+    public void ReportConstFieldRequiresInitializer(TextLocation location, string name)
+    {
+        Report(location, "GS0375", $"Const field '{name}' must have a compile-time constant initializer (e.g. 'const {name} T = value').");
+    }
+
+    /// <summary>
+    /// Issue #948: a <c>const</c> field initializer must be a compile-time
+    /// constant expression. Reported when the bound initializer cannot be
+    /// folded to a literal value.
+    /// </summary>
+    /// <param name="location">The location of the offending initializer.</param>
+    /// <param name="name">The const field name.</param>
+    public void ReportConstFieldInitializerNotConstant(TextLocation location, string name)
+    {
+        Report(location, "GS0376", $"The initializer for const field '{name}' must be a compile-time constant expression.");
+    }
+
+    /// <summary>
+    /// Issue #948: an instance field initializer (the <c>= expr</c> on a
+    /// <c>let</c>/<c>var</c> field) runs before the constructor body and
+    /// therefore cannot reference <c>this</c>, other instance members, or
+    /// constructor parameters — matching C# field-initializer rules.
+    /// </summary>
+    /// <param name="location">The location of the offending reference.</param>
+    /// <param name="memberName">The referenced instance member / parameter name.</param>
+    public void ReportFieldInitializerCannotReferenceInstanceMember(TextLocation location, string memberName)
+    {
+        Report(location, "GS0377", $"A field initializer cannot reference the instance member or constructor parameter '{memberName}' (field initializers run before the constructor body, so 'this' is not available). Assign it in an 'init(...)' constructor instead.");
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -386,6 +386,15 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitFieldAccess(BoundFieldAccessExpression fa)
     {
+        // Issue #948: a const field has no runtime storage — its read is
+        // inlined as the compile-time constant value (matching C# semantics
+        // and the literal field's lack of an ldsfld-able location).
+        if (fa.Field.IsConst)
+        {
+            this.EmitLiteral(new BoundLiteralExpression(null, fa.Field.ConstantValue, fa.Field.Type));
+            return;
+        }
+
         // ADR-0087 §3 R3+R4: when the receiver is a constructed
         // generic user type, the ldfld must reference the field via
         // a MemberRef parented at the TypeSpec. With the field

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -288,6 +288,33 @@ internal sealed class TypeDefEmitter
             }
         }
 
+        // Issue #948: emit const fields as CLR literal fields (Static | Literal
+        // | HasDefault) carrying a Constant row. Their reads are inlined by the
+        // method-body emitter, so no .cctor assignment is generated.
+        if (!structSym.ConstFields.IsDefaultOrEmpty)
+        {
+            foreach (var constField in structSym.ConstFields)
+            {
+                var sigBlob = new BlobBuilder();
+                this.encodeTypeSymbol(new BlobEncoder(sigBlob).FieldSignature(), constField.Type);
+                var attrs = AccessibilityMap.MapFieldAccessibility(constField.Accessibility)
+                    | FieldAttributes.Static | FieldAttributes.Literal | FieldAttributes.HasDefault;
+
+                var handle = this.emitCtx.Metadata.AddFieldDefinition(
+                    attributes: attrs,
+                    name: this.emitCtx.Metadata.GetOrAddString(constField.Name),
+                    signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+                if (firstField.IsNil)
+                {
+                    firstField = handle;
+                }
+
+                this.emitCtx.Metadata.AddConstant(handle, constField.ConstantValue);
+                this.cache.StructFieldDefs[constField] = handle;
+                this.emitUserAttributes(handle, constField, AttributeTargetKind.Field);
+            }
+        }
+
         // Issue #263: emit backing FieldDefs for static auto-properties.
         foreach (var prop in structSym.StaticProperties)
         {

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -435,6 +435,25 @@ public sealed class Lowerer : BoundTreeRewriter
     }
 
     /// <inheritdoc/>
+    /// <summary>
+    /// Issue #948: a <c>const</c> field read has no runtime storage — inline it
+    /// as the compile-time constant literal so all downstream paths (value
+    /// loads, value-type method-call receivers needing an address, etc.) treat
+    /// it uniformly. Matches C# const-read semantics.
+    /// </summary>
+    /// <param name="node">The field-access node.</param>
+    /// <returns>A literal for const fields; otherwise the base rewrite.</returns>
+    protected override BoundExpression RewriteFieldAccessExpression(BoundFieldAccessExpression node)
+    {
+        if (node.Field.IsConst)
+        {
+            return new BoundLiteralExpression(null, node.Field.ConstantValue, node.Field.Type);
+        }
+
+        return base.RewriteFieldAccessExpression(node);
+    }
+
+    /// <inheritdoc/>
     protected override BoundExpression RewritePropertyAccessExpression(BoundPropertyAccessExpression node)
     {
         // ADR-0051: auto-properties lower to backing field access, but ONLY when

--- a/src/Core/CodeAnalysis/Symbols/FieldSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FieldSymbol.cs
@@ -17,13 +17,15 @@ public sealed class FieldSymbol : Symbol
     /// <param name="accessibility">The field accessibility.</param>
     /// <param name="isReadOnly">True when the field is init-only after construction.</param>
     /// <param name="isStatic">True when the field is declared inside a <c>shared</c> block (ADR-0053).</param>
-    public FieldSymbol(string name, TypeSymbol type, Accessibility accessibility, bool isReadOnly = false, bool isStatic = false)
+    /// <param name="isConst">True when the field is a compile-time constant declared with <c>const</c> (Issue #948). Const fields are implicitly static and read-only and emitted as literal fields.</param>
+    public FieldSymbol(string name, TypeSymbol type, Accessibility accessibility, bool isReadOnly = false, bool isStatic = false, bool isConst = false)
         : base(name)
     {
         Type = type;
         Accessibility = accessibility;
         IsReadOnly = isReadOnly;
         IsStatic = isStatic;
+        IsConst = isConst;
     }
 
     /// <inheritdoc/>
@@ -42,6 +44,23 @@ public sealed class FieldSymbol : Symbol
     public bool IsStatic { get; }
 
     /// <summary>
+    /// Gets a value indicating whether this field is a compile-time constant
+    /// declared with <c>const</c> (Issue #948). A const field is implicitly
+    /// static and read-only, is emitted as a CLR <c>literal</c> field carrying
+    /// a <c>Constant</c> row, and its reads are inlined as the literal
+    /// <see cref="ConstantValue"/> rather than a field load.
+    /// </summary>
+    public bool IsConst { get; }
+
+    /// <summary>
+    /// Gets the compile-time constant value for a <see cref="IsConst"/> field
+    /// (Issue #948), or <c>null</c> for non-const fields. The binder folds the
+    /// field initializer to a literal and writes it here; the emitter uses it
+    /// to add the <c>Constant</c> metadata row and to inline const-field reads.
+    /// </summary>
+    public object ConstantValue { get; private set; }
+
+    /// <summary>
     /// Gets the explicit byte offset declared via <c>@FieldOffset(N)</c>
     /// (ADR-0093 / issue #759), or <c>null</c> when the field uses the
     /// default sequential layout. Only valid on fields of types declared
@@ -51,6 +70,16 @@ public sealed class FieldSymbol : Symbol
     /// <c>FieldLayout</c> row.
     /// </summary>
     public int? ExplicitOffset { get; private set; }
+
+    /// <summary>
+    /// Sets the <see cref="ConstantValue"/> for a const field. Intended to be
+    /// called once by the binder after folding the initializer to a literal.
+    /// </summary>
+    /// <param name="value">The compile-time constant value.</param>
+    public void SetConstantValue(object value)
+    {
+        ConstantValue = value;
+    }
 
     /// <summary>
     /// Sets the resolved <see cref="ExplicitOffset"/>. Intended to be

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -222,6 +222,16 @@ public sealed class StructSymbol : TypeSymbol
     /// <summary>Gets the static fields declared inside a <c>shared</c> block (ADR-0053). Populated by the binder; defaults to empty.</summary>
     public ImmutableArray<FieldSymbol> StaticFields { get; private set; } = ImmutableArray<FieldSymbol>.Empty;
 
+    /// <summary>
+    /// Gets the compile-time constant fields declared with <c>const</c>
+    /// (Issue #948). Const fields are implicitly static and read-only; they are
+    /// emitted as CLR <c>literal</c> fields with a <c>Constant</c> row and their
+    /// reads are inlined. Held separately from <see cref="StaticFields"/> so the
+    /// emitter never produces a runtime static field or a <c>.cctor</c>
+    /// assignment for them. Populated by the binder; defaults to empty.
+    /// </summary>
+    public ImmutableArray<FieldSymbol> ConstFields { get; private set; } = ImmutableArray<FieldSymbol>.Empty;
+
     /// <summary>Gets the static methods declared inside a <c>shared</c> block (ADR-0053). Populated by the binder; defaults to empty.</summary>
     public ImmutableArray<FunctionSymbol> StaticMethods { get; private set; } = ImmutableArray<FunctionSymbol>.Empty;
 
@@ -426,6 +436,13 @@ public sealed class StructSymbol : TypeSymbol
         StaticFields = fields;
     }
 
+    /// <summary>Sets <see cref="ConstFields"/> after binding <c>const</c> field declarations (Issue #948).</summary>
+    /// <param name="fields">The bound const field symbols owned by this type.</param>
+    public void SetConstFields(ImmutableArray<FieldSymbol> fields)
+    {
+        ConstFields = fields;
+    }
+
     /// <summary>Sets <see cref="StaticMethods"/> after binding shared-block method declarations (ADR-0053).</summary>
     /// <param name="methods">The bound static method symbols owned by this type.</param>
     public void SetStaticMethods(ImmutableArray<FunctionSymbol> methods)
@@ -470,6 +487,20 @@ public sealed class StructSymbol : TypeSymbol
         if (!StaticFields.IsDefaultOrEmpty)
         {
             foreach (var f in StaticFields)
+            {
+                if (f.Name == name)
+                {
+                    field = f;
+                    return true;
+                }
+            }
+        }
+
+        // Issue #948: const fields are static for lookup purposes (accessed as
+        // `Type.Name`), even though they are emitted as literal fields.
+        if (!ConstFields.IsDefaultOrEmpty)
+        {
+            foreach (var f in ConstFields)
             {
                 if (f.Name == name)
                 {

--- a/src/Core/CodeAnalysis/Syntax/FieldDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/FieldDeclarationSyntax.cs
@@ -68,9 +68,20 @@ public sealed class FieldDeclarationSyntax : SyntaxNode
 
     /// <summary>
     /// Gets a value indicating whether this field was declared with the
-    /// <c>let</c> keyword and is therefore read-only (ADR-0067).
+    /// <c>let</c> keyword and is therefore read-only (ADR-0067). A
+    /// <c>const</c> field (Issue #948) is also read-only; see
+    /// <see cref="IsConst"/>.
     /// </summary>
-    public bool IsReadOnly => VarOrLetKeyword != null && VarOrLetKeyword.Kind == SyntaxKind.LetKeyword;
+    public bool IsReadOnly => VarOrLetKeyword != null
+        && (VarOrLetKeyword.Kind == SyntaxKind.LetKeyword || VarOrLetKeyword.Kind == SyntaxKind.ConstKeyword);
+
+    /// <summary>
+    /// Gets a value indicating whether this field was declared with the
+    /// <c>const</c> keyword (Issue #948) and is therefore a compile-time
+    /// constant: implicitly static, read-only, and emitted as a literal
+    /// field whose initializer must be a constant expression.
+    /// </summary>
+    public bool IsConst => VarOrLetKeyword != null && VarOrLetKeyword.Kind == SyntaxKind.ConstKeyword;
 
     /// <summary>Gets the field identifier.</summary>
     public SyntaxToken Identifier { get; }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -2600,12 +2600,16 @@ public class Parser
         }
 
         // ADR-0067: field declarations must be introduced with `var` (mutable)
-        // or `let` (read-only). The keyword is captured on the syntax node so
-        // the binder can set FieldSymbol.IsReadOnly accordingly. If the user
-        // omits the keyword, surface a precise diagnostic and try to recover
-        // by treating the next identifier as the field name.
+        // or `let` (read-only). Issue #948 adds `const` for compile-time
+        // constant fields (implicitly static and read-only). The keyword is
+        // captured on the syntax node so the binder can set
+        // FieldSymbol.IsReadOnly / IsConst accordingly. If the user omits the
+        // keyword, surface a precise diagnostic and try to recover by treating
+        // the next identifier as the field name.
         SyntaxToken varOrLetKeyword = null;
-        if (Current.Kind == SyntaxKind.VarKeyword || Current.Kind == SyntaxKind.LetKeyword)
+        if (Current.Kind == SyntaxKind.VarKeyword
+            || Current.Kind == SyntaxKind.LetKeyword
+            || Current.Kind == SyntaxKind.ConstKeyword)
         {
             varOrLetKeyword = NextToken();
         }

--- a/test/Compiler.Tests/Emit/Issue948FieldInitializerSugarEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue948FieldInitializerSugarEmitTests.cs
@@ -1,0 +1,410 @@
+// <copyright file="Issue948FieldInitializerSugarEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #948: syntactic sugar for inline field initialization. Fields declared
+/// with <c>const</c>, <c>let</c>, or <c>var</c> may carry an <c>= expr</c>
+/// initializer in the type body. Instance initializers run in declaration order
+/// before each constructor body; <c>const</c> fields become compile-time literal
+/// fields; static initializers run in the static constructor. Each test compiles
+/// via <c>gsc</c>, ilverifies the produced PE, then executes the assembly and
+/// asserts on the captured stdout (or, for negative tests, on the diagnostic).
+/// </summary>
+public class Issue948FieldInitializerSugarEmitTests
+{
+    [Fact]
+    public void Issue948_ConstLetVar_Example_AllReadAtRuntime()
+    {
+        // The exact example from the issue: const + let + var with initializers,
+        // all three read at runtime.
+        var source = """
+            package P
+            import System
+
+            class Foo {
+                const one string = "value"
+                let two string = "something"
+                var three string = "this should work"
+                func Show() string { return one + "|" + two + "|" + three }
+            }
+
+            var f = Foo()
+            Console.WriteLine(f.Show())
+            Console.WriteLine(Foo.one)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("value|something|this should work\nvalue\n", output);
+    }
+
+    [Fact]
+    public void Issue948_InstanceInitializers_RunInDeclarationOrder()
+    {
+        // Each initializer is appended in textual order; later fields can be
+        // computed but order is what we assert here via a side-effecting log.
+        var source = """
+            package P
+            import System
+
+            class Order {
+                var a string = "1"
+                var b string = "2"
+                var c string = "3"
+                func Show() string { return a + b + c }
+            }
+
+            var o = Order()
+            Console.WriteLine(o.Show())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("123\n", output);
+    }
+
+    [Fact]
+    public void Issue948_StaticFieldInitializer_RunsInCctor()
+    {
+        var source = """
+            package P
+            import System
+
+            class Config {
+                shared {
+                    var retries int32 = 3
+                    let name string = "svc"
+                }
+            }
+
+            Console.WriteLine(Config.retries.ToString() + Config.name)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3svc\n", output);
+    }
+
+    [Fact]
+    public void Issue948_ConstField_FoldedToLiteral_UsableExternally()
+    {
+        var source = """
+            package P
+            import System
+
+            class K {
+                const max int32 = 5 * 10
+                const label string = "hi"
+            }
+
+            Console.WriteLine(K.max.ToString() + K.label)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("50hi\n", output);
+    }
+
+    [Fact]
+    public void Issue948_Initializer_ThenExplicitInit_OverridesVar()
+    {
+        // Field initializer runs first, then the init body overrides the var.
+        var source = """
+            package P
+            import System
+
+            class Widget {
+                var n int32 = 10
+
+                init(value int32) {
+                    n = value
+                }
+
+                func Get() int32 { return n }
+            }
+
+            var defaulted = Widget(99)
+            Console.WriteLine(defaulted.Get())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    [Fact]
+    public void Issue948_StructFieldInitializers_AppliedForOmittedFields()
+    {
+        // Value-type composite literal zero-inits storage then applies declared
+        // field initializers for fields the literal omitted.
+        var source = """
+            package P
+            import System
+
+            struct Pt {
+                var x int32 = 3
+                var y int32 = 4
+            }
+
+            var p = Pt{}
+            Console.WriteLine(p.x.ToString() + "," + p.y.ToString())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3,4\n", output);
+    }
+
+    [Fact]
+    public void Issue948_DataStructFieldInitializers_AppliedForOmittedFields()
+    {
+        var source = """
+            package P
+            import System
+
+            data struct Pt {
+                var x int32 = 3
+                var y int32 = 4
+            }
+
+            var p = Pt{}
+            Console.WriteLine(p.x.ToString() + "," + p.y.ToString())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3,4\n", output);
+    }
+
+    [Fact]
+    public void Issue948_Negative_InstanceInitializerReferencesInstanceMember()
+    {
+        var source = """
+            package P
+            import System
+
+            class Foo {
+                var a int32 = 5
+                var b int32 = a + 10
+                func Get() int32 { return b }
+            }
+
+            var f = Foo()
+            Console.WriteLine(f.Get())
+            """;
+
+        var diagnostics = CompileExpectingFailure(source);
+        Assert.Contains("GS0377", diagnostics);
+    }
+
+    [Fact]
+    public void Issue948_Negative_ConstFieldWithNonConstantInitializer()
+    {
+        var source = """
+            package P
+            import System
+
+            class Foo {
+                const len int32 = "abc".Length
+            }
+
+            Console.WriteLine(Foo.len.ToString())
+            """;
+
+        var diagnostics = CompileExpectingFailure(source);
+        Assert.Contains("GS0376", diagnostics);
+    }
+
+    [Fact]
+    public void Issue948_Negative_ConstFieldRequiresInitializer()
+    {
+        var source = """
+            package P
+            import System
+
+            class Foo {
+                const len int32
+            }
+
+            Console.WriteLine(Foo.len.ToString())
+            """;
+
+        var diagnostics = CompileExpectingFailure(source);
+        Assert.Contains("GS0375", diagnostics);
+    }
+
+    // Test infrastructure — mirrors Issue640FieldInitializerEmitTests pattern.
+
+    private static string CompileAndRun(string source)
+    {
+        var (exit, stdout, stderr, _) = CompileAndRunRaw(source);
+        Assert.True(
+            exit == 0,
+            $"exited {exit}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static string CompileExpectingFailure(string source)
+    {
+        var (compileExit, compileOut, _) = CompileOnly(source);
+        Assert.True(
+            compileExit != 0,
+            $"expected compilation to fail but it succeeded:\n{compileOut}");
+        return compileOut;
+    }
+
+    private static (int CompileExit, string CompileOut, string CompileErr) CompileOnly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue948_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            return (compileExit, compileOut.ToString(), compileErr.ToString());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr, string CompileOut) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue948_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(
+                runtimeConfigPath,
+                """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(runtimeConfigPath);
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"), compileOut.ToString());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue948FieldInitializerBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue948FieldInitializerBindingTests.cs
@@ -1,0 +1,78 @@
+// <copyright file="Issue948FieldInitializerBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #948: binder tests for inline `const`/`let`/`var` field initializers in
+/// a type body — constant folding for `const`, and the constraints that a
+/// `const` field needs a constant initializer and that an instance initializer
+/// cannot reference instance members or constructor parameters.
+/// </summary>
+public class Issue948FieldInitializerBindingTests
+{
+    [Fact]
+    public void ConstField_WithConstantInitializer_NoDiagnostics()
+    {
+        const string source = "package P\nclass K {\n  const Max int32 = 5 * 10\n}\n";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0375" || d.Id == "GS0376");
+    }
+
+    [Fact]
+    public void ConstField_WithoutInitializer_ReportsGS0375()
+    {
+        const string source = "package P\nclass K {\n  const Max int32\n}\n";
+        var diagnostics = GetDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0375");
+    }
+
+    [Fact]
+    public void ConstField_WithNonConstantInitializer_ReportsGS0376()
+    {
+        const string source = "package P\nclass K {\n  const Len int32 = \"abc\".Length\n}\n";
+        var diagnostics = GetDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0376");
+    }
+
+    [Fact]
+    public void InstanceInitializer_ReferencingInstanceMember_ReportsGS0377()
+    {
+        const string source = "package P\nclass Foo {\n  var a int32 = 5\n  var b int32 = a + 10\n}\n";
+        var diagnostics = GetDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void InstanceInitializer_ReferencingThis_ReportsGS0377()
+    {
+        const string source = "package P\nclass Foo {\n  var a int32 = 5\n  var b int32 = this.a\n}\n";
+        var diagnostics = GetDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void InstanceInitializer_WithConstantExpression_NoGS0377()
+    {
+        const string source = "package P\nclass Foo {\n  var a int32 = 5\n  var b int32 = 10\n}\n";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0377");
+    }
+
+    private static IEnumerable<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(source);
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/FieldDeclarationParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/FieldDeclarationParserTests.cs
@@ -134,4 +134,41 @@ public class FieldDeclarationParserTests
         var tree = SyntaxTree.Parse(source);
         Assert.Empty(tree.Diagnostics);
     }
+
+    [Fact]
+    public void ParsesConstField_WithInitializer()
+    {
+        // Issue #948: `const` fields are accepted in a type body and carry an
+        // initializer; they are implicitly read-only.
+        const string source = "package P\nclass Counter {\n  const Max int32 = 10\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var field = Assert.Single(structDecl.Fields);
+        Assert.Equal("Max", field.Identifier.Text);
+        Assert.True(field.IsConst);
+        Assert.True(field.IsReadOnly);
+        Assert.NotNull(field.Initializer);
+        Assert.Equal(SyntaxKind.ConstKeyword, field.VarOrLetKeyword.Kind);
+    }
+
+    [Fact]
+    public void ParsesConstField_InSharedBlock()
+    {
+        const string source = "package P\nclass Counter {\n  shared {\n    const Max int32 = 10\n  }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void BareField_GS0288_MentionsConst()
+    {
+        // Issue #948: the GS0288 guidance now also mentions `const`.
+        const string source = "package P\nclass Counter {\n  Value int32\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        var diagnostic = Assert.Single(tree.Diagnostics);
+        Assert.Equal("GS0288", diagnostic.Id);
+        Assert.Contains("const", diagnostic.Message);
+    }
 }

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -474,9 +474,23 @@ members.
 
 | Code | Severity | Message |
 |------|----------|---------|
-| GS0288 | Error | Field declarations require a `var` (mutable) or `let` (read-only) keyword. |
+| GS0288 | Error | Field declarations require a `var` (mutable), `let` (read-only), or `const` (compile-time constant) keyword. |
 
-Cause/fix — `struct Point { x int32; y int32 }` → `struct Point { var x int32; var y int32 }` (or `let` for read-only). The parser recovers by treating the field as `var`, but the error still fires.
+Cause/fix — `struct Point { x int32; y int32 }` → `struct Point { var x int32; var y int32 }` (or `let` for read-only, `const` for a compile-time constant). The parser recovers by treating the field as `var`, but the error still fires.
+
+## Inline field initializer diagnostics (GS0375–GS0377)
+
+Issue #948 — `const`/`let`/`var` fields in a type body may carry an inline
+`= expr` initializer. Instance initializers run before each constructor body in
+declaration order; `const` fields fold to compile-time literal fields; static
+(`shared`) initializers run in the static constructor.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0375 | Error | A `const` field requires an initializer. |
+| GS0376 | Error | A `const` field initializer must be a compile-time constant expression. |
+| GS0377 | Error | A field initializer cannot reference the instance member or constructor parameter `{name}` (field initializers run before the constructor body, so `this` is not available). Assign it in an `init(...)` constructor instead. |
+
 
 ## `deinit` (finalizer) diagnostics (GS0289–GS0292)
 

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -524,6 +524,45 @@ keep their existing behavior: they are assignable only through their declaration
 initializer (materialized into the synthesized static constructor), since G#
 exposes no user-authored static constructor body.
 
+#### Inline field initializers (issue #948)
+
+Any `const`, `let`, or `var` field in a type body may carry an inline
+initializer with the `= expr` suffix:
+
+```gsharp
+class Foo {
+  const one string = "value"
+  let two string = "something"
+  var three string = "this should work"
+}
+```
+
+The semantics match C#:
+
+* An **instance** field initializer (`let`/`var x T = expr`) runs as part of
+  **every** instance constructor, **before** the constructor body, in textual
+  declaration order. This holds for a primary constructor, each explicit
+  `init(...)` constructor, and the synthesized default constructor when no
+  constructor is declared. Because the initializer runs before the constructor
+  body, it may not reference `this`, another instance member of the same object,
+  or a constructor parameter; doing so reports `GS0377` (assign such fields in an
+  `init(...)` body instead). A `var` field initialized inline may still be
+  overwritten by a later `init(...)` body.
+* A `let` field initializer counts as a construction-time write, so it composes
+  with the `initonly` emission described above (the field remains read-only).
+* A **static** field initializer (a `let`/`var` inside a `shared { ... }` block)
+  runs in the static constructor (`.cctor`) in declaration order.
+* A **`const`** field is a **compile-time constant**: it is implicitly static and
+  read-only, its initializer must fold to a constant expression, and it is
+  emitted as a CLR literal field (a `Constant` metadata row) usable in constant
+  contexts and from other assemblies. A `const` field with no initializer reports
+  `GS0375`; a `const` field whose initializer is not a constant expression reports
+  `GS0376`.
+* For **value types** (`struct` / `data struct`), which have no class-style
+  constructor that could run inline initializers, a composite struct literal
+  (`Pt{ ... }`) zero-initializes the storage and then applies each declared field
+  initializer for any field the literal omitted, in declaration order.
+
 ## Expressions
 
 ### Precedence


### PR DESCRIPTION
## Summary

Implements issue #948: syntactic sugar for inline field initialization. Fields declared with `const`, `let`, or `var` may now carry an `= expr` initializer directly in a type body, matching C# semantics.

```gsharp
class Foo {
  const one string = "value"
  let two string = "something"
  var three string = "this should work"
}
```

## Support matrix (before → after)

| Scenario | Before | After |
| --- | --- | --- |
| `const` field w/ initializer in class body | ❌ parse error (GS0288/GS0005) | ✅ folded to CLR literal field |
| `let` instance field w/ initializer (class) | ✅ (#640) | ✅ |
| `var` instance field w/ initializer (class) | ✅ (#640) | ✅ |
| static `let`/`var` in `shared {}` | ✅ (#262) | ✅ |
| `const` in `shared {}` | ❌ | ✅ literal field |
| `data class` field init via composite literal | ✅ | ✅ |
| `struct` / `data struct` field init via composite literal | ❌ silently dropped (0,0) | ✅ omitted fields get declared initializers |
| initializer referencing `this` / instance member | ⚠️ unclear GS0125 | ✅ clean GS0377 |
| `const` w/ non-constant initializer | n/a (didn't parse) | ✅ GS0376 |
| `const` w/o initializer | n/a | ✅ GS0375 |

## Implementation by area

- **Parser** (`Parser.cs`, `FieldDeclarationSyntax.cs`): accept `const` alongside `var`/`let`; `IsConst`/`IsReadOnly` set accordingly; `= expr` initializer captured.
- **Symbols** (`FieldSymbol.cs`, `StructSymbol.cs`): `FieldSymbol.IsConst`/`ConstantValue`; `StructSymbol.ConstFields` kept separate from `StaticFields` (no runtime static field / `.cctor` write); `TryGetStaticField` also searches const fields.
- **Binder** (`DeclarationBinder.cs`, `Binder.cs`, `ExpressionBinder.Literals.cs`): divert `const` fields; fold initializers to compile-time constants (literals, conversions, unary +/-, binary arithmetic/concat/bitwise/shift); enforce const-ness (GS0375/GS0376); reject instance initializers referencing `this`/instance members/primary-ctor params (GS0377); register const fields for bare-name lookup; struct composite literals apply declared initializers for omitted fields.
- **Lowering** (`Lowerer.cs`): inline const field reads as literals — robust for value-type method receivers.
- **Emit** (`TypeDefEmitter.cs`, `MethodBodyEmitter.MemberAccess.cs`): emit const fields as `Static|Literal|HasDefault` FieldDefs with a `Constant` metadata row.

Instance `let`/`var` initializers (#640) still run before each constructor body in declaration order; static `shared` initializers (#262) run in the `.cctor`.

## Tests

- `test/Compiler.Tests/Emit/Issue948FieldInitializerSugarEmitTests.cs` — 10 compile-and-run tests: exact `Foo` example (all three read at runtime), declaration order, static field init, init() override of a `var`, struct + data-struct init, negatives GS0375/GS0376/GS0377. IL-verified.
- `test/Core.Tests/CodeAnalysis/Binding/Issue948FieldInitializerBindingTests.cs` — const folding + GS0375/0376/0377 (incl. `this.x`).
- `test/Core.Tests/CodeAnalysis/Syntax/FieldDeclarationParserTests.cs` — const parsing + GS0288 mentions `const`.

All Issue948 tests pass; existing #640/#947/#262/#524 field/ctor tests and the full cs2gs suite (113) remain green. Full `dotnet build GSharp.sln -c Release -graph` builds with **0 warnings**.

## Docs

- `website/docs/ref/spec.md`: inline field initializer grammar + semantics.
- `website/docs/ref/diagnostics.md`, `docs/diagnostics.md`: GS0288 update + GS0375–GS0377.
- `docs/adr/0115`: note that cs2gs-emitted inline initializers now compile directly.

## Deferred / notes

- An initializer referencing an **explicit `init(...)` constructor parameter** (vs a primary-ctor parameter) still errors with the generic GS0125 rather than GS0377; collecting all `init()` param names would be needed for the cleaner message. Still a correct compile error.
- Static-initializer-references-another-static-field remains GS0125 (pre-existing #262 scope, unchanged).
- Top-level (non-type-body) global `const` folding is out of scope for #948.

Fixes #948
