### PR TITLE
Fix GS0187 for generic-interface impls returning/taking constructed generics (#974)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -4358,7 +4358,7 @@ internal sealed class DeclarationBinder
 
     private static bool SignaturesMatch(FunctionSymbol baseMethod, ImmutableArray<ParameterSymbol> derivedParams, TypeSymbol derivedReturnType, RefKind derivedReturnRefKind)
     {
-        if (baseMethod.Type != derivedReturnType)
+        if (!TypeSignaturesEquivalent(baseMethod.Type, derivedReturnType))
         {
             return false;
         }
@@ -4378,7 +4378,7 @@ internal sealed class DeclarationBinder
 
         for (var i = 0; i < derivedParams.Length; i++)
         {
-            if (baseParams[i].Type != derivedParams[i].Type)
+            if (!TypeSignaturesEquivalent(baseParams[i].Type, derivedParams[i].Type))
             {
                 return false;
             }
@@ -4404,7 +4404,7 @@ internal sealed class DeclarationBinder
     /// </summary>
     private static int FindRefKindMismatchIndex(FunctionSymbol baseMethod, ImmutableArray<ParameterSymbol> derivedParams, TypeSymbol derivedReturnType)
     {
-        if (baseMethod.Type != derivedReturnType)
+        if (!TypeSignaturesEquivalent(baseMethod.Type, derivedReturnType))
         {
             return -1;
         }
@@ -4417,7 +4417,7 @@ internal sealed class DeclarationBinder
 
         for (var i = 0; i < derivedParams.Length; i++)
         {
-            if (baseParams[i].Type != derivedParams[i].Type)
+            if (!TypeSignaturesEquivalent(baseParams[i].Type, derivedParams[i].Type))
             {
                 return -1;
             }
@@ -4436,6 +4436,122 @@ internal sealed class DeclarationBinder
 
     private static ImmutableArray<ParameterSymbol> GetCallableParameters(FunctionSymbol method)
         => method.ExplicitReceiverParameter == null ? method.Parameters : method.Parameters.RemoveAt(0);
+
+    /// <summary>
+    /// Issue #974: structural equivalence used by override / interface-
+    /// implementation signature matching. Constructed generic types are not
+    /// interned (<see cref="ImportedTypeSymbol.GetConstructed"/> and
+    /// <see cref="InterfaceSymbol.Construct"/> can yield fresh instances), so a
+    /// raw reference comparison wrongly rejects, for example, the class method
+    /// <c>func Iter() IEnumerator[T]</c> against the interface requirement
+    /// <c>ISeq[T].Iter() IEnumerator[T]</c> once the interface's type
+    /// parameters have been substituted with the implementing type's
+    /// arguments. Reference identity is honoured first (covering plain type
+    /// parameters, primitives and cached imported types); constructed generics
+    /// are then compared by definition and ordered type arguments, recursing
+    /// through slice / array / nullable wrappers. The comparison stays strict —
+    /// distinct type arguments (e.g. <c>IEnumerator[int32]</c> vs
+    /// <c>IEnumerator[T]</c>) are not equated — so genuinely mismatched
+    /// signatures are still rejected with GS0187.
+    /// </summary>
+    private static bool TypeSignaturesEquivalent(TypeSymbol a, TypeSymbol b)
+    {
+        if (ReferenceEquals(a, b))
+        {
+            return true;
+        }
+
+        if (a == null || b == null)
+        {
+            return false;
+        }
+
+        if (a is StructSymbol sa && b is StructSymbol sb)
+        {
+            return ReferenceEquals(sa.Definition, sb.Definition)
+                && TypeArgumentsEquivalent(sa.TypeArguments, sb.TypeArguments);
+        }
+
+        if (a is InterfaceSymbol ia && b is InterfaceSymbol ib)
+        {
+            return ReferenceEquals(ia.Definition, ib.Definition)
+                && TypeArgumentsEquivalent(ia.TypeArguments, ib.TypeArguments);
+        }
+
+        if (a is ImportedTypeSymbol pa && b is ImportedTypeSymbol pb)
+        {
+            // Constructed imported generics carrying symbolic arguments (e.g.
+            // `IEnumerator[T]`) are compared by open definition and ordered
+            // arguments so an unbound type parameter compares by identity
+            // rather than by its erased `object` CLR projection.
+            if (pa.OpenDefinition != null
+                && pb.OpenDefinition != null
+                && pa.OpenDefinition == pb.OpenDefinition
+                && TypeArgumentsEquivalent(pa.TypeArguments, pb.TypeArguments))
+            {
+                return true;
+            }
+
+            // Otherwise (one or both sides expressed as a plain closed CLR
+            // type, e.g. a fully concrete `IEnumerator[int32]`) fall back to a
+            // closed-type comparison. This is only sound when neither side
+            // carries an unbound type parameter, whose CLR shape is erased to
+            // `object` and would otherwise equate distinct constructions.
+            if (!TypeSymbol.ContainsTypeParameter(pa) && !TypeSymbol.ContainsTypeParameter(pb))
+            {
+                return pa.ClrType != null
+                    && pb.ClrType != null
+                    && ClrTypeUtilities.AreSame(pa.ClrType, pb.ClrType);
+            }
+
+            return false;
+        }
+
+        if (a is SliceTypeSymbol sla && b is SliceTypeSymbol slb)
+        {
+            return TypeSignaturesEquivalent(sla.ElementType, slb.ElementType);
+        }
+
+        if (a is ArrayTypeSymbol ara && b is ArrayTypeSymbol arb)
+        {
+            return ara.Length == arb.Length
+                && TypeSignaturesEquivalent(ara.ElementType, arb.ElementType);
+        }
+
+        if (a is NullableTypeSymbol na && b is NullableTypeSymbol nb)
+        {
+            return TypeSignaturesEquivalent(na.UnderlyingType, nb.UnderlyingType);
+        }
+
+        // Leaf fallback for non-generic types that are not reference-interned
+        // (e.g. a primitive supplied as a concrete type argument such as the
+        // `int32` in `ISeq[int32]`). Type parameters keep an absent ClrType so
+        // distinct parameters are never wrongly equated here.
+        return a.ClrType != null && b.ClrType != null && a.ClrType == b.ClrType;
+    }
+
+    private static bool TypeArgumentsEquivalent(ImmutableArray<TypeSymbol> a, ImmutableArray<TypeSymbol> b)
+    {
+        if (a.IsDefaultOrEmpty && b.IsDefaultOrEmpty)
+        {
+            return true;
+        }
+
+        if (a.IsDefaultOrEmpty || b.IsDefaultOrEmpty || a.Length != b.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < a.Length; i++)
+        {
+            if (!TypeSignaturesEquivalent(a[i], b[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /// <summary>
     /// Issue #490 (ADR-0060 follow-up): validates a function's optional <c>ref</c> return modifier

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -585,6 +585,67 @@ public sealed class InterfaceSymbol : TypeSymbol
             return concrete;
         }
 
+        // Issue #974: a constructed generic interface used as a member type
+        // (e.g. a base interface `ISeq[T]` exposing `IComparable[T]`) carries
+        // the definition's type parameters in its arguments. Recurse so they
+        // are substituted with this constructed instance's type arguments.
+        if (type is InterfaceSymbol iface && !iface.TypeArguments.IsDefaultOrEmpty)
+        {
+            var substitutedArgs = ImmutableArray.CreateBuilder<TypeSymbol>(iface.TypeArguments.Length);
+            var changed = false;
+            for (var i = 0; i < iface.TypeArguments.Length; i++)
+            {
+                var substituted = SubstituteType(iface.TypeArguments[i], subst);
+                substitutedArgs.Add(substituted);
+                changed |= !ReferenceEquals(substituted, iface.TypeArguments[i]);
+            }
+
+            return changed
+                ? Construct(iface.Definition, substitutedArgs.MoveToImmutable())
+                : iface;
+        }
+
+        // Issue #974: a member type that is a constructed imported generic over
+        // the interface's type parameter (e.g. `func Iter() IEnumerator[T]`)
+        // must have its symbolic type arguments rewritten so the constructed
+        // interface exposes `IEnumerator[T_class]` rather than the definition's
+        // `IEnumerator[T_iface]`. Mirrors StructSymbol's construction-time
+        // substitution.
+        if (type is ImportedTypeSymbol imported
+            && imported.OpenDefinition != null
+            && !imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            var substitutedArgs = ImmutableArray.CreateBuilder<TypeSymbol>(imported.TypeArguments.Length);
+            var changed = false;
+            for (var i = 0; i < imported.TypeArguments.Length; i++)
+            {
+                var substituted = SubstituteType(imported.TypeArguments[i], subst);
+                substitutedArgs.Add(substituted);
+                changed |= !ReferenceEquals(substituted, imported.TypeArguments[i]);
+            }
+
+            if (!changed)
+            {
+                return imported;
+            }
+
+            var resolvedClrArgs = new System.Type[substitutedArgs.Count];
+            for (var i = 0; i < substitutedArgs.Count; i++)
+            {
+                resolvedClrArgs[i] = substitutedArgs[i].ClrType ?? typeof(object);
+            }
+
+            try
+            {
+                var closed = imported.OpenDefinition.MakeGenericType(resolvedClrArgs);
+                return ImportedTypeSymbol.GetConstructed(closed, imported.OpenDefinition, substitutedArgs.MoveToImmutable());
+            }
+            catch (System.ArgumentException)
+            {
+                return imported;
+            }
+        }
+
         if (type is SliceTypeSymbol s)
         {
             var sub = SubstituteType(s.ElementType, subst);

--- a/test/Compiler.Tests/Emit/Issue974GenericInterfaceImplEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue974GenericInterfaceImplEmitTests.cs
@@ -1,0 +1,322 @@
+// <copyright file="Issue974GenericInterfaceImplEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #974: a class implementing a generic interface whose method returns
+/// (or takes) a <em>constructed generic</em> built from the interface's type
+/// parameter — e.g. <c>func Iter() IEnumerator[T]</c> satisfying
+/// <c>ISeq[T].Iter() IEnumerator[T]</c> — was rejected with <c>GS0187</c>
+/// ("does not implement interface method"). A method returning the plain type
+/// parameter <c>T</c> matched, so the defect was specific to constructed
+/// generic return / parameter types.
+/// <para>
+/// Root cause: interface-satisfaction signature matching
+/// (<c>DeclarationBinder.SignaturesMatch</c>) compared the interface method's
+/// return / parameter types to the class method's by reference identity. The
+/// interface method carries the interface's type-parameter symbol
+/// (<c>IEnumerator[T_iface]</c>) while the class method carries the class's
+/// (<c>IEnumerator[T_class]</c>); these are distinct <c>TypeSymbol</c>
+/// instances so the comparison never matched. Two fixes combine: (1)
+/// <c>InterfaceSymbol</c> member substitution now recurses into constructed
+/// generic (<c>ImportedTypeSymbol</c> / nested <c>InterfaceSymbol</c>) type
+/// arguments so the constructed interface exposes <c>IEnumerator[T_class]</c>;
+/// (2) signature matching now compares types structurally (definition +
+/// ordered type arguments) instead of by reference, because constructed
+/// generics are not interned.
+/// </para>
+/// </summary>
+public class Issue974GenericInterfaceImplEmitTests
+{
+    [Fact]
+    public void GenericInterface_MethodReturningConstructedGenericOverT_Compiles_And_Runs()
+    {
+        // The exact repro from issue #974: ISeq[T].Iter() IEnumerator[T].
+        var source = """
+            package GapCheck
+            import System
+            import System.Collections.Generic
+
+            interface ISeq[T] {
+                func Iter() IEnumerator[T];
+            }
+
+            class Seq[T] : ISeq[T] {
+                var items List[T] = List[T]()
+                func Push(value T) {
+                    items.Add(value)
+                }
+                func Iter() IEnumerator[T] { return items.GetEnumerator() }
+            }
+
+            var s = Seq[int32]()
+            s.Push(10)
+            s.Push(20)
+            s.Push(30)
+            var e IEnumerator[int32] = s.Iter()
+            while e.MoveNext() {
+                Console.WriteLine(e.Current)
+            }
+            """;
+
+        Assert.Equal("10\n20\n30\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GenericInterface_MethodReturningPlainT_Control_Compiles_And_Runs()
+    {
+        // Control that always compiled: the plain type-parameter return path.
+        var source = """
+            package GapCheck
+            import System
+
+            interface IBox[T] { func Get() T; }
+
+            class Box[T] : IBox[T] {
+                var item T
+                func Set(value T) { item = value }
+                func Get() T { return item }
+            }
+
+            var b = Box[int32]()
+            b.Set(42)
+            Console.WriteLine(b.Get())
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GenericInterface_ImplementedWithConcreteTypeArgument_Compiles_And_Runs()
+    {
+        // The class supplies a concrete type argument: ISeq[int32] satisfied
+        // by func Iter() IEnumerator[int32].
+        var source = """
+            package GapCheck
+            import System
+            import System.Collections.Generic
+
+            interface ISeq[T] {
+                func Iter() IEnumerator[T];
+            }
+
+            class IntSeq : ISeq[int32] {
+                var items List[int32] = List[int32]()
+                func Push(value int32) {
+                    items.Add(value)
+                }
+                func Iter() IEnumerator[int32] { return items.GetEnumerator() }
+            }
+
+            var s = IntSeq()
+            s.Push(7)
+            s.Push(8)
+            var e IEnumerator[int32] = s.Iter()
+            while e.MoveNext() {
+                Console.WriteLine(e.Current)
+            }
+            """;
+
+        Assert.Equal("7\n8\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GenericInterface_MethodTakingConstructedGenericParameter_Compiles_And_Runs()
+    {
+        // The constructed generic appears in a parameter position
+        // (List[T]) as well as in the body, across multiple type
+        // parameters and multiple interfaces on one class.
+        var source = """
+            package GapCheck
+            import System
+            import System.Collections.Generic
+
+            interface ISink[T] {
+                func AddAll(values List[T]) int32;
+            }
+
+            interface IPair[K, V] {
+                func Make() Dictionary[K, V];
+            }
+
+            class Bag[K, V] : ISink[V], IPair[K, V] {
+                var items List[V] = List[V]()
+                func AddAll(values List[V]) int32 {
+                    for v in values {
+                        items.Add(v)
+                    }
+                    return items.Count
+                }
+                func Make() Dictionary[K, V] { return Dictionary[K, V]() }
+            }
+
+            var bag = Bag[string, int32]()
+            var xs = List[int32]()
+            xs.Add(1)
+            xs.Add(2)
+            xs.Add(3)
+            Console.WriteLine(bag.AddAll(xs))
+            """;
+
+        Assert.Equal("3\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GenericInterface_MismatchedConstructedGenericSignature_StillRejectedGS0187()
+    {
+        // Negative guard: the matching must stay strict. A class declared
+        // Seq[T] : ISeq[T] whose Iter() returns IEnumerator[int32] (not
+        // IEnumerator[T]) does NOT satisfy the interface and must still be
+        // rejected with GS0187.
+        var source = """
+            package GapCheck
+            import System.Collections.Generic
+
+            interface ISeq[T] {
+                func Iter() IEnumerator[T];
+            }
+
+            class BadSeq[T] : ISeq[T] {
+                var items List[int32] = List[int32]()
+                func Iter() IEnumerator[int32] { return items.GetEnumerator() }
+            }
+            """;
+
+        var diagnostics = CompileExpectingErrors(source);
+        Assert.Contains(diagnostics, d => d.Contains("GS0187"));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue974_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static List<string> CompileExpectingErrors(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue974_neg_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:library",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit != 0,
+                $"expected gsc to report errors but it succeeded\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            var combined = compileOut.ToString() + compileErr.ToString();
+            return combined.Split('\n').Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A class implementing a **generic interface** whose method returns or takes a **constructed generic** built from the type parameter (e.g. `func Iter() IEnumerator[T]` satisfying `ISeq[T].Iter() IEnumerator[T]`) was wrongly rejected with **GS0187**, even though it declared a method with the identical signature. A method returning the plain type parameter `T` matched fine, so the defect was specific to constructed-generic return/parameter types.

## Root cause (confirmed)

Two distinct defects combined:

1. **`src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs` — `SubstituteType`**: when a constructed interface substitutes its members (`ISeq[T_iface] → ISeq[T_class]`), `SubstituteType` only recursed through slice/array/nullable — **not** into `ImportedTypeSymbol` / nested `InterfaceSymbol` type arguments. So the constructed interface still exposed `Iter() IEnumerator[T_iface]` rather than `IEnumerator[T_class]`.

2. **`src/Core/CodeAnalysis/Binding/DeclarationBinder.cs` — `SignaturesMatch` / `FindRefKindMismatchIndex`**: compared interface vs class return/parameter types by **reference identity** (`baseMethod.Type != derivedReturnType`). Constructed generics are intentionally **not interned** (`ImportedTypeSymbol.GetConstructed` / `InterfaceSymbol.Construct` yield fresh instances), so even with correct substitution the two `IEnumerator[T_class]` instances never compared equal.

## The fix

- Extend `InterfaceSymbol.SubstituteType` to recurse into constructed imported generics and nested constructed interfaces, mirroring the existing `StructSymbol.SubstituteTypeForConstruction`.
- Replace the reference comparisons in signature matching with a new structural `TypeSignaturesEquivalent` helper: honours reference identity first (plain type parameters, primitives, cached imported types), then compares constructed generics by **definition + ordered type arguments**, recursing through slice/array/nullable. It stays **strict** — distinct type arguments are never equated — and handles the mixed representation where a fully-concrete `IEnumerator[int32]` is a plain closed `ImportedTypeSymbol` (no `OpenDefinition`) by falling back to a closed-CLR comparison only when neither side carries an unbound type parameter (whose CLR shape erases to `object`).

This fixes matching when the class passes its own type parameter through (`Seq[T] : ISeq[T]`), supplies a concrete type argument (`IntSeq : ISeq[int32]`), spans multiple type parameters / multiple interfaces, and in both return and parameter positions — while keeping plain-`T` and non-generic cases matching and genuinely wrong signatures rejected.

Out of scope (separate filed concern): explicit interface implementation syntax / the non-generic `IEnumerable.GetEnumerator()` knock-on. Not touched here.

## Verification

- `dotnet build GSharp.sln -c Release -graph` → **0 Warning / 0 Error**.
- Primary repro (`ISeq[T]` / `IEnumerator[T]`) now compiles, **IL-verifies clean**, and runs (iterates + prints `10/20/30`).
- Control (`IBox[T].Get() T`) still compiles + runs.
- Concrete-type-arg impl (`ISeq[int32]`) compiles + runs.
- **Negative**: `class BadSeq[T] : ISeq[T]` with `func Iter() IEnumerator[int32]` is still rejected with **GS0187**.
- New `Issue974GenericInterfaceImplEmitTests` — **5/5 passing**.
- Regression slices green: Interface|Generic (253), Override|Inherit|Shadow (35), Issue949|Issue973|Cycle (15), Core.Tests (3456), Cs2Gs.Tests (129).

Fixes #974