### PR TITLE
Fix BCL method inline 'out var x' overload resolution (GS0159) (#977)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2048,6 +2048,85 @@ internal sealed partial class ExpressionBinder
         }
     }
 
+    /// <summary>
+    /// Issue #977: detects whether the argument at <paramref name="index"/> of an
+    /// imported-method call is an inline <c>out var</c>/<c>out let</c>/<c>out _</c>
+    /// declaration whose type is omitted (and therefore must be inferred from the
+    /// resolved overload). An explicitly typed inline declaration is excluded
+    /// because its local is already declared with a known type in the eager pass.
+    /// </summary>
+    /// <param name="ce">The call expression syntax.</param>
+    /// <param name="index">The source argument index.</param>
+    /// <param name="refArg">The matched ref-argument syntax, when applicable.</param>
+    /// <returns><see langword="true"/> when the argument is a type-omitted inline out declaration.</returns>
+    private static bool TryGetInlineOutVarArgument(CallExpressionSyntax ce, int index, out RefArgumentExpressionSyntax refArg)
+    {
+        refArg = null;
+        if (index < 0 || index >= ce.Arguments.Count)
+        {
+            return false;
+        }
+
+        if (OverloadResolver.UnwrapNamedArgumentValue(ce.Arguments[index]) is RefArgumentExpressionSyntax candidate
+            && candidate.IsInlineDeclaration
+            && candidate.DeclaredType == null)
+        {
+            refArg = candidate;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #977: re-binds inline <c>out var</c>/<c>out let</c>/<c>out _</c>
+    /// placeholder arguments against the by-ref parameters of the resolved
+    /// imported method, declaring each new local with the parameter's pointee
+    /// type. Returns the (possibly rebuilt) argument vector.
+    /// </summary>
+    /// <param name="ce">The call expression syntax.</param>
+    /// <param name="arguments">The bound arguments (with placeholder out-var entries).</param>
+    /// <param name="resolvedMethod">The chosen imported method (constructed if generic).</param>
+    /// <param name="parameterMapping">The source-argument → parameter-position mapping; default for positional calls.</param>
+    /// <returns>The argument vector with inline out-var placeholders rebound.</returns>
+    private ImmutableArray<BoundExpression> RebindInlineOutVarArguments(
+        CallExpressionSyntax ce,
+        ImmutableArray<BoundExpression> arguments,
+        System.Reflection.MethodInfo resolvedMethod,
+        ImmutableArray<int> parameterMapping)
+    {
+        ImmutableArray<BoundExpression>.Builder rebuilt = null;
+        System.Reflection.ParameterInfo[] parameters = null;
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            if (!TryGetInlineOutVarArgument(ce, i, out var refArg))
+            {
+                continue;
+            }
+
+            parameters ??= resolvedMethod.GetParameters();
+            var paramIndex = !parameterMapping.IsDefault && i < parameterMapping.Length ? parameterMapping[i] : i;
+            if (paramIndex < 0 || paramIndex >= parameters.Length)
+            {
+                continue;
+            }
+
+            var clrParameterType = parameters[paramIndex].ParameterType;
+            var pointeeClr = clrParameterType.IsByRef ? clrParameterType.GetElementType() : clrParameterType;
+            var pointeeType = TypeSymbol.FromClrType(pointeeClr);
+            var syntheticParameter = new ParameterSymbol(
+                parameters[paramIndex].Name ?? "value",
+                pointeeType,
+                refKind: RefKind.Out);
+
+            var rebound = BindRefArgumentExpression(refArg, syntheticParameter);
+            rebuilt ??= arguments.ToBuilder();
+            rebuilt[i] = rebound;
+        }
+
+        return rebuilt != null ? rebuilt.ToImmutable() : arguments;
+    }
+
     private BoundExpression BindAccessorCall(BoundExpression receiver, ImportedClassSymbol classSymbol, CallExpressionSyntax ce)
     {
         var methodName = ce.Identifier.Text;
@@ -2451,6 +2530,17 @@ internal sealed partial class ExpressionBinder
             var hasUserClassArg = false;
             for (var i = 0; i < arguments.Length; i++)
             {
+                // Issue #977: an inline `out var`/`out let`/`out _` argument was
+                // bound to a placeholder address-of (Error pointee) in the eager
+                // pass because the parameter type was unknown. Feed a sentinel so
+                // overload resolution treats it as matching any by-ref parameter;
+                // the local's type is inferred from the chosen overload below.
+                if (TryGetInlineOutVarArgument(ce, i, out _))
+                {
+                    argTypes[i] = OverloadResolution.InlineOutVarArgumentType;
+                    continue;
+                }
+
                 // Issue #530: use GetEffectiveArgumentClrType so that a
                 // nullable value type argument (e.g. `int32?`) is matched
                 // as `Nullable<T>` in overload resolution.
@@ -2486,6 +2576,11 @@ internal sealed partial class ExpressionBinder
                     switch (resolution.Outcome)
                     {
                         case OverloadResolution.ResolutionOutcome.Resolved:
+                            // Issue #977: now that the overload is chosen, re-bind
+                            // any inline `out var`/`out let`/`out _` placeholders
+                            // against the resolved by-ref parameter so the new
+                            // local is declared with the inferred pointee type.
+                            arguments = RebindInlineOutVarArguments(ce, arguments, resolution.Best, resolution.ParameterMapping);
                             var instSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(receiver?.Type, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
                             var instSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(resolution.Best, typeArgSymbols, instSymbolicArgs);
                             var instTypeArgSymbolsForCall = !instSymbolicTypeArgs.IsDefault ? instSymbolicTypeArgs : typeArgSymbols;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -177,6 +177,20 @@ internal static class OverloadResolution
     public static Func<Type, Type, bool> UserDefinedImplicitConversionLookup { get; set; }
 
     /// <summary>
+    /// ADR-0060 / issue #977: sentinel argument type representing an inline
+    /// <c>out var</c>/<c>out let</c>/<c>out _</c> declaration whose local type is
+    /// not yet known. Such an argument is applicable to — and only to — a by-ref
+    /// (<c>ref</c>/<c>out</c>/<c>in</c>) parameter; its declared local type is
+    /// inferred from the chosen overload's parameter after resolution succeeds.
+    /// Using a dedicated marker keeps the out-var neutral during betterness
+    /// ranking (it always classifies as an identity conversion against a by-ref
+    /// parameter) while still rejecting non-by-ref candidates.
+    /// </summary>
+#pragma warning disable SA1201 // Elements should appear in the correct order
+    public static readonly Type InlineOutVarArgumentType = typeof(InlineOutVarArgumentMarker);
+#pragma warning restore SA1201
+
+    /// <summary>
     /// Issue #658: per-call supplementary interface check for user-defined G#
     /// classes whose CLR type does not exist at bind time. When set (non-null),
     /// <see cref="ClassifyImplicit"/> invokes this callback as a final
@@ -206,6 +220,14 @@ internal static class OverloadResolution
         if (target is null)
         {
             return ImplicitConversionKind.None;
+        }
+
+        // Issue #977: an inline `out var`/`out let`/`out _` argument has no known
+        // type until an overload is chosen; it matches exactly the by-ref
+        // parameters (out/ref/in) and nothing else.
+        if (ReferenceEquals(source, InlineOutVarArgumentType))
+        {
+            return target.IsByRef ? ImplicitConversionKind.Identity : ImplicitConversionKind.None;
         }
 
         // Issue #533: a null source represents the `nil` literal in G#.
@@ -3135,5 +3157,14 @@ internal static class OverloadResolution
         internal static Result<T> Single(T best, ImmutableArray<int> parameterMapping, bool isExpanded) => new(ResolutionOutcome.Resolved, best, ImmutableArray<T>.Empty, parameterMapping, isExpanded);
 
         internal static Result<T> AmbiguousResult(ImmutableArray<T> tied) => new(ResolutionOutcome.Ambiguous, default, tied, default, false);
+    }
+
+    /// <summary>
+    /// Issue #977: private marker type whose <see cref="Type"/> identity is used as
+    /// the <see cref="InlineOutVarArgumentType"/> sentinel for inline <c>out var</c>
+    /// arguments during overload resolution. Never instantiated.
+    /// </summary>
+    private sealed class InlineOutVarArgumentMarker
+    {
     }
 }

--- a/test/Compiler.Tests/Emit/Issue977BclOutVarEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue977BclOutVarEmitTests.cs
@@ -1,0 +1,229 @@
+// <copyright file="Issue977BclOutVarEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #977: an inline <c>out var</c>/<c>out let</c>/<c>out _</c> argument must
+/// bind against imported (BCL) method overloads, not only user-defined functions.
+/// The defect made <c>d.TryGetValue("a", out var v)</c> fail overload resolution
+/// (<c>GS0159 Cannot find function TryGetValue</c>) even though the equivalent
+/// pre-declared pass-by-address (<c>&amp;slot</c>) and user-function forms bound
+/// fine. These tests cover the imported-method instance-call path:
+/// <list type="bullet">
+/// <item><description>The local declared by <c>out var v</c> is inferred from the
+/// chosen overload's by-ref parameter (e.g. <c>int32</c> for
+/// <c>Dictionary[string,int32].TryGetValue(TKey, out TValue)</c>).</description></item>
+/// <item><description>Type inference is per-instantiation (<c>int32</c> vs
+/// <c>string</c>).</description></item>
+/// <item><description>The pre-declared <c>&amp;slot</c> control and the
+/// user-function <c>out var</c> control keep compiling (no regression).</description></item>
+/// <item><description><c>out _</c> discard against a BCL method also binds.</description></item>
+/// </list>
+/// </summary>
+public class Issue977BclOutVarEmitTests
+{
+    [Fact]
+    public void Dictionary_IntValue_InlineOutVar_HitAndMiss()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            let d = Dictionary[string, int32]()
+            d["a"] = 5
+            let ok = d.TryGetValue("a", out var v)
+            Console.WriteLine(ok)
+            Console.WriteLine(v)
+            let miss = d.TryGetValue("z", out var w)
+            Console.WriteLine(miss)
+            Console.WriteLine(w)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n5\nFalse\n0\n", output);
+    }
+
+    [Fact]
+    public void Dictionary_IntValue_InlineOutVar_LocalIsInferredInt32()
+    {
+        // The inferred local participates in int32 arithmetic, proving the type
+        // was inferred from the `out TValue` parameter (int32), not left as Error.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            let d = Dictionary[string, int32]()
+            d["a"] = 20
+            d.TryGetValue("a", out var v)
+            let doubled int32 = v * 2
+            Console.WriteLine(doubled)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("40\n", output);
+    }
+
+    [Fact]
+    public void Dictionary_StringValue_InlineOutVar_PerInstantiationInference()
+    {
+        // A second instantiation infers `string` for the same `out var` shape,
+        // confirming inference is driven by the constructed receiver type.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            let sd = Dictionary[string, string]()
+            sd["x"] = "hello"
+            let ok = sd.TryGetValue("x", out var s)
+            Console.WriteLine(ok)
+            Console.WriteLine(s)
+            Console.WriteLine(s.Length)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nhello\n5\n", output);
+    }
+
+    [Fact]
+    public void Dictionary_PreDeclaredAddressOf_Control_StillCompiles()
+    {
+        // Control: BCL out via a pre-declared local passed by address (&slot).
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            let d = Dictionary[string, int32]()
+            d["a"] = 7
+            var slot int32
+            let ok = d.TryGetValue("a", &slot)
+            Console.WriteLine(ok)
+            Console.WriteLine(slot)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n7\n", output);
+    }
+
+    [Fact]
+    public void UserFunc_InlineOutVar_Control_StillCompiles()
+    {
+        // Control: a user-defined func with an `out` parameter + inline out var.
+        var source = """
+            package P
+            import System
+
+            func tryProduce(out result int32) bool {
+                result = 42
+                return true
+            }
+
+            let ok = tryProduce(out var n)
+            Console.WriteLine(ok)
+            Console.WriteLine(n)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n42\n", output);
+    }
+
+    [Fact]
+    public void Dictionary_InlineOutDiscard_AgainstBclMethod()
+    {
+        // `out _` discard against a BCL method must also bind and run.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            let d = Dictionary[string, int32]()
+            d["a"] = 9
+            let ok = d.TryGetValue("a", out _)
+            Console.WriteLine(ok)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue977_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Root cause
`d.TryGetValue("a", out var v)` against a BCL/imported method failed overload resolution with `GS0159: Cannot find function TryGetValue`, while the pre-declared `&slot` pass-by-address form and the user-defined `func` + inline `out var` form bound fine.

In the imported-instance-call path (`ExpressionBinder.BindAccessorCall`, `src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs`), an inline `out var`/`out let`/`out _` argument is bound to a placeholder `BoundAddressOfExpression` with an `Error` pointee in the eager argument pass (the parameter type is not known yet). When the path builds the CLR argument-type vector for `OverloadResolution.Resolve`, that `Error` type maps to a `null` CLR type, which sets `argsAllTyped = false` and **skips reflection overload resolution entirely** — so no candidate is found and GS0159 is reported. The user-function path (`OverloadResolver`) already re-binds inline out-var placeholders against the resolved parameter (`OverloadResolver.cs` ~L3093), but the imported-method path had no equivalent.

## The fix
- **`OverloadResolution.cs`**: add an `InlineOutVarArgumentType` sentinel. `ClassifyImplicit` returns `Identity` for it against a by-ref (`ref`/`out`/`in`) parameter and `None` otherwise — making a candidate applicable only when the matched parameter is by-ref, and keeping the out-var neutral during betterness ranking.
- **`ExpressionBinder.Calls.cs`**: in `BindAccessorCall`, feed the sentinel for type-omitted inline out-var argument positions (`TryGetInlineOutVarArgument`). After resolution succeeds, `RebindInlineOutVarArguments` re-binds those placeholders against the chosen overload's by-ref parameter, declaring each new local with the parameter's pointee type. For a constructed generic receiver (e.g. `Dictionary[string,int32]`), reflection has already substituted the type argument, so `out var v` against `TryGetValue(TKey, out TValue)` infers `v : int32` (and `string` for `Dictionary[string,string]`). The `out _` discard shares the same path.

The new local is in scope and definitely-assigned after the call, and the emitted IL passes the out arg by managed reference (ilverify-clean) — matching the user-func and pre-declared `&x` semantics.

## Verification
- Repro now compiles and runs; `out var v` is inferred `int32` with value `5` (hit) and `0` (miss); `Dictionary[string,string]` variant infers `string`.
- Controls unchanged: `&slot` pre-declared pass-by-address and user-func `out var` still compile/run.
- `out _` discard against a BCL method binds and runs.
- New `test/Compiler.Tests/Emit/Issue977BclOutVarEmitTests.cs` (6 facts: compile + ilverify + run) — all pass.
- Targeted slices green: `Issue977` (6), `OutVar|OutArg|Overload|Dictionary|TryParse|TryGet` (80), recent-fix regressions `Issue973|974|975|976` (19).
- `Core.Tests` 3462 passed (1 skip), `Cs2Gs.Tests` 129 passed.
- Full `dotnet build GSharp.sln -c Release -graph`: **0 Warning / 0 Error**; clean `Core` rebuild 0/0.

Fixes #977
