### PR TITLE
Fix emit ICE (GS9998) for a class field of a user struct/data-struct, and its declaration-order GS0113

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -672,6 +672,16 @@ public sealed class Binder
             binder.declarations.BindStructDeclarationBody(structSyntax, owningPackage, structSymbol);
         }
 
+        // Issue #973: now that every class shell has had its base clause bound
+        // and its base class installed, screen the resolved base relation for
+        // transitive inheritance cycles (e.g. `class B : C` / `class C : B`).
+        // The two-phase split declares all type-name shells before any base
+        // clause is bound — which is what makes legitimate forward references
+        // work — so such cycles can no longer be rejected by declaration order
+        // and must be detected explicitly here.
+        binder.declarations.DetectClassInheritanceCycles(
+            declaredStructs.Where(d => d.Symbol.IsClass).Select(d => d.Symbol));
+
         foreach (var (ifaceSyntax, ifaceSymbol) in declaredInterfaces)
         {
             var owningPackage = packageByTree[ifaceSyntax.SyntaxTree];

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -646,13 +646,30 @@ public sealed class Binder
             binder.declarations.BindEnumDeclaration(enumSyntax, owningPackage);
         }
 
+        // Issue #973: declare all struct/class type-name shells first (phase 1),
+        // then bind their bodies (phase 2). Splitting declaration from body
+        // binding lets a field/parameter/base-clause type forward-reference a
+        // user struct or class declared later in the same compilation —
+        // e.g. a `class` whose field type is a `struct` declared below it —
+        // mirroring the two-phase scheme already used for interfaces above.
         var structDeclarations = syntaxTrees.SelectMany(st => st.Root.Members)
                                             .OfType<StructDeclarationSyntax>();
+        var declaredStructs = new List<(StructDeclarationSyntax Syntax, StructSymbol Symbol)>();
         foreach (var structSyntax in structDeclarations)
         {
             var owningPackage = packageByTree[structSyntax.SyntaxTree];
             binder.declarations.ValidateTopLevelProtected(structSyntax.AccessibilityModifier);
-            binder.declarations.BindStructDeclaration(structSyntax, owningPackage);
+            var structSymbol = binder.declarations.DeclareStructShell(structSyntax, owningPackage);
+            if (structSymbol != null)
+            {
+                declaredStructs.Add((structSyntax, structSymbol));
+            }
+        }
+
+        foreach (var (structSyntax, structSymbol) in declaredStructs)
+        {
+            var owningPackage = packageByTree[structSyntax.SyntaxTree];
+            binder.declarations.BindStructDeclarationBody(structSyntax, owningPackage, structSymbol);
         }
 
         foreach (var (ifaceSyntax, ifaceSymbol) in declaredInterfaces)

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -330,7 +330,36 @@ internal sealed class DeclarationBinder
         return enumSymbol;
     }
 
+    /// <summary>
+    /// Issue #973: declares and fully binds a struct/class in a single pass
+    /// (phase 1 + phase 2). Used for nested type declarations, which are bound
+    /// recursively from within their container's body rather than through the
+    /// top-level two-phase loop.
+    /// </summary>
     internal StructSymbol BindStructDeclaration(StructDeclarationSyntax syntax, PackageSymbol package)
+    {
+        var structSymbol = DeclareStructShell(syntax, package);
+        if (structSymbol == null)
+        {
+            return null;
+        }
+
+        BindStructDeclarationBody(syntax, package, structSymbol);
+        return structSymbol;
+    }
+
+    /// <summary>
+    /// Issue #973 (phase 1): declares the struct/class type-name shell and
+    /// registers it in scope BEFORE any member body is bound, so that field,
+    /// parameter, and base-clause types may forward-reference a user type
+    /// declared later in the same compilation (e.g. a <c>class</c> whose field
+    /// type is a <c>struct</c> declared further down). The returned shell has
+    /// empty <see cref="StructSymbol.Fields"/> and
+    /// <see cref="StructSymbol.PrimaryConstructorParameters"/>; those — along
+    /// with the base clause and all members — are bound and installed later by
+    /// <see cref="BindStructDeclarationBody"/>.
+    /// </summary>
+    internal StructSymbol DeclareStructShell(StructDeclarationSyntax syntax, PackageSymbol package)
     {
         var name = syntax.Identifier.Text;
 
@@ -357,8 +386,67 @@ internal sealed class DeclarationBinder
                     binderCtx.CurrentTypeParameters[tp.Name] = tp;
                 }
             }
+        }
+        finally
+        {
+            binderCtx.CurrentTypeParameters = previousTypeParameters;
+        }
 
-            return BindStructDeclarationBody(syntax, package, accessibility, name, typeParameters);
+        // Issue #949 / #973: construct the struct symbol shell now and register
+        // it in scope so that (a) the type may reference itself as a generic
+        // type argument in its own base/interface clause, and (b) any other
+        // user type may reference it by name regardless of declaration order.
+        // Instance fields and primary-constructor parameters are bound and
+        // installed later by BindStructDeclarationBody.
+        var structSymbol = new StructSymbol(
+            name,
+            ImmutableArray<FieldSymbol>.Empty,
+            accessibility,
+            syntax,
+            package.Name,
+            syntax.IsData,
+            syntax.IsInline,
+            syntax.IsClass,
+            ImmutableArray<ParameterSymbol>.Empty,
+            isOpen: syntax.IsOpen && syntax.IsClass,
+            baseClass: null);
+        Binder.AttachDocumentation(structSymbol, syntax);
+
+        if (!typeParameters.IsDefaultOrEmpty)
+        {
+            structSymbol.SetTypeParameters(typeParameters);
+        }
+
+        if (!scope.TryDeclareTypeAlias(name, structSymbol))
+        {
+            Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
+        }
+
+        return structSymbol;
+    }
+
+    /// <summary>
+    /// Issue #973 (phase 2): binds the body of a previously declared struct/class
+    /// shell — its instance fields, primary-constructor parameters, base clause,
+    /// and all members — and installs them on <paramref name="structSymbol"/>.
+    /// Re-establishes the type-parameter scope captured at declaration time so
+    /// member types can reference the type's own type parameters.
+    /// </summary>
+    internal void BindStructDeclarationBody(StructDeclarationSyntax syntax, PackageSymbol package, StructSymbol structSymbol)
+    {
+        var previousTypeParameters = binderCtx.CurrentTypeParameters;
+        try
+        {
+            if (!structSymbol.TypeParameters.IsDefaultOrEmpty)
+            {
+                binderCtx.CurrentTypeParameters = new Dictionary<string, TypeParameterSymbol>();
+                foreach (var tp in structSymbol.TypeParameters)
+                {
+                    binderCtx.CurrentTypeParameters[tp.Name] = tp;
+                }
+            }
+
+            BindStructDeclarationBodyCore(syntax, package, structSymbol);
         }
         finally
         {
@@ -460,13 +548,13 @@ internal sealed class DeclarationBinder
         _ => null,
     };
 
-    private StructSymbol BindStructDeclarationBody(
+    private void BindStructDeclarationBodyCore(
         StructDeclarationSyntax syntax,
         PackageSymbol package,
-        Accessibility accessibility,
-        string name,
-        ImmutableArray<TypeParameterSymbol> typeParameters)
+        StructSymbol structSymbol)
     {
+        var name = structSymbol.Name;
+        var accessibility = structSymbol.Accessibility;
         var seenFieldNames = new HashSet<string>();
         var fields = ImmutableArray.CreateBuilder<FieldSymbol>();
 
@@ -690,37 +778,17 @@ internal sealed class DeclarationBinder
         // any conflicting explicit base.
         var hasAttributeSugar = HasAttributeSugarMarker(syntax.Annotations);
 
-        // Issue #949: construct the struct symbol BEFORE binding its base-type
-        // clause and register it in scope, so the enclosing type may reference
-        // itself as a generic type argument within its own base/interface list
-        // (the common `class Shape : IEquatable[Shape]` pattern). Name
-        // resolution of the self type argument (see `LookupType`) finds this
-        // in-progress symbol. The resolved base class — if any — is installed
-        // afterwards via `SetBaseClass`. Genuine self-inheritance
-        // (`class A : A`) is rejected explicitly in the base-clause loop below.
-        var structSymbol = new StructSymbol(
-            name,
+        // Issue #949 / #973: the struct symbol shell was constructed and
+        // registered in scope by DeclareStructShell (phase 1) so it could be
+        // referenced as a self type argument in its own base/interface clause
+        // and forward-referenced by other user types. Now that the instance
+        // fields and primary-constructor parameters have been bound, install
+        // them on the shell. The resolved base class — if any — is installed
+        // afterwards via SetBaseClass. Genuine self-inheritance (`class A : A`)
+        // is rejected explicitly in the base-clause loop below.
+        structSymbol.SetInstanceFieldsAndPrimaryConstructorParameters(
             fields.ToImmutable(),
-            accessibility,
-            syntax,
-            package.Name,
-            syntax.IsData,
-            syntax.IsInline,
-            syntax.IsClass,
-            primaryCtorParameters,
-            isOpen: syntax.IsOpen && syntax.IsClass,
-            baseClass: null);
-        Binder.AttachDocumentation(structSymbol, syntax);
-
-        if (!typeParameters.IsDefaultOrEmpty)
-        {
-            structSymbol.SetTypeParameters(typeParameters);
-        }
-
-        if (!scope.TryDeclareTypeAlias(name, structSymbol))
-        {
-            Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
-        }
+            primaryCtorParameters);
 
         // Phase 3.B.3 sub-step 3 + 3.B.4: resolve the optional `: X, Y, Z` clause.
         // Each identifier is either the (single) base class or an interface
@@ -2213,8 +2281,6 @@ internal sealed class DeclarationBinder
         // interface / enum) declared inside this aggregate's body, recording the
         // enclosing type so the emitter materialises real CLR nested types.
         BindNestedTypeDeclarations(syntax, structSymbol, package);
-
-        return structSymbol;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -349,6 +349,100 @@ internal sealed class DeclarationBinder
     }
 
     /// <summary>
+    /// Issue #973: detects transitive base-class inheritance cycles among the
+    /// supplied class symbols and reports a diagnostic for each one. Before the
+    /// two-phase declaration split (#973) a base clause could only resolve a
+    /// type declared earlier in source, so a mutual cycle such as
+    /// <c>class B : C</c> / <c>class C : B</c> was implicitly rejected because
+    /// the forward reference failed to resolve. Now that all type-name shells
+    /// are declared before any base clause is bound — which is exactly what
+    /// makes legitimate forward references work — the cycle resolves cleanly
+    /// and must be caught here, after every base class is installed via
+    /// <see cref="StructSymbol.SetBaseClass"/>. Each <see cref="StructSymbol"/>
+    /// has at most one user base class, so the base relation forms a functional
+    /// graph; this walks every node's chain and, on finding a back-edge into the
+    /// current path, reports the cycle and clears the offending base link so the
+    /// later base-chain walks in <see cref="StructSymbol"/> and the emitter do
+    /// not loop forever. Direct self-inheritance (<c>class A : A</c>) never
+    /// reaches here because it is rejected — and its base left unset — in the
+    /// base-clause loop.
+    /// </summary>
+    internal void DetectClassInheritanceCycles(IEnumerable<StructSymbol> classSymbols)
+    {
+        var acyclic = new HashSet<StructSymbol>();
+        foreach (var start in classSymbols)
+        {
+            if (start.BaseClass == null || acyclic.Contains(start))
+            {
+                continue;
+            }
+
+            var path = new List<StructSymbol>();
+            var onPath = new HashSet<StructSymbol>();
+            var current = start;
+            while (current != null)
+            {
+                if (onPath.Contains(current))
+                {
+                    var baseLocation = GetBaseClauseLocation(current);
+                    Diagnostics.ReportClassInheritanceCycle(baseLocation, current.Name);
+
+                    // Break the back-edge so subsequent base-chain walks (member
+                    // lookup, the emitter, etc.) terminate. Binding already
+                    // failed, so the program will not be emitted.
+                    current.SetBaseClass(null);
+                    break;
+                }
+
+                if (acyclic.Contains(current))
+                {
+                    break;
+                }
+
+                path.Add(current);
+                onPath.Add(current);
+                current = current.BaseClass;
+            }
+
+            foreach (var node in path)
+            {
+                acyclic.Add(node);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Issue #973: returns the text location of a class declaration's base-type
+    /// clause (the first base/interface identifier), falling back to the type
+    /// identifier when the base clause carries no usable location. Used to
+    /// anchor inheritance-cycle diagnostics.
+    /// </summary>
+    private static TextLocation GetBaseClauseLocation(StructSymbol classSymbol)
+    {
+        var declaration = classSymbol.Declaration;
+        if (declaration == null)
+        {
+            return default;
+        }
+
+        if (declaration.BaseTypeClauses.Count > 0)
+        {
+            var location = declaration.BaseTypeClauses[0].Identifier?.Location;
+            if (location != null)
+            {
+                return location.Value;
+            }
+        }
+
+        if (declaration.BaseTypeIdentifier != null)
+        {
+            return declaration.BaseTypeIdentifier.Location;
+        }
+
+        return declaration.Identifier.Location;
+    }
+
+    /// <summary>
     /// Issue #973 (phase 1): declares the struct/class type-name shell and
     /// registers it in scope BEFORE any member body is bound, so that field,
     /// parameter, and base-clause types may forward-reference a user type

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1290,6 +1290,23 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0378", $"Class '{typeName}' cannot inherit from itself.");
     }
 
+    /// <summary>
+    /// Issue #973: reports a class that participates in a transitive base-class
+    /// inheritance cycle (e.g. <c>class B : C</c> together with
+    /// <c>class C : B</c>). The two-phase declaration model (#973) declares all
+    /// type-name shells before binding any base clause, so such mutually
+    /// forward-referencing cycles can no longer be screened out by declaration
+    /// order and must be detected explicitly once every base class is resolved.
+    /// Direct self-inheritance (<c>class A : A</c>) is reported separately by
+    /// <see cref="ReportClassInheritsFromItself"/>.
+    /// </summary>
+    /// <param name="location">The text location of the base-type clause.</param>
+    /// <param name="typeName">The declaring type name.</param>
+    public void ReportClassInheritanceCycle(TextLocation location, string typeName)
+    {
+        Report(location, "GS0381", $"Class '{typeName}' is part of an inheritance cycle.");
+    }
+
     /// <summary>Reports base-constructor arguments (<c>: Base(args)</c>) on a class that declares no base class (issue #306).</summary>
     /// <param name="location">The text location of the base-constructor argument list.</param>
     public void ReportBaseConstructorArgumentsWithoutBase(TextLocation location)

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1399,6 +1399,74 @@ internal sealed class ReflectionMetadataEmitter
             fieldList: MetadataTokens.FieldDefinitionHandle(moduleFirstFieldRow),
             methodList: MetadataTokens.MethodDefinitionHandle(1));
 
+        // Issue #973: pre-reserve the TypeDefinitionHandle for every user
+        // TypeDef (interfaces, delegates, classes, structs, enums — top-level
+        // and nested) BEFORE any member signature is encoded. A field, method,
+        // or return signature may reference a user type whose TypeDef row is
+        // emitted later in this same pass — e.g. a `class` field whose type is a
+        // user `struct`, since classes are emitted before structs below. Without
+        // a pre-reserved handle, EncodeTypeSymbol cannot resolve such a forward
+        // reference and throws ("type has no emitted TypeDef").
+        //
+        // The emission order below is fixed and each type contributes exactly
+        // one TypeDef row (the first being `<Module>` at row 1 per ECMA-335), so
+        // the row numbers are fully deterministic at this point. Pre-populating
+        // the caches with the predicted handles lets EncodeTypeSymbol resolve a
+        // referenced type regardless of relative emission order. Each
+        // EmitXxxTypeDef call below re-assigns the identical handle, so emitted
+        // metadata is byte-for-byte unchanged for programs that already
+        // compiled.
+        int reservedTypeDefRow = this.emitCtx.Metadata.GetRowCount(TableIndex.TypeDef) + 1;
+        void ReserveTypeDefHandle(TypeSymbol type)
+        {
+            var handle = MetadataTokens.TypeDefinitionHandle(reservedTypeDefRow++);
+            switch (type)
+            {
+                case InterfaceSymbol ifaceSym:
+                    this.cache.InterfaceTypeDefs[ifaceSym] = handle;
+                    break;
+                case DelegateTypeSymbol delegateSym:
+                    this.cache.DelegateTypeDefs[delegateSym] = handle;
+                    break;
+                case StructSymbol structSym:
+                    this.cache.StructTypeDefs[structSym] = handle;
+                    break;
+                case EnumSymbol enumSym:
+                    this.cache.EnumTypeDefs[enumSym] = handle;
+                    break;
+            }
+        }
+
+        foreach (var i in topInterfaces)
+        {
+            ReserveTypeDefHandle(i);
+        }
+
+        foreach (var d in delegates)
+        {
+            ReserveTypeDefHandle(d);
+        }
+
+        foreach (var c in topClasses)
+        {
+            ReserveTypeDefHandle(c);
+        }
+
+        foreach (var s in topStructs)
+        {
+            ReserveTypeDefHandle(s);
+        }
+
+        foreach (var e in topEnums)
+        {
+            ReserveTypeDefHandle(e);
+        }
+
+        foreach (var nested in nestedOrdered)
+        {
+            ReserveTypeDefHandle(nested);
+        }
+
         // 2a. Phase 3.B.4: Emit interface TypeDefs + their abstract method
         // rows. Interfaces have no fields and only abstract method bodies, so
         // they are the simplest TypeDefs to emit. Their methodList points at

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -153,7 +153,7 @@ public sealed class StructSymbol : TypeSymbol
     }
 
     /// <summary>Gets the field declarations in source order.</summary>
-    public ImmutableArray<FieldSymbol> Fields { get; }
+    public ImmutableArray<FieldSymbol> Fields { get; private set; }
 
     /// <summary>Gets the struct CLR accessibility.</summary>
     public Accessibility Accessibility { get; }
@@ -185,7 +185,7 @@ public sealed class StructSymbol : TypeSymbol
     public bool IsClass { get; }
 
     /// <summary>Gets the Kotlin-style primary constructor parameters (Phase 3.B.3 sub-step 2). Each entry corresponds 1:1 to a field of the same name and type on this class; empty when no primary constructor was declared (default parameterless ctor).</summary>
-    public ImmutableArray<ParameterSymbol> PrimaryConstructorParameters { get; }
+    public ImmutableArray<ParameterSymbol> PrimaryConstructorParameters { get; private set; }
 
     /// <summary>Gets a value indicating whether this type carries an explicit primary constructor (Phase 3.B.3 sub-step 2).</summary>
     public bool HasPrimaryConstructor => !PrimaryConstructorParameters.IsDefaultOrEmpty;
@@ -394,6 +394,26 @@ public sealed class StructSymbol : TypeSymbol
     public void SetInterfaces(ImmutableArray<InterfaceSymbol> interfaces)
     {
         Interfaces = interfaces;
+    }
+
+    /// <summary>
+    /// Issue #973: sets <see cref="Fields"/> and
+    /// <see cref="PrimaryConstructorParameters"/> after the symbol shell is
+    /// declared. The binder declares every top-level struct/class name (with
+    /// empty fields) up front so that field types may forward-reference a user
+    /// type declared later in the same compilation, then binds each body and
+    /// installs the resolved instance fields and primary-constructor parameters
+    /// here. Intended to be called exactly once by the binder during
+    /// <c>BindStructDeclaration</c>.
+    /// </summary>
+    /// <param name="fields">The bound instance field symbols in source order.</param>
+    /// <param name="primaryConstructorParameters">The bound primary-constructor parameters, or empty when none were declared.</param>
+    public void SetInstanceFieldsAndPrimaryConstructorParameters(
+        ImmutableArray<FieldSymbol> fields,
+        ImmutableArray<ParameterSymbol> primaryConstructorParameters)
+    {
+        Fields = fields;
+        PrimaryConstructorParameters = primaryConstructorParameters;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue949SelfTypeArgumentInBaseClauseEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue949SelfTypeArgumentInBaseClauseEmitTests.cs
@@ -271,6 +271,72 @@ public class Issue949SelfTypeArgumentInBaseClauseEmitTests
         Assert.True(diagnostics.Count > 0, "expected an inheritance-cycle diagnostic");
     }
 
+    [Fact]
+    public void ThreeTypeInheritanceCycle_IsRejected()
+    {
+        // A transitive base-class cycle spanning three types (A : B, B : C,
+        // C : A) must be rejected. This guards the multi-hop chain walk in the
+        // post-bind cycle detector (#973), not just the two-type case.
+        var diagnostics = CompileExpectingErrors("""
+            package Probe
+
+            open class A : B {
+                let U int32
+            }
+
+            open class B : C {
+                let V int32
+            }
+
+            open class C : A {
+                let W int32
+            }
+            """);
+
+        Assert.Contains(diagnostics, d => d.Contains("GS0381"));
+    }
+
+    [Fact]
+    public void TwoTypeInheritanceCycle_ReportsGS0381()
+    {
+        // The two-type cycle must surface the dedicated inheritance-cycle
+        // diagnostic (GS0381), distinct from direct self-inheritance (GS0378).
+        var diagnostics = CompileExpectingErrors("""
+            package Probe
+
+            open class B : C {
+                let V int32
+            }
+
+            open class C : B {
+                let W int32
+            }
+            """);
+
+        Assert.Contains(diagnostics, d => d.Contains("GS0381"));
+    }
+
+    [Fact]
+    public void ForwardBaseClassReference_IsAccepted()
+    {
+        // A class deriving from a base declared later in source is a legitimate
+        // forward reference (enabled by the #973 two-phase split) and must NOT
+        // be misreported as an inheritance cycle.
+        var path = CompileLibrary("""
+            package Probe
+
+            class Derived : Base {
+                let V int32
+            }
+
+            open class Base {
+                let W int32
+            }
+            """);
+
+        Assert.True(File.Exists(path));
+    }
+
     private static string CompileLibrary(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue949_lib_").FullName;

--- a/test/Compiler.Tests/Emit/Issue973ClassValueTypeFieldEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue973ClassValueTypeFieldEmitTests.cs
@@ -1,0 +1,220 @@
+// <copyright file="Issue973ClassValueTypeFieldEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #973 — emit + IL-verify + runtime coverage for a <c>class</c> that
+/// declares a field whose type is a user value type (<c>struct</c> or
+/// <c>data struct</c>).
+///
+/// The reported symptom was an internal emit crash
+/// (<c>GS9998: InvalidOperationException: Struct 'S' has no emitted TypeDef.</c>)
+/// when a <c>class</c> field referenced a user <c>struct</c>: classes are
+/// emitted before structs, so when the class field signature was encoded the
+/// struct's TypeDef row had not yet been registered. A second, order-sensitive
+/// symptom (<c>GS0113: Type 'S' doesn't exist.</c>) appeared when the struct was
+/// declared AFTER the class, because struct/class names were declared and their
+/// bodies bound in a single source-order pass.
+///
+/// The fix has two parts:
+///   - Emit: pre-reserve every user TypeDefinitionHandle before any member
+///     signature is encoded, so a forward-referenced type resolves regardless
+///     of relative emission order.
+///   - Bind: declare every struct/class type-name shell first, then bind their
+///     bodies, so a field type can forward-reference a type declared later.
+///
+/// These tests cover the shapes the fix unblocks, asserting the program
+/// compiles, passes IL verification, emits the struct as a real value-type
+/// field of the class, and round-trips a value at runtime — for both
+/// declaration orders and for <c>data struct</c> fields.
+/// </summary>
+public class Issue973ClassValueTypeFieldEmitTests
+{
+    #region Exact repro — struct declared BEFORE the class
+
+    [Fact]
+    public void ClassWithStructField_StructBeforeClass_CompilesVerifiesAndRoundTrips()
+    {
+        var source = """
+            package Probe
+
+            struct S {
+                var X int32
+            }
+
+            class C {
+                var Field S
+                init(f S) { Field = f }
+            }
+
+            public var value = C(S{ X: 7 }).Field.X
+            """;
+
+        var assembly = CompileVerifyAndRun(source);
+
+        Assert.Equal(7, GetField<int>(assembly, "value"));
+        AssertFieldIsValueType(assembly, className: "C", fieldName: "Field", fieldTypeName: "S");
+    }
+
+    #endregion
+
+    #region Order symptom — struct declared AFTER the class (was GS0113)
+
+    [Fact]
+    public void ClassWithStructField_StructAfterClass_CompilesVerifiesAndRoundTrips()
+    {
+        var source = """
+            package Probe
+
+            class C {
+                var Field S
+                init(f S) { Field = f }
+            }
+
+            struct S {
+                var X int32
+            }
+
+            public var value = C(S{ X: 9 }).Field.X
+            """;
+
+        var assembly = CompileVerifyAndRun(source);
+
+        Assert.Equal(9, GetField<int>(assembly, "value"));
+        AssertFieldIsValueType(assembly, className: "C", fieldName: "Field", fieldTypeName: "S");
+    }
+
+    #endregion
+
+    #region data struct field
+
+    [Fact]
+    public void ClassWithDataStructField_CompilesVerifiesAndRoundTrips()
+    {
+        var source = """
+            package Probe
+
+            data struct S {
+                var X int32
+            }
+
+            class C {
+                var Field S
+                init(f S) { Field = f }
+            }
+
+            public var value = C(S{ X: 42 }).Field.X
+            """;
+
+        var assembly = CompileVerifyAndRun(source);
+
+        Assert.Equal(42, GetField<int>(assembly, "value"));
+        AssertFieldIsValueType(assembly, className: "C", fieldName: "Field", fieldTypeName: "S");
+    }
+
+    #endregion
+
+    #region Mutual forward reference between two classes (was GS0113)
+
+    [Fact]
+    public void ClassWithForwardReferencedClassField_CompilesAndRoundTrips()
+    {
+        var source = """
+            package Probe
+
+            class A {
+                var Inner B
+                init(b B) { Inner = b }
+            }
+
+            class B {
+                var X int32
+                init(x int32) { X = x }
+            }
+
+            public var value = A(B(5)).Inner.X
+            """;
+
+        var assembly = CompileVerifyAndRun(source);
+
+        Assert.Equal(5, GetField<int>(assembly, "value"));
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static Assembly CompileVerifyAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_973_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        return assembly;
+    }
+
+    private static T GetField<T>(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var resultField = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (T)resultField!.GetValue(null)!;
+    }
+
+    private static void AssertFieldIsValueType(Assembly assembly, string className, string fieldName, string fieldTypeName)
+    {
+        var classType = assembly.GetTypes().Single(t => t.Name == className);
+        Assert.True(classType.IsClass, $"'{className}' should be emitted as a reference type.");
+
+        var field = classType.GetField(fieldName, BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(field);
+        Assert.Equal(fieldTypeName, field!.FieldType.Name);
+        Assert.True(field.FieldType.IsValueType, $"field '{fieldName}' should be a value type ('{fieldTypeName}').");
+    }
+
+    #endregion
+}

--- a/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
@@ -160,17 +160,15 @@ public class MigrationPipelineTests
     }
 
     /// <summary>
-    /// Pointing the pipeline at <c>corpus/L2-Library</c> now translates cleanly
-    /// (interfaces, casts, owned-struct methods, composite literals, etc. are all
-    /// mapped) and reaches the compile stage, where it captures a
-    /// <c>compile-error</c> triage artifact for the residual <c>GS0144</c>
-    /// static-overload-resolution compiler gap (a sibling <c>shared</c> overload
-    /// is bound by name only, ignoring arity). The artifact carries a non-empty
-    /// diagnostic id and a stable <c>sha256:</c> fingerprint. Gated on compiler
+    /// Issue #973 regression guard: pointing the pipeline at
+    /// <c>corpus/L2-Library</c> (a <c>class Rectangle</c> holding a
+    /// <c>Dimensions</c> value-type field) now migrates GREEN through the
+    /// compile stage. This previously failed with the emit ICE
+    /// <c>GS9998: Struct 'S' has no emitted TypeDef.</c> Gated on compiler
     /// presence (the pipeline resolves <c>gsc</c> up front).
     /// </summary>
     [Fact]
-    public async Task L2_CompileStageFailure_WritesTriageArtifact()
+    public async Task L2_StagesOneAndTwo_AreGreen_WithZeroArtifacts()
     {
         string compiler = FindCompiler();
         if (compiler is null)
@@ -179,12 +177,52 @@ public class MigrationPipelineTests
         }
 
         string corpus = ResolveCorpusDir();
-        string outRoot = NewOutputRoot("l2-capture");
+        string outRoot = NewOutputRoot("l2-green");
+        var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
+
+        // Pin to stages 1–2 so this test stays focused on the compile gate
+        // regardless of the default stage list (which also runs ilverify).
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+
+        CorpusApp l2 = CorpusDiscovery.FindById(corpus, "corpus/L2-Library");
+        Assert.NotNull(l2);
+
+        RunResult result = await pipeline.RunAsync(new[] { l2 });
+        AppResult app = Assert.Single(result.Apps);
+
+        Assert.True(app.Succeeded, "L2 must migrate green through stage 2 (issue #973).");
+        Assert.Empty(app.Artifacts);
+        Assert.All(app.Stages, s => Assert.Equal("passed", s.Status));
+        Assert.Equal(2, app.Stages.Count);
+    }
+
+    /// <summary>
+    /// Pointing the pipeline at <c>corpus/L3-Library</c> translates cleanly but
+    /// reaches the compile stage and captures a <c>compile-error</c> triage
+    /// artifact for residual compiler gaps (generic <c>IEnumerable</c>
+    /// implementation / <c>GetEnumerator</c> overload resolution). The artifact
+    /// carries a non-empty diagnostic id and a stable <c>sha256:</c>
+    /// fingerprint. Gated on compiler presence (the pipeline resolves
+    /// <c>gsc</c> up front).
+    /// </summary>
+    [Fact]
+    public async Task L3_CompileStageFailure_WritesTriageArtifact()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            return;
+        }
+
+        string corpus = ResolveCorpusDir();
+        string outRoot = NewOutputRoot("l3-capture");
         var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
         var pipeline = new MigrationPipeline(options);
 
-        CorpusApp l2 = CorpusDiscovery.FindById(corpus, "corpus/L2-Library");
-        RunResult result = await pipeline.RunAsync(new[] { l2 });
+        CorpusApp l3 = CorpusDiscovery.FindById(corpus, "corpus/L3-Library");
+        RunResult result = await pipeline.RunAsync(new[] { l3 });
         AppResult app = Assert.Single(result.Apps);
 
         Assert.False(app.Succeeded);
@@ -203,8 +241,9 @@ public class MigrationPipelineTests
 
     /// <summary>
     /// Re-running against the same <c>--gsc</c> carries the prior run forward in
-    /// each fingerprint's <c>retryHistory</c> (the §C retry mechanism). Gated on
-    /// compiler presence.
+    /// each fingerprint's <c>retryHistory</c> (the §C retry mechanism). Anchored
+    /// on <c>corpus/L3-Library</c>, which still fails at the compile stage.
+    /// Gated on compiler presence.
     /// </summary>
     [Fact]
     public async Task RetryHistory_AccumulatesAcrossRuns_ForSameFingerprint()
@@ -219,10 +258,10 @@ public class MigrationPipelineTests
         string outRoot = NewOutputRoot("retry");
         var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
 
-        CorpusApp l2 = CorpusDiscovery.FindById(corpus, "corpus/L2-Library");
+        CorpusApp l3 = CorpusDiscovery.FindById(corpus, "corpus/L3-Library");
 
-        RunResult first = await new MigrationPipeline(options).RunAsync(new[] { l2 });
-        RunResult second = await new MigrationPipeline(options).RunAsync(new[] { l2 });
+        RunResult first = await new MigrationPipeline(options).RunAsync(new[] { l3 });
+        RunResult second = await new MigrationPipeline(options).RunAsync(new[] { l3 });
 
         Assert.NotEqual(first.RunId, second.RunId);
 


### PR DESCRIPTION
## Summary
Emitting a `class` with a field whose type is a user `struct`/`data struct` crashed with `GS9998: InvalidOperationException: Struct 'S' has no emitted TypeDef.`, and when the struct was declared **after** the class, binding failed earlier with `GS0113: Type 'S' doesn't exist.` This fixes both, so a class field of a value type compiles, verifies, and round-trips regardless of declaration order.

## Root cause
Two layers of the same defect surface:

- **Emit** (`ReflectionMetadataEmitter`): TypeDef rows are written `interfaces → delegates → classes → structs → enums → nested`. A class's field signatures are encoded while the class TypeDef is emitted — *before* any struct TypeDef row exists — so `EncodeTypeSymbol`'s `cache.StructTypeDefs` lookup missed and threw. (The same hole affected interface methods / enum-typed members referencing later types.)
- **Bind** (`DeclarationBinder`): struct/class names were declared and their bodies bound in a single source-order pass, so a field/parameter/base-clause type could not forward-reference a type declared later — producing `GS0113`.

## Fix
- **Emit:** pre-reserve the `TypeDefinitionHandle` for every user type (interfaces, delegates, classes, structs, enums; top-level and nested) immediately after `<Module>`, before any member signature is encoded. Row numbers are fully deterministic there, so each subsequent `EmitXxxTypeDef` re-assigns the identical handle and emitted metadata is **byte-for-byte unchanged** for programs that already compiled — only previously-missing forward lookups now resolve.
- **Bind:** split struct/class binding into two phases — declare all type-name shells first (`DeclareStructShell`), then bind their bodies (`BindStructDeclarationBody`), mirroring the existing interface scheme. New `StructSymbol.SetInstanceFieldsAndPrimaryConstructorParameters` installs the bound members on the shell.

## Verification
- Repro compiles in **both** declaration orders; `data struct` field and mutual forward references compile and **round-trip at runtime** on net10.0. Controls from the issue still compile.
- New `Issue973ClassValueTypeFieldEmitTests` — 4 facts (struct-before, struct-after, data-struct, mutual class forward-ref), each compiles + **ilverify-clean** + asserts the struct is a real value-type field + runtime value.
- Full `Core.Tests` (3456) pass; 753 related `Emit` tests (struct/field/interface/enum/delegate/generic/nested) pass.
- `cs2gs` `corpus/L2-Library` (the `class Rectangle` holding a `Dimensions` struct field) now migrates **green** end-to-end (translate/compile/ilverify/test-parity). The two L2 *capture* tests that asserted L2 fails were re-pointed to `corpus/L3-Library` (still-failing anchor: residual `GS0187`/`GS0264` generic-enumerator gaps), and an L2-green regression guard was added — cs2gs suite 129 green.
- `GSharp.sln` builds **0 warning / 0 error**.

Fixes #973