### PR TITLE
Fix emit ICE (GS9998) for interpolated string in ': base(...)' constructor-argument position

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
@@ -81,6 +81,18 @@ internal sealed class InterpolatedStringHandlerLowerer : BoundTreeRewriter
             statement = newStatement;
         }
 
+        // Issue #975: base-constructor-initializer arguments (`: base(args)`) are
+        // stored on the constructor / struct symbols rather than inside a method
+        // body, so they bypass the function-body rewrite above. Lower any
+        // interpolated strings sitting in that position too, otherwise the emitter
+        // meets a raw BoundInterpolatedStringExpression and ICEs (GS9998). The
+        // symbols are mutated in place; emission re-runs binding for each call, so
+        // sharing across the discarded pre-lowering program is harmless.
+        foreach (var structSym in program.Structs)
+        {
+            changed |= lowerer.RewriteBaseInitializers(structSym);
+        }
+
         if (!changed)
         {
             return program;
@@ -199,6 +211,73 @@ internal sealed class InterpolatedStringHandlerLowerer : BoundTreeRewriter
             ImmutableArray<BoundExpression>.Empty);
 
         return new BoundBlockExpression(node.Syntax, statements.ToImmutable(), result);
+    }
+
+    /// <summary>
+    /// Issue #975: rewrites the base-constructor-initializer argument lists held by
+    /// the struct's primary constructor and every explicit constructor, lowering any
+    /// interpolated strings (and other handled nodes) in <c>: base(args)</c> position
+    /// the same way ordinary call arguments are lowered. Returns <see langword="true"/>
+    /// when any initializer's arguments were rewritten.
+    /// </summary>
+    /// <param name="structSym">The class whose constructor base initializers to lower.</param>
+    /// <returns><see langword="true"/> when at least one initializer changed.</returns>
+    private bool RewriteBaseInitializers(StructSymbol structSym)
+    {
+        var changed = false;
+
+        var primary = structSym.BaseConstructorInitializer;
+        if (primary != null && this.TryRewriteInitializerArguments(primary, out var loweredPrimary))
+        {
+            structSym.SetBaseConstructorInitializer(loweredPrimary);
+            changed = true;
+        }
+
+        foreach (var ctor in structSym.ExplicitConstructors)
+        {
+            var init = ctor.BaseInitializer;
+            if (init != null && this.TryRewriteInitializerArguments(init, out var loweredInit))
+            {
+                ctor.SetBaseInitializer(loweredInit);
+                changed = true;
+            }
+        }
+
+        return changed;
+    }
+
+    /// <summary>
+    /// Lowers each argument of <paramref name="initializer"/>. When any argument is
+    /// rewritten, produces a replacement initializer targeting the same base
+    /// constructor and reports it via <paramref name="rewritten"/>.
+    /// </summary>
+    /// <param name="initializer">The base-constructor initializer to lower.</param>
+    /// <param name="rewritten">The rewritten initializer when arguments changed; otherwise <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> when the arguments were rewritten.</returns>
+    private bool TryRewriteInitializerArguments(BaseConstructorInitializer initializer, out BaseConstructorInitializer rewritten)
+    {
+        rewritten = null;
+        if (initializer.Arguments.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<BoundExpression>(initializer.Arguments.Length);
+        var changed = false;
+        foreach (var argument in initializer.Arguments)
+        {
+            var loweredArgument = this.RewriteExpression(argument);
+            changed |= loweredArgument != argument;
+            builder.Add(loweredArgument);
+        }
+
+        if (!changed)
+        {
+            return false;
+        }
+
+        rewritten = initializer.WithArguments(builder.ToImmutable());
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/BaseConstructorInitializer.cs
+++ b/src/Core/CodeAnalysis/Symbols/BaseConstructorInitializer.cs
@@ -62,4 +62,19 @@ public sealed class BaseConstructorInitializer
 
     /// <summary>Gets a value indicating whether the targeted base constructor lives on an imported CLR type.</summary>
     public bool IsClrBase => ClrConstructor != null;
+
+    /// <summary>
+    /// Produces a copy of this initializer targeting the same base constructor but
+    /// carrying a different forwarded argument list. Used by the emit-path lowerers
+    /// (e.g. interpolated-string lowering) to replace base-initializer arguments
+    /// with their lowered forms while preserving the resolved target and ref kinds.
+    /// </summary>
+    /// <param name="arguments">The replacement bound argument expressions.</param>
+    /// <returns>A new <see cref="BaseConstructorInitializer"/> with the supplied arguments.</returns>
+    public BaseConstructorInitializer WithArguments(ImmutableArray<BoundExpression> arguments)
+    {
+        return IsClrBase
+            ? new BaseConstructorInitializer(arguments, ClrConstructor, ArgumentRefKinds)
+            : new BaseConstructorInitializer(arguments, GSharpBaseType);
+    }
 }

--- a/test/Compiler.Tests/Emit/Issue975InterpolatedBaseArgEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue975InterpolatedBaseArgEmitTests.cs
@@ -1,0 +1,176 @@
+// <copyright file="Issue975InterpolatedBaseArgEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #975: end-to-end emit tests proving that an interpolated string in a
+/// <c>: base(...)</c> constructor-argument position is lowered like an ordinary
+/// call argument instead of reaching the emitter as a raw
+/// <c>BoundInterpolatedStringExpression</c> (which previously ICE'd with
+/// <c>GS9998</c>). Each test compiles via <c>gsc</c>, runs <c>ilverify</c>, then
+/// executes the produced assembly under <c>dotnet exec</c> to assert the
+/// interpolation renders correctly at runtime.
+/// </summary>
+public class Issue975InterpolatedBaseArgEmitTests
+{
+    [Fact]
+    public void InterpolatedMessage_ForwardedToBase_CompilesAndRuns()
+    {
+        // The exact repro from issue #975: a single-hole interpolated string
+        // forwarded to the base Exception constructor.
+        var source = """
+            package Probe
+            import System
+
+            class E1 : Exception {
+                init(n int32) : base("only $n left") {
+                }
+            }
+
+            try {
+                throw E1(3)
+            } catch (e Exception) {
+                Console.WriteLine(e.Message)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("only 3 left\n", output);
+    }
+
+    [Fact]
+    public void InterpolatedMessage_MultipleHolesAndFormatSpecifier_CompilesAndRuns()
+    {
+        // Multiple holes, an embedded expression hole, an alignment + format
+        // specifier, all in base-initializer position.
+        var source = """
+            package Probe
+            import System
+
+            class E2 : Exception {
+                init(n int32, who string) : base("$who has ${n:D3} items, next [${n + 1,4:X2}]") {
+                }
+            }
+
+            try {
+                throw E2(7, "bob")
+            } catch (e Exception) {
+                Console.WriteLine(e.Message)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("bob has 007 items, next [  08]\n", output);
+    }
+
+    [Fact]
+    public void LiteralAndConcatBaseArguments_StillCompileAndRun()
+    {
+        // Controls from the issue: a plain literal and a string-concat base
+        // argument must keep compiling and rendering correctly.
+        var source = """
+            package Probe
+            import System
+
+            class E3 : Exception { init(n int32) : base("plain literal") { } }
+            class E4 : Exception { init(n int32) : base("only " + n.ToString() + " left") { } }
+
+            try {
+                throw E3(1)
+            } catch (e Exception) {
+                Console.WriteLine(e.Message)
+            }
+            try {
+                throw E4(9)
+            } catch (e Exception) {
+                Console.WriteLine(e.Message)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("plain literal\nonly 9 left\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue975_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Root cause
Base-constructor-initializer arguments (`: base(args)`) are stored on the constructor / struct **symbols** (`ConstructorSymbol.BaseInitializer`, `StructSymbol.BaseConstructorInitializer`), not inside a method body. The emit-path `InterpolatedStringHandlerLowerer.Lower` only rewrites `program.Functions` and `program.Statement`, so those base-initializer arguments were never lowered. The emitter (`ReflectionMetadataEmitter` / `MethodBodyEmitter.EmitBaseConstructorArguments`) then met a raw `BoundInterpolatedStringExpression` in base-arg position and threw `GS9998`. Ordinary call arguments live in method bodies and are lowered, which is why interpolation worked everywhere *except* base-initializer position.

## Fix
`InterpolatedStringHandlerLowerer.Lower` now also walks every struct's primary and explicit constructors and rewrites their base-initializer argument lists through the **same** interpolated-string lowering as ordinary arguments (`src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs`). A small `WithArguments` helper on `BaseConstructorInitializer` produces a replacement initializer that preserves the resolved target constructor and ref kinds while swapping in the lowered arguments. Literal, concat, and ternary base arguments are unaffected — they emit fine already and are returned unchanged.

## Verification
- Repro now compiles **and runs**: `init(n int32) : base("only $n left")` prints `only 3 left`.
- Multiple holes + alignment + format specifier in base position renders correctly (`"$who has ${n:D3} items, next [${n + 1,4:X2}]"` → `bob has 007 items, next [  08]`).
- Controls still compile + run: plain literal and `"only " + n.ToString() + " left"` concat.
- Added `test/Compiler.Tests/Emit/Issue975InterpolatedBaseArgEmitTests.cs` (3 tests): compile via `gsc` + `ilverify`-clean + execute a tiny net10.0 exe that throws/catches a custom `Exception` subclass and asserts `ex.Message`.
- Targeted tests green: `Issue975` (3), and Interpolat/Constructor/Exception/Base/Adr0065/Issue973/Issue974/Issue949 slices (75 passed).
- Full `Core.Tests` (3456 passed) and `Cs2Gs.Tests` (129 passed) green.
- Clean `dotnet build GSharp.sln -c Release -graph` → 0 Warning / 0 Error.

Fixes #975
