### PR TITLE
Allow a struct to declare an interface clause (struct S : I {…}) (#976)

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -693,6 +693,18 @@ self-inheritance cycle and is reported here.
 | --- | --- | --- |
 | GS0378 | Error | Class `{name}` cannot inherit from itself (e.g. `class A : A` or the generic `class A[T] : A[T]`). Naming the enclosing type merely as a type argument of a base/interface type — `class Shape : IEquatable[Shape]` — is legal. |
 
+## Struct base-clause diagnostic (GS0382)
+
+Issue #976: a `struct` (CLR value type) may declare an implemented-interface
+clause (`struct Money : IEquatable[Money] { … }`), mirroring a `class`. Because
+every value type always derives from `System.ValueType`, a struct's clause may
+list **interfaces only** — naming a class or another struct as a base type is
+rejected here.
+
+| ID | Severity | Summary |
+| --- | --- | --- |
+| GS0382 | Error | Struct `{structName}` cannot declare base type `{baseTypeName}`; a struct may only implement interfaces. |
+
 ## Internal compiler error diagnostics (GS9998–GS9999)
 
 | ID | Severity | Description |

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -696,6 +696,32 @@ public sealed class Conversion
             return false;
         }
 
+        // Issue #976: a user-declared value-type struct → imported CLR
+        // interface declared in its `: …` clause. The struct symbol has no
+        // ClrType during binding, so the general CLR-assignability path below
+        // cannot fire — match structurally against `ImplementedClrInterfaces`,
+        // mirroring the class reference-upcast rule. This covers both plain
+        // CLR interfaces (e.g. `IComparable`) and CLR generic interfaces closed
+        // over a user G# type (e.g. `IEquatable[Money]`).
+        if (from is StructSymbol fromValueStruct && !fromValueStruct.IsClass
+            && to?.ClrType != null && to.ClrType.IsInterface)
+        {
+            foreach (var iface in fromValueStruct.ImplementedClrInterfaces)
+            {
+                var ifaceClr = iface?.ClrType;
+                if (ifaceClr == null)
+                {
+                    continue;
+                }
+
+                if (ifaceClr == to.ClrType
+                    || ClrTypeUtilities.IsAssignableByName(to.ClrType, ifaceClr))
+                {
+                    return true;
+                }
+            }
+        }
+
         // Either side imported / CLR-typed: defer to the CLR's own
         // assignability check.
         var fromClr = from?.ClrType;

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -895,11 +895,10 @@ internal sealed class DeclarationBinder
         var implementedClrInterfaces = ImmutableArray.CreateBuilder<TypeSymbol>();
         if (syntax.HasBaseType)
         {
-            if (!syntax.IsClass)
-            {
-                Diagnostics.ReportUnexpectedToken(syntax.BaseColonToken.Location, SyntaxKind.ColonToken, SyntaxKind.OpenBraceToken);
-            }
-            else
+            // Issue #976: the `: …` clause is bound for both classes and
+            // structs. A class may name a single base class plus interfaces; a
+            // struct (CLR value type) may name interfaces only — a base class
+            // or base struct is rejected below with GS0382.
             {
                 var allBaseTypes = ImmutableArray.CreateBuilder<TypeClauseSyntax>();
                 if (syntax.BaseTypeClauses.Count > 0)
@@ -947,6 +946,21 @@ internal sealed class DeclarationBinder
                     if (resolved == null || resolved == TypeSymbol.Error)
                     {
                         continue;
+                    }
+
+                    // Issue #976: a struct (value type) may only list
+                    // interfaces. Reject any resolved type that is not an
+                    // interface (a user/CLR class or another struct) with a
+                    // dedicated diagnostic instead of silently dropping it.
+                    if (!syntax.IsClass)
+                    {
+                        var resolvedIsInterface = resolved is InterfaceSymbol
+                            || (resolved.ClrType != null && resolved.ClrType.IsInterface);
+                        if (!resolvedIsInterface)
+                        {
+                            Diagnostics.ReportStructCannotHaveBaseClass(baseLocation, name, baseName);
+                            continue;
+                        }
                     }
 
                     if (resolved is InterfaceSymbol iface)

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1307,6 +1307,20 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0381", $"Class '{typeName}' is part of an inheritance cycle.");
     }
 
+    /// <summary>
+    /// Issue #976: GS0382 — a <c>struct</c> (value type) named a class or
+    /// another struct in its <c>: …</c> clause. A CLR value type always derives
+    /// from <c>System.ValueType</c> and cannot declare a user base type; its
+    /// clause may list interfaces only.
+    /// </summary>
+    /// <param name="location">The text location of the offending base type.</param>
+    /// <param name="structName">The declaring struct's name.</param>
+    /// <param name="baseTypeName">The illegal base type's name.</param>
+    public void ReportStructCannotHaveBaseClass(TextLocation location, string structName, string baseTypeName)
+    {
+        Report(location, "GS0382", $"Struct '{structName}' cannot declare base type '{baseTypeName}'; a struct may only implement interfaces.");
+    }
+
     /// <summary>Reports base-constructor arguments (<c>: Base(args)</c>) on a class that declares no base class (issue #306).</summary>
     /// <param name="location">The text location of the base-constructor argument list.</param>
     public void ReportBaseConstructorArgumentsWithoutBase(TextLocation location)

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1493,7 +1493,15 @@ internal sealed class ReflectionMetadataEmitter
         void EmitClassTypeDefRow(StructSymbol c)
         {
             this.typeDefEmitter.EmitStructTypeDef(c, structFirstFieldRow[c], classCtorRows[c]);
+            EmitInterfaceImplRows(c);
+        }
 
+        // Issue #976: emit the InterfaceImpl metadata rows for an aggregate
+        // (class OR struct) TypeDef. Value types (structs) declare interface
+        // implementation exactly like classes, so the rows are emitted from a
+        // shared helper rather than only on the class path.
+        void EmitInterfaceImplRows(StructSymbol c)
+        {
             if (!c.Interfaces.IsDefaultOrEmpty)
             {
                 foreach (var iface in c.Interfaces)
@@ -1517,7 +1525,7 @@ internal sealed class ReflectionMetadataEmitter
             }
 
             // Issue #525: emit InterfaceImpl rows for imported CLR interfaces
-            // declared in the base-type clause so the resulting class is a
+            // declared in the base-type clause so the resulting type is a
             // real CLR implementer (`Type.GetInterfaces()` surfaces them and
             // dispatch through an interface receiver hits the G# method).
             if (!c.ImplementedClrInterfaces.IsDefaultOrEmpty)
@@ -1590,6 +1598,7 @@ internal sealed class ReflectionMetadataEmitter
         foreach (var s in topStructs)
         {
             this.typeDefEmitter.EmitStructTypeDef(s, structFirstFieldRow[s], TopStructMethodListRow(s));
+            EmitInterfaceImplRows(s);
         }
 
         // Issue #193: emit enum TypeDefs between non-SM structs and the nested
@@ -1617,6 +1626,7 @@ internal sealed class ReflectionMetadataEmitter
                     break;
                 case StructSymbol ns:
                     this.typeDefEmitter.EmitStructTypeDef(ns, structFirstFieldRow[ns], nestedMethodListRow[ns]);
+                    EmitInterfaceImplRows(ns);
                     break;
                 case EnumSymbol ne:
                     this.typeDefEmitter.EmitEnumTypeDef(ne, enumFirstFieldRow[ne], nestedMethodListRow[ne]);

--- a/test/Compiler.Tests/Emit/Issue976StructImplementsInterfaceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue976StructImplementsInterfaceEmitTests.cs
@@ -1,0 +1,379 @@
+// <copyright file="Issue976StructImplementsInterfaceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #976: a G# <c>struct</c> (CLR value type) may declare an
+/// implemented-interface clause (<c>struct Money : IEquatable[Money] { … }</c>),
+/// mirroring a <c>class</c>. The struct's clause may list interfaces only — a
+/// base class or base struct is rejected with GS0382. Each happy-path test
+/// compiles via <c>gsc</c>, runs <c>ilverify</c> on the produced assembly, then
+/// either reflects the emitted metadata or runs the assembly under
+/// <c>dotnet exec</c> to assert end-to-end behavior (including boxing through
+/// the interface receiver).
+/// </summary>
+public class Issue976StructImplementsInterfaceEmitTests
+{
+    [Fact]
+    public void Struct_ImplementsIEquatable_DirectAndThroughInterface_RunsAndIlVerifies()
+    {
+        // Canonical issue repro: a value-type struct implements
+        // IEquatable[Money], calling Equals directly AND through the
+        // IEquatable[Money] interface (which boxes the struct).
+        var source = """
+            package Probe
+            import System
+
+            struct Money : IEquatable[Money] {
+                var Cents int32
+                func Equals(other Money) bool { return Cents == other.Cents }
+            }
+
+            var a = Money{ Cents: 100 }
+            var b = Money{ Cents: 100 }
+            var c = Money{ Cents: 200 }
+            Console.WriteLine(a.Equals(b))
+            Console.WriteLine(a.Equals(c))
+            var ie IEquatable[Money] = a
+            Console.WriteLine(ie.Equals(b))
+            Console.WriteLine(ie.Equals(c))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\nTrue\nFalse\n", output);
+    }
+
+    [Fact]
+    public void Struct_MetadataDeclaresInterfaceImpl_AndEqualsIsVirtual()
+    {
+        // Reflect over the emitted assembly with a MetadataLoadContext to
+        // confirm the struct TypeDef carries an InterfaceImpl row for
+        // System.IEquatable<Money> and the satisfying method is virtual so the
+        // value type correctly fills the interface slot.
+        var source = """
+            package Probe
+            import System
+
+            struct Money : IEquatable[Money] {
+                var Cents int32
+                func Equals(other Money) bool { return Cents == other.Cents }
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        try
+        {
+            var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+            var resolver = new System.Reflection.PathAssemblyResolver(
+                Directory.GetFiles(runtimeDir, "*.dll")
+                    .Concat(new[] { dllPath }));
+            using var mlc = new MetadataLoadContext(resolver, "System.Private.CoreLib");
+            var asm = mlc.LoadFromAssemblyPath(dllPath);
+            var type = asm.GetType("Probe.Money")
+                ?? throw new InvalidOperationException("type not found");
+
+            Assert.True(type.IsValueType, "Money must be a value type (struct)");
+
+            var interfaces = type.GetInterfaces().Select(i => i.Name).ToArray();
+            Assert.Contains(interfaces, i => i.StartsWith("IEquatable", StringComparison.Ordinal));
+
+            var method = type.GetMethod("Equals", new[] { type })
+                ?? throw new InvalidOperationException("Equals(Money) not found");
+            Assert.True(method.IsVirtual, "Equals(Money) must be virtual to implement the interface");
+        }
+        finally
+        {
+            TryCleanup(dllPath);
+        }
+    }
+
+    [Fact]
+    public void Struct_ImplementsIComparable_DispatchesThroughInterface()
+    {
+        var source = """
+            package Probe
+            import System
+
+            struct Money : IComparable[Money] {
+                var Cents int32
+                func CompareTo(other Money) int32 { return Cents - other.Cents }
+            }
+
+            var a = Money{ Cents: 100 }
+            var b = Money{ Cents: 200 }
+            var ic IComparable[Money] = a
+            Console.WriteLine(ic.CompareTo(b))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("-100\n", output);
+    }
+
+    [Fact]
+    public void DataStruct_ImplementsCustomInterface_DispatchesThroughInterface()
+    {
+        // A `data struct` (value type with a primary constructor) implements a
+        // user-declared G# interface and is consumed through the interface
+        // receiver (which boxes).
+        var source = """
+            package Probe
+            import System
+
+            interface IShape {
+                func Area() float64;
+            }
+
+            data struct Rect(Width float64, Height float64) : IShape {
+                func Area() float64 { return Width * Height }
+            }
+
+            var r = Rect{ Width: 3.0, Height: 4.0 }
+            var s IShape = r
+            Console.WriteLine(s.Area())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("12\n", output);
+    }
+
+    [Fact]
+    public void GenericStruct_ImplementsGenericInterface_DispatchesThroughInterface()
+    {
+        // Ties into #974: a generic struct implements a generic interface whose
+        // member returns the constructed generic type argument. Dispatch
+        // through the constructed interface must reach the struct's body.
+        var source = """
+            package Probe
+            import System
+
+            interface IBox[T] {
+                func Get() T;
+            }
+
+            struct Box[T] : IBox[T] {
+                var Value T
+                func Get() T { return Value }
+            }
+
+            var b = Box[int32]{ Value: 42 }
+            var ib IBox[int32] = b
+            Console.WriteLine(ib.Get())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void Struct_NamingClassAsBase_IsRejected()
+    {
+        // A struct (value type) cannot declare a user class as a base type.
+        var source = """
+            package Probe
+
+            class Base { var X int32 }
+
+            struct S : Base { var Y int32 }
+            """;
+
+        var diagnostics = CompileExpectingErrors(source);
+        Assert.Contains(diagnostics, d => d.Contains("GS0382"));
+    }
+
+    [Fact]
+    public void Struct_FailingToImplementInterfaceMember_IsRejected()
+    {
+        // A struct that declares an interface but does not provide the
+        // required member is rejected with the GS0187 channel.
+        var source = """
+            package Probe
+            import System
+
+            struct Money : IComparable[Money] {
+                var Cents int32
+            }
+            """;
+
+        var diagnostics = CompileExpectingErrors(source);
+        Assert.Contains(diagnostics, d => d.Contains("GS0187"));
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue976_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue976_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static List<string> CompileExpectingErrors(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue976_err_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit != 0, "expected gsc to report errors but it succeeded");
+
+            var combined = compileOut.ToString() + compileErr.ToString();
+            return combined.Split('\n').Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue976StructInterfaceClauseTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue976StructInterfaceClauseTests.cs
@@ -1,0 +1,122 @@
+// <copyright file="Issue976StructInterfaceClauseTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #976: a G# <c>struct</c> (CLR value type) may declare an
+/// implemented-interface clause (<c>struct S : I { … }</c>), mirroring a
+/// <c>class</c>. The parser already accepts the base/interface clause for
+/// structs; the binder accepts interfaces but rejects a class/struct base type
+/// with GS0382, and enforces interface satisfaction via the same GS0187
+/// channel classes use.
+/// </summary>
+public class Issue976StructInterfaceClauseTests
+{
+    [Fact]
+    public void StructInterfaceClause_Parses_WithNoDiagnostics()
+    {
+        const string source = """
+            package P
+            import System
+            struct Money : IEquatable[Money] {
+                var Cents int32
+                func Equals(other Money) bool { return Cents == other.Cents }
+            }
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void StructInterfaceClause_Binds_WithNoDiagnostics()
+    {
+        const string source = """
+            package P
+            import System
+            struct Money : IEquatable[Money] {
+                var Cents int32
+                func Equals(other Money) bool { return Cents == other.Cents }
+            }
+            """;
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void StructImplementsUserInterface_RecordsInterfaceOnSymbol()
+    {
+        const string source = """
+            package P
+            interface IShape {
+                func Area() int32;
+            }
+            struct Square : IShape {
+                var Side int32
+                func Area() int32 { return Side * Side }
+            }
+            """;
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var square = compilation.GlobalScope.Structs
+            .Single(s => s.Name == "Square");
+        Assert.False(square.IsClass, "Square must be a value-type struct");
+        Assert.Contains(square.Interfaces, i => i.Name == "IShape");
+    }
+
+    [Fact]
+    public void StructNamingClassAsBase_ReportsGS0382()
+    {
+        const string source = """
+            package P
+            class Base { var X int32 }
+            struct S : Base { var Y int32 }
+            """;
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0382");
+    }
+
+    [Fact]
+    public void StructNamingAnotherStructAsBase_ReportsGS0382()
+    {
+        const string source = """
+            package P
+            struct Other { var X int32 }
+            struct S : Other { var Y int32 }
+            """;
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0382");
+    }
+
+    [Fact]
+    public void StructMissingInterfaceMember_ReportsGS0187()
+    {
+        const string source = """
+            package P
+            import System
+            struct Money : IComparable[Money] {
+                var Cents int32
+            }
+            """;
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0187");
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.GlobalScope.Diagnostics.ToList();
+    }
+}


### PR DESCRIPTION
## Summary
A `struct` could not declare an implemented-interface clause. The parser already
accepts `struct S : I1, I2 {…}` (it shares `ParseStructDeclaration` with the
class path), but the **binder** rejected the clause for any non-class aggregate
with `GS0005`, so value types had no way to declare interface implementation
(`IEquatable[T]`, `IComparable[T]`, a custom interface).

A CLR value type always derives from `System.ValueType`, so a struct's clause
may list **interfaces only** — never a user base class. This PR implements
exactly that, end to end.

## Root cause
`DeclarationBinder.BindStructDeclarationBodyCore` bound the `: …` clause only
when `syntax.IsClass`; for structs it emitted `GS0005`. The parse tree already
carried the base/interface list.

## Changes by layer
- **Binder** (`DeclarationBinder.cs`): bind the base/interface clause for
  structs too. A struct may list interfaces only — a user/CLR class or another
  struct as a base is rejected with the new **GS0382**. Interface satisfaction
  reuses the existing deferred **GS0187** machinery (including #974
  generic-interface matching).
- **Diagnostics** (`DiagnosticBag.cs`, `docs/diagnostics.md`): new **GS0382**
  "Struct cannot declare base type; a struct may only implement interfaces."
- **Conversion** (`Conversion.cs`): a user value-type struct now implicitly
  converts (boxes) to any CLR interface in its clause, mirroring the class
  reference-upcast rule (`IsValueTypeAssignableToInterface` walks
  `ImplementedClrInterfaces`, incl. symbolic generic interfaces like
  `IEquatable[Money]`).
- **Emit** (`ReflectionMetadataEmitter.cs`): emit `InterfaceImpl` rows for
  struct TypeDefs (top-level and nested) via a shared `EmitInterfaceImplRows`
  helper, so the produced value type is a real CLR implementer. Value-type
  satisfying methods are already promoted to virtual slots (#409).

No `SyntaxKind`/`BoundNodeKind` was added (the base-clause node is reused), so
the coverage matrix is unchanged.

## Verification
- Canonical repro `struct Money : IEquatable[Money]` with `func Equals(other Money) bool`
  compiles, **ilverifies**, and **runs** — calling `Equals` directly AND through
  the `IEquatable[Money]` interface (boxing): `True/False/True/False`.
- `IComparable[Money]`, a `data struct` implementing a custom interface, and a
  generic `struct Box[T] : IBox[T]` (returning the constructed `T`, ties into
  #974) all compile + ilverify + run.
- Negatives: a struct naming a **class** as base → **GS0382**; a struct missing
  an interface member → **GS0187**.
- Decompiled metadata shows `public struct Money : IEquatable<Money>`.
- Build: **0 warning / 0 error** (`dotnet build GSharp.sln -c Release -graph`).
- Tests green: new `Issue976` emit tests (7), new Core.Tests binder/parser unit
  tests (6), full `Core.Tests` (3462), struct/interface/Issue97x emit slices
  (329), and `Cs2Gs.Tests` (129).

## Tests added
- `test/Compiler.Tests/Emit/Issue976StructImplementsInterfaceEmitTests.cs`
- `test/Core.Tests/CodeAnalysis/Binding/Issue976StructInterfaceClauseTests.cs`

Fixes #976
