### PR TITLE
cs2gs: re-baseline corpus on fixed compiler, canonicalize L4, add L5 (#914)

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -343,11 +343,11 @@ A C# local declaration with **no initializer** (`int existing;`, typically a pre
 
 #### B.33 `switch` statement over patterns → G# `switch` block — sample `PatternSwitch.gs`
 
-A C# `switch` **statement** maps to the canonical G# `switch subj { case <pat> { … } default { … } }` block form (sample `PatternSwitch.gs`): each `case` section's labels become a `case <pattern>` arm whose body is the section's statements wrapped in a block, a type pattern `case T x:` maps to `case x is T`, and the per-section `break;` (required in C#) is **dropped** (G# arms do not fall through). The `default:` section maps to a `default { … }` arm. A `when` guard on a case has **no** G# spelling (§G #TBD-7) and a value-returning `switch` statement is emitted as a `switch` **expression** instead (the statement form is not exhaustiveness-checked for value returns), so the translator reserves the block form for void-bodied dispatch. Reuses the same pattern set as the §B switch-expression mapping (type/relational patterns).
+A C# `switch` **statement** maps to the canonical G# `switch subj { case <pat> { … } default { … } }` block form (sample `PatternSwitch.gs`): each `case` section's labels become a `case <pattern>` arm whose body is the section's statements wrapped in a block, a type pattern `case T x:` maps to `case x is T`, and the per-section `break;` (required in C#) is **dropped** (G# arms do not fall through). The `default:` section maps to a `default { … }` arm. A `when` guard on a case has **no** G# spelling (§G #991) and a value-returning `switch` statement is emitted as a `switch` **expression** instead (the statement form is not exhaustiveness-checked for value returns), so the translator reserves the block form for void-bodied dispatch. Reuses the same pattern set as the §B switch-expression mapping (type/relational patterns).
 
 #### B.34 Iterator (`yield return`) → `sequence[T]` generator — sample `TupleSequenceIterators.gs`
 
-A C# iterator method (a body containing `yield return`) returning `IEnumerable<T>`/`IEnumerator<T>` maps to a G# generator whose **return type is rewritten to `sequence[T]`** (the element type `T`), with each `yield return expr;` emitted as a bare `yield expr` (sample `TupleSequenceIterators.gs`). The `IEnumerable<T>` wrapper is **not** carried through — `sequence[T]` is the canonical G# enumeration surface and is directly `for x in …`-iterable. `yield break;` has no G# spelling (§G #TBD-10), and a **user reference-type** element (`sequence[UserClass]`) currently crashes the emitter (§G #TBD-6), so the canonical iterator yields BCL element types (e.g. `string`).
+A C# iterator method (a body containing `yield return`) returning `IEnumerable<T>`/`IEnumerator<T>` maps to a G# generator whose **return type is rewritten to `sequence[T]`** (the element type `T`), with each `yield return expr;` emitted as a bare `yield expr` (sample `TupleSequenceIterators.gs`). The `IEnumerable<T>` wrapper is **not** carried through — `sequence[T]` is the canonical G# enumeration surface and is directly `for x in …`-iterable. `yield break;` has no G# spelling (§G #994), and a **user reference-type** element (`sequence[UserClass]`) currently crashes the emitter (§G #990), so the canonical iterator yields BCL element types (e.g. `string`).
 
 > **Numeric literal promotion at a converted-type site (§B.12 note).** C# applies
 > an implicit `int`→`double`/`float` conversion when an integer literal is passed
@@ -512,9 +512,9 @@ to a single fingerprinted entry that maps to a filed compiler issue. Final matri
 | --- | --- | --- | --- | --- | --- |
 | `corpus/L1-Console` | PASS | PASS | PASS | PASS | — (fully green E2E) |
 | `corpus/L2-Library` | PASS | PASS | PASS | PASS | — (#973 resolved → fully green E2E) |
-| `corpus/L3-Library` | PASS | FAIL | skip | skip | #TBD-1 (`IEnumerable[T]` needs dual `GetEnumerator` overloads → GS0264 + GS0187); `Advanced.gs` compiles standalone |
+| `corpus/L3-Library` | PASS | FAIL | skip | skip | #985 (`IEnumerable[T]` needs dual `GetEnumerator` overloads → GS0264 + GS0187); `Advanced.gs` compiles standalone |
 | `corpus/L4-Console` | PASS | PASS | PASS | PASS | — (fully green E2E; #975/#976/#977 resolved) |
-| `corpus/L5-Console` | PASS | PASS | PASS | PASS | — (fully green E2E; next gap batch #TBD-2…#TBD-10 surfaced and captured, see below) |
+| `corpus/L5-Console` | PASS | PASS | PASS | PASS | — (fully green E2E; next gap batch #986…#994 surfaced and captured, see below) |
 
 **Objective 1 (faithful migration)** is demonstrated by L1 + L2 + L4 + L5 reaching full
 parity (L2 went fully green when #973/#974 were fixed; L5 is fully green E2E) and by
@@ -543,16 +543,16 @@ re-greening earlier stages and surfacing the next layer of gaps:
 | #975 | interpolated string in a `: base(...)` constructor-arg position — emit ICE | GS9998 | resolved (translator emits `: base("…$n…")` directly) |
 | #976 | a `struct` cannot declare a base / interface clause (`struct S : I {…}` won't parse) | GS0005 | resolved (struct interface clause parses; class/struct base → GS0382) |
 | #977 | BCL method invoked with an inline `out var x` declaration fails overload resolution | GS0159 | resolved (inline `out var x` binds for BCL calls) |
-| #TBD-1 | implementing `IEnumerable[T]` needs two `GetEnumerator` overloads differing only by return type (generic `IEnumerator[T]` + non-generic `IEnumerator`) | GS0264 + GS0187 | open (blocks L3-`Generics`; residual after #974) |
-| #TBD-2 | `base.Method()` virtual base-class call has no canonical G# form (`base[Base].M` is interface-only per ADR-0091) | GS0157 / GS0338 | open (translation-unsupported; L5 uses dynamic dispatch instead) |
-| #TBD-3 | an `abstract` (no-body) method on an `open class` → emitter crash | GS9998 (NRE) | open (L5 uses a virtual method with a body) |
-| #TBD-4 | `new T()` construction under a `new()` constraint has no canonical G# form | GS0125 / GS0130 / GS0157 | open (translation-unsupported; L5 has the caller supply the value) |
-| #TBD-5 | a generic auto-property over `T` (`prop Value T`) cannot be member-accessed | GS0158 | open (L5 uses a generic field instead) |
-| #TBD-6 | a user reference-type iterator (`sequence[UserClass]`) → emitter crash | GS9998 | open (L5 yields `string`; `sequence[int32]`/`sequence[string]` compile) |
-| #TBD-7 | a `when` guard on a `switch` statement/expression arm won't parse | GS0005 | open (translation-unsupported) |
-| #TBD-8 | `and`/`or` binary patterns (`> 0 and < 10`) won't parse | GS0005 | open (translation-unsupported) |
-| #TBD-9 | an `is`/`case` type pattern **with** a binder (`x is T t`) leaves the binder unbound | GS0125 | open (L5 uses the no-binder form `x is T`) |
-| #TBD-10 | `yield break` has no canonical G# form | GS0005 | open (translation-unsupported) |
+| #985 | implementing `IEnumerable[T]` needs two `GetEnumerator` overloads differing only by return type (generic `IEnumerator[T]` + non-generic `IEnumerator`) | GS0264 + GS0187 | open (blocks L3-`Generics`; residual after #974) |
+| #986 | `base.Method()` virtual base-class call has no canonical G# form (`base[Base].M` is interface-only per ADR-0091) | GS0157 / GS0338 | open (translation-unsupported; L5 uses dynamic dispatch instead) |
+| #987 | an `abstract` (no-body) method on an `open class` → emitter crash | GS9998 (NRE) | open (L5 uses a virtual method with a body) |
+| #988 | `new T()` construction under a `new()` constraint has no canonical G# form | GS0125 / GS0130 / GS0157 | open (translation-unsupported; L5 has the caller supply the value) |
+| #989 | a generic auto-property over `T` (`prop Value T`) cannot be member-accessed | GS0158 | open (L5 uses a generic field instead) |
+| #990 | a user reference-type iterator (`sequence[UserClass]`) → emitter crash | GS9998 | open (L5 yields `string`; `sequence[int32]`/`sequence[string]` compile) |
+| #991 | a `when` guard on a `switch` statement/expression arm won't parse | GS0005 | open (translation-unsupported) |
+| #992 | `and`/`or` binary patterns (`> 0 and < 10`) won't parse | GS0005 | open (translation-unsupported) |
+| #993 | an `is`/`case` type pattern **with** a binder (`x is T t`) leaves the binder unbound | GS0125 | open (L5 uses the no-binder form `x is T`) |
+| #994 | `yield break` has no canonical G# form | GS0005 | open (translation-unsupported) |
 
 L3 not going fully green is the **intended** objective-2 outcome: the residual
 failure is a real compiler gap, captured and filed rather than worked around or
@@ -618,7 +618,7 @@ if d.TryGetValue("a", out var v) {
 Each was reproduced directly with `gsc` and contrasted with a passing control.
 The orchestrator files the issue and replaces the `#TBD-x` placeholder.
 
-**#TBD-1 — implementing `IEnumerable[T]` needs two `GetEnumerator` overloads → `GS0264` + `GS0187`.**
+**#985 — implementing `IEnumerable[T]` needs two `GetEnumerator` overloads → `GS0264` + `GS0187`.**
 A C# generic collection implements `IEnumerable<T>` by declaring the generic
 `IEnumerator<T> GetEnumerator()` and an explicit-interface non-generic
 `IEnumerator IEnumerable.GetEnumerator()`. G# has no explicit-interface-impl
@@ -670,7 +670,7 @@ class Circle(Radius float64) : Shape {
 }
 ```
 
-**#TBD-2 — `base.Method()` virtual base-class call has no canonical G# form.**
+**#986 — `base.Method()` virtual base-class call has no canonical G# form.**
 A C# `override` that chains to the base implementation via `base.Describe()` has no
 G# spelling: `base.M()` → `GS0157` "Cannot find type base"; the interface-only
 `base[Base].M()` form (ADR-0091) → `GS0338` (valid only for an interface default
@@ -696,7 +696,7 @@ class Circle() : Shape {
 }
 ```
 
-**#TBD-3 — an `abstract` (no-body) method on an `open class` → emitter crash (`GS9998`).**
+**#987 — an `abstract` (no-body) method on an `open class` → emitter crash (`GS9998`).**
 The translator lowers a C# `abstract` method to a no-body `open func F() T;`. The
 parser accepts it, but the emitter throws a `NullReferenceException` (`GS9998`).
 Classification: **compile-error / ICE**. L5 uses a `virtual` method with a default
@@ -715,7 +715,7 @@ open class Shape {
 }
 ```
 
-**#TBD-4 — `new T()` construction under a `new()` constraint has no canonical G# form.**
+**#988 — `new T()` construction under a `new()` constraint has no canonical G# form.**
 A C# generic that constructs its type parameter (`where T : new()`, `new T()`) has
 no G# spelling: `T()` → `GS0130`, `T{}` → `GS0157`, `new T()` → `GS0125`.
 Classification: **translation-unsupported**. L5 has the caller supply the value
@@ -732,7 +732,7 @@ class Factory[T new()] {
 class Box[T class](Value T) { }
 ```
 
-**#TBD-5 — a generic auto-property over `T` (`prop Value T`) cannot be member-accessed (`GS0158`).**
+**#989 — a generic auto-property over `T` (`prop Value T`) cannot be member-accessed (`GS0158`).**
 Declaring `prop Value T` on a generic class and then reading `box.Value` →
 `GS0158` "Cannot find member Value". Classification: **compile-error**. A generic
 **field** (`var Value T`) and a non-generic auto-property both work, so L5 uses a
@@ -750,7 +750,7 @@ class Box[T class] {
 class Box[T class](Value T) { }   // ... box.Value works
 ```
 
-**#TBD-6 — a user reference-type iterator (`sequence[UserClass]`) → emitter crash (`GS9998`).**
+**#990 — a user reference-type iterator (`sequence[UserClass]`) → emitter crash (`GS9998`).**
 A `yield`-generator whose element type is a user reference type
 (`func F() sequence[Shape]`) → `GS9998` "Conversion from '\<T>' to 'object' is not
 yet supported by the emitter". Both `sequence[int32]` and `sequence[string]` (a BCL
@@ -767,7 +767,7 @@ func shapes() sequence[Shape] { yield Shape() }
 func names() sequence[string] { yield "a" }
 ```
 
-**#TBD-7 — a `when` guard won't parse (`GS0005`).**
+**#991 — a `when` guard won't parse (`GS0005`).**
 A `when` guard on a `switch` statement or expression arm (`case > 0 when cond:`) →
 `GS0005` parse error. Classification: **translation-unsupported**. L5 omits guards.
 
@@ -786,7 +786,7 @@ let r = switch n {
 }
 ```
 
-**#TBD-8 — `and`/`or` binary patterns won't parse (`GS0005`).**
+**#992 — `and`/`or` binary patterns won't parse (`GS0005`).**
 A combined relational pattern (`case > 0 and < 10:`) → `GS0005`. Classification:
 **translation-unsupported**. L5 nests single relational patterns instead.
 
@@ -799,7 +799,7 @@ let r = switch n { case > 0 and < 10: "x" default: "y" }
 let r = switch n { case < 10: "x" default: "y" }
 ```
 
-**#TBD-9 — an `is`/`case` type pattern WITH a binder leaves the binder unbound (`GS0125`).**
+**#993 — an `is`/`case` type pattern WITH a binder leaves the binder unbound (`GS0125`).**
 `if x is Shape s` (a type pattern that binds `s`) → `GS0125` "Variable 's' doesn't
 exist" when `s` is used. Classification: **compile-error**. The no-binder form
 `if x is Shape` works, so L5 tests the type without binding.
@@ -813,7 +813,7 @@ if shape is Circle c { Console.WriteLine(c.Area().ToString()) }
 if shape is Circle { Console.WriteLine("a circle") }
 ```
 
-**#TBD-10 — `yield break` has no canonical G# form (`GS0005`).**
+**#994 — `yield break` has no canonical G# form (`GS0005`).**
 A `yield break;` in a generator → `GS0005`. Classification:
 **translation-unsupported**. L5's iterator runs to natural completion.
 

--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -261,6 +261,8 @@ Canonical output uses **width-bearing** primitive names (ADR-0049): C# `int`→`
 
 A `data class`/`data struct` auto-synthesizes value (structural) equality, `GetHashCode`, and the `with` updater. A C# record therefore drops its compiler-synthesized `IEquatable<Self>` from the base clause when emitted as a `data` type — re-stating `: IEquatable[Self]` is redundant because equality already comes from the `data` modifier. (Naming the enclosing type as a base-clause type *argument* is legal since issue #949; the drop is a redundancy filter, not a syntax restriction.) The structural `==`/`!=` and `with` come for free from the `data` modifier.
 
+A **non-`data` `struct`** that *explicitly* implements an interface (`struct Money : IEquatable<Money>` with a hand-written `Equals`) keeps its interface clause: gap #976 — the parser rejecting a `:` after a struct name — is **resolved** (issue #976), so the translator emits `struct Money(Cents int32) : IEquatable[Money]` and the struct's own `Equals`/`GetHashCode` satisfy the interface. A `struct` naming a **class or struct** base (rather than an interface) is now rejected with the dedicated diagnostic `GS0382` rather than the former generic `GS0005`, matching the value-type-has-no-base-class rule. Only the redundant `data`-synthesized `IEquatable[Self]` is dropped (above); a genuinely hand-implemented interface on a plain `struct` is preserved.
+
 #### B.14 Owned value-aggregate methods → lifted receiver-clause funcs — issue #938, ADR-0079
 
 As of issue #938 a `struct`/`data struct` instance method **can** live in the type body — the parser and binder accept an in-body `func` on a value aggregate and bind it warning-free (§B.5). The cs2gs translator nonetheless still **lifts** such a method to a top-level receiver-clause `func (self T) Name(...)` emitted as a sibling immediately after the type, for mechanical reasons (its declaration-lifting pipeline predates the compiler fix). A top-level receiver-clause `func` has no implicit `this`, so inside the lifted body every bare instance-member reference is made explicit through the receiver (`self.X`). This compiles and runs correctly but emits the soft `GS0314` warning (ADR-0079, owned-type receiver clause). Emitting the in-body form instead — now warning-free — is a possible future translator improvement; the `GS0314` it currently produces is an expected, known diagnostic rather than a parity failure. (A plain `struct` still admits no explicit `init`; value types are constructed via primary constructors and struct literals.)
@@ -321,7 +323,7 @@ A C# `try`/`catch`/`finally` maps to the canonical G# `try { } catch (e T) { } f
 
 #### B.28 Custom exception with `: base(message)` → explicit `init` with base chaining — sample `ExplicitConstructor.gs`
 
-A C# constructor with a base initializer `: base(args)` maps to the canonical G# explicit-base form `init(params) : base(args) { … }`. This is how a custom exception (`class FooException : Exception { public FooException(string m) : base(m) { } }`) forwards its message to `System.Exception`. The base arguments are translated as ordinary arguments; a `: this(...)` constructor *delegation* has no canonical form yet and is reported unsupported. (Note the discovered gap #975: an *interpolated string* in base-argument position ICEs the emitter, so an interpolated message is passed as a normal constructor argument and forwarded as a bare parameter.)
+A C# constructor with a base initializer `: base(args)` maps to the canonical G# explicit-base form `init(params) : base(args) { … }`. This is how a custom exception (`class FooException : Exception { public FooException(string m) : base(m) { } }`) forwards its message to `System.Exception`. The base arguments are translated as ordinary arguments; a `: this(...)` constructor *delegation* has no canonical form yet and is reported unsupported. (Gap #975 — interpolated string in base-argument position — is **resolved**: the emitter now lowers an interpolated string in `: base(...)` position, so the translator emits it **directly** — `init(n int32) : base("only $n left")` — with no bare-parameter forward. The base initializer is translated through the same expression path as any call argument, so interpolation, concatenation, and literals all carry over verbatim.)
 
 #### B.29 `using` statement / `using` declaration → `using let` resource — sample `Defer.gs`
 
@@ -329,7 +331,7 @@ A C# `using (var r = expr) { body }` statement maps to a scoped block whose reso
 
 #### B.30 `out`/`ref` arguments → pass-by-address `&x` / inline `out var x` — ADR-0060, sample `TryParseOutVar.gs`
 
-A C# `out`/`ref` argument maps to the canonical G# argument forms. A **pre-declared** `out`/`ref` variable passes **by address**: `d.TryGetValue(k, out existing)` → `d.TryGetValue(k, &existing)`; the uninitialised local binds as a mutable `var existing T` (an immutable `let` requires an initializer — see B.3). An **inline** `out var x` declaration maps to `out var x` and `out _` to the discard `out _`. (Note the discovered gap #977: inline `out var` fails overload resolution against BCL methods, so the pre-declared `&x` form is canonical for BCL `out` calls.)
+A C# `out`/`ref` argument maps to the canonical G# argument forms. A **pre-declared** `out`/`ref` variable passes **by address**: `d.TryGetValue(k, out existing)` → `d.TryGetValue(k, &existing)`; the uninitialised local binds as a mutable `var existing T` (an immutable `let` requires an initializer — see B.3). An **inline** `out var x` declaration maps to `out var x` and `out _` to the discard `out _`. (Gap #977 — inline `out var` failing overload resolution against BCL methods — is **resolved**: an inline `out var x` against a BCL method such as `Dictionary.TryGetValue` now binds, so the translator emits the canonical inline `out var x` form for BCL and user calls alike; the pass-by-address `&x` form remains the canonical mapping for a **pre-declared** `out` target.)
 
 #### B.31 Operator overloading → receiver-clause `operator` funcs — ADR-0035, sample `Operators.gs`
 
@@ -338,6 +340,33 @@ A C# operator overload `public static X operator +(X a, X b)` maps to the canoni
 #### B.32 Uninitialised local → mutable `var name T`
 
 A C# local declaration with **no initializer** (`int existing;`, typically a pre-declared `out` target) binds as a mutable `var name T` rather than `let name T`: an immutable `let` requires an initializer (the spec's binding rules), and the type clause names the zero/default value. With an initializer the binding follows the usual `let`/`var` reassignment analysis (§B.3).
+
+#### B.33 `switch` statement over patterns → G# `switch` block — sample `PatternSwitch.gs`
+
+A C# `switch` **statement** maps to the canonical G# `switch subj { case <pat> { … } default { … } }` block form (sample `PatternSwitch.gs`): each `case` section's labels become a `case <pattern>` arm whose body is the section's statements wrapped in a block, a type pattern `case T x:` maps to `case x is T`, and the per-section `break;` (required in C#) is **dropped** (G# arms do not fall through). The `default:` section maps to a `default { … }` arm. A `when` guard on a case has **no** G# spelling (§G #TBD-7) and a value-returning `switch` statement is emitted as a `switch` **expression** instead (the statement form is not exhaustiveness-checked for value returns), so the translator reserves the block form for void-bodied dispatch. Reuses the same pattern set as the §B switch-expression mapping (type/relational patterns).
+
+#### B.34 Iterator (`yield return`) → `sequence[T]` generator — sample `TupleSequenceIterators.gs`
+
+A C# iterator method (a body containing `yield return`) returning `IEnumerable<T>`/`IEnumerator<T>` maps to a G# generator whose **return type is rewritten to `sequence[T]`** (the element type `T`), with each `yield return expr;` emitted as a bare `yield expr` (sample `TupleSequenceIterators.gs`). The `IEnumerable<T>` wrapper is **not** carried through — `sequence[T]` is the canonical G# enumeration surface and is directly `for x in …`-iterable. `yield break;` has no G# spelling (§G #TBD-10), and a **user reference-type** element (`sequence[UserClass]`) currently crashes the emitter (§G #TBD-6), so the canonical iterator yields BCL element types (e.g. `string`).
+
+> **Numeric literal promotion at a converted-type site (§B.12 note).** C# applies
+> an implicit `int`→`double`/`float` conversion when an integer literal is passed
+> where a floating-point value is expected (e.g. `M(30)` where the parameter is
+> `double`). G# has **no** implicit numeric promotion, so emitting a bare `int32`
+> literal compiles but produces invalid IL — `ilverify` reports `StackUnexpected`
+> (found Int32, expected Double). The translator therefore consults the bound
+> `ConvertedType`: when an integer literal is implicitly converted to a
+> floating-point type it is emitted as a **float literal** (`30` → `30.0`), so the
+> value matches its target type. (Discovered by the L5 pipeline.)
+>
+> **Parameterless constructor initializing a property (§B.3 note).** The
+> primary-constructor / field-initializer canonicalization lifts a `_field = expr`
+> constant assignment out of a dropped constructor into a G# **field** member
+> initializer (`var Name T = expr`). G# has **no property** member initializer
+> (`prop Name T = expr` → `GS0288`/`GS0113`), so when the assigned member is a
+> **property**, the explicit `init()` constructor is **kept** (its body faithfully
+> assigns the property) rather than dropped. (Discovered by the L5 pipeline.)
+
 
 > **Indexer declaration — RESOLVED (#944, ADR-0118).** A C# indexer
 > (`public T this[int i] => _items[i];`) now maps to the canonical G# indexer
@@ -482,20 +511,23 @@ to a single fingerprinted entry that maps to a filed compiler issue. Final matri
 | App | translate | compile | ilverify | test-parity | Blocking gap |
 | --- | --- | --- | --- | --- | --- |
 | `corpus/L1-Console` | PASS | PASS | PASS | PASS | — (fully green E2E) |
-| `corpus/L2-Library` | PASS | FAIL | skip | skip | #973 (class with a value-type field — emit ICE) |
-| `corpus/L3-Library` | PASS | FAIL | skip | skip | #974 (`Repository[T] : IEnumerable[T]` generic-interface impl); `Advanced.gs` compiles standalone |
-| `corpus/L4-Console` | PASS | PASS | PASS | PASS | — (fully green E2E) |
+| `corpus/L2-Library` | PASS | PASS | PASS | PASS | — (#973 resolved → fully green E2E) |
+| `corpus/L3-Library` | PASS | FAIL | skip | skip | #TBD-1 (`IEnumerable[T]` needs dual `GetEnumerator` overloads → GS0264 + GS0187); `Advanced.gs` compiles standalone |
+| `corpus/L4-Console` | PASS | PASS | PASS | PASS | — (fully green E2E; #975/#976/#977 resolved) |
+| `corpus/L5-Console` | PASS | PASS | PASS | PASS | — (fully green E2E; next gap batch #TBD-2…#TBD-10 surfaced and captured, see below) |
 
-**Objective 1 (faithful migration)** is demonstrated by L1 + L4 reaching full
-stdout/test parity and by L2 + L3 translating to canonical G# (L3 now translates
-in full; `Advanced.gs` also compiles standalone). L4 additionally proves the
-canonical mappings for exception handling (custom exception + `base` chaining,
-typed `catch`, `finally`, re-throw), `Dictionary`/`HashSet`, `using`/`IDisposable`,
-nullable value types (`T?`, `.HasValue`/`.Value`, `??`), and operator overloading
-(receiver-clause `operator` funcs). **Objective 2 (gap discovery)** is demonstrated
-by structured, reproduced, and filed compiler gaps surfaced purely by migration
-friction — most of which the compiler team has already fixed, re-greening earlier
-stages and surfacing the next layer of gaps:
+**Objective 1 (faithful migration)** is demonstrated by L1 + L2 + L4 + L5 reaching full
+parity (L2 went fully green when #973/#974 were fixed; L5 is fully green E2E) and by
+L3 translating to canonical G#. L4 additionally proves the canonical mappings for exception
+handling (custom exception + `base` chaining, typed `catch`, `finally`, re-throw),
+`Dictionary`/`HashSet`, `using`/`IDisposable`, nullable value types (`T?`,
+`.HasValue`/`.Value`, `??`), and operator overloading (receiver-clause `operator`
+funcs) — and, since #975/#976/#977 were fixed, the translator emits the **canonical**
+forms for an interpolated `: base(...)` argument, a `struct` interface clause, and
+an inline BCL `out var x` directly (no workaround). **Objective 2 (gap discovery)**
+is demonstrated by structured, reproduced, and filed compiler gaps surfaced purely
+by migration friction — most of which the compiler team has already fixed,
+re-greening earlier stages and surfacing the next layer of gaps:
 
 | Issue | Construct | Diagnostic | Status |
 | --- | --- | --- | --- |
@@ -506,21 +538,30 @@ stages and surfacing the next layer of gaps:
 | #942 | `expr[i].Member` mis-parses `[i]` as type arguments | GS0005 | resolved |
 | #943 | generic-interface constraint `[T IComparable[T]]` won't parse | GS0005 | resolved |
 | #944 | user-indexer declaration form crashes | GS9998 | resolved (ADR-0118) |
-| #973 | a `class` with a user value-type (`struct`/`data struct`) field — emit ICE | GS9998 | open (blocks L2) |
-| #974 | generic-interface impl: method returning a constructed generic over `T` (e.g. `IEnumerator[T]`) fails satisfaction | GS0187 | open (blocks L3-`Generics`) |
-| #975 | interpolated string in a `: base(...)` constructor-arg position — emit ICE | GS9998 | open (discovered by L4; worked around in corpus) |
-| #976 | a `struct` cannot declare a base / interface clause (`struct S : I {…}` won't parse) | GS0005 | open (discovered by L4) |
-| #977 | BCL method invoked with an inline `out var x` declaration fails overload resolution | GS0159 | open (discovered by L4; `&x` pre-declared form works) |
+| #973 | a `class` with a user value-type (`struct`/`data struct`) field — emit ICE | GS9998 | resolved (L2 now compiles) |
+| #974 | generic-interface impl: method returning a constructed generic over `T` (e.g. `IEnumerator[T]`) fails satisfaction | GS0187 | resolved (the generic `GetEnumerator` now satisfies `IEnumerable[T]`) |
+| #975 | interpolated string in a `: base(...)` constructor-arg position — emit ICE | GS9998 | resolved (translator emits `: base("…$n…")` directly) |
+| #976 | a `struct` cannot declare a base / interface clause (`struct S : I {…}` won't parse) | GS0005 | resolved (struct interface clause parses; class/struct base → GS0382) |
+| #977 | BCL method invoked with an inline `out var x` declaration fails overload resolution | GS0159 | resolved (inline `out var x` binds for BCL calls) |
+| #TBD-1 | implementing `IEnumerable[T]` needs two `GetEnumerator` overloads differing only by return type (generic `IEnumerator[T]` + non-generic `IEnumerator`) | GS0264 + GS0187 | open (blocks L3-`Generics`; residual after #974) |
+| #TBD-2 | `base.Method()` virtual base-class call has no canonical G# form (`base[Base].M` is interface-only per ADR-0091) | GS0157 / GS0338 | open (translation-unsupported; L5 uses dynamic dispatch instead) |
+| #TBD-3 | an `abstract` (no-body) method on an `open class` → emitter crash | GS9998 (NRE) | open (L5 uses a virtual method with a body) |
+| #TBD-4 | `new T()` construction under a `new()` constraint has no canonical G# form | GS0125 / GS0130 / GS0157 | open (translation-unsupported; L5 has the caller supply the value) |
+| #TBD-5 | a generic auto-property over `T` (`prop Value T`) cannot be member-accessed | GS0158 | open (L5 uses a generic field instead) |
+| #TBD-6 | a user reference-type iterator (`sequence[UserClass]`) → emitter crash | GS9998 | open (L5 yields `string`; `sequence[int32]`/`sequence[string]` compile) |
+| #TBD-7 | a `when` guard on a `switch` statement/expression arm won't parse | GS0005 | open (translation-unsupported) |
+| #TBD-8 | `and`/`or` binary patterns (`> 0 and < 10`) won't parse | GS0005 | open (translation-unsupported) |
+| #TBD-9 | an `is`/`case` type pattern **with** a binder (`x is T t`) leaves the binder unbound | GS0125 | open (L5 uses the no-binder form `x is T`) |
+| #TBD-10 | `yield break` has no canonical G# form | GS0005 | open (translation-unsupported) |
 
-L2/L3 not going fully green is the **intended** objective-2 outcome: the residual
-failures are real compiler gaps, captured and filed rather than worked around or
+L3 not going fully green is the **intended** objective-2 outcome: the residual
+failure is a real compiler gap, captured and filed rather than worked around or
 hidden. Each closes as the cited compiler issue is fixed and the corpus run
-re-greens automatically — as already happened for #938–#944, which advanced L3
-from `translate FAIL` to `translate PASS` and pushed the frontier into the
-compile stage (#973/#974). L4 reaches full parity because its three discovered
-gaps (#975/#976/#977) each have a canonical-form workaround the translator
-emits (a `base` parameter forward, no struct interface clause, and the
-pass-by-address `&x` out form), so they are documented for the compiler backlog
+re-greens automatically — as already happened for #938–#944 (which advanced L3
+from `translate FAIL` to `translate PASS`) and for #973–#977 (which took L2 fully
+green and let L4 emit the canonical forms #975/#976/#977 instead of the former
+workarounds — an interpolated `: base(...)` argument, a `struct` interface clause,
+and an inline BCL `out var x`), so they are documented for the compiler backlog
 without blocking the migration.
 
 #### Discovered gaps from L4 (minimal repros)
@@ -528,82 +569,272 @@ without blocking the migration.
 Each was reproduced directly with `gsc` and contrasted with a passing control.
 The orchestrator files the issue and replaces the `#TBD-x` placeholder.
 
-**#975 — interpolated string in a `: base(...)` argument → `GS9998` ICE.**
-Translation is correct (canonical `init(params) : base(args)` form, §B.13); the
-emitter ICEs on an interpolated string in base-constructor-argument position.
-Classification: `compile-error` (a real emitter bug, not a translation gap).
+**#975 — interpolated string in a `: base(...)` argument → was `GS9998` ICE; RESOLVED.**
+Translation was already correct (canonical `init(params) : base(args)` form, §B.28);
+the emitter previously ICE'd on an interpolated string in base-constructor-argument
+position. The emitter now lowers it, so the translator emits the interpolated
+string **directly** in base position and the result compiles and runs.
 
 ```gs
-// repro — GS9998: EmitDiagnosticException:
-//   Bound expression kind 'InterpolatedStringExpression' is not yet supported by the emitter.
+// now compiles & runs (was GS9998 EmitDiagnosticException):
 class E1 : Exception {
     init(n int32) : base("only $n left") {
     }
 }
 ```
 
+**#976 — a `struct` may now declare an interface clause → was `GS0005`; RESOLVED.**
+The parser now accepts a `:` interface clause after a struct name, so a C#
+`struct S : IEquatable<S>` maps to the canonical `struct S(…) : IEquatable[S]`;
+the value type's own typed `Equals`/`GetHashCode` satisfy the interface. A struct
+naming a **class/struct** base (not an interface) is now rejected with the
+dedicated `GS0382` rather than the former generic `GS0005`.
+
 ```gs
-// control — both compile and run:
-class E3 : Exception {
-    init(n int32) : base("plain literal") {            // plain literal: OK
-    }
+// now compiles (was GS0005: Unexpected token <ColonToken>):
+struct Money(Cents int32) : IEquatable[Money] {
 }
-class E4 : Exception {
-    init(n int32) : base("only " + n.ToString() + " left") {  // concatenation: OK
-    }
-}
+func (self Money) Equals(other Money) bool { return self.Cents == other.Cents }
+func (self Money) GetHashCode() int32 { return self.Cents }
 ```
 
-Workaround the translator relies on: pass the (interpolated) message as an
-ordinary constructor argument (interpolation works in normal call-argument
-position) and forward the bare parameter to `base` — exactly the canonical
-`ExplicitConstructor.gs` form `init(message string, …) : base(message)`.
-
-**#976 — a `struct` cannot declare a base / interface clause → `GS0005`.**
-No `struct` in `samples/`, the test corpus, or `src/` declares a base or
-interface; the parser rejects the `:` after a struct name. A C# `struct S :
-IEquatable<S>` therefore has no canonical G# spelling; the interface is dropped
-(the value type keeps its typed `Equals`/`GetHashCode` and `operator ==`).
-Classification: `translation-unsupported` (no canonical form) — but L4 avoids it
-by not naming the interface.
+**#977 — BCL method with inline `out var x` → was `GS0159`; RESOLVED.**
+A BCL method (e.g. `Dictionary.TryGetValue`) invoked with an inline `out var x`
+declaration now binds, so the translator emits the canonical inline `out var x`
+form for BCL and user calls alike. The pre-declared pass-by-address `&x` form
+remains canonical for a pre-declared `out` target (§B.30).
 
 ```gs
-// repro — GS0005: Unexpected token <ColonToken>, expected <OpenBraceToken>.
-struct Money : IEquatable[Money] {
-    var Cents int32
-}
-```
-
-```gs
-// control — a class may implement the interface:
-class Money : IEquatable[Money] {
-    var Cents int32
-    func Equals(other Money) bool { return Cents == other.Cents }
-}
-```
-
-**#977 — BCL method with inline `out var x` fails overload resolution → `GS0159`.**
-A user-defined `func` with an `out` parameter resolves an inline `out var x`
-declaration (ADR-0060, `TryParseOutVar.gs`), but the same `out var` shape against
-a BCL method (e.g. `Dictionary.TryGetValue`) fails to bind. Classification:
-`compile-error`; the translator emits the legacy pass-by-address `&x` form (a
-pre-declared `var x T` then `&x`), which binds for BCL methods.
-
-```gs
-// repro — GS0159: Cannot find function TryGetValue.
+// now compiles (was GS0159: Cannot find function TryGetValue):
 let d = Dictionary[string, int32]()
 d["a"] = 5
-d.TryGetValue("a", out var v)
+if d.TryGetValue("a", out var v) {
+    Console.WriteLine(v)
+}
+```
+
+#### Discovered gaps from the L3 re-baseline and L5 (minimal repros)
+
+Each was reproduced directly with `gsc` and contrasted with a passing control.
+The orchestrator files the issue and replaces the `#TBD-x` placeholder.
+
+**#TBD-1 — implementing `IEnumerable[T]` needs two `GetEnumerator` overloads → `GS0264` + `GS0187`.**
+A C# generic collection implements `IEnumerable<T>` by declaring the generic
+`IEnumerator<T> GetEnumerator()` and an explicit-interface non-generic
+`IEnumerator IEnumerable.GetEnumerator()`. G# has no explicit-interface-impl
+syntax, so both map to a method named `GetEnumerator` — but they differ **only by
+return type** (`IEnumerator[T]` vs `IEnumerator`), which G# forbids (`GS0264`).
+With only the generic overload, the non-generic `IEnumerable.GetEnumerator` stays
+unimplemented (`GS0187`). #974 fixed the *generic* satisfaction; this residual gap
+blocks L3-`Generics`. Classification: `compile-error` (no canonical G# spelling can
+implement the dual contract). This is **why the for-in/sequence forms — `for x in
+xs`, `sequence[T]` generators — are the canonical G# enumeration surface**, not a
+hand-written `IEnumerable[T]` implementation.
+
+```gs
+// repro — GS0264 (dual GetEnumerator) + GS0187 (non-generic unimplemented):
+class Repo[T] : IEnumerable[T] {
+    private let _items List[T] = List[T]()
+    func GetEnumerator() IEnumerator[T] { return _items.GetEnumerator() }
+    private func GetEnumerator() IEnumerator { return GetEnumerator() }
+}
 ```
 
 ```gs
-// control — user-func out var binds; BCL via pre-declared &x binds:
-func tryProduce(out result int32) bool { result = 42; return true }
-tryProduce(out var n)            // OK (user func)
-
-var slot int32
-let ok = d.TryGetValue("a", &slot)   // OK (BCL, pass-by-address)
+// control — a generator func yields a sequence[T] (the canonical enumeration form):
+func numbers() sequence[int32] {
+    yield 1
+    yield 2
+}
+for n in numbers() { Console.WriteLine(n) }
 ```
+
+**L5's discovered gaps** follow. L5 itself reaches **full E2E parity** (translate →
+compile → ilverify → test-parity all PASS) by using only the canonical/compiling
+forms; every construct below that has *no* canonical form or that ICEs/mis-compiles
+was held out of L5 and captured here as a verified triage record. The `abstract`
+class modifier has **no** G# spelling (`abstract class Shape {…}` → `GS0125`
+"Variable 'abstract' doesn't exist", the parser not recognising `abstract` as a
+modifier); the translator faithfully **drops** it and emits `open class` (§B.4,
+recorded as Info), so an abstract base does **not** block the compile — its
+non-instantiability is simply not enforced. The canonical polymorphism spelling
+requires `open` on **both** the base class and each overridable method:
+
+```gs
+// control — open class + open method + override (dynamic dispatch works):
+open class Shape {
+    open func Area() float64 { return 0.0 }
+}
+class Circle(Radius float64) : Shape {
+    override func Area() float64 { return 3.14159 * Radius * Radius }
+}
+```
+
+**#TBD-2 — `base.Method()` virtual base-class call has no canonical G# form.**
+A C# `override` that chains to the base implementation via `base.Describe()` has no
+G# spelling: `base.M()` → `GS0157` "Cannot find type base"; the interface-only
+`base[Base].M()` form (ADR-0091) → `GS0338` (valid only for an interface default
+member, `base[IFoo].M`). Classification: **translation-unsupported**. L5 therefore
+calls the inherited member directly (it is not re-declared on the derived type).
+
+```gs
+// repro — GS0157: base.M() does not resolve:
+open class Shape {
+    open func Describe() string { return "shape" }
+}
+class Circle() : Shape {
+    override func Describe() string { return base.Describe() + " circle" }
+}
+```
+```gs
+// control — call the inherited member directly (no base. qualifier):
+open class Shape {
+    open func Describe() string { return "shape" }
+}
+class Circle() : Shape {
+    func Tagged() string { return Describe() + " circle" }
+}
+```
+
+**#TBD-3 — an `abstract` (no-body) method on an `open class` → emitter crash (`GS9998`).**
+The translator lowers a C# `abstract` method to a no-body `open func F() T;`. The
+parser accepts it, but the emitter throws a `NullReferenceException` (`GS9998`).
+Classification: **compile-error / ICE**. L5 uses a `virtual` method with a default
+body instead.
+
+```gs
+// repro — GS9998 NRE on a no-body open func:
+open class Shape {
+    open func Area() float64;
+}
+```
+```gs
+// control — same method WITH a body compiles:
+open class Shape {
+    open func Area() float64 { return 0.0 }
+}
+```
+
+**#TBD-4 — `new T()` construction under a `new()` constraint has no canonical G# form.**
+A C# generic that constructs its type parameter (`where T : new()`, `new T()`) has
+no G# spelling: `T()` → `GS0130`, `T{}` → `GS0157`, `new T()` → `GS0125`.
+Classification: **translation-unsupported**. L5 has the caller supply the value
+(`Box[T](Value T)`) rather than construct it.
+
+```gs
+// repro — none of these construct T:
+class Factory[T new()] {
+    func Make() T { return T() }     // GS0130
+}
+```
+```gs
+// control — the caller supplies the instance:
+class Box[T class](Value T) { }
+```
+
+**#TBD-5 — a generic auto-property over `T` (`prop Value T`) cannot be member-accessed (`GS0158`).**
+Declaring `prop Value T` on a generic class and then reading `box.Value` →
+`GS0158` "Cannot find member Value". Classification: **compile-error**. A generic
+**field** (`var Value T`) and a non-generic auto-property both work, so L5 uses a
+field.
+
+```gs
+// repro — GS0158 on member access of a generic auto-property:
+class Box[T class] {
+    prop Value T
+}
+// ... box.Value  -> GS0158
+```
+```gs
+// control — a generic field resolves:
+class Box[T class](Value T) { }   // ... box.Value works
+```
+
+**#TBD-6 — a user reference-type iterator (`sequence[UserClass]`) → emitter crash (`GS9998`).**
+A `yield`-generator whose element type is a user reference type
+(`func F() sequence[Shape]`) → `GS9998` "Conversion from '\<T>' to 'object' is not
+yet supported by the emitter". Both `sequence[int32]` and `sequence[string]` (a BCL
+reference type) compile. Classification: **compile-error / ICE**. L5's iterator
+yields `string` (the shape descriptions), not `Shape`.
+
+```gs
+// repro — GS9998 emitter crash on a user-class element type:
+open class Shape { }
+func shapes() sequence[Shape] { yield Shape() }
+```
+```gs
+// control — a BCL element type compiles:
+func names() sequence[string] { yield "a" }
+```
+
+**#TBD-7 — a `when` guard won't parse (`GS0005`).**
+A `when` guard on a `switch` statement or expression arm (`case > 0 when cond:`) →
+`GS0005` parse error. Classification: **translation-unsupported**. L5 omits guards.
+
+```gs
+// repro — GS0005 on a when guard:
+let r = switch n {
+    case > 0 when n < 10: "small"
+    default: "other"
+}
+```
+```gs
+// control — relational patterns without a guard parse:
+let r = switch n {
+    case > 0: "positive"
+    default: "other"
+}
+```
+
+**#TBD-8 — `and`/`or` binary patterns won't parse (`GS0005`).**
+A combined relational pattern (`case > 0 and < 10:`) → `GS0005`. Classification:
+**translation-unsupported**. L5 nests single relational patterns instead.
+
+```gs
+// repro — GS0005 on an `and` pattern:
+let r = switch n { case > 0 and < 10: "x" default: "y" }
+```
+```gs
+// control — a single relational pattern parses:
+let r = switch n { case < 10: "x" default: "y" }
+```
+
+**#TBD-9 — an `is`/`case` type pattern WITH a binder leaves the binder unbound (`GS0125`).**
+`if x is Shape s` (a type pattern that binds `s`) → `GS0125` "Variable 's' doesn't
+exist" when `s` is used. Classification: **compile-error**. The no-binder form
+`if x is Shape` works, so L5 tests the type without binding.
+
+```gs
+// repro — GS0125: the pattern binder is not in scope:
+if shape is Circle c { Console.WriteLine(c.Area().ToString()) }
+```
+```gs
+// control — the no-binder type test works:
+if shape is Circle { Console.WriteLine("a circle") }
+```
+
+**#TBD-10 — `yield break` has no canonical G# form (`GS0005`).**
+A `yield break;` in a generator → `GS0005`. Classification:
+**translation-unsupported**. L5's iterator runs to natural completion.
+
+```gs
+// repro — GS0005 on yield break:
+func f() sequence[int32] { yield 1; yield break }
+```
+```gs
+// control — an iterator that simply runs to completion:
+func f() sequence[int32] { yield 1; yield 2 }
+```
+
+Two **translator faithfulness fixes** the L5 pipeline surfaced (no compiler change):
+an integer literal that C# implicitly promotes to a floating-point parameter is now
+emitted as a float literal (`M(30)` where the parameter is `double` → `M(30.0)`) so
+the emitter does not push an `int32` where a `float64` is expected — without this the
+assembly compiled but failed `ilverify` with `StackUnexpected` (found Int32, expected
+Double) (§B.12); and a parameterless constructor that initializes a **property** to a
+constant keeps its explicit `init()` body, because G# has a field member initializer
+(`var Name T = expr`) but no property member initializer (`prop Name T = expr` →
+`GS0288`/`GS0113`) (§B.3).
 
 ## Consequences
 

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
@@ -425,3 +425,75 @@ public sealed class TryStatement : GStatement
     /// <summary>Gets the finally block, or <see langword="null"/>.</summary>
     public BlockStatement FinallyBlock { get; }
 }
+
+/// <summary>
+/// One <c>case</c> (or <c>default</c>) arm of a <see cref="SwitchStatement"/>:
+/// a pattern and a brace-delimited body. When <see cref="Pattern"/> is
+/// <see langword="null"/> the arm is the <c>default</c> arm.
+/// </summary>
+public sealed class SwitchStatementCase : GNode
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SwitchStatementCase"/> class.
+    /// </summary>
+    /// <param name="pattern">The arm pattern, or <see langword="null"/> for the <c>default</c> arm.</param>
+    /// <param name="body">The arm body block.</param>
+    public SwitchStatementCase(GPattern pattern, BlockStatement body)
+    {
+        Pattern = pattern;
+        Body = body;
+    }
+
+    /// <summary>Gets the arm pattern, or <see langword="null"/> for the <c>default</c> arm.</summary>
+    public GPattern Pattern { get; }
+
+    /// <summary>Gets the arm body block.</summary>
+    public BlockStatement Body { get; }
+}
+
+/// <summary>
+/// A <c>switch</c> statement <c>switch subject { case &lt;pattern&gt; { … } default { … } }</c>
+/// used in statement position for side effects (spec §Pattern matching; sample
+/// <c>PatternSwitch.gs</c>). Distinct from <c>SwitchExpression</c>, which yields
+/// a value.
+/// </summary>
+public sealed class SwitchStatement : GStatement
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SwitchStatement"/> class.
+    /// </summary>
+    /// <param name="subject">The value being matched.</param>
+    /// <param name="cases">The ordered case arms.</param>
+    public SwitchStatement(GExpression subject, IReadOnlyList<SwitchStatementCase> cases)
+    {
+        Subject = subject;
+        Cases = cases ?? new List<SwitchStatementCase>();
+    }
+
+    /// <summary>Gets the value being matched.</summary>
+    public GExpression Subject { get; }
+
+    /// <summary>Gets the ordered case arms.</summary>
+    public IReadOnlyList<SwitchStatementCase> Cases { get; }
+}
+
+/// <summary>
+/// A <c>yield</c> statement inside an iterator <c>func</c> whose return type is
+/// <c>sequence[T]</c> (spec §Iterators; sample <c>TupleSequenceIterators.gs</c>).
+/// When <see cref="Expression"/> is non-<see langword="null"/> the statement is
+/// <c>yield &lt;expr&gt;</c> (C# <c>yield return</c>).
+/// </summary>
+public sealed class YieldStatement : GStatement
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="YieldStatement"/> class.
+    /// </summary>
+    /// <param name="expression">The yielded value.</param>
+    public YieldStatement(GExpression expression)
+    {
+        Expression = expression;
+    }
+
+    /// <summary>Gets the yielded value.</summary>
+    public GExpression Expression { get; }
+}

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -619,9 +619,35 @@ public static class GSharpPrinter
             case RawStatement raw:
                 return $"{pad}{raw.Text}";
 
+            case YieldStatement yield:
+                return $"{pad}yield {RenderExpression(yield.Expression, indent)}";
+
+            case SwitchStatement switchStatement:
+                return RenderSwitchStatement(switchStatement, indent);
+
             default:
                 throw new ArgumentException($"Unsupported statement: {statement?.GetType().Name}");
         }
+    }
+
+    private static string RenderSwitchStatement(SwitchStatement switchStatement, int indent)
+    {
+        var pad = Indent(indent);
+        var casePad = Indent(indent + 1);
+        var sb = new StringBuilder();
+        sb.Append($"{pad}switch {RenderExpression(switchStatement.Subject, indent)} {{");
+        foreach (var arm in switchStatement.Cases)
+        {
+            sb.Append('\n');
+            sb.Append(casePad);
+            var head = arm.Pattern == null ? "default" : $"case {RenderPattern(arm.Pattern, indent + 1)}";
+            sb.Append($"{head} {RenderBlock(arm.Body, indent + 1)}");
+        }
+
+        sb.Append('\n');
+        sb.Append(pad);
+        sb.Append('}');
+        return sb.ToString();
     }
 
     private static string RenderForStatement(ForStatement forStatement, int indent)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue975To977CanonicalizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue975To977CanonicalizationTests.cs
@@ -1,0 +1,147 @@
+// <copyright file="Issue975To977CanonicalizationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Canonicalization tests for the three L4-discovered compiler gaps that are now
+/// resolved on the compiler side (ADR-0115 §B.4/§B.28/§B.30, §G):
+/// <list type="bullet">
+/// <item>#975 — an interpolated string in a <c>: base(...)</c> constructor
+/// argument is emitted directly (no bare-parameter forward needed).</item>
+/// <item>#976 — a <c>struct</c> keeps its interface clause
+/// (<c>struct Money : IEquatable[Money]</c>).</item>
+/// <item>#977 — a BCL method invoked with an inline <c>out var x</c> is emitted
+/// inline (no pre-declared <c>&amp;x</c> workaround needed).</item>
+/// </list>
+/// The translator already produces these canonical forms for canonical-capable
+/// C#; these tests lock that in so a regression to the former workaround forms
+/// is caught. Each printed form additionally round-trip-parses with the real
+/// G# parser via <see cref="Translate"/>.
+/// </summary>
+public class Issue975To977CanonicalizationTests
+{
+    /// <summary>
+    /// #975 (ADR-0115 §B.28): an interpolated string in <c>: base(...)</c> arg
+    /// position is emitted directly into the base initializer — the canonical
+    /// <c>init(params) : base($"…")</c> form — now that the emitter no longer
+    /// ICEs (GS9998) on it.
+    /// </summary>
+    [Fact]
+    public void InterpolatedString_InBaseInitializer_EmittedDirectly()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System;
+
+    public sealed class ShortStockException : Exception
+    {
+        public ShortStockException(int n) : base($""only {n} left"") { }
+    }
+}");
+
+        Assert.Contains("init(n int32) : base(\"only $n left\") {", printed);
+    }
+
+    /// <summary>
+    /// #976 (ADR-0115 §B.4): a <c>struct</c> that implements an interface keeps
+    /// its interface clause (<c>struct S : I[…]</c>) now that the parser accepts
+    /// a struct base clause (struct naming a class base is rejected with
+    /// GS0382, but an interface clause is legal).
+    /// </summary>
+    [Fact]
+    public void Struct_ImplementingInterface_KeepsInterfaceClause()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System;
+
+    public struct Money : IEquatable<Money>
+    {
+        public int Cents;
+
+        public Money(int cents)
+        {
+            Cents = cents;
+        }
+
+        public bool Equals(Money other) => Cents == other.Cents;
+
+        public override int GetHashCode() => Cents;
+    }
+}");
+
+        Assert.Contains("struct Money(Cents int32) : IEquatable[Money] {", printed);
+    }
+
+    /// <summary>
+    /// #977 (ADR-0115 §B.30): a BCL method (<c>Dictionary.TryGetValue</c>)
+    /// invoked with an inline <c>out var x</c> declaration is emitted inline as
+    /// <c>out var x</c> — the canonical form — now that BCL overload resolution
+    /// accepts it (no pre-declared <c>&amp;x</c> workaround).
+    /// </summary>
+    [Fact]
+    public void BclMethod_WithInlineOutVar_EmittedInline()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System.Collections.Generic;
+
+    public static class Lookup
+    {
+        public static int Get(Dictionary<string, int> table, string key)
+        {
+            if (table.TryGetValue(key, out var value))
+            {
+                return value;
+            }
+
+            return 0;
+        }
+    }
+}");
+
+        Assert.Contains("if table.TryGetValue(key, out var value) {", printed);
+        Assert.DoesNotContain("&value", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        (string printed, _) = Translate(source);
+        return printed;
+    }
+
+    private static (string Printed, TranslationContext Context) Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return (printed, context);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/L5ConstructTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L5ConstructTranslationTests.cs
@@ -1,0 +1,161 @@
+// <copyright file="L5ConstructTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translation tests for the new C# surface area exercised by the L5-Console
+/// corpus app (ADR-0115 §E/§G): a <c>switch</c> statement over type patterns, a
+/// <c>yield return</c> iterator (with the <c>IEnumerable&lt;T&gt;</c> return
+/// type rewritten to <c>sequence[T]</c>), and the two faithfulness fixes the L5
+/// pipeline surfaced — an integer literal that C# implicitly promotes to a
+/// floating-point parameter is emitted as a float literal, and a parameterless
+/// constructor that initializes a property keeps its explicit <c>init</c> body
+/// (G# has no property member initializer).
+/// </summary>
+public class L5ConstructTranslationTests
+{
+    /// <summary>
+    /// A C# <c>switch</c> statement over type patterns is emitted as the
+    /// canonical G# <c>switch subj { case P { … } default { … } }</c> statement
+    /// form (PatternSwitch.gs), with the per-section <c>break;</c> dropped.
+    /// </summary>
+    [Fact]
+    public void SwitchStatement_OverTypePatterns_EmittedAsSwitchBlock()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class Shapes
+    {
+        public static string Kind(object shape)
+        {
+            switch (shape)
+            {
+                case string s:
+                    return ""text"";
+                default:
+                    return ""other"";
+            }
+        }
+    }
+}");
+
+        Assert.Contains("switch shape {", printed);
+        Assert.Contains("case s is string {", printed);
+        Assert.Contains("default {", printed);
+        Assert.DoesNotContain("break", printed);
+    }
+
+    /// <summary>
+    /// A C# iterator method (<c>yield return</c>) returning
+    /// <c>IEnumerable&lt;string&gt;</c> is emitted with the return type rewritten
+    /// to <c>sequence[string]</c> and a bare <c>yield expr</c> body
+    /// (TupleSequenceIterators.gs).
+    /// </summary>
+    [Fact]
+    public void Iterator_YieldReturn_EmitsSequenceReturnAndYield()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System.Collections.Generic;
+
+    public static class Source
+    {
+        public static IEnumerable<string> Names()
+        {
+            yield return ""a"";
+            yield return ""b"";
+        }
+    }
+}");
+
+        Assert.Contains("sequence[string]", printed);
+        Assert.Contains("yield \"a\"", printed);
+        Assert.DoesNotContain("IEnumerable", printed);
+    }
+
+    /// <summary>
+    /// A C# integer literal argument that the semantic model implicitly promotes
+    /// to a floating-point parameter is emitted as a float literal (e.g.
+    /// <c>30</c> → <c>30.0</c>). G# performs no implicit numeric promotion, so a
+    /// bare <c>int32</c> push to a <c>float64</c> parameter would yield invalid
+    /// IL (ilverify StackUnexpected). ADR-0115 §B.12.
+    /// </summary>
+    [Fact]
+    public void IntegerLiteral_ImplicitlyPromotedToDouble_EmittedAsFloatLiteral()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class Calc
+    {
+        public static double Scale(double factor) => factor * 2.0;
+
+        public static double Run() => Scale(30);
+    }
+}");
+
+        Assert.Contains("Scale(30.0)", printed);
+        Assert.DoesNotContain("Scale(30)", printed);
+    }
+
+    /// <summary>
+    /// A parameterless constructor that assigns a constant to a property keeps
+    /// its explicit <c>init()</c> body — G# accepts a field member initializer
+    /// (<c>var Name T = expr</c>) but rejects a property member initializer
+    /// (<c>prop Name T = expr</c>), so the assignment must stay in the
+    /// constructor (ADR-0115 §B.3).
+    /// </summary>
+    [Fact]
+    public void ParameterlessConstructor_InitializingProperty_KeepsExplicitInit()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class Label
+    {
+        public string Text { get; set; }
+
+        public Label()
+        {
+            Text = ""empty"";
+        }
+    }
+}");
+
+        Assert.Contains("init() {", printed);
+        Assert.Contains("Text = \"empty\"", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -786,6 +786,16 @@ public sealed class CSharpToGSharpTranslator
                         return ConstructorLift.None;
                     }
 
+                    // G# supports a field member initializer (`var Name T = expr`)
+                    // but has no property member initializer (`prop Name T = expr`
+                    // is rejected). A constant assignment to a property therefore
+                    // cannot be lifted to a member initializer; keep the explicit
+                    // 'init' so its body faithfully assigns the property.
+                    if (targetIsProperty)
+                    {
+                        return ConstructorLift.None;
+                    }
+
                     fieldInitializers[targetName] = this.TranslateExpression(assignment.Right);
                 }
             }
@@ -1555,6 +1565,20 @@ public sealed class CSharpToGSharpTranslator
 
                 ITypeSymbol returnType = symbol.ReturnType;
 
+                // An iterator `func` (its body contains a `yield`) declares the G#
+                // `sequence[T]` element type, not the C# `IEnumerable[T]` envelope
+                // (spec §Iterators; sample TupleSequenceIterators.gs). The element
+                // type is the single type argument of the C# IEnumerable<T> /
+                // IEnumerator<T> return.
+                if (IsIteratorBody(node) &&
+                    returnType is INamedTypeSymbol { IsGenericType: true } enumerable &&
+                    enumerable.Name is "IEnumerable" or "IEnumerator")
+                {
+                    GTypeReference element = this.typeMapper.Map(
+                        enumerable.TypeArguments[0], this.context, node.ReturnType.GetLocation());
+                    return new NamedTypeReference("sequence", new[] { element });
+                }
+
                 // A G# `async func` declares the UNWRAPPED result type; the `async`
                 // modifier synthesizes the `Task`/`Task<T>` envelope (samples
                 // AsyncTask.gs, AsyncValueReturns.gs). C# `async Task` → no return
@@ -1575,6 +1599,22 @@ public sealed class CSharpToGSharpTranslator
                 predefined.Keyword.IsKind(SyntaxKind.VoidKeyword)
                     ? null
                     : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
+        }
+
+        private static bool IsIteratorBody(MethodDeclarationSyntax node)
+        {
+            SyntaxNode body = (SyntaxNode)node.Body ?? node.ExpressionBody;
+            if (body == null)
+            {
+                return false;
+            }
+
+            // A `yield` inside a nested local function belongs to that function, not
+            // to this method, so descendants under a local-function boundary are
+            // excluded from the iterator test.
+            return body.DescendantNodes(n => n is not LocalFunctionStatementSyntax)
+                .OfType<YieldStatementSyntax>()
+                .Any();
         }
 
         private List<AttributeUse> MapAttributes(SyntaxList<AttributeListSyntax> attributeLists)
@@ -1817,6 +1857,12 @@ public sealed class CSharpToGSharpTranslator
 
                 case BlockSyntax block:
                     return new[] { (GStatement)this.TranslateBlock(block) };
+
+                case SwitchStatementSyntax switchStatement:
+                    return new[] { this.TranslateSwitchStatement(switchStatement) };
+
+                case YieldStatementSyntax yieldStatement:
+                    return this.TranslateYieldStatement(yieldStatement);
 
                 case EmptyStatementSyntax:
                     return System.Array.Empty<GStatement>();
@@ -2245,9 +2291,24 @@ public sealed class CSharpToGSharpTranslator
                     // `int32 * float64`); hex such as `0xFF0000` is likewise kept
                     // verbatim. The bound type still classifies the literal kind.
                     object value = literal.Token.Value;
-                    return value is float or double or decimal
-                        ? LiteralExpression.Float(literal.Token.Text)
-                        : LiteralExpression.Int(literal.Token.Text);
+                    if (value is float or double or decimal)
+                    {
+                        return LiteralExpression.Float(literal.Token.Text);
+                    }
+
+                    // C# applies an implicit int->double/float promotion at a
+                    // call site (e.g. `M(30)` where the parameter is `double`).
+                    // G# has no such implicit promotion, so the emitter would push
+                    // an int32 where a float64 is expected and produce invalid IL
+                    // (ilverify StackUnexpected). Honor the bound `ConvertedType`
+                    // and emit a float literal so the value matches its target
+                    // type (ADR-0115 §B.12).
+                    if (this.IsConvertedToFloatingPoint(literal))
+                    {
+                        return LiteralExpression.Float(this.ToFloatLiteralText(literal.Token.Text));
+                    }
+
+                    return LiteralExpression.Int(literal.Token.Text);
 
                 case SyntaxKind.StringLiteralExpression:
                     return LiteralExpression.String(literal.Token.ValueText);
@@ -2270,6 +2331,32 @@ public sealed class CSharpToGSharpTranslator
                         $"literal '{literal.Kind()}' has no canonical G# form yet; emitted nil (ADR-0115 §B.12).");
                     return LiteralExpression.Null();
             }
+        }
+
+        private bool IsConvertedToFloatingPoint(LiteralExpressionSyntax literal)
+        {
+            TypeInfo info = this.context.GetTypeInfo(literal);
+            ITypeSymbol original = info.Type;
+            ITypeSymbol converted = info.ConvertedType;
+            if (converted is null || SymbolEqualityComparer.Default.Equals(original, converted))
+            {
+                return false;
+            }
+
+            bool originalIsIntegral = original is { SpecialType: SpecialType.System_SByte
+                or SpecialType.System_Byte or SpecialType.System_Int16 or SpecialType.System_UInt16
+                or SpecialType.System_Int32 or SpecialType.System_UInt32 or SpecialType.System_Int64
+                or SpecialType.System_UInt64 };
+            bool convertedIsFloat = converted.SpecialType is SpecialType.System_Single
+                or SpecialType.System_Double;
+            return originalIsIntegral && convertedIsFloat;
+        }
+
+        private string ToFloatLiteralText(string text)
+        {
+            // A plain integer spelling (`30`) needs a fractional part so the G#
+            // lexer classifies it as float64; an already-float spelling is kept.
+            return text.IndexOfAny(new[] { '.', 'e', 'E' }) >= 0 ? text : text + ".0";
         }
 
         private GExpression TranslateMemberAccess(MemberAccessExpressionSyntax member)
@@ -2817,6 +2904,101 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return new SwitchExpression(subject, arms);
+        }
+
+        private GStatement TranslateSwitchStatement(SwitchStatementSyntax node)
+        {
+            GExpression subject = this.TranslateExpression(node.Expression);
+            var cases = new List<SwitchStatementCase>();
+
+            foreach (SwitchSectionSyntax section in node.Sections)
+            {
+                // A G# switch-statement arm carries a single pattern; a C# section
+                // that stacks multiple `case` labels (fall-through) has no canonical
+                // G# form, so each label is emitted as its own arm sharing the body.
+                var labels = section.Labels.ToList();
+                GExpression guard = null;
+                foreach (SwitchLabelSyntax label in labels)
+                {
+                    if (label is CasePatternSwitchLabelSyntax { WhenClause: { } when })
+                    {
+                        guard = this.TranslateExpression(when.Condition);
+                    }
+                }
+
+                if (guard != null)
+                {
+                    this.context.ReportUnsupported(
+                        node,
+                        "switch-statement 'when' guard has no canonical G# form yet (ADR-0115 §B).");
+                }
+
+                BlockStatement body = this.TranslateSwitchSectionBody(section);
+
+                foreach (SwitchLabelSyntax label in labels)
+                {
+                    switch (label)
+                    {
+                        case CasePatternSwitchLabelSyntax patternLabel:
+                            var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
+                            GPattern pattern = this.TranslatePattern(patternLabel.Pattern, bindings);
+                            cases.Add(new SwitchStatementCase(pattern, body));
+                            break;
+
+                        case CaseSwitchLabelSyntax valueLabel:
+                            cases.Add(new SwitchStatementCase(
+                                new ConstantPattern(this.TranslateExpression(valueLabel.Value)),
+                                body));
+                            break;
+
+                        case DefaultSwitchLabelSyntax:
+                            cases.Add(new SwitchStatementCase(null, body));
+                            break;
+
+                        default:
+                            this.context.ReportUnsupported(
+                                label,
+                                $"switch label '{label.Kind()}' has no canonical G# form yet (ADR-0115 §B).");
+                            break;
+                    }
+                }
+            }
+
+            return new SwitchStatement(subject, cases);
+        }
+
+        private BlockStatement TranslateSwitchSectionBody(SwitchSectionSyntax section)
+        {
+            var statements = new List<GStatement>();
+            foreach (StatementSyntax statement in section.Statements)
+            {
+                // A trailing `break;` only terminates the C# section; G# arms do not
+                // fall through, so the explicit break carries no meaning and is dropped.
+                if (statement is BreakStatementSyntax)
+                {
+                    continue;
+                }
+
+                statements.AddRange(this.TranslateStatement(statement));
+            }
+
+            return new BlockStatement(statements);
+        }
+
+        private IEnumerable<GStatement> TranslateYieldStatement(YieldStatementSyntax node)
+        {
+            // `yield return x` maps to the G# iterator `yield x` (sample
+            // TupleSequenceIterators.gs); the enclosing func's return type is
+            // rewritten to `sequence[T]`. `yield break` has no canonical G# form.
+            if (node.Expression == null)
+            {
+                this.context.ReportUnsupported(
+                    node,
+                    "'yield break' has no canonical G# form yet (ADR-0115 §B).");
+                return new[] { (GStatement)new RawStatement("// unsupported: yield break") };
+            }
+
+            return new[] { (GStatement)new YieldStatement(this.TranslateExpression(node.Expression)) };
         }
 
         private GPattern TranslatePattern(

--- a/tools/cs2gs/README.md
+++ b/tools/cs2gs/README.md
@@ -25,7 +25,7 @@ oracle, §F reporting). This README is the operational quick start.
 | `Cs2Gs.Report` | Aggregates a run into a self-contained `report.html` + `summary.json`. |
 | `Cs2Gs.Cli` | The `cs2gs` command-line front end (`migrate` / `report` verbs). |
 | `Cs2Gs.Tests` | Unit + golden + live tests for all of the above. |
-| `corpus/` | The curated C# **input** corpus (L1–L3) plus xUnit oracles. Isolated from `GSharp.sln`; see [`corpus/README.md`](corpus/README.md). |
+| `corpus/` | The curated C# **input** corpus (L1–L5) plus xUnit oracles. Isolated from `GSharp.sln`; see [`corpus/README.md`](corpus/README.md). |
 
 Why Roslyn here does not contradict ADR-0027 (no Roslyn *in the compiler*):
 `cs2gs` uses Roslyn as an **external, offline C# reader** in a separate process;
@@ -136,18 +136,24 @@ details.
 | App | translate | compile | ilverify | test-parity |
 | --- | --- | --- | --- | --- |
 | `corpus/L1-Console` | PASS | PASS | PASS | PASS |
-| `corpus/L2-Library` | PASS | FAIL (#973) | skip | skip |
-| `corpus/L3-Library` | PASS | FAIL (#974) | skip | skip |
+| `corpus/L2-Library` | PASS | PASS | PASS | PASS |
+| `corpus/L3-Library` | PASS | FAIL (#TBD-1) | skip | skip |
 | `corpus/L4-Console` | PASS | PASS | PASS | PASS |
+| `corpus/L5-Console` | PASS | PASS | PASS | PASS |
 
-L1 and L4 migrate fully green end-to-end. L2 and L3 both translate to canonical G#
-in full; each is now blocked at the **compile** stage by a single open compiler gap
-(#973 a `class` with a value-type field; #974 generic-interface implementation).
-L3's `Advanced.cs` translates and compiles standalone. L4 exercises exception
-handling, `Dictionary`/`HashSet`, `using`/`IDisposable`, nullable value types, and
-operator overloading (see §B.26–B.32 of ADR-0115). As gaps are fixed the
-frontier advances automatically — the seven gaps #938–#944 have already been
-fixed, which is what moved L3 from `translate FAIL` to `translate PASS`.
+L1, L2, L4, and L5 migrate fully green end-to-end. L2 went green when #973/#974 were
+fixed. L4 emits the **canonical** forms for an interpolated `: base(...)` argument,
+a `struct` interface clause, and an inline BCL `out var x` now that #975/#976/#977
+are fixed. L3 translates in full but is blocked at **compile** by a residual gap
+(#TBD-1: `IEnumerable[T]` needs two `GetEnumerator` overloads differing only by
+return type — GS0264 + GS0187). L3's `Advanced.cs` translates and compiles
+standalone. L5 (inheritance/polymorphism, `is`/`switch` pattern matching, a
+`yield return` iterator → `sequence[T]`, generic constraints) reaches **full
+parity** by using only the canonical/compiling forms, and surfaces the next batch
+of gaps (#TBD-2…#TBD-10) — captured as verified triage records (the constructs with
+no canonical form, or that ICE/mis-compile, are held out of L5). As gaps are fixed
+the frontier advances automatically — #938–#944 moved L3 to `translate PASS`, and
+#973–#977 took L2 green and let L4 use the canonical forms.
 
 ## Discovered compiler gaps (objective 2)
 
@@ -160,18 +166,32 @@ fixed, which is what moved L3 from `translate FAIL` to `translate PASS`.
 | [#942](https://github.com/DavidObando/gsharp/issues/942) | `expr[i].Member` mis-parses `[i]` as type arguments | GS0005 | resolved |
 | [#943](https://github.com/DavidObando/gsharp/issues/943) | Generic-interface constraint `[T IComparable[T]]` won't parse | GS0005 | resolved |
 | [#944](https://github.com/DavidObando/gsharp/issues/944) | No user-indexer declaration form; attempts crash | GS9998 | resolved |
-| [#973](https://github.com/DavidObando/gsharp/issues/973) | A `class` with a user `struct`/`data struct` field — emit ICE | GS9998 | open |
-| [#974](https://github.com/DavidObando/gsharp/issues/974) | Generic-interface impl: method returning a constructed generic over `T` (e.g. `IEnumerator[T]`) fails satisfaction | GS0187 | open |
-| #975 | Interpolated string in a `: base(...)` constructor-arg position — emit ICE | GS9998 | open (L4; worked around) |
-| #976 | A `struct` cannot declare a base / interface clause (`struct S : I {…}`) | GS0005 | open (L4) |
-| #977 | BCL method with an inline `out var x` declaration fails overload resolution | GS0159 | open (L4; `&x` works) |
+| [#973](https://github.com/DavidObando/gsharp/issues/973) | A `class` with a user `struct`/`data struct` field — emit ICE | GS9998 | resolved (L2 green) |
+| [#974](https://github.com/DavidObando/gsharp/issues/974) | Generic-interface impl: method returning a constructed generic over `T` (e.g. `IEnumerator[T]`) fails satisfaction | GS0187 | resolved |
+| [#975](https://github.com/DavidObando/gsharp/issues/975) | Interpolated string in a `: base(...)` constructor-arg position — emit ICE | GS9998 | resolved (emitted directly) |
+| [#976](https://github.com/DavidObando/gsharp/issues/976) | A `struct` cannot declare a base / interface clause (`struct S : I {…}`) | GS0005 | resolved (interface clause parses; class base → GS0382) |
+| [#977](https://github.com/DavidObando/gsharp/issues/977) | BCL method with an inline `out var x` declaration fails overload resolution | GS0159 | resolved (inline `out var` binds) |
+| #TBD-1 | Implementing `IEnumerable[T]` needs two `GetEnumerator` overloads differing only by return type | GS0264 + GS0187 | open (blocks L3-`Generics`) |
+| #TBD-2 | `base.Method()` virtual base-class call has no canonical G# form | GS0157 / GS0338 | open (translation-unsupported) |
+| #TBD-3 | An `abstract` (no-body) method on an `open class` crashes the emitter | GS9998 (NRE) | open |
+| #TBD-4 | `new T()` construction under a `new()` constraint has no canonical G# form | GS0125 / GS0130 / GS0157 | open (translation-unsupported) |
+| #TBD-5 | A generic auto-property over `T` (`prop Value T`) cannot be member-accessed | GS0158 | open |
+| #TBD-6 | A user reference-type iterator (`sequence[UserClass]`) crashes the emitter | GS9998 | open |
+| #TBD-7 | A `when` guard on a `switch` arm won't parse | GS0005 | open (translation-unsupported) |
+| #TBD-8 | `and`/`or` binary patterns (`> 0 and < 10`) won't parse | GS0005 | open (translation-unsupported) |
+| #TBD-9 | An `is`/`case` type pattern **with** a binder (`x is T t`) leaves the binder unbound | GS0125 | open |
+| #TBD-10 | `yield break` has no canonical G# form | GS0005 | open (translation-unsupported) |
 
-The three L4 gaps each have a canonical-form workaround the translator emits, so
-L4 reaches full parity while the gaps are recorded for the compiler backlog:
-#975 forwards the message as a normal constructor argument and chains
-`init(message string, …) : base(message)`; #976 drops the struct's interface
-clause (the value type keeps its typed `Equals`/`GetHashCode` + `operator ==`);
-#977 uses the pre-declared pass-by-address `&x` out form for BCL methods.
+Gaps #975/#976/#977 — discovered by L4 — are now **resolved**, so the translator
+emits the canonical forms directly: the interpolated `: base("…$n…")` argument, the
+`struct Money(Cents int32) : IEquatable[Money]` interface clause, and the inline
+BCL `out var x`. The residual L3 gap and the L5 batch (#TBD-2…#TBD-10) are each a
+verified minimal repro (with a contrasting passing control) documented in
+ADR-0115 §G for the compiler backlog. L5 also drove two **translator faithfulness
+fixes** (no compiler change): an `int` literal implicitly promoted to a `double`
+parameter is emitted as a float literal (avoiding an `ilverify` `StackUnexpected`),
+and a parameterless constructor that initializes a **property** keeps its explicit
+`init()` body (G# has no property member initializer).
 
 ## Conventions
 

--- a/tools/cs2gs/README.md
+++ b/tools/cs2gs/README.md
@@ -137,7 +137,7 @@ details.
 | --- | --- | --- | --- | --- |
 | `corpus/L1-Console` | PASS | PASS | PASS | PASS |
 | `corpus/L2-Library` | PASS | PASS | PASS | PASS |
-| `corpus/L3-Library` | PASS | FAIL (#TBD-1) | skip | skip |
+| `corpus/L3-Library` | PASS | FAIL (#985) | skip | skip |
 | `corpus/L4-Console` | PASS | PASS | PASS | PASS |
 | `corpus/L5-Console` | PASS | PASS | PASS | PASS |
 
@@ -145,12 +145,12 @@ L1, L2, L4, and L5 migrate fully green end-to-end. L2 went green when #973/#974 
 fixed. L4 emits the **canonical** forms for an interpolated `: base(...)` argument,
 a `struct` interface clause, and an inline BCL `out var x` now that #975/#976/#977
 are fixed. L3 translates in full but is blocked at **compile** by a residual gap
-(#TBD-1: `IEnumerable[T]` needs two `GetEnumerator` overloads differing only by
+(#985: `IEnumerable[T]` needs two `GetEnumerator` overloads differing only by
 return type — GS0264 + GS0187). L3's `Advanced.cs` translates and compiles
 standalone. L5 (inheritance/polymorphism, `is`/`switch` pattern matching, a
 `yield return` iterator → `sequence[T]`, generic constraints) reaches **full
 parity** by using only the canonical/compiling forms, and surfaces the next batch
-of gaps (#TBD-2…#TBD-10) — captured as verified triage records (the constructs with
+of gaps (#986…#994) — captured as verified triage records (the constructs with
 no canonical form, or that ICE/mis-compile, are held out of L5). As gaps are fixed
 the frontier advances automatically — #938–#944 moved L3 to `translate PASS`, and
 #973–#977 took L2 green and let L4 use the canonical forms.
@@ -171,21 +171,21 @@ the frontier advances automatically — #938–#944 moved L3 to `translate PASS`
 | [#975](https://github.com/DavidObando/gsharp/issues/975) | Interpolated string in a `: base(...)` constructor-arg position — emit ICE | GS9998 | resolved (emitted directly) |
 | [#976](https://github.com/DavidObando/gsharp/issues/976) | A `struct` cannot declare a base / interface clause (`struct S : I {…}`) | GS0005 | resolved (interface clause parses; class base → GS0382) |
 | [#977](https://github.com/DavidObando/gsharp/issues/977) | BCL method with an inline `out var x` declaration fails overload resolution | GS0159 | resolved (inline `out var` binds) |
-| #TBD-1 | Implementing `IEnumerable[T]` needs two `GetEnumerator` overloads differing only by return type | GS0264 + GS0187 | open (blocks L3-`Generics`) |
-| #TBD-2 | `base.Method()` virtual base-class call has no canonical G# form | GS0157 / GS0338 | open (translation-unsupported) |
-| #TBD-3 | An `abstract` (no-body) method on an `open class` crashes the emitter | GS9998 (NRE) | open |
-| #TBD-4 | `new T()` construction under a `new()` constraint has no canonical G# form | GS0125 / GS0130 / GS0157 | open (translation-unsupported) |
-| #TBD-5 | A generic auto-property over `T` (`prop Value T`) cannot be member-accessed | GS0158 | open |
-| #TBD-6 | A user reference-type iterator (`sequence[UserClass]`) crashes the emitter | GS9998 | open |
-| #TBD-7 | A `when` guard on a `switch` arm won't parse | GS0005 | open (translation-unsupported) |
-| #TBD-8 | `and`/`or` binary patterns (`> 0 and < 10`) won't parse | GS0005 | open (translation-unsupported) |
-| #TBD-9 | An `is`/`case` type pattern **with** a binder (`x is T t`) leaves the binder unbound | GS0125 | open |
-| #TBD-10 | `yield break` has no canonical G# form | GS0005 | open (translation-unsupported) |
+| #985 | Implementing `IEnumerable[T]` needs two `GetEnumerator` overloads differing only by return type | GS0264 + GS0187 | open (blocks L3-`Generics`) |
+| #986 | `base.Method()` virtual base-class call has no canonical G# form | GS0157 / GS0338 | open (translation-unsupported) |
+| #987 | An `abstract` (no-body) method on an `open class` crashes the emitter | GS9998 (NRE) | open |
+| #988 | `new T()` construction under a `new()` constraint has no canonical G# form | GS0125 / GS0130 / GS0157 | open (translation-unsupported) |
+| #989 | A generic auto-property over `T` (`prop Value T`) cannot be member-accessed | GS0158 | open |
+| #990 | A user reference-type iterator (`sequence[UserClass]`) crashes the emitter | GS9998 | open |
+| #991 | A `when` guard on a `switch` arm won't parse | GS0005 | open (translation-unsupported) |
+| #992 | `and`/`or` binary patterns (`> 0 and < 10`) won't parse | GS0005 | open (translation-unsupported) |
+| #993 | An `is`/`case` type pattern **with** a binder (`x is T t`) leaves the binder unbound | GS0125 | open |
+| #994 | `yield break` has no canonical G# form | GS0005 | open (translation-unsupported) |
 
 Gaps #975/#976/#977 — discovered by L4 — are now **resolved**, so the translator
 emits the canonical forms directly: the interpolated `: base("…$n…")` argument, the
 `struct Money(Cents int32) : IEquatable[Money]` interface clause, and the inline
-BCL `out var x`. The residual L3 gap and the L5 batch (#TBD-2…#TBD-10) are each a
+BCL `out var x`. The residual L3 gap and the L5 batch (#986…#994) are each a
 verified minimal repro (with a contrasting passing control) documented in
 ADR-0115 §G for the compiler backlog. L5 also drove two **translator faithfulness
 fixes** (no compiler change): an `int` literal implicitly promoted to a `double`

--- a/tools/cs2gs/corpus/L5-Console/L5-Console.csproj
+++ b/tools/cs2gs/corpus/L5-Console/L5-Console.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Corpus.L5</RootNamespace>
+    <AssemblyName>L5-Console</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/tools/cs2gs/corpus/L5-Console/Program.cs
+++ b/tools/cs2gs/corpus/L5-Console/Program.cs
@@ -1,0 +1,230 @@
+// L5-Console: the fifth corpus level. A deterministic shape-catalog program
+// whose stdout is the parity oracle (no timestamps / random / GUIDs / culture).
+//
+// It exercises C# surface area that L1-L4 do not, each a candidate gap source
+// for the C#->G# migration (ADR-0115 section B / G):
+//
+//   * Inheritance & polymorphism: an open base class with a virtual method, a
+//     derived override, protected members, and dynamic dispatch through a
+//     base-typed list.
+//   * Pattern matching: an `is` type pattern, a switch statement over type
+//     patterns, and switch expressions with relational patterns.
+//   * Iterators: a method using `yield return` returning IEnumerable<T>,
+//     consumed in a foreach.
+//   * Generic constraints: a generic method with where T : IComparable<T> and a
+//     generic class with where T : class, new().
+//
+// Constructs with no canonical G# form (a pure `abstract` method, `base.M()`,
+// `when` guards, `and`/`or` patterns, `yield break`, an `is` pattern that binds
+// a variable) are intentionally omitted; they are captured as triage gaps in
+// ADR-0115 section G rather than exercised here.
+//
+// Ordinary, idiomatic C# (underscore private fields, no StyleCop header,
+// implicit `this`) - the migration *input*, not product code.
+using System;
+using System.Collections.Generic;
+
+namespace Corpus.L5
+{
+    // Area 1: an open base with a virtual method and a protected field,
+    // exercised through dynamic dispatch.
+    internal class Shape
+    {
+        protected readonly string _name;
+
+        public Shape(string name)
+        {
+            _name = name;
+        }
+
+        public virtual double Area()
+        {
+            return 0.0;
+        }
+
+        public string Describe()
+        {
+            return _name + " area=" + Area().ToString();
+        }
+    }
+
+    internal sealed class Circle : Shape
+    {
+        private readonly double _radius;
+
+        public Circle(double radius)
+            : base("circle")
+        {
+            _radius = radius;
+        }
+
+        public override double Area()
+        {
+            return _radius * _radius;
+        }
+    }
+
+    internal sealed class Rectangle : Shape
+    {
+        private readonly double _width;
+        private readonly double _height;
+
+        public Rectangle(double width, double height)
+            : base("rectangle")
+        {
+            _width = width;
+            _height = height;
+        }
+
+        public override double Area()
+        {
+            return _width * _height;
+        }
+    }
+
+    // Area 4: a generic class constrained to reference types, holding a value
+    // supplied by the caller (a `new()` constraint with `new T()` construction
+    // has no canonical G# form yet - see ADR-0115 section G).
+    internal sealed class Box<T>
+        where T : class
+    {
+        public readonly T Value;
+
+        public Box(T value)
+        {
+            Value = value;
+        }
+    }
+
+    internal sealed class Label
+    {
+        public string Text { get; set; }
+
+        public Label()
+        {
+            Text = "empty";
+        }
+    }
+
+    internal static class Program
+    {
+        // Area 3: an iterator using yield return. It yields the descriptions of
+        // the large shapes (a user-class element type - sequence[Shape] - ICEs
+        // the emitter, see ADR-0115 section G).
+        private static IEnumerable<string> LargeDescriptions(IReadOnlyList<Shape> shapes, double threshold)
+        {
+            foreach (Shape shape in shapes)
+            {
+                if (shape.Area() > threshold)
+                {
+                    yield return shape.Describe();
+                }
+            }
+        }
+
+        // Area 4: a generic method constrained to IComparable<T>.
+        private static T Max<T>(IReadOnlyList<T> items)
+            where T : IComparable<T>
+        {
+            T best = items[0];
+            for (int i = 1; i < items.Count; i++)
+            {
+                if (items[i].CompareTo(best) > 0)
+                {
+                    best = items[i];
+                }
+            }
+
+            return best;
+        }
+
+        // Area 2: an `is` type pattern (no binder).
+        private static string Classify(Shape shape)
+        {
+            if (shape is Circle)
+            {
+                return "round";
+            }
+
+            return "angular";
+        }
+
+        // Area 2: a switch statement over type patterns (side-effecting).
+        private static void PrintKind(Shape shape)
+        {
+            switch (shape)
+            {
+                case Circle c:
+                    Console.WriteLine("circle r2=" + c.Area().ToString());
+                    break;
+                case Rectangle r:
+                    Console.WriteLine("rectangle wh=" + r.Area().ToString());
+                    break;
+                default:
+                    Console.WriteLine("shape");
+                    break;
+            }
+        }
+
+        // Area 2: a switch expression with relational patterns.
+        private static string Bucket(double area)
+        {
+            return area switch
+            {
+                < 10 => "small",
+                < 100 => "medium",
+                _ => "large",
+            };
+        }
+
+        private static int Sign(int n)
+        {
+            return n switch
+            {
+                > 0 => 1,
+                < 0 => -1,
+                _ => 0,
+            };
+        }
+
+        private static void Main()
+        {
+            var shapes = new List<Shape>
+            {
+                new Circle(2),
+                new Rectangle(4, 9),
+                new Circle(12),
+            };
+
+            // Area 1: dynamic dispatch through the base-typed list.
+            foreach (Shape shape in shapes)
+            {
+                Console.WriteLine(shape.Describe());
+            }
+
+            // Area 2: pattern classification.
+            foreach (Shape shape in shapes)
+            {
+                Console.WriteLine(Classify(shape) + " " + Bucket(shape.Area()));
+                PrintKind(shape);
+            }
+
+            Console.WriteLine(Sign(-3).ToString());
+            Console.WriteLine(Sign(0).ToString());
+            Console.WriteLine(Sign(7).ToString());
+
+            // Area 3: iterator consumed in a foreach.
+            foreach (string description in LargeDescriptions(shapes, 30))
+            {
+                Console.WriteLine("large: " + description);
+            }
+
+            // Area 4: generic method + generic class.
+            var areas = new List<double> { 12.0, 48.0, 75.0 };
+            Console.WriteLine("max=" + Max(areas).ToString());
+
+            var box = new Box<Label>(new Label());
+            Console.WriteLine("box=" + box.Value.Text);
+        }
+    }
+}

--- a/tools/cs2gs/corpus/L5-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/L5-Console/baseline.stdout.golden
@@ -1,0 +1,16 @@
+circle area=4
+rectangle area=36
+circle area=144
+round small
+circle r2=4
+angular medium
+rectangle wh=36
+round large
+circle r2=144
+-1
+0
+1
+large: rectangle area=36
+large: circle area=144
+max=75
+box=empty

--- a/tools/cs2gs/corpus/README.md
+++ b/tools/cs2gs/corpus/README.md
@@ -22,6 +22,7 @@ so the simplest possible gap is isolated first.
 | **L2** | `L2-Library` + `L2-Library.Tests` | classlib + xUnit | `class`/`struct`/`record`/`record struct` (B.4); interface impl + base-clause ordering, get-only/`init` props (B.6, B.11); `public`/`internal` visibility (B.10); `enum`, auto-properties, static members, method overloads (B.11) |
 | **L3** | `L3-Library` + `L3-Library.Tests` | richer classlib + xUnit | generics + constraints `where T : …` (B.7); generic method with inference; indexer (B.11); nullable reference types; extension methods `this T` → receiver clause (B.5); `Func<>`/`Action<>`/lambdas → arrow form (B.8); `switch` expression + type/property/relational patterns; LINQ method **and** query syntax; `async`/`await` over `Task<T>` |
 | **L4** | `L4-Console` | console exe, no tests | exception handling: `try`/typed `catch`/`finally`, custom `Exception` subtype + `: base(message)` chaining, re-throw (B.27, B.28); `Dictionary<K,V>` + `HashSet<T>` (add/`TryGetValue`/`Contains`/`Count`, sorted iteration); `using` statement **and** `using var` over an `IDisposable` (B.29); nullable value types `int?` (`.HasValue`/`.Value`, `??`); operator overloading `+`/`*`/`==`/`!=` on a `struct` → receiver-clause `operator` funcs (B.31); conditional/ternary → if-expression (B.26); pre-declared `out` argument → `&x` (B.30) |
+| **L5** | `L5-Console` | console exe, no tests | inheritance & polymorphism: open base class, `virtual`/`override` method, `protected` field, dynamic dispatch through a base-typed variable (B.4, B.5); `is` type pattern (no binder) + `switch` **statement** over type patterns → `switch subj { case P { … } }` (B.32); `switch` **expression** with relational patterns (`< 10.0`) → colon-arm form; iterator `yield return` returning `IEnumerable<T>` → `sequence[T]` (B.32); generic constraints `where T : class` / `where T : IComparable<T>` → bracket constraint clause (B.7); integer literal implicitly promoted to a `double` parameter → emitted as a float literal (B.12). Surfaces the next compiler-gap batch (ADR-0115 §G): `base.M()` virtual call, `abstract` method, `new T()` under `new()`, generic auto-property over `T`, user-class `sequence[T]` iterator, `when` guards, `and`/`or` patterns, `is`-binder, `yield break` |
 
 Each level builds **and** tests green in C# **first** — that captured C# state
 is the parity oracle.
@@ -50,6 +51,8 @@ committed baseline artifacts:
 | Artifact | Produced from | Role |
 | --- | --- | --- |
 | `L1-Console/baseline.stdout.golden` | running the console exe | golden stdout the G# port must reproduce byte-for-byte |
+| `L4-Console/baseline.stdout.golden` | running the console exe | golden stdout the G# port must reproduce byte-for-byte |
+| `L5-Console/baseline.stdout.golden` | running the console exe | golden stdout the G# port must reproduce byte-for-byte |
 | `L2-Library.Tests/baseline.tests.json` | `dotnet test --logger trx` | sorted `{name → outcome}` + pass/fail/skip counts the G# port must reproduce |
 | `L3-Library.Tests/baseline.tests.json` | `dotnet test --logger trx` | same, for L3 |
 
@@ -81,6 +84,10 @@ a G# run — so pipeline retries always compare against a fixed target
 ```bash
 # build + run L1 and see its (deterministic) stdout
 dotnet run --project L1-Console/L1-Console.csproj -c Release
+
+# build + run L4 / L5 console exes
+dotnet run --project L4-Console/L4-Console.csproj -c Release
+dotnet run --project L5-Console/L5-Console.csproj -c Release
 
 # test L2 / L3
 dotnet test L2-Library.Tests/L2-Library.Tests.csproj -c Release

--- a/tools/cs2gs/corpus/capture-baselines.sh
+++ b/tools/cs2gs/corpus/capture-baselines.sh
@@ -66,6 +66,7 @@ capture_tests() {
 
 capture_console "${CORPUS_DIR}/L1-Console" "L1-Console.csproj"
 capture_console "${CORPUS_DIR}/L4-Console" "L4-Console.csproj"
+capture_console "${CORPUS_DIR}/L5-Console" "L5-Console.csproj"
 capture_tests   "${CORPUS_DIR}/L2-Library.Tests" "L2-Library.Tests.csproj"
 capture_tests   "${CORPUS_DIR}/L3-Library.Tests" "L3-Library.Tests.csproj"
 


### PR DESCRIPTION
Re-baselines the cs2gs corpus against the five just-fixed compiler gaps (#973–#977), locks in the L4 canonical forms, and adds a new **L5-Console** corpus app to discover the next batch of compiler gaps. Compiler (`src/`) untouched; L1–L4 corpus `.cs` unchanged. Refs #914.

## Re-baseline matrix (L1–L5)

| App | translate | compile | ilverify | test-parity |
| --- | --- | --- | --- | --- |
| `corpus/L1-Console` | PASS | PASS | PASS | PASS |
| `corpus/L2-Library` | PASS | PASS | PASS | PASS |
| `corpus/L3-Library` | PASS | **FAIL(2)** | skip | skip |
| `corpus/L4-Console` | PASS | PASS | PASS | PASS |
| `corpus/L5-Console` | PASS | PASS | PASS | PASS |

**L2 is now fully green** (was compile-blocked before #973/#974). **L3** remains blocked only at compile by the residual **#TBD-1** (`IEnumerable[T]` needs two `GetEnumerator` overloads differing only by return type → GS0264 + GS0187) — the intended objective-2 outcome, captured as a triage record. L1/L2/L4/L5 are green E2E. `cs2gs` tests: **136 pass**. `GSharp.sln` builds **0/0**.

## Part 2 — L4 canonicalizations (#975/#976/#977 resolved)

The translator already emits the canonical forms (the workarounds lived only in L4's corpus C#, which is forbidden to change). Added `Issue975To977CanonicalizationTests` to lock them in:

- **#975** interpolated string in `: base(...)` → `init(n int32) : base("only $n left")` (emitted directly, no bare-param forward).
- **#976** struct interface clause kept → `struct Money(Cents int32) : IEquatable[Money]`.
- **#977** inline BCL `out var` → `if table.TryGetValue(key, out var value)` (no pre-declared `&value`).

ADR §B.13/§B.28/§B.30 + the README/ADR gap tables flip #973–#977 to **resolved**.

## Part 3 — L5-Console construct inventory

New deterministic shapes program (mirrors L4). Constructs made to translate canonically:

- **switch statement over patterns** → `switch subj { case x is T { … } default { … } }` (ADR §B.33), per-section `break;` dropped.
- **`yield return` iterator** → return type rewritten `IEnumerable<string>` → `sequence[string]`, body emits bare `yield expr` (ADR §B.34).
- **`is` type pattern (no binder)**, **switch expression with relational patterns**, **generic constraints** `[T class]` / `[T IComparable[T]]`, **open/virtual/override dynamic dispatch**.

Two **translator faithfulness fixes** the L5 pipeline surfaced (no compiler change):

- An `int` literal C# implicitly promotes to a `double` parameter (`M(30)` → `M(30.0)`) is now emitted as a float literal — without it the assembly compiled but failed `ilverify` with `StackUnexpected` (found Int32, expected Double). ADR §B.12 note.
- A parameterless constructor initializing a **property** keeps its explicit `init()` body (G# has a field initializer `var Name T = expr` but no property initializer). ADR §B.3 note.

## Discovered compiler gaps (verified minimal repros in ADR-0115 §G)

| # | C# construct | gsc diagnostic | classification |
| --- | --- | --- | --- |
| #TBD-1 | `IEnumerable[T]` dual `GetEnumerator` (generic + non-generic, differ only by return type) | GS0264 + GS0187 | compile-error (blocks L3) |
| #TBD-2 | `base.Method()` virtual base-class call | GS0157 / GS0338 | translation-unsupported |
| #TBD-3 | `abstract` (no-body) method on an `open class` | GS9998 (NRE) | compile-error / ICE |
| #TBD-4 | `new T()` under a `new()` constraint | GS0125 / GS0130 / GS0157 | translation-unsupported |
| #TBD-5 | generic auto-property over `T` (`prop Value T`) member access | GS0158 | compile-error |
| #TBD-6 | user reference-type iterator (`sequence[UserClass]`) | GS9998 | compile-error / ICE |
| #TBD-7 | `when` guard on a switch arm | GS0005 | translation-unsupported |
| #TBD-8 | `and`/`or` binary patterns (`> 0 and < 10`) | GS0005 | translation-unsupported |
| #TBD-9 | `is`/`case` type pattern **with** a binder (`x is T t`) | GS0125 | compile-error |
| #TBD-10 | `yield break` | GS0005 | translation-unsupported |

Each has a verified `.gs` repro and a contrasting passing control in ADR-0115 §G. `#TBD` placeholders are for the orchestrator to file.

## Infra / docs
- `corpus/capture-baselines.sh`: added the L5 `capture_console` line.
- `corpus/README.md`: added the L5 level-table row + baseline artifact rows.
- `tools/cs2gs/README.md` + ADR-0115: matrix, gap tables, §B.33/§B.34, §B.12/§B.3 notes, §G discovered-gap batch.

**No co-author trailer. Not merged.**
