### PR TITLE
Fix #989: resolve generic auto-property member access

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -547,7 +547,7 @@ re-greening earlier stages and surfacing the next layer of gaps:
 | #986 | `base.Method()` virtual base-class call has no canonical G# form (`base[Base].M` is interface-only per ADR-0091) | GS0157 / GS0338 | **resolved** (issue #986 — `base.M(...)` / `base[Base].M(...)` emit a non-virtual base-class call; ADR-0091 extended) |
 | #987 | an `abstract` (no-body) method on an `open class` → emitter crash | GS9998 (NRE) | **resolved** (issue #987 — no-body `open func F() R;` emits a CLR `abstract virtual` slot; the declaring type becomes `TypeAttributes.Abstract`; new diagnostics GS0386 not-instantiable / GS0387 missing-override / GS0388 abstract-requires-open) |
 | #988 | `new T()` construction under a `new()` constraint has no canonical G# form | GS0125 / GS0130 / GS0157 | **resolved** (issue #988 — `[T new()]` declares a `new()` constraint and `T()` constructs the parameter, lowered to a reified `Activator.CreateInstance<T>()`; new diagnostic GS0389 when constructing without the constraint; GS0152 still guards bad type arguments) |
-| #989 | a generic auto-property over `T` (`prop Value T`) cannot be member-accessed | GS0158 | open (L5 uses a generic field instead) |
+| #989 | a generic auto-property over `T` (`prop Value T`) cannot be member-accessed | GS0158 | **resolved** (issue #989 — `StructSymbol` construction now carries the property table across with the property/indexer type substituted, exactly like fields; the emitter parents the external accessor call at the constructed `TypeSpec` and routes the auto-accessor backing-field token through the self-`TypeSpec` MemberRef so read/write round-trips and IL-verifies) |
 | #990 | a user reference-type iterator (`sequence[UserClass]`) → emitter crash | GS9998 | open (L5 yields `string`; `sequence[int32]`/`sequence[string]` compile) |
 | #991 | a `when` guard on a `switch` statement/expression arm won't parse | GS0005 | open (translation-unsupported) |
 | #992 | `and`/`or` binary patterns (`> 0 and < 10`) won't parse | GS0005 | open (translation-unsupported) |
@@ -752,21 +752,26 @@ func make[T new()]() T { return T() } // also on generic functions
 class Box[T class](Value T) { }
 ```
 
-**#989 — a generic auto-property over `T` (`prop Value T`) cannot be member-accessed (`GS0158`).**
-Declaring `prop Value T` on a generic class and then reading `box.Value` →
-`GS0158` "Cannot find member Value". Classification: **compile-error**. A generic
-**field** (`var Value T`) and a non-generic auto-property both work, so L5 uses a
-field.
+**#989 — a generic auto-property over `T` (`prop Value T`) can now be member-accessed (was `GS0158`).**
+Declaring `prop Value T` on a generic class and then reading `box.Value` previously
+produced `GS0158` "Cannot find member Value" because `StructSymbol` construction
+substituted only the field table, never the property table. **Resolved**:
+construction now carries properties (and indexer parameter/element types) across
+with `T` substituted — the same path generic fields already used — and the
+emitter parents the external accessor call at the constructed `TypeSpec` while
+the auto-accessor body addresses its backing field through the self-`TypeSpec`
+MemberRef. Read and write round-trip and IL-verify; L5 may now use a generic
+auto-property directly.
 
 ```gs
-// repro — GS0158 on member access of a generic auto-property:
+// now resolves — member access of a generic auto-property:
 class Box[T class] {
-    prop Value T
+    prop Value T { get; set; }
 }
-// ... box.Value  -> GS0158
+// ... box.Value  -> binds as the substituted type argument
 ```
 ```gs
-// control — a generic field resolves:
+// control — a generic field resolves (unchanged):
 class Box[T class](Value T) { }   // ... box.Value works
 ```
 

--- a/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
@@ -76,6 +76,7 @@ internal sealed class MemberDefEmitter
     private readonly Func<ParameterHandle> nextParameterHandle;
     private readonly Func<Type, TypeReferenceHandle> getTypeReference;
     private readonly Func<Type, EntityHandle> getTypeHandleForMember;
+    private readonly Func<StructSymbol, FieldSymbol, EntityHandle> resolveFieldToken;
 
     public MemberDefEmitter(
         EmitContext emitCtx,
@@ -85,7 +86,8 @@ internal sealed class MemberDefEmitter
         Action<SignatureTypeEncoder, TypeSymbol> encodeTypeSymbol,
         Func<ParameterHandle> nextParameterHandle,
         Func<Type, TypeReferenceHandle> getTypeReference,
-        Func<Type, EntityHandle> getTypeHandleForMember)
+        Func<Type, EntityHandle> getTypeHandleForMember,
+        Func<StructSymbol, FieldSymbol, EntityHandle> resolveFieldToken)
     {
         this.emitCtx = emitCtx ?? throw new ArgumentNullException(nameof(emitCtx));
         this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
@@ -95,6 +97,7 @@ internal sealed class MemberDefEmitter
         this.nextParameterHandle = nextParameterHandle ?? throw new ArgumentNullException(nameof(nextParameterHandle));
         this.getTypeReference = getTypeReference ?? throw new ArgumentNullException(nameof(getTypeReference));
         this.getTypeHandleForMember = getTypeHandleForMember ?? throw new ArgumentNullException(nameof(getTypeHandleForMember));
+        this.resolveFieldToken = resolveFieldToken ?? throw new ArgumentNullException(nameof(resolveFieldToken));
     }
 
     public void EmitPropertyAccessors(StructSymbol structSym)
@@ -201,10 +204,17 @@ internal sealed class MemberDefEmitter
             if (prop.IsAutoProperty && prop.BackingField != null
                 && this.cache.StructFieldDefs.TryGetValue(prop.BackingField, out var backingHandle))
             {
+                // Issue #989: inside a generic type's own accessor body the
+                // backing-field token must be a self-TypeSpec MemberRef
+                // (Box`1<!0>), not the bare FieldDef, or the verifier rejects
+                // the receiver type on the stack.
+                var backingToken = ReflectionMetadataEmitter.IsUserGenericTypeReference(structSym)
+                    ? this.resolveFieldToken(structSym, prop.BackingField)
+                    : (EntityHandle)backingHandle;
                 var il = new InstructionEncoder(new BlobBuilder());
                 il.LoadArgument(0);
                 il.OpCode(ILOpCode.Ldfld);
-                il.Token(backingHandle);
+                il.Token(backingToken);
                 il.OpCode(ILOpCode.Ret);
                 bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(il);
             }
@@ -267,11 +277,15 @@ internal sealed class MemberDefEmitter
             if (prop.IsAutoProperty && prop.BackingField != null
                 && this.cache.StructFieldDefs.TryGetValue(prop.BackingField, out var backingHandle))
             {
+                // Issue #989: self-TypeSpec field MemberRef for generic types.
+                var backingToken = ReflectionMetadataEmitter.IsUserGenericTypeReference(structSym)
+                    ? this.resolveFieldToken(structSym, prop.BackingField)
+                    : (EntityHandle)backingHandle;
                 var il = new InstructionEncoder(new BlobBuilder());
                 il.LoadArgument(0);
                 il.LoadArgument(1);
                 il.OpCode(ILOpCode.Stfld);
-                il.Token(backingHandle);
+                il.Token(backingToken);
                 il.OpCode(ILOpCode.Ret);
                 bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(il);
             }
@@ -440,9 +454,13 @@ internal sealed class MemberDefEmitter
             if (prop.IsAutoProperty && prop.BackingField != null
                 && this.cache.StructFieldDefs.TryGetValue(prop.BackingField, out var backingHandle))
             {
+                // Issue #989: self-TypeSpec field MemberRef for generic types.
+                var backingToken = ReflectionMetadataEmitter.IsUserGenericTypeReference(structSym)
+                    ? this.resolveFieldToken(structSym, prop.BackingField)
+                    : (EntityHandle)backingHandle;
                 var il = new InstructionEncoder(new BlobBuilder());
                 il.OpCode(ILOpCode.Ldsfld);
-                il.Token(backingHandle);
+                il.Token(backingToken);
                 il.OpCode(ILOpCode.Ret);
                 bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(il);
             }
@@ -488,10 +506,14 @@ internal sealed class MemberDefEmitter
             if (prop.IsAutoProperty && prop.BackingField != null
                 && this.cache.StructFieldDefs.TryGetValue(prop.BackingField, out var backingHandle))
             {
+                // Issue #989: self-TypeSpec field MemberRef for generic types.
+                var backingToken = ReflectionMetadataEmitter.IsUserGenericTypeReference(structSym)
+                    ? this.resolveFieldToken(structSym, prop.BackingField)
+                    : (EntityHandle)backingHandle;
                 var il = new InstructionEncoder(new BlobBuilder());
                 il.LoadArgument(0);
                 il.OpCode(ILOpCode.Stsfld);
-                il.Token(backingHandle);
+                il.Token(backingToken);
                 il.OpCode(ILOpCode.Ret);
                 bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(il);
             }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -604,7 +604,21 @@ internal sealed partial class MethodBodyEmitter
     // so this only fires for computed properties that still reference the accessor.
     private void EmitPropertyAccess(BoundPropertyAccessExpression access)
     {
-        if (!this.outer.cache.PropertyAccessorHandles.TryGetValue(access.Property, out var handles) || !handles.Getter.HasValue)
+        // Issue #989: when the receiver is a constructed generic user type the
+        // accessor must be reached through a MemberRef parented at the
+        // constructed TypeSpec so a property whose type mentions the class type
+        // parameter is read with the substitution applied. The non-generic case
+        // keeps using the plain accessor MethodDef.
+        EntityHandle getterHandle;
+        if (ReflectionMetadataEmitter.IsUserGenericTypeReference(access.StructType))
+        {
+            getterHandle = this.outer.ResolveUserPropertyAccessorToken(access.StructType, access.Property, wantSetter: false);
+        }
+        else if (this.outer.cache.PropertyAccessorHandles.TryGetValue(access.Property, out var handles) && handles.Getter.HasValue)
+        {
+            getterHandle = handles.Getter.Value;
+        }
+        else
         {
             throw new InvalidOperationException(
                 $"Property '{access.Property.Name}' has no emitted getter MethodDef.");
@@ -614,7 +628,7 @@ internal sealed partial class MethodBodyEmitter
         if (access.Receiver == null)
         {
             this.il.OpCode(ILOpCode.Call);
-            this.il.Token(handles.Getter.Value);
+            this.il.Token(getterHandle);
             return;
         }
 
@@ -627,13 +641,24 @@ internal sealed partial class MethodBodyEmitter
         this.EmitInstanceReceiver(access.Receiver);
 
         this.il.OpCode(receiverIsClass ? ILOpCode.Callvirt : ILOpCode.Call);
-        this.il.Token(handles.Getter.Value);
+        this.il.Token(getterHandle);
     }
 
     // ADR-0051 Phase 6: emit IL for BoundPropertyAssignmentExpression (computed properties).
     private void EmitPropertyAssignment(BoundPropertyAssignmentExpression assn)
     {
-        if (!this.outer.cache.PropertyAccessorHandles.TryGetValue(assn.Property, out var handles) || !handles.Setter.HasValue)
+        // Issue #989: route generic constructed receivers through the
+        // TypeSpec-parented MemberRef (mirrors EmitPropertyAccess).
+        EntityHandle setterHandle;
+        if (ReflectionMetadataEmitter.IsUserGenericTypeReference(assn.StructType))
+        {
+            setterHandle = this.outer.ResolveUserPropertyAccessorToken(assn.StructType, assn.Property, wantSetter: true);
+        }
+        else if (this.outer.cache.PropertyAccessorHandles.TryGetValue(assn.Property, out var handles) && handles.Setter.HasValue)
+        {
+            setterHandle = handles.Setter.Value;
+        }
+        else
         {
             throw new InvalidOperationException(
                 $"Property '{assn.Property.Name}' has no emitted setter MethodDef.");
@@ -659,7 +684,7 @@ internal sealed partial class MethodBodyEmitter
             this.il.OpCode(ILOpCode.Dup);
             this.il.StoreLocal(valueSlot);
             this.il.OpCode(ILOpCode.Call);
-            this.il.Token(handles.Setter.Value);
+            this.il.Token(setterHandle);
             this.il.LoadLocal(valueSlot);
             return;
         }
@@ -675,7 +700,7 @@ internal sealed partial class MethodBodyEmitter
         this.il.OpCode(ILOpCode.Dup);
         this.il.StoreLocal(valueSlot);
         this.il.OpCode(receiverIsClass ? ILOpCode.Callvirt : ILOpCode.Call);
-        this.il.Token(handles.Setter.Value);
+        this.il.Token(setterHandle);
 
         // Expression result: the value we just stored — no second receiver
         // evaluation, no getter call.

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -576,7 +576,8 @@ internal sealed class ReflectionMetadataEmitter
             this.EncodeTypeSymbol,
             this.customAttrEncoder.NextParameterHandle,
             this.GetTypeReference,
-            this.GetTypeHandleForMember);
+            this.GetTypeHandleForMember,
+            this.ResolveFieldToken);
 
         // PR-E-8: TypeDefEmitter wires up after MemberDefEmitter. It depends
         // on the same EmitContext/MetadataTokenCache/WellKnownReferences
@@ -6528,6 +6529,111 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         return this.GetUserStructMethodRef(containingType, openDef, method.Name, this.EncodeOpenMethodSignature(method));
+    }
+
+    /// <summary>
+    /// Issue #989: resolves the right token for a call to a user property's
+    /// get/set accessor. For a non-generic containing type returns the bare
+    /// accessor <c>MethodDef</c>; for a constructed generic containing type
+    /// returns a <c>MemberRef</c> parented at the constructed <c>TypeSpec</c>
+    /// so a property whose type mentions a class type parameter (e.g.
+    /// <c>prop Value T</c> on <c>Box[int32]</c>) is accessed with <c>T</c>
+    /// substituted by the runtime. The MemberRef signature mirrors the open
+    /// accessor MethodDef emitted by <c>MemberDefEmitter</c> (which encodes the
+    /// property type with <c>VAR(idx)</c> placeholders).
+    /// </summary>
+    internal EntityHandle ResolveUserPropertyAccessorToken(StructSymbol containingType, PropertySymbol property, bool wantSetter)
+    {
+        // Property accessor MethodDef rows are planned against the OPEN
+        // definition's property (the only type that is emitted), so map the
+        // possibly-substituted constructed property back to the definition's
+        // property by name before consulting PropertyAccessorHandles.
+        var defType = containingType.Definition ?? containingType;
+        var defProp = property;
+        if (!ReferenceEquals(defType, containingType))
+        {
+            foreach (var candidate in property.IsStatic ? defType.StaticProperties : defType.Properties)
+            {
+                if (candidate.Name == property.Name && candidate.IsIndexer == property.IsIndexer)
+                {
+                    defProp = candidate;
+                    break;
+                }
+            }
+        }
+
+        if (!this.cache.PropertyAccessorHandles.TryGetValue(defProp, out var handles))
+        {
+            throw new InvalidOperationException(
+                $"Property '{property.Name}' has no emitted accessor handles.");
+        }
+
+        var accessor = wantSetter ? handles.Setter : handles.Getter;
+        if (!accessor.HasValue)
+        {
+            throw new InvalidOperationException(
+                $"Property '{property.Name}' has no emitted {(wantSetter ? "setter" : "getter")} MethodDef.");
+        }
+
+        if (!IsUserGenericTypeReference(containingType))
+        {
+            return accessor.Value;
+        }
+
+        var accessorName = (wantSetter ? "set_" : "get_") + defProp.Name;
+        return this.GetUserStructMethodRef(
+            containingType,
+            accessor.Value,
+            accessorName,
+            this.EncodeOpenPropertyAccessorSignature(defProp, wantSetter));
+    }
+
+    /// <summary>
+    /// Issue #989: encodes the open accessor signature for a user property,
+    /// matching the MethodDef shape emitted by <c>MemberDefEmitter</c>: a
+    /// getter is <c>instance PropertyType get_Name(indexParams...)</c>; a setter
+    /// is <c>instance void set_Name(indexParams..., PropertyType)</c>. The open
+    /// definition's property type is used so type parameters encode as
+    /// <c>VAR(idx)</c>.
+    /// </summary>
+    private BlobBuilder EncodeOpenPropertyAccessorSignature(PropertySymbol property, bool wantSetter)
+    {
+        var sigBlob = new BlobBuilder();
+        var indexParams = property.Parameters.IsDefaultOrEmpty
+            ? ImmutableArray<ParameterSymbol>.Empty
+            : property.Parameters;
+        if (wantSetter)
+        {
+            new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+                .Parameters(
+                    indexParams.Length + 1,
+                    r => r.Void(),
+                    ps =>
+                    {
+                        foreach (var p in indexParams)
+                        {
+                            EncodeTypeSymbol(ps.AddParameter().Type(isByRef: p.RefKind != RefKind.None), p.Type);
+                        }
+
+                        EncodeTypeSymbol(ps.AddParameter().Type(), property.Type);
+                    });
+        }
+        else
+        {
+            new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+                .Parameters(
+                    indexParams.Length,
+                    r => EncodeTypeSymbol(r.Type(), property.Type),
+                    ps =>
+                    {
+                        foreach (var p in indexParams)
+                        {
+                            EncodeTypeSymbol(ps.AddParameter().Type(isByRef: p.RefKind != RefKind.None), p.Type);
+                        }
+                    });
+        }
+
+        return sigBlob;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -1016,12 +1016,91 @@ public sealed class StructSymbol : TypeSymbol
         }
 
         constructed.SetMethods(definition.Methods);
+
+        // Issue #989: a generic auto-property (or computed property) whose type
+        // mentions the class type parameter must resolve on a constructed
+        // instance with `T` substituted — exactly like instance fields above.
+        // Carry the property tables across with substituted property/indexer
+        // types so `TryGetProperty` finds them and the bound access reports the
+        // substituted type. Accessor FunctionSymbols and backing fields are
+        // shared with the open definition (only the definition is emitted; the
+        // external accessor call is parented at the constructed TypeSpec by the
+        // emitter, and inside-the-type access lowers against the definition).
+        constructed.SetProperties(SubstituteProperties(definition.Properties, subst));
+        constructed.SetStaticProperties(SubstituteProperties(definition.StaticProperties, subst));
+
         if (definition.ImportedBaseType != null)
         {
             constructed.SetImportedBaseType(definition.ImportedBaseType);
         }
 
         return constructed;
+    }
+
+    private static ImmutableArray<PropertySymbol> SubstituteProperties(
+        ImmutableArray<PropertySymbol> properties,
+        Dictionary<TypeParameterSymbol, TypeSymbol> subst)
+    {
+        if (properties.IsDefaultOrEmpty)
+        {
+            return properties;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<PropertySymbol>(properties.Length);
+        foreach (var p in properties)
+        {
+            var newType = SubstituteTypeForConstruction(p.Type, subst);
+
+            var newParams = p.Parameters;
+            var paramsChanged = false;
+            if (!p.Parameters.IsDefaultOrEmpty)
+            {
+                var pb = ImmutableArray.CreateBuilder<ParameterSymbol>(p.Parameters.Length);
+                foreach (var par in p.Parameters)
+                {
+                    var st = SubstituteTypeForConstruction(par.Type, subst);
+                    paramsChanged |= !ReferenceEquals(st, par.Type);
+                    pb.Add(new ParameterSymbol(par.Name, st, isVariadic: par.IsVariadic, isScoped: par.IsScoped));
+                }
+
+                if (paramsChanged)
+                {
+                    newParams = pb.MoveToImmutable();
+                }
+            }
+
+            if (ReferenceEquals(newType, p.Type) && !paramsChanged)
+            {
+                builder.Add(p);
+                continue;
+            }
+
+            var substituted = new PropertySymbol(
+                p.Name,
+                newType,
+                p.Accessibility,
+                p.HasGetter,
+                p.HasSetter,
+                p.IsAutoProperty,
+                p.IsVirtual,
+                p.IsOverride,
+                p.SetterParameterName,
+                p.IsStatic,
+                p.Declaration,
+                p.IsInitOnly)
+            {
+                IsIndexer = p.IsIndexer,
+                Parameters = newParams,
+                BackingField = p.BackingField,
+                GetterSymbol = p.GetterSymbol,
+                SetterSymbol = p.SetterSymbol,
+                GetterBodySyntax = p.GetterBodySyntax,
+                SetterBodySyntax = p.SetterBodySyntax,
+            };
+            builder.Add(substituted);
+        }
+
+        return builder.MoveToImmutable();
     }
 
     private static TypeSymbol SubstituteTypeForConstruction(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> subst)

--- a/test/Compiler.Tests/Emit/Issue989GenericAutoPropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue989GenericAutoPropertyEmitTests.cs
@@ -1,0 +1,212 @@
+// <copyright file="Issue989GenericAutoPropertyEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using GSharp.Compiler.Tests;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #989 regression tests: a generic auto-property (or computed property)
+/// whose type mentions the declaring class's type parameter must resolve on a
+/// constructed instance with the type argument substituted — exactly like a
+/// generic field already did. Previously a read of <c>b.Value</c> where
+/// <c>b : Box[int32]</c> reported <c>GS0158</c> "Cannot find member Value"
+/// because <see cref="GSharp.Core.CodeAnalysis.Symbols.StructSymbol"/>
+/// construction substituted fields but never carried the property table across.
+///
+/// The tests compile hermetic programs with <c>gsc</c> in-process, IL-verify
+/// the produced assembly, and execute it to confirm the substituted accessors
+/// round-trip a value at runtime.
+/// </summary>
+public class Issue989GenericAutoPropertyEmitTests
+{
+    [Fact]
+    public void GenericAutoProperty_ReadOnConstructedType_Compiles()
+    {
+        // The original repro: reading a generic auto-property on a constructed
+        // type must bind (no GS0158) and the access reports the substituted
+        // type so it can be returned as int32.
+        var source = """
+            package T
+
+            class Box[T] {
+                prop Value T { get; set; }
+            }
+
+            func test(b Box[int32]) int32 {
+                return b.Value
+            }
+
+            let bx = Box[int32]()
+            bx.Value = 5
+            System.Console.WriteLine(test(bx).ToString())
+            """;
+
+        Assert.Equal("5\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GenericAutoProperty_WriteThenRead_RoundTripsAtRuntime()
+    {
+        // End-to-end: write then read a generic auto-property on a constructed
+        // type and observe the stored value at runtime.
+        var source = """
+            package T
+            import System
+
+            class Box[T](Value T) {
+                prop Stored T { get; set; }
+            }
+
+            let b = Box[int32](0)
+            b.Stored = 42
+            Console.WriteLine(b.Stored.ToString())
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GenericProperty_ConstructedOverTypeParameter_ResolvesSubstituted()
+    {
+        // A property whose type is constructed over the class type parameter
+        // ([]T) resolves to []int32 on Box[int32] and round-trips. (List[T] is
+        // the same shape but currently hits a separate, pre-existing CLR
+        // closed-generic substitution gap that also affects fields, so the
+        // slice form is used here to isolate the #989 property-substitution
+        // behavior.)
+        var source = """
+            package T
+            import System
+
+            class Box[T] {
+                prop Items []T { get; set; }
+            }
+
+            let b = Box[int32]()
+            let arr = []int32{7, 35}
+            b.Items = arr
+            Console.WriteLine((b.Items[0] + b.Items[1]).ToString())
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue989_").FullName;
+        try
+        {
+            var outPath = Path.Combine(tempDir, "test.dll");
+            var (exit, output) = Compile(source, outPath, tempDir);
+            Assert.True(exit == 0, $"gsc failed: {output}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    private static (int Exit, string Output) Compile(string source, string outPath, string tempDir)
+    {
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        File.WriteAllText(srcPath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+
+        foreach (var bcl in BclReferences.Value)
+        {
+            args.Add("/r:" + bcl);
+        }
+
+        args.Add(srcPath);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        return (compileExit, $"stdout:\n{compileOut}\nstderr:\n{compileErr}");
+    }
+
+    private static void TryDeleteDirectory(string dir)
+    {
+        try
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup; the OS reclaims scratch directories later.
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue989GenericPropertySubstitutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue989GenericPropertySubstitutionTests.cs
@@ -1,0 +1,74 @@
+// <copyright file="Issue989GenericPropertySubstitutionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #989 regression coverage at the member-resolution layer: constructing
+/// a generic class with a concrete type argument must carry the property table
+/// across with the property type substituted, so a generic auto-property
+/// <c>prop Value T</c> resolves on <c>Box[int32]</c> as <c>int32</c> — the same
+/// behavior a generic field already had. Before the fix
+/// <see cref="StructSymbol"/> construction substituted only fields, so
+/// <see cref="TypeMemberModel.TryGetProperty(TypeSymbol, string, out PropertySymbol)"/>
+/// returned <see langword="false"/> on the constructed type (the binder then
+/// reported GS0158).
+/// </summary>
+public class Issue989GenericPropertySubstitutionTests
+{
+    private const string Source = @"package P
+
+class Box[T] {
+    prop Value T { get; set; }
+    var field T
+}
+";
+
+    [Fact]
+    public void Construct_GenericAutoProperty_SubstitutesPropertyType()
+    {
+        var box = GetStruct("Box");
+        var constructed = StructSymbol.Construct(box, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+
+        Assert.True(TypeMemberModel.TryGetProperty(constructed, "Value", out var prop));
+        Assert.Same(TypeSymbol.Int32, prop.Type);
+    }
+
+    [Fact]
+    public void Construct_GenericProperty_MatchesGenericFieldSubstitution()
+    {
+        var box = GetStruct("Box");
+        var constructed = StructSymbol.Construct(box, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+
+        Assert.True(TypeMemberModel.TryGetFieldIncludingInherited(
+            constructed,
+            "field",
+            MemberQuery.Instance(MemberKinds.Field),
+            out var field,
+            out _));
+        Assert.True(TypeMemberModel.TryGetProperty(constructed, "Value", out var prop));
+
+        // The property type now substitutes exactly like the field type.
+        Assert.Same(field.Type, prop.Type);
+        Assert.Same(TypeSymbol.Int32, prop.Type);
+    }
+
+    private static StructSymbol GetStruct(string name)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(Source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Empty(result.Diagnostics);
+        return (StructSymbol)compilation.GlobalScope.Structs.Single(s => s.Name == name);
+    }
+}

--- a/tools/cs2gs/README.md
+++ b/tools/cs2gs/README.md
@@ -175,7 +175,7 @@ the frontier advances automatically — #938–#944 moved L3 to `translate PASS`
 | #986 | `base.Method()` virtual base-class call has no canonical G# form | GS0157 / GS0338 | open (translation-unsupported) |
 | #987 | An `abstract` (no-body) method on an `open class` crashes the emitter | GS9998 (NRE) | open |
 | #988 | `new T()` construction under a `new()` constraint has no canonical G# form | GS0125 / GS0130 / GS0157 | open (translation-unsupported) |
-| #989 | A generic auto-property over `T` (`prop Value T`) cannot be member-accessed | GS0158 | open |
+| #989 | A generic auto-property over `T` (`prop Value T`) cannot be member-accessed | GS0158 | resolved (construction substitutes the property table like fields) |
 | #990 | A user reference-type iterator (`sequence[UserClass]`) crashes the emitter | GS9998 | open |
 | #991 | A `when` guard on a `switch` arm won't parse | GS0005 | open (translation-unsupported) |
 | #992 | `and`/`or` binary patterns (`> 0 and < 10`) won't parse | GS0005 | open (translation-unsupported) |

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -506,6 +506,13 @@ receiver's type arguments. An indexer declared without index parameters reports
 indexers; multi-parameter and overloaded indexers are reserved for a future
 revision.
 
+A property declared on a **generic** type whose type mentions a class type
+parameter (`prop Value T`, or a constructed form such as `prop Items []T`) is
+substituted through the receiver's type arguments on member access, exactly like
+a generic field: reading or writing `box.Value` where `box : Box[int32]` binds
+as `int32` (issue #989). The accessor call on a constructed receiver is emitted
+against the constructed type so the substitution holds at run time.
+
 #### Init-only accessors (issue #946)
 
 A property may declare an **`init` accessor** in place of `set`, in either the


### PR DESCRIPTION
Fixes #989.

## Root cause
A generic auto-property whose type mentions the class type parameter (`prop Value T` on `Box[T]`) could not be member-accessed: reading `b.Value` where `b : Box[int32]` reported **GS0158 "Cannot find member Value"**, while a generic field and a non-generic auto-property both resolved.

`StructSymbol.CreateConstructed` substituted the field, primary-constructor, and interface tables when constructing a closed generic instance, but **never carried the property table across**. The constructed `Box[int32]` therefore had an empty `Properties`, so `TypeMemberModel.TryGetProperty` returned false and the binder fell through to GS0158.

## Fix
- **Symbols** (`StructSymbol.cs`): construction now substitutes `Properties`/`StaticProperties`, mapping `T → int32` in the property/indexer type and indexer parameter types — exactly as fields are already substituted. Accessor `FunctionSymbol`s and backing fields are shared with the open definition (only the definition is emitted).
- **Emit** (`ReflectionMetadataEmitter.cs`, `MethodBodyEmitter.MemberAccess.cs`): an external property read/write on a constructed generic receiver parents the accessor call at the constructed `TypeSpec` via the new `ResolveUserPropertyAccessorToken`, mirroring the existing field/method token paths.
- **Emit** (`MemberDefEmitter.cs`): the auto-accessor body inside the open generic type addresses its backing field through the self-`TypeSpec` field MemberRef (not the bare FieldDef), so the IL verifies.

## Before / after (repro)
```gs
package T
class Box[T] { prop Value T }
func test(b Box[int32]) int32 { return b.Value }
```
- **Before:** `error GS0158: Cannot find member Value.`
- **After:** compiles; `b.Value` binds as `int32`.

## End-to-end evidence
```gs
package T
import System
class Box[T](Value T) { prop Stored T { get; set; } }
let b = Box[int32](0)
b.Stored = 42
Console.WriteLine(b.Stored.ToString())
```
Runtime output: `42`. ilverify: **All Classes and Methods Verified.**

A property constructed over `T` (`prop Items []T`) also resolves to `[]int32` on `Box[int32]` and round-trips.

> Note: `prop Items List[T]` (a closed **CLR** generic over `T`) hits a separate, pre-existing substitution gap that affects generic *fields* too, so it is out of scope here; the slice form `[]T` covers the constructed-over-`T` property requirement.

## Tests
- `test/Compiler.Tests/Emit/Issue989GenericAutoPropertyEmitTests.cs` — read binds, write+read prints `42`, `[]T` property resolves (each compiled, IL-verified, executed).
- `test/Core.Tests/CodeAnalysis/Symbols/Issue989GenericPropertySubstitutionTests.cs` — construction substitutes the property type to match the generic field.

## Validation
- `dotnet build GSharp.sln -c Release -graph --no-incremental` → **0 Warning(s) / 0 Error(s)**.
- New tests pass; no regressions across property/generics/member-resolution Compiler emit (246), Core (3486), Interpreter (45), and LSP (149) tests.

Docs: ADR-0115 §G #989 marked resolved, cs2gs README updated, language spec notes generic property substitution.