### PR TITLE
Fix GS9998 emitter crash for user-typed generators (#990)

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -347,7 +347,7 @@ A C# `switch` **statement** maps to the canonical G# `switch subj { case <pat> {
 
 #### B.34 Iterator (`yield return`) → `sequence[T]` generator — sample `TupleSequenceIterators.gs`
 
-A C# iterator method (a body containing `yield return`) returning `IEnumerable<T>`/`IEnumerator<T>` maps to a G# generator whose **return type is rewritten to `sequence[T]`** (the element type `T`), with each `yield return expr;` emitted as a bare `yield expr` (sample `TupleSequenceIterators.gs`). The `IEnumerable<T>` wrapper is **not** carried through — `sequence[T]` is the canonical G# enumeration surface and is directly `for x in …`-iterable. `yield break;` has no G# spelling (§G #994), and a **user reference-type** element (`sequence[UserClass]`) currently crashes the emitter (§G #990), so the canonical iterator yields BCL element types (e.g. `string`).
+A C# iterator method (a body containing `yield return`) returning `IEnumerable<T>`/`IEnumerator<T>` maps to a G# generator whose **return type is rewritten to `sequence[T]`** (the element type `T`), with each `yield return expr;` emitted as a bare `yield expr` (sample `TupleSequenceIterators.gs`). The `IEnumerable<T>` wrapper is **not** carried through — `sequence[T]` is the canonical G# enumeration surface and is directly `for x in …`-iterable. `yield break;` has no G# spelling (§G #994). A **user reference-type** element (`sequence[UserClass]`) is now fully supported (§G #990, resolved); user `data struct` elements work too.
 
 > **Numeric literal promotion at a converted-type site (§B.12 note).** C# applies
 > an implicit `int`→`double`/`float` conversion when an integer literal is passed
@@ -548,7 +548,7 @@ re-greening earlier stages and surfacing the next layer of gaps:
 | #987 | an `abstract` (no-body) method on an `open class` → emitter crash | GS9998 (NRE) | **resolved** (issue #987 — no-body `open func F() R;` emits a CLR `abstract virtual` slot; the declaring type becomes `TypeAttributes.Abstract`; new diagnostics GS0386 not-instantiable / GS0387 missing-override / GS0388 abstract-requires-open) |
 | #988 | `new T()` construction under a `new()` constraint has no canonical G# form | GS0125 / GS0130 / GS0157 | **resolved** (issue #988 — `[T new()]` declares a `new()` constraint and `T()` constructs the parameter, lowered to a reified `Activator.CreateInstance<T>()`; new diagnostic GS0389 when constructing without the constraint; GS0152 still guards bad type arguments) |
 | #989 | a generic auto-property over `T` (`prop Value T`) cannot be member-accessed | GS0158 | **resolved** (issue #989 — `StructSymbol` construction now carries the property table across with the property/indexer type substituted, exactly like fields; the emitter parents the external accessor call at the constructed `TypeSpec` and routes the auto-accessor backing-field token through the self-`TypeSpec` MemberRef so read/write round-trips and IL-verifies) |
-| #990 | a user reference-type iterator (`sequence[UserClass]`) → emitter crash | GS9998 | open (L5 yields `string`; `sequence[int32]`/`sequence[string]` compile) |
+| #990 | a user reference-type iterator (`sequence[UserClass]`) → emitter crash | GS9998 | **resolved** (user reference- and value-type element iterators emit, ilverify, and run) |
 | #991 | a `when` guard on a `switch` statement/expression arm won't parse | GS0005 | open (translation-unsupported) |
 | #992 | `and`/`or` binary patterns (`> 0 and < 10`) won't parse | GS0005 | open (translation-unsupported) |
 | #993 | an `is`/`case` type pattern **with** a binder (`x is T t`) leaves the binder unbound | GS0125 | open (L5 uses the no-binder form `x is T`) |
@@ -775,16 +775,21 @@ class Box[T class] {
 class Box[T class](Value T) { }   // ... box.Value works
 ```
 
-**#990 — a user reference-type iterator (`sequence[UserClass]`) → emitter crash (`GS9998`).**
+**#990 — a user reference-type iterator (`sequence[UserClass]`) → emitter crash (`GS9998`). RESOLVED.**
 A `yield`-generator whose element type is a user reference type
-(`func F() sequence[Shape]`) → `GS9998` "Conversion from '\<T>' to 'object' is not
-yet supported by the emitter". Both `sequence[int32]` and `sequence[string]` (a BCL
-reference type) compile. Classification: **compile-error / ICE**. L5's iterator
-yields `string` (the shape descriptions), not `Shape`.
+(`func F() sequence[Shape]`) previously emitted `GS9998` "Conversion from '\<T>' to
+'object' is not yet supported by the emitter". The root cause was twofold: (1) the
+synthesized non-generic `IEnumerator.Current` converts the strongly-typed
+`<>2__current` field to `object`, but `IsReferenceCompatible` did not recognise a
+user class (null `ClrType` during emit) as widening to `object`; (2) the SM class's
+`IEnumerable<T>`/`IEnumerator<T>` interface rows and `GetEnumerator` signature erased
+the user element type to `object` (`elementType.ClrType ?? typeof(object)`), producing
+generic-invariance-invalid IL. Both are now fixed; user reference- and value-type
+element iterators compile, ilverify, and run. L5 may now yield the user type directly.
 
 ```gs
-// repro — GS9998 emitter crash on a user-class element type:
-open class Shape { }
+// now compiles, ilverifies, and runs:
+open class Shape { func Tag() string { return "shape" } }
 func shapes() sequence[Shape] { yield Shape() }
 ```
 ```gs

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -444,6 +444,19 @@ internal sealed partial class MethodBodyEmitter
             return true;
         }
 
+        // Issue #990: a user-declared reference type (a `class`, modelled as
+        // a StructSymbol with IsClass == true) has no ClrType during emit
+        // because its TypeDef only exists in the assembly being emitted, so
+        // the CLR-backed rule above cannot fire. Such a reference still
+        // widens to `object` as a no-op (the slot already holds the
+        // reference). This unblocks generators whose element type is a user
+        // class: the synthesized non-generic `IEnumerator.Current` property
+        // converts the strongly-typed `<>2__current` field to `object`.
+        if (b?.ClrType.IsSameAs(typeof(object)) == true && a is StructSymbol userClass && userClass.IsClass)
+        {
+            return true;
+        }
+
         if (a is StructSymbol aClass && b is StructSymbol bClass && aClass.IsClass && bClass.IsClass)
         {
             for (var c = aClass; c != null; c = c.BaseClass)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
@@ -791,9 +791,22 @@ internal sealed class MethodBodyPlanner
         // element types we keep the original CLR-erased path so existing
         // closed-iterator behaviour is unchanged.
         var elementContainsTp = ContainsTypeParameter(elementType);
+
+        // Issue #990: a user-declared element type (a `class` or `data
+        // struct` emitted in this same assembly) has no ClrType, so the
+        // CLR-erased `MakeGenericType(elementType.ClrType ?? object)` path
+        // below would record `IEnumerable<object>` / `IEnumerator<object>`
+        // on the SM class. That makes `shapes()` (signature
+        // `IEnumerable<Shape>`) return a value whose runtime type only
+        // implements `IEnumerable<object>` — invalid under generic
+        // invariance (ilverify StackUnexpected). Route such element types
+        // through the symbolic TypeSpec encoder (which emits a real
+        // reference to the user TypeDef) so the interface rows carry the
+        // strongly-typed `IEnumerable<Shape>` / `IEnumerator<Shape>`.
+        var elementNeedsSymbolic = elementContainsTp || elementType?.ClrType == null;
         EntityHandle enumerableHandle;
         EntityHandle enumeratorHandle;
-        if (elementContainsTp)
+        if (elementNeedsSymbolic)
         {
             enumerableHandle = this.BuildGenericInterfaceTypeSpec(typeof(System.Collections.Generic.IEnumerable<>), elementType);
             enumeratorHandle = this.BuildGenericInterfaceTypeSpec(typeof(System.Collections.Generic.IEnumerator<>), elementType);

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -493,7 +493,15 @@ internal sealed class StateMachineEmitter
             // emit-time remap then translates the outer-method TP to the
             // class's TP. Closed element types continue through the CLR
             // `MakeGenericType` path unchanged.
-            var getEnumeratorType = ContainsOuterMethodTypeParameter(plan.ElementType, outerMethodTPs)
+            // Issue #990: a user-declared element type (`class` / `data
+            // struct`) has no ClrType, so the `MakeGenericType` path would
+            // erase to `IEnumerator<object>`. Route it through the same
+            // symbolic encoder so the GetEnumerator signature stays
+            // strongly typed as `IEnumerator<Shape>`.
+            var elementNeedsSymbolicEnumerator =
+                ContainsOuterMethodTypeParameter(plan.ElementType, outerMethodTPs)
+                || plan.ElementType?.ClrType == null;
+            var getEnumeratorType = elementNeedsSymbolicEnumerator
                 ? (TypeSymbol)ImportedTypeSymbol.GetConstructed(
                     typeof(System.Collections.Generic.IEnumerator<>).MakeGenericType(typeof(object)),
                     typeof(System.Collections.Generic.IEnumerator<>),

--- a/test/Compiler.Tests/Emit/Issue990UserClassIteratorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue990UserClassIteratorEmitTests.cs
@@ -1,0 +1,212 @@
+// <copyright file="Issue990UserClassIteratorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #990 — emit + IL-verify + run coverage for generators whose
+/// element type is a user-declared reference type (e.g.
+/// <c>sequence[Shape]</c> where <c>Shape</c> is a user class).
+/// <para>The crash was a GS9998 ICE: "Conversion from 'Shape' to 'object'
+/// is not yet supported by the emitter". The synthesized non-generic
+/// <c>IEnumerator.Current</c> property converts the strongly-typed
+/// <c>&lt;&gt;2__current</c> field to <c>object</c>; a user class has no
+/// ClrType during emit, so <c>IsReferenceCompatible</c> failed to
+/// recognise the reference widening as a no-op.</para>
+/// </summary>
+public class Issue990UserClassIteratorEmitTests
+{
+    [Fact]
+    public void UserReferenceTypeGenerator_Compiles_And_IlVerifies()
+    {
+        var source = """
+            package T
+            open class Shape { }
+            func shapes() sequence[Shape] { yield Shape() }
+            """;
+
+        // CompileToFile asserts gsc exit 0 and runs ilverify.
+        CompileToFile(source, target: "library");
+    }
+
+    [Fact]
+    public void UserReferenceTypeGenerator_EndToEnd_PrintsShapeTwice()
+    {
+        var source = """
+            package T
+            import System
+            open class Shape { func Tag() string { return "shape" } }
+            func shapes() sequence[Shape] {
+                yield Shape()
+                yield Shape()
+            }
+            for s in shapes() { Console.WriteLine(s.Tag()) }
+            """;
+
+        var output = CompileRunAndCaptureOutput(source);
+
+        var lines = output.Replace("\r\n", "\n").TrimEnd('\n').Split('\n');
+        Assert.Equal(new[] { "shape", "shape" }, lines);
+    }
+
+    [Fact]
+    public void UserReferenceTypeGenerator_AccumulatesMultipleInstances()
+    {
+        var source = """
+            package T
+            open class Box { var value int32 = 0 }
+            func boxes() sequence[Box] {
+                var a = Box()
+                a.value = 10
+                yield a
+                var b = Box()
+                b.value = 20
+                yield b
+                var c = Box()
+                c.value = 30
+                yield c
+            }
+            public var total = 0
+            for b in boxes() { total = total + b.value }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(60, GetIntField(assembly, "total"));
+    }
+
+    [Fact]
+    public void UserValueStructGenerator_AccumulatesCorrectly()
+    {
+        var source = """
+            package T
+            data struct Point { var x int32 }
+            func points() sequence[Point] {
+                yield Point{x: 1}
+                yield Point{x: 2}
+                yield Point{x: 3}
+            }
+            public var total = 0
+            for p in points() { total = total + p.x }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(6, GetIntField(assembly, "total"));
+    }
+
+    [Fact]
+    public void BclStringElementControl_StillCompilesAndRuns()
+    {
+        var source = """
+            package T
+            func names() sequence[string] { yield "a" }
+            public var count = 0
+            for n in names() { count = count + 1 }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(1, GetIntField(assembly, "count"));
+    }
+
+    [Fact]
+    public void BclInt32ElementControl_StillCompilesAndRuns()
+    {
+        var source = """
+            package T
+            func nums() sequence[int32] { yield 1 }
+            public var sum = 0
+            for n in nums() { sum = sum + n }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(1, GetIntField(assembly, "sum"));
+    }
+
+    private static Assembly CompileAndRun(string source)
+    {
+        var outPath = CompileToFile(source, target: "exe");
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        return assembly;
+    }
+
+    private static string CompileRunAndCaptureOutput(string source)
+    {
+        var outPath = CompileToFile(source, target: "exe");
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+
+        using var captured = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(captured);
+        try
+        {
+            entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return captured.ToString();
+    }
+
+    private static string CompileToFile(string source, string target)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_990_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static int GetIntField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (int)field!.GetValue(null)!;
+    }
+}

--- a/tools/cs2gs/README.md
+++ b/tools/cs2gs/README.md
@@ -176,7 +176,7 @@ the frontier advances automatically — #938–#944 moved L3 to `translate PASS`
 | #987 | An `abstract` (no-body) method on an `open class` crashes the emitter | GS9998 (NRE) | open |
 | #988 | `new T()` construction under a `new()` constraint has no canonical G# form | GS0125 / GS0130 / GS0157 | open (translation-unsupported) |
 | #989 | A generic auto-property over `T` (`prop Value T`) cannot be member-accessed | GS0158 | resolved (construction substitutes the property table like fields) |
-| #990 | A user reference-type iterator (`sequence[UserClass]`) crashes the emitter | GS9998 | open |
+| #990 | A user reference-type iterator (`sequence[UserClass]`) crashes the emitter | GS9998 | resolved (user reference- and value-type element iterators emit, ilverify, and run) |
 | #991 | A `when` guard on a `switch` arm won't parse | GS0005 | open (translation-unsupported) |
 | #992 | `and`/`or` binary patterns (`> 0 and < 10`) won't parse | GS0005 | open (translation-unsupported) |
 | #993 | An `is`/`case` type pattern **with** a binder (`x is T t`) leaves the binder unbound | GS0125 | open |


### PR DESCRIPTION
Fixes #990.

## Root cause
A `yield`-generator whose element type is a **user reference type** (`func F() sequence[Shape]` where `Shape` is a user class) crashed the emitter with `GS9998` *"Conversion from 'Shape' to 'object' is not yet supported by the emitter"*. Both `sequence[int32]` and `sequence[string]` (a BCL reference type) already compiled.

Two distinct erasure bugs in the iterator state-machine emit:

1. **`IEnumerator.Current → object` conversion.** The synthesized non-generic `IEnumerator.Current` property converts the strongly-typed `<>2__current` field (`Shape`) to `object`. A user class has a **null `ClrType`** during emit (its TypeDef only exists in the assembly being emitted), so `IsReferenceCompatible` (which gated on `a.ClrType != null`) failed to treat the reference widening to `object` as a no-op, and `EmitConversion` threw.

2. **Interface-row / `GetEnumerator` element erasure.** The SM class's `IEnumerable<T>` / `IEnumerator<T>` interface rows and the `GetEnumerator` return signature were built via `elementType.ClrType ?? typeof(object)`, erasing `Shape` to `object`. The SM therefore only implemented `IEnumerable<object>`, so returning it from `shapes()` (signature `IEnumerable<Shape>`) was generic-invariance-invalid — `ilverify` reported `StackUnexpected`.

## Fix
- `MethodBodyEmitter.cs` — `IsReferenceCompatible` now recognises a user `class` (`StructSymbol` with `IsClass`, null `ClrType`) widening to `object` as a reference-level no-op.
- `MethodBodyPlanner.cs` — route user element types (null `ClrType`) through the symbolic TypeSpec encoder (issue #810 path) so the SM's interface rows carry strongly-typed `IEnumerable<Shape>` / `IEnumerator<Shape>`.
- `StateMachineEmitter.cs` — same symbolic routing for the `GetEnumerator` return signature.

User **value-type** (`data struct`) elements already box correctly via the existing `IsValueTypeSymbol` path; they are also covered by the new tests.

## Before / after (repro)
```gs
package T
open class Shape { }
func shapes() sequence[Shape] { yield Shape() }
```
- **Before:** `error GS9998: NotSupportedException: Conversion from 'Shape' to 'object' is not yet supported by the emitter.`
- **After:** `Wrote repro.dll` (compiles, ilverifies clean).

End-to-end sample prints `shape` twice (verified by `UserReferenceTypeGenerator_EndToEnd_PrintsShapeTwice`).

## Tests
New `test/Compiler.Tests/Emit/Issue990UserClassIteratorEmitTests.cs` (6 tests, all pass):
- user reference-type generator compiles + ilverifies
- end-to-end `for s in shapes()` prints `shape` twice
- generator yielding multiple user instances accumulates correctly
- user `data struct` element generator accumulates correctly
- BCL `string` / `int32` element controls still pass

Regression: Compiler.Tests Sequence/Iterator/Yield/Generator/DataStruct/Async (199 tests) and Core.Tests Iterator/Lowering (311 tests) all green. Full `dotnet build GSharp.sln -c Release -graph --no-incremental` → 0 warnings / 0 errors.

## Docs
- `docs/adr/0115-csharp-to-gsharp-migration-tool.md` §G row #990 marked resolved (with root-cause/fix note).
- `tools/cs2gs/README.md` #990 row marked resolved. The cs2gs translator already maps the user element type faithfully (no `string` dodge in code); the L5 corpus's choice of `string` is independent and left unchanged.
