### PR TITLE
Add `when` guards to switch arms (#991)

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -343,7 +343,7 @@ A C# local declaration with **no initializer** (`int existing;`, typically a pre
 
 #### B.33 `switch` statement over patterns → G# `switch` block — sample `PatternSwitch.gs`
 
-A C# `switch` **statement** maps to the canonical G# `switch subj { case <pat> { … } default { … } }` block form (sample `PatternSwitch.gs`): each `case` section's labels become a `case <pattern>` arm whose body is the section's statements wrapped in a block, a type pattern `case T x:` maps to `case x is T`, and the per-section `break;` (required in C#) is **dropped** (G# arms do not fall through). The `default:` section maps to a `default { … }` arm. A `when` guard on a case has **no** G# spelling (§G #991) and a value-returning `switch` statement is emitted as a `switch` **expression** instead (the statement form is not exhaustiveness-checked for value returns), so the translator reserves the block form for void-bodied dispatch. Reuses the same pattern set as the §B switch-expression mapping (type/relational patterns).
+A C# `switch` **statement** maps to the canonical G# `switch subj { case <pat> { … } default { … } }` block form (sample `PatternSwitch.gs`): each `case` section's labels become a `case <pattern>` arm whose body is the section's statements wrapped in a block, a type pattern `case T x:` maps to `case x is T`, and the per-section `break;` (required in C#) is **dropped** (G# arms do not fall through). The `default:` section maps to a `default { … }` arm. A `when` guard on a case maps to a G# `case <pattern> when <bool> { … }` guard (§G #991, resolved) and a value-returning `switch` statement is emitted as a `switch` **expression** instead (the statement form is not exhaustiveness-checked for value returns), so the translator reserves the block form for void-bodied dispatch. Reuses the same pattern set as the §B switch-expression mapping (type/relational patterns).
 
 #### B.34 Iterator (`yield return`) → `sequence[T]` generator — sample `TupleSequenceIterators.gs`
 
@@ -549,7 +549,7 @@ re-greening earlier stages and surfacing the next layer of gaps:
 | #988 | `new T()` construction under a `new()` constraint has no canonical G# form | GS0125 / GS0130 / GS0157 | **resolved** (issue #988 — `[T new()]` declares a `new()` constraint and `T()` constructs the parameter, lowered to a reified `Activator.CreateInstance<T>()`; new diagnostic GS0389 when constructing without the constraint; GS0152 still guards bad type arguments) |
 | #989 | a generic auto-property over `T` (`prop Value T`) cannot be member-accessed | GS0158 | **resolved** (issue #989 — `StructSymbol` construction now carries the property table across with the property/indexer type substituted, exactly like fields; the emitter parents the external accessor call at the constructed `TypeSpec` and routes the auto-accessor backing-field token through the self-`TypeSpec` MemberRef so read/write round-trips and IL-verifies) |
 | #990 | a user reference-type iterator (`sequence[UserClass]`) → emitter crash | GS9998 | **resolved** (user reference- and value-type element iterators emit, ilverify, and run) |
-| #991 | a `when` guard on a `switch` statement/expression arm won't parse | GS0005 | open (translation-unsupported) |
+| #991 | a `when` guard on a `switch` statement/expression arm won't parse | GS0005 | **resolved** (issue #991 — `case <pattern> when <bool>:` / `case <pattern> when <bool> { … }` parse a contextual `when` guard; an arm matches only when the pattern matches AND the guard is true; guarded arms never satisfy exhaustiveness; cs2gs now translates C# `when` guards to the new form) |
 | #992 | `and`/`or` binary patterns (`> 0 and < 10`) won't parse | GS0005 | open (translation-unsupported) |
 | #993 | an `is`/`case` type pattern **with** a binder (`x is T t`) leaves the binder unbound | GS0125 | open (L5 uses the no-binder form `x is T`) |
 | #994 | `yield break` has no canonical G# form | GS0005 | open (translation-unsupported) |
@@ -797,12 +797,15 @@ func shapes() sequence[Shape] { yield Shape() }
 func names() sequence[string] { yield "a" }
 ```
 
-**#991 — a `when` guard won't parse (`GS0005`).**
-A `when` guard on a `switch` statement or expression arm (`case > 0 when cond:`) →
-`GS0005` parse error. Classification: **translation-unsupported**. L5 omits guards.
+**#991 — a `when` guard (resolved).**
+A `when` guard on a `switch` statement or expression arm (`case > 0 when cond:`) is
+now supported end-to-end in G# (issue #991): the contextual `when` keyword
+introduces a boolean guard, an arm matches only when its pattern matches AND the
+guard is true, and guarded arms never satisfy exhaustiveness. cs2gs translates C#
+`when` guards directly to the new G# form.
 
 ```gs
-// repro — GS0005 on a when guard:
+// now compiles — when guard on a relational pattern:
 let r = switch n {
     case > 0 when n < 10: "small"
     default: "other"

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -703,6 +703,14 @@ public static class BoundNodePrinter
                 WritePattern(arm.Pattern, writer);
             }
 
+            if (arm.Guard != null)
+            {
+                writer.WriteSpace();
+                writer.WriteKeyword("when");
+                writer.WriteSpace();
+                arm.Guard.WriteTo(writer);
+            }
+
             writer.WriteLine();
             writer.WriteNestedStatement(arm.Body);
         }
@@ -805,6 +813,14 @@ public static class BoundNodePrinter
             writer.WriteKeyword(SyntaxKind.CaseKeyword);
             writer.WriteSpace();
             WritePattern(arm.Pattern, writer);
+        }
+
+        if (arm.Guard != null)
+        {
+            writer.WriteSpace();
+            writer.WriteKeyword("when");
+            writer.WriteSpace();
+            arm.Guard.WriteTo(writer);
         }
 
         writer.WriteSpace();

--- a/src/Core/CodeAnalysis/Binding/BoundPatternSwitchArm.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundPatternSwitchArm.cs
@@ -12,11 +12,13 @@ public sealed class BoundPatternSwitchArm : BoundNode
     /// <summary>Initializes a new instance of the <see cref="BoundPatternSwitchArm"/> class.</summary>
     /// <param name="syntax">The originating syntax.</param>
     /// <param name="pattern">The arm pattern, or null for default.</param>
+    /// <param name="guard">The optional boolean guard expression (<c>when</c> clause), or null.</param>
     /// <param name="body">The arm body.</param>
-    public BoundPatternSwitchArm(SyntaxNode syntax, BoundPattern pattern, BoundStatement body)
+    public BoundPatternSwitchArm(SyntaxNode syntax, BoundPattern pattern, BoundExpression guard, BoundStatement body)
         : base(syntax)
     {
         Pattern = pattern;
+        Guard = guard;
         Body = body;
     }
 
@@ -25,6 +27,9 @@ public sealed class BoundPatternSwitchArm : BoundNode
 
     /// <summary>Gets the pattern, or null for default.</summary>
     public BoundPattern Pattern { get; }
+
+    /// <summary>Gets the optional boolean guard expression (<c>when</c> clause), or null when the arm has no guard.</summary>
+    public BoundExpression Guard { get; }
 
     /// <summary>Gets the arm body.</summary>
     public BoundStatement Body { get; }

--- a/src/Core/CodeAnalysis/Binding/BoundSwitchExpressionArm.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundSwitchExpressionArm.cs
@@ -16,11 +16,13 @@ public sealed class BoundSwitchExpressionArm : BoundNode
     /// </summary>
     /// <param name="syntax">The originating syntax.</param>
     /// <param name="pattern">The case pattern, or null for <c>default</c>.</param>
+    /// <param name="guard">The optional boolean guard expression (<c>when</c> clause), or null.</param>
     /// <param name="result">The result expression.</param>
-    public BoundSwitchExpressionArm(SyntaxNode syntax, BoundPattern pattern, BoundExpression result)
+    public BoundSwitchExpressionArm(SyntaxNode syntax, BoundPattern pattern, BoundExpression guard, BoundExpression result)
         : base(syntax)
     {
         Pattern = pattern;
+        Guard = guard;
         Result = result;
     }
 
@@ -29,6 +31,9 @@ public sealed class BoundSwitchExpressionArm : BoundNode
 
     /// <summary>Gets the case pattern expression, or null when this arm is <c>default</c>.</summary>
     public BoundPattern Pattern { get; }
+
+    /// <summary>Gets the optional boolean guard expression (<c>when</c> clause), or null when the arm has no guard.</summary>
+    public BoundExpression Guard { get; }
 
     /// <summary>Gets the result expression.</summary>
     public BoundExpression Result { get; }

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -682,8 +682,9 @@ public abstract class BoundTreeRewriter
         {
             var arm = node.Arms[i];
             var pattern = arm.Pattern == null ? null : RewritePattern(arm.Pattern);
+            var guard = arm.Guard == null ? null : RewriteExpression(arm.Guard);
             var result = RewriteExpression(arm.Result);
-            if (builder == null && (pattern != arm.Pattern || result != arm.Result))
+            if (builder == null && (pattern != arm.Pattern || guard != arm.Guard || result != arm.Result))
             {
                 builder = ImmutableArray.CreateBuilder<BoundSwitchExpressionArm>(node.Arms.Length);
                 for (var j = 0; j < i; j++)
@@ -692,7 +693,7 @@ public abstract class BoundTreeRewriter
                 }
             }
 
-            builder?.Add(new BoundSwitchExpressionArm(null, pattern, result));
+            builder?.Add(new BoundSwitchExpressionArm(null, pattern, guard, result));
         }
 
         if (discriminant == node.Discriminant && builder == null)
@@ -714,8 +715,9 @@ public abstract class BoundTreeRewriter
         {
             var arm = node.Arms[i];
             var pattern = arm.Pattern == null ? null : RewritePattern(arm.Pattern);
+            var guard = arm.Guard == null ? null : RewriteExpression(arm.Guard);
             var body = RewriteStatement(arm.Body);
-            if (builder == null && (pattern != arm.Pattern || body != arm.Body))
+            if (builder == null && (pattern != arm.Pattern || guard != arm.Guard || body != arm.Body))
             {
                 builder = ImmutableArray.CreateBuilder<BoundPatternSwitchArm>(node.Arms.Length);
                 for (var j = 0; j < i; j++)
@@ -724,7 +726,7 @@ public abstract class BoundTreeRewriter
                 }
             }
 
-            builder?.Add(new BoundPatternSwitchArm(null, pattern, body));
+            builder?.Add(new BoundPatternSwitchArm(null, pattern, guard, body));
         }
 
         if (discriminant == node.Discriminant && builder == null)

--- a/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
@@ -460,6 +460,11 @@ public abstract class BoundTreeWalker
                 VisitPattern(arm.Pattern);
             }
 
+            if (arm.Guard != null)
+            {
+                VisitExpression(arm.Guard);
+            }
+
             VisitStatement(arm.Body);
         }
     }
@@ -839,6 +844,11 @@ public abstract class BoundTreeWalker
             if (arm.Pattern != null)
             {
                 VisitPattern(arm.Pattern);
+            }
+
+            if (arm.Guard != null)
+            {
+                VisitExpression(arm.Guard);
             }
 
             VisitExpression(arm.Result);

--- a/src/Core/CodeAnalysis/Binding/ExhaustivenessAnalyzer.cs
+++ b/src/Core/CodeAnalysis/Binding/ExhaustivenessAnalyzer.cs
@@ -40,7 +40,7 @@ public static class ExhaustivenessAnalyzer
         ImmutableArray<StructSymbol> structs,
         DiagnosticBag diagnostics)
     {
-        if (TryGetMissingVariants(discriminantType, arms.Select(a => a.Pattern), structs, out var discriminantDescription, out var missingNames))
+        if (TryGetMissingVariants(discriminantType, arms.Where(a => a.Guard == null).Select(a => a.Pattern), structs, out var discriminantDescription, out var missingNames))
         {
             diagnostics.ReportSwitchExpressionNotExhaustive(location, discriminantDescription, missingNames);
         }
@@ -61,7 +61,7 @@ public static class ExhaustivenessAnalyzer
         ImmutableArray<StructSymbol> structs,
         DiagnosticBag diagnostics)
     {
-        if (TryGetMissingVariants(discriminantType, arms.Select(a => a.Pattern), structs, out var discriminantDescription, out var missingNames))
+        if (TryGetMissingVariants(discriminantType, arms.Where(a => a.Guard == null).Select(a => a.Pattern), structs, out var discriminantDescription, out var missingNames))
         {
             diagnostics.ReportSwitchStatementNotExhaustive(location, discriminantDescription, missingNames);
         }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
@@ -54,7 +54,7 @@ internal sealed partial class ExpressionBinder
         }
 
         var hasDefault = false;
-        var boundArmBuilders = ImmutableArray.CreateBuilder<(SwitchExpressionArmSyntax Syntax, BoundPattern Pattern, BoundExpression Result)>();
+        var boundArmBuilders = ImmutableArray.CreateBuilder<(SwitchExpressionArmSyntax Syntax, BoundPattern Pattern, BoundExpression Guard, BoundExpression Result)>();
 
         foreach (var armSyntax in syntax.Arms)
         {
@@ -68,13 +68,19 @@ internal sealed partial class ExpressionBinder
 
                 hasDefault = true;
                 var result = BindExpression(armSyntax.Result);
-                boundArmBuilders.Add((armSyntax, pattern, result));
+                boundArmBuilders.Add((armSyntax, pattern, null, result));
                 continue;
             }
 
             scope = new BoundScope(scope);
             pattern = patterns.BindPattern(armSyntax.Value, switchType);
-            if (pattern is BoundDiscardPattern)
+
+            // Issue #991: a guarded arm (`when <bool>`) can always fail at
+            // runtime, so it never contributes to exhaustiveness — in
+            // particular a guarded discard `case _ when …` does NOT act as a
+            // default/total arm.
+            var hasGuard = armSyntax.Guard != null;
+            if (pattern is BoundDiscardPattern && !hasGuard)
             {
                 if (hasDefault)
                 {
@@ -85,9 +91,15 @@ internal sealed partial class ExpressionBinder
             }
 
             var frame = StatementBinder.TryClassifyPatternNarrowing(discriminant, pattern);
+            BoundExpression guard = null;
+            if (hasGuard)
+            {
+                guard = BindGuardExpression(armSyntax.Guard, frame);
+            }
+
             var armResult = BindExpressionWithNarrowing(armSyntax.Result, frame);
             scope = scope.Parent;
-            boundArmBuilders.Add((armSyntax, pattern, armResult));
+            boundArmBuilders.Add((armSyntax, pattern, guard, armResult));
         }
 
         if (!hasDefault && !ExhaustivenessAnalyzer.IsExhaustiveDiscriminant(switchType))
@@ -115,7 +127,7 @@ internal sealed partial class ExpressionBinder
                 result = new BoundConversionExpression(null, resultType, result);
             }
 
-            arms.Add(new BoundSwitchExpressionArm(null, arm.Pattern, result));
+            arms.Add(new BoundSwitchExpressionArm(null, arm.Pattern, arm.Guard, result));
         }
 
         var boundArms = arms.ToImmutable();

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -133,6 +133,28 @@ internal sealed partial class ExpressionBinder
         }
     }
 
+    // Issue #991: bind a switch-arm `when` guard as a boolean expression. The
+    // guard sees the same pattern narrowing / smart-cast frame as the arm body
+    // (so `case x is T when …` observes `x` as `T`). A non-bool guard is
+    // reported through the standard conversion diagnostic (GS0017).
+    private BoundExpression BindGuardExpression(ExpressionSyntax syntax, Dictionary<VariableSymbol, TypeSymbol> frame)
+    {
+        if (frame == null)
+        {
+            return BindExpression(syntax, TypeSymbol.Bool);
+        }
+
+        binderCtx.NarrowedVariables.Add(frame);
+        try
+        {
+            return BindExpression(syntax, TypeSymbol.Bool);
+        }
+        finally
+        {
+            binderCtx.NarrowedVariables.RemoveAt(binderCtx.NarrowedVariables.Count - 1);
+        }
+    }
+
     internal BoundExpression BindExpression(ExpressionSyntax syntax, TypeSymbol targetType)
     {
         return conversions.BindConversion(syntax, targetType);

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -1930,6 +1930,27 @@ internal sealed class StatementBinder
         }
     }
 
+    // Issue #991: bind a switch-arm `when` guard as a boolean expression under
+    // the arm's pattern-narrowing frame. A non-bool guard surfaces the standard
+    // conversion diagnostic.
+    private BoundExpression BindGuardExpressionWithNarrowing(ExpressionSyntax syntax, Dictionary<VariableSymbol, TypeSymbol> frame)
+    {
+        if (frame == null)
+        {
+            return bindExpressionWithTargetType(syntax, TypeSymbol.Bool);
+        }
+
+        binderCtx.NarrowedVariables.Add(frame);
+        try
+        {
+            return bindExpressionWithTargetType(syntax, TypeSymbol.Bool);
+        }
+        finally
+        {
+            binderCtx.NarrowedVariables.RemoveAt(binderCtx.NarrowedVariables.Count - 1);
+        }
+    }
+
     private BoundStatement BindMultiAssignmentStatement(MultiAssignmentStatementSyntax syntax)
     {
         var targets = syntax.Targets.ToImmutableArray();
@@ -2030,7 +2051,7 @@ internal sealed class StatementBinder
 
                 hasDefault = true;
                 var defaultBody = BindBlockStatement(caseSyntax.Body);
-                arms.Add(new BoundPatternSwitchArm(null, pattern: null, defaultBody));
+                arms.Add(new BoundPatternSwitchArm(null, pattern: null, guard: null, defaultBody));
 
                 if (!EndsInUnconditionalExit(defaultBody))
                 {
@@ -2046,7 +2067,12 @@ internal sealed class StatementBinder
 
             scope = new BoundScope(scope);
             var pattern = patterns.BindPattern(caseSyntax.Value, switchType);
-            if (pattern is BoundDiscardPattern)
+
+            // Issue #991: a guarded arm (`when <bool>`) can always fail at
+            // runtime, so a guarded discard `case _ when …` does NOT act as a
+            // default/total arm.
+            var hasGuard = caseSyntax.Guard != null;
+            if (pattern is BoundDiscardPattern && !hasGuard)
             {
                 if (hasDefault)
                 {
@@ -2057,9 +2083,23 @@ internal sealed class StatementBinder
             }
 
             var frame = TryClassifyPatternNarrowing(discriminant, pattern);
+            BoundExpression guard = null;
+            if (hasGuard)
+            {
+                guard = BindGuardExpressionWithNarrowing(caseSyntax.Guard, frame);
+            }
+
             var body = BindStatementWithNarrowing(caseSyntax.Body, frame);
             scope = scope.Parent;
-            arms.Add(new BoundPatternSwitchArm(null, pattern, body));
+            arms.Add(new BoundPatternSwitchArm(null, pattern, guard, body));
+
+            // Issue #991: a guarded arm may not actually run even when its
+            // pattern matches, so it cannot contribute a reliable post-switch
+            // narrowing. Conservatively defeat the narrowing merge.
+            if (hasGuard)
+            {
+                mergeFailed = true;
+            }
 
             if (mergeFailed)
             {
@@ -2148,7 +2188,7 @@ internal sealed class StatementBinder
     {
         foreach (var arm in arms)
         {
-            if (arm.Pattern == null || arm.Pattern is BoundDiscardPattern)
+            if ((arm.Pattern == null || arm.Pattern is BoundDiscardPattern) && arm.Guard == null)
             {
                 return true;
             }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
@@ -73,6 +73,12 @@ internal sealed partial class MethodBodyEmitter
                 loadValue: () => this.il.LoadLocal(discriminantSlot),
                 valueType: node.Discriminant.Type,
                 failLabel: nextArm);
+            if (arm.Guard != null)
+            {
+                this.EmitExpression(arm.Guard);
+                this.il.Branch(ILOpCode.Brfalse, nextArm);
+            }
+
             this.EmitStatement(arm.Body);
             this.il.Branch(ILOpCode.Br, endLabel);
             this.il.MarkLabel(nextArm);
@@ -114,6 +120,12 @@ internal sealed partial class MethodBodyEmitter
                 loadValue: () => this.il.LoadLocal(discrSlot),
                 valueType: node.Discriminant.Type,
                 failLabel: nextArm);
+            if (arm.Guard != null)
+            {
+                this.EmitExpression(arm.Guard);
+                this.il.Branch(ILOpCode.Brfalse, nextArm);
+            }
+
             this.EmitExpression(arm.Result);
             this.il.StoreLocal(resultSlot);
             this.il.Branch(ILOpCode.Br, endLabel);

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -253,6 +253,11 @@ internal sealed class SlotPlanner
                     VisitPattern(arm.Pattern);
                 }
 
+                if (arm.Guard != null)
+                {
+                    VisitExpression(arm.Guard);
+                }
+
                 VisitStatement(arm.Body);
             }
         }
@@ -365,6 +370,11 @@ internal sealed class SlotPlanner
                 {
                     AllocatePatternBindings(arm.Pattern, this.locals, this.localTypes, this.typePatternScratchSlots);
                     VisitPattern(arm.Pattern);
+                }
+
+                if (arm.Guard != null)
+                {
+                    VisitExpression(arm.Guard);
                 }
 
                 VisitExpression(arm.Result);

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -2733,6 +2733,12 @@ public sealed class Evaluator
             var bindings = new Dictionary<VariableSymbol, object>();
             if (TryMatchPattern(arm.Pattern, discriminant, bindings))
             {
+                if (arm.Guard != null
+                    && !(bool)EvaluateWithPatternBindings(bindings, () => EvaluateExpression(arm.Guard)))
+                {
+                    continue;
+                }
+
                 return EvaluateWithPatternBindings(bindings, () => EvaluateExpression(arm.Result));
             }
         }
@@ -2756,6 +2762,12 @@ public sealed class Evaluator
             var bindings = new Dictionary<VariableSymbol, object>();
             if (TryMatchPattern(arm.Pattern, discriminant, bindings))
             {
+                if (arm.Guard != null
+                    && !(bool)EvaluateWithPatternBindings(bindings, () => EvaluateExpression(arm.Guard)))
+                {
+                    continue;
+                }
+
                 EvaluateWithPatternBindings(bindings, () => EvaluateStatement((BoundBlockStatement)arm.Body));
                 return;
             }

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -1327,7 +1327,7 @@ public sealed class Lowerer : BoundTreeRewriter
                 var flatArms = ImmutableArray.CreateBuilder<BoundPatternSwitchArm>(ps.Arms.Length);
                 foreach (var arm in ps.Arms)
                 {
-                    flatArms.Add(new BoundPatternSwitchArm(null, arm.Pattern, Flatten(arm.Body)));
+                    flatArms.Add(new BoundPatternSwitchArm(null, arm.Pattern, arm.Guard, Flatten(arm.Body)));
                 }
 
                 builder.Add(new BoundPatternSwitchStatement(null, ps.Discriminant, flatArms.ToImmutable()));

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -5101,13 +5101,31 @@ public class Parser
         {
             var defaultKeyword = MatchToken(SyntaxKind.DefaultKeyword);
             var body = ParseBlockStatement();
-            return new SwitchCaseSyntax(syntaxTree, defaultKeyword, value: null, body);
+            return new SwitchCaseSyntax(syntaxTree, defaultKeyword, value: null, whenKeyword: null, guard: null, body);
         }
 
         var caseKeyword = MatchToken(SyntaxKind.CaseKeyword);
         var value = ParsePattern();
+        var (whenKeyword, guard) = ParseOptionalWhenGuard();
         var caseBody = ParseBlockStatement();
-        return new SwitchCaseSyntax(syntaxTree, caseKeyword, value, caseBody);
+        return new SwitchCaseSyntax(syntaxTree, caseKeyword, value, whenKeyword, guard, caseBody);
+    }
+
+    // Issue #991: a contextual `when <bool-expr>` guard may follow the pattern
+    // in a switch arm. `when` is not a reserved keyword in G#, so it is matched
+    // contextually as an identifier whose text is "when"; this keeps existing
+    // identifiers named `when` usable everywhere else. Returns (null, null) when
+    // no guard is present.
+    private (SyntaxToken WhenKeyword, ExpressionSyntax Guard) ParseOptionalWhenGuard()
+    {
+        if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "when")
+        {
+            var whenKeyword = NextToken();
+            var guard = ParseExpression();
+            return (whenKeyword, guard);
+        }
+
+        return (null, null);
     }
 
     private PatternSyntax ParsePattern()
@@ -6376,14 +6394,15 @@ public class Parser
             var defaultKeyword = MatchToken(SyntaxKind.DefaultKeyword);
             var defaultArrow = MatchSwitchExpressionArmSeparator();
             var defaultResult = ParseExpression();
-            return new SwitchExpressionArmSyntax(syntaxTree, defaultKeyword, value: null, defaultArrow, defaultResult);
+            return new SwitchExpressionArmSyntax(syntaxTree, defaultKeyword, value: null, whenKeyword: null, guard: null, defaultArrow, defaultResult);
         }
 
         var caseKeyword = MatchToken(SyntaxKind.CaseKeyword);
         var value = ParsePattern();
+        var (whenKeyword, guard) = ParseOptionalWhenGuard();
         var arrow = MatchSwitchExpressionArmSeparator();
         var result = ParseExpression();
-        return new SwitchExpressionArmSyntax(syntaxTree, caseKeyword, value, arrow, result);
+        return new SwitchExpressionArmSyntax(syntaxTree, caseKeyword, value, whenKeyword, guard, arrow, result);
     }
 
     // ADR-0074 / issue #714: switch-expression arms accept either `:` (new) or

--- a/src/Core/CodeAnalysis/Syntax/SwitchCaseSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/SwitchCaseSyntax.cs
@@ -16,16 +16,22 @@ public sealed class SwitchCaseSyntax : SyntaxNode
     /// <param name="syntaxTree">The parent syntax tree.</param>
     /// <param name="keyword">The <c>case</c> or <c>default</c> keyword.</param>
     /// <param name="value">The case value pattern (null for <c>default</c>).</param>
+    /// <param name="whenKeyword">The optional <c>when</c> contextual keyword introducing a guard, or null.</param>
+    /// <param name="guard">The optional boolean guard expression following <c>when</c>, or null.</param>
     /// <param name="body">The case body block.</param>
     public SwitchCaseSyntax(
         SyntaxTree syntaxTree,
         SyntaxToken keyword,
         PatternSyntax value,
+        SyntaxToken whenKeyword,
+        ExpressionSyntax guard,
         BlockStatementSyntax body)
         : base(syntaxTree)
     {
         Keyword = keyword;
         Value = value;
+        WhenKeyword = whenKeyword;
+        Guard = guard;
         Body = body;
     }
 
@@ -41,6 +47,16 @@ public sealed class SwitchCaseSyntax : SyntaxNode
     /// Gets the case value pattern, or null when this arm is <c>default</c>.
     /// </summary>
     public PatternSyntax Value { get; }
+
+    /// <summary>
+    /// Gets the optional <c>when</c> contextual keyword token introducing a guard, or null when the arm has no guard.
+    /// </summary>
+    public SyntaxToken WhenKeyword { get; }
+
+    /// <summary>
+    /// Gets the optional boolean guard expression following <c>when</c>, or null when the arm has no guard.
+    /// </summary>
+    public ExpressionSyntax Guard { get; }
 
     /// <summary>
     /// Gets the case body block.

--- a/src/Core/CodeAnalysis/Syntax/SwitchExpressionArmSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/SwitchExpressionArmSyntax.cs
@@ -15,18 +15,24 @@ public sealed class SwitchExpressionArmSyntax : SyntaxNode
     /// <param name="syntaxTree">The parent syntax tree.</param>
     /// <param name="keyword">The <c>case</c> or <c>default</c> keyword.</param>
     /// <param name="value">The case value pattern, or null for <c>default</c>.</param>
+    /// <param name="whenKeyword">The optional <c>when</c> contextual keyword introducing a guard, or null.</param>
+    /// <param name="guard">The optional boolean guard expression following <c>when</c>, or null.</param>
     /// <param name="arrowToken">The <c>:</c> (preferred) or <c>-&gt;</c> (deprecated, ADR-0074) separator token.</param>
     /// <param name="result">The result expression for this arm.</param>
     public SwitchExpressionArmSyntax(
         SyntaxTree syntaxTree,
         SyntaxToken keyword,
         PatternSyntax value,
+        SyntaxToken whenKeyword,
+        ExpressionSyntax guard,
         SyntaxToken arrowToken,
         ExpressionSyntax result)
         : base(syntaxTree)
     {
         Keyword = keyword;
         Value = value;
+        WhenKeyword = whenKeyword;
+        Guard = guard;
         ArrowToken = arrowToken;
         Result = result;
     }
@@ -39,6 +45,12 @@ public sealed class SwitchExpressionArmSyntax : SyntaxNode
 
     /// <summary>Gets the case value pattern, or null when this arm is <c>default</c>.</summary>
     public PatternSyntax Value { get; }
+
+    /// <summary>Gets the optional <c>when</c> contextual keyword token introducing a guard, or null when the arm has no guard.</summary>
+    public SyntaxToken WhenKeyword { get; }
+
+    /// <summary>Gets the optional boolean guard expression following <c>when</c>, or null when the arm has no guard.</summary>
+    public ExpressionSyntax Guard { get; }
 
     /// <summary>Gets the separator token between the pattern and the result expression. Either <c>:</c> (ADR-0074, preferred) or <c>-&gt;</c> (deprecated, warns with GS0302).</summary>
     public SyntaxToken ArrowToken { get; }

--- a/test/Compiler.Tests/Emit/Issue991WhenGuardEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue991WhenGuardEmitTests.cs
@@ -1,0 +1,172 @@
+// <copyright file="Issue991WhenGuardEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #991 — `when` guards on switch arms. Each test compiles via the
+/// in-process <c>gsc</c>, IL-verifies the emitted PE (so the inserted
+/// guard branch is well-formed), and runs the assembly under
+/// <c>dotnet exec</c>, asserting captured stdout.
+/// </summary>
+public class Issue991WhenGuardEmitTests
+{
+    [Fact]
+    public void SwitchExpression_WhenGuard_ClassifySample()
+    {
+        var source = """
+            package T
+            import System
+            func classify(n int32) string {
+                return switch n {
+                    case > 0 when n < 10: "small"
+                    case > 0: "big"
+                    default: "nonpositive"
+                }
+            }
+            Console.WriteLine(classify(5))
+            Console.WriteLine(classify(50))
+            Console.WriteLine(classify(-1))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("small\nbig\nnonpositive\n", output);
+    }
+
+    [Fact]
+    public void SwitchStatement_WhenGuard_ClassifySample()
+    {
+        var source = """
+            package T
+            import System
+            func describe(n int32) {
+                switch n {
+                case > 0 when n < 10 { Console.WriteLine("small") }
+                case > 0 { Console.WriteLine("big") }
+                default { Console.WriteLine("nonpositive") }
+                }
+            }
+            describe(5)
+            describe(50)
+            describe(-1)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("small\nbig\nnonpositive\n", output);
+    }
+
+    [Fact]
+    public void SwitchExpression_WhenGuard_WithTypePatternSmartCast()
+    {
+        // The guard observes the pattern-narrowed discriminant (`a` is `Dog`
+        // inside the `is Dog` arm, so `a.Bark()` resolves to Dog's method).
+        var source = """
+            package T
+            import System
+
+            open class Animal {
+                var Name string
+                open func Describe() string { return Name }
+            }
+            class Dog : Animal {
+                func Bark() string { return Name + ":woof" }
+            }
+            class Cat : Animal {
+                func Purr() string { return Name + ":purr" }
+            }
+
+            func classify(a Animal) string {
+                return switch a {
+                    case d is Dog when a.Bark() == "Rex:woof": "the famous Rex"
+                    case d is Dog: d.Bark()
+                    case c is Cat: c.Purr()
+                    default: a.Describe()
+                }
+            }
+
+            Console.WriteLine(classify(Dog{Name: "Rex"}))
+            Console.WriteLine(classify(Dog{Name: "Buddy"}))
+            Console.WriteLine(classify(Cat{Name: "Whiskers"}))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("the famous Rex\nBuddy:woof\nWhiskers:purr\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue991_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed (exit {compileExit}):\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/SwitchExpressionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/SwitchExpressionTests.cs
@@ -132,6 +132,49 @@ label
         Assert.Equal("maybe", result.Value);
     }
 
+    // Issue #991: `when` guards on switch-expression arms.
+    [Theory]
+    [InlineData("5", "small")]
+    [InlineData("50", "big")]
+    [InlineData("-1", "nonpositive")]
+    public void SwitchExpression_WhenGuard_Evaluates(string input, string expected)
+    {
+        var result = Evaluate($@"
+let v = {input}
+let label = switch v {{ case > 0 when v < 10: ""small"" case > 0: ""big"" default: ""nonpositive"" }}
+label
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(expected, result.Value);
+    }
+
+    [Fact]
+    public void SwitchExpression_GuardedDiscard_DoesNotSatisfyExhaustiveness()
+    {
+        // Issue #991: a guarded discard (`case _ when …`) can fail at runtime,
+        // so it does not act as a total/default arm — the value switch is
+        // still missing a default.
+        var diagnostics = Bind(@"
+let v = 1
+let label = switch v { case > 0: ""pos"" case _ when v < 0: ""neg"" }
+");
+
+        Assert.Contains(diagnostics, d => d.Message == "Switch expression must have a 'default' arm.");
+    }
+
+    [Fact]
+    public void SwitchExpression_NonBoolGuard_Diagnoses()
+    {
+        // Issue #991: a non-bool guard reports the standard conversion error.
+        var diagnostics = Bind(@"
+let v = 1
+let label = switch v { case > 0 when v: ""x"" default: ""y"" }
+");
+
+        Assert.Contains(diagnostics, d => d.Message.Contains("Cannot convert type", System.StringComparison.Ordinal) && d.Message.Contains("'bool'", System.StringComparison.Ordinal));
+    }
+
     private static ImmutableArray<Diagnostic> Bind(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/SwitchStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/SwitchStatementTests.cs
@@ -135,6 +135,37 @@ public class SwitchStatementTests
         Assert.Empty(Bind(src));
     }
 
+    // Issue #991: `when` guards on switch-statement arms.
+    [Fact]
+    public void Switch_WhenGuard_Binds()
+    {
+        var src = @"func F() {
+ var x = 5
+ switch x {
+ case > 0 when x < 10 { var a = ""small"" }
+ case > 0 { var b = ""big"" }
+ default { var c = ""nonpositive"" }
+ }
+}
+";
+        Assert.Empty(Bind(src));
+    }
+
+    [Fact]
+    public void Switch_NonBoolGuard_Diagnoses()
+    {
+        var src = @"func F() {
+ var x = 1
+ switch x {
+ case > 0 when x { var a = 1 }
+ default { var b = 2 }
+ }
+}
+";
+        var diagnostics = Bind(src);
+        Assert.Contains(diagnostics, d => d.Message.Contains("Cannot convert type", System.StringComparison.Ordinal) && d.Message.Contains("'bool'", System.StringComparison.Ordinal));
+    }
+
     private static ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Syntax/PatternParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/PatternParserTests.cs
@@ -64,6 +64,41 @@ public class PatternParserTests
         Assert.Equal(SyntaxKind.DiscardPattern, statement.Cases.Single().Value.Kind);
     }
 
+    // Issue #991: `when` guards parse on switch-expression arms.
+    [Fact]
+    public void SwitchExpression_WhenGuard_ParsesGuardExpression()
+    {
+        var arm = ParseFirstSwitchExpressionArm("let x = switch v { case > 0 when v < 10: 1 default: 0 }");
+        Assert.Equal(SyntaxKind.RelationalPattern, arm.Value.Kind);
+        Assert.NotNull(arm.WhenKeyword);
+        Assert.Equal("when", arm.WhenKeyword.Text);
+        Assert.NotNull(arm.Guard);
+        Assert.Equal(SyntaxKind.BinaryExpression, arm.Guard.Kind);
+    }
+
+    [Fact]
+    public void SwitchExpression_NoGuard_HasNullGuard()
+    {
+        var arm = ParseFirstSwitchExpressionArm("let x = switch v { case > 0: 1 default: 0 }");
+        Assert.Null(arm.WhenKeyword);
+        Assert.Null(arm.Guard);
+    }
+
+    // Issue #991: `when` guards parse on switch-statement arms.
+    [Fact]
+    public void SwitchStatement_WhenGuard_ParsesGuardExpression()
+    {
+        var tree = SyntaxTree.Parse("switch v { case > 0 when v < 10 { } }");
+        Assert.Empty(tree.Diagnostics);
+        var statement = tree.Root.Members.OfType<GlobalStatementSyntax>().Select(m => m.Statement).OfType<SwitchStatementSyntax>().Single();
+        var theCase = statement.Cases.Single();
+        Assert.Equal(SyntaxKind.RelationalPattern, theCase.Value.Kind);
+        Assert.NotNull(theCase.WhenKeyword);
+        Assert.Equal("when", theCase.WhenKeyword.Text);
+        Assert.NotNull(theCase.Guard);
+        Assert.Equal(SyntaxKind.BinaryExpression, theCase.Guard.Kind);
+    }
+
     private static SwitchExpressionArmSyntax ParseFirstSwitchExpressionArm(string source)
     {
         var tree = SyntaxTree.Parse(source);

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
@@ -516,10 +516,12 @@ public sealed class SwitchArm : GNode
     /// </summary>
     /// <param name="pattern">The arm pattern, or <see langword="null"/> for the <c>default</c> arm.</param>
     /// <param name="body">The result expression.</param>
-    public SwitchArm(GPattern pattern, GExpression body)
+    /// <param name="guard">The optional <c>when</c> guard expression, or <see langword="null"/>.</param>
+    public SwitchArm(GPattern pattern, GExpression body, GExpression guard = null)
     {
         Pattern = pattern;
         Body = body;
+        Guard = guard;
     }
 
     /// <summary>Gets the arm pattern, or <see langword="null"/> for the <c>default</c> arm.</summary>
@@ -527,6 +529,9 @@ public sealed class SwitchArm : GNode
 
     /// <summary>Gets the result expression.</summary>
     public GExpression Body { get; }
+
+    /// <summary>Gets the optional <c>when</c> guard expression, or <see langword="null"/> when the arm has no guard.</summary>
+    public GExpression Guard { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
@@ -438,10 +438,12 @@ public sealed class SwitchStatementCase : GNode
     /// </summary>
     /// <param name="pattern">The arm pattern, or <see langword="null"/> for the <c>default</c> arm.</param>
     /// <param name="body">The arm body block.</param>
-    public SwitchStatementCase(GPattern pattern, BlockStatement body)
+    /// <param name="guard">The optional <c>when</c> guard expression, or <see langword="null"/>.</param>
+    public SwitchStatementCase(GPattern pattern, BlockStatement body, GExpression guard = null)
     {
         Pattern = pattern;
         Body = body;
+        Guard = guard;
     }
 
     /// <summary>Gets the arm pattern, or <see langword="null"/> for the <c>default</c> arm.</summary>
@@ -449,6 +451,9 @@ public sealed class SwitchStatementCase : GNode
 
     /// <summary>Gets the arm body block.</summary>
     public BlockStatement Body { get; }
+
+    /// <summary>Gets the optional <c>when</c> guard expression, or <see langword="null"/> when the arm has no guard.</summary>
+    public GExpression Guard { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -482,7 +482,21 @@ public static class GSharpPrinter
         {
             sb.Append('\n');
             sb.Append(armPad);
-            sb.Append(arm.Pattern == null ? "default:" : $"case {RenderPattern(arm.Pattern, indent + 1)}:");
+            string marker;
+            if (arm.Pattern == null)
+            {
+                marker = "default:";
+            }
+            else if (arm.Guard != null)
+            {
+                marker = $"case {RenderPattern(arm.Pattern, indent + 1)} when {RenderExpression(arm.Guard, indent + 1)}:";
+            }
+            else
+            {
+                marker = $"case {RenderPattern(arm.Pattern, indent + 1)}:";
+            }
+
+            sb.Append(marker);
             sb.Append(' ');
             sb.Append(RenderExpression(arm.Body, indent + 1));
         }
@@ -640,7 +654,20 @@ public static class GSharpPrinter
         {
             sb.Append('\n');
             sb.Append(casePad);
-            var head = arm.Pattern == null ? "default" : $"case {RenderPattern(arm.Pattern, indent + 1)}";
+            string head;
+            if (arm.Pattern == null)
+            {
+                head = "default";
+            }
+            else if (arm.Guard != null)
+            {
+                head = $"case {RenderPattern(arm.Pattern, indent + 1)} when {RenderExpression(arm.Guard, indent + 1)}";
+            }
+            else
+            {
+                head = $"case {RenderPattern(arm.Pattern, indent + 1)}";
+            }
+
             sb.Append($"{head} {RenderBlock(arm.Body, indent + 1)}");
         }
 

--- a/tools/cs2gs/Cs2Gs.Tests/L5ConstructTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L5ConstructTranslationTests.cs
@@ -57,6 +57,61 @@ namespace Demo
     }
 
     /// <summary>
+    /// Issue #991: a C# <c>when</c> guard on a switch-statement case is now
+    /// translated to the canonical G# <c>case &lt;pattern&gt; when &lt;bool&gt; { … }</c>
+    /// form instead of being reported as unsupported.
+    /// </summary>
+    [Fact]
+    public void SwitchStatement_WhenGuard_EmittedAsGuardedCase()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class Shapes
+    {
+        public static string Kind(int n)
+        {
+            switch (n)
+            {
+                case > 0 when n < 10:
+                    return ""small"";
+                default:
+                    return ""other"";
+            }
+        }
+    }
+}");
+
+        Assert.Contains("case > 0 when n < 10 {", printed);
+        Assert.DoesNotContain("when' guard has no canonical", printed);
+    }
+
+    /// <summary>
+    /// Issue #991: a C# <c>when</c> guard on a switch-expression arm is now
+    /// translated to the canonical G# <c>case &lt;pattern&gt; when &lt;bool&gt;: …</c>
+    /// form.
+    /// </summary>
+    [Fact]
+    public void SwitchExpression_WhenGuard_EmittedAsGuardedArm()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class Shapes
+    {
+        public static string Kind(int n) => n switch
+        {
+            > 0 when n < 10 => ""small"",
+            > 0 => ""big"",
+            _ => ""other"",
+        };
+    }
+}");
+
+        Assert.Contains("case > 0 when n < 10:", printed);
+    }
+
+    /// <summary>
     /// A C# iterator method (<c>yield return</c>) returning
     /// <c>IEnumerable&lt;string&gt;</c> is emitted with the return type rewritten
     /// to <c>sequence[string]</c> and a bare <c>yield expr</c> body

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -2880,12 +2880,10 @@ public sealed class CSharpToGSharpTranslator
 
             foreach (SwitchExpressionArmSyntax arm in node.Arms)
             {
-                if (arm.WhenClause != null)
-                {
-                    this.context.ReportUnsupported(
-                        arm.WhenClause,
-                        "switch-arm 'when' guard has no canonical G# form yet (ADR-0115 §B).");
-                }
+                // Issue #991: C# `when` guards now have a canonical G# form.
+                GExpression guard = arm.WhenClause != null
+                    ? this.TranslateExpression(arm.WhenClause.Condition)
+                    : null;
 
                 var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
                 GPattern pattern = this.TranslatePattern(arm.Pattern, bindings);
@@ -2908,7 +2906,7 @@ public sealed class CSharpToGSharpTranslator
                     }
                 }
 
-                arms.Add(new SwitchArm(pattern, body));
+                arms.Add(new SwitchArm(pattern, body, guard));
             }
 
             return new SwitchExpression(subject, arms);
@@ -2925,22 +2923,6 @@ public sealed class CSharpToGSharpTranslator
                 // that stacks multiple `case` labels (fall-through) has no canonical
                 // G# form, so each label is emitted as its own arm sharing the body.
                 var labels = section.Labels.ToList();
-                GExpression guard = null;
-                foreach (SwitchLabelSyntax label in labels)
-                {
-                    if (label is CasePatternSwitchLabelSyntax { WhenClause: { } when })
-                    {
-                        guard = this.TranslateExpression(when.Condition);
-                    }
-                }
-
-                if (guard != null)
-                {
-                    this.context.ReportUnsupported(
-                        node,
-                        "switch-statement 'when' guard has no canonical G# form yet (ADR-0115 §B).");
-                }
-
                 BlockStatement body = this.TranslateSwitchSectionBody(section);
 
                 foreach (SwitchLabelSyntax label in labels)
@@ -2950,7 +2932,12 @@ public sealed class CSharpToGSharpTranslator
                         case CasePatternSwitchLabelSyntax patternLabel:
                             var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
                             GPattern pattern = this.TranslatePattern(patternLabel.Pattern, bindings);
-                            cases.Add(new SwitchStatementCase(pattern, body));
+
+                            // Issue #991: C# `when` guards now have a canonical G# form.
+                            GExpression guard = patternLabel.WhenClause != null
+                                ? this.TranslateExpression(patternLabel.WhenClause.Condition)
+                                : null;
+                            cases.Add(new SwitchStatementCase(pattern, body, guard));
                             break;
 
                         case CaseSwitchLabelSyntax valueLabel:

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -690,6 +690,16 @@ default: "many"
 
 Patterns include list-like patterns, property patterns, type tests with `is`, wildcard `_`, relational patterns, and expression patterns.
 
+A pattern in a `switch` arm — in both the expression form and the statement form — may be followed by an optional `when <bool-expr>` guard (issue #991), mirroring C#. `when` is a contextual keyword: it introduces a guard only in this position and remains usable as an ordinary identifier everywhere else. An arm with a guard is selected only when **both** the pattern matches **and** the guard expression evaluates to `true`; otherwise control falls through to the next arm. The guard sees any pattern narrowing / smart-cast in effect for the arm (so the guard of `case x is T when …` observes the discriminator as `T`). A non-`bool` guard is rejected with the standard conversion diagnostic. Because a guarded arm can fail at run time, it never contributes to exhaustiveness: a guarded discard (`case _ when …`) does **not** act as a total/`default` arm, so a value-returning `switch` whose only catch-all is guarded still requires a reachable `default` arm (`GS0176`).
+
+```gsharp
+let description = switch value {
+case > 0 when value < 10: "small"
+case > 0: "big"
+default: "nonpositive"
+}
+```
+
 ### Lambda expressions (ADR-0074, ADR-0076, ADR-0119)
 
 `->` introduces a lambda expression. The **canonical** form omits parameter and return types and lets them be **inferred** from the expected delegate type at the use site (ADR-0119): `(x) -> x + 1`, `(a, b) -> a + b`. A single-parameter lambda may drop the parentheses entirely: `x -> x + 1` (issue #932). Parameter types may also be spelled explicitly when desired (`(x int32) -> x + 1`). The body is either a single expression or a brace-delimited block whose trailing expression (or `return`) supplies the lambda value. Lambdas may capture outer locals; the closure machinery is shared with `func` literals.
@@ -862,7 +872,7 @@ Switch statement cases use block bodies and never fall through. The `fallthrough
 
 ```ebnf
 SwitchStmt = "switch" Expression "{" SwitchCase* "}" .
-SwitchCase = "case" Pattern Block | "default" Block .
+SwitchCase = "case" Pattern [ "when" Expression ] Block | "default" Block .
 ```
 
 When an arm pattern is a type-pattern `<ident> is T` (or any pattern that proves the discriminator's runtime type), the discriminator expression is flow-narrowed to `T` inside the arm body in addition to the bound arm variable — see *Smart casts (flow narrowing)* below.
@@ -1277,10 +1287,11 @@ ReturnStmt        ::= 'return' ('ref' Expression | Expression (',' Expression)*)
 YieldStmt         ::= 'yield' Expression
 
 SwitchStmt        ::= 'switch' Expression '{' SwitchCase* '}'
-SwitchCase        ::= 'case' Pattern Block | 'default' Block
+SwitchCase        ::= 'case' Pattern ('when' Expression)? Block | 'default' Block
 SwitchExpr        ::= 'switch' Expression '{' SwitchArm* '}'
-SwitchArm         ::= 'case' Pattern (':' | '->') Expression | 'default' (':' | '->') Expression
+SwitchArm         ::= 'case' Pattern ('when' Expression)? (':' | '->') Expression | 'default' (':' | '->') Expression
                       (* '->' is the legacy ADR-0009 form. Per ADR-0074 (#714) ':' is the preferred separator; the legacy '->' form is still accepted but emits warning GS0302. *)
+                      (* The optional 'when' guard (#991) selects the arm only when the pattern matches AND the guard is true; 'when' is a contextual keyword. *)
 Pattern           ::= '[' Pattern (',' Pattern)* ']'
                     | '{' identifier ':' Pattern (',' identifier ':' Pattern)* '}'
                     | identifier 'is' TypeClause


### PR DESCRIPTION
Fixes #991.

## Summary
Adds C#-style `when` boolean guards to both switch-expression arms and switch-statement cases. A guarded arm matches only when the **pattern matches AND the guard evaluates `true`**; otherwise control falls through to the next arm.

```gs
func classify(n int32) string {
    return switch n {
        case > 0 when n < 10: "small"
        case > 0: "big"
        default: "nonpositive"
    }
}
```

`when` is implemented as a **contextual keyword** (matched as an identifier in the parser), so **no new `SyntaxKind` or `BoundNodeKind`** is introduced — the guard is an optional field on the existing switch-arm syntax/bound nodes. This keeps the coverage matrix and bound-node exhaustiveness allowlists untouched.

## Design / pipeline
- **Parser** (`Parser.cs`): optional `when <expr>` after the pattern in both arm forms (`ParseOptionalWhenGuard`).
- **Binder** (`StatementBinder.cs`, `ExpressionBinder.SwitchExpr.cs`): guard bound as `bool` (GS0155 if not convertible). The guard sees Kotlin-style pattern narrowing / smart-casts in effect for the arm (`case x is T when x.M()` sees `x` as `T`).
- **Exhaustiveness** (`ExhaustivenessAnalyzer.cs`, `StatementBinder`): guarded arms never count toward exhaustiveness, so a guarded last/default arm does **not** make a value switch exhaustive (matches C#); GS0176 still fires when no total arm is reachable.
- **Lowering / Evaluator / Emit**: guard is part of the arm test; on a failed guard, branch to the next arm (`Brfalse → nextArm`).
- **cs2gs**: C# `when` clauses now translate to the canonical G# guard form instead of being reported unsupported.

## Before / after (repro)
Before: `case > 0 when n < 10:` → **GS0005** "Unexpected token IdentifierToken, expected ColonToken".
After: compiles, ilverifies clean, runs.

```
$ dotnet classify.dll
small
big
nonpositive
```

## Evidence
- Full clean build `dotnet build GSharp.sln -c Release -graph --no-incremental` → **0 Warnings / 0 Errors**.
- `classify` sample compiles, ilverifies clean, prints `small` / `big` / `nonpositive`.
- Core.Tests: **3496 passed**, 0 failed. cs2gs.Tests: **140 passed**, 0 failed. Issue991 emit tests + switch/pattern emit tests pass.
- Non-bool guard → GS0155. Guarded discard does not satisfy exhaustiveness → GS0176.

## Docs
- `website/docs/ref/spec.md`: documents `when` guards + grammar.
- `docs/adr/0115-csharp-to-gsharp-migration-tool.md`: §G #991 marked resolved.