### PR TITLE
Add `protected` access modifier (CIL Family) — Fixes #950

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -197,9 +197,19 @@ Defaults: top-level declarations default to `public` (ADR-0014); top-level `priv
 | `public` | omit (default) | emit `public` where member default is not public |
 | `internal` | `internal` | `internal` |
 | `private` | `private` (ADR-0109) | `private` |
-| `protected` / `protected internal` | nearest supported (`internal`) + triage note | as left |
+| `protected` | `internal` + triage note (no top-level `protected`) | `protected` (issue #950) |
+| `protected internal` / `private protected` | `internal` + triage note | `internal` + triage note |
 
-`protected` has no direct G# spelling today; it is mapped to the closest accessibility and flagged in triage rather than silently dropped.
+Since issue #950, G# has a first-class `protected` member modifier (CIL
+`family`), so the translator maps C# `protected` members directly to G#
+`protected`. Because `protected` is only valid on members of an inheritable
+`open class`, the translator forces any class that declares a `protected` member
+to be emitted as `open` (alongside the existing "subclassed within the
+compilation" rule). The blended forms `protected internal` and `private
+protected` have no single-keyword G# equivalent; they continue to map to the
+nearest supported accessibility (`internal`) with a triage note. There is no
+top-level `protected` in G#, so a `protected` *type* still maps to `internal`
+with a triage note.
 
 #### B.11 Members: fields, properties, constructors, statics, enums, attributes
 
@@ -490,7 +500,7 @@ re-greens automatically.
 - **Roslyn dependency in the toolset.** `Cs2Gs.Translator` carries `Microsoft.CodeAnalysis.CSharp` (and its transitive MSBuild/crypto pins already present in the scaffold). This is a tool-only cost, not a compiler cost, but it is real maintenance surface.
 - **Corpus curation is ongoing work.** The oracle's value scales with corpus breadth; building and maintaining green C# apps is a continuing investment.
 - **"Canonical" must track the language.** Every new G# surface ADR may add or change a section-B rule; the pretty-printer is a living contract, not a one-time write.
-- **Constructs without a canonical form are deferred, not translated.** `protected`, `inline struct` newtype promotion, some `using static` shapes, and any not-yet-mapped construct are triaged rather than guessed — correct, but it means some apps will not migrate until the language or the tool grows.
+- **Constructs without a canonical form are deferred, not translated.** `inline struct` newtype promotion, some `using static` shapes, and any not-yet-mapped construct are triaged rather than guessed — correct, but it means some apps will not migrate until the language or the tool grows. (C# member `protected` is now translated directly to G# `protected` since issue #950; the blended `protected internal` / `private protected` forms remain triaged to `internal`.)
 
 ### Neutral
 

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -180,6 +180,7 @@ PropertyDeclaration
 PropertyInitializer
 PropertyPattern
 PropertyPatternField
+ProtectedKeyword
 PublicKeyword
 QuestionDotToken
 QuestionOpenBracketToken

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -600,6 +600,7 @@ public sealed class Binder
                                                .OfType<TypeAliasDeclarationSyntax>();
         foreach (var typeAlias in typeAliasDeclarations)
         {
+            binder.declarations.ValidateTopLevelProtected(typeAlias.AccessibilityModifier);
             binder.declarations.BindTypeAliasDeclaration(typeAlias);
         }
 
@@ -611,6 +612,7 @@ public sealed class Binder
         foreach (var delegateSyntax in delegateDeclarations)
         {
             var owningPackage = packageByTree[delegateSyntax.SyntaxTree];
+            binder.declarations.ValidateTopLevelProtected(delegateSyntax.AccessibilityModifier);
             binder.declarations.BindDelegateDeclaration(delegateSyntax, owningPackage);
         }
 
@@ -626,6 +628,7 @@ public sealed class Binder
         foreach (var ifaceSyntax in interfaceDeclarations)
         {
             var owningPackage = packageByTree[ifaceSyntax.SyntaxTree];
+            binder.declarations.ValidateTopLevelProtected(ifaceSyntax.AccessibilityModifier);
             var sym = binder.declarations.DeclareInterfaceSymbol(ifaceSyntax, owningPackage);
             if (sym != null)
             {
@@ -638,6 +641,7 @@ public sealed class Binder
         foreach (var enumSyntax in enumDeclarations)
         {
             var owningPackage = packageByTree[enumSyntax.SyntaxTree];
+            binder.declarations.ValidateTopLevelProtected(enumSyntax.AccessibilityModifier);
             binder.declarations.BindEnumDeclaration(enumSyntax, owningPackage);
         }
 
@@ -646,6 +650,7 @@ public sealed class Binder
         foreach (var structSyntax in structDeclarations)
         {
             var owningPackage = packageByTree[structSyntax.SyntaxTree];
+            binder.declarations.ValidateTopLevelProtected(structSyntax.AccessibilityModifier);
             binder.declarations.BindStructDeclaration(structSyntax, owningPackage);
         }
 
@@ -660,6 +665,7 @@ public sealed class Binder
         foreach (var function in functionDeclarations)
         {
             var owningPackage = packageByTree[function.SyntaxTree];
+            binder.declarations.ValidateTopLevelProtected(function.AccessibilityModifier);
             binder.declarations.BindFunctionDeclaration(function, owningPackage);
         }
 
@@ -1729,6 +1735,8 @@ public sealed class Binder
                 return Accessibility.Internal;
             case SyntaxKind.PrivateKeyword:
                 return Accessibility.Private;
+            case SyntaxKind.ProtectedKeyword:
+                return Accessibility.Protected;
             default:
                 return Accessibility.Public;
         }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -366,6 +366,100 @@ internal sealed class DeclarationBinder
         }
     }
 
+    /// <summary>
+    /// Issue #950: reports GS0380 for any member declared <c>protected</c> when
+    /// the enclosing type is not an inheritable <c>open class</c>. Structs
+    /// (value types) and non-open/sealed classes cannot be derived from, so a
+    /// <c>protected</c> member there has no meaning.
+    /// </summary>
+    private void ValidateProtectedMemberPlacement(StructDeclarationSyntax syntax)
+    {
+        if (syntax.IsClass && syntax.IsOpen)
+        {
+            return;
+        }
+
+        foreach (var field in syntax.Fields)
+        {
+            ReportProtectedToken(field.AccessibilityModifier);
+        }
+
+        foreach (var method in syntax.Methods)
+        {
+            ReportProtectedToken(method.AccessibilityModifier);
+        }
+
+        foreach (var prop in syntax.Properties)
+        {
+            ReportProtectedToken(prop.AccessibilityModifier);
+        }
+
+        foreach (var evt in syntax.Events)
+        {
+            ReportProtectedToken(evt.AccessibilityModifier);
+        }
+
+        if (!syntax.Constructors.IsDefaultOrEmpty)
+        {
+            foreach (var ctor in syntax.Constructors)
+            {
+                ReportProtectedToken(ctor.AccessibilityModifier);
+            }
+        }
+
+        if (syntax.SharedBlock != null)
+        {
+            foreach (var field in syntax.SharedBlock.Fields)
+            {
+                ReportProtectedToken(field.AccessibilityModifier);
+            }
+
+            foreach (var method in syntax.SharedBlock.Methods)
+            {
+                ReportProtectedToken(method.AccessibilityModifier);
+            }
+
+            foreach (var prop in syntax.SharedBlock.Properties)
+            {
+                ReportProtectedToken(prop.AccessibilityModifier);
+            }
+
+            foreach (var evt in syntax.SharedBlock.Events)
+            {
+                ReportProtectedToken(evt.AccessibilityModifier);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Issue #950: reports GS0380 when <paramref name="modifier"/> is the
+    /// <c>protected</c> keyword. Used by callers that have already determined
+    /// the surrounding context does not permit <c>protected</c>.
+    /// </summary>
+    private void ReportProtectedToken(SyntaxToken modifier)
+    {
+        if (modifier != null && modifier.Kind == SyntaxKind.ProtectedKeyword)
+        {
+            Diagnostics.ReportProtectedRequiresOpenType(modifier.Location);
+        }
+    }
+
+    /// <summary>
+    /// Issue #950: rejects a top-level declaration marked <c>protected</c>.
+    /// A top-level type or function has no enclosing type to be inherited, so
+    /// <c>protected</c> is meaningless there (GS0380).
+    /// </summary>
+    internal void ValidateTopLevelProtected(SyntaxToken modifier) => ReportProtectedToken(modifier);
+
+    private static SyntaxToken GetMemberAccessibilityModifier(MemberSyntax member) => member switch
+    {
+        StructDeclarationSyntax s => s.AccessibilityModifier,
+        EnumDeclarationSyntax e => e.AccessibilityModifier,
+        InterfaceDeclarationSyntax i => i.AccessibilityModifier,
+        DelegateDeclarationSyntax d => d.AccessibilityModifier,
+        _ => null,
+    };
+
     private StructSymbol BindStructDeclarationBody(
         StructDeclarationSyntax syntax,
         PackageSymbol package,
@@ -375,6 +469,12 @@ internal sealed class DeclarationBinder
     {
         var seenFieldNames = new HashSet<string>();
         var fields = ImmutableArray.CreateBuilder<FieldSymbol>();
+
+        // Issue #950: `protected` is only meaningful on members of an
+        // inheritable `open class`. Reject it on members of a non-open class,
+        // a struct (value types are not inheritable), or a sealed type before
+        // binding the members so the user sees one clean GS0380 diagnostic.
+        ValidateProtectedMemberPlacement(syntax);
 
         // Phase 3.B.3 sub-step 2: Kotlin-style primary constructor parameters
         // declare fields of the same name + type, in source order, in addition
@@ -2141,6 +2241,14 @@ internal sealed class DeclarationBinder
 
         foreach (var nested in containerSyntax.NestedTypes)
         {
+            // Issue #950: a `protected` nested type is only meaningful when the
+            // container is an inheritable `open class`. Otherwise nothing can
+            // derive from the container to reach the nested type.
+            if (!(containerSyntax.IsClass && containerSyntax.IsOpen))
+            {
+                ReportProtectedToken(GetMemberAccessibilityModifier(nested));
+            }
+
             switch (nested)
             {
                 case StructDeclarationSyntax nestedStruct:

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1559,16 +1559,30 @@ internal sealed partial class ExpressionBinder
                         // Issue #186 / #175: dotted field read fires
                         // GS0204 if the field carries `@Obsolete`.
                         reportObsoleteUseIfApplicable(ne.IdentifierToken.Location, field, $"{declaringType.Name}.{field.Name}");
+
+                        // Issue #950: enforce `protected` field access — only the
+                        // declaring type and its derived types may read it.
+                        if (!AccessibilityChecker.IsAccessible(field.Accessibility, declaringType, this.function))
+                        {
+                            Diagnostics.ReportProtectedMemberInaccessible(ne.IdentifierToken.Location, field.Name, declaringType.Name);
+                        }
+
                         return new BoundFieldAccessExpression(null, receiver, declaringType, field);
                     }
 
                     // ADR-0051: check properties before reporting "unable to find member".
-                    if (TypeMemberModel.TryGetProperty(structSym, ne.IdentifierToken.Text, out var prop))
+                    if (TypeMemberModel.TryGetProperty(structSym, ne.IdentifierToken.Text, out var prop, out var propDeclaringType))
                     {
                         if (!prop.HasGetter)
                         {
                             Diagnostics.ReportCannotAssign(ne.Location, ne.IdentifierToken.Text);
                             return new BoundErrorExpression(null);
+                        }
+
+                        // Issue #950: enforce `protected` property access.
+                        if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propDeclaringType, this.function))
+                        {
+                            Diagnostics.ReportProtectedMemberInaccessible(ne.IdentifierToken.Location, prop.Name, propDeclaringType.Name);
                         }
 
                         return new BoundPropertyAccessExpression(null, receiver, structSym, prop);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -495,12 +495,18 @@ internal sealed partial class ExpressionBinder
         if (!TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, syntax.FieldIdentifier.Text, MemberQuery.Instance(MemberKinds.Field), out var field, out var fieldDeclaringType))
         {
             // ADR-0051: check if it's a property.
-            if (TypeMemberModel.TryGetProperty(structSymbol, syntax.FieldIdentifier.Text, out var prop))
+            if (TypeMemberModel.TryGetProperty(structSymbol, syntax.FieldIdentifier.Text, out var prop, out var propDeclaringType))
             {
                 if (!prop.HasSetter)
                 {
                     Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.Text);
                     return new BoundErrorExpression(null);
+                }
+
+                // Issue #950: enforce `protected` property assignment.
+                if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propDeclaringType, this.function))
+                {
+                    Diagnostics.ReportProtectedMemberInaccessible(syntax.FieldIdentifier.Location, prop.Name, propDeclaringType.Name);
                 }
 
                 var propConverted = conversions.BindConversion(syntax.Value.Location, value, prop.Type);
@@ -544,6 +550,13 @@ internal sealed partial class ExpressionBinder
         }
 
         var receiverIsThisField = ReceiverVariableIsThis(variable);
+
+        // Issue #950: enforce `protected` field assignment — only the declaring
+        // type and its derived types may write it.
+        if (!AccessibilityChecker.IsAccessible(field.Accessibility, fieldDeclaringType, this.function))
+        {
+            Diagnostics.ReportProtectedMemberInaccessible(syntax.FieldIdentifier.Location, field.Name, fieldDeclaringType.Name);
+        }
 
         // Issue #947: a read-only field of `this` may be assigned inside the
         // declaring type's constructor; in that case the receiver being `this`

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -3410,6 +3410,16 @@ internal sealed class OverloadResolver
 
     public BoundExpression BindUserInstanceCall(BoundExpression receiver, FunctionSymbol method, ImmutableArray<BoundExpression> arguments, CallExpressionSyntax ce, ImmutableArray<string> argumentNames = default)
     {
+        // Issue #950: enforce `protected` method access — only the declaring
+        // type and its derived types may call it. The emitted IL also carries
+        // CIL `family` accessibility so the CLR enforces the same rule.
+        if (method.Accessibility == Accessibility.Protected
+            && method.ReceiverType is StructSymbol protMethodDeclaringType
+            && !AccessibilityChecker.IsAccessible(method.Accessibility, protMethodDeclaringType, getCurrentFunction()))
+        {
+            Diagnostics.ReportProtectedMemberInaccessible(ce.Identifier.Location, method.Name, protMethodDeclaringType.Name);
+        }
+
         var parameterOffset = method.ExplicitReceiverParameter == null ? 0 : 1;
         var callableParameterCount = method.Parameters.Length - parameterOffset;
 

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1234,6 +1234,39 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0180", message);
     }
 
+    /// <summary>
+    /// Issue #950: GS0379 — a <c>protected</c> member of <paramref name="declaringTypeName"/>
+    /// was accessed from code that is neither the declaring type nor a type
+    /// deriving from it. A <c>protected</c> member is only reachable from the
+    /// declaring type and the bodies of its derived types.
+    /// </summary>
+    /// <param name="location">The text location of the offending access.</param>
+    /// <param name="memberName">The protected member's name.</param>
+    /// <param name="declaringTypeName">The declaring type's name.</param>
+    public void ReportProtectedMemberInaccessible(TextLocation location, string memberName, string declaringTypeName)
+    {
+        Report(
+            location,
+            "GS0379",
+            $"'{declaringTypeName}.{memberName}' is inaccessible due to its protection level: a 'protected' member is only accessible within '{declaringTypeName}' and types derived from it.");
+    }
+
+    /// <summary>
+    /// Issue #950: GS0380 — the <c>protected</c> modifier appears on a member
+    /// (or nested type) whose enclosing type is not an inheritable
+    /// <c>open class</c>. Nothing can derive from a non-<c>open</c> class, a
+    /// <c>struct</c>, a sealed type, an interface, or a top-level declaration,
+    /// so <c>protected</c> there is meaningless.
+    /// </summary>
+    /// <param name="location">The text location of the <c>protected</c> modifier.</param>
+    public void ReportProtectedRequiresOpenType(TextLocation location)
+    {
+        Report(
+            location,
+            "GS0380",
+            "'protected' is only allowed on members of an 'open class' (a type that can be inherited). Mark the enclosing class 'open', or use a different accessibility.");
+    }
+
     /// <summary>Reports an attempt to subclass a sealed (non-<c>open</c>) class. Phase 3.B.3 sub-step 3 / ADR-0017.</summary>
     /// <param name="location">The text location of the base-type identifier.</param>
     /// <param name="baseTypeName">The base type name.</param>

--- a/src/Core/CodeAnalysis/Emit/AccessibilityMap.cs
+++ b/src/Core/CodeAnalysis/Emit/AccessibilityMap.cs
@@ -33,6 +33,7 @@ internal static class AccessibilityMap
         {
             Accessibility.Internal => TypeAttributes.NestedAssembly,
             Accessibility.Private => TypeAttributes.NestedPrivate,
+            Accessibility.Protected => TypeAttributes.NestedFamily,
             _ => TypeAttributes.NestedPublic,
         };
     }
@@ -43,6 +44,7 @@ internal static class AccessibilityMap
         {
             Accessibility.Internal => FieldAttributes.Assembly,
             Accessibility.Private => FieldAttributes.Private,
+            Accessibility.Protected => FieldAttributes.Family,
             _ => FieldAttributes.Public,
         };
     }
@@ -57,6 +59,8 @@ internal static class AccessibilityMap
                 return MethodAttributes.Assembly;
             case Accessibility.Private:
                 return MethodAttributes.Private;
+            case Accessibility.Protected:
+                return MethodAttributes.Family;
             default:
                 return MethodAttributes.Public;
         }

--- a/src/Core/CodeAnalysis/Symbols/Accessibility.cs
+++ b/src/Core/CodeAnalysis/Symbols/Accessibility.cs
@@ -19,4 +19,13 @@ public enum Accessibility
 
     /// <summary>Visible only within the declaring container (CLR type).</summary>
     Private,
+
+    /// <summary>
+    /// Issue #950: visible within the declaring type and within types that
+    /// derive from it (their own bodies). Maps to CLR <c>family</c>
+    /// accessibility. Only valid on members of inheritable (<c>open</c>)
+    /// classes — a non-<c>open</c>/<c>struct</c>/sealed type cannot be derived
+    /// from, so <c>protected</c> there is reported as a clean diagnostic.
+    /// </summary>
+    Protected,
 }

--- a/src/Core/CodeAnalysis/Symbols/AccessibilityChecker.cs
+++ b/src/Core/CodeAnalysis/Symbols/AccessibilityChecker.cs
@@ -1,0 +1,76 @@
+// <copyright file="AccessibilityChecker.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #950: bind-time accessibility checks for the <c>protected</c>
+/// modifier. A <c>protected</c> member is accessible within its declaring type
+/// and within the bodies of types that derive from the declaring type; it is
+/// inaccessible from unrelated external code (e.g. the synthetic
+/// <c>&lt;Program&gt;</c> host or a sibling type).
+/// <para>
+/// Unlike <c>private</c>/<c>internal</c> — which G# leaves to the CLR to
+/// enforce at runtime via the emitted IL accessibility — <c>protected</c> adds
+/// a compile-time check so that external access is reported as a clean
+/// diagnostic (GS0379) rather than surfacing only as a runtime
+/// <see cref="System.MethodAccessException"/>/<see cref="System.FieldAccessException"/>.
+/// The emitted IL still carries CIL <c>family</c> accessibility, so the CLR
+/// independently enforces the same rule.
+/// </para>
+/// </summary>
+internal static class AccessibilityChecker
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when a member declared on
+    /// <paramref name="declaringType"/> with the given
+    /// <paramref name="accessibility"/> is accessible from the body of
+    /// <paramref name="currentFunction"/>. Only the <c>protected</c> case is
+    /// enforced here; every other accessibility is treated as accessible (G#
+    /// defers private/internal enforcement to the CLR).
+    /// </summary>
+    /// <param name="accessibility">The accessed member's accessibility.</param>
+    /// <param name="declaringType">The type that declares the member.</param>
+    /// <param name="currentFunction">The function whose body contains the access (may be <see langword="null"/> for top-level code).</param>
+    /// <returns><see langword="true"/> when the access is permitted.</returns>
+    public static bool IsAccessible(Accessibility accessibility, StructSymbol declaringType, FunctionSymbol currentFunction)
+    {
+        if (accessibility != Accessibility.Protected || declaringType == null)
+        {
+            return true;
+        }
+
+        var enclosingType = (currentFunction?.ReceiverType as StructSymbol)
+            ?? (currentFunction?.StaticOwnerType as StructSymbol);
+
+        for (var t = enclosingType; t != null; t = t.BaseClass)
+        {
+            if (SameDeclaringType(t, declaringType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool SameDeclaringType(StructSymbol a, StructSymbol b)
+    {
+        if (ReferenceEquals(a, b))
+        {
+            return true;
+        }
+
+        // Symbols are normally canonical (one instance per declared type), but
+        // guard against constructed/projected duplicates by comparing the
+        // declaration identity and qualified name as a fallback.
+        if (a.Declaration != null && ReferenceEquals(a.Declaration, b.Declaration))
+        {
+            return true;
+        }
+
+        return string.Equals(a.Name, b.Name, System.StringComparison.Ordinal)
+            && string.Equals(a.PackageName, b.PackageName, System.StringComparison.Ordinal);
+    }
+}

--- a/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
@@ -239,6 +239,20 @@ public static class TypeMemberModel
     /// <param name="property">The found property on success.</param>
     /// <returns>True if found.</returns>
     public static bool TryGetProperty(TypeSymbol type, string name, out PropertySymbol property)
+        => TryGetProperty(type, name, out property, out _);
+
+    /// <summary>
+    /// Issue #950: like <see cref="TryGetProperty(TypeSymbol, string, out PropertySymbol)"/>
+    /// but also surfaces the <see cref="StructSymbol"/> that declares the
+    /// property, so callers can enforce <c>protected</c> accessibility against
+    /// the declaring type.
+    /// </summary>
+    /// <param name="type">The type to resolve against.</param>
+    /// <param name="name">The property name.</param>
+    /// <param name="property">The found property on success.</param>
+    /// <param name="declaringType">The struct/class that declares the property, or <see langword="null"/>.</param>
+    /// <returns>True if found.</returns>
+    public static bool TryGetProperty(TypeSymbol type, string name, out PropertySymbol property, out StructSymbol declaringType)
     {
         if (type is StructSymbol structSymbol)
         {
@@ -256,6 +270,7 @@ public static class TypeMemberModel
                     if (p.Name == name)
                     {
                         property = p;
+                        declaringType = c;
                         return true;
                     }
                 }
@@ -268,12 +283,14 @@ public static class TypeMemberModel
                 if (p.Name == name)
                 {
                     property = p;
+                    declaringType = null;
                     return true;
                 }
             }
         }
 
         property = null;
+        declaringType = null;
         return false;
     }
 

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -238,7 +238,8 @@ public class Parser
         SyntaxToken accessibilityModifier = null;
         if (Current.Kind == SyntaxKind.PublicKeyword ||
             Current.Kind == SyntaxKind.InternalKeyword ||
-            Current.Kind == SyntaxKind.PrivateKeyword)
+            Current.Kind == SyntaxKind.PrivateKeyword ||
+            Current.Kind == SyntaxKind.ProtectedKeyword)
         {
             accessibilityModifier = NextToken();
         }
@@ -1540,7 +1541,8 @@ public class Parser
             {
                 var nestedHeadOffset = (Current.Kind == SyntaxKind.PublicKeyword
                     || Current.Kind == SyntaxKind.InternalKeyword
-                    || Current.Kind == SyntaxKind.PrivateKeyword) ? 1 : 0;
+                    || Current.Kind == SyntaxKind.PrivateKeyword
+                    || Current.Kind == SyntaxKind.ProtectedKeyword) ? 1 : 0;
 
                 if (TryDetectAggregateDeclarationHead(nestedHeadOffset))
                 {
@@ -1579,7 +1581,8 @@ public class Parser
             SyntaxToken memberAccessibility = null;
             if (Current.Kind == SyntaxKind.PublicKeyword ||
                 Current.Kind == SyntaxKind.InternalKeyword ||
-                Current.Kind == SyntaxKind.PrivateKeyword)
+                Current.Kind == SyntaxKind.PrivateKeyword ||
+                Current.Kind == SyntaxKind.ProtectedKeyword)
             {
                 // Accessibility modifier may be followed by an optional
                 // `open`/`override` and an optional `async` (only meaningful
@@ -1997,7 +2000,8 @@ public class Parser
             SyntaxToken memberAccessibility = null;
             if (Current.Kind == SyntaxKind.PublicKeyword ||
                 Current.Kind == SyntaxKind.InternalKeyword ||
-                Current.Kind == SyntaxKind.PrivateKeyword)
+                Current.Kind == SyntaxKind.PrivateKeyword ||
+                Current.Kind == SyntaxKind.ProtectedKeyword)
             {
                 var ahead = 1;
                 while (Peek(ahead).Kind == SyntaxKind.OpenKeyword || Peek(ahead).Kind == SyntaxKind.OverrideKeyword)
@@ -2594,7 +2598,8 @@ public class Parser
         SyntaxToken fieldAccessibility = null;
         if (Current.Kind == SyntaxKind.PublicKeyword ||
             Current.Kind == SyntaxKind.InternalKeyword ||
-            Current.Kind == SyntaxKind.PrivateKeyword)
+            Current.Kind == SyntaxKind.PrivateKeyword ||
+            Current.Kind == SyntaxKind.ProtectedKeyword)
         {
             fieldAccessibility = NextToken();
         }

--- a/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -198,6 +198,8 @@ public static class SyntaxFacts
                 return SyntaxKind.PackageKeyword;
             case "private":
                 return SyntaxKind.PrivateKeyword;
+            case "protected":
+                return SyntaxKind.ProtectedKeyword;
             case "public":
                 return SyntaxKind.PublicKeyword;
             case "range":
@@ -460,6 +462,8 @@ public static class SyntaxFacts
                 return "package";
             case SyntaxKind.PrivateKeyword:
                 return "private";
+            case SyntaxKind.ProtectedKeyword:
+                return "protected";
             case SyntaxKind.PublicKeyword:
                 return "public";
             case SyntaxKind.RangeKeyword:

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -127,6 +127,7 @@ public enum SyntaxKind
     OverrideKeyword,
     PackageKeyword,
     PrivateKeyword,
+    ProtectedKeyword,
     PublicKeyword,
     RangeKeyword,
     ReturnKeyword,

--- a/src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json
+++ b/src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json
@@ -215,7 +215,7 @@
         },
         {
           "name": "keyword.modifier.gsharp",
-          "match": "\\b(public|private|internal|open|sealed|override|const)\\b"
+          "match": "\\b(public|private|protected|internal|open|sealed|override|const)\\b"
         },
         {
           "name": "keyword.modifier.contextual.gsharp",

--- a/test/Compiler.Tests/Emit/Issue950ProtectedModifierEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue950ProtectedModifierEmitTests.cs
@@ -1,0 +1,364 @@
+// <copyright file="Issue950ProtectedModifierEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #950 — the <c>protected</c> access modifier. A <c>protected</c> member
+/// of an <c>open class</c> is accessible from the declaring type and the bodies
+/// of derived types, and is emitted as CIL <c>family</c> accessibility so the
+/// CLR independently enforces the same rule. External access is a compile
+/// error (GS0379); <c>protected</c> on a non-inheritable type is GS0380.
+/// </summary>
+public class Issue950ProtectedModifierEmitTests
+{
+    [Fact]
+    public void DerivedClass_AccessesInheritedProtectedFieldAndMethod_Runs()
+    {
+        CompileVerifyAndRun(
+            """
+            package Maui.Issue950.Tests
+
+            import System
+
+            open class Base {
+                protected var secret int32
+                protected func Reveal() int32 {
+                    return secret
+                }
+            }
+
+            class Derived : Base {
+                func Show() int32 {
+                    secret = 7
+                    return secret + Reveal()
+                }
+            }
+
+            func Main() {
+                let d = Derived{}
+                Console.WriteLine(d.Show())
+            }
+            """,
+            "14\n");
+    }
+
+    [Fact]
+    public void ProtectedVirtualMethod_OverriddenInDerived_DispatchesVirtually()
+    {
+        CompileVerifyAndRun(
+            """
+            package Maui.Issue950.Tests
+
+            import System
+
+            open class Animal {
+                protected open func Sound() string {
+                    return "..."
+                }
+                func Describe() string {
+                    return Sound()
+                }
+            }
+
+            open class Dog : Animal {
+                protected override func Sound() string {
+                    return "Woof"
+                }
+            }
+
+            func Main() {
+                let a = Animal{}
+                let d = Dog{}
+                Console.WriteLine(a.Describe())
+                Console.WriteLine(d.Describe())
+            }
+            """,
+            "...\nWoof\n");
+    }
+
+    /// <summary>
+    /// Guard: a <c>protected</c> field and method of an <c>open class</c> must
+    /// be emitted with CIL <c>family</c> accessibility.
+    /// </summary>
+    [Fact]
+    public void ProtectedMembers_AreEmittedFamily()
+    {
+        var dll = CompileToDll(
+            """
+            package Maui.Issue950.Tests
+
+            import System
+
+            open class Base {
+                protected var secret int32
+                protected func Reveal() int32 {
+                    return secret
+                }
+            }
+
+            func Main() {
+                let b = Base{}
+            }
+            """);
+        try
+        {
+            var fieldAttrs = GetFieldAttributes(dll, "Base", "secret");
+            Assert.Equal(FieldAttributes.Family, fieldAttrs & FieldAttributes.FieldAccessMask);
+
+            var methodAttrs = GetMethodAttributes(dll, "Base", "Reveal");
+            Assert.Equal(MethodAttributes.Family, methodAttrs & MethodAttributes.MemberAccessMask);
+        }
+        finally
+        {
+            TryDeleteDir(Path.GetDirectoryName(dll));
+        }
+    }
+
+    [Fact]
+    public void ExternalCode_AccessesProtectedField_FailsToCompile()
+    {
+        var (exit, output) = TryCompile(
+            """
+            package Maui.Issue950.Tests
+
+            import System
+
+            open class Base {
+                protected var secret int32
+            }
+
+            func Main() {
+                let b = Base{}
+                Console.WriteLine(b.secret)
+            }
+            """);
+        Assert.NotEqual(0, exit);
+        Assert.Contains("GS0379", output);
+    }
+
+    [Fact]
+    public void ExternalCode_CallsProtectedMethod_FailsToCompile()
+    {
+        var (exit, output) = TryCompile(
+            """
+            package Maui.Issue950.Tests
+
+            import System
+
+            open class Base {
+                protected func Reveal() int32 {
+                    return 1
+                }
+            }
+
+            func Main() {
+                let b = Base{}
+                Console.WriteLine(b.Reveal())
+            }
+            """);
+        Assert.NotEqual(0, exit);
+        Assert.Contains("GS0379", output);
+    }
+
+    [Fact]
+    public void ProtectedOnNonOpenClass_FailsToCompile()
+    {
+        var (exit, output) = TryCompile(
+            """
+            package Maui.Issue950.Tests
+
+            class Sealed {
+                protected var secret int32
+            }
+
+            func Main() {
+            }
+            """);
+        Assert.NotEqual(0, exit);
+        Assert.Contains("GS0380", output);
+    }
+
+    [Fact]
+    public void ProtectedOnStruct_FailsToCompile()
+    {
+        var (exit, output) = TryCompile(
+            """
+            package Maui.Issue950.Tests
+
+            struct Val {
+                protected var x int32
+            }
+
+            func Main() {
+            }
+            """);
+        Assert.NotEqual(0, exit);
+        Assert.Contains("GS0380", output);
+    }
+
+    private static FieldAttributes GetFieldAttributes(string dllPath, string typeName, string fieldName)
+    {
+        using var fs = File.OpenRead(dllPath);
+        using var pe = new PEReader(fs);
+        var mr = pe.GetMetadataReader();
+        foreach (var typeHandle in mr.TypeDefinitions)
+        {
+            var type = mr.GetTypeDefinition(typeHandle);
+            if (mr.GetString(type.Name) != typeName)
+            {
+                continue;
+            }
+
+            foreach (var fieldHandle in type.GetFields())
+            {
+                var field = mr.GetFieldDefinition(fieldHandle);
+                if (mr.GetString(field.Name) == fieldName)
+                {
+                    return field.Attributes;
+                }
+            }
+        }
+
+        throw new Xunit.Sdk.XunitException($"field {typeName}.{fieldName} not found in {dllPath}");
+    }
+
+    private static MethodAttributes GetMethodAttributes(string dllPath, string typeName, string methodName)
+    {
+        using var fs = File.OpenRead(dllPath);
+        using var pe = new PEReader(fs);
+        var mr = pe.GetMetadataReader();
+        foreach (var typeHandle in mr.TypeDefinitions)
+        {
+            var type = mr.GetTypeDefinition(typeHandle);
+            if (mr.GetString(type.Name) != typeName)
+            {
+                continue;
+            }
+
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = mr.GetMethodDefinition(methodHandle);
+                if (mr.GetString(method.Name) == methodName)
+                {
+                    return method.Attributes;
+                }
+            }
+        }
+
+        throw new Xunit.Sdk.XunitException($"method {typeName}.{methodName} not found in {dllPath}");
+    }
+
+    private static void CompileVerifyAndRun(string source, string expected)
+    {
+        var dll = CompileToDll(source);
+        try
+        {
+            IlVerifier.Verify(dll);
+
+            var runtimeConfigPath = Path.ChangeExtension(dll, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + dll + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            Assert.Equal(expected, stdout.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            TryDeleteDir(Path.GetDirectoryName(dll));
+        }
+    }
+
+    private static string CompileToDll(string source)
+    {
+        var (exit, output, outPath) = RunCompiler(source);
+        Assert.True(exit == 0, $"compile failed ({exit}): {output}");
+        return outPath;
+    }
+
+    private static (int Exit, string Output) TryCompile(string source)
+    {
+        var (exit, output, outDir) = RunCompiler(source);
+        TryDeleteDir(Path.GetDirectoryName(outDir));
+        return (exit, output);
+    }
+
+    private static (int Exit, string Output, string OutPath) RunCompiler(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue950_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+            srcPath,
+        };
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        return (compileExit, compileOut.ToString() + compileErr.ToString(), outPath);
+    }
+
+    private static void TryDeleteDir(string dir)
+    {
+        try
+        {
+            if (dir != null)
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue950ProtectedModifierTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue950ProtectedModifierTests.cs
@@ -1,0 +1,185 @@
+// <copyright file="Issue950ProtectedModifierTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #950 — the <c>protected</c> access modifier. A <c>protected</c> member
+/// is accessible within its declaring type and within types that derive from it
+/// (their own bodies), and is inaccessible from unrelated external code. It is
+/// only allowed on members of an inheritable <c>open class</c>; structs,
+/// non-open/sealed classes, and top-level declarations reject it (GS0380).
+/// External access reports GS0379.
+/// </summary>
+public class Issue950ProtectedModifierTests
+{
+    [Fact]
+    public void ProtectedKeyword_LexesAsModifier()
+    {
+        Assert.Equal(SyntaxKind.ProtectedKeyword, SyntaxFacts.GetKeywordKind("protected"));
+        Assert.Equal("protected", SyntaxFacts.GetText(SyntaxKind.ProtectedKeyword));
+    }
+
+    [Fact]
+    public void ProtectedField_ParsesWithoutDiagnostics_OnOpenClass()
+    {
+        var source = @"
+open class Base {
+    protected var secret int32
+}
+0
+";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        Assert.DoesNotContain(tree.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void DerivedClass_AccessesInheritedProtectedMember_NoDiagnostics()
+    {
+        var source = @"
+open class Base {
+    protected var secret int32
+    protected func Reveal() int32 {
+        return secret
+    }
+}
+
+class Derived : Base {
+    func Show() int32 {
+        secret = 7
+        return secret + Reveal()
+    }
+}
+
+var d = Derived{}
+d.Show()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(14, result.Value);
+    }
+
+    [Fact]
+    public void ExternalCode_ReadsProtectedField_ReportsGS0379()
+    {
+        var source = @"
+open class Base {
+    protected var secret int32
+}
+
+var b = Base{}
+b.secret
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    [Fact]
+    public void ExternalCode_CallsProtectedMethod_ReportsGS0379()
+    {
+        var source = @"
+open class Base {
+    protected func Reveal() int32 {
+        return 1
+    }
+}
+
+var b = Base{}
+b.Reveal()
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    [Fact]
+    public void ProtectedMember_OnNonOpenClass_ReportsGS0380()
+    {
+        var source = @"
+class Sealed {
+    protected var secret int32
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0380");
+    }
+
+    [Fact]
+    public void ProtectedMember_OnStruct_ReportsGS0380()
+    {
+        var source = @"
+struct Val {
+    protected var x int32
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0380");
+    }
+
+    [Fact]
+    public void ProtectedMethod_OnOpenClass_NoPlacementDiagnostic()
+    {
+        var source = @"
+open class Base {
+    protected func Reveal() int32 {
+        return 1
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0380");
+    }
+
+    [Fact]
+    public void ProtectedTopLevelClass_ReportsGS0380()
+    {
+        var source = @"
+protected class Foo {
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0380");
+    }
+
+    [Fact]
+    public void UnrelatedClass_CallsProtectedMember_ReportsGS0379()
+    {
+        // A sibling type that does NOT derive from Base may not reach a
+        // protected member, even though both are user types in the same file.
+        var source = @"
+open class Base {
+    protected func Reveal() int32 {
+        return 1
+    }
+}
+
+class Other {
+    func Probe(b Base) int32 {
+        return b.Reveal()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -180,6 +180,7 @@ PropertyDeclaration
 PropertyInitializer
 PropertyPattern
 PropertyPatternField
+ProtectedKeyword
 PublicKeyword
 QuestionDotToken
 QuestionOpenBracketToken

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/Visibility.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/Visibility.cs
@@ -22,4 +22,7 @@ public enum Visibility
 
     /// <summary>The <c>private</c> modifier.</summary>
     Private,
+
+    /// <summary>The <c>protected</c> modifier (issue #950).</summary>
+    Protected,
 }

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -62,6 +62,8 @@ public static class GSharpPrinter
                 return "internal ";
             case Visibility.Private:
                 return "private ";
+            case Visibility.Protected:
+                return "protected ";
             default:
                 return string.Empty;
         }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue950ProtectedTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue950ProtectedTranslationTests.cs
@@ -1,0 +1,83 @@
+// <copyright file="Issue950ProtectedTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #950 (ADR-0115 §B.10): the C#→G# translator maps C# <c>protected</c>
+/// to the new G# <c>protected</c> visibility (previously there was no mapping).
+/// Because <c>protected</c> members are only meaningful on inheritable types,
+/// the translator also forces the containing class to be <c>open</c>.
+/// </summary>
+public class Issue950ProtectedTranslationTests
+{
+    private const string Source = @"
+namespace Corpus.Issue950
+{
+    public class Animal
+    {
+        protected int Age;
+
+        protected int GetAge()
+        {
+            return Age;
+        }
+    }
+}
+";
+
+    [Fact]
+    public void ProtectedMembers_MapToProtectedVisibility()
+    {
+        (CompilationUnit unit, _) = Translate();
+        TypeDeclaration animal = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "Animal");
+
+        FieldDeclaration age = animal.Members.OfType<FieldDeclaration>().Single(f => f.Name == "Age");
+        Assert.Equal(Visibility.Protected, age.Visibility);
+
+        MethodDeclaration getAge = animal.Members.OfType<MethodDeclaration>().Single(m => m.Name == "GetAge");
+        Assert.Equal(Visibility.Protected, getAge.Visibility);
+    }
+
+    [Fact]
+    public void ClassWithProtectedMembers_IsForcedOpen()
+    {
+        (CompilationUnit unit, _) = Translate();
+        TypeDeclaration animal = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "Animal");
+        Assert.True(animal.IsOpen);
+    }
+
+    [Fact]
+    public void ProtectedMembers_RenderWithProtectedKeyword()
+    {
+        (CompilationUnit unit, _) = Translate();
+        string rendered = GSharpPrinter.Print(unit);
+        Assert.Contains("protected", rendered, StringComparison.Ordinal);
+        Assert.Contains("open class Animal", rendered, StringComparison.Ordinal);
+    }
+
+    private static (CompilationUnit Unit, TranslationContext Context) Translate()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Animal.cs", Source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return (unit, context);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -415,17 +415,47 @@ public sealed class CSharpToGSharpTranslator
                 case Accessibility.Internal:
                     return Visibility.Internal;
                 case Accessibility.Protected:
+                    // Issue #950: G# now has a first-class `protected` modifier
+                    // (CIL family). It is only valid on members of an `open`
+                    // class; the translator emits `open` on translatable
+                    // non-sealed classes so this maps cleanly.
+                    return Visibility.Protected;
                 case Accessibility.ProtectedOrInternal:
                 case Accessibility.ProtectedAndInternal:
+                    // `protected internal` (family-or-assembly) and
+                    // `private protected` (family-and-assembly) have no single
+                    // G# spelling; map to the nearest accessibility 'internal'.
                     context.Report(new TranslationDiagnostic(
                         symbol.DeclaredAccessibility.ToString(),
-                        $"'{symbol.Name}' is '{symbol.DeclaredAccessibility}'; G# has no 'protected' spelling, mapped to the nearest accessibility 'internal' (ADR-0115 §B.10).",
+                        $"'{symbol.Name}' is '{symbol.DeclaredAccessibility}'; G# has no combined 'protected internal'/'private protected' spelling, mapped to the nearest accessibility 'internal' (ADR-0115 §B.10).",
                         node?.GetLocation(),
                         TranslationSeverity.Warning));
                     return Visibility.Internal;
                 default:
                     return Visibility.Default;
             }
+        }
+
+        /// <summary>
+        /// Issue #950: returns <see langword="true"/> when <paramref name="type"/>
+        /// declares any member with a <c>protected</c>-family accessibility.
+        /// Such a class is intended for inheritance, so it must be emitted as an
+        /// <c>open class</c> for the G# <c>protected</c> modifier to be valid.
+        /// </summary>
+        private static bool HasProtectedMember(INamedTypeSymbol type)
+        {
+            foreach (var member in type.GetMembers())
+            {
+                switch (member.DeclaredAccessibility)
+                {
+                    case Accessibility.Protected:
+                    case Accessibility.ProtectedOrInternal:
+                    case Accessibility.ProtectedAndInternal:
+                        return true;
+                }
+            }
+
+            return false;
         }
 
         private static TypeDeclarationKind? MapAggregateKind(BaseTypeDeclarationSyntax node)
@@ -600,7 +630,7 @@ public sealed class CSharpToGSharpTranslator
                 kind == TypeDeclarationKind.Class &&
                 !symbol.IsSealed &&
                 !symbol.IsStatic &&
-                this.subclassedBases.Contains(symbol.OriginalDefinition);
+                (this.subclassedBases.Contains(symbol.OriginalDefinition) || HasProtectedMember(symbol));
 
             // G# has no `abstract` class modifier (the keyword is not recognized by
             // the parser); a C# `abstract class`/`abstract record` therefore maps to

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -492,6 +492,19 @@ declaration order; `const` fields fold to compile-time literal fields; static
 | GS0377 | Error | A field initializer cannot reference the instance member or constructor parameter `{name}` (field initializers run before the constructor body, so `this` is not available). Assign it in an `init(...)` constructor instead. |
 
 
+## `protected` accessibility diagnostics (GS0379–GS0380)
+
+Issue #950 — the `protected` access modifier (CIL `family`) makes a member
+accessible within its declaring type and the bodies of derived types only.
+Because protection is only meaningful where a derived type can exist,
+`protected` is restricted to members of an inheritable `open class`.
+
+| Code | Severity | Message |
+|------|----------|---------|
+| GS0379 | Error | `'{Type}.{member}' is inaccessible due to its protection level: a 'protected' member is only accessible within '{Type}' and types derived from it.` |
+| GS0380 | Error | `'protected' is only allowed on members of an 'open class' (a type that can be inherited). Mark the enclosing class 'open', or use a different accessibility.` |
+
+
 ## `deinit` (finalizer) diagnostics (GS0289–GS0292)
 
 ADR-0068 / issue #698 — `deinit { … }` declares a CLR finalizer on a

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -52,7 +52,7 @@ letter     = unicode_letter | "_" .
 The reserved keywords are:
 
 ```text
-as async await break case catch chan class const continue default defer do else enum false fallthrough finally for func go goto guard if import interface internal is let map nil open operator override package private public range return scope sealed select sequence struct switch throw true try type using var while
+as async await break case catch chan class const continue default defer do else enum false fallthrough finally for func go goto guard if import interface internal is let map nil open operator override package private protected public range return scope sealed select sequence struct switch throw true try type using var while
 ```
 
 Several words are contextual rather than reserved. `data`, `inline`, `prop`, `event`, `shared`, `init`, `get`, `set`, `add`, `remove`, `raise`, `in`, `out`, `yield`, `with`, `typeof`, `nameof`, and `make` retain identifier status except in the grammar contexts described below. The legacy `record` contextual keyword was removed by ADR-0078; the lexer still recognises it so the parser can emit the GS0307 migration diagnostic (`use data struct` / `data class`).
@@ -366,11 +366,11 @@ ImportDecl      = "import" ( identifier "=" )? identifier { "." identifier } .
 
 ### Top-level declarations
 
-Top-level members are functions, type declarations, variable declarations, or top-level statements. Mixing explicit `Main` and top-level statements is diagnosed. Accessibility modifiers are `public`, `internal`, and `private`; defaults depend on declaration context.
+Top-level members are functions, type declarations, variable declarations, or top-level statements. Mixing explicit `Main` and top-level statements is diagnosed. Accessibility modifiers are `public`, `internal`, `protected`, and `private`; defaults depend on declaration context. The `protected` modifier is only valid on members of an inheritable `open class` (see *Protected accessibility* below); applying it to a top-level declaration, a non-`open` (sealed) class, or a struct member is rejected with GS0380.
 
 ```ebnf
 Member        = Annotation* Accessibility? ( Async? FunctionDecl | TypeDecl | VariableDecl | GlobalStatement ) .
-Accessibility = "public" | "internal" | "private" .
+Accessibility = "public" | "internal" | "protected" | "private" .
 Annotation   = "@" ( AnnotationTarget ":" )? identifier { "." identifier } ( "(" Arguments? ")" )? .
 ```
 
@@ -416,7 +416,7 @@ TypeAliasDecl     = "type" identifier TypeParamList? "=" identifier .
 DelegateAliasDecl = "type" identifier TypeParamList? "=" "delegate" "func" "(" Parameters? ")" TypeClause? .
 AggregateDecl     = Visibility? OpenOrSealed? Data? Inline? AggregateKeyword identifier TypeParamList? PrimaryCtor? BaseClause? AggregateBody? .
 AggregateKeyword  = "class" | "struct" | "enum" | "interface" .
-Visibility        = "public" | "internal" | "private" .
+Visibility        = "public" | "internal" | "private" .  (* type-level; "protected" is a member-only modifier *)
 OpenOrSealed      = "open" | "sealed" .
 PrimaryCtor       = "(" Parameters? ")" .
 BaseClause        = ":" QualifiedTypeName ( "(" Arguments? ")" )? { "," QualifiedTypeName } .
@@ -447,6 +447,37 @@ EventAccessor    = ( "add" | "remove" | "raise" ) ( Block | ";" )? .
 InterfaceBody    = "{" ( InterfaceMethodDecl | PropertyDecl | EventDecl )* "}" .
 InterfaceMethodDecl = "func" identifier "(" Parameters? ")" TypeClause? FunctionBody .  (* FunctionBody ";" = no-body (abstract) marker; issue #881 *)
 ```
+
+#### Protected accessibility (issue #950)
+
+The `protected` modifier (CIL `family`) makes a member accessible **within its
+declaring type and within the bodies of types that derive from it**, and
+inaccessible from unrelated external code. It mirrors C# `protected`:
+
+- A `protected` field, method, property (and its `get`/`set`/`init` accessors),
+  event, or constructor is visible to the declaring class and to any class that
+  derives — directly or transitively — from it, when accessed from the derived
+  class's own body. Access from outside that inheritance chain reports
+  **GS0379** (`'<member>' is inaccessible due to its protection level`).
+- Because protection is only meaningful where a derived type can exist,
+  `protected` is permitted **only on members of an `open class`** (the only
+  inheritable G# types). Applying it to a member of a non-`open`/sealed class, a
+  `struct` member (structs are CLR value types and are never inheritable), a
+  nested type whose container is not an `open class`, or a top-level
+  declaration is rejected with **GS0380**
+  (`'protected' is only valid on members of an inheritable 'open' class`).
+- `protected` composes with `open`/`override`: a `protected open func` may be
+  overridden by a `protected override func` in a derived `open class`, and the
+  call dispatches virtually.
+- Emit: `protected` maps to `MethodAttributes.Family` / `FieldAttributes.Family`
+  (and `TypeAttributes.NestedFamily` for an eligible nested type), so the CLR
+  enforces the same rule on consumers compiled separately and the metadata is
+  IL-verifiable.
+
+Unlike `private`/`internal` — which G# currently leaves to CLR enforcement at
+run time — `protected` is enforced both at bind time (GS0379) and by the emitted
+`family` metadata.
+
 
 #### Indexer members (ADR-0118)
 
@@ -1116,7 +1147,7 @@ Member            ::= Annotation* Accessibility?
                       | DelegateDecl
                       | VariableDecl                 (* requires Accessibility *)
                       | GlobalStatement )
-Accessibility     ::= 'public' | 'internal' | 'private'
+Accessibility     ::= 'public' | 'internal' | 'protected' | 'private'  (* 'protected' is valid only on members of an inheritable 'open class'; see issue #950 *)
 Async             ::= 'async'
 Annotation        ::= '@' (AnnotationTarget ':')? identifier ('.' identifier)* ('(' Arguments? ')')?
 AnnotationTarget  ::= 'field' | 'param' | 'return' | 'type' | 'method' | 'property' | 'event' | 'module' | 'assembly' | 'genericparam'


### PR DESCRIPTION
## Summary

Adds a first-class `protected` access modifier to G#, mirroring C# `protected` / CIL `family`. Fixes #950.

## Semantics
- A `protected` member is accessible within its **declaring type** and the **bodies of types that derive from it**; access from unrelated external code is a compile error (**GS0379**) and is also enforced by the CLR through emitted `family` metadata.
- **Where `protected` is allowed:** only on members of an inheritable `open class`. Applying it to a member of a non-`open`/sealed class, a `struct` member, a nested type whose container is not an `open class`, or a top-level declaration reports **GS0380**.
- **Struct decision:** structs are CLR value types and are never inheritable, so `protected` on a struct member is rejected (GS0380) — consistent with the issue note ("protected would only be usable in `open` classes and structs": G# structs are not inheritable, so only `open class` qualifies).
- Composes with `open`/`override`: a `protected open func` may be overridden by a `protected override func` and dispatches virtually.

## Family mapping
`protected` → `FieldAttributes.Family` / `MethodAttributes.Family` (and `TypeAttributes.NestedFamily` for an eligible nested type). Property `get`/`set`/`init` accessors inherit the property's accessibility automatically. Metadata verified IL-verifiable via `PEReader` assertions.

## Implementation by area
- **Lexer/parser:** `SyntaxKind.ProtectedKeyword`; `SyntaxFacts` text/keyword mapping; accepted at all member-accessibility parse sites.
- **Symbols:** new `Accessibility.Protected`; `AccessibilityChecker.IsAccessible` walks the enclosing type's base-class chain.
- **Binder:** GS0379 enforcement at field/property read & assignment and user instance-method call sites; GS0380 placement validation (`DeclarationBinder`, top-level checks in `Binder`).
- **Emit:** `AccessibilityMap` Family/NestedFamily mappings.
- **cs2gs:** C# member `protected` → G# `protected`; a class declaring a protected member is forced `open`; `protected internal` / `private protected` remain triaged to `internal` (ADR-0115 §B.10 updated).

## Note on existing modifiers
G# currently leaves `private`/`internal` enforcement to the CLR at run time. `protected` is the first accessibility enforced **both** at bind time (GS0379) and via emitted `family` metadata — left `private`/`internal` behavior unchanged.

## Tests
- **Core.Tests** (`Issue950ProtectedModifierTests`): lexing, parsing, derived-access positive (evaluates to 14), GS0379 on external read/call, GS0380 on sealed/struct/top-level.
- **Compiler.Tests** (`Issue950ProtectedModifierEmitTests`): compile+IL-verify+run derived access; protected virtual override dispatch; **Family** field+method metadata assertions; negative compile tests (external access → GS0379; protected on non-open class & struct → GS0380).
- **Cs2Gs.Tests** (`Issue950ProtectedTranslationTests`): protected→protected mapping + forced-open + rendered keyword.
- Updated `coverage-matrix` golden for the new `SyntaxKind`.

## Docs
- `spec.md`: visibility grammar + new *Protected accessibility* section.
- `diagnostics.md`: GS0379 / GS0380.
- ADR-0115 §B.10: cs2gs `protected` mapping.

## Verification
- Full solution build: **0 warnings, 0 errors**.
- Targeted tests pass: Core (10), Emit (7), cs2gs (3); full Core.Tests suite green (3456 passed); Issue909 visibility regression green; full cs2gs suite green (113).